### PR TITLE
Disabling multi-threading for the sync-out since it ends up using too much RAM.

### DIFF
--- a/tools/scripts/ManifestBuilder.rb
+++ b/tools/scripts/ManifestBuilder.rb
@@ -283,7 +283,7 @@ The animation has been skipped.
 
     # Parallelize metadata construction because some objects will require an
     # extra S3 request to get version IDs or image dimensions.
-    Parallel.map(animation_objects.keys, finish: lambda do |name, _, result|
+    Parallel.map(animation_objects.keys, in_threads: 0, finish: lambda do |name, _, result|
       # This lambda runs synchronously after each entry is done processing - it's
       # used to collect up results and warnings to the original process/thread.
       if result.is_a? Hash


### PR DESCRIPTION
Found that the i18n-dev server runs out of memory when using multiple threads. The scrip will still use multiple processes, just not threads.

## Testing story
Manually ran on the `i18n-dev` server

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
