### PR TITLE
Fix bug where only one resource could be added to course dropdowns

### DIFF
--- a/apps/src/lib/levelbuilder/course-editor/CourseEditor.js
+++ b/apps/src/lib/levelbuilder/course-editor/CourseEditor.js
@@ -254,14 +254,14 @@ class CourseEditor extends Component {
           {this.props.migratedTeacherResources && (
             <input
               type="hidden"
-              name="resourceIds[]"
+              name="resourceIds"
               value={this.props.migratedTeacherResources.map(r => r.id)}
             />
           )}
           {this.props.studentResources && (
             <input
               type="hidden"
-              name="studentResourceIds[]"
+              name="studentResourceIds"
               value={this.props.studentResources.map(r => r.id)}
             />
           )}

--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -94,8 +94,8 @@ class CoursesController < ApplicationController
     unit_group.persist_strings_and_scripts_changes(params[:scripts], params[:alternate_scripts], i18n_params)
     unit_group.update_teacher_resources(params[:resourceTypes], params[:resourceLinks]) unless unit_group.has_migrated_script?
     if unit_group.has_migrated_script? && unit_group.course_version
-      unit_group.resources = params[:resourceIds].reject(&:empty?).map {|id| Resource.find(id)} if params.key?(:resourceIds)
-      unit_group.student_resources = params[:studentResourceIds].reject(&:empty?).map {|id| Resource.find(id)} if params.key?(:studentResourceIds)
+      unit_group.resources = params[:resourceIds].split(',').reject(&:empty?).map {|id| Resource.find(id.to_i)} if params.key?(:resourceIds)
+      unit_group.student_resources = params[:studentResourceIds].split(',').reject(&:empty?).map {|id| Resource.find(id.to_i)} if params.key?(:studentResourceIds)
     end
     # Convert checkbox values from a string ("on") to a boolean.
     [:has_verified_resources, :has_numbered_units, :visible, :is_stable].each {|key| params[key] = !!params[key]}

--- a/dashboard/test/controllers/courses_controller_test.rb
+++ b/dashboard/test/controllers/courses_controller_test.rb
@@ -330,11 +330,12 @@ class CoursesControllerTest < ActionController::TestCase
     unit_group.update!(name: 'csp-2017')
     script = create :script, hidden: true, is_migrated: true
     create :unit_group_unit, unit_group: unit_group, script: script, position: 1
-    resource = create :resource, course_version: course_version
+    resource1 = create :resource, course_version: course_version
+    resource2 = create :resource, course_version: course_version
 
-    post :update, params: {course_name: 'csp-2017', scripts: [], title: 'Computer Science Principles', resourceIds: [resource.id]}
+    post :update, params: {course_name: 'csp-2017', scripts: [], title: 'Computer Science Principles', resourceIds: "#{resource1.id},#{resource2.id}"}
     unit_group.reload
-    assert_equal 1, unit_group.resources.length
+    assert_equal 2, unit_group.resources.length
   end
 
   test "update: persists student resources for migrated unit groups" do
@@ -345,11 +346,12 @@ class CoursesControllerTest < ActionController::TestCase
     unit_group.update!(name: 'csp-2017')
     script = create :script, hidden: true, is_migrated: true
     create :unit_group_unit, unit_group: unit_group, script: script, position: 1
-    resource = create :resource, course_version: course_version
+    resource1 = create :resource, course_version: course_version
+    resource2 = create :resource, course_version: course_version
 
-    post :update, params: {course_name: 'csp-2017', scripts: [], title: 'Computer Science Principles', studentResourceIds: [resource.id]}
+    post :update, params: {course_name: 'csp-2017', scripts: [], title: 'Computer Science Principles', studentResourceIds: "#{resource1.id},#{resource2.id}"}
     unit_group.reload
-    assert_equal 1, unit_group.student_resources.length
+    assert_equal 2, unit_group.student_resources.length
   end
 
   test_user_gets_response_for :vocab, response: :success, user: :teacher, params: -> {{course_name: @unit_group_migrated.name}}


### PR DESCRIPTION
See discussion in [Slack](https://codedotorg.slack.com/archives/CNZP84FJ5/p1620664927356300). I misunderstood how the `[]` syntax on the name of an html input worked so the value of `resourceIds` was something like `["1,2"]` (note one string instead of two). This PR changes the form so that `resourceIds` looks like `"1,2"` which we can then split.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
