### PR TITLE
Make all instructions page load

### DIFF
--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -138,7 +138,7 @@ class ScriptsController < ApplicationController
   def instructions
     require_levelbuilder_mode
 
-    script = Script.get_from_cache(params[:script_id])
+    script = Script.get_from_cache(params[:id])
 
     render 'levels/instructions', locals: {stages: script.lessons}
   end

--- a/dashboard/app/views/scripts/show.html.haml
+++ b/dashboard/app/views/scripts/show.html.haml
@@ -73,28 +73,9 @@
         - else
           - lb_path = "https://levelbuilder-studio.code.org#{script_path(@script)}"
           %li= link_to "View on levelbuilder", lb_path
+        %li= link_to "All Instructions", instructions_script_path(@script)
       - unless @script.unit_groups.empty?
         = "This script is in #{@script.unit_groups.length} course#{'s' unless @script.unit_groups.length == 1}:"
         %ul
           - @script.unit_groups.each do |course|
             %li= link_to course_path(course)
-      - levels = Script.get_from_cache(@script.name).lessons.map{ |stage| stage.script_levels.map{ |sl| sl.level }}.flatten
-      .row
-        .span1
-          = "Index"
-        .span3
-          = "Level name"
-        .span3
-          = "Template level"
-        .span3
-          = "Contained levels"
-      - levels.each_with_index do |level, index|
-        .row
-          .span1
-            = index + 1
-          .span3
-            = level.name
-          .span3
-            = level.properties['project_template_level_name']
-          .span3
-            = level.properties['contained_level_names'].try {|names| names.join(", ")}

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -967,8 +967,21 @@ class ScriptsControllerTest < ActionController::TestCase
   test_user_gets_response_for :code, response: :success, user: :teacher, params: -> {{id: @migrated_script.name}}
   test_user_gets_response_for :code, response: :forbidden, user: :teacher, params: -> {{id: @unmigrated_script.name}}
 
-  test_user_gets_response_for :instructions, response: :success, user: :levelbuilder, params: -> {{id: @migrated_script.name}}
-  test_user_gets_response_for :instructions, response: :success, user: :levelbuilder, params: -> {{id: @unmigrated_script.name}}
+  test "view all instructions page for migrated script" do
+    Rails.application.config.stubs(:levelbuilder_mode).returns true
+    sign_in(@levelbuilder)
+
+    get :instructions, params: {id: @migrated_script.name}
+    assert_response :success
+  end
+
+  test "view all instructions page for unmigrated script" do
+    Rails.application.config.stubs(:levelbuilder_mode).returns true
+    sign_in(@levelbuilder)
+
+    get :instructions, params: {id: @unmigrated_script.name}
+    assert_response :success
+  end
 
   def stub_file_writes(script_name)
     filenames_to_stub = ["#{Rails.root}/config/scripts/#{script_name}.script", "#{Rails.root}/config/scripts_json/#{script_name}.script_json"]

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -967,6 +967,9 @@ class ScriptsControllerTest < ActionController::TestCase
   test_user_gets_response_for :code, response: :success, user: :teacher, params: -> {{id: @migrated_script.name}}
   test_user_gets_response_for :code, response: :forbidden, user: :teacher, params: -> {{id: @unmigrated_script.name}}
 
+  test_user_gets_response_for :instructions, response: :success, user: :levelbuilder, params: -> {{id: @migrated_script.name}}
+  test_user_gets_response_for :instructions, response: :success, user: :levelbuilder, params: -> {{id: @unmigrated_script.name}}
+
   def stub_file_writes(script_name)
     filenames_to_stub = ["#{Rails.root}/config/scripts/#{script_name}.script", "#{Rails.root}/config/scripts_json/#{script_name}.script_json"]
     File.stubs(:write).with do |filename, _|


### PR DESCRIPTION
The all instructions page for scripts which is editor facing broke when routes were cleaned up while adding course rollup page routes. This feature had no tests so I did not notice. This PR:

- Fixes the route so it works again
- Adds some basic tests to make sure the page loads
- Updates the extra links box to add a link to the all instructions page while also removing the list of levels because I don't think thats very user friendly
- 
![Screen Shot 2021-04-12 at 4 57 07 PM](https://user-images.githubusercontent.com/208083/114461752-1ee7f700-9bb0-11eb-83e4-28e54b4510c0.png)

## Links

https://codedotorg.atlassian.net/browse/PLAT-82

## Testing story

- Simple controller tests to make sure the page can load successfully
