### PR TITLE
[AiLab] Add dynamic instructions to Summary screen

### DIFF
--- a/apps/src/ailab/Ailab.js
+++ b/apps/src/ailab/Ailab.js
@@ -32,7 +32,10 @@ function getInstructionsDefaults() {
     selectTrainer: 'Set up the training.',
     trainModel: 'Your model is being trained.',
     results: 'Review the results.',
-    saveModel: 'Save the trained model for use in App Lab.'
+    saveModel: 'Save the trained model for use in App Lab.',
+    modelSummary:
+      "You've successfully trained and saved your model. Review your model \
+      details and click Finish to use your trained model in App Lab."
   };
 
   return instructions;


### PR DESCRIPTION
Adding dynamic instructions to the Summary screen:
`You've successfully trained and saved your model. Review your model details and click Finish to use your trained model in App Lab.`

<img width="1405" alt="Screen Shot 2021-04-27 at 8 42 34 PM" src="https://user-images.githubusercontent.com/40412372/116351543-b81a2e80-a7a8-11eb-95dd-6a8b5ffaa669.png">


Related to https://github.com/code-dot-org/ml-playground/pull/151