### PR TITLE
Fix Dropbox content reversion bug

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -56,6 +56,13 @@ Layout/SpaceInsideHashLiteralBraces:
 Style/WordArray:
   MinSize: 5
 
+Rails/UnknownEnv:
+  Environments:
+    - production
+    - development
+    - test
+    - staging
+    - levelbuilder
 # END CODE.ORG OVERRIDES
 
 # BEGIN BLACKLIST: Below are rules we don't plan to enable in the forseeable

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -56,13 +56,6 @@ Layout/SpaceInsideHashLiteralBraces:
 Style/WordArray:
   MinSize: 5
 
-Rails/UnknownEnv:
-  Environments:
-    - production
-    - development
-    - test
-    - staging
-    - levelbuilder
 # END CODE.ORG OVERRIDES
 
 # BEGIN BLACKLIST: Below are rules we don't plan to enable in the forseeable

--- a/aws/ci_build
+++ b/aws/ci_build
@@ -61,6 +61,31 @@ rescue Exception => msg
   return ''
 end
 
+def protected_git_pull
+  # Use a lock file to prevent git-pull and unison, which both modify files in
+  # local repo, to run at the same time on the staging environment.
+  #
+  # Context: On the staging environment, we use the unison tool to sync content
+  # between local Dropbox and git repo. It works most of the time. However, we've
+  # seen half-dozen cases of Dropbox content being reverted. Those cases happened
+  # a few hours or even a few days after content editors had made file changes.
+  # They mostly coincided with the starts of new builds.
+  # This change is a speculative fix to prevent any potential conflicts between
+  # git-pull and unison.
+  #
+  if Rails.env.staging?
+    FileUtils.touch GIT_PULL_STARTED_PATH
+    # Wait a few seconds to give the unison tool time to finish.
+    # Unison is fast and usually finishes in less than 1 second.
+    sleep 2
+  end
+  RakeUtils.git_pull if count > 0
+ensure
+  if Rails.env.staging? && File.exist?(GIT_PULL_STARTED_PATH)
+    FileUtils.rm GIT_PULL_STARTED_PATH
+  end
+end
+
 def build
   Dir.chdir(deploy_dir) do
     return 0 unless RakeUtils.git_updates_available? || File.file?(STARTED) || !CDO.daemon
@@ -68,31 +93,7 @@ def build
 
     RakeUtils.git_fetch
     count = RakeUtils.git_update_count
-
-    # Use a lock file to prevent git-pull and unison, which both modify files in
-    # local repo, to run at the same time on the staging environment.
-    #
-    # Context: On the staging environment, we use the unison tool to sync content
-    # between local Dropbox and git repo. It works most of the time. However, we've
-    # seen half-dozen cases of Dropbox content being reverted. Those cases happened
-    # a few hours or even a few days after content editors had made file changes.
-    # They mostly coincided with the starts of new builds.
-    # This change is a speculative fix to prevent any potential conflicts between
-    # git-pull and unison.
-    #
-    if Rails.env.staging?
-      FileUtils.touch GIT_PULL_STARTED_PATH
-      # Wait a few seconds to give the unison tool time to finish.
-      # Unison is fast and usually finishes in less than 1 second.
-      sleep 2
-    end
-
-    RakeUtils.git_pull if count > 0
-
-    if Rails.env.staging? && File.exist?(GIT_PULL_STARTED_PATH)
-      FileUtils.rm GIT_PULL_STARTED_PATH
-    end
-
+    protected_git_pull
     count = [1, count].max
 
     log = `git log --pretty=format:"%h %s (%an)" -n #{count}`
@@ -125,10 +126,6 @@ def build
     FileUtils.rm STARTED if File.file?(STARTED)
 
     status
-  end
-ensure
-  if Rails.env.staging? && File.exist?(GIT_PULL_STARTED_PATH)
-    FileUtils.rm GIT_PULL_STARTED_PATH
   end
 end
 

--- a/aws/ci_build
+++ b/aws/ci_build
@@ -73,15 +73,15 @@ def protected_git_pull
   # This change is a speculative fix to prevent any potential conflicts between
   # git-pull and unison.
   #
-  if Rails.env.staging?
+  if rack_env?(:staging)
     FileUtils.touch GIT_PULL_STARTED_PATH
     # Wait a few seconds to give the unison tool time to finish.
     # Unison is fast and usually finishes in less than 1 second.
     sleep 2
   end
-  RakeUtils.git_pull if count > 0
+  RakeUtils.git_pull
 ensure
-  if Rails.env.staging? && File.exist?(GIT_PULL_STARTED_PATH)
+  if rack_env?(:staging) && File.exist?(GIT_PULL_STARTED_PATH)
     FileUtils.rm GIT_PULL_STARTED_PATH
   end
 end
@@ -93,7 +93,7 @@ def build
 
     RakeUtils.git_fetch
     count = RakeUtils.git_update_count
-    protected_git_pull
+    protected_git_pull if count > 0
     count = [1, count].max
 
     log = `git log --pretty=format:"%h %s (%an)" -n #{count}`

--- a/aws/ci_build
+++ b/aws/ci_build
@@ -40,6 +40,7 @@ require 'aws-sdk-cloudwatch'
 STARTED = 'build-started'.freeze
 S3_LOGS_BUCKET = 'cdo-build-logs'.freeze
 S3_LOGS_PREFIX = CDO.name.freeze
+GIT_PULL_STARTED_PATH = deploy_dir('git-pull-started').freeze
 
 # Upload the given log to the logs s3 bucket.
 # @param [String] key where uploaded log should be located
@@ -67,7 +68,31 @@ def build
 
     RakeUtils.git_fetch
     count = RakeUtils.git_update_count
+
+    # Use a lock file to prevent git-pull and unison, both modify files in local
+    # repo, to run at the same time on the staging environment.
+    #
+    # Context: On the staging environment, we use the unison tool to sync content
+    # between local Dropbox and git repo. It works most of the time. However, we've
+    # seen half-dozen cases of Dropbox content being reverted. Those cases happened
+    # a few hours or even a few days after content editors had made file changes.
+    # They mostly coincided with the starts of new builds.
+    # This change is a speculative fix to prevent any potential conflicts between
+    # git-pull and unison.
+    #
+    if Rails.env.staging?
+      FileUtils.touch GIT_PULL_STARTED_PATH
+      # Wait a few seconds to give the unison tool time to finish.
+      # Unison is fast and usually finishes in less than 1 second.
+      sleep 2
+    end
+
     RakeUtils.git_pull if count > 0
+
+    if Rails.env.staging? && File.exist?(GIT_PULL_STARTED_PATH)
+      FileUtils.rm GIT_PULL_STARTED_PATH
+    end
+
     count = [1, count].max
 
     log = `git log --pretty=format:"%h %s (%an)" -n #{count}`

--- a/aws/ci_build
+++ b/aws/ci_build
@@ -69,8 +69,8 @@ def build
     RakeUtils.git_fetch
     count = RakeUtils.git_update_count
 
-    # Use a lock file to prevent git-pull and unison, both modify files in local
-    # repo, to run at the same time on the staging environment.
+    # Use a lock file to prevent git-pull and unison, which both modify files in
+    # local repo, to run at the same time on the staging environment.
     #
     # Context: On the staging environment, we use the unison tool to sync content
     # between local Dropbox and git repo. It works most of the time. However, we've
@@ -125,6 +125,10 @@ def build
     FileUtils.rm STARTED if File.file?(STARTED)
 
     status
+  end
+ensure
+  if Rails.env.staging? && File.exist?(GIT_PULL_STARTED_PATH)
+    FileUtils.rm GIT_PULL_STARTED_PATH
   end
 end
 

--- a/bin/cron/sync_dropbox
+++ b/bin/cron/sync_dropbox
@@ -36,6 +36,8 @@ FOLDERS = {
   "hourofcode.com" => "sites.v3/hourofcode.com"
 }.freeze
 
+GIT_PULL_STARTED_PATH = deploy_dir('git-pull-started').freeze
+
 INTERVAL_SECONDS = 5
 TOTAL_SECONDS = 55 - INTERVAL_SECONDS
 
@@ -45,24 +47,28 @@ logger.load # load errors from most recent sync
 while (Time.now - SCRIPT_START) < TOTAL_SECONDS
   attempt_start = Time.now
   logger.reset_new_events # reset new events such that they represent one run through all FOLDERS
-  FOLDERS.each do |key, value|
-    # 'unison' will sync the two folders. It will return true on success and false on failure.
-    # For full details, see unison's man page. Docs are also here: https://www.cis.upenn.edu/~bcpierce/unison/download/releases/stable/unison-manual.html
-    command = "unison /home/ubuntu/Dropbox/Shared/#{key} /home/ubuntu/staging/pegasus/#{value} -silent -ignore \"Name .dropbox\" -auto -perms 0 -dontchmod -log -logfile /home/ubuntu/unison.log"
-    stdout, stderr, _ = Open3.capture3(command)
-    if stdout == "" && stderr == ""
-      HooksUtils.get_unstaged_files.each do |filename|
-        ChatClient.log("<@#{DevelopersTopic.dotd}> INVALID FILENAME: #{filename}", color: 'red') if HooksUtils.prohibited?(filename) && Time.now.sec % 59 == 0
+  # To prevent any potential conflict between git-pull and unison on the staging
+  # environment, only run unison when git-pull is not running.
+  unless File.file?(GIT_PULL_STARTED_PATH)
+    FOLDERS.each do |key, value|
+      # 'unison' will sync the two folders. It will return true on success and false on failure.
+      # For full details, see unison's man page. Docs are also here: https://www.cis.upenn.edu/~bcpierce/unison/download/releases/stable/unison-manual.html
+      command = "unison /home/ubuntu/Dropbox/Shared/#{key} /home/ubuntu/staging/pegasus/#{value} -silent -ignore \"Name .dropbox\" -auto -perms 0 -dontchmod -log -logfile /home/ubuntu/unison.log"
+      stdout, stderr, _ = Open3.capture3(command)
+      if stdout == "" && stderr == ""
+        HooksUtils.get_unstaged_files.each do |filename|
+          ChatClient.log("<@#{DevelopersTopic.dotd}> INVALID FILENAME: #{filename}", color: 'red') if HooksUtils.prohibited?(filename) && Time.now.sec % 59 == 0
+        end
+      else
+        error_message = <<~ERROR_MSG
+                          <!here> Error syncing Dropbox and staging
+                          Dropbox directory: #{key}
+                          pegasus directory: #{value}
+                          stdout: #{stdout}
+                          stderr: #{stderr}
+                        ERROR_MSG
+        logger.record error_message
       end
-    else
-      error_message = <<~ERROR_MSG
-                        <!here> Error syncing Dropbox and staging
-                        Dropbox directory: #{key}
-                        pegasus directory: #{value}
-                        stdout: #{stdout}
-                        stderr: #{stderr}
-                      ERROR_MSG
-      logger.record error_message
     end
   end
   current_time = Time.now


### PR DESCRIPTION
Use a lock file to prevent git-pull and unison, both modify files in local repo, to run at the same time on the staging environment.

## Background
On the staging environment, we use the unison tool to sync content between local Dropbox and git repo. It works most of the time. However, we've seen half-dozen cases of Dropbox content being reverted. Those cases happened a few hours or even a few days after content editors had made file changes. They mostly coincided with the starts of new builds. 

This change is a speculative fix to prevent any potential conflicts between git-pull and unison.

## Test story
Create an adhoc and manually trigger `aws/ci_build`. See [Slack thread](https://codedotorg.slack.com/archives/C03CK49G9/p1619125157440400).

## Links
The most recent case 
- Amy, circuitplayground.md.erb, reverted 4/14/2021. [Slack thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1618854236186400)

Previous cases
- Jake, `international_partners_table.md` reverted 2/8/21 and 12/12/20
- Eric, `donors.haml` reverted 3/2/21
- Eric, `middle-high-alt.md.erb` reverted twice 3/18/21
- Eric, Rosie, `csa.md.erb` reverted 3/18/21
- Amy, `elementary-sign-up.md.erb`, `status_signup.md.erb`, `CSPStatus_Signup.md.erb`, reverted 3/30/2021
- Katie, `landscape.haml` reverted 4/8/2021

Task tracked by https://codedotorg.atlassian.net/browse/FND-1532.

## Scan unison.log to find silently reverted files 
* On the staging machine, search files recently copied from the local git repo to the Dropbox folder:
  `tail ~/unison.log -n 4000 | egrep "Updating file public.*(.md|.erb|.haml) from /home/ubuntu/staging/"`

* For each file, find all the recent moves between the Dropbox folder and local git repo:
  `tail ~/unison.log -n 4000 | egrep "public/circuitplayground.md.erb|started propagating changes at"`

* Check file history in git
  `git log -4 pegasus/sites.v3/code.org/public/circuitplayground.md.erb | grep 'Date'`

* Check build history on Slack channel `#infra-staging`. 
  * Option 1: Search in Slack using `"in:#infra-staging after:4/18/2021 before:4/20/2021 Running CI build"`
  * Option 2: Query from a terminal 
    * `curl -X POST -d @slack_token.txt https://slack.com/api/search.messages?query=in%3A%23infra-staging%20after%3A4%2F19%2F2021%20Running%20CI%20build&sort=timestamp&pretty=1`
    * `slack_token.txt` content: `token: <token_value>`

* A file is inadvertently reverted if it is copied from the git repo to the Dropbox folder but there isn't a git change preceding that.

## Alternative option
`git` creates and removes `index.lock` when it performs tasks affecting the local file system. We could use `index.lock` instead of `git-pull-started`. However, if git-pull starts after unison has started, using `index.lock` doesn't help.
For more information,  see this [Slack thread](https://codedotorg.slack.com/archives/CFTFD6BPV/p1618937464251300).

## Next steps after merging
- [ ] Delete `adhoc-ha-dropbox-reversion-fix` adhoc.
- [ ] Periodically and manually monitor unison.log to detect file reversion. Maybe once a week.
- [ ] Automate the monitoring process by creating a script to merge data from the unison.log, git history and build history.