### PR TITLE
[AiLab] pending delete spinner and show model list without freshly deleted model

### DIFF
--- a/apps/src/code-studio/components/ModelManagerDialog.jsx
+++ b/apps/src/code-studio/components/ModelManagerDialog.jsx
@@ -54,6 +54,7 @@ export default class ModelManagerDialog extends React.Component {
     models: [],
     isModelListPending: true,
     isImportPending: false,
+    isDeletePending: false,
     confirmDialogOpen: false,
     deletionStatus: undefined
   };
@@ -123,16 +124,19 @@ export default class ModelManagerDialog extends React.Component {
   };
 
   deleteModel = () => {
+    this.setState({isDeletePending: true});
     $.ajax({
       url: `/api/v1/ml_models/${this.state.selectedModel.id}`,
       method: 'DELETE'
     }).then(response => {
       if (response.status === 'failure') {
         this.setState({
-          deletionStatus: `Model with id ${response.id} could not be deleted.`
+          deletionStatus: `Model with id ${response.id} could not be deleted.`,
+          isDeletePending: false
         });
       } else {
-        this.setState({confirmDialogOpen: false});
+        this.setState({confirmDialogOpen: false, isDeletePending: false});
+        this.getModelList();
       }
     });
   };
@@ -220,6 +224,8 @@ export default class ModelManagerDialog extends React.Component {
                 onClick={this.deleteModel}
                 icon={'trash'}
                 iconClassName={'fa-trash'}
+                pendingText={'Deleting...'}
+                isPending={this.state.isDeletePending}
               />
             </div>
             <p style={styles.message}>{this.state.deletionStatus}</p>


### PR DESCRIPTION
Follow up to address https://github.com/code-dot-org/code-dot-org/pull/39924#issuecomment-819058418

- State to track deletion pending status 
- Use that state to show spinner and pending message in delete button 
- On successful deletion, return to model manager dialog and show updated model list 


https://user-images.githubusercontent.com/12300669/114638624-1370fa80-9c9a-11eb-8858-a594855b86cc.mov

