### PR TITLE
AiLab: Make prediction in AppLab readonly

### DIFF
--- a/apps/src/applab/ai.js
+++ b/apps/src/applab/ai.js
@@ -49,6 +49,7 @@ function generateCodeDesignElements(modelId, modelData) {
   var predictionId = alphaNumModelName + '_prediction';
   var prediction = designMode.createElement('TEXT_INPUT', x, y);
   prediction.id = 'design_' + predictionId;
+  prediction.readOnly = true;
   y = y + 2 * SPACER_PIXELS;
   var predictButton = designMode.createElement('BUTTON', x, y);
   predictButton.textContent = 'Predict';

--- a/apps/src/applab/sanitizeHtml.js
+++ b/apps/src/applab/sanitizeHtml.js
@@ -203,7 +203,8 @@ export default function sanitizeHtml(
       'value',
       'accept',
       'hidden',
-      'capture'
+      'capture',
+      'readonly'
     ]),
     select: standardAttributes.concat(['multiple', 'size'])
   };


### PR DESCRIPTION
This is one potential approach to having a readonly result for an AiLab prediction in AppLab.

We tried using `contenteditable`, but it doesn't seem to actually prevent user input for an `<input>` control.
