### PR TITLE
Finalize standards UI

### DIFF
--- a/apps/src/templates/lessonOverview/LessonStandards.jsx
+++ b/apps/src/templates/lessonOverview/LessonStandards.jsx
@@ -90,10 +90,9 @@ class Framework extends PureComponent {
       .orderBy(categoryKey, 'shortcode')
       .groupBy(categoryKey)
       .value();
-    const isOpen = getDetailsOpen(this.props.expandMode);
     return (
-      <details key={name} open={isOpen}>
-        <summary>{name}</summary>
+      <div>
+        {name}
         <ul style={{listStyleType: 'none'}}>
           {Object.keys(standardsByCategory).map((categoryShortcode, index) => {
             const standards = standardsByCategory[categoryShortcode];
@@ -108,7 +107,7 @@ class Framework extends PureComponent {
             );
           })}
         </ul>
-      </details>
+      </div>
     );
   }
 }

--- a/apps/src/templates/lessonOverview/LessonStandards.jsx
+++ b/apps/src/templates/lessonOverview/LessonStandards.jsx
@@ -2,6 +2,29 @@ import PropTypes from 'prop-types';
 import React, {PureComponent} from 'react';
 import _ from 'lodash';
 import {standardShape} from './lessonPlanShapes';
+import color from '@cdo/apps/util/color';
+import Radium from 'radium';
+
+export const styles = {
+  frameworkName: {
+    fontFamily: "'Gotham 5r', sans-serif",
+    fontWeight: 'bold',
+    color: color.dark_charcoal
+  },
+  categoryShortcode: {
+    fontFamily: "'Gotham 7r', sans-serif",
+    fontWeight: 'bold',
+    color: color.link_color,
+    ':hover': {
+      textDecoration: 'underline'
+    }
+  },
+  standardShortcode: {
+    fontFamily: "'Gotham 5r', sans-serif",
+    fontWeight: 'bold',
+    color: color.dark_charcoal
+  }
+};
 
 export const ExpandMode = {
   NONE: 'none',
@@ -92,7 +115,7 @@ class Framework extends PureComponent {
       .value();
     return (
       <div>
-        {name}
+        <span style={styles.frameworkName}>{name}</span>
         <ul style={{listStyleType: 'none'}}>
           {Object.keys(standardsByCategory).map((categoryShortcode, index) => {
             const standards = standardsByCategory[categoryShortcode];
@@ -117,7 +140,7 @@ Framework.propTypes = {
   expandMode: expandModeShape
 };
 
-class ParentCategory extends PureComponent {
+class UnconnectedParentCategory extends PureComponent {
   render() {
     const {shortcode, standards} = this.props;
     const description = standards[0].parentCategoryDescription;
@@ -130,7 +153,7 @@ class ParentCategory extends PureComponent {
       <li key={shortcode}>
         <details open={isOpen}>
           <summary>
-            {shortcode}
+            <span style={styles.categoryShortcode}>{shortcode}</span>
             {' - '}
             {description}
           </summary>
@@ -158,13 +181,14 @@ class ParentCategory extends PureComponent {
     );
   }
 }
-ParentCategory.propTypes = {
+UnconnectedParentCategory.propTypes = {
   shortcode: PropTypes.string.isRequired,
   standards: PropTypes.arrayOf(standardShape).isRequired,
   expandMode: expandModeShape
 };
+const ParentCategory = Radium(UnconnectedParentCategory);
 
-class Category extends PureComponent {
+class UnconnectedCategory extends PureComponent {
   render() {
     const {shortcode, standards} = this.props;
     const description = standards[0].categoryDescription;
@@ -172,7 +196,11 @@ class Category extends PureComponent {
     return (
       <li key={shortcode}>
         <details open={isOpen}>
-          <summary>{`${shortcode} - ${description}`}</summary>
+          <summary>
+            <span style={styles.categoryShortcode}>{shortcode}</span>
+            {' - '}
+            {description}
+          </summary>
           <ul>
             {standards.map(standard => (
               <Standard key={standard.shortcode} standard={standard} />
@@ -183,20 +211,23 @@ class Category extends PureComponent {
     );
   }
 }
-Category.propTypes = {
+UnconnectedCategory.propTypes = {
   shortcode: PropTypes.string.isRequired,
   standards: PropTypes.arrayOf(standardShape).isRequired,
   expandMode: expandModeShape
 };
+const Category = Radium(UnconnectedCategory);
 
 class Standard extends PureComponent {
   render() {
     const {standard} = this.props;
     return (
       <li key={standard.shortcode}>
-        {standard.shortcode}
-        {' - '}
-        {standard.description}
+        <summary>
+          <span style={styles.standardShortcode}>{standard.shortcode}</span>
+          {' - '}
+          {standard.description}
+        </summary>
       </li>
     );
   }

--- a/apps/test/unit/templates/lessonOverview/LessonStandardsTest.js
+++ b/apps/test/unit/templates/lessonOverview/LessonStandardsTest.js
@@ -43,12 +43,12 @@ describe('LessonStandards', () => {
     const frameworks = wrapper.find('Framework');
     expect(frameworks.length).to.equal(2);
 
-    const parentCategories = wrapper.find('ParentCategory');
+    const parentCategories = wrapper.find('UnconnectedParentCategory');
     expect(parentCategories.length > 0).to.be.true;
     parentCategories.forEach(parentCategory => {
       expect(isOpen(parentCategory)).to.be.false;
     });
-    const categories = wrapper.find('Category');
+    const categories = wrapper.find('UnconnectedCategory');
     expect(categories.length > 0).to.be.true;
     categories.forEach(category => {
       expect(isOpen(category)).to.be.false;
@@ -63,11 +63,11 @@ describe('LessonStandards', () => {
     const frameworks = wrapper.find('Framework');
     expect(frameworks.length).to.equal(2);
 
-    const parentCategories = frameworks.at(0).find('ParentCategory');
+    const parentCategories = frameworks.at(0).find('UnconnectedParentCategory');
     expect(parentCategories.length).to.equal(1);
     expect(isOpen(parentCategories.at(0))).to.be.true;
 
-    const categories = parentCategories.at(0).find('Category');
+    const categories = parentCategories.at(0).find('UnconnectedCategory');
     expect(categories.length).to.equal(2);
     expect(isOpen(categories.at(0))).to.be.true;
     expect(isOpen(categories.at(1))).to.be.false;
@@ -81,13 +81,13 @@ describe('LessonStandards', () => {
     const frameworks = wrapper.find('Framework');
     expect(frameworks.length).to.equal(2);
 
-    const parentCategories = wrapper.find('ParentCategory');
+    const parentCategories = wrapper.find('UnconnectedParentCategory');
     expect(parentCategories.length > 0).to.be.true;
     parentCategories.forEach(parentCategory => {
       expect(isOpen(parentCategory)).to.be.true;
     });
 
-    const categories = wrapper.find('Category');
+    const categories = wrapper.find('UnconnectedCategory');
     expect(categories.length > 0).to.be.true;
     categories.forEach(category => {
       expect(isOpen(category)).to.be.true;

--- a/apps/test/unit/templates/lessonOverview/LessonStandardsTest.js
+++ b/apps/test/unit/templates/lessonOverview/LessonStandardsTest.js
@@ -42,9 +42,6 @@ describe('LessonStandards', () => {
 
     const frameworks = wrapper.find('Framework');
     expect(frameworks.length).to.equal(2);
-    frameworks.forEach(framework => {
-      expect(isOpen(framework)).to.be.false;
-    });
 
     const parentCategories = wrapper.find('ParentCategory');
     expect(parentCategories.length > 0).to.be.true;
@@ -65,8 +62,6 @@ describe('LessonStandards', () => {
     );
     const frameworks = wrapper.find('Framework');
     expect(frameworks.length).to.equal(2);
-    expect(isOpen(frameworks.at(0))).to.be.true;
-    expect(isOpen(frameworks.at(1))).to.be.false;
 
     const parentCategories = frameworks.at(0).find('ParentCategory');
     expect(parentCategories.length).to.equal(1);
@@ -85,9 +80,6 @@ describe('LessonStandards', () => {
     );
     const frameworks = wrapper.find('Framework');
     expect(frameworks.length).to.equal(2);
-    frameworks.forEach(framework => {
-      expect(isOpen(framework)).to.be.true;
-    });
 
     const parentCategories = wrapper.find('ParentCategory');
     expect(parentCategories.length > 0).to.be.true;


### PR DESCRIPTION
Finishes [PLAT-902]. see [spec](https://docs.google.com/document/d/1QFzo3vdeDyqiuOyVWhmHesuSNOevNhvwSRK9kVyblxQ/edit#heading=h.vighmxgsfwp3). Gets the standards UI on the lesson plan page and the course rollup page looking just like the specs, except the Full Course Alignment button, which is done in the next PR. see commit names for a description of what's changing.

## Screenshots

### before

<img width="578" alt="Screen Shot 2021-04-05 at 9 48 10 PM" src="https://user-images.githubusercontent.com/8001765/113660336-adacbf00-9658-11eb-90bb-d7e8a19fed93.png">

### after

https://user-images.githubusercontent.com/8001765/113645500-d5415e80-963b-11eb-8db5-ac0350209557.mov

### spec
<img width="1146" alt="Screen Shot 2021-04-05 at 6 32 02 PM" src="https://user-images.githubusercontent.com/8001765/113646247-47ff0980-963d-11eb-8a84-156d671c9c1e.png">

## Testing story

* update existing unit test coverage to account for framework name always being visible
* manually verified lesson plan as shown in screenshots above

[PLAT-902]: https://codedotorg.atlassian.net/browse/PLAT-902