### PR TITLE
[Outbreak] Add recovery bars

### DIFF
--- a/dashboard/config/libraries/Outbreak.interpreted.js
+++ b/dashboard/config/libraries/Outbreak.interpreted.js
@@ -168,22 +168,23 @@ function addRecoveryBars() {
   for (var i = 0; i < spriteIds.length; i++) {
     var spriteIdArg = {id: spriteIds[i]};
     var isSick = getProp(spriteIdArg, "sick");
-    if (isSick) {
-      var spriteX = getProp(spriteIdArg, "x");
-      var spriteY = 400 - getProp(spriteIdArg, "y");
-      var recovery = getProp(spriteIdArg, "recovery");
+    if (!isSick) {
+      continue;
+    }
+    var spriteX = getProp(spriteIdArg, "x");
+    var spriteY = 400 - getProp(spriteIdArg, "y");
+    var recovery = getProp(spriteIdArg, "recovery");
 
-      var barWidth = 0.65 * SPRITE_WIDTH;
-      var barY = spriteY - (SPRITE_HEIGHT / 2) - RECOVERY_BAR_HEIGHT * 1.5;
-      var percentFilled = 1 - recovery / RECOVERY_TIME;
+    var barWidth = 0.65 * SPRITE_WIDTH;
+    var barY = spriteY - (SPRITE_HEIGHT / 2) - RECOVERY_BAR_HEIGHT * 1.5;
+    var percentFilled = 1 - recovery / RECOVERY_TIME;
 
-      fill("white");
-      rect(spriteX - barWidth / 2, barY, barWidth, RECOVERY_BAR_HEIGHT);
+    fill("white");
+    rect(spriteX - barWidth / 2, barY, barWidth, RECOVERY_BAR_HEIGHT);
 
-      if (percentFilled > 0) {
-        fill("lime");
-        rect(spriteX - barWidth / 2, barY, percentFilled * barWidth, RECOVERY_BAR_HEIGHT);
-      }
+    if (percentFilled > 0) {
+      fill("lime");
+      rect(spriteX - barWidth / 2, barY, percentFilled * barWidth, RECOVERY_BAR_HEIGHT);
     }
   }
   pop();

--- a/dashboard/config/libraries/Outbreak.interpreted.js
+++ b/dashboard/config/libraries/Outbreak.interpreted.js
@@ -2,7 +2,16 @@
 var RECOVERY_TIME = 250;
 var RECOVERY_BAR_HEIGHT = 5;
 var PERCENT_SICK_AT_SETUP = 10;
+var SPRITE_SIZE = 25;
 /* --------------- END OF CONSTANTS- Curriculum Owned --------------- */
+
+/* -------------- START OF CALCULATED CONSTANTS - Engineering Owned --------------*/
+var ANIMATION_WIDTH = 280; // from animationJson
+var ANIMATION_HEIGHT = 290; // from animationJson
+var BASE_SCALE = 100 / Math.max(ANIMATION_WIDTH, ANIMATION_HEIGHT);
+var SPRITE_WIDTH = ANIMATION_WIDTH * BASE_SCALE * SPRITE_SIZE / 100;
+var SPRITE_HEIGHT = ANIMATION_HEIGHT * BASE_SCALE * SPRITE_SIZE / 100;
+/* --------------- END OF CALCULATED CONSTANTS - Engineering Owned ---------------*/
 
 /* -------------- START OF MONSTER BEHAVIOR DEFINITIONS- Curriculum Owned -------------- */
 function congregatingBehavior(spriteIdArg) {
@@ -81,13 +90,13 @@ repeatForever(function () {
 /* ------------------------- END OF LIBRARY LOGIC ------------------------- */
 
 
-/* --------------- START OF BLOCKS API : Engineering Owned --------------- */
+/* --------------- START OF BLOCKS API - Engineering Owned --------------- */
 function setupOutbreak(numMonsters, callback) {
   var numSick = Math.round(PERCENT_SICK_AT_SETUP * 0.01 * numMonsters);
+  setDefaultSpriteSize(SPRITE_SIZE);
   makeNumSprites(numMonsters - numSick, "healthy");
   makeNumSprites(numSick, "sick");
-  getSick({costume: "sick"}, "sick");
-  setProp({costume: "all"}, "scale", 25);
+  getSick({costume: "sick"});
   callback();
 }
 
@@ -129,7 +138,7 @@ function stopMoving() {
 }
 /* -------------------------- END OF BLOCKS API -------------------------- */
 
-/* --------------- START OF HELPER FUNCTIONS : Engineering Owned --------------- */
+/* --------------- START OF HELPER FUNCTIONS - Engineering Owned --------------- */
 function getSick(spriteIdArg) {
   setProp(spriteIdArg, "sick", true);
   var isWearingMask = getProp(spriteIdArg, "mask");
@@ -160,15 +169,12 @@ function addRecoveryBars() {
     var spriteIdArg = {id: spriteIds[i]};
     var isSick = getProp(spriteIdArg, "sick");
     if (isSick) {
-      var spriteScale = getProp(spriteIdArg, "scale") / 100;
-      var spriteWidth = getProp(spriteIdArg, "width");
-      var spriteHeight = getProp(spriteIdArg, "height");
       var spriteX = getProp(spriteIdArg, "x");
       var spriteY = 400 - getProp(spriteIdArg, "y");
       var recovery = getProp(spriteIdArg, "recovery");
 
-      var barWidth = 0.65 * spriteWidth;
-      var barY = spriteY - (spriteHeight / 2) - RECOVERY_BAR_HEIGHT * 1.5;
+      var barWidth = 0.65 * SPRITE_WIDTH;
+      var barY = spriteY - (SPRITE_HEIGHT / 2) - RECOVERY_BAR_HEIGHT * 1.5;
       var percentFilled = 1 - recovery / RECOVERY_TIME;
 
       fill("white");

--- a/dashboard/config/libraries/Outbreak.interpreted.js
+++ b/dashboard/config/libraries/Outbreak.interpreted.js
@@ -1,3 +1,9 @@
+/* -------------- START OF CONSTANTS- Curriculum Owned -------------- */
+var RECOVERY_TIME = 250;
+var RECOVERY_BAR_HEIGHT = 5;
+var PERCENT_SICK_AT_SETUP = 10;
+/* --------------- END OF CONSTANTS- Curriculum Owned --------------- */
+
 /* -------------- START OF MONSTER BEHAVIOR DEFINITIONS- Curriculum Owned -------------- */
 function congregatingBehavior(spriteIdArg) {
   var speed = getProp(spriteIdArg, "speed") || 1;
@@ -47,8 +53,6 @@ function recoveringBehavior(spriteIdArg) {
 
 
 /* --------------- START OF LIBRARY LOGIC- Curriculum Owned --------------- */
-var RECOVERY_TIME = 250;
-
 function getSickWithProbability(spriteIdArg, probability) {
   if (randomNumber(0, 100) < probability) {
     getSick(spriteIdArg);
@@ -70,13 +74,16 @@ checkTouching("when", {costume: "healthy"}, {costume: "sick_mask"}, function (ex
 checkTouching("when", {costume: "healthy_mask"}, {costume: "sick_mask"}, function (extraArgs) {
   getSickWithProbability({id: extraArgs.subjectSprite}, 37.5);
 });
+
+repeatForever(function () {
+  addRecoveryBars();
+});
 /* ------------------------- END OF LIBRARY LOGIC ------------------------- */
 
 
 /* --------------- START OF BLOCKS API : Engineering Owned --------------- */
 function setupOutbreak(numMonsters, callback) {
-  var percentSick = 10;
-  var numSick = Math.round(percentSick * 0.01 * numMonsters);
+  var numSick = Math.round(PERCENT_SICK_AT_SETUP * 0.01 * numMonsters);
   makeNumSprites(numMonsters - numSick, "healthy");
   makeNumSprites(numSick, "sick");
   getSick({costume: "sick"}, "sick");
@@ -144,5 +151,35 @@ function getHealthy(spriteIdArg) {
 
 function addMonsterBehavior(behaviorFunc) {
   addBehaviorSimple({costume: "all"}, new Behavior(behaviorFunc, []));
+}
+
+function addRecoveryBars() {
+  push();
+  var spriteIds = getSpriteIdsInUse();
+  for (var i = 0; i < spriteIds.length; i++) {
+    var spriteIdArg = {id: spriteIds[i]};
+    var isSick = getProp(spriteIdArg, "sick");
+    if (isSick) {
+      var spriteScale = getProp(spriteIdArg, "scale") / 100;
+      var spriteWidth = getProp(spriteIdArg, "width");
+      var spriteHeight = getProp(spriteIdArg, "height");
+      var spriteX = getProp(spriteIdArg, "x");
+      var spriteY = 400 - getProp(spriteIdArg, "y");
+      var recovery = getProp(spriteIdArg, "recovery");
+
+      var barWidth = 0.65 * spriteWidth;
+      var barY = spriteY - (spriteHeight / 2) - RECOVERY_BAR_HEIGHT * 1.5;
+      var percentFilled = 1 - recovery / RECOVERY_TIME;
+
+      fill("white");
+      rect(spriteX - barWidth / 2, barY, barWidth, RECOVERY_BAR_HEIGHT);
+
+      if (percentFilled > 0) {
+        fill("lime");
+        rect(spriteX - barWidth / 2, barY, percentFilled * barWidth, RECOVERY_BAR_HEIGHT);
+      }
+    }
+  }
+  pop();
 }
 /* -------------------------- END OF HELPER FUNCTIONS -------------------------- */


### PR DESCRIPTION
Adds recovery bars drawn above each sick sprite that shows progress towards recovering.
![May-04-2021 10-27-00](https://user-images.githubusercontent.com/8787187/117044503-5afc0c80-acc3-11eb-8c35-59b17f3da706.gif)

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
[doc](https://docs.google.com/document/d/1AcDqo8Efg2yvZJ6Bag93CF7eoEpPCNMLilyaLk1qHuw/edit#)
## Testing story
There's no good way to write unit tests for code in interpreted libraries. Also, since this is just a prototype, I imagine the functionality will change quite a bit over the next month or two. We should definitely have unit test coverage before HOC, but I don't think it's that important at this point.
