### PR TITLE
Move widget styles to <AppLabView/> & make <TopInstructions/> styles extensible

### DIFF
--- a/apps/src/applab/AppLabView.jsx
+++ b/apps/src/applab/AppLabView.jsx
@@ -43,12 +43,24 @@ class AppLabView extends React.Component {
   }
 
   render() {
-    const codeWorkspaceVisible =
-      ApplabInterfaceMode.CODE === this.props.interfaceMode;
+    const {
+      interfaceMode,
+      widgetMode,
+      isRtl,
+      isEditingProject,
+      screenIds,
+      onScreenCreate,
+      autogenerateML,
+      hasDesignMode,
+      hasDataMode,
+      handleVersionHistory
+    } = this.props;
+
+    const codeWorkspaceVisible = ApplabInterfaceMode.CODE === interfaceMode;
 
     let instructionsStyle = {};
-    if (this.props.widgetMode) {
-      instructionsStyle = this.props.isRtl
+    if (widgetMode) {
+      instructionsStyle = isRtl
         ? styles.widgetInstructionsRtl
         : styles.widgetInstructions;
     }
@@ -59,9 +71,9 @@ class AppLabView extends React.Component {
         <ImportScreensDialog />
         <ExternalRedirectDialog />
         <ApplabVisualizationColumn
-          isEditingProject={this.props.isEditingProject}
-          screenIds={this.props.screenIds}
-          onScreenCreate={this.props.onScreenCreate}
+          isEditingProject={isEditingProject}
+          screenIds={screenIds}
+          onScreenCreate={onScreenCreate}
         />
         <VisualizationResizeBar />
         {/* Applying instructionsStyle to both the container (using style) and instructions (using
@@ -74,13 +86,11 @@ class AppLabView extends React.Component {
           <CodeWorkspace
             withSettingsCog
             style={{display: codeWorkspaceVisible ? 'block' : 'none'}}
-            autogenerateML={this.props.autogenerateML}
+            autogenerateML={autogenerateML}
           />
-          {this.props.hasDesignMode && <ProtectedDesignWorkspace />}
-          {this.props.hasDataMode && (
-            <DataWorkspace
-              handleVersionHistory={this.props.handleVersionHistory}
-            />
+          {hasDesignMode && <ProtectedDesignWorkspace />}
+          {hasDataMode && (
+            <DataWorkspace handleVersionHistory={handleVersionHistory} />
           )}
         </InstructionsWithWorkspace>
       </StudioAppWrapper>

--- a/apps/src/applab/AppLabView.jsx
+++ b/apps/src/applab/AppLabView.jsx
@@ -7,7 +7,7 @@ import ImportScreensDialog from './ImportScreensDialog';
 import ApplabVisualizationColumn from './ApplabVisualizationColumn';
 import StudioAppWrapper from '../templates/StudioAppWrapper';
 import InstructionsWithWorkspace from '../templates/instructions/InstructionsWithWorkspace';
-import {ApplabInterfaceMode} from './constants';
+import {ApplabInterfaceMode, WIDGET_WIDTH} from './constants';
 import CodeWorkspace from '../templates/CodeWorkspace';
 import DataWorkspace from '../storage/dataBrowser/DataWorkspace';
 import ProtectedDesignWorkspace from './ProtectedDesignWorkspace';
@@ -21,6 +21,12 @@ class AppLabView extends React.Component {
   static propTypes = {
     handleVersionHistory: PropTypes.func.isRequired,
     autogenerateML: PropTypes.func.isRequired,
+    isEditingProject: PropTypes.bool.isRequired,
+    screenIds: PropTypes.arrayOf(PropTypes.string).isRequired,
+    onScreenCreate: PropTypes.func.isRequired,
+    onMount: PropTypes.func.isRequired,
+
+    // Provided by redux
     hasDataMode: PropTypes.bool.isRequired,
     hasDesignMode: PropTypes.bool.isRequired,
     interfaceMode: PropTypes.oneOf([
@@ -28,12 +34,8 @@ class AppLabView extends React.Component {
       ApplabInterfaceMode.DESIGN,
       ApplabInterfaceMode.DATA
     ]).isRequired,
-    isEditingProject: PropTypes.bool.isRequired,
-
-    screenIds: PropTypes.arrayOf(PropTypes.string).isRequired,
-    onScreenCreate: PropTypes.func.isRequired,
-
-    onMount: PropTypes.func.isRequired
+    isRtl: PropTypes.bool,
+    widgetMode: PropTypes.bool
   };
 
   componentDidMount() {
@@ -43,6 +45,14 @@ class AppLabView extends React.Component {
   render() {
     const codeWorkspaceVisible =
       ApplabInterfaceMode.CODE === this.props.interfaceMode;
+
+    let instructionsStyle = {};
+    if (this.props.widgetMode) {
+      instructionsStyle = this.props.isRtl
+        ? styles.widgetInstructionsRtl
+        : styles.widgetInstructions;
+    }
+
     return (
       <StudioAppWrapper>
         <ImportProjectDialog />
@@ -54,7 +64,10 @@ class AppLabView extends React.Component {
           onScreenCreate={this.props.onScreenCreate}
         />
         <VisualizationResizeBar />
-        <InstructionsWithWorkspace>
+        <InstructionsWithWorkspace
+          style={instructionsStyle}
+          instructionsStyle={instructionsStyle}
+        >
           <CodeWorkspace
             withSettingsCog
             style={{display: codeWorkspaceVisible ? 'block' : 'none'}}
@@ -75,5 +88,16 @@ class AppLabView extends React.Component {
 export default connect(state => ({
   hasDataMode: state.pageConstants.hasDataMode || false,
   hasDesignMode: state.pageConstants.hasDesignMode || false,
-  interfaceMode: state.interfaceMode
+  interfaceMode: state.interfaceMode,
+  isRtl: state.isRtl,
+  widgetMode: state.pageConstants.widgetMode
 }))(AppLabView);
+
+const styles = {
+  widgetInstructions: {
+    left: WIDGET_WIDTH
+  },
+  widgetInstructionsRtl: {
+    right: WIDGET_WIDTH
+  }
+};

--- a/apps/src/applab/AppLabView.jsx
+++ b/apps/src/applab/AppLabView.jsx
@@ -64,6 +64,9 @@ class AppLabView extends React.Component {
           onScreenCreate={this.props.onScreenCreate}
         />
         <VisualizationResizeBar />
+        {/* Applying instructionsStyle to both the container (using style) and instructions (using
+         * instructionsStyle) is necessary because the instructions element is absolutely positioned.
+         */}
         <InstructionsWithWorkspace
           style={instructionsStyle}
           instructionsStyle={instructionsStyle}

--- a/apps/src/templates/instructions/InstructionsWithWorkspace.jsx
+++ b/apps/src/templates/instructions/InstructionsWithWorkspace.jsx
@@ -97,14 +97,16 @@ export class UnwrappedInstructionsWithWorkspace extends React.Component {
   }
 
   render() {
+    const {style, instructionsStyle, instructionsHeight, children} = this.props;
+
     return (
-      <span style={this.props.style}>
-        <TopInstructions mainStyle={this.props.instructionsStyle} />
+      <span style={style}>
+        <TopInstructions mainStyle={instructionsStyle} />
         <CodeWorkspaceContainer
           ref={this.setCodeWorkspaceContainerRef}
-          topMargin={this.props.instructionsHeight}
+          topMargin={instructionsHeight}
         >
-          {this.props.children}
+          {children}
         </CodeWorkspaceContainer>
       </span>
     );

--- a/apps/src/templates/instructions/InstructionsWithWorkspace.jsx
+++ b/apps/src/templates/instructions/InstructionsWithWorkspace.jsx
@@ -16,7 +16,10 @@ import {setInstructionsMaxHeightAvailable} from '../../redux/instructions';
 export class UnwrappedInstructionsWithWorkspace extends React.Component {
   static propTypes = {
     children: PropTypes.node,
-    // props provided via connect
+    style: PropTypes.object,
+    instructionsStyle: PropTypes.object,
+
+    // Provided by redux
     instructionsHeight: PropTypes.number.isRequired,
     setInstructionsMaxHeightAvailable: PropTypes.func.isRequired
   };
@@ -95,8 +98,8 @@ export class UnwrappedInstructionsWithWorkspace extends React.Component {
 
   render() {
     return (
-      <span>
-        <TopInstructions />
+      <span style={this.props.style}>
+        <TopInstructions mainStyle={this.props.instructionsStyle} />
         <CodeWorkspaceContainer
           ref={this.setCodeWorkspaceContainerRef}
           topMargin={this.props.instructionsHeight}
@@ -109,16 +112,12 @@ export class UnwrappedInstructionsWithWorkspace extends React.Component {
 }
 
 export default connect(
-  function propsFromStore(state) {
-    return {
-      instructionsHeight: state.instructions.renderedHeight
-    };
-  },
-  function propsFromDispatch(dispatch) {
-    return {
-      setInstructionsMaxHeightAvailable(maxHeight) {
-        dispatch(setInstructionsMaxHeightAvailable(maxHeight));
-      }
-    };
-  }
+  state => ({
+    instructionsHeight: state.instructions.renderedHeight
+  }),
+  dispatch => ({
+    setInstructionsMaxHeightAvailable(maxHeight) {
+      dispatch(setInstructionsMaxHeightAvailable(maxHeight));
+    }
+  })
 )(UnwrappedInstructionsWithWorkspace);

--- a/apps/src/templates/instructions/TopInstructions.jsx
+++ b/apps/src/templates/instructions/TopInstructions.jsx
@@ -27,7 +27,6 @@ import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import queryString from 'query-string';
 import InstructionsCSF from './InstructionsCSF';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
-import {WIDGET_WIDTH} from '@cdo/apps/applab/constants';
 import {hasInstructions} from './utils';
 import * as topInstructionsDataApi from './topInstructionsDataApi';
 import TopInstructionsHeader from './TopInstructionsHeader';
@@ -140,7 +139,6 @@ class TopInstructions extends Component {
     isMinecraft: PropTypes.bool.isRequired,
     isBlockly: PropTypes.bool.isRequired,
     isRtl: PropTypes.bool.isRequired,
-    widgetMode: PropTypes.bool,
     mainStyle: PropTypes.object,
     containerStyle: PropTypes.object,
     resizable: PropTypes.bool,
@@ -568,7 +566,6 @@ class TopInstructions extends Component {
       isRtl,
       height,
       isEmbedView,
-      widgetMode,
       levelVideos,
       mapReference,
       referenceLinks,
@@ -596,7 +593,6 @@ class TopInstructions extends Component {
     // instead of inferring it from noInstructionsWhenCollapsed
     const isCSF = !noInstructionsWhenCollapsed;
     const isCSDorCSP = !isCSF;
-    const widgetWidth = WIDGET_WIDTH + 'px';
 
     const topInstructionsStyle = [
       isRtl ? styles.mainRtl : styles.main,
@@ -605,8 +601,7 @@ class TopInstructions extends Component {
         height: height - RESIZER_HEIGHT
       },
       noVisualization && styles.noViz,
-      isEmbedView && styles.embedView,
-      widgetMode && (isRtl ? {right: widgetWidth} : {left: widgetWidth})
+      isEmbedView && styles.embedView
     ];
 
     const instructionsContainerStyle = [
@@ -789,7 +784,6 @@ export default connect(
     hidden: state.pageConstants.isShareView,
     shortInstructions: state.instructions.shortInstructions,
     isRtl: state.isRtl,
-    widgetMode: state.pageConstants.widgetMode,
     dynamicInstructions: getDynamicInstructions(state.instructions),
     dynamicInstructionsKey: state.instructions.dynamicInstructionsKey
   }),

--- a/apps/src/templates/instructions/TopInstructions.jsx
+++ b/apps/src/templates/instructions/TopInstructions.jsx
@@ -599,7 +599,7 @@ class TopInstructions extends Component {
     const widgetWidth = WIDGET_WIDTH + 'px';
 
     const topInstructionsStyle = [
-      !mainStyle && (isRtl ? styles.mainRtl : styles.main),
+      isRtl ? styles.mainRtl : styles.main,
       mainStyle,
       {
         height: height - RESIZER_HEIGHT

--- a/apps/src/templates/lessonOverview/activities/LevelDetailsDialog.jsx
+++ b/apps/src/templates/lessonOverview/activities/LevelDetailsDialog.jsx
@@ -159,7 +159,7 @@ class LevelDetailsDialog extends Component {
           isCollapsed={false}
           hidden={false}
           isEmbedView={false}
-          mainStyle={{paddingBottom: 5}}
+          mainStyle={{paddingBottom: 5, position: 'static'}}
           containerStyle={{
             overflowY: 'auto',
             height: this.state.height - HEADER_HEIGHT


### PR DESCRIPTION
This is pre-factoring for allowing levelbuilders to create AppLab widgets using start & design modes. There are a few things happening here:

1. Move styles for widgetMode out of `<TopInstructions/>` and into `<AppLabView/>` (only AppLab has widget mode, so AppLab should control this configuration).
2. Previously, `<TopInstructions/>` had a mainStyle prop to allow for style configuration, but would ignore the already-existing styles in that component ([here](https://github.com/code-dot-org/code-dot-org/blob/9403b0a46b0131a33bed882dda00a281150dcd8a/apps/src/templates/instructions/TopInstructions.jsx#L602-L603)). This instead allows for both (where mainStyle can override the component's styles) and updates `<LevelDetailsDialog/>` (the only component using the mainStyle prop) accordingly.
3. General organization and clean-up changes.

There is no visual change -- this is a pure refactor -- but some screenshots for reference:

**As a levelbuilder creating an AppLab widget in start mode:**
<img width="1279" alt="Screen Shot 2021-04-27 at 5 14 52 PM" src="https://user-images.githubusercontent.com/9812299/116327664-2a284e80-a77c-11eb-8a3a-e8efbd31b779.png">

**As a user viewing an AppLab widget level:**
<img width="1279" alt="Screen Shot 2021-04-27 at 5 15 07 PM" src="https://user-images.githubusercontent.com/9812299/116327666-2b597b80-a77c-11eb-809f-85400456d4b3.png">

## Links

- [STAR-1549](https://codedotorg.atlassian.net/browse/STAR-1549)

## Testing story

Relies on existing storybook entries and eyes tests.