### PR TITLE
remove user data from cached bonus level summaries

### DIFF
--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -247,15 +247,48 @@ class ScriptLevelsController < ApplicationController
       return
     end
 
-    @stage = Script.get_from_cache(params[:script_id]).lesson_by_relative_position(params[:lesson_position].to_i)
+    user = @user || current_user
+    @stage = Script.get_from_cache(
+      params[:script_id]
+    ).lesson_by_relative_position(
+      params[:lesson_position].to_i
+      )
     @script = @stage.script
+    script_bonus_levels_by_stage = @script.get_bonus_script_levels(@stage)
+
+    # bonus level summaries are cached, so explicitly don't contain any
+    # user-specific data. hence we need to merge the user's progress and
+    # localized level display name and description into the cached data.
+    script_bonus_levels_by_stage.each do |stage|
+      stage[:levels].each do |level_summary|
+        ul = UserLevel.find_by(
+          level_id: level_summary[:level_id], user_id: user.id, script: @script
+        )
+        level_summary[:perfect] = ul&.perfect?
+        localized_level_description = I18n.t(
+          ul.level.name,
+          scope: [:data, :bubble_choice_description],
+          default: ul.level.bubble_choice_description
+        )
+        localized_level_display_name = I18n.t(
+          ul.level.name,
+          scope: [:data, :display_name],
+          default: ul.level.display_name
+        ) || I18n.t('lesson_extras.bonus_level')
+        level_summary[:description] = localized_level_description
+        level_summary[:display_name] = localized_level_display_name
+      end
+    end
+
     @stage_extras = {
-      next_stage_number: @stage.next_level_number_for_lesson_extras(current_user),
+      next_stage_number: @stage.next_level_number_for_lesson_extras(user),
       stage_number: @stage.relative_position,
-      next_level_path: @stage.next_level_path_for_lesson_extras(current_user),
-      bonus_levels: @script.get_bonus_script_levels(@stage, current_user),
+      next_level_path: @stage.next_level_path_for_lesson_extras(user),
+      bonus_levels: script_bonus_levels_by_stage,
     }.camelize_keys
-    @bonus_level_ids = @stage.script_levels.where(bonus: true).map(&:level_ids).flatten
+    @bonus_level_ids = @stage.script_levels.where(bonus: true).map(
+      &:level_ids
+    ).flatten
 
     render 'scripts/stage_extras'
   end

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -256,29 +256,14 @@ class ScriptLevelsController < ApplicationController
     @script = @stage.script
     script_bonus_levels_by_stage = @script.get_bonus_script_levels(@stage)
 
-    # bonus level summaries are cached, so explicitly don't contain any
-    # user-specific data. hence we need to merge the user's progress and
-    # localized level display name and description into the cached data.
+    # bonus level summaries explicitly don't contain any user-specific data,
+    # so we need to merge in the user's progress.
     script_bonus_levels_by_stage.each do |stage|
       stage[:levels].each do |level_summary|
         ul = UserLevel.find_by(
           level_id: level_summary[:level_id], user_id: user.id, script: @script
         )
         level_summary[:perfect] = ul&.perfect?
-
-        level = Level.find(level_summary[:level_id])
-        localized_level_description = I18n.t(
-          level.name,
-          scope: [:data, :bubble_choice_description],
-          default: level.bubble_choice_description
-        )
-        localized_level_display_name = I18n.t(
-          level.name,
-          scope: [:data, :display_name],
-          default: level.display_name
-        ) || I18n.t('lesson_extras.bonus_level')
-        level_summary[:description] = localized_level_description
-        level_summary[:display_name] = localized_level_display_name
       end
     end
 

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -265,15 +265,17 @@ class ScriptLevelsController < ApplicationController
           level_id: level_summary[:level_id], user_id: user.id, script: @script
         )
         level_summary[:perfect] = ul&.perfect?
+
+        level = Level.find(level_summary[:level_id])
         localized_level_description = I18n.t(
-          ul.level.name,
+          level.name,
           scope: [:data, :bubble_choice_description],
-          default: ul.level.bubble_choice_description
+          default: level.bubble_choice_description
         )
         localized_level_display_name = I18n.t(
-          ul.level.name,
+          level.name,
           scope: [:data, :display_name],
-          default: ul.level.display_name
+          default: level.display_name
         ) || I18n.t('lesson_extras.bonus_level')
         level_summary[:description] = localized_level_description
         level_summary[:display_name] = localized_level_display_name

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -867,18 +867,29 @@ class Script < ApplicationRecord
     script_levels[chapter - 1] # order is by chapter
   end
 
-  def get_bonus_script_levels(current_stage)
+  def get_bonus_script_levels(current_lesson)
     unless @all_bonus_script_levels
-      @all_bonus_script_levels = lessons.map do |stage|
+      @all_bonus_script_levels = lessons.map do |lesson|
         {
-          stageNumber: stage.relative_position,
-          levels: stage.script_levels.select(&:bonus).map(&:summarize_as_bonus)
+          stageNumber: lesson.relative_position,
+          levels: lesson.script_levels.select(&:bonus)
         }
       end
-      @all_bonus_script_levels.select! {|stage| stage[:levels].any?}
+      @all_bonus_script_levels.select! {|lesson| lesson[:levels].any?}
     end
 
-    @all_bonus_script_levels.select {|stage| stage[:stageNumber] <= current_stage.absolute_position}
+    lesson_levels = @all_bonus_script_levels.select do |lesson|
+      lesson[:stageNumber] <= current_lesson.absolute_position
+    end
+
+    # we don't cache the level summaries because they include localized text
+    summarized_lesson_levels = lesson_levels.map do |lesson|
+      {
+        stageNumber: lesson[:stageNumber],
+        levels: lesson[:levels].map(&:summarize_as_bonus)
+      }
+    end
+    summarized_lesson_levels
   end
 
   def pre_reader_tts_level?

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -867,12 +867,12 @@ class Script < ApplicationRecord
     script_levels[chapter - 1] # order is by chapter
   end
 
-  def get_bonus_script_levels(current_stage, current_user)
+  def get_bonus_script_levels(current_stage)
     unless @all_bonus_script_levels
       @all_bonus_script_levels = lessons.map do |stage|
         {
           stageNumber: stage.relative_position,
-          levels: stage.script_levels.select(&:bonus).map {|bonus_level| bonus_level.summarize_as_bonus(current_user&.id)}
+          levels: stage.script_levels.select(&:bonus).map(&:summarize_as_bonus)
         }
       end
       @all_bonus_script_levels.select! {|stage| stage[:levels].any?}

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -493,18 +493,15 @@ class ScriptLevel < ApplicationRecord
     extra_levels
   end
 
-  def summarize_as_bonus(user_id = nil)
-    perfect = user_id ? UserLevel.find_by(level: level, user_id: user_id)&.perfect? : false
-    localized_level_description = I18n.t(level.name, scope: [:data, :bubble_choice_description], default: level.bubble_choice_description)
-    localized_level_display_name = I18n.t(level.name, scope: [:data, :display_name], default: level.display_name)
+  def summarize_as_bonus
     {
       id: id.to_s,
+      level_id: level.id.to_s,
       type: level.type,
-      description: localized_level_description,
-      display_name: localized_level_display_name || I18n.t('lesson_extras.bonus_level'),
+      description: level.try(:bubble_choice_description),
+      display_name: level.display_name,
       thumbnail_url: level.try(:thumbnail_url) || level.try(:solution_image_url),
       url: build_script_level_url(self),
-      perfect: perfect,
       maze_summary: {
         map: JSON.parse(level.try(:maze) || '[]'),
         serialized_maze: level.try(:serialized_maze) && JSON.parse(level.try(:serialized_maze)),

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -494,12 +494,14 @@ class ScriptLevel < ApplicationRecord
   end
 
   def summarize_as_bonus
+    localized_level_description = I18n.t(level.name, scope: [:data, :bubble_choice_description], default: level.bubble_choice_description)
+    localized_level_display_name = I18n.t(level.name, scope: [:data, :display_name], default: level.display_name)
     {
       id: id.to_s,
       level_id: level.id.to_s,
       type: level.type,
-      description: level.try(:bubble_choice_description),
-      display_name: level.display_name,
+      description: localized_level_description,
+      display_name: localized_level_display_name || I18n.t('lesson_extras.bonus_level'),
       thumbnail_url: level.try(:thumbnail_url) || level.try(:solution_image_url),
       url: build_script_level_url(self),
       maze_summary: {

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -1880,6 +1880,71 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test "stage extras shows progress for current user if no section and user id" do
+    sign_in @student
+    script = create :script
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
+    script_level = create :script_level, lesson: lesson, script: script
+    script_level.bonus = true
+    script_level.save!
+    create :user_level, user: @student, script: script, level: script_level.level, best_result: 100
+    get :stage_extras, params: {
+      script_id: script_level.script,
+      lesson_position: 1
+    }
+    assert_response :success
+    assert_select 'script[data-extras]', 1
+    extras_data = JSON.parse(
+      css_select('script[data-extras]').first.attribute('data-extras').to_s
+    )
+    assert extras_data['bonusLevels'][0]['levels'][0]['perfect']
+  end
+
+  test "stage extras shows teacher no progress if no section and user id" do
+    sign_in @teacher
+    script = create :script
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
+    script_level = create :script_level, lesson: lesson, script: script
+    script_level.bonus = true
+    script_level.save!
+    create :user_level, user: @student, script: script, level: script_level.level, best_result: 100
+    get :stage_extras, params: {
+      script_id: script_level.script,
+      lesson_position: 1
+    }
+    assert_response :success
+    assert_select 'script[data-extras]', 1
+    extras_data = JSON.parse(
+      css_select('script[data-extras]').first.attribute('data-extras').to_s
+    )
+    refute extras_data['bonusLevels'][0]['levels'][0]['perfect']
+  end
+
+  test "stage extras shows teacher progress for student if section and user id" do
+    sign_in @teacher
+    script = create :script
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
+    script_level = create :script_level, lesson: lesson, script: script
+    script_level.bonus = true
+    script_level.save!
+    create :user_level, user: @student, script: script, level: script_level.level, best_result: 100
+    get :stage_extras, params: {
+      script_id: script_level.script,
+      lesson_position: 1,
+      section_id: @section.id,
+      user_id: @student.id
+    }
+    assert_response :success
+    assert_select 'script[data-extras]', 1
+    extras_data = JSON.parse(
+      css_select('script[data-extras]').first.attribute('data-extras').to_s
+    )
+    assert extras_data['bonusLevels'][0]['levels'][0]['perfect']
+  end
+
   test_user_gets_response_for :show, response: :redirect, user: nil,
     params: -> {script_level_params(@pilot_script_level)},
     name: 'signed out user cannot view pilot script level'

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1497,7 +1497,6 @@ class ScriptTest < ActiveSupport::TestCase
   end
 
   test "get_bonus_script_levels" do
-    student = create :student
     script = create :script
     lesson_group = create :lesson_group, script: script
     lesson1 = create :lesson, script: script, lesson_group: lesson_group
@@ -1508,8 +1507,8 @@ class ScriptTest < ActiveSupport::TestCase
     create :script_level, script: script, lesson: lesson3, bonus: true
     create :script_level, script: script, lesson: lesson3, bonus: true
 
-    bonus_levels1 = script.get_bonus_script_levels(lesson1, student)
-    bonus_levels3 = script.get_bonus_script_levels(lesson3, student)
+    bonus_levels1 = script.get_bonus_script_levels(lesson1)
+    bonus_levels3 = script.get_bonus_script_levels(lesson3)
 
     assert_equal 1, bonus_levels1.length
     assert_equal 1, bonus_levels1[0][:stageNumber]


### PR DESCRIPTION
this is a followup to #39733, which was reverted due to a failing eyes test during DTT. this PR separates out issue (2) mentioned in that PR because when rebasing that PR i encountered merge conflicts that highlight the need to raise awareness of this issue separately from the specific bugs #39733 was addressing.

currently, we cache bonus level summaries on a script instance, and when summarizing the bonus levels, we pass in the current user to get a user-specific summary. however, our script instances are cached per EC2 instance, which means that when we retrieve bonus level summaries, they include user-specific data for whatever user first viewed those bonus levels on that EC2 instance! consequently, every time the page is reloaded it will show the data cached on the EC2 instance that our load balancer routed to.

this results in very unexpected behavior, because each page reload will potentially show different progress, and occasionally even a different language!

this PR updates it so we don't include user data in the cached summaries, and instead add it per request.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [LP-1512]

[LP-1512]: https://codedotorg.atlassian.net/browse/LP-1512