### PR TITLE
Preserve level variants when serializing/seeding migrated scripts

### DIFF
--- a/dashboard/app/models/levels_script_level.rb
+++ b/dashboard/app/models/levels_script_level.rb
@@ -27,7 +27,7 @@ class LevelsScriptLevel < ApplicationRecord
   #
   # @param [ScriptSeed::SeedContext] seed_context - contains preloaded data to use when looking up associated objects
   # @return [Hash<String, String] all information needed to uniquely identify this object across environments.
-  def seeding_key(seed_context)
+  def seeding_key(seed_context, use_existing_level_keys = true)
     my_level = seed_context.levels.select {|l| l.id == level_id}.first
     raise "No Level found for #{self.class}: #{inspect}" unless my_level
     # TODO: make this use the SeedContext?
@@ -35,7 +35,7 @@ class LevelsScriptLevel < ApplicationRecord
 
     my_script_level = seed_context.script_levels.select {|sl| sl.id == script_level_id}.first
     raise "No ScriptLevel found for #{self.class}: #{inspect}" unless my_script_level
-    script_level_seeding_key = my_script_level.seeding_key(seed_context)
+    script_level_seeding_key = my_script_level.seeding_key(seed_context, use_existing_level_keys)
 
     my_key.merge!(script_level_seeding_key) {|key, _, _| raise "Duplicate key when generating seeding_key: #{key}"}
     my_key = my_key.stringify_keys

--- a/dashboard/lib/services/script_seed.rb
+++ b/dashboard/lib/services/script_seed.rb
@@ -791,7 +791,7 @@ module Services
       def seeding_key
         # Just in case the data stored in the level_keys property is out of sync somehow,
         # don't use that data during serialization.
-        object.seeding_key(@scope[:seed_context], use_existing_level_keys: false)
+        object.seeding_key(@scope[:seed_context], false)
       end
 
       def level_keys
@@ -799,7 +799,7 @@ module Services
         # when seeding LevelsScriptLevels.
         # Just in case the data stored in the level_keys property is out of sync somehow,
         # don't use that data during serialization.
-        object.get_level_keys(@scope[:seed_context], use_existing_level_keys: false)
+        object.get_level_keys(@scope[:seed_context], false)
       end
     end
 
@@ -807,7 +807,7 @@ module Services
       attributes :seeding_key
 
       def seeding_key
-        object.seeding_key(@scope[:seed_context])
+        object.seeding_key(@scope[:seed_context], false)
       end
     end
 

--- a/dashboard/test/fixtures/test-serialize-seeding-json.script_json
+++ b/dashboard/test/fixtures/test-serialize-seeding-json.script_json
@@ -221,7 +221,7 @@
       "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
-          "blockly:test-serialize-seeding-json_game1:1_2_1"
+          "test-serialize-seeding-json_blockly_1"
         ],
         "lesson.key": "test-serialize-seeding-json-lg-1-l-1",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
@@ -229,7 +229,7 @@
         "activity_section.key": "test-serialize-seeding-json-lg-1-l-1-a-1-s-1"
       },
       "level_keys": [
-        "blockly:test-serialize-seeding-json_game1:1_2_1"
+        "test-serialize-seeding-json_blockly_1"
       ]
     },
     {
@@ -244,7 +244,7 @@
       "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
-          "blockly:test-serialize-seeding-json_game2:1_2_2"
+          "test-serialize-seeding-json_blockly_2"
         ],
         "lesson.key": "test-serialize-seeding-json-lg-1-l-1",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
@@ -252,7 +252,7 @@
         "activity_section.key": "test-serialize-seeding-json-lg-1-l-1-a-1-s-1"
       },
       "level_keys": [
-        "blockly:test-serialize-seeding-json_game2:1_2_2"
+        "test-serialize-seeding-json_blockly_2"
       ]
     },
     {
@@ -266,7 +266,7 @@
       "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
-          "blockly:test-serialize-seeding-json_game3:1_2_3"
+          "test-serialize-seeding-json_blockly_3"
         ],
         "lesson.key": "test-serialize-seeding-json-lg-1-l-1",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
@@ -274,7 +274,7 @@
         "activity_section.key": "test-serialize-seeding-json-lg-1-l-1-a-1-s-2"
       },
       "level_keys": [
-        "blockly:test-serialize-seeding-json_game3:1_2_3"
+        "test-serialize-seeding-json_blockly_3"
       ]
     },
     {
@@ -289,7 +289,7 @@
       "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
-          "blockly:test-serialize-seeding-json_game4:1_2_4"
+          "test-serialize-seeding-json_blockly_4"
         ],
         "lesson.key": "test-serialize-seeding-json-lg-1-l-1",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
@@ -297,7 +297,7 @@
         "activity_section.key": "test-serialize-seeding-json-lg-1-l-1-a-1-s-2"
       },
       "level_keys": [
-        "blockly:test-serialize-seeding-json_game4:1_2_4"
+        "test-serialize-seeding-json_blockly_4"
       ]
     },
     {
@@ -311,7 +311,7 @@
       "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
-          "blockly:test-serialize-seeding-json_game5:1_2_5"
+          "test-serialize-seeding-json_blockly_5"
         ],
         "lesson.key": "test-serialize-seeding-json-lg-1-l-1",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
@@ -319,7 +319,7 @@
         "activity_section.key": "test-serialize-seeding-json-lg-1-l-1-a-2-s-1"
       },
       "level_keys": [
-        "blockly:test-serialize-seeding-json_game5:1_2_5"
+        "test-serialize-seeding-json_blockly_5"
       ]
     },
     {
@@ -334,7 +334,7 @@
       "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
-          "blockly:test-serialize-seeding-json_game6:1_2_6"
+          "test-serialize-seeding-json_blockly_6"
         ],
         "lesson.key": "test-serialize-seeding-json-lg-1-l-1",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
@@ -342,7 +342,7 @@
         "activity_section.key": "test-serialize-seeding-json-lg-1-l-1-a-2-s-1"
       },
       "level_keys": [
-        "blockly:test-serialize-seeding-json_game6:1_2_6"
+        "test-serialize-seeding-json_blockly_6"
       ]
     },
     {
@@ -356,7 +356,7 @@
       "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
-          "blockly:test-serialize-seeding-json_game7:1_2_7"
+          "test-serialize-seeding-json_blockly_7"
         ],
         "lesson.key": "test-serialize-seeding-json-lg-1-l-1",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
@@ -364,7 +364,7 @@
         "activity_section.key": "test-serialize-seeding-json-lg-1-l-1-a-2-s-2"
       },
       "level_keys": [
-        "blockly:test-serialize-seeding-json_game7:1_2_7"
+        "test-serialize-seeding-json_blockly_7"
       ]
     },
     {
@@ -379,7 +379,7 @@
       "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
-          "blockly:test-serialize-seeding-json_game8:1_2_8"
+          "test-serialize-seeding-json_blockly_8"
         ],
         "lesson.key": "test-serialize-seeding-json-lg-1-l-1",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
@@ -387,7 +387,7 @@
         "activity_section.key": "test-serialize-seeding-json-lg-1-l-1-a-2-s-2"
       },
       "level_keys": [
-        "blockly:test-serialize-seeding-json_game8:1_2_8"
+        "test-serialize-seeding-json_blockly_8"
       ]
     },
     {
@@ -401,7 +401,7 @@
       "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
-          "blockly:test-serialize-seeding-json_game9:1_2_9"
+          "test-serialize-seeding-json_blockly_9"
         ],
         "lesson.key": "test-serialize-seeding-json-lg-1-l-2",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
@@ -409,7 +409,7 @@
         "activity_section.key": "test-serialize-seeding-json-lg-1-l-2-a-1-s-1"
       },
       "level_keys": [
-        "blockly:test-serialize-seeding-json_game9:1_2_9"
+        "test-serialize-seeding-json_blockly_9"
       ]
     },
     {
@@ -424,7 +424,7 @@
       "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
-          "blockly:test-serialize-seeding-json_game10:1_2_10"
+          "test-serialize-seeding-json_blockly_10"
         ],
         "lesson.key": "test-serialize-seeding-json-lg-1-l-2",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
@@ -432,7 +432,7 @@
         "activity_section.key": "test-serialize-seeding-json-lg-1-l-2-a-1-s-1"
       },
       "level_keys": [
-        "blockly:test-serialize-seeding-json_game10:1_2_10"
+        "test-serialize-seeding-json_blockly_10"
       ]
     },
     {
@@ -446,7 +446,7 @@
       "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
-          "blockly:test-serialize-seeding-json_game11:1_2_11"
+          "test-serialize-seeding-json_blockly_11"
         ],
         "lesson.key": "test-serialize-seeding-json-lg-1-l-2",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
@@ -454,7 +454,7 @@
         "activity_section.key": "test-serialize-seeding-json-lg-1-l-2-a-1-s-2"
       },
       "level_keys": [
-        "blockly:test-serialize-seeding-json_game11:1_2_11"
+        "test-serialize-seeding-json_blockly_11"
       ]
     },
     {
@@ -469,7 +469,7 @@
       "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
-          "blockly:test-serialize-seeding-json_game12:1_2_12"
+          "test-serialize-seeding-json_blockly_12"
         ],
         "lesson.key": "test-serialize-seeding-json-lg-1-l-2",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
@@ -477,7 +477,7 @@
         "activity_section.key": "test-serialize-seeding-json-lg-1-l-2-a-1-s-2"
       },
       "level_keys": [
-        "blockly:test-serialize-seeding-json_game12:1_2_12"
+        "test-serialize-seeding-json_blockly_12"
       ]
     },
     {
@@ -491,7 +491,7 @@
       "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
-          "blockly:test-serialize-seeding-json_game13:1_2_13"
+          "test-serialize-seeding-json_blockly_13"
         ],
         "lesson.key": "test-serialize-seeding-json-lg-1-l-2",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
@@ -499,7 +499,7 @@
         "activity_section.key": "test-serialize-seeding-json-lg-1-l-2-a-2-s-1"
       },
       "level_keys": [
-        "blockly:test-serialize-seeding-json_game13:1_2_13"
+        "test-serialize-seeding-json_blockly_13"
       ]
     },
     {
@@ -514,7 +514,7 @@
       "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
-          "blockly:test-serialize-seeding-json_game14:1_2_14"
+          "test-serialize-seeding-json_blockly_14"
         ],
         "lesson.key": "test-serialize-seeding-json-lg-1-l-2",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
@@ -522,7 +522,7 @@
         "activity_section.key": "test-serialize-seeding-json-lg-1-l-2-a-2-s-1"
       },
       "level_keys": [
-        "blockly:test-serialize-seeding-json_game14:1_2_14"
+        "test-serialize-seeding-json_blockly_14"
       ]
     },
     {
@@ -536,7 +536,7 @@
       "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
-          "blockly:test-serialize-seeding-json_game15:1_2_15"
+          "test-serialize-seeding-json_blockly_15"
         ],
         "lesson.key": "test-serialize-seeding-json-lg-1-l-2",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
@@ -544,7 +544,7 @@
         "activity_section.key": "test-serialize-seeding-json-lg-1-l-2-a-2-s-2"
       },
       "level_keys": [
-        "blockly:test-serialize-seeding-json_game15:1_2_15"
+        "test-serialize-seeding-json_blockly_15"
       ]
     },
     {
@@ -559,7 +559,7 @@
       "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
-          "blockly:test-serialize-seeding-json_game16:1_2_16"
+          "test-serialize-seeding-json_blockly_16"
         ],
         "lesson.key": "test-serialize-seeding-json-lg-1-l-2",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
@@ -567,16 +567,16 @@
         "activity_section.key": "test-serialize-seeding-json-lg-1-l-2-a-2-s-2"
       },
       "level_keys": [
-        "blockly:test-serialize-seeding-json_game16:1_2_16"
+        "test-serialize-seeding-json_blockly_16"
       ]
     }
   ],
   "levels_script_levels": [
     {
       "seeding_key": {
-        "level.key": "blockly:test-serialize-seeding-json_game1:1_2_1",
+        "level.key": "test-serialize-seeding-json_blockly_1",
         "script_level.level_keys": [
-          "blockly:test-serialize-seeding-json_game1:1_2_1"
+          "test-serialize-seeding-json_blockly_1"
         ],
         "lesson.key": "test-serialize-seeding-json-lg-1-l-1",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
@@ -586,9 +586,9 @@
     },
     {
       "seeding_key": {
-        "level.key": "blockly:test-serialize-seeding-json_game2:1_2_2",
+        "level.key": "test-serialize-seeding-json_blockly_2",
         "script_level.level_keys": [
-          "blockly:test-serialize-seeding-json_game2:1_2_2"
+          "test-serialize-seeding-json_blockly_2"
         ],
         "lesson.key": "test-serialize-seeding-json-lg-1-l-1",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
@@ -598,9 +598,9 @@
     },
     {
       "seeding_key": {
-        "level.key": "blockly:test-serialize-seeding-json_game3:1_2_3",
+        "level.key": "test-serialize-seeding-json_blockly_3",
         "script_level.level_keys": [
-          "blockly:test-serialize-seeding-json_game3:1_2_3"
+          "test-serialize-seeding-json_blockly_3"
         ],
         "lesson.key": "test-serialize-seeding-json-lg-1-l-1",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
@@ -610,9 +610,9 @@
     },
     {
       "seeding_key": {
-        "level.key": "blockly:test-serialize-seeding-json_game4:1_2_4",
+        "level.key": "test-serialize-seeding-json_blockly_4",
         "script_level.level_keys": [
-          "blockly:test-serialize-seeding-json_game4:1_2_4"
+          "test-serialize-seeding-json_blockly_4"
         ],
         "lesson.key": "test-serialize-seeding-json-lg-1-l-1",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
@@ -622,9 +622,9 @@
     },
     {
       "seeding_key": {
-        "level.key": "blockly:test-serialize-seeding-json_game5:1_2_5",
+        "level.key": "test-serialize-seeding-json_blockly_5",
         "script_level.level_keys": [
-          "blockly:test-serialize-seeding-json_game5:1_2_5"
+          "test-serialize-seeding-json_blockly_5"
         ],
         "lesson.key": "test-serialize-seeding-json-lg-1-l-1",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
@@ -634,9 +634,9 @@
     },
     {
       "seeding_key": {
-        "level.key": "blockly:test-serialize-seeding-json_game6:1_2_6",
+        "level.key": "test-serialize-seeding-json_blockly_6",
         "script_level.level_keys": [
-          "blockly:test-serialize-seeding-json_game6:1_2_6"
+          "test-serialize-seeding-json_blockly_6"
         ],
         "lesson.key": "test-serialize-seeding-json-lg-1-l-1",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
@@ -646,9 +646,9 @@
     },
     {
       "seeding_key": {
-        "level.key": "blockly:test-serialize-seeding-json_game7:1_2_7",
+        "level.key": "test-serialize-seeding-json_blockly_7",
         "script_level.level_keys": [
-          "blockly:test-serialize-seeding-json_game7:1_2_7"
+          "test-serialize-seeding-json_blockly_7"
         ],
         "lesson.key": "test-serialize-seeding-json-lg-1-l-1",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
@@ -658,9 +658,9 @@
     },
     {
       "seeding_key": {
-        "level.key": "blockly:test-serialize-seeding-json_game8:1_2_8",
+        "level.key": "test-serialize-seeding-json_blockly_8",
         "script_level.level_keys": [
-          "blockly:test-serialize-seeding-json_game8:1_2_8"
+          "test-serialize-seeding-json_blockly_8"
         ],
         "lesson.key": "test-serialize-seeding-json-lg-1-l-1",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
@@ -670,9 +670,9 @@
     },
     {
       "seeding_key": {
-        "level.key": "blockly:test-serialize-seeding-json_game9:1_2_9",
+        "level.key": "test-serialize-seeding-json_blockly_9",
         "script_level.level_keys": [
-          "blockly:test-serialize-seeding-json_game9:1_2_9"
+          "test-serialize-seeding-json_blockly_9"
         ],
         "lesson.key": "test-serialize-seeding-json-lg-1-l-2",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
@@ -682,9 +682,9 @@
     },
     {
       "seeding_key": {
-        "level.key": "blockly:test-serialize-seeding-json_game10:1_2_10",
+        "level.key": "test-serialize-seeding-json_blockly_10",
         "script_level.level_keys": [
-          "blockly:test-serialize-seeding-json_game10:1_2_10"
+          "test-serialize-seeding-json_blockly_10"
         ],
         "lesson.key": "test-serialize-seeding-json-lg-1-l-2",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
@@ -694,9 +694,9 @@
     },
     {
       "seeding_key": {
-        "level.key": "blockly:test-serialize-seeding-json_game11:1_2_11",
+        "level.key": "test-serialize-seeding-json_blockly_11",
         "script_level.level_keys": [
-          "blockly:test-serialize-seeding-json_game11:1_2_11"
+          "test-serialize-seeding-json_blockly_11"
         ],
         "lesson.key": "test-serialize-seeding-json-lg-1-l-2",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
@@ -706,9 +706,9 @@
     },
     {
       "seeding_key": {
-        "level.key": "blockly:test-serialize-seeding-json_game12:1_2_12",
+        "level.key": "test-serialize-seeding-json_blockly_12",
         "script_level.level_keys": [
-          "blockly:test-serialize-seeding-json_game12:1_2_12"
+          "test-serialize-seeding-json_blockly_12"
         ],
         "lesson.key": "test-serialize-seeding-json-lg-1-l-2",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
@@ -718,9 +718,9 @@
     },
     {
       "seeding_key": {
-        "level.key": "blockly:test-serialize-seeding-json_game13:1_2_13",
+        "level.key": "test-serialize-seeding-json_blockly_13",
         "script_level.level_keys": [
-          "blockly:test-serialize-seeding-json_game13:1_2_13"
+          "test-serialize-seeding-json_blockly_13"
         ],
         "lesson.key": "test-serialize-seeding-json-lg-1-l-2",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
@@ -730,9 +730,9 @@
     },
     {
       "seeding_key": {
-        "level.key": "blockly:test-serialize-seeding-json_game14:1_2_14",
+        "level.key": "test-serialize-seeding-json_blockly_14",
         "script_level.level_keys": [
-          "blockly:test-serialize-seeding-json_game14:1_2_14"
+          "test-serialize-seeding-json_blockly_14"
         ],
         "lesson.key": "test-serialize-seeding-json-lg-1-l-2",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
@@ -742,9 +742,9 @@
     },
     {
       "seeding_key": {
-        "level.key": "blockly:test-serialize-seeding-json_game15:1_2_15",
+        "level.key": "test-serialize-seeding-json_blockly_15",
         "script_level.level_keys": [
-          "blockly:test-serialize-seeding-json_game15:1_2_15"
+          "test-serialize-seeding-json_blockly_15"
         ],
         "lesson.key": "test-serialize-seeding-json-lg-1-l-2",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
@@ -754,9 +754,9 @@
     },
     {
       "seeding_key": {
-        "level.key": "blockly:test-serialize-seeding-json_game16:1_2_16",
+        "level.key": "test-serialize-seeding-json_blockly_16",
         "script_level.level_keys": [
-          "blockly:test-serialize-seeding-json_game16:1_2_16"
+          "test-serialize-seeding-json_blockly_16"
         ],
         "lesson.key": "test-serialize-seeding-json-lg-1-l-2",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",

--- a/dashboard/test/lib/services/script_seed_test.rb
+++ b/dashboard/test/lib/services/script_seed_test.rb
@@ -82,14 +82,13 @@ module Services
       #   2 queries, one to remove LessonsOpportunityStandards from each Lesson.
       #   1 query to get all the programming environments
       #   1 query to get all the standards frameworks
-      #   17 queries, 1 to populate the Game.by_name cache, and 16 to look up Game objects by id.
       #   1 query to check for a CourseOffering. (Would be a few more if is_course was true)
       # LevelsScriptLevels has queries which scale linearly with the number of rows.
       # As far as I know, to get rid of those queries per row, we'd need to load all Levels into memory. I think
       # this is slower for most individual Scripts, but there could be a savings when seeding multiple Scripts.
       # For now, leaving this as a potential future optimization, since it seems to be reasonably fast as is.
       # The game queries can probably be avoided with a little work, though they only apply for Blockly levels.
-      assert_queries(102) do
+      assert_queries(85) do
         ScriptSeed.seed_from_json(json)
       end
 
@@ -1085,7 +1084,7 @@ module Services
             )
             (1..num_script_levels_per_section).each do |sl_pos|
               game = create :game, name: "#{name_prefix}_game#{sl_num}"
-              level = create :level, name: "#{name_prefix}_blockly_#{sl_num}", level_num: "1_2_#{sl_num}", game: game
+              level = create :level, name: "#{name_prefix}_blockly_#{sl_num}", level_num: "custom", game: game
               create :script_level, activity_section: section, activity_section_position: sl_pos,
                      lesson: lesson, script: script, levels: [level], challenge: sl_num.even?,
                      assessment: false, bonus: false, named_level: false

--- a/dashboard/test/lib/services/script_seed_test.rb
+++ b/dashboard/test/lib/services/script_seed_test.rb
@@ -600,7 +600,6 @@ module Services
     test 'seed deletes script_levels' do
       script = create_script_tree
       original_counts = get_counts
-      original_script_level_ids = script.script_levels.map(&:id)
 
       script_with_deletion, json = get_script_and_json_with_change_and_rollback(script) do
         script.script_levels.first.destroy!
@@ -619,8 +618,6 @@ module Services
       expected_counts['ScriptLevel'] -= 1
       expected_counts['LevelsScriptLevel'] -= 1
       assert_equal expected_counts, get_counts
-      # We need to preserve the script level ids of the remaining script levels, since teacher feedbacks reference them.
-      assert_equal original_script_level_ids.slice(1, original_script_level_ids.length), script.script_levels.map(&:id)
     end
 
     # Resources are owned by the course version. We need to make sure all the


### PR DESCRIPTION
Step 2/4 for [PLAT-371]. Depends on https://github.com/code-dot-org/code-dot-org/pull/40564. There was no actual implementation work to do here, because level variants live within script_levels properties as well levels_script_levels, both of which are already handled by our serialization/seeding code. So all I did was add tests and fix bugs in our existing implementation. I also changed the levels used by the serialization/seeding tests to be "custom" levels, which are the type of all our levels not defined in levels.js files.

## Testing story

new unit tests cover adding and removing variants via serialization and seeding. I also manually verified that adding/removing variants could be safely propagated from levelbuilder to other environments as follows:
1. use `script_level.add_variant` to add a variant to a level. verify resulting changes to script_json
2. `git stash` any resulting changes to script_json
3. `rake seed:single_script` to update the database from what's in script_json. this tests removing level variants via script seed. verify via `script_level.oldest_active_level` that the original level is now active
4. `git stash pop`, restoring changes to script json containing level variants
5. `rake seed:single_script`. this tests adding level variants via script seed.  verify via `script_level.oldest_active_level` that the level added via `script_level.add_variant` is now active

[PLAT-371]: https://codedotorg.atlassian.net/browse/PLAT-371