### PR TITLE
Remove relative positioning breaking related videos (sprite lab)

### DIFF
--- a/apps/src/p5lab/P5LabVisualizationColumn.jsx
+++ b/apps/src/p5lab/P5LabVisualizationColumn.jsx
@@ -174,7 +174,7 @@ class P5LabVisualizationColumn extends React.Component {
     const showPauseButton = isSpritelab && !this.props.hidePauseButton;
 
     return (
-      <div style={{position: 'relative'}}>
+      <div>
         <div style={{position: 'relative'}}>
           <ProtectedVisualizationDiv>
             <Pointable

--- a/dashboard/test/ui/features/learning_platform/level_video.feature
+++ b/dashboard/test/ui/features/learning_platform/level_video.feature
@@ -1,0 +1,10 @@
+@eyes
+Feature: Related video on level
+
+@as_student
+Scenario: Sprite lab level
+  Given I am on "http://studio.code.org/s/allthethings/lessons/36/levels/2"
+  When I open my eyes to test "sprite lab level"
+  And I wait to see "#belowVisualization"
+  And I see no difference for "sprite lab level with related video"
+  And I close my eyes


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Background: Related videos for levels are part of the `BelowVisualization` component. This component is imported in many of the labs and the positioning is set in `StudioApp` (see [resizePinnedBelowVisualization](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/StudioApp.js#L1433)). This positioning should be relative to the `#visualizationColumn` but because of the `position:relative` in `P5LabVisualizationColumn` the positioning isn't relative to the right element and the video doesn't render.

The relative positioning in `P5LabVisualizationColumn` can be tracked back to https://github.com/code-dot-org/code-dot-org/pull/29093 which fixes a bug where text overlaps other content. However, this is no longer needed because another relative positioned div was added here https://github.com/code-dot-org/code-dot-org/commit/38604792d80d7542f0823a9915eb8d5304dc5125#diff-96a12537817e4d583bd37141ddadfb492fe7d96911385cd3fa998f76ad5136ec and is wrapping this content.

TODO:
- [ ] Do I need to approve new baselines in applitools? I was trying to follow the instructions and run the eyes test locally but I wasn't seeing anything in applitools.
## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- [LP-1866](https://codedotorg.atlassian.net/browse/LP-1866)


## Testing story
- Tested in the browser that removing the relative positioning doesn't cause text to overlap here https://studio.code.org/s/coursef-2020/lessons/18/levels/8. 
- Verified locally that videos show up on sprite lab
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
