### PR TITLE
fix lock eyes test

### DIFF
--- a/apps/src/templates/progress/ProgressBubble.jsx
+++ b/apps/src/templates/progress/ProgressBubble.jsx
@@ -175,7 +175,9 @@ class ProgressBubble extends React.Component {
               {level.letter && !smallBubble && (
                 <span id="test-bubble-letter"> {level.letter} </span>
               )}
-              {levelIcon === 'lock' && <FontAwesome icon="lock" />}
+              {levelIcon === 'lock' && !smallBubble && (
+                <FontAwesome icon="lock" />
+              )}
               {pairingIconEnabled && level.paired && (
                 <FontAwesome icon="users" />
               )}

--- a/apps/test/unit/code-studio/progressReduxTest.js
+++ b/apps/test/unit/code-studio/progressReduxTest.js
@@ -154,6 +154,36 @@ const stageData = [
   }
 ];
 
+const lockableStageData = [
+  {
+    script_id: 36,
+    script_name: 'course3',
+    script_stages: 21,
+    id: 264,
+    position: 1,
+    name: 'Computational Thinking',
+    title: 'Stage 1: Computational Thinking',
+    lesson_group_display_name: null,
+    lockable: true,
+    levels: [
+      {
+        ids: ['2106'],
+        activeId: '2106',
+        position: 1,
+        kind: LevelKind.unplugged,
+        icon: null,
+        title: 'Unplugged Activity',
+        url: 'http://localhost-studio.code.org:3000/s/course3/stage/1/puzzle/1',
+        previous: false,
+        is_concept_level: false,
+        bonus: false,
+        display_as_unplugged: true,
+        sublevels: []
+      }
+    ]
+  }
+];
+
 // In the app, this is passed to the client as part of the initial page load. We
 // get this data by running Script::summarize
 const initialScriptOverviewProgress = {
@@ -721,6 +751,15 @@ describe('progressReduxTest', () => {
       assert.equal(results[0][0].levelNumber, null);
       assert.equal(results[0][1].isUnplugged, false);
       assert.equal(results[0][1].levelNumber, 1);
+    });
+
+    it('sets isLocked to true if lesson is lockabe', () => {
+      const results = levelsByLesson({
+        stages: lockableStageData,
+        scriptProgress: {},
+        levelResults: {}
+      });
+      assert.equal(results[0][0].isLocked, true);
     });
   });
 

--- a/dashboard/test/ui/features/hour_of_code/hour_of_code.feature
+++ b/dashboard/test/ui/features/hour_of_code/hour_of_code.feature
@@ -14,14 +14,17 @@ Scenario: Solving puzzle 1, proceeding to puzzle 2, verifying that puzzle 1 appe
   Then I close the dialog
   And I wait until I am on "http://studio.code.org/hoc/2"
   And I wait for the page to fully load
+  And I wait until jQuery Ajax requests are finished
   And I verify progress in the header of the current page is "perfect" for level 1
   # Course overview should also show progress
   Then I navigate to the course page for "hourofcode"
   And I wait for 2 seconds
+  And I wait until jQuery Ajax requests are finished
   And I verify progress for lesson 1 level 1 is "perfect"
   # Course overview in a different script shouldn't show progress
   Then I am on "http://studio.code.org/s/20-hour/lessons/2/levels/2?noautoplay=true"
   Then I wait until I am on "http://studio.code.org/s/20-hour/lessons/2/levels/2?noautoplay=true"
+  And I wait until jQuery Ajax requests are finished
   And I verify progress in the header of the current page is "not_tried" for level 1
   # Level source is saved
   Then I am on "http://studio.code.org/hoc/1?noautoplay=true"
@@ -44,9 +47,11 @@ Scenario: Failing at puzzle 1, refreshing puzzle 1, bubble should show up as att
   Then I reload the page
   And I wait for the page to fully load
   When element "#runButton" is visible
+  And I wait until jQuery Ajax requests are finished
   And I verify progress in the header of the current page is "attempted" for level 1
   And I navigate to the course page for "hourofcode"
   And I wait for 2 seconds
+  And I wait until jQuery Ajax requests are finished
   And I verify progress for lesson 1 level 1 is "attempted"
 
 @no_mobile

--- a/dashboard/test/ui/features/hour_of_code/hour_of_code_signed_in.feature
+++ b/dashboard/test/ui/features/hour_of_code/hour_of_code_signed_in.feature
@@ -19,6 +19,7 @@ Scenario:
   And I verify progress for lesson 1 level 1 is "perfect"
   # Course overview in a different script shouldn't show progress
   Then I am on "http://studio.code.org/s/20-hour/lessons/2/levels/2?noautoplay=true"
+  And I wait until jQuery Ajax requests are finished
   And I verify progress in the header of the current page is "not_tried" for level 1
   # Level source is saved
   Then I am on "http://studio.code.org/hoc/1?noautoplay=true"

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -1705,8 +1705,10 @@ end
 
 Then /^I scroll our lockable lesson into view$/ do
   # use visible pseudo selector as we also have lock icons in (hidden) summary view
-  wait_short_until {@browser.execute_script('return $(".fa-lock:visible").length') > 0}
-  @browser.execute_script('$(".fa-lock:visible")[0].scrollIntoView(true)')
+  # and filter out lock icons in the header
+
+  wait_short_until {@browser.execute_script('return $(".fa-lock:visible").not($(".full_progress_inner .fa-lock")).length') > 0}
+  @browser.execute_script('$(".fa-lock:visible").not($(".full_progress_inner .fa-lock"))[0].scrollIntoView(true)')
 end
 
 Then /^I open the lesson lock dialog$/ do


### PR DESCRIPTION
this PR addresses an issue caused by showing lock icons in locked bubbles in the header which broke an eyes test step. previously we were looking for any `.fa-lock:visible` selector and scrolling to it, but now that we have that selector in the header, we are looking for `tr .fa-lock:visible` so we only find the ones in the table.

this also explicitly hides the lock icon from the small bubbles in the header, and adds a unit test for setting the default `level.isLocked` value based on `lesson.lockable`.