### PR TITLE
Allow viewing script overview page for all scripts

### DIFF
--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -197,9 +197,11 @@ class Ability
 
     # Override Script and ScriptLevel.
     can :read, Script do |script|
-      return script.has_pilot_access?(user) if script.pilot?
-
-      true
+      if script.pilot?
+        script.has_pilot_access?(user)
+      else
+        true
+      end
     end
 
     can :read, ScriptLevel do |script_level, params|

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -85,9 +85,9 @@ class ScriptsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
-  test "should not get show of ECSPD if not signed in" do
+  test "should get show of ECSPD if not signed in" do
     get :show, params: {id: 'ECSPD'}
-    assert_redirected_to_sign_in
+    assert_response :success
   end
 
   test "should not show link to Overview of Courses 1, 2, and 3 if logged in as a student" do

--- a/dashboard/test/models/ability_test.rb
+++ b/dashboard/test/models/ability_test.rb
@@ -29,11 +29,11 @@ class AbilityTest < ActiveSupport::TestCase
 
     refute ability.can?(:read, Section)
 
-    refute ability.can?(:read, Script.find_by_name('ECSPD'))
+    assert ability.can?(:read, Script.find_by_name('ECSPD'))
     assert ability.can?(:read, Script.find_by_name('flappy'))
 
     assert ability.can?(:read, @public_script)
-    refute ability.can?(:read, @login_required_script)
+    assert ability.can?(:read, @login_required_script)
 
     assert ability.can?(:read, @login_required_migrated_lesson)
     assert ability.can?(:student_lesson_plan, @login_required_migrated_lesson)


### PR DESCRIPTION
Required for https://github.com/code-dot-org/code-dot-org/pull/39682

We still prevent users from viewing the levels for these scripts unless authenticated and authorized, but we don't actually need to prevent them from viewing the overview.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
