### PR TITLE
Filter query-string based on http-cache configuration setting

### DIFF
--- a/cookbooks/cdo-varnish/README.md
+++ b/cookbooks/cdo-varnish/README.md
@@ -40,6 +40,7 @@ HTTP cache layers.
     - Note: Objects are already cached based on the `Host` header by default.
     - Note: `headers` is currently only used by CloudFront, while Varnish
       caches objects based on the `Vary` HTTP response header.
+  - `query`: (boolean) Forward query strings to the origin. (default `true`)
   - `cookies`: An allowlist array of HTTP cookie keys to pass to the origin and
     include in the cache key.
     To allowlist all cookies for the path, pass `'all'`.

--- a/cookbooks/cdo-varnish/libraries/helpers.rb
+++ b/cookbooks/cdo-varnish/libraries/helpers.rb
@@ -156,6 +156,9 @@ def process_request(behavior, _)
       cookies.map {|c| extract_cookie(c)}.join + "cookie.filter_except(\"#{cookies.join(',')}\");"
     end
   )
+  if behavior[:query] == false
+    out << "\n" + 'set req.url = regsub(req.url, "\?.*$", "");'
+  end
   REMOVED_HEADERS.each do |remove_header|
     name, value = remove_header.split ':'
     next if behavior[:headers].include? name

--- a/cookbooks/cdo-varnish/libraries/http_cache.rb
+++ b/cookbooks/cdo-varnish/libraries/http_cache.rb
@@ -144,6 +144,15 @@ class HttpCache
             proxy: 'dashboard',
             headers: ALLOWLISTED_HEADERS,
             cookies: allowlisted_cookies
+          },
+          # Cached paths that specifically filter query-parameters.
+          {
+            path: %w(
+              /
+            ),
+            query: false,
+            headers: ALLOWLISTED_HEADERS,
+            cookies: default_cookies
           }
         ],
         # Remaining Pegasus paths are cached, and vary only on language, country, and default cookies.

--- a/lib/cdo/aws/cloudfront.rb
+++ b/lib/cdo/aws/cloudfront.rb
@@ -250,7 +250,7 @@ module AWS
           Cookies: cookie_config,
           # Always explicitly include Host and CloudFront-Forwarded-Proto headers in CloudFront's cache key, to match Varnish defaults.
           Headers: headers,
-          QueryString: true
+          QueryString: behavior_config[:query] != false
         },
         MaxTTL: 31_536_000, # =1 year,
         MinTTL: 0,

--- a/lib/cdo/rack/allowlist.rb
+++ b/lib/cdo/rack/allowlist.rb
@@ -23,6 +23,13 @@ module Rack
         path = request.path
         behavior = behavior_for_path((config[:behaviors] + [config[:default]]), path)
 
+        # Filter query string.
+        if behavior[:query] == false
+          env[Rack::RACK_REQUEST_QUERY_STRING] = ''
+          env[Rack::QUERY_STRING] = ''
+          env[Rack::RACK_REQUEST_QUERY_HASH]&.clear
+        end
+
         # Filter allowlisted request headers.
         headers = behavior[:headers]
         REMOVED_HEADERS.each do |remove_header|

--- a/shared/test/test_varnish_helpers.rb
+++ b/shared/test/test_varnish_helpers.rb
@@ -74,22 +74,24 @@ STR
   BEHAVIOR = {
     dashboard: {
       behaviors: [],
-      default: {cookies: 'all', headers: HEADERS}
+      default: {cookies: 'all', query: true, headers: HEADERS}
     },
     pegasus: {
       behaviors: [
         {
           path: '/api/*',
           headers: HEADERS,
+          query: true,
           cookies: 'all'
         },
         {
           path: '/',
           headers: HEADERS,
+          query: nil, # default true
           cookies: ['1']
         }
       ],
-      default: {cookies: 'none', headers: HEADERS}
+      default: {cookies: 'none', headers: HEADERS, query: false}
     }
   }.freeze
 
@@ -108,6 +110,7 @@ if (req.http.host ~ "(dashboard|studio)") {
     cookie.filter_except("1");
   } else {
     cookie.filter_except("NO_CACHE");
+    set req.url = regsub(req.url, \"\\?.*$\", \"\");
   }
 }
 STR


### PR DESCRIPTION
Improves cacheability on pages that don't use query-string for server-side rendering.

Followup to #40240 following the revert in #40426, with a more conservative change to http cache config. This time, the only changed behavior is to ignore query strings for the pegasus root-path (`code.org/`).