### PR TITLE
Sort standards on lesson edit page

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/standardsEditorRedux.js
+++ b/apps/src/lib/levelbuilder/lesson-editor/standardsEditorRedux.js
@@ -38,7 +38,7 @@ export default function createStandardsReducer(standardType) {
       case ADD_STANDARD: {
         newState = _.sortBy(
           newState.concat([action.newStandard]),
-          'frameworkShortcode',
+          'frameworkName',
           'shortcode'
         );
         break;

--- a/apps/src/lib/levelbuilder/lesson-editor/standardsEditorRedux.js
+++ b/apps/src/lib/levelbuilder/lesson-editor/standardsEditorRedux.js
@@ -36,7 +36,11 @@ export default function createStandardsReducer(standardType) {
       case INIT:
         return action.standards;
       case ADD_STANDARD: {
-        newState = newState.concat([action.newStandard]);
+        newState = _.sortBy(
+          newState.concat([action.newStandard]),
+          'frameworkShortcode',
+          'shortcode'
+        );
         break;
       }
       case REMOVE_STANDARD: {

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/standardsEditorReduxTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/standardsEditorReduxTest.js
@@ -56,7 +56,7 @@ describe('standardsEditorRedux reducer', () => {
   });
 
   it('sorts standards by framework', () => {
-    newStandard.frameworkShortcode = 'framework-0';
+    newStandard.frameworkName = 'Framework A';
     const nextState = standardsEditor(
       initialState,
       addStandard('standard', newStandard)

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/standardsEditorReduxTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/standardsEditorReduxTest.js
@@ -19,7 +19,7 @@ const fakeStandards = [
     frameworkName: 'Framework One',
     categoryShortcode: 'DA',
     categoryDescription: 'Data & Analysis',
-    shortcode: 'shortcode-2',
+    shortcode: 'shortcode-3',
     description: 'Translate between different bit representations of numbers.'
   }
 ];
@@ -36,7 +36,7 @@ describe('standardsEditorRedux reducer', () => {
       frameworkName: 'Framework One',
       categoryShortcode: 'CS',
       categoryDescription: 'Computing Systems',
-      shortcode: 'new-1',
+      shortcode: 'shortcode-4',
       description: 'fake description'
     };
 
@@ -50,8 +50,8 @@ describe('standardsEditorRedux reducer', () => {
     );
     assert.deepEqual(nextState.map(s => s.shortcode), [
       'shortcode-1',
-      'shortcode-2',
-      'new-1'
+      'shortcode-3',
+      'shortcode-4'
     ]);
   });
 
@@ -63,7 +63,7 @@ describe('standardsEditorRedux reducer', () => {
         shortcode: 'shortcode-1'
       })
     );
-    assert.deepEqual(nextState.map(s => s.shortcode), ['shortcode-2']);
+    assert.deepEqual(nextState.map(s => s.shortcode), ['shortcode-3']);
   });
 
   it('adds opportunity standard without adding regular standard', () => {
@@ -73,8 +73,8 @@ describe('standardsEditorRedux reducer', () => {
     );
     assert.deepEqual(nextState.map(s => s.shortcode), [
       'shortcode-1',
-      'shortcode-2',
-      'new-1'
+      'shortcode-3',
+      'shortcode-4'
     ]);
 
     nextState = standardsEditor(
@@ -83,7 +83,7 @@ describe('standardsEditorRedux reducer', () => {
     );
     assert.deepEqual(nextState.map(s => s.shortcode), [
       'shortcode-1',
-      'shortcode-2'
+      'shortcode-3'
     ]);
   });
 });

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/standardsEditorReduxTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/standardsEditorReduxTest.js
@@ -55,6 +55,32 @@ describe('standardsEditorRedux reducer', () => {
     ]);
   });
 
+  it('sorts standards by framework', () => {
+    newStandard.frameworkShortcode = 'framework-0';
+    const nextState = standardsEditor(
+      initialState,
+      addStandard('standard', newStandard)
+    );
+    assert.deepEqual(nextState.map(s => s.shortcode), [
+      'shortcode-4',
+      'shortcode-1',
+      'shortcode-3'
+    ]);
+  });
+
+  it('sorts standards within framework by shortcode', () => {
+    newStandard.shortcode = 'shortcode-2';
+    const nextState = standardsEditor(
+      initialState,
+      addStandard('standard', newStandard)
+    );
+    assert.deepEqual(nextState.map(s => s.shortcode), [
+      'shortcode-1',
+      'shortcode-2',
+      'shortcode-3'
+    ]);
+  });
+
   it('removes standard', () => {
     const nextState = standardsEditor(
       initialState,

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -348,6 +348,7 @@ class Lesson < ApplicationRecord
   # Key names are converted to camelCase here so they can easily be consumed by
   # the client.
   def summarize_for_lesson_edit
+    lesson_standards = standards.sort_by {|s| [s.framework.name, s.shortcode]}
     {
       id: id,
       name: name,
@@ -368,7 +369,7 @@ class Lesson < ApplicationRecord
       programmingEnvironments: ProgrammingEnvironment.all.map(&:summarize_for_lesson_edit),
       programmingExpressions: programming_expressions.map(&:summarize_for_lesson_edit),
       objectives: objectives.map(&:summarize_for_edit),
-      standards: standards.map(&:summarize_for_lesson_edit),
+      standards: lesson_standards.map(&:summarize_for_lesson_edit),
       opportunityStandards: opportunity_standards.map(&:summarize_for_lesson_edit),
       courseVersionId: lesson_group.script.get_course_version&.id,
       scriptIsVisible: !script.hidden,


### PR DESCRIPTION
Finishes [PLAT-897]. While it is possible to make reactabular sort the data for us, it seemed easier to do it in the redux action. If we ever want the user to be able to change how the data is sorted, we can switch to using reactabular to sort the data instead. 

sorts by framework name and then by standard shortcode. for consistency, also add sorting on the backend, since it turns out we were relying on the database ordering there.

### before

https://user-images.githubusercontent.com/8001765/113926531-20c14d00-97a1-11eb-8486-9936addb9b6f.mov

### after

https://user-images.githubusercontent.com/8001765/113927968-04beab00-97a3-11eb-8e61-1f3d16c3fb92.mov

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked


[PLAT-897]: https://codedotorg.atlassian.net/browse/PLAT-897