### PR TITLE
avoid unnecessary renders of student names

### DIFF
--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableStudentList.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableStudentList.jsx
@@ -31,7 +31,8 @@ export default class ProgressTableStudentList extends React.Component {
     scriptData: scriptDataPropType.isRequired,
     headers: PropTypes.arrayOf(PropTypes.string).isRequired,
     studentTimestamps: PropTypes.object,
-    onToggleRow: PropTypes.func.isRequired
+    onToggleRow: PropTypes.func.isRequired,
+    showSectionProgressDetails: PropTypes.bool
   };
 
   constructor(props) {
@@ -75,9 +76,7 @@ export default class ProgressTableStudentList extends React.Component {
         scriptId={scriptData.id}
         lastTimestamp={studentTimestamps[rowData.student.id]}
         studentUrl={studentUrl}
-        onToggleExpand={() => {
-          this.props.onToggleRow(rowData);
-        }}
+        onToggleExpand={this.props.onToggleRow}
         isExpanded={rowData.isExpanded}
       />
     );

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableStudentName.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableStudentName.jsx
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import {connect} from 'react-redux';
 import ReactTooltip from 'react-tooltip';
 import moment from 'moment';
 import firehoseClient from '../../../lib/util/firehose';
@@ -25,7 +24,7 @@ const styles = {
     width: '11px'
   }
 };
-class ProgressTableStudentName extends React.PureComponent {
+export default class ProgressTableStudentName extends React.PureComponent {
   static propTypes = {
     name: PropTypes.string.isRequired,
     studentId: PropTypes.number.isRequired,
@@ -35,14 +34,17 @@ class ProgressTableStudentName extends React.PureComponent {
     studentUrl: PropTypes.string.isRequired,
     onToggleExpand: PropTypes.func.isRequired,
     isExpanded: PropTypes.bool.isRequired,
-
-    // redux provided
     showSectionProgressDetails: PropTypes.bool
   };
 
   constructor(props) {
     super(props);
+    this.toggleExpand = this.toggleExpand.bind(this);
     this.recordStudentNameClick = this.recordStudentNameClick.bind(this);
+  }
+
+  toggleExpand() {
+    this.props.onToggleExpand(this.props.studentId);
   }
 
   recordStudentNameClick() {
@@ -88,7 +90,7 @@ class ProgressTableStudentName extends React.PureComponent {
   }
 
   render() {
-    const {name, studentUrl, onToggleExpand, isExpanded} = this.props;
+    const {name, studentUrl, isExpanded} = this.props;
     const tooltipId = this.tooltipId();
 
     return (
@@ -101,7 +103,7 @@ class ProgressTableStudentName extends React.PureComponent {
         {this.props.showSectionProgressDetails && (
           <CollapserIcon
             isCollapsed={!isExpanded}
-            onClick={onToggleExpand}
+            onClick={this.toggleExpand}
             collapsedIconClass="fa-caret-right"
             expandedIconClass="fa-caret-down"
             style={styles.collapser}
@@ -119,9 +121,3 @@ class ProgressTableStudentName extends React.PureComponent {
     );
   }
 }
-
-export const UnconnectedProgressTableStudentName = ProgressTableStudentName;
-
-export default connect(state => ({
-  showSectionProgressDetails: state.sectionProgress.showSectionProgressDetails
-}))(ProgressTableStudentName);

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableView.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableView.jsx
@@ -96,7 +96,8 @@ class ProgressTableView extends React.Component {
     onClickLesson: PropTypes.func.isRequired,
     lessonOfInterest: PropTypes.number.isRequired,
     studentTimestamps: PropTypes.object.isRequired,
-    localeCode: PropTypes.string
+    localeCode: PropTypes.string,
+    showSectionProgressDetails: PropTypes.bool
   };
 
   constructor(props) {
@@ -181,10 +182,11 @@ class ProgressTableView extends React.Component {
     );
   }
 
-  onToggleRow(rowData) {
+  onToggleRow(studentId) {
     const rowIndex = this.state.rows.findIndex(
-      row => row.student === rowData.student
+      row => row.student.id === studentId
     );
+    const rowData = this.state.rows[rowIndex];
     if (!rowData.isExpanded) {
       this.expandDetailRows(rowData, rowIndex);
     } else {
@@ -242,7 +244,7 @@ class ProgressTableView extends React.Component {
     this.setState({rows});
   }
 
-  onRow = row => {
+  onRow(row) {
     const rowClassName = classnames({
       'dark-row': row.useDarkBackground,
       'primary-row': row.expansionIndex === 0,
@@ -253,7 +255,7 @@ class ProgressTableView extends React.Component {
     return {
       className: rowClassName
     };
-  };
+  }
 
   detailContentViewProps() {
     return {
@@ -346,7 +348,8 @@ export default connect(
       state.sectionProgress.studentLastUpdateByScript[
         state.scriptSelection.scriptId
       ],
-    localeCode: state.locales.localeCode
+    localeCode: state.locales.localeCode,
+    showSectionProgressDetails: state.sectionProgress.showSectionProgressDetails
   }),
   dispatch => ({
     onClickLesson(lessonPosition) {

--- a/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableContainerTest.jsx
+++ b/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableContainerTest.jsx
@@ -237,7 +237,7 @@ describe('ProgressTableView', () => {
     const numDetailRows = wrapper.numDetailRowsPerStudent();
 
     const rowData = wrapper.state.rows[0];
-    wrapper.onToggleRow(rowData);
+    wrapper.onToggleRow(rowData.student.id);
     expect(wrapper.state.rows).to.have.lengthOf(
       STUDENTS.length + numDetailRows
     );
@@ -253,12 +253,11 @@ describe('ProgressTableView', () => {
     const numDetailRows = wrapper.numDetailRowsPerStudent();
 
     const rowData = wrapper.state.rows[0];
-    wrapper.onToggleRow(rowData);
+    wrapper.onToggleRow(rowData.student.id);
     expect(wrapper.state.rows).to.have.lengthOf(
       STUDENTS.length + numDetailRows
     );
-
-    wrapper.onToggleRow(rowData);
+    wrapper.onToggleRow(rowData.student.id);
     expect(wrapper.state.rows).to.have.lengthOf(STUDENTS.length);
   });
 });

--- a/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableStudentNameTest.jsx
+++ b/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableStudentNameTest.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {expect} from '../../../../util/reconfiguredChai';
 import {shallow} from 'enzyme';
-import {UnconnectedProgressTableStudentName as ProgressTableStudentName} from '@cdo/apps/templates/sectionProgress/progressTables/ProgressTableStudentName';
+import ProgressTableStudentName from '@cdo/apps/templates/sectionProgress/progressTables/ProgressTableStudentName';
 import CollapserIcon from '@cdo/apps/templates/CollapserIcon';
 import moment from 'moment';
 

--- a/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableViewTest.jsx
+++ b/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableViewTest.jsx
@@ -155,7 +155,7 @@ describe('ProgressTableView', () => {
         .find(UnconnectedProgressTableView)
         .instance();
       const rowData = container.state.rows[0];
-      container.onToggleRow(rowData);
+      container.onToggleRow(rowData.student.id);
 
       // one call for each of the two lessons
       expect(timeSpentFormatterStub.callCount).to.equal(2);
@@ -219,7 +219,7 @@ describe('ProgressTableView', () => {
         .find(UnconnectedProgressTableView)
         .instance();
       const rowData = container.state.rows[0];
-      container.onToggleRow(rowData);
+      container.onToggleRow(rowData.student.id);
 
       // one call for each of the two lessons
       expect(timeSpentFormatterStub.callCount).to.equal(2);


### PR DESCRIPTION
while using [why-did-you-render](https://github.com/welldone-software/why-did-you-render) to investigate a separate issue, i discovered an unnecessary re-render in `ProgressTableStudentName`, which this PR addresses.

the issue was that we were passing an inline arrow function as the `onToggleRow` callback into the component, so for each render of `ProgressTableStudentList` we were passing a new callback. the resolution was to switch to using a new `toggleExpand` class method in `ProgressTableStudentName` which calls the passed-in callback with the student id instead of `rowData`.

i also updated `ProgressTableStudentName` to not be connected, instead passing the `showSectionProgressDetails` prop from `ProgressTableContainer`. the scrolling of the student list at this point is jankier than the content view, and while that appears to be entirely the fault of rendering the content rows, every little bit of performance optimization in these components helps!