### PR TITLE
cleanup grouped lesson types

### DIFF
--- a/apps/src/code-studio/progressRedux.js
+++ b/apps/src/code-studio/progressRedux.js
@@ -739,7 +739,7 @@ export const groupedLessons = (state, includeBonusLevels = false) => {
         bigQuestions: lessonGroup.big_questions
       },
       lessons: [],
-      levels: []
+      levelsByLesson: []
     };
   });
 
@@ -753,7 +753,7 @@ export const groupedLessons = (state, includeBonusLevels = false) => {
 
     if (byGroup[group]) {
       byGroup[group].lessons.push(lessonAtIndex);
-      byGroup[group].levels.push(lessonLevels);
+      byGroup[group].levelsByLesson.push(lessonLevels);
     }
   });
 
@@ -770,7 +770,7 @@ export const groupedLessons = (state, includeBonusLevels = false) => {
         bigQuestions: null
       },
       lessons: [peerReviewLesson(state)],
-      levels: [peerReviewLevels(state)]
+      levelsByLesson: [peerReviewLevels(state)]
     };
   }
 

--- a/apps/src/templates/progress/DetailProgressTable.jsx
+++ b/apps/src/templates/progress/DetailProgressTable.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ProgressLesson from './ProgressLesson';
-import {groupedLessonType} from './progressTypes';
+import {groupedLessonsType} from './progressTypes';
 
 /**
  * A component that shows progress in a course with more detail than the summary
@@ -8,7 +8,7 @@ import {groupedLessonType} from './progressTypes';
  */
 export default class DetailProgressTable extends React.Component {
   static propTypes = {
-    groupedLesson: groupedLessonType.isRequired
+    groupedLesson: groupedLessonsType.isRequired
   };
 
   render() {

--- a/apps/src/templates/progress/DetailProgressTable.jsx
+++ b/apps/src/templates/progress/DetailProgressTable.jsx
@@ -1,7 +1,6 @@
-import PropTypes from 'prop-types';
 import React from 'react';
 import ProgressLesson from './ProgressLesson';
-import {levelWithProgressType, lessonType} from './progressTypes';
+import {groupedLessonType} from './progressTypes';
 
 /**
  * A component that shows progress in a course with more detail than the summary
@@ -9,13 +8,11 @@ import {levelWithProgressType, lessonType} from './progressTypes';
  */
 export default class DetailProgressTable extends React.Component {
   static propTypes = {
-    lessons: PropTypes.arrayOf(lessonType).isRequired,
-    levelsByLesson: PropTypes.arrayOf(PropTypes.arrayOf(levelWithProgressType))
-      .isRequired
+    groupedLesson: groupedLessonType.isRequired
   };
 
   render() {
-    const {lessons, levelsByLesson} = this.props;
+    const {lessons, levelsByLesson} = this.props.groupedLesson;
     if (lessons.length !== levelsByLesson.length) {
       throw new Error('Inconsistent number of lessons');
     }

--- a/apps/src/templates/progress/DetailProgressTable.story.jsx
+++ b/apps/src/templates/progress/DetailProgressTable.story.jsx
@@ -43,16 +43,15 @@ const levelsByLesson = [
   fakeLevels(2)
 ];
 
+const groupedLesson = {lessons, levelsByLesson};
+
 export default storybook => {
   storybook.storiesOf('Progress/DetailProgressTable', module).addStoryTable([
     {
       name: 'simple DetailProgressTable',
       story: () => (
         <Provider store={createStoreWithHiddenLesson(ViewType.Teacher, null)}>
-          <DetailProgressTable
-            lessons={lessons}
-            levelsByLesson={levelsByLesson}
-          />
+          <DetailProgressTable groupedLesson={groupedLesson} />
         </Provider>
       )
     },
@@ -61,10 +60,7 @@ export default storybook => {
       description: 'lesson 2 should be white with dashed outline',
       story: () => (
         <Provider store={createStoreWithHiddenLesson(ViewType.Teacher, '2')}>
-          <DetailProgressTable
-            lessons={lessons}
-            levelsByLesson={levelsByLesson}
-          />
+          <DetailProgressTable groupedLesson={groupedLesson} />
         </Provider>
       )
     },
@@ -73,10 +69,7 @@ export default storybook => {
       description: 'lesson 2 should be invisible',
       story: () => (
         <Provider store={createStoreWithHiddenLesson(ViewType.Student, '2')}>
-          <DetailProgressTable
-            lessons={lessons}
-            levelsByLesson={levelsByLesson}
-          />
+          <DetailProgressTable groupedLesson={groupedLesson} />
         </Provider>
       )
     }

--- a/apps/src/templates/progress/LessonGroup.jsx
+++ b/apps/src/templates/progress/LessonGroup.jsx
@@ -5,7 +5,7 @@ import {connect} from 'react-redux';
 import DetailProgressTable from '@cdo/apps/templates/progress/DetailProgressTable';
 import SummaryProgressTable from '@cdo/apps/templates/progress/SummaryProgressTable';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
-import {groupedLessonType} from '@cdo/apps/templates/progress/progressTypes';
+import {groupedLessonsType} from '@cdo/apps/templates/progress/progressTypes';
 import color from '@cdo/apps/util/color';
 import LessonGroupInfoDialog from '@cdo/apps/templates/progress/LessonGroupInfoDialog';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
@@ -58,7 +58,7 @@ const styles = {
  */
 class LessonGroup extends React.Component {
   static propTypes = {
-    groupedLesson: groupedLessonType.isRequired,
+    groupedLesson: groupedLessonsType.isRequired,
     isPlc: PropTypes.bool.isRequired,
     isSummaryView: PropTypes.bool.isRequired,
 

--- a/apps/src/templates/progress/LessonGroup.jsx
+++ b/apps/src/templates/progress/LessonGroup.jsx
@@ -5,11 +5,7 @@ import {connect} from 'react-redux';
 import DetailProgressTable from '@cdo/apps/templates/progress/DetailProgressTable';
 import SummaryProgressTable from '@cdo/apps/templates/progress/SummaryProgressTable';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
-import {
-  levelWithProgressType,
-  lessonType,
-  lessonGroupType
-} from '@cdo/apps/templates/progress/progressTypes';
+import {groupedLessonType} from '@cdo/apps/templates/progress/progressTypes';
 import color from '@cdo/apps/util/color';
 import LessonGroupInfoDialog from '@cdo/apps/templates/progress/LessonGroupInfoDialog';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
@@ -62,10 +58,7 @@ const styles = {
  */
 class LessonGroup extends React.Component {
   static propTypes = {
-    lessonGroup: lessonGroupType,
-    lessons: PropTypes.arrayOf(lessonType).isRequired,
-    levelsByLesson: PropTypes.arrayOf(PropTypes.arrayOf(levelWithProgressType))
-      .isRequired,
+    groupedLesson: groupedLessonType.isRequired,
     isPlc: PropTypes.bool.isRequired,
     isSummaryView: PropTypes.bool.isRequired,
 
@@ -102,7 +95,7 @@ class LessonGroup extends React.Component {
         event: 'view_lesson_group_info',
         data_json: JSON.stringify({
           script_id: this.props.scriptId,
-          lesson_group_id: this.props.lessonGroup.id
+          lesson_group_id: this.props.groupedLesson.lessonGroup.id
         })
       },
       {includeUserId: true}
@@ -114,16 +107,8 @@ class LessonGroup extends React.Component {
   };
 
   render() {
-    const {
-      lessonGroup,
-      lessons,
-      levelsByLesson,
-      isSummaryView,
-      isPlc,
-      lessonIsVisible,
-      viewAs,
-      isRtl
-    } = this.props;
+    const {isSummaryView, isPlc, lessonIsVisible, viewAs, isRtl} = this.props;
+    const {lessonGroup, lessons} = this.props.groupedLesson;
 
     // Adjust styles if locale is RTL
     const headingTextStyle = isRtl ? styles.headingTextRTL : styles.headingText;
@@ -181,7 +166,7 @@ class LessonGroup extends React.Component {
               styles.bottom
             ]}
           >
-            <TableType lessons={lessons} levelsByLesson={levelsByLesson} />
+            <TableType groupedLesson={this.props.groupedLesson} />
           </div>
         )}
       </div>

--- a/apps/src/templates/progress/LessonGroup.story.jsx
+++ b/apps/src/templates/progress/LessonGroup.story.jsx
@@ -43,6 +43,12 @@ const levelsByLesson = [
   fakeLevels(2)
 ];
 
+const groupedLesson = {
+  lessonGroup: {displayName: 'My Group'},
+  lessons,
+  levelsByLesson
+};
+
 export default storybook => {
   storybook.storiesOf('Progress/LessonGroup', module).addStoryTable([
     {
@@ -50,11 +56,9 @@ export default storybook => {
       story: () => (
         <Provider store={createStoreWithHiddenLesson(ViewType.Teacher, null)}>
           <LessonGroup
-            lessonGroup={{displayName: 'My Group'}}
+            groupedLesson={groupedLesson}
             isPlc={false}
             isSummaryView={false}
-            lessons={lessons}
-            levelsByLesson={levelsByLesson}
           />
         </Provider>
       )
@@ -65,11 +69,9 @@ export default storybook => {
       story: () => (
         <Provider store={createStoreWithHiddenLesson(ViewType.Teacher, 3)}>
           <LessonGroup
-            lessonGroup={{displayName: 'My Group'}}
+            groupedLesson={groupedLesson}
             isPlc={false}
             isSummaryView={true}
-            lessons={lessons}
-            levelsByLesson={levelsByLesson}
           />
         </Provider>
       )
@@ -80,15 +82,17 @@ export default storybook => {
       story: () => (
         <Provider store={createStoreWithHiddenLesson(ViewType.Teacher, 1)}>
           <LessonGroup
-            lessonGroup={{
-              displayName: 'My Group',
-              description: 'Lesson Group Description',
-              bigQuestions: 'Why? Who? Where?'
+            groupedLesson={{
+              lessonGroup: {
+                displayName: 'My Group',
+                description: 'Lesson Group Description',
+                bigQuestions: 'Why? Who? Where?'
+              },
+              lessons: [lessons[0]],
+              levelsByLesson: [levelsByLesson[0]]
             }}
             isPlc={false}
             isSummaryView={true}
-            lessons={[lessons[0]]}
-            levelsByLesson={[levelsByLesson[0]]}
           />
         </Provider>
       )
@@ -99,15 +103,17 @@ export default storybook => {
       story: () => (
         <Provider store={createStoreWithHiddenLesson(ViewType.Teacher, 1)}>
           <LessonGroup
-            lessonGroup={{
-              displayName: 'My Group',
-              description: 'Lesson Group Description',
-              bigQuestions: 'Why? Who? Where?'
+            groupedLesson={{
+              lessonGroup: {
+                displayName: 'My Group',
+                description: 'Lesson Group Description',
+                bigQuestions: 'Why? Who? Where?'
+              },
+              lessons: [],
+              levelsByLesson: []
             }}
             isPlc={false}
             isSummaryView={true}
-            lessons={[]}
-            levelsByLesson={[]}
           />
         </Provider>
       )
@@ -118,15 +124,17 @@ export default storybook => {
       story: () => (
         <Provider store={createStoreWithHiddenLesson(ViewType.Student, 1)}>
           <LessonGroup
-            lessonGroup={{
-              displayName: 'My Group',
-              description: 'Lesson Group Description',
-              bigQuestions: 'Why? Who? Where?'
+            groupedLesson={{
+              lessonGroup: {
+                displayName: 'My Group',
+                description: 'Lesson Group Description',
+                bigQuestions: 'Why? Who? Where?'
+              },
+              lessons: [lessons[0]],
+              levelsByLesson: [levelsByLesson[0]]
             }}
             isPlc={false}
             isSummaryView={true}
-            lessons={[lessons[0]]}
-            levelsByLesson={[levelsByLesson[0]]}
           />
         </Provider>
       )
@@ -137,11 +145,9 @@ export default storybook => {
       story: () => (
         <Provider store={createStoreWithHiddenLesson(ViewType.Teacher, null)}>
           <LessonGroup
-            lessonGroup={{displayName: 'My Group'}}
+            groupedLesson={groupedLesson}
             isPlc={true}
             isSummaryView={false}
-            lessons={lessons}
-            levelsByLesson={levelsByLesson}
           />
         </Provider>
       )
@@ -152,15 +158,16 @@ export default storybook => {
       story: () => (
         <Provider store={createStoreWithHiddenLesson(ViewType.Teacher, null)}>
           <LessonGroup
-            lessonGroup={{
-              displayName: 'My Group',
-              description: 'Lesson Group Description',
-              bigQuestions: 'Why? Who? Where?'
+            groupedLesson={{
+              ...groupedLesson,
+              lessonGroup: {
+                displayName: 'My Group',
+                description: 'Lesson Group Description',
+                bigQuestions: 'Why? Who? Where?'
+              }
             }}
             isPlc={false}
             isSummaryView={false}
-            lessons={lessons}
-            levelsByLesson={levelsByLesson}
           />
         </Provider>
       )

--- a/apps/src/templates/progress/ProgressTable.jsx
+++ b/apps/src/templates/progress/ProgressTable.jsx
@@ -5,11 +5,7 @@ import {groupedLessons} from '@cdo/apps/code-studio/progressRedux';
 import SummaryProgressTable from './SummaryProgressTable';
 import DetailProgressTable from './DetailProgressTable';
 import LessonGroup from './LessonGroup';
-import {
-  levelWithProgressType,
-  lessonType,
-  lessonGroupType
-} from './progressTypes';
+import {groupedLessonType} from './progressTypes';
 
 export const styles = {
   hidden: {
@@ -21,14 +17,7 @@ class ProgressTable extends React.Component {
   static propTypes = {
     isPlc: PropTypes.bool.isRequired,
     isSummaryView: PropTypes.bool.isRequired,
-    groupedLessons: PropTypes.arrayOf(
-      PropTypes.shape({
-        lessonGroup: lessonGroupType,
-        lessons: PropTypes.arrayOf(lessonType).isRequired,
-        levels: PropTypes.arrayOf(PropTypes.arrayOf(levelWithProgressType))
-          .isRequired
-      })
-    ).isRequired,
+    groupedLessons: PropTypes.arrayOf(groupedLessonType).isRequired,
     minimal: PropTypes.bool
   };
 
@@ -60,16 +49,12 @@ class ProgressTable extends React.Component {
         <div>
           <div style={isSummaryView ? {} : styles.hidden}>
             <SummaryProgressTable
-              lessons={groupedLessons[0].lessons}
-              levelsByLesson={groupedLessons[0].levels}
+              groupedLesson={groupedLessons[0]}
               minimal={minimal}
             />
           </div>
           <div style={isSummaryView ? styles.hidden : {}}>
-            <DetailProgressTable
-              lessons={groupedLessons[0].lessons}
-              levelsByLesson={groupedLessons[0].levels}
-            />
+            <DetailProgressTable groupedLesson={groupedLessons[0]} />
           </div>
         </div>
       );
@@ -80,10 +65,8 @@ class ProgressTable extends React.Component {
             <LessonGroup
               key={group.lessonGroup.displayName}
               isPlc={isPlc}
-              lessonGroup={group.lessonGroup}
+              groupedLesson={group}
               isSummaryView={isSummaryView}
-              lessons={group.lessons}
-              levelsByLesson={group.levels}
             />
           ))}
         </div>

--- a/apps/src/templates/progress/ProgressTable.jsx
+++ b/apps/src/templates/progress/ProgressTable.jsx
@@ -5,7 +5,7 @@ import {groupedLessons} from '@cdo/apps/code-studio/progressRedux';
 import SummaryProgressTable from './SummaryProgressTable';
 import DetailProgressTable from './DetailProgressTable';
 import LessonGroup from './LessonGroup';
-import {groupedLessonType} from './progressTypes';
+import {groupedLessonsType} from './progressTypes';
 
 export const styles = {
   hidden: {
@@ -17,7 +17,7 @@ class ProgressTable extends React.Component {
   static propTypes = {
     isPlc: PropTypes.bool.isRequired,
     isSummaryView: PropTypes.bool.isRequired,
-    groupedLessons: PropTypes.arrayOf(groupedLessonType).isRequired,
+    groupedLessons: PropTypes.arrayOf(groupedLessonsType).isRequired,
     minimal: PropTypes.bool
   };
 

--- a/apps/src/templates/progress/SummaryProgressTable.jsx
+++ b/apps/src/templates/progress/SummaryProgressTable.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import color from '@cdo/apps/util/color';
 import i18n from '@cdo/locale';
-import {levelWithProgressType, lessonType} from './progressTypes';
+import {groupedLessonType} from './progressTypes';
 import SummaryProgressRow, {styles as rowStyles} from './SummaryProgressRow';
 import {connect} from 'react-redux';
 import {lessonIsVisible} from './progressHelpers';
@@ -24,9 +24,7 @@ const styles = {
 
 class SummaryProgressTable extends React.Component {
   static propTypes = {
-    lessons: PropTypes.arrayOf(lessonType).isRequired,
-    levelsByLesson: PropTypes.arrayOf(PropTypes.arrayOf(levelWithProgressType))
-      .isRequired,
+    groupedLesson: groupedLessonType.isRequired,
     minimal: PropTypes.bool,
 
     // redux provided
@@ -35,7 +33,8 @@ class SummaryProgressTable extends React.Component {
   };
 
   render() {
-    const {lessons, levelsByLesson, viewAs, minimal} = this.props;
+    const {viewAs, minimal} = this.props;
+    const {lessons, levelsByLesson} = this.props.groupedLesson;
 
     if (lessons.length !== levelsByLesson.length) {
       throw new Error('Inconsistent number of lessons');

--- a/apps/src/templates/progress/SummaryProgressTable.jsx
+++ b/apps/src/templates/progress/SummaryProgressTable.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import color from '@cdo/apps/util/color';
 import i18n from '@cdo/locale';
-import {groupedLessonType} from './progressTypes';
+import {groupedLessonsType} from './progressTypes';
 import SummaryProgressRow, {styles as rowStyles} from './SummaryProgressRow';
 import {connect} from 'react-redux';
 import {lessonIsVisible} from './progressHelpers';
@@ -24,7 +24,7 @@ const styles = {
 
 class SummaryProgressTable extends React.Component {
   static propTypes = {
-    groupedLesson: groupedLessonType.isRequired,
+    groupedLesson: groupedLessonsType.isRequired,
     minimal: PropTypes.bool,
 
     // redux provided

--- a/apps/src/templates/progress/SummaryProgressTable.story.jsx
+++ b/apps/src/templates/progress/SummaryProgressTable.story.jsx
@@ -12,31 +12,33 @@ import {
 import {Provider} from 'react-redux';
 
 const defaultProps = {
-  lessons: [
-    fakeLesson('Jigsaw', 1, false, 1),
-    fakeLesson('Maze', 2, false, 2),
-    fakeLesson('Artist', 3, false, 3),
-    fakeLesson('Something', 4, false, 4)
-  ],
-  levelsByLesson: [
-    [
-      {
-        ...fakeLevels(1)[0],
-        name: 'First progression'
-      },
-      ...fakeLevels(5, 2).map(level => ({
-        ...level,
-        progression: 'Second Progression'
-      })),
-      {
-        ...fakeLevels(1)[0],
-        name: 'Last progression'
-      }
+  groupedLesson: {
+    lessons: [
+      fakeLesson('Jigsaw', 1, false, 1),
+      fakeLesson('Maze', 2, false, 2),
+      fakeLesson('Artist', 3, false, 3),
+      fakeLesson('Something', 4, false, 4)
     ],
-    fakeLevels(2),
-    fakeLevels(2),
-    fakeLevels(2)
-  ],
+    levelsByLesson: [
+      [
+        {
+          ...fakeLevels(1)[0],
+          name: 'First progression'
+        },
+        ...fakeLevels(5, 2).map(level => ({
+          ...level,
+          progression: 'Second Progression'
+        })),
+        {
+          ...fakeLevels(1)[0],
+          name: 'Last progression'
+        }
+      ],
+      fakeLevels(2),
+      fakeLevels(2),
+      fakeLevels(2)
+    ]
+  },
   viewAs: ViewType.Student,
   lessonIsVisible: () => true
 };
@@ -57,13 +59,17 @@ export default storybook => {
         <Provider store={createStoreWithHiddenLesson(ViewType.Teacher, null)}>
           <SummaryProgressTable
             {...defaultProps}
-            lessons={defaultProps.lessons.map((lesson, index) => ({
-              ...lesson,
-              isFocusArea: index === 1
-            }))}
-            levelsByLesson={defaultProps.levelsByLesson.map((levels, index) =>
-              index === 1 ? fakeLevels(8) : levels
-            )}
+            groupedLesson={{
+              lessons: defaultProps.groupedLesson.lessons.map(
+                (lesson, index) => ({
+                  ...lesson,
+                  isFocusArea: index === 1
+                })
+              ),
+              levelsByLesson: defaultProps.groupedLesson.levelsByLesson.map(
+                (levels, index) => (index === 1 ? fakeLevels(8) : levels)
+              )
+            }}
             lessonIsVisible={() => true}
           />
         </Provider>
@@ -74,43 +80,45 @@ export default storybook => {
       story: () => (
         <Provider store={createStoreWithHiddenLesson(ViewType.Teacher, null)}>
           <SummaryProgressTable
-            lessons={[
-              {
-                id: -1,
-                isFocusArea: false,
-                lockable: false,
-                name: 'You must complete 3 reviews for this unit'
-              }
-            ]}
-            levelsByLesson={[
-              [
+            groupedLesson={{
+              lessons: [
                 {
-                  id: '-1',
-                  name: 'Link to submitted review',
-                  status: LevelStatus.perfect,
-                  isLocked: false,
-                  url: '/peer_reviews/1',
-                  levelNumber: 1
-                },
-                {
-                  id: '-1',
-                  name: 'Review a new submission',
-                  status: LevelStatus.not_tried,
-                  isLocked: false,
-                  url: '/pull-review',
-                  levelNumber: 2
-                },
-                {
-                  id: '-1',
-                  icon: 'fa-lock',
-                  name: 'Reviews unavailable at this time',
-                  status: LevelStatus.locked,
-                  isLocked: false,
-                  url: '',
-                  levelNumber: 3
+                  id: -1,
+                  isFocusArea: false,
+                  lockable: false,
+                  name: 'You must complete 3 reviews for this unit'
                 }
+              ],
+              levelsByLesson: [
+                [
+                  {
+                    id: '-1',
+                    name: 'Link to submitted review',
+                    status: LevelStatus.perfect,
+                    isLocked: false,
+                    url: '/peer_reviews/1',
+                    levelNumber: 1
+                  },
+                  {
+                    id: '-1',
+                    name: 'Review a new submission',
+                    status: LevelStatus.not_tried,
+                    isLocked: false,
+                    url: '/pull-review',
+                    levelNumber: 2
+                  },
+                  {
+                    id: '-1',
+                    icon: 'fa-lock',
+                    name: 'Reviews unavailable at this time',
+                    status: LevelStatus.locked,
+                    isLocked: false,
+                    url: '',
+                    levelNumber: 3
+                  }
+                ]
               ]
-            ]}
+            }}
             lessonIsVisible={() => true}
           />
         </Provider>
@@ -178,12 +186,14 @@ export default storybook => {
         <Provider store={createStoreWithLockedLesson(ViewType.Teacher, true)}>
           <SummaryProgressTable
             {...defaultProps}
-            lessons={[
-              fakeLesson('Jigsaw', 1, false, 1),
-              fakeLesson('Assessment One', 2, true),
-              fakeLesson('Artist', 3, false, 2)
-            ]}
-            levelsByLesson={[fakeLevels(3), fakeLevels(4), fakeLevels(2)]}
+            groupedLesson={{
+              lessons: [
+                fakeLesson('Jigsaw', 1, false, 1),
+                fakeLesson('Assessment One', 2, true),
+                fakeLesson('Artist', 3, false, 2)
+              ],
+              levelsByLesson: [fakeLevels(3), fakeLevels(4), fakeLevels(2)]
+            }}
             viewAs={ViewType.Teacher}
           />
         </Provider>
@@ -195,20 +205,22 @@ export default storybook => {
         <Provider store={createStoreWithLockedLesson(ViewType.Student)}>
           <SummaryProgressTable
             {...defaultProps}
-            lessons={[
-              fakeLesson('Jigsaw', 1, false, 1),
-              fakeLesson('Assessment One', 2, true),
-              fakeLesson('Artist', 3, false, 2)
-            ]}
-            levelsByLesson={[
-              fakeLevels(3),
-              fakeLevels(4).map(level => ({
-                ...level,
-                status: LevelStatus.locked,
-                isLocked: true
-              })),
-              fakeLevels(2)
-            ]}
+            groupedLesson={{
+              lessons: [
+                fakeLesson('Jigsaw', 1, false, 1),
+                fakeLesson('Assessment One', 2, true),
+                fakeLesson('Artist', 3, false, 2)
+              ],
+              levelsByLesson: [
+                fakeLevels(3),
+                fakeLevels(4).map(level => ({
+                  ...level,
+                  status: LevelStatus.locked,
+                  isLocked: true
+                })),
+                fakeLevels(2)
+              ]
+            }}
           />
         </Provider>
       )
@@ -219,12 +231,14 @@ export default storybook => {
         <Provider store={createStoreWithLockedLesson(ViewType.Teacher, true)}>
           <SummaryProgressTable
             {...defaultProps}
-            lessons={[
-              fakeLesson('Jigsaw', 1, false, 1),
-              fakeLesson('Assessment One', 2, true),
-              fakeLesson('Artist', 3, false, 2)
-            ]}
-            levelsByLesson={[fakeLevels(3), fakeLevels(4), fakeLevels(2)]}
+            groupedLesson={{
+              lessons: [
+                fakeLesson('Jigsaw', 1, false, 1),
+                fakeLesson('Assessment One', 2, true),
+                fakeLesson('Artist', 3, false, 2)
+              ],
+              levelsByLesson: [fakeLevels(3), fakeLevels(4), fakeLevels(2)]
+            }}
             viewAs={ViewType.Teacher}
             lessonIsVisible={() => true}
           />
@@ -237,12 +251,14 @@ export default storybook => {
         <Provider store={createStoreWithHiddenLesson(ViewType.Teacher, '2')}>
           <SummaryProgressTable
             {...defaultProps}
-            lessons={[
-              fakeLesson('Jigsaw', 1, false, 1),
-              fakeLesson('Assessment One', 2, true),
-              fakeLesson('Artist', 3, false, 2)
-            ]}
-            levelsByLesson={[fakeLevels(3), fakeLevels(4), fakeLevels(2)]}
+            groupedLesson={{
+              lessons: [
+                fakeLesson('Jigsaw', 1, false, 1),
+                fakeLesson('Assessment One', 2, true),
+                fakeLesson('Artist', 3, false, 2)
+              ],
+              levelsByLesson: [fakeLevels(3), fakeLevels(4), fakeLevels(2)]
+            }}
             viewAs={ViewType.Teacher}
             lessonIsVisible={(lesson, viewAs) =>
               lesson.id !== 2 || viewAs === ViewType.Teacher
@@ -257,10 +273,12 @@ export default storybook => {
         <Provider store={createStoreWithHiddenLesson(ViewType.Teacher, null)}>
           <SummaryProgressTable
             {...defaultProps}
-            lessons={[fakeLesson('Stage with Unplugged', 1, false, 1)]}
-            levelsByLesson={[
-              [fakeLevel({isUnplugged: true}), ...fakeLevels(3)]
-            ]}
+            groupedLesson={{
+              lessons: [fakeLesson('Stage with Unplugged', 1, false, 1)],
+              levelsByLesson: [
+                [fakeLevel({isUnplugged: true}), ...fakeLevels(3)]
+              ]
+            }}
           />
         </Provider>
       )

--- a/apps/src/templates/progress/progressTypes.js
+++ b/apps/src/templates/progress/progressTypes.js
@@ -152,10 +152,11 @@ export const studentLessonProgressType = PropTypes.shape({
 
 /**
  * @typedef {Object} LessonGroup
+ * Summary of a LessonGroup ruby model.
  *
  * @property {string} displayName
  * @property {number} id
- * @property {array} bigQuestion
+ * @property {string} bigQuestion
  * @property {string} description
  */
 const lessonGroupShape = {
@@ -166,13 +167,17 @@ const lessonGroupShape = {
 };
 
 /**
- * @typedef {Object} GroupedLesson
+ * @typedef {Object} GroupedLessons
+ * Type of object returned by `progressRedux.groupedLessons()`.
  *
  * @property {lessonGroupShape} lessonGroup
+ * Summary of the LessonGroup ruby model describing this group of lessons.
  * @property {[lessonType]} lessons
+ * Ordered list of lessons in this group.
  * @property {[[levelWithProgressType]]} levelsByLesson
+ * Ordered list of levels for each of the lessons in this group.
  */
-export const groupedLessonType = PropTypes.shape({
+export const groupedLessonsType = PropTypes.shape({
   lessonGroup: PropTypes.shape(lessonGroupShape),
   lessons: PropTypes.arrayOf(lessonType).isRequired,
   levelsByLesson: PropTypes.arrayOf(PropTypes.arrayOf(levelWithProgressType))

--- a/apps/src/templates/progress/progressTypes.js
+++ b/apps/src/templates/progress/progressTypes.js
@@ -158,9 +158,23 @@ export const studentLessonProgressType = PropTypes.shape({
  * @property {array} bigQuestion
  * @property {string} description
  */
-export const lessonGroupType = PropTypes.shape({
+const lessonGroupShape = {
   id: PropTypes.number,
   displayName: PropTypes.string,
   bigQuestions: PropTypes.string,
   description: PropTypes.string
+};
+
+/**
+ * @typedef {Object} GroupedLesson
+ *
+ * @property {lessonGroupShape} lessonGroup
+ * @property {[lessonType]} lessons
+ * @property {[[levelWithProgressType]]} levelsByLesson
+ */
+export const groupedLessonType = PropTypes.shape({
+  lessonGroup: PropTypes.shape(lessonGroupShape),
+  lessons: PropTypes.arrayOf(lessonType).isRequired,
+  levelsByLesson: PropTypes.arrayOf(PropTypes.arrayOf(levelWithProgressType))
+    .isRequired
 });

--- a/apps/test/unit/templates/progress/DetailProgressTableTest.js
+++ b/apps/test/unit/templates/progress/DetailProgressTableTest.js
@@ -22,9 +22,11 @@ describe('DetailProgressTable', () => {
     fakeLevels(3)
   ];
 
+  const groupedLesson = {lessons, levelsByLesson};
+
   it('has ProgressLesson for each lesson', () => {
     const wrapper = shallow(
-      <DetailProgressTable lessons={lessons} levelsByLesson={levelsByLesson} />
+      <DetailProgressTable groupedLesson={groupedLesson} />
     );
 
     const rows = wrapper.props().children;
@@ -35,8 +37,10 @@ describe('DetailProgressTable', () => {
     assert.throws(() =>
       shallow(
         <DetailProgressTable
-          lessons={lessons}
-          levelsByLesson={levelsByLesson.slice(1)}
+          groupedLesson={{
+            ...groupedLesson,
+            levelsByLesson: levelsByLesson.slice(1)
+          }}
         />
       )
     );

--- a/apps/test/unit/templates/progress/LessonGroupTest.jsx
+++ b/apps/test/unit/templates/progress/LessonGroupTest.jsx
@@ -9,13 +9,15 @@ const DEFAULT_PROPS = {
   isPlc: false,
   isSummaryView: false,
   scriptId: 1,
-  lessonGroup: {
-    displayName: 'jazz',
-    description: 'A chapter about conditionals',
-    bigQuestions: 'Why is the earth round? Can pigs fly?'
+  groupedLesson: {
+    lessonGroup: {
+      displayName: 'jazz',
+      description: 'A chapter about conditionals',
+      bigQuestions: 'Why is the earth round? Can pigs fly?'
+    },
+    lessons: [fakeLesson('lesson1', 1)],
+    levelsByLesson: []
   },
-  lessons: [fakeLesson('lesson1', 1)],
-  levelsByLesson: [],
   lessonIsVisible: () => true,
   viewAs: ViewType.Teacher
 };
@@ -35,10 +37,13 @@ describe('LessonGroup', () => {
   it('renders without lesson group info button when there is no description or big questions', () => {
     const props = {
       ...DEFAULT_PROPS,
-      lessonGroup: {
-        displayName: 'jazz',
-        description: null,
-        bigQuestions: null
+      groupedLesson: {
+        ...DEFAULT_PROPS.groupedLesson,
+        lessonGroup: {
+          displayName: 'jazz',
+          description: null,
+          bigQuestions: null
+        }
       }
     };
     const wrapper = shallow(<LessonGroup {...props} />);
@@ -57,8 +62,11 @@ describe('LessonGroup', () => {
   it('does not render in student view if there are no lessons', () => {
     const props = {
       ...DEFAULT_PROPS,
+      groupedLesson: {
+        ...DEFAULT_PROPS.groupedLesson,
+        lessons: []
+      },
       isSummaryView: true,
-      lessons: [],
       viewAs: ViewType.Student
     };
     const wrapper = shallow(<LessonGroup {...props} />);
@@ -67,8 +75,11 @@ describe('LessonGroup', () => {
   it('does render in teacher view if there are no lessons', () => {
     const props = {
       ...DEFAULT_PROPS,
+      groupedLesson: {
+        ...DEFAULT_PROPS.groupedLesson,
+        lessons: []
+      },
       isSummaryView: true,
-      lessons: [],
       viewAs: ViewType.Teacher
     };
     const wrapper = shallow(<LessonGroup {...props} />);

--- a/apps/test/unit/templates/progress/ProgressTableTest.jsx
+++ b/apps/test/unit/templates/progress/ProgressTableTest.jsx
@@ -14,18 +14,18 @@ const FAKE_LEVELS = [];
 const FAKE_LESSON_1 = {
   lessonGroup: {displayName: 'jazz', userFacing: false},
   lessons: FAKE_LESSONS,
-  levels: FAKE_LEVELS
+  levelsByLesson: FAKE_LEVELS
 };
 const FAKE_LESSON_2 = {
   lessonGroup: {displayName: 'samba', userFacing: true},
   lessons: FAKE_LESSONS,
-  levels: FAKE_LEVELS
+  levelsByLesson: FAKE_LEVELS
 };
 
 const FAKE_LESSON_3 = {
   lessonGroup: {displayName: 'dance', userFacing: true},
   lessons: FAKE_LESSONS,
-  levels: FAKE_LEVELS
+  levelsByLesson: FAKE_LEVELS
 };
 
 const DEFAULT_PROPS = {
@@ -47,10 +47,8 @@ describe('ProgressTable', () => {
         <LessonGroup
           key={FAKE_LESSON_3.lessonGroup.displayName}
           isPlc={DEFAULT_PROPS.isPlc}
-          lessonGroup={FAKE_LESSON_3.lessonGroup}
+          groupedLesson={FAKE_LESSON_3}
           isSummaryView={DEFAULT_PROPS.isSummaryView}
-          lessons={FAKE_LESSON_3.lessons}
-          levelsByLesson={FAKE_LESSON_3.levels}
         />
       </div>
     );
@@ -64,16 +62,10 @@ describe('ProgressTable', () => {
     expect(wrapper).to.containMatchingElement(
       <div>
         <div style={styles.hidden}>
-          <SummaryProgressTable
-            lessons={FAKE_LESSONS}
-            levelsByLesson={FAKE_LEVELS}
-          />
+          <SummaryProgressTable groupedLesson={FAKE_LESSON_1} />
         </div>
         <div style={{}}>
-          <DetailProgressTable
-            lessons={FAKE_LESSONS}
-            levelsByLesson={FAKE_LEVELS}
-          />
+          <DetailProgressTable groupedLesson={FAKE_LESSON_1} />
         </div>
       </div>
     );
@@ -87,16 +79,10 @@ describe('ProgressTable', () => {
     expect(wrapper).to.containMatchingElement(
       <div>
         <div style={{}}>
-          <SummaryProgressTable
-            lessons={FAKE_LESSONS}
-            levelsByLesson={FAKE_LEVELS}
-          />
+          <SummaryProgressTable groupedLesson={FAKE_LESSON_1} />
         </div>
         <div style={styles.hidden}>
-          <DetailProgressTable
-            lessons={FAKE_LESSONS}
-            levelsByLesson={FAKE_LEVELS}
-          />
+          <DetailProgressTable groupedLesson={FAKE_LESSON_1} />
         </div>
       </div>
     );
@@ -115,18 +101,14 @@ describe('ProgressTable', () => {
         <LessonGroup
           key={FAKE_LESSON_3.lessonGroup.displayName}
           isPlc={DEFAULT_PROPS.isPlc}
-          lessonGroup={FAKE_LESSON_3.lessonGroup}
+          groupedLesson={FAKE_LESSON_3}
           isSummaryView={DEFAULT_PROPS.isSummaryView}
-          lessons={FAKE_LESSON_3.lessons}
-          levelsByLesson={FAKE_LESSON_3.levels}
         />
         <LessonGroup
           key={FAKE_LESSON_2.lessonGroup.displayName}
           isPlc={DEFAULT_PROPS.isPlc}
-          lessonGroup={FAKE_LESSON_2.lessonGroup}
+          groupedLesson={FAKE_LESSON_2}
           isSummaryView={DEFAULT_PROPS.isSummaryView}
-          lessons={FAKE_LESSON_2.lessons}
-          levelsByLesson={FAKE_LESSON_2.levels}
         />
       </div>
     );

--- a/apps/test/unit/templates/progress/SummaryProgressTableTest.js
+++ b/apps/test/unit/templates/progress/SummaryProgressTableTest.js
@@ -23,11 +23,12 @@ describe('SummaryProgressTable', () => {
     fakeLevels(3)
   ];
 
+  const groupedLesson = {lessons, levelsByLesson};
+
   it('has every other row be light and dark', () => {
     const wrapper = shallow(
       <SummaryProgressTable
-        lessons={lessons}
-        levelsByLesson={levelsByLesson}
+        groupedLesson={groupedLesson}
         lessonIsVisible={() => true}
       />
     );
@@ -45,8 +46,7 @@ describe('SummaryProgressTable', () => {
   it('does not show hidden rows when viewing as student', () => {
     const wrapper = shallow(
       <SummaryProgressTable
-        lessons={lessons}
-        levelsByLesson={levelsByLesson}
+        groupedLesson={groupedLesson}
         lessonIsVisible={(lesson, viewAs) =>
           lesson.id !== 2 || viewAs === ViewType.Teacher
         }
@@ -63,8 +63,7 @@ describe('SummaryProgressTable', () => {
   it('marks hidden rows as hidden when viewing as teacher', () => {
     const wrapper = shallow(
       <SummaryProgressTable
-        lessons={lessons}
-        levelsByLesson={levelsByLesson}
+        groupedLesson={groupedLesson}
         lessonIsVisible={(lesson, viewAs) =>
           lesson.id !== 2 || viewAs !== ViewType.Student
         }


### PR DESCRIPTION
this PR is one of those cases where a "simple change" turned out to be bigger than expected, mostly due to updating stories and tests. [a comment](https://github.com/code-dot-org/code-dot-org/pull/40345#discussion_r624003034) on #40345 drew attention to the fact that we were composing the same prop type in several components to represent "grouped lessons", so i canonized it as its own type to clean up that  code. 

was it worth the effort? no. did it clean up the code? i like to think so.