### PR TITLE
Fix teacher application export via smaller batch size for Google Sheet uploads

### DIFF
--- a/lib/cdo/google/drive.rb
+++ b/lib/cdo/google/drive.rb
@@ -3,7 +3,7 @@ require 'cdo/chat_client'
 
 module Google
   class Drive
-    BATCH_UPDATE_SIZE = 2000
+    BATCH_UPDATE_SIZE = 1000
 
     class File
       def initialize(session, file)


### PR DESCRIPTION
Our export of teacher application data to Google Sheets is [failing due to a connection timeout](https://app.honeybadger.io/projects/45435/faults/63620661) (ie, the upload into the gsheet takes too long). We faced this issue last year, and [introduced batching to resolve it](https://github.com/code-dot-org/code-dot-org/pull/35219). This PR reduces the batch size even further.

## Testing story

Using [some instructions here](https://github.com/code-dot-org/code-dot-org/pull/32609), I created 4000 dummy applications locally. I was able to reproduce the error before changing the batch size. Then, I successfully uploaded those applications to a test gsheet in a little over 20 minutes.

## PR Checklist:

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
