### PR TITLE
Allow Instructor Review in Professional Learning Courses without Peer Review

### DIFF
--- a/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
@@ -975,10 +975,9 @@ class ScriptEditor extends React.Component {
               <p>
                 Our Professional Learning Courses solicit self-reflections from
                 participants, which are then typically shown to other
-                participants in the enrolled in the course for feedback. This is
-                known as known as "peer review". The instructor of the course
-                also sees these self-reflections and can provide feedback as
-                well.
+                participants enrolled in the course for feedback. This is known
+                as "peer review". The instructor of the course also sees these
+                self-reflections and can provide feedback as well.
                 <br />
                 <br />
                 This setting allows you to collect those same reflections from

--- a/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
@@ -38,8 +38,11 @@ const styles = {
     borderRadius: 4,
     margin: 0
   },
+  label: {
+    fontWeight: 'bolder'
+  },
   checkbox: {
-    margin: '0 0 0 7px'
+    margin: '7px 0 7px 7px'
   },
   dropdown: {
     margin: '0 6px'
@@ -72,6 +75,7 @@ class ScriptEditor extends React.Component {
     initialStudentDetailProgressView: PropTypes.bool,
     initialProfessionalLearningCourse: PropTypes.string,
     initialPeerReviewsRequired: PropTypes.number,
+    initialOnlyInstructorReviewRequired: PropTypes.bool,
     initialWrapupVideo: PropTypes.string,
     initialProjectWidgetVisible: PropTypes.bool,
     initialProjectWidgetTypes: PropTypes.arrayOf(PropTypes.string),
@@ -141,6 +145,8 @@ class ScriptEditor extends React.Component {
       hideableLessons: this.props.initialHideableLessons,
       studentDetailProgressView: this.props.initialStudentDetailProgressView,
       professionalLearningCourse: this.props.initialProfessionalLearningCourse,
+      onlyInstructorReviewRequired: this.props
+        .initialOnlyInstructorReviewRequired,
       peerReviewsRequired: this.props.initialPeerReviewsRequired,
       wrapupVideo: this.props.initialWrapupVideo,
       projectWidgetVisible: this.props.initialProjectWidgetVisible,
@@ -282,6 +288,7 @@ class ScriptEditor extends React.Component {
       hideable_lessons: this.state.hideableLessons,
       student_detail_progress_view: this.state.studentDetailProgressView,
       professional_learning_course: this.state.professionalLearningCourse,
+      only_instructor_review_required: this.state.onlyInstructorReviewRequired,
       peer_reviews_to_complete: this.state.peerReviewsRequired,
       wrapup_video: this.state.wrapupVideo,
       project_widget_visible: this.state.projectWidgetVisible,
@@ -950,6 +957,37 @@ class ScriptEditor extends React.Component {
               />
             </label>
           )}
+          <label style={styles.label}>
+            Only Require Review from Instructor (no Peer Reviews)
+            <input
+              type="checkbox"
+              checked={this.state.onlyInstructorReviewRequired}
+              style={styles.checkbox}
+              onChange={() =>
+                this.setState({
+                  onlyInstructorReviewRequired: !this.state
+                    .onlyInstructorReviewRequired,
+                  peerReviewsRequired: 0
+                })
+              }
+            />
+            <HelpTip>
+              <p>
+                Our Professional Learning Courses solicit self-reflections from
+                participants, which are then typically shown to other
+                participants in the enrolled in the course for feedback. This is
+                known as known as "peer review". The instructor of the course
+                also sees these self-reflections and can provide feedback as
+                well.
+                <br />
+                <br />
+                This setting allows you to collect those same reflections from
+                from workshop participants and have the workshop instructor
+                review them <strong>without</strong> soliciting peer reviews of
+                those reflections by other participants in the workshop.
+              </p>
+            </HelpTip>
+          </label>
           <label>
             Number of Peer Reviews to Complete
             <HelpTip>
@@ -961,6 +999,7 @@ class ScriptEditor extends React.Component {
               onChange={e =>
                 this.setState({peerReviewsRequired: e.target.value})
               }
+              disabled={this.state.onlyInstructorReviewRequired}
             />
           </label>
         </CollapsibleEditorSection>

--- a/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
@@ -38,11 +38,8 @@ const styles = {
     borderRadius: 4,
     margin: 0
   },
-  label: {
-    fontWeight: 'bolder'
-  },
   checkbox: {
-    margin: '7px 0 7px 7px'
+    margin: '0 0 0 7px'
   },
   dropdown: {
     margin: '0 6px'
@@ -957,9 +954,10 @@ class ScriptEditor extends React.Component {
               />
             </label>
           )}
-          <label style={styles.label}>
+          <label>
             Only Require Review from Instructor (no Peer Reviews)
             <input
+              id="only_instructor_review_checkbox"
               type="checkbox"
               checked={this.state.onlyInstructorReviewRequired}
               style={styles.checkbox}
@@ -993,6 +991,7 @@ class ScriptEditor extends React.Component {
               <p>Currently only supported for professional learning courses</p>
             </HelpTip>
             <input
+              id={'number_peer_reviews_input'}
               value={this.state.peerReviewsRequired}
               style={styles.input}
               onChange={e =>

--- a/apps/src/sites/studio/pages/scripts/edit.js
+++ b/apps/src/sites/studio/pages/scripts/edit.js
@@ -64,6 +64,9 @@ export default function initPage(scriptEditorData) {
         initialProfessionalLearningCourse={
           scriptData.professionalLearningCourse || ''
         }
+        initialOnlyInstructorReviewRequired={
+          scriptData.only_instructor_review_required
+        }
         initialPeerReviewsRequired={scriptData.peerReviewsRequired}
         initialWrapupVideo={scriptData.wrapupVideo || ''}
         initialProjectWidgetVisible={scriptData.project_widget_visible}

--- a/apps/test/unit/lib/levelbuilder/script-editor/ScriptEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/ScriptEditorTest.jsx
@@ -222,6 +222,30 @@ describe('ScriptEditor', () => {
     });
   });
 
+  it('disables peer review count when instructor review only selected', () => {
+    const wrapper = createWrapper({
+      initialOnlyInstructorReviewRequired: false,
+      initialPeerReviewsRequired: 2
+    });
+
+    let peerReviewCountInput = wrapper.find('#number_peer_reviews_input');
+
+    expect(peerReviewCountInput.props().disabled).to.be.false;
+    expect(peerReviewCountInput.props().value).to.equal(2);
+
+    const instructorReviewOnlyCheckbox = wrapper.find(
+      '#only_instructor_review_checkbox'
+    );
+    instructorReviewOnlyCheckbox.simulate('change', {
+      target: {checked: true}
+    });
+
+    peerReviewCountInput = wrapper.find('#number_peer_reviews_input');
+
+    expect(peerReviewCountInput.props().disabled).to.be.true;
+    expect(peerReviewCountInput.props().value).to.equal(0);
+  });
+
   describe('Saving Script Editor', () => {
     let clock;
 

--- a/apps/test/unit/lib/levelbuilder/script-editor/ScriptEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/ScriptEditorTest.jsx
@@ -96,8 +96,6 @@ describe('ScriptEditor', () => {
     it('uses old script editor for non migrated script', () => {
       const wrapper = createWrapper({initialHidden: false});
 
-      console.log(wrapper.debug());
-
       expect(wrapper.find('input').length).to.equal(24);
       expect(wrapper.find('input[type="checkbox"]').length).to.equal(12);
       expect(wrapper.find('textarea').length).to.equal(3);

--- a/apps/test/unit/lib/levelbuilder/script-editor/ScriptEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/ScriptEditorTest.jsx
@@ -96,8 +96,10 @@ describe('ScriptEditor', () => {
     it('uses old script editor for non migrated script', () => {
       const wrapper = createWrapper({initialHidden: false});
 
-      expect(wrapper.find('input').length).to.equal(23);
-      expect(wrapper.find('input[type="checkbox"]').length).to.equal(11);
+      console.log(wrapper.debug());
+
+      expect(wrapper.find('input').length).to.equal(24);
+      expect(wrapper.find('input[type="checkbox"]').length).to.equal(12);
       expect(wrapper.find('textarea').length).to.equal(3);
       expect(wrapper.find('select').length).to.equal(5);
       expect(wrapper.find('CollapsibleEditorSection').length).to.equal(8);
@@ -110,8 +112,8 @@ describe('ScriptEditor', () => {
     it('uses new script editor for migrated script', () => {
       const wrapper = createWrapper({initialHidden: false, isMigrated: true});
 
-      expect(wrapper.find('input').length).to.equal(27);
-      expect(wrapper.find('input[type="checkbox"]').length).to.equal(13);
+      expect(wrapper.find('input').length).to.equal(28);
+      expect(wrapper.find('input[type="checkbox"]').length).to.equal(14);
       expect(wrapper.find('textarea').length).to.equal(4);
       expect(wrapper.find('select').length).to.equal(4);
       expect(wrapper.find('CollapsibleEditorSection').length).to.equal(9);

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -212,6 +212,7 @@ class ScriptsController < ApplicationController
       :hideable_lessons,
       :curriculum_path,
       :professional_learning_course,
+      :only_instructor_review_required,
       :peer_reviews_to_complete,
       :wrapup_video,
       :student_detail_progress_view,

--- a/dashboard/app/dsl/script_dsl.rb
+++ b/dashboard/app/dsl/script_dsl.rb
@@ -36,7 +36,9 @@ class ScriptDSL < BaseDSL
   end
 
   integer :id
+
   string :professional_learning_course
+  boolean :only_instructor_review_required
   integer :peer_reviews_to_complete
 
   boolean :hidden
@@ -147,6 +149,7 @@ class ScriptDSL < BaseDSL
       hideable_lessons: @hideable_lessons,
       student_detail_progress_view: @student_detail_progress_view,
       professional_learning_course: @professional_learning_course,
+      only_instructor_review_required: @only_instructor_review_required,
       peer_reviews_to_complete: @peer_reviews_to_complete,
       teacher_resources: @teacher_resources,
       lesson_extras_available: @lesson_extras_available,

--- a/dashboard/app/dsl/script_dsl.rb
+++ b/dashboard/app/dsl/script_dsl.rb
@@ -330,6 +330,7 @@ class ScriptDSL < BaseDSL
     s << "id '#{legacy_script_ids[script.name]}'" if legacy_script_ids[script.name]
 
     s << "professional_learning_course '#{script.professional_learning_course}'" if script.professional_learning_course
+    s << "only_instructor_review_required #{script.only_instructor_review_required}" if script.only_instructor_review_required
     s << "peer_reviews_to_complete #{script.peer_reviews_to_complete}" if script.peer_reviews_to_complete.try(:>, 0)
 
     s << 'hidden false' unless script.hidden

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1367,7 +1367,7 @@ class Script < ApplicationRecord
     # TODO: Set up peer reviews to be more consistent with the rest of the system
     # so that they don't need a bunch of one off cases (example peer reviews
     # don't have a lesson group in the database right now)
-    if has_peer_reviews?
+    if has_peer_reviews? && !only_instructor_review_required?
       levels = []
       peer_reviews_to_complete.times do |x|
         levels << {

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -189,8 +189,9 @@ class Script < ApplicationRecord
   #   script is being updated, so we can regenerate PDFs.
   serialized_attrs %w(
     hideable_lessons
-    peer_reviews_to_complete
     professional_learning_course
+    only_instructor_review_required
+    peer_reviews_to_complete
     redirect_to
     student_detail_progress_view
     project_widget_visible

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1413,6 +1413,7 @@ class Script < ApplicationRecord
       disablePostMilestone: disable_post_milestone?,
       isHocScript: hoc?,
       csf: csf?,
+      only_instructor_review_required: only_instructor_review_required?,
       peerReviewsRequired: peer_reviews_to_complete || 0,
       peerReviewLessonInfo: peer_review_lesson_info,
       student_detail_progress_view: student_detail_progress_view?,
@@ -1646,6 +1647,7 @@ class Script < ApplicationRecord
     nonboolean_keys = [
       :hideable_lessons,
       :professional_learning_course,
+      :only_instructor_review_required,
       :peer_reviews_to_complete,
       :student_detail_progress_view,
       :project_widget_visible,

--- a/dashboard/test/dsl/script_dsl_test.rb
+++ b/dashboard/test/dsl/script_dsl_test.rb
@@ -14,9 +14,10 @@ class ScriptDslTest < ActiveSupport::TestCase
     wrapup_video: nil,
     login_required: false,
     professional_learning_course: nil,
+    only_instructor_review_required: nil,
+    peer_reviews_to_complete: nil,
     hideable_lessons: false,
     student_detail_progress_view: false,
-    peer_reviews_to_complete: nil,
     teacher_resources: [],
     lesson_extras_available: false,
     has_verified_resources: false,
@@ -424,6 +425,17 @@ endvariants
     DSL
     output, _ = ScriptDSL.parse(input_dsl, 'test.script', 'test')
     assert_equal [{"notice": "NoticeHere", "details": "DetailsHere", "link": "/foo/bar", "type": "information"}], output[:announcements]
+  end
+
+  test 'can set only_instructor_review_required' do
+    input_dsl = <<~DSL
+      only_instructor_review_required true
+
+      lesson 'Lesson1', display_name: 'Lesson1'
+      level 'Level 1'
+    DSL
+    output, _ = ScriptDSL.parse(input_dsl, 'test.script', 'test')
+    assert_equal true, output[:only_instructor_review_required]
   end
 
   test 'can set pilot_experiment' do

--- a/dashboard/test/models/peer_review_test.rb
+++ b/dashboard/test/models/peer_review_test.rb
@@ -46,6 +46,17 @@ class PeerReviewTest < ActiveSupport::TestCase
     assert_equal Set[nil, 'escalated'], PeerReview.where(submitter: @user, level: @level).map(&:status).to_set
   end
 
+  test 'submitting a peer reviewed level in instructor review only script should create one escalated PeerReview object' do
+    script_only_instructor_review = create :script, only_instructor_review_required: true
+    script_level_only_instructor_review = create :script_level, levels: [@level], script: script_only_instructor_review
+
+    assert_difference('PeerReview.count', 1) do
+      track_progress @level_source.id, @user, script_level_only_instructor_review
+    end
+
+    assert_equal ['escalated'], PeerReview.where(submitter: @user, level: @level).map(&:status)
+  end
+
   test 'submitting a non peer reviewable level should not create Peer Review objects' do
     @level.peer_reviewable = 'false'
     @level.save

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -854,6 +854,25 @@ class ScriptTest < ActiveSupport::TestCase
     assert_equal 1, summary[:peerReviewsRequired]
   end
 
+  test 'does not include peer reviews in script that only requires instructor review' do
+    # Our script editing UI prevents creating a script with a number of peer reviews
+    # to complete that is not 0 when only instructor review is required.
+    # That said, this test confirms that we would not display a peer review lesson even if this
+    # did occur.
+    script = create(:script,
+      name: 'script-with-peer-review',
+      peer_reviews_to_complete: 1,
+      only_instructor_review_required: true
+    )
+    lesson_group = create(:lesson_group, key: 'key1', script: script)
+    lesson = create(:lesson, script: script, name: 'lesson 1', lesson_group: lesson_group)
+    create(:script_level, script: script, lesson: lesson)
+
+    summary = script.summarize
+
+    assert_nil summary[:peerReviewLessonInfo]
+  end
+
   test 'can summarize script for lesson plan' do
     script = create :script, name: 'my-script'
     lesson_group = create :lesson_group, key: 'lg-1', script: script


### PR DESCRIPTION
In our current Professional Learning Courses, participants conduct self-reflections, which are then presented to other participants in the course for review ("Peer Review"). Their reflections are also presented to the instructor of the course for review ("Instructor Review").

Prior to this change, there was no way to get Instructor Review without getting Peer Review as well. This change separates the two by adding an override property (editable in our Script Editor) that will solicit Instructor Review, but not Peer Review.

**(before) Professional Learning Course Unit (ie, Script) with Peer Review enabled:**

![image](https://user-images.githubusercontent.com/25372625/115900850-4a22df80-a415-11eb-85ef-1bc20708efe0.png)

**(after) Professional Learning Course Unit (ie, Script) with Only Instructor Review (no Peer Review) enabled:**

![image](https://user-images.githubusercontent.com/25372625/115900926-632b9080-a415-11eb-9c1e-6bfc8902b423.png)

## Links

Jira: https://codedotorg.atlassian.net/browse/PLC-1136

## Testing story

Tested manually by:

**New case (only instructor review)**
- Enrolling an account in a Professional Learning Course with the "only instructor review required" setting turned on, and confirming that the "Peer Review" section of the script overview page did not appear.
- Submitted a self-reflection for this enrollee, and confirmed I could write feedback for the enrollee as the instructor.

**Existing case (peer review and instructor review)**
- Enrolled two accounts in a Professional Learning Course with peer reviews required and the "only instructor review required" setting turned off.
- Submitted a self-reflection in one of these accounts, and confirmed a Peer Review request became visible for the other enrollee, and a Instructor Review was requested from the instructor.

This change is effectively boils down to using the new Script property (`only_instructor_review_required`) to:

1. prevent the creation of a `PeerReview` object intended for Peer Review, and
2. do not show Peer Review levels on our script overview page for scripts with this property.

Added unit tests where appropriate to cover these new changes.

## PR Checklist:

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
