### PR TITLE
Fix time spent on bubble choice = sum of sub-level time spent

### DIFF
--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -342,41 +342,6 @@ class ApiController < ApplicationController
     }
   end
 
-  # Get level progress for a set of users within this script.
-  # @param [Enumerable<User>] users
-  # @param [Script] script
-  # @return [Hash]
-  # Example return value (where 1 and 2 are userIds and 135 and 136 are levelIds):
-  #   {
-  #     "1": {
-  #       "135": {"status": "perfect", "result": 100}
-  #       "136": {"status": "perfect", "result": 100}
-  #     },
-  #     "2": {
-  #       "135": {"status": "perfect", "result": 100}
-  #       "136": {"status": "perfect", "result": 100}
-  #     }
-  #   }
-  private def script_progress_for_users(users, script)
-    user_levels = User.user_levels_by_user_by_level(users, script)
-    paired_user_levels_by_user = PairedUserLevel.pairs_by_user(users)
-    progress_by_user = users.inject({}) do |progress, user|
-      progress[user.id] = merge_user_progress_by_level(
-        script: script,
-        user: user,
-        user_levels_by_level: user_levels[user.id],
-        paired_user_levels: paired_user_levels_by_user[user.id],
-        include_timestamp: true
-      )
-      progress
-    end
-    timestamp_by_user = progress_by_user.transform_values do |user|
-      user.values.map {|level| level[:last_progress_at]}.compact.max
-    end
-
-    [progress_by_user, timestamp_by_user]
-  end
-
   def script_structure
     script = Script.get_from_cache(params[:script])
     overview_path = CDO.studio_url(script_path(script))

--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -249,28 +249,6 @@ module UsersHelper
     progress
   end
 
-  # Summarizes a user's level progress for bubble choice level (parent level and sublevels)
-  private def get_bubble_choice_progress(level, user, user_levels_by_level, script_level, paired_user_levels, include_timestamp)
-    progress = {}
-
-    best_sublevel_id = level.best_result_sublevel(user)&.id
-    return progress if best_sublevel_id.nil?
-
-    sum_time_spent = 0
-
-    # get progress for sublevels to save in levels hash
-    level.sublevels.each do |sublevel|
-      ul = user_levels_by_level.try(:[], sublevel.id)
-      sublevel_progress = get_level_progress(ul, script_level, paired_user_levels, include_timestamp)
-      progress[sublevel.id] = sublevel_progress
-      sum_time_spent += sublevel_progress[:time_spent] || 0
-    end
-
-    progress[level.id] = progress[best_sublevel_id].clone
-    progress[level.id][:time_spent] = sum_time_spent if sum_time_spent > 0
-    progress
-  end
-
   # Summarizes a user's progress on a particular level
   private def get_level_progress(user_level, script_level, paired_user_levels, include_timestamp)
     completion_status = activity_css_class(user_level)
@@ -299,6 +277,28 @@ module UsersHelper
       last_progress_at: include_timestamp ? user_level&.updated_at&.to_i : nil,
       time_spent: user_level&.time_spent&.to_i
     }.compact
+  end
+
+  # Summarizes a user's level progress for bubble choice level (parent level and sublevels)
+  private def get_bubble_choice_progress(level, user, user_levels_by_level, script_level, paired_user_levels, include_timestamp)
+    progress = {}
+
+    best_sublevel_id = level.best_result_sublevel(user)&.id
+    return progress if best_sublevel_id.nil?
+
+    sum_time_spent = 0
+
+    # get progress for sublevels to save in levels hash
+    level.sublevels.each do |sublevel|
+      ul = user_levels_by_level.try(:[], sublevel.id)
+      sublevel_progress = get_level_progress(ul, script_level, paired_user_levels, include_timestamp)
+      progress[sublevel.id] = sublevel_progress
+      sum_time_spent += sublevel_progress[:time_spent] || 0
+    end
+
+    progress[level.id] = progress[best_sublevel_id].clone
+    progress[level.id][:time_spent] = sum_time_spent if sum_time_spent > 0
+    progress
   end
 
   # Given a user and a script-level, returns a nil if there is only one page, or an array of

--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -265,7 +265,7 @@ module UsersHelper
 
     # a user_level is submitted if the state is submitted UNLESS it is a peer reviewable level that has been reviewed
     submitted = !!user_level&.submitted &&
-      !(user_level.level&.peer_reviewable? && [ActivityConstants::REVIEW_REJECTED_RESULT, ActivityConstants::REVIEW_ACCEPTED_RESULT].include?(user_level.best_result))
+      !(user_level.level.try(:peer_reviewable?) && [ActivityConstants::REVIEW_REJECTED_RESULT, ActivityConstants::REVIEW_ACCEPTED_RESULT].include?(user_level.best_result))
 
     return {
       status: completion_status,

--- a/dashboard/test/helpers/users_helper_test.rb
+++ b/dashboard/test/helpers/users_helper_test.rb
@@ -313,8 +313,11 @@ class UsersHelperTest < ActionView::TestCase
     )
   end
 
-  def test_merge_user_progress_by_level
-    user = create :user, total_lines: 150
+  def test_script_progress_for_users
+    user_1 = create :user
+    user_2 = create :user
+
+    # set up progress
     script = create :script
 
     lesson_group = create :lesson_group, script: script
@@ -325,36 +328,45 @@ class UsersHelperTest < ActionView::TestCase
     sublevel2 = create :level, name: 'choice_2'
     level = create :bubble_choice_level, sublevels: [sublevel1, sublevel2]
     create :script_level, script: script, levels: [level], lesson: lesson
-    create :user_level, user: user, level: sublevel1, script: script, best_result: ActivityConstants::BEST_PASS_RESULT, time_spent: 180
-    create :user_level, user: user, level: sublevel2, script: script, best_result: 20, time_spent: 300
 
-    user_levels_by_level = user.user_levels_by_level(script)
-    paired_user_levels = PairedUserLevel.pairs(user_levels_by_level.values.map(&:id))
+    sublevel1_user_level = create :user_level, user: user_1, level: sublevel1, script: script, best_result: ActivityConstants::BEST_PASS_RESULT, time_spent: 180
+    sublevel2_user_level = create :user_level, user: user_1, level: sublevel2, script: script, best_result: 20, time_spent: 300
 
-    progress = {
-      # BubbleChoice levels return status/result using the sublevel with the highest best_result.
-      level.id => {
-        status: LEVEL_STATUS.perfect,
-        result: ActivityConstants::BEST_PASS_RESULT,
-        time_spent: 480
+    sublevel1_last_progress = UserLevel.find(sublevel1_user_level.id).updated_at.to_i
+    sublevel2_last_progress = UserLevel.find(sublevel2_user_level.id).updated_at.to_i
+
+    expected_progress = [
+      {
+        user_1.id => {
+          level.id => {
+            status: LEVEL_STATUS.perfect,
+            result: ActivityConstants::BEST_PASS_RESULT,
+            last_progress_at: sublevel1_last_progress,
+            time_spent: 480 # sum of time spent on sublevels
+          },
+          sublevel1.id => {
+            status: LEVEL_STATUS.perfect,
+            result: ActivityConstants::BEST_PASS_RESULT,
+            last_progress_at: sublevel1_last_progress,
+            time_spent: 180
+          },
+          sublevel2.id => {
+            status: LEVEL_STATUS.passed,
+            result: 20,
+            last_progress_at: sublevel2_last_progress,
+            time_spent: 300
+          }
+        },
+        user_2.id => {}
       },
-      sublevel1.id => {
-        status: LEVEL_STATUS.perfect,
-        result: ActivityConstants::BEST_PASS_RESULT,
-        time_spent: 180
-      },
-      sublevel2.id => {
-        status: LEVEL_STATUS.passed,
-        result: 20,
-        time_spent: 300
+      {
+        user_1.id => sublevel1_last_progress,
+        user_2.id => nil
       }
-    }
+    ]
 
-    assert_equal progress, merge_user_progress_by_level(
-      script: script,
-      user: user,
-      user_levels_by_level: user_levels_by_level,
-      paired_user_levels: paired_user_levels
+    assert_equal expected_progress, script_progress_for_users(
+      [user_1, user_2], script
     )
   end
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
- Refactor merge_user_progress_by_level (users_helper function that determines progress for each level)
- Update time_spent for parent bubble choice level to be sum of sublevel time_spent

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
Added unit tests and manually tested a bubble choice by adding progress on multiple choice levels, then checking time spent in the progress table.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
