### PR TITLE
[Spritelab] Add id to prompt submit button

### DIFF
--- a/apps/src/p5lab/spritelab/SpritelabInput.jsx
+++ b/apps/src/p5lab/spritelab/SpritelabInput.jsx
@@ -94,6 +94,7 @@ class SpritelabInput extends React.Component {
               disabled={disabled}
             />
             <button
+              id="spritelabSubmitPrompt"
               style={styles.submitButton}
               type="button"
               onClick={this.onTextSubmit}


### PR DESCRIPTION
Requested by @mikeharv so that a callout can be added to the button on the first level where students use the prompt block