### PR TITLE
Updates to use Maze v2.0.0 (2nd attempt)

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -55,7 +55,7 @@
     "@code-dot-org/johnny-five": "0.11.1-cdo.2",
     "@code-dot-org/js-interpreter-tyrant": "0.2.2",
     "@code-dot-org/js-numbers": "0.1.0-cdo.0",
-    "@code-dot-org/maze": "1.1.0",
+    "@code-dot-org/maze": "2.0.0",
     "@code-dot-org/ml-activities": "0.0.26",
     "@code-dot-org/ml-playground": "0.0.28",
     "@code-dot-org/p5.play": "^1.3.17-cdo",

--- a/apps/src/maze/api.js
+++ b/apps/src/maze/api.js
@@ -23,35 +23,35 @@ var API_FUNCTION = function(fn) {
  * @return {boolean} True if there is a path.
  */
 var isPath = function(direction, id) {
-  var effectiveDirection = Maze.controller.pegmanD + direction;
+  var effectiveDirection = Maze.controller.getPegmanD() + direction;
   var square;
   var command;
   switch (tiles.constrainDirection4(effectiveDirection)) {
     case Direction.NORTH:
       square = Maze.controller.map.getTile(
-        Maze.controller.pegmanY - 1,
-        Maze.controller.pegmanX
+        Maze.controller.getPegmanY() - 1,
+        Maze.controller.getPegmanX()
       );
       command = 'look_north';
       break;
     case Direction.EAST:
       square = Maze.controller.map.getTile(
-        Maze.controller.pegmanY,
-        Maze.controller.pegmanX + 1
+        Maze.controller.getPegmanY(),
+        Maze.controller.getPegmanX() + 1
       );
       command = 'look_east';
       break;
     case Direction.SOUTH:
       square = Maze.controller.map.getTile(
-        Maze.controller.pegmanY + 1,
-        Maze.controller.pegmanX
+        Maze.controller.getPegmanY() + 1,
+        Maze.controller.getPegmanX()
       );
       command = 'look_south';
       break;
     case Direction.WEST:
       square = Maze.controller.map.getTile(
-        Maze.controller.pegmanY,
-        Maze.controller.pegmanX - 1
+        Maze.controller.getPegmanY(),
+        Maze.controller.getPegmanX() - 1
       );
       command = 'look_west';
       break;
@@ -83,31 +83,33 @@ var move = function(direction, id) {
     return;
   }
   // If moving backward, flip the effective direction.
-  var effectiveDirection = Maze.controller.pegmanD + direction;
+  var effectiveDirection = Maze.controller.getPegmanD() + direction;
   var command;
+  const currentPegmanX = Maze.controller.getPegmanX();
+  const currentPegmanY = Maze.controller.getPegmanY();
   switch (tiles.constrainDirection4(effectiveDirection)) {
     case Direction.NORTH:
-      Maze.controller.pegmanY--;
+      Maze.controller.setPegmanY(currentPegmanY - 1);
       command = 'north';
       break;
     case Direction.EAST:
-      Maze.controller.pegmanX++;
+      Maze.controller.setPegmanX(currentPegmanX + 1);
       command = 'east';
       break;
     case Direction.SOUTH:
-      Maze.controller.pegmanY++;
+      Maze.controller.setPegmanY(currentPegmanY + 1);
       command = 'south';
       break;
     case Direction.WEST:
-      Maze.controller.pegmanX--;
+      Maze.controller.setPegmanX(currentPegmanX - 1);
       command = 'west';
       break;
   }
   Maze.executionInfo.queueAction(command, id);
   if (Maze.controller.subtype.isWordSearch()) {
     Maze.controller.subtype.markTileVisited(
-      Maze.controller.pegmanY,
-      Maze.controller.pegmanX,
+      Maze.controller.getPegmanY(),
+      Maze.controller.getPegmanX(),
       false
     );
   }
@@ -122,16 +124,19 @@ var move = function(direction, id) {
  * @param {string} id ID of block that triggered this action.
  */
 var turn = function(direction, id) {
+  const currentD = Maze.controller.getPegmanD();
   if (direction === TurnDirection.RIGHT) {
     // Right turn (clockwise).
-    Maze.controller.pegmanD += TurnDirection.RIGHT;
+    Maze.controller.setPegmanD(currentD + TurnDirection.RIGHT);
     Maze.executionInfo.queueAction('right', id);
   } else {
     // Left turn (counterclockwise).
-    Maze.controller.pegmanD += TurnDirection.LEFT;
+    Maze.controller.setPegmanD(currentD + TurnDirection.LEFT);
     Maze.executionInfo.queueAction('left', id);
   }
-  Maze.controller.pegmanD = tiles.constrainDirection4(Maze.controller.pegmanD);
+  Maze.controller.setPegmanD(
+    tiles.constrainDirection4(Maze.controller.getPegmanD())
+  );
 };
 
 /**
@@ -141,7 +146,7 @@ var turn = function(direction, id) {
  * @param {string} id ID of block that triggered this action.
  */
 var turnTo = function(newDirection, id) {
-  var currentDirection = Maze.controller.pegmanD;
+  var currentDirection = Maze.controller.getPegmanD();
   if (isTurnAround(currentDirection, newDirection)) {
     var shouldTurnCWToPreferStageFront = currentDirection - newDirection < 0;
     var relativeTurnDirection = shouldTurnCWToPreferStageFront
@@ -237,24 +242,24 @@ exports.isPathLeft = API_FUNCTION(function(id) {
 });
 
 exports.pilePresent = API_FUNCTION(function(id) {
-  var x = Maze.controller.pegmanX;
-  var y = Maze.controller.pegmanY;
+  var x = Maze.controller.getPegmanX();
+  var y = Maze.controller.getPegmanY();
   return (
     Maze.controller.map.isDirt(y, x) && Maze.controller.map.getValue(y, x) > 0
   );
 });
 
 exports.holePresent = API_FUNCTION(function(id) {
-  var x = Maze.controller.pegmanX;
-  var y = Maze.controller.pegmanY;
+  var x = Maze.controller.getPegmanX();
+  var y = Maze.controller.getPegmanY();
   return (
     Maze.controller.map.isDirt(y, x) && Maze.controller.map.getValue(y, x) < 0
   );
 });
 
 exports.currentPositionNotClear = API_FUNCTION(function(id) {
-  var x = Maze.controller.pegmanX;
-  var y = Maze.controller.pegmanY;
+  var x = Maze.controller.getPegmanX();
+  var y = Maze.controller.getPegmanY();
   return (
     Maze.controller.map.isDirt(y, x) && Maze.controller.map.getValue(y, x) !== 0
   );
@@ -262,15 +267,15 @@ exports.currentPositionNotClear = API_FUNCTION(function(id) {
 
 exports.fill = API_FUNCTION(function(id) {
   Maze.executionInfo.queueAction('putdown', id);
-  var x = Maze.controller.pegmanX;
-  var y = Maze.controller.pegmanY;
+  var x = Maze.controller.getPegmanX();
+  var y = Maze.controller.getPegmanY();
   Maze.controller.map.setValue(y, x, Maze.controller.map.getValue(y, x) + 1);
 });
 
 exports.dig = API_FUNCTION(function(id) {
   Maze.executionInfo.queueAction('pickup', id);
-  var x = Maze.controller.pegmanX;
-  var y = Maze.controller.pegmanY;
+  var x = Maze.controller.getPegmanX();
+  var y = Maze.controller.getPegmanY();
   Maze.controller.map.setValue(y, x, Maze.controller.map.getValue(y, x) - 1);
 });
 
@@ -301,15 +306,15 @@ exports.makeHoney = API_FUNCTION(function(id) {
 });
 
 exports.atFlower = API_FUNCTION(function(id) {
-  var col = Maze.controller.pegmanX;
-  var row = Maze.controller.pegmanY;
+  var col = Maze.controller.getPegmanX();
+  var row = Maze.controller.getPegmanY();
   Maze.executionInfo.queueAction('at_flower', id);
   return Maze.controller.subtype.isFlower(row, col, true);
 });
 
 exports.atHoneycomb = API_FUNCTION(function(id) {
-  var col = Maze.controller.pegmanX;
-  var row = Maze.controller.pegmanY;
+  var col = Maze.controller.getPegmanX();
+  var row = Maze.controller.getPegmanY();
   Maze.executionInfo.queueAction('at_honeycomb', id);
   return Maze.controller.subtype.isHive(row, col, true);
 });
@@ -411,8 +416,8 @@ exports.atSprout = API_FUNCTION(function(id) {
  */
 
 exports.collect = API_FUNCTION(function(id) {
-  var col = Maze.controller.pegmanX;
-  var row = Maze.controller.pegmanY;
+  var col = Maze.controller.getPegmanX();
+  var row = Maze.controller.getPegmanY();
   if (Maze.controller.subtype.tryCollect(row, col)) {
     Maze.executionInfo.queueAction('pickup', id);
   } else {

--- a/apps/src/maze/results/resultsHandler.js
+++ b/apps/src/maze/results/resultsHandler.js
@@ -18,8 +18,8 @@ export default class ResultsHandler {
   succeeded() {
     if (this.maze_.subtype.finish) {
       return (
-        this.maze_.pegmanX === this.maze_.subtype.finish.x &&
-        this.maze_.pegmanY === this.maze_.subtype.finish.y
+        this.maze_.getPegmanX() === this.maze_.subtype.finish.x &&
+        this.maze_.getPegmanY() === this.maze_.subtype.finish.y
       );
     }
   }

--- a/apps/test/integration/levelSolutions/maze/wordsearch/wordsearch_1.js
+++ b/apps/test/integration/levelSolutions/maze/wordsearch/wordsearch_1.js
@@ -40,7 +40,10 @@ module.exports = {
       customValidator: function() {
         // Make sure pegman made it to the end, rather than ending as soon as
         // he tried to leave the path
-        return Maze.controller.pegmanX === 3 && Maze.controller.pegmanY === 1;
+        return (
+          Maze.controller.getPegmanX() === 3 &&
+          Maze.controller.getPegmanY() === 1
+        );
       },
       xml:
         '<xml>' +

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1622,9 +1622,10 @@
   version "0.1.0-cdo.0"
   resolved "https://registry.yarnpkg.com/@code-dot-org/js-numbers/-/js-numbers-0.1.0-cdo.0.tgz#810092a993c3c75441f2e5a3282f1257d9670715"
 
-"@code-dot-org/maze@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/maze/-/maze-1.1.0.tgz#7c8185adf06a9172e3bde4ccd6f6738a787b2a7c"
+"@code-dot-org/maze@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/maze/-/maze-2.0.0.tgz#5280fffa4dd31d149bcdc144d6a5c0670e4232a0"
+  integrity sha512-ramVIVblbgGbLetYv5qlgs0qPGWZwjo2AdcDAF6t9Qpeu/HHElXOM/Y475rebwk8Mei5RYjnz5MbpCWMU3JX0g==
 
 "@code-dot-org/ml-activities@0.0.26":
   version "0.0.26"


### PR DESCRIPTION
Re-creating [this PR](https://github.com/code-dot-org/code-dot-org/pull/40491) because it caused an unexpected eyes test failure. The failure ended up being because there were some changes in the Maze repo prior to my changes that had never been published as an npm package, so v2.0.0 picked them up for the first time. The change that caused the failure is [here](https://github.com/code-dot-org/maze/pull/15), it got rid of a special case that the first hour of code levels should not have randomized tiles. We will need to update the eyes test when this change goes in to have an ignore region around the randomized tiles.