### PR TITLE
Fix typo in Resource PDF generation

### DIFF
--- a/dashboard/lib/services/curriculum_pdfs/resources.rb
+++ b/dashboard/lib/services/curriculum_pdfs/resources.rb
@@ -91,7 +91,7 @@ module Services
 
           # If file is already a PDF, we can just download it; otherwise, we
           # need to export to convert it.
-          if file.available_content_types.include? "appliction/pdf"
+          if file.available_content_types.include? "application/pdf"
             file.download_to_file(path)
           else
             # The intuitive option here would be to use


### PR DESCRIPTION
Specifically, in the comparison which was trying to determine whether or not a file should be downloaded or exported, which resulted in us trying to export files that should be downloaded.

Also added a unit test to cover this case.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
