### PR TITLE
Stream rake output from pegasus:setup_db command during builds

### DIFF
--- a/lib/rake/build.rake
+++ b/lib/rake/build.rake
@@ -121,7 +121,7 @@ namespace :build do
       if CDO.daemon
         ChatClient.log 'Updating <b>pegasus</b> database...'
         begin
-          RakeUtils.rake 'pegasus:setup_db', (rack_env?(:test) ? '--trace' : nil)
+          RakeUtils.rake_stream_output 'pegasus:setup_db', (rack_env?(:test) ? '--trace' : nil)
         rescue => e
           ChatClient.log "/quote #{e.message}\n#{CDO.backtrace e}", message_format: 'text'
           raise e


### PR DESCRIPTION
Very similar to the change in #39583.

When `rake pegasus:setup_db` fails, we have to re-run the command on the staging/test machine to see why it failed. Now, the output of this command will stream to the build logs so any error output will be available and we won't need to re-run the command.