### PR TITLE
Sprite upload page

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -629,7 +629,9 @@ describe('entry tests', () => {
     'scripts/new': './src/sites/studio/pages/scripts/new.js',
     'shared/_check_admin': './src/sites/studio/pages/shared/_check_admin.js',
     'shared_blockly_functions/edit':
-      './src/sites/studio/pages/shared_blockly_functions/edit.js'
+      './src/sites/studio/pages/shared_blockly_functions/edit.js',
+    'sprite_management/sprite_upload':
+      './src/sites/studio/pages/sprite_management/sprite_upload.js'
   };
 
   var pegasusEntries = {

--- a/apps/src/code-studio/assets/SpriteUpload.js
+++ b/apps/src/code-studio/assets/SpriteUpload.js
@@ -22,13 +22,16 @@ export default class SpriteUpload extends React.Component {
         <h1>Sprite Upload</h1>
         <form onSubmit={this.handleSubmit}>
           <label>
-            Select Sprite to Add to Library:
-            <br />
+            <h4> Sprite Category: </h4>
+            <input type="text" />
+          </label>
+          <label>
+            <h4> Select Sprite to Add to Library: </h4>
             <input type="file" ref="uploader" onChange={this.handleChange} />
           </label>
           <br />
           <label>
-            Image Preview:
+            <h4> Image Preview: </h4>
             <img src={this.state.file} />
           </label>
           <br />

--- a/apps/src/code-studio/assets/SpriteUpload.js
+++ b/apps/src/code-studio/assets/SpriteUpload.js
@@ -1,0 +1,40 @@
+import React from 'react';
+
+export default class SpriteUpload extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      file: null
+    };
+  }
+
+  handleSubmit(event) {}
+
+  handleChange = event => {
+    this.setState({
+      file: URL.createObjectURL(event.target.files[0])
+    });
+  };
+
+  render() {
+    return (
+      <div>
+        <h1>Sprite Upload</h1>
+        <form onSubmit={this.handleSubmit}>
+          <label>
+            Select Sprite to Add to Library:
+            <br />
+            <input type="file" ref="uploader" onChange={this.handleChange} />
+          </label>
+          <br />
+          <label>
+            Image Preview:
+            <img src={this.state.file} />
+          </label>
+          <br />
+          <button type="submit">Upload to Library</button>
+        </form>
+      </div>
+    );
+  }
+}

--- a/apps/src/sites/studio/pages/sprite_management/sprite_upload.js
+++ b/apps/src/sites/studio/pages/sprite_management/sprite_upload.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+$(document).ready(function() {
+  ReactDOM.render(
+    <h2>Sprite Upload</h2>,
+    document.getElementById('sprite-upload-container')
+  );
+});

--- a/apps/src/sites/studio/pages/sprite_management/sprite_upload.js
+++ b/apps/src/sites/studio/pages/sprite_management/sprite_upload.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import SpriteUpload from '@cdo/apps/code-studio/assets/SpriteUpload';
 
 $(document).ready(function() {
   ReactDOM.render(
-    <h2>Sprite Upload</h2>,
+    <SpriteUpload />,
     document.getElementById('sprite-upload-container')
   );
 });

--- a/dashboard/app/controllers/sprite_management_controller.rb
+++ b/dashboard/app/controllers/sprite_management_controller.rb
@@ -1,4 +1,7 @@
 class SpriteManagementController < ApplicationController
+  before_action :require_levelbuilder_mode
+  before_action :authenticate_user!
+
   def sprite_upload
   end
 end

--- a/dashboard/app/controllers/sprite_management_controller.rb
+++ b/dashboard/app/controllers/sprite_management_controller.rb
@@ -1,0 +1,4 @@
+class SpriteManagementController < ApplicationController
+  def sprite_upload
+  end
+end

--- a/dashboard/app/views/sprite_management/sprite_upload.haml
+++ b/dashboard/app/views/sprite_management/sprite_upload.haml
@@ -1,0 +1,2 @@
+#sprite-upload-container
+  -# populated by React

--- a/dashboard/app/views/sprite_management/sprite_upload.haml
+++ b/dashboard/app/views/sprite_management/sprite_upload.haml
@@ -1,2 +1,5 @@
+- content_for(:head) do
+  %script{src: webpack_asset_path('js/sprite_management/sprite_upload.js')}
+
 #sprite-upload-container
   -# populated by React

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -820,6 +820,8 @@ Dashboard::Application.routes.draw do
 
   get '/javabuilder/access_token', to: 'javabuilder_sessions#get_access_token'
 
+  get '/sprites/sprite_upload', to: 'sprite_management#sprite_upload'
+
   namespace :foorm do
     resources :forms, only: [:create] do
       member do


### PR DESCRIPTION
Part one of moving sprite management to levelbuilder. This is just UI and doesn't connect to anything yet. Is available only at /sprites/sprite-upload, but not linked to from anywhere, so I didn't hide it behind a flag. Gif shows example usage.

![example](https://user-images.githubusercontent.com/2959170/115439637-a55d9380-a1c3-11eb-9d11-8557926700ce.gif)


## Follow-up work
Connecting this form to S3 and adding it to the extra-links on levelbuilder. Tracked in Jira.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
