### PR TITLE
Revert "Filter query-string based on http-cache configuration setting"

### DIFF
--- a/cookbooks/cdo-varnish/README.md
+++ b/cookbooks/cdo-varnish/README.md
@@ -40,7 +40,6 @@ HTTP cache layers.
     - Note: Objects are already cached based on the `Host` header by default.
     - Note: `headers` is currently only used by CloudFront, while Varnish
       caches objects based on the `Vary` HTTP response header.
-  - `query`: (boolean) Forward query strings to the origin. (default `true`)
   - `cookies`: An allowlist array of HTTP cookie keys to pass to the origin and
     include in the cache key.
     To allowlist all cookies for the path, pass `'all'`.

--- a/cookbooks/cdo-varnish/libraries/helpers.rb
+++ b/cookbooks/cdo-varnish/libraries/helpers.rb
@@ -156,9 +156,6 @@ def process_request(behavior, _)
       cookies.map {|c| extract_cookie(c)}.join + "cookie.filter_except(\"#{cookies.join(',')}\");"
     end
   )
-  if behavior[:query] == false
-    out << "\n" + 'set req.url = regsub(req.url, "\?.*$", "");'
-  end
   REMOVED_HEADERS.each do |remove_header|
     name, value = remove_header.split ':'
     next if behavior[:headers].include? name

--- a/cookbooks/cdo-varnish/libraries/http_cache.rb
+++ b/cookbooks/cdo-varnish/libraries/http_cache.rb
@@ -103,7 +103,6 @@ class HttpCache
           {
             path: '/api/hour/*',
             headers: ALLOWLISTED_HEADERS,
-            query: true,
             # Allow the company cookie to be read and set to track company users for tutorials.
             cookies: allowlisted_cookies + ['company']
           },
@@ -111,7 +110,6 @@ class HttpCache
           {
             path: STATIC_ASSET_EXTENSION_PATHS + %w(/files/* /images/* /fonts/*),
             headers: [],
-            query: false,
             cookies: 'none'
           },
           # Dashboard-based API paths in Pegasus are session-specific, allowlist all cookies.
@@ -133,14 +131,12 @@ class HttpCache
               /poste*
             ),
             headers: ALLOWLISTED_HEADERS,
-            query: true,
             cookies: allowlisted_cookies
           },
           {
             path: '/dashboardapi/*',
             proxy: 'dashboard',
             headers: ALLOWLISTED_HEADERS,
-            query: true,
             cookies: allowlisted_cookies
           },
           {
@@ -148,30 +144,6 @@ class HttpCache
             proxy: 'dashboard',
             headers: ALLOWLISTED_HEADERS,
             cookies: allowlisted_cookies
-          },
-          # Cached paths that vary based on query-parameters.
-          {
-            path: %w(
-              /curriculum/*
-              /advocacy*
-              /yourschool
-              /certificates
-              /congrats
-              /custom-certificates
-              /printcertificate*
-            ),
-            query: true,
-            headers: ALLOWLISTED_HEADERS,
-            cookies: default_cookies
-          },
-          # Cached paths that specifically filter query-parameters.
-          {
-            path: %w(
-              /
-            ),
-            query: false,
-            headers: ALLOWLISTED_HEADERS,
-            cookies: default_cookies
           }
         ],
         # Remaining Pegasus paths are cached, and vary only on language, country, and default cookies.
@@ -188,14 +160,12 @@ class HttpCache
             path: '/assets/*',
             proxy: 'cdo-assets',
             headers: [],
-            query: false,
             cookies: 'none'
           },
           {
             path: '/restricted/*',
             proxy: 'cdo-restricted',
             headers: [],
-            query: false,
             cookies: 'none',
             trusted_signer: true,
           },
@@ -207,7 +177,6 @@ class HttpCache
               /v3/libraries/*
             ),
             headers: ALLOWLISTED_HEADERS,
-            query: true,
             cookies: allowlisted_cookies
           },
           {
@@ -220,7 +189,6 @@ class HttpCache
               /milestone/*
             ),
             headers: ALLOWLISTED_HEADERS + ['User-Agent'],
-            query: true,
             cookies: allowlisted_cookies
           },
           # Some script levels in cacheable scripts are project-backed and
@@ -250,21 +218,18 @@ class HttpCache
           {
             path: '/api/*',
             headers: ALLOWLISTED_HEADERS,
-            query: true,
             cookies: allowlisted_cookies
           },
           {
-            # For static-asset paths, don't forward any cookies, query params or additional headers.
+            # For static-asset paths, don't forward any cookies or additional headers.
             path: STATIC_ASSET_EXTENSION_PATHS + %w(/blockly/media/*),
             headers: [],
-            query: false,
             cookies: 'none'
           },
           {
             path: '/v2/*',
             proxy: 'pegasus',
             headers: ALLOWLISTED_HEADERS,
-            query: true,
             cookies: allowlisted_cookies
           },
           {
@@ -273,26 +238,22 @@ class HttpCache
               /v3/sources-public/*
             ),
             headers: [],
-            query: false,
             cookies: 'none'
           },
           {
             path: '/xhr*',
             headers: ALLOWLISTED_HEADERS + ALLOWED_WEB_REQUEST_HEADERS,
-            query: true,
             cookies: allowlisted_cookies
           },
           {
             path: '/curriculum_tracking_pixel',
             headers: [],
-            query: true,
             cookies: allowlisted_cookies
           }
         ],
         # Default Dashboard paths are session-specific, allowlist all session cookies and language header.
         default: {
           headers: ALLOWLISTED_HEADERS,
-          query: true,
           cookies: allowlisted_cookies
         }
       }

--- a/lib/cdo/aws/cloudfront.rb
+++ b/lib/cdo/aws/cloudfront.rb
@@ -250,7 +250,7 @@ module AWS
           Cookies: cookie_config,
           # Always explicitly include Host and CloudFront-Forwarded-Proto headers in CloudFront's cache key, to match Varnish defaults.
           Headers: headers,
-          QueryString: behavior_config[:query] != false
+          QueryString: true
         },
         MaxTTL: 31_536_000, # =1 year,
         MinTTL: 0,

--- a/lib/cdo/rack/allowlist.rb
+++ b/lib/cdo/rack/allowlist.rb
@@ -23,13 +23,6 @@ module Rack
         path = request.path
         behavior = behavior_for_path((config[:behaviors] + [config[:default]]), path)
 
-        # Filter query string.
-        if behavior[:query] == false
-          env[Rack::RACK_REQUEST_QUERY_STRING] = ''
-          env[Rack::QUERY_STRING] = ''
-          env[Rack::RACK_REQUEST_QUERY_HASH]&.clear
-        end
-
         # Filter allowlisted request headers.
         headers = behavior[:headers]
         REMOVED_HEADERS.each do |remove_header|

--- a/shared/test/test_varnish_helpers.rb
+++ b/shared/test/test_varnish_helpers.rb
@@ -74,24 +74,22 @@ STR
   BEHAVIOR = {
     dashboard: {
       behaviors: [],
-      default: {cookies: 'all', query: true, headers: HEADERS}
+      default: {cookies: 'all', headers: HEADERS}
     },
     pegasus: {
       behaviors: [
         {
           path: '/api/*',
           headers: HEADERS,
-          query: true,
           cookies: 'all'
         },
         {
           path: '/',
           headers: HEADERS,
-          query: nil, # default true
           cookies: ['1']
         }
       ],
-      default: {cookies: 'none', headers: HEADERS, query: false}
+      default: {cookies: 'none', headers: HEADERS}
     }
   }.freeze
 
@@ -110,7 +108,6 @@ if (req.http.host ~ "(dashboard|studio)") {
     cookie.filter_except("1");
   } else {
     cookie.filter_except("NO_CACHE");
-    set req.url = regsub(req.url, \"\\?.*$\", \"\");
   }
 }
 STR


### PR DESCRIPTION
Re-applies the revert commit in #40426, which was accidentally re-applied in [this merge commit](https://github.com/code-dot-org/code-dot-org/commit/eb8581399f28ba65c35656b2065c9a6a9790a5cb#diff-1c78ab370e56b61084057b6e015a36b8469f3a9870783ab4bbdad53e03bc18ce).