### PR TITLE
move opportunity standards editor into its own collapsible editor sec…

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
@@ -463,7 +463,12 @@ class LessonEditor extends Component {
                 standards={standards}
                 frameworks={frameworks}
               />
-              <h3>Opportunity Standards</h3>
+            </CollapsibleEditorSection>
+            <CollapsibleEditorSection
+              title="Opportunity Standards"
+              collapsed={true}
+              fullwidth={true}
+            >
               <StandardsEditor
                 standardType={'opportunityStandard'}
                 standards={opportunityStandards}

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/LessonEditorTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/LessonEditorTest.js
@@ -120,7 +120,7 @@ describe('LessonEditor', () => {
         .props().disabled
     ).to.equal(false);
     expect(wrapper.find('AnnouncementsEditor').length).to.equal(1);
-    expect(wrapper.find('CollapsibleEditorSection').length).to.equal(11);
+    expect(wrapper.find('CollapsibleEditorSection').length).to.equal(12);
     expect(wrapper.find('ResourcesEditor').length).to.equal(1);
     expect(wrapper.find('VocabulariesEditor').length).to.equal(1);
     expect(wrapper.find('ProgrammingExpressionsEditor').length).to.equal(1);


### PR DESCRIPTION
Finishes [PLAT-970].

### before

![Screen Shot 2021-04-30 at 10 15 02 PM](https://user-images.githubusercontent.com/8001765/116771582-8e0f7900-aa01-11eb-839a-825c74839113.png)


### after

![Screen Shot 2021-04-30 at 10 14 33 PM](https://user-images.githubusercontent.com/8001765/116771592-a1badf80-aa01-11eb-9418-5e26bed2750c.png)


## Testing story

Updated existing unit tests. manually verified that standards and opportunity standards can still found and added to the lesson plan.

[PLAT-970]: https://codedotorg.atlassian.net/browse/PLAT-970