### PR TITLE
Add comment around gamelab_setBackgroundImage support

### DIFF
--- a/apps/src/p5lab/spritelab/backgrounds.json
+++ b/apps/src/p5lab/spritelab/backgrounds.json
@@ -1,4 +1,8 @@
 {
+  "//": [
+    "This file is required for the gamelab_setBackgroundImage block.",
+    "That block is deprecated, but must be supported as older levels and user projects use it."
+  ],
   "backgrounds": [
     {
       "name": "cave",

--- a/apps/src/p5lab/spritelab/backgrounds.json
+++ b/apps/src/p5lab/spritelab/backgrounds.json
@@ -1,7 +1,7 @@
 {
   "//": [
     "This file is required for the gamelab_setBackgroundImage block.",
-    "That block is deprecated, but must be supported as older levels and user projects use it."
+    "That block is deprecated in favor of gamelab_setBackgroundImageAs, but must be supported as older levels and user projects use it."
   ],
   "backgrounds": [
     {


### PR DESCRIPTION
Adding a comment to explain why this file is needed so we don't remove it before we're ready (as I almost did in this [Slack thread](https://codedotorg.slack.com/archives/CN4T89YP8/p1618332796006500)).

This file is only used for the `gamelab_setBackgroundImage` block, which is now deprecated in favor of `gamelab_setBackgroundImageAs`. However, the former block is still used in 141 levels and in an unknown number of user projects, so we still need to support it.