### PR TITLE
bundle open_uri_redirections in every environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -122,7 +122,7 @@ end
 gem 'factory_girl_rails', group: [:development, :staging, :test, :adhoc]
 
 # For pegasus PDF generation.
-gem 'open_uri_redirections', require: false, group: [:development, :staging, :test]
+gem 'open_uri_redirections', require: false
 
 # Ref: https://github.com/tmm1/gctools/pull/17
 gem 'gctools', github: 'wjordan/gctools', ref: 'ruby-2.5'


### PR DESCRIPTION
Needed to unblock DTP. See [slack](https://codedotorg.slack.com/archives/CNZP84FJ5/p1617926969011600?thread_ts=1617923299.004600&cid=CNZP84FJ5) for context.

## Testing story

levelbuilder failed during the seed step. this change made it pass. this suggests the same fix will work for production.