### PR TITLE
FND-1557 Join Section Eyes Fix

### DIFF
--- a/apps/src/templates/studioHomepages/JoinSection.jsx
+++ b/apps/src/templates/studioHomepages/JoinSection.jsx
@@ -38,6 +38,7 @@ const styles = {
   },
   wordBox: {
     width: styleConstants['content-width'] - 475,
+    flexGrow: 1,
     marginLeft: 25,
     marginTop: 25,
     marginBottom: 25,


### PR DESCRIPTION
Previously merged changes caused Eyes failure on the Join Section component. The end button margin was uneven (see images below).

Flexbox was applied to this section for another RTL improvement story, now we apply flex-grow to the word box so it fills up the remaining space and re-aligns the end button margins in both LTR and RTL.

## Links

- jira ticket: [FND-1557](https://codedotorg.atlassian.net/browse/FND-1557?atlOrigin=eyJpIjoiZmQzYmM2ZGIwYjNlNDlmYjhjMzJmOGVhMTY5YWIxNjEiLCJwIjoiaiJ9)


## Testing story

No tests effected

## Images

BEFORE:
![image](https://user-images.githubusercontent.com/9528376/114918083-4a572580-9dec-11eb-9bce-3dd017446bac.png)

AFTER:
![image](https://user-images.githubusercontent.com/9528376/114918150-5e028c00-9dec-11eb-8247-bbc246944a8b.png)


## PR Checklist:

- [X] Tests provide adequate coverage
- [X] Privacy and Security impacts have been assessed
- [X] Code is well-commented
- [X] New features are translatable or updates will not break translations
- [X] Relevant documentation has been added or updated
- [X] User impact is well-understood and desirable
- [X] Pull Request is labeled appropriately
- [X] Follow-up work items (including potential tech debt) are tracked and linked
