### PR TITLE
Show lesson extras option when editing section from teacher dashboard

### DIFF
--- a/apps/src/sites/studio/pages/teacher_dashboard/show.js
+++ b/apps/src/sites/studio/pages/teacher_dashboard/show.js
@@ -15,7 +15,8 @@ import teacherSections, {
   setValidAssignments,
   setValidGrades,
   setTextToSpeechScriptIds,
-  setPreReaderScriptIds
+  setPreReaderScriptIds,
+  setStageExtrasScriptIds
 } from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import sectionData, {setSection} from '@cdo/apps/redux/sectionDataRedux';
 import stats from '@cdo/apps/templates/teacherDashboard/statsRedux';
@@ -49,6 +50,7 @@ const {
   localeCode,
   textToSpeechScriptIds,
   preReaderScriptIds,
+  lessonExtrasScriptIds,
   showSectionProgressDetails
 } = scriptData;
 const baseUrl = `/teacher_dashboard/sections/${section.id}`;
@@ -82,6 +84,7 @@ $(document).ready(function() {
   store.dispatch(setValidAssignments(validCourses, validScripts));
   store.dispatch(setValidGrades(validGrades));
   store.dispatch(setLocaleCode(localeCode));
+  store.dispatch(setStageExtrasScriptIds(lessonExtrasScriptIds));
   store.dispatch(setTextToSpeechScriptIds(textToSpeechScriptIds));
   store.dispatch(setPreReaderScriptIds(preReaderScriptIds));
   store.dispatch(setShowSectionProgressDetails(showSectionProgressDetails));

--- a/dashboard/app/views/teacher_dashboard/show.html.haml
+++ b/dashboard/app/views/teacher_dashboard/show.html.haml
@@ -13,6 +13,7 @@
   teacher_dashboard_data[:localeCode] = request.locale
   teacher_dashboard_data[:textToSpeechScriptIds] = Script.text_to_speech_script_ids
   teacher_dashboard_data[:preReaderScriptIds] = Script.pre_reader_script_ids
+  teacher_dashboard_data[:lessonExtrasScriptIds] = Script.lesson_extras_script_ids
   teacher_dashboard_data[:showSectionProgressDetails] = SingleUserExperiment.enabled?(user: current_user, experiment_name: 'section-progress-details-pilot')
 
 %script{src: webpack_asset_path('js/teacher_dashboard/show.js'), data: {dashboard: teacher_dashboard_data.to_json}}


### PR DESCRIPTION
Adds the option to "Enable Lesson Extras" when editing the section details of a section assigned to a script that allows lesson extras (eg, courses A-F):

![image](https://user-images.githubusercontent.com/25372625/113623097-b67aa200-9612-11eb-8bf0-2836c8a6e79b.png)

This option appears when editing a section from the homepage of Code Studio (ie, /home), but was not appearing when editing a section from the Teacher Dashboard. This PR adds logic to initialize the list of scripts that support lesson extras in the Redux store in the [same way we do on the teacher homepage](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/controllers/home_controller.rb#L100).

Maybe worth at some point looking at the fact that we have separate initialization for Code Studio homepage and the teacher dashboard, despite there being a lot of overlap?

## Links

- Jira ticket: [LP-1750](https://codedotorg.atlassian.net/browse/LP-1750)

## Testing story

Tested manually, confirming that the option to turn on lesson extras appeared in the dialog where it did not before, and confirmed that an update to a section's true/false of whether it had lesson extras turned on.

## PR Checklist:

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
