### PR TITLE
Require course version in order to add teacher/student resources to migrated script/unit

### DIFF
--- a/apps/src/lib/levelbuilder/course-editor/ResourcesEditor.js
+++ b/apps/src/lib/levelbuilder/course-editor/ResourcesEditor.js
@@ -80,6 +80,15 @@ export default class ResourcesEditor extends Component {
       ({type, link}) => link && type
     );
 
+    // If using migrated resources, we have to have a course version id
+    if (useMigratedResources && !this.props.courseVersionId) {
+      return (
+        <strong>
+          Cannot add resources to migrated script without course version.
+        </strong>
+      );
+    }
+
     // Resources contains maxResources entries. For the empty entries, we want to
     // show just one, so we slice to the lastNonEmpty +1 to get an empty entry
     // and +1 more because slice is exclusive.

--- a/apps/src/lib/levelbuilder/course-editor/ResourcesEditor.js
+++ b/apps/src/lib/levelbuilder/course-editor/ResourcesEditor.js
@@ -84,7 +84,9 @@ export default class ResourcesEditor extends Component {
     if (useMigratedResources && !this.props.courseVersionId) {
       return (
         <strong>
-          Cannot add resources to migrated script without course version.
+          Cannot add resources to migrated script without course version. A
+          script must belong to a course or have 'Is a Standalone Course'
+          checked to have a course version.
         </strong>
       );
     }

--- a/apps/test/unit/lib/levelbuilder/course-editor/ResourcesEditorTest.js
+++ b/apps/test/unit/lib/levelbuilder/course-editor/ResourcesEditorTest.js
@@ -138,9 +138,41 @@ describe('ResourcesEditor', () => {
           }
         ]}
         useMigratedResources={true}
+        courseVersionId={1}
       />
     );
     expect(wrapper.find('Connect(ResourcesEditor)').length).to.equal(1);
+  });
+
+  it('uses no editor for migrated resources without courseVersionId', () => {
+    const wrapper = shallow(
+      <ResourcesEditor
+        {...defaultProps}
+        resources={undefined}
+        migratedTeacherResources={[
+          {
+            id: 1,
+            key: 'curriculum',
+            name: 'Curriculum',
+            url: 'https://example.com/a'
+          },
+          {
+            id: 2,
+            key: 'vocabulary',
+            name: 'Vocabulary',
+            url: 'https://example.com/b'
+          }
+        ]}
+        useMigratedResources={true}
+        courseVersionId={null}
+      />
+    );
+    expect(wrapper.find('Connect(ResourcesEditor)').length).to.equal(0);
+    expect(
+      wrapper.contains(
+        'Cannot add resources to migrated script without course version.'
+      )
+    );
   });
 
   describe('Resource', () => {

--- a/apps/test/unit/lib/levelbuilder/script-editor/ScriptEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/ScriptEditorTest.jsx
@@ -108,7 +108,11 @@ describe('ScriptEditor', () => {
     });
 
     it('uses new script editor for migrated script', () => {
-      const wrapper = createWrapper({initialHidden: false, isMigrated: true});
+      const wrapper = createWrapper({
+        initialHidden: false,
+        isMigrated: true,
+        initialCourseVersionId: 1
+      });
 
       expect(wrapper.find('input').length).to.equal(28);
       expect(wrapper.find('input[type="checkbox"]').length).to.equal(14);


### PR DESCRIPTION
Closes [PLAT-995](https://codedotorg.atlassian.net/browse/PLAT-995).

It's not the prettiest experience but it works. No editor and a message as to why:
![Screen Shot 2021-05-07 at 10 56 02 AM](https://user-images.githubusercontent.com/46464143/117489892-fd65fb00-af22-11eb-8fdf-0dde551767de.png)


<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
