### PR TITLE
Refactor InstructionsCSF

### DIFF
--- a/apps/src/templates/instructions/InstructionsCSF.jsx
+++ b/apps/src/templates/instructions/InstructionsCSF.jsx
@@ -3,51 +3,25 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import Radium from 'radium';
-import classNames from 'classnames';
 import {connect} from 'react-redux';
-import CollapserButton from './CollapserButton';
-import ScrollButtons from './ScrollButtons';
 import ThreeColumns from './ThreeColumns';
-import PromptIcon from './PromptIcon';
-import HintDisplayLightbulb from '../HintDisplayLightbulb';
-import HintPrompt from './HintPrompt';
-import InlineFeedback from './InlineFeedback';
-import InlineHint from './InlineHint';
-import ChatBubble from './ChatBubble';
-import LegacyButton from '../LegacyButton';
 import {Z_INDEX as OVERLAY_Z_INDEX} from '../Overlay';
-import i18n from '@cdo/locale';
-import SafeMarkdown from '../SafeMarkdown';
-import {getOuterHeight, scrollTo, shouldDisplayChatTips} from './utils';
 import {levenshtein} from '../../utils';
-import color from '../../util/color';
-import commonStyles from '../../commonStyles';
-import Instructions from './Instructions';
 import styleConstants from '../../styleConstants';
+import InstructionsCsfLeftCol from './InstructionsCsfLeftCol';
+import InstructionsCsfRightCol from './InstructionsCsfRightCol';
+import InstructionsCsfMiddleCol from './InstructionsCsfMiddleCol';
 
 var instructions = require('../../redux/instructions');
 
 const HEADER_HEIGHT = styleConstants['workspace-headers-height'];
 const RESIZER_HEIGHT = styleConstants['resize-bar-width'];
 
-const PROMPT_ICON_WIDTH = 60; // 50 + 10 for padding
-const AUTHORED_HINTS_EXTRA_WIDTH = 30; // 40 px, but 10 overlap with prompt icon
-
 // Minecraft-specific styles
 const craftStyles = {
   body: {
     // $below-header-background from craft/style.scss
     backgroundColor: '#646464'
-  },
-  collapserButton: {
-    padding: 5,
-    marginBottom: 0
-  },
-  scrollButtons: {
-    left: 38
-  },
-  scrollButtonsRtl: {
-    right: 38
   }
 };
 
@@ -82,44 +56,6 @@ const styles = {
     bottom: HEADER_HEIGHT + RESIZER_HEIGHT,
     right: 0,
     marginRight: 0
-  },
-  collapserButton: {
-    position: 'absolute',
-    right: 0,
-    marginTop: 5,
-    marginRight: 5
-  },
-  scrollButtons: {
-    position: 'relative',
-    top: 50,
-    left: 25
-  },
-  scrollButtonsRtl: {
-    position: 'relative',
-    top: 50,
-    right: 25
-  },
-  // bubble has pointer cursor by default. override that if no hints
-  noAuthoredHints: {
-    cursor: 'default',
-    marginBottom: 0
-  },
-  authoredHints: {
-    // raise by 20 so that the lightbulb "floats" without causing the original
-    // icon to move. This strangeness happens in part because prompt-icon-cell
-    // is managed outside of React
-    marginBottom: 0
-  },
-  instructions: {
-    padding: '5px 0'
-  },
-  instructionsWithTips: {
-    width: 'calc(100% - 20px)',
-    float: 'right'
-  },
-  instructionsWithTipsRtl: {
-    width: 'calc(100% - 20px)',
-    float: 'left'
   }
 };
 
@@ -180,11 +116,11 @@ class InstructionsCSF extends React.Component {
   };
 
   state = {
-    rightColWidth: {
-      collapsed: undefined,
-      uncollapsed: undefined,
-      empty: 10
-    },
+    rightColWidth: 0,
+    rightColHeight: 0,
+    leftColWidth: 0,
+    leftColHeight: 0,
+    middleColHeight: 0,
     promptForHint: false,
     displayScrollButtons: true
   };
@@ -208,8 +144,6 @@ class InstructionsCSF extends React.Component {
         }
       }.bind(this)
     );
-
-    this.updateRightColumnWidth();
   }
 
   /**
@@ -245,9 +179,13 @@ class InstructionsCSF extends React.Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    this.updateRightColumnWidth();
+    this.setCanScrollInstructions();
+    this.calculateRenderedHeight();
+    this.props.adjustMaxNeededHeight();
+  }
 
-    const contentContainer = this.instructions.parentElement;
+  setCanScrollInstructions() {
+    const contentContainer = this.getScrollTarget();
     const canScroll =
       contentContainer.scrollHeight > contentContainer.clientHeight;
     if (canScroll !== this.state.displayScrollButtons) {
@@ -257,22 +195,9 @@ class InstructionsCSF extends React.Component {
         displayScrollButtons: canScroll
       });
     }
+  }
 
-    const gotNewHint = prevProps.hints.length !== this.props.hints.length;
-    if (gotNewHint) {
-      const images = ReactDOM.findDOMNode(
-        this.instructions
-      ).getElementsByTagName('img');
-      for (let i = 0, image; (image = images[i]); i++) {
-        image.onload =
-          image.onload || this.scrollInstructionsToBottom.bind(this);
-      }
-    }
-
-    if (this.props.feedback || this.state.promptForHint || gotNewHint) {
-      this.scrollInstructionsToBottom();
-    }
-
+  calculateRenderedHeight() {
     const minHeight = this.getMinHeight();
     const maxHeight = this.getMaxHeight();
     const heightOutOfBounds =
@@ -285,35 +210,7 @@ class InstructionsCSF extends React.Component {
       );
       this.props.setInstructionsRenderedHeight(newHeight);
     }
-
-    this.props.adjustMaxNeededHeight();
   }
-
-  updateRightColumnWidth = () => {
-    if (
-      this.shouldDisplayCollapserButton() &&
-      this.getRightColWidth() === undefined
-    ) {
-      // Update right col width now that we know how much space it needs, and
-      // rerender if it has changed. One thing to note is that if we end up
-      // resizing our column significantly, it can result in our maxNeededHeight
-      // being inaccurate. This isn't that big a deal except that it means when we
-      // adjust maxNeededHeight below, it might not be as large as we want.
-      const width = $(ReactDOM.findDOMNode(this.collapser)).outerWidth(true);
-
-      // setting state in componentDidUpdate will trigger another
-      // re-render and is discouraged; unfortunately in this case we
-      // can't do it earlier in the lifecycle as we need to examine the
-      // actual DOM to determine the desired value. We are careful to
-      // only actually update the state when it has changed, which will
-      // prevent the possibility of an infinite loop and should serve to
-      // minimize excess rerenders.
-      let rightColWidth = Object.assign({}, this.state.rightColWidth);
-      rightColWidth[this.getCurrentRightColWidthProperty()] = width;
-      // eslint-disable-next-line react/no-did-update-set-state
-      this.setState({rightColWidth});
-    }
-  };
 
   /**
    * @param {boolean} collapsed whether or not the height should be
@@ -323,34 +220,37 @@ class InstructionsCSF extends React.Component {
    * the height of the little icon if we're not collapsed
    */
   getMinHeight(collapsed = this.props.collapsed) {
-    const collapseButtonHeight = getOuterHeight(this.collapser, true);
-    const scrollButtonsHeight =
-      !collapsed && this.scrollButtons ? this.scrollButtons.getMinHeight() : 0;
+    const {leftColHeight, rightColHeight} = this.state;
+    const middleColHeight = this.getMinInstructionsHeight();
 
-    const minIconHeight = this.icon ? getOuterHeight(this.icon, true) : 0;
+    return (
+      Math.max(leftColHeight, middleColHeight, rightColHeight) +
+      this.contentWrapperHeight()
+    );
+  }
+
+  // this doesn't make any sense...
+  getMinInstructionsHeight(collapsed = this.props.collapsed) {
     const instructionsHeight = Math.min(
-      getOuterHeight(this.instructions, true),
+      this.state.middleColHeight,
       this.props.maxHeight
     );
+
     const minInstructionsHeight =
-      this.props.collapsed ||
-      this.props.overlayVisible ||
-      this.props.isEmbedView
+      collapsed || this.props.overlayVisible || this.props.isEmbedView
         ? instructionsHeight
         : 0;
 
-    const domNode = $(ReactDOM.findDOMNode(this));
-    const margins = domNode.outerHeight(true) - domNode.outerHeight(false);
+    return minInstructionsHeight;
+  }
 
-    const leftColHeight = minIconHeight;
-    const middleColHeight = minInstructionsHeight;
-    const rightColHeight = collapseButtonHeight + scrollButtonsHeight;
-    return (
-      Math.max(leftColHeight, middleColHeight, rightColHeight) +
-      margins +
-      HEADER_HEIGHT +
-      RESIZER_HEIGHT
-    );
+  getMarginsHeight() {
+    const domNode = $(ReactDOM.findDOMNode(this));
+    return domNode.outerHeight(true) - domNode.outerHeight(false);
+  }
+
+  contentWrapperHeight() {
+    return this.getMarginsHeight() + HEADER_HEIGHT + RESIZER_HEIGHT;
   }
 
   /**
@@ -360,24 +260,10 @@ class InstructionsCSF extends React.Component {
    * @returns {number} The max height of the top instructions
    */
   getMaxHeight(collapsed = this.props.collapsed) {
-    const collapseButtonHeight = getOuterHeight(this.collapser, true);
-    const scrollButtonsHeight =
-      !collapsed && this.scrollButtons ? this.scrollButtons.getMinHeight() : 0;
-
-    const minIconHeight = this.icon ? getOuterHeight(this.icon, true) : 0;
-    const instructionsHeight = getOuterHeight(this.instructions, true);
-
-    const domNode = $(ReactDOM.findDOMNode(this));
-    const margins = domNode.outerHeight(true) - domNode.outerHeight(false);
-
-    const leftColHeight = minIconHeight;
-    const middleColHeight = instructionsHeight;
-    const rightColHeight = collapseButtonHeight + scrollButtonsHeight;
+    const {leftColHeight, middleColHeight, rightColHeight} = this.state;
     return (
       Math.max(leftColHeight, middleColHeight, rightColHeight) +
-      margins +
-      HEADER_HEIGHT +
-      RESIZER_HEIGHT
+      this.contentWrapperHeight()
     );
   }
 
@@ -385,41 +271,8 @@ class InstructionsCSF extends React.Component {
    * @return {Element} scrollTarget
    */
   getScrollTarget = () => {
-    return this.instructions.parentElement;
-  };
-
-  /**
-   * Manually scroll instructions to bottom. When we have multiple
-   * elements in instructions, "bottom" is defined as 10 pixels above
-   * the top of the bottommost element. This is so we don't scroll past
-   * the beginning of a long element, and so we scroll to a position
-   * such that you can see that there is an element above it which you
-   * can scroll up to.
-   */
-  scrollInstructionsToBottom() {
-    const instructions = this.instructions;
-    const contentContainer = instructions.parentElement;
-    if (instructions.children.length > 1) {
-      const lastChild = instructions.children[instructions.children.length - 1];
-      scrollTo(contentContainer, lastChild.offsetTop - 10);
-    } else {
-      scrollBy(contentContainer, contentContainer.scrollHeight);
-    }
-  }
-
-  /**
-   * Handle a click to the hint display bubble (lightbulb)
-   */
-  handleClickBubble = () => {
-    // If we don't have authored hints to display, clicking bubble shouldnt do anything
-    if (this.props.hasAuthoredHints && this.props.hasUnseenHint) {
-      this.setState({
-        promptForHint: true
-      });
-      if (this.props.collapsed) {
-        this.props.handleClickCollapser();
-      }
-    }
+    // can't seem to get this to work with refs
+    return document.querySelector('.csf-top-instructions').parentElement;
   };
 
   dismissHintPrompt = () => {
@@ -428,96 +281,53 @@ class InstructionsCSF extends React.Component {
     });
   };
 
-  showHint = () => {
-    this.dismissHintPrompt();
-    this.props.showNextHint();
-    this.props.clearFeedback();
+  shouldDisplayHintPrompt = () => {
+    return this.state && this.state.promptForHint && !this.props.collapsed;
   };
 
-  shouldDisplayHintPrompt() {
-    return this.state && this.state.promptForHint && !this.props.collapsed;
-  }
+  hasShortInstructions = () => {
+    return (
+      !!this.props.shortInstructions &&
+      !this.shortAndLongInstructionsAreEquivalent()
+    );
+  };
 
-  shouldDisplayCollapserButton() {
-    // if we have "extra" (non-instruction) content, we should always
-    // give the option of collapsing it
-    if (
-      this.props.hints.length ||
-      this.shouldDisplayHintPrompt() ||
-      this.props.feedback
-    ) {
-      return true;
-    }
-
-    // Otherwise, only show the button if we have two versions of
-    // instruction we want to toggle between
-    return this.props.longInstructions && !this.shouldIgnoreShortInstructions();
-  }
-
-  shouldIgnoreShortInstructions() {
-    // If we have no short instructions, always ignore them.
-    if (!this.props.shortInstructions) {
-      return true;
-    }
-
-    // Otherwise, if we have no long instructions, never ignore the short ones.
-    // Note that we would only decide to ignore short instructions in
-    // the absense of long instructions when the short instructions
-    // themselves were less than 10 characters, which can easily happen
-    // in ideo- or logographic languages.
-    if (!this.props.longInstructions) {
+  shortAndLongInstructionsAreEquivalent() {
+    if (!this.props.shortInstructions || !this.props.longInstructions) {
       return false;
     }
-
-    // if short instructions and long instructions have a Levenshtein
-    // Edit Distance of less than or equal to 10, ignore short
-    // instructions and only show long.
-    let dist = levenshtein(
+    const dist = levenshtein(
       this.props.longInstructions,
       this.props.shortInstructions
     );
     return dist <= 10;
   }
 
-  shouldDisplayShortInstructions() {
-    return (
-      !this.shouldIgnoreShortInstructions() &&
-      (this.props.collapsed || !this.props.longInstructions)
-    );
-  }
+  requestHint = () => {
+    this.setState({
+      promptForHint: true
+    });
+    this.props.collapsed && this.props.handleClickCollapser();
+  };
 
-  getAvatar() {
-    // Show the "sad" avatar if there is failure feedback. Otherwise,
-    // show the default avatar.
-    return this.props.feedback && this.props.feedback.isFailure
-      ? this.props.failureAvatar
-      : this.props.smallStaticAvatar;
-  }
+  setRightColWidth = width => {
+    this.setState({rightColWidth: width || 0});
+  };
 
-  /**
-   * this.state.rightColWidth contains three key/value pairs, reflecting the
-   * three different possible states for the right column content. This simple
-   * helper method returns the key corresponding to our current state.
-   *
-   * @returns {string} the key to this.state.rightColWidth which represents our
-   *          current state
-   */
-  getCurrentRightColWidthProperty() {
-    if (this.shouldDisplayCollapserButton()) {
-      return this.props.collapsed ? 'collapsed' : 'uncollapsed';
-    } else {
-      return 'empty';
-    }
-  }
+  setRightColHeight = height => {
+    this.setState({rightColHeight: height || 0});
+  };
 
-  getRightColWidth() {
-    return this.state.rightColWidth[this.getCurrentRightColWidthProperty()];
-  }
+  setLeftColWidth = width => {
+    this.setState({leftColWidth: width || 0});
+  };
 
-  legacyButtonClicked = () => {
-    this.props.hideOverlay();
-    this.props.setInstructionsRenderedHeight(this.getMinHeight());
-    this.props.adjustMaxNeededHeight();
+  setLeftColHeight = height => {
+    this.setState({leftColHeight: height || 0});
+  };
+
+  setMiddleColHeight = height => {
+    this.setState({middleColHeight: height || 0});
   };
 
   render() {
@@ -530,18 +340,6 @@ class InstructionsCSF extends React.Component {
       this.props.overlayVisible && styles.withOverlay
     ];
 
-    const markdown = this.shouldDisplayShortInstructions()
-      ? this.props.shortInstructions
-      : this.props.longInstructions;
-
-    const ttsUrl = this.shouldDisplayShortInstructions()
-      ? this.props.ttsShortInstructionsUrl
-      : this.props.ttsLongInstructionsUrl;
-
-    const leftColWidth =
-      (this.getAvatar() ? PROMPT_ICON_WIDTH : 10) +
-      (this.props.hasAuthoredHints ? AUTHORED_HINTS_EXTRA_WIDTH : 0);
-
     return (
       <div style={mainStyle}>
         <ThreeColumns
@@ -552,169 +350,33 @@ class InstructionsCSF extends React.Component {
             ],
             left: this.props.isRtl ? styles.leftColRtl : styles.leftCol
           }}
-          leftColWidth={leftColWidth}
-          rightColWidth={this.getRightColWidth() || 0}
+          leftColWidth={this.state.leftColWidth}
+          rightColWidth={this.state.rightColWidth}
           height={this.props.height - HEADER_HEIGHT - RESIZER_HEIGHT}
         >
-          <div
-            style={[
-              commonStyles.bubble,
-              this.props.hasAuthoredHints
-                ? styles.authoredHints
-                : styles.noAuthoredHints
-            ]}
-          >
-            <div
-              className={classNames({
-                'prompt-icon-cell': true,
-                authored_hints: this.props.hasAuthoredHints
-              })}
-              onClick={this.handleClickBubble}
-            >
-              {this.props.hasAuthoredHints && <HintDisplayLightbulb />}
-              {this.getAvatar() && (
-                <PromptIcon
-                  src={this.getAvatar()}
-                  ref={c => {
-                    this.icon = c;
-                  }}
-                />
-              )}
-            </div>
-          </div>
-          <div
-            ref={c => {
-              this.instructions = c;
-            }}
-            className="csf-top-instructions"
-            style={[
-              styles.instructions,
-              shouldDisplayChatTips(this.props.skinId) &&
-                (this.props.isRtl
-                  ? styles.instructionsWithTipsRtl
-                  : styles.instructionsWithTips)
-            ]}
-          >
-            <ChatBubble
-              ttsUrl={ttsUrl}
-              textToSpeechEnabled={this.props.textToSpeechEnabled}
-              isMinecraft={this.props.isMinecraft}
-              skinId={this.props.skinId}
-            >
-              <Instructions
-                ref={c => {
-                  this.instructions = c;
-                }}
-                longInstructions={markdown}
-                onResize={this.props.adjustMaxNeededHeight}
-                inputOutputTable={
-                  this.props.collapsed ? undefined : this.props.inputOutputTable
-                }
-                imgURL={this.props.aniGifURL}
-                inTopPane
-                isBlockly={this.props.isBlockly}
-                noInstructionsWhenCollapsed={false}
-              />
-              {this.props.shortInstructions2 && (
-                <div className="secondary-instructions">
-                  <SafeMarkdown markdown={this.props.shortInstructions2} />
-                </div>
-              )}
-              {this.props.overlayVisible && (
-                <div>
-                  <hr />
-                  <LegacyButton
-                    type="primary"
-                    onClick={this.legacyButtonClicked}
-                  >
-                    {i18n.dialogOK()}
-                  </LegacyButton>
-                </div>
-              )}
-            </ChatBubble>
-            {!this.props.collapsed &&
-              this.props.hints &&
-              this.props.hints.map(hint => (
-                <InlineHint
-                  key={hint.hintId}
-                  borderColor={color.yellow}
-                  markdown={hint.markdown}
-                  ttsUrl={hint.ttsUrl}
-                  ttsMessage={hint.ttsMessage}
-                  block={hint.block}
-                  video={hint.hintVideo}
-                />
-              ))}
-            {/*
-              The `key` prop on the InlineFeedback component is a workaround for a React 15.x problem
-              with efficiently updating inline blockly xml within this message. By providing a
-              changing key prop, we force the component to entirely unmount and re-mount when the
-              message contents change.  This may not be a problem once we upgrade to React 16.
-            */}
-            {this.props.feedback && !this.props.collapsed && (
-              <InlineFeedback
-                key={this.props.feedback.message}
-                borderColor={
-                  this.props.isMinecraft ? color.white : color.charcoal
-                }
-                message={this.props.feedback.message}
-                isMinecraft={this.props.isMinecraft}
-                skinId={this.props.skinId}
-                textToSpeechEnabled={this.props.textToSpeechEnabled}
-              />
-            )}
-            {this.shouldDisplayHintPrompt() && (
-              <HintPrompt
-                borderColor={color.yellow}
-                onConfirm={this.showHint}
-                onDismiss={this.dismissHintPrompt}
-                isMinecraft={this.props.isMinecraft}
-                skinId={this.props.skinId}
-                textToSpeechEnabled={this.props.textToSpeechEnabled}
-              />
-            )}
-          </div>
-          <div>
-            <CollapserButton
-              ref={c => {
-                this.collapser = c;
-              }}
-              style={[
-                styles.collapserButton,
-                this.props.isMinecraft && craftStyles.collapserButton,
-                !this.shouldDisplayCollapserButton() && commonStyles.hidden
-              ]}
-              collapsed={this.props.collapsed}
-              onClick={this.props.handleClickCollapser}
-              isMinecraft={this.props.isMinecraft}
-              isRtl={this.props.isRtl}
-            />
-            {!this.props.collapsed && (
-              <ScrollButtons
-                style={[
-                  this.props.isRtl
-                    ? styles.scrollButtonsRtl
-                    : styles.scrollButtons,
-                  this.props.isMinecraft &&
-                    (this.props.isRtl
-                      ? craftStyles.scrollButtonsRtl
-                      : craftStyles.scrollButtons)
-                ]}
-                ref={c => {
-                  this.scrollButtons = c;
-                }}
-                getScrollTarget={this.getScrollTarget}
-                visible={this.state.displayScrollButtons}
-                height={
-                  this.props.height -
-                  HEADER_HEIGHT -
-                  RESIZER_HEIGHT -
-                  styles.scrollButtons.top
-                }
-                isMinecraft={this.props.isMinecraft}
-              />
-            )}
-          </div>
+          <InstructionsCsfLeftCol
+            requestHint={this.requestHint}
+            setColWidth={this.setLeftColWidth}
+            setColHeight={this.setLeftColHeight}
+          />
+          <InstructionsCsfMiddleCol
+            dismissHintPrompt={this.dismissHintPrompt}
+            shouldDisplayHintPrompt={this.shouldDisplayHintPrompt}
+            hasShortInstructions={this.hasShortInstructions}
+            adjustMaxNeededHeight={this.props.adjustMaxNeededHeight}
+            promptForHint={this.state.promptForHint}
+            setColHeight={this.setMiddleColHeight}
+          />
+          <InstructionsCsfRightCol
+            hasShortInstructions={this.hasShortInstructions()}
+            promptForHint={this.state.promptForHint}
+            displayScrollButtons={this.state.displayScrollButtons}
+            getScrollTarget={this.getScrollTarget}
+            handleClickCollapser={this.props.handleClickCollapser}
+            setColWidth={this.setRightColWidth}
+            setColHeight={this.setRightColHeight}
+            shouldDisplayHintPrompt={this.shouldDisplayHintPrompt}
+          />
         </ThreeColumns>
       </div>
     );

--- a/apps/src/templates/instructions/InstructionsCSF.jsx
+++ b/apps/src/templates/instructions/InstructionsCSF.jsx
@@ -8,6 +8,7 @@ import ThreeColumns from './ThreeColumns';
 import {Z_INDEX as OVERLAY_Z_INDEX} from '../Overlay';
 import {levenshtein} from '../../utils';
 import {getOuterHeight} from './utils';
+import debounce from 'lodash/debounce';
 import styleConstants from '../../styleConstants';
 import InstructionsCsfLeftCol from './InstructionsCsfLeftCol';
 import InstructionsCsfRightCol from './InstructionsCsfRightCol';
@@ -114,15 +115,23 @@ class InstructionsCSF extends React.Component {
     noVisualization: false
   };
 
-  state = {
-    rightColWidth: 0,
-    rightColHeight: 0,
-    leftColWidth: 0,
-    leftColHeight: 0,
-    middleColHeight: 0,
-    promptForHint: false,
-    displayScrollButtons: true
-  };
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      rightColWidth: 0,
+      rightColHeight: 0,
+      leftColWidth: 0,
+      leftColHeight: 0,
+      promptForHint: false,
+      displayScrollButtons: true
+    };
+
+    this.debouncedCalculateRenderedHeight = debounce(
+      this.calculateRenderedHeight,
+      300
+    );
+  }
 
   /**
    * Calculate our initial height (based off of rendered height of instructions)
@@ -179,7 +188,7 @@ class InstructionsCSF extends React.Component {
 
   componentDidUpdate() {
     this.setCanScrollInstructions();
-    this.calculateRenderedHeight();
+    this.debouncedCalculateRenderedHeight();
     this.props.adjustMaxNeededHeight();
   }
 

--- a/apps/src/templates/instructions/InstructionsCSF.jsx
+++ b/apps/src/templates/instructions/InstructionsCSF.jsx
@@ -65,16 +65,11 @@ class InstructionsCSF extends React.Component {
     handleClickCollapser: PropTypes.func,
     adjustMaxNeededHeight: PropTypes.func,
     overlayVisible: PropTypes.bool,
-    skinId: PropTypes.string,
     isMinecraft: PropTypes.bool.isRequired,
-    isBlockly: PropTypes.bool.isRequired,
-    inputOutputTable: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number)),
     noVisualization: PropTypes.bool,
     hideOverlay: PropTypes.func.isRequired,
-    aniGifURL: PropTypes.string,
     isRtl: PropTypes.bool.isRequired,
     isEmbedView: PropTypes.bool,
-
     hints: PropTypes.arrayOf(
       PropTypes.shape({
         hintId: PropTypes.string.isRequired,
@@ -83,28 +78,15 @@ class InstructionsCSF extends React.Component {
         video: PropTypes.string
       })
     ).isRequired,
-    hasUnseenHint: PropTypes.bool.isRequired,
-    showNextHint: PropTypes.func.isRequired,
-    hasAuthoredHints: PropTypes.bool.isRequired,
-
     collapsed: PropTypes.bool.isRequired,
 
     shortInstructions: PropTypes.string,
-    shortInstructions2: PropTypes.string,
     longInstructions: PropTypes.string,
 
-    clearFeedback: PropTypes.func.isRequired,
     feedback: PropTypes.shape({
       message: PropTypes.string.isRequired,
       isFailure: PropTypes.bool
     }),
-
-    smallStaticAvatar: PropTypes.string,
-    failureAvatar: PropTypes.string,
-
-    ttsShortInstructionsUrl: PropTypes.string,
-    ttsLongInstructionsUrl: PropTypes.string,
-    textToSpeechEnabled: PropTypes.bool,
 
     height: PropTypes.number.isRequired,
     maxHeight: PropTypes.number.isRequired,
@@ -387,33 +369,19 @@ export default connect(
   function propsFromStore(state) {
     return {
       overlayVisible: state.instructions.overlayVisible,
-      skinId: state.pageConstants.skinId,
       isMinecraft: !!state.pageConstants.isMinecraft,
-      isBlockly: !!state.pageConstants.isBlockly,
-      aniGifURL: state.pageConstants.aniGifURL,
-      inputOutputTable: state.pageConstants.inputOutputTable,
       isRtl: state.isRtl,
       noVisualization: state.pageConstants.noVisualization,
       feedback: state.instructions.feedback,
       collapsed: state.instructions.isCollapsed,
       hints: state.authoredHints.seenHints,
-      hasUnseenHint: state.authoredHints.unseenHints.length > 0,
-      hasAuthoredHints: state.instructions.hasAuthoredHints,
-      showNextHint: state.pageConstants.showNextHint,
       height: state.instructions.renderedHeight,
       maxHeight: Math.min(
         state.instructions.maxAvailableHeight,
         state.instructions.maxNeededHeight
       ),
-      ttsShortInstructionsUrl: state.pageConstants.ttsShortInstructionsUrl,
-      ttsLongInstructionsUrl: state.pageConstants.ttsLongInstructionsUrl,
-      textToSpeechEnabled:
-        state.pageConstants.textToSpeechEnabled || state.pageConstants.isK1,
       shortInstructions: state.instructions.shortInstructions,
-      shortInstructions2: state.instructions.shortInstructions2,
-      longInstructions: state.instructions.longInstructions,
-      smallStaticAvatar: state.pageConstants.smallStaticAvatar,
-      failureAvatar: state.pageConstants.failureAvatar
+      longInstructions: state.instructions.longInstructions
     };
   },
   function propsFromDispatch(dispatch) {
@@ -423,9 +391,6 @@ export default connect(
       },
       setInstructionsRenderedHeight(height) {
         dispatch(instructions.setInstructionsRenderedHeight(height));
-      },
-      clearFeedback(height) {
-        dispatch(instructions.setFeedback(null));
       }
     };
   },

--- a/apps/src/templates/instructions/InstructionsCSF.jsx
+++ b/apps/src/templates/instructions/InstructionsCSF.jsx
@@ -221,8 +221,10 @@ class InstructionsCSF extends React.Component {
   };
 
   getMarginsHeight() {
-    const domNode = $(ReactDOM.findDOMNode(this));
-    return domNode.outerHeight(true) - domNode.outerHeight(false);
+    return (
+      getOuterHeight(this.instructionsCsfWrapper, true) -
+      getOuterHeight(this.instructionsCsfWrapper, false)
+    );
   }
 
   contentWrapperHeight() {
@@ -260,23 +262,25 @@ class InstructionsCSF extends React.Component {
     return this.state && this.state.promptForHint && !this.props.collapsed;
   };
 
-  hasShortInstructions = () => {
-    return (
-      !!this.props.shortInstructions &&
-      !this.shortAndLongInstructionsAreEquivalent()
-    );
-  };
+  hasShortAndLongInstructions = () => {
+    const shortInstructionsExist = !!this.props.shortInstructions;
 
-  shortAndLongInstructionsAreEquivalent() {
-    if (!this.props.shortInstructions || !this.props.longInstructions) {
-      return false;
-    }
+    // In information theory, linguistics, and computer science, the Levenshtein distance
+    // is a string metric for measuring the difference between two sequences.
     const dist = levenshtein(
       this.props.longInstructions,
       this.props.shortInstructions
     );
-    return dist <= 10;
-  }
+
+    // if the levenshtein distance between short and long instructions is <= 10
+    // we consider the instructions to be equivalent
+    const shortAndLongInstructionsAreEquivalent = dist <= 10;
+
+    const hasValidShortInstructions =
+      shortInstructionsExist && !shortAndLongInstructionsAreEquivalent;
+
+    return hasValidShortInstructions && !!this.props.longInstructions;
+  };
 
   requestHint = () => {
     this.setState({
@@ -319,10 +323,13 @@ class InstructionsCSF extends React.Component {
       this.props.overlayVisible && styles.withOverlay
     ];
 
-    const hasShortInstructions = this.hasShortInstructions();
+    const hasShortAndLongInstructions = this.hasShortAndLongInstructions();
 
     return (
-      <div style={mainStyle}>
+      <div
+        style={mainStyle}
+        ref={wrapper => (this.instructionsCsfWrapper = wrapper)}
+      >
         <ThreeColumns
           styles={{
             container: [
@@ -347,13 +354,12 @@ class InstructionsCSF extends React.Component {
             }
             dismissHintPrompt={this.dismissHintPrompt}
             shouldDisplayHintPrompt={this.shouldDisplayHintPrompt}
-            hasShortInstructions={hasShortInstructions}
             adjustMaxNeededHeight={this.props.adjustMaxNeededHeight}
             promptForHint={this.state.promptForHint}
             getMinInstructionsHeight={this.getMinInstructionsHeight}
+            hasShortAndLongInstructions={hasShortAndLongInstructions}
           />
           <InstructionsCsfRightCol
-            hasShortInstructions={hasShortInstructions}
             promptForHint={this.state.promptForHint}
             displayScrollButtons={this.state.displayScrollButtons}
             getScrollTarget={this.getScrollTarget}
@@ -361,6 +367,7 @@ class InstructionsCSF extends React.Component {
             setColWidth={this.setRightColWidth}
             setColHeight={this.setRightColHeight}
             shouldDisplayHintPrompt={this.shouldDisplayHintPrompt}
+            hasShortAndLongInstructions={hasShortAndLongInstructions}
           />
         </ThreeColumns>
       </div>

--- a/apps/src/templates/instructions/InstructionsCSF.jsx
+++ b/apps/src/templates/instructions/InstructionsCSF.jsx
@@ -7,6 +7,7 @@ import {connect} from 'react-redux';
 import ThreeColumns from './ThreeColumns';
 import {Z_INDEX as OVERLAY_Z_INDEX} from '../Overlay';
 import {levenshtein} from '../../utils';
+import {getOuterHeight} from './utils';
 import styleConstants from '../../styleConstants';
 import InstructionsCsfLeftCol from './InstructionsCsfLeftCol';
 import InstructionsCsfRightCol from './InstructionsCsfRightCol';
@@ -213,7 +214,7 @@ class InstructionsCSF extends React.Component {
 
   getMinInstructionsHeight = (collapsed = this.props.collapsed) => {
     if (collapsed || this.props.overlayVisible || this.props.isEmbedView) {
-      return Math.min(this.state.middleColHeight, this.props.maxHeight);
+      return Math.min(this.getMiddleColHeight(), this.props.maxHeight);
     } else {
       return 0;
     }
@@ -234,10 +235,10 @@ class InstructionsCSF extends React.Component {
    * current collapsed state.
    * @returns {number} The max height of the top instructions
    */
-  getMaxHeight(collapsed = this.props.collapsed) {
-    const {leftColHeight, middleColHeight, rightColHeight} = this.state;
+  getMaxHeight() {
+    const {leftColHeight, rightColHeight} = this.state;
     return (
-      Math.max(leftColHeight, middleColHeight, rightColHeight) +
+      Math.max(leftColHeight, this.getMiddleColHeight(), rightColHeight) +
       this.contentWrapperHeight()
     );
   }
@@ -285,24 +286,28 @@ class InstructionsCSF extends React.Component {
   };
 
   setRightColWidth = width => {
-    this.setState({rightColWidth: width || 0});
+    width !== this.state.rightColWidth &&
+      this.setState({rightColWidth: width || 0});
   };
 
   setRightColHeight = height => {
-    this.setState({rightColHeight: height || 0});
+    height !== this.state.rightColHeight &&
+      this.setState({rightColHeight: height || 0});
   };
 
   setLeftColWidth = width => {
-    this.setState({leftColWidth: width || 0});
+    width !== this.state.leftColWidth &&
+      this.setState({leftColWidth: width || 0});
   };
 
   setLeftColHeight = height => {
-    this.setState({leftColHeight: height || 0});
+    height !== this.state.leftColHeight &&
+      this.setState({leftColHeight: height || 0});
   };
 
-  setMiddleColHeight = height => {
-    this.setState({middleColHeight: height || 0});
-  };
+  getMiddleColHeight() {
+    return this.instructions ? getOuterHeight(this.instructions, true) : 0;
+  }
 
   render() {
     const mainStyle = [
@@ -345,7 +350,6 @@ class InstructionsCSF extends React.Component {
             hasShortInstructions={hasShortInstructions}
             adjustMaxNeededHeight={this.props.adjustMaxNeededHeight}
             promptForHint={this.state.promptForHint}
-            setColHeight={this.setMiddleColHeight}
             getMinInstructionsHeight={this.getMinInstructionsHeight}
           />
           <InstructionsCsfRightCol

--- a/apps/src/templates/instructions/InstructionsCSF.jsx
+++ b/apps/src/templates/instructions/InstructionsCSF.jsx
@@ -60,6 +60,22 @@ const styles = {
   }
 };
 
+/**
+ * InstructionsCSF is made up of 3 ThreeColumns:
+ * Left column: displays an avatar and a lightbulb (if hints are available) used for requesting hints
+ * Middle column: displays the chat bubble with either short or long instructions, hints (if available)
+ * and feedback (if available)
+ * Right column: displays an expand and collapse button (if instructions are expandable/collapsible)
+ * and arrows for scrolling the middle column if it overflows the container
+
+ * Why do we have width calculations?
+ * The ThreeColumns component requires explicit widths of the left and right columns. We get these
+ * widths by using callbacks setRightColWidth and setLeftColWidth. After the left and right columns render
+ * or update, the widths are recalculated.
+
+ * Why do we have height calculations?
+ * The height calculations are used to determine how far the instructions resizer can be dragged
+*/
 class InstructionsCSF extends React.Component {
   static propTypes = {
     teacherViewingStudentWork: PropTypes.bool,
@@ -289,19 +305,21 @@ class InstructionsCSF extends React.Component {
     this.props.collapsed && this.props.handleClickCollapser();
   };
 
+  // needed to set width for ThreeColumns
   setRightColWidth = width => {
     width !== this.state.rightColWidth &&
       this.setState({rightColWidth: width || 0});
   };
 
-  setRightColHeight = height => {
-    height !== this.state.rightColHeight &&
-      this.setState({rightColHeight: height || 0});
-  };
-
+  // needed to set width for ThreeColumns
   setLeftColWidth = width => {
     width !== this.state.leftColWidth &&
       this.setState({leftColWidth: width || 0});
+  };
+
+  setRightColHeight = height => {
+    height !== this.state.rightColHeight &&
+      this.setState({rightColHeight: height || 0});
   };
 
   setLeftColHeight = height => {
@@ -323,6 +341,11 @@ class InstructionsCSF extends React.Component {
       this.props.overlayVisible && styles.withOverlay
     ];
 
+    const threeColumnsStyles = {
+      container: [styles.body, this.props.isMinecraft && craftStyles.body],
+      left: this.props.isRtl ? styles.leftColRtl : styles.leftCol
+    };
+
     const hasShortAndLongInstructions = this.hasShortAndLongInstructions();
 
     return (
@@ -331,13 +354,7 @@ class InstructionsCSF extends React.Component {
         ref={wrapper => (this.instructionsCsfWrapper = wrapper)}
       >
         <ThreeColumns
-          styles={{
-            container: [
-              styles.body,
-              this.props.isMinecraft && craftStyles.body
-            ],
-            left: this.props.isRtl ? styles.leftColRtl : styles.leftCol
-          }}
+          styles={threeColumnsStyles}
           leftColWidth={this.state.leftColWidth}
           rightColWidth={this.state.rightColWidth}
           height={this.props.height - HEADER_HEIGHT - RESIZER_HEIGHT}

--- a/apps/src/templates/instructions/InstructionsCSF.jsx
+++ b/apps/src/templates/instructions/InstructionsCSF.jsx
@@ -246,9 +246,7 @@ class InstructionsCSF extends React.Component {
    * @return {Element} scrollTarget
    */
   getScrollTarget = () => {
-    // couldn't manage to get the parent element when using ref
-    // so used querySelector instead
-    return document.querySelector('.csf-top-instructions').parentElement;
+    return this.instructions.parentElement;
   };
 
   dismissHintPrompt = () => {
@@ -338,6 +336,10 @@ class InstructionsCSF extends React.Component {
             setColHeight={this.setLeftColHeight}
           />
           <InstructionsCsfMiddleCol
+            ref={instructions =>
+              (this.instructions =
+                instructions && instructions.getWrappedInstance().instructions)
+            }
             dismissHintPrompt={this.dismissHintPrompt}
             shouldDisplayHintPrompt={this.shouldDisplayHintPrompt}
             hasShortInstructions={hasShortInstructions}

--- a/apps/src/templates/instructions/InstructionsCSF.jsx
+++ b/apps/src/templates/instructions/InstructionsCSF.jsx
@@ -148,7 +148,7 @@ class InstructionsCSF extends React.Component {
     }
   }
 
-  componentWillUpdate(nextProps, nextState) {
+  componentWillUpdate(nextProps) {
     const gotNewFeedback = !this.props.feedback && nextProps.feedback;
     if (gotNewFeedback) {
       this.setState({
@@ -160,7 +160,7 @@ class InstructionsCSF extends React.Component {
     }
   }
 
-  componentDidUpdate(prevProps, prevState) {
+  componentDidUpdate() {
     this.setCanScrollInstructions();
     this.calculateRenderedHeight();
     this.props.adjustMaxNeededHeight();
@@ -203,7 +203,7 @@ class InstructionsCSF extends React.Component {
    */
   getMinHeight(collapsed = this.props.collapsed) {
     const {leftColHeight, rightColHeight} = this.state;
-    const middleColHeight = this.getMinInstructionsHeight();
+    const middleColHeight = this.getMinInstructionsHeight(collapsed);
 
     return (
       Math.max(leftColHeight, middleColHeight, rightColHeight) +
@@ -211,20 +211,13 @@ class InstructionsCSF extends React.Component {
     );
   }
 
-  // this doesn't make any sense...
-  getMinInstructionsHeight(collapsed = this.props.collapsed) {
-    const instructionsHeight = Math.min(
-      this.state.middleColHeight,
-      this.props.maxHeight
-    );
-
-    const minInstructionsHeight =
-      collapsed || this.props.overlayVisible || this.props.isEmbedView
-        ? instructionsHeight
-        : 0;
-
-    return minInstructionsHeight;
-  }
+  getMinInstructionsHeight = (collapsed = this.props.collapsed) => {
+    if (collapsed || this.props.overlayVisible || this.props.isEmbedView) {
+      return Math.min(this.state.middleColHeight, this.props.maxHeight);
+    } else {
+      return 0;
+    }
+  };
 
   getMarginsHeight() {
     const domNode = $(ReactDOM.findDOMNode(this));
@@ -253,7 +246,8 @@ class InstructionsCSF extends React.Component {
    * @return {Element} scrollTarget
    */
   getScrollTarget = () => {
-    // can't seem to get this to work with refs
+    // couldn't manage to get the parent element when using ref
+    // so used querySelector instead
     return document.querySelector('.csf-top-instructions').parentElement;
   };
 
@@ -322,6 +316,8 @@ class InstructionsCSF extends React.Component {
       this.props.overlayVisible && styles.withOverlay
     ];
 
+    const hasShortInstructions = this.hasShortInstructions();
+
     return (
       <div style={mainStyle}>
         <ThreeColumns
@@ -344,13 +340,14 @@ class InstructionsCSF extends React.Component {
           <InstructionsCsfMiddleCol
             dismissHintPrompt={this.dismissHintPrompt}
             shouldDisplayHintPrompt={this.shouldDisplayHintPrompt}
-            hasShortInstructions={this.hasShortInstructions}
+            hasShortInstructions={hasShortInstructions}
             adjustMaxNeededHeight={this.props.adjustMaxNeededHeight}
             promptForHint={this.state.promptForHint}
             setColHeight={this.setMiddleColHeight}
+            getMinInstructionsHeight={this.getMinInstructionsHeight}
           />
           <InstructionsCsfRightCol
-            hasShortInstructions={this.hasShortInstructions()}
+            hasShortInstructions={hasShortInstructions}
             promptForHint={this.state.promptForHint}
             displayScrollButtons={this.state.displayScrollButtons}
             getScrollTarget={this.getScrollTarget}

--- a/apps/src/templates/instructions/InstructionsCsfLeftCol.jsx
+++ b/apps/src/templates/instructions/InstructionsCsfLeftCol.jsx
@@ -1,0 +1,150 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Radium from 'radium';
+import classNames from 'classnames';
+import {connect} from 'react-redux';
+import PromptIcon from './PromptIcon';
+import HintDisplayLightbulb from '../HintDisplayLightbulb';
+import {getOuterHeight} from './utils';
+import commonStyles from '../../commonStyles';
+
+var instructions = require('../../redux/instructions');
+
+const PROMPT_ICON_WIDTH = 60; // 50 + 10 for padding
+const AUTHORED_HINTS_EXTRA_WIDTH = 30; // 40 px, but 10 overlap with prompt icon
+
+const styles = {
+  // bubble has pointer cursor by default. override that if no hints
+  noAuthoredHints: {
+    cursor: 'default',
+    marginBottom: 0
+  },
+  authoredHints: {
+    // raise by 20 so that the lightbulb "floats" without causing the original
+    // icon to move. This strangeness happens in part because prompt-icon-cell
+    // is managed outside of React
+    marginBottom: 0
+  }
+};
+
+class InstructionsCsfLeftCol extends React.Component {
+  static propTypes = {
+    requestHint: PropTypes.func.isRequired,
+    setColWidth: PropTypes.func.isRequired,
+    setColHeight: PropTypes.func.isRequired,
+    // from redux
+    hasUnseenHint: PropTypes.bool.isRequired,
+    hasAuthoredHints: PropTypes.bool.isRequired,
+    collapsed: PropTypes.bool.isRequired,
+    smallStaticAvatar: PropTypes.string,
+    failureAvatar: PropTypes.string,
+    feedback: PropTypes.shape({
+      message: PropTypes.string.isRequired,
+      isFailure: PropTypes.bool
+    })
+  };
+
+  componentDidMount() {
+    this.updateDimensions();
+  }
+
+  componentDidUpdate() {
+    this.updateDimensions();
+  }
+
+  updateDimensions() {
+    this.props.setColWidth(this.getColumnWidth());
+    this.props.setColHeight(this.getColumnHeight());
+  }
+
+  /**
+   * Handle a click to the hint display bubble (lightbulb)
+   */
+  handleClickBubble = () => {
+    // If we don't have authored hints to display, clicking bubble shouldnt do anything
+    if (this.props.hasAuthoredHints && this.props.hasUnseenHint) {
+      this.props.requestHint();
+    }
+  };
+
+  getAvatar() {
+    // Show the "sad" avatar if there is failure feedback. Otherwise,
+    // show the default avatar.
+    return this.props.feedback && this.props.feedback.isFailure
+      ? this.props.failureAvatar
+      : this.props.smallStaticAvatar;
+  }
+
+  getColumnWidth = () => {
+    return (
+      (this.getAvatar() ? PROMPT_ICON_WIDTH : 10) +
+      (this.props.hasAuthoredHints ? AUTHORED_HINTS_EXTRA_WIDTH : 0)
+    );
+  };
+
+  getColumnHeight = () => {
+    return getOuterHeight(this.leftCol, true);
+  };
+
+  render() {
+    return (
+      <div
+        ref={c => {
+          this.leftCol = c;
+        }}
+        style={[
+          commonStyles.bubble,
+          this.props.hasAuthoredHints
+            ? styles.authoredHints
+            : styles.noAuthoredHints
+        ]}
+      >
+        <div
+          className={classNames({
+            'prompt-icon-cell': true,
+            authored_hints: this.props.hasAuthoredHints
+          })}
+          onClick={this.handleClickBubble}
+        >
+          {this.props.hasAuthoredHints && <HintDisplayLightbulb />}
+          {this.getAvatar() && (
+            <PromptIcon
+              src={this.getAvatar()}
+              ref={c => {
+                this.icon = c;
+              }}
+            />
+          )}
+        </div>
+      </div>
+    );
+  }
+}
+
+export default connect(
+  function propsFromStore(state) {
+    return {
+      hasUnseenHint: state.authoredHints.unseenHints.length > 0,
+      hasAuthoredHints: state.instructions.hasAuthoredHints,
+      collapsed: state.instructions.isCollapsed,
+      smallStaticAvatar: state.pageConstants.smallStaticAvatar,
+      failureAvatar: state.pageConstants.failureAvatar,
+      feedback: state.instructions.feedback
+    };
+  },
+  function propsFromDispatch(dispatch) {
+    return {
+      hideOverlay: function() {
+        dispatch(instructions.hideOverlay());
+      },
+      setInstructionsRenderedHeight(height) {
+        dispatch(instructions.setInstructionsRenderedHeight(height));
+      },
+      clearFeedback(height) {
+        dispatch(instructions.setFeedback(null));
+      }
+    };
+  },
+  null,
+  {withRef: true}
+)(Radium(InstructionsCsfLeftCol));

--- a/apps/src/templates/instructions/InstructionsCsfLeftCol.jsx
+++ b/apps/src/templates/instructions/InstructionsCsfLeftCol.jsx
@@ -14,14 +14,7 @@ const AUTHORED_HINTS_EXTRA_WIDTH = 30; // 40 px, but 10 overlap with prompt icon
 const styles = {
   // bubble has pointer cursor by default. override that if no hints
   noAuthoredHints: {
-    cursor: 'default',
-    marginBottom: 0
-  },
-  authoredHints: {
-    // raise by 20 so that the lightbulb "floats" without causing the original
-    // icon to move. This strangeness happens in part because prompt-icon-cell
-    // is managed outside of React
-    marginBottom: 0
+    cursor: 'default'
   }
 };
 
@@ -93,7 +86,7 @@ class InstructionsCsfLeftCol extends React.Component {
         }}
         style={[
           commonStyles.bubble,
-          hasAuthoredHints ? styles.authoredHints : styles.noAuthoredHints
+          !hasAuthoredHints && styles.noAuthoredHints
         ]}
       >
         <div

--- a/apps/src/templates/instructions/InstructionsCsfLeftCol.jsx
+++ b/apps/src/templates/instructions/InstructionsCsfLeftCol.jsx
@@ -8,8 +8,6 @@ import HintDisplayLightbulb from '../HintDisplayLightbulb';
 import {getOuterHeight} from './utils';
 import commonStyles from '../../commonStyles';
 
-var instructions = require('../../redux/instructions');
-
 const PROMPT_ICON_WIDTH = 60; // 50 + 10 for padding
 const AUTHORED_HINTS_EXTRA_WIDTH = 30; // 40 px, but 10 overlap with prompt icon
 
@@ -132,19 +130,7 @@ export default connect(
       feedback: state.instructions.feedback
     };
   },
-  function propsFromDispatch(dispatch) {
-    return {
-      hideOverlay: function() {
-        dispatch(instructions.hideOverlay());
-      },
-      setInstructionsRenderedHeight(height) {
-        dispatch(instructions.setInstructionsRenderedHeight(height));
-      },
-      clearFeedback(height) {
-        dispatch(instructions.setFeedback(null));
-      }
-    };
-  },
+  null,
   null,
   {withRef: true}
 )(Radium(InstructionsCsfLeftCol));

--- a/apps/src/templates/instructions/InstructionsCsfLeftCol.jsx
+++ b/apps/src/templates/instructions/InstructionsCsfLeftCol.jsx
@@ -33,7 +33,6 @@ class InstructionsCsfLeftCol extends React.Component {
     // from redux
     hasUnseenHint: PropTypes.bool.isRequired,
     hasAuthoredHints: PropTypes.bool.isRequired,
-    collapsed: PropTypes.bool.isRequired,
     smallStaticAvatar: PropTypes.string,
     failureAvatar: PropTypes.string,
     feedback: PropTypes.shape({
@@ -85,6 +84,8 @@ class InstructionsCsfLeftCol extends React.Component {
   };
 
   render() {
+    const {hasAuthoredHints} = this.props;
+
     return (
       <div
         ref={c => {
@@ -92,39 +93,30 @@ class InstructionsCsfLeftCol extends React.Component {
         }}
         style={[
           commonStyles.bubble,
-          this.props.hasAuthoredHints
-            ? styles.authoredHints
-            : styles.noAuthoredHints
+          hasAuthoredHints ? styles.authoredHints : styles.noAuthoredHints
         ]}
       >
         <div
-          className={classNames({
-            'prompt-icon-cell': true,
-            authored_hints: this.props.hasAuthoredHints
+          className={classNames('prompt-icon-cell', {
+            authored_hints: hasAuthoredHints
           })}
           onClick={this.handleClickBubble}
         >
-          {this.props.hasAuthoredHints && <HintDisplayLightbulb />}
-          {this.getAvatar() && (
-            <PromptIcon
-              src={this.getAvatar()}
-              ref={c => {
-                this.icon = c;
-              }}
-            />
-          )}
+          {hasAuthoredHints && <HintDisplayLightbulb />}
+          {this.getAvatar() && <PromptIcon src={this.getAvatar()} />}
         </div>
       </div>
     );
   }
 }
 
+export const UnconnectedInstructionsCsfLeftCol = Radium(InstructionsCsfLeftCol);
+
 export default connect(
   function propsFromStore(state) {
     return {
       hasUnseenHint: state.authoredHints.unseenHints.length > 0,
       hasAuthoredHints: state.instructions.hasAuthoredHints,
-      collapsed: state.instructions.isCollapsed,
       smallStaticAvatar: state.pageConstants.smallStaticAvatar,
       failureAvatar: state.pageConstants.failureAvatar,
       feedback: state.instructions.feedback

--- a/apps/src/templates/instructions/InstructionsCsfLeftCol.jsx
+++ b/apps/src/templates/instructions/InstructionsCsfLeftCol.jsx
@@ -55,10 +55,10 @@ class InstructionsCsfLeftCol extends React.Component {
   }
 
   /**
-   * Handle a click to the hint display bubble (lightbulb)
+   * Handle a click to the hint display lightbulb
    */
-  handleClickBubble = () => {
-    // If we don't have authored hints to display, clicking bubble shouldnt do anything
+  handleClickLightbulb = () => {
+    // If we don't have authored hints to display, clicking lightbulb shouldnt do anything
     if (this.props.hasAuthoredHints && this.props.hasUnseenHint) {
       this.props.requestHint();
     }
@@ -100,7 +100,7 @@ class InstructionsCsfLeftCol extends React.Component {
           className={classNames('prompt-icon-cell', {
             authored_hints: hasAuthoredHints
           })}
-          onClick={this.handleClickBubble}
+          onClick={this.handleClickLightbulb}
         >
           {hasAuthoredHints && <HintDisplayLightbulb />}
           {this.getAvatar() && <PromptIcon src={this.getAvatar()} />}

--- a/apps/src/templates/instructions/InstructionsCsfMiddleCol.jsx
+++ b/apps/src/templates/instructions/InstructionsCsfMiddleCol.jsx
@@ -9,7 +9,7 @@ import ChatBubble from './ChatBubble';
 import LegacyButton from '../LegacyButton';
 import i18n from '@cdo/locale';
 import SafeMarkdown from '../SafeMarkdown';
-import {scrollTo, shouldDisplayChatTips, getOuterHeight} from './utils';
+import {scrollTo, shouldDisplayChatTips} from './utils';
 import color from '../../util/color';
 import Instructions from './Instructions';
 
@@ -36,7 +36,6 @@ class InstructionsCsfMiddleCol extends React.Component {
     hasShortInstructions: PropTypes.bool.isRequired,
     adjustMaxNeededHeight: PropTypes.func.isRequired,
     promptForHint: PropTypes.bool.isRequired,
-    setColHeight: PropTypes.func.isRequired,
     getMinInstructionsHeight: PropTypes.func.isRequired,
 
     // from redux:
@@ -72,13 +71,7 @@ class InstructionsCsfMiddleCol extends React.Component {
     setInstructionsRenderedHeight: PropTypes.func.isRequired
   };
 
-  componentDidMount() {
-    this.updateDimensions();
-  }
-
   componentDidUpdate(prevProps) {
-    this.updateDimensions();
-
     const gotNewHint = prevProps.hints.length !== this.props.hints.length;
     if (gotNewHint) {
       this.handleHintOnLoad();
@@ -87,10 +80,6 @@ class InstructionsCsfMiddleCol extends React.Component {
     if (this.props.feedback || this.props.promptForHint || gotNewHint) {
       this.scrollInstructionsToBottom();
     }
-  }
-
-  updateDimensions() {
-    this.props.setColHeight(getOuterHeight(this.instructions, true));
   }
 
   handleHintOnLoad() {

--- a/apps/src/templates/instructions/InstructionsCsfMiddleCol.jsx
+++ b/apps/src/templates/instructions/InstructionsCsfMiddleCol.jsx
@@ -34,10 +34,11 @@ class InstructionsCsfMiddleCol extends React.Component {
   static propTypes = {
     dismissHintPrompt: PropTypes.func.isRequired,
     shouldDisplayHintPrompt: PropTypes.func.isRequired,
-    hasShortInstructions: PropTypes.func.isRequired,
+    hasShortInstructions: PropTypes.bool.isRequired,
     adjustMaxNeededHeight: PropTypes.func.isRequired,
     promptForHint: PropTypes.bool.isRequired,
     setColHeight: PropTypes.func.isRequired,
+    getMinInstructionsHeight: PropTypes.func.isRequired,
 
     // from redux:
     overlayVisible: PropTypes.bool,
@@ -120,7 +121,6 @@ class InstructionsCsfMiddleCol extends React.Component {
       scrollBy(contentContainer, contentContainer.scrollHeight);
     }
   }
-  //  maureen deal with scroll instructionstobottom
 
   showHint = () => {
     this.props.dismissHintPrompt();
@@ -130,14 +130,16 @@ class InstructionsCsfMiddleCol extends React.Component {
 
   shouldDisplayShortInstructions() {
     return (
-      this.props.hasShortInstructions() &&
+      this.props.hasShortInstructions &&
       (this.props.collapsed || !this.props.longInstructions)
     );
   }
 
   closeOverlay = () => {
     this.props.hideOverlay();
-    this.props.setInstructionsRenderedHeight(this.getMinHeight());
+    this.props.setInstructionsRenderedHeight(
+      this.props.getMinInstructionsHeight()
+    );
     this.props.adjustMaxNeededHeight();
   };
 
@@ -242,6 +244,10 @@ class InstructionsCsfMiddleCol extends React.Component {
   }
 }
 
+export const UnconnectedInstructionsCsfMiddleCol = Radium(
+  InstructionsCsfMiddleCol
+);
+
 export default connect(
   function propsFromStore(state) {
     return {
@@ -273,7 +279,7 @@ export default connect(
       setInstructionsRenderedHeight(height) {
         dispatch(instructions.setInstructionsRenderedHeight(height));
       },
-      clearFeedback(height) {
+      clearFeedback() {
         dispatch(instructions.setFeedback(null));
       }
     };

--- a/apps/src/templates/instructions/InstructionsCsfMiddleCol.jsx
+++ b/apps/src/templates/instructions/InstructionsCsfMiddleCol.jsx
@@ -33,10 +33,10 @@ class InstructionsCsfMiddleCol extends React.Component {
   static propTypes = {
     dismissHintPrompt: PropTypes.func.isRequired,
     shouldDisplayHintPrompt: PropTypes.func.isRequired,
-    hasShortInstructions: PropTypes.bool.isRequired,
     adjustMaxNeededHeight: PropTypes.func.isRequired,
     promptForHint: PropTypes.bool.isRequired,
     getMinInstructionsHeight: PropTypes.func.isRequired,
+    hasShortAndLongInstructions: PropTypes.bool.isRequired,
 
     // from redux:
     overlayVisible: PropTypes.bool,
@@ -118,8 +118,8 @@ class InstructionsCsfMiddleCol extends React.Component {
 
   shouldDisplayShortInstructions() {
     return (
-      this.props.hasShortInstructions &&
-      (this.props.collapsed || !this.props.longInstructions)
+      (this.props.hasShortAndLongInstructions && this.props.collapsed) ||
+      !this.props.longInstructions
     );
   }
 

--- a/apps/src/templates/instructions/InstructionsCsfMiddleCol.jsx
+++ b/apps/src/templates/instructions/InstructionsCsfMiddleCol.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
-import Radium from 'radium';
 import {connect} from 'react-redux';
 import HintPrompt from './HintPrompt';
 import InlineFeedback from './InlineFeedback';
@@ -152,19 +151,19 @@ class InstructionsCsfMiddleCol extends React.Component {
       ? this.props.ttsShortInstructionsUrl
       : this.props.ttsLongInstructionsUrl;
 
+    const tipsStyle = shouldDisplayChatTips(this.props.skinId)
+      ? this.props.isRtl
+        ? styles.instructionsWithTipsRtl
+        : styles.instructionsWithTips
+      : {};
+
     return (
       <div
         ref={c => {
           this.instructions = c;
         }}
         className="csf-top-instructions"
-        style={[
-          styles.instructions,
-          shouldDisplayChatTips(this.props.skinId) &&
-            (this.props.isRtl
-              ? styles.instructionsWithTipsRtl
-              : styles.instructionsWithTips)
-        ]}
+        style={{...styles.instructions, ...tipsStyle}}
       >
         <ChatBubble
           ttsUrl={ttsUrl}
@@ -244,9 +243,7 @@ class InstructionsCsfMiddleCol extends React.Component {
   }
 }
 
-export const UnconnectedInstructionsCsfMiddleCol = Radium(
-  InstructionsCsfMiddleCol
-);
+export const UnconnectedInstructionsCsfMiddleCol = InstructionsCsfMiddleCol;
 
 export default connect(
   function propsFromStore(state) {
@@ -286,4 +283,4 @@ export default connect(
   },
   null,
   {withRef: true}
-)(Radium(InstructionsCsfMiddleCol));
+)(InstructionsCsfMiddleCol);

--- a/apps/src/templates/instructions/InstructionsCsfMiddleCol.jsx
+++ b/apps/src/templates/instructions/InstructionsCsfMiddleCol.jsx
@@ -1,0 +1,283 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
+import Radium from 'radium';
+import {connect} from 'react-redux';
+import HintPrompt from './HintPrompt';
+import InlineFeedback from './InlineFeedback';
+import InlineHint from './InlineHint';
+import ChatBubble from './ChatBubble';
+import LegacyButton from '../LegacyButton';
+import i18n from '@cdo/locale';
+import SafeMarkdown from '../SafeMarkdown';
+import {scrollTo, shouldDisplayChatTips, getOuterHeight} from './utils';
+import color from '../../util/color';
+import Instructions from './Instructions';
+
+var instructions = require('../../redux/instructions');
+
+const styles = {
+  instructions: {
+    padding: '5px 0'
+  },
+  instructionsWithTips: {
+    width: 'calc(100% - 20px)',
+    float: 'right'
+  },
+  instructionsWithTipsRtl: {
+    width: 'calc(100% - 20px)',
+    float: 'left'
+  }
+};
+
+class InstructionsCsfMiddleCol extends React.Component {
+  static propTypes = {
+    dismissHintPrompt: PropTypes.func.isRequired,
+    shouldDisplayHintPrompt: PropTypes.func.isRequired,
+    hasShortInstructions: PropTypes.func.isRequired,
+    adjustMaxNeededHeight: PropTypes.func.isRequired,
+    promptForHint: PropTypes.bool.isRequired,
+    setColHeight: PropTypes.func.isRequired,
+
+    // from redux:
+    overlayVisible: PropTypes.bool,
+    skinId: PropTypes.string,
+    isMinecraft: PropTypes.bool.isRequired,
+    isBlockly: PropTypes.bool.isRequired,
+    aniGifURL: PropTypes.string,
+    inputOutputTable: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number)),
+    isRtl: PropTypes.bool.isRequired,
+    feedback: PropTypes.shape({
+      message: PropTypes.string.isRequired,
+      isFailure: PropTypes.bool
+    }),
+    collapsed: PropTypes.bool.isRequired,
+    hints: PropTypes.arrayOf(
+      PropTypes.shape({
+        hintId: PropTypes.string.isRequired,
+        markdown: PropTypes.string.isRequired,
+        block: PropTypes.object, // XML
+        video: PropTypes.string
+      })
+    ).isRequired,
+    showNextHint: PropTypes.func.isRequired,
+    ttsShortInstructionsUrl: PropTypes.string,
+    ttsLongInstructionsUrl: PropTypes.string,
+    textToSpeechEnabled: PropTypes.bool,
+    shortInstructions: PropTypes.string,
+    shortInstructions2: PropTypes.string,
+    longInstructions: PropTypes.string,
+    clearFeedback: PropTypes.func.isRequired,
+    hideOverlay: PropTypes.func.isRequired,
+    setInstructionsRenderedHeight: PropTypes.func.isRequired
+  };
+
+  componentDidMount() {
+    this.updateDimensions();
+  }
+
+  componentDidUpdate(prevProps) {
+    this.updateDimensions();
+
+    const gotNewHint = prevProps.hints.length !== this.props.hints.length;
+    if (gotNewHint) {
+      this.handleHintOnLoad();
+    }
+
+    if (this.props.feedback || this.props.promptForHint || gotNewHint) {
+      this.scrollInstructionsToBottom();
+    }
+  }
+
+  updateDimensions() {
+    this.props.setColHeight(getOuterHeight(this.instructions, true));
+  }
+
+  handleHintOnLoad() {
+    const images = ReactDOM.findDOMNode(this.instructions).getElementsByTagName(
+      'img'
+    );
+    for (let i = 0, image; (image = images[i]); i++) {
+      image.onload = image.onload || this.scrollInstructionsToBottom.bind(this);
+    }
+  }
+
+  /**
+   * Manually scroll instructions to bottom. When we have multiple
+   * elements in instructions, "bottom" is defined as 10 pixels above
+   * the top of the bottommost element. This is so we don't scroll past
+   * the beginning of a long element, and so we scroll to a position
+   * such that you can see that there is an element above it which you
+   * can scroll up to.
+   */
+  scrollInstructionsToBottom() {
+    const instructions = this.instructions;
+    const contentContainer = instructions.parentElement;
+    if (instructions.children.length > 1) {
+      const lastChild = instructions.children[instructions.children.length - 1];
+      scrollTo(contentContainer, lastChild.offsetTop - 10);
+    } else {
+      scrollBy(contentContainer, contentContainer.scrollHeight);
+    }
+  }
+  //  maureen deal with scroll instructionstobottom
+
+  showHint = () => {
+    this.props.dismissHintPrompt();
+    this.props.showNextHint();
+    this.props.clearFeedback();
+  };
+
+  shouldDisplayShortInstructions() {
+    return (
+      this.props.hasShortInstructions() &&
+      (this.props.collapsed || !this.props.longInstructions)
+    );
+  }
+
+  closeOverlay = () => {
+    this.props.hideOverlay();
+    this.props.setInstructionsRenderedHeight(this.getMinHeight());
+    this.props.adjustMaxNeededHeight();
+  };
+
+  render() {
+    const markdown = this.shouldDisplayShortInstructions()
+      ? this.props.shortInstructions
+      : this.props.longInstructions;
+
+    const ttsUrl = this.shouldDisplayShortInstructions()
+      ? this.props.ttsShortInstructionsUrl
+      : this.props.ttsLongInstructionsUrl;
+
+    return (
+      <div
+        ref={c => {
+          this.instructions = c;
+        }}
+        className="csf-top-instructions"
+        style={[
+          styles.instructions,
+          shouldDisplayChatTips(this.props.skinId) &&
+            (this.props.isRtl
+              ? styles.instructionsWithTipsRtl
+              : styles.instructionsWithTips)
+        ]}
+      >
+        <ChatBubble
+          ttsUrl={ttsUrl}
+          textToSpeechEnabled={this.props.textToSpeechEnabled}
+          isMinecraft={this.props.isMinecraft}
+          skinId={this.props.skinId}
+        >
+          <Instructions
+            ref={c => {
+              this.instructions = c;
+            }}
+            longInstructions={markdown}
+            onResize={this.props.adjustMaxNeededHeight}
+            inputOutputTable={
+              this.props.collapsed ? undefined : this.props.inputOutputTable
+            }
+            imgURL={this.props.aniGifURL}
+            inTopPane
+            isBlockly={this.props.isBlockly}
+            noInstructionsWhenCollapsed={false}
+          />
+          {this.props.shortInstructions2 && (
+            <div className="secondary-instructions">
+              <SafeMarkdown markdown={this.props.shortInstructions2} />
+            </div>
+          )}
+          {this.props.overlayVisible && (
+            <div>
+              <hr />
+              <LegacyButton type="primary" onClick={this.closeOverlay}>
+                {i18n.dialogOK()}
+              </LegacyButton>
+            </div>
+          )}
+        </ChatBubble>
+        {!this.props.collapsed &&
+          this.props.hints &&
+          this.props.hints.map(hint => (
+            <InlineHint
+              key={hint.hintId}
+              borderColor={color.yellow}
+              markdown={hint.markdown}
+              ttsUrl={hint.ttsUrl}
+              ttsMessage={hint.ttsMessage}
+              block={hint.block}
+              video={hint.hintVideo}
+            />
+          ))}
+        {/*
+              The `key` prop on the InlineFeedback component is a workaround for a React 15.x problem
+              with efficiently updating inline blockly xml within this message. By providing a
+              changing key prop, we force the component to entirely unmount and re-mount when the
+              message contents change.  This may not be a problem once we upgrade to React 16.
+            */}
+        {this.props.feedback && !this.props.collapsed && (
+          <InlineFeedback
+            key={this.props.feedback.message}
+            borderColor={this.props.isMinecraft ? color.white : color.charcoal}
+            message={this.props.feedback.message}
+            isMinecraft={this.props.isMinecraft}
+            skinId={this.props.skinId}
+            textToSpeechEnabled={this.props.textToSpeechEnabled}
+          />
+        )}
+        {this.props.shouldDisplayHintPrompt() && (
+          <HintPrompt
+            borderColor={color.yellow}
+            onConfirm={this.showHint}
+            onDismiss={this.props.dismissHintPrompt}
+            isMinecraft={this.props.isMinecraft}
+            skinId={this.props.skinId}
+            textToSpeechEnabled={this.props.textToSpeechEnabled}
+          />
+        )}
+      </div>
+    );
+  }
+}
+
+export default connect(
+  function propsFromStore(state) {
+    return {
+      overlayVisible: state.instructions.overlayVisible,
+      skinId: state.pageConstants.skinId,
+      isMinecraft: !!state.pageConstants.isMinecraft,
+      isBlockly: !!state.pageConstants.isBlockly,
+      aniGifURL: state.pageConstants.aniGifURL,
+      inputOutputTable: state.pageConstants.inputOutputTable,
+      isRtl: state.isRtl,
+      feedback: state.instructions.feedback,
+      collapsed: state.instructions.isCollapsed,
+      hints: state.authoredHints.seenHints,
+      showNextHint: state.pageConstants.showNextHint,
+      ttsShortInstructionsUrl: state.pageConstants.ttsShortInstructionsUrl,
+      ttsLongInstructionsUrl: state.pageConstants.ttsLongInstructionsUrl,
+      textToSpeechEnabled:
+        state.pageConstants.textToSpeechEnabled || state.pageConstants.isK1,
+      shortInstructions: state.instructions.shortInstructions,
+      shortInstructions2: state.instructions.shortInstructions2,
+      longInstructions: state.instructions.longInstructions
+    };
+  },
+  function propsFromDispatch(dispatch) {
+    return {
+      hideOverlay: function() {
+        dispatch(instructions.hideOverlay());
+      },
+      setInstructionsRenderedHeight(height) {
+        dispatch(instructions.setInstructionsRenderedHeight(height));
+      },
+      clearFeedback(height) {
+        dispatch(instructions.setFeedback(null));
+      }
+    };
+  },
+  null,
+  {withRef: true}
+)(Radium(InstructionsCsfMiddleCol));

--- a/apps/src/templates/instructions/InstructionsCsfRightCol.jsx
+++ b/apps/src/templates/instructions/InstructionsCsfRightCol.jsx
@@ -118,8 +118,9 @@ class InstructionsCsfRightCol extends React.Component {
 
   getColumnHeight(collapsed = this.props.collapsed) {
     const collapseButtonHeight = getOuterHeight(this.collapser, true);
-    const scrollButtonsHeight =
-      !collapsed && this.scrollButtons ? this.scrollButtons.getMinHeight() : 0;
+    const scrollButtonsHeight = this.scrollButtons
+      ? this.scrollButtons.getMinHeight()
+      : 0;
     return collapseButtonHeight + scrollButtonsHeight;
   }
 

--- a/apps/src/templates/instructions/InstructionsCsfRightCol.jsx
+++ b/apps/src/templates/instructions/InstructionsCsfRightCol.jsx
@@ -6,28 +6,17 @@ import Radium from 'radium';
 import {connect} from 'react-redux';
 import CollapserButton from './CollapserButton';
 import ScrollButtons from './ScrollButtons';
-import commonStyles from '../../commonStyles';
 import styleConstants from '../../styleConstants';
 import {getOuterHeight} from './utils';
 
 const HEADER_HEIGHT = styleConstants['workspace-headers-height'];
 const RESIZER_HEIGHT = styleConstants['resize-bar-width'];
 
-// Minecraft-specific styles
-const craftStyles = {
-  collapserButton: {
-    padding: 5,
-    marginBottom: 0
-  },
-  scrollButtons: {
-    left: 38
-  },
-  scrollButtonsRtl: {
-    right: 38
-  }
-};
-
 const styles = {
+  column: {
+    display: 'flex',
+    justifyContent: 'center'
+  },
   collapserButton: {
     position: 'absolute',
     right: 0,
@@ -42,6 +31,18 @@ const styles = {
     position: 'relative',
     top: 50,
     margin: '0px'
+  },
+  craftStyles: {
+    collapserButton: {
+      padding: 5,
+      marginBottom: 0
+    },
+    scrollButtons: {
+      left: 38
+    },
+    scrollButtonsRtl: {
+      right: 38
+    }
   }
 };
 
@@ -112,11 +113,9 @@ class InstructionsCsfRightCol extends React.Component {
     const scrollButtonWidth = this.props.displayScrollButtons
       ? $(ReactDOM.findDOMNode(this.scrollButtons)).outerWidth(true)
       : 0;
-    const width = Math.max(collapserWidth, scrollButtonWidth);
-    return width;
+    return Math.max(collapserWidth, scrollButtonWidth);
   }
 
-  // do I need collapse param?
   getColumnHeight(collapsed = this.props.collapsed) {
     const collapseButtonHeight = getOuterHeight(this.collapser, true);
     const scrollButtonsHeight =
@@ -125,40 +124,40 @@ class InstructionsCsfRightCol extends React.Component {
   }
 
   render() {
+    const displayCollapserButton = this.shouldDisplayCollapserButton();
+
     const scrollButtonsHeight =
       this.props.height -
       HEADER_HEIGHT -
       RESIZER_HEIGHT -
-      (this.shouldDisplayCollapserButton()
-        ? styles.scrollButtonsBelowCollapser.top
-        : 0);
+      (displayCollapserButton ? styles.scrollButtonsBelowCollapser.top : 0);
 
     return (
-      <div style={{display: 'flex', justifyContent: 'center'}}>
-        <CollapserButton
-          ref={c => {
-            this.collapser = c;
-          }}
-          style={[
-            styles.collapserButton,
-            this.props.isMinecraft && craftStyles.collapserButton,
-            !this.shouldDisplayCollapserButton() && commonStyles.hidden
-          ]}
-          collapsed={this.props.collapsed}
-          onClick={this.props.handleClickCollapser}
-          isMinecraft={this.props.isMinecraft}
-          isRtl={this.props.isRtl}
-        />
+      <div style={styles.column}>
+        {displayCollapserButton && (
+          <CollapserButton
+            ref={c => {
+              this.collapser = c;
+            }}
+            style={[
+              styles.collapserButton,
+              this.props.isMinecraft && styles.craftStyles.collapserButton
+            ]}
+            collapsed={this.props.collapsed}
+            onClick={this.props.handleClickCollapser}
+            isMinecraft={this.props.isMinecraft}
+            isRtl={this.props.isRtl}
+          />
+        )}
         {this.props.displayScrollButtons && (
           <ScrollButtons
             style={[
               styles.scrollButtons,
               this.props.isMinecraft &&
                 (this.props.isRtl
-                  ? craftStyles.scrollButtonsRtl
-                  : craftStyles.scrollButtons),
-              this.shouldDisplayCollapserButton() &&
-                styles.scrollButtonsBelowCollapser
+                  ? styles.craftStyles.scrollButtonsRtl
+                  : styles.craftStyles.scrollButtons),
+              displayCollapserButton && styles.scrollButtonsBelowCollapser
             ]}
             ref={c => {
               this.scrollButtons = c;
@@ -173,6 +172,10 @@ class InstructionsCsfRightCol extends React.Component {
     );
   }
 }
+
+export const UnconnectedInstructionsCsfRightCol = Radium(
+  InstructionsCsfRightCol
+);
 
 export default connect(
   function propsFromStore(state) {

--- a/apps/src/templates/instructions/InstructionsCsfRightCol.jsx
+++ b/apps/src/templates/instructions/InstructionsCsfRightCol.jsx
@@ -10,8 +10,6 @@ import commonStyles from '../../commonStyles';
 import styleConstants from '../../styleConstants';
 import {getOuterHeight} from './utils';
 
-var instructions = require('../../redux/instructions');
-
 const HEADER_HEIGHT = styleConstants['workspace-headers-height'];
 const RESIZER_HEIGHT = styleConstants['resize-bar-width'];
 
@@ -188,19 +186,7 @@ export default connect(
       isRtl: state.isRtl
     };
   },
-  function propsFromDispatch(dispatch) {
-    return {
-      hideOverlay: function() {
-        dispatch(instructions.hideOverlay());
-      },
-      setInstructionsRenderedHeight(height) {
-        dispatch(instructions.setInstructionsRenderedHeight(height));
-      },
-      clearFeedback(height) {
-        dispatch(instructions.setFeedback(null));
-      }
-    };
-  },
+  null,
   null,
   {withRef: true}
 )(Radium(InstructionsCsfRightCol));

--- a/apps/src/templates/instructions/InstructionsCsfRightCol.jsx
+++ b/apps/src/templates/instructions/InstructionsCsfRightCol.jsx
@@ -1,0 +1,206 @@
+import $ from 'jquery';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
+import Radium from 'radium';
+import {connect} from 'react-redux';
+import CollapserButton from './CollapserButton';
+import ScrollButtons from './ScrollButtons';
+import commonStyles from '../../commonStyles';
+import styleConstants from '../../styleConstants';
+import {getOuterHeight} from './utils';
+
+var instructions = require('../../redux/instructions');
+
+const HEADER_HEIGHT = styleConstants['workspace-headers-height'];
+const RESIZER_HEIGHT = styleConstants['resize-bar-width'];
+
+// Minecraft-specific styles
+const craftStyles = {
+  collapserButton: {
+    padding: 5,
+    marginBottom: 0
+  },
+  scrollButtons: {
+    left: 38
+  },
+  scrollButtonsRtl: {
+    right: 38
+  }
+};
+
+const styles = {
+  collapserButton: {
+    position: 'absolute',
+    right: 0,
+    marginTop: 5,
+    marginRight: 5
+  },
+  scrollButtons: {
+    margin: '0px 5px',
+    minWidth: '40px'
+  },
+  scrollButtonsBelowCollapser: {
+    position: 'relative',
+    top: 50,
+    margin: '0px'
+  }
+};
+
+class InstructionsCsfRightCol extends React.Component {
+  static propTypes = {
+    shouldDisplayHintPrompt: PropTypes.func.isRequired,
+    hasShortInstructions: PropTypes.bool.isRequired,
+    promptForHint: PropTypes.bool.isRequired,
+    displayScrollButtons: PropTypes.bool.isRequired,
+    getScrollTarget: PropTypes.func.isRequired,
+    handleClickCollapser: PropTypes.func.isRequired,
+    setColWidth: PropTypes.func.isRequired,
+    setColHeight: PropTypes.func.isRequired,
+
+    // from redux
+    collapsed: PropTypes.bool.isRequired,
+    hints: PropTypes.arrayOf(
+      PropTypes.shape({
+        hintId: PropTypes.string.isRequired,
+        markdown: PropTypes.string.isRequired,
+        block: PropTypes.object, // XML
+        video: PropTypes.string
+      })
+    ).isRequired,
+    feedback: PropTypes.shape({
+      message: PropTypes.string.isRequired,
+      isFailure: PropTypes.bool
+    }),
+    longInstructions: PropTypes.string,
+    height: PropTypes.number.isRequired,
+    isMinecraft: PropTypes.bool.isRequired,
+    isRtl: PropTypes.bool.isRequired
+  };
+
+  componentDidMount() {
+    this.updateDimensions();
+  }
+
+  componentDidUpdate() {
+    this.updateDimensions();
+  }
+
+  updateDimensions() {
+    this.props.setColWidth(this.getColumnWidth());
+    this.props.setColHeight(this.getColumnHeight());
+  }
+
+  shouldDisplayCollapserButton() {
+    // if we have "extra" (non-instruction) content, we should always
+    // give the option of collapsing it
+    const hasExtraContent =
+      this.props.hints.length ||
+      this.props.shouldDisplayHintPrompt() ||
+      this.props.feedback;
+
+    // Otherwise, only show the button if we have two versions of
+    // instruction we want to toggle between
+    const hasShortAndLongInstructions =
+      this.props.longInstructions && this.props.hasShortInstructions;
+
+    return hasExtraContent || hasShortAndLongInstructions;
+  }
+
+  getColumnWidth() {
+    const collapserWidth = this.shouldDisplayCollapserButton()
+      ? $(ReactDOM.findDOMNode(this.collapser)).outerWidth(true)
+      : 0;
+    const scrollButtonWidth = this.props.displayScrollButtons
+      ? $(ReactDOM.findDOMNode(this.scrollButtons)).outerWidth(true)
+      : 0;
+    const width = Math.max(collapserWidth, scrollButtonWidth);
+    return width;
+  }
+
+  // do I need collapse param?
+  getColumnHeight(collapsed = this.props.collapsed) {
+    const collapseButtonHeight = getOuterHeight(this.collapser, true);
+    const scrollButtonsHeight =
+      !collapsed && this.scrollButtons ? this.scrollButtons.getMinHeight() : 0;
+    return collapseButtonHeight + scrollButtonsHeight;
+  }
+
+  render() {
+    const scrollButtonsHeight =
+      this.props.height -
+      HEADER_HEIGHT -
+      RESIZER_HEIGHT -
+      (this.shouldDisplayCollapserButton()
+        ? styles.scrollButtonsBelowCollapser.top
+        : 0);
+
+    return (
+      <div style={{display: 'flex', justifyContent: 'center'}}>
+        <CollapserButton
+          ref={c => {
+            this.collapser = c;
+          }}
+          style={[
+            styles.collapserButton,
+            this.props.isMinecraft && craftStyles.collapserButton,
+            !this.shouldDisplayCollapserButton() && commonStyles.hidden
+          ]}
+          collapsed={this.props.collapsed}
+          onClick={this.props.handleClickCollapser}
+          isMinecraft={this.props.isMinecraft}
+          isRtl={this.props.isRtl}
+        />
+        {this.props.displayScrollButtons && (
+          <ScrollButtons
+            style={[
+              styles.scrollButtons,
+              this.props.isMinecraft &&
+                (this.props.isRtl
+                  ? craftStyles.scrollButtonsRtl
+                  : craftStyles.scrollButtons),
+              this.shouldDisplayCollapserButton() &&
+                styles.scrollButtonsBelowCollapser
+            ]}
+            ref={c => {
+              this.scrollButtons = c;
+            }}
+            getScrollTarget={this.props.getScrollTarget}
+            visible={true}
+            height={scrollButtonsHeight}
+            isMinecraft={this.props.isMinecraft}
+          />
+        )}
+      </div>
+    );
+  }
+}
+
+export default connect(
+  function propsFromStore(state) {
+    return {
+      collapsed: state.instructions.isCollapsed,
+      hints: state.authoredHints.seenHints,
+      feedback: state.instructions.feedback,
+      longInstructions: state.instructions.longInstructions,
+      height: state.instructions.renderedHeight,
+      isMinecraft: !!state.pageConstants.isMinecraft,
+      isRtl: state.isRtl
+    };
+  },
+  function propsFromDispatch(dispatch) {
+    return {
+      hideOverlay: function() {
+        dispatch(instructions.hideOverlay());
+      },
+      setInstructionsRenderedHeight(height) {
+        dispatch(instructions.setInstructionsRenderedHeight(height));
+      },
+      clearFeedback(height) {
+        dispatch(instructions.setFeedback(null));
+      }
+    };
+  },
+  null,
+  {withRef: true}
+)(Radium(InstructionsCsfRightCol));

--- a/apps/src/templates/instructions/InstructionsCsfRightCol.jsx
+++ b/apps/src/templates/instructions/InstructionsCsfRightCol.jsx
@@ -118,7 +118,7 @@ class InstructionsCsfRightCol extends React.Component {
 
   getColumnHeight() {
     const collapseButtonHeight = getOuterHeight(this.collapser, true);
-    const scrollButtonsHeight = this.props.displayScrollButtons
+    const scrollButtonsHeight = this.scrollButtons
       ? this.scrollButtons.getMinHeight()
       : 0;
     return collapseButtonHeight + scrollButtonsHeight;

--- a/apps/src/templates/instructions/InstructionsCsfRightCol.jsx
+++ b/apps/src/templates/instructions/InstructionsCsfRightCol.jsx
@@ -49,13 +49,13 @@ const styles = {
 class InstructionsCsfRightCol extends React.Component {
   static propTypes = {
     shouldDisplayHintPrompt: PropTypes.func.isRequired,
-    hasShortInstructions: PropTypes.bool.isRequired,
     promptForHint: PropTypes.bool.isRequired,
     displayScrollButtons: PropTypes.bool.isRequired,
     getScrollTarget: PropTypes.func.isRequired,
     handleClickCollapser: PropTypes.func.isRequired,
     setColWidth: PropTypes.func.isRequired,
     setColHeight: PropTypes.func.isRequired,
+    hasShortAndLongInstructions: PropTypes.bool.isRequired,
 
     // from redux
     collapsed: PropTypes.bool.isRequired,
@@ -71,7 +71,6 @@ class InstructionsCsfRightCol extends React.Component {
       message: PropTypes.string.isRequired,
       isFailure: PropTypes.bool
     }),
-    longInstructions: PropTypes.string,
     height: PropTypes.number.isRequired,
     isMinecraft: PropTypes.bool.isRequired,
     isRtl: PropTypes.bool.isRequired
@@ -100,10 +99,7 @@ class InstructionsCsfRightCol extends React.Component {
 
     // Otherwise, only show the button if we have two versions of
     // instruction we want to toggle between
-    const hasShortAndLongInstructions =
-      this.props.longInstructions && this.props.hasShortInstructions;
-
-    return hasExtraContent || hasShortAndLongInstructions;
+    return hasExtraContent || this.props.hasShortAndLongInstructions;
   }
 
   getColumnWidth() {
@@ -184,7 +180,6 @@ export default connect(
       collapsed: state.instructions.isCollapsed,
       hints: state.authoredHints.seenHints,
       feedback: state.instructions.feedback,
-      longInstructions: state.instructions.longInstructions,
       height: state.instructions.renderedHeight,
       isMinecraft: !!state.pageConstants.isMinecraft,
       isRtl: state.isRtl

--- a/apps/src/templates/instructions/InstructionsCsfRightCol.jsx
+++ b/apps/src/templates/instructions/InstructionsCsfRightCol.jsx
@@ -116,9 +116,9 @@ class InstructionsCsfRightCol extends React.Component {
     return Math.max(collapserWidth, scrollButtonWidth);
   }
 
-  getColumnHeight(collapsed = this.props.collapsed) {
+  getColumnHeight() {
     const collapseButtonHeight = getOuterHeight(this.collapser, true);
-    const scrollButtonsHeight = this.scrollButtons
+    const scrollButtonsHeight = this.props.displayScrollButtons
       ? this.scrollButtons.getMinHeight()
       : 0;
     return collapseButtonHeight + scrollButtonsHeight;

--- a/apps/src/templates/instructions/ScrollButtons.jsx
+++ b/apps/src/templates/instructions/ScrollButtons.jsx
@@ -133,7 +133,7 @@ class ScrollButtons extends React.Component {
     const upStyle = {
       opacity: this.props.visible ? 1 : 0,
       top: this.getMargin(),
-      marginBottom: '3px'
+      margin: '0 0 3px 0'
     };
 
     const downStyle = {

--- a/apps/src/templates/instructions/ScrollButtons.jsx
+++ b/apps/src/templates/instructions/ScrollButtons.jsx
@@ -132,7 +132,8 @@ class ScrollButtons extends React.Component {
   render() {
     const upStyle = {
       opacity: this.props.visible ? 1 : 0,
-      top: this.getMargin()
+      top: this.getMargin(),
+      marginBottom: '3px'
     };
 
     const downStyle = {
@@ -186,6 +187,7 @@ class ScrollButtons extends React.Component {
         ref={c => {
           this.scrollDown = c;
         }}
+        className="uitest-scroll-button-down"
         key="scrollDown"
         onMouseDown={this.scrollStartDown}
         style={[styles.all, styles.arrow, styles.arrowDown, downStyle]}

--- a/apps/test/unit/templates/instructions/InstructionsCSFTest.jsx
+++ b/apps/test/unit/templates/instructions/InstructionsCSFTest.jsx
@@ -32,17 +32,28 @@ describe('InstructionsCSF', () => {
         longInstructions: 'Use this new block.'
       })
     );
+
+    // Avoid `attachTo: document.body` Warning
+    const div = document.createElement('div');
+    div.setAttribute('id', 'container');
+    document.body.appendChild(div);
   });
 
   afterEach(() => {
     restoreRedux();
+
+    const div = document.getElementById('container');
+    if (div) {
+      document.body.removeChild(div);
+    }
   });
 
   it('can change feedback when rendering different blockly blocks', () => {
     const wrapper = mount(
       <Provider store={getStore()}>
         <InstructionsCSF {...DEFAULT_PROPS} />
-      </Provider>
+      </Provider>,
+      {attachTo: document.getElementById('container')} // needed for getScrollTarget
     );
 
     failWithMessage('Repeat block: <xml><block type="controls_repeat"/></xml>');

--- a/apps/test/unit/templates/instructions/InstructionsCSFTest.jsx
+++ b/apps/test/unit/templates/instructions/InstructionsCSFTest.jsx
@@ -32,20 +32,10 @@ describe('InstructionsCSF', () => {
         longInstructions: 'Use this new block.'
       })
     );
-
-    // Avoid `attachTo: document.body` Warning
-    const div = document.createElement('div');
-    div.setAttribute('id', 'container');
-    document.body.appendChild(div);
   });
 
   afterEach(() => {
     restoreRedux();
-
-    const div = document.getElementById('container');
-    if (div) {
-      document.body.removeChild(div);
-    }
   });
 
   it('can change feedback when rendering different blockly blocks', () => {

--- a/apps/test/unit/templates/instructions/InstructionsCsfLeftColTest.jsx
+++ b/apps/test/unit/templates/instructions/InstructionsCsfLeftColTest.jsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import {expect} from '../../../util/reconfiguredChai';
+import sinon from 'sinon';
+import {UnconnectedInstructionsCsfLeftCol as InstructionsCsfLeftCol} from '@cdo/apps/templates/instructions/InstructionsCsfLeftCol';
+import PromptIcon from '@cdo/apps/templates/instructions/PromptIcon';
+import HintDisplayLightbulb from '@cdo/apps/templates/HintDisplayLightbulb';
+
+const DEFAULT_PROPS = {
+  requestHint: () => {},
+  setColWidth: () => {},
+  setColHeight: () => {},
+  hasUnseenHint: true,
+  hasAuthoredHints: true,
+  smallStaticAvatar: 'small-avatar',
+  failureAvatar: 'failure-avatar',
+  feedback: null
+};
+
+const setUp = (overrideProps = {}) => {
+  const props = {...DEFAULT_PROPS, ...overrideProps};
+  return shallow(<InstructionsCsfLeftCol {...props} />);
+};
+
+describe('InstructionsCsfLeftCol', () => {
+  it('sets col width and height on mount', () => {
+    const setColWidthSpy = sinon.spy();
+    const setColHeightSpy = sinon.spy();
+    setUp({setColHeight: setColHeightSpy, setColWidth: setColWidthSpy});
+
+    // should be called after mount:
+    expect(setColWidthSpy.calledOnce).to.be.true;
+    expect(setColHeightSpy.calledOnce).to.be.true;
+  });
+
+  it('calls requestHint on clicking .prompt-icon-cell when hasAuthoredHints and hasUnseenHint', () => {
+    const requestHintSpy = sinon.spy();
+    const wrapper = setUp({
+      hasAuthoredHints: true,
+      hasUnseenHint: true,
+      requestHint: requestHintSpy
+    });
+    wrapper.find('.prompt-icon-cell').simulate('click');
+    expect(requestHintSpy.calledOnce).to.be.true;
+  });
+
+  it('does not call requestHint on clicking .prompt-icon-cell when not hasAuthoredHints', () => {
+    const requestHintSpy = sinon.spy();
+    const wrapper = setUp({
+      hasAuthoredHints: false,
+      hasUnseenHint: true,
+      requestHint: requestHintSpy
+    });
+    wrapper.find('.prompt-icon-cell').simulate('click');
+    expect(requestHintSpy.calledOnce).to.be.false;
+  });
+
+  it('displays failureAvatar when there is failure feedback', () => {
+    const failureAvatarSrc = 'failure-avatar-src';
+    const wrapper = setUp({
+      failureAvatar: failureAvatarSrc,
+      feedback: {message: 'failure', isFailure: true}
+    });
+    expect(wrapper.find(PromptIcon).props().src).to.equal(failureAvatarSrc);
+  });
+
+  it('displays smallStaticAvatar when feedback is not failure', () => {
+    const smallAvatarSrc = 'small-avatar-src';
+    const wrapper = setUp({
+      smallStaticAvatar: smallAvatarSrc,
+      feedback: {message: 'feedback', isFailure: false}
+    });
+    expect(wrapper.find(PromptIcon).props().src).to.equal(smallAvatarSrc);
+  });
+
+  it('displays hint lightbulb when hasAuthoredHints', () => {
+    const wrapper = setUp({
+      hasAuthoredHints: true
+    });
+    expect(wrapper.find(HintDisplayLightbulb)).to.have.length(1);
+  });
+});

--- a/apps/test/unit/templates/instructions/InstructionsCsfMiddleColTest.jsx
+++ b/apps/test/unit/templates/instructions/InstructionsCsfMiddleColTest.jsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import {expect} from '../../../util/reconfiguredChai';
+import sinon from 'sinon';
+import {UnconnectedInstructionsCsfMiddleCol as InstructionsCsfMiddleCol} from '@cdo/apps/templates/instructions/InstructionsCsfMiddleCol';
+import Instructions from '@cdo/apps/templates/instructions/Instructions';
+import LegacyButton from '@cdo/apps/templates/LegacyButton';
+import InlineHint from '@cdo/apps/templates/instructions/InlineHint';
+import InlineFeedback from '@cdo/apps/templates/instructions/InlineFeedback';
+import HintPrompt from '@cdo/apps/templates/instructions/HintPrompt';
+
+const DEFAULT_PROPS = {
+  dismissHintPrompt: () => {},
+  shouldDisplayHintPrompt: () => {},
+  hasShortInstructions: true,
+  adjustMaxNeededHeight: () => {},
+  promptForHint: false,
+  setColHeight: () => {},
+  getMinInstructionsHeight: () => {},
+  overlayVisible: false,
+  skinId: 'skin-id',
+  isMinecraft: false,
+  isBlockly: true,
+  aniGifURL: undefined,
+  inputOutputTable: undefined,
+  isRtl: false,
+  feedback: undefined,
+  collapsed: false,
+  hints: [],
+  showNextHint: () => {},
+  ttsShortInstructionsUrl: 'tts short instructions',
+  ttsLongInstructionsUrl: 'tts long instructions',
+  textToSpeechEnabled: true,
+  shortInstructions: 'short instructions',
+  shortInstructions2: undefined,
+  longInstructions: 'long instructions',
+  clearFeedback: () => {},
+  hideOverlay: () => {},
+  setInstructionsRenderedHeight: () => {}
+};
+
+const setUp = (overrideProps = {}) => {
+  const props = {...DEFAULT_PROPS, ...overrideProps};
+  return shallow(<InstructionsCsfMiddleCol {...props} />);
+};
+
+describe('InstructionsCsfMiddleCol', () => {
+  it('calls setColHeight when the component mounts', () => {
+    const setColHeightSpy = sinon.spy();
+    setUp({setColHeight: setColHeightSpy});
+    expect(setColHeightSpy.calledOnce).to.be.true;
+  });
+
+  it('passes inputOutputTable to Instructions when not collapsed', () => {
+    const inputOutputTable = [[1, 2, 3, 4]];
+    const wrapper = setUp({collapsed: false, inputOutputTable});
+    expect(wrapper.find(Instructions).props().inputOutputTable).to.equal(
+      inputOutputTable
+    );
+  });
+
+  it('passes undefed for inputOutputTable to Instructions when collapsed', () => {
+    const inputOutputTable = [[1, 2, 3, 4]];
+    const wrapper = setUp({collapsed: true, inputOutputTable});
+    expect(wrapper.find(Instructions).props().inputOutputTable).to.equal(
+      undefined
+    );
+  });
+
+  it('display secondary instructions when shortInstructions2 exists', () => {
+    const wrapper = setUp({shortInstructions2: 'short instructions 2'});
+    expect(wrapper.find('.secondary-instructions')).to.have.length(1);
+  });
+
+  it('display LegacyButton when overlayVisible', () => {
+    const wrapper = setUp({overlayVisible: true});
+    expect(wrapper.find(LegacyButton)).to.have.length(1);
+  });
+
+  it('calls hideOverlay when overlayVisible and LegacyButton is clicked', () => {
+    const hideOverlaySpy = sinon.spy();
+    const wrapper = setUp({overlayVisible: true, hideOverlay: hideOverlaySpy});
+    wrapper.find(LegacyButton).simulate('click');
+    expect(hideOverlaySpy.calledOnce).to.be.true;
+  });
+
+  it('display InlineHint when hints and not collapsed', () => {
+    const hint = {
+      hintId: 'hint-id',
+      markdown: 'hint markdown'
+    };
+    const wrapper = setUp({hints: [hint], collapsed: false});
+    expect(wrapper.find(InlineHint)).to.have.length(1);
+  });
+
+  it('hide InlineHints when hints exist and collapsed', () => {
+    const hint = {
+      hintId: 'hint-id',
+      markdown: 'hint markdown'
+    };
+    const wrapper = setUp({hints: [hint], collapsed: true});
+    expect(wrapper.find(InlineHint)).to.have.length(0);
+  });
+
+  it('displays InlineFeedback when feedback and not collapsed', () => {
+    const feedback = {
+      message: 'some feedback',
+      isFailure: false
+    };
+    const wrapper = setUp({feedback, collapsed: false});
+    expect(wrapper.find(InlineFeedback)).to.have.length(1);
+  });
+
+  it('hides InlineFeedback when feedback exists and collapsed', () => {
+    const feedback = {
+      message: 'some feedback',
+      isFailure: false
+    };
+    const wrapper = setUp({feedback, collapsed: true});
+    expect(wrapper.find(InlineFeedback)).to.have.length(0);
+  });
+
+  it('displays HintPrompt when shouldDisplayHintPrompt returns true', () => {
+    const wrapper = setUp({shouldDisplayHintPrompt: () => true});
+    expect(wrapper.find(HintPrompt)).to.have.length(1);
+  });
+});

--- a/apps/test/unit/templates/instructions/InstructionsCsfMiddleColTest.jsx
+++ b/apps/test/unit/templates/instructions/InstructionsCsfMiddleColTest.jsx
@@ -45,12 +45,6 @@ const setUp = (overrideProps = {}) => {
 };
 
 describe('InstructionsCsfMiddleCol', () => {
-  it('calls setColHeight when the component mounts', () => {
-    const setColHeightSpy = sinon.spy();
-    setUp({setColHeight: setColHeightSpy});
-    expect(setColHeightSpy.calledOnce).to.be.true;
-  });
-
   it('passes inputOutputTable to Instructions when not collapsed', () => {
     const inputOutputTable = [[1, 2, 3, 4]];
     const wrapper = setUp({collapsed: false, inputOutputTable});

--- a/apps/test/unit/templates/instructions/InstructionsCsfMiddleColTest.jsx
+++ b/apps/test/unit/templates/instructions/InstructionsCsfMiddleColTest.jsx
@@ -12,7 +12,7 @@ import HintPrompt from '@cdo/apps/templates/instructions/HintPrompt';
 const DEFAULT_PROPS = {
   dismissHintPrompt: () => {},
   shouldDisplayHintPrompt: () => {},
-  hasShortInstructions: true,
+  hasShortAndLongInstructions: true,
   adjustMaxNeededHeight: () => {},
   promptForHint: false,
   setColHeight: () => {},
@@ -45,6 +45,44 @@ const setUp = (overrideProps = {}) => {
 };
 
 describe('InstructionsCsfMiddleCol', () => {
+  it('passes short instructions to Instructions component if in a collapsed state with both short and long instructions', () => {
+    const shortInstructions = 'test short instructions';
+    const wrapper = setUp({
+      hasShortAndLongInstructions: true,
+      collapsed: true,
+      shortInstructions
+    });
+    expect(wrapper.find(Instructions).props().longInstructions).to.equal(
+      shortInstructions
+    );
+  });
+
+  it('passes short instructions to Instructions component if not in a collapsed state with no long instructions', () => {
+    const shortInstructions = 'test short instructions';
+    const longInstructions = undefined;
+    const wrapper = setUp({
+      hasShortAndLongInstructions: false,
+      collapsed: false,
+      shortInstructions,
+      longInstructions
+    });
+    expect(wrapper.find(Instructions).props().longInstructions).to.equal(
+      shortInstructions
+    );
+  });
+
+  it('passes long instructions to Instructions component if not in a collapsed state with both short and long instructions', () => {
+    const longInstructions = 'test long instructions';
+    const wrapper = setUp({
+      hasShortAndLongInstructions: true,
+      collapsed: false,
+      longInstructions
+    });
+    expect(wrapper.find(Instructions).props().longInstructions).to.equal(
+      longInstructions
+    );
+  });
+
   it('passes inputOutputTable to Instructions when not collapsed', () => {
     const inputOutputTable = [[1, 2, 3, 4]];
     const wrapper = setUp({collapsed: false, inputOutputTable});
@@ -53,7 +91,7 @@ describe('InstructionsCsfMiddleCol', () => {
     );
   });
 
-  it('passes undefed for inputOutputTable to Instructions when collapsed', () => {
+  it('passes undefined for inputOutputTable to Instructions when collapsed', () => {
     const inputOutputTable = [[1, 2, 3, 4]];
     const wrapper = setUp({collapsed: true, inputOutputTable});
     expect(wrapper.find(Instructions).props().inputOutputTable).to.equal(

--- a/apps/test/unit/templates/instructions/InstructionsCsfRightColTest.jsx
+++ b/apps/test/unit/templates/instructions/InstructionsCsfRightColTest.jsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import {expect} from '../../../util/reconfiguredChai';
+import sinon from 'sinon';
+import {UnconnectedInstructionsCsfRightCol as InstructionsCsfRightCol} from '@cdo/apps/templates/instructions/InstructionsCsfRightCol';
+import CollapserButton from '@cdo/apps/templates/instructions/CollapserButton';
+import ScrollButtons from '@cdo/apps/templates/instructions/ScrollButtons';
+
+const DEFAULT_PROPS = {
+  shouldDisplayHintPrompt: () => {},
+  hasShortInstructions: false,
+  promptForHint: false,
+  displayScrollButtons: false,
+  getScrollTarget: () => {},
+  handleClickCollapser: () => {},
+  setColWidth: () => {},
+  setColHeight: () => {},
+  collapsed: false,
+  hints: [],
+  feedback: undefined,
+  longInstructions: 'longgggg instructions',
+  height: 225,
+  isMinecraft: false,
+  isRtl: false
+};
+
+const setUp = (overrideProps = {}) => {
+  const props = {...DEFAULT_PROPS, ...overrideProps};
+  return shallow(<InstructionsCsfRightCol {...props} />);
+};
+
+describe('InstructionsCsfRightCol', () => {
+  it('sets col width and height on mount', () => {
+    const setColWidthSpy = sinon.spy();
+    const setColHeightSpy = sinon.spy();
+    setUp({setColHeight: setColHeightSpy, setColWidth: setColWidthSpy});
+
+    // should be called after mount:
+    expect(setColWidthSpy.calledOnce).to.be.true;
+    expect(setColHeightSpy.calledOnce).to.be.true;
+  });
+
+  it('displays collapser button if there is feedback', () => {
+    const wrapper = setUp({feedback: {message: 'feedback', isFailure: false}});
+    expect(wrapper.find(CollapserButton)).to.have.length(1);
+  });
+
+  it('displays collapser button if there are hints', () => {
+    const hint = {
+      hintId: 'hint-id',
+      markdown: 'hint markdown'
+    };
+    const wrapper = setUp({hints: [hint]});
+    expect(wrapper.find(CollapserButton)).to.have.length(1);
+  });
+
+  it('displays collapser button if there are long and short instructions', () => {
+    const wrapper = setUp({
+      hasShortInstructions: true,
+      longInstructions: 'some long instructions'
+    });
+    expect(wrapper.find(CollapserButton)).to.have.length(1);
+  });
+
+  it('displays scroll buttons if displayScrollButtons prop is true', () => {
+    const wrapper = setUp({
+      displayScrollButtons: true
+    });
+    expect(wrapper.find(ScrollButtons)).to.have.length(1);
+  });
+
+  it('hides scroll buttons if displayScrollButtons prop is false', () => {
+    const wrapper = setUp({
+      displayScrollButtons: false
+    });
+    expect(wrapper.find(ScrollButtons)).to.have.length(0);
+  });
+
+  it('calls handleClickCollapser when CollapserButton is clicked', () => {
+    // set up with short and long instructions so collapser is displayed
+    const handleClickCollapserSpy = sinon.spy();
+    const wrapper = setUp({
+      hasShortInstructions: true,
+      longInstructions: 'some long instructions',
+      handleClickCollapser: handleClickCollapserSpy
+    });
+    wrapper.find(CollapserButton).simulate('click');
+    expect(handleClickCollapserSpy.calledOnce).to.be.true;
+  });
+});

--- a/apps/test/unit/templates/instructions/InstructionsCsfRightColTest.jsx
+++ b/apps/test/unit/templates/instructions/InstructionsCsfRightColTest.jsx
@@ -8,7 +8,7 @@ import ScrollButtons from '@cdo/apps/templates/instructions/ScrollButtons';
 
 const DEFAULT_PROPS = {
   shouldDisplayHintPrompt: () => {},
-  hasShortInstructions: false,
+  hasShortAndLongInstructions: false,
   promptForHint: false,
   displayScrollButtons: false,
   getScrollTarget: () => {},
@@ -18,7 +18,6 @@ const DEFAULT_PROPS = {
   collapsed: false,
   hints: [],
   feedback: undefined,
-  longInstructions: 'longgggg instructions',
   height: 225,
   isMinecraft: false,
   isRtl: false
@@ -56,8 +55,7 @@ describe('InstructionsCsfRightCol', () => {
 
   it('displays collapser button if there are long and short instructions', () => {
     const wrapper = setUp({
-      hasShortInstructions: true,
-      longInstructions: 'some long instructions'
+      hasShortAndLongInstructions: true
     });
     expect(wrapper.find(CollapserButton)).to.have.length(1);
   });
@@ -80,8 +78,7 @@ describe('InstructionsCsfRightCol', () => {
     // set up with short and long instructions so collapser is displayed
     const handleClickCollapserSpy = sinon.spy();
     const wrapper = setUp({
-      hasShortInstructions: true,
-      longInstructions: 'some long instructions',
+      hasShortAndLongInstructions: true,
       handleClickCollapser: handleClickCollapserSpy
     });
     wrapper.find(CollapserButton).simulate('click');

--- a/dashboard/test/ui/features/learning_platform/instructions/top_instructions.feature
+++ b/dashboard/test/ui/features/learning_platform/instructions/top_instructions.feature
@@ -11,10 +11,8 @@ Scenario: CSF Top Instructions
   And I am on "http://studio.code.org/s/course4/stage/3/puzzle/5?noautoplay=true"
   And I wait for the page to fully load
   And I see no difference for "artist long instructions"
-  Then I click selector ".fa-chevron-circle-up"
-  And I see no difference for "artist long instructions collapsed"
-  Then I click selector ".fa-chevron-circle-down"
-  And I see no difference for "artist long instructions uncollapsed"
+  Then I click selector ".uitest-scroll-button-down"
+  And I see no difference for "artist long instructions"
 
   Then I am on "http://studio.code.org/s/allthethings/stage/2/puzzle/7?noautoplay=true"
   And I wait for the page to fully load


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Previously, whether the arrows showed on the CSF instructions was based on both whether the instructions overflowed the content box and whether the instructions were in the collapsed state (must be expanded state to show. arrows). The InstructionsCSF component was very long with a lot of complicated hard-to-parse logic. The changes here 
1. refactor the InstructionsCSF component: split columns into `InstructionsCsfLeftCol`, `InstructionsCsfMiddleCol` and `InstructionsCsfRightCol` components
![Screen Shot 2021-04-09 at 10 41 52 AM](https://user-images.githubusercontent.com/24235215/114438847-24781980-9b7d-11eb-975f-90228634b4c3.png)
2. simplify the logic to calculate height and width of each column
3. update component to show arrows anytime the instructions overflow the container
![Screen Shot 2021-04-12 at 10 46 22 AM](https://user-images.githubusercontent.com/24235215/114438958-4376ab80-9b7d-11eb-86dd-bc2712a59628.png)



## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
-  Added unit tests for new components
- Manually tested CSF levels (such as levels in `s/coursef-2020/stage/4`, for minecraft `/s/coursef-2020/stage/1`)
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
