### PR TITLE
Don't link to level if there's an onBubbleClick prop in ProgressLevelSet

### DIFF
--- a/apps/src/templates/progress/ProgressLevelSet.jsx
+++ b/apps/src/templates/progress/ProgressLevelSet.jsx
@@ -86,7 +86,8 @@ class ProgressLevelSet extends React.Component {
     } = this.props;
 
     const multiLevelStep = levels.length > 1;
-    const url = multiLevelStep ? undefined : levels[0].url;
+    const url = multiLevelStep || onBubbleClick ? undefined : levels[0].url;
+    const onClick = multiLevelStep ? undefined : () => onBubbleClick(levels[0]);
 
     // Adjust column styles if locale is RTL
     const col2Style = isRtl ? styles.col2RTL : styles.col2;
@@ -126,7 +127,7 @@ class ProgressLevelSet extends React.Component {
               />
             </td>
             <td style={col2Style}>
-              <a href={url}>
+              <a href={url} onClick={onClick}>
                 <div style={{...styles.nameText, ...styles.text}}>{name}</div>
               </a>
             </td>

--- a/apps/test/unit/templates/progress/ProgressLevelSetTest.js
+++ b/apps/test/unit/templates/progress/ProgressLevelSetTest.js
@@ -22,6 +22,22 @@ describe('ProgressLevelSet', function() {
     assert.equal(wrapper.find('Connect(ProgressPill)').props().text, '1');
   });
 
+  it('has a pill and no link for a single level with an onBubbleClick prop', () => {
+    const wrapper = shallow(
+      <ProgressLevelSet
+        name="My Level Name"
+        levels={fakeLevels(1)}
+        disabled={false}
+        onBubbleClick={() => {}}
+      />
+    );
+
+    assert.equal(wrapper.find('Connect(ProgressPill)').length, 1);
+    assert.equal(wrapper.find('Connect(ProgressBubbleSet)').length, 0);
+    assert.equal(wrapper.find('Connect(ProgressPill)').props().text, '1');
+    assert.isUndefined(wrapper.find('a').props().href);
+  });
+
   it('has a pill and bubbles when we have multiple levels', () => {
     const wrapper = shallow(
       <ProgressLevelSet


### PR DESCRIPTION
Resolves [PLAT-976](https://codedotorg.atlassian.net/browse/PLAT-976). When there was only one level, there was a sneaky link to the level, which could cause data loss on the edit page. This PR uses the onBubbleClick handler there instead of the link.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
