### PR TITLE
Set user_return_to in GET /maker/google_oauth_confirm_login

### DIFF
--- a/dashboard/app/controllers/maker_controller.rb
+++ b/dashboard/app/controllers/maker_controller.rb
@@ -133,6 +133,8 @@ class MakerController < ApplicationController
   # This route is need to convert the GET request from the Maker App into
   # a POST that can be used to login via Google OAuth
   def confirm_login
+    return_to = params[:user_return_to]
+    session[:user_return_to] = return_to if return_to.present?
   end
 
   # POST /maker/complete

--- a/dashboard/app/views/maker/confirm_login.html.haml
+++ b/dashboard/app/views/maker/confirm_login.html.haml
@@ -2,4 +2,4 @@
 
 %p= I18n.t('maker.google_oauth.confirm_login')
 
-= button_to  I18n.t(:confirm), user_google_oauth2_omniauth_authorize_path
+= button_to I18n.t(:confirm), user_google_oauth2_omniauth_authorize_path

--- a/dashboard/test/integration/omniauth/google_oauth2_test.rb
+++ b/dashboard/test/integration/omniauth/google_oauth2_test.rb
@@ -336,11 +336,5 @@ module OmniauthCallbacksControllerTests
         refresh_token: 'fake-refresh-token'
       )
     end
-
-    # The user signs in through Google, which hits the oauth callback
-    # and redirects to something else: homepage, finish_sign_up, etc.
-    def sign_in_through_google
-      sign_in_through AuthenticationOption::GOOGLE
-    end
   end
 end

--- a/dashboard/test/integration/omniauth/maker_oauth_test.rb
+++ b/dashboard/test/integration/omniauth/maker_oauth_test.rb
@@ -1,0 +1,34 @@
+require 'test_helper'
+require_relative './utils'
+
+class MakerOAuthTest < ActionDispatch::IntegrationTest
+  include OmniauthCallbacksControllerTests::Utils
+
+  test "confirm_login redirects to expected route after Google SSO" do
+    auth_hash = mock_google_oauth
+    create(:user, :google_sso_provider, uid: auth_hash.uid)
+    redirect_route = '/my/new/route'
+
+    get '/maker/google_oauth_confirm_login', params: {user_return_to: redirect_route}
+    assert_select 'form.button_to', 1
+    assert_select 'form.button_to' do
+      assert_select '[method=?]', 'post'
+      assert_select '[action=?]', '/users/auth/google_oauth2'
+    end
+
+    # "Click" the button by executing its action (POSTing to the Google OAuth sign-in route).
+    sign_in_through_google
+
+    assert_equal 'Signed in!', flash.notice
+    assert_redirected_to redirect_route
+  end
+
+  private
+
+  def mock_google_oauth
+    mock_oauth_for AuthenticationOption::GOOGLE, generate_auth_hash(
+      provider: AuthenticationOption::GOOGLE,
+      refresh_token: 'fake-refresh-token'
+    )
+  end
+end

--- a/dashboard/test/integration/omniauth/utils.rb
+++ b/dashboard/test/integration/omniauth/utils.rb
@@ -43,6 +43,12 @@ module OmniauthCallbacksControllerTests
       follow_redirect!
     end
 
+    # The user signs in through Google, which hits the oauth callback
+    # and redirects to something else: homepage, finish_sign_up, etc.
+    def sign_in_through_google
+      sign_in_through AuthenticationOption::GOOGLE
+    end
+
     def finish_sign_up(auth_hash, user_type)
       post '/users', params: finish_sign_up_params(
         name: auth_hash[:info]&.name,


### PR DESCRIPTION
This bug came up while investigating a different ticket -- [STAR-1496](https://codedotorg.atlassian.net/browse/STAR-1496) (using Google OAuth from the Maker App fails for users with unmigrated accounts).

Local repro steps (these don't repro on production because the bug hadn't been released yet):
1. Click “log in with google” in the Maker App
2. Click “confirm” from the browser tab that opens after step 1
3. Go through the Google OAuth process

**Expected:** the browser redirects to /maker/display_google_oauth_code with the “magic code” to copy-paste back into the Maker App
**Actual:** the browser redirects to /home

This was happening because in [browser/#76](https://github.com/code-dot-org/browser/pull/76), we changed the "Login with Google" route in the Maker App:
- old route: `GET /users/sign_in?user_return_to=/maker/display_google_oauth_code` 
- new route: `GET /maker/google_oauth_confirm_login?user_return_to=/maker/display_google_oauth_code`

This change was intentional, but broke the `user_return_to` feature because [the old route set `session[:user_return_to]`](https://github.com/code-dot-org/code-dot-org/blob/c8bbe0d570d95c5f5d6c84f52d8a344ea65ce1a6/dashboard/app/controllers/sessions_controller.rb#L9), but the new route didn't. Now, `session[:user_return_to]` will be set in the new route.

## Testing story

Added an integration test for this scenario.