### PR TITLE
Update sign-in links for picture and word logins

### DIFF
--- a/apps/src/templates/teacherDashboard/SignInInstructions.jsx
+++ b/apps/src/templates/teacherDashboard/SignInInstructions.jsx
@@ -34,7 +34,7 @@ export default class SignInInstructions extends React.Component {
             <p>{i18n.signingInWordIntro()}</p>
             <SafeMarkdown
               markdown={i18n.signingInWordPic1({
-                joinLink: `${studioUrlPrefix}/join/${sectionCode}`,
+                joinLink: `${studioUrlPrefix}/sections/${sectionCode}`,
                 sectionCode: sectionCode,
                 codeOrgLink: pegasus('/')
               })}
@@ -49,7 +49,7 @@ export default class SignInInstructions extends React.Component {
             <p>{i18n.signingInPicIntro()}</p>
             <SafeMarkdown
               markdown={i18n.signingInWordPic1({
-                joinLink: `${studioUrlPrefix}/join/${sectionCode}`,
+                joinLink: `${studioUrlPrefix}/sections/${sectionCode}`,
                 sectionCode: sectionCode,
                 codeOrgLink: pegasus('/')
               })}


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Updated sign-in links from teacher manage dashboard for word and picture logins from https://studio.code.org/join/[sectioncode] to https://studio.code.org/sections/[sectioncode].

Tested locally that links appeared correctly and worked when clicked

### Words
<img width="1036" alt="Screen Shot 2021-03-30 at 5 45 24 PM" src="https://user-images.githubusercontent.com/24235215/113075292-7f733f00-9181-11eb-8cbc-d042ba91c5b9.png">

### Pictures
<img width="1001" alt="Screen Shot 2021-03-30 at 5 47 26 PM" src="https://user-images.githubusercontent.com/24235215/113075299-81d59900-9181-11eb-9426-483a0fe017d8.png">

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: [LP-1814](https://codedotorg.atlassian.net/browse/LP-1814)
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
