### PR TITLE
[AiLab] bump ml-playground version to 25

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -57,7 +57,7 @@
     "@code-dot-org/js-numbers": "0.1.0-cdo.0",
     "@code-dot-org/maze": "1.1.0",
     "@code-dot-org/ml-activities": "0.0.26",
-    "@code-dot-org/ml-playground": "0.0.24",
+    "@code-dot-org/ml-playground": "0.0.25",
     "@code-dot-org/p5.play": "^1.3.14-cdo",
     "@code-dot-org/piskel": "0.13.0-cdo.6",
     "@code-dot-org/redactable-markdown": "0.4.0",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1637,10 +1637,10 @@
     messageformat "^1.1.0"
     react-typist "^2.0.5"
 
-"@code-dot-org/ml-playground@0.0.24":
-  version "0.0.24"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/ml-playground/-/ml-playground-0.0.24.tgz#ba460848487ad31c0a99ea64f2e7ebb49598a80c"
-  integrity sha512-KkdElvyV3bXfVmlRqNklYanFFbWC8UcfzUcGRGeLDu1hYPKtiHBv5s+JLCk/xucVmRHPq0UEQxCYhwKHjOtvng==
+"@code-dot-org/ml-playground@0.0.25":
+  version "0.0.25"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/ml-playground/-/ml-playground-0.0.25.tgz#468bccf6cc22b51f1b6bb402cc1342a320db5b2e"
+  integrity sha512-KkhMrF22B7YJzCM6aO5E269Zv0xG/lA0W5WTNybJSKzQIm6YvCXvSSNOYRs6z36kXzooKPePjhYiYEqh2cs8UQ==
   dependencies:
     "@fortawesome/fontawesome-svg-core" "^1.2.25"
     "@fortawesome/free-regular-svg-icons" "^5.11.2"


### PR DESCRIPTION
Suspect this bump will fix a parameterization bug (details [here](https://codedotorg.slack.com/archives/C016VGH1BT6/p1618584748035100)) and I'm eager to get https://github.com/code-dot-org/ml-playground/pull/144 into Code Studio so the Curriculum team can start re-training models. 

https://github.com/code-dot-org/ml-playground/pull/148