### PR TITLE
Support empty lessons in progress tables

### DIFF
--- a/apps/src/templates/progress/progressHelpers.js
+++ b/apps/src/templates/progress/progressHelpers.js
@@ -146,6 +146,15 @@ export function lessonIsAllAssessment(levels) {
 }
 
 /**
+ * Checks if there are any levels in a lesson.
+ * @param {object} lesson the lesson to check
+ * @returns {bool} If the lesson has any levels
+ */
+export function lessonHasLevels(lesson) {
+  return !!lesson.levels?.length;
+}
+
+/**
  * Computes summary of a student's progress in a lesson's levels.
  * @param {{id: studentLevelProgressType}} studentLevelProgress
  * An object keyed by level id containing objects representing the student's

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableContentView.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableContentView.jsx
@@ -8,7 +8,10 @@ import {
   studentTableRowType,
   scrollbarWidth
 } from '../sectionProgressConstants';
-import {lessonIsAllAssessment} from '@cdo/apps/templates/progress/progressHelpers';
+import {
+  lessonIsAllAssessment,
+  lessonHasLevels
+} from '@cdo/apps/templates/progress/progressHelpers';
 import progressTableStyles from './progressTableStyles.scss';
 import ProgressTableLessonNumber from './ProgressTableLessonNumber';
 
@@ -68,7 +71,7 @@ export default class ProgressTableContentView extends React.Component {
     const lesson = this.props.scriptData.stages[columnIndex];
     const includeArrow =
       this.props.includeHeaderArrows &&
-      (!!lesson.levels?.length &&
+      (lessonHasLevels(lesson) &&
         (lesson.levels.length > 1 || lesson.levels[0].isUnplugged));
     return (
       <div

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableContentView.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableContentView.jsx
@@ -68,7 +68,8 @@ export default class ProgressTableContentView extends React.Component {
     const lesson = this.props.scriptData.stages[columnIndex];
     const includeArrow =
       this.props.includeHeaderArrows &&
-      (lesson.levels.length > 1 || lesson.levels[0].isUnplugged);
+      (!!lesson.levels?.length &&
+        (lesson.levels.length > 1 || lesson.levels[0].isUnplugged));
     return (
       <div
         style={styles.headerContainer}
@@ -100,19 +101,24 @@ export default class ProgressTableContentView extends React.Component {
    * constrain column widths to the provided values. When it's absent, the
    * columns will size themselves based on their content.
    *
-   * Note: Due to the nuances of reactabular's implementation, header cells
+   * One exception is that we provide a fixed width for empty columns when a
+   * lesson has no levels.
+   *
+   * Note: due to the nuances of reactabular's implementation, header cells
    * are unable to base their width on the content of body cells, nor
    * vice versa. Consequently, for headers to properly align with their body
    * columns when explicit column widths are not provided, the max content
    * width of header cells must match the max content width of body cells.
    */
   columnWidthStyle(index) {
-    const {columnWidths} = this.props;
-    return columnWidths
-      ? {
-          style: {minWidth: columnWidths[index], maxWidth: columnWidths[index]}
-        }
-      : {};
+    const {columnWidths, scriptData} = this.props;
+    let width = null;
+    if (columnWidths) {
+      width = columnWidths[index];
+    } else if (!scriptData.stages[index].levels?.length) {
+      width = parseInt(progressTableStyles.MIN_COLUMN_WIDTH);
+    }
+    return width ? {style: {minWidth: width, maxWidth: width}} : {};
   }
 
   render() {

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableContentView.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableContentView.jsx
@@ -118,7 +118,7 @@ export default class ProgressTableContentView extends React.Component {
     let width = null;
     if (columnWidths) {
       width = columnWidths[index];
-    } else if (!scriptData.stages[index].levels?.length) {
+    } else if (!lessonHasLevels(scriptData.stages[index])) {
       width = parseInt(progressTableStyles.MIN_COLUMN_WIDTH);
     }
     return width ? {style: {minWidth: width, maxWidth: width}} : {};

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableDetailCell.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableDetailCell.jsx
@@ -102,6 +102,9 @@ export default class ProgressTableDetailCell extends React.Component {
   }
 
   render() {
+    if (!this.props.levels?.length) {
+      return null;
+    }
     return (
       <div
         style={{...styles.container, ...progressStyles.cellContent}}

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableDetailCell.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableDetailCell.jsx
@@ -5,6 +5,7 @@ import {
   studentLevelProgressType
 } from '@cdo/apps/templates/progress/progressTypes';
 import ProgressTableLevelBubble from './ProgressTableLevelBubble';
+import {lessonHasLevels} from '@cdo/apps/templates/progress/progressHelpers';
 import * as progressStyles from '@cdo/apps/templates/progress/progressStyles';
 import color from '@cdo/apps/util/color';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
@@ -102,7 +103,7 @@ export default class ProgressTableDetailCell extends React.Component {
   }
 
   render() {
-    if (!this.props.levels?.length) {
+    if (!lessonHasLevels({levels: this.props.levels})) {
       return null;
     }
     return (

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableView.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableView.jsx
@@ -29,8 +29,6 @@ import {
 import firehoseClient from '@cdo/apps/lib/util/firehose';
 import classnames from 'classnames';
 
-const SUMMARY_VIEW_COLUMN_WIDTH = 40;
-
 /**
  * Since our progress tables are built out of standard HTML table elements,
  * we can leverage CSS classes for laying out and styling those elements.
@@ -256,7 +254,7 @@ class ProgressTableView extends React.Component {
   summaryContentViewProps() {
     return {
       columnWidths: new Array(this.props.scriptData.stages.length).fill(
-        SUMMARY_VIEW_COLUMN_WIDTH
+        parseInt(progressTableStyles.MIN_COLUMN_WIDTH)
       ),
       lessonCellFormatters: this.summaryCellFormatters,
       includeHeaderArrows: false

--- a/apps/src/templates/sectionProgress/progressTables/progressTableStyles.scss
+++ b/apps/src/templates/sectionProgress/progressTables/progressTableStyles.scss
@@ -98,4 +98,5 @@ $content-view-width: $content-width - $student-list-width;
   CONTENT_VIEW_WIDTH: $content-view-width / 1px;
   ROW_HEIGHT: $row-height / 1px;
   MAX_ROWS: $max-rows;
+  MIN_COLUMN_WIDTH: 40;
 }

--- a/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableContentViewTest.jsx
+++ b/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableContentViewTest.jsx
@@ -3,6 +3,7 @@ import {expect} from '../../../../util/reconfiguredChai';
 import {mount} from 'enzyme';
 import ProgressTableContentView from '@cdo/apps/templates/sectionProgress/progressTables/ProgressTableContentView';
 import ProgressTableLessonNumber from '@cdo/apps/templates/sectionProgress/progressTables/ProgressTableLessonNumber';
+import progressTableStyles from '@cdo/apps/templates/sectionProgress/progressTables/progressTableStyles.scss';
 import * as Virtualized from 'reactabular-virtualized';
 import {
   fakeLevel,
@@ -23,7 +24,8 @@ const LESSON_3 = fakeLessonWithLevels({
   position: 3,
   levels: [fakeLevel({isUnplugged: true})]
 });
-const LESSONS = [LESSON_1, LESSON_2, LESSON_3];
+const LESSON_4 = fakeLessonWithLevels({position: 4, levels: []});
+const LESSONS = [LESSON_1, LESSON_2, LESSON_3, LESSON_4];
 
 const STUDENT_ROWS = fakeRowsForStudents(STUDENTS);
 
@@ -63,8 +65,8 @@ describe('ProgressTableContentView', () => {
 
   it('displays lesson number as a ProgressTableLessonNumber', () => {
     const wrapper = setUp();
-    // one for each of the 3 lessons
-    expect(wrapper.find(ProgressTableLessonNumber)).to.have.length(3);
+    // one for each of the 4 lessons
+    expect(wrapper.find(ProgressTableLessonNumber)).to.have.length(4);
   });
 
   it('passes includeArrow false to ProgressTableLessonNumber if includeHeaderArrows is false', () => {
@@ -81,6 +83,7 @@ describe('ProgressTableContentView', () => {
     expect(lessonNumbers.at(0).props().includeArrow).to.be.false; // first lesson only has one level
     expect(lessonNumbers.at(1).props().includeArrow).to.be.true; // second lesson only has 3 levels
     expect(lessonNumbers.at(2).props().includeArrow).to.be.true; // third lesson only has one unplugged level
+    expect(lessonNumbers.at(3).props().includeArrow).to.be.false; // fourth lesson has no levels
   });
 
   it('passes highlighted true to ProgressTableLessonNumber for the lessonOfInterest', () => {
@@ -123,5 +126,14 @@ describe('ProgressTableContentView', () => {
     expect(FORMATTERS[0].callCount).to.equal(expectedCallCount);
     expect(FORMATTERS[1].callCount).to.equal(expectedCallCount);
     expect(FORMATTERS[2].callCount).to.equal(expectedCallCount);
+  });
+
+  it('uses a fixed column width for empty lessons', () => {
+    const wrapper = setUp({columnWidths: null});
+    const headers = wrapper.find('th');
+    expect(headers.at(0).props().style?.maxWidth).to.be.undefined;
+    expect(headers.at(3).props().style.maxWidth).to.equal(
+      parseInt(progressTableStyles.MIN_COLUMN_WIDTH)
+    );
   });
 });

--- a/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableContentViewTest.jsx
+++ b/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableContentViewTest.jsx
@@ -131,7 +131,11 @@ describe('ProgressTableContentView', () => {
   it('uses a fixed column width for empty lessons', () => {
     const wrapper = setUp({columnWidths: null});
     const headers = wrapper.find('th');
+    expect(headers.at(0).props().style?.minWidth).to.be.undefined;
     expect(headers.at(0).props().style?.maxWidth).to.be.undefined;
+    expect(headers.at(3).props().style.minWidth).to.equal(
+      parseInt(progressTableStyles.MIN_COLUMN_WIDTH)
+    );
     expect(headers.at(3).props().style.maxWidth).to.equal(
       parseInt(progressTableStyles.MIN_COLUMN_WIDTH)
     );

--- a/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableDetailCellTest.jsx
+++ b/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableDetailCellTest.jsx
@@ -41,6 +41,11 @@ describe('ProgressTableDetailCell', () => {
     firehoseClient.putRecord.restore();
   });
 
+  it('renders nothing if levels array is empty', () => {
+    const wrapper = setUp({levels: []});
+    expect(wrapper).to.be.empty;
+  });
+
   it('displays a progress table level bubble for each level and sublevel', () => {
     const wrapper = setUp();
     const levelBubble1 = wrapper.findWhere(node => node.key() === '123_1');


### PR DESCRIPTION
our curriculum writers are starting to create lessons without any levels, so our progress table needs to support that use case. this PR updates the layout logic of `ProgressTableContentView` to use an empty fixed-width column if `lesson.levels` is empty.

## Links
- jira ticket: [LP-1889]

[LP-1889]: https://codedotorg.atlassian.net/browse/LP-1889