### PR TITLE
Fixing build_script_level_path_for_translations to use quotes instead of backticks

### DIFF
--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -9,6 +9,7 @@ require 'cdo/languages'
 require 'net/http'
 require 'uri'
 require 'json'
+require 'addressable'
 
 module LevelsHelper
   include ApplicationHelper
@@ -45,13 +46,14 @@ module LevelsHelper
     if script_level.script.name == Script::HOC_NAME
       hoc_chapter_path(script_level.chapter)
     elsif script_level.script.name == Script::FLAPPY_NAME
-      flappy_chapter_path(script_level.chapter)
+      flappy_chapter_path(script_level.chapter
+      )
     elsif !script_level.lesson.numbered_lesson?
       script_lockable_stage_script_level_path(script_level.script, script_level.lesson, script_level)
     elsif script_level.bonus
-      "/s/#{script_level.script.name}/stage/#{script_level.lesson.relative_position}/extras?level_name=#{script_level.level.name}"
+      Addressable::URI.encode("/s/#{script_level.script.name}/stage/#{script_level.lesson.relative_position}/extras?level_name=#{script_level.level.name}")
     else
-      "/s/#{script_level.script.name}/stage/#{script_level.lesson.relative_position}/puzzle/#{script_level.position}"
+      Addressable::URI.encode("/s/#{script_level.script.name}/stage/#{script_level.lesson.relative_position}/puzzle/#{script_level.position}")
     end
   end
 

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -49,9 +49,9 @@ module LevelsHelper
     elsif !script_level.lesson.numbered_lesson?
       script_lockable_stage_script_level_path(script_level.script, script_level.lesson, script_level)
     elsif script_level.bonus
-      `/s/#{script_level.script.name}/stage/#{script_level.lesson.relative_position}/extras?level_name=#{script_level.level.name}`
+      "/s/#{script_level.script.name}/stage/#{script_level.lesson.relative_position}/extras?level_name=#{script_level.level.name}"
     else
-      `/s/#{script_level.script.name}/stage/#{script_level.lesson.relative_position}/puzzle/#{script_level.position}`
+      "/s/#{script_level.script.name}/stage/#{script_level.lesson.relative_position}/puzzle/#{script_level.position}"
     end
   end
 

--- a/dashboard/test/helpers/levels_helper_test.rb
+++ b/dashboard/test/helpers/levels_helper_test.rb
@@ -448,11 +448,11 @@ class LevelsHelperTest < ActionView::TestCase
     input_dsl = <<~DSL
       lesson 'Test bonus level links', display_name: 'Test bonus level links'
       level 'Level1'
-      level 'BonusLevel1', bonus: true
+      level 'Bonus Level 1', bonus: true
     DSL
 
     create :level, name: 'Level1'
-    create :level, name: 'BonusLevel1'
+    create :level, name: 'Bonus Level 1'
 
     script_data, _ = ScriptDSL.parse(input_dsl, 'test_bonus_level_links')
 
@@ -462,7 +462,7 @@ class LevelsHelperTest < ActionView::TestCase
     )
 
     bonus_script_level = script.lessons.first.script_levels[1]
-    assert_equal '/s/test_bonus_level_links/stage/1/extras?level_name=BonusLevel1', build_script_level_path_for_translations(bonus_script_level)
+    assert_equal '/s/test_bonus_level_links/stage/1/extras?level_name=Bonus%20Level%201', build_script_level_path_for_translations(bonus_script_level)
   end
 
   test 'build_script_level_path_for_translations for normal level' do
@@ -476,12 +476,12 @@ class LevelsHelperTest < ActionView::TestCase
     script_data, _ = ScriptDSL.parse(input_dsl, 'test_level_links')
 
     script = Script.add_script(
-      {name: 'test_level_links'},
+      {name: 'test level links'},
       script_data[:lesson_groups]
     )
 
     script_level = script.lessons.first.script_levels[0]
-    assert_equal '/s/test_level_links/stage/1/puzzle/1', build_script_level_path_for_translations(script_level)
+    assert_equal '/s/test%20level%20links/stage/1/puzzle/1', build_script_level_path_for_translations(script_level)
   end
 
   test 'build_script_level_path differentiates lesson and survey' do

--- a/dashboard/test/helpers/levels_helper_test.rb
+++ b/dashboard/test/helpers/levels_helper_test.rb
@@ -462,7 +462,7 @@ class LevelsHelperTest < ActionView::TestCase
     )
 
     bonus_script_level = script.lessons.first.script_levels[1]
-    assert_equal `/s/test_bonus_level_links/stage/1/extras?level_name=BonusLevel1`, build_script_level_path_for_translations(bonus_script_level)
+    assert_equal '/s/test_bonus_level_links/stage/1/extras?level_name=BonusLevel1', build_script_level_path_for_translations(bonus_script_level)
   end
 
   test 'build_script_level_path_for_translations for normal level' do
@@ -481,7 +481,7 @@ class LevelsHelperTest < ActionView::TestCase
     )
 
     script_level = script.lessons.first.script_levels[0]
-    assert_equal `/s/test_level_links/stage/1/puzzle/1`, build_script_level_path_for_translations(script_level)
+    assert_equal '/s/test_level_links/stage/1/puzzle/1', build_script_level_path_for_translations(script_level)
   end
 
   test 'build_script_level_path differentiates lesson and survey' do


### PR DESCRIPTION
I was playing around with `build_script_level_path_for_translations` and noticed it wasn't working as expected. It was always returning null. I then investigate the unit tests, and although they pass, it's because they aren't actually doing anything. The "strings" returned from `build_script_level_path_for_translations` were actually surrounded by backticks(\`) instead of single-quotes('). This is ruby syntax for executing a command in the OS. This was silently throwing an error and returning null. Both the unit tests and `build_script_level_path_for_translations` were using backticks.

* Fixed `build_script_level_path_for_translations` to correctly return Strings.
* Fixed `build_script_level_path_for_translations` to work with levels which have white spaces in the name.

## Testing story
* Ran unit tests

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
