### PR TITLE
Be able to mark javalab files as support or starter in levelbuilder

### DIFF
--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -430,6 +430,8 @@ class LevelsController < ApplicationController
       {if_block_options: []},
       {place_block_options: []},
       {play_sound_options: []},
+      {visible: []},
+      {visible: {}},
       :visible,
       {start_sources: {}}
     ]

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -236,8 +236,6 @@ class LevelsController < ApplicationController
   # PATCH/PUT /levels/1
   # PATCH/PUT /levels/1.json
   def update
-    puts level_params
-    puts "hi there"
     if level_params[:name] &&
         @level.name != level_params[:name] &&
         @level.name.downcase == level_params[:name].downcase
@@ -430,10 +428,7 @@ class LevelsController < ApplicationController
       {if_block_options: []},
       {place_block_options: []},
       {play_sound_options: []},
-      {visible: []},
       {visible: {}},
-      :visible,
-      {start_sources: {}}
     ]
 
     # http://stackoverflow.com/questions/8929230/why-is-the-first-element-always-blank-in-my-rails-multi-select

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -236,6 +236,8 @@ class LevelsController < ApplicationController
   # PATCH/PUT /levels/1
   # PATCH/PUT /levels/1.json
   def update
+    puts level_params
+    puts "hi there"
     if level_params[:name] &&
         @level.name != level_params[:name] &&
         @level.name.downcase == level_params[:name].downcase
@@ -428,6 +430,8 @@ class LevelsController < ApplicationController
       {if_block_options: []},
       {place_block_options: []},
       {play_sound_options: []},
+      :visible,
+      {start_sources: {}}
     ]
 
     # http://stackoverflow.com/questions/8929230/why-is-the-first-element-always-blank-in-my-rails-multi-select

--- a/dashboard/app/models/levels/javalab.rb
+++ b/dashboard/app/models/levels/javalab.rb
@@ -52,6 +52,13 @@ class Javalab < Level
     self.examples = examples.select(&:present?)
   end
 
+  def assign_attributes(params)
+    puts 'assign attributes'
+    puts params
+    puts 'visible'
+    puts params[:visible]
+  end
+
   # Return an 'appOptions' hash derived from the level contents
   def non_blockly_puzzle_level_options
     options = Rails.cache.fetch("#{cache_key}/non_blockly_puzzle_level_options/v2") do

--- a/dashboard/app/models/levels/javalab.rb
+++ b/dashboard/app/models/levels/javalab.rb
@@ -53,10 +53,13 @@ class Javalab < Level
   end
 
   def assign_attributes(params)
-    puts 'assign attributes'
-    puts params
-    puts 'visible'
-    puts params[:visible]
+    # puts 'assign attributes!'
+    # puts params
+    # puts 'hello'
+    params[:visible].keys.map(&:to_s).each do |filename|
+      puts filename
+      puts params[:visible][filename]
+    end
   end
 
   # Return an 'appOptions' hash derived from the level contents

--- a/dashboard/app/models/levels/javalab.rb
+++ b/dashboard/app/models/levels/javalab.rb
@@ -53,12 +53,8 @@ class Javalab < Level
   end
 
   def assign_attributes(params)
-    # puts 'assign attributes!'
-    # puts params
-    # puts 'hello'
     params[:visible].keys.map(&:to_s).each do |filename|
-      puts filename
-      puts params[:visible][filename]
+      start_sources[filename]["visible"] = params[:visible][filename] === "true"
     end
   end
 

--- a/dashboard/app/views/levels/editors/_javalab.html.haml
+++ b/dashboard/app/views/levels/editors/_javalab.html.haml
@@ -2,6 +2,7 @@
 = render partial: 'levels/editors/fields/teacher_only_markdown', locals: {f: f}
 = render partial: 'levels/editors/fields/bubble_choice_sublevel', locals: {f: f}
 = render partial: 'levels/editors/fields/encrypted_examples', locals: {f: f, level_type: 'javalab'}
+= render partial: 'levels/editors/fields/javalab_files_fields', locals: {f: f}
 = render partial: 'levels/editors/fields/sharing', locals: {f: f}
 = render partial: 'levels/editors/fields/callouts', locals: {f: f}
 = render partial: 'levels/editors/fields/audit_log', locals: {f: f}

--- a/dashboard/app/views/levels/editors/fields/_javalab_files_fields.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_javalab_files_fields.html.haml
@@ -12,7 +12,5 @@
         %td
           = filename
         %td
-          %select
-            %option{value: 'support', selected: @level.start_sources[filename]["visible"] === false} Support
-            %option{value: 'starter', selected: @level.start_sources[filename]["visible"] === true} Starter
+          = f.select :visible, options_for_select([["Support", false], ["Starter", true]], @level.start_sources[filename]["visible"]), {selected: @level.start_sources[filename]["visible"]}
         %td TBD

--- a/dashboard/app/views/levels/editors/fields/_javalab_files_fields.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_javalab_files_fields.html.haml
@@ -12,8 +12,5 @@
         %td
           = filename
         %td
-          -# %select{name: "level[visible[#{filename}]]"}
-          -#   %option{value: false, selected: !@level.start_sources[filename]["visible"]}= "Support"
-          -#   %option{value: true, selected: @level.start_sources[filename]["visible"]}= "Starter"
-          = f.select "visible[#{filename}]", options_for_select([["Support", false], ["Starter", true]], @level.start_sources[filename]["visible"]), {selected: @level.start_sources[filename]["visible"]}
+          = f.select "visible[#{filename}]", options_for_select([["Starter", true], ["Support", false]], @level.start_sources[filename]["visible"]), {selected: @level.start_sources[filename]["visible"]}
         %td TBD

--- a/dashboard/app/views/levels/editors/fields/_javalab_files_fields.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_javalab_files_fields.html.haml
@@ -1,0 +1,18 @@
+%h1.control-legend{data: {toggle: "collapse", target: "#javalab_files"}}
+  Source Files
+
+#javalab_files.in.collapse
+  %table.javalab_file_table
+    %tr
+      %th File
+      %th Type
+      %th Actions
+    - @level.start_sources.keys.map{|key| key.to_s}.each do |filename|
+      %tr
+        %td
+          = filename
+        %td
+          %select
+            %option{value: 'support', selected: @level.start_sources[filename]["visible"] === false} Support
+            %option{value: 'starter', selected: @level.start_sources[filename]["visible"] === true} Starter
+        %td TBD

--- a/dashboard/app/views/levels/editors/fields/_javalab_files_fields.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_javalab_files_fields.html.haml
@@ -12,5 +12,8 @@
         %td
           = filename
         %td
-          = f.select :visible, options_for_select([["Support", false], ["Starter", true]], @level.start_sources[filename]["visible"]), {selected: @level.start_sources[filename]["visible"]}
+          -# %select{name: "level[visible[#{filename}]]"}
+          -#   %option{value: false, selected: !@level.start_sources[filename]["visible"]}= "Support"
+          -#   %option{value: true, selected: @level.start_sources[filename]["visible"]}= "Starter"
+          = f.select "visible[#{filename}]", options_for_select([["Support", false], ["Starter", true]], @level.start_sources[filename]["visible"]), {selected: @level.start_sources[filename]["visible"]}
         %td TBD


### PR DESCRIPTION
Adds a field to levelbuilder on javalab levels that displays all of the files in the level and has a dropdown to set a file as Starter (visible) or Support (not visible).

<img width="1020" alt="Screen Shot 2021-04-27 at 12 39 38 PM" src="https://user-images.githubusercontent.com/17147070/116304284-406fe380-a757-11eb-858d-d29cecac4fbf.png">
<img width="1070" alt="Screen Shot 2021-04-27 at 12 38 32 PM" src="https://user-images.githubusercontent.com/17147070/116304289-41a11080-a757-11eb-8c6d-9f8044b1f5a1.png">

## Links

- design in first screenshot here: [CSA Design Level Building](https://docs.google.com/document/d/1m7s_DF2JM4ZRbbihj3HsuAA3n-wePegLvcwFQjEx2sA/edit#heading=h.bj1j0htqouu)
- jira ticket: [CSA-238](https://codedotorg.atlassian.net/browse/CSA-238?atlOrigin=eyJpIjoiZjZjOTlkNDgwMDk4NGRjYmI1YjQwMzFkNmQ5NWRkMjkiLCJwIjoiaiJ9)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
