### PR TITLE
ProgressTableLevelBubble caching

### DIFF
--- a/apps/src/templates/progress/BubbleFactory.jsx
+++ b/apps/src/templates/progress/BubbleFactory.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import classNames from 'classnames';
 import i18n from '@cdo/locale';
-import {LevelStatus} from '@cdo/apps/util/sharedConstants';
 import {
   bubbleStyles,
   BubbleSize,
@@ -102,12 +101,12 @@ LinkWrapper.propTypes = {
  */
 
 export function getBubbleContent(
+  isLocked,
   isUnplugged,
   isBonus,
   isPaired,
   title,
-  bubbleSize,
-  status
+  bubbleSize
 ) {
   if (bubbleSize === BubbleSize.dot) {
     // dot-sized bubbles are too small for content
@@ -115,7 +114,7 @@ export function getBubbleContent(
   }
   return isUnplugged ? (
     <span>{i18n.unpluggedActivity()}</span>
-  ) : isBubbleLockedForStatus(status) ? (
+  ) : isLocked ? (
     <FontAwesome icon="lock" />
   ) : isPaired ? (
     <FontAwesome icon="users" />

--- a/apps/src/templates/progress/BubbleFactory.jsx
+++ b/apps/src/templates/progress/BubbleFactory.jsx
@@ -134,10 +134,8 @@ export function getBubbleShape(isUnplugged, isConcept) {
     : BubbleShape.circle;
 }
 
-export function getBubbleClassNames(isDisabled, status) {
-  return classNames('progress-bubble', {
-    enabled: isBubbleEnabled(isDisabled, status)
-  });
+export function getBubbleClassNames(isEnabled) {
+  return classNames('progress-bubble', {enabled: isEnabled});
 }
 
 export const unitTestExports = {

--- a/apps/src/templates/progress/BubbleFactory.jsx
+++ b/apps/src/templates/progress/BubbleFactory.jsx
@@ -1,0 +1,145 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import FontAwesome from '@cdo/apps/templates/FontAwesome';
+import classNames from 'classnames';
+import i18n from '@cdo/locale';
+import {LevelStatus} from '@cdo/apps/util/sharedConstants';
+import {
+  bubbleStyles,
+  BubbleSize,
+  BubbleShape,
+  mainBubbleStyle,
+  diamondContainerStyle
+} from '@cdo/apps/templates/progress/progressStyles';
+
+/**
+ * Base bubble component defined in terms of shape, size, and style, as opposed
+ * to level-related properties. This component is itself only an empty styled
+ * container, and expects the bubble content (e.g. level number, icon, text) to
+ * be passed in as its children.
+ * @param {BubbleShape} shape
+ * @param {BubbleSize} size
+ * @param {object} progressStyle contains border and background colors
+ * @param {string} classNames applies hover effect if enabled
+ * @param {node} children the content to render inside the bubble
+ */
+export function BasicBubble({
+  shape,
+  size,
+  progressStyle,
+  classNames,
+  children
+}) {
+  const bubbleStyle = mainBubbleStyle(shape, size, progressStyle);
+  if (shape === BubbleShape.diamond) {
+    return (
+      <DiamondContainer
+        size={size}
+        bubbleStyle={bubbleStyle}
+        classNames={classNames}
+      >
+        {children}
+      </DiamondContainer>
+    );
+  }
+  return (
+    <div className={classNames} style={bubbleStyle}>
+      {children}
+    </div>
+  );
+}
+BasicBubble.propTypes = {
+  shape: PropTypes.oneOf(Object.values(BubbleShape)).isRequired,
+  size: PropTypes.oneOf(Object.values(BubbleSize)).isRequired,
+  progressStyle: PropTypes.object,
+  classNames: PropTypes.string,
+  children: PropTypes.node
+};
+
+/**
+ * Container applying rotation transforms and forcing diamond bubbles to have
+ * the same size as circles.
+ * @param {BubbleSize} size
+ * @param {object} bubbleStyle contains rotation transform and progress style
+ * @param {string} classNames applies hover effect if enabled
+ * @param {node} children
+ */
+function DiamondContainer({size, bubbleStyle, classNames, children}) {
+  return (
+    /* Constrain size */
+    <div style={diamondContainerStyle(size)}>
+      {/* Apply rotation transform, progress style, and hover effect */}
+      <div className={classNames} style={bubbleStyle}>
+        {/* Undo the rotation from the parent */}
+        <div style={bubbleStyles.diamondContentTransform}>{children}</div>
+      </div>
+    </div>
+  );
+}
+DiamondContainer.propTypes = {
+  size: PropTypes.oneOf(Object.values(BubbleSize)).isRequired,
+  bubbleStyle: PropTypes.object,
+  classNames: PropTypes.string,
+  children: PropTypes.node
+};
+
+export function LinkWrapper({url, children}) {
+  return (
+    <a href={url} style={bubbleStyles.link}>
+      {children}
+    </a>
+  );
+}
+LinkWrapper.propTypes = {
+  url: PropTypes.string.isRequired,
+  children: PropTypes.element.isRequired
+};
+
+/**
+ * =======================
+ * Helpers
+ * =======================
+ */
+
+export function getBubbleContent(
+  isUnplugged,
+  isBonus,
+  isPaired,
+  title,
+  bubbleSize,
+  status
+) {
+  if (bubbleSize === BubbleSize.dot) {
+    // dot-sized bubbles are too small for content
+    return null;
+  }
+  return isUnplugged ? (
+    <span>{i18n.unpluggedActivity()}</span>
+  ) : isBubbleLockedForStatus(status) ? (
+    <FontAwesome icon="lock" />
+  ) : isPaired ? (
+    <FontAwesome icon="users" />
+  ) : isBonus ? (
+    <FontAwesome icon="flag-checkered" />
+  ) : title ? (
+    <span>{title}</span>
+  ) : null;
+}
+
+export function getBubbleShape(isUnplugged, isConcept) {
+  return isUnplugged
+    ? BubbleShape.pill
+    : isConcept
+    ? BubbleShape.diamond
+    : BubbleShape.circle;
+}
+
+export function getBubbleClassNames(isDisabled, status) {
+  return classNames('progress-bubble', {
+    enabled: isBubbleEnabled(isDisabled, status)
+  });
+}
+
+export const unitTestExports = {
+  DiamondContainer
+};

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableDetailCell.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableDetailCell.jsx
@@ -63,7 +63,6 @@ export default class ProgressTableDetailCell extends React.Component {
               onClick={_ => this.recordBubbleClick(sublevel.id)}
             >
               <ProgressTableLevelBubble
-                levelId={sublevel.id}
                 levelStatus={subStatus}
                 bubbleSize={progressStyles.BubbleSize.letter}
                 isBonus={sublevel.bonus}

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableDetailCell.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableDetailCell.jsx
@@ -69,7 +69,6 @@ export default class ProgressTableDetailCell extends React.Component {
                 isConcept={sublevel.isConceptLevel}
                 title={sublevel.bubbleText}
                 url={this.buildBubbleUrl(sublevel)}
-                useCache={true}
               />
             </div>
           );
@@ -95,7 +94,6 @@ export default class ProgressTableDetailCell extends React.Component {
             isConcept={level.isConceptLevel}
             title={level.bubbleText}
             url={url}
-            useCache={true}
           />
         </div>
         {level.sublevels && this.renderSublevels(level)}

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableDetailCell.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableDetailCell.jsx
@@ -63,12 +63,14 @@ export default class ProgressTableDetailCell extends React.Component {
               onClick={_ => this.recordBubbleClick(sublevel.id)}
             >
               <ProgressTableLevelBubble
+                levelId={sublevel.id}
                 levelStatus={subStatus}
                 bubbleSize={progressStyles.BubbleSize.letter}
                 isBonus={sublevel.bonus}
                 isConcept={sublevel.isConceptLevel}
                 title={sublevel.bubbleText}
                 url={this.buildBubbleUrl(sublevel)}
+                useCache={true}
               />
             </div>
           );
@@ -94,6 +96,7 @@ export default class ProgressTableDetailCell extends React.Component {
             isConcept={level.isConceptLevel}
             title={level.bubbleText}
             url={url}
+            useCache={true}
           />
         </div>
         {level.sublevels && this.renderSublevels(level)}

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableDetailCell.story.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableDetailCell.story.jsx
@@ -17,11 +17,11 @@ const statusForLevel = [
 const levels = fakeLevels(5);
 levels[0].isConceptLevel = true;
 
-const diamondLevels = fakeLevels(2, {startLevel: 6});
+const diamondLevels = fakeLevels(2);
 diamondLevels[0].isConceptLevel = true;
 diamondLevels[1].isConceptLevel = true;
 
-const unpluggedLevel = fakeLevel({id: 8, isUnplugged: true});
+const unpluggedLevel = fakeLevel({id: 2, isUnplugged: true});
 
 const studentProgress = fakeProgressForLevels(levels);
 levels.forEach(
@@ -31,17 +31,12 @@ levels.forEach(
 const pairedProgress = fakeProgressForLevels(levels);
 pairedProgress[levels[0].id].paired = true;
 
-const sublevels = fakeLevels(5, {startLevel: 9});
+const sublevels = fakeLevels(5);
 sublevels.forEach((sub, index) => {
   sub.bubbleText = String.fromCharCode('a'.charCodeAt(0) + index);
 });
 const levelWithSublevels = fakeLevels(1)[0];
 levelWithSublevels.sublevels = sublevels;
-
-const sublevelProgress = fakeProgressForLevels(sublevels);
-sublevels.forEach(
-  (level, index) => (sublevelProgress[level.id].status = statusForLevel[index])
-);
 
 /**
  * This wrapper places the component in the same table structure that will be
@@ -77,7 +72,7 @@ export default storybook => {
               studentId={1}
               sectionId={1}
               levels={[levelWithSublevels]}
-              studentProgress={{...studentProgress, ...sublevelProgress}}
+              studentProgress={studentProgress}
             />
           )
       },

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableDetailCell.story.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableDetailCell.story.jsx
@@ -17,11 +17,11 @@ const statusForLevel = [
 const levels = fakeLevels(5);
 levels[0].isConceptLevel = true;
 
-const diamondLevels = fakeLevels(2);
+const diamondLevels = fakeLevels(2, {startLevel: 6});
 diamondLevels[0].isConceptLevel = true;
 diamondLevels[1].isConceptLevel = true;
 
-const unpluggedLevel = fakeLevel({id: 2, isUnplugged: true});
+const unpluggedLevel = fakeLevel({id: 8, isUnplugged: true});
 
 const studentProgress = fakeProgressForLevels(levels);
 levels.forEach(
@@ -31,12 +31,17 @@ levels.forEach(
 const pairedProgress = fakeProgressForLevels(levels);
 pairedProgress[levels[0].id].paired = true;
 
-const sublevels = fakeLevels(5);
+const sublevels = fakeLevels(5, {startLevel: 9});
 sublevels.forEach((sub, index) => {
   sub.bubbleText = String.fromCharCode('a'.charCodeAt(0) + index);
 });
 const levelWithSublevels = fakeLevels(1)[0];
 levelWithSublevels.sublevels = sublevels;
+
+const sublevelProgress = fakeProgressForLevels(sublevels);
+sublevels.forEach(
+  (level, index) => (sublevelProgress[level.id].status = statusForLevel[index])
+);
 
 /**
  * This wrapper places the component in the same table structure that will be
@@ -72,7 +77,7 @@ export default storybook => {
               studentId={1}
               sectionId={1}
               levels={[levelWithSublevels]}
-              studentProgress={studentProgress}
+              studentProgress={{...studentProgress, ...sublevelProgress}}
             />
           )
       },
@@ -136,19 +141,6 @@ export default storybook => {
               studentId={1}
               sectionId={1}
               levels={[unpluggedLevel]}
-              studentProgress={studentProgress}
-            />
-          )
-      },
-      {
-        name: 'level with sublevels',
-        description: 'Should show small dots for sublevels',
-        story: () =>
-          wrapped(
-            <ProgressTableDetailCell
-              studentId={1}
-              sectionId={1}
-              levels={[levelWithSublevels]}
               studentProgress={studentProgress}
             />
           )

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableLevelBubble.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableLevelBubble.jsx
@@ -73,7 +73,6 @@ export default class ProgressTableLevelBubble extends React.PureComponent {
       title,
       bubbleSize
     } = this.props;
-
     const content = getBubbleContent(
       isLocked,
       isUnplugged,
@@ -82,12 +81,24 @@ export default class ProgressTableLevelBubble extends React.PureComponent {
       title,
       bubbleSize
     );
+    return this.renderBasicBubble(
+      getBubbleShape(isUnplugged, isConcept),
+      bubbleSize,
+      levelProgressStyle(levelStatus, levelKind),
+      content
+    );
+  }
 
+  /**
+   * We use this helper as a testing hook to intercept the explicit props used
+   * to render the `BasicBubble`.
+   */
+  renderBasicBubble(shape, size, progressStyle, content) {
     return (
       <BasicBubble
-        shape={getBubbleShape(isUnplugged, isConcept)}
-        size={bubbleSize}
-        progressStyle={levelProgressStyle(levelStatus, levelKind)}
+        shape={shape}
+        size={size}
+        progressStyle={progressStyle}
         classNames={getBubbleClassNames(true)}
       >
         {content}

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableLevelBubble.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableLevelBubble.jsx
@@ -1,30 +1,27 @@
 import React from 'react';
-import ReactDOMServer from 'react-dom/server';
 import PropTypes from 'prop-types';
-import FontAwesome from '@cdo/apps/templates/FontAwesome';
-import classNames from 'classnames';
-import i18n from '@cdo/locale';
 import {LevelKind} from '@cdo/apps/util/sharedConstants';
+import {BubbleSize} from '@cdo/apps/templates/progress/progressStyles';
 import {
-  bubbleStyles,
-  BubbleSize,
-  BubbleShape,
-  mainBubbleStyle,
-  diamondContainerStyle,
-  levelProgressStyle
-} from '@cdo/apps/templates/progress/progressStyles';
-
-/**
- * Our progress table displays thousands of bubbles. However, the vast majority
- * of those are duplicated in all aspects except the url they link to. Thus we
- * are able to improve rendering performance by caching the HTML for the
- * underlying `BasicBubble` to avoid recreating ones we already have.
- */
-const bubbleHtmlCache = {};
+  BasicBubble,
+  LinkWrapper,
+  getBubbleContent,
+  getBubbleShape
+} from '@cdo/apps/templates/progress/BubbleFactory';
+import CachedElement from '@cdo/apps/util/CachedElement';
+import {levelProgressStyle} from '../../progress/progressStyles';
 
 /**
  * Top-level bubble component responsible for configuring BasicBubble based on
  * properties of a level and student progress.
+ *
+ * Our progress table displays thousands of these bubbles. However, the vast
+ * majority of them are duplicated in all aspects except the url they link to.
+ * Thus we are able to improve rendering performance by caching the HTML for the
+ * underlying `BasicBubble` to avoid recreating ones we already have.
+ *
+ * Note: if adding pr removing props in this component, be sure to read the
+ * comment for `getCacheKey` and update accordingly if necessary.
  */
 export default class ProgressTableLevelBubble extends React.PureComponent {
   static propTypes = {
@@ -37,35 +34,72 @@ export default class ProgressTableLevelBubble extends React.PureComponent {
     isPaired: PropTypes.bool,
     bubbleSize: PropTypes.oneOf(Object.values(BubbleSize)).isRequired,
     title: PropTypes.string,
-    url: PropTypes.string,
-    useCache: PropTypes.bool
+    url: PropTypes.string
   };
 
   static defaultProps = {
     bubbleSize: BubbleSize.full
   };
 
-  getBubbleShape() {
-    return this.props.isUnplugged
-      ? BubbleShape.pill
-      : this.props.isConcept
-      ? BubbleShape.diamond
-      : BubbleShape.circle;
+  constructor(props) {
+    super(props);
+    this.createBubbleElement = this.createBubbleElement.bind(this);
   }
 
-  /**
-   * We can't use our usual `progressStyles.hoverStyle` for hover effect here
-   * because we can't use radium in our cached html, so instead we
-   * conditionally add a CSS class to accomplish the same thing.
-   */
-  getClassNames() {
-    return classNames('progress-bubble', {
-      enabled: this.isEnabled()
-    });
+  render() {
+    return (
+      <LinkWrapper url={this.props.url}>
+        <CachedElement
+          elementType={'BasicBubble'}
+          cacheKey={this.getCacheKey()}
+          createElement={this.createBubbleElement}
+        />
+      </LinkWrapper>
+    );
+  }
+
+  createBubbleElement() {
+    const {
+      levelStatus,
+      levelKind,
+      isUnplugged,
+      isConcept,
+      isBonus,
+      isPaired,
+      title,
+      bubbleSize
+    } = this.props;
+    return (
+      <BasicBubble
+        shape={getBubbleShape(isUnplugged, isConcept)}
+        size={bubbleSize}
+        progressStyle={levelProgressStyle(levelStatus, levelKind)}
+        classNames="progress-bubble"
+      >
+        {getBubbleContent(
+          isUnplugged,
+          isBonus,
+          isPaired,
+          title,
+          bubbleSize,
+          levelStatus
+        )}
+      </BasicBubble>
+    );
   }
 
   /**
    * Determines the simplest key to use for this bubble configuration.
+   *
+   * Note: a more general approach to cache key generation was considered, but
+   * we found that taking advantage of our contextual knowledge of what makes a
+   * key/bubble pair unique enables us to to optimize key length, which results
+   * in a noticeable-enough performance improvement to warrant the additional
+   * complexity here.
+   *
+   * However, that means future maintainers of this component will need to
+   * think carefully about whether the addition or removal of props in this
+   * component will require an update to this function.
    */
   getCacheKey() {
     const {
@@ -73,181 +107,44 @@ export default class ProgressTableLevelBubble extends React.PureComponent {
       levelStatus,
       levelKind,
       isUnplugged,
+      isConcept,
       isBonus,
       isPaired,
       title,
       bubbleSize
     } = this.props;
 
-    let statusString = `status=${levelStatus}`;
+    // sacrificing key readability for every little performance boost ("sts")
+    let statusString = `sts=${levelStatus}`;
+
+    // we need to explicitly specify if the level is an assessment since
+    // assessment bubble are a different color than regular bubbles.
     if (levelKind === LevelKind.assessment) {
-      statusString = `assessment:${statusString}`;
+      statusString = `ass:${statusString}`;
     }
 
+    // letter bubbles and unplugged bubbles are all of the same shape and
+    // content, so for those we can return a shorter key.
     if (bubbleSize === BubbleSize.letter) {
-      return `letter:title=${title}&${statusString}`;
+      return `ltr:ttl=${title}&${statusString}`;
     } else if (isUnplugged) {
-      `unplugged:${statusString}`;
+      return `unp:${statusString}`;
     }
 
-    const shapeString = `shape=${this.getBubbleShape()}`;
+    // in the general case, we need to include all the properties that affect
+    // the bubble's style in the cache key, which include the shape, status,
+    // and all the props used to determine the content
+    const shapeString = `shp=${getBubbleShape(isUnplugged, isConcept)}`;
     const contentString = isLocked
-      ? `locked:`
+      ? `lkd:`
       : isPaired
-      ? `paired:`
+      ? `prd:`
       : isBonus
-      ? `bonus:`
+      ? `bns:`
       : title
-      ? `title=${title}`
+      ? `ttl=${title}`
       : null;
 
     return `${contentString}&${shapeString}&${statusString}`;
   }
-
-  /**
-   * Retrieve cached html if we have it, otherwise create and cache it.
-   */
-  getOrCreateHtml() {
-    const cacheKey = this.getCacheKey();
-    let bubbleHtml = bubbleHtmlCache[cacheKey];
-    if (!bubbleHtml) {
-      bubbleHtml = this.createHtml();
-      bubbleHtmlCache[cacheKey] = bubbleHtml;
-    }
-    return bubbleHtml;
-  }
-
-  createHtml() {
-    return ReactDOMServer.renderToStaticMarkup(this.createBubbleElement());
-  }
-
-  createBubbleElement() {
-    return (
-      <BasicBubble
-        shape={this.getBubbleShape()}
-        size={this.props.bubbleSize}
-        progressStyle={levelProgressStyle(
-          this.props.levelStatus,
-          this.props.levelKind
-        )}
-        classNames="progress-bubble"
-      >
-        {this.renderContent()}
-      </BasicBubble>
-    );
-  }
-
-  renderContent() {
-    const {isUnplugged, isBonus, isPaired, title, bubbleSize} = this.props;
-    if (bubbleSize === BubbleSize.dot) {
-      // dot-sized bubbles are too small for content
-      return null;
-    }
-    return isUnplugged ? (
-      <span>{i18n.unpluggedActivity()}</span>
-    ) : this.isLocked() ? (
-      <FontAwesome icon="lock" />
-    ) : isPaired ? (
-      <FontAwesome icon="users" />
-    ) : isBonus ? (
-      <FontAwesome icon="flag-checkered" />
-    ) : title ? (
-      <span>{title}</span>
-    ) : null;
-  }
-
-  render() {
-    let bubble;
-    if (this.props.useCache) {
-      const bubbleHtml = this.getOrCreateHtml();
-      // eslint-disable-next-line react/no-danger
-      bubble = <div dangerouslySetInnerHTML={{__html: bubbleHtml}} />;
-    } else {
-      bubble = this.createBubbleElement();
-    }
-    return <LinkWrapper url={this.props.url}>{bubble}</LinkWrapper>;
-  }
 }
-
-/**
- * Base bubble component defined in terms of shape, size, and style, as opposed
- * to level-related properties. This component is itself only an empty styled
- * container, and expects the bubble content (e.g. level number, icon, text) to
- * be passed in as its children.
- * @param {BubbleShape} shape
- * @param {BubbleSize} size
- * @param {object} progressStyle contains border and background colors
- * @param {string} classNames applies hover effect if enabled
- * @param {node} children the content to render inside the bubble
- */
-function BasicBubble({shape, size, progressStyle, classNames, children}) {
-  const bubbleStyle = mainBubbleStyle(shape, size, progressStyle);
-  if (shape === BubbleShape.diamond) {
-    return (
-      <DiamondContainer
-        size={size}
-        bubbleStyle={bubbleStyle}
-        classNames={classNames}
-      >
-        {children}
-      </DiamondContainer>
-    );
-  }
-  return (
-    <div className={classNames} style={bubbleStyle}>
-      {children}
-    </div>
-  );
-}
-BasicBubble.propTypes = {
-  shape: PropTypes.oneOf(Object.values(BubbleShape)).isRequired,
-  size: PropTypes.oneOf(Object.values(BubbleSize)).isRequired,
-  progressStyle: PropTypes.object,
-  classNames: PropTypes.string,
-  children: PropTypes.node
-};
-
-/**
- * Container applying rotation transforms and forcing diamond bubbles to have
- * the same size as circles.
- * @param {BubbleSize} size
- * @param {object} bubbleStyle contains rotation transform and progress style
- * @param {string} classNames applies hover effect if enabled
- * @param {node} children
- */
-function DiamondContainer({size, bubbleStyle, classNames, children}) {
-  return (
-    /* Constrain size */
-    <div style={diamondContainerStyle(size)}>
-      {/* Apply rotation transform, progress style, and hover effect */}
-      <div className={classNames} style={bubbleStyle}>
-        {/* Undo the rotation from the parent */}
-        <div style={bubbleStyles.diamondContentTransform}>{children}</div>
-      </div>
-    </div>
-  );
-}
-DiamondContainer.propTypes = {
-  size: PropTypes.oneOf(Object.values(BubbleSize)).isRequired,
-  bubbleStyle: PropTypes.object,
-  classNames: PropTypes.string,
-  children: PropTypes.node
-};
-
-function LinkWrapper({url, children}) {
-  return (
-    <a href={url} style={bubbleStyles.link}>
-      {children}
-    </a>
-  );
-}
-LinkWrapper.propTypes = {
-  url: PropTypes.string.isRequired,
-  children: PropTypes.element.isRequired
-};
-
-export const unitTestExports = {
-  DiamondContainer,
-  BasicBubble,
-  LinkWrapper
-};

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableLevelBubble.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableLevelBubble.jsx
@@ -6,6 +6,7 @@ import {
   BasicBubble,
   LinkWrapper,
   getBubbleContent,
+  getBubbleClassNames,
   getBubbleShape
 } from '@cdo/apps/templates/progress/BubbleFactory';
 import CachedElement from '@cdo/apps/util/CachedElement';
@@ -71,21 +72,24 @@ export default class ProgressTableLevelBubble extends React.PureComponent {
       title,
       bubbleSize
     } = this.props;
+
+    const content = getBubbleContent(
+      isUnplugged,
+      isBonus,
+      isPaired,
+      title,
+      bubbleSize,
+      levelStatus
+    );
+
     return (
       <BasicBubble
         shape={getBubbleShape(isUnplugged, isConcept)}
         size={bubbleSize}
         progressStyle={levelProgressStyle(levelStatus, levelKind)}
-        classNames="progress-bubble"
+        classNames={getBubbleClassNames(true)}
       >
-        {getBubbleContent(
-          isUnplugged,
-          isBonus,
-          isPaired,
-          title,
-          bubbleSize,
-          levelStatus
-        )}
+        {content}
       </BasicBubble>
     );
   }

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableLevelBubble.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableLevelBubble.jsx
@@ -12,18 +12,20 @@ import CachedElement from '@cdo/apps/util/CachedElement';
 import {levelProgressStyle} from '../../progress/progressStyles';
 
 /**
- * Top-level bubble component responsible for configuring BasicBubble based on
- * properties of a level and student progress.
+ * Bubble component designed specifically for use in our section progress
+ * table, responsible for configuring `BasicBubble` based on properties of a
+ * level and student progress, and generating cache keys from same.
  *
  * Our progress table displays thousands of these bubbles. However, the vast
  * majority of them are duplicated in all aspects except the url they link to.
- * Thus we are able to improve rendering performance by caching the HTML for the
- * underlying `BasicBubble` to avoid recreating ones we already have.
- *
- * Note: if adding pr removing props in this component, be sure to read the
- * comment for `getCacheKey` and update accordingly if necessary.
+ * Thus we are able to improve rendering performance by caching the HTML for
+ * the underlying `BasicBubble` to avoid recreating ones we already have.
  */
 export default class ProgressTableLevelBubble extends React.PureComponent {
+  /**
+   * Note: if adding or removing props in this component, be sure to read the
+   * comment for `getCacheKey` and update accordingly if necessary.
+   */
   static propTypes = {
     levelStatus: PropTypes.string,
     levelKind: PropTypes.string,
@@ -100,6 +102,11 @@ export default class ProgressTableLevelBubble extends React.PureComponent {
    * However, that means future maintainers of this component will need to
    * think carefully about whether the addition or removal of props in this
    * component will require an update to this function.
+   *
+   * The general requirement is that if a property affects how the rendered
+   * bubble will appear, it should be included in the key. That includes
+   * properties related to shape and size, as well as anything passed into
+   * `getProgressStyle` and `getBubbleContent`.
    */
   getCacheKey() {
     const {
@@ -117,10 +124,10 @@ export default class ProgressTableLevelBubble extends React.PureComponent {
     // sacrificing key readability for every little performance boost ("sts")
     let statusString = `sts=${levelStatus}`;
 
-    // we need to explicitly specify if the level is an assessment since
-    // assessment bubble are a different color than regular bubbles.
+    // we need to explicitly specify if the level is an assessment, since
+    // assessment bubbles are a different color than regular bubbles.
     if (levelKind === LevelKind.assessment) {
-      statusString = `ass:${statusString}`;
+      statusString = `asmt:${statusString}`;
     }
 
     // letter bubbles and unplugged bubbles are all of the same shape and
@@ -132,8 +139,8 @@ export default class ProgressTableLevelBubble extends React.PureComponent {
     }
 
     // in the general case, we need to include all the properties that affect
-    // the bubble's style in the cache key, which include the shape, status,
-    // and all the props used to determine the content
+    // the bubble's appearance in the cache key, which include the shape,
+    // status, and all the props used to determine the content
     const shapeString = `shp=${getBubbleShape(isUnplugged, isConcept)}`;
     const contentString = isLocked
       ? `lkd:`

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableLevelBubble.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableLevelBubble.jsx
@@ -65,6 +65,7 @@ export default class ProgressTableLevelBubble extends React.PureComponent {
     const {
       levelStatus,
       levelKind,
+      isLocked,
       isUnplugged,
       isConcept,
       isBonus,
@@ -74,12 +75,12 @@ export default class ProgressTableLevelBubble extends React.PureComponent {
     } = this.props;
 
     const content = getBubbleContent(
+      isLocked,
       isUnplugged,
       isBonus,
       isPaired,
       title,
-      bubbleSize,
-      levelStatus
+      bubbleSize
     );
 
     return (

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableLevelBubble.story.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableLevelBubble.story.jsx
@@ -49,7 +49,6 @@ export default storybook => {
           story: () =>
             wrapped(
               <ProgressTableLevelBubble
-                levelId={'1'}
                 levelStatus={LevelStatus.not_tried}
                 levelKind={LevelKind.level}
                 isLocked={true}
@@ -65,7 +64,6 @@ export default storybook => {
             story: () =>
               wrapped(
                 <ProgressTableLevelBubble
-                  levelId={'2'}
                   levelStatus={status}
                   levelKind={LevelKind.level}
                   title={'3'}
@@ -80,7 +78,6 @@ export default storybook => {
             story: () =>
               wrapped(
                 <ProgressTableLevelBubble
-                  levelId={'3'}
                   levelStatus={status}
                   levelKind={LevelKind.level}
                   title={'3'}
@@ -96,7 +93,6 @@ export default storybook => {
             story: () =>
               wrapped(
                 <ProgressTableLevelBubble
-                  levelId={'4'}
                   levelStatus={status}
                   levelKind={LevelKind.assessment}
                   title={'3'}
@@ -111,7 +107,6 @@ export default storybook => {
             story: () =>
               wrapped(
                 <ProgressTableLevelBubble
-                  levelId={'5'}
                   levelStatus={status}
                   levelKind={LevelKind.level}
                   title={'3'}
@@ -127,7 +122,6 @@ export default storybook => {
             story: () =>
               wrapped(
                 <ProgressTableLevelBubble
-                  levelId={'6'}
                   levelStatus={status}
                   levelKind={LevelKind.level}
                   title={'3'}
@@ -143,7 +137,6 @@ export default storybook => {
             story: () =>
               wrapped(
                 <ProgressTableLevelBubble
-                  levelId={'7'}
                   levelStatus={status}
                   levelKind={LevelKind.level}
                   title={'3'}
@@ -159,7 +152,6 @@ export default storybook => {
             story: () =>
               wrapMultiple([
                 <ProgressTableLevelBubble
-                  levelId={'8'}
                   levelStatus={LevelStatus.perfect}
                   bubbleSize={BubbleSize.letter}
                   title={'a'}
@@ -167,7 +159,6 @@ export default storybook => {
                   key={1}
                 />,
                 <ProgressTableLevelBubble
-                  levelId={'9'}
                   levelStatus={LevelStatus.attempted}
                   bubbleSize={BubbleSize.letter}
                   title={'b'}
@@ -175,7 +166,6 @@ export default storybook => {
                   key={2}
                 />,
                 <ProgressTableLevelBubble
-                  levelId={'10'}
                   levelStatus={LevelStatus.not_tried}
                   bubbleSize={BubbleSize.letter}
                   title={'c'}
@@ -191,7 +181,6 @@ export default storybook => {
             story: () =>
               wrapMultiple([
                 <ProgressTableLevelBubble
-                  levelId={'11'}
                   levelStatus={LevelStatus.perfect}
                   isConcept={true}
                   bubbleSize={BubbleSize.dot}
@@ -200,7 +189,6 @@ export default storybook => {
                   key={1}
                 />,
                 <ProgressTableLevelBubble
-                  levelId={'12'}
                   levelStatus={LevelStatus.attempted}
                   bubbleSize={BubbleSize.dot}
                   title={'b'}
@@ -208,7 +196,6 @@ export default storybook => {
                   key={2}
                 />,
                 <ProgressTableLevelBubble
-                  levelId={'13'}
                   levelStatus={LevelStatus.not_tried}
                   bubbleSize={BubbleSize.dot}
                   title={'c'}

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableLevelBubble.story.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableLevelBubble.story.jsx
@@ -49,6 +49,7 @@ export default storybook => {
           story: () =>
             wrapped(
               <ProgressTableLevelBubble
+                levelId={'1'}
                 levelStatus={LevelStatus.not_tried}
                 levelKind={LevelKind.level}
                 isLocked={true}
@@ -64,6 +65,7 @@ export default storybook => {
             story: () =>
               wrapped(
                 <ProgressTableLevelBubble
+                  levelId={'2'}
                   levelStatus={status}
                   levelKind={LevelKind.level}
                   title={'3'}
@@ -78,6 +80,7 @@ export default storybook => {
             story: () =>
               wrapped(
                 <ProgressTableLevelBubble
+                  levelId={'3'}
                   levelStatus={status}
                   levelKind={LevelKind.level}
                   title={'3'}
@@ -93,6 +96,7 @@ export default storybook => {
             story: () =>
               wrapped(
                 <ProgressTableLevelBubble
+                  levelId={'4'}
                   levelStatus={status}
                   levelKind={LevelKind.assessment}
                   title={'3'}
@@ -107,6 +111,7 @@ export default storybook => {
             story: () =>
               wrapped(
                 <ProgressTableLevelBubble
+                  levelId={'5'}
                   levelStatus={status}
                   levelKind={LevelKind.level}
                   title={'3'}
@@ -122,6 +127,7 @@ export default storybook => {
             story: () =>
               wrapped(
                 <ProgressTableLevelBubble
+                  levelId={'6'}
                   levelStatus={status}
                   levelKind={LevelKind.level}
                   title={'3'}
@@ -137,6 +143,7 @@ export default storybook => {
             story: () =>
               wrapped(
                 <ProgressTableLevelBubble
+                  levelId={'7'}
                   levelStatus={status}
                   levelKind={LevelKind.level}
                   title={'3'}
@@ -152,6 +159,7 @@ export default storybook => {
             story: () =>
               wrapMultiple([
                 <ProgressTableLevelBubble
+                  levelId={'8'}
                   levelStatus={LevelStatus.perfect}
                   bubbleSize={BubbleSize.letter}
                   title={'a'}
@@ -159,6 +167,7 @@ export default storybook => {
                   key={1}
                 />,
                 <ProgressTableLevelBubble
+                  levelId={'9'}
                   levelStatus={LevelStatus.attempted}
                   bubbleSize={BubbleSize.letter}
                   title={'b'}
@@ -166,6 +175,7 @@ export default storybook => {
                   key={2}
                 />,
                 <ProgressTableLevelBubble
+                  levelId={'10'}
                   levelStatus={LevelStatus.not_tried}
                   bubbleSize={BubbleSize.letter}
                   title={'c'}
@@ -181,6 +191,7 @@ export default storybook => {
             story: () =>
               wrapMultiple([
                 <ProgressTableLevelBubble
+                  levelId={'11'}
                   levelStatus={LevelStatus.perfect}
                   isConcept={true}
                   bubbleSize={BubbleSize.dot}
@@ -189,6 +200,7 @@ export default storybook => {
                   key={1}
                 />,
                 <ProgressTableLevelBubble
+                  levelId={'12'}
                   levelStatus={LevelStatus.attempted}
                   bubbleSize={BubbleSize.dot}
                   title={'b'}
@@ -196,6 +208,7 @@ export default storybook => {
                   key={2}
                 />,
                 <ProgressTableLevelBubble
+                  levelId={'13'}
                   levelStatus={LevelStatus.not_tried}
                   bubbleSize={BubbleSize.dot}
                   title={'c'}

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableLevelIconSet.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableLevelIconSet.jsx
@@ -29,7 +29,6 @@ const placeholderUnpluggedBubble = (
   <div style={styles.unpluggedPlaceholderContainer}>
     <div>
       <ProgressTableLevelBubble
-        levelId="0"
         levelStatus={LevelStatus.not_tried}
         isUnplugged={true}
         isDisabled={true}

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableLevelIconSet.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableLevelIconSet.jsx
@@ -29,6 +29,7 @@ const placeholderUnpluggedBubble = (
   <div style={styles.unpluggedPlaceholderContainer}>
     <div>
       <ProgressTableLevelBubble
+        levelId="0"
         levelStatus={LevelStatus.not_tried}
         isUnplugged={true}
         isDisabled={true}

--- a/apps/src/templates/sectionProgress/progressTables/progressTableStyles.scss
+++ b/apps/src/templates/sectionProgress/progressTables/progressTableStyles.scss
@@ -92,6 +92,19 @@ $content-view-width: $content-width - $student-list-width;
   }
 }
 
+.progress-bubble {
+  &.enabled {
+    transition: background-color 0.2s ease-out, border-color 0.2s ease-out,
+      color 0.2s ease-out;
+    &:hover {
+      text-decoration: none;
+      color: $white !important;
+      border-color: $level_current !important;
+      background-color: $level_current !important;
+    }
+  }
+}
+
 :export {
   MAX_BODY_HEIGHT: $max-height / 1px;
   STUDENT_LIST_WIDTH: $student-list-width / 1px;

--- a/apps/src/util/CachedElement.jsx
+++ b/apps/src/util/CachedElement.jsx
@@ -16,6 +16,7 @@ export default function CachedElement({elementType, cacheKey, createElement}) {
     htmlCache[cacheKey] = elementHtml;
     elementsHtmlCache[elementType] = htmlCache;
   }
+  // since we generated this html ourselves, we know it is safe
   // eslint-disable-next-line react/no-danger
   return <div dangerouslySetInnerHTML={{__html: elementHtml}} />;
 }

--- a/apps/src/util/CachedElement.jsx
+++ b/apps/src/util/CachedElement.jsx
@@ -2,12 +2,6 @@ import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 import PropTypes from 'prop-types';
 
-const elementsHtmlCache = {};
-
-function createHtml(element) {
-  return ReactDOMServer.renderToStaticMarkup(element);
-}
-
 export default function CachedElement({elementType, cacheKey, createElement}) {
   const htmlCache = elementsHtmlCache[elementType] || {};
   let elementHtml = htmlCache[cacheKey];
@@ -24,4 +18,21 @@ CachedElement.propTypes = {
   elementType: PropTypes.string.isRequired,
   cacheKey: PropTypes.string.isRequired,
   createElement: PropTypes.func.isRequired
+};
+
+function createHtml(element) {
+  return ReactDOMServer.renderToStaticMarkup(element);
+}
+
+function clearElementsCache() {
+  Object.keys(elementsHtmlCache).forEach(key => {
+    delete elementsHtmlCache[key];
+  });
+}
+
+const elementsHtmlCache = {};
+
+export const unitTestExports = {
+  clearElementsCache,
+  elementsHtmlCache
 };

--- a/apps/src/util/CachedElement.jsx
+++ b/apps/src/util/CachedElement.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import ReactDOMServer from 'react-dom/server';
+import PropTypes from 'prop-types';
+
+const elementsHtmlCache = {};
+
+function createHtml(element) {
+  return ReactDOMServer.renderToStaticMarkup(element);
+}
+
+export default function CachedElement({elementType, cacheKey, createElement}) {
+  const htmlCache = elementsHtmlCache[elementType] || {};
+  let elementHtml = htmlCache[cacheKey];
+  if (!elementHtml) {
+    elementHtml = createHtml(createElement());
+    htmlCache[cacheKey] = elementHtml;
+    elementsHtmlCache[elementType] = htmlCache;
+  }
+  // eslint-disable-next-line react/no-danger
+  return <div dangerouslySetInnerHTML={{__html: elementHtml}} />;
+}
+CachedElement.propTypes = {
+  elementType: PropTypes.string.isRequired,
+  cacheKey: PropTypes.string.isRequired,
+  createElement: PropTypes.func.isRequired
+};

--- a/apps/test/unit/templates/sectionProgress/ProgressTableLevelBubbleTest.jsx
+++ b/apps/test/unit/templates/sectionProgress/ProgressTableLevelBubbleTest.jsx
@@ -1,24 +1,24 @@
 import {expect} from '../../../util/reconfiguredChai';
 import React from 'react';
 import {shallow, mount} from 'enzyme';
-import ProgressTableLevelBubble, {
-  unitTestExports
-} from '@cdo/apps/templates/sectionProgress/progressTables/ProgressTableLevelBubble';
+import ProgressTableLevelBubble from '@cdo/apps/templates/sectionProgress/progressTables/ProgressTableLevelBubble';
 import color from '@cdo/apps/util/color';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import {LevelStatus, LevelKind} from '@cdo/apps/util/sharedConstants';
+import {unitTestExports as cacheExports} from '@cdo/apps/util/CachedElement';
 import i18n from '@cdo/locale';
+import sinon from 'sinon';
 import {
   BubbleSize,
   BubbleShape
 } from '@cdo/apps/templates/progress/progressStyles';
+import {LinkWrapper} from '@cdo/apps/templates/progress/BubbleFactory';
 
 const TITLE = '1';
 
 const defaultProps = {
   levelStatus: LevelStatus.not_tried,
   levelKind: LevelKind.level,
-  isDisabled: false,
   title: TITLE,
   url: '/foo/bar'
 };
@@ -51,129 +51,125 @@ const assessmentBackgrounds = {
 };
 
 /**
- * Helper function to retrieve the style object of a rendered bubble with the
- * provided status and prpos.
+ * ProgressTableLevelBubble's primary purpose is to determine the shape, size,
+ * style, and cache key for an underlying BasicBubble. Consequently many of our
+ * tests need to verify porperties of the underlying BasicBubble. However,
+ * since what the component actually renders is the cached HTML representation
+ * of the BasicBubble, we use a spy to intercept the BasicBubble returned from
+ * ProgressTableLevelBubble.createBubbleElement for easier verification.
  */
-function bubbleContainerStyleForStatus(status, propOverrides = {}) {
-  const wrapper = mount(
-    <ProgressTableLevelBubble
-      {...defaultProps}
-      {...propOverrides}
-      levelStatus={status}
-    />
-  );
+const elementSpy = sinon.spy(
+  ProgressTableLevelBubble.prototype,
+  'createBubbleElement'
+);
 
-  return wrapper
-    .find(unitTestExports.BasicBubble)
-    .at(0)
-    .childAt(0)
-    .props().style;
+/**
+ * The spy's history is reset after each test so this will give us the first
+ * BasicBubble rendered during this test.
+ */
+function getFirstRenderedBasicBubble(propOverrides = {}) {
+  mount(<ProgressTableLevelBubble {...defaultProps} {...propOverrides} />);
+  const renderedBubble = elementSpy.returnValues[0];
+  return mount(renderedBubble);
+}
+
+/**
+ * Helper function to retrieve the style object of a rendered bubble with the
+ * provided status and props.
+ */
+function basicBubbleStyleForStatus(status, propOverrides = {}) {
+  const wrapper = getFirstRenderedBasicBubble({
+    ...propOverrides,
+    levelStatus: status
+  });
+  return wrapper.childAt(0).props().style;
+}
+
+function getCacheSize() {
+  return Object.keys(cacheExports.elementsHtmlCache['BasicBubble']).length;
 }
 
 describe('ProgressTableLevelBubble', () => {
+  afterEach(() => {
+    elementSpy.resetHistory();
+    cacheExports.clearElementsCache();
+  });
+
   it('renders a link', () => {
     const wrapper = shallow(<ProgressTableLevelBubble {...defaultProps} />);
-    expect(wrapper.find(unitTestExports.LinkWrapper)).to.have.lengthOf(1);
+    expect(wrapper.find(LinkWrapper)).to.have.lengthOf(1);
   });
 
   it('renders default bubble with circle shape', () => {
-    const wrapper = mount(<ProgressTableLevelBubble {...defaultProps} />);
-    expect(wrapper.find(unitTestExports.BasicBubble).props().shape).to.equal(
-      BubbleShape.circle
-    );
+    const wrapper = getFirstRenderedBasicBubble();
+    expect(wrapper.props().shape).to.equal(BubbleShape.circle);
   });
 
   it('renders concept bubble with diamond shape', () => {
-    const wrapper = mount(
-      <ProgressTableLevelBubble {...defaultProps} isConcept={true} />
-    );
-    expect(wrapper.find(unitTestExports.BasicBubble).props().shape).to.equal(
-      BubbleShape.diamond
-    );
+    const wrapper = getFirstRenderedBasicBubble({isConcept: true});
+    expect(wrapper.props().shape).to.equal(BubbleShape.diamond);
   });
 
   it('renders unplugged bubble with pill shape', () => {
-    const wrapper = mount(
-      <ProgressTableLevelBubble {...defaultProps} isUnplugged={true} />
-    );
-    expect(wrapper.find(unitTestExports.BasicBubble).props().shape).to.equal(
-      BubbleShape.pill
-    );
+    const wrapper = getFirstRenderedBasicBubble({isUnplugged: true});
+    expect(wrapper.props().shape).to.equal(BubbleShape.pill);
   });
 
   it('shows correct text in unplugged bubble', () => {
-    const wrapper = mount(
-      <ProgressTableLevelBubble {...defaultProps} isUnplugged={true} />
-    );
-    expect(wrapper.find(unitTestExports.BasicBubble).text()).to.equal(
-      i18n.unpluggedActivity()
-    );
+    const wrapper = getFirstRenderedBasicBubble({isUnplugged: true});
+    expect(wrapper.text()).to.equal(i18n.unpluggedActivity());
   });
 
   it('shows title in normal bubble', () => {
-    const wrapper = mount(<ProgressTableLevelBubble {...defaultProps} />);
-    expect(wrapper.find(unitTestExports.BasicBubble).text()).to.equal(TITLE);
+    const wrapper = getFirstRenderedBasicBubble();
+    expect(wrapper.text()).to.equal(TITLE);
   });
 
   it('shows title in concept bubble', () => {
-    const wrapper = mount(
-      <ProgressTableLevelBubble {...defaultProps} concept={true} />
-    );
-    expect(wrapper.find(unitTestExports.BasicBubble).text()).to.equal(TITLE);
+    const wrapper = getFirstRenderedBasicBubble({isConcept: true});
+    expect(wrapper.text()).to.equal(TITLE);
   });
 
   it('shows title in letter bubble', () => {
-    const wrapper = mount(
-      <ProgressTableLevelBubble
-        {...defaultProps}
-        bubbleSize={BubbleSize.letter}
-      />
-    );
-    expect(wrapper.find(unitTestExports.BasicBubble).text()).to.equal(TITLE);
+    const wrapper = getFirstRenderedBasicBubble({
+      bubbleSize: BubbleSize.letter
+    });
+    expect(wrapper.text()).to.equal(TITLE);
   });
 
   it('does not show title in dot bubble', () => {
-    const wrapper = mount(
-      <ProgressTableLevelBubble {...defaultProps} bubbleSize={BubbleSize.dot} />
-    );
-    expect(wrapper.find(unitTestExports.BasicBubble).text()).to.equal('');
+    const wrapper = getFirstRenderedBasicBubble({bubbleSize: BubbleSize.dot});
+    expect(wrapper.text()).to.equal('');
   });
 
   it('shows correct icon when locked', () => {
-    const wrapper = mount(
-      <ProgressTableLevelBubble {...defaultProps} isLocked={true} />
-    );
+    const wrapper = getFirstRenderedBasicBubble({
+      isLocked: true
+    });
     const icon = wrapper.find(FontAwesome);
     expect(icon).to.have.lengthOf(1);
     expect(icon.at(0).props().icon).to.equal('lock');
   });
 
   it('shows correct icon for bonus', () => {
-    const wrapper = mount(
-      <ProgressTableLevelBubble {...defaultProps} isBonus={true} />
-    );
+    const wrapper = getFirstRenderedBasicBubble({isBonus: true});
     const icon = wrapper.find(FontAwesome);
     expect(icon).to.have.lengthOf(1);
     expect(icon.at(0).props().icon).to.equal('flag-checkered');
   });
 
   it('shows correct icon for paired', () => {
-    const wrapper = mount(
-      <ProgressTableLevelBubble {...defaultProps} isPaired={true} />
-    );
+    const wrapper = getFirstRenderedBasicBubble({isPaired: true});
     const icon = wrapper.find(FontAwesome);
     expect(icon).to.have.lengthOf(1);
     expect(icon.at(0).props().icon).to.equal('users');
   });
 
   it('only shows paired icon for bonus + paired', () => {
-    const wrapper = mount(
-      <ProgressTableLevelBubble
-        {...defaultProps}
-        isBonus={true}
-        isPaired={true}
-      />
-    );
+    const wrapper = getFirstRenderedBasicBubble({
+      isBonus: true,
+      isPaired: true
+    });
     const icon = wrapper.find(FontAwesome);
     expect(icon).to.have.lengthOf(1);
     expect(icon.at(0).props().icon).to.equal('users');
@@ -181,21 +177,21 @@ describe('ProgressTableLevelBubble', () => {
 
   Object.keys(borderColors).forEach(status => {
     it(`shows correct border color for status ${status} - not assessment`, () => {
-      const style = bubbleContainerStyleForStatus(status);
+      const style = basicBubbleStyleForStatus(status);
       expect(style.borderColor).to.equal(borderColors[status]);
     });
   });
 
   Object.keys(backgroundColors).forEach(status => {
     it(`shows correct background color for status ${status} - not assessment`, () => {
-      const style = bubbleContainerStyleForStatus(status);
+      const style = basicBubbleStyleForStatus(status);
       expect(style.backgroundColor).to.equal(backgroundColors[status]);
     });
   });
 
   Object.keys(assessmentBorders).forEach(status => {
     it(`shows correct border color for status ${status} - assessment`, () => {
-      const style = bubbleContainerStyleForStatus(status, {
+      const style = basicBubbleStyleForStatus(status, {
         levelKind: LevelKind.assessment
       });
       expect(style.borderColor).to.equal(assessmentBorders[status]);
@@ -204,17 +200,55 @@ describe('ProgressTableLevelBubble', () => {
 
   Object.keys(assessmentBackgrounds).forEach(status => {
     it(`shows correct background color for status ${status} - assessment`, () => {
-      const style = bubbleContainerStyleForStatus(status, {
+      const style = basicBubbleStyleForStatus(status, {
         levelKind: LevelKind.assessment
       });
       expect(style.backgroundColor).to.equal(assessmentBackgrounds[status]);
     });
   });
 
-  it('renders raw HTML if useCache is true', () => {
-    const wrapper = mount(
-      <ProgressTableLevelBubble {...defaultProps} useCache={true} />
-    );
-    expect(wrapper.find('div').props().dangerouslySetInnerHTML).to.exist;
+  describe('caching', () => {
+    it('renders raw HTML instead of component tree', () => {
+      const wrapper = mount(<ProgressTableLevelBubble {...defaultProps} />);
+      expect(wrapper.find('div').props().dangerouslySetInnerHTML).to.exist;
+    });
+
+    it('only caches one element when rendering two identical bubbles', () => {
+      mount(<ProgressTableLevelBubble {...defaultProps} />);
+      mount(<ProgressTableLevelBubble {...defaultProps} />);
+      expect(elementSpy.calledOnce).to.be.true;
+      expect(getCacheSize()).to.equal(1);
+    });
+
+    it('caches two elements when rendering two different bubbles', () => {
+      mount(<ProgressTableLevelBubble {...defaultProps} />);
+      mount(<ProgressTableLevelBubble {...defaultProps} isUnplugged={true} />);
+      expect(elementSpy.calledTwice).to.be.true;
+      expect(getCacheSize()).to.equal(2);
+    });
+
+    it('renders the same cached html for different bubbles that look the same', () => {
+      // paired icon overrides title so these two should appear the same
+      const wrapperA = mount(
+        <ProgressTableLevelBubble {...defaultProps} isPaired={true} />
+      );
+      const wrapperB = mount(
+        <ProgressTableLevelBubble {...defaultProps} title="2" isPaired={true} />
+      );
+      expect(elementSpy.calledOnce).to.be.true;
+      expect(getCacheSize()).to.equal(1);
+      expect(
+        wrapperA.find('div').props().dangerouslySetInnerHTML.__html
+      ).to.equal(wrapperB.find('div').props().dangerouslySetInnerHTML.__html);
+    });
+
+    it('only caches one element when rendering same bubbles with different urls', () => {
+      mount(<ProgressTableLevelBubble {...defaultProps} />);
+      mount(
+        <ProgressTableLevelBubble {...defaultProps} url={'/foo/bar/baz'} />
+      );
+      expect(elementSpy.calledOnce).to.be.true;
+      expect(getCacheSize()).to.equal(1);
+    });
   });
 });

--- a/apps/test/unit/templates/sectionProgress/ProgressTableLevelBubbleTest.jsx
+++ b/apps/test/unit/templates/sectionProgress/ProgressTableLevelBubbleTest.jsx
@@ -61,10 +61,9 @@ const assessmentBackgrounds = {
  * of the BasicBubble, we use a spy to intercept the props used to render the
  * BasicBubble so we can render it here for easier verification.
  */
-const renderPropsSpy = sinon.spy(
-  ProgressTableLevelBubble.prototype,
-  'renderBasicBubble'
-);
+const renderPropsSpy = sinon
+  .createSandbox()
+  .spy(ProgressTableLevelBubble.prototype, 'renderBasicBubble');
 
 /**
  * The spy's history is reset before each test so this will give us the first
@@ -110,12 +109,12 @@ function getCacheSize() {
 describe('ProgressTableLevelBubble', () => {
   beforeEach(() => {
     renderPropsSpy.resetHistory();
-    cacheExports.clearElementsCache();
+    cacheExports.clearElementsCache('BasicBubble');
   });
 
   after(() => {
     renderPropsSpy.resetHistory();
-    cacheExports.clearElementsCache();
+    cacheExports.clearElementsCache('BasicBubble');
   });
 
   it('renders a link', () => {

--- a/apps/test/unit/templates/sectionProgress/ProgressTableLevelBubbleTest.jsx
+++ b/apps/test/unit/templates/sectionProgress/ProgressTableLevelBubbleTest.jsx
@@ -76,7 +76,10 @@ function getFirstRenderedBasicBubble(propOverrides = {}) {
   mount(<ProgressTableLevelBubble {...defaultProps} {...propOverrides} />);
 
   // next we get the args passed to `renderBasicBubble` to render the bubble
-  const [shape, size, progressStyle, content] = [...renderPropsSpy.args[0]];
+  const shape = renderPropsSpy.args[0][0];
+  const size = renderPropsSpy.args[0][1];
+  const progressStyle = renderPropsSpy.args[0][2];
+  const content = renderPropsSpy.args[0][3];
 
   // finally we render the `BasicBubble` itself so we can verifty its props
   // (since the underlying `CachedElement` rendered it as raw HTML when

--- a/apps/test/unit/templates/sectionProgress/ProgressTableLevelBubbleTest.jsx
+++ b/apps/test/unit/templates/sectionProgress/ProgressTableLevelBubbleTest.jsx
@@ -16,6 +16,7 @@ import {
 const TITLE = '1';
 
 const defaultProps = {
+  levelId: '1',
   levelStatus: LevelStatus.not_tried,
   levelKind: LevelKind.level,
   isDisabled: false,
@@ -209,5 +210,12 @@ describe('ProgressTableLevelBubble', () => {
       });
       expect(style.backgroundColor).to.equal(assessmentBackgrounds[status]);
     });
+  });
+
+  it('renders raw HTML if useCache is true', () => {
+    const wrapper = mount(
+      <ProgressTableLevelBubble {...defaultProps} useCache={true} />
+    );
+    expect(wrapper.find('div').props().dangerouslySetInnerHTML).to.exist;
   });
 });

--- a/apps/test/unit/templates/sectionProgress/ProgressTableLevelBubbleTest.jsx
+++ b/apps/test/unit/templates/sectionProgress/ProgressTableLevelBubbleTest.jsx
@@ -53,7 +53,7 @@ const assessmentBackgrounds = {
 /**
  * ProgressTableLevelBubble's primary purpose is to determine the shape, size,
  * style, and cache key for an underlying BasicBubble. Consequently many of our
- * tests need to verify porperties of the underlying BasicBubble. However,
+ * tests need to verify properties of the underlying BasicBubble. However,
  * since what the component actually renders is the cached HTML representation
  * of the BasicBubble, we use a spy to intercept the BasicBubble returned from
  * ProgressTableLevelBubble.createBubbleElement for easier verification.
@@ -64,12 +64,20 @@ const elementSpy = sinon.spy(
 );
 
 /**
- * The spy's history is reset after each test so this will give us the first
+ * The spy's history is reset before each test so this will give us the first
  * BasicBubble rendered during this test.
  */
 function getFirstRenderedBasicBubble(propOverrides = {}) {
+  // first we render the bubble we want to test, which will call
+  // `createBubbleElement` in the process
   mount(<ProgressTableLevelBubble {...defaultProps} {...propOverrides} />);
+
+  // next we get the rendered `BasicBubble` returned by `createBubbleElement`
   const renderedBubble = elementSpy.returnValues[0];
+
+  // finally we render the `BasicBubble` itself so we can verifty its props
+  // (since the underlying `CachedElement` rendered it as raw HTML when
+  // rendering the `ProgressTableLevelBubble`)
   return mount(renderedBubble);
 }
 
@@ -90,7 +98,12 @@ function getCacheSize() {
 }
 
 describe('ProgressTableLevelBubble', () => {
-  afterEach(() => {
+  beforeEach(() => {
+    elementSpy.resetHistory();
+    cacheExports.clearElementsCache();
+  });
+
+  after(() => {
     elementSpy.resetHistory();
     cacheExports.clearElementsCache();
   });

--- a/apps/test/unit/templates/sectionProgress/ProgressTableLevelBubbleTest.jsx
+++ b/apps/test/unit/templates/sectionProgress/ProgressTableLevelBubbleTest.jsx
@@ -16,7 +16,6 @@ import {
 const TITLE = '1';
 
 const defaultProps = {
-  levelId: '1',
   levelStatus: LevelStatus.not_tried,
   levelKind: LevelKind.level,
   isDisabled: false,

--- a/apps/test/unit/util/CachedElementTest.jsx
+++ b/apps/test/unit/util/CachedElementTest.jsx
@@ -36,7 +36,12 @@ const defaultProps = {
 const spy = sinon.spy(createDiv);
 
 describe('CachedElement', () => {
-  afterEach(() => {
+  beforeEach(() => {
+    spy.resetHistory();
+    unitTestExports.clearElementsCache();
+  });
+
+  after(() => {
     spy.resetHistory();
     unitTestExports.clearElementsCache();
   });

--- a/apps/test/unit/util/CachedElementTest.jsx
+++ b/apps/test/unit/util/CachedElementTest.jsx
@@ -1,0 +1,139 @@
+import {expect} from '../../util/reconfiguredChai';
+import React from 'react';
+import {mount} from 'enzyme';
+import sinon from 'sinon';
+import CachedElement, {unitTestExports} from '@cdo/apps/util/CachedElement';
+
+const cache = unitTestExports.elementsHtmlCache;
+const defaultType = 'div';
+const defaultContent = '1';
+const defaultKeys = ['key1', 'key2', 'key3'];
+const defaultHtml = '<div>1</div>';
+const nestedHtml = `<div>${defaultHtml}</div>`;
+
+function getCacheSize(type = defaultType) {
+  return Object.keys(cache[type]).length;
+}
+
+function getCachedElement(type = defaultType, key = defaultKeys[0]) {
+  return cache[type][key];
+}
+
+function createDiv(content = defaultContent) {
+  return <div>{content}</div>;
+}
+
+function createNested() {
+  return <CachedElement {...defaultProps} />;
+}
+
+const defaultProps = {
+  elementType: defaultType,
+  cacheKey: defaultKeys[0],
+  createElement: createDiv
+};
+
+const spy = sinon.spy(createDiv);
+
+describe('CachedElement', () => {
+  afterEach(() => {
+    spy.resetHistory();
+    unitTestExports.clearElementsCache();
+  });
+
+  it('caches and renders raw HTML', () => {
+    const wrapper = mount(
+      <CachedElement
+        elementType="CachedElement"
+        cacheKey={defaultKeys[0]}
+        createElement={createNested}
+      />
+    );
+    expect(spy.calledOnce);
+    expect(getCacheSize()).to.equal(1);
+    expect(getCacheSize('CachedElement')).to.equal(1);
+
+    // verify that the nested `CachedElement` isn't in the tree
+    expect(wrapper.find(CachedElement)).to.have.lengthOf(1);
+    expect(wrapper.find(CachedElement).find(CachedElement)).to.be.empty;
+
+    expect(getCachedElement()).to.equal(defaultHtml);
+    expect(getCachedElement('CachedElement')).to.equal(nestedHtml);
+    expect(wrapper.html()).to.include(nestedHtml);
+    expect(wrapper.childAt(0).props().dangerouslySetInnerHTML.__html).to.equal(
+      nestedHtml
+    );
+  });
+
+  it('only caches one element when rendering multiple with same key', () => {
+    const wrapper = mount(
+      <div>
+        <CachedElement {...defaultProps} />
+        <CachedElement {...defaultProps} />
+        <CachedElement {...defaultProps} />
+      </div>
+    );
+    expect(spy.calledOnce);
+    expect(getCacheSize()).to.equal(1);
+
+    const cached = wrapper.find(CachedElement);
+    expect(cached).to.have.lengthOf(3);
+
+    const cachedHtml = getCachedElement();
+    cached.forEach(node => {
+      expect(node.childAt(0).props().dangerouslySetInnerHTML.__html).to.equal(
+        cachedHtml
+      );
+    });
+  });
+
+  it('does not reuse identical elements with different keys', () => {
+    const wrapper = mount(
+      <div>
+        <CachedElement {...defaultProps} />
+        <CachedElement {...defaultProps} cacheKey={defaultKeys[1]} />
+        <CachedElement {...defaultProps} cacheKey={defaultKeys[2]} />
+      </div>
+    );
+    expect(spy.calledThrice);
+    expect(getCacheSize()).to.equal(3);
+
+    const cached = wrapper.find(CachedElement);
+    expect(cached).to.have.lengthOf(3);
+
+    cached.forEach(node => {
+      expect(node.childAt(0).props().dangerouslySetInnerHTML.__html).to.equal(
+        defaultHtml
+      );
+    });
+  });
+
+  it('always renders first element cached for a given key', () => {
+    const wrapper = mount(
+      <div>
+        <CachedElement {...defaultProps} />
+        <CachedElement {...defaultProps} createElement={() => createDiv('2')} />
+        <CachedElement {...defaultProps} createElement={() => createDiv('3')} />
+      </div>
+    );
+    expect(spy.calledOnce);
+    expect(getCacheSize()).to.equal(1);
+    expect(wrapper.text()).to.include('1');
+    expect(wrapper.text()).not.to.include('2');
+    expect(wrapper.text()).not.to.include('3');
+  });
+
+  it('partitions cache by type', () => {
+    mount(
+      <div>
+        <CachedElement {...defaultProps} />
+        <CachedElement {...defaultProps} elementType="a" />
+        <CachedElement {...defaultProps} elementType="p" />
+      </div>
+    );
+    expect(spy.calledThrice);
+    expect(getCacheSize()).to.equal(1);
+    expect(getCacheSize('a')).to.equal(1);
+    expect(getCacheSize('p')).to.equal(1);
+  });
+});

--- a/apps/test/unit/util/CachedElementTest.jsx
+++ b/apps/test/unit/util/CachedElementTest.jsx
@@ -38,12 +38,12 @@ const spy = sinon.spy(createDiv);
 describe('CachedElement', () => {
   beforeEach(() => {
     spy.resetHistory();
-    unitTestExports.clearElementsCache();
+    unitTestExports.clearElementsCache(defaultType);
   });
 
   after(() => {
     spy.resetHistory();
-    unitTestExports.clearElementsCache();
+    unitTestExports.clearElementsCache(defaultType);
   });
 
   it('caches and renders raw HTML', () => {
@@ -60,7 +60,12 @@ describe('CachedElement', () => {
 
     // verify that the nested `CachedElement` isn't in the tree
     expect(wrapper.find(CachedElement)).to.have.lengthOf(1);
-    expect(wrapper.find(CachedElement).find(CachedElement)).to.be.empty;
+    expect(
+      wrapper
+        .find(CachedElement)
+        .childAt(0)
+        .find(CachedElement)
+    ).to.be.empty;
 
     expect(getCachedElement()).to.equal(defaultHtml);
     expect(getCachedElement('CachedElement')).to.equal(nestedHtml);


### PR DESCRIPTION
while investigating the bug fixed by #40177 i started by exploring if it was a rendering or performance issue. that issue ended up being unrelated to rendering/performance, but as part of my exploration i took a quick pass at a performance optimization i've been considering for awhile: caching the frequently-reused parts of the bubbles.

aside from the url the bubbles link to, the vast majority of them differ only in a small set of unique content/styling options. for example, each row of the table displays bubbles with identical content as the other rows, and often even identical to other cells. and considering that many bubbles are often in the `not_tried` state, huge portions of the table are often duplicated.

this PR introduces caching the raw HTML for each unique bubble, and rendering that directly. this introduces a lot of additional complexity to the component, but also results in a noticeable improvement in scrolling performance.

my thinking is that if we like this approach, i will move all the caching logic into the `BubbleFactory` concept we've been mentioning, and use it only in the progress table. i'm happy to hop on a call to discuss the pros and cons if this approach if desired.

### Note:
while cleaning up this PR i discovered that our original implementation of this component broke the hover effect, because Radium doesn't work with functional components. this PR solves that by replacing the Radium styling with a new CSS class, since Radium also can't do anything with the raw HTML. if we decide not to move forward with this PR i will open a new PR to specifically address the hover issue.