### PR TITLE
Add missing annotations for new restrict_section column

### DIFF
--- a/dashboard/app/models/sections/clever_section.rb
+++ b/dashboard/app/models/sections/clever_section.rb
@@ -20,6 +20,7 @@
 #  sharing_disabled     :boolean          default(FALSE), not null
 #  hidden               :boolean          default(FALSE), not null
 #  tts_autoplay_enabled :boolean          default(FALSE), not null
+#  restrict_section     :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/dashboard/app/models/sections/email_section.rb
+++ b/dashboard/app/models/sections/email_section.rb
@@ -20,6 +20,7 @@
 #  sharing_disabled     :boolean          default(FALSE), not null
 #  hidden               :boolean          default(FALSE), not null
 #  tts_autoplay_enabled :boolean          default(FALSE), not null
+#  restrict_section     :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/dashboard/app/models/sections/google_classroom_section.rb
+++ b/dashboard/app/models/sections/google_classroom_section.rb
@@ -20,6 +20,7 @@
 #  sharing_disabled     :boolean          default(FALSE), not null
 #  hidden               :boolean          default(FALSE), not null
 #  tts_autoplay_enabled :boolean          default(FALSE), not null
+#  restrict_section     :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/dashboard/app/models/sections/omni_auth_section.rb
+++ b/dashboard/app/models/sections/omni_auth_section.rb
@@ -20,6 +20,7 @@
 #  sharing_disabled     :boolean          default(FALSE), not null
 #  hidden               :boolean          default(FALSE), not null
 #  tts_autoplay_enabled :boolean          default(FALSE), not null
+#  restrict_section     :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/dashboard/app/models/sections/picture_section.rb
+++ b/dashboard/app/models/sections/picture_section.rb
@@ -20,6 +20,7 @@
 #  sharing_disabled     :boolean          default(FALSE), not null
 #  hidden               :boolean          default(FALSE), not null
 #  tts_autoplay_enabled :boolean          default(FALSE), not null
+#  restrict_section     :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -20,6 +20,7 @@
 #  sharing_disabled     :boolean          default(FALSE), not null
 #  hidden               :boolean          default(FALSE), not null
 #  tts_autoplay_enabled :boolean          default(FALSE), not null
+#  restrict_section     :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/dashboard/app/models/sections/word_section.rb
+++ b/dashboard/app/models/sections/word_section.rb
@@ -20,6 +20,7 @@
 #  sharing_disabled     :boolean          default(FALSE), not null
 #  hidden               :boolean          default(FALSE), not null
 #  tts_autoplay_enabled :boolean          default(FALSE), not null
+#  restrict_section     :boolean          default(FALSE)
 #
 # Indexes
 #


### PR DESCRIPTION
Adds model annotations for a recent migration:

https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/db/migrate/20210409201400_add_restrict_section_to_sections.rb

## Testing Story

These were the annotations generated when I ran the migration locally.