### PR TITLE
Maker Setup Page: change yml key used to construct URL to download Maker App

### DIFF
--- a/apps/src/lib/kits/maker/ui/SetupGuide.jsx
+++ b/apps/src/lib/kits/maker/ui/SetupGuide.jsx
@@ -367,7 +367,7 @@ const latestInstaller = _.memoize(latestYamlUrl => {
     .then(response => response.text())
     .then(text => yaml.safeLoad(text))
     .then(datum => ({
-      filename: datum.url,
+      filename: datum.path,
       version: datum.version
     }));
 });


### PR DESCRIPTION
Changes the key we are using to fetch Maker App downloads from `url` to `path`

The latest version of electron-builder has changed the format of the `latest.yml` file it creates and uploads to S3 when releasing the app. The [maker setup page](https://studio.code.org/maker/setup) requests these yml files to construct URLs to download the current version of our app for each operating system. Fortunately *this change is backwards compatible* so we do not need to time this with immediately uploading the new yml format.

Old format
```
version: 1.1.8
releaseDate: '2021-04-21T01:47:09.744Z'
path: Code.org Maker App-1.1.8-mac.dmg
url: Code.org Maker App-1.1.8-mac.dmg
sha512: >-
  mtzBJe4ZbwqQkZXmcqiY3JMd4cud/LC/3X6Tng0TbwEU4vDVT2lF7WYxiEJ6Z9iLZT6aoQayF4qx1+eMlT8RoQ==
```

New format
```
version: 1.1.9
files:
  - url: Code.org-Maker-App-1.1.9-mac.zip
    sha512: Zl4+pIVjZw6e3FTOieNVFtBJa4A5z6Q7yh3Pnx5INjC2upQE0pRMtIpgvWe6SBFv9W+AG0d8poB7Ao0RkRABKw==
    size: 77504746
    blockMapSize: 82239
  - url: Code.org-Maker-App-1.1.9-mac.dmg
    sha512: L92OvScYqBik04+fv49jIObtKDSvPVV70MTcet8WqRnKZ9RYppP3VzaPtTBR7MtYL6oHHw/JgXporM/21fr+vw==
    size: 79871725
path: Code.org-Maker-App-1.1.9-mac.zip
sha512: Zl4+pIVjZw6e3FTOieNVFtBJa4A5z6Q7yh3Pnx5INjC2upQE0pRMtIpgvWe6SBFv9W+AG0d8poB7Ao0RkRABKw==
releaseDate: '2021-04-21T22:12:39.800Z'
```

## Links
[Maker Setup Page](https://studio.code.org/maker/setup)
[latest.yml](https://downloads.code.org/maker/latest.yml)

In support of [STAR-1026](https://codedotorg.atlassian.net/browse/STAR-1026)

## Testing story
I have tested this locally. I didn't see any unit tests for this file and I am not sure a good way of testing this change without some significant refactoring. Happy to take a pass at that if someone thinks it is critical and can point me down a path

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy
This needs to be deployed before releasing the newest Maker App.