### PR TITLE
add link to edit lesson on levelbuilder

### DIFF
--- a/dashboard/app/views/lessons/show.html.haml
+++ b/dashboard/app/views/lessons/show.html.haml
@@ -12,3 +12,6 @@
     %ul
       - if Rails.application.config.levelbuilder_mode
         %li= link_to "Edit", edit_lesson_path({id: @lesson.id})
+      - else
+        %li= link_to 'edit on levelbuilder', URI.join("https://levelbuilder-studio.code.org/", script_lesson_path(@lesson.script, @lesson)).to_s
+


### PR DESCRIPTION
quick win / feature request from curriculum to be able to navigate from the lesson plan on code studio to the same page on levelbuilder.

## Testing story

manually verified by turning off levelbuilder mode locally:
![Screen Shot 2021-04-27 at 11 20 46 AM](https://user-images.githubusercontent.com/8001765/116292636-c33e7180-a74a-11eb-8022-3979f796b425.png)
verified that clicking the link loads the correct page on levelbuilder.