### PR TITLE
Show tweetdeck to latam language mode in addition to latam geolocations

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/views/home_highlights.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/home_highlights.haml
@@ -50,7 +50,7 @@
           %button 
             =hoc_s(:highlights_see_more)
 -elsif latam_country_code?(@country) || @country == 'la' || @language == 'la'
-  -# For LATAM countries, show only the LATAM HoC Twitter Feed.
+  -# For LATAM countries and Spanish-LATAM language, show only the LATAM HoC Twitter Feed.
   -# For historical reasons, we also use 'la' code to represent LATAM countries in
   -# i18n/countries.json. Unfortunately, it is a real country code for Laos Republic
   -# (ISO_3166-1_alpha-2 codes). We should change it to a different code later.

--- a/pegasus/sites.v3/hourofcode.com/views/home_highlights.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/home_highlights.haml
@@ -49,7 +49,7 @@
         %a{href: "/highlights"}
           %button 
             =hoc_s(:highlights_see_more)
--elsif latam_country_code?(@country) || @country == 'la'
+-elsif latam_country_code?(@country) || @country == 'la' || @language == 'la'
   -# For LATAM countries, show only the LATAM HoC Twitter Feed.
   -# For historical reasons, we also use 'la' code to represent LATAM countries in
   -# i18n/countries.json. Unfortunately, it is a real country code for Laos Republic


### PR DESCRIPTION
International program would like to show the tweetdeck associated with the #horadelcodigo hashtag not only to LATAM geolocation but also to Spanish-LATAM language modes on the hourofcode.com page. This change adds an additional conditional for @language. We are okay with the fact that some of the tweets may be in Portuguese.

## Testing story
Tested locally: 
**Before (hourofcode.com/us/la):**
<img width="674" alt="Screenshot 2021-04-21 153521" src="https://user-images.githubusercontent.com/2933346/115630007-2e55f700-a2b8-11eb-8067-da37e99d8f7d.png">

**After (hourofcode.com/us/la, hourofcode.com/la/la, etc.):**
<img width="671" alt="Screenshot 2021-04-21 153615" src="https://user-images.githubusercontent.com/2933346/115630048-3ada4f80-a2b8-11eb-8019-05b786a3f4ab.png">

## Follow-up work
This is an example of how we conflate language and location. A overarching strategy for translation vs localization is in the works.