### PR TITLE
Create IAM Policy granting permission to Redshift import/export S3 Bucket

### DIFF
--- a/aws/cloudformation/data.yml.erb
+++ b/aws/cloudformation/data.yml.erb
@@ -74,6 +74,23 @@ Resources:
       ReplicationInstanceIdentifier: !Ref AWS::StackName
       ReplicationSubnetGroupIdentifier: !ImportValue VPC-DMSSubnetGroup
       VpcSecurityGroupIds: [!ImportValue VPC-DMSSecurityGroup]
+  # Note that this is an incomplete set of Policies attached to the
+  # redshift-s3 Role. The Role itself and other Policies were generated manually
+  # in the AWS Console, and we should continue to move these Resources here over time.
+  RedshiftS3Policy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: RedshiftS3Policy
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: RedshiftS3ImportExportBucket
+            Effect: Allow
+            Action:
+              - 's3:*'
+            Resource:
+              - 'arn:aws:s3:::cdo-data-sharing-internal/*'
+              - 'arn:aws:s3:::cdo-data-sharing-internal'
   RDSEndpoint:
     Type: AWS::DMS::Endpoint
     Properties:


### PR DESCRIPTION
Introduces a new Policy that specifies the access that we want the `redshift-s3` Role to have to access S3. This is specifically for our new Foorm export to Redshift nightly job, which uses S3 as a staging area before completing the import to Redshift.

## Testing story

Before merging this PR, we will confirm that this change modifies the `redshift-s3` role as expected.