### PR TITLE
FND-1491 Classroom Section List RTL Styles

### DIFF
--- a/apps/src/templates/studioHomepages/JoinSection.jsx
+++ b/apps/src/templates/studioHomepages/JoinSection.jsx
@@ -5,9 +5,11 @@ import color from '@cdo/apps/util/color';
 import i18n from '@cdo/locale';
 import styleConstants from '../../styleConstants';
 import Button from '@cdo/apps/templates/Button';
+import {connect} from 'react-redux';
 
 const styles = {
   main: {
+    display: 'flex',
     borderWidth: 1,
     borderStyle: 'solid',
     borderColor: color.border_gray,
@@ -43,8 +45,18 @@ const styles = {
     borderWidth: 1,
     borderColor: 'red'
   },
+  wordBoxRTL: {
+    width: styleConstants['content-width'] - 475,
+    marginRight: 25,
+    marginTop: 25,
+    marginBottom: 25,
+    float: 'left',
+    borderWidth: 1,
+    borderColor: 'red'
+  },
   actionBox: {
-    float: 'right'
+    float: 'right',
+    display: 'flex'
   },
   inputBox: {
     float: 'left',
@@ -69,11 +81,14 @@ const INITIAL_STATE = {
   sectionCode: ''
 };
 
-export default class JoinSection extends React.Component {
+class JoinSection extends React.Component {
   static propTypes = {
     enrolledInASection: PropTypes.bool.isRequired,
     updateSections: PropTypes.func.isRequired,
-    updateSectionsResult: PropTypes.func.isRequired
+    updateSectionsResult: PropTypes.func.isRequired,
+
+    // Provided by Redux
+    isRtl: PropTypes.bool
   };
 
   state = {...INITIAL_STATE};
@@ -139,7 +154,10 @@ export default class JoinSection extends React.Component {
   };
 
   render() {
-    const {enrolledInASection} = this.props;
+    const {enrolledInASection, isRtl} = this.props;
+
+    // Adjust styles for RTL
+    const wordBoxStyle = isRtl ? styles.wordBoxRTL : styles.wordBox;
 
     return (
       <div
@@ -148,7 +166,7 @@ export default class JoinSection extends React.Component {
           ...(enrolledInASection ? styles.main : styles.mainDashed)
         }}
       >
-        <div style={styles.wordBox}>
+        <div style={wordBoxStyle}>
           <div style={styles.heading}>{i18n.joinASection()}</div>
           <div style={styles.details}>{i18n.joinSectionDescription()}</div>
         </div>
@@ -178,3 +196,9 @@ export default class JoinSection extends React.Component {
     );
   }
 }
+
+export const UnconnectedJoinSection = JoinSection;
+
+export default connect(state => ({
+  isRtl: state.isRtl
+}))(JoinSection);

--- a/apps/src/templates/studioHomepages/JoinSection.jsx
+++ b/apps/src/templates/studioHomepages/JoinSection.jsx
@@ -46,13 +46,8 @@ const styles = {
     borderColor: 'red'
   },
   wordBoxRTL: {
-    width: styleConstants['content-width'] - 475,
-    marginRight: 25,
-    marginTop: 25,
-    marginBottom: 25,
-    float: 'left',
-    borderWidth: 1,
-    borderColor: 'red'
+    marginLeft: 0,
+    marginRight: 25
   },
   actionBox: {
     float: 'right',
@@ -157,7 +152,7 @@ class JoinSection extends React.Component {
     const {enrolledInASection, isRtl} = this.props;
 
     // Adjust styles for RTL
-    const wordBoxStyle = isRtl ? styles.wordBoxRTL : styles.wordBox;
+    const wordBoxStyle = {...styles.wordBox, ...(isRtl && styles.wordBoxRTL)};
 
     return (
       <div

--- a/apps/src/templates/studioHomepages/JoinSection.story.jsx
+++ b/apps/src/templates/studioHomepages/JoinSection.story.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import JoinSection from './JoinSection';
+import {UnconnectedJoinSection as JoinSection} from './JoinSection';
 import {action} from '@storybook/addon-actions';
 
 export default storybook => {

--- a/apps/src/templates/tables/tableConstants.js
+++ b/apps/src/templates/tables/tableConstants.js
@@ -29,7 +29,8 @@ export const tableLayoutStyles = {
     borderRightWidth: 1,
     paddingTop: 20,
     paddingBottom: 20,
-    color: color.charcoal
+    color: color.charcoal,
+    textAlign: 'inherit'
   },
   link: {
     color: color.teal,
@@ -39,6 +40,9 @@ export const tableLayoutStyles = {
   },
   unsortableHeader: {
     paddingLeft: 25
+  },
+  unsortableHeaderRTL: {
+    paddingRight: 25
   }
 };
 

--- a/apps/src/templates/teacherDashboard/OwnedSectionsTable.jsx
+++ b/apps/src/templates/teacherDashboard/OwnedSectionsTable.jsx
@@ -42,6 +42,7 @@ const styles = {
     borderLeft: 0
   },
   unsortableHeader: tableLayoutStyles.unsortableHeader,
+  unsortableHeaderRTL: tableLayoutStyles.unsortableHeaderRTL,
   colButton: {
     paddingTop: 20,
     paddingLeft: 20,
@@ -169,7 +170,8 @@ class OwnedSectionsTable extends Component {
     onEdit: PropTypes.func.isRequired,
 
     //Provided by redux
-    sectionRows: PropTypes.arrayOf(sortableSectionShape).isRequired
+    sectionRows: PropTypes.arrayOf(sortableSectionShape).isRequired,
+    isRtl: PropTypes.bool
   };
 
   state = {
@@ -212,6 +214,9 @@ class OwnedSectionsTable extends Component {
 
   getColumns = sortable => {
     const colStyle = {...tableLayoutStyles.cell, ...styles.sectionCol};
+    const unsortableHeaderStyle = this.props.isRtl
+      ? styles.unsortableHeaderRTL
+      : styles.unsortableHeader;
     return [
       {
         //displays nothing, but used as initial sort
@@ -254,7 +259,7 @@ class OwnedSectionsTable extends Component {
         header: {
           label: i18n.course(),
           props: {
-            style: {...tableLayoutStyles.headerCell, ...styles.unsortableHeader}
+            style: {...tableLayoutStyles.headerCell, ...unsortableHeaderStyle}
           }
         },
         cell: {
@@ -279,7 +284,7 @@ class OwnedSectionsTable extends Component {
         header: {
           label: i18n.loginInfo(),
           props: {
-            style: {...tableLayoutStyles.headerCell, ...styles.unsortableHeader}
+            style: {...tableLayoutStyles.headerCell, ...unsortableHeaderStyle}
           }
         },
         cell: {
@@ -327,5 +332,6 @@ class OwnedSectionsTable extends Component {
 export const UnconnectedOwnedSectionsTable = OwnedSectionsTable;
 
 export default connect((state, ownProps) => ({
-  sectionRows: getSectionRows(state, ownProps.sectionIds)
+  sectionRows: getSectionRows(state, ownProps.sectionIds),
+  isRtl: state.isRtl
 }))(OwnedSectionsTable);

--- a/apps/test/unit/templates/studioHomepages/JoinSectionTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/JoinSectionTest.jsx
@@ -2,7 +2,7 @@ import {expect} from '../../../util/deprecatedChai';
 import sinon from 'sinon';
 import React from 'react';
 import {shallow} from 'enzyme';
-import JoinSection from '@cdo/apps/templates/studioHomepages/JoinSection';
+import {UnconnectedJoinSection as JoinSection} from '@cdo/apps/templates/studioHomepages/JoinSection';
 
 const DEFAULT_PROPS = {
   enrolledInASection: false,


### PR DESCRIPTION
The Classroom Sections list had table headers which were left aligned. By inheriting the text-align property of the parent and conditionally applying margins this is now resolved.

The Join Section call to action component had RLT text but the form itself was not ordered in an RTL fashion. Applying display  flex to these components makes them flow correctly in RTL context and does not effect LTR languages.

## Links

- jira ticket: [FND-1491](https://codedotorg.atlassian.net/browse/FND-1491?atlOrigin=eyJpIjoiNDhiYzQ2NjA3ZGVjNDBhMWI0ZGMyMTNjMmY3YTAzZmYiLCJwIjoiaiJ9)

## Testing story

No new tests, though JoinSection is now a connected component, so I change the Story and Test files to use the proper unconnected component.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [X] Tests provide adequate coverage
- [X] Privacy and Security impacts have been assessed
- [X] Code is well-commented
- [X] New features are translatable or updates will not break translations
- [X] Relevant documentation has been added or updated
- [X] User impact is well-understood and desirable
- [X] Pull Request is labeled appropriately
- [X] Follow-up work items (including potential tech debt) are tracked and linked

## Images

BEFORE:
![image](https://user-images.githubusercontent.com/9528376/113620697-4c68f980-9620-11eb-9f7e-99abb087d61b.png)
![image](https://user-images.githubusercontent.com/9528376/113620713-512dad80-9620-11eb-80af-89b654812cdd.png)

AFTER:
![image](https://user-images.githubusercontent.com/9528376/113620743-5b4fac00-9620-11eb-8c36-4cadcc787ecc.png)
![image](https://user-images.githubusercontent.com/9528376/113620772-6276ba00-9620-11eb-9525-d856e480f1d0.png)

