### PR TITLE
Add standards summary padding

### DIFF
--- a/apps/src/templates/lessonOverview/LessonStandards.jsx
+++ b/apps/src/templates/lessonOverview/LessonStandards.jsx
@@ -23,6 +23,12 @@ export const styles = {
     fontFamily: "'Gotham 5r', sans-serif",
     fontWeight: 'bold',
     color: color.dark_charcoal
+  },
+  summary: {
+    padding: 3
+  },
+  standard: {
+    padding: 3
   }
 };
 
@@ -145,7 +151,7 @@ class UnconnectedParentCategory extends PureComponent {
     return (
       <li key={shortcode}>
         <details open={isOpen}>
-          <summary>
+          <summary style={styles.summary}>
             <span style={styles.categoryShortcode}>{shortcode}</span>
             {' - '}
             {description}
@@ -189,7 +195,7 @@ class UnconnectedCategory extends PureComponent {
     return (
       <li key={shortcode}>
         <details open={isOpen}>
-          <summary>
+          <summary style={styles.summary}>
             <span style={styles.categoryShortcode}>{shortcode}</span>
             {' - '}
             {description}
@@ -215,12 +221,10 @@ class Standard extends PureComponent {
   render() {
     const {standard} = this.props;
     return (
-      <li key={standard.shortcode}>
-        <summary>
-          <span style={styles.standardShortcode}>{standard.shortcode}</span>
-          {' - '}
-          {standard.description}
-        </summary>
+      <li key={standard.shortcode} style={styles.standard}>
+        <span style={styles.standardShortcode}>{standard.shortcode}</span>
+        {' - '}
+        {standard.description}
       </li>
     );
   }


### PR DESCRIPTION
Finishes https://codedotorg.atlassian.net/browse/PLAT-972. Adds 3px padding to summary component in standards section of lesson plan.

|  before | after  |
|---|---|
| ![Screen Shot 2021-05-13 at 2 48 43 PM](https://user-images.githubusercontent.com/8001765/118192849-a4530700-b3fb-11eb-9f14-73eca8a33ad6.png)  | ![Screen Shot 2021-05-13 at 2 48 54 PM](https://user-images.githubusercontent.com/8001765/118192860-a9b05180-b3fb-11eb-8235-54470c929942.png)  |
| ![Screen Shot 2021-05-13 at 3 02 11 PM](https://user-images.githubusercontent.com/8001765/118193251-3fe47780-b3fc-11eb-9b18-8def3d7b8ebb.png) | ![Screen Shot 2021-05-13 at 2 49 42 PM](https://user-images.githubusercontent.com/8001765/118193335-5b4f8280-b3fc-11eb-8326-5810371f308f.png) |

## Testing story

manually verified visual changes shown in screenshots. existing tests verify there are no regressions in functionality.
