### PR TITLE
Fix the key for buzzer.playNotes

### DIFF
--- a/dashboard/config/scripts_json/csd6-2021.script_json
+++ b/dashboard/config/scripts_json/csd6-2021.script_json
@@ -10637,7 +10637,7 @@
       "seeding_key": {
         "lesson.key": "Making Music",
         "programming_environment.name": "applab",
-        "programming_expression.key": "buzzerplaynotes"
+        "programming_expression.key": "buzzer.playNotes"
       }
     },
     {


### PR DESCRIPTION
Two people this week ran into issues seeding and it looks like one of the programming expression keys in script_json did not get fully updated by a previous PR.