### PR TITLE
Accuweather hostname and alpha order update

### DIFF
--- a/dashboard/app/controllers/xhr_proxy_controller.rb
+++ b/dashboard/app/controllers/xhr_proxy_controller.rb
@@ -61,7 +61,7 @@ class XhrProxyController < ApplicationController
     data.cityofchicago.org
     data.gv.at
     data.nasa.gov
-    developer.accuweather.com
+    dataservice.accuweather.com
     dweet.io
     enclout.com
     herokuapp.com
@@ -69,18 +69,18 @@ class XhrProxyController < ApplicationController
     images-api.nasa.gov
     isenseproject.org
     lakeside-cs.org
-    opentdb.com
-    pixabay.com
-    pokeapi.co
-    qrng.anu.edu.au
-    quandl.com
-    rejseplanen.dk
     maker.ifttt.com
     myschoolapp.com
     noaa.gov
     numbersapi.com
+    opentdb.com
     pastebin.com
+    pixabay.com
+    pokeapi.co
+    qrng.anu.edu.au
+    quandl.com
     random.org
+    rejseplanen.dk
     restcountries.eu
     runescape.com
     sessionserver.mojang.com


### PR DESCRIPTION
The developer.accuweather.com API has been updated to use  dataservice.accuweather.com, which was an issue reported via Zendesk. While fixing this I noticed we have some hostnames out of order, so cleaning up the order in this change as well.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

https://codeorg.zendesk.com/agent/tickets/331914

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
