### PR TITLE
Don't convert file data to string when saving project files

### DIFF
--- a/apps/src/weblab/CdoBramble.js
+++ b/apps/src/weblab/CdoBramble.js
@@ -449,7 +449,7 @@ export default class CdoBramble {
     };
 
     this.getFileData(this.prependProjectPath(filename), (err, fileData) => {
-      !err && currentFileData.push({name: filename, data: fileData.toString()});
+      !err && currentFileData.push({name: filename, data: fileData});
       next(err);
     });
   }
@@ -551,7 +551,7 @@ export default class CdoBramble {
       // Map array of files to an object with structure {filename: fileData}
       const reduceToObj = filesArray =>
         filesArray.reduce((acc, val) => {
-          acc[val.name] = val.data;
+          acc[val.name] = val.data?.toString();
           return acc;
         }, {});
       const startObj = reduceToObj(startSourceFiles);


### PR DESCRIPTION
Fixes a bug where images weren't being saved correctly from curriculum starter image files because the image data was converted to a string before saving, causing us to save corrupted image data.

**Repro steps (as of the time of writing, this will consistently repro on production):**
1. Visit a level with a starter image (e.g., `/s/csd2-2020/stage/9/puzzle/6`)
2. Make any code change (to trigger a project save)
3. Reload the page

_Expected:_ My change was saved, and all assets render properly.
_Actual:_ My change was saved, but image assets do not render properly (render as broken image links).

Users that have encountered this situation will need to reset version history to get back to a good state.

## Links

- [Slack thread](https://codedotorg.slack.com/archives/C1B3PNDL7/p1617978473173700)
- Zendesk tickets: [1](https://codeorg.zendesk.com/agent/tickets/328431), [2](https://codeorg.zendesk.com/agent/tickets/328176), [3](https://codeorg.zendesk.com/agent/tickets/328246), [4](https://codeorg.zendesk.com/agent/tickets/328419)

## Testing story

This issue wasn't caught by unit tests since we have to mock this data. I've created a ticket as follow-up work to cover this scenario with a UI test (likely an Eyes test).

## Follow-up work

- [STAR-1525](https://codedotorg.atlassian.net/browse/STAR-1525) (create a UI test for this scenario)