### PR TITLE
Script to reshape Foorm Submissions and Forms for analytics

### DIFF
--- a/bin/cron/process_foorm_data
+++ b/bin/cron/process_foorm_data
@@ -15,6 +15,14 @@ SUBMISSIONS_TO_TABLE_NAME = 'analysis.foorm_submissions_reshaped'
 FORMS_FROM_FILE_NAME = 'forms.csv'
 FORMS_TO_TABLE_NAME = 'analysis_pii.foorm_forms_reshaped'
 
+# Main method responsible for reshaping Foorm data
+# and importing to our analytics database (Redshift).
+# For each of our Foorm models (Forms and Submissions), we:
+# 1) delete any existing files (if any) from previous iterations of this job,
+# 2) reshape each record from our database into a CSV format,
+# 3) write that CSV to an S3 bucket,
+# 4) copy the contents of that CSV into a Redshift table,
+# 5) delete the CSV from S3.
 def main
   redshift_client = RedshiftClient.instance
 

--- a/bin/cron/process_foorm_data
+++ b/bin/cron/process_foorm_data
@@ -6,26 +6,35 @@ abort 'Script already running' unless only_one_running?(__FILE__)
 
 require_relative '../../dashboard/config/environment'
 
+S3_BUCKET_NAME = 'cdo-data-sharing-internal'
+aws_account_id = Aws::STS::Client.new.get_caller_identity.account
+REDSHIFT_S3_ACCESS_ROLE_ARN = "arn:aws:iam::#{aws_account_id}:role/redshift-s3"
+
+SUBMISSIONS_FROM_FILE_NAME = 'submissions.csv'
+SUBMISSIONS_TO_TABLE_NAME = 'analysis.foorm_submissions_reshaped'
+FORMS_FROM_FILE_NAME = 'forms.csv'
+FORMS_TO_TABLE_NAME = 'analysis_pii.foorm_forms_reshaped'
+
 def main
   redshift_client = RedshiftClient.instance
 
   # Processes and uploads Foorm submissions to Redshift for analytics use via S3.
-  AWS::S3.delete_from_bucket('cdo-data-sharing-internal', 'submissions.csv')
+  AWS::S3.delete_from_bucket(S3_BUCKET_NAME, SUBMISSIONS_FROM_FILE_NAME)
   reshaped_submissions = Pd::Foorm::SubmissionAnalyticsParser.reshape_all_submissions_into_csv
-  AWS::S3.upload_to_bucket('cdo-data-sharing-internal', 'submissions.csv', reshaped_submissions, no_random: true)
-  write_submissions_to_redshift(redshift_client)
+  AWS::S3.upload_to_bucket(S3_BUCKET_NAME, SUBMISSIONS_FROM_FILE_NAME, reshaped_submissions, no_random: true)
+  write_submissions_to_redshift(redshift_client, REDSHIFT_S3_ACCESS_ROLE_ARN)
 
   # Processes and uploads Foorm forms to Redshift for analytics use via S3.
-  AWS::S3.delete_from_bucket('cdo-data-sharing-internal', 'forms.csv')
+  AWS::S3.delete_from_bucket(S3_BUCKET_NAME, FORMS_FROM_FILE_NAME)
   reshaped_forms = Pd::Foorm::FormAnalyticsParser.reshape_all_forms_into_csv
-  AWS::S3.upload_to_bucket('cdo-data-sharing-internal', 'forms.csv', reshaped_forms, no_random: true)
-  write_forms_to_redshift(redshift_client)
+  AWS::S3.upload_to_bucket(S3_BUCKET_NAME, FORMS_FROM_FILE_NAME, reshaped_forms, no_random: true)
+  write_forms_to_redshift(redshift_client, REDSHIFT_S3_ACCESS_ROLE_ARN)
 end
 
-def write_forms_to_redshift(redshift_client)
+def write_forms_to_redshift(client, arn)
   query = <<~SQL
-    DROP TABLE IF EXISTS analysis.foorm_forms_reshaped;
-    CREATE TABLE analysis.foorm_forms_reshaped
+    DROP TABLE IF EXISTS #{FORMS_TO_TABLE_NAME};
+    CREATE TABLE #{FORMS_TO_TABLE_NAME}
     (
       form_id                 int,
       form_name               varchar,
@@ -40,20 +49,20 @@ def write_forms_to_redshift(redshift_client)
       num_response_options    int
     );
 
-    COPY analysis.foorm_forms_reshaped
-    FROM 's3://cdo-data-sharing-internal/forms.csv'
-    IAM_ROLE 'arn:aws:iam::awsaccountIDHere:role/redshift-s3'
+    COPY #{FORMS_TO_TABLE_NAME}
+    FROM 's3://#{S3_BUCKET_NAME}/#{FORMS_FROM_FILE_NAME}'
+    IAM_ROLE '#{arn}'
     CSV
     IGNOREHEADER 1;
   SQL
 
-  redshift_client.exec(query)
+  client.exec(query)
 end
 
-def write_submissions_to_redshift(redshift_client)
+def write_submissions_to_redshift(client, arn)
   query = <<~SQL
-    DROP TABLE IF EXISTS analysis.foorm_submissions_reshaped;
-    CREATE TABLE IF NOT EXISTS analysis.foorm_submissions_reshaped
+    DROP TABLE IF EXISTS #{SUBMISSIONS_TO_TABLE_NAME};
+    CREATE TABLE IF NOT EXISTS #{SUBMISSIONS_TO_TABLE_NAME}
     (
       submission_id    int,
       question_name    varchar,
@@ -62,20 +71,20 @@ def write_submissions_to_redshift(redshift_client)
       response_text    varchar(max)
     );
 
-    COPY analysis.foorm_submissions_reshaped
-    FROM 's3://cdo-data-sharing-internal/submissions.csv'
-    IAM_ROLE 'arn:aws:iam::awsaccountIDHere:role/redshift-s3'
+    COPY #{SUBMISSIONS_TO_TABLE_NAME}
+    FROM 's3://#{S3_BUCKET_NAME}/#{SUBMISSIONS_FROM_FILE_NAME}'
+    IAM_ROLE  '#{arn}'
     CSV
     IGNOREHEADER 1;
   SQL
 
-  redshift_client.exec(query)
+  client.exec(query)
 end
 
 begin
   main
 ensure
   # If processing fails at any point, delete CSVs from S3.
-  AWS::S3.delete_from_bucket('cdo-data-sharing-internal', 'submissions.csv')
-  AWS::S3.delete_from_bucket('cdo-data-sharing-internal', 'forms.csv')
+  AWS::S3.delete_from_bucket(S3_BUCKET_NAME, SUBMISSIONS_FROM_FILE_NAME)
+  AWS::S3.delete_from_bucket(S3_BUCKET_NAME, FORMS_FROM_FILE_NAME)
 end

--- a/bin/cron/process_foorm_data
+++ b/bin/cron/process_foorm_data
@@ -1,0 +1,81 @@
+#!/usr/bin/env ruby
+
+require_relative '../../lib/cdo/redshift'
+require_relative 'only_one'
+abort 'Script already running' unless only_one_running?(__FILE__)
+
+require_relative '../../dashboard/config/environment'
+
+def main
+  redshift_client = RedshiftClient.instance
+
+  # Processes and uploads Foorm submissions to Redshift for analytics use via S3.
+  AWS::S3.delete_from_bucket('cdo-data-sharing-internal', 'submissions.csv')
+  reshaped_submissions = Pd::Foorm::SubmissionAnalyticsParser.reshape_all_submissions_into_csv
+  AWS::S3.upload_to_bucket('cdo-data-sharing-internal', 'submissions.csv', reshaped_submissions, no_random: true)
+  write_submissions_to_redshift(redshift_client)
+
+  # Processes and uploads Foorm forms to Redshift for analytics use via S3.
+  AWS::S3.delete_from_bucket('cdo-data-sharing-internal', 'forms.csv')
+  reshaped_forms = Pd::Foorm::FormAnalyticsParser.reshape_all_forms_into_csv
+  AWS::S3.upload_to_bucket('cdo-data-sharing-internal', 'forms.csv', reshaped_forms, no_random: true)
+  write_forms_to_redshift(redshift_client)
+end
+
+def write_forms_to_redshift(redshift_client)
+  query = <<~SQL
+    DROP TABLE IF EXISTS analysis.foorm_forms_reshaped;
+    CREATE TABLE analysis.foorm_forms_reshaped
+    (
+      form_id                 int,
+      form_name               varchar,
+      form_version            int,
+      question_type           varchar,
+      question_name           varchar,
+      question_text           varchar(max),
+      matrix_item_name        varchar,
+      matrix_item_text        varchar(max),
+      is_facilitator_specific int,
+      response_options        varchar(max),
+      num_response_options    int
+    );
+
+    COPY analysis.foorm_forms_reshaped
+    FROM 's3://cdo-data-sharing-internal/forms.csv'
+    IAM_ROLE 'arn:aws:iam::awsaccountIDHere:role/redshift-s3'
+    CSV
+    IGNOREHEADER 1;
+  SQL
+
+  redshift_client.exec(query)
+end
+
+def write_submissions_to_redshift(redshift_client)
+  query = <<~SQL
+    DROP TABLE IF EXISTS analysis.foorm_submissions_reshaped;
+    CREATE TABLE IF NOT EXISTS analysis.foorm_submissions_reshaped
+    (
+      submission_id    int,
+      question_name    varchar,
+      matrix_item_name varchar,
+      response_value   varchar,
+      response_text    varchar(max)
+    );
+
+    COPY analysis.foorm_submissions_reshaped
+    FROM 's3://cdo-data-sharing-internal/submissions.csv'
+    IAM_ROLE 'arn:aws:iam::awsaccountIDHere:role/redshift-s3'
+    CSV
+    IGNOREHEADER 1;
+  SQL
+
+  redshift_client.exec(query)
+end
+
+begin
+  main
+ensure
+  # If processing fails at any point, delete CSVs from S3.
+  AWS::S3.delete_from_bucket('cdo-data-sharing-internal', 'submissions.csv')
+  AWS::S3.delete_from_bucket('cdo-data-sharing-internal', 'forms.csv')
+end

--- a/bin/cron/process_foorm_data
+++ b/bin/cron/process_foorm_data
@@ -10,10 +10,10 @@ S3_BUCKET_NAME = 'cdo-data-sharing-internal'
 aws_account_id = Aws::STS::Client.new.get_caller_identity.account
 REDSHIFT_S3_ACCESS_ROLE_ARN = "arn:aws:iam::#{aws_account_id}:role/redshift-s3"
 
-SUBMISSIONS_FROM_FILE_NAME = 'submissions.csv'
-SUBMISSIONS_TO_TABLE_NAME = 'analysis.foorm_submissions_reshaped'
-FORMS_FROM_FILE_NAME = 'forms.csv'
-FORMS_TO_TABLE_NAME = 'analysis_pii.foorm_forms_reshaped'
+SUBMISSIONS_S3_CSV_NAME = 'submissions.csv'
+SUBMISSIONS_REDSHIFT_TABLE_NAME = 'analysis.foorm_submissions_reshaped'
+FORMS_S3_CSV_NAME = 'forms.csv'
+FORMS_REDSHIFT_TABLE_NAME = 'analysis_pii.foorm_forms_reshaped'
 
 # Main method responsible for reshaping Foorm data
 # and importing to our analytics database (Redshift).
@@ -27,22 +27,22 @@ def main
   redshift_client = RedshiftClient.instance
 
   # Processes and uploads Foorm submissions to Redshift for analytics use via S3.
-  AWS::S3.delete_from_bucket(S3_BUCKET_NAME, SUBMISSIONS_FROM_FILE_NAME)
+  AWS::S3.delete_from_bucket(S3_BUCKET_NAME, SUBMISSIONS_S3_CSV_NAME)
   reshaped_submissions = Pd::Foorm::SubmissionAnalyticsParser.reshape_all_submissions_into_csv
-  AWS::S3.upload_to_bucket(S3_BUCKET_NAME, SUBMISSIONS_FROM_FILE_NAME, reshaped_submissions, no_random: true)
+  AWS::S3.upload_to_bucket(S3_BUCKET_NAME, SUBMISSIONS_S3_CSV_NAME, reshaped_submissions, no_random: true)
   write_submissions_to_redshift(redshift_client, REDSHIFT_S3_ACCESS_ROLE_ARN)
 
   # Processes and uploads Foorm forms to Redshift for analytics use via S3.
-  AWS::S3.delete_from_bucket(S3_BUCKET_NAME, FORMS_FROM_FILE_NAME)
+  AWS::S3.delete_from_bucket(S3_BUCKET_NAME, FORMS_S3_CSV_NAME)
   reshaped_forms = Pd::Foorm::FormAnalyticsParser.reshape_all_forms_into_csv
-  AWS::S3.upload_to_bucket(S3_BUCKET_NAME, FORMS_FROM_FILE_NAME, reshaped_forms, no_random: true)
+  AWS::S3.upload_to_bucket(S3_BUCKET_NAME, FORMS_S3_CSV_NAME, reshaped_forms, no_random: true)
   write_forms_to_redshift(redshift_client, REDSHIFT_S3_ACCESS_ROLE_ARN)
 end
 
 def write_forms_to_redshift(client, arn)
   query = <<~SQL
-    DROP TABLE IF EXISTS #{FORMS_TO_TABLE_NAME};
-    CREATE TABLE #{FORMS_TO_TABLE_NAME}
+    DROP TABLE IF EXISTS #{FORMS_REDSHIFT_TABLE_NAME};
+    CREATE TABLE #{FORMS_REDSHIFT_TABLE_NAME}
     (
       form_id                 int,
       form_name               varchar,
@@ -57,8 +57,8 @@ def write_forms_to_redshift(client, arn)
       num_response_options    int
     );
 
-    COPY #{FORMS_TO_TABLE_NAME}
-    FROM 's3://#{S3_BUCKET_NAME}/#{FORMS_FROM_FILE_NAME}'
+    COPY #{FORMS_REDSHIFT_TABLE_NAME}
+    FROM 's3://#{S3_BUCKET_NAME}/#{FORMS_S3_CSV_NAME}'
     IAM_ROLE '#{arn}'
     CSV
     IGNOREHEADER 1;
@@ -69,8 +69,8 @@ end
 
 def write_submissions_to_redshift(client, arn)
   query = <<~SQL
-    DROP TABLE IF EXISTS #{SUBMISSIONS_TO_TABLE_NAME};
-    CREATE TABLE IF NOT EXISTS #{SUBMISSIONS_TO_TABLE_NAME}
+    DROP TABLE IF EXISTS #{SUBMISSIONS_REDSHIFT_TABLE_NAME};
+    CREATE TABLE IF NOT EXISTS #{SUBMISSIONS_REDSHIFT_TABLE_NAME}
     (
       submission_id    int,
       question_name    varchar,
@@ -79,8 +79,8 @@ def write_submissions_to_redshift(client, arn)
       response_text    varchar(max)
     );
 
-    COPY #{SUBMISSIONS_TO_TABLE_NAME}
-    FROM 's3://#{S3_BUCKET_NAME}/#{SUBMISSIONS_FROM_FILE_NAME}'
+    COPY #{SUBMISSIONS_REDSHIFT_TABLE_NAME}
+    FROM 's3://#{S3_BUCKET_NAME}/#{SUBMISSIONS_S3_CSV_NAME}'
     IAM_ROLE  '#{arn}'
     CSV
     IGNOREHEADER 1;
@@ -93,6 +93,6 @@ begin
   main
 ensure
   # If processing fails at any point, delete CSVs from S3.
-  AWS::S3.delete_from_bucket(S3_BUCKET_NAME, SUBMISSIONS_FROM_FILE_NAME)
-  AWS::S3.delete_from_bucket(S3_BUCKET_NAME, FORMS_FROM_FILE_NAME)
+  AWS::S3.delete_from_bucket(S3_BUCKET_NAME, SUBMISSIONS_S3_CSV_NAME)
+  AWS::S3.delete_from_bucket(S3_BUCKET_NAME, FORMS_S3_CSV_NAME)
 end

--- a/dashboard/lib/pd/foorm/form_analytics_parser.rb
+++ b/dashboard/lib/pd/foorm/form_analytics_parser.rb
@@ -21,10 +21,11 @@ module Pd::Foorm
       num_response_options
     )
 
-    # Iterates over all Foorm Forms, and exports them to a CSV.
-    # Each row represents a single question.
-    def self.reshape_all_forms_and_export_to_csv
-      CSV.open('./test_forms.csv', 'wb') do |csv|
+    # Iterates over all Foorm Forms, returning a comma-separated string
+    # with each line represents a single question.
+    # @return [String] a CSV formatted string with each line containing a Form question.
+    def self.reshape_all_forms_into_csv
+      CSV.generate do |csv|
         csv << HEADERS
 
         # Loads 1000 records at a time to manage loading records into memory.

--- a/dashboard/lib/pd/foorm/submission_analytics_parser.rb
+++ b/dashboard/lib/pd/foorm/submission_analytics_parser.rb
@@ -14,10 +14,11 @@ module Pd::Foorm
       response_text
     )
 
-    # Iterates over all Foorm Submissions, and exports them to a CSV.
-    # Each row represents an answer to a single question.
-    def self.reshape_all_submissions_and_export_to_csv
-      CSV.open('./test_submissions.csv', 'wb') do |csv|
+    # Iterates over all Foorm Submissions, returning a comma-separated string
+    # with each line represents a user's answer to a single question.
+    # @return [String] a CSV formatted string with each line containing an answer.
+    def self.reshape_all_submissions_into_csv
+      CSV.generate do |csv|
         csv << HEADERS
 
         # Loads 1000 records at a time to manage loading records into memory.


### PR DESCRIPTION
Script to process and upload reshaped Foorm Forms and Submissions to Redshift via S3. Does not turn on script yet (eventually will be executed as a cronjob).

## Testing story

Tested manually, albeit with a very limited set of fake Submissions in my local database.

## Follow-up work

1. Execute this script manually on production-daemon.
2. Create new S3 bucket (via CloudFormation, with appropriate security settings) to be staging area for this script. Modify this script to use that new bucket.
3.  Set up cron to run this regularly. May want to add appropriate monitoring as well.

## PR Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
