### PR TITLE
Fix javalab button colors in dark mode

### DIFF
--- a/shared/css/color.scss
+++ b/shared/css/color.scss
@@ -5,6 +5,8 @@
 //   apps/src/color.js during the apps build process.
 
 $black: #000;
+$darkest_gray: #272822;
+$dark_slate_gray: #282c34;
 $dark_charcoal: #4d575f;
 $charcoal: #5b6770;
 $light_gray: #949ca2;


### PR DESCRIPTION
I misunderstood how the color.js file works and accidentally removed the background color of the run, settings, stop, and continue buttons in dark mode (making them light grey). This moves those colors I meant to add into color.scss so they'll be generated with the rest of the colors in color.js 

Buttons now that I've added back their colors
<img width="291" alt="Screen Shot 2021-04-21 at 2 48 21 PM" src="https://user-images.githubusercontent.com/17147070/115625250-a15b6f80-a2b0-11eb-9054-7f2ce5c31878.png">


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
