### PR TITLE
write helper method to add a level variant

### DIFF
--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -710,6 +710,7 @@ class ScriptLevel < ApplicationRecord
     raise "can only be used on migrated scripts" unless script.is_migrated
     raise "expected 1 existing level but found: #{levels.map(&:key)}" unless levels.count == 1
     raise "expected empty variants property but found #{variants}" if variants
+    raise "cannot add variant to non-custom level" unless levels.first.level_num == 'custom'
     existing_level = levels.first
 
     levels << new_level

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -714,6 +714,7 @@ class ScriptLevel < ApplicationRecord
 
     levels << new_level
     update!(
+      level_keys: levels.map(&:key),
       variants: {
         existing_level.name => {"active" => false}
       }

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -705,4 +705,21 @@ class ScriptLevel < ApplicationRecord
     end
     self.levels = levels
   end
+
+  def add_variant(new_level)
+    raise "can only be used on migrated scripts" unless script.is_migrated
+    raise "expected 1 existing level but found: #{levels.map(&:key)}" unless levels.count == 1
+    raise "expected empty variants property but found #{variants}" if variants
+    existing_level = levels.first
+
+    levels << new_level
+    update!(
+      variants: {
+        existing_level.name => {"active" => false}
+      }
+    )
+    if Rails.application.config.levelbuilder_mode
+      script.write_script_json
+    end
+  end
 end

--- a/dashboard/test/models/script_level_test.rb
+++ b/dashboard/test/models/script_level_test.rb
@@ -815,7 +815,7 @@ class ScriptLevelTest < ActiveSupport::TestCase
     assert_equal 'Validation failed: Script level activity_section.lesson does not match lesson', error.message
   end
 
-  test 'add_variant adds variant level within migrated script' do
+  test 'adds variant to custom level in migrated script' do
     Rails.application.config.stubs(:levelbuilder_mode).returns false
 
     script = create :script, is_migrated: true
@@ -840,6 +840,25 @@ class ScriptLevelTest < ActiveSupport::TestCase
       script_level.add_variant level3
     end
     assert_includes e.message, "expected 1 existing level"
+  end
+
+  # variants do not appear to work for non-custom levels
+  test 'cannot add variant to non custom level' do
+    Rails.application.config.stubs(:levelbuilder_mode).returns false
+
+    script = create :script, is_migrated: true
+    lesson_group = create :lesson_group, script: script
+    lesson = create :lesson, lesson_group: lesson_group, script: script
+    level1 = create :level
+    level2 = create :level
+    script_level = create :script_level, script: script, lesson: lesson, levels: [level1]
+    assert_equal level1, script_level.oldest_active_level
+    assert script_level.active?(level1)
+
+    e = assert_raises do
+      script_level.add_variant level2
+    end
+    assert_equal "cannot add variant to non-custom level", e.message
   end
 
   test 'cannot add variant to legacy script' do

--- a/dashboard/test/models/script_level_test.rb
+++ b/dashboard/test/models/script_level_test.rb
@@ -821,14 +821,16 @@ class ScriptLevelTest < ActiveSupport::TestCase
     script = create :script, is_migrated: true
     lesson_group = create :lesson_group, script: script
     lesson = create :lesson, lesson_group: lesson_group, script: script
-    level1 = create :level
-    level2 = create :level
+    level1 = create :level, level_num: 'custom'
+    level2 = create :level, level_num: 'custom'
     script_level = create :script_level, script: script, lesson: lesson, levels: [level1]
     assert_equal level1, script_level.oldest_active_level
     assert script_level.active?(level1)
 
     script_level.add_variant level2
     script_level.reload
+    assert_equal [level1, level2], script_level.levels
+    assert_equal [level1.key, level2.key], script_level.level_keys
     assert_equal level2, script_level.oldest_active_level
     assert script_level.active?(level2)
     refute script_level.active?(level1)
@@ -846,8 +848,8 @@ class ScriptLevelTest < ActiveSupport::TestCase
     script = create :script
     lesson_group = create :lesson_group, script: script
     lesson = create :lesson, lesson_group: lesson_group, script: script
-    level1 = create :level
-    level2 = create :level
+    level1 = create :level, level_num: 'custom'
+    level2 = create :level, level_num: 'custom'
     script_level = create :script_level, script: script, lesson: lesson, levels: [level1]
     assert_equal level1, script_level.oldest_active_level
 


### PR DESCRIPTION
Starts [PLAT-371]. Because we are short on time for soft launch, this PR adds a way for engineers to add a level variant in the most common scenario, rather than building a way to do it in the levelbuilder UI.

if we need to apply a second variant, or if a variant needed to be removed, an engineer would have to do that manually, or we'd have to add new functionality to a helper method at that time.

From inspecting the code, it looks like variants probably never worked on non-custom levels, because those can only be uniquely identified by key and not just by name: https://github.com/code-dot-org/code-dot-org/blob/dfc3367f0a7253146735d283441dcf2c35a9b911/dashboard/app/models/script_level.rb#L179-L180 so, this PR raises if you try to add a variant to a non-custom level (e.g. `blockly:Jigsaw:1`).

## Testing story

Unit tests verify the behavior of `oldest_active_level`, which is what is used to decide which level to use in [select_level](https://github.com/code-dot-org/code-dot-org/blob/d325873232db4cae15cdf59e3a61656b40c7fa26/dashboard/app/controllers/script_levels_controller.rb#L464-L463) whenever a user views a script level page.

I also manually verified that after running the new helper method, I am directed to the newly specified active level:
1. http://localhost-studio.code.org:3000/s/coursea-2021/lessons/4/levels/2 --> level "courseB_Scrat_ramp1_2021" loads
2. go to `bin/dashboard-console` and enter the following:
```
level_1 = Level.find_by_name('courseB_Scrat_ramp1_2021')
script = Script.find_by_name('coursea-2021')
script_level = level_1.script_levels.find_by!(script: script)
level_2 = Level.find_by_name('Standalone_Artist_1')
script_level.add_variant(level_2)
``` 
3. http://localhost-studio.code.org:3000/s/coursea-2021/lessons/4/levels/2 --> level "Standalone_Artist_1" loads 

## Follow-up work

see [PLAT-371]. more work is needed before the results of this change will survive serialization/seeding, or script/lesson update.

[PLAT-371]: https://codedotorg.atlassian.net/browse/PLAT-371
[PLAT-371]: https://codedotorg.atlassian.net/browse/PLAT-371