### PR TITLE
moving teacher section login type choice redirects into this new PR

### DIFF
--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
@@ -3,6 +3,7 @@ import $ from 'jquery';
 import {reload} from '@cdo/apps/utils';
 import {OAuthSectionTypes} from '@cdo/apps/lib/ui/accounts/constants';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
+import {navigateToHref} from '../../utils';
 
 /**
  * @const {string[]} The only properties that can be updated by the user
@@ -297,6 +298,19 @@ export const finishEditingSection = () => (dispatch, getState) => {
           serverSection: result
         });
         resolve(result);
+        /* If user is creating a new section, re-route the user to
+           the appropriate location:
+            - If creating from the teacher home page, send user to
+              the "Manage Students" tab of the newly-created section.
+            - Else send user back to the page where they triggered
+              the Create/Edit Section dialog. */
+        if (section.id < 0) {
+          window.history.back();
+          let lastUrl = window.location.href;
+          if (lastUrl.endsWith('/home')) {
+            navigateToHref(`/teacher_dashboard/sections/${result.id}/manage`);
+          }
+        }
       })
       .fail((jqXhr, status) => {
         dispatch({type: EDIT_SECTION_FAILURE});


### PR DESCRIPTION
## Summary
Changed user flow for teachers creating new sections and editing existing sections. If they were making a new one on the home page, they would be taken to the 'Manage Students' tab of the newly-created section, whereas if they were creating/editing from another tab, they would be returned to that tab once they were done.

## Links
Spec (only Requirement 6 reflects this PR): https://docs.google.com/document/d/1YaC8yPL4QUNshj0zXmCZJ1o-FcGYb1Dexv9J0-acHuM/edit#
(Changes to reflect Requirements 1-5 of the spec above can be found at the following PR: https://github.com/code-dot-org/code-dot-org/pull/40384)

## Testing story
I tested manually. I tried the different combinations of creating and editing a section from different parts of the website to ensure that once the creation is complete, the user is sent to the correct part of the site.

### Scenarios (where users trigger given action -> where they should be sent):
#### The following images show where I am automatically taken when I click the "Save" button on the Create/Edit Section tab(s).

### Creating a section from teacher homepage -> Manage Students tab for new section
![TeachDashPre](https://user-images.githubusercontent.com/56283563/115054042-a1183a00-9e94-11eb-82c1-0dbb03132add.JPG)
![TeachDashPost](https://user-images.githubusercontent.com/56283563/115054050-a2e1fd80-9e94-11eb-905a-bc9d14a64053.JPG)

### Creating a section from the script or course overview pages -> Return them to that page once done
![NewSectionElsewhereStep1](https://user-images.githubusercontent.com/56283563/115054083-ac6b6580-9e94-11eb-9abe-66ac1211857e.JPG)
![NewSectionElsewhereStep2](https://user-images.githubusercontent.com/56283563/115054088-ae352900-9e94-11eb-96dd-1923382c2b0c.JPG)
![NewSectionElsewhereStep3](https://user-images.githubusercontent.com/56283563/115054093-af665600-9e94-11eb-8e58-a7109ee7ba53.JPG)

### Editing a section from the teacher homepage -> Return to where event was triggered (teacher homepage)
![EditFromDashboardPre](https://user-images.githubusercontent.com/56283563/115054132-bb521800-9e94-11eb-8374-c038cd7a8472.JPG)
![EditFromDashboardPost](https://user-images.githubusercontent.com/56283563/115054137-bd1bdb80-9e94-11eb-8246-cb364437c4ca.JPG)

### Editing a section while on the page for that section -> Return to where event was triggered (same page)
![EditFromSectionPre](https://user-images.githubusercontent.com/56283563/115054160-c311bc80-9e94-11eb-9c4c-74e0518b7ab4.JPG)
![EditFromSectionPost](https://user-images.githubusercontent.com/56283563/115054164-c5741680-9e94-11eb-9223-8eaa71cb2a27.JPG)

## Follow-up work
-Deciding where exactly to send teachers in each scenario to ensure it is as helpful as possible.
-Performing an A|B experiment to see if this new change is more helpful or more confusing for teachers to navigate.

## Privacy
  1.	Does this change involve the collection, use, or sharing of new Personal Data? As far as I can tell, no.
  2.	Does this change involve a new or changed use or sharing of existing Personal Data? As far as I can tell, no.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
