### PR TITLE
Rollup Pages: Print View Set Up & Fix Blocks Display

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -337,6 +337,7 @@ describe('entry tests', () => {
           ['build/package/css/courses.css', 'style/courses.scss'],
           ['build/package/css/scripts.css', 'style/scripts.scss'],
           ['build/package/css/lessons.css', 'style/lessons.scss'],
+          ['build/package/css/rollups.css', 'style/rollups.scss'],
           [
             'build/package/css/levelbuilder.css',
             'style/code-studio/levelbuilder.scss'

--- a/apps/style/rollups.scss
+++ b/apps/style/rollups.scss
@@ -1,0 +1,2 @@
+@import "markdown";
+@import "pdf_printing";

--- a/dashboard/app/views/courses/code.html.haml
+++ b/dashboard/app/views/courses/code.html.haml
@@ -2,6 +2,9 @@
 - data[:course_summary] = @course_summary
 
 - content_for(:head) do
+  %link{href: asset_path('css/rollups.css'), rel: 'stylesheet', type: 'text/css'}
   %script{ src: webpack_asset_path('js/courses/code.js'), data: {courses_rollup: data.to_json}}
+
+  = render partial: 'shared/emulate_print_media'
 
 #roll_up

--- a/dashboard/app/views/courses/resources.html.haml
+++ b/dashboard/app/views/courses/resources.html.haml
@@ -2,6 +2,9 @@
 - data[:course_summary] = @course_summary
 
 - content_for(:head) do
+  %link{href: asset_path('css/rollups.css'), rel: 'stylesheet', type: 'text/css'}
   %script{ src: webpack_asset_path('js/courses/resources.js'), data: {courses_rollup: data.to_json}}
+
+  = render partial: 'shared/emulate_print_media'
 
 #roll_up

--- a/dashboard/app/views/courses/standards.html.haml
+++ b/dashboard/app/views/courses/standards.html.haml
@@ -2,6 +2,9 @@
 - data[:course_summary] = @course_summary
 
 - content_for(:head) do
+  %link{href: asset_path('css/rollups.css'), rel: 'stylesheet', type: 'text/css'}
   %script{ src: webpack_asset_path('js/courses/standards.js'), data: {courses_rollup: data.to_json}}
+
+  = render partial: 'shared/emulate_print_media'
 
 #roll_up

--- a/dashboard/app/views/courses/vocab.html.haml
+++ b/dashboard/app/views/courses/vocab.html.haml
@@ -2,6 +2,9 @@
 - data[:course_summary] = @course_summary
 
 - content_for(:head) do
+  %link{href: asset_path('css/rollups.css'), rel: 'stylesheet', type: 'text/css'}
   %script{ src: webpack_asset_path('js/courses/vocab.js'), data: {courses_rollup: data.to_json}}
+
+  = render partial: 'shared/emulate_print_media'
 
 #roll_up

--- a/dashboard/app/views/scripts/code.html.haml
+++ b/dashboard/app/views/scripts/code.html.haml
@@ -2,6 +2,9 @@
 - data[:unit_summary] = @unit_summary
 
 - content_for(:head) do
+  %link{href: asset_path('css/rollups.css'), rel: 'stylesheet', type: 'text/css'}
   %script{ src: webpack_asset_path('js/scripts/code.js'), data: {unit_rollup: data.to_json}}
+
+  = render partial: 'shared/emulate_print_media'
 
 #roll_up

--- a/dashboard/app/views/scripts/resources.html.haml
+++ b/dashboard/app/views/scripts/resources.html.haml
@@ -2,6 +2,9 @@
 - data[:unit_summary] = @unit_summary
 
 - content_for(:head) do
+  %link{href: asset_path('css/rollups.css'), rel: 'stylesheet', type: 'text/css'}
   %script{ src: webpack_asset_path('js/scripts/resources.js'), data: {unit_rollup: data.to_json}}
+
+  = render partial: 'shared/emulate_print_media'
 
 #roll_up

--- a/dashboard/app/views/scripts/standards.html.haml
+++ b/dashboard/app/views/scripts/standards.html.haml
@@ -2,6 +2,9 @@
 - data[:unit_summary] = @unit_summary
 
 - content_for(:head) do
+  %link{href: asset_path('css/rollups.css'), rel: 'stylesheet', type: 'text/css'}
   %script{ src: webpack_asset_path('js/scripts/standards.js'), data: {unit_rollup: data.to_json}}
+
+  = render partial: 'shared/emulate_print_media'
 
 #roll_up

--- a/dashboard/app/views/scripts/vocab.html.haml
+++ b/dashboard/app/views/scripts/vocab.html.haml
@@ -2,6 +2,9 @@
 - data[:unit_summary] = @unit_summary
 
 - content_for(:head) do
+  %link{href: asset_path('css/rollups.css'), rel: 'stylesheet', type: 'text/css'}
   %script{ src: webpack_asset_path('js/scripts/vocab.js'), data: {unit_rollup: data.to_json}}
+
+  = render partial: 'shared/emulate_print_media'
 
 #roll_up


### PR DESCRIPTION
Fix Blocks Display on Roll Up Pages for Course and Unit:
<img width="1014" alt="Screen Shot 2021-04-12 at 10 15 23 PM" src="https://user-images.githubusercontent.com/208083/114486857-959ae980-9bdc-11eb-8584-19bd5e74aece.png">


While I was in there setting up CSS I added in the basic print view stuff we have for lessons because I know we have talked about wanting to make these pages printable. 

<img width="1173" alt="Screen Shot 2021-04-12 at 10 13 31 PM" src="https://user-images.githubusercontent.com/208083/114486960-be22e380-9bdc-11eb-8b20-eab623f8f345.png">


## Links

https://codedotorg.atlassian.net/browse/PLAT-946

## Testing story

- Tested manually

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
