### PR TITLE
[Spritelab] Add when all prompts answered event block

### DIFF
--- a/apps/src/p5lab/spritelab/commands.js
+++ b/apps/src/p5lab/spritelab/commands.js
@@ -188,6 +188,10 @@ export const commands = {
     eventCommands.spriteClicked(condition, spriteArg, callback);
   },
 
+  whenAllPromptsAnswered(callback) {
+    eventCommands.whenAllPromptsAnswered(callback);
+  },
+
   whenSpriteCreated(spriteArg, callback) {
     eventCommands.whenSpriteCreated(spriteArg, callback);
   },

--- a/apps/src/p5lab/spritelab/commands/eventCommands.js
+++ b/apps/src/p5lab/spritelab/commands/eventCommands.js
@@ -39,6 +39,10 @@ export const commands = {
     }
   },
 
+  whenAllPromptsAnswered(callback) {
+    coreLibrary.addEvent('whenAllPromptsAnswered', {}, callback);
+  },
+
   whenSpriteCreated(spriteArg, callback) {
     if (spriteArg && spriteArg.costume) {
       coreLibrary.addEvent(

--- a/dashboard/config/blocks/GamelabJr/gamelab_whenAllPromptsAnswered.json
+++ b/dashboard/config/blocks/GamelabJr/gamelab_whenAllPromptsAnswered.json
@@ -1,0 +1,16 @@
+{
+  "category": "",
+  "config": {
+    "color": [
+      140,
+      1,
+      0.74
+    ],
+    "func": "whenAllPromptsAnswered",
+    "blockText": "when all prompts answered",
+    "callbackParams": [
+      "extraArgs"
+    ],
+    "eventBlock": true
+  }
+}


### PR DESCRIPTION
This will be used in Amy BW's Poem Bot lesson for CSC (and eventually other lessons as well)

![image](https://user-images.githubusercontent.com/8787187/114908570-11f61e00-9dd1-11eb-9c14-b3969639e7a4.png)
![image](https://user-images.githubusercontent.com/8787187/114908634-20443a00-9dd1-11eb-8cc4-1664ef1c058b.png)


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
