### PR TITLE
Fix paths to required files

### DIFF
--- a/bin/i18n/translation_status/update_translation_status.rb
+++ b/bin/i18n/translation_status/update_translation_status.rb
@@ -1,9 +1,9 @@
 #!/usr/bin/env ruby
-require_relative '../cron/only_one'
+require_relative '../../cron/only_one'
 abort 'Script already running' unless only_one_running?(__FILE__)
 
-require_relative '../../lib/cdo/redshift'
-require_relative '../../dashboard/config/environment'
+require_relative '../../../lib/cdo/redshift'
+require_relative '../../../dashboard/config/environment'
 
 # Gets all unique string keys added to the i18n_string_tracking_events table
 # over the last N days.


### PR DESCRIPTION
Fix a bug in https://github.com/code-dot-org/code-dot-org/pull/40092. I moved `update_translation_status.rb` to `translation_status` folder, but forgot to update paths to the required files. 