### PR TITLE
Move validateProjectChanged and getAllFileDataFromBramble to CdoBramble

### DIFF
--- a/apps/src/weblab/CdoBramble.js
+++ b/apps/src/weblab/CdoBramble.js
@@ -217,7 +217,7 @@ export default class CdoBramble {
   }
 
   uploadAllFilesToServer(callback) {
-    this.getAllFileData((err, fileData) => {
+    this.getAllFileData((err, files) => {
       if (err) {
         callback(err);
         return;
@@ -231,14 +231,14 @@ export default class CdoBramble {
           }
 
           this.lastSyncedVersionId = newVersionId;
-          if (index >= fileData.length - 1) {
+          if (index >= files.length - 1) {
             callback(null, true /* preWriteHook was successful */);
           } else {
             uploadEntry(index + 1);
           }
         };
 
-        const {name, data} = fileData[index];
+        const {name, data} = files[index];
         this.api.changeProjectFile(
           name,
           data,

--- a/apps/test/unit/weblab/CdoBrambleTest.js
+++ b/apps/test/unit/weblab/CdoBrambleTest.js
@@ -242,16 +242,16 @@ describe('CdoBramble', () => {
   });
 
   describe('uploadAllFilesToServer', () => {
-    let fileEntries;
+    let fileData;
 
     beforeEach(() => {
-      fileEntries = [{path: 'index.html'}, {path: 'style.css'}];
-      sinon.stub(cdoBramble, 'shell').returns({
-        ls: (path, callback) => callback(null, fileEntries)
-      });
+      fileData = [
+        {name: 'index.html', data: '<div></div>'},
+        {name: 'style.css', data: '* {margin: 0;}'}
+      ];
       sinon
-        .stub(cdoBramble, 'getFileData')
-        .callsFake((path, callback) => callback(null, 'my file data'));
+        .stub(cdoBramble, 'getAllFileData')
+        .callsFake(callback => callback(fileData));
       sinon
         .stub(cdoBramble.api, 'changeProjectFile')
         .callsFake((filename, fileData, callback) =>
@@ -263,39 +263,9 @@ describe('CdoBramble', () => {
       cdoBramble.uploadAllFilesToServer((error, wasSuccessful) => {
         expect(error).to.equal(null);
         expect(wasSuccessful).to.be.true;
-        expect(console.error).not.to.have.been.called;
-        expect(cdoBramble.getFileData).to.have.been.calledTwice;
+        expect(cdoBramble.getAllFileData).to.have.been.calledOnce;
         expect(cdoBramble.api.changeProjectFile).to.have.been.calledTwice;
         expect(cdoBramble.lastSyncedVersionId).to.equal('new-version-id');
-        done();
-      });
-    });
-
-    it('exits early if request for file entries fails', done => {
-      cdoBramble.shell.restore();
-      sinon.stub(cdoBramble, 'shell').returns({
-        ls: (path, callback) => callback(new Error(), null)
-      });
-
-      cdoBramble.uploadAllFilesToServer((error, wasSuccessful) => {
-        expect(error).not.to.equal(null);
-        expect(wasSuccessful).to.be.undefined;
-        expect(console.error).to.have.been.calledOnce;
-        expect(cdoBramble.getFileData).not.to.have.been.called;
-        done();
-      });
-    });
-
-    it('exits early if getFileData fails', done => {
-      cdoBramble.getFileData.restore();
-      sinon
-        .stub(cdoBramble, 'getFileData')
-        .callsFake((path, callback) => callback(new Error(), null));
-
-      cdoBramble.uploadAllFilesToServer((error, wasSuccessful) => {
-        expect(error).not.to.equal(null);
-        expect(wasSuccessful).to.be.undefined;
-        expect(cdoBramble.getFileData).to.have.been.calledOnce;
         done();
       });
     });
@@ -311,7 +281,7 @@ describe('CdoBramble', () => {
       cdoBramble.uploadAllFilesToServer((error, wasSuccessful) => {
         expect(error).not.to.equal(null);
         expect(wasSuccessful).to.be.undefined;
-        expect(cdoBramble.getFileData).to.have.been.calledOnce;
+        expect(cdoBramble.getAllFileData).to.have.been.calledOnce;
         expect(cdoBramble.api.changeProjectFile).to.have.been.calledOnce;
         done();
       });

--- a/apps/test/unit/weblab/CdoBrambleTest.js
+++ b/apps/test/unit/weblab/CdoBrambleTest.js
@@ -252,7 +252,7 @@ describe('CdoBramble', () => {
       ];
       sinon
         .stub(cdoBramble, 'getAllFileData')
-        .callsFake(callback => callback(fileData));
+        .callsFake(callback => callback(null, fileData));
       sinon
         .stub(cdoBramble.api, 'changeProjectFile')
         .callsFake((filename, fileData, callback) =>
@@ -267,6 +267,21 @@ describe('CdoBramble', () => {
         expect(cdoBramble.getAllFileData).to.have.been.calledOnce;
         expect(cdoBramble.api.changeProjectFile).to.have.been.calledTwice;
         expect(cdoBramble.lastSyncedVersionId).to.equal('new-version-id');
+        done();
+      });
+    });
+
+    it('exits early if files cannot be read', done => {
+      cdoBramble.getAllFileData.restore();
+      sinon
+        .stub(cdoBramble, 'getAllFileData')
+        .callsFake(callback => callback(new Error(), null));
+
+      cdoBramble.uploadAllFilesToServer((error, wasSuccessful) => {
+        expect(error).not.to.equal(null);
+        expect(wasSuccessful).to.be.undefined;
+        expect(cdoBramble.getAllFileData).to.have.been.calledOnce;
+        expect(cdoBramble.api.changeProjectFile).not.to.have.been.called;
         done();
       });
     });
@@ -559,7 +574,7 @@ describe('CdoBramble', () => {
       const userFiles = [{name: 'index.html'}, {name: 'style.css'}];
       sinon
         .stub(cdoBramble, 'getAllFileData')
-        .callsFake(callback => callback(userFiles));
+        .callsFake(callback => callback(null, userFiles));
 
       cdoBramble.validateProjectChanged(projectChanged => {
         expect(projectChanged).to.be.true;
@@ -571,7 +586,7 @@ describe('CdoBramble', () => {
       const userFiles = [{name: 'style.css'}];
       sinon
         .stub(cdoBramble, 'getAllFileData')
-        .callsFake(callback => callback(userFiles));
+        .callsFake(callback => callback(null, userFiles));
 
       cdoBramble.validateProjectChanged(projectChanged => {
         expect(projectChanged).to.be.true;
@@ -583,7 +598,7 @@ describe('CdoBramble', () => {
       const userFiles = [{name: 'index.html', data: '<p></p>'}];
       sinon
         .stub(cdoBramble, 'getAllFileData')
-        .callsFake(callback => callback(userFiles));
+        .callsFake(callback => callback(null, userFiles));
 
       cdoBramble.validateProjectChanged(projectChanged => {
         expect(projectChanged).to.be.true;
@@ -606,7 +621,7 @@ describe('CdoBramble', () => {
       sinon.stub(cdoBramble.api, 'getStartSources').returns(startSources);
       sinon
         .stub(cdoBramble, 'getAllFileData')
-        .callsFake(callback => callback(userFiles));
+        .callsFake(callback => callback(null, userFiles));
 
       cdoBramble.validateProjectChanged(projectChanged => {
         expect(projectChanged).to.be.true;
@@ -625,7 +640,7 @@ describe('CdoBramble', () => {
         .returns({files: [...files]});
       sinon
         .stub(cdoBramble, 'getAllFileData')
-        .callsFake(callback => callback([...files]));
+        .callsFake(callback => callback(null, [...files]));
 
       cdoBramble.validateProjectChanged(projectChanged => {
         expect(projectChanged).to.be.false;
@@ -642,7 +657,7 @@ describe('CdoBramble', () => {
       sinon.stub(cdoBramble.api, 'getStartSources').returns(startSources);
       sinon
         .stub(cdoBramble, 'getAllFileData')
-        .callsFake(callback => callback(userFiles));
+        .callsFake(callback => callback(null, userFiles));
 
       cdoBramble.validateProjectChanged(projectChanged => {
         expect(projectChanged).to.be.false;


### PR DESCRIPTION
Follow-up to #39788.

This PR moves functionality (from brambleHost.js to CdoBramble.js) for creating and saving new WebLab projects. The pre-existing code that this PR re-implements is primarily the `validateProjectChanged` function:
https://github.com/code-dot-org/code-dot-org/blob/111cb22aab2d83510d130be91adc71333da7fedf/apps/src/weblab/brambleHost.js#L306-L334

Other changes in this PR:
- Implement helper function [`getAllFileDataFromBramble`](https://github.com/code-dot-org/code-dot-org/blob/111cb22aab2d83510d130be91adc71333da7fedf/apps/src/weblab/brambleHost.js#L336-L365)
- Refactor `uploadAllFilesToServer` to use the new `getAllFileData` helper mentioned above (it was previously doing the same work in that function -- now that that functionality is needed elsewhere, it should be in its own function)

## Links

- [STAR-1447](https://codedotorg.atlassian.net/browse/STAR-1447)

## Testing story

Adds unit tests.

## Follow-up work

Defined in #39654.