### PR TITLE
Integrate Javalab with start_sources

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -2079,9 +2079,8 @@ StudioApp.prototype.setConfigValues_ = function(config) {
     config.level.lastAttempt || config.level.startBlocks || '';
   this.vizAspectRatio = config.vizAspectRatio || 1.0;
   this.nativeVizWidth = config.nativeVizWidth || this.maxVisualizationWidth;
-  console.log(config.level);
+
   if (config.level.initializationBlocks) {
-    // What are initializationBlocks? Is this where I get the blocks to show things?
     var xml = parseXmlElement(config.level.initializationBlocks);
     this.initializationBlocks = Blockly.Generator.xmlToBlocks(
       'JavaScript',

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -2079,8 +2079,9 @@ StudioApp.prototype.setConfigValues_ = function(config) {
     config.level.lastAttempt || config.level.startBlocks || '';
   this.vizAspectRatio = config.vizAspectRatio || 1.0;
   this.nativeVizWidth = config.nativeVizWidth || this.maxVisualizationWidth;
-
+  console.log(config.level);
   if (config.level.initializationBlocks) {
+    // What are initializationBlocks? Is this where I get the blocks to show things?
     var xml = parseXmlElement(config.level.initializationBlocks);
     this.initializationBlocks = Blockly.Generator.xmlToBlocks(
       'JavaScript',

--- a/apps/src/javalab/Javalab.js
+++ b/apps/src/javalab/Javalab.js
@@ -103,6 +103,8 @@ Javalab.prototype.init = function(config) {
 
   registerReducers({javalab});
 
+  // If we're in editBlock mode (for editing start_sources) we set up the save button to save
+  // the project file information into start_souurces on the level.
   if (config.level.editBlocks) {
     config.level.lastAttempt = '';
     showLevelBuilderSaveButton(() => ({

--- a/apps/src/javalab/Javalab.js
+++ b/apps/src/javalab/Javalab.js
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import {Provider} from 'react-redux';
 import {getStore, registerReducers} from '../redux';
 import JavalabView from './JavalabView';
-import javalab, {getEditorText} from './javalabRedux';
+import javalab, {getProjectFileInfo} from './javalabRedux';
 import {TestResults} from '@cdo/apps/constants';
 import project from '@cdo/apps/code-studio/initApp/project';
 import {queryParams} from '@cdo/apps/code-studio/utils';
@@ -106,9 +106,7 @@ Javalab.prototype.init = function(config) {
   if (config.level.editBlocks) {
     config.level.lastAttempt = '';
     showLevelBuilderSaveButton(() => ({
-      // This is what you will save as start_blocks
-      // Need to sync with Molly on where I should get this information for real, especially with multifile
-      start_blocks: getEditorText(getStore().getState())
+      start_sources: getProjectFileInfo(getStore().getState())
     }));
   }
 

--- a/apps/src/javalab/Javalab.js
+++ b/apps/src/javalab/Javalab.js
@@ -3,11 +3,12 @@ import ReactDOM from 'react-dom';
 import {Provider} from 'react-redux';
 import {getStore, registerReducers} from '../redux';
 import JavalabView from './JavalabView';
-import javalab from './javalabRedux';
+import javalab, {getEditorText} from './javalabRedux';
 import {TestResults} from '@cdo/apps/constants';
 import project from '@cdo/apps/code-studio/initApp/project';
 import {queryParams} from '@cdo/apps/code-studio/utils';
 import {onSave} from './JavalabFileManagement';
+import {showLevelBuilderSaveButton} from '@cdo/apps/code-studio/header';
 
 /**
  * On small mobile devices, when in portrait orientation, we show an overlay
@@ -101,6 +102,15 @@ Javalab.prototype.init = function(config) {
   });
 
   registerReducers({javalab});
+
+  if (config.level.editBlocks) {
+    config.level.lastAttempt = '';
+    showLevelBuilderSaveButton(() => ({
+      // This is what you will save as start_blocks
+      // Need to sync with Molly on where I should get this information for real, especially with multifile
+      start_blocks: getEditorText(getStore().getState())
+    }));
+  }
 
   ReactDOM.render(
     <Provider store={getStore()}>

--- a/apps/src/javalab/Javalab.js
+++ b/apps/src/javalab/Javalab.js
@@ -104,7 +104,7 @@ Javalab.prototype.init = function(config) {
   registerReducers({javalab});
 
   // If we're in editBlock mode (for editing start_sources) we set up the save button to save
-  // the project file information into start_souurces on the level.
+  // the project file information into start_sources on the level.
   if (config.level.editBlocks) {
     config.level.lastAttempt = '';
     showLevelBuilderSaveButton(() => ({

--- a/apps/src/javalab/JavalabEditor.jsx
+++ b/apps/src/javalab/JavalabEditor.jsx
@@ -90,7 +90,7 @@ class JavalabEditor extends React.Component {
     e.preventDefault();
     const {filename, setFilename} = this.props;
     const {newFilename} = this.state;
-    // We don't want to actually save the file if we're editing startSources
+    // We don't want to actually save the file if we're editing startSources.
     if (!window.appOptions.level.editBlocks) {
       renameProjectFile(filename, newFilename);
     }

--- a/apps/src/javalab/JavalabEditor.jsx
+++ b/apps/src/javalab/JavalabEditor.jsx
@@ -90,7 +90,10 @@ class JavalabEditor extends React.Component {
     e.preventDefault();
     const {filename, setFilename} = this.props;
     const {newFilename} = this.state;
-    renameProjectFile(filename, newFilename);
+    // We don't want to actually save the file if we're editing startSources
+    if (!window.appOptions.level.editBlocks) {
+      renameProjectFile(filename, newFilename);
+    }
     setFilename(newFilename);
     this.onProjectChanged();
     this.setState({renameFileActive: false});

--- a/apps/src/javalab/JavalabFileManagement.js
+++ b/apps/src/javalab/JavalabFileManagement.js
@@ -92,7 +92,13 @@ function loadFiles(success, failure, version) {
 
 function populateFiles(fileEntries, success, failure) {
   if (fileEntries.length === 0) {
-    // TODO: make starter code more customizable
+    // TODO: enable multi-file
+    const startSources = window.appOptions.level.startSources;
+    if (startSources) {
+      const filename = Object.keys(startSources)[0];
+      getStore().dispatch(setFileName(filename));
+      getStore().dispatch(setEditorText(startSources[filename].text));
+    }
     success();
   } else {
     // TODO: enable multi-file

--- a/apps/src/javalab/javalabRedux.js
+++ b/apps/src/javalab/javalabRedux.js
@@ -49,6 +49,16 @@ export const getEditorText = state => {
   return state.javalab.editorText;
 };
 
+export const getProjectFileInfo = state => {
+  // TODO: enable multi-file
+  let data = {};
+  data[state.javalab.filename] = {
+    text: state.javalab.editorText,
+    visible: true
+  };
+  return data;
+};
+
 // Reducer
 export default function reducer(state = initialState, action) {
   if (action.type === APPEND_CONSOLE_LOG) {

--- a/apps/test/unit/javalab/JavalabEditorTest.js
+++ b/apps/test/unit/javalab/JavalabEditorTest.js
@@ -25,6 +25,7 @@ describe('Java Lab Editor Test', () => {
     defaultProps = {
       onCommitCode: () => {}
     };
+    window.appOptions = {level: {}};
   });
 
   afterEach(() => {
@@ -81,6 +82,35 @@ describe('Java Lab Editor Test', () => {
       // should have called project changed and updated redux
       expect(JavalabFileManagement.onProjectChanged).to.have.been.calledOnce;
       expect(store.getState().javalab.filename).to.equal('NewFilename.java');
+    });
+
+    it('updates state on Rename save and does not call JavalabFileManagement functions when in editBlocks mode', () => {
+      const editor = createWrapper();
+      window.appOptions.level.editBlocks = 'start_sources';
+
+      const activateRenameBtn = editor.find('button').first();
+      activateRenameBtn.invoke('onClick')();
+
+      // first input should be file rename text input
+      const renameInput = editor.find('input').first();
+      renameInput.invoke('onChange')({target: {value: 'NewFilename.java'}});
+
+      // save button not clicked, should not yet have set project changed
+      // or change filename in redux
+      expect(JavalabFileManagement.onProjectChanged).to.not.have.been.called;
+      expect(store.getState().javalab.filename).to.not.equal(
+        'NewFilename.java'
+      );
+
+      // submit form, should trigger file rename
+      const form = editor.find('form').first();
+      // stub preventDefault function
+      form.invoke('onSubmit')({preventDefault: () => {}});
+      expect(JavalabFileManagement.renameProjectFile).to.not.have.been.called;
+      // should have called project changed and updated redux
+      expect(JavalabFileManagement.onProjectChanged).to.have.been.calledOnce;
+      expect(store.getState().javalab.filename).to.equal('NewFilename.java');
+      window.appOptions.level.editBlocks = null;
     });
   });
 });

--- a/apps/test/unit/javalab/JavalabFileManagementTest.js
+++ b/apps/test/unit/javalab/JavalabFileManagementTest.js
@@ -13,15 +13,18 @@ import {
 import {populateFiles} from '@cdo/apps/javalab/JavalabFileManagement';
 
 describe('JavalabFileManagement', () => {
+  let appOptions;
   beforeEach(() => {
     stubRedux();
     registerReducers({javalab});
+    appOptions = window.appOptions;
     window.appOptions = {level: {}};
     sinon.stub(getStore(), 'dispatch');
   });
 
   afterEach(() => {
     restoreRedux();
+    window.appOptions = appOptions;
   });
 
   describe('populateFiles', () => {

--- a/apps/test/unit/javalab/JavalabFileManagementTest.js
+++ b/apps/test/unit/javalab/JavalabFileManagementTest.js
@@ -1,0 +1,55 @@
+import sinon from 'sinon';
+import {expect} from '../../util/reconfiguredChai';
+import javalab, {
+  setFileName,
+  setEditorText
+} from '@cdo/apps/javalab/javalabRedux';
+import {
+  getStore,
+  registerReducers,
+  stubRedux,
+  restoreRedux
+} from '@cdo/apps/redux';
+import {populateFiles} from '@cdo/apps/javalab/JavalabFileManagement';
+
+describe('JavalabFileManagement', () => {
+  beforeEach(() => {
+    stubRedux();
+    registerReducers({javalab});
+    window.appOptions = {level: {}};
+    sinon.stub(getStore(), 'dispatch');
+  });
+
+  afterEach(() => {
+    restoreRedux();
+  });
+
+  describe('populateFiles', () => {
+    it('populates start_sources if there are any and there are no file entries', () => {
+      window.appOptions.level = {
+        startSources: {
+          'File.java': {
+            text: 'Some code',
+            visible: true
+          }
+        }
+      };
+      const successStub = sinon.stub();
+      populateFiles([], successStub, () => {});
+      expect(successStub).to.have.been.calledOnce;
+      expect(getStore().dispatch).to.have.been.calledWith(
+        setFileName('File.java')
+      );
+      expect(getStore().dispatch).to.have.been.calledWith(
+        setEditorText('Some code')
+      );
+    });
+
+    it('succeeds if there are no file entries and no start sources', () => {
+      window.appOptions.level = {};
+      const successStub = sinon.stub();
+      populateFiles([], successStub, () => {});
+      expect(successStub).to.have.been.calledOnce;
+    });
+  });
+});

--- a/apps/test/unit/javalab/javalabReduxTest.js
+++ b/apps/test/unit/javalab/javalabReduxTest.js
@@ -1,0 +1,36 @@
+import {expect} from '../../util/reconfiguredChai';
+import javalab, {
+  setFileName,
+  setEditorText,
+  getProjectFileInfo
+} from '@cdo/apps/javalab/javalabRedux';
+import {
+  getStore,
+  registerReducers,
+  stubRedux,
+  restoreRedux
+} from '@cdo/apps/redux';
+
+describe('javalabRedux', () => {
+  beforeEach(() => {
+    stubRedux();
+    registerReducers({javalab});
+  });
+
+  afterEach(() => {
+    restoreRedux();
+  });
+
+  describe('getProjectFileInfo', () => {
+    it('creates start_sources json', () => {
+      getStore().dispatch(setFileName('File.java'));
+      getStore().dispatch(setEditorText('code'));
+      expect(getProjectFileInfo(getStore().getState())).to.deep.equal({
+        'File.java': {
+          text: 'code',
+          visible: true
+        }
+      });
+    });
+  });
+});

--- a/dashboard/app/views/levels/_admin.html.haml
+++ b/dashboard/app/views/levels/_admin.html.haml
@@ -26,6 +26,9 @@
               - unless @level.uses_droplet?
                 %button{type: 'button', onclick: 'window.levelbuilder.copyWorkspaceToClipboard()', class: 'btn btn-default btn-sm'}
                   Copy workspace to clipboard
+            - elsif @level.is_a? Javalab
+              %ul
+                %li= link_to "[s]tart", edit_blocks_level_path(@level, :start_sources), { accesskey: 's' }
         - else
           %li (Cannot edit)
         - if can? :delete, @level


### PR DESCRIPTION
Adds the edit start_sources link to Extra links, the ability to edit and save start sources, and the populating of a new project with its start_sources.

On the level:
<img width="1440" alt="Screen Shot 2021-04-09 at 2 39 31 PM" src="https://user-images.githubusercontent.com/17147070/114243994-7f71fc80-9942-11eb-9f14-6b8a7402a3d0.png">

On the edit start_sources page: 
<img width="1440" alt="Screen Shot 2021-04-09 at 2 39 16 PM" src="https://user-images.githubusercontent.com/17147070/114243999-813bc000-9942-11eb-9f3a-f2d2301f34de.png">


## Links

- jira ticket: [CSA-204](https://codedotorg.atlassian.net/browse/CSA-204?atlOrigin=eyJpIjoiNTYxMGMzYjFhNmQ1NGVjNDg1NDA0ODZlM2U2NTBkYzEiLCJwIjoiaiJ9)


## Follow-up work

Adding a section on the level edit page to control whether a start_sources file is visible or not.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
