### PR TITLE
Improve course roll up pages UI

### DIFF
--- a/apps/src/templates/courseRollupPages/RollupLessonEntrySection.jsx
+++ b/apps/src/templates/courseRollupPages/RollupLessonEntrySection.jsx
@@ -45,9 +45,12 @@ export default class RollupLessonEntrySection extends Component {
 
     return (
       <div style={styles.main}>
-        <div style={styles.object}>
-          <h4>{this.props.objectToRollUp}</h4>
-        </div>
+        {(this.props.objectToRollUp === 'Resources' ||
+          this.props.objectToRollUp === 'Prep') && (
+          <div style={styles.object}>
+            <h4>{this.props.objectToRollUp}</h4>
+          </div>
+        )}
         <div style={styles.entries}>
           {this.props.objectToRollUp === 'Vocabulary' &&
             this.props.lesson.vocabularies.length > 0 &&

--- a/apps/src/templates/courseRollupPages/RollupLessonEntrySection.jsx
+++ b/apps/src/templates/courseRollupPages/RollupLessonEntrySection.jsx
@@ -66,12 +66,15 @@ export default class RollupLessonEntrySection extends Component {
               <p>{i18n.rollupNoVocab()}</p>
             )}
           {this.props.objectToRollUp === 'Code' &&
-            this.props.lesson.programmingExpressions.length > 0 &&
-            this.props.lesson.programmingExpressions.map(expression => (
-              <li key={expression.name}>
-                <StyledCodeBlock programmingExpression={expression} />
-              </li>
-            ))}
+            this.props.lesson.programmingExpressions.length > 0 && (
+              <ul>
+                {this.props.lesson.programmingExpressions.map(expression => (
+                  <li key={expression.name}>
+                    <StyledCodeBlock programmingExpression={expression} />
+                  </li>
+                ))}
+              </ul>
+            )}
           {this.props.objectToRollUp === 'Code' &&
             this.props.lesson.programmingExpressions.length <= 0 && (
               <p>{i18n.rollupNoCode()}</p>


### PR DESCRIPTION
https://codedotorg.atlassian.net/browse/PLAT-947

- Remove the type row from Vocab, Code and Standards roll up

<img width="999" alt="Screen Shot 2021-04-09 at 10 16 19 PM" src="https://user-images.githubusercontent.com/208083/114255765-5e7dcb80-9983-11eb-9b63-be9994fa8ac2.png">

- Make sure blocks show on same line as the bullet

<img width="1007" alt="Screen Shot 2021-04-09 at 10 30 14 PM" src="https://user-images.githubusercontent.com/208083/114255743-2b3b3c80-9983-11eb-9ac4-6597deb8bcce.png">

- Resources page still has type header: 

<img width="1055" alt="Screen Shot 2021-04-09 at 10 17 10 PM" src="https://user-images.githubusercontent.com/208083/114255749-32624a80-9983-11eb-9e76-b29ff3d445b5.png">
