### PR TITLE
[AiLab] Use new features & label fields

### DIFF
--- a/apps/src/MLTrainers.js
+++ b/apps/src/MLTrainers.js
@@ -45,7 +45,11 @@ export function predict(modelData) {
     // Re-instantiate the trained model.
     const model = KNN.load(modelData.trainedModel);
     // Prepare test data.
-    const testValues = modelData.selectedFeatures.map(feature =>
+    const features = modelData.features
+      ? modelData.features.map(feature => feature.id)
+      : modelData.selectedFeatures;
+
+    const testValues = features.map(feature =>
       convertTestValue(
         modelData.featureNumberKey,
         feature,
@@ -55,13 +59,11 @@ export function predict(modelData) {
     // Make a prediction.
     const rawPrediction = model.predict(testValues);
     // Convert prediction to human readable (if needed)
-    const prediction = Object.keys(modelData.featureNumberKey).includes(
-      modelData.labelColumn
-    )
-      ? getKeyByValue(
-          modelData.featureNumberKey[modelData.labelColumn],
-          rawPrediction
-        )
+
+    const label = modelData.label ? modelData.label.id : model.labelColumn;
+
+    const prediction = Object.keys(modelData.featureNumberKey).includes(label)
+      ? getKeyByValue(modelData.featureNumberKey[label], rawPrediction)
       : parseFloat(rawPrediction);
     return prediction;
   } else {

--- a/apps/src/applab/ai.js
+++ b/apps/src/applab/ai.js
@@ -8,50 +8,93 @@ function generateCodeDesignElements(modelId, modelData) {
   var SPACER_PIXELS = 20;
   designMode.onInsertEvent(`var data = {};`);
   var inputFields = [];
-  modelData.selectedFeatures.forEach(feature => {
-    y = y + SPACER_PIXELS;
-    var label = designMode.createElement('LABEL', x, y);
-    var alphaNumFeature = stripSpaceAndSpecial(feature);
-    let fieldId;
-    label.id = 'design_' + alphaNumFeature + '_label';
-    label.style.width = '300px';
-    y = y + SPACER_PIXELS;
-    if (Object.keys(modelData.featureNumberKey).includes(feature)) {
-      // create dropdown menu for each categorical feature
-      label.textContent = feature + ':';
-      fieldId = alphaNumFeature + '_dropdown';
-      var select = designMode.createElement('DROPDOWN', x, y);
-      select.id = 'design_' + fieldId;
-      // App Lab automatically adds "option 1" and "option 2", remove them.
-      select.options.remove(0);
-      select.options.remove(0);
-      Object.keys(modelData.featureNumberKey[feature]).forEach(option => {
-        var optionElement = document.createElement('option');
-        optionElement.text = option;
-        select.options.add(optionElement);
-      });
+  if (modelData.features && modelData.label) {
+    modelData.features.forEach(feature => {
       y = y + SPACER_PIXELS;
-    } else {
-      // create text input field for each continuous feature
-      label.textContent = feature;
-      var labelMinMax = designMode.createElement('LABEL', x, y);
-      // return a string of min and max values rounded to two decimal places
-      var min = modelData.extremumsByColumn[feature].min.toFixed(2);
-      var max = modelData.extremumsByColumn[feature].max.toFixed(2);
-      // unary plus operator returns a number and truncates trailing zeroes
-      labelMinMax.textContent = `(min: ${+min}, max: ${+max}):`;
-      labelMinMax.style.width = '300px';
+      var label = designMode.createElement('LABEL', x, y);
+      var alphaNumFeature = stripSpaceAndSpecial(feature);
+      let fieldId;
+      label.id = 'design_' + alphaNumFeature + '_label';
+      label.style.width = '300px';
       y = y + SPACER_PIXELS;
-      var input = designMode.createElement('TEXT_INPUT', x, y);
-      fieldId = alphaNumFeature + '_input';
-      input.id = 'design_' + fieldId;
+      if (feature.values) {
+        // Create dropdown menu for each categorical feature.
+        label.textContent = feature + ':';
+        fieldId = alphaNumFeature + '_dropdown';
+        var select = designMode.createElement('DROPDOWN', x, y);
+        select.id = 'design_' + fieldId;
+        // App Lab automatically adds "option 1" and "option 2", remove them.
+        select.options.remove(0);
+        select.options.remove(0);
+        feature.values.forEach(option => {
+          var optionElement = document.createElement('option');
+          optionElement.text = option;
+          select.options.add(optionElement);
+        });
+        y = y + SPACER_PIXELS;
+      } else {
+        // Create text input field for each continuous feature.
+        label.textContent = feature;
+        var labelMinMax = designMode.createElement('LABEL', x, y);
+        var min = feature.min.toFixed(2);
+        var max = feature.max.toFixed(2);
+        // Unary plus operator returns a number and truncates trailing zeroes.
+        labelMinMax.textContent = `(min: ${+min}, max: ${+max}):`;
+        labelMinMax.style.width = '300px';
+        y = y + SPACER_PIXELS;
+        var input = designMode.createElement('TEXT_INPUT', x, y);
+        fieldId = alphaNumFeature + '_input';
+        input.id = 'design_' + fieldId;
+        y = y + SPACER_PIXELS;
+      }
+      var addFeature = `data.${alphaNumFeature} = getText("${fieldId}");`;
+      inputFields.push(addFeature);
+    });
+  } else {
+    modelData.selectedFeatures.forEach(feature => {
       y = y + SPACER_PIXELS;
-    }
-    var addFeature = `data.${alphaNumFeature} = getText("${fieldId}");`;
-    inputFields.push(addFeature);
-  });
+      var label = designMode.createElement('LABEL', x, y);
+      var alphaNumFeature = stripSpaceAndSpecial(feature);
+      let fieldId;
+      label.id = 'design_' + alphaNumFeature + '_label';
+      label.style.width = '300px';
+      y = y + SPACER_PIXELS;
+      if (Object.keys(modelData.featureNumberKey).includes(feature)) {
+        // create dropdown menu for each categorical feature
+        label.textContent = feature + ':';
+        fieldId = alphaNumFeature + '_dropdown';
+        var select = designMode.createElement('DROPDOWN', x, y);
+        select.id = 'design_' + fieldId;
+        // App Lab automatically adds "option 1" and "option 2", remove them.
+        select.options.remove(0);
+        select.options.remove(0);
+        Object.keys(modelData.featureNumberKey[feature]).forEach(option => {
+          var optionElement = document.createElement('option');
+          optionElement.text = option;
+          select.options.add(optionElement);
+        });
+        y = y + SPACER_PIXELS;
+      } else {
+        // create text input field for each continuous feature
+        label.textContent = feature;
+        var labelMinMax = designMode.createElement('LABEL', x, y);
+        // return a string of min and max values rounded to two decimal places
+        var min = modelData.extremumsByColumn[feature].min.toFixed(2);
+        var max = modelData.extremumsByColumn[feature].max.toFixed(2);
+        // unary plus operator returns a number and truncates trailing zeroes
+        labelMinMax.textContent = `(min: ${+min}, max: ${+max}):`;
+        labelMinMax.style.width = '300px';
+        y = y + SPACER_PIXELS;
+        var input = designMode.createElement('TEXT_INPUT', x, y);
+        fieldId = alphaNumFeature + '_input';
+        input.id = 'design_' + fieldId;
+        y = y + SPACER_PIXELS;
+      }
+      var addFeature = `data.${alphaNumFeature} = getText("${fieldId}");`;
+      inputFields.push(addFeature);
+    });
+  }
   y = y + 2 * SPACER_PIXELS;
-  // predicted feature
   var label = designMode.createElement('LABEL', x, y);
   label.textContent = modelData.labelColumn;
   var alphaNumModelName = stripSpaceAndSpecial(modelData.name);
@@ -59,12 +102,11 @@ function generateCodeDesignElements(modelId, modelData) {
   label.style.width = '300px';
   y = y + SPACER_PIXELS;
   var predictionId = alphaNumModelName + '_prediction';
-  // text input field to display prediction
+  // Text input field to display prediction.
   var prediction = designMode.createElement('TEXT_INPUT', x, y);
   prediction.id = 'design_' + predictionId;
   prediction.readOnly = true;
   y = y + 2 * SPACER_PIXELS;
-  // predict button
   var predictButton = designMode.createElement('BUTTON', x, y);
   predictButton.textContent = 'Predict';
   var predictButtonId = alphaNumModelName + '_predict';

--- a/apps/src/applab/ai.js
+++ b/apps/src/applab/ai.js
@@ -12,14 +12,14 @@ function generateCodeDesignElements(modelId, modelData) {
     modelData.features.forEach(feature => {
       y = y + SPACER_PIXELS;
       var label = designMode.createElement('LABEL', x, y);
-      var alphaNumFeature = stripSpaceAndSpecial(feature);
+      var alphaNumFeature = stripSpaceAndSpecial(feature.id);
       let fieldId;
       label.id = 'design_' + alphaNumFeature + '_label';
       label.style.width = '300px';
       y = y + SPACER_PIXELS;
       if (feature.values) {
         // Create dropdown menu for each categorical feature.
-        label.textContent = feature + ':';
+        label.textContent = feature.id + ':';
         fieldId = alphaNumFeature + '_dropdown';
         var select = designMode.createElement('DROPDOWN', x, y);
         select.id = 'design_' + fieldId;
@@ -34,7 +34,7 @@ function generateCodeDesignElements(modelId, modelData) {
         y = y + SPACER_PIXELS;
       } else {
         // Create text input field for each continuous feature.
-        label.textContent = feature;
+        label.textContent = feature.id;
         var labelMinMax = designMode.createElement('LABEL', x, y);
         var min = feature.min.toFixed(2);
         var max = feature.max.toFixed(2);


### PR DESCRIPTION
Continuation of work from https://github.com/code-dot-org/ml-playground/pull/144  in accordance with the data reorganization plan outlined [here](https://docs.google.com/document/d/1HSoypNk8O-8hSJQ0eZfgkOoDtT9703NNFlQXoQK1UxY/edit#bookmark=id.xs7n38y6s9vg).  This sets up paths to support new fields (`features` and `label`) while maintaining support for old fields (`labelColumn` and `selectedFeatures`) in code that generates App Lab design elements and pre-populates code and in the code that gets a prediction back from the machine learning model. Deleting, importing, and getting a prediction back now work for both "old" and "new" models. 

Next, I will coordinate with the Curriculum team to re-make models as needed and update the `ModelCard` component to use the new fields. 