### PR TITLE
Fix isNotStartedLevel 

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -3405,14 +3405,9 @@ StudioApp.prototype.isResponsiveFromConfig = function(config) {
  */
 StudioApp.prototype.isNotStartedLevel = function(config) {
   const progress = getStore().getState().progress;
-
   if (config.hasContainedLevels || config.level.isProjectLevel) {
     return false;
-  } else if (
-    ['Gamelab', 'Applab', 'Weblab', 'Spritelab', 'Dance'].includes(
-      config.levelGameName
-    )
-  ) {
+  } else if (config.level.isChannelBacked) {
     return config.readonlyWorkspace && !config.channel;
   } else {
     return (

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -3398,22 +3398,15 @@ StudioApp.prototype.isResponsiveFromConfig = function(config) {
 /**
  * Checks if the level a teacher is viewing of a students has
  * not been started.
- * For contained levels don't show the banner ever.
- * Otherwise if its a channel backed level check for the channel. Lastly
- * if its not a channel backed level and its not free play we know it has
- * not been started if no progress has been made.
+ * For contained levels and project levels don't show the banner ever.
+ * Otherwise check if the teacher is viewing (readonlyWorkspace) and if
+ * the level has been started.
  */
-StudioApp.prototype.isNotStartedLevel = function(config) {
-  const progress = getStore().getState().progress;
+StudioApp.prototype.displayNotStartedBanner = function(config) {
   if (config.hasContainedLevels || config.level.isProjectLevel) {
     return false;
-  } else if (config.level.isChannelBacked) {
-    return config.readonlyWorkspace && !config.channel;
   } else {
-    return (
-      config.readonlyWorkspace &&
-      progress.levelResults[progress.currentLevelId] === undefined
-    );
+    return config.readonlyWorkspace && !config.level.isStarted;
   }
 };
 
@@ -3442,7 +3435,7 @@ StudioApp.prototype.setPageConstants = function(config, appSpecificConstants) {
       isChallengeLevel: !!config.isChallengeLevel,
       isEmbedView: !!config.embed,
       isResponsive: this.isResponsiveFromConfig(config),
-      isNotStartedLevel: this.isNotStartedLevel(config),
+      displayNotStartedBanner: this.displayNotStartedBanner(config),
       isShareView: !!config.share,
       pinWorkspaceToBottom: !!config.pinWorkspaceToBottom,
       noInstructionsWhenCollapsed: !!config.noInstructionsWhenCollapsed,

--- a/apps/src/redux/pageConstants.js
+++ b/apps/src/redux/pageConstants.js
@@ -16,7 +16,7 @@ var ALLOWED_KEYS = new Set([
   'isResponsive',
   'isIframeEmbed',
   'isReadOnlyWorkspace',
-  'isNotStartedLevel',
+  'displayNotStartedBanner',
   'isShareView',
   'isProjectLevel',
   'isSubmittable',

--- a/apps/src/templates/CodeWorkspace.jsx
+++ b/apps/src/templates/CodeWorkspace.jsx
@@ -19,7 +19,7 @@ import {queryParams} from '../code-studio/utils';
 
 class CodeWorkspace extends React.Component {
   static propTypes = {
-    studentHasNotStartedLevel: PropTypes.bool,
+    displayNotStartedBanner: PropTypes.bool,
     isRtl: PropTypes.bool.isRequired,
     editCode: PropTypes.bool.isRequired,
     readonlyWorkspace: PropTypes.bool.isRequired,
@@ -211,7 +211,7 @@ class CodeWorkspace extends React.Component {
             className={this.props.pinWorkspaceToBottom ? 'pin_bottom' : ''}
           />
         )}
-        {this.props.studentHasNotStartedLevel && !inCsfExampleSolution && (
+        {this.props.displayNotStartedBanner && !inCsfExampleSolution && (
           <div style={styles.studentNotStartedWarning}>
             {i18n.levelNotStartedWarning()}
           </div>
@@ -252,7 +252,7 @@ const styles = {
 
 export const UnconnectedCodeWorkspace = Radium(CodeWorkspace);
 export default connect(state => ({
-  studentHasNotStartedLevel: state.pageConstants.isNotStartedLevel,
+  displayNotStartedBanner: state.pageConstants.displayNotStartedBanner,
   editCode: state.pageConstants.isDroplet,
   isRtl: state.isRtl,
   readonlyWorkspace: state.pageConstants.isReadOnlyWorkspace,

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -107,6 +107,16 @@ module LevelsHelper
     channel_token&.channel
   end
 
+  # If given a level and a user, returns whether any work has been done
+  # on the level
+  def level_started?(level, user)
+    if level.channel_backed? # maureen make sure user is present or this will fail
+      return get_channel_for(level, user).present?
+    else
+      user.last_attempt(level).present?
+    end
+  end
+
   def select_and_track_autoplay_video
     return if @level.try(:autoplay_blocked_by_level?)
 
@@ -278,6 +288,10 @@ module LevelsHelper
       @app_options[:level][:levelVideos] = @level.related_videos.map(&:summarize)
       @app_options[:level][:mapReference] = @level.map_reference
       @app_options[:level][:referenceLinks] = @level.reference_links
+
+      if @user || current_user
+        @app_options[:level][:isStarted] = level_started?(@level, @user || current_user)
+      end
     end
 
     if current_user

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -107,12 +107,12 @@ module LevelsHelper
     channel_token&.channel
   end
 
-  # If given a level and a user and optional script, returns whether the level
+  # If given a level, script and a user, returns whether the level
   # has been started by the user. A channel-backed level is considered started when a
   # channel is created for the level, which happens when the user first visits the level page.
   # Other levels are considered started when progress has been saved for the level (for example
   # clicking the run button saves progress).
-  def level_started?(level, user, script = nil)
+  def level_started?(level, script, user)
     return false unless user.present?
 
     if level.channel_backed?
@@ -294,8 +294,8 @@ module LevelsHelper
       @app_options[:level][:mapReference] = @level.map_reference
       @app_options[:level][:referenceLinks] = @level.reference_links
 
-      if @user || current_user
-        @app_options[:level][:isStarted] = level_started?(@level, @user || current_user, @script)
+      if (@user || current_user) && @script
+        @app_options[:level][:isStarted] = level_started?(@level, @script, @user || current_user)
       end
     end
 

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -107,13 +107,13 @@ module LevelsHelper
     channel_token&.channel
   end
 
-  # If given a level and a user, returns whether any work has been done
-  # on the level
-  def level_started?(level, user)
+  # If given a level and a user and optional script, returns whether the level
+  # has been started by the user
+  def level_started?(level, user, script = nil)
     if level.channel_backed? # maureen make sure user is present or this will fail
       return get_channel_for(level, user).present?
     else
-      user.last_attempt(level).present?
+      user.last_attempt(level, script).present?
     end
   end
 
@@ -290,7 +290,7 @@ module LevelsHelper
       @app_options[:level][:referenceLinks] = @level.reference_links
 
       if @user || current_user
-        @app_options[:level][:isStarted] = level_started?(@level, @user || current_user)
+        @app_options[:level][:isStarted] = level_started?(@level, @user || current_user, @script)
       end
     end
 

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -108,9 +108,14 @@ module LevelsHelper
   end
 
   # If given a level and a user and optional script, returns whether the level
-  # has been started by the user
+  # has been started by the user. A channel-backed level is considered started when a
+  # channel is created for the level, which happens when the user first visits the level page.
+  # Other levels are considered started when progress has been saved for the level (for example
+  # clicking the run button saves progress).
   def level_started?(level, user, script = nil)
-    if level.channel_backed? # maureen make sure user is present or this will fail
+    return false unless user.present?
+
+    if level.channel_backed?
       return get_channel_for(level, user).present?
     else
       user.last_attempt(level, script).present?

--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -376,7 +376,6 @@ class Blockly < Level
       end
 
       level_prop['levelId'] = level_num
-      level_prop['isChannelBacked'] = channel_backed?
       level_prop['images'] = JSON.parse(level_prop['images']) if level_prop['images'].present?
 
       # Blockly requires startDirection as an integer not a string

--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -376,6 +376,7 @@ class Blockly < Level
       end
 
       level_prop['levelId'] = level_num
+      level_prop['isChannelBacked'] = channel_backed?
       level_prop['images'] = JSON.parse(level_prop['images']) if level_prop['images'].present?
 
       # Blockly requires startDirection as an integer not a string

--- a/dashboard/test/helpers/levels_helper_test.rb
+++ b/dashboard/test/helpers/levels_helper_test.rb
@@ -254,16 +254,20 @@ class LevelsHelperTest < ActionView::TestCase
   test 'level_started? should return true if a channel exists for a channel backed level' do
     user = create :user
     applab_level = create :applab # is channel backed
+    script = create(:script)
+    create(:script_level, levels: [applab_level], script: script)
     create :channel_token, level: applab_level, storage_id: storage_id_for_user_id(user.id)
 
-    assert_equal true, level_started?(applab_level, user)
+    assert_equal true, level_started?(applab_level, user, script)
   end
 
   test 'level_started? should return false if a channel does not exist for a channel backed level' do
     user = create :user
     applab_level = create :applab # is channel backed
+    script = create(:script)
+    create(:script_level, levels: [applab_level], script: script)
 
-    assert_equal false, level_started?(applab_level, user)
+    assert_equal false, level_started?(applab_level, user, script)
   end
 
   test 'level_started? should return true if progress exists for a level that is not channel backed' do
@@ -273,14 +277,16 @@ class LevelsHelperTest < ActionView::TestCase
     create(:script_level, levels: [maze_level], script: script)
     create :user_level, level: maze_level, user: user, script: script
 
-    assert_equal true, level_started?(maze_level, user)
+    assert_equal true, level_started?(maze_level, user, script)
   end
 
   test 'level_started? should return false if progress does not exist for a level that is not channel backed' do
     user = create :user
     maze_level = create :maze
+    script = create(:script)
+    create(:script_level, levels: [maze_level], script: script)
 
-    assert_equal false, level_started?(maze_level, user)
+    assert_equal false, level_started?(maze_level, user, script)
   end
 
   test 'a teacher viewing student work should see isStarted value for student' do

--- a/dashboard/test/helpers/levels_helper_test.rb
+++ b/dashboard/test/helpers/levels_helper_test.rb
@@ -258,7 +258,7 @@ class LevelsHelperTest < ActionView::TestCase
     create(:script_level, levels: [applab_level], script: script)
     create :channel_token, level: applab_level, storage_id: storage_id_for_user_id(user.id)
 
-    assert_equal true, level_started?(applab_level, user, script)
+    assert_equal true, level_started?(applab_level, script, user)
   end
 
   test 'level_started? should return false if a channel does not exist for a channel backed level' do
@@ -267,7 +267,7 @@ class LevelsHelperTest < ActionView::TestCase
     script = create(:script)
     create(:script_level, levels: [applab_level], script: script)
 
-    assert_equal false, level_started?(applab_level, user, script)
+    assert_equal false, level_started?(applab_level, script, user)
   end
 
   test 'level_started? should return true if progress exists for a level that is not channel backed' do
@@ -277,7 +277,7 @@ class LevelsHelperTest < ActionView::TestCase
     create(:script_level, levels: [maze_level], script: script)
     create :user_level, level: maze_level, user: user, script: script
 
-    assert_equal true, level_started?(maze_level, user, script)
+    assert_equal true, level_started?(maze_level, script, user)
   end
 
   test 'level_started? should return false if progress does not exist for a level that is not channel backed' do
@@ -286,17 +286,19 @@ class LevelsHelperTest < ActionView::TestCase
     script = create(:script)
     create(:script_level, levels: [maze_level], script: script)
 
-    assert_equal false, level_started?(maze_level, user, script)
+    assert_equal false, level_started?(maze_level, script, user)
   end
 
   test 'a teacher viewing student work should see isStarted value for student' do
-    create :user
-    applab_level = create :applab
+    @user = create :user
+    @level = create :applab
+    @script = script = create(:script)
+    create(:script_level, levels: [@level], script: script)
 
     teacher = create :teacher
     sign_in teacher
     # create progress on level for teacher to ensure we get back student isStarted value
-    create :channel_token, level: applab_level, storage_id: storage_id_for_user_id(teacher.id)
+    create :channel_token, level: @level, storage_id: storage_id_for_user_id(teacher.id)
 
     assert_equal false, app_options[:level][:isStarted]
   end

--- a/dashboard/test/helpers/levels_helper_test.rb
+++ b/dashboard/test/helpers/levels_helper_test.rb
@@ -251,6 +251,50 @@ class LevelsHelperTest < ActionView::TestCase
     assert_equal true, view_options[:readonly_workspace]
   end
 
+  test 'level_started? should return true if a channel exists for a channel backed level' do
+    user = create :user
+    applab_level = create :applab # is channel backed
+    create :channel_token, level: applab_level, storage_id: storage_id_for_user_id(user.id)
+
+    assert_equal true, level_started?(applab_level, user)
+  end
+
+  test 'level_started? should return false if a channel does not exist for a channel backed level' do
+    user = create :user
+    applab_level = create :applab # is channel backed
+
+    assert_equal false, level_started?(applab_level, user)
+  end
+
+  test 'level_started? should return true if progress exists for a level that is not channel backed' do
+    user = create :user
+    maze_level = create :maze
+    script = create(:script)
+    create(:script_level, levels: [maze_level], script: script)
+    create :user_level, level: maze_level, user: user, script: script
+
+    assert_equal true, level_started?(maze_level, user)
+  end
+
+  test 'level_started? should return false if progress does not exist for a level that is not channel backed' do
+    user = create :user
+    maze_level = create :maze
+
+    assert_equal false, level_started?(maze_level, user)
+  end
+
+  test 'a teacher viewing student work should see isStarted value for student' do
+    create :user
+    applab_level = create :applab
+
+    teacher = create :teacher
+    sign_in teacher
+    # create progress on level for teacher to ensure we get back student isStarted value
+    create :channel_token, level: applab_level, storage_id: storage_id_for_user_id(teacher.id)
+
+    assert_equal false, app_options[:level][:isStarted]
+  end
+
   test 'applab levels should include pairing_driver and pairing_channel_id when viewed by navigator' do
     @level = create :applab
     @driver = create :student

--- a/dashboard/test/models/blockly_test.rb
+++ b/dashboard/test/models/blockly_test.rb
@@ -646,10 +646,4 @@ XML
     assert_equal 'translated long instructions', summary[:longInstructions]
     assert_equal 'translated short instructions', summary[:shortInstructions]
   end
-
-  test 'blockly_level_options returns expected options' do
-    level = create(:level, :blockly, level_num: 'level1')
-    expected_level_options = {"sharedBlocks" => [], "levelId" => "level1", "isChannelBacked" => false, "editCode" => false}
-    assert_equal level.blockly_level_options, expected_level_options
-  end
 end

--- a/dashboard/test/models/blockly_test.rb
+++ b/dashboard/test/models/blockly_test.rb
@@ -646,4 +646,10 @@ XML
     assert_equal 'translated long instructions', summary[:longInstructions]
     assert_equal 'translated short instructions', summary[:shortInstructions]
   end
+
+  test 'blockly_level_options returns expected options' do
+    level = create(:level, :blockly, level_num: 'level1')
+    expected_level_options = {"sharedBlocks" => [], "levelId" => "level1", "isChannelBacked" => false, "editCode" => false}
+    assert_equal level.blockly_level_options, expected_level_options
+  end
 end


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
The config value `isNotStartedLevel` was being set by assuming that every 'Gamelab', 'Applab', 'Weblab', 'Spritelab', 'Dance' was channel backed. The dance lab level `/s/coursed-2020/lessons/7/levels/9` is not channel backed so a channel didn't exist for the level and therefore `isNotStartedLevel` was being set to true incorrectly. This resulted in the teacher seeing the level not started banner. 

The changes in this PR rename `isNotStartedLevel` to `displayNotStartedBanner` to more accurately represent the return value of the function. It also changes how we determine if the level has been started by checking for a channel if a level is channel backed and checking for a user_level for any other level.

Before:
![Screen Shot 2021-05-12 at 2 39 51 PM](https://user-images.githubusercontent.com/24235215/118047830-34c41580-b330-11eb-8522-abd705bc00b3.png)

After:
![Screen Shot 2021-05-12 at 2 39 18 PM](https://user-images.githubusercontent.com/24235215/118047842-38579c80-b330-11eb-9cf9-46ad30eb5ac2.png)




## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: [LP-1875](https://codedotorg.atlassian.net/browse/LP-1875)
-->

## Testing story
Added a test for the new config value and tested locally.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
