### PR TITLE
Write script_id when creating new ChannelTokens

### DIFF
--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -448,7 +448,7 @@ class ApiController < ApplicationController
           response[:pairingAttempt] = edit_level_source_path(recent_attempt)
         elsif level.channel_backed?
           @level = level
-          recent_channel = get_channel_for(level, recent_user) if recent_user
+          recent_channel = get_channel_for(level, script.id, recent_user) if recent_user
           response[:pairingChannelId] = recent_channel if recent_channel
         end
       end

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -517,7 +517,7 @@ class ScriptLevelsController < ApplicationController
     # Add video generation URL for only the last level of Dance
     # If we eventually want to add video generation for other levels or level
     # types, this is the condition that should be extended.
-    replay_video_view_options(get_channel_for(@level, current_user)) if @level.channel_backed? && @level.is_a?(Dancelab)
+    replay_video_view_options(get_channel_for(@level, @script_level.script_id, current_user)) if @level.channel_backed? && @level.is_a?(Dancelab)
 
     @@fallback_responses ||= {}
     @fallback_response = @@fallback_responses[@script_level.id] ||= {

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -117,7 +117,7 @@ module LevelsHelper
     return false unless user.present?
 
     if level.channel_backed?
-      return get_channel_for(level, user).present?
+      return get_channel_for(level, script.id, user).present?
     else
       user.last_attempt(level, script).present?
     end

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -85,7 +85,7 @@ module LevelsHelper
   # If given a user, find the channel associated with the given level/user.
   # Otherwise, gets the storage_id associated with the (potentially signed out)
   # current user, and either finds or creates a channel for the level
-  def get_channel_for(level, user = nil)
+  def get_channel_for(level, script_id = nil, user = nil)
     if user
       # "answers" are in the channel so instead of doing
       # set_level_source to load answers when looking at another user,
@@ -98,6 +98,7 @@ module LevelsHelper
         level,
         request.ip,
         user_storage_id,
+        script_id,
         {
           hidden: true,
         }
@@ -178,7 +179,7 @@ module LevelsHelper
 
     if (@level.channel_backed? && params[:action] != 'edit_blocks') || @level.is_a?(Javalab)
       view_options(
-        channel: get_channel_for(@level, @user),
+        channel: get_channel_for(@level, @script&.id, @user),
         server_project_level_id: @level.project_template_level.try(:id),
       )
       # readonly if viewing another user's channel
@@ -253,7 +254,7 @@ module LevelsHelper
         if recent_attempt
           level_view_options(@level.id, pairing_attempt: edit_level_source_path(recent_attempt)) if recent_attempt
         elsif @level.channel_backed?
-          recent_channel = get_channel_for(@level, recent_user) if recent_user
+          recent_channel = get_channel_for(@level, @script&.id, recent_user) if recent_user
           level_view_options(@level.id, pairing_channel_id: recent_channel) if recent_channel
         end
       end
@@ -803,7 +804,7 @@ module LevelsHelper
   def firebase_shared_auth_token
     return nil unless CDO.firebase_shared_secret
 
-    base_channel = params[:channel_id] || get_channel_for(@level, @user)
+    base_channel = params[:channel_id] || get_channel_for(@level, @script&.id, @user)
     payload = {
       uid: user_or_session_id,
       is_dashboard_user: !!current_user,
@@ -829,7 +830,7 @@ module LevelsHelper
   def firebase_auth_token
     return nil unless CDO.firebase_secret
 
-    base_channel = params[:channel_id] || get_channel_for(@level, @user)
+    base_channel = params[:channel_id] || get_channel_for(@level, @script&.id, @user)
     payload = {
       uid: user_or_session_id,
       is_dashboard_user: !!current_user,

--- a/dashboard/app/models/channel_token.rb
+++ b/dashboard/app/models/channel_token.rb
@@ -43,7 +43,7 @@ class ChannelToken < ApplicationRecord
 
         return channel_token if channel_token
 
-        # script_id was recently added to the channel_token table. while the backfills and code changes are
+        # script_id was recently added to the channel_token table. While the backfills and code changes are
         # in progress (https://codedotorg.atlassian.net/browse/LP-1395), script_id will be written to the table
         # but not used in the query for a channel_token yet.
         create!(level: level.host_level, storage_id: user_storage_id, script_id: script_id) do |ct|

--- a/dashboard/app/models/channel_token.rb
+++ b/dashboard/app/models/channel_token.rb
@@ -40,10 +40,10 @@ class ChannelToken < ApplicationRecord
       Retryable.retryable on: [Mysql2::Error, ActiveRecord::RecordNotUnique], matching: /Duplicate entry/ do
         # your own channel
         channel_token = find_by(level: level.host_level, storage_id: user_storage_id)
-        
+
         return channel_token if channel_token
-        
-        # script_id was recently added to the channel_token table. while the backfills and code changes are 
+
+        # script_id was recently added to the channel_token table. while the backfills and code changes are
         # in progress (https://codedotorg.atlassian.net/browse/LP-1395), script_id will be written to the table
         # but not used in the query for a channel_token yet.
         create!(level: level.host_level, storage_id: user_storage_id, script_id: script_id) do |ct|

--- a/dashboard/app/models/channel_token.rb
+++ b/dashboard/app/models/channel_token.rb
@@ -31,7 +31,7 @@ class ChannelToken < ApplicationRecord
   # @param [String] user_storage_id The if of the storage app associated with the channel token request.
   # @param [Hash] data
   # @return [ChannelToken] The channel token (new or existing).
-  def self.find_or_create_channel_token(level, ip, user_storage_id, data = {})
+  def self.find_or_create_channel_token(level, ip, user_storage_id, script_id = nil, data = {})
     storage_app = StorageApps.new(user_storage_id)
     # If `create` fails because it was beat by a competing request, a second
     # `find_by` should succeed.
@@ -39,7 +39,14 @@ class ChannelToken < ApplicationRecord
     SeamlessDatabasePool.use_master_connection do
       Retryable.retryable on: [Mysql2::Error, ActiveRecord::RecordNotUnique], matching: /Duplicate entry/ do
         # your own channel
-        find_or_create_by!(level: level.host_level, storage_id: user_storage_id) do |ct|
+        channel_token = find_by(level: level.host_level, storage_id: user_storage_id)
+        
+        return channel_token if channel_token
+        
+        # script_id was recently added to the channel_token table. while the backfills and code changes are 
+        # in progress (https://codedotorg.atlassian.net/browse/LP-1395), script_id will be written to the table
+        # but not used in the query for a channel_token yet.
+        create!(level: level.host_level, storage_id: user_storage_id, script_id: script_id) do |ct|
           # Get a new channel_id.
           channel = create_channel ip, storage_app, data: data, standalone: false
           _, ct.storage_app_id = storage_decrypt_channel_id(channel)

--- a/dashboard/db/migrate/20210331171524_add_script_id_to_channel_tokens.rb
+++ b/dashboard/db/migrate/20210331171524_add_script_id_to_channel_tokens.rb
@@ -1,7 +1,0 @@
-class AddScriptIdToChannelTokens < ActiveRecord::Migration[5.2]
-  def change
-    add_column :channel_tokens, :script_id, :integer
-    remove_index :channel_tokens, [:storage_id, :level_id]
-    add_index :channel_tokens, [:storage_id, :level_id, :script_id], unique: true
-  end
-end

--- a/dashboard/db/migrate/20210331171524_add_script_id_to_channel_tokens.rb
+++ b/dashboard/db/migrate/20210331171524_add_script_id_to_channel_tokens.rb
@@ -1,0 +1,7 @@
+class AddScriptIdToChannelTokens < ActiveRecord::Migration[5.2]
+  def change
+    add_column :channel_tokens, :script_id, :integer
+    remove_index :channel_tokens, [:storage_id, :level_id]
+    add_index :channel_tokens, [:storage_id, :level_id, :script_id], unique: true
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -243,14 +243,11 @@ ActiveRecord::Schema.define(version: 2021_08_20_182004) do
     t.datetime "updated_at"
     t.integer "storage_id", null: false
     t.integer "script_id"
-    t.datetime "deleted_at"
     t.index ["storage_app_id"], name: "index_channel_tokens_on_storage_app_id"
     t.index ["storage_id", "level_id", "script_id", "deleted_at"], name: "index_channel_tokens_unique", unique: true
     t.index ["storage_id"], name: "index_channel_tokens_on_storage_id"
-  end
 
   create_table "circuit_playground_discount_applications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
-    t.integer "user_id", null: false
     t.integer "unit_6_intention"
     t.boolean "full_discount"
     t.boolean "admin_set_status", default: false, null: false

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -243,11 +243,14 @@ ActiveRecord::Schema.define(version: 2021_08_20_182004) do
     t.datetime "updated_at"
     t.integer "storage_id", null: false
     t.integer "script_id"
+    t.datetime "deleted_at"
     t.index ["storage_app_id"], name: "index_channel_tokens_on_storage_app_id"
     t.index ["storage_id", "level_id", "script_id", "deleted_at"], name: "index_channel_tokens_unique", unique: true
     t.index ["storage_id"], name: "index_channel_tokens_on_storage_id"
+  end
 
   create_table "circuit_playground_discount_applications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+    t.integer "user_id", null: false
     t.integer "unit_6_intention"
     t.boolean "full_discount"
     t.boolean "admin_set_status", default: false, null: false

--- a/dashboard/lib/sample_data.rb
+++ b/dashboard/lib/sample_data.rb
@@ -205,6 +205,7 @@ class SampleData
               script_level.levels.first,
               '127.0.0.1',
               find_or_create_storage_id_for_user_id(student_user.id),
+              script.id,
               {
                 hidden: true
               }

--- a/dashboard/test/helpers/levels_helper_test.rb
+++ b/dashboard/test/helpers/levels_helper_test.rb
@@ -206,13 +206,17 @@ class LevelsHelperTest < ActionView::TestCase
     user = create :user
     sign_in user
 
-    channel = get_channel_for(@level)
+    script = create(:script)
+    level = create(:level, :blockly)
+    create(:script_level, script: script, levels: [@level, level])
+
+    channel = get_channel_for(@level, script.id)
     # Request it again, should get the same channel
-    assert_equal channel, get_channel_for(@level)
+    assert_equal channel, get_channel_for(@level, script.id)
 
     # Request it for a different level, should get a different channel
     level = create(:level, :blockly)
-    assert_not_equal channel, get_channel_for(level)
+    assert_not_equal channel, get_channel_for(level, script.id)
   end
 
   test 'applab levels should have channels' do
@@ -228,10 +232,12 @@ class LevelsHelperTest < ActionView::TestCase
     @user = create :user
     sign_in create(:user)
 
+    script = create(:script)
     @level = create :applab
+    create(:script_level, script: script, levels: [@level])
 
     # channel does not exist
-    assert_nil get_channel_for(@level, @user)
+    assert_nil get_channel_for(@level, script.id, @user)
   end
 
   test 'applab levels should load channel when viewing student solution of a student with a channel' do
@@ -239,11 +245,13 @@ class LevelsHelperTest < ActionView::TestCase
     @user = create :user
     sign_in create(:user)
 
+    script = create(:script)
     @level = create :applab
+    create(:script_level, script: script, levels: [@level])
 
     # channel exists
     create :channel_token, level: @level, storage_id: storage_id_for_user_id(@user.id)
-    assert_not_nil get_channel_for(@level, @user)
+    assert_not_nil get_channel_for(@level, script.id, @user)
 
     # calling app_options should set readonly_workspace, since we're viewing for
     # different user

--- a/dashboard/test/models/channel_token_test.rb
+++ b/dashboard/test/models/channel_token_test.rb
@@ -6,7 +6,9 @@ class ChannelTokenTest < ActiveSupport::TestCase
   self.use_transactional_test_case = true
 
   setup_all do
+    @script = create :script
     @level = create :level
+    create :script_level, script: @script levels: [@level]
     @fake_ip = '127.0.0.1'
   end
 
@@ -14,7 +16,8 @@ class ChannelTokenTest < ActiveSupport::TestCase
     channel_token = ChannelToken.find_or_create_channel_token(
       @level,
       @fake_ip,
-      get_storage_id
+      get_storage_id,
+      @script.id
     )
 
     storage_id, storage_app_id = storage_decrypt_channel_id(channel_token.channel)

--- a/dashboard/test/models/channel_token_test.rb
+++ b/dashboard/test/models/channel_token_test.rb
@@ -24,4 +24,30 @@ class ChannelTokenTest < ActiveSupport::TestCase
     assert_equal storage_id, channel_token.storage_id
     assert_equal storage_app_id, channel_token.storage_app_id
   end
+
+  test 'find_or_create_channel_token returns the channel_token if one exists' do
+    level = create :level
+    expected_channel_token = create :channel_token, level: level, storage_id: get_storage_id
+
+    channel_token = ChannelToken.find_or_create_channel_token(
+      level,
+      @fake_ip,
+      get_storage_id,
+      @script.id
+    )
+
+    assert_equal expected_channel_token.id, channel_token.id
+  end
+
+  test 'find_or_create_channel_token will create a new channel token with script_id if no channel token exists' do
+    level = create :level
+    channel_token = ChannelToken.find_or_create_channel_token(
+      level,
+      @fake_ip,
+      get_storage_id,
+      @script.id
+    )
+
+    assert_equal channel_token.script_id, @script.id
+  end
 end

--- a/dashboard/test/models/channel_token_test.rb
+++ b/dashboard/test/models/channel_token_test.rb
@@ -27,12 +27,13 @@ class ChannelTokenTest < ActiveSupport::TestCase
 
   test 'find_or_create_channel_token returns the channel_token if one exists' do
     level = create :level
-    expected_channel_token = create :channel_token, level: level, storage_id: get_storage_id
+    storage_id = get_storage_id
+    expected_channel_token = create :channel_token, level: level, storage_id: storage_id
 
     channel_token = ChannelToken.find_or_create_channel_token(
       level,
       @fake_ip,
-      get_storage_id,
+      storage_id,
       @script.id
     )
 

--- a/dashboard/test/models/channel_token_test.rb
+++ b/dashboard/test/models/channel_token_test.rb
@@ -8,7 +8,7 @@ class ChannelTokenTest < ActiveSupport::TestCase
   setup_all do
     @script = create :script
     @level = create :level
-    create :script_level, script: @script levels: [@level]
+    create :script_level, script: @script, levels: [@level]
     @fake_ip = '127.0.0.1'
   end
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Updates `find_or_create_channel_token` to take a `script_id` which is used only when creating a new channel_token record. All methods calling `find_or_create_channel_token` are updated accordingly. Note that querying for channel_tokens remains unchanged for now until we have backfilled all the records with empty script_ids.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
- jira ticket: [LP-1842](https://codedotorg.atlassian.net/browse/LP-1842)
<!--
- spec: []()

-->

## Testing story
Added unit tests & tested locally that starting work on a channel-backed level stores the script id and that channel-backed levels that had work done on them previously load as expected.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

## Follow-up work
Next up is writing script_id backfills for the existing channel_token records. For the full list of tasks see https://codedotorg.atlassian.net/browse/LP-1395.
<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
