### PR TITLE
Do not scroll to top of page while editing Foorm configuration

### DIFF
--- a/apps/src/code-studio/pd/foorm/Foorm.jsx
+++ b/apps/src/code-studio/pd/foorm/Foorm.jsx
@@ -67,11 +67,18 @@ export default class Foorm extends React.Component {
 
     this.surveyModel = new Survey.Model(this.props.formQuestions);
 
-    // Prevents focus from moving from codemirror in Foorm Editor
-    // (where survey editors can edit survey configuration and see changes live)
-    // to the first question of the rendered SurveyJS Survey.
+    // Settings to avoid jumping around the page
+    // when SurveyJS produces changes in focus/scrolling
+    // while editing a Foorm configuration.
     if (this.props.inEditorMode) {
+      // Prevents focus from moving from codemirror in Foorm Editor
+      // to the first question of the rendered SurveyJS Survey.
       this.surveyModel.focusFirstQuestionAutomatic = false;
+
+      // Prevents automatic scrolling to top of rendered SurveyJS Survey while editing a long configuration file.
+      this.surveyModel.onScrollingElementToTop.add((unused, options) => {
+        options.cancel = true;
+      });
     }
   }
 


### PR DESCRIPTION
Survey editors noted that, while editing Foorm JSON configuration that is quite long, the page would jump to the top while editing. We traced this issue to a SurveyJS setting that scrolls an element? the top element? into view. We found an override in their documentation that will prevent the autoscrolling from happening, and we specify that override only while editing Foorm configuration (not while people are filling out Foorm Forms).

## Links

- jira ticket: [PLC-1190](https://codedotorg.atlassian.net/browse/PLC-1190)

## Testing story

I tested this change manually.