### PR TITLE
Prepare for new course and script publishing states edit ui

### DIFF
--- a/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
@@ -254,7 +254,7 @@ class ScriptEditor extends React.Component {
       description: this.state.description,
       student_description: this.state.studentDescription,
       announcements: JSON.stringify(this.state.announcements),
-      visible_to_teachers: !this.state.hidden,
+      hidden: this.state.hidden,
       is_stable: this.state.isStable,
       deprecated: this.state.deprecated,
       login_required: this.state.loginRequired,

--- a/apps/src/lib/levelbuilder/script-editor/VisibleAndPilotExperiment.jsx
+++ b/apps/src/lib/levelbuilder/script-editor/VisibleAndPilotExperiment.jsx
@@ -18,7 +18,7 @@ export default class VisibleAndPilotExperiment extends React.Component {
   };
 
   static defaultProps = {
-    paramName: 'visible_to_teachers'
+    paramName: 'hidden'
   };
 
   render() {

--- a/apps/src/sites/studio/pages/courses/edit.js
+++ b/apps/src/sites/studio/pages/courses/edit.js
@@ -45,10 +45,10 @@ function showCourseEditor() {
         versionTitle={courseEditorData.course_summary.version_title}
         familyName={courseEditorData.course_summary.family_name}
         versionYear={courseEditorData.course_summary.version_year}
-        initialVisible={courseEditorData.course_summary.visible}
-        isStable={courseEditorData.course_summary.is_stable}
+        initialVisible={courseEditorData.course_summary.visible || false}
+        isStable={courseEditorData.course_summary.is_stable || false}
         initialPilotExperiment={
-          courseEditorData.course_summary.pilot_experiment
+          courseEditorData.course_summary.pilot_experiment || ''
         }
         descriptionShort={courseEditorData.course_summary.description_short}
         initialDescriptionStudent={

--- a/apps/src/sites/studio/pages/scripts/edit.js
+++ b/apps/src/sites/studio/pages/scripts/edit.js
@@ -54,7 +54,7 @@ export default function initPage(scriptEditorData) {
         name={scriptEditorData.script.name}
         i18nData={scriptEditorData.i18n}
         initialHidden={valueOr(scriptData.hidden, true)}
-        initialIsStable={scriptData.is_stable}
+        initialIsStable={scriptData.is_stable || false}
         initialDeprecated={scriptData.deprecated}
         initialLoginRequired={scriptData.loginRequired}
         initialHideableLessons={scriptData.hideable_lessons}
@@ -76,7 +76,7 @@ export default function initPage(scriptEditorData) {
         initialLessonLevelData={lessonLevelData}
         initialHasVerifiedResources={scriptData.has_verified_resources}
         initialCurriculumPath={scriptData.curriculum_path || ''}
-        initialPilotExperiment={scriptData.pilot_experiment}
+        initialPilotExperiment={scriptData.pilot_experiment || ''}
         initialEditorExperiment={scriptData.editor_experiment || ''}
         initialAnnouncements={announcements}
         initialSupportedLocales={scriptData.supported_locales || []}

--- a/apps/test/unit/lib/levelbuilder/script-editor/ScriptEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/ScriptEditorTest.jsx
@@ -484,7 +484,7 @@ describe('ScriptEditor', () => {
       const wrapper = createWrapper({
         initialHidden: false
       });
-      const checkbox = wrapper.find('input[name="visible_to_teachers"]');
+      const checkbox = wrapper.find('input[name="hidden"]');
       expect(checkbox.prop('checked')).to.be.true;
     });
 
@@ -492,7 +492,7 @@ describe('ScriptEditor', () => {
       const wrapper = createWrapper({
         initialHidden: true
       });
-      const checkbox = wrapper.find('input[name="visible_to_teachers"]');
+      const checkbox = wrapper.find('input[name="hidden"]');
       expect(checkbox.prop('checked')).to.be.false;
     });
   });

--- a/apps/test/unit/lib/levelbuilder/script-editor/VisibleAndPilotExperimentTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/VisibleAndPilotExperimentTest.jsx
@@ -25,7 +25,7 @@ describe('VisibleAndPilotExperiment', () => {
         pilotExperiment="test-pilot"
       />
     );
-    const checkbox = wrapper.find('input[name="visible_to_teachers"]');
+    const checkbox = wrapper.find('input[name="hidden"]');
     expect(checkbox.prop('disabled')).to.be.true;
     expect(checkbox.prop('checked')).to.be.false;
   });
@@ -33,7 +33,7 @@ describe('VisibleAndPilotExperiment', () => {
   it('visible updates state as pilotExperiment changes', () => {
     const wrapper = mount(<VisibleAndPilotExperiment {...defaultProps} />);
     const visibleInTeacherDashboard = () =>
-      wrapper.find('input[name="visible_to_teachers"]');
+      wrapper.find('input[name="hidden"]');
     const pilotExperiment = () =>
       wrapper.find('input[name="pilot_experiment"]');
 

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -226,7 +226,7 @@ class ScriptsController < ApplicationController
 
   def general_params
     h = params.permit(
-      :visible_to_teachers,
+      :hidden,
       :deprecated,
       :curriculum_umbrella,
       :family_name,
@@ -262,9 +262,7 @@ class ScriptsController < ApplicationController
       supported_locales: [],
     ).to_h
     h[:peer_reviews_to_complete] = h[:peer_reviews_to_complete].to_i > 0 ? h[:peer_reviews_to_complete].to_i : nil
-    h[:hidden] = !h[:visible_to_teachers]
     h[:announcements] = JSON.parse(h[:announcements]) if h[:announcements]
-    h.delete(:visible_to_teachers)
     h
   end
 

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1419,7 +1419,7 @@ class Script < ApplicationRecord
       beta_title: Script.beta?(name) ? I18n.t('beta') : nil,
       course_id: unit_group.try(:id),
       hidden: hidden,
-      is_stable: is_stable,
+      is_stable: !!is_stable,
       loginRequired: login_required,
       plc: professional_learning_course?,
       hideable_lessons: hideable_lessons?,
@@ -1600,7 +1600,7 @@ class Script < ApplicationRecord
           version_year: s.version_year,
           version_title: s.version_year,
           can_view_version: s.can_view_version?(user),
-          is_stable: s.is_stable,
+          is_stable: !!s.is_stable,
           locales: s.supported_locale_names
         }
       end

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -659,7 +659,7 @@ class ScriptsControllerTest < ActionController::TestCase
       script: {name: script.name},
       script_text: '',
       pilot_experiment: 'pilot-experiment',
-      hidden: false,
+      hidden: false
     }
 
     assert_response :success
@@ -681,7 +681,7 @@ class ScriptsControllerTest < ActionController::TestCase
       script: {name: script.name},
       script_text: '',
       pilot_experiment: '',
-      hidden: false,
+      hidden: false
     }
 
     assert_response :success

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -409,7 +409,7 @@ class ScriptsControllerTest < ActionController::TestCase
       id: script.id,
       script: {name: script.name},
       script_text: '',
-      visible_to_teachers: true
+      hidden: false
     }
     assert_response :forbidden
     script.reload
@@ -430,7 +430,7 @@ class ScriptsControllerTest < ActionController::TestCase
       id: script.id,
       script: {name: script.name},
       script_text: '',
-      visible_to_teachers: true
+      hidden: false
     }
     assert_response :success
     script.reload
@@ -449,7 +449,7 @@ class ScriptsControllerTest < ActionController::TestCase
       id: script.id,
       script: {name: script.name},
       script_text: '',
-      visible_to_teachers: true
+      hidden: false
     }
     assert_response :success
     script.reload
@@ -467,7 +467,7 @@ class ScriptsControllerTest < ActionController::TestCase
       id: script.id,
       script: {name: script.name},
       script_text: '',
-      visible_to_teachers: true
+      hidden: false
     }
     assert_response :forbidden
     script.reload
@@ -659,7 +659,7 @@ class ScriptsControllerTest < ActionController::TestCase
       script: {name: script.name},
       script_text: '',
       pilot_experiment: 'pilot-experiment',
-      visible_to_teachers: true,
+      hidden: false,
     }
 
     assert_response :success
@@ -681,7 +681,7 @@ class ScriptsControllerTest < ActionController::TestCase
       script: {name: script.name},
       script_text: '',
       pilot_experiment: '',
-      visible_to_teachers: true,
+      hidden: false,
     }
 
     assert_response :success


### PR DESCRIPTION
A couple of small clean-ups before bigger PRs to move to the edit UI for publishing courses/scripts.

1. Get rid of intermediate variable visible_to_teachers
2. Add defaults for visible/hidden, is_stable, and pilot_experiment in editors
3. Make sure when summarizing is_stable to turn it into a boolean

## Links

Prep for: https://codedotorg.atlassian.net/browse/PLAT-1050

## Testing story

Relying on existing tests