### PR TITLE
raise if dsl filename not found

### DIFF
--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -248,6 +248,10 @@ namespace :seed do
       # rake seed:dsls DSL_FILENAME=k-1_Artistloops_multi1.multi
       dsls_glob = ENV['DSL_FILENAME'] ? Dir.glob("config/scripts/**/#{ENV['DSL_FILENAME']}") : DSLS_GLOB
 
+      # This is only expected to happen when DSL_FILENAME is set and the
+      # filename is not found
+      raise "no matching dsl-defined level files found" unless dsls_glob.count > 0
+
       # Parse each .[dsl] file and setup its model.
       dsls_glob.each do |filename|
         dsl_class = DSL_TYPES.detect {|type| filename.include?(".#{type.underscore}")}.try(:constantize)

--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -250,7 +250,9 @@ namespace :seed do
 
       # This is only expected to happen when DSL_FILENAME is set and the
       # filename is not found
-      raise "no matching dsl-defined level files found" unless dsls_glob.count > 0
+      unless dsls_glob.count > 0
+        raise 'no matching dsl-defined level files found. please check filename for exact case and spelling.'
+      end
 
       # Parse each .[dsl] file and setup its model.
       dsls_glob.each do |filename|


### PR DESCRIPTION
dsl-defined levels names do not exactly match their filenames. Because of this, it is easy to make a case error when running `rake seed:dsls DSL_FILENAME=...`. also there is no warning if the file is not found. therefore, this PR raises if the file was not found, making it a bit easier to figure out what went wrong.

## Testing story

manually verified the following:
* `rake seed:scripts` succeeds (needed to run this rather than `rake seed:dsls` directly so that some pre-requisites would also be run)
* `rake seed:dsls DSL_FILENAME=k-1_Artistloops_multi1.multi` succeeds. this is the correct filename
* `rake seed:dsls DSL_FILENAME=k-1_ARTISTLOOPS_multi1.multi` succeeds. filename differs only by case. I think this might differ from what @hannahbergam saw because of some OS settings on filename case sensitivity. Hannah, if you run this, I would expect it to raise.
* `rake seed:dsls DSL_FILENAME=bogus.multi` raises
