### PR TITLE
Don't use react fragment shorthand in enroll page

### DIFF
--- a/apps/src/code-studio/pd/workshop_enrollment/workshop_details.jsx
+++ b/apps/src/code-studio/pd/workshop_enrollment/workshop_details.jsx
@@ -55,10 +55,10 @@ export default class WorkshopDetails extends React.Component {
             : this.props.workshop.location_name}
           {!this.props.workshop.virtual &&
             this.props.workshop.location_address && (
-              <>
+              <React.Fragment>
                 <br />
                 {this.props.workshop.location_address}
-              </>
+              </React.Fragment>
             )}
         </div>
       </div>


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

`<> </>` react fragments are only supported in react 16+, oops..

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

[Reported here](https://codedotorg.slack.com/archives/C0T10H26N/p1620772292068600)

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

Manually tested locally on a non-virtual workshop

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
