### PR TITLE
Add an i18n tracking_updates cronjob

### DIFF
--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -105,6 +105,7 @@
       cronjob at:'00 02 * * *', do:deploy_dir('bin', 'cron', 'export_mysql_database_to_redshift')
       cronjob at:'0 0 * * *', do:deploy_dir('bin', 'cron', 'build_contact_rollups_v2')
       cronjob at:'0 2 * * *', do:deploy_dir('bin', 'cron', 'hoc_student_name_cleanup')
+      cronjob at:'30 * * * *', do:deploy_dir('bin', 'i18n', 'translation_status/tracking_updates.rb')
 
       # RDS backup window is 08:50-09:20, so by 11:50 backups should definitely be ready
       cronjob at:'50 11 * * *', do:deploy_dir('bin', 'cron', 'push_latest_aurora_backup_to_secondary_account')

--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -105,7 +105,7 @@
       cronjob at:'00 02 * * *', do:deploy_dir('bin', 'cron', 'export_mysql_database_to_redshift')
       cronjob at:'0 0 * * *', do:deploy_dir('bin', 'cron', 'build_contact_rollups_v2')
       cronjob at:'0 2 * * *', do:deploy_dir('bin', 'cron', 'hoc_student_name_cleanup')
-      cronjob at:'30 * * * *', do:deploy_dir('bin', 'i18n', 'translation_status/tracking_updates.rb')
+      cronjob at:'30 * * * *', do:deploy_dir('bin', 'i18n', 'translation_status/tracking_updates')
 
       # RDS backup window is 08:50-09:20, so by 11:50 backups should definitely be ready
       cronjob at:'50 11 * * *', do:deploy_dir('bin', 'cron', 'push_latest_aurora_backup_to_secondary_account')


### PR DESCRIPTION
[FND-1541](https://codedotorg.atlassian.net/browse/FND-1541) 
The job runs script `bin/i18n/translation_status/tracking_updates.rb` once every hour at minute 30. 
(Since most cronjobs start at minute 0, I chose 30 to avoid resource contention.)

**DO NOT** merge until [FND-1540](https://codedotorg.atlassian.net/browse/FND-1540) is done!

## Links
[Slack thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1621275345148500) on adding a new cronjob.
