### PR TITLE
[Applab Datasets] Disable spotify cron job

### DIFF
--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -100,7 +100,6 @@
       cronjob at:'1 7 * * 6', do:deploy_dir('bin', 'cron', 'cleanup_workshop_attendance_codes')
       cronjob at:'31 16 * * 1-5', do:deploy_dir('bin', 'cron', 'zendesk_slack_report')
       cronjob at:'5 12 * * *', do:deploy_dir('bin', 'cron', 'applab_datasets', 'daily_weather')
-      cronjob at:'0 12 * * *', do:deploy_dir('bin', 'cron', 'applab_datasets', 'spotify')
       cronjob at:'0 12 * * *', do:deploy_dir('bin', 'cron', 'applab_datasets', 'covid19')
       cronjob at:'00 02 * * *', do:deploy_dir('bin', 'cron', 'export_mysql_database_to_redshift')
       cronjob at:'0 0 * * *', do:deploy_dir('bin', 'cron', 'build_contact_rollups_v2')


### PR DESCRIPTION
We got a report that the Top 200 USA dataset was blank ([slack](https://codedotorg.slack.com/archives/C1B3PNDL7/p1618844924218100))

Running the script locally, it looks like we're getting permission denied:
![image](https://user-images.githubusercontent.com/8787187/115266213-df0f9b00-a0ec-11eb-868c-d001684b7659.png)

If you go to https://spotifycharts.com/regional/us/daily/latest/download, you see something like this (and the file does download correctly after that):
![image](https://user-images.githubusercontent.com/8787187/115266351-fea6c380-a0ec-11eb-919a-e61cfa6776da.png)

which I think explains why the request is failing in our script.

I manually fixed the Top 200 USA dataset, but it will get deleted again next time the job runs.
I'm not really sure what the fix will be here, but we should disable the cron job for now. The data will get stale, but that's better than being deleted.