### PR TITLE
Show CSP survey in script select dropdown

### DIFF
--- a/lib/cdo/script_constants.rb
+++ b/lib/cdo/script_constants.rb
@@ -193,6 +193,7 @@ module ScriptConstants
       CSP8_2020_NAME = 'csp8-2020'.freeze,
       CSP9_2020_NAME = 'csp9-2020'.freeze,
       CSP10_2020_NAME = 'csp10-2020'.freeze,
+      CSP_POST_SURVEY_2020_NAME = 'csp-post-survey-2020'.freeze
     ].freeze,
     csp_2019: [
       CSP1_2019_NAME = 'csp1-2019'.freeze,


### PR DESCRIPTION
Shows the CSP post-course survey for students as an option when selecting a course or unit.

## Testing story

I seeded the new survey script locally, and confirmed that the dropdown appeared as expected:

![image](https://user-images.githubusercontent.com/25372625/116315057-d78f6800-a764-11eb-8d57-d3f1c51d7f05.png)

I also confirmed it appears in the dropdown when creating a new section.