### PR TITLE
Drop contact rollups V1 tables

### DIFF
--- a/pegasus/migrations/136_drop_contact_rollups.rb
+++ b/pegasus/migrations/136_drop_contact_rollups.rb
@@ -1,0 +1,18 @@
+Sequel.migration do
+  up do
+    # "Contact rollups" is a process that syncs emails we've collected to our marketing platform (Pardot).
+    # The first version was built using a Pegasus table, which we've since deprecated.
+    # We (as of April 2021) manage this process in Dashboard.
+    # See this file (ContactRollupsV2) for more details:
+    # https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/lib/contact_rollups_v2.rb
+    drop_table(:contact_rollups)
+
+    # This table was generated dynamically if you ran the contact rollups process
+    # (ie, was never created by migration).
+    # See deleted file here: https://github.com/code-dot-org/code-dot-org/blob/486fd1f360397cf4bfc9334828c5b640eeb390c8/lib/cdo/contact_rollups.rb#L331
+    # Which was removed in this PR: https://github.com/code-dot-org/code-dot-org/pull/37901
+    # Dropping this table conditionally on it existing, as it will only exist in environments where Contact Rollups V1
+    # has been run.
+    drop_table?(:contact_rollups_daily)
+  end
+end


### PR DESCRIPTION
Drops unused Pegasus tables that were used in the first version of our Contact Rollups process, which syncs emails/metadata to our marketing platform (Pardot).

Belated follow-up to https://github.com/code-dot-org/code-dot-org/pull/37901 from a few months ago, which removed all code referencing the first version of contact rollups

## Testing story

I executed this migration locally via `bundle exec rake pegasus:setup_db` in the pegasus directory, and observed that both `contact_rollups` and `contact_rollups_daily` were deleted from my local db (I had the `_daily` table because I had run CRv1 locally, other developers may not have it).

## Deployment strategy

I think we should be fine to just have this be executed as part of our normal deployment process -- @sureshc, LMK if you disagree.

## PR Checklist:

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
