### PR TITLE
Revert "Show the display name of bubble choice levels"

### DIFF
--- a/apps/src/templates/progress/ProgressBubble.jsx
+++ b/apps/src/templates/progress/ProgressBubble.jsx
@@ -152,9 +152,7 @@ class ProgressBubble extends React.Component {
 
     const number = level.levelNumber;
     const url = level.url;
-    const levelName = this.props.smallBubble
-      ? level.display_name || level.name
-      : level.name || level.progressionDisplayName;
+    const levelName = level.name || level.progressionDisplayName;
     const levelIcon = getIconForLevel(level);
 
     const disabled = this.props.disabled || levelIcon === 'lock';


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#39817. Turns out I broke the hover behavior on levels, just like Dani was worried about 🙃 