### PR TITLE
include before and after data in lesson update error

### DIFF
--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -65,6 +65,8 @@ class LessonsController < ApplicationController
       old_lesson_data['resources']&.map! {|v| v['id']}
       if old_lesson_data.to_json != current_lesson_data.to_json
         msg = "Could not update the lesson because the contents of the lesson has changed outside of this editor. Reload the page and try saving again."
+        msg += "\nold_lesson_data: #{JSON.pretty_generate(old_lesson_data)}"
+        msg += "\ncurrent_lesson_data: #{JSON.pretty_generate(current_lesson_data)}"
         raise msg
       end
     end


### PR DESCRIPTION
Finishes https://codedotorg.atlassian.net/browse/PLAT-964. 

## Testing story

Manually verified via Chrome network tab that error details appear in the response returned to the browser.

## Follow-up work

- [x] Confirm error details show up in honey badger: https://app.honeybadger.io/projects/3240/faults/78890334
