### PR TITLE
Remove unused codeorg-logo.png from WebLab project start_sources

### DIFF
--- a/dashboard/config/scripts/levels/New Web Lab Project.level
+++ b/dashboard/config/scripts/levels/New Web Lab Project.level
@@ -5,12 +5,11 @@
   "level_num": "custom",
   "user_id": 2,
   "properties": {
-    "start_sources": "{\r\n  \"files\": [\r\n    {\r\n      \"name\": \"index.html\",\r\n      \"data\": \"<!DOCTYPE html>\\n<html>\\n  <head>\\n    <link rel=\\\"stylesheet\\\" href=\\\"style.css\\\">\\n  </head>\\n  <body>\\n    \\n  </body>\\n</html>\"\r\n    },\r\n    {\r\n      \"name\": \"style.css\",\r\n      \"data\": \"body {\\n  background: white;\\n}\\np {\\n  color: black;\\n}\\nh1 {\\n  font-weight: bold;\\n}\"\r\n    },\r\n    {\r\n      \"name\": \"codeorg-logo.png\"\r\n    }\r\n  ]\r\n}\r\n",
+    "start_sources": "{\r\n  \"files\": [\r\n    {\r\n      \"name\": \"index.html\",\r\n      \"data\": \"<!DOCTYPE html>\\n<html>\\n  <head>\\n    <link rel=\\\"stylesheet\\\" href=\\\"style.css\\\">\\n  </head>\\n  <body>\\n    \\n  </body>\\n</html>\"\r\n    },\r\n    {\r\n      \"name\": \"style.css\",\r\n      \"data\": \"body {\\n  background: white;\\n}\\np {\\n  color: black;\\n}\\nh1 {\\n  font-weight: bold;\\n}\"\r\n    }\r\n  ]\r\n}\r\n",
     "is_project_level": "true"
   },
   "published": true,
   "notes": "",
-  "level_concept_difficulty": {
-  }
+  "level_concept_difficulty": {}
 }]]></config>
 </Weblab>


### PR DESCRIPTION
Removes the unused `codeorg-logo.png` from `start_sources` when creating a new standalone WebLab project. This file is unused because it doesn't have a URL or data property, which is required for start sources (more explicitly, just a filename isn't enough information for populating a start source).

That meant that every time a new WebLab project was created, this error was triggered:
https://github.com/code-dot-org/code-dot-org/blob/fe6c3802551d463ca0b5767acf061b72bb923e33/apps/src/weblab/CdoBramble.js#L537-L539

(That error previously lived [here](https://github.com/code-dot-org/code-dot-org/blame/29e5bfe97220d44e2f93bb5cac301e6b493ede4d/apps/src/weblab/brambleHost.js#L119). The URL for `codeorg-logo.png` was removed in [this commit](https://github.com/code-dot-org/code-dot-org/commit/18622edb57c91424f8e34c965abc3bfb75b5a407#diff-13c429598b7f7c82d76986f8b48582cee16bd42a08315d1e193187b87d9c6088), so this file has been unused since 2017.)

## Testing story

Tested manually.