### PR TITLE
Log clicks to download script and lesson pdfs 

### DIFF
--- a/apps/src/code-studio/components/progress/ScriptOverviewTopRow.jsx
+++ b/apps/src/code-studio/components/progress/ScriptOverviewTopRow.jsx
@@ -206,6 +206,7 @@ class ScriptOverviewTopRow extends React.Component {
                 {pdfDropdownOptions.map(option => (
                   <a
                     key={option.key}
+                    href={option.url}
                     onClick={() =>
                       this.recordAndNavigateToPdf(option.key, option.url)
                     }

--- a/apps/src/code-studio/components/progress/ScriptOverviewTopRow.jsx
+++ b/apps/src/code-studio/components/progress/ScriptOverviewTopRow.jsx
@@ -16,7 +16,6 @@ import ResourcesDropdown from '@cdo/apps/code-studio/components/progress/Resourc
 import UnitCalendarButton from '@cdo/apps/code-studio/components/progress/UnitCalendarButton';
 import {unitCalendarLesson} from '../../../templates/progress/unitCalendarLessonShapes';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
-import {windowOpen} from '@cdo/apps/utils';
 
 export const NOT_STARTED = 'NOT_STARTED';
 export const IN_PROGRESS = 'IN_PROGRESS';
@@ -83,7 +82,8 @@ class ScriptOverviewTopRow extends React.Component {
     scriptResourcesPdfUrl: PropTypes.string
   };
 
-  recordAndNavigateToPdf = (firehoseKey, url) => {
+  recordAndNavigateToPdf = (e, firehoseKey, url) => {
+    e.preventDefault();
     firehoseClient.putRecord(
       {
         study: 'pdf-click',
@@ -97,7 +97,7 @@ class ScriptOverviewTopRow extends React.Component {
       {
         includeUserId: true,
         callback: () => {
-          windowOpen(url);
+          window.location.href = url;
         }
       }
     );

--- a/apps/src/code-studio/components/progress/ScriptOverviewTopRow.jsx
+++ b/apps/src/code-studio/components/progress/ScriptOverviewTopRow.jsx
@@ -15,6 +15,8 @@ import {sectionsForDropdown} from '@cdo/apps/templates/teacherDashboard/teacherS
 import ResourcesDropdown from '@cdo/apps/code-studio/components/progress/ResourcesDropdown';
 import UnitCalendarButton from '@cdo/apps/code-studio/components/progress/UnitCalendarButton';
 import {unitCalendarLesson} from '../../../templates/progress/unitCalendarLessonShapes';
+import firehoseClient from '@cdo/apps/lib/util/firehose';
+import {windowOpen} from '@cdo/apps/utils';
 
 export const NOT_STARTED = 'NOT_STARTED';
 export const IN_PROGRESS = 'IN_PROGRESS';
@@ -79,6 +81,26 @@ class ScriptOverviewTopRow extends React.Component {
     isMigrated: PropTypes.bool,
     scriptOverviewPdfUrl: PropTypes.string,
     scriptResourcesPdfUrl: PropTypes.string
+  };
+
+  recordAndNavigateToPdf = (firehoseKey, url) => {
+    firehoseClient.putRecord(
+      {
+        study: 'pdf-click',
+        study_group: 'script',
+        event: 'open-pdf',
+        data_json: JSON.stringify({
+          name: this.props.scriptName,
+          pdfType: firehoseKey
+        })
+      },
+      {
+        includeUserId: true,
+        callback: () => {
+          windowOpen(url);
+        }
+      }
+    );
   };
 
   compilePdfDropdownOptions = () => {
@@ -182,7 +204,12 @@ class ScriptOverviewTopRow extends React.Component {
                 color={Button.ButtonColor.blue}
               >
                 {pdfDropdownOptions.map(option => (
-                  <a key={option.key} href={option.url}>
+                  <a
+                    key={option.key}
+                    onClick={() =>
+                      this.recordAndNavigateToPdf(option.key, option.url)
+                    }
+                  >
                     {option.name}
                   </a>
                 ))}

--- a/apps/src/templates/lessonOverview/LessonOverview.jsx
+++ b/apps/src/templates/lessonOverview/LessonOverview.jsx
@@ -6,9 +6,11 @@ import Activity from '@cdo/apps/templates/lessonOverview/activities/Activity';
 import Button from '@cdo/apps/templates/Button';
 import DropdownButton from '@cdo/apps/templates/DropdownButton';
 import EnhancedSafeMarkdown from '@cdo/apps/templates/EnhancedSafeMarkdown';
+import firehoseClient from '@cdo/apps/lib/util/firehose';
 import InlineMarkdown from '@cdo/apps/templates/InlineMarkdown';
 import LessonAgenda from '@cdo/apps/templates/lessonOverview/LessonAgenda';
 import LessonNavigationDropdown from '@cdo/apps/templates/lessonOverview/LessonNavigationDropdown';
+import {linkWithQueryParams, windowOpen} from '@cdo/apps/utils';
 import ResourceList from '@cdo/apps/templates/lessonOverview/ResourceList';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import color from '@cdo/apps/util/color';
@@ -19,7 +21,6 @@ import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import {announcementShape} from '@cdo/apps/code-studio/announcementsRedux';
 import {lessonShape} from '@cdo/apps/templates/lessonOverview/lessonPlanShapes';
 import Announcements from '../../code-studio/components/progress/Announcements';
-import {linkWithQueryParams} from '@cdo/apps/utils';
 import LessonStandards, {ExpandMode} from './LessonStandards';
 import StyledCodeBlock from './StyledCodeBlock';
 import VerifiedResourcesNotification from '@cdo/apps/templates/courseOverview/VerifiedResourcesNotification';
@@ -84,19 +85,39 @@ class LessonOverview extends Component {
     hasVerifiedResources: PropTypes.bool.isRequired
   };
 
+  recordAndNavigateToPdf = (firehoseKey, url) => {
+    firehoseClient.putRecord(
+      {
+        study: 'pdf-click',
+        study_group: 'lesson',
+        event: 'open-pdf',
+        data_json: JSON.stringify({
+          name: this.props.lesson.key,
+          pdfType: firehoseKey
+        })
+      },
+      {
+        includeUserId: true,
+        callback: () => {
+          windowOpen(url);
+        }
+      }
+    );
+  };
+
   compilePdfDropdownOptions = () => {
     const {lessonPlanPdfUrl, scriptResourcesPdfUrl} = this.props.lesson;
     const options = [];
     if (lessonPlanPdfUrl) {
       options.push({
-        key: 'lessonPlan',
+        key: 'singleLessonPlan',
         name: i18n.printLessonPlan(),
         url: lessonPlanPdfUrl
       });
     }
     if (scriptResourcesPdfUrl) {
       options.push({
-        key: 'scriptResource',
+        key: 'scriptResources',
         name: i18n.printHandouts(),
         url: scriptResourcesPdfUrl
       });
@@ -134,12 +155,15 @@ class LessonOverview extends Component {
                 <div style={{marginRight: 5}}>
                   <DropdownButton
                     color={Button.ButtonColor.gray}
-                    href={lesson.lessonPlanPdfUrl}
-                    target="_blank"
                     text={i18n.printingOptions()}
                   >
                     {pdfDropdownOptions.map(option => (
-                      <a key={option.key} href={option.url}>
+                      <a
+                        key={option.key}
+                        onClick={() =>
+                          this.recordAndNavigateToPdf(option.key, option.url)
+                        }
+                      >
                         {option.name}
                       </a>
                     ))}

--- a/apps/src/templates/lessonOverview/LessonOverview.jsx
+++ b/apps/src/templates/lessonOverview/LessonOverview.jsx
@@ -10,7 +10,7 @@ import firehoseClient from '@cdo/apps/lib/util/firehose';
 import InlineMarkdown from '@cdo/apps/templates/InlineMarkdown';
 import LessonAgenda from '@cdo/apps/templates/lessonOverview/LessonAgenda';
 import LessonNavigationDropdown from '@cdo/apps/templates/lessonOverview/LessonNavigationDropdown';
-import {linkWithQueryParams, windowOpen} from '@cdo/apps/utils';
+import {linkWithQueryParams} from '@cdo/apps/utils';
 import ResourceList from '@cdo/apps/templates/lessonOverview/ResourceList';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import color from '@cdo/apps/util/color';
@@ -85,7 +85,9 @@ class LessonOverview extends Component {
     hasVerifiedResources: PropTypes.bool.isRequired
   };
 
-  recordAndNavigateToPdf = (firehoseKey, url) => {
+  recordAndNavigateToPdf = (e, firehoseKey, url) => {
+    // Prevent navigation to url until callback
+    e.preventDefault();
     firehoseClient.putRecord(
       {
         study: 'pdf-click',
@@ -99,10 +101,11 @@ class LessonOverview extends Component {
       {
         includeUserId: true,
         callback: () => {
-          windowOpen(url);
+          window.location.href = url;
         }
       }
     );
+    return false;
   };
 
   compilePdfDropdownOptions = () => {
@@ -160,9 +163,10 @@ class LessonOverview extends Component {
                     {pdfDropdownOptions.map(option => (
                       <a
                         key={option.key}
-                        onClick={() =>
-                          this.recordAndNavigateToPdf(option.key, option.url)
+                        onClick={e =>
+                          this.recordAndNavigateToPdf(e, option.key, option.url)
                         }
+                        href={option.url}
                       >
                         {option.name}
                       </a>

--- a/apps/test/unit/code-studio/components/progress/ScriptOverviewTopRowTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/ScriptOverviewTopRowTest.jsx
@@ -295,6 +295,10 @@ describe('ScriptOverviewTopRow', () => {
       .find(DropdownButton)
       .first()
       .props().children;
+    expect(dropdownLinks.map(link => link.props.href)).to.eql([
+      '/link/to/script_overview.pdf',
+      '/link/to/script_resources.pdf'
+    ]);
     expect(dropdownLinks.map(link => link.props.children)).to.eql([
       'Print Lesson Plans',
       'Print Handouts'

--- a/apps/test/unit/code-studio/components/progress/ScriptOverviewTopRowTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/ScriptOverviewTopRowTest.jsx
@@ -295,10 +295,6 @@ describe('ScriptOverviewTopRow', () => {
       .find(DropdownButton)
       .first()
       .props().children;
-    expect(dropdownLinks.map(link => link.props.href)).to.eql([
-      '/link/to/script_overview.pdf',
-      '/link/to/script_resources.pdf'
-    ]);
     expect(dropdownLinks.map(link => link.props.children)).to.eql([
       'Print Lesson Plans',
       'Print Handouts'

--- a/apps/test/unit/templates/lessonOverview/LessonOverviewTest.js
+++ b/apps/test/unit/templates/lessonOverview/LessonOverviewTest.js
@@ -295,6 +295,10 @@ describe('LessonOverview', () => {
       .find(DropdownButton)
       .first()
       .props().children;
+    expect(dropdownLinks.map(link => link.props.href)).to.eql([
+      '/link/to/lesson_plan.pdf',
+      '/link/to/script_resources.pdf'
+    ]);
     expect(dropdownLinks.map(link => link.props.children)).to.eql([
       'Print Lesson Plan',
       'Print Handouts'

--- a/apps/test/unit/templates/lessonOverview/LessonOverviewTest.js
+++ b/apps/test/unit/templates/lessonOverview/LessonOverviewTest.js
@@ -295,10 +295,6 @@ describe('LessonOverview', () => {
       .find(DropdownButton)
       .first()
       .props().children;
-    expect(dropdownLinks.map(link => link.props.href)).to.eql([
-      '/link/to/lesson_plan.pdf',
-      '/link/to/script_resources.pdf'
-    ]);
     expect(dropdownLinks.map(link => link.props.children)).to.eql([
       'Print Lesson Plan',
       'Print Handouts'


### PR DESCRIPTION
Logs clicks to download the pdfs on the lesson and script overview pages. Example data would be:

study: 'pdf-click',
study_group: 'script/lesson',
event: 'open-pdf',
data_json: {
  name: "coursea-2021",
  pdfType: "scriptResources"
}

This does change the behavior slightly to open in the same tab. I talked to Tess and she agreed that this wasn't a requirement here. I kept the `href` attribute on the links in order to allow users to right click and open in a new tab.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
