### PR TITLE
prevent adding the same standard twice

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/StandardsEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/StandardsEditor.jsx
@@ -179,7 +179,12 @@ class StandardsEditor extends Component {
 
   render() {
     const columns = this.getColumns();
-    const searchBoxKey = this.state.frameworkShortcode;
+    const standardShortcodes = this.props.standards
+      .map(standard => standard.shortcode)
+      .join(',');
+    const searchBoxKey = `${
+      this.state.frameworkShortcode
+    },${standardShortcodes}`;
     return (
       <div>
         <label>

--- a/apps/src/lib/levelbuilder/lesson-editor/StandardsEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/StandardsEditor.jsx
@@ -179,6 +179,7 @@ class StandardsEditor extends Component {
 
   render() {
     const columns = this.getColumns();
+    const searchBoxKey = this.state.frameworkShortcode;
     return (
       <div>
         <label>
@@ -204,7 +205,7 @@ class StandardsEditor extends Component {
           // Specify a key in order to force this component to remount when
           // framework changes. Otherwise, it may return stale results when
           // a query is repeated after changing the framework.
-          key={this.state.frameworkShortcode}
+          key={searchBoxKey}
           onSearchSelect={this.onSearchSelect}
           searchUrl={'standards/search'}
           constructOptions={this.constructSearchOptions}


### PR DESCRIPTION
Finishes [PLAT-886]. The SearchBox uses react-select, which caches the results of its queries for data that it uses to populate the dropdown. Today we use the react key on the SearchBox to make it re-render when the framework changes, wiping its cache. this PR augments that approach by adding the list of standard shortcodes to the key, so that it is forced to re-render whenever a new standard is added.

### before

https://user-images.githubusercontent.com/8001765/113906271-ec419700-9788-11eb-8b28-efd0cefb4538.mov

### after

https://user-images.githubusercontent.com/8001765/113906290-efd51e00-9788-11eb-9b70-3ffe6b69adbf.mov

## Testing Story

manually verified as shown in screenshots. 

## Follow-up work

you can see from the videos that the standards are not sorted by shortcode. this is tracked in [PLAT-897].

[PLAT-886]: https://codedotorg.atlassian.net/browse/PLAT-886
[PLAT-897]: https://codedotorg.atlassian.net/browse/PLAT-897