### PR TITLE
[AiLab] Tweaked failure case in saveTrainedModel

### DIFF
--- a/apps/src/ailab/Ailab.js
+++ b/apps/src/ailab/Ailab.js
@@ -168,7 +168,7 @@ Ailab.prototype.initMLActivities = function() {
           return resolve();
         })
         .fail((jqHXhr, status) => {
-          callback(JSON.stringify({status: 'failure'}));
+          callback({status: 'failure'});
           return reject();
         });
     });


### PR DESCRIPTION
In the saveTrainedModel function, the failure case is now passing an object to the callback instead of a string. This PR addresses an issue brought up in https://github.com/code-dot-org/ml-playground/pull/151, where the error message didn't appear as expected in response to a 500 error. 

Before: 
![Screen Shot 2021-05-05 at 11 10 20 AM](https://user-images.githubusercontent.com/40412372/117202663-ebf5e500-ada2-11eb-831e-25c25b3dd290.png)
![Screen Shot 2021-05-05 at 11 10 28 AM](https://user-images.githubusercontent.com/40412372/117202666-eef0d580-ada2-11eb-86fb-f82965b63015.png)


After: 
![Screen Shot 2021-05-05 at 12 01 23 PM](https://user-images.githubusercontent.com/40412372/117202679-f3b58980-ada2-11eb-8230-a94fca33ce1b.png)

https://user-images.githubusercontent.com/40412372/117203869-670bcb00-ada4-11eb-9ebc-419c6b19c655.mov


