### PR TITLE
always serialize script_levels in a consistent manner to script json

### DIFF
--- a/dashboard/lib/services/script_seed.rb
+++ b/dashboard/lib/services/script_seed.rb
@@ -760,6 +760,11 @@ module Services
         !!object.assessment
       end
 
+      def properties
+        # sort properties hash by key
+        object.properties.sort.to_h
+      end
+
       def named_level
         !!object.named_level
       end

--- a/dashboard/lib/services/script_seed.rb
+++ b/dashboard/lib/services/script_seed.rb
@@ -712,6 +712,11 @@ module Services
         :seeding_key
       )
 
+      def properties
+        # sort properties hash by key
+        object.properties.sort.to_h
+      end
+
       def seeding_key
         object.seeding_key(@scope[:seed_context])
       end
@@ -725,6 +730,11 @@ module Services
         :seeding_key
       )
 
+      def properties
+        # sort properties hash by key
+        object.properties.sort.to_h
+      end
+
       def seeding_key
         object.seeding_key(@scope[:seed_context])
       end
@@ -737,6 +747,11 @@ module Services
         :properties,
         :seeding_key
       )
+
+      def properties
+        # sort properties hash by key
+        object.properties.sort.to_h
+      end
 
       def seeding_key
         object.seeding_key(@scope[:seed_context])

--- a/dashboard/lib/services/script_seed.rb
+++ b/dashboard/lib/services/script_seed.rb
@@ -756,6 +756,18 @@ module Services
         :level_keys
       )
 
+      def assessment
+        !!object.assessment
+      end
+
+      def named_level
+        !!object.named_level
+      end
+
+      def bonus
+        !!object.bonus
+      end
+
       def seeding_key
         # Just in case the data stored in the level_keys property is out of sync somehow,
         # don't use that data during serialization.

--- a/dashboard/test/fixtures/test-serialize-seeding-json.script_json
+++ b/dashboard/test/fixtures/test-serialize-seeding-json.script_json
@@ -214,11 +214,11 @@
       "chapter": 1,
       "position": 1,
       "activity_section_position": 1,
-      "assessment": null,
+      "assessment": false,
       "properties": {
       },
-      "named_level": null,
-      "bonus": null,
+      "named_level": false,
+      "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
           "blockly:test-serialize-seeding-json_game1:1_2_1"
@@ -236,12 +236,12 @@
       "chapter": 2,
       "position": 2,
       "activity_section_position": 2,
-      "assessment": null,
+      "assessment": false,
       "properties": {
         "challenge": true
       },
-      "named_level": null,
-      "bonus": null,
+      "named_level": false,
+      "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
           "blockly:test-serialize-seeding-json_game2:1_2_2"
@@ -259,11 +259,11 @@
       "chapter": 3,
       "position": 3,
       "activity_section_position": 1,
-      "assessment": null,
+      "assessment": false,
       "properties": {
       },
-      "named_level": null,
-      "bonus": null,
+      "named_level": false,
+      "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
           "blockly:test-serialize-seeding-json_game3:1_2_3"
@@ -281,12 +281,12 @@
       "chapter": 4,
       "position": 4,
       "activity_section_position": 2,
-      "assessment": null,
+      "assessment": false,
       "properties": {
         "challenge": true
       },
-      "named_level": null,
-      "bonus": null,
+      "named_level": false,
+      "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
           "blockly:test-serialize-seeding-json_game4:1_2_4"
@@ -304,11 +304,11 @@
       "chapter": 5,
       "position": 5,
       "activity_section_position": 1,
-      "assessment": null,
+      "assessment": false,
       "properties": {
       },
-      "named_level": null,
-      "bonus": null,
+      "named_level": false,
+      "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
           "blockly:test-serialize-seeding-json_game5:1_2_5"
@@ -326,12 +326,12 @@
       "chapter": 6,
       "position": 6,
       "activity_section_position": 2,
-      "assessment": null,
+      "assessment": false,
       "properties": {
         "challenge": true
       },
-      "named_level": null,
-      "bonus": null,
+      "named_level": false,
+      "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
           "blockly:test-serialize-seeding-json_game6:1_2_6"
@@ -349,11 +349,11 @@
       "chapter": 7,
       "position": 7,
       "activity_section_position": 1,
-      "assessment": null,
+      "assessment": false,
       "properties": {
       },
-      "named_level": null,
-      "bonus": null,
+      "named_level": false,
+      "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
           "blockly:test-serialize-seeding-json_game7:1_2_7"
@@ -371,12 +371,12 @@
       "chapter": 8,
       "position": 8,
       "activity_section_position": 2,
-      "assessment": null,
+      "assessment": false,
       "properties": {
         "challenge": true
       },
-      "named_level": null,
-      "bonus": null,
+      "named_level": false,
+      "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
           "blockly:test-serialize-seeding-json_game8:1_2_8"
@@ -394,11 +394,11 @@
       "chapter": 9,
       "position": 1,
       "activity_section_position": 1,
-      "assessment": null,
+      "assessment": false,
       "properties": {
       },
-      "named_level": null,
-      "bonus": null,
+      "named_level": false,
+      "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
           "blockly:test-serialize-seeding-json_game9:1_2_9"
@@ -416,12 +416,12 @@
       "chapter": 10,
       "position": 2,
       "activity_section_position": 2,
-      "assessment": null,
+      "assessment": false,
       "properties": {
         "challenge": true
       },
-      "named_level": null,
-      "bonus": null,
+      "named_level": false,
+      "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
           "blockly:test-serialize-seeding-json_game10:1_2_10"
@@ -439,11 +439,11 @@
       "chapter": 11,
       "position": 3,
       "activity_section_position": 1,
-      "assessment": null,
+      "assessment": false,
       "properties": {
       },
-      "named_level": null,
-      "bonus": null,
+      "named_level": false,
+      "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
           "blockly:test-serialize-seeding-json_game11:1_2_11"
@@ -461,12 +461,12 @@
       "chapter": 12,
       "position": 4,
       "activity_section_position": 2,
-      "assessment": null,
+      "assessment": false,
       "properties": {
         "challenge": true
       },
-      "named_level": null,
-      "bonus": null,
+      "named_level": false,
+      "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
           "blockly:test-serialize-seeding-json_game12:1_2_12"
@@ -484,11 +484,11 @@
       "chapter": 13,
       "position": 5,
       "activity_section_position": 1,
-      "assessment": null,
+      "assessment": false,
       "properties": {
       },
-      "named_level": null,
-      "bonus": null,
+      "named_level": false,
+      "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
           "blockly:test-serialize-seeding-json_game13:1_2_13"
@@ -506,12 +506,12 @@
       "chapter": 14,
       "position": 6,
       "activity_section_position": 2,
-      "assessment": null,
+      "assessment": false,
       "properties": {
         "challenge": true
       },
-      "named_level": null,
-      "bonus": null,
+      "named_level": false,
+      "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
           "blockly:test-serialize-seeding-json_game14:1_2_14"
@@ -529,11 +529,11 @@
       "chapter": 15,
       "position": 7,
       "activity_section_position": 1,
-      "assessment": null,
+      "assessment": false,
       "properties": {
       },
-      "named_level": null,
-      "bonus": null,
+      "named_level": false,
+      "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
           "blockly:test-serialize-seeding-json_game15:1_2_15"
@@ -551,12 +551,12 @@
       "chapter": 16,
       "position": 8,
       "activity_section_position": 2,
-      "assessment": null,
+      "assessment": false,
       "properties": {
         "challenge": true
       },
-      "named_level": null,
-      "bonus": null,
+      "named_level": false,
+      "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
           "blockly:test-serialize-seeding-json_game16:1_2_16"

--- a/dashboard/test/lib/services/script_seed_test.rb
+++ b/dashboard/test/lib/services/script_seed_test.rb
@@ -279,7 +279,7 @@ module Services
         updated_script_level = script.script_levels.first
         updated_script_level.update!(challenge: 'foo')
         updated_script_level.levels += [new_level]
-        create :script_level, lesson: script.lessons.last, script: script, levels: [new_level]
+        create :script_level, lesson: script.lessons.last, script: script, levels: [new_level], assessment: false, bonus: false, named_level: false
       end
 
       ScriptSeed.seed_from_json(json)

--- a/dashboard/test/lib/services/script_seed_test.rb
+++ b/dashboard/test/lib/services/script_seed_test.rb
@@ -1089,7 +1089,9 @@ module Services
             (1..num_script_levels_per_section).each do |sl_pos|
               game = create :game, name: "#{name_prefix}_game#{sl_num}"
               level = create :level, name: "#{name_prefix}_blockly_#{sl_num}", level_num: "1_2_#{sl_num}", game: game
-              create :script_level, activity_section: section, activity_section_position: sl_pos, lesson: lesson, script: script, levels: [level], challenge: sl_num.even?
+              create :script_level, activity_section: section, activity_section_position: sl_pos,
+                     lesson: lesson, script: script, levels: [level], challenge: sl_num.even?,
+                     assessment: false, bonus: false, named_level: false
               sl_num += 1
             end
           end


### PR DESCRIPTION
## Background

Follows #40362. Mostly finishes [PLAT-659]. There are two major buckets of reasons for why parts of script json oscillate after lesson save or script save when no substantial changes are made:
1. script level booleans assessment, bonus, and named_level oscillate between `null` and `false`
2. the order of items within the properties hash changes

The following repro steps show some examples of this:
1. go to http://localhost-studio.code.org:3000/s/csd1-2021/lessons/2
2. open the lesson edit page
3. save the lesson
4. commit any local changes to git
5. go to http://localhost-studio.code.org:3000/s/csd1-2021/edit
6. save the script
7. run `git diff`

EXPECTED: no local changes to csd1-2021.script_json besides `serialized_at`
ACTUAL: many diffs in csd1-2021.script_json which look like this:

<img width="559" alt="Screen Shot 2021-05-01 at 1 07 24 PM" src="https://user-images.githubusercontent.com/8001765/116793933-93f76f80-aa7e-11eb-8877-c428a8ab0c7a.png">

the root cause is generally that lesson save and script save product logically equivalent but non-identical DB contents, and the script serialization code today does not attempt to normalize these differences when serializing.

## Description

This PR solves both problems listed above by standardizing the way we serialize to script json. it does _not_ try to standardize the data stored in the database. this would be harder, because there are more ways to write to the database. Instead, this PR touches just one codepath which is always used when writing script json.

## Testing story

* existing unit tests verify that the functionality of serializing is not broken by these changes
* manually verified the repro steps listed above now produce expected behavior
* manually verified that various combinations of adding/editing via lesson edit page followed by saving the script page no longer cause script json contents to oscillate

## Follow-up work

because there is so much noise in the script json diffs right now, it is hard to see if there are any other cases I've missed which may be generating diffs. the plan is to leave this work item open for a few days and see if anything unexpected is still showing up in the diffs within [levelbuilder content commits](https://github.com/code-dot-org/code-dot-org/search?q=levelbuilder+content&type=commits).

[PLAT-659]: https://codedotorg.atlassian.net/browse/PLAT-659