### PR TITLE
Added localeCode to PiskelEditor

### DIFF
--- a/apps/src/p5lab/AnimationTab/PiskelEditor.jsx
+++ b/apps/src/p5lab/AnimationTab/PiskelEditor.jsx
@@ -8,7 +8,6 @@ import PiskelApi from '@code-dot-org/piskel';
 import * as shapes from '../shapes';
 import {editAnimation, removePendingFramesAction} from '../animationListModule';
 import {show, Goal} from '../AnimationPicker/animationPickerModule';
-import {getStore} from '@cdo/apps/redux';
 
 /**
  * @const {string} domain-relative URL to Piskel index.html
@@ -36,7 +35,8 @@ class PiskelEditor extends React.Component {
     onNewFrameClick: PropTypes.func.isRequired,
     pendingFrames: PropTypes.object,
     removePendingFrames: PropTypes.func.isRequired,
-    isBlockly: PropTypes.bool
+    isBlockly: PropTypes.bool,
+    locales: PropTypes.object.isRequired
   };
 
   componentDidMount() {
@@ -64,7 +64,7 @@ class PiskelEditor extends React.Component {
     this.piskel.onAddFrame(this.onAddFrame);
 
     const iframe = document.getElementById('piskelFrame');
-    iframe.contentWindow.locale = getStore().getState().locales.localeCode;
+    iframe.contentWindow.locale = this.props.locales.localeCode;
   }
 
   componentWillUnmount() {
@@ -227,7 +227,8 @@ export default connect(
     channelId: state.pageConstants.channelId,
     allAnimationsSingleFrame: !!state.pageConstants.allAnimationsSingleFrame,
     pendingFrames: state.animationList.pendingFrames,
-    isBlockly: state.pageConstants.isBlockly
+    isBlockly: state.pageConstants.isBlockly,
+    locales: state.locales
   }),
   dispatch => ({
     editAnimation: (key, props) => dispatch(editAnimation(key, props)),

--- a/apps/src/p5lab/AnimationTab/PiskelEditor.jsx
+++ b/apps/src/p5lab/AnimationTab/PiskelEditor.jsx
@@ -36,7 +36,7 @@ class PiskelEditor extends React.Component {
     pendingFrames: PropTypes.object,
     removePendingFrames: PropTypes.func.isRequired,
     isBlockly: PropTypes.bool,
-    locales: PropTypes.object
+    localeCode: PropTypes.string
   };
 
   componentDidMount() {
@@ -63,7 +63,7 @@ class PiskelEditor extends React.Component {
     this.piskel.onStateSaved(this.onAnimationSaved);
     this.piskel.onAddFrame(this.onAddFrame);
 
-    this.iframe.contentWindow.locale = this.props.locales.localeCode;
+    this.iframe.contentWindow.locale = this.props.localeCode;
   }
 
   componentWillUnmount() {
@@ -226,7 +226,7 @@ export default connect(
     allAnimationsSingleFrame: !!state.pageConstants.allAnimationsSingleFrame,
     pendingFrames: state.animationList.pendingFrames,
     isBlockly: state.pageConstants.isBlockly,
-    locales: state.locales
+    localeCode: state.locales.localeCode
   }),
   dispatch => ({
     editAnimation: (key, props) => dispatch(editAnimation(key, props)),

--- a/apps/src/p5lab/AnimationTab/PiskelEditor.jsx
+++ b/apps/src/p5lab/AnimationTab/PiskelEditor.jsx
@@ -36,7 +36,7 @@ class PiskelEditor extends React.Component {
     pendingFrames: PropTypes.object,
     removePendingFrames: PropTypes.func.isRequired,
     isBlockly: PropTypes.bool,
-    locales: PropTypes.object.isRequired
+    locales: PropTypes.object
   };
 
   componentDidMount() {

--- a/apps/src/p5lab/AnimationTab/PiskelEditor.jsx
+++ b/apps/src/p5lab/AnimationTab/PiskelEditor.jsx
@@ -63,8 +63,7 @@ class PiskelEditor extends React.Component {
     this.piskel.onStateSaved(this.onAnimationSaved);
     this.piskel.onAddFrame(this.onAddFrame);
 
-    const iframe = document.getElementById('piskelFrame');
-    iframe.contentWindow.locale = this.props.locales.localeCode;
+    this.iframe.contentWindow.locale = this.props.locales.localeCode;
   }
 
   componentWillUnmount() {
@@ -214,7 +213,6 @@ class PiskelEditor extends React.Component {
       <iframe
         ref={iframe => (this.iframe = iframe)}
         style={this.props.style}
-        id="piskelFrame"
         src={PISKEL_PATH}
       />
     );

--- a/apps/src/p5lab/AnimationTab/PiskelEditor.jsx
+++ b/apps/src/p5lab/AnimationTab/PiskelEditor.jsx
@@ -8,6 +8,7 @@ import PiskelApi from '@code-dot-org/piskel';
 import * as shapes from '../shapes';
 import {editAnimation, removePendingFramesAction} from '../animationListModule';
 import {show, Goal} from '../AnimationPicker/animationPickerModule';
+import {getStore} from '@cdo/apps/redux';
 
 /**
  * @const {string} domain-relative URL to Piskel index.html
@@ -61,6 +62,9 @@ class PiskelEditor extends React.Component {
     this.piskel.onPiskelReady(this.onPiskelReady);
     this.piskel.onStateSaved(this.onAnimationSaved);
     this.piskel.onAddFrame(this.onAddFrame);
+
+    const iframe = document.getElementById('piskelFrame');
+    iframe.contentWindow.locale = getStore().getState().locales.localeCode;
   }
 
   componentWillUnmount() {
@@ -210,6 +214,7 @@ class PiskelEditor extends React.Component {
       <iframe
         ref={iframe => (this.iframe = iframe)}
         style={this.props.style}
+        id="piskelFrame"
         src={PISKEL_PATH}
       />
     );

--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -77,6 +77,8 @@ import {
 import project from '@cdo/apps/code-studio/initApp/project';
 import {setExportGeneratedProperties} from '@cdo/apps/code-studio/components/exportDialogRedux';
 import {hasInstructions} from '@cdo/apps/templates/instructions/utils';
+import {setLocaleCode} from '@cdo/apps/redux/localesRedux';
+import getScriptData from '@cdo/apps/util/getScriptData';
 
 const defaultMobileControlsConfig = {
   spaceButtonVisible: true,
@@ -322,6 +324,15 @@ P5Lab.prototype.init = function(config) {
   config.enableShowLinesCount = false;
 
   const onMount = () => {
+    try {
+      const localeCode = getScriptData('appoptions').locale;
+      getStore().dispatch(setLocaleCode(localeCode));
+    } catch (exception) {
+      console.log('Got an error while trying to parse for the locale code');
+      console.log(exception);
+      getStore().dispatch(setLocaleCode('en_us'));
+    }
+
     this.setupReduxSubscribers(getStore());
     if (config.level.watchersPrepopulated) {
       try {

--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -78,7 +78,6 @@ import project from '@cdo/apps/code-studio/initApp/project';
 import {setExportGeneratedProperties} from '@cdo/apps/code-studio/components/exportDialogRedux';
 import {hasInstructions} from '@cdo/apps/templates/instructions/utils';
 import {setLocaleCode} from '@cdo/apps/redux/localesRedux';
-import getScriptData from '@cdo/apps/util/getScriptData';
 
 const defaultMobileControlsConfig = {
   spaceButtonVisible: true,
@@ -325,11 +324,11 @@ P5Lab.prototype.init = function(config) {
 
   const onMount = () => {
     try {
-      const localeCode = getScriptData('appoptions').locale;
+      const localeCode = window.appOptions.locale;
       getStore().dispatch(setLocaleCode(localeCode));
     } catch (exception) {
-      console.log('Got an error while trying to parse for the locale code');
-      console.log(exception);
+      console.warn('Unable to retrieve locale code, defaulting to en_us');
+      console.warn(exception);
       getStore().dispatch(setLocaleCode('en_us'));
     }
 

--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -327,8 +327,10 @@ P5Lab.prototype.init = function(config) {
       const localeCode = window.appOptions.locale;
       getStore().dispatch(setLocaleCode(localeCode));
     } catch (exception) {
-      console.warn('Unable to retrieve locale code, defaulting to en_us');
-      console.warn(exception);
+      console.warn(
+        'Unable to retrieve locale code, defaulting to en_us',
+        exception
+      );
       getStore().dispatch(setLocaleCode('en_us'));
     }
 

--- a/apps/src/p5lab/reducers.js
+++ b/apps/src/p5lab/reducers.js
@@ -13,6 +13,7 @@ import animationTab from './AnimationTab/animationTabModule';
 import locationPicker from './spritelab/locationPickerModule';
 import textConsole from './spritelab/textConsoleModule';
 import spritelabInputList from './spritelab/spritelabInputModule';
+import locales from '@cdo/apps/redux/localesRedux';
 var errorDialogStack = require('./errorDialogStackModule').default;
 var P5LabInterfaceMode = require('./constants').P5LabInterfaceMode;
 
@@ -62,5 +63,6 @@ module.exports = {
   gridOverlay,
   locationPicker,
   textConsole,
-  spritelabInputList
+  spritelabInputList,
+  locales
 };


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
## Overview
This change adds the localeCode to the redux store so that PiskelEditor.jsx can retrieve 
the code and send it to the Piskel iframe contentWindow property

## Links
This change is needed to help accomplish this ticket [Jira Ticket](https://codedotorg.atlassian.net/browse/FND-1562?atlOrigin=eyJpIjoiOWM3ZDFiMjI2OTNkNDUyYzg5NzZmOTM2MGRlMTE4NjgiLCJwIjoiaiJ9)

## Testing Done
In P5lab.js, I added a try/catch for errors. Also, used getScriptData to help me get the data.

I passed down a script name that does not exist 'salvador'. This causes getScriptData to throw an error
and my try/catch will handle and set the locale to default `en_us`
![image (3)](https://user-images.githubusercontent.com/18276475/116756317-bf1b8980-a9c0-11eb-8d08-6536285daf1c.png)
![image (4)](https://user-images.githubusercontent.com/18276475/116756342-ca6eb500-a9c0-11eb-803b-c44dd58c600a.png)

Now when it gets passed to PiskelRepo you can see that it is the default `en_us`.
![image (5)](https://user-images.githubusercontent.com/18276475/116756361-d2c6f000-a9c0-11eb-8e2b-4433875f5dcd.png)

### Now for a successful case,
It gets the locale `es_es` and stores it in the redux store. Now in the PiskelRepo we can see that it is has been passed down.
![image (7)](https://user-images.githubusercontent.com/18276475/116756428-ec683780-a9c0-11eb-8f24-c5b651d45c46.png)
![image (6)](https://user-images.githubusercontent.com/18276475/116756427-ec683780-a9c0-11eb-991c-28e32619882d.png)

I also tested by changing the JS context to be that of the Piskel Iframe and when you put on the console `window.locale` the correct locale appears.
![image (8)](https://user-images.githubusercontent.com/18276475/116756512-17eb2200-a9c1-11eb-918c-4c97796b1359.png)

## Follow-up work
Now we need to use the locale code in Piskel Repo to know which locales strings to load

## PR Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
