### PR TITLE
Fix retake lock bug

### DIFF
--- a/apps/src/constants.js
+++ b/apps/src/constants.js
@@ -104,9 +104,9 @@ export const TestResults = {
 
   SUBMITTED_RESULT: 1000,
   // LOCKED_RESULT and READONLY_SUBMISSION_RESULT are never stored on the backend.
-  // They are used to encode locked/readonly information into a TestResult. Eventually,
-  // we want to remove these and look at levelProgress.locked and levelProgress.readonly
-  // instead. (LP-1865)
+  // They are used to encode locked/readonly information into a TestResult.
+  // Eventually, we want to remove these and look at studentlevelProgressType.locked
+  // and studentlevelProgressType.readonly instead. (LP-1865)
   LOCKED_RESULT: 1001,
   READONLY_SUBMISSION_RESULT: 1002,
 

--- a/apps/src/constants.js
+++ b/apps/src/constants.js
@@ -103,8 +103,13 @@ export const TestResults = {
   BETTER_THAN_IDEAL: 102,
 
   SUBMITTED_RESULT: 1000,
+  // LOCKED_RESULT and READONLY_SUBMISSION_RESULT are never stored on the backend.
+  // They are used to encode locked/readonly information into a TestResult. Eventually,
+  // we want to remove these and look at levelProgress.locked and levelProgress.readonly
+  // instead. (LP-1865)
   LOCKED_RESULT: 1001,
   READONLY_SUBMISSION_RESULT: 1002,
+
   REVIEW_REJECTED_RESULT: 1500,
   REVIEW_ACCEPTED_RESULT: 2000
 };

--- a/apps/src/templates/FinishDialog.story.jsx
+++ b/apps/src/templates/FinishDialog.story.jsx
@@ -23,7 +23,7 @@ const achievements = [
   {
     isAchieved: true,
     iconUrl: '',
-    message: 'Effecient!'
+    message: 'Efficient!'
   }
 ];
 
@@ -76,6 +76,7 @@ const mockProgress = {
   courseId: null,
   currentStageId: 40,
   hasFullProgress: false,
+  scriptProgress: {},
   levelResults: {
     1815: 17,
     1818: 100,

--- a/apps/src/templates/progress/progressHelpers.js
+++ b/apps/src/templates/progress/progressHelpers.js
@@ -70,11 +70,7 @@ export function stageLocked(levels) {
   // an identical locked/unlocked state.
   // Given this, we should be able to look at the last level in our collection
   // to determine whether the LG (and thus the stage) should be considered locked.
-  const level = levels[levels.length - 1];
-  return (
-    level.status === LevelStatus.locked ||
-    (level.kind === 'assessment' && level.status === 'submitted')
-  );
+  return levels[levels.length - 1].locked;
 }
 
 /**

--- a/apps/src/templates/progress/progressHelpers.js
+++ b/apps/src/templates/progress/progressHelpers.js
@@ -70,7 +70,7 @@ export function stageLocked(levels) {
   // an identical locked/unlocked state.
   // Given this, we should be able to look at the last level in our collection
   // to determine whether the LG (and thus the stage) should be considered locked.
-  return levels[levels.length - 1].locked;
+  return !!levels[levels.length - 1].locked;
 }
 
 /**

--- a/apps/src/templates/progress/progressTypes.js
+++ b/apps/src/templates/progress/progressTypes.js
@@ -103,6 +103,14 @@ export const studentLevelProgressType = PropTypes.shape(
   studentLevelProgressShape
 );
 
+/*
+ * @typedef {Object} scriptProgressType
+ *
+ * scriptProgressType represents a user's progress in a script.  It is a map of
+ * levelId -> studentLevelProgressType objects.
+ */
+export const scriptProgressType = PropTypes.objectOf(studentLevelProgressType);
+
 /**
  * @typedef {Object} Lesson
  *

--- a/apps/test/unit/code-studio/progressReduxTest.js
+++ b/apps/test/unit/code-studio/progressReduxTest.js
@@ -650,6 +650,7 @@ describe('progressReduxTest', () => {
             isCurrentLevel: false,
             isConceptLevel: false,
             paired: undefined,
+            locked: undefined,
             bonus: false,
             sublevels: []
           },
@@ -671,6 +672,7 @@ describe('progressReduxTest', () => {
             isCurrentLevel: false,
             isConceptLevel: false,
             paired: undefined,
+            locked: undefined,
             bonus: false,
             sublevels: []
           },
@@ -692,6 +694,7 @@ describe('progressReduxTest', () => {
             isCurrentLevel: false,
             isConceptLevel: false,
             paired: undefined,
+            locked: undefined,
             bonus: true,
             sublevels: []
           }
@@ -715,6 +718,7 @@ describe('progressReduxTest', () => {
             isCurrentLevel: false,
             isConceptLevel: false,
             paired: undefined,
+            locked: undefined,
             bonus: false,
             sublevels: []
           },
@@ -736,6 +740,7 @@ describe('progressReduxTest', () => {
             isCurrentLevel: false,
             isConceptLevel: false,
             paired: undefined,
+            locked: undefined,
             bonus: false,
             sublevels: []
           },
@@ -757,6 +762,7 @@ describe('progressReduxTest', () => {
             isCurrentLevel: false,
             isConceptLevel: false,
             paired: undefined,
+            locked: undefined,
             bonus: false,
             sublevels: []
           }
@@ -798,6 +804,7 @@ describe('progressReduxTest', () => {
             ]
           }
         ],
+        scriptProgress: {},
         levelResults: {}
       });
       assert.equal(results[0][0].isUnplugged, true);
@@ -1069,6 +1076,7 @@ describe('progressReduxTest', () => {
           }
         ],
         stages: [fakeLesson('Lesson Group', 'lesson1', 1)],
+        scriptProgress: {},
         levelResults: {},
         focusAreaStageIds: []
       };
@@ -1096,6 +1104,7 @@ describe('progressReduxTest', () => {
           fakeLesson('Lesson Group', 'lesson2', 2),
           fakeLesson('Lesson Group', 'lesson3', 3)
         ],
+        scriptProgress: {},
         levelResults: {},
         focusAreaStageIds: []
       };
@@ -1129,6 +1138,7 @@ describe('progressReduxTest', () => {
             lessons: []
           }
         ],
+        scriptProgress: {},
         levelResults: {},
         focusAreaStageIds: []
       };
@@ -1476,6 +1486,7 @@ describe('progressReduxTest', () => {
         'progress/UPDATE_FOCUS_AREAS',
         'stageLock/AUTHORIZE_LOCKABLE',
         'progress/SET_SCRIPT_COMPLETED',
+        'progress/SET_SCRIPT_PROGRESS',
         'progress/MERGE_RESULTS',
         'progress/MERGE_PEER_REVIEW_PROGRESS',
         'progress/SET_CURRENT_STAGE_ID'

--- a/apps/test/unit/templates/progress/ProgressLessonTest.js
+++ b/apps/test/unit/templates/progress/ProgressLessonTest.js
@@ -81,7 +81,7 @@ describe('ProgressLesson', () => {
     assert.equal(wrapper.find('ProgressLessonContent').props().disabled, true);
   });
 
-  it('renders with dashbed border when locked for individual student', () => {
+  it('renders with dashed border when locked for individual student', () => {
     const wrapper = shallow(
       <ProgressLesson
         {...defaultProps}
@@ -89,7 +89,7 @@ describe('ProgressLesson', () => {
         lessonLockedForSection={() => false}
         levels={defaultProps.levels.map(level => ({
           ...level,
-          status: LevelStatus.locked
+          locked: true
         }))}
       />
     );

--- a/apps/test/unit/templates/progress/SummaryProgressRowTest.js
+++ b/apps/test/unit/templates/progress/SummaryProgressRowTest.js
@@ -104,7 +104,10 @@ describe('SummaryProgressRow', () => {
       <SummaryProgressRow
         {...baseProps}
         lesson={fakeLesson('Maze', 1, true)}
-        lockedForSection={true}
+        levels={baseProps.levels.map((level, index) => ({
+          ...level,
+          locked: index === baseProps.levels.length - 1 ? true : false // lock last level
+        }))}
       />
     );
     assert.equal(
@@ -118,11 +121,7 @@ describe('SummaryProgressRow', () => {
 
   it('has an unlock icon when lockable and unlocked', () => {
     const wrapper = shallow(
-      <SummaryProgressRow
-        {...baseProps}
-        lesson={fakeLesson('Maze', 1, true)}
-        lockedForSection={false}
-      />
+      <SummaryProgressRow {...baseProps} lesson={fakeLesson('Maze', 1, true)} />
     );
     assert.equal(
       wrapper

--- a/apps/test/unit/templates/progress/progressHelpersTest.js
+++ b/apps/test/unit/templates/progress/progressHelpersTest.js
@@ -156,10 +156,9 @@ describe('progressHelpers', () => {
 
   describe('stageLocked', () => {
     it('returns true when we only have a level group and it is locked', () => {
-      const levels = fakeLevels(3).map(level => ({
+      const levels = fakeLevels(3).map((level, index) => ({
         ...level,
-        kind: LevelKind.assessment,
-        status: LevelStatus.locked
+        locked: index === 2 ? true : false // lock last level in level group
       }));
       assert.strictEqual(true, stageLocked(levels));
     });
@@ -172,14 +171,12 @@ describe('progressHelpers', () => {
       }));
 
       it('returns true when level group is locked', () => {
-        const levels = baseLevels.map(level => ({
+        // lock last level in level group
+        const levels = baseLevels.map((level, index) => ({
           ...level,
-          // lock assessment levels/pages
-          status:
-            level.kind === LevelKind.assessment
-              ? LevelStatus.locked
-              : level.status
+          locked: index === 3 ? true : false // lock last level in level group
         }));
+
         assert.strictEqual(true, stageLocked(levels));
       });
 

--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -183,6 +183,7 @@ module UsersHelper
               # for now, we don't allow authorized teachers to be "locked"
               if locked && !user.authorized_teacher?
                 progress[level_id] = {
+                  # TODO: Stop sending status here when front-end stops using LEVEL_STATUS.locked (LP-1865)
                   status: LEVEL_STATUS.locked,
                   locked: true
                 }
@@ -215,6 +216,7 @@ module UsersHelper
           # for now, we don't allow authorized teachers to be "locked"
           if locked && !user.authorized_teacher?
             progress[level_id] = {
+              # TODO: Stop sending status here when front-end stops using LEVEL_STATUS.locked (LP-1865)
               status: LEVEL_STATUS.locked,
               locked: true
             }

--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -183,7 +183,8 @@ module UsersHelper
               # for now, we don't allow authorized teachers to be "locked"
               if locked && !user.authorized_teacher?
                 progress[level_id] = {
-                  status: LEVEL_STATUS.locked
+                  status: LEVEL_STATUS.locked,
+                  locked: true
                 }
               end
               next
@@ -214,7 +215,8 @@ module UsersHelper
           # for now, we don't allow authorized teachers to be "locked"
           if locked && !user.authorized_teacher?
             progress[level_id] = {
-              status: LEVEL_STATUS.locked
+              status: LEVEL_STATUS.locked,
+              locked: true
             }
           end
           next

--- a/dashboard/test/helpers/users_helper_test.rb
+++ b/dashboard/test/helpers/users_helper_test.rb
@@ -181,7 +181,7 @@ class UsersHelperTest < ActionView::TestCase
     # No user level exists, show locked progress
     assert UserLevel.find_by(user: user, level: level).nil?
     assert_equal(
-      {level.id => {status: LEVEL_STATUS.locked}},
+      {level.id => {status: LEVEL_STATUS.locked, locked: true}},
       summarize_user_progress(script, user)[:progress]
     )
 

--- a/dashboard/test/ui/features/learning_platform/stage_lock.feature
+++ b/dashboard/test/ui/features/learning_platform/stage_lock.feature
@@ -141,6 +141,7 @@ Scenario: Lock settings for students who never submit
   When I sign in as "billy"
   And I am on "http://studio.code.org/s/allthethings"
   And I wait until element "td:contains(Anonymous student survey 2)" is visible
+  Then element "td:contains(Anonymous student survey 2) .fa-unlock" is visible
   Then I verify progress for stage 31 level 1 is "not_tried"
   Then I verify progress for stage 31 level 2 is "not_tried"
   Then I verify progress for stage 31 level 3 is "not_tried"
@@ -208,6 +209,9 @@ Scenario: Lock settings for retake not submit scenario
   # now editable, and student can submit
 
   When I sign in as "babby"
+  And I am on "http://studio.code.org/s/allthethings"
+  And I wait until element "td:contains(Anonymous student survey 2)" is visible
+  Then element "td:contains(Anonymous student survey 2) .fa-unlock" is visible
   When I am on "http://studio.code.org/s/allthethings/lockable/1/puzzle/1/page/4"
   And I click selector ".submitButton" once I see it
   And I wait to see a dialog titled "Submit your survey"
@@ -276,5 +280,8 @@ Scenario: Lock settings for retake after submit scenario
   # now editable, and student can see unsubmit button
 
   When I sign in as "frank"
+  And I am on "http://studio.code.org/s/allthethings"
+  And I wait until element "td:contains(Anonymous student survey 2)" is visible
+  Then element "td:contains(Anonymous student survey 2) .fa-unlock" is visible
   When I am on "http://studio.code.org/s/allthethings/lockable/1/puzzle/1/page/4"
   Then element ".unsubmitButton" is visible


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

This is the fix for [LP-1839](https://codedotorg.atlassian.net/browse/LP-1839) which was introduced by #38685.  

On the script overview page, we now store the entire levelProgress objects returned by the server in redux( store.progress.scriptProgress.).  Long-term, we expect scriptProgress to replace levelResults everywhere, but to keep the scope of this fix manageable, we update only stageLocked.

One possible next step is to remove LevelStatus.locked and LevelStatus.readonly, tracked as [LP-1865](https://codedotorg.atlassian.net/browse/LP-1865).

(cc: Dani and Dave since you're also in this area.  Feel free to review if you'd like or just skim to get an idea of the changes we're making.)

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
See also [LP-1862](https://codedotorg.atlassian.net/browse/LP-1862) for a detailed description of the code paths prior to this change.

## Testing story

Stage lock UI tests were updated to catch the issue in this bug.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
