### PR TITLE
Switched coordinates overlay display as (y,x) in RTL languages

### DIFF
--- a/apps/src/applab/AppLabTooltipOverlay.jsx
+++ b/apps/src/applab/AppLabTooltipOverlay.jsx
@@ -19,7 +19,8 @@ export class AppLabTooltipOverlay extends React.Component {
     mouseX: PropTypes.number,
     mouseY: PropTypes.number,
     // Provided by redux
-    isInDesignMode: PropTypes.bool.isRequired
+    isInDesignMode: PropTypes.bool.isRequired,
+    isRtl: PropTypes.bool
   };
 
   state = {
@@ -82,7 +83,7 @@ export class AppLabTooltipOverlay extends React.Component {
 
   render() {
     const dragPoint = draggedElementDropPoint();
-    let tooltipProviders = [coordinatesProvider()];
+    let tooltipProviders = [coordinatesProvider(false, this.props.isRtl)];
     if (this.state.hoveredControlId) {
       tooltipProviders.push(this.getElementIdText);
     }
@@ -100,6 +101,7 @@ export class AppLabTooltipOverlay extends React.Component {
   }
 }
 export default connect(state => ({
+  isRtl: state.isRtl,
   isInDesignMode: state.interfaceMode === ApplabInterfaceMode.DESIGN
 }))(AppLabTooltipOverlay);
 

--- a/apps/src/p5lab/P5LabVisualizationColumn.jsx
+++ b/apps/src/p5lab/P5LabVisualizationColumn.jsx
@@ -60,7 +60,8 @@ class P5LabVisualizationColumn extends React.Component {
     cancelPicker: PropTypes.func.isRequired,
     selectPicker: PropTypes.func.isRequired,
     updatePicker: PropTypes.func.isRequired,
-    consoleMessages: PropTypes.array.isRequired
+    consoleMessages: PropTypes.array.isRequired,
+    isRtl: PropTypes.bool
   };
 
   constructor(props) {
@@ -160,7 +161,7 @@ class P5LabVisualizationColumn extends React.Component {
   }
 
   render() {
-    const {isResponsive, isShareView} = this.props;
+    const {isResponsive, isShareView, isRtl} = this.props;
     const divGameLabStyle = {
       touchAction: 'none',
       width: APP_WIDTH,
@@ -191,7 +192,9 @@ class P5LabVisualizationColumn extends React.Component {
             >
               <GridOverlay show={this.props.showGrid} showWhileRunning={true} />
               <CrosshairOverlay flip={isSpritelab} />
-              <TooltipOverlay providers={[coordinatesProvider(isSpritelab)]} />
+              <TooltipOverlay
+                providers={[coordinatesProvider(isSpritelab, isRtl)]}
+              />
             </VisualizationOverlay>
           </ProtectedVisualizationDiv>
           <TextConsole consoleMessages={this.props.consoleMessages} />
@@ -242,7 +245,8 @@ export default connect(
     awaitingContainedResponse: state.runState.awaitingContainedResponse,
     showGrid: state.gridOverlay,
     pickingLocation: isPickingLocation(state.locationPicker),
-    consoleMessages: state.textConsole
+    consoleMessages: state.textConsole,
+    isRtl: state.isRtl
   }),
   dispatch => ({
     toggleShowGrid: mode => dispatch(toggleGridOverlay(mode)),

--- a/apps/src/studio/StudioVisualizationColumn.jsx
+++ b/apps/src/studio/StudioVisualizationColumn.jsx
@@ -19,7 +19,9 @@ var StudioVisualizationColumn = function(props) {
         <svg version="1.1" id="svgStudio" />
         <VisualizationOverlay width={400} height={400}>
           <CrosshairOverlay />
-          <TooltipOverlay providers={[coordinatesProvider()]} />
+          <TooltipOverlay
+            providers={[coordinatesProvider(false, !!props.isRtl)]}
+          />
         </VisualizationOverlay>
       </ProtectedVisualizationDiv>
       <GameButtons>
@@ -40,7 +42,8 @@ var StudioVisualizationColumn = function(props) {
 };
 
 StudioVisualizationColumn.propTypes = {
-  finishButton: PropTypes.bool.isRequired
+  finishButton: PropTypes.bool.isRequired,
+  isRtl: PropTypes.bool
 };
 
 module.exports = StudioVisualizationColumn;

--- a/apps/src/studio/studio.js
+++ b/apps/src/studio/studio.js
@@ -2384,9 +2384,12 @@ Studio.init = function(config) {
     appSpecificConstants.failureAvatar = config.skin.blankAvatar;
   }
   studioApp().setPageConstants(config, appSpecificConstants);
-
+  var isRtl = getStore().getState().isRtl;
   var visualizationColumn = (
-    <StudioVisualizationColumn finishButton={!level.isProjectLevel} />
+    <StudioVisualizationColumn
+      isRtl={isRtl}
+      finishButton={!level.isProjectLevel}
+    />
   );
 
   ReactDOM.render(

--- a/apps/src/templates/TooltipOverlay.jsx
+++ b/apps/src/templates/TooltipOverlay.jsx
@@ -164,7 +164,7 @@ export function coordinatesProvider(flip = false, isRtl = false) {
   return props => {
     const y = flip ? props.height - props.mouseY : props.mouseY;
     if (isRtl) {
-      return `y: ${Math.round(y)}, x: ${Math.round(props.mouseX)}`;
+      return `${Math.round(y)} :y, ${Math.round(props.mouseX)} :x`;
     } else {
       return `x: ${Math.round(props.mouseX)}, y: ${Math.round(y)}`;
     }

--- a/apps/src/templates/TooltipOverlay.jsx
+++ b/apps/src/templates/TooltipOverlay.jsx
@@ -164,7 +164,16 @@ export function coordinatesProvider(flip = false, isRtl = false) {
   return props => {
     const y = flip ? props.height - props.mouseY : props.mouseY;
     if (isRtl) {
-      return `${Math.round(y)} :y, ${Math.round(props.mouseX)} :x`;
+      return [
+        '\u202A',
+        Math.round(y),
+        ' :y',
+        ', ',
+        Math.round(props.mouseX),
+        ' :',
+        'x',
+        '\u202C'
+      ].join(''); // We have to use unicode to explicitly set the SVG text to LTR when the documen is using RTL
     } else {
       return `x: ${Math.round(props.mouseX)}, y: ${Math.round(y)}`;
     }

--- a/apps/src/templates/TooltipOverlay.jsx
+++ b/apps/src/templates/TooltipOverlay.jsx
@@ -164,16 +164,8 @@ export function coordinatesProvider(flip = false, isRtl = false) {
   return props => {
     const y = flip ? props.height - props.mouseY : props.mouseY;
     if (isRtl) {
-      return [
-        '\u202A',
-        Math.round(y),
-        ' :y',
-        ', ',
-        Math.round(props.mouseX),
-        ' :',
-        'x',
-        '\u202C'
-      ].join(''); // We have to use unicode to explicitly set the SVG text to LTR when the documen is using RTL
+      // We have to use unicode to explicitly set the SVG text to LTR when the document is using RTL
+      return `\u202A${Math.round(y)} :y, ${Math.round(props.mouseX)} :x\u202C`;
     } else {
       return `x: ${Math.round(props.mouseX)}, y: ${Math.round(y)}`;
     }

--- a/apps/src/templates/TooltipOverlay.jsx
+++ b/apps/src/templates/TooltipOverlay.jsx
@@ -160,9 +160,13 @@ export function textProvider(label) {
  * Simple provider that formats and renders the mouse coordinates.
  * @returns {function(): string}
  */
-export function coordinatesProvider(flip) {
+export function coordinatesProvider(flip = false, isRtl = false) {
   return props => {
     const y = flip ? props.height - props.mouseY : props.mouseY;
-    return `x: ${Math.round(props.mouseX)}, y: ${Math.round(y)}`;
+    if (isRtl) {
+      return `y: ${Math.round(y)}, x: ${Math.round(props.mouseX)}`;
+    } else {
+      return `x: ${Math.round(props.mouseX)}, y: ${Math.round(y)}`;
+    }
   };
 }

--- a/apps/src/templates/VisualizationOverlay.jsx
+++ b/apps/src/templates/VisualizationOverlay.jsx
@@ -118,6 +118,7 @@ export class VisualizationOverlay extends React.Component {
         baseProfile="full"
         width={this.props.width}
         height={this.props.height}
+        style={{left: 'auto'}}
         viewBox={'0 0 ' + this.props.width + ' ' + this.props.height}
         pointerEvents="none"
       >

--- a/apps/style/VisualizationOverlay.scss
+++ b/apps/style/VisualizationOverlay.scss
@@ -4,8 +4,7 @@
 #visualizationOverlay {
   position: absolute;
   top: 0;
-  left: 0;
-
+  left: auto;
   overflow: hidden;
   outline: none;
   -webkit-touch-callout: none;

--- a/apps/test/unit/templates/TooltipOverlayTest.js
+++ b/apps/test/unit/templates/TooltipOverlayTest.js
@@ -173,7 +173,7 @@ describe('TooltipOverlay', () => {
       };
       const isRtl = true;
       expect(coordinatesProvider(false, isRtl)(props)).to.equal(
-        `${props.mouseY} :y, ${props.mouseX} :x`
+        `\u202A${props.mouseY} :y, ${props.mouseX} :x\u202C`
       );
     });
   });

--- a/apps/test/unit/templates/TooltipOverlayTest.js
+++ b/apps/test/unit/templates/TooltipOverlayTest.js
@@ -166,6 +166,16 @@ describe('TooltipOverlay', () => {
       };
       expect(coordinatesProvider()(props)).to.equal('x: 1, y: 3');
     });
+    it('reverse the direction of the coordinates in a RTL language', function() {
+      const props = {
+        mouseX: 50,
+        mouseY: 100
+      };
+      const isRtl = true;
+      expect(coordinatesProvider(false, isRtl)(props)).to.equal(
+        `y: ${props.mouseY}, x: ${props.mouseX}`
+      );
+    });
   });
 
   function shallowRender(x, y, providers = [], above = false) {

--- a/apps/test/unit/templates/TooltipOverlayTest.js
+++ b/apps/test/unit/templates/TooltipOverlayTest.js
@@ -173,7 +173,7 @@ describe('TooltipOverlay', () => {
       };
       const isRtl = true;
       expect(coordinatesProvider(false, isRtl)(props)).to.equal(
-        `y: ${props.mouseY}, x: ${props.mouseX}`
+        `${props.mouseY} :y, ${props.mouseX} :x`
       );
     });
   });


### PR DESCRIPTION
1. Changed the `coordinatesProvider` code used in the _TooltipOverlay_ component to swap the direction of the coordinates displayed when isRTL is true.
2. Added `isRTL` property from redux store to all components that use `coordinatesProvider`
3. Fixed issue with tooltip overlay clipping outside of canvas on RTL languages.

**Before**
![before](https://user-images.githubusercontent.com/16450271/114091336-2e98d000-987e-11eb-9199-3d7898c70813.png)

**After (no background due to my limited s3 access)**
![after](https://user-images.githubusercontent.com/16450271/114091432-4c663500-987e-11eb-9e55-2817c265435b.png)

Part of [FND-1488
](https://codedotorg.atlassian.net/secure/RapidBoard.jspa?rapidView=28&projectKey=FND&modal=detail&selectedIssue=FND-1488)

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
