### PR TITLE
Rename stage to lesson in teacher scores code

### DIFF
--- a/apps/src/templates/sectionProgress/standards/StandardsViewHeaderButtons.jsx
+++ b/apps/src/templates/sectionProgress/standards/StandardsViewHeaderButtons.jsx
@@ -119,14 +119,14 @@ class StandardsViewHeaderButtons extends Component {
 
     for (var i = 0; i < selectedLessonIds.length; i++) {
       selectedLessonScores[i] = {
-        stage_id: selectedLessonIds[i],
+        lesson_id: selectedLessonIds[i],
         score: TeacherScores.COMPLETE
       };
     }
 
     for (var j = 0; j < unselectedLessonIds.length; j++) {
       unselectedLessonScores[j] = {
-        stage_id: unselectedLessonIds[j],
+        lesson_id: unselectedLessonIds[j],
         score: TeacherScores.INCOMPLETE
       };
     }
@@ -138,7 +138,7 @@ class StandardsViewHeaderButtons extends Component {
       dataType: 'json',
       data: JSON.stringify({
         section_id: sectionId,
-        stage_scores: selectedLessonScores.concat(unselectedLessonScores)
+        lesson_scores: selectedLessonScores.concat(unselectedLessonScores)
       })
     }).done(() => {
       if (this.state.isLessonStatusDialogOpen) {

--- a/dashboard/app/controllers/api/v1/teacher_scores_controller.rb
+++ b/dashboard/app/controllers/api/v1/teacher_scores_controller.rb
@@ -3,15 +3,15 @@ class Api::V1::TeacherScoresController < Api::V1::JsonApiController
   authorize_resource
 
   # POST /teacher_scores
-  def score_stages_for_section
+  def score_lessons_for_section
     section = Section.find(params[:section_id])
     if section.user_id == current_user.id
       TeacherScore.transaction do
-        params[:stage_scores].each do |stage_score|
-          TeacherScore.score_stage_for_section(
+        params[:lesson_scores].each do |lesson_score|
+          TeacherScore.score_lesson_for_section(
             params[:section_id],
-            stage_score[:stage_id],
-            stage_score[:score]
+            lesson_score[:lesson_id],
+            lesson_score[:score]
           )
         end
         head :no_content
@@ -42,6 +42,6 @@ class Api::V1::TeacherScoresController < Api::V1::JsonApiController
   # Never trust parameters from the scary internet, only allow the following
   # list through.
   def teacher_score_params
-    params.require(:teacher_score).permit(:user_level_id, :score, :teacher_id, :section_id, :stage_id, :script_id)
+    params.require(:teacher_score).permit(:user_level_id, :score, :teacher_id, :section_id, :lesson_id, :script_id)
   end
 end

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -113,7 +113,7 @@ class Ability
         can :create, Pd::InternationalOptIn, user_id: user.id
         can :manage, :maker_discount
         can :update_last_confirmation_date, UserSchoolInfo, user_id: user.id
-        can [:score_stages_for_section, :get_teacher_scores_for_script], TeacherScore, user_id: user.id
+        can [:score_lessons_for_section, :get_teacher_scores_for_script], TeacherScore, user_id: user.id
       end
 
       if user.facilitator?

--- a/dashboard/app/models/teacher_score.rb
+++ b/dashboard/app/models/teacher_score.rb
@@ -15,17 +15,17 @@
 #
 
 class TeacherScore < ApplicationRecord
-  def self.score_stage_for_section(
+  def self.score_lesson_for_section(
     section_id,
-    stage_id,
+    lesson_id,
     score
   )
     section = Section.find(section_id)
     student_ids = section.students.pluck(:id)
     teacher_id = section.user_id
-    stage = Lesson.find(stage_id)
-    script_id = stage.script.id
-    level_ids = stage.script_levels.map(&:level_id)
+    lesson = Lesson.find(lesson_id)
+    script_id = lesson.script.id
+    level_ids = lesson.script_levels.map(&:level_id)
 
     student_ids.each do |student_id|
       level_ids.each do |level_id|
@@ -57,24 +57,24 @@ class TeacherScore < ApplicationRecord
   end
 
   def self.get_level_scores_for_script_for_section(script_id, section_id, page)
-    level_scores_by_student_by_stage_by_script = {}
+    level_scores_by_student_by_lesson_by_script = {}
     # Teacher scores are currently only relevant for unplugged lessons
-    stages = Script.find(script_id).lessons.select(&:unplugged)
+    lessons = Script.find(script_id).lessons.select(&:unplugged)
     student_ids = Section.find(section_id).students.page(page).per(50).pluck(:id)
-    stage_student_level_scores = {}
-    stages.each do |lesson|
-      level_scores = get_level_scores_for_stage_for_students(lesson, student_ids)
+    lesson_student_level_scores = {}
+    lessons.each do |lesson|
+      level_scores = get_level_scores_for_lesson_for_students(lesson, student_ids)
       unless level_scores.empty?
-        stage_student_level_scores[lesson.id] = level_scores
+        lesson_student_level_scores[lesson.id] = level_scores
       end
     end
-    level_scores_by_student_by_stage_by_script[script_id] = stage_student_level_scores
-    level_scores_by_student_by_stage_by_script
+    level_scores_by_student_by_lesson_by_script[script_id] = lesson_student_level_scores
+    level_scores_by_student_by_lesson_by_script
   end
 
-  def self.get_level_scores_for_stage_for_students(stage, student_ids)
-    script_id = stage.script_id
-    level_ids = stage.script_levels.map(&:level_id)
+  def self.get_level_scores_for_lesson_for_students(lesson, student_ids)
+    script_id = lesson.script_id
+    level_ids = lesson.script_levels.map(&:level_id)
     user_levels = UserLevel.select(:id, :level_id, :user_id).where(user_id: student_ids, level_id: level_ids, script_id: script_id)
 
     teacher_scores = TeacherScore.select(:score, :created_at, :user_level_id).where(

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -815,7 +815,7 @@ Dashboard::Application.routes.draw do
   post '/dashboardapi/v1/users/:user_id/set_standards_report_info_to_seen', to: 'api/v1/users#set_standards_report_info_to_seen'
 
   # Routes used by teacher scores
-  post '/dashboardapi/v1/teacher_scores', to: 'api/v1/teacher_scores#score_stages_for_section'
+  post '/dashboardapi/v1/teacher_scores', to: 'api/v1/teacher_scores#score_lessons_for_section'
   get '/dashboardapi/v1/teacher_scores/:section_id/:script_id', to: 'api/v1/teacher_scores#get_teacher_scores_for_script', defaults: {format: 'json'}
 
   # We want to allow searchs with dots, for instance "St. Paul", so we specify

--- a/dashboard/test/controllers/api/v1/teacher_scores_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/teacher_scores_controller_test.rb
@@ -11,29 +11,29 @@ class Api::V1::TeacherScoresControllerTest < ActionDispatch::IntegrationTest
     @script = create :script
   end
 
-  test 'score_stage_for_section is forbidden if signed out' do
+  test 'score_lesson_for_section is forbidden if signed out' do
     post '/dashboardapi/v1/teacher_scores', params: {
-      section_id: @section.id, stage_scores: [{stage_id: @lesson.id, score: 100}]
+      section_id: @section.id, lesson_scores: [{lesson_id: @lesson.id, score: 100}]
     }
     assert_response 302
   end
 
-  test 'score_stage_for_section is forbidden if student' do
+  test 'score_lesson_for_section is forbidden if student' do
     sign_in @student
     post '/dashboardapi/v1/teacher_scores', params: {
-      section_id: @section.id, stage_scores: [{stage_id: @lesson.id, score: 100}]
+      section_id: @section.id, lesson_scores: [{lesson_id: @lesson.id, score: 100}]
     }
     assert_response :forbidden
   end
 
-  test 'score_stage_for_section is forbidden for teacher who does not own section' do
+  test 'score_lesson_for_section is forbidden for teacher who does not own section' do
     sign_in @teacher
     section_2 = create :section
-    post '/dashboardapi/v1/teacher_scores', params: {section_id: section_2.id, stage_scores: [{stage_id: @lesson.id, score: 100}]}
+    post '/dashboardapi/v1/teacher_scores', params: {section_id: section_2.id, lesson_scores: [{lesson_id: @lesson.id, score: 100}]}
     assert_response :forbidden
   end
 
-  test 'score_stages_for_section succeeds with only one lesson' do
+  test 'score_lessons_for_section succeeds with only one lesson' do
     teacher = create :teacher
     section = create :section, teacher: teacher
     section.students << create(:student)
@@ -50,12 +50,12 @@ class Api::V1::TeacherScoresControllerTest < ActionDispatch::IntegrationTest
     lesson = script_level.lesson
 
     sign_in teacher
-    post '/dashboardapi/v1/teacher_scores', params: {section_id: section.id, stage_scores: [{stage_id: lesson.id, score: 100}]}
+    post '/dashboardapi/v1/teacher_scores', params: {section_id: section.id, lesson_scores: [{lesson_id: lesson.id, score: 100}]}
     assert TeacherScore.where(teacher_id: teacher.id).exists?
     assert_response :no_content
   end
 
-  test 'score_stages_for_section fails if lesson is not found' do
+  test 'score_lessons_for_section fails if lesson is not found' do
     teacher = create :teacher
     section = create :section, teacher: teacher
     section.students << create(:student)
@@ -74,7 +74,7 @@ class Api::V1::TeacherScoresControllerTest < ActionDispatch::IntegrationTest
     )
     destroyed_lesson = create :lesson
     destroyed_lesson.destroy
-    post '/dashboardapi/v1/teacher_scores', params: {section_id: section.id, stage_scores: [{stage_id: lesson.id, score: 100}, {stage_id: destroyed_lesson.id, score: 0}]}
+    post '/dashboardapi/v1/teacher_scores', params: {section_id: section.id, lesson_scores: [{lesson_id: lesson.id, score: 100}, {lesson_id: destroyed_lesson.id, score: 0}]}
     refute TeacherScore.where(teacher_id: teacher.id).exists?
     assert_response :forbidden
   end
@@ -101,7 +101,7 @@ class Api::V1::TeacherScoresControllerTest < ActionDispatch::IntegrationTest
     lesson_group = create :lesson_group, script: script
     lesson = create :lesson, script: script, lesson_group: lesson_group, unplugged: true
     script_level = create(
-      :script_level,
+      :sclessonlevel,
       script: script,
       lesson: lesson,
       levels: [
@@ -111,7 +111,7 @@ class Api::V1::TeacherScoresControllerTest < ActionDispatch::IntegrationTest
     level = script_level.levels[0]
     score = 100
 
-    post '/dashboardapi/v1/teacher_scores', params: {section_id: section.id, stage_scores: [{stage_id: lesson.id, score: score}]}
+    post '/dashboardapi/v1/teacher_scores', params: {section_id: section.id, lesson_scores: [{lesson_id: lesson.id, score: score}]}
 
     get "/dashboardapi/v1/teacher_scores/#{section.id}/#{script.id}"
 
@@ -145,7 +145,7 @@ class Api::V1::TeacherScoresControllerTest < ActionDispatch::IntegrationTest
       create :user_level, user: student, level: level, script: script
     end
 
-    post '/dashboardapi/v1/teacher_scores', params: {section_id: section.id, stage_scores: [{stage_id: lesson.id, score: score}]}
+    post '/dashboardapi/v1/teacher_scores', params: {section_id: section.id, lesson_scores: [{lesson_id: lesson.id, score: score}]}
 
     assert_queries 6 do
       get "/dashboardapi/v1/teacher_scores/#{section.id}/#{script.id}"

--- a/dashboard/test/controllers/api/v1/teacher_scores_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/teacher_scores_controller_test.rb
@@ -101,7 +101,7 @@ class Api::V1::TeacherScoresControllerTest < ActionDispatch::IntegrationTest
     lesson_group = create :lesson_group, script: script
     lesson = create :lesson, script: script, lesson_group: lesson_group, unplugged: true
     script_level = create(
-      :sclessonlevel,
+      :script_level,
       script: script,
       lesson: lesson,
       levels: [

--- a/dashboard/test/models/teacher_score_test.rb
+++ b/dashboard/test/models/teacher_score_test.rb
@@ -78,12 +78,12 @@ class TeacherScoreTest < ActiveSupport::TestCase
     assert_equal(newly_created_teacher_score.user_level_id, user_level.id)
   end
 
-  test 'score stage for section' do
+  test 'score lesson for section' do
     teacher_scores_count_before = TeacherScore.all.count
     user_level_count_before = UserLevel.all.count
     student_count = @section.students.count
 
-    TeacherScore.score_stage_for_section(
+    TeacherScore.score_lesson_for_section(
       @section.id, @lesson.id, @score
     )
 
@@ -95,7 +95,7 @@ class TeacherScoreTest < ActiveSupport::TestCase
     assert_equal(teacher_scores_count_after, teacher_scores_count_before + student_count)
   end
 
-  test 'get scores for stage looks at most recent score' do
+  test 'get scores for lesson looks at most recent score' do
     Timecop.freeze do
       TeacherScore.score_level_for_student(
         @teacher.id, @student_1.id, @level_1.id, @script.id, @score
@@ -108,16 +108,16 @@ class TeacherScoreTest < ActiveSupport::TestCase
       )
     end
 
-    assert_equal(TeacherScore.get_level_scores_for_stage_for_students(@lesson, @section.students.pluck(:id)), {@student_1.id => {@level_1.id => @score_2}})
+    assert_equal(TeacherScore.get_level_scores_for_lesson_for_students(@lesson, @section.students.pluck(:id)), {@student_1.id => {@level_1.id => @score_2}})
   end
 
-  test 'get scores for stage for students' do
-    TeacherScore.score_stage_for_section(
+  test 'get scores for lesson for students' do
+    TeacherScore.score_lesson_for_section(
       @section.id, @lesson.id, @score
     )
 
     assert_equal(
-      TeacherScore.get_level_scores_for_stage_for_students(
+      TeacherScore.get_level_scores_for_lesson_for_students(
         @lesson,
         @section.students.pluck(:id)
       ),
@@ -130,7 +130,7 @@ class TeacherScoreTest < ActiveSupport::TestCase
   end
 
   test 'get scores for script for section' do
-    TeacherScore.score_stage_for_section(
+    TeacherScore.score_lesson_for_section(
       @section.id, @lesson.id, @score
     )
     page = 1


### PR DESCRIPTION
As part of on-going efforts to use "lesson" rather than "stage" across the codebase (e.g. https://codedotorg.atlassian.net/browse/PLAT-981) I updated the code related to Teacher Scores to use "lesson". 