### PR TITLE
Fix seeding when all lessons_programming_expressions have been removed

### DIFF
--- a/dashboard/lib/services/script_seed.rb
+++ b/dashboard/lib/services/script_seed.rb
@@ -518,9 +518,8 @@ module Services
 
     def self.import_lessons_vocabularies(lessons_vocabularies_data, seed_context)
       return [] unless seed_context.script.get_course_version
-      return [] if lessons_vocabularies_data.blank?
 
-      lessons_vocabularies_to_import = lessons_vocabularies_data.map do |lv_data|
+      lessons_vocabularies_to_import = (lessons_vocabularies_data || []).map do |lv_data|
         lesson_id = seed_context.lessons.select {|l| l.key == lv_data['seeding_key']['lesson.key']}.first&.id
         raise 'No lesson found' if lesson_id.nil?
 
@@ -545,9 +544,7 @@ module Services
     end
 
     def self.import_lessons_programming_expressions(lessons_programming_expressions_data, seed_context)
-      return [] if lessons_programming_expressions_data.blank?
-
-      lessons_programming_expressions_to_import = lessons_programming_expressions_data.map do |lpe_data|
+      lessons_programming_expressions_to_import = (lessons_programming_expressions_data || []).map do |lpe_data|
         lesson_id = seed_context.lessons.select {|l| l.key == lpe_data['seeding_key']['lesson.key']}.first&.id
         raise 'No lesson found' if lesson_id.nil?
 

--- a/dashboard/test/lib/services/script_seed_test.rb
+++ b/dashboard/test/lib/services/script_seed_test.rb
@@ -776,6 +776,26 @@ module Services
       assert_equal expected_counts, get_counts
     end
 
+    test 'seed deletes all lesson programming expressions' do
+      script = create_script_tree
+      original_counts = get_counts
+
+      script_with_deletion, json = get_script_and_json_with_change_and_rollback(script) do
+        script.lessons.each do |lesson|
+          lesson.programming_expressions = []
+          assert_equal 0, lesson.programming_expressions.count
+        end
+      end
+
+      ScriptSeed.seed_from_json(json)
+      script = Script.with_seed_models.find(script.id)
+
+      assert_script_trees_equal script_with_deletion, script
+      expected_counts = original_counts.clone
+      expected_counts['LessonsProgrammingExpression'] = 0
+      assert_equal expected_counts, get_counts
+    end
+
     test 'seed can only find programming expression if programming environment matches' do
       script = create_script_tree(num_lessons_per_group: 1)
       json = ScriptSeed.serialize_seeding_json(script)


### PR DESCRIPTION
All the programming expressions were removed from CSF. However, that meant that `lessons_programming_expressions` was empty and triggered an early return from the seeding function, never updating the lessons. Vocabulary also has this problem. Instead, we should handle a nil value for the list by using an empty array instead. 


## Testing story

tested locally, also added a unit test

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
