### PR TITLE
Adding 'restore_markdown_headers' error logs in sync-out

### DIFF
--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -429,8 +429,18 @@ def restore_markdown_headers
       # that extension unless we check both with and without.
       source_path = File.join(File.dirname(source_path), File.basename(source_path, ".partial"))
     end
-    source_header, _source_content, _source_line = Documents.new.helpers.parse_yaml_header(source_path)
-    header, content, _line = Documents.new.helpers.parse_yaml_header(path)
+    begin
+      source_header, _source_content, _source_line = Documents.new.helpers.parse_yaml_header(source_path)
+    rescue Exception => err
+      puts "Error parsing yaml header in source_path=#{source_path} for path=#{path}"
+      raise err
+    end
+    begin
+      header, content, _line = Documents.new.helpers.parse_yaml_header(path)
+    rescue Exception => err
+      puts "Error parsing yaml header path=#{path}"
+      raise err
+    end
     I18nScriptUtils.sanitize_header!(header)
     restored_header = source_header.merge(header)
     I18nScriptUtils.write_markdown_with_header(content, restored_header, path)


### PR DESCRIPTION
Adding some simple error logging to make debugging easier. This will print out the translation file which failed to be parsed so we can investigate the issue with it. Otherwise the exception only says:
```
Sync out failed from the error: undefined method `[]' for nil:NilClass
```

## Testing story
Manually ran the sync-out to debug an issue related to this code.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
