### PR TITLE
Set the mode on the allthethings fish level

### DIFF
--- a/dashboard/config/scripts/levels/allthethings HOC ML Fish 1.level
+++ b/dashboard/config/scripts/levels/allthethings HOC ML Fish 1.level
@@ -5,6 +5,7 @@
   "level_num": "custom",
   "user_id": 155,
   "properties": {
+    "mode": "short"
   },
   "published": true,
   "notes": ""


### PR DESCRIPTION
In an unrelated bug bash, I noticed that the allthethings oceans level wasn't working with a bunch of console errors:
![Screen Shot 2021-04-16 at 12 21 08 PM](https://user-images.githubusercontent.com/46464143/115076798-ec8d1100-9eb1-11eb-8b13-806fac27b2a7.png)

The fix is just to add the mode to the level config. Obviously we're not using this level in any tests but it's good to not have a level on production that spits out thousands of errors.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
