### PR TITLE
Don't make progress reports to server for levelbuilders in start mode

### DIFF
--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -618,6 +618,12 @@ Applab.init = function(config) {
 
   Applab.handleVersionHistory = studioApp().getVersionHistoryHandler(config);
 
+  // Skip onAttempt for levelbuilders in start mode. This method sends a progress report
+  // to the server and breaks the levelbuilder's start code in AppLab.
+  if (config.isStartMode) {
+    delete config.onAttempt;
+  }
+
   var onMount = function() {
     studioApp().init(config);
 


### PR DESCRIPTION
Fixes a bug where a levelbuilder's start code would be overwritten with `<xml></xml>`, which breaks the level. This was happening because, by default at certain points, we call [`onAttempt`](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/code-studio/initApp/loadApp.js#L79) to send a milestone report to the server to report on users' progress. This was called when a levelbuilder switched between code and design mode, which they do often while building AppLab levels in start mode.

It shouldn't be necessary to call `onAttempt` ever in AppLab start mode because we aren't storing progress for levelbuilders. Instead, when the levelbuilder wants to save start blocks, they use the "Save" button in the upper-left corner.

The video below displays the "before" behavior / bug repro:
1. In start mode, I load a level that already has starter code.
2. I switch to design mode and refresh the page.
3. When the level loads, my starter code has been replaced with `<xml></xml>`.
4. I write starter code again, click "Save," and refresh the page.
5. When the level loads, my starter code is as expected.

https://user-images.githubusercontent.com/9812299/117228729-7acc2700-adce-11eb-8cba-273a10dab0ec.mov

This was happening because `onAttempt` was calling `POST /levels/:id/update_blocks/start_blocks` with no body, which would nuke the existing start blocks and replace them with empty XML.

## Links

- [STAR-1181](https://codedotorg.atlassian.net/browse/STAR-1181)

## Testing story

Relies on existing tests.