### PR TITLE
Replace setTimeout to prevent Blockly.fireUiEvent from executing afte…

### DIFF
--- a/apps/test/unit/StudioAppTest.js
+++ b/apps/test/unit/StudioAppTest.js
@@ -13,7 +13,11 @@ import {listStore} from '@cdo/apps/code-studio/assets';
 import * as commonReducers from '@cdo/apps/redux/commonReducers';
 import {registerReducers, stubRedux, restoreRedux} from '@cdo/apps/redux';
 import project from '@cdo/apps/code-studio/initApp/project';
-import {sandboxDocumentBody} from '../util/testUtils';
+import {
+  sandboxDocumentBody,
+  replaceOnWindow,
+  restoreOnWindow
+} from '../util/testUtils';
 import sampleLibrary from './code-studio/components/libraries/sampleLibrary.json';
 import {createLibraryClosure} from '@cdo/apps/code-studio/components/libraries/libraryParser';
 import * as utils from '@cdo/apps/utils';
@@ -28,6 +32,7 @@ describe('StudioApp', () => {
       stubStudioApp();
       stubRedux();
       registerReducers(commonReducers);
+      replaceOnWindow('setTimeout', () => {});
 
       codeWorkspaceDiv = document.createElement('div');
       codeWorkspaceDiv.id = 'codeWorkspace';
@@ -46,6 +51,7 @@ describe('StudioApp', () => {
     afterEach(() => {
       restoreStudioApp();
       restoreRedux();
+      restoreOnWindow('setTimeout');
 
       document.body.removeChild(codeWorkspaceDiv);
       document.body.removeChild(containerDiv);


### PR DESCRIPTION
…r test finishes

I can't get this test to fail locally, so this is a somewhat speculative fix for [STAR-1286](https://codedotorg.atlassian.net/browse/STAR-1286) (de-flake `StudioApp.singleton` unit tests).

Every time these tests fail, they fail in the same way and point to this line:
https://github.com/code-dot-org/code-dot-org/blob/ed3a4d8e8c826e93de587177b6b51c3737040129/apps/src/StudioApp.js#L2957

Example flaky failure:
<img width="634" alt="Screen Shot 2021-05-11 at 10 42 40 AM" src="https://user-images.githubusercontent.com/9812299/117860999-c6a32400-b245-11eb-9452-fa36f422b1b1.png">

This call to `Blockly.fireUiEvent` is the only usage in this repo (also see #37413), and it cannot be removed because it fixes a mobile Safari bug (see #18937) that I don't believe has been addressed.

We aren't testing this functionality and its hard-coded, asynchronous nature is likely causing a scoping issue that leads to these tests failing every once in a while. These tests tend to fail ~1/month, so it will take some time for us to determine whether or not this is actually the issue, but I have reasonably high confidence due to the consistent stack trace.

## Links

- [STAR-1286](https://codedotorg.atlassian.net/browse/STAR-1286)