### PR TITLE
remove user data from cached bonus level summaries #2

### DIFF
--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -247,15 +247,35 @@ class ScriptLevelsController < ApplicationController
       return
     end
 
-    @stage = Script.get_from_cache(params[:script_id]).lesson_by_relative_position(params[:lesson_position].to_i)
+    user = @user || current_user
+    @stage = Script.get_from_cache(
+      params[:script_id]
+    ).lesson_by_relative_position(
+      params[:lesson_position].to_i
+      )
     @script = @stage.script
+    script_bonus_levels_by_stage = @script.get_bonus_script_levels(@stage)
+
+    # bonus level summaries explicitly don't contain any user-specific data,
+    # so we need to merge in the user's progress.
+    script_bonus_levels_by_stage.each do |stage|
+      stage[:levels].each do |level_summary|
+        ul = UserLevel.find_by(
+          level_id: level_summary[:level_id], user_id: user.id, script: @script
+        )
+        level_summary[:perfect] = ul&.perfect?
+      end
+    end
+
     @stage_extras = {
-      next_stage_number: @stage.next_level_number_for_lesson_extras(current_user),
+      next_stage_number: @stage.next_level_number_for_lesson_extras(user),
       stage_number: @stage.relative_position,
-      next_level_path: @stage.next_level_path_for_lesson_extras(current_user),
-      bonus_levels: @script.get_bonus_script_levels(@stage, current_user),
+      next_level_path: @stage.next_level_path_for_lesson_extras(user),
+      bonus_levels: script_bonus_levels_by_stage,
     }.camelize_keys
-    @bonus_level_ids = @stage.script_levels.where(bonus: true).map(&:level_ids).flatten
+    @bonus_level_ids = @stage.script_levels.where(bonus: true).map(
+      &:level_ids
+    ).flatten
 
     render 'scripts/stage_extras'
   end

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -247,7 +247,6 @@ class ScriptLevelsController < ApplicationController
       return
     end
 
-    user = @user || current_user
     @stage = Script.get_from_cache(
       params[:script_id]
     ).lesson_by_relative_position(
@@ -256,14 +255,17 @@ class ScriptLevelsController < ApplicationController
     @script = @stage.script
     script_bonus_levels_by_stage = @script.get_bonus_script_levels(@stage)
 
-    # bonus level summaries explicitly don't contain any user-specific data,
-    # so we need to merge in the user's progress.
-    script_bonus_levels_by_stage.each do |stage|
-      stage[:levels].each do |level_summary|
-        ul = UserLevel.find_by(
-          level_id: level_summary[:level_id], user_id: user.id, script: @script
-        )
-        level_summary[:perfect] = ul&.perfect?
+    user = @user || current_user
+    unless user.nil?
+      # bonus level summaries explicitly don't contain any user-specific data,
+      # so we need to merge in the user's progress.
+      script_bonus_levels_by_stage.each do |stage|
+        stage[:levels].each do |level_summary|
+          ul = UserLevel.find_by(
+            level_id: level_summary[:level_id], user_id: user.id, script: @script
+          )
+          level_summary[:perfect] = ul&.perfect?
+        end
       end
     end
 

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -493,18 +493,17 @@ class ScriptLevel < ApplicationRecord
     extra_levels
   end
 
-  def summarize_as_bonus(user_id = nil)
-    perfect = user_id ? UserLevel.find_by(level: level, user_id: user_id)&.perfect? : false
+  def summarize_as_bonus
     localized_level_description = I18n.t(level.name, scope: [:data, :bubble_choice_description], default: level.bubble_choice_description)
     localized_level_display_name = I18n.t(level.name, scope: [:data, :display_name], default: level.display_name)
     {
       id: id.to_s,
+      level_id: level.id.to_s,
       type: level.type,
       description: localized_level_description,
       display_name: localized_level_display_name || I18n.t('lesson_extras.bonus_level'),
       thumbnail_url: level.try(:thumbnail_url) || level.try(:solution_image_url),
       url: build_script_level_url(self),
-      perfect: perfect,
       maze_summary: {
         map: JSON.parse(level.try(:maze) || '[]'),
         serialized_maze: level.try(:serialized_maze) && JSON.parse(level.try(:serialized_maze)),

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -1945,6 +1945,28 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     assert extras_data['bonusLevels'][0]['levels'][0]['perfect']
   end
 
+  test "stage extras shows no progress if no current user" do
+    script = create :script
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
+    script_level = create :script_level, lesson: lesson, script: script
+    script_level.bonus = true
+    script_level.save!
+    create :user_level, user: @student, script: script, level: script_level.level, best_result: 100
+    get :stage_extras, params: {
+      script_id: script_level.script,
+      lesson_position: 1,
+      section_id: @section.id,
+      user_id: @student.id
+    }
+    assert_response :success
+    assert_select 'script[data-extras]', 1
+    extras_data = JSON.parse(
+      css_select('script[data-extras]').first.attribute('data-extras').to_s
+    )
+    refute extras_data['bonusLevels'][0]['levels'][0]['perfect']
+  end
+
   test_user_gets_response_for :show, response: :redirect, user: nil,
     params: -> {script_level_params(@pilot_script_level)},
     name: 'signed out user cannot view pilot script level'

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -1880,6 +1880,71 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test "stage extras shows progress for current user if no section and user id" do
+    sign_in @student
+    script = create :script
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
+    script_level = create :script_level, lesson: lesson, script: script
+    script_level.bonus = true
+    script_level.save!
+    create :user_level, user: @student, script: script, level: script_level.level, best_result: 100
+    get :stage_extras, params: {
+      script_id: script_level.script,
+      lesson_position: 1
+    }
+    assert_response :success
+    assert_select 'script[data-extras]', 1
+    extras_data = JSON.parse(
+      css_select('script[data-extras]').first.attribute('data-extras').to_s
+    )
+    assert extras_data['bonusLevels'][0]['levels'][0]['perfect']
+  end
+
+  test "stage extras shows teacher no progress if no section and user id" do
+    sign_in @teacher
+    script = create :script
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
+    script_level = create :script_level, lesson: lesson, script: script
+    script_level.bonus = true
+    script_level.save!
+    create :user_level, user: @student, script: script, level: script_level.level, best_result: 100
+    get :stage_extras, params: {
+      script_id: script_level.script,
+      lesson_position: 1
+    }
+    assert_response :success
+    assert_select 'script[data-extras]', 1
+    extras_data = JSON.parse(
+      css_select('script[data-extras]').first.attribute('data-extras').to_s
+    )
+    refute extras_data['bonusLevels'][0]['levels'][0]['perfect']
+  end
+
+  test "stage extras shows teacher progress for student if section and user id" do
+    sign_in @teacher
+    script = create :script
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
+    script_level = create :script_level, lesson: lesson, script: script
+    script_level.bonus = true
+    script_level.save!
+    create :user_level, user: @student, script: script, level: script_level.level, best_result: 100
+    get :stage_extras, params: {
+      script_id: script_level.script,
+      lesson_position: 1,
+      section_id: @section.id,
+      user_id: @student.id
+    }
+    assert_response :success
+    assert_select 'script[data-extras]', 1
+    extras_data = JSON.parse(
+      css_select('script[data-extras]').first.attribute('data-extras').to_s
+    )
+    assert extras_data['bonusLevels'][0]['levels'][0]['perfect']
+  end
+
   test_user_gets_response_for :show, response: :redirect, user: nil,
     params: -> {script_level_params(@pilot_script_level)},
     name: 'signed out user cannot view pilot script level'

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1553,7 +1553,6 @@ class ScriptTest < ActiveSupport::TestCase
   end
 
   test "get_bonus_script_levels" do
-    student = create :student
     script = create :script
     lesson_group = create :lesson_group, script: script
     lesson1 = create :lesson, script: script, lesson_group: lesson_group
@@ -1564,8 +1563,8 @@ class ScriptTest < ActiveSupport::TestCase
     create :script_level, script: script, lesson: lesson3, bonus: true
     create :script_level, script: script, lesson: lesson3, bonus: true
 
-    bonus_levels1 = script.get_bonus_script_levels(lesson1, student)
-    bonus_levels3 = script.get_bonus_script_levels(lesson3, student)
+    bonus_levels1 = script.get_bonus_script_levels(lesson1)
+    bonus_levels3 = script.get_bonus_script_levels(lesson3)
 
     assert_equal 1, bonus_levels1.length
     assert_equal 1, bonus_levels1[0][:stageNumber]


### PR DESCRIPTION
this PR reintroduces #40035, which was reverted when honeybadger alerted us that it caused a livesite issue.

the fix was simply to check `user.nil?` before attempting to merge user progress into the cached bonus level summaries.

the first commit in this PR is a squash of the commits from #40035, and the second commit is the fix.