### PR TITLE
Update 'Add Slide' button to add an actual slide icon

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCard.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCard.jsx
@@ -367,6 +367,29 @@ class ActivitySectionCard extends Component {
     );
   };
 
+  insertMarkdownSyntaxAtSelection = newText => {
+    // If we (for whatever reason) don't have a reference for the textarea, we
+    // can't get the selection location. In that case, we could probably do
+    // nothing or throw an error or something. For now, let's just default to
+    // appending the text to the end.
+    if (!this.editorTextAreaRef) {
+      return this.appendMarkdownSyntax(newText);
+    }
+    const currentText = this.props.activitySection.text;
+    const selectionStart = this.editorTextAreaRef.selectionStart;
+    const selectionEnd = this.editorTextAreaRef.selectionEnd || selectionStart;
+    const resultingText =
+      currentText.slice(0, selectionStart) +
+      newText +
+      currentText.slice(selectionEnd);
+    this.props.updateActivitySectionField(
+      this.props.activityPosition,
+      this.props.activitySection.position,
+      'text',
+      resultingText
+    );
+  };
+
   appendProgrammingExpressionLink = programmingExpression => {
     this.appendMarkdownSyntax(
       buildProgrammingExpressionMarkdown(programmingExpression)
@@ -382,7 +405,9 @@ class ActivitySectionCard extends Component {
   };
 
   appendSlide = () => {
-    this.appendMarkdownSyntax(' [slide]');
+    this.insertMarkdownSyntaxAtSelection(
+      '<i class="fa fa-list-alt" aria-hidden="true"></i>'
+    );
   };
 
   handleRemoveLevel = levelPos => {
@@ -503,6 +528,7 @@ class ActivitySectionCard extends Component {
         {hasLessonPlan && (
           <textarea
             value={this.props.activitySection.text}
+            ref={ref => (this.editorTextAreaRef = ref)}
             rows={Math.max(
               this.props.activitySection.text.split(/\r\n|\r|\n/).length + 1,
               2

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/ActivitySectionCardTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/ActivitySectionCardTest.jsx
@@ -272,4 +272,48 @@ describe('ActivitySectionCard', () => {
 
     expect(moveActivitySection).to.not.have.been.called;
   });
+
+  it('can insert at text cusor positon with insertMarkdownSyntaxAtSelection', () => {
+    const wrapper = mount(
+      <Provider store={store}>
+        <ActivitySectionCard {...defaultProps} />
+      </Provider>
+    );
+    const instance = wrapper.find('ActivitySectionCard').instance();
+
+    // inserting without a cursor position will insert at the beginning
+    instance.insertMarkdownSyntaxAtSelection('new syntax ');
+    expect(updateActivitySectionField.lastCall.args[3]).to.equal(
+      'new syntax Simple text'
+    );
+
+    // inserting with a cursor position will insert at that position
+    instance.editorTextAreaRef.selectionStart = 6;
+    instance.insertMarkdownSyntaxAtSelection(' new syntax');
+    expect(updateActivitySectionField.lastCall.args[3]).to.equal(
+      'Simple new syntax text'
+    );
+  });
+
+  it('can replace selected text with insertMarkdownSyntaxAtSelection', () => {
+    const wrapper = mount(
+      <Provider store={store}>
+        <ActivitySectionCard {...defaultProps} />
+      </Provider>
+    );
+    const instance = wrapper.find('ActivitySectionCard').instance();
+    instance.editorTextAreaRef.selectionStart = 0;
+    instance.editorTextAreaRef.selectionEnd = 6;
+    instance.insertMarkdownSyntaxAtSelection('Basic insertion');
+    expect(updateActivitySectionField.lastCall.args[3]).to.equal(
+      'Basic insertion text'
+    );
+
+    instance.editorTextAreaRef.selectionStart = 7;
+    instance.editorTextAreaRef.selectionEnd = 11;
+    instance.insertMarkdownSyntaxAtSelection('example');
+    expect(updateActivitySectionField.lastCall.args[3]).to.equal(
+      'Simple example'
+    );
+  });
 });


### PR DESCRIPTION
Specifically, to add the icon at the position of the cursor. Also supports replacing selected text.

## Follow-up work

- replace all existing instances of `[slide]` syntax with fontawesome icon
- update other buttons to also insert at cursor?

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
