### PR TITLE
Add join models for student resources

### DIFF
--- a/dashboard/app/models/scripts_student_resource.rb
+++ b/dashboard/app/models/scripts_student_resource.rb
@@ -1,0 +1,17 @@
+# == Schema Information
+#
+# Table name: scripts_student_resources
+#
+#  id          :bigint           not null, primary key
+#  script_id   :integer
+#  resource_id :integer
+#
+# Indexes
+#
+#  index_scripts_student_resources_on_resource_id_and_script_id  (resource_id,script_id)
+#  index_scripts_student_resources_on_script_id_and_resource_id  (script_id,resource_id) UNIQUE
+#
+class ScriptsStudentResource < ApplicationRecord
+  belongs_to :script
+  belongs_to :resource
+end

--- a/dashboard/app/models/unit_groups_student_resource.rb
+++ b/dashboard/app/models/unit_groups_student_resource.rb
@@ -1,0 +1,17 @@
+# == Schema Information
+#
+# Table name: unit_groups_student_resources
+#
+#  id            :bigint           not null, primary key
+#  unit_group_id :integer
+#  resource_id   :integer
+#
+# Indexes
+#
+#  index_ug_student_resources_on_resource_id_and_unit_group_id  (resource_id,unit_group_id)
+#  index_ug_student_resources_on_unit_group_id_and_resource_id  (unit_group_id,resource_id) UNIQUE
+#
+class UnitGroupsStudentResource < ApplicationRecord
+  belongs_to :unit_group
+  belongs_to :resource
+end

--- a/dashboard/db/migrate/20210402163201_create_scripts_student_resources.rb
+++ b/dashboard/db/migrate/20210402163201_create_scripts_student_resources.rb
@@ -1,0 +1,17 @@
+class CreateScriptsStudentResources < ActiveRecord::Migration[5.2]
+  def change
+    create_table :scripts_student_resources do |t|
+      t.integer :script_id
+      t.integer :resource_id
+
+      t.index [:script_id, :resource_id], unique: true
+      t.index [:resource_id, :script_id]
+    end
+
+    reversible do |dir|
+      dir.up do
+        execute "ALTER TABLE scripts_student_resources CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci"
+      end
+    end
+  end
+end

--- a/dashboard/db/migrate/20210402163219_create_unit_groups_student_resources.rb
+++ b/dashboard/db/migrate/20210402163219_create_unit_groups_student_resources.rb
@@ -1,0 +1,18 @@
+class CreateUnitGroupsStudentResources < ActiveRecord::Migration[5.2]
+  def change
+    create_table :unit_groups_student_resources do |t|
+      t.integer :unit_group_id
+      t.integer :resource_id
+
+      # The index names Rails gives are too long, so shorten them a bit
+      t.index [:unit_group_id, :resource_id], unique: true, name: 'index_ug_student_resources_on_unit_group_id_and_resource_id'
+      t.index [:resource_id, :unit_group_id], name: 'index_ug_student_resources_on_resource_id_and_unit_group_id'
+    end
+
+    reversible do |dir|
+      dir.up do
+        execute "ALTER TABLE unit_groups_student_resources CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci"
+      end
+    end
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_27_012046) do
+ActiveRecord::Schema.define(version: 2021_04_02_163219) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -1498,6 +1498,13 @@ ActiveRecord::Schema.define(version: 2021_03_27_012046) do
     t.index ["script_id", "resource_id"], name: "index_scripts_resources_on_script_id_and_resource_id", unique: true
   end
 
+  create_table "scripts_student_resources", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+    t.integer "script_id"
+    t.integer "resource_id"
+    t.index ["resource_id", "script_id"], name: "index_scripts_student_resources_on_resource_id_and_script_id"
+    t.index ["script_id", "resource_id"], name: "index_scripts_student_resources_on_script_id_and_resource_id", unique: true
+  end
+
   create_table "secret_pictures", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "path", null: false
@@ -1729,6 +1736,13 @@ ActiveRecord::Schema.define(version: 2021_03_27_012046) do
     t.integer "resource_id"
     t.index ["resource_id", "unit_group_id"], name: "index_unit_groups_resources_on_resource_id_and_unit_group_id"
     t.index ["unit_group_id", "resource_id"], name: "index_unit_groups_resources_on_unit_group_id_and_resource_id", unique: true
+  end
+
+  create_table "unit_groups_student_resources", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+    t.integer "unit_group_id"
+    t.integer "resource_id"
+    t.index ["resource_id", "unit_group_id"], name: "index_ug_student_resources_on_resource_id_and_unit_group_id"
+    t.index ["unit_group_id", "resource_id"], name: "index_ug_student_resources_on_unit_group_id_and_resource_id", unique: true
   end
 
   create_table "user_geos", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|


### PR DESCRIPTION
Adds support for a student resources dropdown for scripts and unit groups, which will be shown in a dropdown similar to teacher resources.

Part of [PLAT-644](https://codedotorg.atlassian.net/browse/PLAT-644). The steps to this project will be:
1. (This PR) Add the models needed for student resources
2. (#39917, still in draft) Seed and serialize these models
3. Add an edit UI to the script and course edit pages. This will be a lot easier than the work for teacher resources as this is a new feature.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
