### PR TITLE
sort serialized resources by key

### DIFF
--- a/dashboard/lib/services/script_seed.rb
+++ b/dashboard/lib/services/script_seed.rb
@@ -45,7 +45,7 @@ module Services
 
       activities = script.lessons.map(&:lesson_activities).flatten
       sections = activities.map(&:activity_sections).flatten
-      resources = script.lessons.map(&:resources).flatten.concat(script.resources).concat(script.student_resources).uniq
+      resources = script.lessons.map(&:resources).flatten.concat(script.resources).concat(script.student_resources).uniq.sort_by(&:key)
       lessons_resources = script.lessons.map(&:lessons_resources).flatten
       vocabularies = script.lessons.map(&:vocabularies).flatten
       lessons_vocabularies = script.lessons.map(&:lessons_vocabularies).flatten


### PR DESCRIPTION
Starts [PLAT-659]. There are many small differences causing noise in script_json files, due some combination of alternating save scripts, saving lessons, and possibly other things. This eliminates the biggest source of noise. subsequent PRs will attempt to eliminate the rest.

## Testing story

* unit test coverage verifies behavior of script serialization code
* manually verified that saving scripts and lessons results in script json with resources in the specified order

## Deployment strategy

## Follow-up work

go onto levelbuilder and re-serialize all scripts. this is easier to do on levelbuilder rather than in this PR, to avoid merge conflicts.

[PLAT-659]: https://codedotorg.atlassian.net/browse/PLAT-659