### PR TITLE
Update search routes for programming expressions, vocab and resources

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/FindProgrammingExpressionDialog.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/FindProgrammingExpressionDialog.jsx
@@ -167,7 +167,7 @@ class FindProgrammingExpressionDialog extends Component {
       params.programmingEnvironmentName = this.state.filteredProgrammingEnvironment;
     }
 
-    fetch('/programmingexpressionsearch?' + new URLSearchParams(params))
+    fetch('/programming_expression/search?' + new URLSearchParams(params))
       .then(response => response.json())
       .then(data => {
         this.setState({

--- a/apps/src/lib/levelbuilder/lesson-editor/FindProgrammingExpressionDialog.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/FindProgrammingExpressionDialog.jsx
@@ -167,7 +167,7 @@ class FindProgrammingExpressionDialog extends Component {
       params.programmingEnvironmentName = this.state.filteredProgrammingEnvironment;
     }
 
-    fetch('/programming_expression/search?' + new URLSearchParams(params))
+    fetch('/programming_expressions/search?' + new URLSearchParams(params))
       .then(response => response.json())
       .then(data => {
         this.setState({

--- a/apps/src/lib/levelbuilder/lesson-editor/ResourcesEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ResourcesEditor.jsx
@@ -288,7 +288,7 @@ class ResourcesEditor extends Component {
             </label>
             <SearchBox
               onSearchSelect={this.onSearchSelect}
-              searchUrl={'resourcesearch'}
+              searchUrl={'resources/search'}
               constructOptions={this.constructSearchOptions}
               additionalQueryParams={{
                 courseVersionId: this.props.courseVersionId

--- a/apps/src/lib/levelbuilder/lesson-editor/VocabulariesEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/VocabulariesEditor.jsx
@@ -236,7 +236,7 @@ class VocabulariesEditor extends Component {
             additionalQueryParams={{
               courseVersionId: this.props.courseVersionId
             }}
-            searchUrl={'vocabulary/search'}
+            searchUrl={'vocabularies/search'}
             constructOptions={this.constructSearchOptions}
           />
         </div>

--- a/apps/src/lib/levelbuilder/lesson-editor/VocabulariesEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/VocabulariesEditor.jsx
@@ -236,7 +236,7 @@ class VocabulariesEditor extends Component {
             additionalQueryParams={{
               courseVersionId: this.props.courseVersionId
             }}
-            searchUrl={'vocabularysearch'}
+            searchUrl={'vocabulary/search'}
             constructOptions={this.constructSearchOptions}
           />
         </div>

--- a/dashboard/app/controllers/programming_expressions_controller.rb
+++ b/dashboard/app/controllers/programming_expressions_controller.rb
@@ -1,5 +1,5 @@
 class ProgrammingExpressionsController < ApplicationController
-  # GET /programming_expression/search
+  # GET /programming_expressions/search
   def search
     programming_environment =
       if params.key? :programmingEnvironmentId

--- a/dashboard/app/controllers/programming_expressions_controller.rb
+++ b/dashboard/app/controllers/programming_expressions_controller.rb
@@ -1,5 +1,5 @@
 class ProgrammingExpressionsController < ApplicationController
-  # GET /programmingexpressionsearch
+  # GET /programming_expression/search
   def search
     programming_environment =
       if params.key? :programmingEnvironmentId

--- a/dashboard/app/controllers/resources_controller.rb
+++ b/dashboard/app/controllers/resources_controller.rb
@@ -1,7 +1,7 @@
 class ResourcesController < ApplicationController
   before_action :require_levelbuilder_mode_or_test_env, except: [:index, :show]
 
-  # GET /resourcesearch
+  # GET /resources/search
   def search
     render json: ResourcesAutocomplete.get_search_matches(params[:query], params[:limit], params[:courseVersionId])
   end

--- a/dashboard/app/controllers/vocabularies_controller.rb
+++ b/dashboard/app/controllers/vocabularies_controller.rb
@@ -1,7 +1,7 @@
 class VocabulariesController < ApplicationController
   before_action :require_levelbuilder_mode_or_test_env, except: [:show]
 
-  # GET /vocabulary/search
+  # GET /vocabularies/search
   def search
     render json: VocabularyAutocomplete.get_search_matches(params[:query], params[:limit], params[:courseVersionId])
   end

--- a/dashboard/app/controllers/vocabularies_controller.rb
+++ b/dashboard/app/controllers/vocabularies_controller.rb
@@ -1,7 +1,7 @@
 class VocabulariesController < ApplicationController
   before_action :require_levelbuilder_mode_or_test_env, except: [:show]
 
-  # GET /vocabularysearch
+  # GET /vocabulary/search
   def search
     render json: VocabularyAutocomplete.get_search_matches(params[:query], params[:limit], params[:courseVersionId])
   end

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -298,9 +298,23 @@ Dashboard::Application.routes.draw do
   resources :resources, only: [:create, :update]
   resources :vocabularies, only: [:create, :update]
 
-  get '/resourcesearch', to: 'resources#search', defaults: {format: 'json'}
-  get '/vocabularysearch', to: 'vocabularies#search', defaults: {format: 'json'}
-  get '/programmingexpressionsearch', to: 'programming_expressions#search', defaults: {format: 'json'}
+  resources :resources, only: [] do
+    collection do
+      get :search
+    end
+  end
+
+  resources :vocabularies, only: [] do
+    collection do
+      get :search
+    end
+  end
+
+  resources :programming_expressions, only: [] do
+    collection do
+      get :search
+    end
+  end
 
   resources :standards, only: [] do
     collection do

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -295,16 +295,14 @@ Dashboard::Application.routes.draw do
   get '/s/csp10-2020/lockable/1(*all)', to: redirect(path: '/s/csp10-2020/stage/14%{all}')
 
   resources :lessons, only: [:edit, :update]
-  resources :resources, only: [:create, :update]
-  resources :vocabularies, only: [:create, :update]
 
-  resources :resources, only: [] do
+  resources :resources, only: [:create, :update] do
     collection do
       get :search
     end
   end
 
-  resources :vocabularies, only: [] do
+  resources :vocabularies, only: [:create, :update] do
     collection do
       get :search
     end


### PR DESCRIPTION
I really liked the way Dave set up the route for searching for standards so I thought it would be good to move everything over to the same set up. It had the added benefit of it makes the routes file cleaner :) 

## Testing story

There are existing tests for these routes. I also went to the lesson edit page and tried each one manually.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
