### PR TITLE
Add a button to launch plc courses on script edit page

### DIFF
--- a/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
@@ -97,6 +97,7 @@ class ScriptEditor extends React.Component {
     initialWeeklyInstructionalMinutes: PropTypes.number,
     isMigrated: PropTypes.bool,
     initialIncludeStudentLessonPlans: PropTypes.bool,
+    initialPlcCourseLaunched: PropTypes.bool,
 
     // from redux
     lessonGroups: PropTypes.arrayOf(lessonGroupShape).isRequired,
@@ -117,7 +118,7 @@ class ScriptEditor extends React.Component {
       isSaving: false,
       error: null,
       lastSaved: null,
-      plcCourseLaunchStatus: null,
+      plcCourseLaunchError: null,
       familyName: this.props.initialFamilyName,
       isCourse: this.props.initialIsCourse,
       showCalendar: this.props.initialShowCalendar,
@@ -157,7 +158,8 @@ class ScriptEditor extends React.Component {
       teacherResources: resources,
       hasImportedLessonDescriptions: false,
       oldScriptText: this.props.initialLessonLevelData,
-      includeStudentLessonPlans: this.props.initialIncludeStudentLessonPlans
+      includeStudentLessonPlans: this.props.initialIncludeStudentLessonPlans,
+      plcCourseLaunched: this.props.initialPlcCourseLaunched
     };
   }
 
@@ -342,10 +344,12 @@ class ScriptEditor extends React.Component {
       contentType: 'application/json;charset=UTF-8'
     })
       .done(() => {
-        this.setState({plcCourseLaunchStatus: 'Course Launched'});
+        this.setState({
+          plcCourseLaunched: true
+        });
       })
       .fail(error => {
-        this.setState({plcCourseLaunchStatus: error.responseText});
+        this.setState({plcCourseLaunchError: error.responseText});
       });
   };
 
@@ -932,7 +936,8 @@ class ScriptEditor extends React.Component {
               onClick={this.launchPlcCourse}
               color={Button.ButtonColor.purple}
               disabled={
-                !(this.state.title && this.state.professionalLearningCourse)
+                !(this.state.title && this.state.professionalLearningCourse) ||
+                this.state.plcCourseLaunched
               }
             />
             <HelpTip>
@@ -949,15 +954,14 @@ class ScriptEditor extends React.Component {
                 </p>
               )}
             </HelpTip>
-            {this.state.plcCourseLaunchStatus && (
-              <span
-                style={
-                  this.state.plcCourseLaunchStatus === 'Course Launched'
-                    ? {color: color.level_perfect}
-                    : {color: color.red}
-                }
-              >
-                {this.state.plcCourseLaunchStatus}
+            {this.state.plcCourseLaunched && (
+              <span style={{color: color.level_perfect}}>
+                {'Course Launched'}
+              </span>
+            )}
+            {this.state.plcCourseLaunchError && (
+              <span style={{color: color.red}}>
+                {this.state.plcCourseLaunchError}
               </span>
             )}
           </div>

--- a/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
@@ -931,12 +931,23 @@ class ScriptEditor extends React.Component {
               text="Launch PLC Course"
               onClick={this.launchPlcCourse}
               color={Button.ButtonColor.purple}
+              disabled={
+                !(this.state.title && this.state.professionalLearningCourse)
+              }
             />
             <HelpTip>
-              <p>
-                In order for users to be able to make progress on this plc
-                course you need to launch it.
-              </p>
+              {this.state.title && this.state.professionalLearningCourse && (
+                <p>
+                  In order for users to be able to make progress on this plc
+                  course you need to launch it.
+                </p>
+              )}
+              {!(this.state.title && this.state.professionalLearningCourse) && (
+                <p>
+                  You must set title and professional learning course in order
+                  to launch a professional learning course.
+                </p>
+              )}
             </HelpTip>
             {this.state.plcCourseLaunchStatus && (
               <span

--- a/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
@@ -927,6 +927,7 @@ class ScriptEditor extends React.Component {
           </label>
           <div>
             <Button
+              name="launch_plc_course"
               text="Launch PLC Course"
               onClick={this.launchPlcCourse}
               color={Button.ButtonColor.purple}

--- a/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
@@ -24,6 +24,7 @@ import {
 } from '@cdo/apps/lib/levelbuilder/script-editor/scriptEditorRedux';
 import {lessonGroupShape} from '@cdo/apps/lib/levelbuilder/shapes';
 import SaveBar from '@cdo/apps/lib/levelbuilder/SaveBar';
+import Button from '@cdo/apps/templates/Button';
 
 const styles = {
   input: {
@@ -116,6 +117,7 @@ class ScriptEditor extends React.Component {
       isSaving: false,
       error: null,
       lastSaved: null,
+      plcCourseLaunchStatus: null,
       familyName: this.props.initialFamilyName,
       isCourse: this.props.initialIsCourse,
       showCalendar: this.props.initialShowCalendar,
@@ -327,6 +329,23 @@ class ScriptEditor extends React.Component {
       })
       .fail(error => {
         this.setState({isSaving: false, error: error.responseText});
+      });
+  };
+
+  launchPlcCourse = event => {
+    event.preventDefault();
+
+    $.ajax({
+      url: `/plc/${this.state.title}/launch`,
+      method: 'PUT',
+      dataType: 'json',
+      contentType: 'application/json;charset=UTF-8'
+    })
+      .done(() => {
+        this.setState({plcCourseLaunchStatus: 'Course Launched'});
+      })
+      .fail(error => {
+        this.setState({plcCourseLaunchStatus: error.responseText});
       });
   };
 
@@ -906,6 +925,30 @@ class ScriptEditor extends React.Component {
               }
             />
           </label>
+          <div>
+            <Button
+              text="Launch PLC Course"
+              onClick={this.launchPlcCourse}
+              color={Button.ButtonColor.purple}
+            />
+            <HelpTip>
+              <p>
+                In order for users to be able to make progress on this plc
+                course you need to launch it.
+              </p>
+            </HelpTip>
+            {this.state.plcCourseLaunchStatus && (
+              <span
+                style={
+                  this.state.plcCourseLaunchStatus === 'Course Launched'
+                    ? {color: color.level_perfect}
+                    : {color: color.red}
+                }
+              >
+                {this.state.plcCourseLaunchStatus}
+              </span>
+            )}
+          </div>
         </CollapsibleEditorSection>
 
         <CollapsibleEditorSection title="Lesson Groups and Lessons">

--- a/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
@@ -47,6 +47,12 @@ const styles = {
     marginBottom: 10,
     border: '1px solid ' + color.light_gray,
     padding: 10
+  },
+  courseLaunchedText: {
+    color: color.level_perfect
+  },
+  courseLaunchedErrorText: {
+    color: color.red
   }
 };
 
@@ -97,7 +103,7 @@ class ScriptEditor extends React.Component {
     initialWeeklyInstructionalMinutes: PropTypes.number,
     isMigrated: PropTypes.bool,
     initialIncludeStudentLessonPlans: PropTypes.bool,
-    initialPlcCourseLaunched: PropTypes.bool,
+    initialIsPlcCourseLaunched: PropTypes.bool,
 
     // from redux
     lessonGroups: PropTypes.arrayOf(lessonGroupShape).isRequired,
@@ -159,7 +165,7 @@ class ScriptEditor extends React.Component {
       hasImportedLessonDescriptions: false,
       oldScriptText: this.props.initialLessonLevelData,
       includeStudentLessonPlans: this.props.initialIncludeStudentLessonPlans,
-      plcCourseLaunched: this.props.initialPlcCourseLaunched
+      isPlcCourseLaunched: this.props.initialIsPlcCourseLaunched
     };
   }
 
@@ -345,7 +351,7 @@ class ScriptEditor extends React.Component {
     })
       .done(() => {
         this.setState({
-          plcCourseLaunched: true
+          isPlcCourseLaunched: true
         });
       })
       .fail(error => {
@@ -937,7 +943,7 @@ class ScriptEditor extends React.Component {
               color={Button.ButtonColor.purple}
               disabled={
                 !(this.state.title && this.state.professionalLearningCourse) ||
-                this.state.plcCourseLaunched
+                this.state.isPlcCourseLaunched
               }
             />
             <HelpTip>
@@ -954,13 +960,11 @@ class ScriptEditor extends React.Component {
                 </p>
               )}
             </HelpTip>
-            {this.state.plcCourseLaunched && (
-              <span style={{color: color.level_perfect}}>
-                {'Course Launched'}
-              </span>
+            {this.state.isPlcCourseLaunched && (
+              <span style={styles.courseLaunchedText}>Course Launched</span>
             )}
             {this.state.plcCourseLaunchError && (
-              <span style={{color: color.red}}>
+              <span style={styles.courseLaunchedErrorText}>
                 {this.state.plcCourseLaunchError}
               </span>
             )}

--- a/apps/src/sites/studio/pages/scripts/edit.js
+++ b/apps/src/sites/studio/pages/scripts/edit.js
@@ -81,7 +81,7 @@ export default function initPage(scriptEditorData) {
         initialIncludeStudentLessonPlans={
           scriptData.includeStudentLessonPlans || false
         }
-        initialPlcCourseLaunched={scriptData.plc_course_launched}
+        initialIsPlcCourseLaunched={scriptData.is_plc_course_launched}
       />
     </Provider>,
     document.querySelector('.edit_container')

--- a/apps/src/sites/studio/pages/scripts/edit.js
+++ b/apps/src/sites/studio/pages/scripts/edit.js
@@ -81,6 +81,7 @@ export default function initPage(scriptEditorData) {
         initialIncludeStudentLessonPlans={
           scriptData.includeStudentLessonPlans || false
         }
+        initialPlcCourseLaunched={scriptData.plc_course_launched}
       />
     </Provider>,
     document.querySelector('.edit_container')

--- a/apps/test/unit/lib/levelbuilder/script-editor/ScriptEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/ScriptEditorTest.jsx
@@ -450,8 +450,17 @@ describe('ScriptEditor', () => {
   });
 
   describe('Professional Learning Course', () => {
-    it('successfully launch plc course', () => {
+    it('disable launching plc course without title and professional learning course', () => {
       const wrapper = createWrapper({});
+
+      const launchButton = wrapper.find('Button[name="launch_plc_course"]');
+      expect(launchButton.contains('Launch PLC Course')).to.be.true;
+      expect(launchButton.props().disabled).to.be.true;
+    });
+    it('successfully launch plc course', () => {
+      const wrapper = createWrapper({
+        initialProfessionalLearningCourse: 'PLC Course'
+      });
       const scriptEditor = wrapper.find('ScriptEditor');
 
       const launchButton = wrapper.find('Button[name="launch_plc_course"]');
@@ -473,10 +482,14 @@ describe('ScriptEditor', () => {
       expect(scriptEditor.state().plcCourseLaunchStatus).to.equal(
         'Course Launched'
       );
+
+      server.restore();
     });
 
     it('launch plc course gives error', () => {
-      const wrapper = createWrapper({});
+      const wrapper = createWrapper({
+        initialProfessionalLearningCourse: 'PLC Course'
+      });
       const scriptEditor = wrapper.find('ScriptEditor');
 
       const launchButton = wrapper.find('Button[name="launch_plc_course"]');
@@ -499,6 +512,8 @@ describe('ScriptEditor', () => {
       expect(scriptEditor.state().plcCourseLaunchStatus).to.equal(
         'There was an error'
       );
+
+      server.restore();
     });
   });
 });

--- a/apps/test/unit/lib/levelbuilder/script-editor/ScriptEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/ScriptEditorTest.jsx
@@ -18,8 +18,9 @@ import sinon from 'sinon';
 import * as utils from '@cdo/apps/utils';
 
 describe('ScriptEditor', () => {
-  let defaultProps, store;
+  let defaultProps, store, server;
   beforeEach(() => {
+    server = sinon.fakeServer.create();
     sinon.stub(utils, 'navigateToHref');
     stubRedux();
 
@@ -73,6 +74,7 @@ describe('ScriptEditor', () => {
   afterEach(() => {
     restoreRedux();
     utils.navigateToHref.restore();
+    server.restore();
   });
 
   const createWrapper = overrideProps => {
@@ -219,7 +221,6 @@ describe('ScriptEditor', () => {
       let returnData = {
         scriptPath: '/s/test-script'
       };
-      let server = sinon.fakeServer.create();
       server.respondWith('PUT', `/s/1`, [
         200,
         {'Content-Type': 'application/json'},
@@ -256,7 +257,6 @@ describe('ScriptEditor', () => {
       const scriptEditor = wrapper.find('ScriptEditor');
 
       let returnData = 'There was an error';
-      let server = sinon.fakeServer.create();
       server.respondWith('PUT', `/s/1`, [
         404,
         {'Content-Type': 'application/json'},
@@ -283,8 +283,6 @@ describe('ScriptEditor', () => {
       expect(
         wrapper.find('.saveBar').contains('Error Saving: There was an error')
       ).to.be.true;
-
-      server.restore();
     });
 
     it('shows error when showCalendar is true and weeklyInstructionalMinutes not provided', () => {
@@ -292,7 +290,6 @@ describe('ScriptEditor', () => {
       const scriptEditor = wrapper.find('ScriptEditor');
 
       let returnData = 'There was an error';
-      let server = sinon.fakeServer.create();
       server.respondWith('PUT', `/s/1`, [
         404,
         {'Content-Type': 'application/json'},
@@ -318,8 +315,6 @@ describe('ScriptEditor', () => {
             'Error Saving: Please provide instructional minutes per week in Unit Calendar Settings.'
           )
       ).to.be.true;
-
-      server.restore();
     });
 
     it('shows error when showCalendar is true and weeklyInstructionalMinutes is invalid', () => {
@@ -330,7 +325,6 @@ describe('ScriptEditor', () => {
       const scriptEditor = wrapper.find('ScriptEditor');
 
       let returnData = 'There was an error';
-      let server = sinon.fakeServer.create();
       server.respondWith('PUT', `/s/1`, [
         404,
         {'Content-Type': 'application/json'},
@@ -356,8 +350,6 @@ describe('ScriptEditor', () => {
             'Error Saving: Please provide a positive number of instructional minutes per week in Unit Calendar Settings.'
           )
       ).to.be.true;
-
-      server.restore();
     });
 
     it('can save and close', () => {
@@ -367,7 +359,6 @@ describe('ScriptEditor', () => {
       let returnData = {
         scriptPath: '/s/test-script'
       };
-      let server = sinon.fakeServer.create();
       server.respondWith('PUT', `/s/1`, [
         200,
         {'Content-Type': 'application/json'},
@@ -389,8 +380,6 @@ describe('ScriptEditor', () => {
       expect(utils.navigateToHref).to.have.been.calledWith(
         `/s/test-script${window.location.search}`
       );
-
-      server.restore();
     });
 
     it('shows error when save and keep editing has error saving', () => {
@@ -398,7 +387,6 @@ describe('ScriptEditor', () => {
       const scriptEditor = wrapper.find('ScriptEditor');
 
       let returnData = 'There was an error';
-      let server = sinon.fakeServer.create();
       server.respondWith('PUT', `/s/1`, [
         404,
         {'Content-Type': 'application/json'},
@@ -426,8 +414,6 @@ describe('ScriptEditor', () => {
       expect(
         wrapper.find('.saveBar').contains('Error Saving: There was an error')
       ).to.be.true;
-
-      server.restore();
     });
   });
 
@@ -468,7 +454,6 @@ describe('ScriptEditor', () => {
 
       expect(scriptEditor.state().plcCourseLaunchStatus).to.equal(null);
 
-      let server = sinon.fakeServer.create();
       server.respondWith('PUT', `/plc/Test-Script/launch`, [
         200,
         {'Content-Type': 'application/json'},
@@ -482,8 +467,6 @@ describe('ScriptEditor', () => {
       expect(scriptEditor.state().plcCourseLaunchStatus).to.equal(
         'Course Launched'
       );
-
-      server.restore();
     });
 
     it('launch plc course gives error', () => {
@@ -498,7 +481,6 @@ describe('ScriptEditor', () => {
       expect(scriptEditor.state().plcCourseLaunchStatus).to.equal(null);
 
       let returnData = 'There was an error';
-      let server = sinon.fakeServer.create();
       server.respondWith('PUT', `/plc/Test-Script/launch`, [
         404,
         {'Content-Type': 'application/json'},
@@ -512,8 +494,6 @@ describe('ScriptEditor', () => {
       expect(scriptEditor.state().plcCourseLaunchStatus).to.equal(
         'There was an error'
       );
-
-      server.restore();
     });
   });
 });

--- a/apps/test/unit/lib/levelbuilder/script-editor/ScriptEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/ScriptEditorTest.jsx
@@ -47,6 +47,7 @@ describe('ScriptEditor', () => {
       initialAnnouncements: [],
       curriculumUmbrella: 'CSF',
       i18nData: {
+        title: 'Test-Script',
         stageDescriptions: [],
         description:
           '# TEACHER Title \n This is the unit description with [link](https://studio.code.org/home) **Bold** *italics*',
@@ -445,6 +446,59 @@ describe('ScriptEditor', () => {
       });
       const checkbox = wrapper.find('input[name="visible_to_teachers"]');
       expect(checkbox.prop('checked')).to.be.false;
+    });
+  });
+
+  describe('Professional Learning Course', () => {
+    it('successfully launch plc course', () => {
+      const wrapper = createWrapper({});
+      const scriptEditor = wrapper.find('ScriptEditor');
+
+      const launchButton = wrapper.find('Button[name="launch_plc_course"]');
+      expect(launchButton.contains('Launch PLC Course')).to.be.true;
+
+      expect(scriptEditor.state().plcCourseLaunchStatus).to.equal(null);
+
+      let server = sinon.fakeServer.create();
+      server.respondWith('PUT', `/plc/Test-Script/launch`, [
+        200,
+        {'Content-Type': 'application/json'},
+        'Success'
+      ]);
+
+      launchButton.simulate('click');
+      server.respond();
+      scriptEditor.update();
+
+      expect(scriptEditor.state().plcCourseLaunchStatus).to.equal(
+        'Course Launched'
+      );
+    });
+
+    it('launch plc course gives error', () => {
+      const wrapper = createWrapper({});
+      const scriptEditor = wrapper.find('ScriptEditor');
+
+      const launchButton = wrapper.find('Button[name="launch_plc_course"]');
+      expect(launchButton.contains('Launch PLC Course')).to.be.true;
+
+      expect(scriptEditor.state().plcCourseLaunchStatus).to.equal(null);
+
+      let returnData = 'There was an error';
+      let server = sinon.fakeServer.create();
+      server.respondWith('PUT', `/plc/Test-Script/launch`, [
+        404,
+        {'Content-Type': 'application/json'},
+        returnData
+      ]);
+
+      launchButton.simulate('click');
+      server.respond();
+      scriptEditor.update();
+
+      expect(scriptEditor.state().plcCourseLaunchStatus).to.equal(
+        'There was an error'
+      );
     });
   });
 });

--- a/apps/test/unit/lib/levelbuilder/script-editor/ScriptEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/ScriptEditorTest.jsx
@@ -460,7 +460,7 @@ describe('ScriptEditor', () => {
       let i18nCopy = _.cloneDeep(defaultProps.i18nData);
       i18nCopy['title'] = 'Test-Script';
       const wrapper = createWrapper({
-        initialPlcCourseLaunched: true,
+        initialIsPlcCourseLaunched: true,
         initialProfessionalLearningCourse: 'PLC Course',
         i18nData: i18nCopy
       });
@@ -474,7 +474,7 @@ describe('ScriptEditor', () => {
       let i18nCopy = _.cloneDeep(defaultProps.i18nData);
       i18nCopy['title'] = 'Test-Script';
       const wrapper = createWrapper({
-        initialPlcCourseLaunched: false,
+        initialIsPlcCourseLaunched: false,
         initialProfessionalLearningCourse: 'PLC Course',
         i18nData: i18nCopy
       });
@@ -493,14 +493,14 @@ describe('ScriptEditor', () => {
       server.respond();
       scriptEditor.update();
 
-      expect(scriptEditor.state().plcCourseLaunched).to.be.true;
+      expect(scriptEditor.state().isPlcCourseLaunched).to.be.true;
     });
 
     it('launch plc course gives error', () => {
       let i18nCopy = _.cloneDeep(defaultProps.i18nData);
       i18nCopy['title'] = 'Test-Script';
       const wrapper = createWrapper({
-        initialPlcCourseLaunched: false,
+        initialIsPlcCourseLaunched: false,
         initialProfessionalLearningCourse: 'PLC Course',
         i18nData: i18nCopy
       });

--- a/apps/test/unit/lib/levelbuilder/script-editor/ScriptEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/ScriptEditorTest.jsx
@@ -457,7 +457,7 @@ describe('ScriptEditor', () => {
       server.respondWith('PUT', `/plc/Test-Script/launch`, [
         200,
         {'Content-Type': 'application/json'},
-        'Success'
+        JSON.stringify({})
       ]);
 
       launchButton.simulate('click');

--- a/dashboard/app/controllers/plc/course_unit_controller.rb
+++ b/dashboard/app/controllers/plc/course_unit_controller.rb
@@ -1,4 +1,6 @@
 class Plc::CourseUnitController < ApplicationController
+  before_action :require_levelbuilder_mode_or_test_env
+
   # PUT /launch/:course_unit_name
   def launch
     course_unit = Plc::CourseUnit.find_by(unit_name: params[:course_unit_name])

--- a/dashboard/app/controllers/plc/course_unit_controller.rb
+++ b/dashboard/app/controllers/plc/course_unit_controller.rb
@@ -1,0 +1,8 @@
+class Plc::CourseUnitController < ApplicationController
+  # PUT /launch/:course_unit_name
+  def launch
+    course_unit = Plc::CourseUnit.find_by(unit_name: params[:course_unit_name])
+    raise ActiveRecord::RecordNotFound unless course_unit
+    course_unit.launch
+  end
+end

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1479,7 +1479,7 @@ class Script < ApplicationRecord
     summary = summarize(include_lessons)
     summary[:lesson_groups] = lesson_groups.map(&:summarize_for_script_edit)
     summary[:lessonLevelData] = ScriptDSL.serialize_lesson_groups(self)
-    summary[:plc_course_launched] = plc_course_unit&.started?
+    summary[:is_plc_course_launched] = plc_course_unit&.started?
     summary
   end
 

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1479,6 +1479,7 @@ class Script < ApplicationRecord
     summary = summarize(include_lessons)
     summary[:lesson_groups] = lesson_groups.map(&:summarize_for_script_edit)
     summary[:lessonLevelData] = ScriptDSL.serialize_lesson_groups(self)
+    summary[:plc_course_launched] = plc_course_unit&.started?
     summary
   end
 

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -455,6 +455,7 @@ Dashboard::Application.routes.draw do
 
   get '/plc/user_course_enrollments/group_view', to: 'plc/user_course_enrollments#group_view'
   get '/plc/user_course_enrollments/manager_view/:id', to: 'plc/user_course_enrollments#manager_view', as: 'plc_user_course_enrollment_manager_view'
+  put '/plc/:course_unit_name/launch/', to: 'plc/course_unit#launch'
 
   namespace :plc do
     root to: 'plc#index'

--- a/dashboard/test/controllers/plc/course_unit_controller_test.rb
+++ b/dashboard/test/controllers/plc/course_unit_controller_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+class Plc::CourseUnitControllerTest < ActionController::TestCase
+  setup do
+    @plc_course = create(:plc_course)
+    @course_unit = create(:plc_course_unit, plc_course: @plc_course, unit_name: 'PLC Course')
+
+    custom_i18n = {
+      'data' => {
+        'script' => {
+          'name' => {
+            @course_unit.script.name => {
+              'title' => @course_unit.unit_name
+            }
+          }
+        }
+      }
+    }
+
+    I18n.backend.store_translations 'en-US', custom_i18n
+  end
+
+  test "launching course sets started to true" do
+    refute @course_unit.started
+    put :launch, params: {course_unit_name: @course_unit.script.title_for_display}
+    @course_unit.reload
+    assert @course_unit.started
+  end
+end


### PR DESCRIPTION
Adds a button on the Script Edit page in the Professional Learning Section which allows a levelbuilder to launch a PLC Course.  You have to set a title for the script and a professional learning course for the button to be enabled. 

Needs more information to launch: 
<img width="1010" alt="Screen Shot 2021-03-31 at 1 05 07 PM" src="https://user-images.githubusercontent.com/208083/113183170-bac54a80-9221-11eb-913d-310cc1f61d8a.png">

Ready to Launch: 
<img width="1006" alt="Screen Shot 2021-03-31 at 1 04 43 PM" src="https://user-images.githubusercontent.com/208083/113183115-ab460180-9221-11eb-8b1b-a148697cc487.png">

Already launched or was just launched: 
<img width="1038" alt="Screen Shot 2021-03-31 at 1 04 02 PM" src="https://user-images.githubusercontent.com/208083/113183061-9a958b80-9221-11eb-843f-9f968fc90f07.png">


## Links

https://codedotorg.atlassian.net/browse/PLAT-780

## Testing story

- Added test for new launch controller
- Added unit tests for new launch button on script edit page