### PR TITLE
Translate display names and descriptions for lesson extras

### DIFF
--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -51,6 +51,7 @@ def get_i18n_strings(level)
   elsif level.is_a?(Level)
     %w(
       display_name
+      bubble_choice_description
       short_instructions
       long_instructions
       failure_message_overrides

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -495,11 +495,13 @@ class ScriptLevel < ApplicationRecord
 
   def summarize_as_bonus(user_id = nil)
     perfect = user_id ? UserLevel.find_by(level: level, user_id: user_id)&.perfect? : false
+    localized_level_description = I18n.t(level.name, scope: [:data, :bubble_choice_description], default: level.bubble_choice_description)
+    localized_level_display_name = I18n.t(level.name, scope: [:data, :display_name], default: level.display_name)
     {
       id: id.to_s,
       type: level.type,
-      description: level.try(:bubble_choice_description),
-      display_name: level.display_name || I18n.t('lesson_extras.bonus_level'),
+      description: localized_level_description,
+      display_name: localized_level_display_name || I18n.t('lesson_extras.bonus_level'),
       thumbnail_url: level.try(:thumbnail_url) || level.try(:solution_image_url),
       url: build_script_level_url(self),
       perfect: perfect,


### PR DESCRIPTION
[FND-1467](https://codedotorg.atlassian.net/browse/FND-1467)
This change does 2 things
1. Adds level's description to the i18n pipeline
2. Renders translated level's display names and descriptions correctly in the lesson extras view (or stage_extras view).

Before (https://studio.code.org/s/coursef-2020/stage/3/extras/lang/es-mx)
  <img width="451" alt="Screen Shot 2021-04-07 at 6 40 57 PM" src="https://user-images.githubusercontent.com/46507039/113955572-da83e200-97d0-11eb-9393-e05fe7673747.png">

After (on localhost)
  <img width="447" alt="Screen Shot 2021-04-07 at 6 40 19 PM" src="https://user-images.githubusercontent.com/46507039/113955569-d9eb4b80-97d0-11eb-9cbd-489da3e6ec58.png">

## Testing story
- Ran `sync-in.rb` to produce `i18n/locales/source/course_content/2020/coursef-2020.json` below. Verified it could extract the level's `display_name` and `bubble_choice_description`.
  ```json
  {
    "https://studio.code.org/s/coursef-2020/stage/3/extras?level_name=spritelab_extras_repeat": {
      "display_name": "Lots of sprites!",
      "bubble_choice_description": "Create many matching sprites quickly using loops!",
    }
  }
  ```

- Created a fake `sync-down` result at `i18n/locales/es-MX/course_content/2020/coursef-2020.json` with translations
  ```json
  {
    "https://studio.code.org/s/coursef-2020/stage/3/extras?level_name=spritelab_extras_repeat": {
      "display_name": "es-MX translated display name",
      "bubble_choice_description": "es-MX translated bubble choice description",
    }
  }
  ```

 
- Ran `sync-out.rb` and verified that the display name and description are distributed correctly to `dashboard/config/locales/display_name.es-MX.json`
  ```json
  {
    "es-MX": {
      "data": {
        "display_name": {
          "spritelab_extras_repeat": "es-MX translated display name"
        }
      }
    }
  }
  ```
  and `dashboard/config/locales/bubble_choice_description.es-MX.json`.
  ```json
  {
    "es-MX": {
      "data": {
        "bubble_choice_description": {
          "spritelab_extras_repeat": "es-MX translated bubble choice description"
        }
      }
    }
  }
  ```

- Verified that lesson extra were displayed correctly in different languages 
    - en-US view should be in English: http://localhost-studio.code.org:3000/s/coursef-2020/stage/3/extras/lang/en-us
    - es-MX view should be in Spanish: http://localhost-studio.code.org:3000/s/coursef-2020/stage/3/extras/lang/es-mx
    - el-GR view should be in English because we didn't have translations for Greece: http://localhost-studio.code.org:3000/s/coursef-2020/stage/3/extras/lang/el-gr

- Verified that the rendering code is safe against user-generated content. 
  Rendering `display_name`:
  https://github.com/code-dot-org/code-dot-org/blob/97de9db301efdf8d4bdcf967bb560c7b7a4bf0f9/apps/src/code-studio/components/SublevelCard.jsx#L193-L199
  Rendering `description`:
  https://github.com/code-dot-org/code-dot-org/blob/97de9db301efdf8d4bdcf967bb560c7b7a4bf0f9/apps/src/code-studio/components/SublevelCard.jsx#L202-L207
  Both are safe because we just treat them as plain strings.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
