### PR TITLE
One time export of teachers enrolled in virtual workshops

### DIFF
--- a/bin/oneoff/unsent_virtual_pd_workshop_emails.rb
+++ b/bin/oneoff/unsent_virtual_pd_workshop_emails.rb
@@ -1,0 +1,16 @@
+#!/usr/bin/env ruby
+
+require_relative '../../dashboard/config/environment'
+
+workshops = Pd::Workshop.future.
+  where("pd_workshops.properties LIKE '%\"virtual\":true%'").
+  where("pd_workshops.course": ["CS Principles", "CS Discoveries"])
+
+CSV.open(ARGV[0], 'wb') do |csv|
+  csv << ['teacher email', 'teacher id', 'teacher name', 'enrollment date']
+  workshops.each do |workshop|
+    workshop.enrollments.each do |enrollment|
+      csv << [enrollment.email.to_s, enrollment.user_id.to_s, "#{enrollment.first_name} #{enrollment.last_name}", enrollment.created_at.to_s]
+    end
+  end
+end


### PR DESCRIPTION
Adds a small script to export the teachers enrolled in virtual workshops that haven't started yet, which will begin to have emails automatically sent (the currently enrolled teachers haven't gotten any emails yet).

Required fields: email, teacher id, teacher name, enrolled date

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- PR that turns on emails: [40126](https://github.com/code-dot-org/code-dot-org/pull/40126)
- jira ticket: [PLC-1173](https://codedotorg.atlassian.net/browse/PLC-1173)

## Testing story

Tested on staging with manually created workshops/enrollments
Shouldn't have any impact on data (read-only)
