### PR TITLE
Updating hostnames for the allowed list

### DIFF
--- a/dashboard/app/controllers/xhr_proxy_controller.rb
+++ b/dashboard/app/controllers/xhr_proxy_controller.rb
@@ -26,16 +26,15 @@ class XhrProxyController < ApplicationController
 
   # 'code.org' is included so applab apps can access the tables and properties of other applab apps.
   ALLOWED_HOSTNAME_SUFFIXES = %w(
-    allrecipes.com
     apex.oracle.com
+    api.blizzard.com
     api.coinlayer.com
-    api.data.gov
     api.datamuse.com
     api.energidataservice.dk
     api.exchangeratesapi.io
     api.football-data.org
     api.foursquare.com
-    api.fungenerators.com
+    api.github.com
     api.mojang.com
     api.nasa.gov
     api.nookipedia.com
@@ -45,6 +44,7 @@ class XhrProxyController < ApplicationController
     api.pegelalarm.at
     api.randomuser.me
     api.rebrandly.com
+    api.scryfall.com
     api.si.edu
     api.spacexdata.com
     api.spotify.com
@@ -53,10 +53,8 @@ class XhrProxyController < ApplicationController
     api.uclassify.com
     api.waqi.info
     api.zippopotam.us
-    atlas.media.mit.edu
     bible-api.com
     code.org
-    compete.hsctf.com
     covidtracking.com
     cryptonator.com
     data.austintexas.gov
@@ -64,50 +62,39 @@ class XhrProxyController < ApplicationController
     data.gv.at
     data.nasa.gov
     developer.accuweather.com
-    developers.zomato.com
-    donordrive.com
     dweet.io
     enclout.com
-    githubusercontent.com
-    hamlin.myschoolapp.com
     herokuapp.com
     hubblesite.org
     images-api.nasa.gov
     isenseproject.org
     lakeside-cs.org
-    maps.googleapis.com
     opentdb.com
     pixabay.com
     pokeapi.co
     qrng.anu.edu.au
     quandl.com
-    quizlet.com
     rejseplanen.dk
     maker.ifttt.com
-    maps.googleapis.com
+    myschoolapp.com
     noaa.gov
     numbersapi.com
     pastebin.com
     random.org
     restcountries.eu
-    rhcloud.com
     runescape.com
-    samples.openweathermap.org
     sessionserver.mojang.com
-    sheets.googleapis.com
     spreadsheets.google.com
     stats.minecraftservers.org
-    swapi.co
+    swapi.dev
     textures.minecraft.net
     thecatapi.com
     thedogapi.com
     theunitedstates.io
     transitchicago.com
-    translate.yandex.net
     vpic.nhtsa.dot.gov
     wikipedia.org
     worldclockapi.com
-    words.bighugelabs.com
   ).freeze
 
   # How long the content is allowed to be cached

--- a/dashboard/test/controllers/xhr_proxy_controller_test.rb
+++ b/dashboard/test/controllers/xhr_proxy_controller_test.rb
@@ -30,9 +30,8 @@ class XhrProxyControllerTest < ActionController::TestCase
   end
 
   test "should handle query parameters" do
-    url = 'https://api.data.gov/ed/collegescorecard/v1/schools?api_key=test'
-    stub_request(:get, url).to_return(body: XHR_DATA, headers: {content_type: XHR_CONTENT_TYPE})
-    get :get, params: {u: url, c: @channel_id}
+    stub_request(:get, XHR_URI).to_return(body: XHR_DATA, headers: {content_type: XHR_CONTENT_TYPE})
+    get :get, params: {u: XHR_URI, c: @channel_id}
     assert_response :success
     assert_equal XHR_DATA, response.body
   end


### PR DESCRIPTION
Adding:
- api.blizzard.com - student request, adds Blizzard gaming API support
- api.scryfall.com - student request, adds Magic the Gathering card game API support 

Replacing:
- swapi.co - discontinued and can be replaced by swapi.dev https://swapi.dev/about
- githubusercontent.com - no longer supported and can be replaced by api.github.com
- hamlin.myschoolapp.com - replacing with the generic myschoolapp.com so it is not school specific 

Removing:
- api.data.gov — this is just where you get the API key, separate hostnames per service data from federal agencies like the National Park Service, Smithsonian, Department of Justice, FDA, and more - there are so many of these we can let them be requested individually and the Smithsonian for instance is already on our list 
- allrecipes.com - no longer supported
- api.fungenerators.com - costs money with no free option, should be removed
- atlas.media.mit.edu - no longer supported 
- compete.hsctf.com - no longer supported 
- developers.zomato.com - no longer supported 
- donordrive.com - no clear API documentation
- quizlet.com - no longer supported 
- rhcloud.com - no longer supported
- samples.openweathermap.org - remove as this is just sample data 
- sheets.googleapis.com - not needed as we already list googleapis.com
- maps.googleapis.com - not needed as we already list googleapis.com
- translate.yandex.net - costs money, no free option, should be removed
- words.bighugelabs.com - this provides synonyms and antonyms, however, based on this sample API response the content could be inappropriate thus removing

## Links

https://codeorg.zendesk.com/agent/tickets/330908
https://codeorg.zendesk.com/agent/tickets/330690
https://docs.google.com/document/d/1dmVne4jWN4lBLyGERlwPiMK5sDtwCWBh5J1deSonSs0/edit?usp=sharing

## Notes

Are there any risks to removal that require further testing? Most of the remove cases are not working APIs today so low risk, however a few do work but cost money or we believe should be removed. 

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
