### PR TITLE
Fix Maker Lab Redux Error

### DIFF
--- a/apps/src/lib/kits/maker/ui/SetupGuide.jsx
+++ b/apps/src/lib/kits/maker/ui/SetupGuide.jsx
@@ -51,11 +51,7 @@ export default class SetupGuide extends React.Component {
     );
 
     if (isCodeOrgBrowser() || isChromeOS()) {
-      return (
-        <Provider store={store}>
-          <SetupChecklist setupChecker={this.setupChecker} />;
-        </Provider>
-      );
+      return <SetupChecklist setupChecker={this.setupChecker} />;
     }
     return (
       <Provider store={store}>

--- a/apps/src/lib/kits/maker/ui/SetupGuide.jsx
+++ b/apps/src/lib/kits/maker/ui/SetupGuide.jsx
@@ -17,6 +17,10 @@ import Button from '../../../../templates/Button';
 import ToggleGroup from '../../../../templates/ToggleGroup';
 import FontAwesome from '../../../../templates/FontAwesome';
 import {CHROME_APP_WEBSTORE_URL} from '../util/makerConstants';
+import {createStore, combineReducers} from 'redux';
+import isRtl from '@cdo/apps/code-studio/isRtlRedux';
+import responsive from '@cdo/apps/code-studio/responsiveRedux';
+import {Provider} from 'react-redux';
 
 const DOWNLOAD_PREFIX = 'https://downloads.code.org/maker/';
 const WINDOWS = 'windows';
@@ -38,10 +42,26 @@ export default class SetupGuide extends React.Component {
   }
 
   render() {
+    // Create store for Provider
+    const store = createStore(
+      combineReducers({
+        isRtl,
+        responsive
+      })
+    );
+
     if (isCodeOrgBrowser() || isChromeOS()) {
-      return <SetupChecklist setupChecker={this.setupChecker} />;
+      return (
+        <Provider store={store}>
+          <SetupChecklist setupChecker={this.setupChecker} />;
+        </Provider>
+      );
     }
-    return <Downloads />;
+    return (
+      <Provider store={store}>
+        <Downloads />
+      </Provider>
+    );
   }
 }
 


### PR DESCRIPTION
A few children components of the Maker lab have become connected components, and thus need Redux store Provider at the root of the Maker lab app.

## Follow-up work

@epeach taking ownership of upping test coverage for this page.

## Images

BEFORE:
![image](https://user-images.githubusercontent.com/9528376/115050768-b778c280-9ea1-11eb-9556-82a485b2f198.png)

AFTER:
![image](https://user-images.githubusercontent.com/9528376/115050788-bcd60d00-9ea1-11eb-8548-4becceb1d69a.png)



## PR Checklist:

- [X] Tests provide adequate coverage
- [X] Privacy and Security impacts have been assessed
- [X] Code is well-commented
- [X] New features are translatable or updates will not break translations
- [X] Relevant documentation has been added or updated
- [X] User impact is well-understood and desirable
- [X] Pull Request is labeled appropriately
- [X] Follow-up work items (including potential tech debt) are tracked and linked
