### PR TITLE
Rename levelProgress in script overview redux store to levelResults

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -559,7 +559,7 @@ StudioApp.prototype.init = function(config) {
     document.body.appendChild(startDialogDiv);
     const progress = getStore().getState().progress;
     const isComplete =
-      progress.levelProgress[progress.currentLevelId] >=
+      progress.levelResults[progress.currentLevelId] >=
       TestResults.MINIMUM_OPTIMAL_RESULT;
     ReactDOM.render(
       <ChallengeDialog
@@ -3418,7 +3418,7 @@ StudioApp.prototype.isNotStartedLevel = function(config) {
   } else {
     return (
       config.readonlyWorkspace &&
-      progress.levelProgress[progress.currentLevelId] === undefined
+      progress.levelResults[progress.currentLevelId] === undefined
     );
   }
 };

--- a/apps/src/code-studio/components/lessonExtras/LessonExtras.story.jsx
+++ b/apps/src/code-studio/components/lessonExtras/LessonExtras.story.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import LessonExtras from './LessonExtras';
-import progress, {mergeProgress} from '@cdo/apps/code-studio/progressRedux';
+import progress, {mergeResults} from '@cdo/apps/code-studio/progressRedux';
 import {Provider} from 'react-redux';
 import {createStore, combineReducers} from 'redux';
 import {withInfo} from '@storybook/addon-info';
@@ -12,7 +12,7 @@ function configureStore() {
     })
   );
   store.dispatch(
-    mergeProgress({
+    mergeResults({
       6: 100,
       7: 100,
       8: 100

--- a/apps/src/code-studio/components/progress/LessonProgress.story.jsx
+++ b/apps/src/code-studio/components/progress/LessonProgress.story.jsx
@@ -5,7 +5,7 @@ import LessonProgress from './LessonProgress';
 import stageLock from '../../stageLockRedux';
 import progress, {
   initProgress,
-  mergeProgress,
+  mergeResults,
   setStageExtrasEnabled
 } from '../../progressRedux';
 import {TestResults} from '@cdo/apps/constants';
@@ -105,7 +105,7 @@ export default storybook => {
         ]
       })
     );
-    store.dispatch(mergeProgress({123: TestResults.ALL_PASS}));
+    store.dispatch(mergeResults({123: TestResults.ALL_PASS}));
     store.dispatch(setStageExtrasEnabled(showStageExtras));
     return store;
   };

--- a/apps/src/code-studio/components/progress/ScriptOverview.jsx
+++ b/apps/src/code-studio/components/progress/ScriptOverview.jsx
@@ -56,7 +56,7 @@ class ScriptOverview extends React.Component {
     isMigrated: PropTypes.bool,
 
     // redux provided
-    perLevelProgress: PropTypes.object.isRequired,
+    perLevelResults: PropTypes.object.isRequired,
     scriptCompleted: PropTypes.bool.isRequired,
     scriptId: PropTypes.number.isRequired,
     scriptName: PropTypes.string.isRequired,
@@ -94,7 +94,7 @@ class ScriptOverview extends React.Component {
       teacherResources,
       migratedTeacherResources,
       studentResources,
-      perLevelProgress,
+      perLevelResults,
       scriptCompleted,
       scriptId,
       scriptName,
@@ -128,7 +128,7 @@ class ScriptOverview extends React.Component {
     let scriptProgress = NOT_STARTED;
     if (scriptCompleted) {
       scriptProgress = COMPLETED;
-    } else if (Object.keys(perLevelProgress).length > 0) {
+    } else if (Object.keys(perLevelResults).length > 0) {
       scriptProgress = IN_PROGRESS;
     }
 
@@ -203,7 +203,7 @@ class ScriptOverview extends React.Component {
 
 export const UnconnectedScriptOverview = Radium(ScriptOverview);
 export default connect((state, ownProps) => ({
-  perLevelProgress: state.progress.levelProgress,
+  perLevelResults: state.progress.levelResults,
   scriptCompleted: !!state.progress.scriptCompleted,
   scriptId: state.progress.scriptId,
   scriptName: state.progress.scriptName,

--- a/apps/src/code-studio/progress.js
+++ b/apps/src/code-studio/progress.js
@@ -16,7 +16,7 @@ import {getHiddenStages, initializeHiddenScripts} from './hiddenStageRedux';
 import {TestResults} from '@cdo/apps/constants';
 import {
   initProgress,
-  overwriteProgress,
+  overwriteResults,
   disablePostMilestone,
   setIsHocScript,
   setIsAge13Required,
@@ -146,8 +146,8 @@ function populateProgress(store, signedIn, progressData, scriptName) {
       clientState.clearProgress();
     }
 
-    if (data.progress) {
-      store.dispatch(overwriteProgress(data.progress));
+    if (data.levelResults) {
+      store.dispatch(overwriteResults(data.levelResults));
     }
 
     if (data.isVerifiedTeacher) {
@@ -163,7 +163,7 @@ function populateProgress(store, signedIn, progressData, scriptName) {
 /**
  * Returns a promise that, when resolved, returns an object with two properties:
  * - usingDbProgress: indicates if level progress came from the database
- * - progress: map from level id to result
+ * - levelResults: map from level id to result
  *
  * This function contains logic that determines whether progress data should
  * come from the data embedded in the html page (passed in as progressData),
@@ -182,14 +182,14 @@ function getLevelProgress(signedIn, progressData, scriptName) {
       // User is signed in, return a resolved promise with the given progress data
       return Promise.resolve({
         usingDbProgress: true,
-        progress: extractLevelResults(progressData)
+        levelResults: extractLevelResults(progressData)
       });
     case false:
       // User is not signed in, return a resolved promise with progress data
       // retrieved from session storage
       return Promise.resolve({
         usingDbProgress: false,
-        progress: clientState.levelProgress(scriptName)
+        levelResults: clientState.levelProgress(scriptName)
       });
     case null:
       // We do not know if user is signed in or not, send a request to the server
@@ -199,12 +199,12 @@ function getLevelProgress(signedIn, progressData, scriptName) {
           if (data.signedIn) {
             return {
               usingDbProgress: true,
-              progress: extractLevelResults(data)
+              levelResults: extractLevelResults(data)
             };
           } else {
             return {
               usingDbProgress: false,
-              progress: clientState.levelProgress(scriptName)
+              levelResults: clientState.levelProgress(scriptName)
             };
           }
         })
@@ -344,7 +344,7 @@ function queryUserProgress(store, scriptData, currentLevelId) {
     // to reduxQueryUserProgress above.)
     if (!data.signedIn) {
       store.dispatch(
-        overwriteProgress(clientState.levelProgress(scriptData.name))
+        overwriteResults(clientState.levelProgress(scriptData.name))
       );
     }
 

--- a/apps/src/code-studio/progressRedux.js
+++ b/apps/src/code-studio/progressRedux.js
@@ -17,8 +17,8 @@ import {authorizeLockable} from './stageLockRedux';
 
 // Action types
 export const INIT_PROGRESS = 'progress/INIT_PROGRESS';
-const CLEAR_PROGRESS = 'progress/CLEAR_PROGRESS';
-const MERGE_PROGRESS = 'progress/MERGE_PROGRESS';
+const CLEAR_RESULTS = 'progress/CLEAR_RESULTS';
+const MERGE_RESULTS = 'progress/MERGE_RESULTS';
 const MERGE_PEER_REVIEW_PROGRESS = 'progress/MERGE_PEER_REVIEW_PROGRESS';
 const UPDATE_FOCUS_AREAS = 'progress/UPDATE_FOCUS_AREAS';
 const SHOW_TEACHER_INFO = 'progress/SHOW_TEACHER_INFO';
@@ -32,7 +32,7 @@ const SET_CURRENT_STAGE_ID = 'progress/SET_CURRENT_STAGE_ID';
 const SET_SCRIPT_COMPLETED = 'progress/SET_SCRIPT_COMPLETED';
 const SET_STAGE_EXTRAS_ENABLED = 'progress/SET_STAGE_EXTRAS_ENABLED';
 const USE_DB_PROGRESS = 'progress/USE_DB_PROGRESS';
-const OVERWRITE_PROGRESS = 'progress/OVERWRITE_PROGRESS';
+const OVERWRITE_RESULTS = 'progress/OVERWRITE_RESULTS';
 
 const PEER_REVIEW_ID = -1;
 
@@ -53,7 +53,7 @@ const initialState = {
 
   // The remaining fields do change after initialization
   // a mapping of level id to result
-  levelProgress: {},
+  levelResults: {},
   focusAreaStageIds: [],
   peerReviewLessonInfo: null,
   peerReviewsPerformed: [],
@@ -113,36 +113,36 @@ export default function reducer(state = initialState, action) {
     };
   }
 
-  if (action.type === CLEAR_PROGRESS) {
+  if (action.type === CLEAR_RESULTS) {
     return {
       ...state,
-      levelProgress: initialState.levelProgress
+      levelResults: initialState.levelResults
     };
   }
 
-  if (action.type === OVERWRITE_PROGRESS) {
+  if (action.type === OVERWRITE_RESULTS) {
     return {
       ...state,
-      levelProgress: action.levelProgress
+      levelResults: action.levelResults
     };
   }
 
-  if (action.type === MERGE_PROGRESS) {
-    let newLevelProgress = {};
+  if (action.type === MERGE_RESULTS) {
+    let newLevelResults = {};
     const combinedLevels = Object.keys({
-      ...state.levelProgress,
-      ...action.levelProgress
+      ...state.levelResults,
+      ...action.levelResults
     });
     combinedLevels.forEach(key => {
-      newLevelProgress[key] = mergeActivityResult(
-        state.levelProgress[key],
-        action.levelProgress[key]
+      newLevelResults[key] = mergeActivityResult(
+        state.levelResults[key],
+        action.levelResults[key]
       );
     });
 
     return {
       ...state,
-      levelProgress: newLevelProgress
+      levelResults: newLevelResults
     };
   }
 
@@ -316,7 +316,7 @@ const userProgressFromServer = (state, dispatch, userId = null) => {
   // If we have a userId, we can clear any progress in redux and request all progress
   // from the server.
   if (userId) {
-    dispatch(clearProgress());
+    dispatch(clearResults());
   }
 
   return $.ajax({
@@ -359,8 +359,8 @@ const userProgressFromServer = (state, dispatch, userId = null) => {
 
     // Merge progress from server
     if (data.progress) {
-      const levelProgress = _.mapValues(data.progress, getLevelResult);
-      dispatch(mergeProgress(levelProgress));
+      const levelResults = _.mapValues(data.progress, getLevelResult);
+      dispatch(mergeResults(levelResults));
 
       if (data.peerReviewsPerformed) {
         dispatch(mergePeerReviewProgress(data.peerReviewsPerformed));
@@ -411,22 +411,22 @@ export const initProgress = ({
   currentPageNumber
 });
 
-export const clearProgress = () => ({
-  type: CLEAR_PROGRESS
+export const clearResults = () => ({
+  type: CLEAR_RESULTS
 });
 
 export const useDbProgress = () => ({
   type: USE_DB_PROGRESS
 });
 
-export const mergeProgress = levelProgress => ({
-  type: MERGE_PROGRESS,
-  levelProgress
+export const mergeResults = levelResults => ({
+  type: MERGE_RESULTS,
+  levelResults: levelResults
 });
 
-export const overwriteProgress = levelProgress => ({
-  type: OVERWRITE_PROGRESS,
-  levelProgress
+export const overwriteResults = levelResults => ({
+  type: OVERWRITE_RESULTS,
+  levelResults: levelResults
 });
 
 export const mergePeerReviewProgress = peerReviewsPerformed => ({
@@ -525,7 +525,7 @@ const peerReviewLesson = state => ({
  */
 const peerReviewLevels = state =>
   state.peerReviewLessonInfo.levels.map((level, index) => ({
-    // These aren't true levels (i.e. we won't have an entry in levelProgress),
+    // These aren't true levels (i.e. we won't have an entry in levelResults),
     // so always use a specific id that won't collide with real levels
     id: PEER_REVIEW_ID,
     status: level.locked ? LevelStatus.locked : level.status,
@@ -550,10 +550,10 @@ const isCurrentLevel = (currentLevelId, level) => {
  * The level object passed down to use via the server (and stored in stage.stages.levels)
  * contains more data than we need. This (a) filters to the parts our views care
  * about and (b) determines current status based on the current state of
- * state.levelProgress
+ * state.levelResults
  */
 const levelWithStatus = (
-  {levelProgress, levelPairing = {}, currentLevelId, isSublevel = false},
+  {levelResults, levelPairing = {}, currentLevelId, isSublevel = false},
   level
 ) => {
   if (level.kind !== LevelKind.unplugged && !isSublevel) {
@@ -566,7 +566,7 @@ const levelWithStatus = (
   const normalizedLevel = processedLevel(level);
   return {
     ...normalizedLevel,
-    status: statusForLevel(level, levelProgress),
+    status: statusForLevel(level, levelResults),
     isCurrentLevel: isCurrentLevel(currentLevelId, normalizedLevel),
     paired: levelPairing[level.activeId],
     readonlyAnswers: level.readonly_answers
@@ -578,20 +578,20 @@ const levelWithStatus = (
  */
 export const levelsByLesson = ({
   stages,
-  levelProgress,
+  levelResults,
   levelPairing,
   currentLevelId
 }) =>
   stages.map(stage =>
     stage.levels.map(level => {
       let statusLevel = levelWithStatus(
-        {levelProgress, levelPairing, currentLevelId},
+        {levelResults, levelPairing, currentLevelId},
         level
       );
       if (statusLevel.sublevels) {
         statusLevel.sublevels = level.sublevels.map(sublevel =>
           levelWithStatus(
-            {levelProgress, levelPairing, currentLevelId, isSublevel: true},
+            {levelResults, levelPairing, currentLevelId, isSublevel: true},
             sublevel
           )
         );
@@ -614,8 +614,8 @@ export const lessonExtrasUrl = (state, stageId) =>
     : '';
 
 export const isPerfect = (state, levelId) =>
-  !!state.levelProgress &&
-  state.levelProgress[levelId] >= TestResults.MINIMUM_OPTIMAL_RESULT;
+  !!state.levelResults &&
+  state.levelResults[levelId] >= TestResults.MINIMUM_OPTIMAL_RESULT;
 
 export const getPercentPerfect = levels => {
   const puzzleLevels = levels.filter(level => !level.isConceptLevel);
@@ -632,13 +632,13 @@ export const getPercentPerfect = levels => {
 };
 
 /**
- * Given a level and levelProgress (both from our redux store state), determine
+ * Given a level and levelResults (both from our redux store state), determine
  * the status for that level.
  * @param {object} level - Level object from state.stages.levels
- * @param {object<number, TestResult>} levelProgress - Mapping from levelId to
+ * @param {object<number, TestResult>} levelResults - Mapping from levelId to
  *   TestResult
  */
-export function statusForLevel(level, levelProgress) {
+export function statusForLevel(level, levelResults) {
   // Peer Reviews use a level object to track their state, but have some subtle
   // differences from regular levels (such as a separate id namespace). Unlike
   // levels, Peer Reviews store status on the level object (for the time being)
@@ -658,11 +658,11 @@ export function statusForLevel(level, levelProgress) {
   // Worth noting that in the majority of cases, ids will be a single
   // id here
   const id =
-    level.uid || level.level_id || bestResultLevelId(level.ids, levelProgress);
-  let status = activityCssClass(levelProgress[id]);
+    level.uid || level.level_id || bestResultLevelId(level.ids, levelResults);
+  let status = activityCssClass(levelResults[id]);
   if (
     level.uid &&
-    level.ids.every(id => levelProgress[id] === TestResults.LOCKED_RESULT)
+    level.ids.every(id => levelResults[id] === TestResults.LOCKED_RESULT)
   ) {
     status = LevelStatus.locked;
   }

--- a/apps/src/code-studio/reporting.js
+++ b/apps/src/code-studio/reporting.js
@@ -6,7 +6,7 @@ import {TestResults} from '@cdo/apps/constants';
 import {PostMilestoneMode} from '@cdo/apps/util/sharedConstants';
 import {getContainedLevelId} from '@cdo/apps/code-studio/levels/codeStudioLevels';
 import {getStore} from '@cdo/apps/redux';
-import {mergeProgress} from '@cdo/apps/code-studio/progressRedux';
+import {mergeResults} from '@cdo/apps/code-studio/progressRedux';
 var clientState = require('./clientState');
 
 var lastAjaxRequest;
@@ -250,9 +250,7 @@ reporting.sendReport = function(report) {
 
   // Update Redux
   const store = getStore();
-  store.dispatch(
-    mergeProgress({[appOptions.serverLevelId]: report.testResult})
-  );
+  store.dispatch(mergeResults({[appOptions.serverLevelId]: report.testResult}));
 
   // If progress is not being saved in the database, save it locally.
   // (Note: Either way, we still send a milestone report to the server so we can

--- a/apps/src/fish/Fish.js
+++ b/apps/src/fish/Fish.js
@@ -1,5 +1,3 @@
-/* global appOptions */
-
 import React from 'react';
 import ReactDOM from 'react-dom';
 import FishView from './FishView';
@@ -8,7 +6,6 @@ import {getStore} from '../redux';
 import {setAssetPath} from '@code-dot-org/ml-activities/dist/assetPath';
 import {TestResults} from '@cdo/apps/constants';
 import fishMsg from './locale';
-import {mergeResults} from '@cdo/apps/code-studio/progressRedux';
 
 /**
  * On small mobile devices, when in portrait orientation, we show an overlay
@@ -99,10 +96,6 @@ Fish.prototype.init = function(config) {
 
 // Called by the fish app when it wants to go to the next level.
 Fish.prototype.onContinue = function() {
-  const store = getStore();
-  store.dispatch(
-    mergeResults({[appOptions.serverLevelId]: TestResults.ALL_PASS})
-  );
   const onReportComplete = result => {
     this.studioApp_.onContinue();
   };

--- a/apps/src/fish/Fish.js
+++ b/apps/src/fish/Fish.js
@@ -8,7 +8,7 @@ import {getStore} from '../redux';
 import {setAssetPath} from '@code-dot-org/ml-activities/dist/assetPath';
 import {TestResults} from '@cdo/apps/constants';
 import fishMsg from './locale';
-import {mergeProgress} from '@cdo/apps/code-studio/progressRedux';
+import {mergeResults} from '@cdo/apps/code-studio/progressRedux';
 
 /**
  * On small mobile devices, when in portrait orientation, we show an overlay
@@ -101,7 +101,7 @@ Fish.prototype.init = function(config) {
 Fish.prototype.onContinue = function() {
   const store = getStore();
   store.dispatch(
-    mergeProgress({[appOptions.serverLevelId]: TestResults.ALL_PASS})
+    mergeResults({[appOptions.serverLevelId]: TestResults.ALL_PASS})
   );
   const onReportComplete = result => {
     this.studioApp_.onContinue();

--- a/apps/src/templates/FinishDialog.story.jsx
+++ b/apps/src/templates/FinishDialog.story.jsx
@@ -76,7 +76,7 @@ const mockProgress = {
   courseId: null,
   currentStageId: 40,
   hasFullProgress: false,
-  levelProgress: {
+  levelResults: {
     1815: 17,
     1818: 100,
     1819: 30,

--- a/apps/test/unit/code-studio/components/progress/ScriptOverviewTest.js
+++ b/apps/test/unit/code-studio/components/progress/ScriptOverviewTest.js
@@ -12,7 +12,7 @@ const defaultProps = {
   isSignedIn: true,
   isVerifiedTeacher: true,
   hasVerifiedResources: true,
-  perLevelProgress: {},
+  perLevelResults: {},
   scriptCompleted: false,
   scriptId: 123,
   scriptName: 'csp1',

--- a/apps/test/unit/code-studio/progressReduxTest.js
+++ b/apps/test/unit/code-studio/progressReduxTest.js
@@ -9,7 +9,7 @@ import reducer, {
   initProgress,
   isPerfect,
   getPercentPerfect,
-  mergeProgress,
+  mergeResults,
   mergePeerReviewProgress,
   disablePostMilestone,
   setIsHocScript,
@@ -220,8 +220,8 @@ describe('progressReduxTest', () => {
         initProgress(initialScriptOverviewProgress)
       );
 
-      // Create a mergeProgress action with level progress, but no peer reviews
-      const action = mergeProgress({
+      // Create a mergeResults action with level progress, but no peer reviews
+      const action = mergeResults({
         // stage 2 level 2 is pass
         339: TestResults.ALL_PASS,
         // stage 2 level 3 is incomplete
@@ -229,7 +229,7 @@ describe('progressReduxTest', () => {
       });
       const nextState = reducer(initializedState, action);
 
-      assert.deepEqual(nextState.levelProgress, {
+      assert.deepEqual(nextState.levelResults, {
         339: TestResults.ALL_PASS,
         341: TestResults.MISSING_RECOMMENDED_BLOCK_UNFINISHED
       });
@@ -242,7 +242,7 @@ describe('progressReduxTest', () => {
       // Construct state with a single stage/level that has progress, but is
       // not perfect
       const state = {
-        levelProgress: {
+        levelResults: {
           '341': TestResults.MISSING_RECOMMENDED_BLOCK_UNFINISHED
         },
         stages: [
@@ -260,16 +260,16 @@ describe('progressReduxTest', () => {
       };
 
       // update progress to perfect
-      const action = mergeProgress({'341': TestResults.ALL_PASS});
+      const action = mergeResults({'341': TestResults.ALL_PASS});
       const nextState = reducer(state, action);
-      assert.equal(nextState.levelProgress['341'], TestResults.ALL_PASS);
+      assert.equal(nextState.levelResults['341'], TestResults.ALL_PASS);
     });
 
     it('cannot move progress backwards', () => {
       // Construct state with a single stage/level that has progress, which is
       // perfect
       const state = {
-        levelProgress: {
+        levelResults: {
           '339': TestResults.ALL_PASS
         },
         stages: [
@@ -287,11 +287,11 @@ describe('progressReduxTest', () => {
       };
 
       // try to update progress to a worse result
-      const action = mergeProgress({
+      const action = mergeResults({
         341: TestResults.MISSING_RECOMMENDED_BLOCK_UNFINISHED
       });
       const nextState = reducer(state, action);
-      assert.equal(nextState.levelProgress['339'], TestResults.ALL_PASS);
+      assert.equal(nextState.levelResults['339'], TestResults.ALL_PASS);
     });
 
     it('initially sets postMilestoneDisabled to false', () => {
@@ -406,10 +406,10 @@ describe('progressReduxTest', () => {
           ids: ['5275'],
           uid: '5275_0'
         };
-        const levelProgress = {
+        const levelResults = {
           '5275': TestResults.LOCKED_RESULT
         };
-        const status = statusForLevel(level, levelProgress);
+        const status = statusForLevel(level, levelResults);
         assert.strictEqual(status, LevelStatus.locked);
       });
 
@@ -418,12 +418,12 @@ describe('progressReduxTest', () => {
           ids: ['5275'],
           uid: '5275_0'
         };
-        const levelProgress = {
+        const levelResults = {
           '5275': TestResults.UNSUBMITTED_ATTEMPT,
           '5275_0': TestResults.UNSUBMITTED_ATTEMPT,
           '5275_1': TestResults.GENERIC_FAIL
         };
-        const status = statusForLevel(level, levelProgress);
+        const status = statusForLevel(level, levelResults);
         assert.strictEqual(status, LevelStatus.attempted);
       });
 
@@ -431,10 +431,10 @@ describe('progressReduxTest', () => {
         const level = {
           ids: ['123']
         };
-        const levelProgress = {
+        const levelResults = {
           '123': TestResults.ALL_PASS
         };
-        const status = statusForLevel(level, levelProgress);
+        const status = statusForLevel(level, levelResults);
         assert.strictEqual(status, LevelStatus.perfect);
       });
 
@@ -442,10 +442,10 @@ describe('progressReduxTest', () => {
         const level = {
           ids: ['123']
         };
-        const levelProgress = {
+        const levelResults = {
           '999': TestResults.ALL_PASS
         };
-        const status = statusForLevel(level, levelProgress);
+        const status = statusForLevel(level, levelResults);
         assert.strictEqual(status, LevelStatus.not_tried);
       });
 
@@ -454,8 +454,8 @@ describe('progressReduxTest', () => {
           kind: LevelKind.peer_review,
           locked: true
         };
-        const levelProgress = {};
-        const status = statusForLevel(level, levelProgress);
+        const levelResults = {};
+        const status = statusForLevel(level, levelResults);
         assert.strictEqual(status, LevelStatus.locked);
       });
 
@@ -465,8 +465,8 @@ describe('progressReduxTest', () => {
           locked: false,
           status: LevelStatus.perfect
         };
-        const levelProgress = {};
-        const status = statusForLevel(level, levelProgress);
+        const levelResults = {};
+        const status = statusForLevel(level, levelResults);
         assert.strictEqual(status, LevelStatus.perfect);
       });
       it('returns LevelStatus.completed_assessment for assessment level', () => {
@@ -474,10 +474,10 @@ describe('progressReduxTest', () => {
           ids: ['123'],
           kind: LevelKind.assessment
         };
-        const levelProgress = {
+        const levelResults = {
           '123': TestResults.ALL_PASS
         };
-        const status = statusForLevel(level, levelProgress);
+        const status = statusForLevel(level, levelResults);
         assert.strictEqual(status, LevelStatus.completed_assessment);
       });
     });
@@ -541,7 +541,7 @@ describe('progressReduxTest', () => {
       // construct an initial state where we have 1 stage of non-peer reviews
       // with some progress, and 1 stage of peer reviews
       const state = {
-        levelProgress: {
+        levelResults: {
           '341': TestResults.MISSING_RECOMMENDED_BLOCK_UNFINISHED
         },
         stages: [stageData[1]],
@@ -574,9 +574,9 @@ describe('progressReduxTest', () => {
       const nextState = reducer(state, action);
 
       assert.deepEqual(
-        nextState.levelProgress,
-        state.levelProgress,
-        'no change to levelProgress'
+        nextState.levelResults,
+        state.levelResults,
+        'no change to levelResults'
       );
       const peerReviewLevels = nextState.peerReviewLessonInfo.levels;
       assert.equal(
@@ -622,7 +622,7 @@ describe('progressReduxTest', () => {
       );
 
       // merge some progress so that we have statuses
-      const action = mergeProgress({
+      const action = mergeResults({
         // stage 2 level 2 is pass
         '339': TestResults.ALL_PASS,
         // stage 2 level 3 is incomplete
@@ -798,7 +798,7 @@ describe('progressReduxTest', () => {
             ]
           }
         ],
-        levelProgress: {}
+        levelResults: {}
       });
       assert.equal(results[0][0].isUnplugged, true);
       assert.equal(results[0][0].levelNumber, null);
@@ -1068,7 +1068,7 @@ describe('progressReduxTest', () => {
           }
         ],
         stages: [fakeLesson('Lesson Group', 'lesson1', 1)],
-        levelProgress: {},
+        levelResults: {},
         focusAreaStageIds: []
       };
 
@@ -1093,7 +1093,7 @@ describe('progressReduxTest', () => {
           fakeLesson('Lesson Group', 'lesson2', 2),
           fakeLesson('Lesson Group', 'lesson3', 3)
         ],
-        levelProgress: {},
+        levelResults: {},
         focusAreaStageIds: []
       };
 
@@ -1125,7 +1125,7 @@ describe('progressReduxTest', () => {
             lessons: []
           }
         ],
-        levelProgress: {},
+        levelResults: {},
         focusAreaStageIds: []
       };
 
@@ -1295,14 +1295,14 @@ describe('progressReduxTest', () => {
 
     it('returns false if the level was not started', () => {
       const state = {
-        levelProgress: {}
+        levelResults: {}
       };
       assert.isFalse(isPerfect(state, levelId));
     });
 
     it('returns false if the level was not perfected', () => {
       const state = {
-        levelProgress: {
+        levelResults: {
           '1': TestResults.MINIMUM_PASS_RESULT
         }
       };
@@ -1311,7 +1311,7 @@ describe('progressReduxTest', () => {
 
     it('returns true if the level was perfected', () => {
       const state = {
-        levelProgress: {
+        levelResults: {
           '1': TestResults.ALL_PASS
         }
       };
@@ -1433,7 +1433,7 @@ describe('progressReduxTest', () => {
       const promise = userProgressFromServer(state, dispatch, 1);
       server.respond();
       return promise.then(responseData => {
-        assert.deepEqual(['progress/CLEAR_PROGRESS'], getDispatchActions());
+        assert.deepEqual(['progress/CLEAR_RESULTS'], getDispatchActions());
         assert.deepEqual({}, responseData);
       });
     });
@@ -1465,14 +1465,14 @@ describe('progressReduxTest', () => {
       server.respond();
 
       const expectedDispatchActions = [
-        'progress/CLEAR_PROGRESS',
+        'progress/CLEAR_RESULTS',
         'verifiedTeacher/SET_VERIFIED',
         'progress/SET_IS_SUMMARY_VIEW',
         'progress/SHOW_TEACHER_INFO',
         'progress/UPDATE_FOCUS_AREAS',
         'stageLock/AUTHORIZE_LOCKABLE',
         'progress/SET_SCRIPT_COMPLETED',
-        'progress/MERGE_PROGRESS',
+        'progress/MERGE_RESULTS',
         'progress/MERGE_PEER_REVIEW_PROGRESS',
         'progress/SET_CURRENT_STAGE_ID'
       ];


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

To fix LP-1862, I will be adding a progress object (of type studentLevelProgressType) to the redux store for the scripts overview page.  The most logical name for this object is `levelProgress` but a field using that name is currently holding a map of level id --> level result.  After trying to workaround this, I decided to just rename the existing levelProgress field to levelResult.  This actually makes a lot of calling code read better so I think it's a step in the right direction.

While doing the renames, I noticed that fish levels are incorrectly dispatching a mergeProgress to the redux store.  This was added as a [hotfix](https://github.com/code-dot-org/code-dot-org/pull/38126) before HoC and should have been removed with #39575.  Removal of this code should be the only functional change in this PR.


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
