### PR TITLE
Redact/Restore Course and Script overviews

### DIFF
--- a/bin/i18n/package.json
+++ b/bin/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@code-dot-org/redactable-markdown": "0.6.0",
-    "@code-dot-org/remark-plugins": "0.2.0"
+    "@code-dot-org/redactable-markdown": "0.8.0",
+    "@code-dot-org/remark-plugins": "1.2.1"
   }
 }

--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -26,6 +26,7 @@ def sync_in
   I18nScriptUtils.run_bash_script "bin/i18n-codeorg/in.sh"
   redact_level_content
   redact_block_content
+  redact_script_and_course_content
   localize_markdown_content
   puts "Sync in completed successfully"
 rescue => e
@@ -433,6 +434,32 @@ def redact_block_content
   FileUtils.mkdir_p(File.dirname(backup))
   FileUtils.cp(source, backup)
   RedactRestoreUtils.redact(source, source, ['blockfield'], 'txt')
+end
+
+def redact_script_and_course_content
+  plugins = %w(resourceLink vocabularyDefinition)
+  fields = %w(description student_description description_student description_teacher)
+
+  %w(script course).each do |type|
+    puts "Redacting #{type} content"
+    source = File.join(I18N_SOURCE_DIR, "dashboard/#{type}s.yml")
+
+    # Save the original data, for restoration
+    original = source.sub("source", "original")
+    FileUtils.mkdir_p(File.dirname(original))
+    FileUtils.cp(source, original)
+
+    # Redact the specific subset of fields within each script that we care about.
+    data = YAML.load_file(source)
+    data['en']['data'][type]['name'].values.each do |datum|
+      markdown_data = datum.slice(*fields)
+      redacted_data = RedactRestoreUtils.redact_data(markdown_data, plugins, 'md')
+      datum.merge!(redacted_data)
+    end
+
+    # Overwrite source file with redacted data
+    File.write(source, I18nScriptUtils.to_crowdin_yaml(data))
+  end
 end
 
 def localize_markdown_content

--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -143,11 +143,20 @@ def restore_redacted_files
         File.open(translated_path, "w") do |file|
           file.write(JSON.pretty_generate(translated_data.deep_merge(restored_data)))
         end
-      elsif original_path == 'i18n/locales/original/dashboard/blocks.yml'
-        RedactRestoreUtils.restore(original_path, translated_path, translated_path, ['blockfield'], 'txt')
       else
-        RedactRestoreUtils.restore(original_path, translated_path, translated_path)
+        plugins = []
+        if original_path == 'i18n/locales/original/dashboard/blocks.yml'
+          plugins << 'blockfield'
+        elsif [
+          'i18n/locales/original/dashboard/scripts.yml',
+          'i18n/locales/original/dashboard/courses.yml'
+        ].include? original_path
+          plugins << 'resourceLink'
+          plugins << 'vocabularyDefinition'
+        end
+        RedactRestoreUtils.restore(original_path, translated_path, translated_path, plugins, 'txt')
       end
+
       find_malformed_links_images(locale, translated_path)
     end
     I18nScriptUtils.upload_malformed_restorations(locale)


### PR DESCRIPTION
Specifically, redact vocab and resource syntaxes from the markdown preprocessor.

**NOTE** that because this is the first time these files are being run through the redaction/restoration process, there will be some misc yaml formatting changes that happen the first time this is executed, which will result is a larger-than-normal sync diff.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
