### PR TITLE
Generate Metadata for Sprite Upload

### DIFF
--- a/apps/src/assetManagement/animationLibraryApi.js
+++ b/apps/src/assetManagement/animationLibraryApi.js
@@ -17,16 +17,9 @@ export function getManifest(appType, locale = 'en_us') {
   and error calls the associated function
  * @param destination {String} path to sprite location in the animation-library folder
  * @param imageData {Blob} sprite image data to upload
- * @param onSuccess {function} callback function for success upload
- * @param onError {function} callback function for upload error
  * @returns {Promise} resolves if successful upload, rejects otherwise
  */
-export function uploadSpriteToAnimationLibrary(
-  destination,
-  imageData,
-  onSuccess,
-  onError
-) {
+export function uploadSpriteToAnimationLibrary(destination, imageData) {
   return fetch(`/api/v1/animation-library` + destination, {
     method: 'POST',
     headers: {
@@ -40,12 +33,10 @@ export function uploadSpriteToAnimationLibrary(
           `Sprite Upload Error(${response.status}: ${response.statusText})`
         );
       }
-      onSuccess(UploadType.SPRITE);
       return Promise.resolve();
     })
     .catch(err => {
-      onError(UploadType.SPRITE, err.toString());
-      return Promise.reject();
+      return Promise.reject(err);
     });
 }
 
@@ -53,16 +44,9 @@ export function uploadSpriteToAnimationLibrary(
   and error calls the associated function
  * @param destination {String} path to metadata location in the animation-library folder
  * @param jsonData {String} JSON object of metadata to upload
- * @param onSuccess {function} callback function for success upload
- * @param onError {function} callback function for upload error
  * @returns {Promise} resolves if successful upload, rejects otherwise
  */
-export function uploadMetadataToAnimationLibrary(
-  destination,
-  jsonData,
-  onSuccess,
-  onError
-) {
+export function uploadMetadataToAnimationLibrary(destination, jsonData) {
   return fetch(`/api/v1/animation-library` + destination, {
     method: 'POST',
     headers: {
@@ -76,11 +60,9 @@ export function uploadMetadataToAnimationLibrary(
           `Metadata Upload Error(${response.status}: ${response.statusText})`
         );
       }
-      onSuccess(UploadType.METADATA);
       return Promise.resolve();
     })
     .catch(err => {
-      onError(UploadType.METADATA, err.toString());
-      return Promise.reject();
+      return Promise.reject(err);
     });
 }

--- a/apps/src/assetManagement/animationLibraryApi.js
+++ b/apps/src/assetManagement/animationLibraryApi.js
@@ -19,6 +19,7 @@ export function getManifest(appType, locale = 'en_us') {
  * @param imageData {Blob} sprite image data to upload
  * @param onSuccess {function} callback function for success upload
  * @param onError {function} callback function for upload error
+ * @returns {Promise} resolves if successful upload, rejects otherwise
  */
 export function uploadSpriteToAnimationLibrary(
   destination,
@@ -34,10 +35,17 @@ export function uploadSpriteToAnimationLibrary(
     body: imageData
   })
     .then(response => {
-      onSuccess(UploadType.SPRITE, response);
+      if (!response.ok) {
+        throw new Error(
+          `Sprite Upload Error(${response.status}: ${response.statusText})`
+        );
+      }
+      onSuccess(UploadType.SPRITE);
+      return Promise.resolve();
     })
     .catch(err => {
-      onError(UploadType.SPRITE, err);
+      onError(UploadType.SPRITE, err.toString());
+      return Promise.reject();
     });
 }
 
@@ -47,6 +55,7 @@ export function uploadSpriteToAnimationLibrary(
  * @param jsonData {String} JSON object of metadata to upload
  * @param onSuccess {function} callback function for success upload
  * @param onError {function} callback function for upload error
+ * @returns {Promise} resolves if successful upload, rejects otherwise
  */
 export function uploadMetadataToAnimationLibrary(
   destination,
@@ -62,9 +71,16 @@ export function uploadMetadataToAnimationLibrary(
     body: jsonData
   })
     .then(response => {
-      onSuccess(UploadType.METADATA, response);
+      if (!response.ok) {
+        throw new Error(
+          `Metadata Upload Error(${response.status}: ${response.statusText})`
+        );
+      }
+      onSuccess(UploadType.METADATA);
+      return Promise.resolve();
     })
     .catch(err => {
-      onError(UploadType.METADATA, err);
+      onError(UploadType.METADATA, err.toString());
+      return Promise.reject();
     });
 }

--- a/apps/src/assetManagement/animationLibraryApi.js
+++ b/apps/src/assetManagement/animationLibraryApi.js
@@ -44,13 +44,13 @@ export function uploadSpriteToAnimationLibrary(
 /* Uploads the given JSON of sprite metadata to the animation library at the specified path. On success
   and error calls the associated function
  * @param destination {String} path to metadata location in the animation-library folder
- * @param JSONData {String} JSON object of metadata to upload
+ * @param jsonData {String} JSON object of metadata to upload
  * @param onSuccess {function} callback function for success upload
  * @param onError {function} callback function for upload error
  */
 export function uploadMetadataToAnimationLibrary(
   destination,
-  JSONData,
+  jsonData,
   onSuccess,
   onError
 ) {
@@ -59,7 +59,7 @@ export function uploadMetadataToAnimationLibrary(
     headers: {
       'Content-Type': 'application/json'
     },
-    body: JSONData
+    body: jsonData
   })
     .then(response => {
       onSuccess(UploadType.METADATA, response);

--- a/apps/src/assetManagement/animationLibraryApi.js
+++ b/apps/src/assetManagement/animationLibraryApi.js
@@ -1,3 +1,8 @@
+export const UploadType = {
+  SPRITE: 'Sprite',
+  JSON: 'JSON'
+};
+
 /* Returns the animation manifest of either GameLab or SpriteLab in the specified locale
  * @param appType {String} "gamelab" or "spritelab"
  * @param locale {String} language locale, defaults to 'en_us'
@@ -29,9 +34,30 @@ export function uploadSpriteToAnimationLibrary(
     body: imageData
   })
     .then(response => {
-      onSuccess(response);
+      onSuccess(UploadType.SPRITE, response);
     })
     .catch(err => {
-      onError(err);
+      onError(UploadType.SPRITE, err);
+    });
+}
+
+export function uploadJSONtoAnimationLibrary(
+  destination,
+  JSONData,
+  onSuccess,
+  onError
+) {
+  return fetch(`/api/v1/animation-library` + destination, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSONData
+  })
+    .then(response => {
+      onSuccess(UploadType.JSON, response);
+    })
+    .catch(err => {
+      onError(UploadType.JSON, err);
     });
 }

--- a/apps/src/assetManagement/animationLibraryApi.js
+++ b/apps/src/assetManagement/animationLibraryApi.js
@@ -41,6 +41,13 @@ export function uploadSpriteToAnimationLibrary(
     });
 }
 
+/* Uploads the given JSON of sprite metadata to the animation library at the specified path. On success
+  and error calls the associated function
+ * @param destination {String} path to metadata location in the animation-library folder
+ * @param JSONData {String} JSON object of metadata to upload
+ * @param onSuccess {function} callback function for success upload
+ * @param onError {function} callback function for upload error
+ */
 export function uploadMetadataToAnimationLibrary(
   destination,
   JSONData,

--- a/apps/src/assetManagement/animationLibraryApi.js
+++ b/apps/src/assetManagement/animationLibraryApi.js
@@ -1,6 +1,6 @@
 export const UploadType = {
   SPRITE: 'Sprite',
-  JSON: 'JSON'
+  METADATA: 'Metadata'
 };
 
 /* Returns the animation manifest of either GameLab or SpriteLab in the specified locale
@@ -41,7 +41,7 @@ export function uploadSpriteToAnimationLibrary(
     });
 }
 
-export function uploadJSONtoAnimationLibrary(
+export function uploadMetadataToAnimationLibrary(
   destination,
   JSONData,
   onSuccess,
@@ -55,9 +55,9 @@ export function uploadJSONtoAnimationLibrary(
     body: JSONData
   })
     .then(response => {
-      onSuccess(UploadType.JSON, response);
+      onSuccess(UploadType.METADATA, response);
     })
     .catch(err => {
-      onError(UploadType.JSON, err);
+      onError(UploadType.METADATA, err);
     });
 }

--- a/apps/src/code-studio/assets/SpriteUpload.jsx
+++ b/apps/src/code-studio/assets/SpriteUpload.jsx
@@ -20,11 +20,7 @@ export default class SpriteUpload extends React.Component {
     currentCategories: [],
     aliases: [],
     metadata: '',
-    spriteUploadStatus: {
-      success: null,
-      message: ''
-    },
-    metadataUploadStatus: {
+    uploadStatus: {
       success: null,
       message: ''
     }
@@ -60,47 +56,27 @@ export default class SpriteUpload extends React.Component {
     // The sprite and metadata JSON should have the same name, but different file extensions
     let jsonDestination = destination.replace('.png', '.json');
 
-    return uploadSpriteToAnimationLibrary(
-      destination,
-      fileData,
-      this.onSuccess,
-      this.onError
-    )
-      .then(() =>
-        uploadMetadataToAnimationLibrary(
-          jsonDestination,
-          metadata,
-          this.onSuccess,
-          this.onError
-        )
-      )
+    return uploadSpriteToAnimationLibrary(destination, fileData)
+      .then(() => uploadMetadataToAnimationLibrary(jsonDestination, metadata))
+      .then(() => {
+        this.setState({
+          uploadStatus: {
+            success: true,
+            message: 'Successfully Uploaded Sprite and Metadata'
+          }
+        });
+      })
       .catch(error => {
         if (error) {
           console.log(error);
         }
+        this.setState({
+          uploadStatus: {
+            success: false,
+            message: `${error.toString()}: Error Uploading Sprite or Metadata. Please try again. If this occurs again, please reach out to an engineer.`
+          }
+        });
       });
-  };
-
-  // 'uploadType' indicates whether the response comes from uploading the sprite file or the metadata file
-  onSuccess = uploadType => {
-    let styledUploadType = uploadType.toLowerCase();
-    this.setState({
-      [`${styledUploadType}UploadStatus`]: {
-        success: true,
-        message: `${uploadType} Successfully Uploaded`
-      }
-    });
-  };
-
-  // 'uploadType' indicates whether the response comes from uploading the sprite file or the metadata file
-  onError = (uploadType, message) => {
-    let styledUploadType = uploadType.toLowerCase();
-    this.setState({
-      [`${styledUploadType}UploadStatus`]: {
-        success: false,
-        message: message
-      }
-    });
   };
 
   handleImageChange = event => {
@@ -145,8 +121,7 @@ export default class SpriteUpload extends React.Component {
 
   render() {
     const {
-      spriteUploadStatus,
-      metadataUploadStatus,
+      uploadStatus,
       filePreviewURL,
       currentCategories,
       spriteAvailability,
@@ -262,18 +237,10 @@ export default class SpriteUpload extends React.Component {
           <p
             style={{
               ...styles.uploadStatusMessage,
-              ...(!spriteUploadStatus.success && styles.uploadFailure)
+              ...(!uploadStatus.success && styles.uploadFailure)
             }}
           >
-            {spriteUploadStatus.message}
-          </p>
-          <p
-            style={{
-              ...styles.uploadStatusMessage,
-              ...(!metadataUploadStatus.success && styles.uploadFailure)
-            }}
-          >
-            {metadataUploadStatus.message}
+            {uploadStatus.message}
           </p>
         </form>
       </div>

--- a/apps/src/code-studio/assets/SpriteUpload.jsx
+++ b/apps/src/code-studio/assets/SpriteUpload.jsx
@@ -65,42 +65,42 @@ export default class SpriteUpload extends React.Component {
       fileData,
       this.onSuccess,
       this.onError
-    ).then(() =>
-      uploadMetadataToAnimationLibrary(
-        jsonDestination,
-        metadata,
-        this.onSuccess,
-        this.onError
+    )
+      .then(() =>
+        uploadMetadataToAnimationLibrary(
+          jsonDestination,
+          metadata,
+          this.onSuccess,
+          this.onError
+        )
       )
-    );
+      .catch(error => {
+        if (error) {
+          console.log(error);
+        }
+      });
   };
 
   // 'uploadType' indicates whether the response comes from uploading the sprite file or the metadata file
-  onSuccess = (uploadType, response) => {
-    let responseMessage = response.ok
-      ? `${uploadType} Successfully Uploaded`
-      : `${uploadType} Upload Error(${response.status}: ${
-          response.statusText
-        })`;
+  onSuccess = uploadType => {
     let styledUploadType = uploadType.toLowerCase();
     this.setState({
       [`${styledUploadType}UploadStatus`]: {
-        success: response.ok,
-        message: responseMessage
+        success: true,
+        message: `${uploadType} Successfully Uploaded`
       }
     });
   };
 
   // 'uploadType' indicates whether the response comes from uploading the sprite file or the metadata file
-  onError = (uploadType, error) => {
+  onError = (uploadType, message) => {
     let styledUploadType = uploadType.toLowerCase();
     this.setState({
       [`${styledUploadType}UploadStatus`]: {
         success: false,
-        message: error.toString()
+        message: message
       }
     });
-    console.error(error);
   };
 
   handleImageChange = event => {

--- a/apps/src/code-studio/assets/SpriteUpload.jsx
+++ b/apps/src/code-studio/assets/SpriteUpload.jsx
@@ -197,7 +197,9 @@ export default class SpriteUpload extends React.Component {
             Generate Sprite Metadata
           </button>
           <h3>Metadata JSON</h3>
-          <p>{this.state.metadata}</p>
+          <p>
+            <code>{this.state.metadata}</code>
+          </p>
           <br />
 
           {!uploadButtonDisabled && (

--- a/apps/src/code-studio/assets/SpriteUpload.jsx
+++ b/apps/src/code-studio/assets/SpriteUpload.jsx
@@ -75,7 +75,7 @@ export default class SpriteUpload extends React.Component {
     );
   };
 
-  // 'uploadType' indicates whether the response comes from uploading the 'Image' file or the 'Metadata' file
+  // 'uploadType' indicates whether the response comes from uploading the sprite file or the metadata file
   onSuccess = (uploadType, response) => {
     let responseMessage = response.ok
       ? `${uploadType} Successfully Uploaded`
@@ -93,7 +93,7 @@ export default class SpriteUpload extends React.Component {
     }
   };
 
-  // 'uploadType' indicates whether the response comes from uploading the 'Image' file or the 'Metadata' file
+  // 'uploadType' indicates whether the response comes from uploading the sprite file or the metadata file
   onError = (uploadType, error) => {
     if (uploadType === UploadType.SPRITE) {
       this.setState({

--- a/apps/src/code-studio/assets/SpriteUpload.jsx
+++ b/apps/src/code-studio/assets/SpriteUpload.jsx
@@ -4,7 +4,7 @@ import {makeEnum} from '@cdo/apps/utils';
 import {
   getManifest,
   uploadSpriteToAnimationLibrary,
-  uploadJSONtoAnimationLibrary,
+  uploadMetadataToAnimationLibrary,
   UploadType
 } from '@cdo/apps/assetManagement/animationLibraryApi';
 
@@ -66,7 +66,7 @@ export default class SpriteUpload extends React.Component {
       this.onSuccess,
       this.onError
     ).then(() =>
-      uploadJSONtoAnimationLibrary(
+      uploadMetadataToAnimationLibrary(
         JSONDestination,
         metadata,
         this.onSuccess,
@@ -86,7 +86,7 @@ export default class SpriteUpload extends React.Component {
       this.setState({
         imageUploadStatus: {success: response.ok, message: responseMessage}
       });
-    } else if (uploadType === UploadType.JSON) {
+    } else if (uploadType === UploadType.METADATA) {
       this.setState({
         metadataUploadStatus: {success: response.ok, message: responseMessage}
       });
@@ -99,7 +99,7 @@ export default class SpriteUpload extends React.Component {
       this.setState({
         imageUploadStatus: {success: false, message: error.toString()}
       });
-    } else if (uploadType === UploadType.JSON) {
+    } else if (uploadType === UploadType.METADATA) {
       this.setState({
         metadataUploadStatus: {success: false, message: error.toString()}
       });

--- a/apps/src/code-studio/assets/SpriteUpload.jsx
+++ b/apps/src/code-studio/assets/SpriteUpload.jsx
@@ -128,48 +128,53 @@ export default class SpriteUpload extends React.Component {
       <div>
         <h1>Sprite Upload</h1>
         <form onSubmit={this.handleSubmit}>
-          <label>
-            <h3>Sprite Category:</h3>
-            <p>
-              Select whether the sprite should only be available in a specific
-              level or whether it should be available in the sprite library.
-            </p>
+          <h2 style={styles.spriteUploadStep}>
+            Step 1: Select where the sprite should be uploaded
+          </h2>
+          <h3>Sprite Category:</h3>
+          <p>
+            Select whether the sprite should only be available in a specific
+            level or whether it should be available in the sprite library.
+          </p>
+          <div>
+            <label>
+              Level-specific sprite:
+              <input
+                type="radio"
+                name="spriteAvailability"
+                style={styles.radioButton}
+                value={SpriteLocation.level}
+                onChange={this.handleAvailabilityChange}
+              />
+            </label>
+            <label>
+              Library sprite:
+              <input
+                type="radio"
+                name="spriteAvailability"
+                style={styles.radioButton}
+                value={SpriteLocation.library}
+                onChange={this.handleAvailabilityChange}
+              />
+            </label>
+          </div>
+          {spriteAvailability === SpriteLocation.library && (
             <div>
-              <label>
-                Level-specific sprite:
-                <input
-                  type="radio"
-                  name="spriteAvailability"
-                  style={styles.radioButton}
-                  value={SpriteLocation.level}
-                  onChange={this.handleAvailabilityChange}
-                />
-              </label>
-              <label>
-                Library sprite:
-                <input
-                  type="radio"
-                  name="spriteAvailability"
-                  style={styles.radioButton}
-                  value={SpriteLocation.library}
-                  onChange={this.handleAvailabilityChange}
-                />
-              </label>
+              <label>Category:</label>
+              <select onChange={this.handleCategoryChange}>
+                <option value="">Select an Option</option>
+                {(currentCategories || []).map(category => (
+                  <option key={category} value={category}>
+                    {category}
+                  </option>
+                ))}
+              </select>
             </div>
-            {spriteAvailability === SpriteLocation.library && (
-              <div>
-                <label>Category:</label>
-                <select onChange={this.handleCategoryChange}>
-                  <option value="">Select an Option</option>
-                  {(currentCategories || []).map(category => (
-                    <option key={category} value={category}>
-                      {category}
-                    </option>
-                  ))}
-                </select>
-              </div>
-            )}
-          </label>
+          )}
+
+          <h2 style={styles.spriteUploadStep}>
+            Step 2: Select the sprite to upload
+          </h2>
           <label>
             <h3>Select Sprite to Add to Library:</h3>
             <input
@@ -185,6 +190,10 @@ export default class SpriteUpload extends React.Component {
             <img id="sprite-image-preview" src={filePreviewURL} />
           </label>
           <br />
+
+          <h2 style={styles.spriteUploadStep}>
+            Step 3: Generate metadata for the sprite
+          </h2>
           <label>
             <h3>Enter the aliases for this sprite</h3>
             <p>
@@ -197,13 +206,20 @@ export default class SpriteUpload extends React.Component {
             Generate Sprite Metadata
           </button>
           <h3>Metadata JSON</h3>
-          <p>
-            <code>{this.state.metadata}</code>
-          </p>
+          {!!this.state.metadata && (
+            <p>
+              <code>{this.state.metadata}</code>
+            </p>
+          )}
           <br />
 
           {!uploadButtonDisabled && (
-            <button type="submit">Upload to Library</button>
+            <div>
+              <h2 style={styles.spriteUploadStep}>
+                Step 4: Upload the sprite and metadata to sprite library
+              </h2>
+              <button type="submit">Upload to Library</button>
+            </div>
           )}
           <p
             style={{
@@ -228,5 +244,8 @@ const styles = {
   },
   radioButton: {
     margin: 10
+  },
+  spriteUploadStep: {
+    borderTop: '1px solid gray'
   }
 };

--- a/apps/src/code-studio/assets/SpriteUpload.jsx
+++ b/apps/src/code-studio/assets/SpriteUpload.jsx
@@ -17,6 +17,8 @@ export default class SpriteUpload extends React.Component {
     spriteAvailability: '',
     category: '',
     currentCategories: [],
+    aliases: [],
+    metadata: '',
     uploadStatus: {
       success: null,
       message: ''
@@ -86,6 +88,25 @@ export default class SpriteUpload extends React.Component {
 
   handleAvailabilityChange = event => {
     this.setState({spriteAvailability: event.target.value, category: ''});
+  };
+
+  handleAliasChange = event => {
+    let aliases = event.target.value;
+    aliases = aliases.split(',');
+    let processedAliases = aliases.map(alias => alias.trim());
+    this.setState({aliases: processedAliases});
+  };
+
+  generateMetadata = () => {
+    let image = document.getElementById('sprite-image-preview');
+    let metadata = {};
+    metadata['name'] = this.state.filename;
+    metadata['aliases'] = this.state.aliases;
+    metadata['frameCount'] = 1;
+    metadata['frameSize'] = {x: image.width, y: image.height};
+    metadata['looping'] = true;
+    metadata['frameDelay'] = 2;
+    this.setState({metadata: JSON.stringify(metadata)});
   };
 
   render() {
@@ -161,9 +182,24 @@ export default class SpriteUpload extends React.Component {
           <br />
           <label>
             <h3>Image Preview:</h3>
-            <img src={filePreviewURL} />
+            <img id="sprite-image-preview" src={filePreviewURL} />
           </label>
           <br />
+          <label>
+            <h3>Enter the aliases for this sprite</h3>
+            <p>
+              Separate aliases by commas. Example: "peach, stonefruit,
+              delicious"
+            </p>
+            <input type="text" onChange={this.handleAliasChange} />
+          </label>
+          <button type="button" onClick={this.generateMetadata}>
+            Generate Sprite Metadata
+          </button>
+          <h3>Metadata JSON</h3>
+          <p>{this.state.metadata}</p>
+          <br />
+
           {!uploadButtonDisabled && (
             <button type="submit">Upload to Library</button>
           )}

--- a/shared/middleware/animation_library_api.rb
+++ b/shared/middleware/animation_library_api.rb
@@ -45,7 +45,7 @@ class AnimationLibraryApi < Sinatra::Base
   #
   post %r{/api/v1/animation-library/level_animations/(.+)} do |animation_name|
     dont_cache
-    if request.content_type == 'image/png'
+    if request.content_type == 'image/png' || request.content_type == 'application/json'
       body = request.body
       key = "level_animations/#{animation_name}"
 
@@ -61,7 +61,7 @@ class AnimationLibraryApi < Sinatra::Base
   #
   post %r{/api/v1/animation-library/spritelab/([^/]+)/(.+)} do |category, animation_name|
     dont_cache
-    if request.content_type == 'image/png'
+    if request.content_type == 'image/png' || request.content_type == 'application/json'
       body = request.body
       key = "spritelab/#{category}/#{animation_name}"
 


### PR DESCRIPTION
Next Part of the Sprite Upload Task. Translates https://github.com/code-dot-org/code-dot-org/blob/staging/tools/scripts/generateSingleFrameAnimationMetadata.rb to the new Sprite Upload page, displays the output and saves it to S3 as <filename>.json.

Also added some styling to break up the steps on the page as it was getting kind of long.

Looks like: 
![Screenshot from 2021-05-18 13-59-48](https://user-images.githubusercontent.com/2959170/118724235-346dc380-b7e3-11eb-8846-d258d2788190.png)


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
