### PR TITLE
Support downloading files that are already PDFs

### DIFF
--- a/dashboard/lib/services/curriculum_pdfs/resources.rb
+++ b/dashboard/lib/services/curriculum_pdfs/resources.rb
@@ -63,7 +63,14 @@ module Services
             StringIO.new(CDO.gdrive_export_secret&.to_json || "")
           )
           file = @google_drive_session.file_by_url(url)
-          file.export_as_file(path)
+
+          # If file is already a PDF, we can just download it; otherwise, we
+          # need to export to convert it.
+          if file.available_content_types.include? "appliction/pdf"
+            file.download_to_file(path)
+          else
+            file.export_as_file(path)
+          end
         end
 
         def fetch_resource_pdf(resource, directory="/tmp/")


### PR DESCRIPTION
Some of our Resources are google drive files that are already PDFs. For example, [Stevie and the Big Project](https://drive.google.com/file/d/0B-uvt08wYSQqTUFzaGxKSk45QkU/view) from Course B Programming in Harvester.

For some reason, trying to export these files as PDFs doesn't work; we have to _download_ them instead.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
