### PR TITLE
Allow Foorm configuration changes from levelbuilder

### DIFF
--- a/tools/hooks/restrict_levelbuilder_changes.rb
+++ b/tools/hooks/restrict_levelbuilder_changes.rb
@@ -7,6 +7,7 @@ LIBRARIES_DIR = File.expand_path(REPO_DIR + '/dashboard/config/libraries', __FIL
 LEVELS_DIR = File.expand_path(REPO_DIR + '/dashboard/config/scripts', __FILE__).freeze
 COURSES_DIR = File.expand_path(REPO_DIR + '/dashboard/config/courses', __FILE__).freeze
 VIDEO_THUMBNAILS_DIR = File.expand_path(REPO_DIR + '/dashboard/public/c/video_thumbnails', __FILE__).freeze
+FOORM_DIR = File.expand_path(REPO_DIR + '/dashboard/config/foorm', __FILE__).freeze
 WHITELISTED_FILES = %w(
   dashboard/config/locales/dsls.en.yml
   dashboard/config/locales/scripts.en.yml
@@ -25,6 +26,6 @@ staged_files = HooksUtils.get_staged_files
 
 staged_files.each do |filename|
   raise "#{ERROR_MESSAGE}\nFile blocked: #{filename}" unless filename.start_with?(
-    BLOCKS_DIR, SHARED_FUNCTIONS_DIR, LIBRARIES_DIR, LEVELS_DIR, COURSES_DIR, VIDEO_THUMBNAILS_DIR
+    BLOCKS_DIR, SHARED_FUNCTIONS_DIR, LIBRARIES_DIR, LEVELS_DIR, COURSES_DIR, VIDEO_THUMBNAILS_DIR, FOORM_DIR
   ) || WHITELISTED_FILES.include?(filename)
 end


### PR DESCRIPTION
Edits to existing Foorm Forms and Libraries Questions are now being made on levelbuilder by survey creators, and should be allowed when syncing content changes from levelbuilder.