### PR TITLE
add no_redirect param to level urls in level details dialog

### DIFF
--- a/apps/src/templates/lessonOverview/activities/LevelDetailsDialog.jsx
+++ b/apps/src/templates/lessonOverview/activities/LevelDetailsDialog.jsx
@@ -208,6 +208,8 @@ class LevelDetailsDialog extends Component {
   }
 
   recordSeeFullLevelClick = (level, scriptLevel) => {
+    const baseUrl = level.url || scriptLevel.url;
+    const url = `${baseUrl}?no_redirect=1`;
     firehoseClient.putRecord(
       {
         study: 'lesson-plan',
@@ -220,7 +222,7 @@ class LevelDetailsDialog extends Component {
       {
         includeUserId: true,
         callback: () => {
-          windowOpen(level.url || scriptLevel.url, 'noopener', 'noreferrer');
+          windowOpen(url, 'noopener', 'noreferrer');
         }
       }
     );

--- a/apps/test/unit/templates/lessonOverview/activities/LevelDetailsDialogTest.jsx
+++ b/apps/test/unit/templates/lessonOverview/activities/LevelDetailsDialogTest.jsx
@@ -62,7 +62,7 @@ describe('LevelDetailsDialogTest', () => {
     levelLink.simulate('click');
     expect(firehoseClient.putRecord).to.have.been.calledOnce;
     firehoseClient.putRecord.yieldTo('callback');
-    expect(utils.windowOpen).to.have.been.calledWith('level.url');
+    expect(utils.windowOpen).to.have.been.calledWith('level.url?no_redirect=1');
 
     utils.windowOpen.restore();
     firehoseClient.putRecord.restore();


### PR DESCRIPTION
Finishes https://codedotorg.atlassian.net/browse/PLAT-990. The simplest solution is to always add the no_redirect param, even though we only really need it when navigating to a non-recommended CSF course as a student or signed-out user. 

This solution has the added benefit that someday when we have '22 and '23 versions of the course, and the '21 version is no longer "recommended", the See Full Level button will keep sending you to the right place for signed out users in CSF. To see what I mean, sign out and go to these two links:
* https://studio.code.org/s/coursea-2019/lessons/8/levels/4 --> redirects to /s/coursea-2020?redirect_warning=true
* https://studio.code.org/s/coursea-2019/lessons/8/levels/4?no_redirect=1 --> takes you to the specified level

The bug report shows the old behavior. here is the new behavior for a signed-out user navigating to a non-recommended CSF level:

https://user-images.githubusercontent.com/8001765/116791022-7caf8680-aa6c-11eb-9bcd-3e3f29386d67.mov

This gsheet shows the old and new behavior in other scenarios: https://docs.google.com/spreadsheets/d/1v0lIwiO5fcDA61wpwEUv_t-j4K15kdGNx67_HOI60V8/edit#gid=0

## Testing story

updated existing unit test. because no conditional logic is added, I didn't add any new test cases. also manually verified the See Full Level button still takes you to the right place when signed in or signed on on at least one CSF lesson and one CSD lesson.

After following the no_redirect url when signed in as a teacher, I clicked around in the teacher panel to reload the page with various other combinations of viewAs and user_id url params. the no_redirect param remains in the URL, and does not seem to interfere with any of our existing functionality.

## Caveat

the `no_redirect` param seems somewhat sticky. If a teacher ends up on a lesson plan for a non-recommended version year, and then click through the level details to see a level, they may never see a version warning, because we preserve the url param across most page navigations. I am not too worried about this, since I think our version warnings are a bit over the top anyway, but I thought it would be worth at least calling out here.