### PR TITLE
Fixing bootstrap files to address missing triangles in marketing summary blocks

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/bootstrap.css
+++ b/pegasus/sites.v3/code.org/public/css/bootstrap.css
@@ -21,10 +21,6 @@ hgroup,
 main,
 nav,
 section,
-summary {
-  display: block;
-}
-
 audio,
 canvas,
 video {

--- a/pegasus/sites.v3/code.org/public/css/bootstrap.css
+++ b/pegasus/sites.v3/code.org/public/css/bootstrap.css
@@ -21,6 +21,10 @@ hgroup,
 main,
 nav,
 section,
+summary {
+  display: block;
+}
+
 audio,
 canvas,
 video {

--- a/pegasus/sites.v3/code.org/styles/040-page.css
+++ b/pegasus/sites.v3/code.org/styles/040-page.css
@@ -62,6 +62,13 @@ em strong, strong em {
   font-family: Gotham\ 7i, sans-serif
 }
 
+/*This can be removed when Bootstrap is updated, as they've addressed
+the bug in the newest version. As-is, this overrides the display:block
+setting that removes our triangle dropdowns on list items.*/
+summary {
+  display: list-item;
+}
+
 th a:active, th a:hover, th a:link, th a:visited {
   color: #fff
 }

--- a/pegasus/sites.v3/csedweek.org/public/css/bootstrap.css
+++ b/pegasus/sites.v3/csedweek.org/public/css/bootstrap.css
@@ -21,10 +21,6 @@ hgroup,
 main,
 nav,
 section,
-summary {
-  display: block;
-}
-
 audio,
 canvas,
 video {

--- a/pegasus/sites.v3/csedweek.org/public/css/bootstrap.css
+++ b/pegasus/sites.v3/csedweek.org/public/css/bootstrap.css
@@ -21,6 +21,10 @@ hgroup,
 main,
 nav,
 section,
+summary {
+  display: block;
+}
+
 audio,
 canvas,
 video {


### PR DESCRIPTION
Picking this up as an extension of Dave's fixes on studio.code.org according to this ticket (and in it, the linked bug description and PR): https://codedotorg.atlassian.net/browse/LP-1856

This will be fixed whenever we update our version of bootstrap- documentation here: https://github.com/twbs/bootstrap/issues/21060

If you don't want to distill from the above git conversation, here's a TL;DR: there is a bug in bootstrap that causes summary display:block to override list view, which has been addressed in the latest version. The recommended fix is what has been implemented in this PR.

I checked both csedweek.org and hourofcode.com and could not find any instances of this bug, so only updating in our code.org files for now.

From the README in this directory: "This directory contains CSS stylesheets that will be bundled into a single `style.css` file (along with the files in `styles_min/`) and externally-loaded in most pages. "

Before:

![image](https://user-images.githubusercontent.com/37230822/115624321-52610a80-a2af-11eb-83a9-53d55c2a513d.png)

After: 

![image](https://user-images.githubusercontent.com/37230822/115770622-c956db80-a361-11eb-98aa-fcf48ff1c40c.png)

