### PR TITLE
Allow 'viewAs' toggle on script overview when signed out

### DIFF
--- a/apps/src/code-studio/progress.js
+++ b/apps/src/code-studio/progress.js
@@ -251,7 +251,7 @@ progress.renderCourseProgress = function(scriptData) {
   if (scriptData.student_detail_progress_view) {
     store.dispatch(setStudentDefaultsSummaryView(false));
   }
-  initViewAs(store, scriptData);
+  progress.initViewAs(store, scriptData);
   queryUserProgress(store, scriptData, null);
 
   const teacherResources = (scriptData.teacher_resources || []).map(
@@ -306,15 +306,24 @@ progress.retrieveProgress = function(scriptName, scriptData, currentLevelId) {
   });
 };
 
-function initViewAs(store, scriptData) {
-  // Set our initial view type from current user's user_type or our query string.
+/* Set our initial view type (Student or Teacher) from current user's user_type
+ * or our query string. */
+progress.initViewAs = function(store, scriptData) {
+  // Default to Student, unless current user is a teacher
   let initialViewAs = ViewType.Student;
   if (scriptData.user_type === 'teacher') {
-    const query = queryString.parse(location.search);
-    initialViewAs = query.viewAs || ViewType.Teacher;
+    initialViewAs = ViewType.Teacher;
   }
+
+  // If current user is not a student (ie, a teacher or signed out), allow the
+  // 'viewAs' query parameter to override;
+  if (scriptData.user_type !== 'student') {
+    const query = queryString.parse(location.search);
+    initialViewAs = query.viewAs || initialViewAs;
+  }
+
   store.dispatch(setViewType(initialViewAs));
-}
+};
 
 /**
  * Query the server for user_progress data for this script, and update the store


### PR DESCRIPTION
Whereas previously it only worked if you were signed in with a teacher account.

Required for https://github.com/code-dot-org/code-dot-org/pull/39682

Note that we do still prevent the param from working when signed in as a student; I don't know whether or not we actually care about that, but for the sake of reducing the scope of changes I decided to stick close to the original logic.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
