### PR TITLE
Add 'Code Block' button to more markdown editors

### DIFF
--- a/apps/src/lib/levelbuilder/MarkdownEnabledTextarea.jsx
+++ b/apps/src/lib/levelbuilder/MarkdownEnabledTextarea.jsx
@@ -1,8 +1,11 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import {buildProgrammingExpressionMarkdown} from '@cdo/apps/templates/lessonOverview/StyledCodeBlock';
+
 import UploadImageDialog from './lesson-editor/UploadImageDialog';
 import FindResourceDialog from './lesson-editor/FindResourceDialog';
+import FindProgrammingExpressionDialog from './lesson-editor/FindProgrammingExpressionDialog';
 
 const styles = {
   container: {
@@ -60,12 +63,20 @@ export default class MarkdownEnabledTextarea extends React.Component {
     this.setState({addResourceLinkOpen: true});
   };
 
+  handleOpenAddProgrammingExpression = () => {
+    this.setState({addProgrammingExpressionOpen: true});
+  };
+
   handleCloseUploadImage = () => {
     this.setState({uploadImageOpen: false});
   };
 
   handleCloseAddResourceLink = () => {
     this.setState({addResourceLinkOpen: false});
+  };
+
+  handleCloseAddProgrammingExpression = () => {
+    this.setState({addProgrammingExpressionOpen: false});
   };
 
   handleConfirmAddResourceLink = resourceKey => {
@@ -80,6 +91,16 @@ export default class MarkdownEnabledTextarea extends React.Component {
     this.changeMarkdown(this.props.markdown + `\n\n![${param}](${url})`);
   };
 
+  handleAddProgrammingExpression = programmingExpression => {
+    if (programmingExpression) {
+      this.changeMarkdown(
+        this.props.markdown +
+          buildProgrammingExpressionMarkdown(programmingExpression)
+      );
+    }
+    this.handleCloseAddProgrammingExpression();
+  };
+
   render() {
     return (
       <div>
@@ -91,27 +112,38 @@ export default class MarkdownEnabledTextarea extends React.Component {
             style={styles.input}
             value={this.props.markdown}
           />
-          {this.props.features.imageUpload && (
-            <button
-              className="btn"
-              onClick={this.handleOpenUploadImage}
-              type="button"
-            >
-              <i style={styles.icon} className="fa fa-plus-circle" />
-              Image
-            </button>
-          )}
-          {this.props.features.resourceLink && (
-            <button
-              className="btn"
-              onClick={this.handleOpenAddResourceLink}
-              type="button"
-            >
-              <i style={styles.icon} className="fa fa-plus-circle" />
-              Resource
-            </button>
-          )}
+          <div className="btn-toolbar">
+            <div className="btn-group">
+              <a
+                className="btn dropdown-toggle"
+                data-toggle="dropdown"
+                href="#"
+              >
+                Add&hellip; <span className="caret" />
+              </a>
+              <ul className="dropdown-menu">
+                {this.props.features.imageUpload && (
+                  <li>
+                    <a onClick={this.handleOpenUploadImage}>Image</a>
+                  </li>
+                )}
+                {this.props.features.resourceLink && (
+                  <li>
+                    <a onClick={this.handleOpenAddResourceLink}>Resource</a>
+                  </li>
+                )}
+                {this.props.features.programmingExpression && (
+                  <li>
+                    <a onClick={this.handleOpenAddProgrammingExpression}>
+                      Code Block
+                    </a>
+                  </li>
+                )}
+              </ul>
+            </div>
+          </div>
         </div>
+
         {this.props.features.imageUpload && (
           <UploadImageDialog
             handleClose={this.handleCloseUploadImage}
@@ -124,6 +156,13 @@ export default class MarkdownEnabledTextarea extends React.Component {
             handleClose={this.handleCloseAddResourceLink}
             handleConfirm={this.handleConfirmAddResourceLink}
             isOpen={!!this.state.addResourceLinkOpen}
+          />
+        )}
+        {this.props.features.programmingExpression && (
+          <FindProgrammingExpressionDialog
+            handleClose={this.handleCloseAddProgrammingExpression}
+            handleConfirm={this.handleAddProgrammingExpression}
+            isOpen={!!this.state.addProgrammingExpressionOpen}
           />
         )}
       </div>

--- a/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
@@ -315,7 +315,11 @@ class LessonEditor extends Component {
             handleMarkdownChange={e =>
               this.setState({overview: e.target.value})
             }
-            features={{imageUpload: true, resourceLink: true}}
+            features={{
+              imageUpload: true,
+              resourceLink: true,
+              programmingExpression: true
+            }}
           />
           <TextareaWithMarkdownPreview
             markdown={studentOverview}
@@ -327,7 +331,7 @@ class LessonEditor extends Component {
             handleMarkdownChange={e =>
               this.setState({studentOverview: e.target.value})
             }
-            features={{imageUpload: true}}
+            features={{imageUpload: true, programmingExpression: true}}
           />
         </CollapsibleEditorSection>
         {hasLessonPlan && (
@@ -352,7 +356,11 @@ class LessonEditor extends Component {
                 handleMarkdownChange={e =>
                   this.setState({purpose: e.target.value})
                 }
-                features={{imageUpload: true, resourceLink: true}}
+                features={{
+                  imageUpload: true,
+                  resourceLink: true,
+                  programmingExpression: true
+                }}
               />
               <TextareaWithMarkdownPreview
                 markdown={preparation}
@@ -361,7 +369,11 @@ class LessonEditor extends Component {
                 handleMarkdownChange={e =>
                   this.setState({preparation: e.target.value})
                 }
-                features={{imageUpload: true, resourceLink: true}}
+                features={{
+                  imageUpload: true,
+                  resourceLink: true,
+                  programmingExpression: true
+                }}
               />
             </CollapsibleEditorSection>
 

--- a/apps/test/unit/lib/levelbuilder/MarkdownEnabledTextareaTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/MarkdownEnabledTextareaTest.jsx
@@ -31,14 +31,27 @@ describe('MarkdownEnabledTextarea', () => {
     expect(wrapper.find('button').length).to.equal(0);
 
     wrapper.setProps({features: {imageUpload: true}});
-    expect(wrapper.find('button').length).to.equal(1);
-    expect(wrapper.find('button').text()).to.equal('Image');
+    expect(
+      wrapper
+        .find('.btn-toolbar')
+        .find('li')
+        .map(li => li.text())
+    ).to.eql(['Image']);
 
     wrapper.setProps({features: {resourceLink: true}});
-    expect(wrapper.find('button').length).to.equal(1);
-    expect(wrapper.find('button').text()).to.equal('Resource');
+    expect(
+      wrapper
+        .find('.btn-toolbar')
+        .find('li')
+        .map(li => li.text())
+    ).to.eql(['Resource']);
 
     wrapper.setProps({features: {imageUpload: true, resourceLink: true}});
-    expect(wrapper.find('button').length).to.equal(2);
+    expect(
+      wrapper
+        .find('.btn-toolbar')
+        .find('li')
+        .map(li => li.text())
+    ).to.eql(['Image', 'Resource']);
   });
 });

--- a/apps/test/unit/lib/levelbuilder/script-editor/UnitCardTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/UnitCardTest.jsx
@@ -109,49 +109,11 @@ describe('UnitCard', () => {
     expect(wrapper.find('LessonToken')).to.have.lengthOf(4);
     expect(wrapper.find('textarea')).to.have.lengthOf(4);
 
-    expect(wrapper.find('button')).to.have.lengthOf(7);
-    expect(
-      wrapper
-        .find('button')
-        .at(0)
-        .text()
-    ).to.include('Image');
-    expect(
-      wrapper
-        .find('button')
-        .at(1)
-        .text()
-    ).to.include('Image');
-    expect(
-      wrapper
-        .find('button')
-        .at(2)
-        .text()
-    ).to.include('Lesson');
-    expect(
-      wrapper
-        .find('button')
-        .at(3)
-        .text()
-    ).to.include('Image');
-    expect(
-      wrapper
-        .find('button')
-        .at(4)
-        .text()
-    ).to.include('Image');
-    expect(
-      wrapper
-        .find('button')
-        .at(5)
-        .text()
-    ).to.include('Lesson');
-    expect(
-      wrapper
-        .find('button')
-        .at(6)
-        .text()
-    ).to.include('Add Lesson Group');
+    expect(wrapper.find('button').map(b => b.text())).to.eql([
+      'Lesson',
+      'Lesson',
+      'Add Lesson Group'
+    ]);
   });
 
   it('displays UnitCard correctly when single user facing lesson groups', () => {


### PR DESCRIPTION
Specifically, to the lesson Overview, Preparation, and Purpose field editors.

Also, the editor for the actitivity secion markdown field is starting to get a _lot_ of buttons; we're going to want to make some changes there (and probably also do something to unify the editor we use for that with the one we use for these fields), so to start playing around with some ideas for what we could do I've collapsed the two-now-three buttons that we had in this editor down to a single dropdown! I think this will work much better, but either way doing this will let us get some early feedback from our editors.

![Peek 2021-04-21 15-02](https://user-images.githubusercontent.com/244100/115626668-ae795e00-a2b2-11eb-87fd-2819ece036a3.gif)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
