### PR TITLE
Javalab: add issuer to JWT token

### DIFF
--- a/dashboard/app/controllers/javabuilder_sessions_controller.rb
+++ b/dashboard/app/controllers/javabuilder_sessions_controller.rb
@@ -28,6 +28,7 @@ class JavabuilderSessionsController < ApplicationController
     session_id = SecureRandom.hex(18)
     payload = {
       iat: issued_at_time,
+      iss: CDO.dashboard_hostname,
       exp: expiration_time,
       sid: session_id,
       uid: current_user.id,


### PR DESCRIPTION
Add CDO.dashboard_hostname as the issuer to the JWT token we use to authenticate with Javabuilder. 


## Follow-up work
We will use the issuer when when authorizing with API Gateway to prefix the user with the appropriate environment. This will make debugging easier. We can also use the issuer for further validation in the future if we want to.

## PR Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
