### PR TITLE
Revert "Revert "AppLab widget mode styling clean-up""

### DIFF
--- a/apps/src/applab/Visualization.jsx
+++ b/apps/src/applab/Visualization.jsx
@@ -49,6 +49,7 @@ const styles = {
 
 class Visualization extends React.Component {
   static propTypes = {
+    // Provided by redux
     visualizationHasPadding: PropTypes.bool.isRequired,
     isShareView: PropTypes.bool.isRequired,
     isPaused: PropTypes.bool.isRequired,
@@ -58,12 +59,6 @@ class Visualization extends React.Component {
     widgetMode: PropTypes.bool
   };
 
-  state = {
-    appWidth: this.props.widgetMode
-      ? applabConstants.WIDGET_WIDTH
-      : applabConstants.APP_WIDTH
-  };
-
   handleDisableMaker = () => project.setMakerEnabled(null);
 
   handleTryAgain = () => {
@@ -71,27 +66,30 @@ class Visualization extends React.Component {
     studioApp().runButtonClick();
   };
 
+  getVisualizationClassNames = () => {
+    const {widgetMode, isResponsive, visualizationHasPadding} = this.props;
+
+    if (widgetMode) {
+      return classNames('widgetWidth', 'widgetHeight');
+    }
+
+    return classNames({
+      responsive: isResponsive,
+      with_padding: visualizationHasPadding
+    });
+  };
+
   render() {
-    const {appWidth} = this.state;
+    const appWidth = applabConstants.getAppWidth(this.props);
     const appHeight =
       applabConstants.APP_HEIGHT - applabConstants.FOOTER_HEIGHT;
 
     return (
       <div
         id={VISUALIZATION_DIV_ID}
-        className={
-          this.props.widgetMode
-            ? 'widgetWidth widgetHeight'
-            : classNames({
-                responsive: this.props.isResponsive,
-                with_padding: this.props.visualizationHasPadding
-              })
-        }
+        className={this.getVisualizationClassNames()}
         style={[
-          !this.props.isResponsive && {
-            ...styles.nonResponsive,
-            ...{width: appWidth}
-          },
+          !this.props.isResponsive && styles.nonResponsive,
           this.props.isShareView && styles.share,
           this.props.playspacePhoneFrame && styles.phoneFrame,
           this.props.playspacePhoneFrame &&

--- a/apps/src/applab/Visualization.jsx
+++ b/apps/src/applab/Visualization.jsx
@@ -89,7 +89,10 @@ class Visualization extends React.Component {
         id={VISUALIZATION_DIV_ID}
         className={this.getVisualizationClassNames()}
         style={[
-          !this.props.isResponsive && styles.nonResponsive,
+          !this.props.isResponsive && {
+            ...styles.nonResponsive,
+            width: appWidth // Required for the project share page.
+          },
           this.props.isShareView && styles.share,
           this.props.playspacePhoneFrame && styles.phoneFrame,
           this.props.playspacePhoneFrame &&

--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -149,15 +149,7 @@ function loadLevel() {
   Applab.timeoutFailureTick = level.timeoutFailureTick || Infinity;
   Applab.minWorkspaceHeight = level.minWorkspaceHeight;
   Applab.softButtons_ = level.softButtons || {};
-
-  // Historically, appWidth and appHeight were customizable on a per level basis.
-  // This led to lots of hackery in the code to properly scale the visualization
-  // area. Width/height are now constant, but much of the hackery still remains
-  // since I don't understand it well enough.
-  Applab.appWidth = level.widgetMode
-    ? applabConstants.WIDGET_WIDTH
-    : applabConstants.APP_WIDTH;
-
+  Applab.appWidth = applabConstants.getAppWidth(level);
   Applab.appHeight = applabConstants.APP_HEIGHT;
 
   // In share mode we need to reserve some number of pixels for our in-app

--- a/apps/src/applab/constants.js
+++ b/apps/src/applab/constants.js
@@ -9,7 +9,9 @@ import {
 export {ICON_PREFIX, ICON_PREFIX_REGEX, DATA_URL_PREFIX_REGEX, ABSOLUTE_REGEXP};
 export const FOOTER_HEIGHT = 30;
 export const APP_WIDTH = 320;
-export const WIDGET_WIDTH = 600;
+export const WIDGET_WIDTH = 600; // Note: This constant is also maintained in applab/style.scss.
+export const getAppWidth = config =>
+  config?.widgetMode ? WIDGET_WIDTH : APP_WIDTH;
 export const APP_HEIGHT = 480;
 export const DESIGN_ELEMENT_ID_PREFIX = 'design_';
 export const NEW_SCREEN = 'New screen...';

--- a/apps/src/applab/designElements/screen.jsx
+++ b/apps/src/applab/designElements/screen.jsx
@@ -136,11 +136,9 @@ export default {
   themeValues: themeValues.screen,
 
   create: function() {
-    let pageConstants = getStore().getState().pageConstants;
-    let width =
-      pageConstants && pageConstants.widgetMode
-        ? applabConstants.WIDGET_WIDTH
-        : applabConstants.APP_WIDTH;
+    const width = applabConstants.getAppWidth(
+      getStore().getState().pageConstants
+    );
     const element = document.createElement('div');
     element.setAttribute('class', 'screen');
     element.setAttribute('tabIndex', '1');

--- a/apps/style/applab/style.scss
+++ b/apps/style/applab/style.scss
@@ -9,6 +9,8 @@
 $root: '/blockly/media/applab/'; //TODO: Parameterize for asset pipeline
 $defaultWidth: 320px;
 $defaultFooterlessHeight: 450px;
+$widgetWidth: 600px; // Note: This constant is also maintained in applab/constants.js.
+$widgetHeight: $defaultFooterlessHeight;
 
 div#visualization {
   height: 562.5px;
@@ -231,16 +233,6 @@ div#visualizationResizeBar {
   }
 }
 
-.widgetWidth {
-  width: 600px !important;
-  max-width: 600px !important;
-}
-
-.widgetHeight {
-  height: 450px !important;
-  max-height: 450px !important;
-}
-
 #visualizationColumn.wireframeShare {
   max-width: none !important;
   // If you change this width and height,
@@ -271,6 +263,18 @@ div#visualizationResizeBar {
 #visualizationColumn.chromelessShare {
   #playSpaceHeader, #gameButtons {
     display: none;
+  }
+}
+
+#visualizationColumn, #visualization {
+  &.widgetWidth {
+    width: $widgetWidth;
+    max-width: $widgetWidth;
+  }
+
+  &.widgetHeight {
+    height: $widgetHeight;
+    max-height: $widgetHeight;
   }
 }
 

--- a/apps/test/unit/applab/ApplabVisualizationColumnTest.js
+++ b/apps/test/unit/applab/ApplabVisualizationColumnTest.js
@@ -7,6 +7,7 @@ import {WIDGET_WIDTH} from '@cdo/apps/applab/constants';
 describe('AppLabVisualizationColumn', () => {
   describe('in widget mode', () => {
     let visualizationColumn;
+
     beforeEach(() => {
       visualizationColumn = shallow(
         <UnconnectedApplabVisualizationColumn
@@ -17,7 +18,6 @@ describe('AppLabVisualizationColumn', () => {
           nonResponsiveWidth={0}
           isRunning={false}
           hideSource={false}
-          isIframeEmbed={false}
           pinWorkspaceToBottom={false}
           awaitingContainedResponse={false}
           isEditingProject={false}
@@ -25,28 +25,27 @@ describe('AppLabVisualizationColumn', () => {
           onScreenCreate={() => {}}
           isPaused={false}
           // relevant to widget mode tests
-          widgetMode={true}
-          playspacePhoneFrame={true}
+          widgetMode
+          isIframeEmbed
+          playspacePhoneFrame
         />
       );
     });
 
-    afterEach(() => {
-      visualizationColumn = undefined;
+    it('renders IFrameEmbedOverlay with the correct appWidth', () => {
+      const iframeEmbed = visualizationColumn.find('IFrameEmbedOverlay');
+      expect(iframeEmbed).to.have.lengthOf(1);
+      expect(iframeEmbed.prop('appWidth')).to.equal(WIDGET_WIDTH);
     });
 
-    it('rendered width equals widget width', () => {
-      expect(visualizationColumn.state().renderedWidth).to.equal(WIDGET_WIDTH);
-    });
-
-    it('class name is widgetWidth', () => {
+    it('className includes widgetWidth', () => {
       expect(visualizationColumn.instance().getClassNames()).to.include(
         'widgetWidth'
       );
     });
 
     it('does not render a ResetButton', () => {
-      expect(visualizationColumn.find('ResetButton')).to.be.empty;
+      expect(visualizationColumn.find('ResetButton')).to.not.have.length;
     });
 
     it('displays a centered finish button', () => {

--- a/apps/test/unit/applab/VisualizationTest.js
+++ b/apps/test/unit/applab/VisualizationTest.js
@@ -15,21 +15,30 @@ describe('Visualization', () => {
           isShareView={false}
           isPaused={false}
           isRunning={false}
-          playspacePhoneFrame={true}
           isResponsive={false}
           // relevant to widget mode tests
-          widgetMode={true}
+          widgetMode
+          playspacePhoneFrame
         />
       );
     });
 
-    it('uses the widgetWidth and widgetHeight class', () => {
-      expect(visualization.find('div.widgetWidth')).to.have.lengthOf(1);
-      expect(visualization.find('div.widgetHeight')).to.have.lengthOf(1);
+    it('uses the widgetWidth and widgetHeight classes', () => {
+      expect(visualization.instance().getVisualizationClassNames()).to.equal(
+        'widgetWidth widgetHeight'
+      );
     });
 
-    it('has a width equal to WIDGET_WIDTH', () => {
-      expect(visualization.state().appWidth).to.equal(WIDGET_WIDTH);
+    it('applies the correct width to child elements', () => {
+      const vizOverlay = visualization.find('Connect(VisualizationOverlay)');
+      expect(vizOverlay).to.have.lengthOf(1);
+      expect(vizOverlay.prop('width')).to.equal(WIDGET_WIDTH);
+
+      const makerOverlay = visualization.find(
+        'Connect(UnconnectedMakerStatusOverlay)'
+      );
+      expect(makerOverlay).to.have.lengthOf(1);
+      expect(makerOverlay.prop('width')).to.equal(WIDGET_WIDTH);
     });
   });
 });


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#40346, re-enabling #40315 with the addition of [b5471b0](https://github.com/code-dot-org/code-dot-org/pull/40348/commits/b5471b0db3777f826e272042aaf80eae3617d3fb), which fixes a bug introduced in the original PR.

The bug was caught by an eyes test (but not until my change hit the test machine, as the bug was mobile-only). [Relevant Slack thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1619741388391200).

[This commit](https://github.com/code-dot-org/code-dot-org/pull/40315/commits/731b4341b3587bddf0ea192d170b95fd8ca7056b) introduced the bug -- I thought setting width using both the `.widgetWidth` class and via the `style` prop was redundant and unnecessary, but it apparently isn't.

**Applitools eyes screenshot:**
The AppLab share page width extended past the app width (in white -- the "extended" area is in gray).
<img width="1158" alt="Screen Shot 2021-04-30 at 11 23 36 AM" src="https://user-images.githubusercontent.com/9812299/116737850-94bcd280-a9a6-11eb-840e-1bf72512b9d3.png">

**Before:**
<img width="522" alt="Screen Shot 2021-04-30 at 11 37 30 AM" src="https://user-images.githubusercontent.com/9812299/116739453-8ec7f100-a9a8-11eb-8cec-0aff52f44f2c.png">

**After:**
<img width="532" alt="Screen Shot 2021-04-30 at 11 31 56 AM" src="https://user-images.githubusercontent.com/9812299/116739467-92f40e80-a9a8-11eb-8f08-ade4df46b334.png">