### PR TITLE
populate frameworks dropdown on lesson edit page using data from server

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
@@ -185,6 +185,7 @@ class LessonEditor extends Component {
       announcements
     } = this.state;
     const {relatedLessons, standards, opportunityStandards} = this.props;
+    const frameworks = this.props.initialLessonData.frameworks;
     return (
       <div style={styles.editor}>
         <h1>Editing Lesson "{displayName}"</h1>
@@ -446,11 +447,13 @@ class LessonEditor extends Component {
               <StandardsEditor
                 standardType={'standard'}
                 standards={standards}
+                frameworks={frameworks}
               />
               <h3>Opportunity Standards</h3>
               <StandardsEditor
                 standardType={'opportunityStandard'}
                 standards={opportunityStandards}
+                frameworks={frameworks}
               />
             </CollapsibleEditorSection>
           </div>

--- a/apps/src/lib/levelbuilder/lesson-editor/StandardsEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/StandardsEditor.jsx
@@ -9,7 +9,7 @@ import {
   addStandard,
   removeStandard
 } from '@cdo/apps/lib/levelbuilder/lesson-editor/standardsEditorRedux';
-import {standardShape} from '@cdo/apps/lib/levelbuilder/shapes';
+import {standardShape, frameworkShape} from '@cdo/apps/lib/levelbuilder/shapes';
 import SearchBox from '@cdo/apps/lib/levelbuilder/lesson-editor/SearchBox';
 
 const styles = {
@@ -36,6 +36,7 @@ class StandardsEditor extends Component {
   static propTypes = {
     standardType: PropTypes.string.isRequired,
     standards: PropTypes.arrayOf(standardShape).isRequired,
+    frameworks: PropTypes.arrayOf(frameworkShape).isRequired,
 
     // provided by redux
     addStandard: PropTypes.func.isRequired,
@@ -192,16 +193,11 @@ class StandardsEditor extends Component {
         </label>
         <select onChange={this.handleSelectFramework} style={styles.select}>
           <option value="">(none)</option>
-          <option value="iste">ISTE Standards for Students</option>
-          <option value="ccela">
-            Common Core English Language Arts Standards
-          </option>
-          <option value="ccmath">Common Core Math Standards</option>
-          <option value="ngss">Next Generation Science Standards</option>
-          <option value="csta">
-            CSTA K-12 Computer Science Standards (2017)
-          </option>
-          <option value="csp2021">CSP Conceptual Framework</option>
+          {this.props.frameworks.map(framework => (
+            <option key={framework.shortcode} value={framework.shortcode}>
+              {framework.name}
+            </option>
+          ))}
         </select>
         <label>
           <strong>Select a Standard to add</strong>

--- a/apps/src/lib/levelbuilder/shapes.jsx
+++ b/apps/src/lib/levelbuilder/shapes.jsx
@@ -110,6 +110,11 @@ export const programmingExpressionShape = PropTypes.shape({
   programmingEnvironmentName: PropTypes.string.isRequired
 });
 
+export const frameworkShape = PropTypes.shape({
+  name: PropTypes.string.isRequired,
+  shortcode: PropTypes.string.isRequired
+});
+
 export const standardShape = PropTypes.shape({
   frameworkShortcode: PropTypes.string.isRequired,
   frameworkName: PropTypes.string.isRequired,

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/LessonEditorTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/LessonEditorTest.js
@@ -70,7 +70,8 @@ describe('LessonEditor', () => {
         courseVersionId: 1,
         scriptPath: '/s/my-script/',
         lessonPath: '/lessons/1',
-        scriptIsVisible: false
+        scriptIsVisible: false,
+        frameworks: []
       }
     };
   });

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/StandardsEditorTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/StandardsEditorTest.js
@@ -31,6 +31,7 @@ describe('StandardsEditor', () => {
     defaultProps = {
       standardType: 'standard',
       standards: fakeStandards,
+      frameworks: [],
       addStandard,
       removeStandard
     };

--- a/dashboard/app/models/framework.rb
+++ b/dashboard/app/models/framework.rb
@@ -14,6 +14,13 @@
 #  index_frameworks_on_shortcode  (shortcode) UNIQUE
 #
 class Framework < ApplicationRecord
+  def summarize_for_lesson_edit
+    {
+      name: name,
+      shortcode: shortcode
+    }
+  end
+
   def self.seed_all
     filename = 'config/standards/frameworks.csv'
     CSV.foreach(filename, {headers: true}) do |row|

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -370,6 +370,7 @@ class Lesson < ApplicationRecord
       programmingExpressions: programming_expressions.map(&:summarize_for_lesson_edit),
       objectives: objectives.map(&:summarize_for_edit),
       standards: lesson_standards.map(&:summarize_for_lesson_edit),
+      frameworks: Framework.all.map(&:summarize_for_lesson_edit),
       opportunityStandards: opportunity_standards.map(&:summarize_for_lesson_edit),
       courseVersionId: lesson_group.script.get_course_version&.id,
       scriptIsVisible: !script.hidden,


### PR DESCRIPTION
Finishes [PLAT-885].

## Testing story

No end to end tests for adding standards via lesson edit page yet, so I just verified this manually. No change to existing behavior while adding a few different standards using a few different values from the framework dropdown.

[PLAT-885]: https://codedotorg.atlassian.net/browse/PLAT-885