### PR TITLE
added change to pass locale to piskel repo

### DIFF
--- a/apps/src/p5lab/AnimationTab/PiskelEditor.jsx
+++ b/apps/src/p5lab/AnimationTab/PiskelEditor.jsx
@@ -61,6 +61,10 @@ class PiskelEditor extends React.Component {
     this.piskel.onPiskelReady(this.onPiskelReady);
     this.piskel.onStateSaved(this.onAnimationSaved);
     this.piskel.onAddFrame(this.onAddFrame);
+
+    // Added a sample locale so that Piskel Repo has access to it
+    const iframe = document.getElementById('piskelFrame');
+    iframe.contentWindow.locale = 'en_us';
   }
 
   componentWillUnmount() {
@@ -211,6 +215,7 @@ class PiskelEditor extends React.Component {
         ref={iframe => (this.iframe = iframe)}
         style={this.props.style}
         src={PISKEL_PATH}
+        id="piskelFrame"
       />
     );
   }


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
## Overview
This change adds the locale to the Piskel frame by using iframe's `.contentWindow` so that in the 
Piskel repo we can access the locale. The change is done in the componentDidMount lifecycle method. It also adds an id to the Piskel Frame to make it easier to identify.

## Links
[Jira Ticket](https://codedotorg.atlassian.net/browse/FND-1562?atlOrigin=eyJpIjoiNjQ3MzY3ZGI1MzgyNGI1ZmE1YWQ1NjUwMmNlMjFiZjEiLCJwIjoiaiJ9)

## Testing story
In Stroke.js in Piskel Repo, I added a console.log statement to print out `window.locale`. By doing this, it printed out `en_us` which is the locale I added to the iframe in PiskelEditor.jsx component in code-dot-org repo.

Also in the browser console, I changed the JavaScript context to refer to the Piskel Iframe. Then I printed out `window.locale` and `en_us` appeared.

## Follow-up work
Need to figure out how to retrieve the locale the user currently selected. I see there is `apps/src/redux/localesRedux.js `that might be helpful

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
