### PR TITLE
Require form version in simple survey form model (MiscSurvey refactor)

### DIFF
--- a/dashboard/app/controllers/foorm/simple_survey_forms_controller.rb
+++ b/dashboard/app/controllers/foorm/simple_survey_forms_controller.rb
@@ -46,7 +46,7 @@ module Foorm
 
       form_questions = ::Foorm::Form.get_questions_for_name_and_version(
         form_data[:form_name],
-        form_data[:form_version] || 0
+        form_data[:form_version]
       )
 
       return render_404 unless form_questions
@@ -86,7 +86,7 @@ module Foorm
 
       form_questions = ::Foorm::Form.get_questions_for_name_and_version(
         form_data[:form_name],
-        form_data[:form_version] || 0
+        form_data[:form_version]
       )
 
       key_params = {

--- a/dashboard/app/models/foorm/simple_survey_form.rb
+++ b/dashboard/app/models/foorm/simple_survey_form.rb
@@ -6,7 +6,7 @@
 #  path         :string(255)      not null
 #  kind         :string(255)
 #  form_name    :string(255)      not null
-#  form_version :integer
+#  form_version :integer          not null
 #  properties   :text(65535)
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
@@ -22,6 +22,8 @@ class Foorm::SimpleSurveyForm < ApplicationRecord
     'survey_data',
     'allow_multiple_submissions'
   ]
+
+  belongs_to :form, foreign_key: [:form_name, :form_version], primary_key: [:name, :version]
 
   validates :path, presence: true, format: {with: /\A[a-z0-9_]+\z/}
 

--- a/dashboard/db/migrate/20210511160631_require_form_version_in_simple_survey_forms.rb
+++ b/dashboard/db/migrate/20210511160631_require_form_version_in_simple_survey_forms.rb
@@ -1,0 +1,13 @@
+class RequireFormVersionInSimpleSurveyForms < ActiveRecord::Migration[5.2]
+  def change
+    reversible do |dir|
+      dir.up do
+        Foorm::SimpleSurveyForm.
+          where(form_version: nil).
+          update_all(form_version: 0)
+      end
+    end
+
+    change_column_null :foorm_simple_survey_forms, :form_version, false
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_01_040241) do
+ActiveRecord::Schema.define(version: 2021_05_11_160631) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -490,7 +490,7 @@ ActiveRecord::Schema.define(version: 2021_05_01_040241) do
     t.string "path", null: false
     t.string "kind"
     t.string "form_name", null: false
-    t.integer "form_version"
+    t.integer "form_version", null: false
     t.text "properties"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/dashboard/test/models/foorm/simple_survey_submission_test.rb
+++ b/dashboard/test/models/foorm/simple_survey_submission_test.rb
@@ -8,7 +8,7 @@ class Foorm::SimpleSurveySubmissionTest < ActiveSupport::TestCase
   end
 
   test 'save simple survey submission' do
-    simple_survey_form = Foorm::SimpleSurveyForm.create({form_name: @foorm_form.name, path: 'a_url'})
+    simple_survey_form = Foorm::SimpleSurveyForm.create({form_name: @foorm_form.name, form_version: 0, path: 'a_url'})
 
     simple_survey_submission = Foorm::SimpleSurveySubmission.new(user_id: @teacher.id, simple_survey_form_id: simple_survey_form.id)
     simple_survey_submission.save_with_foorm_submission({'question1': 'answer1'}, @foorm_form.name, @foorm_form.version)


### PR DESCRIPTION
I originally did not require form version in the `SimpleSurveyForm` model -- that decision has made adding a nice `belongs_to` specifying the Form that the SimpleSurveyForm is associated with challenging (impossible?)

This migration backfills all existing rows where the form version is nil to be 0, which is the default value used if the form version is nil currently.

## Testing story

I ran this migration locally with rows in my database that had nil form versions, and noted that they changed to 0 once this had run.