### PR TITLE
Fix time spent pilot not showing up

### DIFF
--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableStudentList.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableStudentList.jsx
@@ -78,6 +78,7 @@ export default class ProgressTableStudentList extends React.Component {
         studentUrl={studentUrl}
         onToggleExpand={this.props.onToggleRow}
         isExpanded={rowData.isExpanded}
+        showSectionProgressDetails={this.props.showSectionProgressDetails}
       />
     );
   }

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableView.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableView.jsx
@@ -302,6 +302,7 @@ class ProgressTableView extends React.Component {
               studentTimestamps={this.props.studentTimestamps}
               localeCode={this.props.localeCode}
               onToggleRow={this.onToggleRow}
+              showSectionProgressDetails={this.props.showSectionProgressDetails}
             />
           </div>
           <div style={styles.contentView} className="content-view">

--- a/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableStudentListTest.jsx
+++ b/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableStudentListTest.jsx
@@ -4,6 +4,7 @@ import {shallow, mount} from 'enzyme';
 import sinon from 'sinon';
 import i18n from '@cdo/locale';
 import ProgressTableStudentList from '@cdo/apps/templates/sectionProgress/progressTables/ProgressTableStudentList';
+import ProgressTableStudentName from '@cdo/apps/templates/sectionProgress/progressTables/ProgressTableStudentName';
 import * as Sticky from 'reactabular-sticky';
 import * as Virtualized from 'reactabular-virtualized';
 import {
@@ -57,6 +58,13 @@ describe('ProgressTableStudentList', () => {
     expect(studentRows).to.have.length(2);
     expect(studentRows.includes(STUDENT_ROWS[0])).to.be.true;
     expect(studentRows.includes(STUDENT_ROWS[1])).to.be.true;
+  });
+
+  it('passes prop showSectionProgressDetails to ProgressTableStudentName', () => {
+    const wrapper = setUp({showSectionProgressDetails: true});
+    expect(
+      wrapper.first(ProgressTableStudentName).props().showSectionProgressDetails
+    ).to.be.true;
   });
 
   it('displays detail labels if detail rows are passed in', () => {

--- a/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableStudentListTest.jsx
+++ b/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableStudentListTest.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {expect} from '../../../../util/reconfiguredChai';
 import {shallow, mount} from 'enzyme';
-import sinon from 'sinon';
 import i18n from '@cdo/locale';
 import ProgressTableStudentList from '@cdo/apps/templates/sectionProgress/progressTables/ProgressTableStudentList';
 import ProgressTableStudentName from '@cdo/apps/templates/sectionProgress/progressTables/ProgressTableStudentName';
@@ -61,19 +60,18 @@ describe('ProgressTableStudentList', () => {
   });
 
   it('passes prop showSectionProgressDetails to ProgressTableStudentName', () => {
-    const wrapper = setUp({showSectionProgressDetails: true});
+    const wrapper = mount(
+      <ProgressTableStudentList
+        {...DEFAULT_PROPS}
+        showSectionProgressDetails={true}
+      />
+    );
     expect(
       wrapper.first(ProgressTableStudentName).props().showSectionProgressDetails
     ).to.be.true;
   });
 
   it('displays detail labels if detail rows are passed in', () => {
-    // ProgressTableStudentName is a connected component so we need to stub
-    // the student name formatter to avoid setting up a store
-    sinon
-      .stub(ProgressTableStudentList.prototype, 'studentNameFormatter')
-      .callsFake(_ => <div />);
-
     // reactabular initially only renders three rows, so we use a single
     // student to avoid needing to workaround that.
     const rows = [STUDENT_ROWS[0], ...DETAIL_ROWS];
@@ -84,7 +82,5 @@ describe('ProgressTableStudentList', () => {
     );
     expect(wrapper.contains(i18n.timeSpentMins())).to.be.true;
     expect(wrapper.contains(i18n.lastUpdatedTitle())).to.be.true;
-
-    sinon.restore();
   });
 });

--- a/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableViewTest.jsx
+++ b/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableViewTest.jsx
@@ -97,7 +97,7 @@ describe('ProgressTableView', () => {
       .false;
   });
 
-  it('passes something down to child', () => {
+  it('passes showSectionProgressDetails down to ProgressTableStudentList', () => {
     const overrideState = {sectionProgress: {showSectionProgressDetails: true}};
     const wrapper = setUp(ViewType.SUMMARY, overrideState);
     expect(

--- a/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableViewTest.jsx
+++ b/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableViewTest.jsx
@@ -97,6 +97,14 @@ describe('ProgressTableView', () => {
       .false;
   });
 
+  it('passes something down to child', () => {
+    const overrideState = {sectionProgress: {showSectionProgressDetails: true}};
+    const wrapper = setUp(ViewType.SUMMARY, overrideState);
+    expect(
+      wrapper.find(ProgressTableStudentList).props().showSectionProgressDetails
+    ).to.be.true;
+  });
+
   describe('summary view', () => {
     it('renders a SummaryViewLegend', () => {
       const wrapper = setUp(ViewType.SUMMARY);


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
During this refactor https://github.com/code-dot-org/code-dot-org/pull/40176, the `ProgressTableStudentName` component was converted to a non-connected component. The ancestor `ProgressTableView` was pulling in `showSectionProgressDetails` instead with the intention to pass it down to the `ProgressTableStudentName` component, however that part was missing. This change threads the value through to `ProgressTableStudentName` through props.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
Tested locally and added unit tests
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
