### PR TITLE
Add student resources edit ui on script and course edit pages

### DIFF
--- a/apps/src/lib/levelbuilder/course-editor/CourseEditor.js
+++ b/apps/src/lib/levelbuilder/course-editor/CourseEditor.js
@@ -54,7 +54,6 @@ class CourseEditor extends Component {
     scriptsInCourse: PropTypes.arrayOf(PropTypes.string).isRequired,
     scriptNames: PropTypes.arrayOf(PropTypes.string).isRequired,
     initialTeacherResources: PropTypes.arrayOf(resourceShape),
-    initialMigratedTeacherResources: PropTypes.arrayOf(migratedResourceShape),
     hasVerifiedResources: PropTypes.bool.isRequired,
     hasNumberedUnits: PropTypes.bool.isRequired,
     courseFamilies: PropTypes.arrayOf(PropTypes.string).isRequired,
@@ -64,7 +63,8 @@ class CourseEditor extends Component {
     courseVersionId: PropTypes.number,
 
     // Provided by redux
-    migratedTeacherResources: PropTypes.arrayOf(PropTypes.object)
+    migratedTeacherResources: PropTypes.arrayOf(migratedResourceShape),
+    studentResources: PropTypes.arrayOf(migratedResourceShape)
   };
 
   constructor(props) {
@@ -273,12 +273,19 @@ class CourseEditor extends Component {
           </label>
         </CollapsibleEditorSection>
 
-        <CollapsibleEditorSection title="Teacher Resources">
+        <CollapsibleEditorSection title="Resources Dropdowns">
           {this.props.migratedTeacherResources && (
             <input
               type="hidden"
               name="resourceIds[]"
               value={this.props.migratedTeacherResources.map(r => r.id)}
+            />
+          )}
+          {this.props.studentResources && (
+            <input
+              type="hidden"
+              name="studentResourceIds[]"
+              value={this.props.studentResources.map(r => r.id)}
             />
           )}
           <div>
@@ -296,6 +303,20 @@ class CourseEditor extends Component {
               }
               courseVersionId={this.props.courseVersionId}
               useMigratedResources={this.props.useMigratedResources}
+            />
+          </div>
+          <div>
+            <div>
+              Select the Student Resource buttons you'd like to have show up on
+              the top of the course overview page
+            </div>
+
+            <ResourcesEditor
+              inputStyle={styles.input}
+              migratedResources={this.props.studentResources}
+              courseVersionId={this.props.courseVersionId}
+              useMigratedResources
+              studentFacing
             />
           </div>
         </CollapsibleEditorSection>
@@ -322,5 +343,6 @@ class CourseEditor extends Component {
 export const UnconnectedCourseEditor = CourseEditor;
 
 export default connect(state => ({
-  migratedTeacherResources: state.resources
+  migratedTeacherResources: state.resources,
+  studentResources: state.studentResources
 }))(CourseEditor);

--- a/apps/src/lib/levelbuilder/course-editor/CourseEditor.js
+++ b/apps/src/lib/levelbuilder/course-editor/CourseEditor.js
@@ -305,20 +305,22 @@ class CourseEditor extends Component {
               useMigratedResources={this.props.useMigratedResources}
             />
           </div>
-          <div>
+          {this.props.useMigratedResources && (
             <div>
-              Select the Student Resource buttons you'd like to have show up on
-              the top of the course overview page
-            </div>
+              <div>
+                Select the Student Resource buttons you'd like to have show up
+                on the top of the course overview page
+              </div>
 
-            <ResourcesEditor
-              inputStyle={styles.input}
-              migratedResources={this.props.studentResources}
-              courseVersionId={this.props.courseVersionId}
-              useMigratedResources
-              studentFacing
-            />
-          </div>
+              <ResourcesEditor
+                inputStyle={styles.input}
+                migratedResources={this.props.studentResources}
+                courseVersionId={this.props.courseVersionId}
+                useMigratedResources
+                studentFacing
+              />
+            </div>
+          )}
         </CollapsibleEditorSection>
 
         <CollapsibleEditorSection title="Units">

--- a/apps/src/lib/levelbuilder/course-editor/CourseEditor.js
+++ b/apps/src/lib/levelbuilder/course-editor/CourseEditor.js
@@ -288,12 +288,10 @@ class CourseEditor extends Component {
               value={this.props.studentResources.map(r => r.id)}
             />
           )}
+          Select the resources you'd like to have show up in the dropdown at the
+          top of the course overview page:
           <div>
-            <div>
-              Select the Teacher Resources buttons you'd like to have show up on
-              the top of the course overview page
-            </div>
-
+            <h4>Teacher Resources</h4>
             <ResourcesEditor
               inputStyle={styles.input}
               resources={teacherResources}
@@ -307,11 +305,7 @@ class CourseEditor extends Component {
           </div>
           {this.props.useMigratedResources && (
             <div>
-              <div>
-                Select the Student Resource buttons you'd like to have show up
-                on the top of the course overview page
-              </div>
-
+              <h4>Student Resources</h4>
               <ResourcesEditor
                 inputStyle={styles.input}
                 migratedResources={this.props.studentResources}

--- a/apps/src/lib/levelbuilder/course-editor/ResourcesEditor.js
+++ b/apps/src/lib/levelbuilder/course-editor/ResourcesEditor.js
@@ -41,6 +41,7 @@ export default class ResourcesEditor extends Component {
     resources: PropTypes.array,
     migratedResources: PropTypes.arrayOf(migratedResourceShape),
     useMigratedResources: PropTypes.bool.isRequired,
+    studentFacing: PropTypes.bool,
     updateResources: PropTypes.func,
     courseVersionId: PropTypes.number
   };
@@ -98,7 +99,10 @@ export default class ResourcesEditor extends Component {
         {useMigratedResources ? (
           <MigratedResourceEditor
             courseVersionId={this.props.courseVersionId}
-            resourceContext="teacherResource"
+            resourceContext={
+              this.props.studentFacing ? 'studentResource' : 'teacherResource'
+            }
+            resources={this.props.migratedResources}
           />
         ) : (
           resources
@@ -122,6 +126,7 @@ export default class ResourcesEditor extends Component {
             resources={(resources || []).filter(x => !!x.type)}
             migratedResources={this.props.migratedResources}
             useMigratedResources={this.props.useMigratedResources}
+            studentFacing={this.props.studentFacing}
           />
         </div>
       </div>

--- a/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
@@ -392,6 +392,7 @@ class LessonEditor extends Component {
                     this.state.originalLessonData.courseVersionId
                   }
                   resourceContext="lessonResource"
+                  resources={this.props.resources}
                 />
               ) : (
                 <h4>

--- a/apps/src/lib/levelbuilder/lesson-editor/ResourcesEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ResourcesEditor.jsx
@@ -58,9 +58,9 @@ class ResourcesEditor extends Component {
   static propTypes = {
     courseVersionId: PropTypes.number,
     resourceContext: PropTypes.string.isRequired,
+    resources: PropTypes.arrayOf(resourceShape).isRequired,
 
     // Provided by redux
-    resources: PropTypes.arrayOf(resourceShape).isRequired,
     addResource: PropTypes.func.isRequired,
     editResource: PropTypes.func.isRequired,
     removeResource: PropTypes.func.isRequired
@@ -320,9 +320,7 @@ class ResourcesEditor extends Component {
 export const UnconnectedResourcesEditor = ResourcesEditor;
 
 export default connect(
-  state => ({
-    resources: state.resources
-  }),
+  state => ({}),
   {
     addResource,
     editResource,

--- a/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
@@ -106,6 +106,7 @@ class ScriptEditor extends React.Component {
     levelKeyList: PropTypes.object.isRequired,
     migratedTeacherResources: PropTypes.arrayOf(migratedResourceShape)
       .isRequired,
+    studentResources: PropTypes.arrayOf(migratedResourceShape).isRequired,
     init: PropTypes.func.isRequired
   };
 
@@ -306,6 +307,9 @@ class ScriptEditor extends React.Component {
       resourceLinks: this.state.teacherResources.map(resource => resource.link),
       resourceTypes: this.state.teacherResources.map(resource => resource.type),
       resourceIds: this.props.migratedTeacherResources.map(
+        resource => resource.id
+      ),
+      studentResourceIds: this.props.studentResources.map(
         resource => resource.id
       ),
       is_migrated: this.props.isMigrated,
@@ -845,6 +849,20 @@ class ScriptEditor extends React.Component {
                 migratedResources={this.props.migratedTeacherResources}
               />
             </div>
+            <h4>Student Resources</h4>
+            <div>
+              <div>
+                Select the Student Resources buttons you'd like to have show up
+                on the top of the script overview page
+              </div>
+              <ResourcesEditor
+                inputStyle={styles.input}
+                useMigratedResources
+                courseVersionId={this.props.initialCourseVersionId}
+                migratedResources={this.props.studentResources}
+                studentFacing
+              />
+            </div>
           </div>
         </CollapsibleEditorSection>
         {this.props.isMigrated && (
@@ -957,7 +975,8 @@ export default connect(
   state => ({
     lessonGroups: state.lessonGroups,
     levelKeyList: state.levelKeyList,
-    migratedTeacherResources: state.resources
+    migratedTeacherResources: state.resources,
+    studentResources: state.studentResources
   }),
   {
     init

--- a/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
@@ -811,7 +811,7 @@ class ScriptEditor extends React.Component {
           )}
         </CollapsibleEditorSection>
 
-        <CollapsibleEditorSection title="Teacher Resources Settings">
+        <CollapsibleEditorSection title="Resources Dropdowns">
           <label>
             Has Resources for Verified Teachers
             <input
@@ -831,13 +831,12 @@ class ScriptEditor extends React.Component {
               </p>
             </HelpTip>
           </label>
+          Select the resources you'd like to have show up in the dropdown at the
+          top of the script overview page:
           <div>
             <h4>Teacher Resources</h4>
             <div>
-              <div>
-                Select the Teacher Resources buttons you'd like to have show up
-                on the top of the script overview page
-              </div>
+              <div />
               <ResourcesEditor
                 inputStyle={styles.input}
                 resources={this.state.teacherResources}

--- a/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
@@ -849,20 +849,22 @@ class ScriptEditor extends React.Component {
                 migratedResources={this.props.migratedTeacherResources}
               />
             </div>
-            <h4>Student Resources</h4>
-            <div>
+            {this.props.isMigrated && (
               <div>
-                Select the Student Resources buttons you'd like to have show up
-                on the top of the script overview page
+                <h4>Student Resources</h4>
+                <div>
+                  Select the Student Resources buttons you'd like to have show
+                  up on the top of the script overview page
+                </div>
+                <ResourcesEditor
+                  inputStyle={styles.input}
+                  useMigratedResources
+                  courseVersionId={this.props.initialCourseVersionId}
+                  migratedResources={this.props.studentResources}
+                  studentFacing
+                />
               </div>
-              <ResourcesEditor
-                inputStyle={styles.input}
-                useMigratedResources
-                courseVersionId={this.props.initialCourseVersionId}
-                migratedResources={this.props.studentResources}
-                studentFacing
-              />
-            </div>
+            )}
           </div>
         </CollapsibleEditorSection>
         {this.props.isMigrated && (

--- a/apps/src/sites/studio/pages/courses/edit.js
+++ b/apps/src/sites/studio/pages/courses/edit.js
@@ -18,12 +18,19 @@ function showCourseEditor() {
     courseEditorData.course_summary.teacher_resources || []
   ).map(([type, link]) => ({type, link}));
 
-  registerReducers({resources: createResourcesReducer('teacherResource')});
+  registerReducers({
+    resources: createResourcesReducer('teacherResource'),
+    studentResources: createResourcesReducer('studentResource')
+  });
   const store = getStore();
   store.dispatch(
     initResources(
       'teacherResource',
       courseEditorData.course_summary.migrated_teacher_resources || []
+    ),
+    initResources(
+      'studentResource',
+      courseEditorData.course_summary.student_resources || []
     )
   );
 

--- a/apps/src/sites/studio/pages/scripts/edit.js
+++ b/apps/src/sites/studio/pages/scripts/edit.js
@@ -26,6 +26,7 @@ export default function initPage(scriptEditorData) {
   registerReducers({
     ...reducers,
     resources: createResourcesReducer('teacherResource'),
+    studentResources: createResourcesReducer('studentResource'),
     isRtl
   });
   const store = getStore();
@@ -40,7 +41,8 @@ export default function initPage(scriptEditorData) {
     initResources(
       'teacherResource',
       scriptData.migrated_teacher_resources || []
-    )
+    ),
+    initResources('studentResource', scriptData.student_resources || [])
   );
 
   let announcements = scriptData.announcements || [];

--- a/apps/test/unit/lib/levelbuilder/course-editor/CourseEditorTest.js
+++ b/apps/test/unit/lib/levelbuilder/course-editor/CourseEditorTest.js
@@ -41,7 +41,8 @@ describe('CourseEditor', () => {
     stubRedux();
     registerReducers({
       teacherSections,
-      resources: createResourcesReducer('teacherResource')
+      resources: createResourcesReducer('teacherResource'),
+      studentResources: createResourcesReducer('studentResource')
     });
   });
 
@@ -108,9 +109,12 @@ describe('CourseEditor', () => {
           ]}
         />
       );
-      expect(wrapper.find('ResourcesEditor').length).to.equal(1);
-      expect(wrapper.find('ResourcesEditor').props().useMigratedResources).to.be
-        .true;
+      expect(
+        wrapper
+          .find('ResourcesEditor')
+          .first()
+          .props().useMigratedResources
+      ).to.be.true;
     });
   });
 

--- a/apps/test/unit/lib/levelbuilder/script-editor/ScriptEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/ScriptEditorTest.jsx
@@ -17,7 +17,6 @@ import {
 import createResourcesReducer, {
   initResources
 } from '@cdo/apps/lib/levelbuilder/lesson-editor/resourcesEditorRedux';
-import MigratedResourcesEditor from '@cdo/apps/lib/levelbuilder/lesson-editor/ResourcesEditor';
 import sinon from 'sinon';
 import * as utils from '@cdo/apps/utils';
 
@@ -30,7 +29,8 @@ describe('ScriptEditor', () => {
     registerReducers({
       ...reducers,
       isRtl,
-      resources: createResourcesReducer('teacherResource')
+      resources: createResourcesReducer('teacherResource'),
+      studentResources: createResourcesReducer('studentResource')
     });
     store = getStore();
     store.dispatch(
@@ -110,7 +110,7 @@ describe('ScriptEditor', () => {
     it('uses new script editor for migrated script', () => {
       const wrapper = createWrapper({initialHidden: false, isMigrated: true});
 
-      expect(wrapper.find('input').length).to.equal(25);
+      expect(wrapper.find('input').length).to.equal(26);
       expect(wrapper.find('input[type="checkbox"]').length).to.equal(12);
       expect(wrapper.find('textarea').length).to.equal(4);
       expect(wrapper.find('select').length).to.equal(4);
@@ -169,7 +169,12 @@ describe('ScriptEditor', () => {
         const wrapper = createWrapper({
           isMigrated: true
         });
-        expect(wrapper.find(MigratedResourcesEditor).length).to.equal(1);
+        expect(
+          wrapper
+            .find('ResourcesEditor')
+            .first()
+            .props().useMigratedResources
+        ).to.be.true;
       });
     });
 

--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -94,7 +94,8 @@ class CoursesController < ApplicationController
     unit_group.persist_strings_and_scripts_changes(params[:scripts], params[:alternate_scripts], i18n_params)
     unit_group.update_teacher_resources(params[:resourceTypes], params[:resourceLinks]) unless unit_group.has_migrated_script?
     if unit_group.has_migrated_script? && unit_group.course_version
-      unit_group.resources = params[:resourceIds].map {|id| Resource.find(id)}
+      unit_group.resources = params[:resourceIds].reject(&:empty?).map {|id| Resource.find(id)}
+      unit_group.student_resources = params[:studentResourceIds].reject(&:empty?).map {|id| Resource.find(id)}
     end
     # Convert checkbox values from a string ("on") to a boolean.
     [:has_verified_resources, :has_numbered_units, :visible, :is_stable].each {|key| params[key] = !!params[key]}

--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -94,8 +94,8 @@ class CoursesController < ApplicationController
     unit_group.persist_strings_and_scripts_changes(params[:scripts], params[:alternate_scripts], i18n_params)
     unit_group.update_teacher_resources(params[:resourceTypes], params[:resourceLinks]) unless unit_group.has_migrated_script?
     if unit_group.has_migrated_script? && unit_group.course_version
-      unit_group.resources = params[:resourceIds].reject(&:empty?).map {|id| Resource.find(id)}
-      unit_group.student_resources = params[:studentResourceIds].reject(&:empty?).map {|id| Resource.find(id)}
+      unit_group.resources = params[:resourceIds].reject(&:empty?).map {|id| Resource.find(id)} if params.key?(:resourceIds)
+      unit_group.student_resources = params[:studentResourceIds].reject(&:empty?).map {|id| Resource.find(id)} if params.key?(:studentResourceIds)
     end
     # Convert checkbox values from a string ("on") to a boolean.
     [:has_verified_resources, :has_numbered_units, :visible, :is_stable].each {|key| params[key] = !!params[key]}

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -231,6 +231,7 @@ class ScriptsController < ApplicationController
       resourceTypes: [],
       resourceLinks: [],
       resourceIds: [],
+      studentResourceIds: [],
       project_widget_types: [],
       supported_locales: [],
     ).to_h

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1257,6 +1257,7 @@ class Script < ApplicationRecord
     end
     update_teacher_resources(general_params[:resourceTypes], general_params[:resourceLinks]) unless general_params[:is_migrated]
     update_migrated_teacher_resources(general_params[:resourceIds]) if general_params[:is_migrated]
+    update_student_resources(general_params[:studentResourceIds]) if general_params[:is_migrated]
     begin
       if Rails.application.config.levelbuilder_mode
         script = Script.find_by_name(script_name)
@@ -1302,6 +1303,10 @@ class Script < ApplicationRecord
   def update_migrated_teacher_resources(resource_ids)
     teacher_resources = (resource_ids || []).map {|id| Resource.find(id)}
     self.resources = teacher_resources
+  end
+
+  def update_student_resources(resource_ids)
+    self.student_resources = (resource_ids || []).map {|id| Resource.find(id)}
   end
 
   def self.rake

--- a/dashboard/test/controllers/courses_controller_test.rb
+++ b/dashboard/test/controllers/courses_controller_test.rb
@@ -337,6 +337,21 @@ class CoursesControllerTest < ActionController::TestCase
     assert_equal 1, unit_group.resources.length
   end
 
+  test "update: persists student resources for migrated unit groups" do
+    sign_in @levelbuilder
+    Rails.application.config.stubs(:levelbuilder_mode).returns true
+    course_version = create :course_version, :with_unit_group
+    unit_group = course_version.content_root
+    unit_group.update!(name: 'csp-2017')
+    script = create :script, hidden: true, is_migrated: true
+    create :unit_group_unit, unit_group: unit_group, script: script, position: 1
+    resource = create :resource, course_version: course_version
+
+    post :update, params: {course_name: 'csp-2017', scripts: [], title: 'Computer Science Principles', studentResourceIds: [resource.id]}
+    unit_group.reload
+    assert_equal 1, unit_group.student_resources.length
+  end
+
   test_user_gets_response_for :vocab, response: :success, user: :teacher, params: -> {{course_name: @unit_group_migrated.name}}
   test_user_gets_response_for :vocab, response: 404, user: :teacher, params: -> {{course_name: @unit_group_unmigrated.name}}
 

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -624,6 +624,29 @@ class ScriptsControllerTest < ActionController::TestCase
     assert_equal teacher_resources.map(&:key), Script.find_by_name(script.name).resources.map {|r| r[:key]}
   end
 
+  test 'updates migrated student resources' do
+    sign_in @levelbuilder
+    Rails.application.config.stubs(:levelbuilder_mode).returns true
+
+    script = create :script, hidden: true, is_migrated: true
+    stub_file_writes(script.name)
+
+    course_version = create :course_version, content_root: script
+    student_resources = [
+      create(:resource, course_version: course_version),
+      create(:resource, course_version: course_version)
+    ]
+
+    post :update, params: {
+      id: script.id,
+      script: {name: script.name},
+      script_text: '',
+      studentResourceIds: student_resources.map(&:id),
+      is_migrated: true
+    }
+    assert_equal student_resources.map(&:key), Script.find_by_name(script.name).student_resources.map {|r| r[:key]}
+  end
+
   test 'updates pilot_experiment' do
     sign_in @levelbuilder
     Rails.application.config.stubs(:levelbuilder_mode).returns true


### PR DESCRIPTION
Finishes [PLAT-644](https://codedotorg.atlassian.net/browse/PLAT-644). Adds a resource editor for student resources on the script and course edit page.

<img width="1100" alt="Screen Shot 2021-04-14 at 7 37 51 AM" src="https://user-images.githubusercontent.com/46464143/114741034-3da8d380-9cff-11eb-87c6-f8d9fdab1789.png">


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
