### PR TITLE
Set Redshift maintenance window to a timeslot that doesn't conflict with daily import

### DIFF
--- a/aws/cloudformation/data.yml.erb
+++ b/aws/cloudformation/data.yml.erb
@@ -60,6 +60,9 @@ Resources:
       MasterUsername: {Ref: RedshiftUsername}
       MasterUserPassword: {Ref: RedshiftPassword}
       NodeType: dc1.large
+      # This maintenance can interfere with the daily export from MySQL to Redshift which starts at 02:00 UTC, so set it
+      # to start at least 1 hour before the export begins (it typically takes 15 minutes).
+      PreferredMaintenanceWindow: 'Tue:01:00-Tue:01:30'
       PubliclyAccessible: true
       VpcSecurityGroupIds: [!ImportValue VPC-RedshiftSecurityGroup]
   TableauSync:


### PR DESCRIPTION
For the last few weeks, the daily export from the production MySQL database to Redshift has failed each Wednesday morning (PDT). See [Slack discussion](https://codedotorg.slack.com/archives/C0SUN2W3D/p1620843048161700).

Analysis of Database Migration Service logs in CloudWatch indicates that the root cause is that the Redshift cluster's [maintenance window was set](https://console.aws.amazon.com/redshiftv2/home?region=us-east-1#cluster-details?cluster=data-production-tableau-1em9qvcugvhev&tab=maintenance) (randomly by the AWS Redshift service) to Tue 21:00-21:30 PDT (Wed 04:00-04:30 UTC), interrupting the daily export which is [configured to start at 02:00 UTC each day](https://github.com/code-dot-org/code-dot-org/blob/643004904993b71627de2b11831c0557abfddf5e/cookbooks/cdo-apps/templates/default/crontab.erb#L105). [Redshift Event logs indicate](https://console.aws.amazon.com/redshiftv2/home?region=us-east-1#events) that the maintenance typically takes ~15 minutes, so explicitly setting the maintenance window to Tue 01:00-01:30 UTC should ensure weekly maintenance is complete before daily data import process starts.





## Links


## Testing story

```
$ bundle exec rake stack:data:validate RAILS_ENV=production

Pending update for stack `DATA-production`:
Modify DMSCronLevelSourcesPii [AWS::DMS::ReplicationTask] Properties Replacement: Conditional (TargetEndpointArn)
Modify DMSCronPii [AWS::DMS::ReplicationTask] Properties Replacement: Conditional (TargetEndpointArn, TableMappings)
Modify DMSCronUserHierarchyPii [AWS::DMS::ReplicationTask] Properties Replacement: Conditional (TargetEndpointArn)
Modify DMSCronUserHierarchy [AWS::DMS::ReplicationTask] Properties Replacement: Conditional (TargetEndpointArn)
Modify DMSCronUserLevels [AWS::DMS::ReplicationTask] Properties Replacement: Conditional (TargetEndpointArn)
Modify DMSCron [AWS::DMS::ReplicationTask] Properties Replacement: Conditional (TargetEndpointArn)
Modify RedshiftEndpoint [AWS::DMS::Endpoint] Properties Replacement: Conditional (ServerName, Port)
Modify Tableau [AWS::Redshift::Cluster] Properties (PreferredMaintenanceWindow)
```

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
