### PR TITLE
Add review_state to teacher_feedbacks

### DIFF
--- a/dashboard/app/models/teacher_feedback.rb
+++ b/dashboard/app/models/teacher_feedback.rb
@@ -17,6 +17,7 @@
 #  seen_on_feedback_page_at :datetime
 #  script_id                :integer          not null
 #  analytics_section_id     :integer
+#  review_state             :string(255)
 #
 # Indexes
 #

--- a/dashboard/db/migrate/20210514195057_add_review_state_to_teacher_feedbacks.rb
+++ b/dashboard/db/migrate/20210514195057_add_review_state_to_teacher_feedbacks.rb
@@ -1,0 +1,5 @@
+class AddReviewStateToTeacherFeedbacks < ActiveRecord::Migration[5.2]
+  def change
+    add_column :teacher_feedbacks, :review_state, :string
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_11_160631) do
+ActiveRecord::Schema.define(version: 2021_05_14_195057) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -1717,6 +1717,7 @@ ActiveRecord::Schema.define(version: 2021_05_11_160631) do
     t.datetime "seen_on_feedback_page_at"
     t.integer "script_id", null: false
     t.integer "analytics_section_id"
+    t.string "review_state"
     t.index ["student_id", "level_id", "teacher_id"], name: "index_feedback_on_student_and_level_and_teacher_id"
     t.index ["teacher_id"], name: "index_teacher_feedbacks_on_teacher_id"
   end


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Adds a nullable string column called `review_state` to teacher_feedbacks table. I tested locally that adding and viewing teacher feedbacks still works. As a follow-up, I'll set validation to ensure that only certain strings (KeepWorking, Completed) are set in the column.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: [LP-1893](https://codedotorg.atlassian.net/browse/LP-1893)
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
