### PR TITLE
[AiLab] add About the Data section to Model Cards

### DIFF
--- a/apps/src/code-studio/components/ModelCard.jsx
+++ b/apps/src/code-studio/components/ModelCard.jsx
@@ -9,7 +9,6 @@ const styles = {
     backgroundColor: color.lighter_gray,
     borderRadius: 5,
     padding: 20,
-    margin: 10,
     whiteSpace: 'normal',
     lineHeight: 1.5,
     maxHeight: 'calc(80vh - 140px)',
@@ -25,11 +24,19 @@ const styles = {
   bold: {
     fontFamily: "'Gotham 7r', sans-serif"
   },
+  header: {
+    fontFamily: "'Gotham 7r', sans-serif",
+    marginTop: 0,
+    lineHeight: '20px'
+  },
   heading: {
     fontFamily: "'Gotham 7r', sans-serif",
     fontSize: 14,
     marginBottom: 5,
     textAlign: 'center'
+  },
+  details: {
+    marginBottom: 0
   }
 };
 
@@ -46,34 +53,49 @@ export default class ModelCard extends React.Component {
       <div>
         {model && metadata && (
           <div style={styles.container}>
-            <h3 style={styles.bold}>{metadata.name}</h3>
-            <div style={{marginBottom: 10}}>
+            <h3 style={styles.header}>{metadata.name}</h3>
+            <div>
               <span style={styles.bold}>Id: </span>
               <span>{this.props.model.id}</span>
             </div>
+            <br />
             <div style={styles.subPanel}>
               <div style={styles.heading}>Summary</div>
-              <p>
+              <p style={styles.details}>
                 Predict {metadata.labelColumn} based on{' '}
                 {metadata.selectedFeatures?.join(', ')} with{' '}
                 {metadata.summaryStat?.stat}% accuracy.
               </p>
             </div>
             <div style={styles.subPanel}>
+              <div style={styles.heading}>About the Data</div>
+              <p style={styles.details}>
+                {metadata.datasetDetails?.description}
+              </p>
+              <br />
+              {metadata.datasetDetails?.numRows && (
+                <p style={styles.details}>
+                  Dataset size: {metadata.datasetDetails?.numRows} rows
+                </p>
+              )}
+            </div>
+            <div style={styles.subPanel}>
               <div style={styles.heading}>Intended Uses</div>
-              <p>{metadata.potentialUses}</p>
+              <p style={styles.details}>{metadata.potentialUses}</p>
             </div>
             <div style={styles.subPanel}>
               <div style={styles.heading}>Warnings</div>
-              <p>{metadata.potentialMisuses}</p>
+              <p style={styles.details}>{metadata.potentialMisuses}</p>
             </div>
             <div style={styles.subPanel}>
               <div style={styles.heading}>Label</div>
-              <p>{metadata.labelColumn}</p>
+              <p style={styles.details}>{metadata.labelColumn}</p>
             </div>
             <div style={styles.subPanel}>
               <div style={styles.heading}>Features</div>
-              <p>{metadata.selectedFeatures?.join(', ')}</p>
+              <p style={styles.details}>
+                {metadata.selectedFeatures?.join(', ')}
+              </p>
             </div>
           </div>
         )}


### PR DESCRIPTION
Follow up to #39971, including addressing feedback on styling.  Surfaces the the data from https://github.com/code-dot-org/ml-playground/pull/140 to show an "About the Data" section on Model Cards.

![Screen Shot 2021-04-14 at 5 19 52 PM](https://user-images.githubusercontent.com/12300669/114781195-60aaa600-9d46-11eb-8018-9167640113f3.png)
