### PR TITLE
Updates to import script for moving content from CB to LB

### DIFF
--- a/bin/curriculum/import_unit_details.rb
+++ b/bin/curriculum/import_unit_details.rb
@@ -127,7 +127,7 @@ def main(options)
       lesson_group.update_from_curriculum_builder(cb_chapter) if options.models.include?('LessonGroup')
     end
 
-    script.fix_script_level_positions
+    script.fix_script_level_positions(true)
     script.update!(show_calendar: !!cb_unit['show_calendar'], is_migrated: true)
     script.write_script_dsl
     script.write_script_json

--- a/bin/curriculum/import_unit_details.rb
+++ b/bin/curriculum/import_unit_details.rb
@@ -127,8 +127,8 @@ def main(options)
       lesson_group.update_from_curriculum_builder(cb_chapter) if options.models.include?('LessonGroup')
     end
 
-    script.fix_script_level_positions(true)
     script.update!(show_calendar: !!cb_unit['show_calendar'], is_migrated: true)
+    script.fix_script_level_positions
     script.write_script_dsl
     script.write_script_json
 

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1111,9 +1111,9 @@ class Script < ApplicationRecord
   # 3. activity_section_position: position within the ActivitySection.
   # This method uses activity_section_position as the source of truth to set the
   # values of position and chapter on all script levels in the script.
-  def fix_script_level_positions(importing=false)
+  def fix_script_level_positions
     reload
-    raise 'cannot fix script level positions on non-migrated scripts' unless is_migrated || importing
+    raise 'cannot fix script level positions on non-migrated scripts' unless is_migrated
     prevent_legacy_script_levels_in_migrated_scripts
 
     chapter = 0

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1111,9 +1111,9 @@ class Script < ApplicationRecord
   # 3. activity_section_position: position within the ActivitySection.
   # This method uses activity_section_position as the source of truth to set the
   # values of position and chapter on all script levels in the script.
-  def fix_script_level_positions
+  def fix_script_level_positions(importing=false)
     reload
-    raise 'cannot fix script level positions on non-migrated scripts' unless is_migrated
+    raise 'cannot fix script level positions on non-migrated scripts' unless is_migrated || importing
     prevent_legacy_script_levels_in_migrated_scripts
 
     chapter = 0

--- a/lib/cdo/lesson_import_helper.rb
+++ b/lib/cdo/lesson_import_helper.rb
@@ -44,6 +44,8 @@ module LessonImportHelper
         lesson.creative_commons_license = cb_lesson_data['creative_commons_license']
         lesson.assessment_opportunities = cb_lesson_data['assessment'] unless cb_lesson_data['assessment'].blank?
         lesson.save!
+
+        Script.merge_and_write_i18n(lesson.i18n_hash, lesson.script.name)
       end
       if models_to_import.include?('Objective')
         lesson.objectives = cb_lesson_data['objectives'].map do |o|
@@ -326,7 +328,7 @@ module LessonImportHelper
   def self.create_activity_section_with_levels(script_levels, lesson_activity_id, progression_name="")
     return nil if script_levels.empty?
     activity_section = ActivitySection.new
-    activity_section.name = progression_name
+    activity_section.progression_name = progression_name
     activity_section.key ||= SecureRandom.uuid
     activity_section.position = 0
     activity_section.lesson_activity_id = lesson_activity_id

--- a/lib/cdo/lesson_import_helper.rb
+++ b/lib/cdo/lesson_import_helper.rb
@@ -98,9 +98,10 @@ module LessonImportHelper
     return [] if cb_vocab.blank?
     cb_vocab.map do |cb_vocabulary|
       raise unless cb_vocabulary['word']
+      key = cb_vocabulary['word'].downcase.tr(" ", "_")
       vocab = Vocabulary.find_or_initialize_by(
         course_version_id: course_version_id,
-        key: cb_vocabulary['word']
+        key: key
       )
       vocab.word = cb_vocabulary['word']
       vocab.definition =

--- a/lib/cdo/lesson_import_helper.rb
+++ b/lib/cdo/lesson_import_helper.rb
@@ -80,7 +80,7 @@ module LessonImportHelper
       raise unless cb_resource['slug']
       resource = Resource.find_or_initialize_by(
         course_version_id: course_version_id,
-        key: cb_resource['slug']
+        key: cb_resource['slug'].downcase.tr(" ", "_")
       )
       resource.name = cb_resource['name']
       resource.url = cb_resource['url']


### PR DESCRIPTION
While was importing AI ML into CSD (and when I did the test PL import) I noticed some things about the import script which have not been updated as we have made changes based on feedback. This tries to add some of the easier wins of updating the import script. There are still other things we will need to update that I did by hand here.

Updated:
- We couldn't use fix_script_level_positions because of the new error when you try to run it on non-migrated script. I added a parameter to the method so it will know when you are importing and allow it for that case.
- Keys for resources and vocab need to be downcase and use underscores because of the new validation on those keys
- We need to save the lesson overviews in the i18n information after they are imported
- Progression names need to be stored in the new progression name fields instead of the activity section name

## Testing story

I made these updates and then used them to import the AI ML unit. 

## Follow-up work

Still needs to be updated:
- Activity section for the last progression still has progression name as the activity section title
- We don't pull over unit overview or unit titles. Do we want to?
- Code blocks don't get updated to the new syntax during the import
-  You have to save the script for resources and vocab roll-up pages to be added by the add rollup pages button. Probably need to save the script somewhere in the import?
- Need to update resource and vocab inline markdown syntax through import to the new format with course version information
Tracked in: https://codedotorg.atlassian.net/browse/PLAT-1026