### PR TITLE
Start creating a script to copy level concept difficulty from year to year

### DIFF
--- a/bin/curriculum/copy_level_concept_difficulties_between_years.rb
+++ b/bin/curriculum/copy_level_concept_difficulties_between_years.rb
@@ -13,16 +13,20 @@ def main
     script.script_levels.each do |sl|
       puts "Level: " + sl.level.name
       next if sl.level.level_concept_difficulty
-      parent_level = Level.find_by(id: sl.level.parent_level_id)
-      next unless parent_level
-      puts "Parent Level: " + parent_level.name
-      #make a new level_concept_difficulty that is same as parent_levels
-      new_lcd = parent_level.level_concept_difficulty.dup
-      # Assign it to the level
-      sl.level.level_concept_difficulty = new_lcd
-      sl.level.save! if sl.level.changed?
+      copy_lcd_from_parent(sl)
     end
   end
+end
+
+def copy_lcd_from_parent(sl)
+  parent_level = Level.find_by(id: sl.level.parent_level_id)
+  next unless parent_level
+  puts "Parent Level: " + parent_level.name
+  #make a new level_concept_difficulty that is same as parent_levels
+  new_lcd = parent_level.level_concept_difficulty.dup
+  # Assign it to the level
+  sl.level.level_concept_difficulty = new_lcd
+  sl.level.save! if sl.level.changed?
 end
 
 main

--- a/bin/curriculum/copy_level_concept_difficulties_between_years.rb
+++ b/bin/curriculum/copy_level_concept_difficulties_between_years.rb
@@ -1,9 +1,7 @@
 #!/usr/bin/env ruby
 require_relative '../../dashboard/config/environment'
 
-def main
-  year_to_copy_to = '2020'
-
+def main(year_to_copy_to)
   script_names = ['coursea-' + year_to_copy_to, 'courseb-' + year_to_copy_to, 'coursec-' + year_to_copy_to,
                   'coursed-' + year_to_copy_to, 'coursee-' + year_to_copy_to, 'coursef-' + year_to_copy_to,
                   'pre-express-' + year_to_copy_to, 'express-' + year_to_copy_to]
@@ -13,20 +11,21 @@ def main
     script.script_levels.each do |sl|
       puts "Level: " + sl.level.name
       next if sl.level.level_concept_difficulty
-      copy_lcd_from_parent(sl)
+      copy_lcd_from_parent(sl.level)
     end
   end
 end
 
-def copy_lcd_from_parent(sl)
-  parent_level = Level.find_by(id: sl.level.parent_level_id)
-  next unless parent_level
+def copy_lcd_from_parent(level)
+  parent_level = Level.find_by(id: level.parent_level_id)
+  return unless parent_level
   puts "Parent Level: " + parent_level.name
   #make a new level_concept_difficulty that is same as parent_levels
   new_lcd = parent_level.level_concept_difficulty.dup
   # Assign it to the level
-  sl.level.level_concept_difficulty = new_lcd
-  sl.level.save! if sl.level.changed?
+  level.level_concept_difficulty = new_lcd
+  level.save! if level.changed?
 end
 
-main
+main('2020')
+main('2021')

--- a/bin/curriculum/copy_level_concept_difficulties_between_years.rb
+++ b/bin/curriculum/copy_level_concept_difficulties_between_years.rb
@@ -1,0 +1,28 @@
+#!/usr/bin/env ruby
+require_relative '../../dashboard/config/environment'
+
+def main
+  year_to_copy_to = '2020'
+
+  script_names = ['coursea-' + year_to_copy_to, 'courseb-' + year_to_copy_to, 'coursec-' + year_to_copy_to,
+                  'coursed-' + year_to_copy_to, 'coursee-' + year_to_copy_to, 'coursef-' + year_to_copy_to,
+                  'pre-express-' + year_to_copy_to, 'express-' + year_to_copy_to]
+  csf_scripts = script_names.map {|name| Script.find_by(name: name)}
+
+  csf_scripts.each do |script|
+    script.script_levels.each do |sl|
+      puts "Level: " + sl.level.name
+      next if sl.level.level_concept_difficulty
+      parent_level = Level.find_by(id: sl.level.parent_level_id)
+      next unless parent_level
+      puts "Parent Level: " + parent_level.name
+      #make a new level_concept_difficulty that is same as parent_levels
+      new_lcd = parent_level.level_concept_difficulty.dup
+      # Assign it to the level
+      sl.level.level_concept_difficulty = new_lcd
+      sl.level.save! if sl.level.changed?
+    end
+  end
+end
+
+main


### PR DESCRIPTION
Mike [reported in slack](https://codedotorg.slack.com/archives/CNZP84FJ5/p1621279309003400) that the `level_concept_difficulty` for levels in 2020 did not get copied over from 2019. This means that also 2021 did not get the `level_concept_difficulty` information either. This script will allow us to look for the `parent_level_id` for a level, which we set when we copy levels using either `clone_with_name` or `clone_with_suffix`. Using the `parent_level_id` we can find out the `level_concept_difficulty` for the parent level and then duplicate it and add it to the original level. 

This script will need to be run on levelbuilder since that is where we cloned the scripts and level ids are specific to the environment. 

## Links

https://codedotorg.atlassian.net/browse/PLAT-1066

## Testing story

- Locally I copied a level that has `level_concept_difficulty`
- Then I tried running `copy_lcd_from_parent` on the copied level and it worked

I can't test the script fully locally because the parent_level_ids are specific to levelbuilder.