### PR TITLE
Making curriculum links on hourofcode.com/learn pages language-aware

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/public/learn/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/learn/index.haml
@@ -112,7 +112,7 @@ social:
   - tutorial[:string_platforms]                     = hoc_s(prefix + "string_platforms")
   - tutorial[:string_detail_platforms]              = hoc_s(prefix + "string_detail_platforms")
   - tutorial[:string_detail_programming_languages]  = hoc_s(prefix + "string_detail_programming_languages")
-  - tutorial[:teachers_notes]                       = CDO.curriculum_url(request.locale, tutorial[:teachers_notes], false)
+  - tutorial[:teachers_notes]                       = CDO.curriculum_url(locale_code, tutorial[:teachers_notes], false)
 
 #tutorials
 

--- a/pegasus/sites.v3/hourofcode.com/public/learn/robotics.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/learn/robotics.haml
@@ -85,7 +85,7 @@ social:
   - tutorial[:string_platforms]                     = hoc_s(prefix + "string_platforms")
   - tutorial[:string_detail_platforms]              = hoc_s(prefix + "string_detail_platforms")
   - tutorial[:string_detail_programming_languages]  = hoc_s(prefix + "string_detail_programming_languages")
-  - tutorial[:teachers_notes]                       = CDO.curriculum_url(request.locale, tutorial[:teachers_notes], false)
+  - tutorial[:teachers_notes]                       = CDO.curriculum_url(locale_code, tutorial[:teachers_notes], false)
 
 #tutorials
 


### PR DESCRIPTION
[FND-1406](https://codedotorg.atlassian.net/browse/FND-1406) 
Making curriculum links on the `hourofcode.com/learn` and `hourofcode.com/learn/robotics` page language-aware.
Changing the language on those 2 pages will make their curriculum links point to the localized lesson plans. 

## locale_code vs. request.locale
When changing language on the `hourofcode.com/learn` pages, only `locale_code` is updated. `request.locale` is not changed. The reasons are:

`locale_code` is the result of converting `@language` to locale, e.g. _la_ to _es-mx_, or _po_ to _pt-br_.
  https://github.com/code-dot-org/code-dot-org/blob/f37e8fd1adc0f9d95585e187e2ff0e833daef4be/pegasus/sites.v3/hourofcode.com/public/learn/index.haml#L94
  
  https://github.com/code-dot-org/code-dot-org/blob/8a6f853f7d2abe3664520d6950c13c83740486b6/pegasus/helpers/hourofcode_helpers.rb#L116-L120

`@language` comes from the possible language embedded in an URL, e.g. https://hourofcode.com/us/es/learn. 
  https://github.com/code-dot-org/code-dot-org/blob/8a6f853f7d2abe3664520d6950c13c83740486b6/pegasus/helpers/hourofcode_helpers.rb#L49

Meanwhile, `request.locale` gets its value from `env['cdo.locale']`
  https://github.com/code-dot-org/code-dot-org/blob/aafe2062b90f48a12a17e236c63f2164235557c5/lib/cdo/rack/request.rb#L26-L28

, which comes from the `varnish_locale` or `cookie_locale`. 
  https://github.com/code-dot-org/code-dot-org/blob/65a46d3b8cb8eb616dc8fb5e5ab63eeebf80bcee/shared/middleware/varnish_environment.rb#L14-L16

  https://github.com/code-dot-org/code-dot-org/blob/65a46d3b8cb8eb616dc8fb5e5ab63eeebf80bcee/shared/middleware/varnish_environment.rb#L22-L28

When changing language on `hourofcode.com/learn`, the code below simply tells the browser to redirect the page to a new URL using `window.location.href`. For example, redirecting from https://hourofcode.com/us/en/learn to https://hourofcode.com/us/la/learn. 

  https://github.com/code-dot-org/code-dot-org/blob/9001e3acced43867fe5a234e69d8d4dfc251f0bd/pegasus/sites.v3/hourofcode.com/views/language_dropdown.haml#L4

This redirecting doesn't change any request's headers or cookies. Thus, only `locale_code` is updated while `request.locale` is not.


## Testing story
- Open http://localhost.code.org:3000/learn. 
- Click on the Dance Party tutorial. Verify that the _Teacher Notes_ link points to the default lesson plan (English) https://curriculum.code.org/hoc/plugged/8. 
  (The debugging info on the page is just to demonstrate how different locale variables change when the page's language change.)
  <img width="1000" alt="Screen Shot 2021-04-08 at 8 36 26 PM" src="https://user-images.githubusercontent.com/46507039/114139495-fcaa5c80-98c3-11eb-8e9f-09836afcdf99.png">

- Change the language to es-MX (LATAM). 
- Open the Dance Party tutorial. Verify that the _Teacher Notes_ link points to the es-Mx lesson plan: https://curriculum.code.org/es-mx/hoc/plugged/8 
  <img width="1004" alt="Screen Shot 2021-04-08 at 8 35 07 PM" src="https://user-images.githubusercontent.com/46507039/114139536-06cc5b00-98c4-11eb-946a-84b7eaaa3afb.png">

- Change the language to it-IT
- Open the Dance Party tutorial. Verify that the _Teacher Notes_ link points to the it-IT lesson plan https://curriculum.code.org/it-it/hoc/plugged/8.
  <img width="1006" alt="Screen Shot 2021-04-08 at 8 32 40 PM" src="https://user-images.githubusercontent.com/46507039/114139552-0cc23c00-98c4-11eb-9862-9facb2bc7169.png">

- Did the same exercise with http://localhost.code.org:3000/learn/robotics.


## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
