### PR TITLE
Post progress update when 'Continue' is clicked for StandaloneVideo, etc.

### DIFF
--- a/apps/src/code-studio/levels/postOnContinue.js
+++ b/apps/src/code-studio/levels/postOnContinue.js
@@ -1,8 +1,11 @@
 /* global appOptions */
 
 /**
- * A set of helpers used for cases where we want to make our milestone post on
- * page load rather than on clicking continue
+ * A set of helpers used for cases where we want to make our milestone post
+ * when clicking 'Continue'.
+ *
+ * Note: There is similar (but more complex) functionality in levels/_dialog.js.
+ * Consider merging the two implementations at some point.
  */
 
 import {getResult} from '@cdo/apps/code-studio/levels/codeStudioLevels';
@@ -16,7 +19,7 @@ import {TestResults} from '@cdo/apps/constants';
  * Make our milestone post with some simple configuration. Note, this assumes
  * the level is a type that will always post "success".
  */
-export function postMilestoneForPageLoad() {
+export function onContinue() {
   // In cases where this is used, we register the default getResult function, so
   // this will just be { response: 'ok', result: true }
   const result = getResult();
@@ -38,23 +41,16 @@ export function postMilestoneForPageLoad() {
     level: appOptions.dialog.level,
     result: result.result,
     pass: true,
-    testResult: TestResults.ALL_PASS
+    testResult: TestResults.ALL_PASS,
+    onComplete: function() {
+      const lastServerResponse = getLastServerResponse();
+      let url = lastServerResponse && lastServerResponse.nextRedirect;
+      if (!url) {
+        const fallback = JSON.parse(appOptions.dialog.fallbackResponse);
+        url = fallback.success.redirect;
+      }
+
+      window.location.href = url;
+    }
   });
-}
-
-/**
- * Code to run when clicking continue on a page where we make our milestone
- * post on page load. In this case, if we heard back we want to check the response
- * for the next page to go to. If we didn't hear back, just use the fallback.
- * In practice, these will be identical.
- */
-export function onContinue() {
-  const lastServerResponse = getLastServerResponse();
-  let url = lastServerResponse && lastServerResponse.nextRedirect;
-  if (!url) {
-    const fallback = JSON.parse(appOptions.dialog.fallbackResponse);
-    url = fallback.success.redirect;
-  }
-
-  window.location.href = url;
 }

--- a/apps/src/code-studio/levels/postOnContinue.js
+++ b/apps/src/code-studio/levels/postOnContinue.js
@@ -20,6 +20,13 @@ import {TestResults} from '@cdo/apps/constants';
  * the level is a type that will always post "success".
  */
 export function onContinue() {
+  // prevent multiple milestone reports
+  const submitButton = $('.submitButton');
+  if (submitButton.attr('disabled')) {
+    return;
+  }
+  submitButton.attr('disabled', true);
+
   // In cases where this is used, we register the default getResult function, so
   // this will just be { response: 'ok', result: true }
   const result = getResult();

--- a/apps/src/sites/studio/pages/levels/_curriculum_reference.js
+++ b/apps/src/sites/studio/pages/levels/_curriculum_reference.js
@@ -1,15 +1,9 @@
 import $ from 'jquery';
 import {registerGetResult} from '@cdo/apps/code-studio/levels/codeStudioLevels';
-import {
-  postMilestoneForPageLoad,
-  onContinue
-} from '@cdo/apps/code-studio/levels/postOnLoad';
+import {onContinue} from '@cdo/apps/code-studio/levels/postOnContinue';
 
 $(document).ready(() => {
   registerGetResult();
-
-  // make milestone post
-  postMilestoneForPageLoad();
 
   // handle click on continue (results in navigating to next puzzle)
   $('.submitButton').click(onContinue);

--- a/apps/src/sites/studio/pages/levels/_external.js
+++ b/apps/src/sites/studio/pages/levels/_external.js
@@ -1,9 +1,6 @@
 import $ from 'jquery';
 import {registerGetResult} from '@cdo/apps/code-studio/levels/codeStudioLevels';
-import {
-  postMilestoneForPageLoad,
-  onContinue
-} from '@cdo/apps/code-studio/levels/postOnLoad';
+import {onContinue} from '@cdo/apps/code-studio/levels/postOnContinue';
 
 $(document).ready(() => {
   const script = document.querySelector('script[data-external]');
@@ -16,9 +13,6 @@ $(document).ready(() => {
   }
 
   registerGetResult();
-
-  // make milestone post
-  postMilestoneForPageLoad();
 
   // Handle click on the continue button (results in navigating to next puzzle)
   // Note: We're using this pattern instead of

--- a/apps/src/sites/studio/pages/levels/_standalone_video.js
+++ b/apps/src/sites/studio/pages/levels/_standalone_video.js
@@ -1,9 +1,6 @@
 import $ from 'jquery';
 import {registerGetResult} from '@cdo/apps/code-studio/levels/codeStudioLevels';
-import {
-  postMilestoneForPageLoad,
-  onContinue
-} from '@cdo/apps/code-studio/levels/postOnLoad';
+import {onContinue} from '@cdo/apps/code-studio/levels/postOnContinue';
 import {createVideoWithFallback} from '@cdo/apps/code-studio/videos';
 import getScriptData from '@cdo/apps/util/getScriptData';
 import React from 'react';
@@ -13,9 +10,6 @@ import _ from 'lodash';
 
 $(document).ready(() => {
   registerGetResult();
-
-  // make milestone post
-  postMilestoneForPageLoad();
 
   // handle click on continue (results in navigating to next puzzle)
   $('.submitButton').click(onContinue);

--- a/dashboard/test/ui/features/learning_platform/level_types/standalone_video.feature
+++ b/dashboard/test/ui/features/learning_platform/level_types/standalone_video.feature
@@ -1,0 +1,11 @@
+Feature: Standalone video levels
+
+@as_student
+Scenario: Progress is posted when continue is clicked
+  Given I am on "http://localhost-studio.code.org:3000/s/allthethings/lessons/34/levels/1"
+  And I wait until element ".submitButton" is visible
+  Then I verify progress in the header of the current page is "not_tried" for level 1
+  When I click ".submitButton" to load a new page
+  And I am on "http://localhost-studio.code.org:3000/s/allthethings/lessons/34/levels/1"
+  And I wait until element ".submitButton" is visible
+  Then I verify progress in the header of the current page is "perfect" for level 1


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Currently, StandaloneVideo, CurriculumReference, and External post progress when the level is loaded (a.k.a. "auto-green").  With this PR, these levels now post progress when 'Continue' is clicked, making the behavior more similar to other level types.

I opted for a more targeted fix that touches only postOnLoad.js (now renamed to postOnContinue.js).  A bigger cleanup that we could do in the future is to change these level types to use _dialog.js.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [LP-1847](https://codedotorg.atlassian.net/browse/LP-1847)

## Testing story

Added new UI test.  Verified that the UI test fails against production but passes against my local server.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
