### PR TITLE
fixes for time spent pilot

### DIFF
--- a/apps/src/templates/manageStudents/ManageStudentsActionsCell.jsx
+++ b/apps/src/templates/manageStudents/ManageStudentsActionsCell.jsx
@@ -33,7 +33,7 @@ const styles = {
   }
 };
 
-class ManageStudentActionsCell extends Component {
+class ManageStudentsActionsCell extends Component {
   static propTypes = {
     id: PropTypes.number.isRequired, // the student's user id
     sectionId: PropTypes.number,
@@ -300,7 +300,7 @@ class ManageStudentActionsCell extends Component {
   }
 }
 
-export const UnconnectedManageStudentActionsCell = ManageStudentActionsCell;
+export const UnconnectedManageStudentsActionsCell = ManageStudentsActionsCell;
 
 export default connect(
   state => ({}),
@@ -324,4 +324,4 @@ export default connect(
       dispatch(setSection(section));
     }
   })
-)(ManageStudentActionsCell);
+)(ManageStudentsActionsCell);

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableStudentName.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableStudentName.jsx
@@ -68,7 +68,7 @@ class ProgressTableStudentName extends React.PureComponent {
   renderTooltip() {
     const id = this.tooltipId();
     const timestamp = this.props.lastTimestamp
-      ? moment(this.props.lastTimestamp).calendar()
+      ? moment.unix(this.props.lastTimestamp).calendar()
       : i18n.none();
     return (
       <ReactTooltip

--- a/apps/src/templates/sectionProgress/progressTables/progressTableHelpers.js
+++ b/apps/src/templates/sectionProgress/progressTables/progressTableHelpers.js
@@ -10,7 +10,7 @@ export function timeSpentFormatter(studentProgress) {
 
 export function lastUpdatedFormatter(studentProgress) {
   if (studentProgress?.lastTimestamp) {
-    return moment(studentProgress.lastTimestamp).format('M/D');
+    return moment.unix(studentProgress.lastTimestamp).format('M/D');
   }
   return missingDataFormatter(studentProgress, 'lastTimestamp');
 }

--- a/apps/src/templates/sectionProgress/progressTables/progressTableHelpers.js
+++ b/apps/src/templates/sectionProgress/progressTables/progressTableHelpers.js
@@ -3,7 +3,7 @@ import moment from 'moment';
 export function timeSpentFormatter(studentProgress) {
   if (studentProgress?.timeSpent) {
     const minutes = studentProgress.timeSpent / 60;
-    return `${Math.round(minutes)}`;
+    return `${Math.ceil(minutes)}`;
   }
   return missingDataFormatter(studentProgress, 'timeSpent');
 }

--- a/apps/src/templates/sectionProgress/progressTables/progressTableStyles.scss
+++ b/apps/src/templates/sectionProgress/progressTables/progressTableStyles.scss
@@ -19,7 +19,7 @@ $content-view-width: $content-width - $student-list-width;
   th {
     background-color: $table-header;
     color: $charcoal;
-    border-width: 0px 1px 1px 0px;
+    border-width: 0px 1px 2px 0px;
     border-color: $border-gray;
     height: $row-height;
   }

--- a/apps/src/templates/sectionProgress/sectionProgressLoader.js
+++ b/apps/src/templates/sectionProgress/sectionProgressLoader.js
@@ -86,7 +86,7 @@ export function loadScriptProgress(scriptId, sectionId) {
         sectionProgress.studentLastUpdateByScript = {
           [scriptId]: {
             ...sectionProgress.studentLastUpdateByScript[scriptId],
-            ...processStudentTimestamps(data.student_last_updates)
+            ...data.student_last_updates
           }
         };
       });
@@ -111,11 +111,6 @@ export function loadScriptProgress(scriptId, sectionId) {
       getStore().dispatch(fetchStudentLevelScores(scriptId, sectionId));
     }
   });
-}
-
-function processStudentTimestamps(timestamps) {
-  const studentTimestamps = _.mapValues(timestamps, seconds => seconds * 1000);
-  return studentTimestamps;
 }
 
 function postProcessDataByScript(scriptData) {

--- a/apps/src/templates/sectionProgress/sectionProgressRedux.js
+++ b/apps/src/templates/sectionProgress/sectionProgressRedux.js
@@ -1,5 +1,4 @@
 import {SET_SCRIPT} from '@cdo/apps/redux/scriptSelectionRedux';
-import {SET_SECTION} from '@cdo/apps/redux/sectionDataRedux';
 import firehoseClient from '../../lib/util/firehose';
 import {ViewType} from './sectionProgressConstants';
 
@@ -99,14 +98,6 @@ export default function sectionProgress(state = initialState, action) {
     return {
       ...state,
       showSectionProgressDetails: action.showSectionProgressDetails
-    };
-  }
-  if (action.type === SET_SECTION) {
-    // Setting the section is the first action to be called when switching
-    // sections, which requires us to reset our state. This might need to change
-    // once switching sections is in react/redux.
-    return {
-      ...initialState
     };
   }
   if (action.type === ADD_DATA_BY_SCRIPT) {

--- a/apps/test/unit/templates/manageStudents/ManageStudentsActionsCellTest.js
+++ b/apps/test/unit/templates/manageStudents/ManageStudentsActionsCellTest.js
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import {shallow} from 'enzyme';
 import {expect} from '../../../util/deprecatedChai';
 import * as client from '@cdo/apps/util/userSectionClient';
-import {UnconnectedManageStudentActionsCell as ManageStudentsActionsCell} from '@cdo/apps/templates/manageStudents/ManageStudentsActionsCell';
+import {UnconnectedManageStudentsActionsCell as ManageStudentsActionsCell} from '@cdo/apps/templates/manageStudents/ManageStudentsActionsCell';
 
 const DEFAULT_PROPS = {
   id: 2,

--- a/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableStudentNameTest.jsx
+++ b/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableStudentNameTest.jsx
@@ -10,7 +10,7 @@ const DEFAULT_PROPS = {
   studentId: 1,
   sectionId: 1,
   scriptId: 1,
-  lastTimestamp: 1611964800000,
+  lastTimestamp: 1611964800,
   studentUrl: '/student-link',
   onToggleExpand: () => {},
   isExpanded: false

--- a/apps/test/unit/templates/sectionProgress/progressTables/progressTableHelpersTest.js
+++ b/apps/test/unit/templates/sectionProgress/progressTables/progressTableHelpersTest.js
@@ -43,7 +43,7 @@ describe('progressTableHelpers', () => {
 
     it('returns timestamp in month and day format', () => {
       const studentProgress = {lastTimestamp: 1614841198};
-      expect(lastUpdatedFormatter(studentProgress)).to.equal('1/19');
+      expect(lastUpdatedFormatter(studentProgress)).to.equal('3/4');
     });
   });
 });

--- a/apps/test/unit/templates/sectionProgress/progressTables/progressTableHelpersTest.js
+++ b/apps/test/unit/templates/sectionProgress/progressTables/progressTableHelpersTest.js
@@ -21,8 +21,9 @@ describe('progressTableHelpers', () => {
     });
 
     it('returns timeSpent in minutes', () => {
-      const studentProgress = {timeSpent: 140}; // 140 seconds = 2 minutes
-      expect(timeSpentFormatter(studentProgress)).to.equal('2');
+      // 140 seconds rounds up to 3 minutes
+      const studentProgress = {timeSpent: 140};
+      expect(timeSpentFormatter(studentProgress)).to.equal('3');
     });
   });
 

--- a/apps/test/unit/templates/sectionProgress/sectionProgressLoaderTest.js
+++ b/apps/test/unit/templates/sectionProgress/sectionProgressLoaderTest.js
@@ -186,9 +186,9 @@ const fullExpectedResult = {
   },
   studentLastUpdateByScript: {
     123: {
-      '100': 0,
-      '101': timeInSeconds * 1000,
-      '102': (timeInSeconds + 1) * 1000
+      '100': null,
+      '101': timeInSeconds,
+      '102': timeInSeconds + 1
     }
   }
 };


### PR DESCRIPTION
this includes a few fixes to the functionality for the time spent pilot

1. main issue: we were parsing timestamp values of seconds as milliseconds, resulting in the wrong displayed date
2. modifying a section in the "manage students" tab was resetting our section progress redux, so we were losing the flag for the pilot
3. expanding rows PR regressed table header border widths
4. update to round time spent values up instead of down, to avoid lots of 0's

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [LP-1845]


[LP-1845]: https://codedotorg.atlassian.net/browse/LP-1845