### PR TITLE
fix issue with image misalignment on minecraft tutorial

### DIFF
--- a/pegasus/sites.v3/code.org/views/minecraft_2020_promo.haml
+++ b/pegasus/sites.v3/code.org/views/minecraft_2020_promo.haml
@@ -19,7 +19,7 @@
       %a{href: mee_link, target: '_blank'}
         %button.tutorial-button{style: "color: #4d575f; background-color: white; border-color: white; font-size: 14px"}
           = mee_link_text
-      - if language_dir_class 'rtl'
+      - if language_dir_class == 'rtl'
         %img{style: "position: absolute; top: 10px; left: 10px; width: 60px;", src: '/images/mc/new_tag.png'}
       - else
         %img{style: "position: absolute; top: 10px; right: 10px; width: 60px", src: '/images/mc/new_tag.png'}


### PR DESCRIPTION

The RTL fixes on the minecraft page included changing the alignment of the Tale of Two Villages tutorial box based on the language. The "new" image wasn't aligning correctly in English after this, caused by an invalid if statement in the haml file.


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
