### PR TITLE
[Spritelab] Improve dragging behavior

### DIFF
--- a/apps/src/p5lab/spritelab/commands/behaviorCommands.js
+++ b/apps/src/p5lab/spritelab/commands/behaviorCommands.js
@@ -14,10 +14,18 @@ export const commands = {
   draggableFunc(p5Inst) {
     return spriteArg => {
       let sprite = coreLibrary.getSpriteArray(spriteArg)[0];
-      if (p5Inst.mousePressedOver(sprite) && !sprite.dragging) {
-        sprite.dragging = true;
-        sprite.xOffset = sprite.x - p5Inst.World.mouseX;
-        sprite.yOffset = sprite.y - p5Inst.World.mouseY;
+      const allSprites = coreLibrary.getSpriteArray({costume: 'all'});
+      if (p5Inst.mousePressedOver(sprite) && p5Inst.mouseWentDown()) {
+        const topOtherSprite = Math.max(
+          ...allSprites
+            .filter(s => s !== sprite && p5Inst.mousePressedOver(s))
+            .map(s => s.depth)
+        );
+        if (sprite.depth > topOtherSprite) {
+          sprite.dragging = true;
+          sprite.xOffset = sprite.x - p5Inst.World.mouseX;
+          sprite.yOffset = sprite.y - p5Inst.World.mouseY;
+        }
       }
       if (sprite.dragging) {
         sprite.x = p5Inst.World.mouseX + sprite.xOffset;

--- a/apps/test/unit/p5lab/spritelab/behaviorCommandsTest.js
+++ b/apps/test/unit/p5lab/spritelab/behaviorCommandsTest.js
@@ -1,4 +1,5 @@
 /* global p5 */
+import sinon from 'sinon';
 import {expect} from '../../../util/reconfiguredChai';
 import * as coreLibrary from '@cdo/apps/p5lab/spritelab/coreLibrary';
 import {commands as actionCommands} from '@cdo/apps/p5lab/spritelab/commands/actionCommands';
@@ -16,6 +17,91 @@ describe('Behavior Commands', () => {
     let sheet = new p5Wrapper.p5.SpriteSheet(image, frames);
     animation = new p5Wrapper.p5.Animation(sheet);
     coreLibrary.reset();
+  });
+
+  describe('draggableFunc', () => {
+    let mousePressedOverStub, mouseWentDownStub, mouseWentUpStub;
+    beforeEach(() => {
+      mousePressedOverStub = sinon.stub(p5Wrapper.p5, 'mousePressedOver');
+      mouseWentDownStub = sinon.stub(p5Wrapper.p5, 'mouseWentDown');
+      mouseWentUpStub = sinon.stub(p5Wrapper.p5, 'mouseWentUp');
+    });
+
+    afterEach(() => {
+      mousePressedOverStub.restore();
+      mouseWentDownStub.restore();
+      mouseWentUpStub.restore();
+    });
+
+    it('can drag a sprite', () => {
+      makeSprite({name: 'sprite', location: {x: 200, y: 200}});
+      const sprite = coreLibrary.getSpriteArray({name: 'sprite'})[0];
+      mousePressedOverStub.returns(true);
+      mouseWentDownStub.returns(true);
+      behaviorCommands.draggableFunc(p5Wrapper.p5)({name: 'sprite'});
+      expect(sprite.dragging).to.be.true;
+    });
+
+    it('dragging moves the sprite to the mouse position', () => {
+      makeSprite({name: 'sprite', location: {x: 200, y: 200}});
+      const sprite = coreLibrary.getSpriteArray({name: 'sprite'})[0];
+      p5Wrapper.p5.mouseX = 200;
+      p5Wrapper.p5.mouseY = 200;
+      // First tick, press down on the sprite to start the drag.
+      mousePressedOverStub.returns(true);
+      mouseWentDownStub.returns(true);
+      behaviorCommands.draggableFunc(p5Wrapper.p5)({name: 'sprite'});
+      expect(sprite.dragging).to.be.true;
+
+      // Next tick, sprite moves to new mouse position.
+      mouseWentDownStub.returns(false);
+      p5Wrapper.p5.mouseX = 100;
+      p5Wrapper.p5.mouseY = 100;
+      behaviorCommands.draggableFunc(p5Wrapper.p5)({name: 'sprite'});
+
+      expect(sprite.x).to.equal(100);
+      expect(sprite.y).to.equal(100);
+    });
+
+    it('drag ends when mouse goes up', () => {
+      makeSprite({name: 'sprite', location: {x: 200, y: 200}});
+      const sprite = coreLibrary.getSpriteArray({name: 'sprite'})[0];
+      p5Wrapper.p5.mouseX = 200;
+      p5Wrapper.p5.mouseY = 200;
+      // First tick, press down on the sprite to start the drag.
+      mousePressedOverStub.returns(true);
+      mouseWentDownStub.returns(true);
+      behaviorCommands.draggableFunc(p5Wrapper.p5)({name: 'sprite'});
+      expect(sprite.dragging).to.be.true;
+
+      // Next tick, mouse went up, so sprite moves to new mouse position
+      // and drag ends.
+      mouseWentDownStub.returns(false);
+      mouseWentUpStub.returns(true);
+      p5Wrapper.p5.mouseX = 100;
+      p5Wrapper.p5.mouseY = 100;
+      behaviorCommands.draggableFunc(p5Wrapper.p5)({name: 'sprite'});
+      expect(sprite.x).to.equal(100);
+      expect(sprite.y).to.equal(100);
+      expect(sprite.dragging).to.be.false;
+    });
+
+    it('only drags the top sprite', () => {
+      makeSprite({name: 'bottom', location: {x: 200, y: 200}});
+      const bottom = coreLibrary.getSpriteArray({name: 'bottom'})[0];
+
+      makeSprite({name: 'top', location: {x: 200, y: 200}});
+      const top = coreLibrary.getSpriteArray({name: 'top'})[0];
+
+      mousePressedOverStub.returns(true);
+      mouseWentDownStub.returns(true);
+
+      behaviorCommands.draggableFunc(p5Wrapper.p5)({name: 'top'});
+      expect(top.dragging).to.be.true;
+
+      behaviorCommands.draggableFunc(p5Wrapper.p5)({name: 'bottom'});
+      expect(!!bottom.dragging).to.be.false;
+    });
   });
 
   describe('followingTargetsFunc', () => {


### PR DESCRIPTION
Improve dragging behavior. Now you can only drag one sprite at a time, and we use depth to determine which sprite to drag if sprites are overlapping.
Before
![Apr-12-2021 12-56-31](https://user-images.githubusercontent.com/8787187/114454921-fc45e600-9b8f-11eb-8c49-64dd33712e2f.gif)

After
![Apr-12-2021 12-54-13](https://user-images.githubusercontent.com/8787187/114454931-fea84000-9b8f-11eb-8717-1ffeda1ad270.gif)

![image](https://user-images.githubusercontent.com/8787187/114453254-36ae8380-9b8e-11eb-9e3d-f132a1d67eea.png)


## Links

[jira](https://codedotorg.atlassian.net/browse/STAR-1511)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
