### PR TITLE
allow multiple single quotes in lesson group description

### DIFF
--- a/apps/src/lib/levelbuilder/script-editor/scriptEditorRedux.js
+++ b/apps/src/lib/levelbuilder/script-editor/scriptEditorRedux.js
@@ -304,7 +304,7 @@ export const mapLessonGroupDataForEditor = rawLessonGroups => {
 };
 
 // Replace ' with \'
-const escape = str => str.replace(/'/, "\\'");
+const escape = str => str.replace(/'/g, "\\'");
 
 export const getSerializedLessonGroups = (rawLessonGroups, levelKeyList) => {
   const lessonGroups = _.cloneDeep(rawLessonGroups);

--- a/apps/test/unit/code-studio/scriptEditorReduxTest.js
+++ b/apps/test/unit/code-studio/scriptEditorReduxTest.js
@@ -113,6 +113,27 @@ describe('scriptEditorRedux reducer tests', () => {
           "lesson 'f', display_name: 'F', has_lesson_plan: false\n\n"
       );
     });
+
+    it('serializes lesson group with single quotes in description', () => {
+      initialState.lessonGroups[0].description = "a'b'c'd";
+      let serializedLessonGroups = getSerializedLessonGroups(
+        initialState.lessonGroups,
+        initialState.levelKeyList
+      );
+
+      // Verify that the JSON contains serialized lesson groups.
+      expect(serializedLessonGroups).to.equal(
+        "lesson_group 'lg-key', display_name: 'Display Name'\n" +
+          "lesson_group_description 'a\\'b\\'c\\'d'\n" +
+          "lesson 'a', display_name: 'A', has_lesson_plan: true, unplugged: true\n\n" +
+          "lesson 'b', display_name: 'B', has_lesson_plan: false\n\n" +
+          "lesson 'c', display_name: 'C', has_lesson_plan: true\n\n" +
+          "lesson_group 'lg-key-2', display_name: 'Display Name 2'\n" +
+          "lesson 'd', display_name: 'D', has_lesson_plan: true\n\n" +
+          "lesson 'e', display_name: 'E', has_lesson_plan: true\n\n" +
+          "lesson 'f', display_name: 'F', has_lesson_plan: false\n\n"
+      );
+    });
   });
 
   it('mapLessonGroupDataForEditor', () => {

--- a/apps/test/unit/code-studio/scriptEditorReduxTest.js
+++ b/apps/test/unit/code-studio/scriptEditorReduxTest.js
@@ -20,6 +20,7 @@ const getInitialState = () => ({
       id: 1,
       key: 'lg-key',
       displayName: 'Display Name',
+      description: 'My Description',
       position: 1,
       userFacing: true,
       lessons: [
@@ -102,6 +103,7 @@ describe('scriptEditorRedux reducer tests', () => {
       // Verify that the JSON contains serialized lesson groups.
       expect(serializedLessonGroups).to.equal(
         "lesson_group 'lg-key', display_name: 'Display Name'\n" +
+          "lesson_group_description 'My Description'\n" +
           "lesson 'a', display_name: 'A', has_lesson_plan: true, unplugged: true\n\n" +
           "lesson 'b', display_name: 'B', has_lesson_plan: false\n\n" +
           "lesson 'c', display_name: 'C', has_lesson_plan: true\n\n" +

--- a/apps/test/unit/code-studio/scriptEditorReduxTest.js
+++ b/apps/test/unit/code-studio/scriptEditorReduxTest.js
@@ -92,23 +92,25 @@ describe('scriptEditorRedux reducer tests', () => {
   let initialState;
   beforeEach(() => (initialState = getInitialState()));
 
-  it('getSerializedLessonGroups', () => {
-    let serializedLessonGroups = getSerializedLessonGroups(
-      initialState.lessonGroups,
-      initialState.levelKeyList
-    );
+  describe('getSerializedLessonGroups', () => {
+    it('serializes default state', () => {
+      let serializedLessonGroups = getSerializedLessonGroups(
+        initialState.lessonGroups,
+        initialState.levelKeyList
+      );
 
-    // Verify that the JSON contains serialized lesson groups.
-    expect(serializedLessonGroups).to.equal(
-      "lesson_group 'lg-key', display_name: 'Display Name'\n" +
-        "lesson 'a', display_name: 'A', has_lesson_plan: true, unplugged: true\n\n" +
-        "lesson 'b', display_name: 'B', has_lesson_plan: false\n\n" +
-        "lesson 'c', display_name: 'C', has_lesson_plan: true\n\n" +
-        "lesson_group 'lg-key-2', display_name: 'Display Name 2'\n" +
-        "lesson 'd', display_name: 'D', has_lesson_plan: true\n\n" +
-        "lesson 'e', display_name: 'E', has_lesson_plan: true\n\n" +
-        "lesson 'f', display_name: 'F', has_lesson_plan: false\n\n"
-    );
+      // Verify that the JSON contains serialized lesson groups.
+      expect(serializedLessonGroups).to.equal(
+        "lesson_group 'lg-key', display_name: 'Display Name'\n" +
+          "lesson 'a', display_name: 'A', has_lesson_plan: true, unplugged: true\n\n" +
+          "lesson 'b', display_name: 'B', has_lesson_plan: false\n\n" +
+          "lesson 'c', display_name: 'C', has_lesson_plan: true\n\n" +
+          "lesson_group 'lg-key-2', display_name: 'Display Name 2'\n" +
+          "lesson 'd', display_name: 'D', has_lesson_plan: true\n\n" +
+          "lesson 'e', display_name: 'E', has_lesson_plan: true\n\n" +
+          "lesson 'f', display_name: 'F', has_lesson_plan: false\n\n"
+      );
+    });
   });
 
   it('mapLessonGroupDataForEditor', () => {


### PR DESCRIPTION
Saving the script edit page was failing when the lesson group description contained more than one single quote. See [slack](https://codedotorg.slack.com/archives/CNZP84FJ5/p1618351932072500?thread_ts=1618351625.071900&cid=CNZP84FJ5) for context. 

## Testing story

new unit tests show the original problem is fixed.