### PR TITLE
Move the verified teacher warning to top of page

### DIFF
--- a/apps/src/templates/courseOverview/CourseOverview.js
+++ b/apps/src/templates/courseOverview/CourseOverview.js
@@ -199,6 +199,7 @@ class CourseOverview extends Component {
             }}
           />
         )}
+        {showNotification && <VerifiedResourcesNotification />}
         <div style={styles.titleWrapper}>
           <h1 style={styles.title}>{assignmentFamilyTitle}</h1>
           {filteredVersions.length > 1 && (
@@ -218,7 +219,6 @@ class CourseOverview extends Component {
               : descriptionTeacher
           }
         />
-        {showNotification && <VerifiedResourcesNotification />}
         <div>
           <CourseOverviewTopRow
             sectionsInfo={sectionsInfo}


### PR DESCRIPTION
Noticed that the verified teacher warning was not showing at the top of the page like all the other notifications on the the course page so moved it up.

### Before
<img width="1083" alt="Screen Shot 2021-05-13 at 4 14 39 PM" src="https://user-images.githubusercontent.com/208083/118182015-7aeba880-b406-11eb-8616-26bd0759887a.png">

### After
<img width="1026" alt="Screen Shot 2021-05-13 at 4 14 59 PM" src="https://user-images.githubusercontent.com/208083/118182013-7a531200-b406-11eb-9b12-668b8d9882a2.png">