### PR TITLE
Revert "Temporarily disable the import_google_sheets job"

### DIFF
--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -49,7 +49,7 @@
   if node['cdo-apps']['daemon']
     if node.chef_environment == 'staging' && node.name == 'staging' # 'real' staging only
       cronjob at:'@reboot', do:home_dir('.dropbox-dist', 'dropboxd')
-      # cronjob at:'*/5 * * * *', do:deploy_dir('bin', 'cron', 'import_google_sheets')
+      cronjob at:'*/5 * * * *', do:deploy_dir('bin', 'cron', 'import_google_sheets')
       cronjob at:'* * * * *', do:deploy_dir('bin', 'cron', 'sync_dropbox')
       cronjob at:'*/2 * * * *', do:deploy_dir('bin', 'cron', 'run_server_generate_pdfs')
       cronjob at:'*/2 * * * *', do:pegasus_dir('sites','virtual','run_server_generate_curriculum_pdfs')


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#39872

Thread here for reference: https://codedotorg.slack.com/archives/C0T0PNTM3/p1617309794310400. It was discovered that the v3 folder was not in the pegasus directory what was there was a v3 shortcut which pointed to the folder (this must have happened when the permissions of the files were changed from Anthony's account to site.googlecloud).

On staging, the issue with the gsheet sync could be reproduced by querying for a sheet, for example `cdo_donors` with @session.file_by_title(['Pegasus', 'v3', 'cdo-donors']), which returned nil. We decided to move the real v3 folder from the top-level "My Drive" folder to the Pegasus folder. After making this change, querying @session.file_by_title(['Pegasus', 'v3', 'cdo-donors']) returned the expected file on staging. 

To further verify the change, in staging/pegasus I ran `rake PEGASUS_RAKE_LOGGER=true seed:sync i18n:sync 2>&1` and saw the results here https://codedotorg.slack.com/archives/C03CK8E51/p1617743090260000. 