### PR TITLE
Seed CSP survey in UI tests

### DIFF
--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -133,6 +133,7 @@ namespace :seed do
     'csp8-2020',
     'csp9-2020',
     'csp10-2020',
+    'csp-post-survey-2020',
     'dance',
     'events',
     'express-2017',


### PR DESCRIPTION
We're adding a survey to the end of CSP for students to take. The survey is implemented as a single lesson in a script at the end of the course. Adding that script to our UI test seeding logic so it does not fail.