### PR TITLE
Add logic to show display_name for bubble choice levels

### DIFF
--- a/apps/src/templates/lessonOverview/activities/ProgressionDetails.jsx
+++ b/apps/src/templates/lessonOverview/activities/ProgressionDetails.jsx
@@ -30,6 +30,12 @@ export default class ProgressionDetails extends Component {
   };
 
   convertScriptLevelForProgression = scriptLevel => {
+    const subLevelsForProgression = scriptLevel.sublevels
+      ? scriptLevel.sublevels.map(l => {
+          l.isSublevel = true;
+          return l;
+        })
+      : undefined;
     const activeLevel =
       scriptLevel.levels.length > 1
         ? scriptLevel.levels.filter(level => {
@@ -50,7 +56,7 @@ export default class ProgressionDetails extends Component {
       levelNumber: scriptLevel.levelNumber,
       bonus: scriptLevel.bonus,
       level: activeLevel,
-      sublevels: scriptLevel.sublevels
+      sublevels: subLevelsForProgression
     };
   };
 

--- a/apps/src/templates/progress/ProgressBubble.jsx
+++ b/apps/src/templates/progress/ProgressBubble.jsx
@@ -123,8 +123,9 @@ class ProgressBubble extends React.Component {
     }
 
     const tooltipId = _.uniqueId();
-    let tooltipText =
-      levelName || (level.isUnplugged && i18n.unpluggedActivity()) || '';
+    let tooltipText = level.isSublevel
+      ? level.display_name
+      : levelName || (level.isUnplugged && i18n.unpluggedActivity()) || '';
     if (number) {
       tooltipText = `${number}. ${tooltipText}`;
     }

--- a/apps/test/unit/templates/progress/ProgressBubbleTest.js
+++ b/apps/test/unit/templates/progress/ProgressBubbleTest.js
@@ -229,6 +229,24 @@ describe('ProgressBubble', () => {
     );
   });
 
+  it('uses display name when isSublevel is true', () => {
+    const wrapper = shallow(
+      <ProgressBubble
+        {...defaultProps}
+        level={{
+          ...defaultProps.level,
+          display_name: 'Display Name',
+          name: 'display_name',
+          isSublevel: true
+        }}
+      />
+    );
+    assert.equal(
+      wrapper.find('TooltipWithIcon').props().text,
+      '1. Display Name'
+    );
+  });
+
   it('renders a small bubble if smallBubble is true', () => {
     const wrapper = shallow(
       <ProgressBubble {...defaultProps} smallBubble={true} />


### PR DESCRIPTION
Take 2 at [PLAT-924](https://codedotorg.atlassian.net/browse/PLAT-924)! This adds a flag to sublevels, which when present, uses the display name on the level. As this boolean is set by `ProgressionDetails` it shouldn't have an effect anywhere else, until other places are updated.


https://user-images.githubusercontent.com/46464143/118565240-a7653480-b726-11eb-95b1-c688cff4457a.mov





## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
