### PR TITLE
More level details polish

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1008,7 +1008,6 @@
   "levelIncompleteError": "Keep coding! Something's not quite right yet.",
   "levelN": "LEVEL {levelNumber}",
   "levelNotStartedWarning": "This student has not started the level.",
-  "levelPreview": "Level Preview",
   "levelsAttempted": "Levels attempted in",
   "levelStatus": "Level Status",
   "levelType": "Level Type",

--- a/apps/src/templates/lessonOverview/activities/LevelDetailsDialog.jsx
+++ b/apps/src/templates/lessonOverview/activities/LevelDetailsDialog.jsx
@@ -273,7 +273,7 @@ class LevelDetailsDialog extends Component {
         fullWidth={!hasVideo}
         style={{...levelSpecificStyling}}
       >
-        <h1>{i18n.levelPreview()}</h1>
+        <h1>{level.display_name || scriptLevel.name || level.name}</h1>
         {this.renderBubbleChoiceBubbles()}
         <div className="level-details">{preview}</div>
         <DialogFooter rightAlign>

--- a/apps/src/templates/lessonOverview/activities/LevelDetailsDialog.jsx
+++ b/apps/src/templates/lessonOverview/activities/LevelDetailsDialog.jsx
@@ -19,7 +19,7 @@ import {connect} from 'react-redux';
 
 const VIDEO_WIDTH = 670;
 const VIDEO_HEIGHT = 375;
-const VIDEO_MODAL_WIDTH = 700;
+const VIDEO_MODAL_WIDTH = 720;
 const HEADER_HEIGHT = styleConstants['workspace-headers-height'];
 const MAX_LEVEL_HEIGHT = 550;
 

--- a/apps/style/lessons.scss
+++ b/apps/style/lessons.scss
@@ -1,3 +1,4 @@
+@import "font";
 @import "markdown";
 @import "pdf_printing";
 
@@ -49,6 +50,8 @@
 .modal .level-details {
   a {
     color: $link_color;
+    font-family: $gotham-regular, sans-serif;
+    font-weight: normal;
     &:hover {
       color: $link_color;
       background: none;

--- a/apps/test/unit/templates/lessonOverview/activities/LevelDetailsDialogTest.jsx
+++ b/apps/test/unit/templates/lessonOverview/activities/LevelDetailsDialogTest.jsx
@@ -63,11 +63,13 @@ describe('LevelDetailsDialogTest', () => {
         {...defaultProps}
         scriptLevel={{
           url: 'level.url',
-          level: {type: 'External', markdown: 'This is some text.'}
+          level: {type: 'External', markdown: 'This is some text.'},
+          name: 'External Markdown Level'
         }}
       />
     );
     expect(wrapper.contains('This is some text.')).to.be.true;
+    expect(wrapper.find('h1').contains('External Markdown Level')).to.be.true;
   });
 
   it('can display the video and teacher markdown for an external markdown level', () => {
@@ -214,14 +216,16 @@ describe('LevelDetailsDialogTest', () => {
           status: 'not_tried',
           name: 'sublevel1',
           type: 'External',
-          markdown: 'Markdown1'
+          markdown: 'Markdown1',
+          display_name: 'Choice 1'
         },
         {
           id: '2',
           status: 'not_tried',
           name: 'sublevel2',
           type: 'External',
-          markdown: 'Markdown1'
+          markdown: 'Markdown1',
+          display_name: 'Choice 2'
         }
       ]
     };
@@ -238,6 +242,7 @@ describe('LevelDetailsDialogTest', () => {
         .first()
         .props().markdown
     ).to.equal('Markdown1');
+    expect(wrapper.find('h1').contains('Choice 1')).to.be.true;
   });
 
   it('can display a CSD/CSP puzzle level', () => {


### PR DESCRIPTION
Some more feedback that's come up with week:
- Use the level name as the title instead of "Level Preview" ([jira](https://codedotorg.atlassian.net/browse/PLAT-925))
- Fix some links in "Help & Tips" being bolded ([jira](https://codedotorg.atlassian.net/browse/PLAT-922))
- Adjust the width of the modal for video levels as there was occasionally some horizontal overflow

Only downside with the level name being in the modal is that some levels write the name of the level in the instructions, which may look a bit weird
<img width="1298" alt="Screen Shot 2021-04-01 at 8 43 54 AM" src="https://user-images.githubusercontent.com/46464143/113320319-3decac00-92c7-11eb-8b20-d10aa75fc54d.png">

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
