### PR TITLE
Additional foorm survey validation on names

### DIFF
--- a/apps/src/code-studio/initializeCodeMirror.js
+++ b/apps/src/code-studio/initializeCodeMirror.js
@@ -49,7 +49,7 @@ function initializeCodeMirror(target, mode, options = {}) {
     callback,
     attachments,
     onUpdateLinting,
-    getAnnotations,
+    additionalAnnotations,
     preview
   } = options;
   let updatePreview;
@@ -92,6 +92,18 @@ function initializeCodeMirror(target, mode, options = {}) {
       };
     }
   }
+
+  const getAnnotations = (text, options, cm) => {
+    const cmValidation = cm.getHelper(CodeMirror.Pos(0, 0), 'lint')(
+      text,
+      {},
+      cm
+    );
+    const additionalValidation = additionalAnnotations
+      ? additionalAnnotations(text, options, cm)
+      : [];
+    return [...cmValidation, ...additionalValidation];
+  };
 
   var editor = CodeMirror.fromTextArea(node, {
     mode: mode,

--- a/apps/src/code-studio/initializeCodeMirror.js
+++ b/apps/src/code-studio/initializeCodeMirror.js
@@ -116,7 +116,7 @@ function initializeCodeMirror(target, mode, options = {}) {
     lineWrapping: true,
     gutters: ['CodeMirror-lint-markers'],
     lint: {
-      getAnnotations,
+      getAnnotations: additionalAnnotations ? getAnnotations : undefined,
       onUpdateLinting
     }
   });

--- a/apps/src/code-studio/initializeCodeMirror.js
+++ b/apps/src/code-studio/initializeCodeMirror.js
@@ -38,13 +38,20 @@ CodeMirrorSpellChecker({
  * @param {function} [options.callback] - onChange callback for editor
  * @param {boolean} [options.attachments] - whether to enable attachment
  *        uploading in this editor.
- * @param {function} [options.onUpdateLinting]
+ * @param {function} [options.onUpdateLinting] - callback called when linting is finished
+ * @param {function} [options.getAnnotations] - optional function to override linting behavior
  * @param {(string|Element)} [options.preview] - element or id of element to
  *        populate with a preview. If none specified, will look for an element
  *        by appending "_preview" to the id of the target element.
  */
 function initializeCodeMirror(target, mode, options = {}) {
-  let {callback, attachments, onUpdateLinting, preview} = options;
+  let {
+    callback,
+    attachments,
+    onUpdateLinting,
+    getAnnotations,
+    preview
+  } = options;
   let updatePreview;
 
   // Code mirror parses html using xml mode
@@ -97,6 +104,7 @@ function initializeCodeMirror(target, mode, options = {}) {
     lineWrapping: true,
     gutters: ['CodeMirror-lint-markers'],
     lint: {
+      getAnnotations,
       onUpdateLinting
     }
   });

--- a/apps/src/sites/studio/pages/foorm/forms/editorHelpers.js
+++ b/apps/src/sites/studio/pages/foorm/forms/editorHelpers.js
@@ -20,8 +20,9 @@ const nameKeyValidator = new RegExp(/^[a-z0-9_]+$/i);
 // (non-basic characters can get stripped when being transferred to the server)
 export const lintFoormKeys = (text, options, cm) => {
   const annotations = [];
-  const nameEntries = Array.from(text.matchAll(nameKeyRegex));
-  nameEntries.forEach(match => {
+
+  let match;
+  while ((match = nameKeyRegex.exec(text)) !== null) {
     const nameValue = match[1];
     if (!nameKeyValidator.test(nameValue)) {
       annotations.push({
@@ -31,7 +32,7 @@ export const lintFoormKeys = (text, options, cm) => {
         to: cm.posFromIndex(match.index + match[0].length)
       });
     }
-  });
+  }
 
   return annotations;
 };

--- a/apps/test/unit/sites/studio/pages/foorm/forms/editorHelpersTest.js
+++ b/apps/test/unit/sites/studio/pages/foorm/forms/editorHelpersTest.js
@@ -30,12 +30,12 @@ describe('foorm linting', () => {
     assert(annotations.length === 2);
     assert(
       annotations[1].message ===
-        'Question keys should only contain letters and underscores.'
+        'Question names should only contain letters and underscores.'
     );
     assert(annotations[0].severity === 'error');
     assert(
       annotations[1].message ===
-        'Question keys should only contain letters and underscores.'
+        'Question names should only contain letters and underscores.'
     );
     assert(annotations[1].severity === 'error');
   });

--- a/apps/test/unit/sites/studio/pages/foorm/forms/editorHelpersTest.js
+++ b/apps/test/unit/sites/studio/pages/foorm/forms/editorHelpersTest.js
@@ -1,0 +1,42 @@
+import {assert} from 'chai';
+import {lintFoormKeys} from '@cdo/apps/sites/studio/pages/foorm/forms/editorHelpers';
+
+const fakeCodeMirror = {
+  posFromIndex: x => ({from: 0, to: 1})
+};
+
+const testValidJson = `{
+  "name": "valid",
+  "somethingElse": "534%$3g3gj90n 0o23-=+;[;fd]",
+  "nested": {
+    "value": "also_valid"
+  }
+}`;
+const testErrorJson = `{
+  "name": "not valid",
+  "somethingElse": "534%$3g3gj90n 0o23-=+;[;fd]",
+  "nested": {
+    "value": "[not_valid]"
+  }
+}`;
+
+describe('foorm linting', () => {
+  it("doesn't find errors in valid json", () => {
+    const annotations = lintFoormKeys(testValidJson, {}, fakeCodeMirror);
+    assert(annotations.length === 0);
+  });
+  it('finds errors in bad json', () => {
+    const annotations = lintFoormKeys(testErrorJson, {}, fakeCodeMirror);
+    assert(annotations.length === 2);
+    assert(
+      annotations[1].message ===
+        'Question keys should only contain letters and underscores.'
+    );
+    assert(annotations[0].severity === 'error');
+    assert(
+      annotations[1].message ===
+        'Question keys should only contain letters and underscores.'
+    );
+    assert(annotations[1].severity === 'error');
+  });
+});


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Adds some additional linting validation to the foorm form json editor to prevent "name" and "value" keys from having values outside of alphanumeric and underscores. This stems from an issue where the keys have extra characters stripped away when uploaded to the server.
Functionally, this change hooks into the getAnnotations step of the codeMirror linter, runs the default lint step, and adds additional error messages when needed.

see: [code mirror docs](https://codemirror.net/doc/manual.html#addon_lint)

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [PLC-1200](https://codedotorg.atlassian.net/browse/PLC-1200)

## Testing story

Added some unit tests, and tested manually on localhost.
