### PR TITLE
Update preview to beta and assignable to preview for published states

### DIFF
--- a/apps/src/lib/levelbuilder/CourseVersionPublishingEditor.jsx
+++ b/apps/src/lib/levelbuilder/CourseVersionPublishingEditor.jsx
@@ -3,7 +3,7 @@ import React, {Component} from 'react';
 import HelpTip from '@cdo/apps/lib/ui/HelpTip';
 import color from '@cdo/apps/util/color';
 
-const publishedStates = ['Pilot', 'Preview', 'Assignable', 'Recommended'];
+const publishedStates = ['Pilot', 'Beta', 'Preview', 'Recommended'];
 
 export default class CourseVersionPublishingEditor extends Component {
   static propTypes = {
@@ -32,7 +32,7 @@ export default class CourseVersionPublishingEditor extends Component {
         this.props.updateVisible(false);
         this.props.updateIsStable(false);
         break;
-      case 'Assignable':
+      case 'Preview':
         this.props.updatePilotExperiment('');
         this.props.updateVisible(true);
         this.props.updateIsStable(false);
@@ -42,7 +42,7 @@ export default class CourseVersionPublishingEditor extends Component {
         this.props.updateVisible(true);
         this.props.updateIsStable(true);
         break;
-      case 'Preview':
+      case 'Beta':
       default:
         this.props.updatePilotExperiment('');
         this.props.updateVisible(false);
@@ -122,14 +122,14 @@ export default class CourseVersionPublishingEditor extends Component {
                   </td>
                 </tr>
                 <tr>
-                  <td style={styles.tableBorder}>Preview</td>
+                  <td style={styles.tableBorder}>Beta</td>
                   <td style={styles.tableBorder}>
                     Anyone who has the link can view the course and make
                     progress on it. It is not assignable by teachers yet.
                   </td>
                 </tr>
                 <tr>
-                  <td style={styles.tableBorder}>Assignable</td>
+                  <td style={styles.tableBorder}>Preview</td>
                   <td style={styles.tableBorder}>
                     The course is now a choice in the dropdown that is
                     assignable but is not the recommended course.

--- a/apps/src/lib/levelbuilder/course-editor/CourseEditor.js
+++ b/apps/src/lib/levelbuilder/course-editor/CourseEditor.js
@@ -81,10 +81,10 @@ class CourseEditor extends Component {
       publishedState: this.props.initialVisible
         ? this.props.initialIsStable
           ? 'Recommended'
-          : 'Assignable'
+          : 'Preview'
         : this.props.initialPilotExperiment
         ? 'Pilot'
-        : 'Preview'
+        : 'Beta'
     };
   }
 

--- a/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
@@ -150,10 +150,10 @@ class ScriptEditor extends React.Component {
       publishedState: !this.props.initialHidden
         ? this.props.initialIsStable
           ? 'Recommended'
-          : 'Assignable'
+          : 'Preview'
         : this.props.initialPilotExperiment
         ? 'Pilot'
-        : 'Preview'
+        : 'Beta'
     };
   }
 

--- a/apps/test/unit/lib/levelbuilder/CourseVersionPublishingEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/CourseVersionPublishingEditorTest.jsx
@@ -34,7 +34,7 @@ describe('CourseVersionPublishedStateSelector', () => {
       updatePublishedState,
       families: ['family1', 'family2', 'family3'],
       versionYearOptions: ['1990', '1991', '1992'],
-      publishedState: 'Preview'
+      publishedState: 'Beta'
     };
   });
 
@@ -57,7 +57,7 @@ describe('CourseVersionPublishedStateSelector', () => {
       <CourseVersionPublishingEditor {...defaultProps} />
     );
     expect(wrapper.find('.publishedStateSelector').props().value).to.equal(
-      'Preview'
+      'Beta'
     );
     expect(wrapper.find('input').length).to.equal(0);
   });
@@ -75,6 +75,20 @@ describe('CourseVersionPublishedStateSelector', () => {
     expect(updateIsStable).to.have.been.calledWith(false);
   });
 
+  it('updates visible, isStable, and pilotExperiment when publish state changed to beta', () => {
+    const wrapper = shallow(
+      <CourseVersionPublishingEditor {...defaultProps} />
+    );
+
+    wrapper
+      .find('.publishedStateSelector')
+      .simulate('change', {target: {value: 'Beta'}});
+
+    expect(updateVisible).to.have.been.calledWith(false);
+    expect(updateIsStable).to.have.been.calledWith(false);
+    expect(updatePilotExperiment).to.have.been.calledWith('');
+  });
+
   it('updates visible, isStable, and pilotExperiment when publish state changed to preview', () => {
     const wrapper = shallow(
       <CourseVersionPublishingEditor {...defaultProps} />
@@ -83,20 +97,6 @@ describe('CourseVersionPublishedStateSelector', () => {
     wrapper
       .find('.publishedStateSelector')
       .simulate('change', {target: {value: 'Preview'}});
-
-    expect(updateVisible).to.have.been.calledWith(false);
-    expect(updateIsStable).to.have.been.calledWith(false);
-    expect(updatePilotExperiment).to.have.been.calledWith('');
-  });
-
-  it('updates visible, isStable, and pilotExperiment when publish state changed to assignable', () => {
-    const wrapper = shallow(
-      <CourseVersionPublishingEditor {...defaultProps} />
-    );
-
-    wrapper
-      .find('.publishedStateSelector')
-      .simulate('change', {target: {value: 'Assignable'}});
 
     expect(updateVisible).to.have.been.calledWith(true);
     expect(updateIsStable).to.have.been.calledWith(false);

--- a/apps/test/unit/lib/levelbuilder/course-editor/CourseEditorTest.js
+++ b/apps/test/unit/lib/levelbuilder/course-editor/CourseEditorTest.js
@@ -157,10 +157,10 @@ describe('CourseEditor', () => {
   });
 
   describe('Publish State', () => {
-    it('published state is preview when visible and isStable are false and there is no pilot experiment', () => {
+    it('published state is beta when visible and isStable are false and there is no pilot experiment', () => {
       const wrapper = createWrapper({});
       const courseEditor = wrapper.find('CourseEditor');
-      expect(courseEditor.state().publishedState).to.equal('Preview');
+      expect(courseEditor.state().publishedState).to.equal('Beta');
     });
 
     it('published state is pilot if there is a pilot experiment', () => {
@@ -169,10 +169,10 @@ describe('CourseEditor', () => {
       expect(courseEditor.state().publishedState).to.equal('Pilot');
     });
 
-    it('published state is assignable if visible is true but isStable is false', () => {
+    it('published state is preview if visible is true but isStable is false', () => {
       const wrapper = createWrapper({initialVisible: true});
       const courseEditor = wrapper.find('CourseEditor');
-      expect(courseEditor.state().publishedState).to.equal('Assignable');
+      expect(courseEditor.state().publishedState).to.equal('Preview');
     });
 
     it('published state is recommended if visible and isStable are true', () => {

--- a/apps/test/unit/lib/levelbuilder/script-editor/ScriptEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/ScriptEditorTest.jsx
@@ -255,10 +255,10 @@ describe('ScriptEditor', () => {
   });
 
   describe('Publish State', () => {
-    it('published state is preview when visible and isStable are false and there is no pilot experiment', () => {
+    it('published state is beta when visible and isStable are false and there is no pilot experiment', () => {
       const wrapper = createWrapper({});
       const scriptEditor = wrapper.find('ScriptEditor');
-      expect(scriptEditor.state().publishedState).to.equal('Preview');
+      expect(scriptEditor.state().publishedState).to.equal('Beta');
     });
 
     it('published state is pilot if there is a pilot experiment', () => {
@@ -267,10 +267,10 @@ describe('ScriptEditor', () => {
       expect(scriptEditor.state().publishedState).to.equal('Pilot');
     });
 
-    it('published state is assignable if visible is true but isStable is false', () => {
+    it('published state is preview if visible is true but isStable is false', () => {
       const wrapper = createWrapper({initialHidden: false});
       const scriptEditor = wrapper.find('ScriptEditor');
-      expect(scriptEditor.state().publishedState).to.equal('Assignable');
+      expect(scriptEditor.state().publishedState).to.equal('Preview');
     });
 
     it('published state is recommended if visible and isStable are true', () => {


### PR DESCRIPTION
Based on the conversation with the curriculum team we are going to use the following terms for the published states:

1. In Development
2. Pilot
3. Beta
4. Preview
5. Recommended

This PR updates to that language for the new editor dropdown. 

https://codedotorg.atlassian.net/browse/PLAT-1050