### PR TITLE
FND 1375 Instructor Image on Wrong Side

### DIFF
--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -1732,6 +1732,12 @@ a.WireframeButtons_active, div.WireframeButtons_active {
   margin-left: -400px;
 }
 
+html[dir='rtl'] .instructions-markdown img {
+  float: right !important;
+  padding-left: 10px !important;
+  padding-right: 0px !important;
+}
+
 @import "RotateContainer";
 @import "HideToolbarHelper";
 @import "blockly";

--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -1732,12 +1732,6 @@ a.WireframeButtons_active, div.WireframeButtons_active {
   margin-left: -400px;
 }
 
-html[dir='rtl'] .instructions-markdown img {
-  float: right !important;
-  padding-left: 10px !important;
-  padding-right: 0px !important;
-}
-
 @import "RotateContainer";
 @import "HideToolbarHelper";
 @import "blockly";

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -2919,6 +2919,19 @@ $modal-no-icon-gap: 22px;
 
 .instructions-markdown {
   padding-top: 19px;
+
+  .instructor-image {
+    float: left;
+    padding-right: 10px;
+  }
+}
+
+html[dir="rtl"] .instructions-markdown {
+  .instructor-image {
+    float: right;
+    padding-left: 10px;
+    padding-right: 0;
+  }
 }
 
 .markdown-level-header-text {


### PR DESCRIPTION
The instructor should be on the right side of the text in RTL context.

The instructor image comes from the back-end in markdown and has float:left inline styles that must be overridden using a global CSS style when global HTML direction is RTL.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [FND-1375](https://codedotorg.atlassian.net/browse/FND-1375?atlOrigin=eyJpIjoiN2Y4MThhYjkzZmI2NGZhODk5MTc2NGRkNmRkMzk2YjciLCJwIjoiaiJ9)


## Images

BEFORE:
![image](https://user-images.githubusercontent.com/9528376/114465940-6b7e0300-9bad-11eb-845b-b6f010575ae5.png)

AFTER:
![image](https://user-images.githubusercontent.com/9528376/114465966-75076b00-9bad-11eb-82a0-091843f8a199.png)



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [X] Tests provide adequate coverage
- [X] Privacy and Security impacts have been assessed
- [X] Code is well-commented
- [X] New features are translatable or updates will not break translations
- [X] Relevant documentation has been added or updated
- [X] User impact is well-understood and desirable
- [X] Pull Request is labeled appropriately
- [X] Follow-up work items (including potential tech debt) are tracked and linked
