### PR TITLE
AppLab widget mode styling clean-up

### DIFF
--- a/apps/src/applab/ApplabVisualizationColumn.jsx
+++ b/apps/src/applab/ApplabVisualizationColumn.jsx
@@ -1,7 +1,7 @@
 import GameButtons, {ResetButton} from '../templates/GameButtons';
 import IFrameEmbedOverlay from '../templates/IFrameEmbedOverlay';
 import * as color from '../util/color';
-import {WIDGET_WIDTH, APP_WIDTH, APP_HEIGHT} from './constants';
+import {getAppWidth, APP_HEIGHT} from './constants';
 import React from 'react';
 import PropTypes from 'prop-types';
 import Radium from 'radium';
@@ -73,9 +73,8 @@ class ApplabVisualizationColumn extends React.Component {
     onScreenCreate: PropTypes.func.isRequired
   };
 
-  state = {renderedWidth: this.props.widgetMode ? WIDGET_WIDTH : APP_WIDTH};
-
   getClassNames() {
+    // TODO: DESTRUCTURE PROPS
     const chromelessShare = dom.isMobile() && !dom.isIPad();
     return classNames({
       with_padding: this.props.visualizationHasPadding,
@@ -104,7 +103,7 @@ class ApplabVisualizationColumn extends React.Component {
       this.props.isIframeEmbed && !this.props.isRunning && (
         <IFrameEmbedOverlay
           key="2"
-          appWidth={this.state.renderedWidth}
+          appWidth={getAppWidth(this.props)}
           appHeight={APP_HEIGHT}
         />
       )

--- a/apps/src/applab/ApplabVisualizationColumn.jsx
+++ b/apps/src/applab/ApplabVisualizationColumn.jsx
@@ -76,14 +76,10 @@ class ApplabVisualizationColumn extends React.Component {
   state = {renderedWidth: this.props.widgetMode ? WIDGET_WIDTH : APP_WIDTH};
 
   getClassNames() {
-    if (this.props.widgetMode) {
-      return 'widgetWidth';
-    }
-
     const chromelessShare = dom.isMobile() && !dom.isIPad();
     return classNames({
       with_padding: this.props.visualizationHasPadding,
-      responsive: this.props.isResponsive,
+      responsive: this.props.isResponsive && !this.props.widgetMode,
       pin_bottom: !this.props.hideSource && this.props.pinWorkspaceToBottom,
 
       // the below replicates some logic in StudioApp.handleHideSource_ which
@@ -91,7 +87,8 @@ class ApplabVisualizationColumn extends React.Component {
       // parameters. This logic really shouldn't live in StudioApp, so I don't
       // feel too bad about copying it here, where it should really live...
       chromelessShare: chromelessShare && this.props.isShareView,
-      wireframeShare: !chromelessShare && this.props.isShareView
+      wireframeShare: !chromelessShare && this.props.isShareView,
+      widgetWidth: this.props.widgetMode
     });
   }
 

--- a/apps/src/applab/ApplabVisualizationColumn.jsx
+++ b/apps/src/applab/ApplabVisualizationColumn.jsx
@@ -53,6 +53,11 @@ const styles = {
  */
 class ApplabVisualizationColumn extends React.Component {
   static propTypes = {
+    isEditingProject: PropTypes.bool.isRequired,
+    screenIds: PropTypes.arrayOf(PropTypes.string).isRequired,
+    onScreenCreate: PropTypes.func.isRequired,
+
+    // Provided by redux
     isReadOnlyWorkspace: PropTypes.bool.isRequired,
     visualizationHasPadding: PropTypes.bool.isRequired,
     isShareView: PropTypes.bool.isRequired,
@@ -65,12 +70,7 @@ class ApplabVisualizationColumn extends React.Component {
     pinWorkspaceToBottom: PropTypes.bool.isRequired,
     isPaused: PropTypes.bool,
     awaitingContainedResponse: PropTypes.bool.isRequired,
-    widgetMode: PropTypes.bool,
-
-    // non redux backed
-    isEditingProject: PropTypes.bool.isRequired,
-    screenIds: PropTypes.arrayOf(PropTypes.string).isRequired,
-    onScreenCreate: PropTypes.func.isRequired
+    widgetMode: PropTypes.bool
   };
 
   getClassNames() {

--- a/apps/src/applab/ApplabVisualizationColumn.jsx
+++ b/apps/src/applab/ApplabVisualizationColumn.jsx
@@ -187,21 +187,18 @@ class ApplabVisualizationColumn extends React.Component {
 
 export const UnconnectedApplabVisualizationColumn = ApplabVisualizationColumn;
 
-export default connect(function propsFromStore(state) {
-  return {
-    isReadOnlyWorkspace: state.pageConstants.isReadOnlyWorkspace,
-    visualizationHasPadding: state.pageConstants.visualizationHasPadding,
-    isShareView: state.pageConstants.isShareView,
-    isResponsive: isResponsiveFromState(state),
-    nonResponsiveWidth:
-      state.pageConstants.nonResponsiveVisualizationColumnWidth,
-    isIframeEmbed: state.pageConstants.isIframeEmbed,
-    hideSource: state.pageConstants.hideSource,
-    isRunning: state.runState.isRunning,
-    awaitingContainedResponse: state.runState.awaitingContainedResponse,
-    isPaused: state.runState.isDebuggerPaused,
-    playspacePhoneFrame: state.pageConstants.playspacePhoneFrame,
-    pinWorkspaceToBottom: state.pageConstants.pinWorkspaceToBottom,
-    widgetMode: state.pageConstants.widgetMode
-  };
-})(Radium(ApplabVisualizationColumn));
+export default connect(state => ({
+  isReadOnlyWorkspace: state.pageConstants.isReadOnlyWorkspace,
+  visualizationHasPadding: state.pageConstants.visualizationHasPadding,
+  isShareView: state.pageConstants.isShareView,
+  isResponsive: isResponsiveFromState(state),
+  nonResponsiveWidth: state.pageConstants.nonResponsiveVisualizationColumnWidth,
+  isIframeEmbed: state.pageConstants.isIframeEmbed,
+  hideSource: state.pageConstants.hideSource,
+  isRunning: state.runState.isRunning,
+  awaitingContainedResponse: state.runState.awaitingContainedResponse,
+  isPaused: state.runState.isDebuggerPaused,
+  playspacePhoneFrame: state.pageConstants.playspacePhoneFrame,
+  pinWorkspaceToBottom: state.pageConstants.pinWorkspaceToBottom,
+  widgetMode: state.pageConstants.widgetMode
+}))(Radium(ApplabVisualizationColumn));

--- a/apps/src/applab/ApplabVisualizationColumn.jsx
+++ b/apps/src/applab/ApplabVisualizationColumn.jsx
@@ -74,20 +74,28 @@ class ApplabVisualizationColumn extends React.Component {
   };
 
   getClassNames() {
-    // TODO: DESTRUCTURE PROPS
+    const {
+      visualizationHasPadding,
+      isResponsive,
+      widgetMode,
+      hideSource,
+      pinWorkspaceToBottom,
+      isShareView
+    } = this.props;
     const chromelessShare = dom.isMobile() && !dom.isIPad();
+
     return classNames({
-      with_padding: this.props.visualizationHasPadding,
-      responsive: this.props.isResponsive && !this.props.widgetMode,
-      pin_bottom: !this.props.hideSource && this.props.pinWorkspaceToBottom,
+      with_padding: visualizationHasPadding,
+      responsive: isResponsive && !widgetMode,
+      pin_bottom: !hideSource && pinWorkspaceToBottom,
 
       // the below replicates some logic in StudioApp.handleHideSource_ which
       // imperatively changes the css classes depending on various share
       // parameters. This logic really shouldn't live in StudioApp, so I don't
       // feel too bad about copying it here, where it should really live...
-      chromelessShare: chromelessShare && this.props.isShareView,
-      wireframeShare: !chromelessShare && this.props.isShareView,
-      widgetWidth: this.props.widgetMode
+      chromelessShare: chromelessShare && isShareView,
+      wireframeShare: !chromelessShare && isShareView,
+      widgetWidth: widgetMode
     });
   }
 
@@ -98,9 +106,24 @@ class ApplabVisualizationColumn extends React.Component {
   }
 
   render() {
+    const {
+      isIframeEmbed,
+      isRunning,
+      playspacePhoneFrame,
+      isPaused,
+      screenIds,
+      awaitingContainedResponse,
+      onScreenCreate,
+      isResponsive,
+      nonResponsiveWidth,
+      isReadOnlyWorkspace,
+      isEditingProject,
+      widgetMode
+    } = this.props;
+
     let visualization = [
       <Visualization key="1" />,
-      this.props.isIframeEmbed && !this.props.isRunning && (
+      isIframeEmbed && !isRunning && (
         <IFrameEmbedOverlay
           key="2"
           appWidth={getAppWidth(this.props)}
@@ -110,16 +133,16 @@ class ApplabVisualizationColumn extends React.Component {
     ];
     // Share view still uses image for phone frame. Would eventually like it to
     // use same code
-    if (this.props.playspacePhoneFrame) {
+    if (playspacePhoneFrame) {
       // wrap our visualization in a phone frame
       visualization = (
         <PhoneFrame
-          isDark={this.props.isRunning}
-          showSelector={!this.props.isRunning}
-          isPaused={this.props.isPaused}
-          screenIds={this.props.screenIds}
-          runButtonDisabled={this.props.awaitingContainedResponse}
-          onScreenCreate={this.props.onScreenCreate}
+          isDark={isRunning}
+          showSelector={!isRunning}
+          isPaused={isPaused}
+          screenIds={screenIds}
+          runButtonDisabled={awaitingContainedResponse}
+          onScreenCreate={onScreenCreate}
         >
           {visualization}
         </PhoneFrame>
@@ -130,19 +153,17 @@ class ApplabVisualizationColumn extends React.Component {
       <div
         id="visualizationColumn"
         className={this.getClassNames()}
-        style={[
-          !this.props.isResponsive && {maxWidth: this.props.nonResponsiveWidth}
-        ]}
+        style={[!isResponsive && {maxWidth: nonResponsiveWidth}]}
       >
-        {!this.props.isReadOnlyWorkspace && (
+        {!isReadOnlyWorkspace && (
           <PlaySpaceHeader
-            isEditingProject={this.props.isEditingProject}
-            screenIds={this.props.screenIds}
-            onScreenCreate={this.props.onScreenCreate}
+            isEditingProject={isEditingProject}
+            screenIds={screenIds}
+            onScreenCreate={onScreenCreate}
           />
         )}
         {visualization}
-        {this.props.isIframeEmbed && !this.props.widgetMode && (
+        {isIframeEmbed && !widgetMode && (
           <div style={styles.resetButtonWrapper}>
             <ResetButton hideText style={styles.resetButton} />
           </div>
@@ -153,7 +174,7 @@ class ApplabVisualizationColumn extends React.Component {
             <CompletionButton />
           </div>
         </GameButtons>
-        {this.props.awaitingContainedResponse && (
+        {awaitingContainedResponse && (
           <div style={styles.containedInstructions}>
             {i18n.predictionInstructions()}
           </div>

--- a/apps/src/applab/Visualization.jsx
+++ b/apps/src/applab/Visualization.jsx
@@ -89,10 +89,7 @@ class Visualization extends React.Component {
         id={VISUALIZATION_DIV_ID}
         className={this.getVisualizationClassNames()}
         style={[
-          !this.props.isResponsive && {
-            ...styles.nonResponsive,
-            ...{width: appWidth}
-          },
+          !this.props.isResponsive && styles.nonResponsive,
           this.props.isShareView && styles.share,
           this.props.playspacePhoneFrame && styles.phoneFrame,
           this.props.playspacePhoneFrame &&

--- a/apps/src/applab/Visualization.jsx
+++ b/apps/src/applab/Visualization.jsx
@@ -71,6 +71,19 @@ class Visualization extends React.Component {
     studioApp().runButtonClick();
   };
 
+  getVisualizationClassNames = () => {
+    const {widgetMode, isResponsive, visualizationHasPadding} = this.props;
+
+    if (widgetMode) {
+      return classNames('widgetWidth', 'widgetHeight');
+    }
+
+    return classNames({
+      responsive: isResponsive,
+      with_padding: visualizationHasPadding
+    });
+  };
+
   render() {
     const {appWidth} = this.state;
     const appHeight =
@@ -79,14 +92,7 @@ class Visualization extends React.Component {
     return (
       <div
         id={VISUALIZATION_DIV_ID}
-        className={
-          this.props.widgetMode
-            ? 'widgetWidth widgetHeight'
-            : classNames({
-                responsive: this.props.isResponsive,
-                with_padding: this.props.visualizationHasPadding
-              })
-        }
+        className={this.getVisualizationClassNames()}
         style={[
           !this.props.isResponsive && {
             ...styles.nonResponsive,

--- a/apps/src/applab/Visualization.jsx
+++ b/apps/src/applab/Visualization.jsx
@@ -49,6 +49,7 @@ const styles = {
 
 class Visualization extends React.Component {
   static propTypes = {
+    // Provided by redux
     visualizationHasPadding: PropTypes.bool.isRequired,
     isShareView: PropTypes.bool.isRequired,
     isPaused: PropTypes.bool.isRequired,

--- a/apps/src/applab/Visualization.jsx
+++ b/apps/src/applab/Visualization.jsx
@@ -58,12 +58,6 @@ class Visualization extends React.Component {
     widgetMode: PropTypes.bool
   };
 
-  state = {
-    appWidth: this.props.widgetMode
-      ? applabConstants.WIDGET_WIDTH
-      : applabConstants.APP_WIDTH
-  };
-
   handleDisableMaker = () => project.setMakerEnabled(null);
 
   handleTryAgain = () => {
@@ -85,7 +79,7 @@ class Visualization extends React.Component {
   };
 
   render() {
-    const {appWidth} = this.state;
+    const appWidth = applabConstants.getAppWidth(this.props);
     const appHeight =
       applabConstants.APP_HEIGHT - applabConstants.FOOTER_HEIGHT;
 

--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -149,12 +149,6 @@ function loadLevel() {
   Applab.timeoutFailureTick = level.timeoutFailureTick || Infinity;
   Applab.minWorkspaceHeight = level.minWorkspaceHeight;
   Applab.softButtons_ = level.softButtons || {};
-
-  // TODO: REMOVE OUTDATED COMMENT
-  // Historically, appWidth and appHeight were customizable on a per level basis.
-  // This led to lots of hackery in the code to properly scale the visualization
-  // area. Width/height are now constant, but much of the hackery still remains
-  // since I don't understand it well enough.
   Applab.appWidth = applabConstants.getAppWidth(level);
   Applab.appHeight = applabConstants.APP_HEIGHT;
 

--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -150,14 +150,12 @@ function loadLevel() {
   Applab.minWorkspaceHeight = level.minWorkspaceHeight;
   Applab.softButtons_ = level.softButtons || {};
 
+  // TODO: REMOVE OUTDATED COMMENT
   // Historically, appWidth and appHeight were customizable on a per level basis.
   // This led to lots of hackery in the code to properly scale the visualization
   // area. Width/height are now constant, but much of the hackery still remains
   // since I don't understand it well enough.
-  Applab.appWidth = level.widgetMode
-    ? applabConstants.WIDGET_WIDTH
-    : applabConstants.APP_WIDTH;
-
+  Applab.appWidth = applabConstants.getAppWidth(level);
   Applab.appHeight = applabConstants.APP_HEIGHT;
 
   // In share mode we need to reserve some number of pixels for our in-app

--- a/apps/src/applab/constants.js
+++ b/apps/src/applab/constants.js
@@ -10,6 +10,8 @@ export {ICON_PREFIX, ICON_PREFIX_REGEX, DATA_URL_PREFIX_REGEX, ABSOLUTE_REGEXP};
 export const FOOTER_HEIGHT = 30;
 export const APP_WIDTH = 320;
 export const WIDGET_WIDTH = 600; // Note: This constant is also maintained in applab/style.scss.
+export const getAppWidth = config =>
+  config?.widgetMode ? WIDGET_WIDTH : APP_WIDTH;
 export const APP_HEIGHT = 480;
 export const DESIGN_ELEMENT_ID_PREFIX = 'design_';
 export const NEW_SCREEN = 'New screen...';

--- a/apps/src/applab/constants.js
+++ b/apps/src/applab/constants.js
@@ -9,7 +9,7 @@ import {
 export {ICON_PREFIX, ICON_PREFIX_REGEX, DATA_URL_PREFIX_REGEX, ABSOLUTE_REGEXP};
 export const FOOTER_HEIGHT = 30;
 export const APP_WIDTH = 320;
-export const WIDGET_WIDTH = 600;
+export const WIDGET_WIDTH = 600; // Note: This constant is also maintained in applab/style.scss.
 export const APP_HEIGHT = 480;
 export const DESIGN_ELEMENT_ID_PREFIX = 'design_';
 export const NEW_SCREEN = 'New screen...';

--- a/apps/src/applab/designElements/screen.jsx
+++ b/apps/src/applab/designElements/screen.jsx
@@ -136,11 +136,9 @@ export default {
   themeValues: themeValues.screen,
 
   create: function() {
-    let pageConstants = getStore().getState().pageConstants;
-    let width =
-      pageConstants && pageConstants.widgetMode
-        ? applabConstants.WIDGET_WIDTH
-        : applabConstants.APP_WIDTH;
+    const width = applabConstants.getAppWidth(
+      getStore().getState().pageConstants
+    );
     const element = document.createElement('div');
     element.setAttribute('class', 'screen');
     element.setAttribute('tabIndex', '1');

--- a/apps/style/applab/style.scss
+++ b/apps/style/applab/style.scss
@@ -9,7 +9,7 @@
 $root: '/blockly/media/applab/'; //TODO: Parameterize for asset pipeline
 $defaultWidth: 320px;
 $defaultFooterlessHeight: 450px;
-$widgetWidth: 600px;
+$widgetWidth: 600px; // Note: This constant is also maintained in applab/constants.js.
 $widgetHeight: $defaultFooterlessHeight;
 
 div#visualization {

--- a/apps/style/applab/style.scss
+++ b/apps/style/applab/style.scss
@@ -9,6 +9,8 @@
 $root: '/blockly/media/applab/'; //TODO: Parameterize for asset pipeline
 $defaultWidth: 320px;
 $defaultFooterlessHeight: 450px;
+$widgetWidth: 600px;
+$widgetHeight: $defaultFooterlessHeight;
 
 div#visualization {
   height: 562.5px;
@@ -231,16 +233,6 @@ div#visualizationResizeBar {
   }
 }
 
-.widgetWidth {
-  width: 600px !important;
-  max-width: 600px !important;
-}
-
-.widgetHeight {
-  height: 450px !important;
-  max-height: 450px !important;
-}
-
 #visualizationColumn.wireframeShare {
   max-width: none !important;
   // If you change this width and height,
@@ -271,6 +263,18 @@ div#visualizationResizeBar {
 #visualizationColumn.chromelessShare {
   #playSpaceHeader, #gameButtons {
     display: none;
+  }
+}
+
+#visualizationColumn, #visualization {
+  &.widgetWidth {
+    width: $widgetWidth;
+    max-width: $widgetWidth;
+  }
+
+  &.widgetHeight {
+    height: $widgetHeight;
+    max-height: $widgetHeight;
   }
 }
 

--- a/apps/test/unit/applab/ApplabVisualizationColumnTest.js
+++ b/apps/test/unit/applab/ApplabVisualizationColumnTest.js
@@ -7,6 +7,7 @@ import {WIDGET_WIDTH} from '@cdo/apps/applab/constants';
 describe('AppLabVisualizationColumn', () => {
   describe('in widget mode', () => {
     let visualizationColumn;
+
     beforeEach(() => {
       visualizationColumn = shallow(
         <UnconnectedApplabVisualizationColumn
@@ -17,7 +18,6 @@ describe('AppLabVisualizationColumn', () => {
           nonResponsiveWidth={0}
           isRunning={false}
           hideSource={false}
-          isIframeEmbed={false}
           pinWorkspaceToBottom={false}
           awaitingContainedResponse={false}
           isEditingProject={false}
@@ -25,28 +25,27 @@ describe('AppLabVisualizationColumn', () => {
           onScreenCreate={() => {}}
           isPaused={false}
           // relevant to widget mode tests
-          widgetMode={true}
-          playspacePhoneFrame={true}
+          widgetMode
+          isIframeEmbed
+          playspacePhoneFrame
         />
       );
     });
 
-    afterEach(() => {
-      visualizationColumn = undefined;
+    it('renders IFrameEmbedOverlay with the correct appWidth', () => {
+      const iframeEmbed = visualizationColumn.find('IFrameEmbedOverlay');
+      expect(iframeEmbed).to.have.lengthOf(1);
+      expect(iframeEmbed.prop('appWidth')).to.equal(WIDGET_WIDTH);
     });
 
-    it('rendered width equals widget width', () => {
-      expect(visualizationColumn.state().renderedWidth).to.equal(WIDGET_WIDTH);
-    });
-
-    it('class name is widgetWidth', () => {
+    it('className includes widgetWidth', () => {
       expect(visualizationColumn.instance().getClassNames()).to.include(
         'widgetWidth'
       );
     });
 
     it('does not render a ResetButton', () => {
-      expect(visualizationColumn.find('ResetButton')).to.be.empty;
+      expect(visualizationColumn.find('ResetButton')).to.not.have.length;
     });
 
     it('displays a centered finish button', () => {

--- a/apps/test/unit/applab/VisualizationTest.js
+++ b/apps/test/unit/applab/VisualizationTest.js
@@ -15,21 +15,30 @@ describe('Visualization', () => {
           isShareView={false}
           isPaused={false}
           isRunning={false}
-          playspacePhoneFrame={true}
           isResponsive={false}
           // relevant to widget mode tests
-          widgetMode={true}
+          widgetMode
+          playspacePhoneFrame
         />
       );
     });
 
-    it('uses the widgetWidth and widgetHeight class', () => {
-      expect(visualization.find('div.widgetWidth')).to.have.lengthOf(1);
-      expect(visualization.find('div.widgetHeight')).to.have.lengthOf(1);
+    it('uses the widgetWidth and widgetHeight classes', () => {
+      expect(visualization.instance().getVisualizationClassNames()).to.equal(
+        'widgetWidth widgetHeight'
+      );
     });
 
-    it('has a width equal to WIDGET_WIDTH', () => {
-      expect(visualization.state().appWidth).to.equal(WIDGET_WIDTH);
+    it('applies the correct width to child elements', () => {
+      const vizOverlay = visualization.find('Connect(VisualizationOverlay)');
+      expect(vizOverlay).to.have.lengthOf(1);
+      expect(vizOverlay.prop('width')).to.equal(WIDGET_WIDTH);
+
+      const makerOverlay = visualization.find(
+        'Connect(UnconnectedMakerStatusOverlay)'
+      );
+      expect(makerOverlay).to.have.lengthOf(1);
+      expect(makerOverlay.prop('width')).to.equal(WIDGET_WIDTH);
     });
   });
 });


### PR DESCRIPTION
Follow-up to #40298.

More pre-factoring for [STAR-1549](https://codedotorg.atlassian.net/browse/STAR-1549) (allowing levelbuilders to create AppLab widgets with start & design modes). A few things happening here:

1. Consolidate AppLab app width calculation into a function (`getAppWidth` in applab/constants.js).
2. Consolidate widget mode styles to remove unnecessary conditionals where possible.
3. Remove `!important` from `.widgetWidth` and `.widgetHeight` classes using specificity rules.
4. General organization and clean-up.

## Links

- [STAR-1549](https://codedotorg.atlassian.net/browse/STAR-1549)

## Testing story

Relies on existing storybook and eyes tests.