### PR TITLE
Pause contact rollups nightly job

### DIFF
--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -102,7 +102,9 @@
       cronjob at:'5 12 * * *', do:deploy_dir('bin', 'cron', 'applab_datasets', 'daily_weather')
       cronjob at:'0 12 * * *', do:deploy_dir('bin', 'cron', 'applab_datasets', 'covid19')
       cronjob at:'00 02 * * *', do:deploy_dir('bin', 'cron', 'export_mysql_database_to_redshift')
-      cronjob at:'0 0 * * *', do:deploy_dir('bin', 'cron', 'build_contact_rollups_v2')
+      # Temporarily stop contact rollups daily sync with Pardot so we can do a pull FROM Pardot
+      # and avoid accidentally re-uploading contacts that have been deleted by our marketing team.
+      # cronjob at:'0 0 * * *', do:deploy_dir('bin', 'cron', 'build_contact_rollups_v2')
       cronjob at:'0 2 * * *', do:deploy_dir('bin', 'cron', 'hoc_student_name_cleanup')
 
       # RDS backup window is 08:50-09:20, so by 11:50 backups should definitely be ready


### PR DESCRIPTION
Pause contact rollups nightly job so we can manually download a list from Pardot of deleted prospects. If we try to sync to Pardot currently, we will resuscitate 700K prospects that have been manually deleted by our marketing team.

We've done this sync from Pardot once before, more details [here](https://github.com/code-dot-org/code-dot-org/pull/34732). At the time, the Contact Rollups process wasn't running nightly, so we didn't have to worry about what would happen if we tried to sync to Pardot before we had imported the list of newly deleted prospects.