### PR TITLE
Accomodate Mapbox response in flaky PLC workshop dashboard test

### DIFF
--- a/dashboard/test/ui/README.md
+++ b/dashboard/test/ui/README.md
@@ -67,13 +67,9 @@ Run all UI tests using the local chromedriver against your localhost. Faster tha
 
 `./runner.rb -l`
 
-Run all UI tests for a given browser/os combination - full list of combinations is in browsers.json
-
-`./runner.rb --config ChromeLatestWin7`
-
 Run all UI tests for a given browser
 
-`./runner.rb --browser Chrome`
+`./runner.rb --config Chrome`
 
 Run all tests in a given feature file for all browser/os combinations
 
@@ -89,11 +85,11 @@ Run one feature using chromedriver against your local machine with html output
 
 Run one feature in one saucelabs browser against your local machine with html output (requires SauceConnect, described earlier)
 
-`./runner.rb -l -f features/big_game_remix.feature -c ChromeLatestWin7 --html`
+`./runner.rb -l -f features/big_game_remix.feature -c Chrome --html`
 
 Run **eyes tests** on one feature in one saucelabs browser against your local machine with html output (requires SauceConnect, described earlier)
 
-`./runner.rb -l -f features/angle_helper.feature -c ChromeLatestWin7 --html --eyes`
+`./runner.rb -l -f features/angle_helper.feature -c Chrome --html --eyes`
 
 ## Tips
 

--- a/dashboard/test/ui/features/plc/pd/workshop_dashboard.feature
+++ b/dashboard/test/ui/features/plc/pd/workshop_dashboard.feature
@@ -9,6 +9,8 @@ Scenario: New workshop: CSF intro
 
   And I press keys "Code.org Office" for element "input#location_name"
   And I press keys "Seattle, WA" for element "#mapbox-location-search-container input"
+  # Wait for Mapbox to respond
+  And I wait until element "#mapbox-geocoder-container > div > div.suggestions-wrapper > ul" is visible
   And I press keys "25" for element "input#capacity"
   And I select the "CS Fundamentals" option in dropdown "course"
   And I select the "Intro" option in dropdown "subject"
@@ -41,6 +43,8 @@ Scenario: New workshop: CSD units 2-3 with 2 facilitators
 
   And I press keys "Code.org Office" for element "input#location_name"
   And I press keys "Seattle, WA" for element "#mapbox-location-search-container input"
+  # Wait for Mapbox to respond
+  And I wait until element "#mapbox-geocoder-container > div > div.suggestions-wrapper > ul" is visible
   And I press keys "25" for element "input#capacity"
   And I select the "CS Discoveries" option in dropdown "course"
   And I select the "Academic Year Workshop 1" option in dropdown "subject"
@@ -73,6 +77,8 @@ Scenario: New workshop: CSP local summer with 1 facilitator
 
   And I press keys "Code.org Office" for element "input#location_name"
   And I press keys "Seattle, WA" for element "#mapbox-location-search-container input"
+  # Wait for Mapbox to respond
+  And I wait until element "#mapbox-geocoder-container > div > div.suggestions-wrapper > ul" is visible
   And I press keys "25" for element "input#capacity"
   And I select the "CS Principles" option in dropdown "course"
   And I select the "5-day Summer" option in dropdown "subject"

--- a/dashboard/test/ui/features/plc/pd/workshop_dashboard.feature
+++ b/dashboard/test/ui/features/plc/pd/workshop_dashboard.feature
@@ -9,8 +9,6 @@ Scenario: New workshop: CSF intro
 
   And I press keys "Code.org Office" for element "input#location_name"
   And I press keys "Seattle, WA" for element "#mapbox-location-search-container input"
-  # Wait for Mapbox to respond
-  And I wait until element "#mapbox-geocoder-container > div > div.suggestions-wrapper > ul" is visible
   And I press keys "25" for element "input#capacity"
   And I select the "CS Fundamentals" option in dropdown "course"
   And I select the "Intro" option in dropdown "subject"
@@ -24,6 +22,11 @@ Scenario: New workshop: CSF intro
 
   And I press keys "These are my CSF notes" for element "textarea#notes"
   And I select the "Test CSF Facilitator" facilitator at index 0
+
+  # Before doing eyes check, accept suggestion from Mapbox if visible on the page.
+  # If we do not accept a suggestion, a dropdown of location options can obscure part of the page
+  # and cause the eyes check to fail.
+  And I click "#mapbox-geocoder-container > div > div.suggestions-wrapper > ul > li" if it is visible
 
   And I see no difference for "new workshop details: CSF"
 
@@ -43,8 +46,6 @@ Scenario: New workshop: CSD units 2-3 with 2 facilitators
 
   And I press keys "Code.org Office" for element "input#location_name"
   And I press keys "Seattle, WA" for element "#mapbox-location-search-container input"
-  # Wait for Mapbox to respond
-  And I wait until element "#mapbox-geocoder-container > div > div.suggestions-wrapper > ul" is visible
   And I press keys "25" for element "input#capacity"
   And I select the "CS Discoveries" option in dropdown "course"
   And I select the "Academic Year Workshop 1" option in dropdown "subject"
@@ -59,6 +60,11 @@ Scenario: New workshop: CSD units 2-3 with 2 facilitators
   And I select the "Test CSD Facilitator 1" facilitator at index 0
   And I press the first "#add-facilitator-btn" element
   And I select the "Test CSD Facilitator 2" facilitator at index 1
+
+  # Before doing eyes check, accept suggestion from Mapbox if visible on the page.
+  # If we do not accept a suggestion, a dropdown of location options can obscure part of the page
+  # and cause the eyes check to fail.
+  And I click "#mapbox-geocoder-container > div > div.suggestions-wrapper > ul > li" if it is visible
 
   And I see no difference for "new workshop details: CSD"
 
@@ -77,8 +83,6 @@ Scenario: New workshop: CSP local summer with 1 facilitator
 
   And I press keys "Code.org Office" for element "input#location_name"
   And I press keys "Seattle, WA" for element "#mapbox-location-search-container input"
-  # Wait for Mapbox to respond
-  And I wait until element "#mapbox-geocoder-container > div > div.suggestions-wrapper > ul" is visible
   And I press keys "25" for element "input#capacity"
   And I select the "CS Principles" option in dropdown "course"
   And I select the "5-day Summer" option in dropdown "subject"
@@ -90,6 +94,11 @@ Scenario: New workshop: CSP local summer with 1 facilitator
 
   And I press keys "These are my CSP notes" for element "textarea#notes"
   And I select the "Test CSP Facilitator" facilitator at index 0
+
+  # Before doing eyes check, accept suggestion from Mapbox if visible on the page.
+  # If we do not accept a suggestion, a dropdown of location options can obscure part of the page
+  # and cause the eyes check to fail.
+  And I click "#mapbox-geocoder-container > div > div.suggestions-wrapper > ul > li" if it is visible
 
   And I see no difference for "new workshop details: CSP"
 

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -491,6 +491,14 @@ When /^I click "([^"]*)"( once it exists)?(?: to load a new (page|tab))?$/ do |s
   page_load(load) {element.click}
 end
 
+When /^I click "([^"]*)" if it is visible$/ do |selector|
+  if @browser.execute_script(jquery_is_element_visible(selector))
+    find = -> {@browser.find_element(:css, selector)}
+    element = find.call
+    element.click
+  end
+end
+
 When /^I select the end of "([^"]*)"$/ do |selector|
   @browser.execute_script("document.querySelector(\"#{selector}\").setSelectionRange(9999, 9999);")
 end


### PR DESCRIPTION
~~Introduces a wait until Mapbox has responded with results for a location query before proceeding with the test. This test has failed intermittently when Mapbox takes a little bit to respond, and the dropdown with Mapbox's suggestions for a location then doesn't get re-hidden by selecting the next element where we're inputting information in the form.~~

Relying on the ability to connect to the Mapbox API broke this test in Drone, as we do not have Mapbox keys set up. The new approach now implemented in this PR is to click on one of the results from Mapbox if it is visible on the page, and do nothing if not.

I'll have to add an ignore region to this eyes test as well, such that if we do click on a response from Mapbox (which will fill in the "Location Address" field and override the default "Seattle, WA"), we do not get eyes diffs.

Historical failure: https://app.saucelabs.com/tests/90615d79f5e341baa117d6ca16be34d5#50
Historical success: https://app.saucelabs.com/tests/ce3ff47d1c234c23ae06959d7fe5a8ac/watch#42

I also include some cleanup of our README that I encountered while working on this.

Note that these are eyes tests, and only run in Chrome as a result. I was messing around trying to test my change, and noticed that this Mapbox input field [doesn't render at all in at least the old version of Firefox we use in tests](https://app.saucelabs.com/tests/74292a2f0c494862a51cbbde78f4512f#18)? Works fine for me on Mac/Firefox 70.

## Links

- jira ticket: [PLC-1117](https://codedotorg.atlassian.net/browse/PLC-1117)

## Testing story

I tested via SauceLabs that this new step (as implemented) was able to dismiss the options provided by Mapbox, and overwrote the "Seattle, WA" text with the formatted text provided by Mapbox ("Seattle, Washington, United States").

## PR Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
