### PR TITLE
Helpers to parse Foorm forms and submissions for analytics

### DIFF
--- a/dashboard/app/models/foorm/submission.rb
+++ b/dashboard/app/models/foorm/submission.rb
@@ -50,6 +50,7 @@ class Foorm::Submission < ApplicationRecord
     formatted_answers
   end
 
+  # Rename question ID and matrix question ID to question name, as the "question ID" represents the "name" field for a question
   # For a given question_id-answer key-value pair from a submission's answers,
   # returns a hash with either a single key-value pair (for question types other than matrix) and a human readable response to a question,
   # or a hash with multiple values (for matrix questions) with a human readable response to each sub-question.

--- a/dashboard/app/models/foorm/submission.rb
+++ b/dashboard/app/models/foorm/submission.rb
@@ -43,26 +43,25 @@ class Foorm::Submission < ApplicationRecord
     parsed_answers = JSON.parse(answers)
 
     # Then, merge in formatted versions of each answer in the submission.
-    parsed_answers.each do |question_id, answer|
-      formatted_answers.merge! get_formatted_answer(question_id, answer)
+    parsed_answers.each do |question_name, answer|
+      formatted_answers.merge! get_formatted_answer(question_name, answer)
     end
 
     formatted_answers
   end
 
-  # Rename question ID and matrix question ID to question name, as the "question ID" represents the "name" field for a question
-  # For a given question_id-answer key-value pair from a submission's answers,
+  # For a given question_name-answer key-value pair from a submission's answers,
   # returns a hash with either a single key-value pair (for question types other than matrix) and a human readable response to a question,
   # or a hash with multiple values (for matrix questions) with a human readable response to each sub-question.
-  # @param [String] question_id
+  # @param [String] question_name
   # @param [String] answer the stored value representing a user's answer to a question (either a key that can be paired with a human readable answer, or the answer itself)
   # @return [Hash] a human readable version of the answer(s) associated with a given question ID
-  def get_formatted_answer(question_id, answer)
-    question_details = form.get_question_details(question_id)
+  def get_formatted_answer(question_name, answer)
+    question_details = form.get_question_details(question_name)
 
     # If question isn't in the Form, return as-is.
     # This is expected for metadata about the submission.
-    return {question_id => answer} if question_details.nil?
+    return {question_name => answer} if question_details.nil?
 
     case question_details[:type]
     when ANSWER_MATRIX
@@ -70,18 +69,18 @@ class Foorm::Submission < ApplicationRecord
 
       pairs = {}
       answer.each do |matrix_question_id, matrix_question_answer|
-        key = Foorm::Form.get_matrix_question_id(question_id, matrix_question_id)
+        key = Foorm::Form.get_matrix_question_id(question_name, matrix_question_id)
         pairs[key] = choices[matrix_question_answer]
       end
       return pairs
     when ANSWER_RATING, ANSWER_TEXT
-      return {question_id => answer}
+      return {question_name => answer}
     when ANSWER_SINGLE_SELECT
       choices = question_details[:choices]
-      return {question_id => choices[answer]}
+      return {question_name => choices[answer]}
     when ANSWER_MULTI_SELECT
       choices = question_details[:choices]
-      return {question_id => answer.map {|selected| choices[selected]}.compact.sort.join(', ')}
+      return {question_name => answer.map {|selected| choices[selected]}.compact.sort.join(', ')}
     end
 
     # Return blank hash if question_type not found

--- a/dashboard/lib/pd/foorm/foorm_parser.rb
+++ b/dashboard/lib/pd/foorm/foorm_parser.rb
@@ -80,6 +80,9 @@ module Pd::Foorm
         if question_data[:type] == TYPE_PANEL_DYNAMIC
           elements = question_data[:templateElements]
         end
+
+        # Facilitator-specific questions are identified
+        # as panels that are named "facilitators"
         if question_data[:name] == 'facilitators'
           is_facilitator_question = true
         end
@@ -161,11 +164,6 @@ module Pd::Foorm
         end
       end
       choices_obj
-    end
-
-    def self.fill_question_placeholders(question)
-      question && question.sub!("{panel.facilitator_name}", "my facilitator")
-      question
     end
   end
 end

--- a/dashboard/lib/pd/foorm/form_analytics_parser.rb
+++ b/dashboard/lib/pd/foorm/form_analytics_parser.rb
@@ -1,4 +1,8 @@
 module Pd::Foorm
+  # Responsible for taking Forms (ie, a survey comprised of many questions)
+  # from our in-house survey system (Foorm)
+  # and processing them into a "one row per question" format
+  # for export to CSV, and, ultimately, to our analytics database (Redshift).
   class FormAnalyticsParser
     include Constants
     extend Helper

--- a/dashboard/lib/pd/foorm/form_analytics_parser.rb
+++ b/dashboard/lib/pd/foorm/form_analytics_parser.rb
@@ -22,28 +22,20 @@ module Pd::Foorm
     )
 
     def self.reshape_all_forms_and_export_to_csv
-      reshaped_forms = reshape_forms(::Foorm::Form.all)
-      reshaped_forms_to_csv(reshaped_forms)
-    end
-
-    def self.reshaped_forms_to_csv(reshaped_forms)
       CSV.open('./test_forms.csv', 'wb') do |csv|
         csv << HEADERS
-        reshaped_forms.each do |question|
-          row = question.stringify_keys.values_at(*HEADERS)
-          csv << row
+
+        # Loads 1000 records at a time to manage loading records into memory.
+        # Probably unnecessary optimization until we have many more Forms.
+        ::Foorm::Form.find_each do |form|
+          reshaped_form = reshape_form(form)
+
+          reshaped_form.each do |question|
+            row = question.stringify_keys.values_at(*HEADERS)
+            csv << row
+          end
         end
       end
-    end
-
-    def self.reshape_forms(forms)
-      reshaped_forms = []
-
-      forms.each do |form|
-        reshaped_forms = reshaped_forms.concat reshape_form(form)
-      end
-
-      reshaped_forms
     end
 
     def self.reshape_form(form)

--- a/dashboard/lib/pd/foorm/form_analytics_parser.rb
+++ b/dashboard/lib/pd/foorm/form_analytics_parser.rb
@@ -1,23 +1,23 @@
 module Pd::Foorm
-  HEADERS = %w(
-    form_id
-    form_name
-    form_version
-    question_type
-    question_name
-    question_text
-    matrix_item_name
-    matrix_item_text
-    is_facilitator_specific
-    response_options
-    num_response_options
-  )
-
   class FormAnalyticsParser
     include Constants
     extend Helper
 
-    def self.reshape_all_forms
+    HEADERS = %w(
+      form_id
+      form_name
+      form_version
+      question_type
+      question_name
+      question_text
+      matrix_item_name
+      matrix_item_text
+      is_facilitator_specific
+      response_options
+      num_response_options
+    )
+
+    def self.reshape_all_forms_and_export_to_csv
       reshaped_forms = reshape_forms(::Foorm::Form.all)
       reshaped_forms_to_csv(reshaped_forms)
     end

--- a/dashboard/lib/pd/foorm/form_analytics_parser.rb
+++ b/dashboard/lib/pd/foorm/form_analytics_parser.rb
@@ -1,0 +1,125 @@
+module Pd::Foorm
+  HEADERS = %w(
+    form_id
+    form_name
+    form_version
+    question_type
+    question_name
+    question_text
+    matrix_item_name
+    matrix_item_text
+    is_facilitator_specific
+    response_options
+    num_response_options
+  )
+
+  class FormAnalyticsParser
+    include Constants
+    extend Helper
+
+    def self.reshape_all_forms
+      reshaped_forms = reshape_forms_for_analytics_export(::Foorm::Form.all)
+      reshaped_forms_to_csv(reshaped_forms)
+    end
+
+    def self.reshaped_forms_to_csv(reshaped_forms)
+      CSV.open('./test.csv', 'wb') do |csv|
+        csv << HEADERS
+        reshaped_forms.each do |question|
+          row = question.stringify_keys.values_at(*HEADERS)
+          csv << row
+        end
+      end
+    end
+
+    def self.reshape_forms_for_analytics_export(forms)
+      reshaped_forms = []
+
+      forms.each do |form|
+        reshaped_forms = reshaped_forms.concat reshape_form_for_analytics_export(form)
+      end
+
+      reshaped_forms
+    end
+
+    def self.reshape_form_for_analytics_export(form)
+      reshaped_form_questions_with_metadata = []
+
+      form_metadata = {
+        form_id: form.id,
+        form_name: form.name,
+        form_version: form.version
+      }
+
+      parsed_form_questions = FoormParser.parse_form_questions(form.questions)
+      reshaped_form_questions = reshape_form_questions_for_analytics_export(parsed_form_questions)
+
+      reshaped_form_questions.each do |reshaped_form_question|
+        reshaped_form_questions_with_metadata << form_metadata.merge(reshaped_form_question)
+      end
+
+      reshaped_form_questions_with_metadata
+    end
+
+    # matrix item name
+    # item name
+    # item type
+    # item text
+    # response options
+    # num response options
+    # item position ? <- display data
+    # library question ID ?
+    # library question name ?
+    # visible if ?
+    # @return [Array] List of hashes (each representing a question in the form) with keys representing headers for export to a tabular format.
+    def self.reshape_form_questions_for_analytics_export(parsed_form_questions)
+      reshaped_form_questions = []
+
+      # Two sections -- general and facilitator
+      parsed_form_questions.each do |section, questions|
+        questions.each do |question_name, question_details|
+          # Information relevant to all question types
+          reshaped_form_question = {
+            question_name: question_name,
+            question_text: fill_question_placeholders(question_details[:title]),
+            question_type: question_details[:type],
+            is_facilitator_specific:  section == :facilitator ? 1 : 0
+          }
+
+          case question_details[:type]
+          when ANSWER_TEXT
+            reshaped_form_questions << reshaped_form_question
+          when ANSWER_SINGLE_SELECT, ANSWER_MULTI_SELECT, ANSWER_RATING
+            readable_response_options = question_details[:choices].values
+
+            additional_attributes = {
+              response_options: readable_response_options,
+              num_response_options: readable_response_options.length
+            }
+
+            reshaped_form_question.merge! additional_attributes
+            reshaped_form_questions << reshaped_form_question
+          when ANSWER_MATRIX
+            readable_response_options = question_details[:columns].values
+
+            question_details[:rows].each do |matrix_item_name, matrix_item_text|
+              reshaped_matrix_item = reshaped_form_question.clone
+
+              additional_attributes = {
+                matrix_item_name: matrix_item_name,
+                matrix_item_text: matrix_item_text,
+                response_options: readable_response_options,
+                num_response_options: readable_response_options.length
+              }
+
+              reshaped_matrix_item.merge! additional_attributes
+              reshaped_form_questions << reshaped_matrix_item
+            end
+          end
+        end
+      end
+
+      reshaped_form_questions
+    end
+  end
+end

--- a/dashboard/lib/pd/foorm/form_analytics_parser.rb
+++ b/dashboard/lib/pd/foorm/form_analytics_parser.rb
@@ -18,12 +18,12 @@ module Pd::Foorm
     extend Helper
 
     def self.reshape_all_forms
-      reshaped_forms = reshape_forms_for_analytics_export(::Foorm::Form.all)
+      reshaped_forms = reshape_forms(::Foorm::Form.all)
       reshaped_forms_to_csv(reshaped_forms)
     end
 
     def self.reshaped_forms_to_csv(reshaped_forms)
-      CSV.open('./test.csv', 'wb') do |csv|
+      CSV.open('./test_forms.csv', 'wb') do |csv|
         csv << HEADERS
         reshaped_forms.each do |question|
           row = question.stringify_keys.values_at(*HEADERS)
@@ -32,17 +32,17 @@ module Pd::Foorm
       end
     end
 
-    def self.reshape_forms_for_analytics_export(forms)
+    def self.reshape_forms(forms)
       reshaped_forms = []
 
       forms.each do |form|
-        reshaped_forms = reshaped_forms.concat reshape_form_for_analytics_export(form)
+        reshaped_forms = reshaped_forms.concat reshape_form(form)
       end
 
       reshaped_forms
     end
 
-    def self.reshape_form_for_analytics_export(form)
+    def self.reshape_form(form)
       reshaped_form_questions_with_metadata = []
 
       form_metadata = {
@@ -52,7 +52,7 @@ module Pd::Foorm
       }
 
       parsed_form_questions = FoormParser.parse_form_questions(form.questions)
-      reshaped_form_questions = reshape_form_questions_for_analytics_export(parsed_form_questions)
+      reshaped_form_questions = reshape_form_questions(parsed_form_questions)
 
       reshaped_form_questions.each do |reshaped_form_question|
         reshaped_form_questions_with_metadata << form_metadata.merge(reshaped_form_question)
@@ -61,18 +61,9 @@ module Pd::Foorm
       reshaped_form_questions_with_metadata
     end
 
-    # matrix item name
-    # item name
-    # item type
-    # item text
-    # response options
-    # num response options
-    # item position ? <- display data
-    # library question ID ?
-    # library question name ?
-    # visible if ?
-    # @return [Array] List of hashes (each representing a question in the form) with keys representing headers for export to a tabular format.
-    def self.reshape_form_questions_for_analytics_export(parsed_form_questions)
+    # @param [Hash] parsed_form_questions
+    # @return [Array] Array of hashes (each representing a question in the form) with keys representing headers for export to a tabular format.
+    def self.reshape_form_questions(parsed_form_questions)
       reshaped_form_questions = []
 
       # Two sections -- general and facilitator

--- a/dashboard/lib/pd/foorm/form_analytics_parser.rb
+++ b/dashboard/lib/pd/foorm/form_analytics_parser.rb
@@ -21,13 +21,15 @@ module Pd::Foorm
       num_response_options
     )
 
+    # Iterates over all Foorm Forms, and exports them to a CSV.
+    # Each row represents a single question.
     def self.reshape_all_forms_and_export_to_csv
       CSV.open('./test_forms.csv', 'wb') do |csv|
         csv << HEADERS
 
         # Loads 1000 records at a time to manage loading records into memory.
-        # Probably unnecessary optimization until we have many more Forms.
-        ::Foorm::Form.find_each do |form|
+        # An unnecessary optimization at this point, as we only have 10s of Forms.
+        ::Foorm::Form.find_each(batch_size: 1000) do |form|
           reshaped_form = reshape_form(form)
 
           reshaped_form.each do |question|
@@ -38,6 +40,8 @@ module Pd::Foorm
       end
     end
 
+    # @param [Foorm::Form] form Form to reshape
+    # @return [Array] array of hashes, each representing a single question in the Form
     def self.reshape_form(form)
       reshaped_form_questions_with_metadata = []
 

--- a/dashboard/lib/pd/foorm/helper.rb
+++ b/dashboard/lib/pd/foorm/helper.rb
@@ -40,6 +40,11 @@ module Pd::Foorm
       end
     end
 
+    def fill_question_placeholders(question)
+      question && question.sub!("{panel.facilitator_name}", "my facilitator")
+      question
+    end
+
     protected
 
     def get_friendly_agenda(workshop_agenda)

--- a/dashboard/lib/pd/foorm/submission_analytics_parser.rb
+++ b/dashboard/lib/pd/foorm/submission_analytics_parser.rb
@@ -1,4 +1,8 @@
 module Pd::Foorm
+  # Responsible for taking Submissions (ie, a response submitted by a user to one of our Forms)
+  # from our in-house survey system (Foorm)
+  # and processing them into a "one row per question answered" format
+  # for export to CSV, and, ultimately, to our analytics database (Redshift).
   class SubmissionAnalyticsParser
     include Constants
 

--- a/dashboard/lib/pd/foorm/submission_analytics_parser.rb
+++ b/dashboard/lib/pd/foorm/submission_analytics_parser.rb
@@ -14,13 +14,14 @@ module Pd::Foorm
       response_text
     )
 
-    # Loads 1000 records at a time to manage loading records into memory.
+    # Iterates over all Foorm Submissions, and exports them to a CSV.
+    # Each row represents an answer to a single question.
     def self.reshape_all_submissions_and_export_to_csv
       CSV.open('./test_submissions.csv', 'wb') do |csv|
         csv << HEADERS
 
-        # Loads 1000 records at a time
-        ::Foorm::Submission.find_each do |submission|
+        # Loads 1000 records at a time to manage loading records into memory.
+        ::Foorm::Submission.find_each(batch_size: 1000) do |submission|
           reshaped_submission = reshape_submission(submission)
 
           reshaped_submission.each do |answer|
@@ -31,6 +32,8 @@ module Pd::Foorm
       end
     end
 
+    # @param [Foorm::Submission] submission Submission to reshape
+    # @return [Array] array of hashes, each representing a user's answer to a single question
     def self.reshape_submission(submission)
       reshaped_submission_answers_with_metadata = []
 

--- a/dashboard/lib/pd/foorm/submission_analytics_parser.rb
+++ b/dashboard/lib/pd/foorm/submission_analytics_parser.rb
@@ -14,29 +14,21 @@ module Pd::Foorm
       response_text
     )
 
+    # Loads 1000 records at a time to manage loading records into memory.
     def self.reshape_all_submissions_and_export_to_csv
-      reshaped_submissions = reshape_submissions(::Foorm::Submission.all)
-      reshaped_submissions_to_csv(reshaped_submissions)
-    end
-
-    def self.reshaped_submissions_to_csv(reshaped_submissions)
       CSV.open('./test_submissions.csv', 'wb') do |csv|
         csv << HEADERS
-        reshaped_submissions.each do |answer|
-          row = answer.stringify_keys.values_at(*HEADERS)
-          csv << row
+
+        # Loads 1000 records at a time
+        ::Foorm::Submission.find_each do |submission|
+          reshaped_submission = reshape_submission(submission)
+
+          reshaped_submission.each do |answer|
+            row = answer.stringify_keys.values_at(*HEADERS)
+            csv << row
+          end
         end
       end
-    end
-
-    def self.reshape_submissions(submissions)
-      reshaped_submissions = []
-
-      submissions.each do |submission|
-        reshaped_submissions = reshaped_submissions.concat reshape_submission(submission)
-      end
-
-      reshaped_submissions
     end
 
     def self.reshape_submission(submission)

--- a/dashboard/lib/pd/foorm/submission_analytics_parser.rb
+++ b/dashboard/lib/pd/foorm/submission_analytics_parser.rb
@@ -1,0 +1,78 @@
+module Pd::Foorm
+  HEADERS = %w(
+    submission_id
+    form_question_name
+    matrix_item_name
+    response_value
+    response_text
+  )
+
+  class SubmissionAnalyticsParser
+    def self.write_foorm_submissions_csv_to_file_and_bucket_long_for_form(form)
+      CSV.open('./test.csv', 'wb') do |csv|
+        csv << ['submission_id', 'question_key', 'answer']
+      end
+      #AWS::S3.upload_to_bucket('cdo-data-sharing-internal', file_name_from_form_name(form), IO.read('./test.csv'), no_random: true)
+    end
+
+    def self.reshaped_submission_answer(submission)
+      reshaped_submission_answers = []
+
+      parsed_answers = JSON.parse(submission.answers)
+
+      parsed_answers.each do |question_name, answer|
+        question_details = submission.form.get_question_details(question_name)
+
+        reshaped_submission_answer = {
+          question_name: question_name
+        }
+
+        # If question isn't in the Form, return as-is.
+        # This is expected for metadata about the submission.
+        if question_details.nil?
+          reshaped_submission_answer[:response_text] = answer
+          reshaped_submission_answers << reshaped_submission_answer
+          next
+        end
+
+        case question_details[:type]
+        when ANSWER_MATRIX
+          choices = question_details[:columns]
+
+          answer.each do |matrix_item_name, matrix_item_answer|
+            reshaped_matrix_item_submission = reshaped_submission_answer.clone
+
+            additional_attributes = {
+              matrix_item_name: matrix_item_name,
+              response_value: matrix_item_name,
+              response_text: choices[matrix_item_answer]
+            }
+
+            reshaped_matrix_item_submission.merge! additional_attributes
+
+            reshaped_submission_answers << reshaped_matrix_item_submission
+          end
+          #### Ended editing here
+        when ANSWER_RATING, ANSWER_TEXT
+          puts 'this one is for you, rubocop'
+          # additional_attributes = {
+          #   response_text: answer
+          # }
+        when ANSWER_SINGLE_SELECT
+          choices = question_details[:choices]
+          return {question_id => choices[answer]}
+        when ANSWER_MULTI_SELECT
+          choices = question_details[:choices]
+          return {question_id => answer.map {|selected| choices[selected]}.compact.sort.join(', ')}
+        end
+
+        # Return blank hash if question_type not found
+        return {}
+      end
+      # need to split out matrix question id
+      # need to include question key (not just plain text question)
+      rows = submission.formatted_answers.map {|question_key, answer| [submission.id, question_key, answer]}
+      rows.each {|row| csv << row}
+    end
+  end
+end

--- a/dashboard/lib/pd/foorm/submission_analytics_parser.rb
+++ b/dashboard/lib/pd/foorm/submission_analytics_parser.rb
@@ -1,31 +1,63 @@
 module Pd::Foorm
   HEADERS = %w(
     submission_id
-    form_question_name
+    question_name
     matrix_item_name
     response_value
     response_text
   )
 
   class SubmissionAnalyticsParser
-    def self.write_foorm_submissions_csv_to_file_and_bucket_long_for_form(form)
-      CSV.open('./test.csv', 'wb') do |csv|
-        csv << ['submission_id', 'question_key', 'answer']
-      end
-      #AWS::S3.upload_to_bucket('cdo-data-sharing-internal', file_name_from_form_name(form), IO.read('./test.csv'), no_random: true)
+    include Constants
+
+    def self.reshape_all_submissions
+      reshaped_submissions = reshape_submissions(::Foorm::Submission.all)
+      reshaped_submissions_to_csv(reshaped_submissions)
     end
 
-    def self.reshaped_submission_answer(submission)
-      reshaped_submission_answers = []
+    def self.reshaped_submissions_to_csv(reshaped_submissions)
+      CSV.open('./test_submissions.csv', 'wb') do |csv|
+        csv << HEADERS
+        reshaped_submissions.each do |answer|
+          row = answer.stringify_keys.values_at(*HEADERS)
+          csv << row
+        end
+      end
+    end
+
+    def self.reshape_submissions(submissions)
+      reshaped_submissions = []
+
+      submissions.each do |submission|
+        reshaped_submissions = reshaped_submissions.concat reshape_submission(submission)
+      end
+
+      reshaped_submissions
+    end
+
+    def self.reshape_submission(submission)
+      reshaped_submission_answers_with_metadata = []
+
+      submission_metadata = {
+        submission_id: submission.id
+      }
 
       parsed_answers = JSON.parse(submission.answers)
+      reshaped_submission_answers = reshape_submission_answers(parsed_answers, submission.form)
+
+      reshaped_submission_answers.each do |reshaped_submission_answer|
+        reshaped_submission_answers_with_metadata << submission_metadata.merge(reshaped_submission_answer)
+      end
+
+      reshaped_submission_answers_with_metadata
+    end
+
+    def self.reshape_submission_answers(parsed_answers, form)
+      reshaped_submission_answers = []
 
       parsed_answers.each do |question_name, answer|
-        question_details = submission.form.get_question_details(question_name)
-
-        reshaped_submission_answer = {
-          question_name: question_name
-        }
+        reshaped_submission_answer = {question_name: question_name}
+        question_details = form&.get_question_details(question_name)
 
         # If question isn't in the Form, return as-is.
         # This is expected for metadata about the submission.
@@ -34,6 +66,16 @@ module Pd::Foorm
           reshaped_submission_answers << reshaped_submission_answer
           next
         end
+
+        # What are we doing here? (if we want to refactor)
+        # take base hash
+        # get additional attributes
+        # merge those additional attributes into hash
+        # add hash into list of all answers
+        #
+        # Challenges:
+        # Make this work for matrix questions
+        # Make this work for questions that are not in the Form
 
         case question_details[:type]
         when ANSWER_MATRIX
@@ -44,35 +86,39 @@ module Pd::Foorm
 
             additional_attributes = {
               matrix_item_name: matrix_item_name,
-              response_value: matrix_item_name,
+              response_value: matrix_item_answer,
               response_text: choices[matrix_item_answer]
             }
 
             reshaped_matrix_item_submission.merge! additional_attributes
-
             reshaped_submission_answers << reshaped_matrix_item_submission
           end
-          #### Ended editing here
         when ANSWER_RATING, ANSWER_TEXT
-          puts 'this one is for you, rubocop'
-          # additional_attributes = {
-          #   response_text: answer
-          # }
+          reshaped_submission_answer[:response_text] = answer
+
+          reshaped_submission_answers << reshaped_submission_answer
         when ANSWER_SINGLE_SELECT
           choices = question_details[:choices]
-          return {question_id => choices[answer]}
+          additional_attributes = {
+            response_value: answer,
+            response_text: choices[answer]
+          }
+
+          reshaped_submission_answer.merge! additional_attributes
+          reshaped_submission_answers << reshaped_submission_answer
         when ANSWER_MULTI_SELECT
           choices = question_details[:choices]
-          return {question_id => answer.map {|selected| choices[selected]}.compact.sort.join(', ')}
-        end
+          additional_attributes = {
+            response_value: answer,
+            response_text: answer.map {|selected| choices[selected]}.compact.sort.join(', ')
+          }
 
-        # Return blank hash if question_type not found
-        return {}
+          reshaped_submission_answer.merge! additional_attributes
+          reshaped_submission_answers << reshaped_submission_answer
+        end
       end
-      # need to split out matrix question id
-      # need to include question key (not just plain text question)
-      rows = submission.formatted_answers.map {|question_key, answer| [submission.id, question_key, answer]}
-      rows.each {|row| csv << row}
+
+      reshaped_submission_answers
     end
   end
 end

--- a/dashboard/test/lib/pd/foorm/form_analytics_parser_test.rb
+++ b/dashboard/test/lib/pd/foorm/form_analytics_parser_test.rb
@@ -1,0 +1,87 @@
+require 'test_helper'
+
+module Pd::Foorm
+  class FormAnalyticsParserTest < ActiveSupport::TestCase
+    setup_all do
+      @form = create :foorm_form_csf_intro_post_survey
+      @reshaped_form = FormAnalyticsParser.reshape_form(@form)
+    end
+
+    teardown_all {@form.delete}
+
+    test 'reshape_form formats matrix question as expected' do
+      assert_includes @reshaped_form, {
+        form_id: @form.id,
+        form_name: @form.name,
+        form_version: @form.version,
+        question_type: 'matrix',
+        question_name: 'overall_success',
+        question_text: 'How much do you agree or disagree with the following statements about the workshop overall?',
+        matrix_item_name: 'more_prepared',
+        matrix_item_text: 'I feel more prepared to teach the material covered in this workshop than before I came.',
+        is_facilitator_specific: 0,
+        response_options: ['Strongly Disagree', 'Disagree', 'Slightly Disagree', 'Neutral', 'Slightly Agree', 'Agree', 'Strongly Agree'],
+        num_response_options: 7
+      }
+    end
+
+    test 'reshape_form formats matrix question as expected for facilitator question' do
+      assert_includes @reshaped_form, {
+        form_id: @form.id,
+        form_name: @form.name,
+        form_version: @form.version,
+        question_type: 'matrix',
+        question_name: 'facilitator_effectiveness',
+        question_text: 'During my workshop, my facilitator did the following:',
+        matrix_item_name: 'on_track',
+        matrix_item_text: 'Kept the workshop and participants on track.',
+        is_facilitator_specific: 1,
+        response_options: ['Strongly Disagree', 'Disagree', 'Slightly Disagree', 'Neutral', 'Slightly Agree', 'Agree', 'Strongly Agree'],
+        num_response_options: 7
+      }
+    end
+
+    test 'reshape_form formats comment question as expected' do
+      assert_includes @reshaped_form, {
+        form_id: @form.id,
+        form_name: @form.name,
+        form_version: @form.version,
+        question_type: 'text',
+        question_name: 'supported',
+        question_text: 'What supported your learning the most today and why?',
+        is_facilitator_specific: 0
+      }
+    end
+
+    test 'reshape_form formats single select question as expected' do
+      assert_includes @reshaped_form, {
+        form_id: @form.id,
+        form_name: @form.name,
+        form_version: @form.version,
+        question_type: 'singleSelect',
+        question_name: 'permission',
+        question_text: 'I give the workshop organizer permission to quote my written feedback from today for use on social media, promotional materials, and other communications.',
+        is_facilitator_specific: 0,
+        response_options: ['Yes, I give the workshop organizer permission to quote me and use my name.', 'Yes, I give the workshop organizer permission to quote me, but I want to be anonymous.', 'No, I do not give the workshop organizer my permission.'],
+        num_response_options: 3
+      }
+    end
+
+    test 'reshape_form formats multi select question as expected' do
+      form_with_multi_select_question = create :foorm_form, :with_multi_select_question
+      reshaped_form_with_multi_select_question = FormAnalyticsParser.reshape_form(form_with_multi_select_question)
+
+      assert_includes reshaped_form_with_multi_select_question, {
+        form_id: form_with_multi_select_question.id,
+        form_name: form_with_multi_select_question.name,
+        form_version: form_with_multi_select_question.version,
+        question_type: 'multiSelect',
+        question_name: 'not_members_spice_girls',
+        question_text: 'Which of the following are NOT names of members of the Spice Girls?',
+        is_facilitator_specific: 0,
+        response_options: %w(Sporty Radical Spicy Posh Ginger),
+        num_response_options: 5
+      }
+    end
+  end
+end

--- a/dashboard/test/lib/pd/foorm/submission_analytics_parser_test.rb
+++ b/dashboard/test/lib/pd/foorm/submission_analytics_parser_test.rb
@@ -1,0 +1,73 @@
+require 'test_helper'
+
+module Pd::Foorm
+  class SubmissionAnalyticsParserTest < ActiveSupport::TestCase
+    setup_all {@form = create :foorm_form_csf_intro_post_survey}
+    teardown_all {@form.delete}
+
+    test 'reshape_submission formats matrix question response as expected' do
+      submission = create :csf_intro_post_foorm_submission, :answers_low
+      reshaped_submission = SubmissionAnalyticsParser.reshape_submission(submission)
+
+      assert_includes reshaped_submission, {
+        submission_id: submission.id,
+        question_name: 'overall_success',
+        matrix_item_name: 'more_prepared',
+        response_value: '1',
+        response_text: 'Strongly Disagree'
+      }
+    end
+
+    test 'reshape_submission formats matrix question response as expected for facilitator question' do
+      submission = create :csf_intro_post_facilitator_foorm_submission, :answers_high
+      reshaped_submission = SubmissionAnalyticsParser.reshape_submission(submission)
+
+      assert_includes reshaped_submission, {
+        submission_id: submission.id,
+        question_name: 'facilitator_effectiveness',
+        matrix_item_name: 'on_track',
+        response_value: '7',
+        response_text: 'Strongly Agree'
+      }
+    end
+
+    test 'reshape_submission formats comment question response as expected' do
+      submission = create :csf_intro_post_foorm_submission, :answers_low
+      reshaped_submission = SubmissionAnalyticsParser.reshape_submission(submission)
+
+      assert_includes reshaped_submission, {
+        submission_id: submission.id,
+        question_name: 'supported',
+        response_text: 'lots'
+      }
+    end
+
+    test 'reshape_submission formats single select question response as expected' do
+      submission = create :csf_intro_post_foorm_submission, :answers_low
+      reshaped_submission = SubmissionAnalyticsParser.reshape_submission(submission)
+
+      assert_includes reshaped_submission, {
+        submission_id: submission.id,
+        question_name: 'permission',
+        response_value: 'no',
+        response_text: 'No, I do not give the workshop organizer my permission.'
+      }
+    end
+
+    test 'reshape_submission formats multi select question response as expected' do
+      form_with_multi_select_question = create :foorm_form, :with_multi_select_question
+      submission = create :basic_foorm_submission,
+        :with_multi_select_answer,
+        form_name: form_with_multi_select_question.name
+
+      reshaped_submission = SubmissionAnalyticsParser.reshape_submission(submission)
+
+      assert_includes reshaped_submission, {
+        submission_id: submission.id,
+        question_name: 'not_members_spice_girls',
+        response_value: %w(radical spicy),
+        response_text: 'Radical, Spicy'
+      }
+    end
+  end
+end


### PR DESCRIPTION
Introduces new helpers, Foorm::FormAnalyticsParser and Foorm::SubmissionAnalyticsParser, which reshape Forms and Submissions, respectively, into a format for export in a tabular format.

Note this code isn't actually called anywhere right now -- if you were to call it (say, from the Rails console), it would write two CSVs to the Dashboard directory.

The structure of these helpers is similar to the existing Foorm::FoormParser helper, with a bunch of methods defined on a class. I'm not sure if this is a great practice (there's nothing really "object-y" about this), so would love input on what format makes sense (a module?)

## Testing story

I've added unit tests to cover the types of questions that currently appear in Forms. I also manually tested with the limited set of Forms and Submissions that I have in my local database.

## Follow-up work

- I want to test this on a production clone and see how it performs, from a memory utilization / database load / timing perspective.
- We will likely need to implement some batching here, such that all Submissions are not loaded into memory at once.
- Suresh has suggested his preference would be that we do not put these in a CSV in S3 as an intermediate step -- in any case, we'll have to come up with some solution for actually loading this data into Redshift.
- There are more steps to this work (setting up cron to run regularly, etc.), but I won't list them all here.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
