### PR TITLE
Make sure that scissors and assessment icon from hidden print calendar does not show on script overview

### DIFF
--- a/apps/style/_pdf_printing.scss
+++ b/apps/style/_pdf_printing.scss
@@ -4,7 +4,7 @@
 @media screen {
   .print-only {
     height: 0;
-    visibility: hidden;
+    display: none;
   }
 }
 


### PR DESCRIPTION
The hidden calendar view which we add to printing of the script overview page was still showing the unplugged icon. Updating to `display:none` instead of `visibility:hidden` seemed to fix the issue

Before:
<img width="1146" alt="Screen Shot 2021-04-13 at 8 55 48 PM" src="https://user-images.githubusercontent.com/208083/114638922-a1e57c00-9c9a-11eb-960c-88e5f65bab9a.png">

After:
<img width="1154" alt="Screen Shot 2021-04-13 at 8 56 08 PM" src="https://user-images.githubusercontent.com/208083/114638942-add13e00-9c9a-11eb-99e0-72e76171e712.png">



## Links

https://codedotorg.atlassian.net/browse/PLAT-931

## Testing story

- Manual testing