### PR TITLE
Wait for page to load in thank donors interstitial UI test

### DIFF
--- a/dashboard/test/ui/features/xteam/school_info_confirmation_dialog.feature
+++ b/dashboard/test/ui/features/xteam/school_info_confirmation_dialog.feature
@@ -15,8 +15,6 @@ Feature: School Info Confirmation Dialog
 Scenario: School Info Confirmation Dialog
   # Teacher account is created with partial school info
   Given I create a teacher named "Teacher_Chuba" and go home
-  # Wait for homepage to load before reloading the page.
-  Then I wait until element "#header-banner" is visible
   # The date of the teacher's account is updated to 7 days ago to simulate time travel
   # This enables the condition (see school_info_interstitial helper.rb) that checks
   # the age of the account to determine when to show the school info interstitial.
@@ -38,7 +36,6 @@ Scenario: School Info Confirmation Dialog
   # One week later, the teacher does not see the prompt
   And eight days pass for user "Teacher_Chuba"
   Then I reload the page
-  Then I wait until element "#header-banner" is visible
   And element ".modal" is not visible
 
   # One year later, the teacher sees the school info confirmation dialog

--- a/dashboard/test/ui/features/xteam/school_info_confirmation_dialog.feature
+++ b/dashboard/test/ui/features/xteam/school_info_confirmation_dialog.feature
@@ -15,6 +15,8 @@ Feature: School Info Confirmation Dialog
 Scenario: School Info Confirmation Dialog
   # Teacher account is created with partial school info
   Given I create a teacher named "Teacher_Chuba" and go home
+  # Wait for homepage to load before reloading the page.
+  Then I wait until element "#header-banner" is visible
   # The date of the teacher's account is updated to 7 days ago to simulate time travel
   # This enables the condition (see school_info_interstitial helper.rb) that checks
   # the age of the account to determine when to show the school info interstitial.
@@ -36,6 +38,7 @@ Scenario: School Info Confirmation Dialog
   # One week later, the teacher does not see the prompt
   And eight days pass for user "Teacher_Chuba"
   Then I reload the page
+  Then I wait until element "#header-banner" is visible
   And element ".modal" is not visible
 
   # One year later, the teacher sees the school info confirmation dialog

--- a/dashboard/test/ui/features/xteam/thank_donors_interstitial.feature
+++ b/dashboard/test/ui/features/xteam/thank_donors_interstitial.feature
@@ -20,6 +20,8 @@ Feature: Thank Donors Interstitial
   Scenario: New student sign in from code.org does not show donor interstitial on mobile
     Given I delete the cookie named "has_seen_thank_donors"
     Then I create a student who has never signed in named "Bob" and go home
+    # Wait for homepage to load before confirming that modal is not visible
+    Then I wait until element "#header-banner" is visible
     Then element "#thank-donors-modal" is not visible
 
   @eyes


### PR DESCRIPTION
We have an interstitial to thank our donors that appears on the Code Studio homepage on first log in -- it is not responsive, so we test that it does not appear on small screens (ie, phones). That test is failing intermittently as we sometimes try to confirm that the interstitial is not there before the page has loaded.

This change introduces an explicit wait until the homepage has loaded -- this test has [failed frequently recently ](https://cucumber-logs.s3.amazonaws.com/test/test/iPhone_xteam_thank_donors_interstitial_output.html?versionId=z7KuQUDTAkUKZxdraRQIDXj_fyeBY8q8)as it checked for whether the modal was present before the page had loaded.

## Testing story

Tested iPhone via Saucelabs tunnel locally, as well as via [test all browsers] in Drone.

## PR Checklist:

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
