### PR TITLE
add Full Course Alignment button to lesson plan page

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -861,6 +861,7 @@
   "freePlayUnchangedFail": "Are you sure you're finished? It looks like you have more work to do on this level. If you choose to continue, this level will be marked as \"In progress\" so you can come back to finish it later.",
   "freePlayUnchangedFailInline": "It looks like you haven't finished working on this level yet. Try adding some more blocks!",
   "fromWhen": "(From {when}):",
+  "fullCourseAlignment": "Full Course Alignment",
   "gdprDialogHeaderUpdated": "Do you agree that Code.org may transfer data (including personal data) from your use of this site to the United States for the purpose of hosting and processing such data?",
   "gdprDialogDetailsUpdated": "Code.org is a US-based not-for-profit website and the laws governing data collection in the U.S. may differ from the laws in your country.",
   "gdprDialogVisitPrivacyPolicy": "Visit Code.org’s Privacy Policy to learn more.",

--- a/apps/src/templates/lessonOverview/LessonOverview.jsx
+++ b/apps/src/templates/lessonOverview/LessonOverview.jsx
@@ -148,6 +148,7 @@ class LessonOverview extends Component {
                 <LessonStandards
                   standards={lesson.standards}
                   expandMode={ExpandMode.FIRST}
+                  courseVersionStandardsUrl={lesson.courseVersionStandardsUrl}
                 />
               </div>
             )}

--- a/apps/src/templates/lessonOverview/LessonStandards.jsx
+++ b/apps/src/templates/lessonOverview/LessonStandards.jsx
@@ -4,6 +4,8 @@ import _ from 'lodash';
 import {standardShape} from './lessonPlanShapes';
 import color from '@cdo/apps/util/color';
 import Radium from 'radium';
+import Button from '@cdo/apps/templates/Button';
+import i18n from '@cdo/locale';
 
 export const styles = {
   frameworkName: {
@@ -79,6 +81,14 @@ export default class LessonStandards extends PureComponent {
       .value();
     return (
       <div>
+        <Button
+          __useDeprecatedTag
+          color={Button.ButtonColor.gray}
+          href="/"
+          style={{marginRight: 10}}
+          target="_blank"
+          text={i18n.fullCourseAlignment()}
+        />
         {Object.keys(standardsByFramework).map((frameworkName, index) => {
           const standards = standardsByFramework[frameworkName];
           const expandMode = getChildExpandMode(this.props.expandMode, index);

--- a/apps/src/templates/lessonOverview/LessonStandards.jsx
+++ b/apps/src/templates/lessonOverview/LessonStandards.jsx
@@ -74,21 +74,23 @@ function getDetailsOpen(expandMode) {
 
 export default class LessonStandards extends PureComponent {
   render() {
-    const {standards} = this.props;
+    const {standards, courseVersionStandardsUrl} = this.props;
     const standardsByFramework = _(standards)
       .orderBy('frameworkName')
       .groupBy('frameworkName')
       .value();
     return (
       <div>
-        <Button
-          __useDeprecatedTag
-          color={Button.ButtonColor.gray}
-          href="/"
-          style={{marginRight: 10}}
-          target="_blank"
-          text={i18n.fullCourseAlignment()}
-        />
+        {courseVersionStandardsUrl && (
+          <Button
+            __useDeprecatedTag
+            color={Button.ButtonColor.gray}
+            href={courseVersionStandardsUrl}
+            style={{marginBottom: 5}}
+            target="_blank"
+            text={i18n.fullCourseAlignment()}
+          />
+        )}
         {Object.keys(standardsByFramework).map((frameworkName, index) => {
           const standards = standardsByFramework[frameworkName];
           const expandMode = getChildExpandMode(this.props.expandMode, index);
@@ -107,7 +109,8 @@ export default class LessonStandards extends PureComponent {
 }
 LessonStandards.propTypes = {
   standards: PropTypes.arrayOf(standardShape).isRequired,
-  expandMode: expandModeShape
+  expandMode: expandModeShape,
+  courseVersionStandardsUrl: PropTypes.string
 };
 
 class Framework extends PureComponent {

--- a/apps/src/templates/lessonOverview/LessonStandards.story.jsx
+++ b/apps/src/templates/lessonOverview/LessonStandards.story.jsx
@@ -22,6 +22,15 @@ export default storybook => {
       )
     },
     {
+      name: 'many standards with full course alignment button',
+      story: () => (
+        <LessonStandards
+          standards={cspStandards.concat(cstaStandards)}
+          courseVersionStandardsUrl="/path/to/standards"
+        />
+      )
+    },
+    {
       name: 'expand first of many standards',
       story: () => (
         <LessonStandards

--- a/apps/src/templates/lessonOverview/lessonPlanShapes.jsx
+++ b/apps/src/templates/lessonOverview/lessonPlanShapes.jsx
@@ -91,7 +91,8 @@ export const lessonShape = PropTypes.shape({
   programmingExpressions: PropTypes.arrayOf(PropTypes.object).isRequired,
   objectives: PropTypes.arrayOf(PropTypes.object).isRequired,
   assessmentOpportunities: PropTypes.string,
-  lessonPlanPdfUrl: PropTypes.string
+  lessonPlanPdfUrl: PropTypes.string,
+  courseVersionStandardsUrl: PropTypes.string
 });
 
 export const studentLessonShape = PropTypes.shape({

--- a/apps/test/unit/templates/lessonOverview/LessonStandardsTest.js
+++ b/apps/test/unit/templates/lessonOverview/LessonStandardsTest.js
@@ -93,6 +93,24 @@ describe('LessonStandards', () => {
       expect(isOpen(category)).to.be.true;
     });
   });
+
+  it('renders without Full Course Alignment button by default', () => {
+    const standard = cspStandards[0];
+    const wrapper = mount(<LessonStandards standards={[standard]} />);
+    const button = wrapper.find('Button');
+    expect(button.length).to.equal(0);
+  });
+
+  it('renders with Full Course Alignment button when url is provided', () => {
+    const standard = cspStandards[0];
+    const url = '/path/to/standards';
+    const wrapper = mount(
+      <LessonStandards standards={[standard]} courseVersionStandardsUrl={url} />
+    );
+    const button = wrapper.find('Button');
+    expect(button.length).to.equal(1);
+    expect(button.prop('href')).to.equal(url);
+  });
 });
 
 function isOpen(wrapper) {

--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -43,6 +43,12 @@ class CourseVersion < ApplicationRecord
 
   alias_attribute :version_year, :key
 
+  # For now, delegate any fields stored on the content root so that we can start
+  # accessing them via course version. In the future, these fields will be moved
+  # into the course version itself.
+
+  delegate :name, to: :content_root
+
   # Seeding method for creating / updating / deleting the CourseVersion for the given
   # potential content root, i.e. a Script or UnitGroup.
   #

--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -20,6 +20,8 @@
 #
 
 class CourseVersion < ApplicationRecord
+  include Rails.application.routes.url_helpers
+
   belongs_to :course_offering
   has_many :resources
   has_many :vocabularies
@@ -97,7 +99,6 @@ class CourseVersion < ApplicationRecord
   end
 
   def all_standards_url
-    prefix = content_root_type === 'UnitGroup' ? 'courses' : 's'
-    "/#{prefix}/#{name}/standards"
+    content_root_type === 'UnitGroup' ? standards_course_path(content_root) : standards_script_path(content_root)
   end
 end

--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -99,6 +99,6 @@ class CourseVersion < ApplicationRecord
   end
 
   def all_standards_url
-    content_root_type === 'UnitGroup' ? standards_course_path(content_root) : standards_script_path(content_root)
+    content_root_type == 'UnitGroup' ? standards_course_path(content_root) : standards_script_path(content_root)
   end
 end

--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -95,4 +95,9 @@ class CourseVersion < ApplicationRecord
   def contained_lessons
     units.map(&:lessons).flatten
   end
+
+  def all_standards_url
+    prefix = content_root_type === 'UnitGroup' ? 'courses' : 's'
+    "/#{prefix}/#{name}/standards"
+  end
 end

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -243,6 +243,11 @@ class Lesson < ApplicationRecord
     CDO.code_org_url "/curriculum/#{script.name}/#{relative_position}"
   end
 
+  def course_version_standards_url
+    course_version_name = script.get_course_version&.name
+    CDO.studio_url "/courses/#{course_version_name}/standards" if course_version_name
+  end
+
   def summarize(include_bonus_levels = false, for_edit: false)
     lesson_summary = Rails.cache.fetch("#{cache_key}/lesson_summary/#{I18n.locale}/#{include_bonus_levels}") do
       cached_levels = include_bonus_levels ? cached_script_levels : cached_script_levels.reject(&:bonus)
@@ -393,7 +398,8 @@ class Lesson < ApplicationRecord
       opportunityStandards: opportunity_standards.map(&:summarize_for_lesson_show),
       is_teacher: user&.teacher?,
       assessmentOpportunities: Services::MarkdownPreprocessor.process(assessment_opportunities),
-      lessonPlanPdfUrl: lesson_plan_pdf_url
+      lessonPlanPdfUrl: lesson_plan_pdf_url,
+      courseVersionStandardsUrl: course_version_standards_url
     }
   end
 

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -244,8 +244,7 @@ class Lesson < ApplicationRecord
   end
 
   def course_version_standards_url
-    course_version_name = script.get_course_version&.name
-    CDO.studio_url "/courses/#{course_version_name}/standards" if course_version_name
+    script.get_course_version&.all_standards_url
   end
 
   def summarize(include_bonus_levels = false, for_edit: false)

--- a/dashboard/config/courses/fit2019-apprentice.course
+++ b/dashboard/config/courses/fit2019-apprentice.course
@@ -4,5 +4,8 @@
 
   ],
   "properties": {
-  }
+  },
+  "resources": [
+
+  ]
 }

--- a/dashboard/config/courses/fit2019-apprentice.course
+++ b/dashboard/config/courses/fit2019-apprentice.course
@@ -4,8 +4,5 @@
 
   ],
   "properties": {
-  },
-  "resources": [
-
-  ]
+  }
 }

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -855,4 +855,44 @@ class LessonTest < ActiveSupport::TestCase
 
     [script, level1, level2, lesson, script_level]
   end
+
+  test 'course_version_standards_url returns nil without course version' do
+    script = create :script
+    lesson_group = create :lesson_group, script: script
+    lesson = create :lesson, lesson_group: lesson_group, script: script
+    refute script.get_course_version
+    refute lesson.course_version_standards_url
+  end
+
+  test 'course_version_standards_url in unit group returns courses path' do
+    script = create :script
+    lesson_group = create :lesson_group, script: script
+    lesson = create :lesson, lesson_group: lesson_group, script: script
+
+    # family name and version year must be set in order for a unit group to have
+    # a course offering and course version.
+    unit_group = create :unit_group, family_name: 'my-family', version_year: '1999'
+    create :unit_group_unit, script: script, unit_group: unit_group, position: 1
+
+    # adds course offering and course version
+    CourseOffering.add_course_offering(unit_group)
+    assert script.get_course_version
+    assert_equal unit_group, script.get_course_version.content_root
+
+    expected_url = CDO.studio_url "/courses/#{unit_group.name}/standards"
+    assert_equal expected_url, lesson.course_version_standards_url
+  end
+
+  test 'course_version_standards_url in standalone script returns script path' do
+    script = create :script, is_course: true, family_name: 'my-family', version_year: '1999'
+    lesson_group = create :lesson_group, script: script
+    lesson = create :lesson, lesson_group: lesson_group, script: script
+
+    CourseOffering.add_course_offering(script)
+    assert script.get_course_version
+    assert_equal script, script.get_course_version.content_root
+
+    expected_url = CDO.studio_url "/s/#{script.name}/standards"
+    assert_equal expected_url, lesson.course_version_standards_url
+  end
 end

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -879,7 +879,7 @@ class LessonTest < ActiveSupport::TestCase
     assert script.get_course_version
     assert_equal unit_group, script.get_course_version.content_root
 
-    expected_url = CDO.studio_url "/courses/#{unit_group.name}/standards"
+    expected_url = "/courses/#{unit_group.name}/standards"
     assert_equal expected_url, lesson.course_version_standards_url
   end
 
@@ -892,7 +892,7 @@ class LessonTest < ActiveSupport::TestCase
     assert script.get_course_version
     assert_equal script, script.get_course_version.content_root
 
-    expected_url = CDO.studio_url "/s/#{script.name}/standards"
+    expected_url = "/s/#{script.name}/standards"
     assert_equal expected_url, lesson.course_version_standards_url
   end
 end


### PR DESCRIPTION
Finishes [PLAT-863]. Depends on #39910.

### before

![Screen Shot 2021-04-05 at 6 28 01 PM](https://user-images.githubusercontent.com/8001765/113645978-bd1e0f00-963c-11eb-8368-88c9a9e64c52.png)

### after

![Screen Shot 2021-04-05 at 6 29 02 PM](https://user-images.githubusercontent.com/8001765/113646033-d626c000-963c-11eb-8de9-f1c4b643b853.png)

## Testing story

* new unit tests verify whether the button appears or not
* new unit tests for generating the correct standards url
* manually verified that the button takes to to the standards rollup page for lessons in csp-2021, csd-2021, and coursea-2021

[PLAT-863]: https://codedotorg.atlassian.net/browse/PLAT-863