### PR TITLE
Add server side encryption to internal data sharing S3 bucket

### DIFF
--- a/aws/cloudformation/s3_buckets.yml
+++ b/aws/cloudformation/s3_buckets.yml
@@ -80,6 +80,10 @@ Resources:
     DeletionPolicy: Retain
     Properties:
       BucketName: 'cdo-data-sharing-internal'
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: 'aws:kms'
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true


### PR DESCRIPTION
Sets all objects added to the `cdo-data-sharing-internal` bucket to be encrypted at rest.

## Testing story

We uploaded this change manually via CloudFormation in the AWS Web Console, and observed that it successfully modified the bucket's properties to encrypt new objects.