### PR TITLE
The i18n system now uses new URL system

### DIFF
--- a/bin/i18n/i18n_script_utils.rb
+++ b/bin/i18n/i18n_script_utils.rb
@@ -128,7 +128,7 @@ class I18nScriptUtils
 
   def self.get_level_url_key(script, level)
     script_level = level.script_levels.find_by_script_id(script.id)
-    path = script_level.build_script_level_path_for_translations(script_level)
+    path = script_level.build_script_level_path(script_level)
     URI.join("https://studio.code.org", path)
   end
 

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -39,22 +39,6 @@ module LevelsHelper
     end
   end
 
-  # This is a a temporary method to help with moving translations onto the new level urls. To start this will
-  # keep translations on the old URL until foundations can do the work to bring them over to the new url
-  def build_script_level_path_for_translations(script_level)
-    if script_level.script.name == Script::HOC_NAME
-      hoc_chapter_path(script_level.chapter)
-    elsif script_level.script.name == Script::FLAPPY_NAME
-      flappy_chapter_path(script_level.chapter)
-    elsif !script_level.lesson.numbered_lesson?
-      script_lockable_stage_script_level_path(script_level.script, script_level.lesson, script_level)
-    elsif script_level.bonus
-      `/s/#{script_level.script.name}/stage/#{script_level.lesson.relative_position}/extras?level_name=#{script_level.level.name}`
-    else
-      `/s/#{script_level.script.name}/stage/#{script_level.lesson.relative_position}/puzzle/#{script_level.position}`
-    end
-  end
-
   def build_script_level_url(script_level, params = {})
     url_from_path(build_script_level_path(script_level, params))
   end

--- a/dashboard/test/helpers/levels_helper_test.rb
+++ b/dashboard/test/helpers/levels_helper_test.rb
@@ -425,65 +425,6 @@ class LevelsHelperTest < ActionView::TestCase
     assert_not can_view_solution?
   end
 
-  test 'build_script_level_path_for_translations for survey' do
-    input_dsl = <<~DSL
-      lesson 'Survey1', display_name: 'Survey1', has_lesson_plan: false, lockable: true;
-      assessment 'LockableAssessment1';
-    DSL
-
-    create :level, name: 'LockableAssessment1'
-
-    script_data, _ = ScriptDSL.parse(input_dsl, 'a filename')
-
-    script = Script.add_script(
-      {name: 'test_script'},
-      script_data[:lesson_groups]
-    )
-
-    stage = script.lessons[0]
-    assert_equal '/s/test_script/lockable/1/levels/1', build_script_level_path_for_translations(stage.script_levels[0])
-  end
-
-  test 'build_script_level_path_for_translations for bonus' do
-    input_dsl = <<~DSL
-      lesson 'Test bonus level links', display_name: 'Test bonus level links'
-      level 'Level1'
-      level 'BonusLevel1', bonus: true
-    DSL
-
-    create :level, name: 'Level1'
-    create :level, name: 'BonusLevel1'
-
-    script_data, _ = ScriptDSL.parse(input_dsl, 'test_bonus_level_links')
-
-    script = Script.add_script(
-      {name: 'test_bonus_level_links'},
-      script_data[:lesson_groups]
-    )
-
-    bonus_script_level = script.lessons.first.script_levels[1]
-    assert_equal `/s/test_bonus_level_links/stage/1/extras?level_name=BonusLevel1`, build_script_level_path_for_translations(bonus_script_level)
-  end
-
-  test 'build_script_level_path_for_translations for normal level' do
-    input_dsl = <<~DSL
-      lesson 'Test bonus level links', display_name: 'Level Link Test'
-      level 'Level1'
-    DSL
-
-    create :level, name: 'Level1'
-
-    script_data, _ = ScriptDSL.parse(input_dsl, 'test_level_links')
-
-    script = Script.add_script(
-      {name: 'test_level_links'},
-      script_data[:lesson_groups]
-    )
-
-    script_level = script.lessons.first.script_levels[0]
-    assert_equal `/s/test_level_links/stage/1/puzzle/1`, build_script_level_path_for_translations(script_level)
-  end
-
   test 'build_script_level_path differentiates lesson and survey' do
     # (position 1) Survey 1 (lockable: true, has_lesson_plan: false)
     # (position 2) Lesson 1 (lockable: false, has_lesson_plan: false)


### PR DESCRIPTION
The URLs we use for puzzles recently changed and the i18n system uses those URLs as the key for translatable strings. The foundations team didn't have time to handle doing a migration to the new URLs, so `build_script_level_path_for_translations` was created as a stop-gap.
We have uploaded all the strings to Crowdin using the new URL's, which means we can remove `build_script_level_path_for_translations` and use the normal `build_script_level_path` method.
## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
