### PR TITLE
Codemirror vertical scroll

### DIFF
--- a/apps/style/javalab/style.scss
+++ b/apps/style/javalab/style.scss
@@ -21,7 +21,10 @@ body {
 
 .cm-scroller { overflow: auto; }
 
-.cm-wrap { border: 1px solid silver }
+.cm-wrap { 
+  border: 1px solid silver;
+  max-height: 100%;
+}
 
 #codeWorkspace {
   border: none !important;


### PR DESCRIPTION
Make the editor scroll on overflow instead of extending into the console area. This is the suggested fix for CodeMirror6 [according to this page](https://codemirror.net/6/examples/styling/): “By default, the editor adjusts to the height of its content, but you can make cm-scroller overflow: auto, and assign a height or max-height to `cm-editor, to make the editor scrollable.”

https://user-images.githubusercontent.com/17147070/113631599-8b964b00-961e-11eb-95fc-bfe0ab2f9d6c.mov

## Links

- jira ticket: [CSA-177](https://codedotorg.atlassian.net/browse/CSA-177?atlOrigin=eyJpIjoiY2YyODM2ODhmMDcxNDlhYmIyODI4MzU2ZTAzYTEwMGQiLCJwIjoiaiJ9)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
