### PR TITLE
collapse all standards categories on lesson plan page

### DIFF
--- a/apps/src/templates/lessonOverview/LessonOverview.jsx
+++ b/apps/src/templates/lessonOverview/LessonOverview.jsx
@@ -21,7 +21,7 @@ import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import {announcementShape} from '@cdo/apps/code-studio/announcementsRedux';
 import {lessonShape} from '@cdo/apps/templates/lessonOverview/lessonPlanShapes';
 import Announcements from '../../code-studio/components/progress/Announcements';
-import LessonStandards, {ExpandMode} from './LessonStandards';
+import LessonStandards from './LessonStandards';
 import StyledCodeBlock from './StyledCodeBlock';
 import VerifiedResourcesNotification from '@cdo/apps/templates/courseOverview/VerifiedResourcesNotification';
 
@@ -198,10 +198,7 @@ class LessonOverview extends Component {
                     />
                   )}
                 </div>
-                <LessonStandards
-                  standards={lesson.standards}
-                  expandMode={ExpandMode.FIRST}
-                />
+                <LessonStandards standards={lesson.standards} />
               </div>
             )}
             {lesson.opportunityStandards.length > 0 && (

--- a/apps/src/templates/lessonOverview/LessonStandards.jsx
+++ b/apps/src/templates/lessonOverview/LessonStandards.jsx
@@ -28,17 +28,12 @@ export const styles = {
 
 export const ExpandMode = {
   NONE: 'none',
-  FIRST: 'first',
   ALL: 'all'
 };
 
 const expandModeShape = PropTypes.oneOf([
   // The component should not be expanded.
   ExpandMode.NONE,
-
-  // The component should be expanded. Its first child and the first child of
-  // each of its descendants should also be expanded.
-  ExpandMode.FIRST,
 
   // This component and all its descendants should be expanded.
   ExpandMode.ALL
@@ -55,8 +50,6 @@ function getChildExpandMode(parentExpandMode, index) {
   switch (parentExpandMode) {
     case ExpandMode.ALL:
       return ExpandMode.ALL;
-    case ExpandMode.FIRST:
-      return index === 0 ? ExpandMode.FIRST : ExpandMode.NONE;
     case ExpandMode.NONE:
       return ExpandMode.NONE;
   }
@@ -67,7 +60,7 @@ function getChildExpandMode(parentExpandMode, index) {
  * @returns {boolean} Whether the component's details element should be expanded
  */
 function getDetailsOpen(expandMode) {
-  return expandMode === ExpandMode.ALL || expandMode === ExpandMode.FIRST;
+  return expandMode === ExpandMode.ALL;
 }
 
 export default class LessonStandards extends PureComponent {

--- a/apps/src/templates/lessonOverview/LessonStandards.story.jsx
+++ b/apps/src/templates/lessonOverview/LessonStandards.story.jsx
@@ -22,15 +22,6 @@ export default storybook => {
       )
     },
     {
-      name: 'expand first of many standards',
-      story: () => (
-        <LessonStandards
-          standards={cspStandards.concat(cstaStandards)}
-          expandMode={ExpandMode.FIRST}
-        />
-      )
-    },
-    {
       name: 'expand all of many standards',
       story: () => (
         <LessonStandards

--- a/apps/test/unit/templates/lessonOverview/LessonStandardsTest.js
+++ b/apps/test/unit/templates/lessonOverview/LessonStandardsTest.js
@@ -55,24 +55,6 @@ describe('LessonStandards', () => {
     });
   });
 
-  it('renders many standards with first standard expanded', () => {
-    const standards = cspStandards.concat(cstaStandards);
-    const wrapper = mount(
-      <LessonStandards standards={standards} expandMode={ExpandMode.FIRST} />
-    );
-    const frameworks = wrapper.find('Framework');
-    expect(frameworks.length).to.equal(2);
-
-    const parentCategories = frameworks.at(0).find('UnconnectedParentCategory');
-    expect(parentCategories.length).to.equal(1);
-    expect(isOpen(parentCategories.at(0))).to.be.true;
-
-    const categories = parentCategories.at(0).find('UnconnectedCategory');
-    expect(categories.length).to.equal(2);
-    expect(isOpen(categories.at(0))).to.be.true;
-    expect(isOpen(categories.at(1))).to.be.false;
-  });
-
   it('renders many standards with all standards expanded', () => {
     const standards = cspStandards.concat(cstaStandards);
     const wrapper = mount(


### PR DESCRIPTION
Finishes https://codedotorg.atlassian.net/browse/PLAT-1022 . It's not the standard per se that's now being collapsed, rather it is the first standards category or parent category.

## before

https://levelbuilder-studio.code.org/s/csp1-2021/lessons/4

![Screen Shot 2021-05-13 at 2 31 39 PM](https://user-images.githubusercontent.com/8001765/118190433-f6922900-b3f7-11eb-87dd-bf95f6609196.png)

## after

![Screen Shot 2021-05-13 at 2 28 17 PM](https://user-images.githubusercontent.com/8001765/118190243-b2068d80-b3f7-11eb-9386-8c08a55531ee.png)

## Testing story

updated existing test coverage