### PR TITLE
Set width on lesson navigation dropdown so that it doesn't change siz…

### DIFF
--- a/apps/src/templates/lessonOverview/LessonNavigationDropdown.jsx
+++ b/apps/src/templates/lessonOverview/LessonNavigationDropdown.jsx
@@ -14,6 +14,15 @@ const styles = {
   },
   boldText: {
     fontFamily: '"Gotham 7r", sans-serif'
+  },
+  section: {
+    width: 300,
+    fontFamily: '"Gotham 4r", sans-serif',
+    backgroundColor: color.lightest_purple
+  },
+  lesson: {
+    width: 300,
+    fontFamily: '"Gotham 4r", sans-serif'
   }
 };
 
@@ -123,14 +132,7 @@ export default class LessonNavigationDropdown extends Component {
               key={index}
               onClick={this.handleDropdownClick.bind(this, listItem)}
               className={listItem.link ? 'navigate' : 'no-navigation'} // Used to specify if the dropdown should collapse when clicked
-              style={
-                listItem.link
-                  ? {fontFamily: '"Gotham 4r", sans-serif'}
-                  : {
-                      fontFamily: '"Gotham 4r", sans-serif',
-                      backgroundColor: color.lightest_purple
-                    }
-              }
+              style={listItem.link ? styles.lesson : styles.section}
             >
               {listItem.link && (
                 <span style={{marginLeft: 10}}>


### PR DESCRIPTION
The lesson navigation dropdown would change size if different sets of lessons in different lesson groups took up different amount of space. This sets a standard size to be used by all the elements so that the component does not change size. I check this on a couple different scripts and it seems to work well for short as well as long names. Sometimes long names are on two lines but I think thats ok.
