### PR TITLE
filter out bonus levels when stage extras disabled in progress table

### DIFF
--- a/apps/src/templates/sectionProgress/sectionProgressLoader.js
+++ b/apps/src/templates/sectionProgress/sectionProgressLoader.js
@@ -55,7 +55,7 @@ export function loadScriptProgress(scriptId, sectionId) {
     .then(response => response.json())
     .then(scriptData => {
       sectionProgress.scriptDataByScript = {
-        [scriptId]: postProcessDataByScript(scriptData)
+        [scriptId]: postProcessDataByScript(scriptData, sectionData.stageExtras)
       };
 
       if (
@@ -113,7 +113,7 @@ export function loadScriptProgress(scriptId, sectionId) {
   });
 }
 
-function postProcessDataByScript(scriptData) {
+function postProcessDataByScript(scriptData, includeBonusLevels) {
   // Filter to match scriptDataPropType
   const filteredScriptData = {
     id: scriptData.id,
@@ -131,11 +131,18 @@ function postProcessDataByScript(scriptData) {
   }
   return {
     ...filteredScriptData,
-    stages: filteredScriptData.stages.map(stage => {
-      return {
-        ...stage,
-        levels: stage.levels.map(level => processedLevel(level))
-      };
-    })
+    stages: filteredScriptData.stages.map(lesson =>
+      postProcessLessonData(lesson, includeBonusLevels)
+    )
+  };
+}
+
+function postProcessLessonData(lesson, includeBonusLevels) {
+  const levels = includeBonusLevels
+    ? lesson.levels
+    : lesson.levels.filter(level => !level.bonus);
+  return {
+    ...lesson,
+    levels: levels.map(level => processedLevel(level))
   };
 }

--- a/apps/test/unit/templates/sectionProgress/sectionProgressLoaderTest.js
+++ b/apps/test/unit/templates/sectionProgress/sectionProgressLoaderTest.js
@@ -1,5 +1,6 @@
 import {expect} from '../../../util/reconfiguredChai';
 import sinon from 'sinon';
+import _ from 'lodash';
 import {loadScriptProgress} from '@cdo/apps/templates/sectionProgress/sectionProgressLoader';
 import * as sectionProgress from '@cdo/apps/templates/sectionProgress/sectionProgressRedux';
 import * as progressHelpers from '@cdo/apps/templates/progress/progressHelpers';
@@ -334,6 +335,7 @@ describe('sectionProgressLoader.loadScript', () => {
     });
 
     describe('the first time', () => {
+      let stageExtras = true;
       beforeEach(() => {
         reduxStub.returns({
           getState: () => {
@@ -345,7 +347,8 @@ describe('sectionProgressLoader.loadScript', () => {
               },
               sectionData: {
                 section: {
-                  students: ['student']
+                  students: ['student'],
+                  stageExtras: stageExtras
                 }
               }
             };
@@ -425,6 +428,59 @@ describe('sectionProgressLoader.loadScript', () => {
         });
         loadScriptProgress(123, 0);
         expect(addDataByScriptStub).to.have.been.calledWith(fullExpectedResult);
+        progressHelpers.processedLevel.restore();
+      });
+
+      it('filters out bonus levels when section.stageExtras is false', () => {
+        stageExtras = false;
+        const scriptResponse = _.cloneDeep(serverScriptResponse);
+        scriptResponse.lessons[0].levels.push({bonus: true});
+
+        sinon.stub(progressHelpers, 'processedLevel').returnsArg(0);
+        addDataByScriptStub = sinon.spy(sectionProgress, 'addDataByScript');
+
+        fetchStub.onCall(0).returns({
+          then: sinon.stub().returns({
+            then: sinon.stub().callsArgWith(0, scriptResponse)
+          })
+        });
+        fetchStub.onCall(1).returns({
+          then: sinon.stub().returns({
+            then: sinon.stub().callsArgWith(0, serverProgressResponse)
+          })
+        });
+        loadScriptProgress(123, 0);
+        expect(addDataByScriptStub).to.have.been.calledWith(fullExpectedResult);
+        progressHelpers.processedLevel.restore();
+      });
+
+      it('does not filter bonus levels when section.stageExtras is true', () => {
+        stageExtras = true;
+        const bonusLevel = {id: '2002', bonus: true};
+
+        const scriptResponse = _.cloneDeep(serverScriptResponse);
+        scriptResponse.lessons[0].levels.push(bonusLevel);
+
+        const expectedResult = _.cloneDeep(fullExpectedResult);
+        expectedResult.scriptDataByScript[123].stages[0].levels.push(
+          bonusLevel
+        );
+
+        sinon.stub(progressHelpers, 'processedLevel').returnsArg(0);
+        addDataByScriptStub = sinon.spy(sectionProgress, 'addDataByScript');
+
+        fetchStub.onCall(0).returns({
+          then: sinon.stub().returns({
+            then: sinon.stub().callsArgWith(0, scriptResponse)
+          })
+        });
+        fetchStub.onCall(1).returns({
+          then: sinon.stub().returns({
+            then: sinon.stub().callsArgWith(0, serverProgressResponse)
+          })
+        });
+        loadScriptProgress(123, 0);
+        expect(addDataByScriptStub).to.have.been.calledWith(expectedResult);
         progressHelpers.processedLevel.restore();
       });
     });


### PR DESCRIPTION
currently, we show bonus levels in our progress tables even when stage extras are disabled for the section. this PR update `sectionProgressLoader` to filter them out based on the `section.stageExtras` property.

i would have preferred to make this change on the backend, but that looked like a bit of a rabbit hole and this method was quick and easy.