### PR TITLE
Allow survey creators to set variable values in simple surveys (MiscSurvey refactor)

### DIFF
--- a/dashboard/app/controllers/foorm/simple_survey_forms_controller.rb
+++ b/dashboard/app/controllers/foorm/simple_survey_forms_controller.rb
@@ -19,7 +19,7 @@ module Foorm
         # Leaving optional "kind" blank in form stores a blank string without intervention.
         # Store nil in that case.
         Foorm::SimpleSurveyForm.create!(
-          kind: params[:kind] == '' ? nil : params[:kind],
+          kind: params[:kind].presence,
           path: params[:path],
           form_name: form.name,
           form_version: form.version,

--- a/dashboard/app/views/foorm/simple_survey_forms/index.haml
+++ b/dashboard/app/views/foorm/simple_survey_forms/index.haml
@@ -12,6 +12,6 @@
   Note that some surveys are disabled after they've been used (disabling currently only accessible to engineers),
   so you may see a message saying the survey has closed on some of these pages.
 
-- Foorm::SimpleSurveyForm.all.pluck(:path).sort.uniq do |path|
+- Foorm::SimpleSurveyForm.all.pluck(:path).sort.uniq.each do |path|
   %p
     = link_to path, CDO.studio_url("form/#{path}", CDO.default_scheme)

--- a/dashboard/app/views/foorm/simple_survey_forms/new.haml
+++ b/dashboard/app/views/foorm/simple_survey_forms/new.haml
@@ -10,6 +10,7 @@
   for the list of URLs currently in use.
 
 = form_with model: @foorm_simple_survey_form, url: foorm_simple_survey_forms_path do |f|
+  %h2 Survey Options
   .field
     = f.label :path, 'Path suffix where survey will appear (studio.code.org/form/your_path_here). Lower case letters, numbers, and underscores only.'
     = f.text_field :path
@@ -33,8 +34,8 @@
     leave these fields blank.
   .field
     - (0..2).to_a.each do |id|
-      = f.label "survey_data_name_#{id}", 'Name', style: 'display: inline'
-      = f.text_field "survey_data_name_#{id}"
+      = f.label "survey_data_key_#{id}", 'Name', style: 'display: inline'
+      = f.text_field "survey_data_key_#{id}", style: 'margin-right: 10px'
       = f.label "survey_data_value_#{id}", 'Value', style: 'display: inline'
       = f.text_field "survey_data_value_#{id}"
       %br

--- a/dashboard/app/views/foorm/simple_survey_forms/new.haml
+++ b/dashboard/app/views/foorm/simple_survey_forms/new.haml
@@ -30,8 +30,11 @@
   %p
     If your survey uses variables to fill placeholder text with a specified value (eg, a course name),
     include the name of the placeholder (eg, course) and the value
-    you want to appear in the survey (eg, CS Principles). Otherwise,
-    leave these fields blank.
+    you want to appear in the survey (eg, CS Principles).
+  %p
+    Please let an engineer know if your survey uses more than 3 variables.
+  %p
+    If your survey does not use variables, leave these fields blank.
   .field
     - (0..2).to_a.each do |id|
       = f.label "survey_data_key_#{id}", 'Name', style: 'display: inline'

--- a/dashboard/app/views/foorm/simple_survey_forms/new.haml
+++ b/dashboard/app/views/foorm/simple_survey_forms/new.haml
@@ -14,13 +14,29 @@
     = f.label :path, 'Path suffix where survey will appear (studio.code.org/form/your_path_here). Lower case letters, numbers, and underscores only.'
     = f.text_field :path
   .field
+    = f.label :form_key, 'Form to appear on page:'
+    = select_tag :form_key,
+      options_from_collection_for_select(Foorm::Form.where(published: true), 'key', 'key'),
+      style: 'width: 300px'
+  .field
     = f.label :kind, 'Survey identifier (optional, for analysis)'
     = f.text_field :kind
   .field
-    = f.label :form_key, 'Form to appear on page:'
-    = select_tag :form_key,
-      options_from_collection_for_select(Foorm::Form.where(published: true), 'key', 'key')
-  .field
-    = f.label :allow_multiple_submissions, 'Allow multiple submissions by the same user?'
     = f.check_box :allow_multiple_submissions
+    = f.label :allow_multiple_submissions, 'Allow multiple submissions by the same user?'
+  %h2
+    Variables (optional)
+  %p
+    If your survey uses variables to fill placeholder text with a specified value (eg, a course name),
+    include the name of the placeholder (eg, course) and the value
+    you want to appear in the survey (eg, CS Principles). Otherwise,
+    leave these fields blank.
+  .field
+    - (0..2).to_a.each do |id|
+      = f.label "survey_data_name_#{id}", 'Name', style: 'display: inline'
+      = f.text_field "survey_data_name_#{id}"
+      = f.label "survey_data_value_#{id}", 'Value', style: 'display: inline'
+      = f.text_field "survey_data_value_#{id}"
+      %br
+
   %button.btn.btn-primary{type: 'submit', style: 'margin: 0'} Create

--- a/dashboard/test/controllers/foorm/simple_survey_forms_controller_test.rb
+++ b/dashboard/test/controllers/foorm/simple_survey_forms_controller_test.rb
@@ -3,12 +3,19 @@ require 'test_helper'
 module Foorm
   class SimpleSurveyFormsControllerTest < ActionDispatch::IntegrationTest
     setup do
-      @admin = create(:admin)
+      @admin = create :admin
       @teacher = create :teacher
       @user = create :user
       @foorm_form = create :foorm_form
       @simple_survey_form = create :foorm_simple_survey_form, form_name: @foorm_form.name
       @disabled_simple_survey_form = create :foorm_simple_survey_form, form_name: @foorm_form.name, path: 'disabled_path'
+
+      @base_success_params = {
+        path: 'test_url_path',
+        kind: '',
+        form_key: @foorm_form.key,
+        allow_multiple_submissions: '1'
+      }
 
       DCDO.set('foorm_simple_survey_disabled', [@disabled_simple_survey_form.path])
     end
@@ -74,16 +81,13 @@ module Foorm
     test 'admin can create new simple survey form' do
       sign_in @admin
 
-      post foorm_simple_survey_forms_path, params: {
-        path: 'test_url_path',
-        form_key: @foorm_form.key,
-        allow_multiple_submissions: '1'
-      }
+      post foorm_simple_survey_forms_path, params: @base_success_params
       assert_response :success
 
       created_simple_survey_form = Foorm::SimpleSurveyForm.find_by(path: 'test_url_path')
       assert created_simple_survey_form
       assert_equal 'test_url_path', created_simple_survey_form.path
+      assert_nil created_simple_survey_form.kind
       assert_equal @foorm_form.name, created_simple_survey_form.form_name
       assert_equal @foorm_form.version, created_simple_survey_form.form_version
       assert_equal({'allow_multiple_submissions' => true}, created_simple_survey_form.properties)
@@ -99,6 +103,31 @@ module Foorm
       }
 
       assert_response :bad_request
+    end
+
+    test 'admin can successfully create new simple survey form with survey data' do
+      sign_in @admin
+
+      post foorm_simple_survey_forms_path, params: @base_success_params.merge(
+        {
+          survey_data_key_1: 'a_key',
+          survey_data_value_1: 'a_value'
+        }
+      )
+      assert_response :success
+
+      expected_survey_data = {'a_key' => 'a_value'}
+
+      created_simple_survey_form = Foorm::SimpleSurveyForm.find_by(path: 'test_url_path')
+      assert_equal expected_survey_data, created_simple_survey_form.properties['survey_data']
+    end
+
+    test 'parse_survey_data raises error when key provided with no value' do
+      sign_in @admin
+
+      post foorm_simple_survey_forms_path, params: @base_success_params.merge(survey_data_key_1: 'a_key')
+
+      assert_equal 'Must provide a name and value for any survey variables.', JSON.parse(@response.body)['error']
     end
   end
 end


### PR DESCRIPTION
We want to allow admins to set variables to use in surveys. Adds some minimal setup to allow setting those variables:

![image](https://user-images.githubusercontent.com/25372625/117721177-63a58480-b194-11eb-8acf-67eda304c6fb.png)

## Testing story

Tested manually by using an existing form that accepts variables (`surveys/teachers/teacher_end_of_year_survey`), and set my own value to an existing variable name (`course`) used in the survey. Survey rendered with the value I selected. I also added unit tests to cover the new controller code.