### PR TITLE
Add 450 to the calendar weekly minutes options

### DIFF
--- a/apps/src/code-studio/components/progress/UnitCalendarDialog.jsx
+++ b/apps/src/code-studio/components/progress/UnitCalendarDialog.jsx
@@ -6,7 +6,7 @@ import Button from '@cdo/apps/templates/Button';
 import UnitCalendar from './UnitCalendar';
 import {unitCalendarLesson} from '@cdo/apps/templates/progress/unitCalendarLessonShapes';
 
-const WEEKLY_INSTRUCTIONAL_MINUTES_OPTIONS = [45, 90, 135, 180, 225];
+const WEEKLY_INSTRUCTIONAL_MINUTES_OPTIONS = [45, 90, 135, 180, 225, 450];
 export const WEEK_WIDTH = 585;
 
 export default class UnitCalendarDialog extends Component {

--- a/apps/src/code-studio/components/progress/UnitCalendarLessonChunk.jsx
+++ b/apps/src/code-studio/components/progress/UnitCalendarLessonChunk.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import {unitCalendarLessonChunk} from '@cdo/apps/templates/progress/unitCalendarLessonShapes';
 import color from '@cdo/apps/util/color';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
+import ReactTooltip from 'react-tooltip';
 
 class UnitCalendarLessonChunk extends Component {
   static propTypes = {
@@ -31,11 +32,15 @@ class UnitCalendarLessonChunk extends Component {
       isStart,
       isEnd,
       isMajority,
-      url
+      url,
+      lessonNumber
     } = this.props.lessonChunk;
 
+    const chunkWidth = Math.floor(minuteWidth * duration) - 10;
+    const smallChunk = chunkWidth < 50;
+
     let chunkStyle = {
-      width: Math.floor(minuteWidth * duration) - 10,
+      width: chunkWidth,
       ...styles.box,
       ...(assessment
         ? isHover
@@ -48,11 +53,15 @@ class UnitCalendarLessonChunk extends Component {
       ...(isEnd ? styles.isEnd : styles.isNotEnd)
     };
 
+    let displayTitle = smallChunk ? lessonNumber : title;
+
     return (
       <a
         style={chunkStyle}
         target="_blank"
         rel="noopener noreferrer"
+        data-for={`lesson-information-${lessonNumber}`}
+        data-tip
         href={url}
         onMouseEnter={this.handleMouseEnter}
         onMouseOut={this.handleMouseOut}
@@ -94,9 +103,18 @@ class UnitCalendarLessonChunk extends Component {
               onMouseEnter={this.handleMouseEnter}
               onMouseOut={this.handleMouseOut}
             >
-              {title}
+              {displayTitle}
             </div>
           </div>
+        )}
+        {smallChunk && (
+          <ReactTooltip
+            id={`lesson-information-${lessonNumber}`}
+            role="tooltip"
+            effect="solid"
+          >
+            <div>{title}</div>
+          </ReactTooltip>
         )}
       </a>
     );

--- a/apps/test/unit/code-studio/components/progress/UnitCalendarDialogTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/UnitCalendarDialogTest.jsx
@@ -37,7 +37,7 @@ describe('UnitCalendarDialog', () => {
         weeklyInstructionalMinutes={45}
       />
     );
-    expect(wrapper.find('option').length).to.equal(5);
+    expect(wrapper.find('option').length).to.equal(6);
     expect(
       wrapper.containsMatchingElement(
         <option value={45} key={`minutes-45`}>
@@ -65,7 +65,7 @@ describe('UnitCalendarDialog', () => {
         weeklyInstructionalMinutes={20}
       />
     );
-    expect(wrapper.find('option').length).to.equal(6);
+    expect(wrapper.find('option').length).to.equal(7);
     expect(
       wrapper.containsMatchingElement(
         <option value={20} key={`minutes-20`}>

--- a/apps/test/unit/code-studio/components/progress/UnitCalendarLessonChunkTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/UnitCalendarLessonChunkTest.jsx
@@ -3,11 +3,13 @@ import React from 'react';
 import {shallow} from 'enzyme';
 import UnitCalendarLessonChunk from '@cdo/apps/code-studio/components/progress/UnitCalendarLessonChunk';
 import color from '@cdo/apps/util/color';
+import ReactTooltip from 'react-tooltip';
 
 const sampleLessonChunk = {
   id: 1,
+  lessonNumber: 5,
   title: 'test',
-  duration: 10,
+  duration: 100,
   assessment: true,
   unplugged: true,
   isStart: true,
@@ -167,6 +169,33 @@ describe('UnitCalendarLessonChunk', () => {
     expect(
       wrapper.containsMatchingElement(<div>{sampleLessonChunk.title}</div>)
     ).to.be.false;
+  });
+
+  it('shows lesson number with tooltip if small chunk', () => {
+    const wrapper = shallow(
+      <UnitCalendarLessonChunk
+        minuteWidth={1}
+        lessonChunk={{
+          ...sampleLessonChunk,
+          duration: 30
+        }}
+        isHover={false}
+        handleHover={() => console.log('hover')}
+      />
+    );
+
+    expect(
+      wrapper.containsMatchingElement(
+        <div>{sampleLessonChunk.lessonNumber}</div>
+      )
+    ).to.be.true;
+    expect(
+      wrapper.containsMatchingElement(
+        <ReactTooltip>
+          <div>{sampleLessonChunk.title}</div>
+        </ReactTooltip>
+      )
+    ).to.be.true;
   });
 
   it('hides assessment icon if not assessment', () => {

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -322,6 +322,7 @@ class Lesson < ApplicationRecord
   def summarize_for_calendar
     {
       id: id,
+      lessonNumber: relative_position,
       title: localized_title,
       duration: lesson_activities.map(&:summarize).sum {|activity| activity[:duration] || 0},
       assessment: !!assessment,


### PR DESCRIPTION
There was a request to add 450 minutes to the calendar dropdown. When you move to something this high the titles don't fit well so we move to use the number instead and then show the full title in a tooltip.

<img width="740" alt="Screen Shot 2021-05-17 at 1 09 18 PM" src="https://user-images.githubusercontent.com/208083/118529686-cad1b480-b711-11eb-9345-f47014089293.png">

## Links

Slack Convo: https://codedotorg.slack.com/archives/CNZP84FJ5/p1621193914484700

## Testing story

- Added unit test
- Tested manually