### PR TITLE
Fix progress table scrolling

### DIFF
--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableContentView.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableContentView.jsx
@@ -57,8 +57,10 @@ export default class ProgressTableContentView extends React.Component {
     this.scrollToSelectedLesson();
   }
 
-  componentDidUpdate() {
-    this.scrollToSelectedLesson();
+  componentDidUpdate(prevProps) {
+    if (prevProps.lessonOfInterest !== this.props.lessonOfInterest) {
+      this.scrollToSelectedLesson();
+    }
   }
 
   scrollToSelectedLesson() {


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Progress table only scrolls to selected lesson on component update if the selected lesson changes (previously it was also scrolling when toggling the expander).

Changes based on the refactor for LP-1860
## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: [LP-1859](https://codedotorg.atlassian.net/browse/LP-1859)
-->

## Testing story
Tested locally
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
