### PR TITLE
Make lesson extras flag match bubble choice behavior #2

### DIFF
--- a/apps/src/code-studio/components/SublevelCard.jsx
+++ b/apps/src/code-studio/components/SublevelCard.jsx
@@ -46,11 +46,6 @@ const styles = {
     color: color.white,
     opacity: 0.8
   },
-  flagBubble: {
-    fontSize: 30,
-    height: 30,
-    width: 30
-  },
   column: {
     marginLeft: MARGIN * 2,
     display: 'flex',
@@ -158,11 +153,8 @@ export default class SublevelCard extends React.Component {
 
     if (isLessonExtra) {
       return (
-        <a style={styles.flagBubble} href={this.getSublevelUrl()}>
-          <LessonExtrasFlagIcon
-            perfect={sublevel.perfect}
-            style={styles.flagBubble}
-          />
+        <a href={this.getSublevelUrl()}>
+          <LessonExtrasFlagIcon isPerfect={sublevel.perfect} size={30} />
         </a>
       );
     }

--- a/apps/src/code-studio/components/progress/LessonProgress.jsx
+++ b/apps/src/code-studio/components/progress/LessonProgress.jsx
@@ -11,7 +11,7 @@ import {
 } from '@cdo/apps/code-studio/progressRedux';
 import ProgressBubble from '@cdo/apps/templates/progress/ProgressBubble';
 import {levelType} from '@cdo/apps/templates/progress/progressTypes';
-import {LevelKind} from '@cdo/apps/util/sharedConstants';
+import {LevelKind, LevelStatus} from '@cdo/apps/util/sharedConstants';
 import $ from 'jquery';
 
 const styles = {
@@ -83,7 +83,8 @@ class LessonProgress extends Component {
     lessonTrophyEnabled: PropTypes.bool,
     width: PropTypes.number,
     setDesiredWidth: PropTypes.func,
-    currentPageNumber: PropTypes.number
+    currentPageNumber: PropTypes.number,
+    currentLevelId: PropTypes.string
   };
 
   getFullWidth() {
@@ -161,11 +162,31 @@ class LessonProgress extends Component {
     return {headerFullProgressOffset: 0, vignetteStyle: null};
   }
 
+  isBonusComplete() {
+    return this.props.levels.some(
+      level => level.bonus && level.status === LevelStatus.perfect
+    );
+  }
+
+  /**
+   * Determines if we're on a bonus level page, in which case we want to pass
+   * `isSelected=true` into our `LessonExtrasProgressBubble` component.
+   * `isLessonExtras` indicates whether we're on the bonus level selection
+   * page, and `currentLevel.bonus` indicates whether we're on an actual
+   * bonus level page.
+   */
+  isOnBonusLevel() {
+    const {isLessonExtras, levels, currentLevelId} = this.props;
+    return (
+      isLessonExtras ||
+      levels.some(level => level.id === currentLevelId && level.bonus)
+    );
+  }
+
   render() {
     const {
       currentPageNumber,
       lessonExtrasUrl,
-      isLessonExtras,
       lessonTrophyEnabled
     } = this.props;
     let levels = this.props.levels;
@@ -182,6 +203,8 @@ class LessonProgress extends Component {
       headerFullProgressOffset,
       vignetteStyle
     } = this.getFullProgressOffset();
+
+    const onBonusLevel = this.isOnBonusLevel();
 
     return (
       <div
@@ -224,10 +247,11 @@ class LessonProgress extends Component {
               );
             })}
             {lessonExtrasUrl && !lessonTrophyEnabled && (
-              <div ref={isLessonExtras ? 'currentLevel' : null}>
+              <div ref={onBonusLevel ? 'currentLevel' : null}>
                 <LessonExtrasProgressBubble
                   lessonExtrasUrl={lessonExtrasUrl}
-                  perfect={isLessonExtras}
+                  isPerfect={this.isBonusComplete()}
+                  isSelected={onBonusLevel}
                 />
               </div>
             )}
@@ -253,5 +277,6 @@ export default connect(state => ({
     state.progress.currentStageId
   ),
   isLessonExtras: state.progress.isLessonExtras,
-  currentPageNumber: state.progress.currentPageNumber
+  currentPageNumber: state.progress.currentPageNumber,
+  currentLevelId: state.progress.currentLevelId
 }))(LessonProgress);

--- a/apps/src/code-studio/components/progress/LessonProgress.story.jsx
+++ b/apps/src/code-studio/components/progress/LessonProgress.story.jsx
@@ -81,19 +81,28 @@ const unplugged = {
   url: 'http://studio.code.org/s/course1/stage/1/puzzle/1'
 };
 
+const bonus = {
+  ids: ['100'],
+  activeId: '100',
+  title: 1,
+  bonus: true
+};
+
 export default storybook => {
   const createStoreForLevels = (
     levels,
     currentLevelIndex,
     showStageExtras,
-    onStageExtras
+    onStageExtras,
+    bonusCompleted
   ) => {
     const store = createStore(combineReducers({progress, stageLock}));
     store.dispatch(
       initProgress({
-        currentLevelId: onStageExtras
-          ? 'stage_extras'
-          : levels[currentLevelIndex].ids[0].toString(),
+        currentLevelId: currentLevelIndex
+          ? levels[currentLevelIndex].ids[0].toString()
+          : null,
+        isLessonExtras: onStageExtras,
         scriptName: 'csp1',
         saveAnswersBeforeNavigation: false,
         stages: [
@@ -105,7 +114,11 @@ export default storybook => {
         ]
       })
     );
-    store.dispatch(mergeProgress({123: TestResults.ALL_PASS}));
+    const results = {123: TestResults.ALL_PASS};
+    if (bonusCompleted) {
+      results[100] = TestResults.ALL_PASS;
+    }
+    store.dispatch(mergeProgress(results));
     store.dispatch(setStageExtrasEnabled(showStageExtras));
     return store;
   };
@@ -169,14 +182,15 @@ export default storybook => {
     },
 
     {
-      name: 'with lesson extras',
+      name: 'with lesson extras not started',
       // Provide an outer div to simulate some of the CSS that gets leaked into
       // this component
       story: () => {
         const store = createStoreForLevels(
           [activityPuzzle, conceptPuzzle],
           1,
-          true /* showStageExtras */
+          true /* showStageExtras */,
+          false /* onStageExtras */
         );
         return (
           <div style={{display: 'inline-block'}} className="header_level">
@@ -189,15 +203,59 @@ export default storybook => {
     },
 
     {
-      name: 'with lesson extras as current level',
+      name: 'with lesson extras completed',
+      // Provide an outer div to simulate some of the CSS that gets leaked into
+      // this component
+      story: () => {
+        const store = createStoreForLevels(
+          [activityPuzzle, conceptPuzzle, bonus],
+          1,
+          true /* showStageExtras */,
+          false /* onStageExtras */,
+          true /* bonusCompleted */
+        );
+        return (
+          <div style={{display: 'inline-block'}} className="header_level">
+            <Provider store={store}>
+              <LessonProgress />
+            </Provider>
+          </div>
+        );
+      }
+    },
+
+    {
+      name: 'with lesson extras as current level, not started',
       // Provide an outer div to simulate some of the CSS that gets leaked into
       // this component
       story: () => {
         const store = createStoreForLevels(
           [activityPuzzle, conceptPuzzle],
-          1,
+          null,
           true /* showStageExtras */,
           true /* onStageExtras */
+        );
+        return (
+          <div style={{display: 'inline-block'}} className="header_level">
+            <Provider store={store}>
+              <LessonProgress />
+            </Provider>
+          </div>
+        );
+      }
+    },
+
+    {
+      name: 'with lesson extras as current level, completed',
+      // Provide an outer div to simulate some of the CSS that gets leaked into
+      // this component
+      story: () => {
+        const store = createStoreForLevels(
+          [activityPuzzle, conceptPuzzle, bonus],
+          null,
+          true /* showStageExtras */,
+          true /* onStageExtras */,
+          true /* bonusCompleted */
         );
         return (
           <div style={{display: 'inline-block'}} className="header_level">

--- a/apps/src/templates/progress/LessonExtrasFlagIcon.jsx
+++ b/apps/src/templates/progress/LessonExtrasFlagIcon.jsx
@@ -1,53 +1,49 @@
-import React, {Component} from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import Radium from 'radium';
 import color from '@cdo/apps/util/color';
 
 const styles = {
-  flagNormal: {
-    color: color.white
-  },
-  checkFlagNormal: {
-    color: color.lighter_gray
-  },
-  perfect: {
-    color: color.level_perfect
-  },
-  hoverOverlay: {
+  default: {
+    color: color.lighter_gray,
     ':hover': {
       color: color.orange
     }
   },
+  selected: {
+    color: color.charcoal
+  },
+  perfect: {
+    color: color.level_perfect
+  },
   smallStack: {
     width: '1em',
-    height: '1em',
+    height: '1.1em',
     lineHeight: '1em'
   }
 };
 
-class LessonExtrasFlagIcon extends Component {
+class LessonExtrasFlagIcon extends React.PureComponent {
   static propTypes = {
-    perfect: PropTypes.bool,
-    style: PropTypes.object
+    isPerfect: PropTypes.bool,
+    isSelected: PropTypes.bool,
+    size: PropTypes.number
   };
 
   render() {
-    const {perfect, style} = this.props;
+    const {isPerfect, isSelected, size} = this.props;
+    const sizeStyle = {...styles.smallStack, fontSize: size};
+    const colorStyle = {
+      ...styles.default,
+      ...(isSelected && styles.selected),
+      ...(isPerfect && styles.perfect)
+    };
 
     return (
-      <div style={style}>
-        <span className="fa-stack fa-1x" style={styles.smallStack}>
-          <i className="fa fa-flag fa-stack-1x" style={styles.flagNormal} />
-          <i
-            className="fa fa-flag-checkered fa-stack-1x"
-            style={{
-              ...styles.checkFlagNormal,
-              ...styles.hoverOverlay,
-              ...(perfect && styles.perfect)
-            }}
-          />
-        </span>
-      </div>
+      <span className="fa-stack fa-1x" style={sizeStyle}>
+        <i className="fa fa-flag fa-stack-1x fa-inverse" />
+        <i className="fa fa-flag-checkered fa-stack-1x" style={colorStyle} />
+      </span>
     );
   }
 }

--- a/apps/src/templates/progress/LessonExtrasProgressBubble.jsx
+++ b/apps/src/templates/progress/LessonExtrasProgressBubble.jsx
@@ -6,39 +6,51 @@ import TooltipWithIcon from './TooltipWithIcon';
 import {currentLocation} from '../../utils';
 import LessonExtrasFlagIcon from './LessonExtrasFlagIcon';
 
-const styles = {
-  main: {
-    width: 21,
-    height: 24
-  }
-};
+const LARGE_FLAG_SIZE = 24;
+const SMALL_FLAG_SIZE = 16;
 
 export default class LessonExtrasProgressBubble extends Component {
   static propTypes = {
     lessonExtrasUrl: PropTypes.string.isRequired,
-    perfect: PropTypes.bool
+    isPerfect: PropTypes.bool,
+    isSelected: PropTypes.bool
   };
 
-  render() {
-    const {lessonExtrasUrl, perfect} = this.props;
+  /**
+   * we need to preserve query params for e.g. section and student id, but when
+   * we're on an actual bonus level (as opposed to the selection page), the
+   * level id is included in the params, so we need to remove it to allow this
+   * url to link back to the bonus level selection page.
+   */
+  getUrl() {
+    let url = this.props.lessonExtrasUrl;
+    const query = new URLSearchParams(currentLocation().search);
+    query.delete('id');
+    if ([...query.keys()].length > 0) {
+      url = `${url}?${query}`;
+    }
+    return url;
+  }
 
+  render() {
+    const {isPerfect, isSelected} = this.props;
     const tooltipId = _.uniqueId();
     return (
       <a
-        href={lessonExtrasUrl + currentLocation().search}
-        style={styles.main}
+        href={this.getUrl()}
         data-tip
         data-for={tooltipId}
         aria-describedby={tooltipId}
       >
-        <LessonExtrasFlagIcon perfect={perfect} style={styles.main} />
+        <LessonExtrasFlagIcon
+          isPerfect={isPerfect}
+          isSelected={isSelected}
+          size={isSelected ? LARGE_FLAG_SIZE : SMALL_FLAG_SIZE}
+        />
         <TooltipWithIcon
           tooltipId={tooltipId}
           icon={'flag-checkered'}
           text={i18n.stageExtras()}
-          // Currently a lesson extra can not also be an assessment so this should always be false
-          // TODO (dmcavoy) : When we change the way we mark levels as assessment refactor
-          includeAssessmentIcon={false}
         />
       </a>
     );

--- a/apps/test/unit/templates/progress/LessonExtrasFlagIconTest.jsx
+++ b/apps/test/unit/templates/progress/LessonExtrasFlagIconTest.jsx
@@ -4,13 +4,9 @@ import {shallow} from 'enzyme';
 import LessonExtrasFlagIcon from '@cdo/apps/templates/progress/LessonExtrasFlagIcon';
 import color from '@cdo/apps/util/color';
 
-const defaultProps = {
-  perfect: false
-};
-
 describe('LessonExtrasFlagIcon', () => {
-  it('has a grey flag icon when not current level', () => {
-    const wrapper = shallow(<LessonExtrasFlagIcon {...defaultProps} />);
+  it('has a grey flag icon when not selected, not perfect', () => {
+    const wrapper = shallow(<LessonExtrasFlagIcon />);
     assert.equal(
       wrapper
         .find('i')
@@ -20,10 +16,19 @@ describe('LessonExtrasFlagIcon', () => {
     );
   });
 
-  it('has a green flag icon when level result is perfect', () => {
-    const wrapper = shallow(
-      <LessonExtrasFlagIcon {...defaultProps} perfect={true} />
+  it('has a charcoal flag icon when selected, not perfect', () => {
+    const wrapper = shallow(<LessonExtrasFlagIcon isSelected={true} />);
+    assert.equal(
+      wrapper
+        .find('i')
+        .at(1)
+        .props().style.color,
+      color.charcoal
     );
+  });
+
+  it('has a green flag icon when level result is perfect', () => {
+    const wrapper = shallow(<LessonExtrasFlagIcon isPerfect={true} />);
     assert.equal(
       wrapper
         .find('i')

--- a/apps/test/unit/templates/progress/LessonExtrasProgressBubbleTest.js
+++ b/apps/test/unit/templates/progress/LessonExtrasProgressBubbleTest.js
@@ -3,11 +3,13 @@ import {stub} from 'sinon';
 import React from 'react';
 import {shallow} from 'enzyme';
 import LessonExtrasProgressBubble from '@cdo/apps/templates/progress/LessonExtrasProgressBubble';
+import LessonExtrasFlagIcon from '@cdo/apps/templates/progress/LessonExtrasFlagIcon';
 import * as utils from '@cdo/apps/utils';
 
 const defaultProps = {
   lessonExtrasUrl: '/extras',
-  perfect: false
+  isPerfect: false,
+  isSelected: false
 };
 
 describe('LessonExtrasProgressBubble', () => {
@@ -34,8 +36,24 @@ describe('LessonExtrasProgressBubble', () => {
     assert.equal(wrapper.props().href, '/extras?foo=1');
   });
 
-  it('renders flag icon', () => {
+  it('removes id from query params', () => {
+    utils.currentLocation.restore();
+    stub(utils, 'currentLocation').returns({search: '?id=1&foo=1'});
+
     const wrapper = shallow(<LessonExtrasProgressBubble {...defaultProps} />);
-    assert.equal(1, wrapper.find('LessonExtrasFlagIcon').length);
+
+    assert.equal(wrapper.props().href, '/extras?foo=1');
+  });
+
+  it('renders a small flag icon when not selected', () => {
+    const wrapper = shallow(<LessonExtrasProgressBubble {...defaultProps} />);
+    assert.equal(16, wrapper.find(LessonExtrasFlagIcon).props().size);
+  });
+
+  it('renders a large flag icon when selected', () => {
+    const wrapper = shallow(
+      <LessonExtrasProgressBubble {...defaultProps} isSelected={true} />
+    );
+    assert.equal(24, wrapper.find(LessonExtrasFlagIcon).props().size);
   });
 });

--- a/dashboard/app/views/layouts/_header.html.haml
+++ b/dashboard/app/views/layouts/_header.html.haml
@@ -106,7 +106,7 @@
 
     script_data = script.summarize_header
     lesson_group_data = script.lesson_groups.map(&:summarize)
-    stage_data = (@stage || script_level.lesson).summarize
+    stage_data = (@stage || script_level.lesson).summarize(include_bonus_levels = true)
     # If caching, we don't know the sign in state, and should be nil
     signed_in = @public_caching ? 'null' : !brakeman_no_warn(current_user).nil?
 


### PR DESCRIPTION
this PR reintroduces the changes from #39733, which was [reverted](https://github.com/code-dot-org/code-dot-org/pull/39880) due to a failing eyes test during DTT. however, issue (2) from that PR was separated out into #40035 for wider review, so is not included here.