### PR TITLE
Fix purging user with duplicate authentication options

### DIFF
--- a/dashboard/test/helpers/delete_accounts_helper_test.rb
+++ b/dashboard/test/helpers/delete_accounts_helper_test.rb
@@ -501,6 +501,7 @@ class DeleteAccountsHelperTest < ActionView::TestCase
   # Table: dashboard.authentication_options
   # Note: acts_as_paranoid
   #
+
   test "removes the user primary_contact_info" do
     # Problem noticed on 11/29/2018
     # Account purged failed on a user account that had no authentication_options
@@ -570,7 +571,7 @@ class DeleteAccountsHelperTest < ActionView::TestCase
     assert_empty AuthenticationOption.with_deleted.where(id: ids)
   end
 
-  test "purges user with duplicated authentication option" do
+  test "purges user with duplicate authentication option" do
     # Create an user with an Google authentication option,
     # then destroy (soft-delete) the authentication option.
     user = create :user

--- a/dashboard/test/helpers/delete_accounts_helper_test.rb
+++ b/dashboard/test/helpers/delete_accounts_helper_test.rb
@@ -501,7 +501,6 @@ class DeleteAccountsHelperTest < ActionView::TestCase
   # Table: dashboard.authentication_options
   # Note: acts_as_paranoid
   #
-
   test "removes the user primary_contact_info" do
     # Problem noticed on 11/29/2018
     # Account purged failed on a user account that had no authentication_options
@@ -569,6 +568,24 @@ class DeleteAccountsHelperTest < ActionView::TestCase
 
     assert_empty AuthenticationOption.where(id: ids)
     assert_empty AuthenticationOption.with_deleted.where(id: ids)
+  end
+
+  test "purges user with duplicated authentication option" do
+    # Create an user with an Google authentication option,
+    # then destroy (soft-delete) the authentication option.
+    user = create :user
+    auth_id = SecureRandom.uuid
+    google_auth = create :google_authentication_option, user: user, email: user.email, authentication_id: auth_id
+    google_auth.destroy
+
+    # Recreate the same Google authentication option.
+    # Now the user has duplicate authentication options, one active, one soft-deleted.
+    create :google_authentication_option, user: user, email: user.email, authentication_id: auth_id
+    user.reload
+
+    assert_nothing_raised do
+      purge_user user
+    end
   end
 
   #

--- a/lib/cdo/delete_accounts_helper.rb
+++ b/lib/cdo/delete_accounts_helper.rb
@@ -281,7 +281,8 @@ class DeleteAccountsHelper
   end
 
   def purge_user_authentications(user)
-    user.authentication_options.with_deleted.each(&:really_destroy!)
+    # Delete most recently destroyed (soft-deleted) record first
+    user.authentication_options.with_deleted.order(deleted_at: :desc).each(&:really_destroy!)
   end
 
   # Purges (deletes and cleans) various pieces of information owned by the user in our system.
@@ -313,7 +314,7 @@ class DeleteAccountsHelper
     # authentication options, one active and one soft-deleted.
     # Purging that user will fail because of ActiveRecord::RecordNotUnique
     # (Mysql2::Error: Duplicate entry) exception.
-    # To prevent that issue, destroy authentication options first.
+    # To prevent that issue, hard-deleting authentication options first.
     purge_user_authentications user
 
     user.destroy

--- a/lib/cdo/delete_accounts_helper.rb
+++ b/lib/cdo/delete_accounts_helper.rb
@@ -280,6 +280,10 @@ class DeleteAccountsHelper
     end
   end
 
+  def purge_user_authentications(user)
+    user.authentication_options.with_deleted.each(&:really_destroy!)
+  end
+
   # Purges (deletes and cleans) various pieces of information owned by the user in our system.
   # Noops if the user is already marked as purged.
   # @param [User] user The user to purge.
@@ -304,6 +308,13 @@ class DeleteAccountsHelper
     # emails stored in primary_contact_info, which will be destroyed.
     # If the user account was already soft-deleted, then fallback to the :email attribute.
     user_email = (user.email&.blank?) ? user.read_attribute(:email) : user.email
+
+    # There is a bug in our system that causes a user to have duplicate
+    # authentication options, one active and one soft-deleted.
+    # Purging that user will fail because of ActiveRecord::RecordNotUnique
+    # (Mysql2::Error: Duplicate entry) exception.
+    # To prevent that issue, destroy authentication options first.
+    purge_user_authentications user
 
     user.destroy
 


### PR DESCRIPTION
[FND-1388](https://codedotorg.atlassian.net/browse/FND-1388) 
Fix purging user having duplicate authentication options by hard-deleting authentication options before purging the user. (Purging = soft-deleting and anonymizing data.) 

## Background
We've seen multiple failures when purging users because of an error like this ([slack](https://codedotorg.slack.com/archives/C6B838SB0/p1619683713004800))
> Mysql2::Error: Duplicate entry 'google_oauth2-<authentication_id>-2020-12-05 08:09:13' for key 'index_auth_on_cred_type_and_auth_id': UPDATE `authentication_options` SET `deleted_at` = '2020-12-05 08:09:13', `updated_at` = '2020-12-05 08:09:13' WHERE `authentication_options`.`id` = 16142353

It only happened with user having duplicate authentication options, one active and one soft-deleted. When [purging that user,](https://github.com/code-dot-org/code-dot-org/blob/7480f7c3a2504bf86f6accd957bba02b7f0bc3ef/lib/cdo/delete_accounts_helper.rb#L290) its active authentication options were soft-deleted (`destroy`) and then all authentication options were really deleted (`really_destroy!`). 
https://github.com/code-dot-org/code-dot-org/blob/a5ce8dba974d2334e384b47b7c552284c34695a1/lib/cdo/delete_accounts_helper.rb#L308
https://github.com/code-dot-org/code-dot-org/blob/32992fc9981ee915153e0d8df4cf285120cd6dd4/dashboard/app/models/user.rb#L2073

The problem is paranoia's [`really_destroy!`](https://github.com/rubysherpas/paranoia/blob/032a2ad4df8e623b6a276edd22305ef3b63b5b91/lib/paranoia.rb#L145-L168) soft-deletes records before really deletes them. Soft-deleting duplicate authentication entries too close to each other triggered a violation of an UNIQUE constraint on the `authentication_options` table.
https://github.com/code-dot-org/code-dot-org/blob/96bb1e930700e3b0843a4f61841b0784a1e4a162/dashboard/app/models/authentication_option.rb#L18

_(For why a user can have duplicate authentication options, see this [slack discussion](https://codedotorg.slack.com/archives/CFTFD6BPV/p1619734982382300).)_

## Testing story
- New and existing `DeleteAccountsHelper` unit tests for authentication_options.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
