### PR TITLE
Allow multiple resources types to be edited simultaneously

### DIFF
--- a/apps/src/lib/levelbuilder/course-editor/ResourcesEditor.js
+++ b/apps/src/lib/levelbuilder/course-editor/ResourcesEditor.js
@@ -98,6 +98,7 @@ export default class ResourcesEditor extends Component {
         {useMigratedResources ? (
           <MigratedResourceEditor
             courseVersionId={this.props.courseVersionId}
+            resourceContext="teacherResource"
           />
         ) : (
           teacherResources

--- a/apps/src/lib/levelbuilder/lesson-editor/ActivitiesEditor.story.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivitiesEditor.story.jsx
@@ -4,7 +4,7 @@ import {createStoreWithReducers, registerReducers} from '@cdo/apps/redux';
 import reducers, {
   init
 } from '@cdo/apps/lib/levelbuilder/lesson-editor/activitiesEditorRedux';
-import resourcesEditor, {
+import createResourcesReducer, {
   initResources
 } from '@cdo/apps/lib/levelbuilder/lesson-editor/resourcesEditorRedux';
 import vocabulariesEditor, {
@@ -20,7 +20,7 @@ import {
 const createStoreWithLessonPlan = () => {
   registerReducers({
     ...reducers,
-    resources: resourcesEditor,
+    resources: createResourcesReducer('lessonResource'),
     vocabularies: vocabulariesEditor
   });
   const store = createStoreWithReducers();
@@ -33,7 +33,7 @@ const createStoreWithLessonPlan = () => {
 const createStoreWithoutLessonPlan = () => {
   registerReducers({
     ...reducers,
-    resources: resourcesEditor,
+    resources: createResourcesReducer('lessonResource'),
     vocabularies: vocabulariesEditor
   });
   const store = createStoreWithReducers();

--- a/apps/src/lib/levelbuilder/lesson-editor/ActivitiesEditor.story.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivitiesEditor.story.jsx
@@ -17,15 +17,17 @@ import {
   searchOptions
 } from '../../../../test/unit/lib/levelbuilder/lesson-editor/activitiesTestData';
 
+const resourcesEditor = createResourcesReducer('lessonResource');
+
 const createStoreWithLessonPlan = () => {
   registerReducers({
     ...reducers,
-    resources: createResourcesReducer('lessonResource'),
+    resources: resourcesEditor,
     vocabularies: vocabulariesEditor
   });
   const store = createStoreWithReducers();
   store.dispatch(init(sampleActivities, searchOptions, []));
-  store.dispatch(initResources([]));
+  store.dispatch(initResources('lessonResource', []));
   store.dispatch(initVocabularies([]));
   return store;
 };
@@ -33,14 +35,14 @@ const createStoreWithLessonPlan = () => {
 const createStoreWithoutLessonPlan = () => {
   registerReducers({
     ...reducers,
-    resources: createResourcesReducer('lessonResource'),
+    resources: resourcesEditor,
     vocabularies: vocabulariesEditor
   });
   const store = createStoreWithReducers();
   store.dispatch(
     init([sampleActivityForLessonWithoutLessonPlan], searchOptions, [])
   );
-  store.dispatch(initResources([]));
+  store.dispatch(initResources('lessonResource', []));
   store.dispatch(initVocabularies([]));
   return store;
 };

--- a/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
@@ -390,6 +390,7 @@ class LessonEditor extends Component {
                   courseVersionId={
                     this.state.originalLessonData.courseVersionId
                   }
+                  resourceContext="lessonResource"
                 />
               ) : (
                 <h4>

--- a/apps/src/lib/levelbuilder/lesson-editor/ResourcesEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ResourcesEditor.jsx
@@ -57,6 +57,7 @@ const styles = {
 class ResourcesEditor extends Component {
   static propTypes = {
     courseVersionId: PropTypes.number,
+    resourceContext: PropTypes.string.isRequired,
 
     // Provided by redux
     resources: PropTypes.arrayOf(resourceShape).isRequired,
@@ -196,7 +197,7 @@ class ResourcesEditor extends Component {
   }
 
   onSearchSelect = e => {
-    this.props.addResource(e.resource);
+    this.props.addResource(this.props.resourceContext, e.resource);
   };
 
   constructResourceOption = resource => ({
@@ -206,11 +207,11 @@ class ResourcesEditor extends Component {
   });
 
   addResource = resource => {
-    this.props.addResource(resource);
+    this.props.addResource(this.props.resourceContext, resource);
   };
 
   saveEditResource = resource => {
-    this.props.editResource(resource);
+    this.props.editResource(this.props.resourceContext, resource);
   };
 
   handleRemoveResourceDialogOpen = resource => {
@@ -222,7 +223,10 @@ class ResourcesEditor extends Component {
   };
 
   removeResource = () => {
-    this.props.removeResource(this.state.resourceToRemove.key);
+    this.props.removeResource(
+      this.props.resourceContext,
+      this.state.resourceToRemove.key
+    );
     this.handleRemoveResourceDialogClose();
   };
 

--- a/apps/src/lib/levelbuilder/lesson-editor/resourcesEditorRedux.js
+++ b/apps/src/lib/levelbuilder/lesson-editor/resourcesEditorRedux.js
@@ -10,23 +10,27 @@ const REMOVE_RESOURCE = 'resourcesEditor/REMOVE_RESOURCE';
 // Contains operations that can be done for migrated resources,
 // i.e. ones backed by the Resource model on Rails
 
-export const initResources = resources => ({
+export const initResources = (resourceContext, resources) => ({
   type: INIT,
+  resourceContext,
   resources
 });
 
-export const addResource = newResource => ({
+export const addResource = (resourceContext, newResource) => ({
   type: ADD_RESOURCE,
+  resourceContext,
   newResource
 });
 
-export const editResource = updatedResource => ({
+export const editResource = (resourceContext, updatedResource) => ({
   type: EDIT_RESOURCE,
+  resourceContext,
   updatedResource
 });
 
-export const removeResource = key => ({
+export const removeResource = (resourceContext, key) => ({
   type: REMOVE_RESOURCE,
+  resourceContext,
   key
 });
 
@@ -42,34 +46,40 @@ function validateResource(resource, location) {
   PropTypes.checkPropTypes(propTypes, {resource}, 'property', location);
 }
 
-export default function resources(state = [], action) {
-  let newState = _.cloneDeep(state);
+export default function createResourcesReducer(resourceContext) {
+  return function resources(state = [], action) {
+    if (resourceContext !== action.resourceContext) {
+      return state;
+    }
 
-  switch (action.type) {
-    case INIT:
-      validateResourceList(action.resources, action.type);
-      return action.resources;
-    case ADD_RESOURCE: {
-      validateResource(action.newResource, action.type);
-      newState = newState.concat([action.newResource]);
-      break;
-    }
-    case EDIT_RESOURCE: {
-      validateResource(action.updatedResource, action.type);
-      const resourceToEdit = newState.find(
-        resource => resource.key === action.updatedResource.key
-      );
-      Object.assign(resourceToEdit, action.updatedResource);
-      break;
-    }
-    case REMOVE_RESOURCE: {
-      const resourceToRemove = newState.find(
-        resource => resource.key === action.key
-      );
-      newState.splice(newState.indexOf(resourceToRemove), 1);
-      break;
-    }
-  }
+    let newState = _.cloneDeep(state);
 
-  return newState;
+    switch (action.type) {
+      case INIT:
+        validateResourceList(action.resources, action.type);
+        return action.resources;
+      case ADD_RESOURCE: {
+        validateResource(action.newResource, action.type);
+        newState = newState.concat([action.newResource]);
+        break;
+      }
+      case EDIT_RESOURCE: {
+        validateResource(action.updatedResource, action.type);
+        const resourceToEdit = newState.find(
+          resource => resource.key === action.updatedResource.key
+        );
+        Object.assign(resourceToEdit, action.updatedResource);
+        break;
+      }
+      case REMOVE_RESOURCE: {
+        const resourceToRemove = newState.find(
+          resource => resource.key === action.key
+        );
+        newState.splice(newState.indexOf(resourceToRemove), 1);
+        break;
+      }
+    }
+
+    return newState;
+  };
 }

--- a/apps/src/sites/studio/pages/courses/edit.js
+++ b/apps/src/sites/studio/pages/courses/edit.js
@@ -22,6 +22,7 @@ function showCourseEditor() {
   const store = getStore();
   store.dispatch(
     initResources(
+      'teacherResource',
       courseEditorData.course_summary.migrated_teacher_resources || []
     )
   );

--- a/apps/src/sites/studio/pages/courses/edit.js
+++ b/apps/src/sites/studio/pages/courses/edit.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import CourseEditor from '@cdo/apps/lib/levelbuilder/course-editor/CourseEditor';
-import resourcesEditor, {
+import createResourcesReducer, {
   initResources
 } from '@cdo/apps/lib/levelbuilder/lesson-editor/resourcesEditorRedux';
 import {Provider} from 'react-redux';
@@ -18,7 +18,7 @@ function showCourseEditor() {
     courseEditorData.course_summary.teacher_resources || []
   ).map(([type, link]) => ({type, link}));
 
-  registerReducers({resources: resourcesEditor});
+  registerReducers({resources: createResourcesReducer('teacherResource')});
   const store = getStore();
   store.dispatch(
     initResources(

--- a/apps/src/sites/studio/pages/lessons/edit.js
+++ b/apps/src/sites/studio/pages/lessons/edit.js
@@ -7,7 +7,7 @@ import reducers, {
   init,
   mapActivityDataForEditor
 } from '@cdo/apps/lib/levelbuilder/lesson-editor/activitiesEditorRedux';
-import resourcesEditor, {
+import createResourcesReducer, {
   initResources
 } from '@cdo/apps/lib/levelbuilder/lesson-editor/resourcesEditorRedux';
 import createStandardsReducer, {
@@ -34,7 +34,7 @@ $(document).ready(function() {
   registerReducers({
     ...reducers,
     instructionsDialog: instructionsDialog,
-    resources: resourcesEditor,
+    resources: createResourcesReducer('lessonResource'),
     vocabularies: vocabulariesEditor,
     programmingExpressions: programmingExpressionsEditor,
     standards: createStandardsReducer('standard'),

--- a/apps/src/sites/studio/pages/lessons/edit.js
+++ b/apps/src/sites/studio/pages/lessons/edit.js
@@ -45,7 +45,7 @@ $(document).ready(function() {
   store.dispatch(
     init(activities, searchOptions, lessonData.programmingEnvironments)
   );
-  store.dispatch(initResources(lessonData.resources || []));
+  store.dispatch(initResources('lessonResource', lessonData.resources || []));
   store.dispatch(initVocabularies(lessonData.vocabularies || []));
   store.dispatch(
     initProgrammingExpressions(lessonData.programmingExpressions || [])

--- a/apps/src/sites/studio/pages/scripts/edit.js
+++ b/apps/src/sites/studio/pages/scripts/edit.js
@@ -10,7 +10,7 @@ import reducers, {
   init,
   mapLessonGroupDataForEditor
 } from '@cdo/apps/lib/levelbuilder/script-editor/scriptEditorRedux';
-import resourcesEditor, {
+import createResourcesReducer, {
   initResources
 } from '@cdo/apps/lib/levelbuilder/lesson-editor/resourcesEditorRedux';
 import ScriptEditor from '@cdo/apps/lib/levelbuilder/script-editor/ScriptEditor';
@@ -23,7 +23,11 @@ export default function initPage(scriptEditorData) {
 
   const locales = scriptEditorData.locales;
 
-  registerReducers({...reducers, resources: resourcesEditor, isRtl});
+  registerReducers({
+    ...reducers,
+    resources: createResourcesReducer('teacherResource'),
+    isRtl
+  });
   const store = getStore();
   store.dispatch(init(lessonGroups, scriptEditorData.levelKeyList));
   const teacherResources = (scriptData.teacher_resources || []).map(

--- a/apps/src/sites/studio/pages/scripts/edit.js
+++ b/apps/src/sites/studio/pages/scripts/edit.js
@@ -36,7 +36,12 @@ export default function initPage(scriptEditorData) {
       link
     })
   );
-  store.dispatch(initResources(scriptData.migrated_teacher_resources || []));
+  store.dispatch(
+    initResources(
+      'teacherResource',
+      scriptData.migrated_teacher_resources || []
+    )
+  );
 
   let announcements = scriptData.announcements || [];
 

--- a/apps/test/unit/lib/levelbuilder/course-editor/CourseEditorTest.js
+++ b/apps/test/unit/lib/levelbuilder/course-editor/CourseEditorTest.js
@@ -9,7 +9,7 @@ import {
   registerReducers
 } from '@cdo/apps/redux';
 import teacherSections from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
-import resourcesEditor from '@cdo/apps/lib/levelbuilder/lesson-editor/resourcesEditorRedux';
+import createResourcesReducer from '@cdo/apps/lib/levelbuilder/lesson-editor/resourcesEditorRedux';
 import {Provider} from 'react-redux';
 import ResourceType from '@cdo/apps/templates/courseOverview/resourceType';
 
@@ -39,7 +39,10 @@ const defaultProps = {
 describe('CourseEditor', () => {
   beforeEach(() => {
     stubRedux();
-    registerReducers({teacherSections, resources: resourcesEditor});
+    registerReducers({
+      teacherSections,
+      resources: createResourcesReducer('teacherResource')
+    });
   });
 
   afterEach(() => {

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/ActivitySectionCardTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/ActivitySectionCardTest.jsx
@@ -15,7 +15,7 @@ import {sampleActivities, searchOptions} from './activitiesTestData';
 import reducers, {
   init
 } from '@cdo/apps/lib/levelbuilder/lesson-editor/activitiesEditorRedux';
-import resourcesEditor, {
+import createResourcesReducer, {
   initResources
 } from '@cdo/apps/lib/levelbuilder/lesson-editor/resourcesEditorRedux';
 import vocabulariesEditor, {
@@ -39,13 +39,13 @@ describe('ActivitySectionCard', () => {
     stubRedux();
     registerReducers({
       ...reducers,
-      resources: resourcesEditor,
+      resources: createResourcesReducer('lessonResource'),
       vocabularies: vocabulariesEditor
     });
 
     store = getStore();
     store.dispatch(init(sampleActivities, searchOptions, []));
-    store.dispatch(initResources(resourceTestData));
+    store.dispatch(initResources('lessonResource', resourceTestData));
     store.dispatch(initVocabularies([]));
 
     setTargetActivitySection = sinon.spy();

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/LessonEditorTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/LessonEditorTest.js
@@ -11,7 +11,7 @@ import {
 import reducers, {
   init
 } from '@cdo/apps/lib/levelbuilder/lesson-editor/activitiesEditorRedux';
-import resourcesEditor, {
+import createResourcesReducer, {
   initResources
 } from '@cdo/apps/lib/levelbuilder/lesson-editor/resourcesEditorRedux';
 import vocabulariesEditor, {
@@ -37,7 +37,7 @@ describe('LessonEditor', () => {
     stubRedux();
     registerReducers({
       ...reducers,
-      resources: resourcesEditor,
+      resources: createResourcesReducer('lessonResource'),
       vocabularies: vocabulariesEditor,
       programmingExpressions: programmingExpressionsEditor,
       standards: createStandardsReducer('standard'),

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/ResourceEditorTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/ResourceEditorTest.js
@@ -13,6 +13,7 @@ describe('ResourcesEditor', () => {
     removeResource = sinon.spy();
     defaultProps = {
       resources: resourceTestData,
+      resourceContext: 'testResource',
       addResource,
       editResource,
       removeResource

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/resourcesEditorReduxTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/resourcesEditorReduxTest.js
@@ -1,5 +1,5 @@
 import {assert} from 'chai';
-import resourceEditor, {
+import createResourcesReducer, {
   addResource,
   editResource,
   removeResource
@@ -10,13 +10,20 @@ import _ from 'lodash';
 const getInitialState = () => _.cloneDeep(resourceTestData);
 
 describe('resourcesEditorRedux reducer tests', () => {
-  let initialState;
-  beforeEach(() => (initialState = getInitialState()));
+  let initialState, resourcesEditor;
+  beforeEach(() => {
+    initialState = getInitialState();
+    resourcesEditor = createResourcesReducer('lessonResource');
+  });
 
   it('add resource', () => {
-    const nextState = resourceEditor(
+    const nextState = resourcesEditor(
       initialState,
-      addResource({key: 'new-key', name: 'new-name', url: 'new-fake.url'})
+      addResource('lessonResource', {
+        key: 'new-key',
+        name: 'new-name',
+        url: 'new-fake.url'
+      })
     );
     assert.deepEqual(nextState.map(r => r.key), [
       'resource-1',
@@ -28,18 +35,49 @@ describe('resourcesEditorRedux reducer tests', () => {
   it('edit resource', () => {
     const editedResource = _.cloneDeep(resourceTestData[0]);
     editedResource.name = 'new name';
-    const nextState = resourceEditor(
+    const nextState = resourcesEditor(
       initialState,
-      editResource(editedResource)
+      editResource('lessonResource', editedResource)
     );
     assert.deepEqual(nextState.map(r => r.name), ['new name', 'Resource 2']);
   });
 
   it('remove resource', () => {
-    const nextState = resourceEditor(
+    const nextState = resourcesEditor(
       initialState,
-      removeResource('resource-1')
+      removeResource('lessonResource', 'resource-1')
     );
     assert.deepEqual(nextState.map(r => r.key), ['resource-2']);
+  });
+
+  it('can add teacher resource without adding student resource', () => {
+    const teacherResourcesEditor = createResourcesReducer('teacherResource');
+    const studentResourcesEditor = createResourcesReducer('studentResource');
+    const nextTeacherResourceState = teacherResourcesEditor(
+      initialState,
+      addResource('teacherResource', {
+        key: 'new-teacher-resource-key',
+        name: 'new-teacher-resource0name',
+        url: 'new-fake.url'
+      })
+    );
+    const nextStudentResourceState = studentResourcesEditor(
+      initialState,
+      addResource('studentResource', {
+        key: 'new-student-resource-key',
+        name: 'new-student-resourcename',
+        url: 'new-fake.url'
+      })
+    );
+    assert.deepEqual(nextTeacherResourceState.map(r => r.key), [
+      'resource-1',
+      'resource-2',
+      'new-teacher-resource-key'
+    ]);
+    assert.deepEqual(nextStudentResourceState.map(r => r.key), [
+      'resource-1',
+      'resource-2',
+      'new-student-resource-key'
+    ]);
   });
 });

--- a/apps/test/unit/lib/levelbuilder/script-editor/ScriptEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/ScriptEditorTest.jsx
@@ -14,7 +14,7 @@ import {
   getStore,
   registerReducers
 } from '@cdo/apps/redux';
-import resourcesEditor, {
+import createResourcesReducer, {
   initResources
 } from '@cdo/apps/lib/levelbuilder/lesson-editor/resourcesEditorRedux';
 import MigratedResourcesEditor from '@cdo/apps/lib/levelbuilder/lesson-editor/ResourcesEditor';
@@ -27,7 +27,11 @@ describe('ScriptEditor', () => {
     sinon.stub(utils, 'navigateToHref');
     stubRedux();
 
-    registerReducers({...reducers, isRtl, resources: resourcesEditor});
+    registerReducers({
+      ...reducers,
+      isRtl,
+      resources: createResourcesReducer('teacherResource')
+    });
     store = getStore();
     store.dispatch(
       init(


### PR DESCRIPTION
This work is needed for editing student resources for script and unit groups as both will be edited on the same page. I'm breaking it out into a separate PR because this shouldn't have any effect on current functionality and I'm going to be doing some work on the resources editing for a couple tasks in parallel and this will likely reduce merge conflicts.

I'm following the pattern that Dave used for standards in #39767.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
