### PR TITLE
Cleanup ProgressTableLevelBubble #2

### DIFF
--- a/apps/src/templates/progress/progressStyles.js
+++ b/apps/src/templates/progress/progressStyles.js
@@ -1,22 +1,13 @@
 import color from '@cdo/apps/util/color';
+import {makeEnum} from '@cdo/apps/utils';
 import {LevelStatus, LevelKind} from '@cdo/apps/util/sharedConstants';
 import progressTableStyles from '@cdo/apps/templates/sectionProgress/progressTables/progressTableStyles.scss';
 
-export const DOT_SIZE = 30;
-export const DIAMOND_DOT_SIZE = 22;
-export const SMALL_DOT_SIZE = 9;
-export const SMALL_DIAMOND_SIZE = 6;
-export const BUBBLE_BORDER_WIDTH = 2;
-
-// Hard-coded container width to ensure all big bubbles have the same width
-// regardless of shape (circle vs. diamond).
-// Two pixels on each side for margin, plus 2 x border width
-export const BUBBLE_CONTAINER_WIDTH = DOT_SIZE + 4 + 2 * BUBBLE_BORDER_WIDTH;
-
-export const LETTER_BUBBLE_SIZE = 16;
-export const LETTER_BUBBLE_MARGIN = 3;
-export const LETTER_BUBBLE_CONTAINER_WIDTH =
-  LETTER_BUBBLE_SIZE + 2 * LETTER_BUBBLE_MARGIN + 2 * BUBBLE_BORDER_WIDTH;
+/**
+ * ======================================
+ * Layout helpers
+ * ======================================
+ */
 
 export const flex = {
   display: 'flex',
@@ -28,18 +19,41 @@ export const flexBetween = {...flex, justifyContent: 'space-between'};
 
 export const inlineBlock = {display: 'inline-block'};
 
-export const link = {
-  ...inlineBlock,
-  textDecoration: 'none'
+export const tightlyConstrainedSizeStyle = size => {
+  return {
+    minWidth: size,
+    maxWidth: size,
+    minHeight: size,
+    maxHeight: size
+  };
 };
+
+export const marginLeftRight = margin => {
+  return {
+    marginLeft: margin,
+    marginRight: margin
+  };
+};
+
+export const marginTopBottom = margin => {
+  return {
+    marginTop: margin,
+    marginBottom: margin
+  };
+};
+
+/**
+ * ======================================
+ * Shared styles
+ * ======================================
+ */
 
 export const font = {
   fontFamily: '"Gotham 5r", sans-serif'
 };
 
-export const CELL_PADDING = 4;
 export const cellContent = {
-  padding: `0px ${CELL_PADDING}px`
+  padding: '0px 4px'
 };
 
 export const studentListContent = {
@@ -52,7 +66,6 @@ export const studentListContent = {
   overflow: 'hidden'
 };
 
-// Style used when hovering
 export const hoverStyle = {
   ':hover': {
     textDecoration: 'none',
@@ -62,6 +75,216 @@ export const hoverStyle = {
   },
   transition:
     'background-color .2s ease-out, border-color .2s ease-out, color .2s ease-out'
+};
+
+/**
+ * ======================================
+ * Bubble styles
+ * ======================================
+ */
+
+export const BubbleSize = makeEnum('dot', 'letter', 'full');
+export const BubbleShape = makeEnum('circle', 'diamond', 'pill');
+
+/**
+ * Note: these constants will be removed in favor of `bubbleSizes` below once
+ * we finish cleaning up all of our bubble components.
+ */
+export const DOT_SIZE = 30;
+export const DIAMOND_DOT_SIZE = 22;
+export const SMALL_DOT_SIZE = 9;
+export const SMALL_DIAMOND_SIZE = 6;
+
+const LARGE_FONT = 16;
+const SMALL_FONT = 12;
+
+const bubbleSizes = {
+  [BubbleShape.circle]: {
+    [BubbleSize.dot]: 13,
+    [BubbleSize.letter]: 20,
+    [BubbleSize.full]: 30
+  },
+  [BubbleShape.diamond]: {
+    [BubbleSize.dot]: 10,
+    [BubbleSize.full]: 23
+  },
+  [BubbleShape.pill]: {}
+};
+
+const bubbleMargins = {
+  [BubbleSize.dot]: 3,
+  [BubbleSize.letter]: 3,
+  [BubbleSize.full]: 2
+};
+
+/**
+ * We use fixed-size containers to make diamond bubbles the same width as
+ * circle bubbles, so we use BubbleShape.circle to compute.
+ *
+ * Container width is the width of the bubble plus the left and right margins.
+ */
+export const bubbleContainerWidths = {
+  [BubbleSize.dot]:
+    bubbleSizes[BubbleShape.circle][BubbleSize.dot] +
+    2 * bubbleMargins[BubbleSize.dot],
+  [BubbleSize.letter]:
+    bubbleSizes[BubbleShape.circle][BubbleSize.letter] +
+    2 * bubbleMargins[BubbleSize.letter],
+  [BubbleSize.full]:
+    bubbleSizes[BubbleShape.circle][BubbleSize.full] +
+    2 * bubbleMargins[BubbleSize.full]
+};
+
+const fontSizes = {
+  [BubbleShape.circle]: {
+    [BubbleSize.letter]: SMALL_FONT,
+    [BubbleSize.full]: LARGE_FONT
+  },
+  [BubbleShape.diamond]: {
+    [BubbleSize.full]: LARGE_FONT
+  }
+};
+
+export const bubbleStyles = {
+  main: {
+    ...flex,
+    ...font,
+    ...marginTopBottom(3),
+    boxSizing: 'border-box',
+    letterSpacing: -0.11,
+    position: 'relative',
+    whiteSpace: 'nowrap'
+  },
+  pill: {
+    borderRadius: 20,
+    fontSize: SMALL_FONT,
+    padding: '6px 10px'
+  },
+  diamond: {
+    ...marginTopBottom(6),
+    transform: 'rotate(45deg)',
+    padding: 2
+  },
+  diamondContentTransform: {
+    transform: 'rotate(-45deg)'
+  },
+  bonusDisabled: {
+    backgroundColor: color.lighter_gray,
+    color: color.white
+  },
+  link: {
+    ...inlineBlock,
+    textDecoration: 'none'
+  }
+};
+
+/**
+ * Computes style for shape/size, and merges with `progressStyle` previously
+ * computed by `getProgressStyle` below.
+ */
+export function mainBubbleStyle(shape, size, progressStyle) {
+  return {
+    ...bubbleStyles.main,
+    ...shapeSizeStyle(shape, size),
+    ...progressStyle
+  };
+}
+
+export function diamondContainerStyle(size) {
+  const containerWidth = bubbleContainerWidths[size];
+  return {
+    ...flex,
+    width: containerWidth,
+    height: containerWidth
+  };
+}
+
+function circleStyle(size) {
+  const bubbleSize = bubbleSizes[BubbleShape.circle][size];
+  const fontSize = fontSizes[BubbleShape.circle][size];
+  const horizontalMargin = marginLeftRight(bubbleMargins[size]);
+  return {
+    ...tightlyConstrainedSizeStyle(bubbleSize),
+    borderRadius: bubbleSize,
+    fontSize: fontSize,
+    lineHeight: fontSize,
+    ...horizontalMargin
+  };
+}
+
+function diamondStyle(size) {
+  const bubbleSize = bubbleSizes[BubbleShape.diamond][size];
+  const fontSize = fontSizes[BubbleShape.diamond][size];
+  return {
+    ...bubbleStyles.diamond,
+    ...tightlyConstrainedSizeStyle(bubbleSize),
+    borderRadius: size === BubbleSize.full ? 4 : 2,
+    fontSize: fontSize,
+    lineHeight: fontSize
+  };
+}
+
+function shapeSizeStyle(shape, size) {
+  return shape === BubbleShape.pill
+    ? bubbleStyles.pill
+    : shape === BubbleShape.diamond
+    ? diamondStyle(size)
+    : circleStyle(size);
+}
+
+/**
+ * Get border and background styling based on level and student progress.
+ *
+ * Note: `levelProgressStyle` below is used by our legacy bubble components,
+ * but once those get wrapped into our new components these two functions can
+ * be merged into one.
+ */
+export function getProgressStyle({
+  levelStatus,
+  levelKind,
+  isDisabled,
+  isBonus
+}) {
+  return {
+    ...(!isDisabled && hoverStyle),
+    ...levelProgressStyle(levelStatus, levelKind, isDisabled),
+    ...(isDisabled && isBonus && bubbleStyles.bonusDisabled)
+  };
+}
+
+/**
+ * Given a level object, figure out styling related to its color, border color,
+ * and background color
+ */
+export const levelProgressStyle = (levelStatus, levelKind, disabled) => {
+  let style = {
+    borderWidth: 2,
+    borderColor: color.lighter_gray,
+    borderStyle: 'solid',
+    color: color.charcoal,
+    backgroundColor: color.level_not_tried
+  };
+
+  // We don't return early for disabled assessments that have been submitted
+  // so that they still show their submitted status.
+  if (
+    (disabled && levelStatus !== LevelStatus.submitted) ||
+    !levelStatus ||
+    levelStatus === levelStatus.not_tried ||
+    levelStatus === LevelStatus.locked
+  ) {
+    return style;
+  }
+
+  const statusStyle =
+    levelKind === LevelKind.assessment
+      ? assessmentStatusStyle[levelStatus]
+      : levelStatusStyle[levelStatus];
+
+  return {
+    ...style,
+    ...statusStyle
+  };
 };
 
 const assessmentStatusStyle = {
@@ -136,39 +359,4 @@ const levelStatusStyle = {
     borderColor: color.level_perfect,
     backgroundColor: color.level_perfect
   }
-};
-
-/**
- * Given a level object, figure out styling related to its color, border color,
- * and background color
- */
-export const levelProgressStyle = (levelStatus, levelKind, disabled) => {
-  let style = {
-    borderWidth: BUBBLE_BORDER_WIDTH,
-    borderColor: color.lighter_gray,
-    borderStyle: 'solid',
-    color: color.charcoal,
-    backgroundColor: color.level_not_tried
-  };
-
-  // We don't return early for disabled assessments that have been submitted
-  // so that they still show their submitted status.
-  if (
-    (disabled && levelStatus !== LevelStatus.submitted) ||
-    !levelStatus ||
-    levelStatus === levelStatus.not_tried ||
-    levelStatus === LevelStatus.locked
-  ) {
-    return style;
-  }
-
-  const statusStyle =
-    levelKind === LevelKind.assessment
-      ? assessmentStatusStyle[levelStatus]
-      : levelStatusStyle[levelStatus];
-
-  return {
-    ...style,
-    ...statusStyle
-  };
 };

--- a/apps/src/templates/progress/progressStyles.js
+++ b/apps/src/templates/progress/progressStyles.js
@@ -102,19 +102,33 @@ const bubbleSizes = {
   [BubbleShape.circle]: {
     [BubbleSize.dot]: 13,
     [BubbleSize.letter]: 20,
-    [BubbleSize.full]: 30
+    [BubbleSize.full]: 34
   },
   [BubbleShape.diamond]: {
     [BubbleSize.dot]: 10,
-    [BubbleSize.full]: 23
+    [BubbleSize.full]: 26
   },
   [BubbleShape.pill]: {}
 };
 
-const bubbleMargins = {
+const circleMargins = {
   [BubbleSize.dot]: 3,
   [BubbleSize.letter]: 3,
   [BubbleSize.full]: 2
+};
+
+const bubbleBorderRadii = {
+  [BubbleShape.circle]: {
+    [BubbleSize.dot]: bubbleSizes[BubbleShape.circle][BubbleSize.dot],
+    [BubbleSize.letter]: bubbleSizes[BubbleShape.circle][BubbleSize.letter],
+    [BubbleSize.full]: bubbleSizes[BubbleShape.circle][BubbleSize.full]
+  },
+  [BubbleShape.diamond]: {
+    [BubbleSize.dot]: 2,
+    [BubbleSize.letter]: 2,
+    [BubbleSize.full]: 4
+  },
+  [BubbleShape.pill]: {}
 };
 
 /**
@@ -126,23 +140,18 @@ const bubbleMargins = {
 export const bubbleContainerWidths = {
   [BubbleSize.dot]:
     bubbleSizes[BubbleShape.circle][BubbleSize.dot] +
-    2 * bubbleMargins[BubbleSize.dot],
+    2 * circleMargins[BubbleSize.dot],
   [BubbleSize.letter]:
     bubbleSizes[BubbleShape.circle][BubbleSize.letter] +
-    2 * bubbleMargins[BubbleSize.letter],
+    2 * circleMargins[BubbleSize.letter],
   [BubbleSize.full]:
     bubbleSizes[BubbleShape.circle][BubbleSize.full] +
-    2 * bubbleMargins[BubbleSize.full]
+    2 * circleMargins[BubbleSize.full]
 };
 
 const fontSizes = {
-  [BubbleShape.circle]: {
-    [BubbleSize.letter]: SMALL_FONT,
-    [BubbleSize.full]: LARGE_FONT
-  },
-  [BubbleShape.diamond]: {
-    [BubbleSize.full]: LARGE_FONT
-  }
+  [BubbleSize.letter]: SMALL_FONT,
+  [BubbleSize.full]: LARGE_FONT
 };
 
 export const bubbleStyles = {
@@ -199,38 +208,28 @@ export function diamondContainerStyle(size) {
   };
 }
 
-function circleStyle(size) {
-  const bubbleSize = bubbleSizes[BubbleShape.circle][size];
-  const fontSize = fontSizes[BubbleShape.circle][size];
-  const horizontalMargin = marginLeftRight(bubbleMargins[size]);
-  return {
-    ...tightlyConstrainedSizeStyle(bubbleSize),
-    borderRadius: bubbleSize,
-    fontSize: fontSize,
-    lineHeight: fontSize,
-    ...horizontalMargin
-  };
-}
-
-function diamondStyle(size) {
-  const bubbleSize = bubbleSizes[BubbleShape.diamond][size];
-  const fontSize = fontSizes[BubbleShape.diamond][size];
-  return {
-    ...bubbleStyles.diamond,
-    ...tightlyConstrainedSizeStyle(bubbleSize),
-    borderRadius: size === BubbleSize.full ? 4 : 2,
-    fontSize: fontSize,
-    lineHeight: fontSize
-  };
-}
-
 function shapeSizeStyle(shape, size) {
-  return shape === BubbleShape.pill
-    ? bubbleStyles.pill
-    : shape === BubbleShape.diamond
-    ? diamondStyle(size)
-    : circleStyle(size);
+  if (shape === BubbleShape.pill) {
+    return bubbleStyles.pill;
+  }
+
+  const bubbleSize = bubbleSizes[shape][size];
+  const fontSize = fontSizes[size];
+  return {
+    ...tightlyConstrainedSizeStyle(bubbleSize),
+    borderRadius: bubbleBorderRadii[shape][size],
+    fontSize: fontSize,
+    lineHeight: `${fontSize}px`,
+    ...(shape === BubbleShape.circle && marginLeftRight(circleMargins[size])),
+    ...(shape === BubbleShape.diamond && bubbleStyles.diamond)
+  };
 }
+
+/**
+ * ======================================
+ * Progress styles
+ * ======================================
+ */
 
 /**
  * Get border and background styling based on level and student progress.

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableDetailCell.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableDetailCell.jsx
@@ -84,10 +84,10 @@ export default class ProgressTableDetailCell extends React.Component {
             >
               <ProgressTableLevelBubble
                 levelStatus={subStatus}
-                disabled={!!level.bonus && !this.props.stageExtrasEnabled}
-                smallBubble={true}
-                bonus={sublevel.bonus}
-                concept={sublevel.isConceptLevel}
+                isDisabled={!!level.bonus && !this.props.stageExtrasEnabled}
+                bubbleSize={progressStyles.BubbleSize.letter}
+                isBonus={sublevel.bonus}
+                isConcept={sublevel.isConceptLevel}
                 title={sublevel.bubbleText}
                 url={this.buildBubbleUrl(sublevel)}
               />
@@ -111,11 +111,11 @@ export default class ProgressTableDetailCell extends React.Component {
           <ProgressTableLevelBubble
             levelStatus={status}
             levelKind={level.kind}
-            disabled={!!level.bonus && !stageExtrasEnabled}
-            unplugged={level.isUnplugged}
-            bonus={level.bonus}
-            paired={paired}
-            concept={level.isConceptLevel}
+            isDisabled={!!level.bonus && !stageExtrasEnabled}
+            isUnplugged={level.isUnplugged}
+            isBonus={level.bonus}
+            isPaired={paired}
+            isConcept={level.isConceptLevel}
             title={level.bubbleText}
             url={url}
           />

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableLevelBubble.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableLevelBubble.jsx
@@ -3,181 +3,146 @@ import Radium from 'radium';
 import PropTypes from 'prop-types';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import i18n from '@cdo/locale';
-import * as progressStyles from '@cdo/apps/templates/progress/progressStyles';
-import color from '@cdo/apps/util/color';
 import {LevelStatus} from '@cdo/apps/util/sharedConstants';
+import {
+  bubbleStyles,
+  BubbleSize,
+  BubbleShape,
+  mainBubbleStyle,
+  diamondContainerStyle,
+  getProgressStyle
+} from '@cdo/apps/templates/progress/progressStyles';
 
-const styles = {
-  container: {
-    ...progressStyles.flex,
-    width: progressStyles.BUBBLE_CONTAINER_WIDTH
-  },
-  main: {
-    ...progressStyles.font,
-    boxSizing: 'content-box',
-    letterSpacing: -0.11,
-    position: 'relative',
-    margin: '3px 0px'
-  },
-  large: {
-    ...progressStyles.flex,
-    fontSize: 16
-  },
-  largeCircle: {
-    width: progressStyles.DOT_SIZE,
-    height: progressStyles.DOT_SIZE,
-    borderRadius: progressStyles.DOT_SIZE
-  },
-  largeDiamond: {
-    width: progressStyles.DIAMOND_DOT_SIZE,
-    height: progressStyles.DIAMOND_DOT_SIZE,
-    borderRadius: 4,
-    transform: 'rotate(45deg)',
-    margin: '6px 0px'
-  },
-  smallCircle: {
-    ...progressStyles.flex,
-    width: progressStyles.LETTER_BUBBLE_SIZE,
-    height: progressStyles.LETTER_BUBBLE_SIZE,
-    borderRadius: progressStyles.LETTER_BUBBLE_SIZE,
-    lineHeight: '12px',
-    fontSize: 12,
-    margin: progressStyles.LETTER_BUBBLE_MARGIN
-  },
-  contents: {
-    whiteSpace: 'nowrap',
-    lineHeight: '16px'
-  },
-  diamondContents: {
-    // undo the rotation from the parent
-    transform: 'rotate(-45deg)'
-  },
-  bonusDisabled: {
-    backgroundColor: color.lighter_gray,
-    color: color.white
-  },
-  unplugged: {
-    ...progressStyles.flex,
-    borderRadius: 20,
-    padding: '6px 10px',
-    fontSize: 12,
-    whiteSpace: 'nowrap'
+/**
+ * Top-level bubble component responsible for configuring BasicBubble based on
+ * properties of a level and student progress.
+ */
+class ProgressTableLevelBubble extends React.PureComponent {
+  static propTypes = {
+    levelStatus: PropTypes.string,
+    levelKind: PropTypes.string,
+    isDisabled: PropTypes.bool,
+    isUnplugged: PropTypes.bool,
+    isConcept: PropTypes.bool,
+    isBonus: PropTypes.bool,
+    isPaired: PropTypes.bool,
+    bubbleSize: PropTypes.oneOf(Object.values(BubbleSize)).isRequired,
+    title: PropTypes.string,
+    url: PropTypes.string
+  };
+
+  static defaultProps = {
+    bubbleSize: BubbleSize.full
+  };
+
+  renderContent() {
+    const {
+      levelStatus,
+      isUnplugged,
+      isBonus,
+      isPaired,
+      title,
+      bubbleSize
+    } = this.props;
+    if (bubbleSize === BubbleSize.dot) {
+      // dot-sized bubbles are too small for content
+      return null;
+    }
+    const isLocked = levelStatus === LevelStatus.locked;
+    return isUnplugged ? (
+      <span>{i18n.unpluggedActivity()}</span>
+    ) : isLocked ? (
+      <FontAwesome icon="lock" />
+    ) : isPaired ? (
+      <FontAwesome icon="users" />
+    ) : isBonus ? (
+      <FontAwesome icon="flag-checkered" />
+    ) : title ? (
+      <span>{title}</span>
+    ) : null;
   }
+
+  render() {
+    const {isUnplugged, isConcept, isDisabled, bubbleSize} = this.props;
+    const bubbleShape = isUnplugged
+      ? BubbleShape.pill
+      : isConcept
+      ? BubbleShape.diamond
+      : BubbleShape.circle;
+
+    const bubble = (
+      <BasicBubble
+        shape={bubbleShape}
+        size={bubbleSize}
+        progressStyle={getProgressStyle(this.props)}
+      >
+        {this.renderContent()}
+      </BasicBubble>
+    );
+
+    if (isDisabled) {
+      return bubble;
+    }
+    return <LinkWrapper {...this.props}>{bubble}</LinkWrapper>;
+  }
+}
+
+/**
+ * Base bubble component defined in terms of shape, size, and style, as opposed
+ * to level-related properties. This component is itself only an empty styled
+ * container, and expects the bubble content (e.g. level number, icon, text) to
+ * be passed in as its children.
+ * @param {BubbleShape} shape
+ * @param {BubbleSize} size
+ * @param {object} progressStyle contains border and background colors
+ * @param {node} children the content to render inside the bubble
+ */
+function BasicBubble({shape, size, progressStyle, children}) {
+  const bubbleStyle = mainBubbleStyle(shape, size, progressStyle);
+  if (shape === BubbleShape.diamond) {
+    return (
+      <DiamondContainer size={size} bubbleStyle={bubbleStyle}>
+        {children}
+      </DiamondContainer>
+    );
+  }
+  return <div style={bubbleStyle}>{children}</div>;
+}
+BasicBubble.propTypes = {
+  shape: PropTypes.oneOf(Object.values(BubbleShape)).isRequired,
+  size: PropTypes.oneOf(Object.values(BubbleSize)).isRequired,
+  progressStyle: PropTypes.object,
+  children: PropTypes.node
 };
 
-function levelStyle(props) {
-  const {levelStatus, levelKind, disabled} = props;
-  return {
-    ...(!disabled && progressStyles.hoverStyle),
-    ...progressStyles.levelProgressStyle(levelStatus, levelKind, disabled)
-  };
-}
-
-function mainStyle(props) {
-  return {
-    ...styles.main,
-    ...levelStyle(props)
-  };
-}
-
-function largeStyle(props) {
-  const {disabled, bonus} = props;
-  return {
-    ...mainStyle(props),
-    ...styles.large,
-    ...(disabled && bonus && styles.bonusDisabled)
-  };
-}
-
-function largeContentStyle(props) {
-  const {bonus, paired} = props;
-  return {
-    ...progressStyles.flex,
-    ...styles.contents,
-    fontSize: paired || bonus ? 14 : 16
-  };
-}
-
-function UnpluggedBubble(props) {
+/**
+ * Container applying rotation transforms and forcing diamond bubbles to have
+ * the same size as circles.
+ * @param {BubbleSize} size
+ * @param {object} bubbleStyle contains rotation transform and progress style
+ * @param {node} children
+ */
+function DiamondContainer({size, bubbleStyle, children}) {
   return (
-    <div
-      style={{
-        ...styles.main,
-        ...styles.unplugged,
-        ...levelStyle(props)
-      }}
-    >
-      <Content {...props} />
-    </div>
-  );
-}
-
-function SmallCircle(props) {
-  return (
-    <div style={{...mainStyle(props), ...styles.smallCircle}}>
-      <Content {...props} />
-    </div>
-  );
-}
-
-function LargeBubble(props) {
-  const BubbleType = props.concept ? LargeDiamond : LargeCircle;
-  return (
-    <div style={styles.container}>
-      <BubbleType {...props} />
-    </div>
-  );
-}
-LargeBubble.propTypes = {
-  concept: PropTypes.bool
-};
-
-function LargeCircle(props) {
-  return (
-    <div style={{...largeStyle(props), ...styles.largeCircle}}>
-      <div style={largeContentStyle(props)}>
-        <Content {...props} />
+    /* Constrain size */
+    <div style={diamondContainerStyle(size)}>
+      {/* Apply rotation transform and progress style */}
+      <div style={bubbleStyle}>
+        {/* Undo the rotation from the parent */}
+        <div style={bubbleStyles.diamondContentTransform}>{children}</div>
       </div>
     </div>
   );
 }
-
-function LargeDiamond(props) {
-  return (
-    <div style={{...largeStyle(props), ...styles.largeDiamond}}>
-      <div style={{...largeContentStyle(props), ...styles.diamondContents}}>
-        <Content {...props} />
-      </div>
-    </div>
-  );
-}
-
-function Content(props) {
-  const {levelStatus, unplugged, bonus, paired, title} = props;
-  const locked = levelStatus === LevelStatus.locked;
-  return unplugged ? (
-    <span>{i18n.unpluggedActivity()}</span>
-  ) : locked ? (
-    <FontAwesome icon="lock" />
-  ) : paired ? (
-    <FontAwesome icon="users" />
-  ) : bonus ? (
-    <FontAwesome icon="flag-checkered" />
-  ) : title ? (
-    <span>{title}</span>
-  ) : null;
-}
-Content.propTypes = {
-  levelStatus: PropTypes.string,
-  unplugged: PropTypes.bool,
-  bonus: PropTypes.bool,
-  paired: PropTypes.bool,
-  title: PropTypes.string
+DiamondContainer.propTypes = {
+  size: PropTypes.oneOf(Object.values(BubbleSize)).isRequired,
+  bubbleStyle: PropTypes.object,
+  children: PropTypes.node
 };
 
 function LinkWrapper(props) {
   return (
-    <a href={props.url} style={progressStyles.link}>
+    <a href={props.url} style={bubbleStyles.link}>
       {props.children}
     </a>
   );
@@ -187,43 +152,10 @@ LinkWrapper.propTypes = {
   children: PropTypes.element.isRequired
 };
 
-class ProgressTableLevelBubble extends React.PureComponent {
-  static propTypes = {
-    levelStatus: PropTypes.string,
-    levelKind: PropTypes.string,
-    disabled: PropTypes.bool.isRequired,
-    unplugged: PropTypes.bool,
-    smallBubble: PropTypes.bool,
-    bonus: PropTypes.bool,
-    paired: PropTypes.bool,
-    concept: PropTypes.bool,
-    title: PropTypes.string,
-    url: PropTypes.string.isRequired
-  };
-
-  render() {
-    const BubbleType = this.props.smallBubble
-      ? SmallCircle
-      : this.props.unplugged
-      ? UnpluggedBubble
-      : LargeBubble;
-
-    const bubble = <BubbleType {...this.props} />;
-
-    if (this.props.disabled) {
-      return bubble;
-    }
-    return <LinkWrapper {...this.props}>{bubble}</LinkWrapper>;
-  }
-}
-
 export default Radium(ProgressTableLevelBubble);
 
 export const unitTestExports = {
-  UnpluggedBubble,
-  SmallCircle,
-  LargeCircle,
-  LargeDiamond,
-  Content,
+  DiamondContainer,
+  BasicBubble,
   LinkWrapper
 };

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableLevelBubble.story.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableLevelBubble.story.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ProgressTableLevelBubble from './ProgressTableLevelBubble';
 import {LevelKind, LevelStatus} from '@cdo/apps/util/sharedConstants';
 import color from '@cdo/apps/util/color';
+import {BubbleSize} from '@cdo/apps/templates/progress/progressStyles';
 
 const statuses = [
   LevelStatus.locked,
@@ -51,7 +52,7 @@ export default storybook => {
               <ProgressTableLevelBubble
                 levelStatus={LevelStatus.not_tried}
                 levelKind={LevelKind.level}
-                disabled={true}
+                isDisabled={true}
                 title={'3'}
                 url={'/foo/bar'}
               />
@@ -66,7 +67,6 @@ export default storybook => {
                 <ProgressTableLevelBubble
                   levelStatus={status}
                   levelKind={LevelKind.level}
-                  disabled={false}
                   title={'3'}
                   url={'/foo/bar'}
                 />
@@ -81,10 +81,10 @@ export default storybook => {
                 <ProgressTableLevelBubble
                   levelStatus={status}
                   levelKind={LevelKind.level}
-                  disabled={status === LevelStatus.locked}
+                  isDisabled={status === LevelStatus.locked}
                   title={'3'}
                   url={'/foo/bar'}
-                  concept={true}
+                  isConcept={true}
                 />
               )
           }))
@@ -97,7 +97,7 @@ export default storybook => {
                 <ProgressTableLevelBubble
                   levelStatus={status}
                   levelKind={LevelKind.assessment}
-                  disabled={status === LevelStatus.locked}
+                  isDisabled={status === LevelStatus.locked}
                   title={'3'}
                   url={'/foo/bar'}
                 />
@@ -112,10 +112,10 @@ export default storybook => {
                 <ProgressTableLevelBubble
                   levelStatus={status}
                   levelKind={LevelKind.level}
-                  disabled={status === LevelStatus.locked}
+                  isDisabled={status === LevelStatus.locked}
                   title={'3'}
                   url={'/foo/bar'}
-                  paired={true}
+                  isPaired={true}
                 />
               )
           }))
@@ -128,10 +128,10 @@ export default storybook => {
                 <ProgressTableLevelBubble
                   levelStatus={status}
                   levelKind={LevelKind.level}
-                  disabled={status === LevelStatus.locked}
+                  isDisabled={status === LevelStatus.locked}
                   title={'3'}
                   url={'/foo/bar'}
-                  bonus={true}
+                  isBonus={true}
                 />
               )
           }))
@@ -144,39 +144,72 @@ export default storybook => {
                 <ProgressTableLevelBubble
                   levelStatus={status}
                   levelKind={LevelKind.level}
-                  disabled={status === LevelStatus.locked}
+                  isDisabled={status === LevelStatus.locked}
                   title={'3'}
                   url={'/foo/bar'}
-                  unplugged={true}
+                  isUnplugged={true}
                 />
               )
           }))
         )
         .concat([
           {
-            name: 'small bubbles',
+            name: 'letter bubbles',
             story: () =>
               wrapMultiple([
                 <ProgressTableLevelBubble
                   levelStatus={LevelStatus.perfect}
-                  disabled={false}
-                  smallBubble={true}
+                  isDisabled={false}
+                  bubbleSize={BubbleSize.letter}
                   title={'a'}
                   url={'/foo/bar'}
                   key={1}
                 />,
                 <ProgressTableLevelBubble
                   levelStatus={LevelStatus.attempted}
-                  disabled={false}
-                  smallBubble={true}
+                  isDisabled={false}
+                  bubbleSize={BubbleSize.letter}
                   title={'b'}
                   url={'/foo/bar'}
                   key={2}
                 />,
                 <ProgressTableLevelBubble
                   levelStatus={LevelStatus.not_tried}
-                  disabled={false}
-                  smallBubble={true}
+                  isDisabled={false}
+                  bubbleSize={BubbleSize.letter}
+                  title={'c'}
+                  url={'/foo/bar'}
+                  key={3}
+                />
+              ])
+          }
+        ])
+        .concat([
+          {
+            name: 'dot bubbles',
+            story: () =>
+              wrapMultiple([
+                <ProgressTableLevelBubble
+                  levelStatus={LevelStatus.perfect}
+                  isDisabled={false}
+                  isConcept={true}
+                  bubbleSize={BubbleSize.dot}
+                  title={'a'}
+                  url={'/foo/bar'}
+                  key={1}
+                />,
+                <ProgressTableLevelBubble
+                  levelStatus={LevelStatus.attempted}
+                  isDisabled={false}
+                  bubbleSize={BubbleSize.dot}
+                  title={'b'}
+                  url={'/foo/bar'}
+                  key={2}
+                />,
+                <ProgressTableLevelBubble
+                  levelStatus={LevelStatus.not_tried}
+                  isDisabled={false}
+                  bubbleSize={BubbleSize.dot}
                   title={'c'}
                   url={'/foo/bar'}
                   key={3}

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableLevelIconSet.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableLevelIconSet.jsx
@@ -30,8 +30,8 @@ const placeholderUnpluggedBubble = (
     <div>
       <ProgressTableLevelBubble
         levelStatus={LevelStatus.not_tried}
-        unplugged={true}
-        disabled={true}
+        isUnplugged={true}
+        isDisabled={true}
         url=""
       />
     </div>

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableLevelSpacer.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableLevelSpacer.jsx
@@ -9,7 +9,8 @@ const styles = {
   },
   node: {
     ...progressStyles.inlineBlock,
-    minWidth: progressStyles.BUBBLE_CONTAINER_WIDTH,
+    minWidth:
+      progressStyles.bubbleContainerWidths[progressStyles.BubbleSize.full],
     textAlign: 'center'
   }
 };
@@ -24,7 +25,9 @@ function SublevelSpacer({sublevelCount}) {
   return (
     <span
       style={{
-        width: sublevelCount * progressStyles.LETTER_BUBBLE_CONTAINER_WIDTH
+        width:
+          sublevelCount *
+          progressStyles.bubbleContainerWidths[progressStyles.BubbleSize.letter]
       }}
     />
   );

--- a/apps/test/unit/templates/sectionProgress/ProgressTableLevelBubbleTest.jsx
+++ b/apps/test/unit/templates/sectionProgress/ProgressTableLevelBubbleTest.jsx
@@ -8,13 +8,17 @@ import color from '@cdo/apps/util/color';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import {LevelStatus, LevelKind} from '@cdo/apps/util/sharedConstants';
 import i18n from '@cdo/locale';
+import {
+  BubbleSize,
+  BubbleShape
+} from '@cdo/apps/templates/progress/progressStyles';
 
 const TITLE = '1';
 
 const defaultProps = {
   levelStatus: LevelStatus.not_tried,
   levelKind: LevelKind.level,
-  disabled: false,
+  isDisabled: false,
   title: TITLE,
   url: '/foo/bar'
 };
@@ -62,11 +66,9 @@ function bubbleContainerStyleForStatus(status, propOverrides = {}) {
       levelStatus={status}
     />
   );
-  const bubbleType = propOverrides.concept
-    ? unitTestExports.LargeDiamond
-    : unitTestExports.LargeCircle;
+
   return wrapper
-    .find(bubbleType)
+    .find(unitTestExports.BasicBubble)
     .at(0)
     .childAt(0)
     .props().style;
@@ -80,41 +82,72 @@ describe('ProgressTableLevelBubble', () => {
 
   it('does not render a link when disabled', () => {
     const wrapper = shallow(
-      <ProgressTableLevelBubble {...defaultProps} disabled={true} />
+      <ProgressTableLevelBubble {...defaultProps} isDisabled={true} />
     );
     expect(wrapper.find(unitTestExports.LinkWrapper)).to.have.lengthOf(0);
   });
 
+  it('renders default bubble with circle shape', () => {
+    const wrapper = mount(<ProgressTableLevelBubble {...defaultProps} />);
+    expect(wrapper.find(unitTestExports.BasicBubble).props().shape).to.equal(
+      BubbleShape.circle
+    );
+  });
+
+  it('renders concept bubble with diamond shape', () => {
+    const wrapper = mount(
+      <ProgressTableLevelBubble {...defaultProps} isConcept={true} />
+    );
+    expect(wrapper.find(unitTestExports.BasicBubble).props().shape).to.equal(
+      BubbleShape.diamond
+    );
+  });
+
+  it('renders unplugged bubble with pill shape', () => {
+    const wrapper = mount(
+      <ProgressTableLevelBubble {...defaultProps} isUnplugged={true} />
+    );
+    expect(wrapper.find(unitTestExports.BasicBubble).props().shape).to.equal(
+      BubbleShape.pill
+    );
+  });
+
   it('shows correct text in unplugged bubble', () => {
     const wrapper = mount(
-      <ProgressTableLevelBubble {...defaultProps} unplugged={true} />
+      <ProgressTableLevelBubble {...defaultProps} isUnplugged={true} />
     );
-    expect(wrapper.find(unitTestExports.UnpluggedBubble)).to.have.lengthOf(1);
-    expect(wrapper.find(unitTestExports.Content).text()).to.equal(
+    expect(wrapper.find(unitTestExports.BasicBubble).text()).to.equal(
       i18n.unpluggedActivity()
     );
   });
 
   it('shows title in normal bubble', () => {
     const wrapper = mount(<ProgressTableLevelBubble {...defaultProps} />);
-    expect(wrapper.find(unitTestExports.LargeCircle)).to.have.lengthOf(1);
-    expect(wrapper.find(unitTestExports.Content).text()).to.equal(TITLE);
+    expect(wrapper.find(unitTestExports.BasicBubble).text()).to.equal(TITLE);
   });
 
   it('shows title in concept bubble', () => {
     const wrapper = mount(
       <ProgressTableLevelBubble {...defaultProps} concept={true} />
     );
-    expect(wrapper.find(unitTestExports.LargeDiamond)).to.have.lengthOf(1);
-    expect(wrapper.find(unitTestExports.Content).text()).to.equal(TITLE);
+    expect(wrapper.find(unitTestExports.BasicBubble).text()).to.equal(TITLE);
   });
 
-  it('shows title in small bubble', () => {
+  it('shows title in letter bubble', () => {
     const wrapper = mount(
-      <ProgressTableLevelBubble {...defaultProps} smallBubble={true} />
+      <ProgressTableLevelBubble
+        {...defaultProps}
+        bubbleSize={BubbleSize.letter}
+      />
     );
-    expect(wrapper.find(unitTestExports.SmallCircle)).to.have.lengthOf(1);
-    expect(wrapper.find(unitTestExports.Content).text()).to.equal(TITLE);
+    expect(wrapper.find(unitTestExports.BasicBubble).text()).to.equal(TITLE);
+  });
+
+  it('does not show title in dot bubble', () => {
+    const wrapper = mount(
+      <ProgressTableLevelBubble {...defaultProps} bubbleSize={BubbleSize.dot} />
+    );
+    expect(wrapper.find(unitTestExports.BasicBubble).text()).to.equal('');
   });
 
   it('shows correct icon when locked', () => {
@@ -131,7 +164,7 @@ describe('ProgressTableLevelBubble', () => {
 
   it('shows correct icon for bonus', () => {
     const wrapper = mount(
-      <ProgressTableLevelBubble {...defaultProps} bonus={true} />
+      <ProgressTableLevelBubble {...defaultProps} isBonus={true} />
     );
     const icon = wrapper.find(FontAwesome);
     expect(icon).to.have.lengthOf(1);
@@ -140,7 +173,7 @@ describe('ProgressTableLevelBubble', () => {
 
   it('shows correct icon for paired', () => {
     const wrapper = mount(
-      <ProgressTableLevelBubble {...defaultProps} paired={true} />
+      <ProgressTableLevelBubble {...defaultProps} isPaired={true} />
     );
     const icon = wrapper.find(FontAwesome);
     expect(icon).to.have.lengthOf(1);
@@ -149,18 +182,15 @@ describe('ProgressTableLevelBubble', () => {
 
   it('only shows paired icon for bonus + paired', () => {
     const wrapper = mount(
-      <ProgressTableLevelBubble {...defaultProps} bonus={true} paired={true} />
+      <ProgressTableLevelBubble
+        {...defaultProps}
+        isBonus={true}
+        isPaired={true}
+      />
     );
     const icon = wrapper.find(FontAwesome);
     expect(icon).to.have.lengthOf(1);
     expect(icon.at(0).props().icon).to.equal('users');
-  });
-
-  it('renders a diamond for concept levels', () => {
-    const style = bubbleContainerStyleForStatus(LevelStatus.not_tried, {
-      concept: true
-    });
-    expect(style.transform).to.equal('rotate(45deg)');
   });
 
   Object.keys(borderColors).forEach(status => {

--- a/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableDetailCellTest.jsx
+++ b/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableDetailCellTest.jsx
@@ -56,14 +56,14 @@ describe('ProgressTableDetailCell', () => {
     const wrapper = setUp();
     const levelBubble3 = wrapper.findWhere(node => node.key() === '999_3');
     const progressBubble = levelBubble3.find(ProgressTableLevelBubble);
-    expect(progressBubble.props().disabled).to.be.true;
+    expect(progressBubble.props().isDisabled).to.be.true;
   });
 
   it('disable is false for progress bubble if there is a bonus and stageExtrasEnabled is true', () => {
     const wrapper = setUp({stageExtrasEnabled: true});
     const levelBubble3 = wrapper.findWhere(node => node.key() === '999_3');
     const progressBubble = levelBubble3.find(ProgressTableLevelBubble);
-    expect(progressBubble.props().disabled).to.be.false;
+    expect(progressBubble.props().isDisabled).to.be.false;
   });
 
   it('generates the right url for level bubble', () => {

--- a/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableLevelIconSetTest.jsx
+++ b/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableLevelIconSetTest.jsx
@@ -3,7 +3,10 @@ import {expect} from '../../../../util/reconfiguredChai';
 import {mount} from 'enzyme';
 import ProgressTableLevelIconSet from '@cdo/apps/templates/sectionProgress/progressTables/ProgressTableLevelIconSet';
 import {unitTestExports} from '@cdo/apps/templates/sectionProgress/progressTables/ProgressTableLevelSpacer';
-import {LETTER_BUBBLE_CONTAINER_WIDTH} from '@cdo/apps/templates/progress/progressStyles';
+import {
+  bubbleContainerWidths,
+  BubbleSize
+} from '@cdo/apps/templates/progress/progressStyles';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import {fakeLevels} from '@cdo/apps/templates/progress/progressTestHelpers';
 
@@ -29,7 +32,7 @@ describe('ProgressTableLevelIconSet', () => {
     const wrapper = mount(<ProgressTableLevelIconSet {...DEFAULT_PROPS} />);
     const sublevelSpacer = wrapper.find(unitTestExports.SublevelSpacer);
     expect(sublevelSpacer.childAt(0).props().style.width).to.equal(
-      2 * LETTER_BUBBLE_CONTAINER_WIDTH
+      2 * bubbleContainerWidths[BubbleSize.letter]
     );
   });
 });


### PR DESCRIPTION
this PR reintroduces #40015, which was reverted when a bug was discovered causing the content columns in `ProgressTableDetailView` to scroll past the bottom of the student list, resulting in white space at the bottom of the content view and misalignment with the student name rows.

the bug turned out to be caused by an inadvertent shrinking of the progress bubbles' content size during the refactor work, which resulted in the table thinking it could fit more rows than it had, thus resulting in that extra white space at the bottom.

the fix was simply to revert the bubble sizes to match what they were previously. details in the comments.