### PR TITLE
Show user facing lesson group for unit with single lesson group

### DIFF
--- a/apps/src/code-studio/progressRedux.js
+++ b/apps/src/code-studio/progressRedux.js
@@ -698,6 +698,7 @@ export const groupedLessons = (state, includeBonusLevels = false) => {
     byGroup[lessonGroup.display_name] = {
       lessonGroup: {
         id: lessonGroup.id,
+        userFacing: lessonGroup.user_facing,
         displayName: lessonGroup.display_name,
         description: lessonGroup.description,
         bigQuestions: lessonGroup.big_questions

--- a/apps/src/templates/progress/ProgressTable.jsx
+++ b/apps/src/templates/progress/ProgressTable.jsx
@@ -45,7 +45,10 @@ class ProgressTable extends React.Component {
   render() {
     const {isSummaryView, isPlc, groupedLessons, minimal} = this.props;
 
-    if (groupedLessons.length === 1) {
+    if (
+      groupedLessons.length === 1 &&
+      !groupedLessons[0].lessonGroup.userFacing
+    ) {
       // Render both tables, and toggle hidden state via CSS as this has better
       // perf implications than rendering just one at a time when toggling.
       return (

--- a/apps/test/unit/code-studio/progressReduxTest.js
+++ b/apps/test/unit/code-studio/progressReduxTest.js
@@ -1064,6 +1064,7 @@ describe('progressReduxTest', () => {
             id: '1',
             display_name: 'Lesson Group',
             description: 'This is a lesson group',
+            user_facing: false,
             big_questions: ' - Why'
           }
         ],
@@ -1076,6 +1077,7 @@ describe('progressReduxTest', () => {
       assert.equal(groups.length, 1);
       assert.equal(groups[0].lessonGroup.displayName, 'Lesson Group');
       assert.equal(groups[0].lessonGroup.description, 'This is a lesson group');
+      assert.equal(groups[0].lessonGroup.userFacing, false);
     });
 
     it('returns a single group if all lessons have the same lesson group', () => {
@@ -1085,6 +1087,7 @@ describe('progressReduxTest', () => {
             id: 1,
             display_name: 'Lesson Group',
             description: 'This is a lesson group',
+            user_facing: false,
             big_questions: 'Why?'
           }
         ],
@@ -1115,7 +1118,8 @@ describe('progressReduxTest', () => {
             id: 1,
             display_name: 'Lesson Group',
             description: null,
-            big_questions: null
+            big_questions: null,
+            user_facing: false
           }
         ],
         stages: [

--- a/apps/test/unit/templates/progress/ProgressTableTest.jsx
+++ b/apps/test/unit/templates/progress/ProgressTableTest.jsx
@@ -12,15 +12,22 @@ import LessonGroup from '@cdo/apps/templates/progress/LessonGroup';
 const FAKE_LESSONS = [];
 const FAKE_LEVELS = [];
 const FAKE_LESSON_1 = {
-  lessonGroup: {displayName: 'jazz'},
+  lessonGroup: {displayName: 'jazz', userFacing: false},
   lessons: FAKE_LESSONS,
   levels: FAKE_LEVELS
 };
 const FAKE_LESSON_2 = {
-  lessonGroup: {displayName: 'samba'},
+  lessonGroup: {displayName: 'samba', userFacing: true},
   lessons: FAKE_LESSONS,
   levels: FAKE_LEVELS
 };
+
+const FAKE_LESSON_3 = {
+  lessonGroup: {displayName: 'dance', userFacing: true},
+  lessons: FAKE_LESSONS,
+  levels: FAKE_LEVELS
+};
+
 const DEFAULT_PROPS = {
   isPlc: false,
   isSummaryView: false,
@@ -28,7 +35,28 @@ const DEFAULT_PROPS = {
 };
 
 describe('ProgressTable', () => {
-  it('renders a single lesson in full view', () => {
+  it('renders a single lesson with user facing lesson group in full view', () => {
+    const wrapper = shallow(
+      <ProgressTable {...DEFAULT_PROPS} groupedLessons={[FAKE_LESSON_3]} />,
+      {
+        disableLifecycleMethods: true
+      }
+    );
+    expect(wrapper).to.containMatchingElement(
+      <div>
+        <LessonGroup
+          key={FAKE_LESSON_3.lessonGroup.displayName}
+          isPlc={DEFAULT_PROPS.isPlc}
+          lessonGroup={FAKE_LESSON_3.lessonGroup}
+          isSummaryView={DEFAULT_PROPS.isSummaryView}
+          lessons={FAKE_LESSON_3.lessons}
+          levelsByLesson={FAKE_LESSON_3.levels}
+        />
+      </div>
+    );
+  });
+
+  it('renders a single lesson without user facing lesson group in full view', () => {
     const wrapper = shallow(
       <ProgressTable {...DEFAULT_PROPS} isSummaryView={false} />,
       {disableLifecycleMethods: true}
@@ -51,7 +79,7 @@ describe('ProgressTable', () => {
     );
   });
 
-  it('renders a single lesson in summary view', () => {
+  it('renders a single lesson without user facing lesson group in summary view', () => {
     const wrapper = shallow(
       <ProgressTable {...DEFAULT_PROPS} isSummaryView={true} />,
       {disableLifecycleMethods: true}
@@ -78,19 +106,19 @@ describe('ProgressTable', () => {
     const wrapper = shallow(
       <ProgressTable
         {...DEFAULT_PROPS}
-        groupedLessons={[FAKE_LESSON_1, FAKE_LESSON_2]}
+        groupedLessons={[FAKE_LESSON_3, FAKE_LESSON_2]}
       />,
       {disableLifecycleMethods: true}
     );
     expect(wrapper).to.containMatchingElement(
       <div>
         <LessonGroup
-          key={FAKE_LESSON_1.lessonGroup.displayName}
+          key={FAKE_LESSON_3.lessonGroup.displayName}
           isPlc={DEFAULT_PROPS.isPlc}
-          lessonGroup={FAKE_LESSON_1.lessonGroup}
+          lessonGroup={FAKE_LESSON_3.lessonGroup}
           isSummaryView={DEFAULT_PROPS.isSummaryView}
-          lessons={FAKE_LESSON_1.lessons}
-          levelsByLesson={FAKE_LESSON_1.levels}
+          lessons={FAKE_LESSON_3.lessons}
+          levelsByLesson={FAKE_LESSON_3.levels}
         />
         <LessonGroup
           key={FAKE_LESSON_2.lessonGroup.displayName}


### PR DESCRIPTION
We want to always show user facing lesson groups on the script overview page even if there is only one. 

Example script with one user facing lesson group:

<img width="1128" alt="Screen Shot 2021-04-13 at 9 15 34 PM" src="https://user-images.githubusercontent.com/208083/114640117-6d26f400-9c9d-11eb-99ae-49ce0d1e0f4b.png">


Example script with one non-user facing lesson group:

<img width="1150" alt="Screen Shot 2021-04-13 at 9 15 41 PM" src="https://user-images.githubusercontent.com/208083/114640109-68fad680-9c9d-11eb-85a0-7f975f13f384.png">


## Links

https://codedotorg.atlassian.net/browse/PLAT-556

## Testing story

- Added new unit test for ProgressTable to check that a single lesson group that is user facing will be rendered
- Updated other existing tests for new behavior