### PR TITLE
Handle 404s in Resource PDF generation

### DIFF
--- a/dashboard/lib/services/curriculum_pdfs/resources.rb
+++ b/dashboard/lib/services/curriculum_pdfs/resources.rb
@@ -93,22 +93,30 @@ module Services
           path = File.join(directory, filename)
           return path if File.exist?(path)
 
-          if resource.url.start_with?("https://docs.google.com/", "https://drive.google.com/")
-            # We don't want to export forms
-            return nil if resource.url.start_with?("https://docs.google.com/forms")
-            begin
-              export_from_google(resource.url, path)
+          begin
+            if resource.url.start_with?("https://docs.google.com/", "https://drive.google.com/")
+              # We don't want to export forms
+              return nil if resource.url.start_with?("https://docs.google.com/forms")
+              begin
+                export_from_google(resource.url, path)
+                return path
+              rescue Google::Apis::ClientError, Google::Apis::ServerError, GoogleDrive::Error => e
+                ChatClient.log(
+                  "Google error when trying to fetch PDF for resource #{resource.key.inspect} (#{resource.url}): #{e}",
+                  color: 'red'
+                )
+                return nil
+              end
+            elsif resource.url.end_with?(".pdf")
+              IO.copy_stream(URI.open(resource.url), path)
               return path
-            rescue Google::Apis::ClientError, Google::Apis::ServerError, GoogleDrive::Error, URI::InvalidURIError => e
-              ChatClient.log(
-                "error from Google when trying to fetch PDF for resource #{resource.key.inspect}: #{e}",
-                color: 'red'
-              )
-              return nil
             end
-          elsif resource.url.end_with?(".pdf")
-            IO.copy_stream(URI.open(resource.url), path)
-            return path
+          rescue URI::InvalidURIError, OpenURI::HTTPError => e
+            ChatClient.log(
+              "URI error when trying to fetch PDF for resource #{resource.key.inspect} (#{resource.url}): #{e}",
+              color: 'red'
+            )
+            return nil
           end
         end
       end


### PR DESCRIPTION
Add a handler for `OpenURI::HTTPError`, which will happen whenever a URL 404s. Also rearrange handlers to include the "externally-hosted pdf" resources, not just Google drive resources.

## Follow-up Work

This is a quick fix to address a staging build issue; unit tests to follow in a future PR.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
