### PR TITLE
Moved JavalabViewTest to use shallow rendering

### DIFF
--- a/apps/src/javalab/JavalabView.jsx
+++ b/apps/src/javalab/JavalabView.jsx
@@ -221,6 +221,7 @@ class JavalabView extends React.Component {
   }
 }
 
+export const UnconnectedJavalabView = JavalabView;
 export default connect(
   state => ({
     isProjectLevel: state.pageConstants.isProjectLevel,
@@ -232,4 +233,4 @@ export default connect(
     appendOutputLog: log => dispatch(appendOutputLog(log)),
     toggleDarkMode: () => dispatch(toggleDarkMode())
   })
-)(JavalabView);
+)(UnconnectedJavalabView);

--- a/apps/test/unit/javalab/JavalabViewTest.js
+++ b/apps/test/unit/javalab/JavalabViewTest.js
@@ -1,80 +1,84 @@
 import React from 'react';
 import {expect} from '../../util/reconfiguredChai';
-import {mount} from 'enzyme';
-import JavalabView from '@cdo/apps/javalab/JavalabView';
-import {Provider} from 'react-redux';
-import pageConstants, {setPageConstants} from '@cdo/apps/redux/pageConstants';
-import {
-  getStore,
-  registerReducers,
-  stubRedux,
-  restoreRedux
-} from '@cdo/apps/redux';
-import javalab, {toggleDarkMode} from '@cdo/apps/javalab/javalabRedux';
+import {shallow} from 'enzyme';
+// import JavalabView from '@cdo/apps/javalab/JavalabView';
+import {UnconnectedJavalabView as JavalabView} from '@cdo/apps/javalab/JavalabView';
+// import {Provider} from 'react-redux';
+// import pageConstants, {setPageConstants} from '@cdo/apps/redux/pageConstants';
+// import {
+//   getStore,
+//   registerReducers,
+//   stubRedux,
+//   restoreRedux
+// } from '@cdo/apps/redux';
+// import javalab, {toggleDarkMode} from '@cdo/apps/javalab/javalabRedux';
 import color from '@cdo/apps/util/color';
 global.$ = require('jquery');
 
 describe('Java Lab View Test', () => {
-  let store, defaultProps;
+  let defaultProps;
 
   beforeEach(() => {
-    stubRedux();
-    registerReducers({javalab});
-    registerReducers({pageConstants});
-    store = getStore();
-    store.dispatch(
-      setPageConstants({
-        isProjectLevel: true,
-        isReadOnlyWorkspace: false,
-        channelId: 'id',
-        isEmbedView: false,
-        isShareView: false
-      })
-    );
+    // stubRedux();
+    // registerReducers({javalab});
+    // registerReducers({pageConstants});
+    // store = getStore();
+    // store.dispatch(
+    //   setPageConstants({
+    //     isProjectLevel: true,
+    //     isReadOnlyWorkspace: false,
+    //     channelId: 'id',
+    //     isEmbedView: false,
+    //     isShareView: false
+    //   })
+    // );
     defaultProps = {
       onMount: () => {},
       onContinue: () => {},
-      onCommitCode: () => {}
+      onCommitCode: () => {},
+      isProjectLevel: false,
+      isReadOnlyWorkspace: false,
+      isDarkMode: false
     };
   });
 
   afterEach(() => {
-    restoreRedux();
+    // restoreRedux();
   });
 
-  const createWrapper = () => {
-    return mount(
-      <Provider store={store}>
-        <JavalabView {...defaultProps} />
-      </Provider>
-    );
-  };
+  // const createWrapper = () => {
+  //   return shallow(
+  //     // <Provider store={store}>
+  //       <JavalabView {...defaultProps} />
+  //     // </Provider>
+  //   );
+  // };
 
   describe('getButtonStyles', () => {
     it('Is cyan or orange in light mode', () => {
-      const editor = createWrapper();
+      let editor = shallow(<JavalabView {...defaultProps} />);
       const notSettings = editor
-        .find('JavalabView')
+        // .find('JavalabView')
         .instance()
         .getButtonStyles(false);
       expect(notSettings.backgroundColor).to.equal(color.cyan);
       const settings = editor
-        .find('JavalabView')
+        // .find('JavalabView')
         .instance()
         .getButtonStyles(true);
       expect(settings.backgroundColor).to.equal(color.orange);
     });
 
     it('Is grey in dark mode', () => {
-      const editor = createWrapper();
-      store.dispatch(toggleDarkMode());
+      let props = {...defaultProps, isDarkMode: true};
+      let editor = shallow(<JavalabView {...props} />);
       const notSettings = editor
-        .find('JavalabView')
+        // .find('JavalabView')
         .instance()
         .getButtonStyles(false);
       expect(notSettings.backgroundColor).to.equal('#272822');
       const settings = editor
-        .find('JavalabView')
+        // .find('JavalabView')
         .instance()
         .getButtonStyles(false);
       expect(settings.backgroundColor).to.equal('#272822');


### PR DESCRIPTION
Mockup of potential workaround using a deprecated pattern that was the recommended testing pattern from back when our current version of redux was the recommended version. https://stackoverflow.com/a/49634952

Workaround: Export the unwrapped version of the component. This is no longer recommended, but was the recommended pattern in 2018, when react-redux 4.4.9 was the main version.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
