### PR TITLE
store only is_migrated true in migrated .script files

### DIFF
--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -109,7 +109,7 @@ class ScriptsController < ApplicationController
       has_course: @script&.unit_groups&.any?,
       i18n: @script ? @script.summarize_i18n_for_edit : {},
       levelKeyList: @script.is_migrated ? Level.key_list : {},
-      lessonLevelData: @script_file,
+      lessonLevelData: @script_dsl_text,
       locales: options_for_locale_select,
       script_families: ScriptConstants::FAMILY_NAMES,
       version_year_options: Script.get_version_year_options,
@@ -190,7 +190,7 @@ class ScriptsController < ApplicationController
   private
 
   def set_script_file
-    @script_file = ScriptDSL.serialize_lesson_groups(@script)
+    @script_dsl_text = ScriptDSL.serialize_lesson_groups(@script)
   end
 
   def rake

--- a/dashboard/app/dsl/script_dsl.rb
+++ b/dashboard/app/dsl/script_dsl.rb
@@ -320,6 +320,9 @@ class ScriptDSL < BaseDSL
   end
 
   def self.serialize_to_string(script)
+    # the serialized data for migrated scripts lives in the .script_json file
+    return "is_migrated true\n" if script.is_migrated
+
     s = []
     # Legacy script IDs
     legacy_script_ids = {
@@ -361,7 +364,6 @@ class ScriptDSL < BaseDSL
     s << 'deprecated true' if script.deprecated
     s << 'is_course true' if script.is_course
     s << "background '#{script.background}'" if script.background
-    s << 'is_migrated true' if script.is_migrated
 
     s << '' unless s.empty?
     s << serialize_lesson_groups(script)

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1261,12 +1261,14 @@ class Script < ApplicationRecord
     begin
       if Rails.application.config.levelbuilder_mode
         script = Script.find_by_name(script_name)
-        # Save in our custom Script DSL format. This is still what we're using currently to sync data
-        # across environments. The CPlat team is working on replacing it a new JSON-based approach.
+        # Save in our custom Script DSL format. This is how we currently sync
+        # data across environments for non-migrated scripts.
         script.write_script_dsl
 
-        # Also save in JSON format for "new seeding". This has not been launched yet for most scripts, but as part of
-        # pre-launch testing, we'll start generating these files in addition to the old .script files.
+        # Also save in JSON format for "new seeding". This is how we currently
+        # sync data across environments for non-migrated scripts. As part of
+        # pre-launch testing, we also generate these files for legacy scripts in
+        # addition to the old .script files.
         script.write_script_json
       end
       true

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1266,7 +1266,7 @@ class Script < ApplicationRecord
         script.write_script_dsl
 
         # Also save in JSON format for "new seeding". This is how we currently
-        # sync data across environments for non-migrated scripts. As part of
+        # sync data across environments for migrated scripts. As part of
         # pre-launch testing, we also generate these files for legacy scripts in
         # addition to the old .script files.
         script.write_script_json

--- a/dashboard/test/dsl/script_dsl_test.rb
+++ b/dashboard/test/dsl/script_dsl_test.rb
@@ -901,13 +901,7 @@ level 'Level 3'
       }
     script_text = ScriptDSL.serialize_to_string(script)
     expected = <<~SCRIPT
-      hidden false
-      new_name 'new name'
-      family_name 'family name'
-      version_year '2001'
-      is_course true
       is_migrated true
-
     SCRIPT
     assert_equal expected, script_text
   end


### PR DESCRIPTION
Finishes [PLAT-859].

In theory, this change should be safe because we already ignore most of the .script file contents aside from the is_migrated flag when seeding migrated scripts: https://github.com/code-dot-org/code-dot-org/blob/19f9a1c5ca48576f8012336d3b3f8122e6ca99bb/dashboard/app/models/script.rb#L1028-L1030

It takes a bit of inspection of the code just above this to convince yourself that the other accesses to other parts of the parsed script data will be harmless after this change. The code could definitely benefit from being cleaned up so that the migrated script more clearly does not use any of the old script logic. However, I'm erring on the side of changing the least amount possible, since this code will soon be going away once all scripts are migrated.

## side benefit

This fix also fixes the issue mentioned in the the Jira item above about scripts.en.yml changing during seed on staging/test/prod. The reason this was happening was because lesson names were stored in 3 places (script dsl, script json, and scripts.en.yml) but lesson update was failing to update 1 of them (script dsl). Then during seed the scripts.en.yml was getting overwritten with the value from script dsl by this codepath:
* https://github.com/code-dot-org/code-dot-org/blob/19f9a1c5ca48576f8012336d3b3f8122e6ca99bb/dashboard/app/models/script.rb#L1001-L1003
* https://github.com/code-dot-org/code-dot-org/blob/19f9a1c5ca48576f8012336d3b3f8122e6ca99bb/dashboard/app/models/script.rb#L1009

This PR fixes the problem because now no lesson names are pulled out of the script dsl.

## Testing story

Unit tests verify that this does not break serialization of non-migrated scripts, and that the correct output is produced for migrated scripts. 

There are also lots of UI tests making sure that seeding of legacy scripts is working. Based on that, my manual testing focused on migrated scripts.

Here is one set of manual tests I did:
1. go to http://localhost-studio.code.org:3000/s/csp1-2021/edit and press save --> .script file is updated to contain only `is_migrated true`
2. commit those changes to git
3. remove contents from that script via `Script.find_by_name('csp1-2021').lesson_groups.destroy_all`
4. reseed that script via `rake seed:single_script SCRIPT_NAME=csp1-2021`
5. at this point, there may be changes in the database which we cannot see.
6. go to http://localhost-studio.code.org:3000/s/csp1-2021/edit and press save --> no substantial changes to csp1-2021.script_json, thanks in part to #40372

After step 6, I feel reasonably confident that the system is still propagating script data to other environments for migrated scripts. If there were changes to the DB contents in step 5, then I'd expect them to show up in csp1-2021.script_json after step 6.

I am open to other scenarios to test here.

## Deployment strategy

I am planning to follow the normal deploy process for shipping this change. Once this PR reaches levelbuilder, I'll do `write_script_dsl` on each migrated script there to get their .script files into the new desired state. this will help avoid merge conflicts that might happen if I include the changes to the .script files in this PR.



[PLAT-859]: https://codedotorg.atlassian.net/browse/PLAT-859
