### PR TITLE
Additional validations for names of Foorm library questions

### DIFF
--- a/apps/src/code-studio/pd/foorm/editor/components/FoormEntityEditor.jsx
+++ b/apps/src/code-studio/pd/foorm/editor/components/FoormEntityEditor.jsx
@@ -48,6 +48,7 @@ class FoormEntityEditor extends React.Component {
     saveBar: PropTypes.node,
     validateURL: PropTypes.string,
     validateDataKey: PropTypes.string,
+    validateInExistingEntityContext: PropTypes.bool,
 
     // populated by redux
     questions: PropTypes.object
@@ -224,6 +225,9 @@ class FoormEntityEditor extends React.Component {
           livePreviewStatus={this.state.livePreviewStatus}
           validateURL={this.props.validateURL}
           validateDataKey={this.props.validateDataKey}
+          validateInExistingEntityContext={
+            this.props.validateInExistingEntityContext
+          }
           headerTitle={this.props.headerTitle}
         />
         <div style={styles.foormEditor}>

--- a/apps/src/code-studio/pd/foorm/editor/components/FoormEntityEditorHeader.jsx
+++ b/apps/src/code-studio/pd/foorm/editor/components/FoormEntityEditorHeader.jsx
@@ -42,10 +42,12 @@ class FoormEntityEditorHeader extends Component {
     livePreviewStatus: PropTypes.string,
     validateURL: PropTypes.string,
     validateDataKey: PropTypes.string,
+    validateInExistingEntityContext: PropTypes.bool,
     headerTitle: PropTypes.node,
 
     // populated by Redux
-    questions: PropTypes.object
+    questions: PropTypes.object,
+    foormEntityId: PropTypes.number
   };
 
   constructor(props) {
@@ -60,14 +62,25 @@ class FoormEntityEditorHeader extends Component {
 
   validateQuestions = () => {
     this.setState({validationStarted: true});
+
+    const requestData = {
+      [this.props.validateDataKey]: this.props.questions
+    };
+
+    // By default, we validate the JSON representing the Foorm configuration
+    // without the context of its existing database entry (if it exists).
+    // For library questions, we want to make sure that information in the JSON (question name)
+    // remains in sync with the name in the database entry.
+    if (this.props.validateInExistingEntityContext) {
+      requestData['id'] = this.props.foormEntityId;
+    }
+
     $.ajax({
       url: this.props.validateURL,
       type: 'post',
       contentType: 'application/json',
       processData: false,
-      data: JSON.stringify({
-        [this.props.validateDataKey]: this.props.questions
-      })
+      data: JSON.stringify(requestData)
     })
       .done(result => {
         this.setState({
@@ -141,5 +154,6 @@ class FoormEntityEditorHeader extends Component {
 }
 
 export default connect(state => ({
-  questions: state.foorm.questions || {}
+  questions: state.foorm.questions || {},
+  foormEntityId: state.foorm.foormEntityId
 }))(FoormEntityEditorHeader);

--- a/apps/src/code-studio/pd/foorm/editor/foormEditorRedux.js
+++ b/apps/src/code-studio/pd/foorm/editor/foormEditorRedux.js
@@ -97,6 +97,10 @@ const initialState = {
   saveError: null,
   lastSaved: null,
   lastSavedQuestions: '',
+  // Represents either form ID or library question ID -- our database ID for the thing being edited.
+  // Needed for validation of library questions.
+  // to do would be to move references to formId and libraryQuestionId to use this.
+  foormEntityId: null,
   // State specific to Foorm Form editor
   formId: null,
   formName: null,
@@ -131,7 +135,8 @@ export default function foormEditorRedux(state = initialState, action) {
       isFormPublished: action.formData['published'],
       formName: action.formData['name'],
       formVersion: action.formData['version'],
-      formId: action.formData['id']
+      formId: action.formData['id'],
+      foormEntityId: action.formData['id']
     };
   }
   if (action.type === SET_LIBRARY_QUESTION_DATA) {
@@ -139,7 +144,8 @@ export default function foormEditorRedux(state = initialState, action) {
       ...state,
       questions: action.libraryQuestionData['question'],
       libraryQuestionName: action.libraryQuestionData['name'],
-      libraryQuestionId: action.libraryQuestionData['id']
+      libraryQuestionId: action.libraryQuestionData['id'],
+      foormEntityId: action.libraryQuestionData['id']
     };
   }
   if (action.type === SET_LIBRARY_DATA) {

--- a/apps/src/code-studio/pd/foorm/editor/library/FoormLibraryEditorManager.jsx
+++ b/apps/src/code-studio/pd/foorm/editor/library/FoormLibraryEditorManager.jsx
@@ -287,6 +287,7 @@ class FoormLibraryEditorManager extends React.Component {
               '/api/v1/pd/foorm/library_questions/validate_library_question'
             }
             validateDataKey={'question'}
+            validateInExistingEntityContext={true}
             saveBar={this.renderSaveBar()}
           />
         )}

--- a/dashboard/app/controllers/api/v1/pd/foorm/library_questions_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/foorm/library_questions_controller.rb
@@ -9,7 +9,7 @@ class Api::V1::Pd::Foorm::LibraryQuestionsController < ApplicationController
     if library_question.errors.empty?
       return render status: 200, json: {}
     else
-      return render status: 500, json: {error: library_question.errors}
+      return render status: 500, json: {error: library_question.errors[:question].join(', ')}
     end
   end
 end

--- a/dashboard/app/controllers/api/v1/pd/foorm/library_questions_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/foorm/library_questions_controller.rb
@@ -3,8 +3,11 @@ class Api::V1::Pd::Foorm::LibraryQuestionsController < ApplicationController
   def validate_library_question
     authorize! :validate_library_question, :pd_foorm
 
-    library_question = Foorm::LibraryQuestion.new(question: params[:question].to_json)
-    library_question.validate_library_question
+    library_question = params[:id] ?
+                         Foorm::LibraryQuestion.find(params[:id]) :
+                         Foorm::LibraryQuestion.new
+    library_question.question = params[:question].to_json
+    library_question.validate_question
 
     if library_question.errors.empty?
       return render status: 200, json: {}

--- a/dashboard/app/models/foorm/library.rb
+++ b/dashboard/app/models/foorm/library.rb
@@ -16,6 +16,7 @@
 class Foorm::Library < ApplicationRecord
   include Seeded
 
+  # To consider: should a Foorm::Library go through all of the same validations as a Foorm::Form?
   has_many :library_questions, primary_key: [:name, :version], foreign_key: [:library_name, :library_version]
   validates :name, :version, presence: true
 

--- a/dashboard/app/models/foorm/library_question.rb
+++ b/dashboard/app/models/foorm/library_question.rb
@@ -23,7 +23,7 @@ class Foorm::LibraryQuestion < ApplicationRecord
 
   belongs_to :library, primary_key: [:name, :version], foreign_key: [:library_name, :library_version], required: true
 
-  validate :validate_library_question
+  validate :validate_question
   validates :question_name, :question, presence: true
   validates_uniqueness_of :question_name, scope: [:library_name, :library_version]
 
@@ -45,7 +45,7 @@ class Foorm::LibraryQuestion < ApplicationRecord
     end
   end
 
-  def validate_library_question
+  def validate_question
     # Keep question name stored in the question JSON field in sync with what's in the database
     if JSON.parse(question)['name'] != question_name
       raise InvalidFoormConfigurationError, 'library question name in question JSON must match name of library question name in database.'

--- a/dashboard/app/models/foorm/library_question.rb
+++ b/dashboard/app/models/foorm/library_question.rb
@@ -19,10 +19,13 @@
 class Foorm::LibraryQuestion < ApplicationRecord
   include Seeded
 
+  class InvalidFoormConfigurationError < StandardError; end
+
   belongs_to :library, primary_key: [:name, :version], foreign_key: [:library_name, :library_version], required: true
 
   validate :validate_library_question
   validates :question_name, :question, presence: true
+  validates_uniqueness_of :question_name, scope: [:library_name, :library_version]
 
   after_commit :write_to_file
 
@@ -42,10 +45,12 @@ class Foorm::LibraryQuestion < ApplicationRecord
     end
   end
 
-  # TO DO: names need to be tracked in the question column (and JSON) to make sure libraries continue to be valid SurveyJS.
-  # TO DO: check that the library question has the same name in the question as in the question_name field.
-  # TO DO: check that the library question name is unique within the library (there is DB validation for this)
   def validate_library_question
+    # Keep question name stored in the question JSON field in sync with what's in the database
+    if JSON.parse(question)['name'] != question_name
+      raise InvalidFoormConfigurationError, 'library question name in question JSON must match name of library question name in database'
+    end
+
     Foorm::Form.validate_element(JSON.parse(question).deep_symbolize_keys, Set.new)
   rescue StandardError => e
     errors.add(:question, e.message)

--- a/dashboard/app/models/foorm/library_question.rb
+++ b/dashboard/app/models/foorm/library_question.rb
@@ -24,6 +24,7 @@ class Foorm::LibraryQuestion < ApplicationRecord
   belongs_to :library, primary_key: [:name, :version], foreign_key: [:library_name, :library_version], required: true
 
   validate :validate_library_question
+  validate :question_name_must_match
   validates :question_name, :question, presence: true
   validates_uniqueness_of :question_name, scope: [:library_name, :library_version]
 
@@ -46,14 +47,16 @@ class Foorm::LibraryQuestion < ApplicationRecord
   end
 
   def validate_library_question
+    Foorm::Form.validate_element(JSON.parse(question).deep_symbolize_keys, Set.new)
+  rescue StandardError => e
+    errors.add(:question, e.message)
+  end
+
+  def question_name_must_match
     # Keep question name stored in the question JSON field in sync with what's in the database
     if JSON.parse(question)['name'] != question_name
       raise InvalidFoormConfigurationError, 'library question name in question JSON must match name of library question name in database'
     end
-
-    Foorm::Form.validate_element(JSON.parse(question).deep_symbolize_keys, Set.new)
-  rescue StandardError => e
-    errors.add(:question, e.message)
   end
 
   def write_to_file

--- a/dashboard/test/controllers/foorm/library_questions_controller_test.rb
+++ b/dashboard/test/controllers/foorm/library_questions_controller_test.rb
@@ -33,14 +33,15 @@ module Foorm
 
     test 'update succeeds on existing library' do
       library = create :foorm_library, :with_questions
-      library_question_id = library.library_questions.first.id
+      library_question = library.library_questions.first
+      library_question_id = library_question.id
 
       levelbuilder = create :levelbuilder
       sign_in levelbuilder
 
       put :update, params: {
         id: library_question_id,
-        question: {pages: [{elements: [{name: "test"}]}]}
+        question: {name: library_question.question_name, type: 'html'}
       }
 
       assert_response :success
@@ -54,7 +55,7 @@ module Foorm
 
       post :create, params: {
         library_id: library.id,
-        question: {pages: [{elements: [{name: "test"}]}]},
+        question: {name: 'test_question_name', type: 'html'},
         name: 'test_question_name'
       }
 
@@ -71,7 +72,7 @@ module Foorm
 
       post :create, params: {
         library_name: 'test_library_name',
-        question: {pages: [{elements: [{name: "test"}]}]},
+        question: {name: 'test_question_name', type: 'html'},
         name: 'test_question_name'
       }
 
@@ -86,7 +87,7 @@ module Foorm
       sign_in levelbuilder
 
       post :create, params: {
-        question: {pages: [{elements: [{name: "test"}]}]},
+        question: {name: 'test_question_name', type: 'html'},
         name: 'test_question_name'
       }
 
@@ -101,7 +102,7 @@ module Foorm
 
       post :create, params: {
         library_id: library.id,
-        question: {pages: [{elements: [{name: "test"}]}]}
+        question: {name: 'test_question_name', type: 'html'}
       }
 
       assert_includes JSON.parse(response.body)['question_name'], 'is required'

--- a/dashboard/test/factories/foorm_factories.rb
+++ b/dashboard/test/factories/foorm_factories.rb
@@ -1139,7 +1139,7 @@ FactoryGirl.define do
   factory :foorm_library_question, class: 'Foorm::LibraryQuestion' do
     sequence(:library_name) {|n| "surveys/pd/library_name#{n}"}
     library_version 0
-    sequence(:question_name) {|n| "library_question_name#{n}"}
+    sequence(:question_name) {|n| "what_supported#{n}"}
     sequence(:question) do |n|
       "{
         \"type\": \"comment\",

--- a/dashboard/test/models/foorm/library_question_test.rb
+++ b/dashboard/test/models/foorm/library_question_test.rb
@@ -80,7 +80,7 @@ class Foorm::LibraryQuestionTest < ActiveSupport::TestCase
     assert_empty library_question.published_forms_appeared_in
   end
 
-  test 'library question JSON cannot be updated with question name different than what is in' do
+  test 'library question JSON cannot be updated with question name different than what is in database entry' do
     library = create :foorm_library, :with_questions
     library_question = library.library_questions.first
 

--- a/dashboard/test/models/foorm/library_question_test.rb
+++ b/dashboard/test/models/foorm/library_question_test.rb
@@ -11,7 +11,7 @@ class Foorm::LibraryQuestionTest < ActiveSupport::TestCase
 
     library = create :foorm_library, :with_questions
     library_question = library.library_questions.first
-    library_question.question = JSON.generate({pages: [{elements: [{name: "test"}]}]})
+    library_question.question = JSON.generate({name: library_question.question_name})
     library_question.save
   end
 
@@ -20,7 +20,7 @@ class Foorm::LibraryQuestionTest < ActiveSupport::TestCase
 
     library = create :foorm_library, :with_questions
     library_question = library.library_questions.first
-    library_question.question = JSON.generate({pages: [{elements: [{name: "test"}]}]})
+    library_question.question = JSON.generate({name: library_question.question_name})
     library_question.save
   end
 
@@ -78,5 +78,20 @@ class Foorm::LibraryQuestionTest < ActiveSupport::TestCase
         ]
     }"
     assert_empty library_question.published_forms_appeared_in
+  end
+
+  test 'library question JSON cannot be updated with question name different than what is in' do
+    library = create :foorm_library, :with_questions
+    library_question = library.library_questions.first
+
+    assert library_question.valid?
+    parsed_question_json = JSON.parse(library_question.question)
+    parsed_question_json['name'] = 'new name'
+
+    library_question.question = JSON.pretty_generate(parsed_question_json)
+    refute library_question.valid?
+
+    library_question.question_name = 'new name'
+    assert library_question.valid?
   end
 end


### PR DESCRIPTION
A bit of cleanup for editing library questions to prevent the name of a library question (stored as an attribute on the model) getting out of sync with the JSON representation of the question's name (stored in the JSON attribute `question`, which is ultimately what we save to file when a content editor edits a library question).

Here's an example of how you could end up with two different values for a library question name (this would more commonly happen if a content editor updated the `name` property in the JSON they were editing).

```
library_question = Foorm::LibraryQuestion.last
library_question.question_name (let's say this is 'old name')

parsed_library_question_json = JSON.parse(library_question.question)
parsed_library_question_json['name'] = 'a new name'
library_question.question = JSON.generate(parsed_library_question_json)
library_question.save (this succeeds without changes introduced in this PR)

JSON.parse(library_question.question)['name'] (returns 'a new name')
library_question.question (returns 'old name')
```

## Testing story

Tested manually, and added a unit test to cover this new validation.

## PR Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
