### PR TITLE
Remove pause button outline when button is clicked

### DIFF
--- a/apps/src/templates/PauseButton.jsx
+++ b/apps/src/templates/PauseButton.jsx
@@ -69,7 +69,7 @@ class PauseButton extends React.Component {
         onClick={this.togglePause}
         style={buttonStyle}
         disabled={!this.props.isRunning}
-        id="pause-button"
+        className="accessibility-friendly-no-focus-outline"
       >
         <div style={styles.container}>
           <i

--- a/apps/src/templates/PauseButton.jsx
+++ b/apps/src/templates/PauseButton.jsx
@@ -69,7 +69,7 @@ class PauseButton extends React.Component {
         onClick={this.togglePause}
         style={buttonStyle}
         disabled={!this.props.isRunning}
-        className="accessibility-friendly-no-focus-outline"
+        className="no-focus-outline"
       >
         <div style={styles.container}>
           <i

--- a/apps/src/templates/PauseButton.jsx
+++ b/apps/src/templates/PauseButton.jsx
@@ -69,6 +69,7 @@ class PauseButton extends React.Component {
         onClick={this.togglePause}
         style={buttonStyle}
         disabled={!this.props.isRunning}
+        id="pause-button"
       >
         <div style={styles.container}>
           <i

--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -107,7 +107,10 @@ html[dir='rtl'] #visualizationColumn {
   }
 }
 
-.accessibility-friendly-no-focus-outline:focus:not(:focus-visible) {
+// Use the focus-visible pseudoclass to hide the outline when clicked.
+// This leaves the outline behavior unchanged for keyboard navigation.
+// Note: this isn't supported in every browser yet.
+.no-focus-outline:focus:not(:focus-visible) {
   outline: none;
 }
 

--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -107,6 +107,10 @@ html[dir='rtl'] #visualizationColumn {
   }
 }
 
+#pause-button:focus:not(:focus-visible) {
+  outline: none;
+}
+
 div.droplet-palette-group-header {
   @include font;
   line-height: 24px;

--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -107,7 +107,7 @@ html[dir='rtl'] #visualizationColumn {
   }
 }
 
-#pause-button:focus:not(:focus-visible) {
+.accessibility-friendly-no-focus-outline:focus:not(:focus-visible) {
   outline: none;
 }
 


### PR DESCRIPTION
Use the [focus-visible](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible) pseudoclass to hide the outline when the pause/play button is clicked while leaving the outline behavior unchanged for keyboard navigation.

In edit mode with keyboard navigation:
<img width="322" alt="Screen Shot 2021-04-02 at 1 34 30 PM" src="https://user-images.githubusercontent.com/17147070/113452504-f8a8a700-93b8-11eb-9f09-3ab19c91468b.png">

In edit mode with click:
<img width="335" alt="Screen Shot 2021-04-02 at 1 33 48 PM" src="https://user-images.githubusercontent.com/17147070/113452460-e0d12300-93b8-11eb-8ac5-98e8d891e779.png">

In view mode with keyboard navigation:
<img width="473" alt="Screen Shot 2021-04-02 at 1 35 11 PM" src="https://user-images.githubusercontent.com/17147070/113452533-09f1b380-93b9-11eb-88d7-438afa049ef9.png">

In view mode with click:
<img width="458" alt="Screen Shot 2021-04-02 at 1 35 23 PM" src="https://user-images.githubusercontent.com/17147070/113452541-0eb66780-93b9-11eb-90fc-48ef3f403188.png">


One thing to note is that this isn't supported in every browser yet. [Here](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible#browser_compatibility) is the browser compatibility list.

## Links

- jira ticket: [STAR-1510](https://codedotorg.atlassian.net/browse/STAR-1510?atlOrigin=eyJpIjoiMjE3NGYxZjczY2Y3NGM1ZWE5YjhjNWY4ZWZkYzk0NGYiLCJwIjoiaiJ9)
- :focus-visible docs: [here](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible)


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
