### PR TITLE
Adding a levelbuilder area including a dropdown option for the visual display type

### DIFF
--- a/dashboard/app/models/levels/dsl_defined.rb
+++ b/dashboard/app/models/levels/dsl_defined.rb
@@ -172,7 +172,6 @@ class DSLDefined < Level
 
     level_params = {}
     level_params[:encrypted] = level_encrypted? if level_encrypted?
-    level_params[:neighborhood_enabled] = neighborhood_enabled? if neighborhood_enabled?
     self.class.create_from_level_builder({dsl_text: new_dsl}, level_params) if new_dsl
   end
 
@@ -197,14 +196,6 @@ class DSLDefined < Level
 
   def encrypted=(value)
     properties['encrypted'] = value
-  end
-
-  def neighborhood_enabled?
-    properties['neighborhood_enabled'].present? && properties['neighborhood_enabled'] != "false"
-  end
-
-  def neighborhood_enabled=(value)
-    properties['neighborhood_enabled'] = value
   end
 
   # don't allow markdown in DSL levels unless child class overrides this

--- a/dashboard/app/models/levels/dsl_defined.rb
+++ b/dashboard/app/models/levels/dsl_defined.rb
@@ -172,6 +172,7 @@ class DSLDefined < Level
 
     level_params = {}
     level_params[:encrypted] = level_encrypted? if level_encrypted?
+    level_params[:neighborhood_enabled] = neighborhood_enabled? if neighborhood_enabled?
     self.class.create_from_level_builder({dsl_text: new_dsl}, level_params) if new_dsl
   end
 
@@ -196,6 +197,14 @@ class DSLDefined < Level
 
   def encrypted=(value)
     properties['encrypted'] = value
+  end
+
+  def neighborhood_enabled?
+    properties['neighborhood_enabled'].present? && properties['neighborhood_enabled'] != "false"
+  end
+
+  def neighborhood_enabled=(value)
+    properties['neighborhood_enabled'] = value
   end
 
   # don't allow markdown in DSL levels unless child class overrides this

--- a/dashboard/app/models/levels/javalab.rb
+++ b/dashboard/app/models/levels/javalab.rb
@@ -31,6 +31,7 @@ class Javalab < Level
     is_project_level
     submittable
     encrypted_examples
+    neighborhood_enabled
   )
 
   before_save :fix_examples

--- a/dashboard/app/models/levels/javalab.rb
+++ b/dashboard/app/models/levels/javalab.rb
@@ -31,7 +31,7 @@ class Javalab < Level
     is_project_level
     submittable
     encrypted_examples
-    neighborhood_enabled
+    csa_view_mode
   )
 
   before_save :fix_examples

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -87,6 +87,7 @@ class Level < ApplicationRecord
     rubric_performance_level_4
     mini_rubric
     encrypted
+    neighborhood_enabled
     editor_experiment
     teacher_markdown
     bubble_choice_description

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -87,7 +87,6 @@ class Level < ApplicationRecord
     rubric_performance_level_4
     mini_rubric
     encrypted
-    neighborhood_enabled
     editor_experiment
     teacher_markdown
     bubble_choice_description

--- a/dashboard/app/views/levels/edit.html.haml
+++ b/dashboard/app/views/levels/edit.html.haml
@@ -25,7 +25,6 @@
         %p the level cannot be renamed because it is a standalone project level.
   .field
     = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :encrypted, description: "Encrypt this level's properties"}
-    = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :neighborhood_enabled, description: "Display Neighborhood visualization"}
 
   / Only enter name to create new records of certain level types.
   - unless @level.is_a?(Fish) || (@level.new_record? && @level.is_a?(Blockly))

--- a/dashboard/app/views/levels/edit.html.haml
+++ b/dashboard/app/views/levels/edit.html.haml
@@ -25,6 +25,7 @@
         %p the level cannot be renamed because it is a standalone project level.
   .field
     = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :encrypted, description: "Encrypt this level's properties"}
+    = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :neighborhood_enabled, description: "Display Neighborhood visualization"}
 
   / Only enter name to create new records of certain level types.
   - unless @level.is_a?(Fish) || (@level.new_record? && @level.is_a?(Blockly))

--- a/dashboard/app/views/levels/editors/_javalab.html.haml
+++ b/dashboard/app/views/levels/editors/_javalab.html.haml
@@ -1,8 +1,8 @@
 = render partial: 'levels/editors/fields/instructions_area', locals: {f: f}
 = render partial: 'levels/editors/fields/teacher_only_markdown', locals: {f: f}
 = render partial: 'levels/editors/fields/bubble_choice_sublevel', locals: {f: f}
+= render partial: 'levels/editors/fields/special_variables', locals: {f: f}
 = render partial: 'levels/editors/fields/encrypted_examples', locals: {f: f, level_type: 'javalab'}
 = render partial: 'levels/editors/fields/sharing', locals: {f: f}
 = render partial: 'levels/editors/fields/callouts', locals: {f: f}
 = render partial: 'levels/editors/fields/audit_log', locals: {f: f}
-= render partial: 'levels/editors/fields/neighborhood_enabled', locals: {f: f}

--- a/dashboard/app/views/levels/editors/_javalab.html.haml
+++ b/dashboard/app/views/levels/editors/_javalab.html.haml
@@ -5,3 +5,4 @@
 = render partial: 'levels/editors/fields/sharing', locals: {f: f}
 = render partial: 'levels/editors/fields/callouts', locals: {f: f}
 = render partial: 'levels/editors/fields/audit_log', locals: {f: f}
+= render partial: 'levels/editors/fields/neighborhood_enabled', locals: {f: f}

--- a/dashboard/app/views/levels/editors/_javalab.html.haml
+++ b/dashboard/app/views/levels/editors/_javalab.html.haml
@@ -1,7 +1,7 @@
 = render partial: 'levels/editors/fields/instructions_area', locals: {f: f}
 = render partial: 'levels/editors/fields/teacher_only_markdown', locals: {f: f}
 = render partial: 'levels/editors/fields/bubble_choice_sublevel', locals: {f: f}
-= render partial: 'levels/editors/fields/special_variables', locals: {f: f}
+= render partial: 'levels/editors/fields/csa_fields', locals: {f: f}
 = render partial: 'levels/editors/fields/encrypted_examples', locals: {f: f, level_type: 'javalab'}
 = render partial: 'levels/editors/fields/sharing', locals: {f: f}
 = render partial: 'levels/editors/fields/callouts', locals: {f: f}

--- a/dashboard/app/views/levels/editors/fields/_csa_fields.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_csa_fields.html.haml
@@ -1,0 +1,6 @@
+%h1.control-legend{data: {toggle: "collapse", target: "#csa_features"}}
+  CSA Features
+
+#csa_features.in.collapse
+  = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :csa_view_mode, description: "Select either Neighborhood, Theater, or Console View"}
+

--- a/dashboard/app/views/levels/editors/fields/_csa_fields.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_csa_fields.html.haml
@@ -2,5 +2,6 @@
   CSA Features
 
 #csa_features.in.collapse
-  = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :csa_view_mode, description: "Select either Neighborhood, Theater, or Console View"}
-
+  .field
+    Select the desired CSA view:
+    = f.select :csa_view_mode, options_for_select([['Console', 'console'], ['Neighborhood', 'neighborhood'], ['Theater', 'theater']])

--- a/dashboard/app/views/levels/editors/fields/_neighborhood_enabled.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_neighborhood_enabled.html.haml
@@ -1,7 +1,0 @@
-%h1.control-legend{data: {toggle: "collapse", target: "#special_vars_area"}}
-  Special Variables
-
-#special_vars_area.in.collapse
-  - if @level.respond_to? :neighborhood_enabled
-    = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :neighborhood_enabled, description: "Display Neighborhood visualization"}
-    %p If set, this level will display the neighborhood visualization area

--- a/dashboard/app/views/levels/editors/fields/_neighborhood_enabled.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_neighborhood_enabled.html.haml
@@ -1,0 +1,7 @@
+%h1.control-legend{data: {toggle: "collapse", target: "#special_vars_area"}}
+  Special Variables
+
+#special_vars_area.in.collapse
+  - if @level.respond_to? :neighborhood_enabled
+    = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :neighborhood_enabled, description: "Display Neighborhood visualization"}
+    %p If set, this level will display the neighborhood visualization area

--- a/dashboard/app/views/levels/editors/fields/_special_variables.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_special_variables.html.haml
@@ -1,6 +1,0 @@
-%h1.control-legend{data: {toggle: "collapse", target: "#special_vars_area"}}
-  Special Variables
-
-#special_vars_area.in.collapse
-  = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :neighborhood_enabled, description: "Display Neighborhood visualization"}
-

--- a/dashboard/app/views/levels/editors/fields/_special_variables.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_special_variables.html.haml
@@ -1,0 +1,6 @@
+%h1.control-legend{data: {toggle: "collapse", target: "#special_vars_area"}}
+  Special Variables
+
+#special_vars_area.in.collapse
+  = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :neighborhood_enabled, description: "Display Neighborhood visualization"}
+


### PR DESCRIPTION
This PR adds csa view mode attribute on the level that signifies whether the neighborhood, theater, or console views will be selected for display.

jira ticket: https://codedotorg.atlassian.net/browse/CSA-288

How this field looks on the level:
![image](https://user-images.githubusercontent.com/37230822/116628862-db59f080-a904-11eb-8321-0e39a2addea8.png)

How this attribute appears in the javalab level:
![image](https://user-images.githubusercontent.com/37230822/116629092-59b69280-a905-11eb-99fa-7c2592222a60.png)

