### PR TITLE
edited styling to prevent button from moving

### DIFF
--- a/apps/src/javalab/JavalabEditor.jsx
+++ b/apps/src/javalab/JavalabEditor.jsx
@@ -39,6 +39,8 @@ const style = {
   fileMenuToggleButton: {
     margin: '0, 0, 0, 4px',
     padding: 0,
+    height: 20,
+    width: 10,
     backgroundColor: 'transparent',
     border: 'none',
     ':hover': {

--- a/apps/src/javalab/JavalabEditor.jsx
+++ b/apps/src/javalab/JavalabEditor.jsx
@@ -40,7 +40,7 @@ const style = {
     margin: '0, 0, 0, 4px',
     padding: 0,
     height: 20,
-    width: 10,
+    width: 13,
     backgroundColor: 'transparent',
     border: 'none',
     ':hover': {


### PR DESCRIPTION
This PR fixes a bug where clicking the dropdown arrow forces the entire tab and window below to move slightly down and to the right. Setting a height and width to force the outline that appears to a smaller area prevents this change in size from affecting the other modules. 

I know 13 px for width is a strange number, but it is the size that allows for a one pixel buffer on each side of the arrow, so the icon is centered.

I've tested this locally on both Chrome and Edge.

Please see terrible screen recording via phone below, as my screen recorder is broken.

![iphone-button](https://user-images.githubusercontent.com/37230822/118037697-0c81ea00-b323-11eb-910d-7b3560b195fa.gif)

What it was before:
![gif-button-move](https://user-images.githubusercontent.com/37230822/118037175-59b18c00-b322-11eb-8883-0a9e1f156158.gif)


Jira ticket: https://codedotorg.atlassian.net/browse/CSA-318