### PR TITLE
Adding TFI (Friday Institute) back into the dropdown menu

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
@@ -66,6 +66,14 @@ const placeholderSession = {
   endTime: '5:00pm'
 };
 
+// When selecting whether a workshop is virtual through the UI,
+// a user is really selecting two things:
+//  a) whether the workshop is occurring virtually, and
+//  b) if there's a third party responsible for the content/structure of the workshop.
+// These two things are stored as separate attributes in the workshop model.
+const virtualWorkshopTypes = ['regional', 'friday_institute'];
+const thirdPartyProviders = ['friday_institute'];
+
 export class WorkshopForm extends React.Component {
   static contextTypes = {
     router: PropTypes.object.isRequired
@@ -92,6 +100,7 @@ export class WorkshopForm extends React.Component {
       regional_partner_name: PropTypes.string,
       regional_partner_id: PropTypes.number,
       virtual: PropTypes.bool,
+      third_party_provider: PropTypes.string,
       suppress_email: PropTypes.bool,
       organizer: PropTypes.shape({
         id: PropTypes.number,
@@ -130,7 +139,8 @@ export class WorkshopForm extends React.Component {
       showTypeOptionsHelpDisplay: false,
       regional_partner_id: '',
       virtual: false,
-      suppress_email: false
+      suppress_email: false,
+      third_party_provider: null
     };
 
     if (props.workshop) {
@@ -151,7 +161,8 @@ export class WorkshopForm extends React.Component {
           'regional_partner_id',
           'organizer',
           'virtual',
-          'suppress_email'
+          'suppress_email',
+          'third_party_provider'
         ])
       );
       initialState.sessions = this.prepareSessionsForForm(
@@ -409,7 +420,7 @@ export class WorkshopForm extends React.Component {
                 </HelpTip>
               </ControlLabel>
               <SelectIsVirtual
-                value={this.state.virtual}
+                value={this.currentVirtualStatus()}
                 onChange={this.handleVirtualChange}
                 readOnly={
                   this.props.readOnly ||
@@ -663,16 +674,32 @@ export class WorkshopForm extends React.Component {
     return location;
   };
 
+  currentVirtualStatus = () => {
+    const {virtual, third_party_provider} = this.state;
+
+    // First, check if the third party provider is a valid
+    // virtual workshop type.
+    if (virtualWorkshopTypes.includes(third_party_provider)) {
+      return third_party_provider;
+    } else if (virtual) {
+      return 'regional';
+    } else {
+      return 'in_person';
+    }
+  };
+
   handleVirtualChange = event => {
     // This field gets its own handler both so we can coerce its value to
     // boolean, and so we can enforce some business logic that says:
     // Virtual workshops ALWAYS suppress email.
-    const virtual = event.target.value === 'true';
+    const value = event.target.value;
+    const virtual = virtualWorkshopTypes.includes(value);
     const suppress_email = virtual || this.state.suppress_email;
 
     this.setState({
       virtual,
-      suppress_email
+      suppress_email,
+      third_party_provider: thirdPartyProviders.includes(value) ? value : null
     });
   };
 
@@ -759,6 +786,7 @@ export class WorkshopForm extends React.Component {
       notes: this.state.notes,
       virtual: this.state.virtual,
       suppress_email: this.state.suppress_email,
+      third_party_provider: this.state.third_party_provider,
       sessions_attributes: this.prepareSessionsForApi(
         this.state.sessions,
         this.state.destroyedSessions
@@ -1082,16 +1110,19 @@ const SelectIsVirtual = ({value, readOnly, onChange}) => (
     style={readOnly ? styles.readOnlyInput : undefined}
     disabled={readOnly}
   >
-    <option key={false} value={false}>
+    <option key={'in_person'} value={'in_person'}>
       No, this is an in-person workshop.
     </option>
-    <option key={true} value={true}>
-      Yes, this is a virtual workshop.
+    <option key={'friday_institute'} value={'friday_institute'}>
+      Yes, this is a Code.org-Friday Institute virtual workshop.
+    </option>
+    <option key={'regional'} value={'regional'}>
+      Yes, this is a regional virtual workshop.
     </option>
   </FormControl>
 );
 SelectIsVirtual.propTypes = {
-  value: PropTypes.bool.isRequired,
+  value: PropTypes.string.isRequired,
   readOnly: PropTypes.bool,
   onChange: PropTypes.func.isRequired
 };

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop.jsx
@@ -103,7 +103,8 @@ export class Workshop extends React.Component {
             'potential_organizers',
             'created_at',
             'virtual',
-            'suppress_email'
+            'suppress_email',
+            'third_party_provider'
           ])
         });
       })

--- a/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
@@ -310,6 +310,7 @@ class Api::V1::Pd::WorkshopsController < ::ApplicationController
       :organizer_id,
       :virtual,
       :suppress_email,
+      :third_party_provider,
       sessions_attributes: [:id, :start, :end, :_destroy],
     ]
 

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -62,7 +62,7 @@ class Pd::Workshop < ApplicationRecord
     # organization.
     # Only current allowed values are "friday_institute" and nil.
     # "friday_institute" represents The Friday Institute,
-    # a regional partner whose model of virtual workshop was used
+    # a regional partner whose model of virtual workshop is being used
     # by several partners during summer 2020.
     'third_party_provider',
 
@@ -86,6 +86,7 @@ class Pd::Workshop < ApplicationRecord
   validate :all_virtual_workshops_suppress_email
   validate :all_academic_year_workshops_suppress_email
   validates_inclusion_of :third_party_provider, in: %w(friday_institute), allow_nil: true
+  validate :friday_institute_workshops_must_be_virtual
   validate :virtual_only_subjects_must_be_virtual
 
   validates :funding_type,
@@ -125,6 +126,12 @@ class Pd::Workshop < ApplicationRecord
   def all_academic_year_workshops_suppress_email
     if MUST_SUPPRESS_EMAIL_SUBJECTS.include?(subject) && !suppress_email?
       errors.add :properties, 'All academic year workshops must suppress email.'
+    end
+  end
+
+  def friday_institute_workshops_must_be_virtual
+    if friday_institute? && !virtual?
+      errors.add :properties, 'Friday Institute workshops must be virtual'
     end
   end
 

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -63,7 +63,7 @@ class Pd::Workshop < ApplicationRecord
     # Only current allowed values are "friday_institute" and nil.
     # "friday_institute" represents The Friday Institute,
     # a regional partner whose model of virtual workshop is being used
-    # by several partners during summer 2020.
+    # by several partners.
     'third_party_provider',
 
     # If true, our system will not send enrollees reminders related to this workshop.

--- a/dashboard/app/serializers/api/v1/pd/workshop_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/workshop_serializer.rb
@@ -4,7 +4,7 @@ class Api::V1::Pd::WorkshopSerializer < ActiveModel::Serializer
     :enrolled_teacher_count, :sessions, :account_required_for_attendance?,
     :enrollment_code, :pre_workshop_survey_url, :attended, :on_map, :funded, :funding_type, :ready_to_close?,
     :workshop_starting_date, :date_and_location_name, :regional_partner_name, :regional_partner_id,
-    :scholarship_workshop?, :can_delete, :created_at, :virtual, :suppress_email
+    :scholarship_workshop?, :can_delete, :created_at, :virtual, :suppress_email, :third_party_provider
 
   def sessions
     object.sessions.map do |session|

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -1451,6 +1451,15 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     assert workshop.valid?
   end
 
+  test 'friday_institute workshops must be virtual' do
+    workshop = build :workshop, third_party_provider: 'friday_institute', virtual: false
+    refute workshop.valid?
+
+    workshop.virtual = true
+    workshop.suppress_email = true
+    assert workshop.valid?
+  end
+
   test 'workshops third_party_provider must be nil or from specified list' do
     workshop = build :workshop, third_party_provider: 'unknown_pd_provider'
     refute workshop.valid?

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -1466,10 +1466,6 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
 
     workshop.third_party_provider = nil
     assert workshop.valid?
-
-    # friday_institute is in list of approved third party providers
-    workshop.third_party_provider = 'friday_institute'
-    assert workshop.valid?
   end
 
   private


### PR DESCRIPTION
This update is compiled by studying these two PRs from last summer to add/remove this same item:

Add TFI option PR: https://github.com/code-dot-org/code-dot-org/pull/35120

Remove TFI option PR: https://github.com/code-dot-org/code-dot-org/pull/36269

Ticket here: https://codedotorg.atlassian.net/browse/PLC-1157