### PR TITLE
Explicitly focus facilitator select control before workshop eyes check

### DIFF
--- a/dashboard/test/ui/features/plc/pd/workshop_dashboard.feature
+++ b/dashboard/test/ui/features/plc/pd/workshop_dashboard.feature
@@ -27,6 +27,7 @@ Scenario: New workshop: CSF intro
   # If we do not accept a suggestion, a dropdown of location options can obscure part of the page
   # and cause the eyes check to fail.
   And I click "#mapbox-geocoder-container > div > div.suggestions-wrapper > ul > li" if it is visible
+  And I focus selector "select#facilitator0"
 
   And I see no difference for "new workshop details: CSF"
 
@@ -65,6 +66,7 @@ Scenario: New workshop: CSD units 2-3 with 2 facilitators
   # If we do not accept a suggestion, a dropdown of location options can obscure part of the page
   # and cause the eyes check to fail.
   And I click "#mapbox-geocoder-container > div > div.suggestions-wrapper > ul > li" if it is visible
+  And I focus selector "select#facilitator1"
 
   And I see no difference for "new workshop details: CSD"
 
@@ -99,6 +101,7 @@ Scenario: New workshop: CSP local summer with 1 facilitator
   # If we do not accept a suggestion, a dropdown of location options can obscure part of the page
   # and cause the eyes check to fail.
   And I click "#mapbox-geocoder-container > div > div.suggestions-wrapper > ul > li" if it is visible
+  And I focus selector "select#facilitator0"
 
   And I see no difference for "new workshop details: CSP"
 


### PR DESCRIPTION
A recent fix for one cause of flakiness (timing of Mapbox response -- https://github.com/code-dot-org/code-dot-org/pull/40106) caused another issue where the focus on the control would shift after dismissing the (sometimes) visible Mapbox dropdown. This change refocuses the last element selected before the eyes check, such that we are consistent in which control is focused before running the eyes check.

## Testing story

Ran this in Applitools via Saucelabs, and the change looked as expected (refocused the last control after dismissing the Mapbox dropdown).