### PR TITLE
Hide the lesson group information in the level mini view

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -337,6 +337,7 @@ describe('entry tests', () => {
           ['build/package/css/courses.css', 'style/curriculum/courses.scss'],
           ['build/package/css/scripts.css', 'style/curriculum/scripts.scss'],
           ['build/package/css/lessons.css', 'style/curriculum/lessons.scss'],
+          ['build/package/css/levels.css', 'style/curriculum/levels.scss'],
           ['build/package/css/rollups.css', 'style/curriculum/rollups.scss'],
           [
             'build/package/css/levelbuilder.css',

--- a/apps/style/curriculum/levels.scss
+++ b/apps/style/curriculum/levels.scss
@@ -1,0 +1,1 @@
+@import "pdf_printing";

--- a/dashboard/app/views/levels/show.html.haml
+++ b/dashboard/app/views/levels/show.html.haml
@@ -16,6 +16,7 @@
 
 - if @script_level
   - level_data = { redirect_script_url: @redirect_script_url, script_name: @script_level.script&.name, course_name: @script_level.script&.unit_group&.name, tts_autoplay_enabled: @tts_autoplay_enabled}
+  %link{href: asset_path('css/levels.css'), rel: 'stylesheet', type: 'text/css'}
   %script{ src: webpack_asset_path('js/levels/show.js'), data: { level: level_data.to_json } }
   -# Mount point for RedirectDialog React component.
   %div#redirect-dialog


### PR DESCRIPTION
We have lesson group information which we only want to show in the print view of the script overview but is showing in the mini view on levels because they share the same components. This hides that content on the mini view.

### Before
<img width="845" alt="Screen Shot 2021-05-11 at 9 07 13 PM" src="https://user-images.githubusercontent.com/208083/117903078-e0238a80-b29c-11eb-86e5-9ff32f6b40fe.png">

### After
<img width="765" alt="Screen Shot 2021-05-11 at 9 03 44 PM" src="https://user-images.githubusercontent.com/208083/117902953-95097780-b29c-11eb-9294-a01743a5c409.png">

## Links

https://codedotorg.atlassian.net/browse/PLAT-1039

## Testing story

- Tested manually locally