### PR TITLE
Updating CSF pilot to allow joining by URL

### DIFF
--- a/dashboard/app/models/experiments/experiment.rb
+++ b/dashboard/app/models/experiments/experiment.rb
@@ -83,7 +83,7 @@ class Experiment < ApplicationRecord
     {
       name: 'csf-2021-pilot',
       label: 'CSF 2021 Pilot',
-      allow_joining_via_url: false
+      allow_joining_via_url: true
     },
     {
       name: 'csd-2021-preview',


### PR DESCRIPTION
As simple as can be! Just updating pilot flag so the url can be sent out.