### PR TITLE
Allow non-migrated users to use Google OAuth from Maker App

### DIFF
--- a/dashboard/app/controllers/maker_controller.rb
+++ b/dashboard/app/controllers/maker_controller.rb
@@ -123,7 +123,7 @@ class MakerController < ApplicationController
   def display_code
     # Generate encrypted code to display to user
     user_auth = current_user&.find_credential(AuthenticationOption::GOOGLE)
-    if user_auth.nil_or_empty?
+    if user_auth.nil?
       @secret_code = nil
       return
     end

--- a/dashboard/app/controllers/maker_controller.rb
+++ b/dashboard/app/controllers/maker_controller.rb
@@ -122,10 +122,14 @@ class MakerController < ApplicationController
   # renders a page for users to copy and paste a login key
   def display_code
     # Generate encrypted code to display to user
-    user_auth = current_user.authentication_options.find_by_credential_type(AuthenticationOption::GOOGLE)
-    @secret_code = Encryption.encrypt_string_utf8(
-      Time.now.strftime('%Y%m%dT%H%M%S%z') + user_auth['authentication_id'] + user_auth['credential_type']
-    )
+    user_auth = current_user&.find_credential(AuthenticationOption::GOOGLE)
+    if user_auth.nil_or_empty?
+      @secret_code = nil
+      return
+    end
+
+    secret_str = Time.now.strftime('%Y%m%dT%H%M%S%z') + user_auth[:authentication_id] + user_auth[:credential_type]
+    @secret_code = Encryption.encrypt_string_utf8(secret_str)
   end
 
   # GET /maker/confirm_login

--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -37,17 +37,17 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     if time_difference >= 5
       flash.now[:alert] = I18n.t('maker.google_oauth.error_token_expired')
       return render 'maker/login_code'
-    elsif !secret.ends_with?('google_oauth2')
+    elsif !secret.ends_with?(AuthenticationOption::GOOGLE)
       flash.now[:alert] = I18n.t('maker.google_oauth.error_wrong_provider')
       return render 'maker/login_code'
     else
       secret.slice!(AuthenticationOption::GOOGLE)
     end
 
-    # Check user id all numbers
+    # Check authentication_id only contains numbers.
     if secret.scan(/\D/).empty?
       # Look up user and use devise to sign user in
-      user = AuthenticationOption.find_by(credential_type: AuthenticationOption::GOOGLE, authentication_id: secret)&.user
+      user = User.find_by_credential(type: AuthenticationOption::GOOGLE, id: secret)
       sign_in_and_redirect user
     else
       flash.now[:alert] = I18n.t('maker.google_oauth.error_invalid_user')

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -624,6 +624,19 @@ class User < ApplicationRecord
     )
   end
 
+  # Get information for an SSO provider.
+  # @param [String] type A credential type / provider type.
+  # @returns [AuthenticationOption|Hash|nil] Returns an AuthenticationOption for migrated
+  #   users, a Hash for non-migrated users, or nil if there is no matching credential.
+  def find_credential(type)
+    if migrated?
+      authentication_options.find_by(credential_type: type)
+    else
+      return nil unless provider == type
+      {authentication_id: uid, credential_type: provider}
+    end
+  end
+
   def self.find_channel_owner(encrypted_channel_id)
     owner_storage_id, _ = storage_decrypt_channel_id(encrypted_channel_id)
     user_id = PEGASUS_DB[:user_storage_ids].first(id: owner_storage_id)[:user_id]

--- a/dashboard/test/controllers/maker_controller_test.rb
+++ b/dashboard/test/controllers/maker_controller_test.rb
@@ -3,6 +3,8 @@ require 'test_helper'
 class MakerControllerTest < ActionController::TestCase
   include Devise::Test::ControllerHelpers
 
+  STUB_ENCRYPTION_KEY = SecureRandom.base64(Encryption::KEY_LENGTH / 8)
+
   setup do
     @student = create :student
     @teacher = create :teacher
@@ -311,6 +313,7 @@ class MakerControllerTest < ActionController::TestCase
   end
 
   test "display_code: displays secret code if matching credential is found" do
+    CDO.stubs(:properties_encryption_key).returns(STUB_ENCRYPTION_KEY)
     user = create :user, :google_sso_provider
     sign_in user
 

--- a/dashboard/test/controllers/maker_controller_test.rb
+++ b/dashboard/test/controllers/maker_controller_test.rb
@@ -297,6 +297,27 @@ class MakerControllerTest < ActionController::TestCase
     refute application.full_discount
   end
 
+  test "display_code: does not display secret code if no current_user" do
+    get :display_code
+    assert_select "#maker_code", count: 1, value: nil
+  end
+
+  test "display_code: does not display secret code if no matching credential is found" do
+    user = create :user, :clever_sso_provider
+    sign_in user
+
+    get :display_code
+    assert_select "#maker_code", count: 1, value: nil
+  end
+
+  test "display_code: displays secret code if matching credential is found" do
+    user = create :user, :google_sso_provider
+    sign_in user
+
+    get :display_code
+    assert_select "#maker_code", count: 1, value: /.+/
+  end
+
   test "complete: fails if not given a signature" do
     DCDO.stubs(:get).with('currently_distributing_discount_codes', false).returns(true)
     sign_in @teacher

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -4195,6 +4195,27 @@ class UserTest < ActiveSupport::TestCase
       )
   end
 
+  test 'find_credential returns matching AuthenticationOption if one exists for migrated user' do
+    user = create :user, :google_sso_provider
+    assert_equal user.authentication_options.first, user.find_credential(AuthenticationOption::GOOGLE)
+  end
+
+  test 'find_credential returns nil if no matching AuthenticationOption for migrated user' do
+    user = create :user, :clever_sso_provider
+    assert_nil user.find_credential(AuthenticationOption::GOOGLE)
+  end
+
+  test 'find_credential returns matching hash for non-migrated user if provider matches' do
+    user = create :user, :google_sso_provider, :demigrated
+    expected_cred = {credential_type: AuthenticationOption::GOOGLE, authentication_id: user.uid}
+    assert_equal expected_cred, user.find_credential(AuthenticationOption::GOOGLE)
+  end
+
+  test 'find_credential returns nil for non-migrated user if provider does not match' do
+    user = create :user, :demigrated
+    assert_nil user.find_credential(AuthenticationOption::GOOGLE)
+  end
+
   test 'not depended_upon_for_login? for student' do
     student = create :student
     refute student.depended_upon_for_login?


### PR DESCRIPTION
This change allows non-migrated user accounts to sign in using Google OAuth from the Maker App. This didn't work previously (user saw a "sad bee") because we were checking for a matching Google AuthenticationOption on the user, which will only exist if the user has been migrated to multi-auth. If the user isn't migrated, we will check the User directly for a matching Google provider and associated uid.

## Links

- [STAR-1496](https://codedotorg.atlassian.net/browse/STAR-1496)

## Testing story

Adds unit tests for new code and this scenario.