### PR TITLE
Update Curriculum PDF rake tasks

### DIFF
--- a/dashboard/lib/services/curriculum_pdfs/resources.rb
+++ b/dashboard/lib/services/curriculum_pdfs/resources.rb
@@ -30,14 +30,25 @@ module Services
           end
 
           # Merge all gathered PDFs
-          filename = ActiveStorage::Filename.new(script.localized_title + " - Resources.pdf").sanitized
-          subdirectory = File.dirname(get_script_overview_pathname(script))
-          destination = File.join(directory, subdirectory, filename)
+          destination = File.join(directory, get_script_resources_pdf_pathname(script))
           FileUtils.mkdir_p(File.dirname(destination))
           PDF.merge_local_pdfs(destination, *pdfs)
           FileUtils.remove_entry_secure(pdfs_dir)
 
           return destination
+        end
+
+        def get_script_resources_pdf_pathname(script)
+          filename = ActiveStorage::Filename.new(script.localized_title + " - Resources.pdf").sanitized
+          subdirectory = File.dirname(get_script_overview_pathname(script))
+          return Pathname.new(File.join(subdirectory, filename))
+        end
+
+        def script_resources_pdf_exists_for?(script)
+          AWS::S3.cached_exists_in_bucket?(
+            S3_BUCKET,
+            get_script_resources_pdf_pathname(script).to_s
+          )
         end
 
         def generate_lesson_resources_title_page(lesson, directory="/tmp/")

--- a/dashboard/lib/services/curriculum_pdfs/resources.rb
+++ b/dashboard/lib/services/curriculum_pdfs/resources.rb
@@ -93,7 +93,7 @@ module Services
             begin
               export_from_google(resource.url, path)
               return path
-            rescue Google::Apis::ClientError, Google::Apis::ServerError, GoogleDrive::Error => e
+            rescue Google::Apis::ClientError, Google::Apis::ServerError, GoogleDrive::Error, URI::InvalidURIError => e
               ChatClient.log(
                 "error from Google when trying to fetch PDF for resource #{resource.key.inspect}: #{e}",
                 color: 'red'

--- a/dashboard/lib/services/curriculum_pdfs/script_overview.rb
+++ b/dashboard/lib/services/curriculum_pdfs/script_overview.rb
@@ -21,6 +21,13 @@ module Services
           File.join(get_base_url, pathname)
         end
 
+        def script_overview_pdf_exists_for?(script)
+          AWS::S3.cached_exists_in_bucket?(
+            S3_BUCKET,
+            get_script_overview_pathname(script).to_s
+          )
+        end
+
         def generate_script_overview_pdf(script, directory="/tmp/")
           ChatClient.log("Generating script overview PDF for #{script.name.inspect}")
           pdfs_dir = Dir.mktmpdir(__method__.to_s)

--- a/dashboard/lib/tasks/curriculum_pdfs.rake
+++ b/dashboard/lib/tasks/curriculum_pdfs.rake
@@ -41,7 +41,7 @@ namespace :curriculum_pdfs do
         any_pdf_generated = false
 
         get_pdfless_lessons(script).each do |lesson|
-          puts "Generating missing PDF for #{lesson.key} (from #{script.name})"
+          puts "Generating missing PDFs for #{lesson.key} (from #{script.name})"
           Services::CurriculumPdfs.generate_lesson_pdf(lesson, dir)
           Services::CurriculumPdfs.generate_lesson_pdf(lesson, dir, true)
           any_pdf_generated = true
@@ -60,7 +60,7 @@ namespace :curriculum_pdfs do
         end
 
         if any_pdf_generated
-          puts "Generated all missing PDFs for #{script.name}, uploading results to S3"
+          puts "Generated all missing PDFs for #{script.name}; uploading results to S3"
           Services::CurriculumPdfs.upload_generated_pdfs_to_s3(dir)
         end
       end


### PR DESCRIPTION
Handful of minor fixes:

- added new Script Overview and Resources PDFs to the various generation methods
- rearranged some logic to ensure that we upload each script as it finishes, rather than uploading everything all at once at the end
  - I believe this is why we had the mistaken belief that the "regenerate all" script wasn't replacing files on S3; we (as in, I) weren't letting the very long-running script finish.
- added an error handler for invalid resource URLs

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
