### PR TITLE
Include unit number in unit breadcrumb on lesson plan

### DIFF
--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1520,7 +1520,7 @@ class Script < ApplicationRecord
 
   def summarize_for_lesson_show(is_student = false)
     {
-      displayName: localized_title,
+      displayName: title_for_display,
       link: link,
       lessons: lessons.select(&:has_lesson_plan).map {|lesson| lesson.summarize_for_lesson_dropdown(is_student)}
     }


### PR DESCRIPTION
<img width="1035" alt="Screen Shot 2021-04-12 at 11 11 57 PM" src="https://user-images.githubusercontent.com/208083/114491446-a51e3080-9be4-11eb-8b6b-3f93ae14baf6.png">

## Links

https://codedotorg.atlassian.net/browse/PLAT-959
