### PR TITLE
Prerequisites for hard deleting contact rollups V1 tables

### DIFF
--- a/aws/dms/tasks.yml
+++ b/aws/dms/tasks.yml
@@ -1,6 +1,5 @@
 cron-pii:
 - dashboard.census_submissions
-- pegasus.contact_rollups
 - pegasus.contacts
 - pegasus.forms
 - pegasus.form_geos

--- a/lib/cdo/delete_accounts_helper.rb
+++ b/lib/cdo/delete_accounts_helper.rb
@@ -318,7 +318,6 @@ class DeleteAccountsHelper
     clean_user_sections(user.id)
     remove_user_from_sections_as_student(user)
     remove_poste_data(user_email) if user_email&.present?
-    remove_from_deprecated_contact_rollups_by_user_id(user.id)
     set_pardot_deletion_via_contact_rollups(user_email) if user_email&.present?
     purge_unshared_studio_person(user)
     anonymize_user(user)
@@ -344,7 +343,6 @@ class DeleteAccountsHelper
     migrated_users.or(unmigrated_users).each {|u| purge_user u}
 
     remove_poste_data(email)
-    remove_from_deprecated_contact_rollups_by_email(email)
     set_pardot_deletion_via_contact_rollups(email)
     clean_pegasus_forms_for_email(email)
   end

--- a/lib/cdo/delete_accounts_helper.rb
+++ b/lib/cdo/delete_accounts_helper.rb
@@ -174,21 +174,6 @@ class DeleteAccountsHelper
     @pegasus_db[:contacts].where(id: contact_ids).delete
   end
 
-  # TODO: Fully remove the deprecated V1 of contact rollups,
-  # (ie, remove the contact_rollups table), at which point this step can be removed.
-  # @param [Integer] The user ID to purge from deprecated contact rollups table.
-  def remove_from_deprecated_contact_rollups_by_user_id(user_id)
-    @log.puts "Removing from deprecated contact rollups"
-    @pegasus_db[:contact_rollups].where(dashboard_user_id: user_id).delete
-  end
-
-  # TODO: Fully remove the deprecated V1 of contact rollups,
-  # (ie, remove the contact_rollups table), at which point this step can be removed.
-  # @param [Integer] The email to purge from deprecated contact rollups table.
-  def remove_from_deprecated_contact_rollups_by_email(email)
-    @pegasus_db[:contact_rollups].where(email: email).delete
-  end
-
   # Marks emails for deletion from Pardot via contact rollups process.
   def set_pardot_deletion_via_contact_rollups(email)
     if User.find_by_email(email)


### PR DESCRIPTION
In preparation for https://github.com/code-dot-org/code-dot-org/pull/40251, a couple of prerequisites:

- removes some steps and associated tests from our delete accounts helpers that deletes rows from the old contact rollups tables (thought I had already done this in https://github.com/code-dot-org/code-dot-org/pull/37901)
- removes the contact rollups table (soon to be deleted) from our nightly sync to Redshift.

## Testing story

I did no testing of these changes.

## Follow-up work

I'll manually delete the version of contact_rollups that has been copied to Redshift manually (this change stops the nightly sync).