### PR TITLE
Add Validation option to start sources edit page, javalab redux

### DIFF
--- a/apps/src/javalab/JavalabEditor.jsx
+++ b/apps/src/javalab/JavalabEditor.jsx
@@ -4,6 +4,7 @@ import Radium from 'radium';
 import {
   setSource,
   sourceVisibilityUpdated,
+  sourceValidationUpdated,
   renameFile,
   removeFile
 } from './javalabRedux';
@@ -65,6 +66,7 @@ class JavalabEditor extends React.Component {
     // populated by redux
     setSource: PropTypes.func,
     sourceVisibilityUpdated: PropTypes.func,
+    sourceValidationUpdated: PropTypes.func,
     renameFile: PropTypes.func,
     removeFile: PropTypes.func,
     sources: PropTypes.object,
@@ -87,6 +89,7 @@ class JavalabEditor extends React.Component {
     this.onDeleteFile = this.onDeleteFile.bind(this);
     this.onOpenFile = this.onOpenFile.bind(this);
     this.toggleFileVisibility = this.toggleFileVisibility.bind(this);
+    this.makeeValidationFile = this.makeValidationFile.bind(this);
     this._codeMirrors = {};
 
     // fileMetadata is a dictionary of file key -> filename.
@@ -193,7 +196,21 @@ class JavalabEditor extends React.Component {
   toggleFileVisibility(key) {
     this.props.sourceVisibilityUpdated(
       this.state.fileMetadata[key],
-      !this.props.sources[this.state.fileMetadata[key]].visible
+      !this.props.sources[this.state.fileMetadata[key]].visible,
+      false
+    );
+    this.setState({
+      showMenu: false,
+      contextTarget: null
+    });
+  }
+
+  // This will only ever be called when making a file a validation file
+  makeValidationFile(key) {
+    this.props.sourceValidationUpdated(
+      this.state.fileMetadata[key],
+      false,
+      true
     );
     this.setState({
       showMenu: false,
@@ -474,6 +491,8 @@ class JavalabEditor extends React.Component {
                         icon={
                           sources[fileMetadata[tabKey]].visible
                             ? 'eye'
+                            : sources[fileMetadata[tabKey]].isValidationFile
+                            ? 'flask'
                             : 'eye-slash'
                         }
                       />
@@ -531,6 +550,13 @@ class JavalabEditor extends React.Component {
               sources[fileMetadata[activeTabKey]] &&
               sources[fileMetadata[activeTabKey]].visible
             }
+            fileIsValidation={
+              sources[fileMetadata[activeTabKey]] &&
+              sources[fileMetadata[activeTabKey]].isValidationFile
+            }
+            changeValidationFromTabMenu={() =>
+              this.makeValidationFile(activeTabKey)
+            }
           />
         </div>
         <DeleteConfirmationDialog
@@ -576,8 +602,10 @@ export default connect(
   }),
   dispatch => ({
     setSource: (filename, source) => dispatch(setSource(filename, source)),
-    sourceVisibilityUpdated: (filename, isVisible) =>
-      dispatch(sourceVisibilityUpdated(filename, isVisible)),
+    sourceVisibilityUpdated: (filename, isVisible, isValidationFile) =>
+      dispatch(sourceVisibilityUpdated(filename, isVisible, isValidationFile)),
+    sourceValidationUpdated: (filename, isVisible, isValidationFile) =>
+      dispatch(sourceValidationUpdated(filename, isVisible, isValidationFile)),
     renameFile: (oldFilename, newFilename) =>
       dispatch(renameFile(oldFilename, newFilename)),
     removeFile: filename => dispatch(removeFile(filename))

--- a/apps/src/javalab/JavalabEditor.jsx
+++ b/apps/src/javalab/JavalabEditor.jsx
@@ -90,6 +90,7 @@ class JavalabEditor extends React.Component {
     this.onOpenFile = this.onOpenFile.bind(this);
     this.updateVisibility = this.updateVisibility.bind(this);
     this.updateValidation = this.updateValidation.bind(this);
+    this.updateFileType = this.updateFileType.bind(this);
     this._codeMirrors = {};
 
     // fileMetadata is a dictionary of file key -> filename.
@@ -210,6 +211,11 @@ class JavalabEditor extends React.Component {
       showMenu: false,
       contextTarget: null
     });
+  }
+
+  updateFileType(key, isVisible, isValidation) {
+    this.updateVisibility(key, isVisible);
+    this.updateValidation(key, isValidation);
   }
 
   getTabKey(index) {
@@ -536,8 +542,8 @@ class JavalabEditor extends React.Component {
             cancelTabMenu={this.cancelTabMenu}
             renameFromTabMenu={this.renameFromTabMenu}
             deleteFromTabMenu={this.deleteFromTabMenu}
-            changeVisibilityFromTabMenu={isVisible =>
-              this.updateVisibility(activeTabKey, isVisible)
+            changeFileTypeFromTabMenu={(isVisible, isValidation) =>
+              this.updateFileType(activeTabKey, isVisible, isValidation)
             }
             showVisibilityOption={isEditingStartSources}
             fileIsVisible={
@@ -547,9 +553,6 @@ class JavalabEditor extends React.Component {
             fileIsValidation={
               sources[fileMetadata[activeTabKey]] &&
               sources[fileMetadata[activeTabKey]].isValidation
-            }
-            changeValidationFromTabMenu={isValidation =>
-              this.updateValidation(activeTabKey, isValidation)
             }
           />
         </div>

--- a/apps/src/javalab/JavalabEditor.jsx
+++ b/apps/src/javalab/JavalabEditor.jsx
@@ -88,8 +88,8 @@ class JavalabEditor extends React.Component {
     this.onCreateFile = this.onCreateFile.bind(this);
     this.onDeleteFile = this.onDeleteFile.bind(this);
     this.onOpenFile = this.onOpenFile.bind(this);
-    this.toggleFileVisibility = this.toggleFileVisibility.bind(this);
-    this.makeeValidationFile = this.makeValidationFile.bind(this);
+    this.updateVisibility = this.updateVisibility.bind(this);
+    this.updateValidation = this.updateValidation.bind(this);
     this._codeMirrors = {};
 
     // fileMetadata is a dictionary of file key -> filename.
@@ -97,7 +97,7 @@ class JavalabEditor extends React.Component {
     // tab order is an ordered list of file keys.
     let orderedTabKeys = [];
     Object.keys(props.sources).forEach((file, index) => {
-      if (props.sources[file].visible || props.isEditingStartSources) {
+      if (props.sources[file].isVisible || props.isEditingStartSources) {
         let tabKey = this.getTabKey(index);
         fileMetadata[tabKey] = file;
         orderedTabKeys.push(tabKey);
@@ -193,24 +193,18 @@ class JavalabEditor extends React.Component {
     };
   };
 
-  toggleFileVisibility(key) {
-    this.props.sourceVisibilityUpdated(
-      this.state.fileMetadata[key],
-      !this.props.sources[this.state.fileMetadata[key]].visible,
-      false
-    );
+  updateVisibility(key, isVisible) {
+    this.props.sourceVisibilityUpdated(this.state.fileMetadata[key], isVisible);
     this.setState({
       showMenu: false,
       contextTarget: null
     });
   }
 
-  // This will only ever be called when making a file a validation file
-  makeValidationFile(key) {
+  updateValidation(key, isValidation) {
     this.props.sourceValidationUpdated(
       this.state.fileMetadata[key],
-      false,
-      true
+      isValidation
     );
     this.setState({
       showMenu: false,
@@ -489,9 +483,9 @@ class JavalabEditor extends React.Component {
                       <FontAwesome
                         style={style.fileTypeIcon}
                         icon={
-                          sources[fileMetadata[tabKey]].visible
+                          sources[fileMetadata[tabKey]].isVisible
                             ? 'eye'
-                            : sources[fileMetadata[tabKey]].isValidationFile
+                            : sources[fileMetadata[tabKey]].isValidation
                             ? 'flask'
                             : 'eye-slash'
                         }
@@ -542,20 +536,20 @@ class JavalabEditor extends React.Component {
             cancelTabMenu={this.cancelTabMenu}
             renameFromTabMenu={this.renameFromTabMenu}
             deleteFromTabMenu={this.deleteFromTabMenu}
-            changeVisibilityFromTabMenu={() =>
-              this.toggleFileVisibility(activeTabKey)
+            changeVisibilityFromTabMenu={isVisible =>
+              this.updateVisibility(activeTabKey, isVisible)
             }
             showVisibilityOption={isEditingStartSources}
             fileIsVisible={
               sources[fileMetadata[activeTabKey]] &&
-              sources[fileMetadata[activeTabKey]].visible
+              sources[fileMetadata[activeTabKey]].isVisible
             }
             fileIsValidation={
               sources[fileMetadata[activeTabKey]] &&
-              sources[fileMetadata[activeTabKey]].isValidationFile
+              sources[fileMetadata[activeTabKey]].isValidation
             }
-            changeValidationFromTabMenu={() =>
-              this.makeValidationFile(activeTabKey)
+            changeValidationFromTabMenu={isValidation =>
+              this.updateValidation(activeTabKey, isValidation)
             }
           />
         </div>
@@ -602,10 +596,10 @@ export default connect(
   }),
   dispatch => ({
     setSource: (filename, source) => dispatch(setSource(filename, source)),
-    sourceVisibilityUpdated: (filename, isVisible, isValidationFile) =>
-      dispatch(sourceVisibilityUpdated(filename, isVisible, isValidationFile)),
-    sourceValidationUpdated: (filename, isVisible, isValidationFile) =>
-      dispatch(sourceValidationUpdated(filename, isVisible, isValidationFile)),
+    sourceVisibilityUpdated: (filename, isVisible) =>
+      dispatch(sourceVisibilityUpdated(filename, isVisible)),
+    sourceValidationUpdated: (filename, isValidation) =>
+      dispatch(sourceValidationUpdated(filename, isValidation)),
     renameFile: (oldFilename, newFilename) =>
       dispatch(renameFile(oldFilename, newFilename)),
     removeFile: filename => dispatch(removeFile(filename))

--- a/apps/src/javalab/JavalabEditorTabMenu.jsx
+++ b/apps/src/javalab/JavalabEditorTabMenu.jsx
@@ -53,7 +53,7 @@ class JavalabTabMenuComponent extends Component {
         {showVisibilityOption && !fileIsVisible && (
           <button
             type="button"
-            key="visibility"
+            key="starter"
             onClick={() => {
               changeFileTypeFromTabMenu(
                 true /*isVisible*/,

--- a/apps/src/javalab/JavalabEditorTabMenu.jsx
+++ b/apps/src/javalab/JavalabEditorTabMenu.jsx
@@ -12,8 +12,7 @@ class JavalabTabMenuComponent extends Component {
     cancelTabMenu: PropTypes.func.isRequired,
     renameFromTabMenu: PropTypes.func.isRequired,
     deleteFromTabMenu: PropTypes.func.isRequired,
-    changeVisibilityFromTabMenu: PropTypes.func.isRequired,
-    changeValidationFromTabMenu: PropTypes.func.isRequired,
+    changeFileTypeFromTabMenu: PropTypes.func.isRequired,
     showVisibilityOption: PropTypes.bool.isRequired,
     fileIsVisible: PropTypes.bool,
     fileIsValidation: PropTypes.bool
@@ -29,8 +28,7 @@ class JavalabTabMenuComponent extends Component {
       deleteFromTabMenu,
       cancelTabMenu,
       showVisibilityOption,
-      changeVisibilityFromTabMenu,
-      changeValidationFromTabMenu,
+      changeFileTypeFromTabMenu,
       fileIsVisible,
       fileIsValidation
     } = this.props;
@@ -57,8 +55,10 @@ class JavalabTabMenuComponent extends Component {
             type="button"
             key="visibility"
             onClick={() => {
-              changeVisibilityFromTabMenu(true);
-              changeValidationFromTabMenu(false);
+              changeFileTypeFromTabMenu(
+                true /*isVisible*/,
+                false /*isValidation*/
+              );
             }}
             style={styles.anchor}
           >
@@ -70,8 +70,10 @@ class JavalabTabMenuComponent extends Component {
             type="button"
             key="support"
             onClick={() => {
-              changeVisibilityFromTabMenu(false);
-              changeValidationFromTabMenu(false);
+              changeFileTypeFromTabMenu(
+                false /*isVisible*/,
+                false /*isValidation*/
+              );
             }}
             style={styles.anchor}
           >
@@ -83,8 +85,10 @@ class JavalabTabMenuComponent extends Component {
             type="button"
             key="validation"
             onClick={() => {
-              changeVisibilityFromTabMenu(false);
-              changeValidationFromTabMenu(true);
+              changeFileTypeFromTabMenu(
+                false /*isVisible*/,
+                true /*isValidation*/
+              );
             }}
             style={styles.anchor}
           >

--- a/apps/src/javalab/JavalabEditorTabMenu.jsx
+++ b/apps/src/javalab/JavalabEditorTabMenu.jsx
@@ -13,8 +13,10 @@ class JavalabTabMenuComponent extends Component {
     renameFromTabMenu: PropTypes.func.isRequired,
     deleteFromTabMenu: PropTypes.func.isRequired,
     changeVisibilityFromTabMenu: PropTypes.func.isRequired,
+    changeValidationFromTabMenu: PropTypes.func.isRequired,
     showVisibilityOption: PropTypes.bool.isRequired,
-    fileIsVisible: PropTypes.bool
+    fileIsVisible: PropTypes.bool,
+    fileIsValidation: PropTypes.bool
   };
 
   state = {
@@ -28,7 +30,9 @@ class JavalabTabMenuComponent extends Component {
       cancelTabMenu,
       showVisibilityOption,
       changeVisibilityFromTabMenu,
-      fileIsVisible
+      changeValidationFromTabMenu,
+      fileIsVisible,
+      fileIsValidation
     } = this.props;
     return (
       <div>
@@ -48,14 +52,34 @@ class JavalabTabMenuComponent extends Component {
         >
           Delete
         </button>
-        {showVisibilityOption && (
+        {showVisibilityOption && !fileIsVisible && (
           <button
             type="button"
             key="visibility"
             onClick={changeVisibilityFromTabMenu}
             style={styles.anchor}
           >
-            {fileIsVisible ? 'Make support file' : 'Make starter file'}
+            Make starter file
+          </button>
+        )}
+        {showVisibilityOption && (fileIsVisible || fileIsValidation) && (
+          <button
+            type="button"
+            key="support"
+            onClick={changeVisibilityFromTabMenu}
+            style={styles.anchor}
+          >
+            Make support file
+          </button>
+        )}
+        {showVisibilityOption && !fileIsValidation && (
+          <button
+            type="button"
+            key="validation"
+            onClick={changeValidationFromTabMenu}
+            style={styles.anchor}
+          >
+            Make validation file
           </button>
         )}
         <button

--- a/apps/src/javalab/JavalabEditorTabMenu.jsx
+++ b/apps/src/javalab/JavalabEditorTabMenu.jsx
@@ -56,7 +56,10 @@ class JavalabTabMenuComponent extends Component {
           <button
             type="button"
             key="visibility"
-            onClick={changeVisibilityFromTabMenu}
+            onClick={() => {
+              changeVisibilityFromTabMenu(true);
+              changeValidationFromTabMenu(false);
+            }}
             style={styles.anchor}
           >
             Make starter file
@@ -66,7 +69,10 @@ class JavalabTabMenuComponent extends Component {
           <button
             type="button"
             key="support"
-            onClick={changeVisibilityFromTabMenu}
+            onClick={() => {
+              changeVisibilityFromTabMenu(false);
+              changeValidationFromTabMenu(false);
+            }}
             style={styles.anchor}
           >
             Make support file
@@ -76,7 +82,10 @@ class JavalabTabMenuComponent extends Component {
           <button
             type="button"
             key="validation"
-            onClick={changeValidationFromTabMenu}
+            onClick={() => {
+              changeVisibilityFromTabMenu(false);
+              changeValidationFromTabMenu(true);
+            }}
             style={styles.anchor}
           >
             Make validation file

--- a/apps/src/javalab/javalabRedux.js
+++ b/apps/src/javalab/javalabRedux.js
@@ -11,7 +11,7 @@ const REMOVE_FILE = 'javalab/REMOVE_FILE';
 
 const initialState = {
   consoleLogs: [],
-  sources: {'MyClass.java': {text: '', visible: true, isValidationFile: false}},
+  sources: {'MyClass.java': {text: '', isVisible: true, isValidation: false}},
   isDarkMode: false
 };
 
@@ -50,17 +50,15 @@ export const setSource = (
   isValidation
 });
 
-export const sourceVisibilityUpdated = (filename, isVisible, isValidation) => ({
+export const sourceVisibilityUpdated = (filename, isVisible) => ({
   type: SOURCE_VISIBILITY_UPDATED,
   filename,
-  isVisible,
-  isValidation
+  isVisible
 });
 
-export const sourceValidationUpdated = (filename, isVisible, isValidation) => ({
+export const sourceValidationUpdated = (filename, isValidation) => ({
   type: SOURCE_VALIDATION_UPDATED,
   filename,
-  isVisible,
   isValidation
 });
 
@@ -95,7 +93,8 @@ export default function reducer(state = initialState, action) {
     let newSources = {...state.sources};
     newSources[action.filename] = {
       text: action.source,
-      visible: action.isVisible
+      isVisible: action.isVisible,
+      isValidation: action.isValidation
     };
     return {
       ...state,
@@ -104,8 +103,7 @@ export default function reducer(state = initialState, action) {
   }
   if (action.type === SOURCE_VISIBILITY_UPDATED) {
     let newSources = {...state.sources};
-    newSources[action.filename].visible = action.isVisible;
-    newSources[action.filename].isValidationFile = action.isValidation;
+    newSources[action.filename].isVisible = action.isVisible;
     return {
       ...state,
       sources: newSources
@@ -113,8 +111,7 @@ export default function reducer(state = initialState, action) {
   }
   if (action.type === SOURCE_VALIDATION_UPDATED) {
     let newSources = {...state.sources};
-    newSources[action.filename].visible = action.isVisible;
-    newSources[action.filename].isValidationFile = action.isValidation;
+    newSources[action.filename].isValidation = action.isValidation;
     return {
       ...state,
       sources: newSources

--- a/apps/src/javalab/javalabRedux.js
+++ b/apps/src/javalab/javalabRedux.js
@@ -4,13 +4,14 @@ const APPEND_CONSOLE_LOG = 'javalab/APPEND_CONSOLE_LOG';
 const RENAME_FILE = 'javalab/RENAME_FILE';
 const SET_SOURCE = 'javalab/SET_SOURCE';
 const SOURCE_VISIBILITY_UPDATED = 'javalab/SOURCE_VISIBILITY_UPDATED';
+const SOURCE_VALIDATION_UPDATED = 'javalab/SOURCE_VALIDATION_UPDATED';
 const SET_ALL_SOURCES = 'javalab/SET_ALL_SOURCES';
 const COLOR_PREFERENCE_UPDATED = 'javalab/COLOR_PREFERENCE_UPDATED';
 const REMOVE_FILE = 'javalab/REMOVE_FILE';
 
 const initialState = {
   consoleLogs: [],
-  sources: {'MyClass.java': {text: '', visible: true}},
+  sources: {'MyClass.java': {text: '', visible: true, isValidationFile: false}},
   isDarkMode: false
 };
 
@@ -36,17 +37,31 @@ export const renameFile = (oldFilename, newFilename) => ({
   newFilename
 });
 
-export const setSource = (filename, source, isVisible = true) => ({
+export const setSource = (
+  filename,
+  source,
+  isVisible = true,
+  isValidation = false
+) => ({
   type: SET_SOURCE,
   filename,
   source,
-  isVisible
+  isVisible,
+  isValidation
 });
 
-export const sourceVisibilityUpdated = (filename, isVisible) => ({
+export const sourceVisibilityUpdated = (filename, isVisible, isValidation) => ({
   type: SOURCE_VISIBILITY_UPDATED,
   filename,
-  isVisible
+  isVisible,
+  isValidation
+});
+
+export const sourceValidationUpdated = (filename, isVisible, isValidation) => ({
+  type: SOURCE_VALIDATION_UPDATED,
+  filename,
+  isVisible,
+  isValidation
 });
 
 // Updates the user preferences to reflect change
@@ -90,6 +105,16 @@ export default function reducer(state = initialState, action) {
   if (action.type === SOURCE_VISIBILITY_UPDATED) {
     let newSources = {...state.sources};
     newSources[action.filename].visible = action.isVisible;
+    newSources[action.filename].isValidationFile = action.isValidation;
+    return {
+      ...state,
+      sources: newSources
+    };
+  }
+  if (action.type === SOURCE_VALIDATION_UPDATED) {
+    let newSources = {...state.sources};
+    newSources[action.filename].visible = action.isVisible;
+    newSources[action.filename].isValidationFile = action.isValidation;
     return {
       ...state,
       sources: newSources

--- a/apps/test/unit/javalab/JavalabEditorTest.js
+++ b/apps/test/unit/javalab/JavalabEditorTest.js
@@ -12,7 +12,11 @@ import {
 } from '@cdo/apps/redux';
 import {oneDark} from '@codemirror/theme-one-dark';
 import {lightMode} from '@cdo/apps/javalab/editorSetup';
-import javalab, {setIsDarkMode} from '@cdo/apps/javalab/javalabRedux';
+import javalab, {
+  setIsDarkMode,
+  sourceVisibilityUpdated,
+  sourceValidationUpdated
+} from '@cdo/apps/javalab/javalabRedux';
 import {setAllSources} from '../../../src/javalab/javalabRedux';
 import commonReducers from '@cdo/apps/redux/commonReducers';
 import {setPageConstants} from '@cdo/apps/redux/pageConstants';
@@ -210,6 +214,31 @@ describe('Java Lab Editor Test', () => {
       expect(dispatchSpy).to.have.been.calledWith({
         reconfigure: {style: lightMode}
       });
+    });
+  });
+
+  describe('File type updates', () => {
+    it('updates visibility', () => {
+      const first = 'Class0.java';
+      const second = 'Class1.java';
+      const editor = createWrapper();
+      const javalabEditor = editor.find('JavalabEditor').instance();
+
+      javalabEditor.onCreateFile(first);
+      javalabEditor.onCreateFile(second);
+
+      expect(store.getState().javalab.sources[first].isVisible).to.be.true;
+      expect(store.getState().javalab.sources[first].isValidation).to.be.false;
+      store.dispatch(sourceVisibilityUpdated(first, false));
+      expect(store.getState().javalab.sources[first].isVisible).to.be.false;
+      expect(store.getState().javalab.sources[first].isValidation).to.be.false;
+
+      expect(store.getState().javalab.sources[second].isVisible).to.be.true;
+      expect(store.getState().javalab.sources[second].isValidation).to.be.false;
+      store.dispatch(sourceVisibilityUpdated(second, false));
+      store.dispatch(sourceValidationUpdated(second, true));
+      expect(store.getState().javalab.sources[second].isVisible).to.be.false;
+      expect(store.getState().javalab.sources[second].isValidation).to.be.true;
     });
   });
 

--- a/apps/test/unit/javalab/JavalabEditorTest.js
+++ b/apps/test/unit/javalab/JavalabEditorTest.js
@@ -160,8 +160,8 @@ describe('Java Lab Editor Test', () => {
       const javalabEditor = editor.find('JavalabEditor').instance();
       store.dispatch(
         setAllSources({
-          'Class1.java': {text: '', visible: true},
-          'Class2.java': {text: '', visible: true}
+          'Class1.java': {text: '', isVisible: true, isValidation: false},
+          'Class2.java': {text: '', isVisible: true, isValidation: false}
         })
       );
 
@@ -275,8 +275,8 @@ describe('Java Lab Editor Test', () => {
       const javalabEditor = editor.find('JavalabEditor').instance();
       store.dispatch(
         setAllSources({
-          'Class1.java': {text: '', visible: true},
-          'Class2.java': {text: '', visible: true}
+          'Class1.java': {text: '', isVisible: true, isValidation: false},
+          'Class2.java': {text: '', isVisible: true, isValidation: false}
         })
       );
 


### PR DESCRIPTION
This PR adds the isValidation file type, so the files can now be Starter, Support, or Validation. Depending on which the file is, the other two will appear as options in the tab menu dropdown as shown below. I tried to make this update while changing as little as possible about visibility, as it is used in many other places.

Visibility and validation are inherently tied. A validation file is not visible, and support and starter files are not validation (though one is visible and one is not). Thus, every time a file is selection, both updateValidation and updateVisibility are called to ensure the status is correctly maintained. The redux calls are separate, reflecting the design in JavalabEditor.

Jira: https://codedotorg.atlassian.net/browse/CSA-294

The three options are pasted below. Notice the icons and different dropdown menu items:
![StarterExample](https://user-images.githubusercontent.com/37230822/118180067-f8092480-b3ea-11eb-8c66-b67751ca4d1d.jpg)
![SupportExample](https://user-images.githubusercontent.com/37230822/118180074-fa6b7e80-b3ea-11eb-8308-54ea65162580.jpg)
![ValidationExample](https://user-images.githubusercontent.com/37230822/118180082-fc354200-b3ea-11eb-8bd7-cda104ba1d14.jpg)
