### PR TITLE
Update “Beyond K-12” card to link to `/beyond`

### DIFF
--- a/apps/src/templates/studioHomepages/CourseBlocksStudentGradeBands.jsx
+++ b/apps/src/templates/studioHomepages/CourseBlocksStudentGradeBands.jsx
@@ -24,7 +24,7 @@ class CourseBlocksStudentGradeBands extends Component {
     {
       heading: i18n.courseBlocksGradeBandsUniversity(),
       description: i18n.courseBlocksGradeBandsUniversityDescription(),
-      path: '/student/university'
+      path: '/beyond'
     }
   ];
 


### PR DESCRIPTION
this is a quick followup to #40355, which missed one of the updates included in the [spec](https://docs.google.com/document/d/1QrDuSVKQ1nPFujq_MAwSRBC2XXE1Of9a_OTGhNnNMZA/edit). we updated the copy for the "Beyond K-12" card on the student-facing `/courses` page, but missed the part about updating the link.

## Links
- [spec](https://docs.google.com/document/d/1QrDuSVKQ1nPFujq_MAwSRBC2XXE1Of9a_OTGhNnNMZA/edit)
- jira ticket: [LP-1918]


[LP-1918]: https://codedotorg.atlassian.net/browse/LP-1918