### PR TITLE
Fixing sync-out script to work on OSX

### DIFF
--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -90,7 +90,9 @@ def rename_from_crowdin_name_to_locale
   # Now, any remaining directories named after the language name (rather than
   # the four-letter language code) represent languages downloaded from crowdin
   # that aren't in our system. Remove them.
-  FileUtils.rm_r Dir.glob("i18n/locales/[A-Z]*")
+  # A regex is used in the .select rather than Dir.glob because Dir.glob will ignore
+  # character case on file systems which are case insensitive by default, such as OSX.
+  FileUtils.rm_r Dir.glob("i18n/locales/*").select {|path| path =~ /i18n\/locales\/[A-Z].*/}
 end
 
 def find_malformed_links_images(locale, file_path)


### PR DESCRIPTION
The `sync-out` script renames directories from they plain English names to 4 letter locale code i.e. `i18n/locales/German` becomes `i18n/locales/de-DE`. The sync-out script then deletes all the languages we didn't convert to a 4 letter locale code. It detects an unconverted language name by checking if the first character is Capitalized. However, checking for case using `Dir.glob` doesn't work for Macbook developers because the disk is case-insensitve by default. Rather than have developers reformat their drives and risk other native apps failing, instead use a regex to identify if the first letter is capitalized.

## Testing story
* Ran the sync-out on my Macbook and confirmed the behavior is correct now.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
