### PR TITLE
raise if level name is not found when seeding one custom level

### DIFF
--- a/dashboard/lib/level_loader.rb
+++ b/dashboard/lib/level_loader.rb
@@ -23,6 +23,14 @@ class LevelLoader
   def self.import_levels(level_file_glob)
     level_file_paths = file_paths_from_glob(level_file_glob)
 
+    # This is only expected to happen when LEVEL_NAME is set and the
+    # filename is not found
+    unless level_file_paths.count > 0
+      raise 'no matching level names found. '\
+        'please check level name for exact case and spelling. '\
+        'the level name is the level filename without the .level suffix.'
+    end
+
     # Use a transaction because loading levels requires two separate imports.
     Level.transaction do
       level_md5s_by_name = Hash[Level.pluck(:name, :md5)]


### PR DESCRIPTION
Gives a warning message when trying to seed a single custom level fails:

![Screen Shot 2021-04-30 at 1 59 51 PM](https://user-images.githubusercontent.com/8001765/116755213-f1c48280-a9be-11eb-858f-b7815861b39e.png)
