### PR TITLE
Add show to save bar

### DIFF
--- a/apps/src/lib/levelbuilder/SaveBar.jsx
+++ b/apps/src/lib/levelbuilder/SaveBar.jsx
@@ -8,45 +8,59 @@ export default class SaveBar extends Component {
     lastSaved: PropTypes.number,
     error: PropTypes.string,
     handleSave: PropTypes.func.isRequired,
+    handleView: PropTypes.func.isRequired,
     isSaving: PropTypes.bool
   };
 
   render() {
     return (
       <div style={styles.saveButtonBackground} className="saveBar">
-        {this.props.lastSaved && !this.props.error && (
-          <div style={styles.lastSaved} className="lastSavedMessage">
-            {`Last saved at: ${new Date(
-              this.props.lastSaved
-            ).toLocaleString()}`}
-          </div>
-        )}
-        {this.props.error && (
-          <div style={styles.error}>{`Error Saving: ${this.props.error}`}</div>
-        )}
-        {this.props.isSaving && (
-          <div style={styles.spinner}>
-            <FontAwesome icon="spinner" className="fa-spin" />
-          </div>
-        )}
         <button
           className="btn"
           type="button"
           style={styles.saveButton}
-          onClick={e => this.props.handleSave(e, false)}
+          onClick={this.props.handleView}
           disabled={this.props.isSaving}
         >
-          Save and Keep Editing
+          Show
         </button>
-        <button
-          className="btn btn-primary"
-          type="submit"
-          style={styles.saveButton}
-          onClick={e => this.props.handleSave(e, true)}
-          disabled={this.props.isSaving}
-        >
-          Save and Close
-        </button>
+        <div style={styles.saveButtonArea}>
+          {this.props.lastSaved && !this.props.error && (
+            <div style={styles.lastSaved} className="lastSavedMessage">
+              {`Last saved at: ${new Date(
+                this.props.lastSaved
+              ).toLocaleString()}`}
+            </div>
+          )}
+          {this.props.error && (
+            <div style={styles.error}>{`Error Saving: ${
+              this.props.error
+            }`}</div>
+          )}
+          {this.props.isSaving && (
+            <div style={styles.spinner}>
+              <FontAwesome icon="spinner" className="fa-spin" />
+            </div>
+          )}
+          <button
+            className="btn"
+            type="button"
+            style={styles.saveButton}
+            onClick={e => this.props.handleSave(e, false)}
+            disabled={this.props.isSaving}
+          >
+            Save and Keep Editing
+          </button>
+          <button
+            className="btn btn-primary"
+            type="submit"
+            style={styles.saveButton}
+            onClick={e => this.props.handleSave(e, true)}
+            disabled={this.props.isSaving}
+          >
+            Save and Close
+          </button>
+        </div>
       </div>
     );
   }
@@ -63,6 +77,11 @@ const styles = {
     height: 50,
     width: '100%',
     zIndex: 900,
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'space-between'
+  },
+  saveButtonArea: {
     display: 'flex',
     justifyContent: 'flex-end'
   },

--- a/apps/src/lib/levelbuilder/course-editor/CourseEditor.js
+++ b/apps/src/lib/levelbuilder/course-editor/CourseEditor.js
@@ -41,6 +41,7 @@ class CourseEditor extends Component {
     initialAnnouncements: PropTypes.arrayOf(announcementShape).isRequired,
     useMigratedResources: PropTypes.bool.isRequired,
     courseVersionId: PropTypes.number,
+    coursePath: PropTypes.string.isRequired,
 
     // Provided by redux
     migratedTeacherResources: PropTypes.arrayOf(migratedResourceShape),
@@ -90,6 +91,10 @@ class CourseEditor extends Component {
 
   handleUpdateAnnouncements = newAnnouncements => {
     this.setState({announcements: newAnnouncements});
+  };
+
+  handleView = () => {
+    navigateToHref(linkWithQueryParams(this.props.coursePath));
   };
 
   handleSave = (event, shouldCloseAfterSave) => {
@@ -362,6 +367,7 @@ class CourseEditor extends Component {
         </CollapsibleEditorSection>
         <SaveBar
           handleSave={this.handleSave}
+          handleView={this.handleView}
           error={this.state.error}
           isSaving={this.state.isSaving}
           lastSaved={this.state.lastSaved}

--- a/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
@@ -72,6 +72,12 @@ class LessonEditor extends Component {
     };
   }
 
+  handleView = () => {
+    navigateToHref(
+      linkWithQueryParams(this.state.originalLessonData.lessonPath)
+    );
+  };
+
   handleSave = (event, shouldCloseAfterSave) => {
     event.preventDefault();
 
@@ -456,6 +462,7 @@ class LessonEditor extends Component {
 
         <SaveBar
           handleSave={this.handleSave}
+          handleView={this.handleView}
           error={this.state.error}
           isSaving={this.state.isSaving}
           lastSaved={this.state.lastSaved}

--- a/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
@@ -78,6 +78,7 @@ class ScriptEditor extends React.Component {
     isMigrated: PropTypes.bool,
     initialIncludeStudentLessonPlans: PropTypes.bool,
     initialCourseVersionId: PropTypes.number,
+    scriptPath: PropTypes.string.isRequired,
 
     // from redux
     lessonGroups: PropTypes.arrayOf(lessonGroupShape).isRequired,
@@ -193,6 +194,10 @@ class ScriptEditor extends React.Component {
     } else {
       this.setState({showCalendar: !this.state.showCalendar});
     }
+  };
+
+  handleView = () => {
+    navigateToHref(linkWithQueryParams(this.props.scriptPath));
   };
 
   handleSave = (event, shouldCloseAfterSave) => {
@@ -948,6 +953,7 @@ class ScriptEditor extends React.Component {
         </CollapsibleEditorSection>
         <SaveBar
           handleSave={this.handleSave}
+          handleView={this.handleView}
           error={this.state.error}
           isSaving={this.state.isSaving}
           lastSaved={this.state.lastSaved}

--- a/apps/src/sites/studio/pages/scripts/edit.js
+++ b/apps/src/sites/studio/pages/scripts/edit.js
@@ -103,6 +103,7 @@ export default function initPage(scriptEditorData) {
         initialIncludeStudentLessonPlans={
           scriptData.includeStudentLessonPlans || false
         }
+        scriptPath={scriptData.scriptPath}
       />
     </Provider>,
     document.querySelector('.edit_container')

--- a/apps/test/unit/lib/levelbuilder/SaveBarTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/SaveBarTest.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {mount} from 'enzyme';
+import {shallow} from 'enzyme';
 import {expect} from '../../../util/reconfiguredChai';
 import sinon from 'sinon';
 import SaveBar from '@cdo/apps/lib/levelbuilder/SaveBar';
@@ -19,13 +19,13 @@ describe('SaveBar', () => {
   });
 
   it('renders default props', () => {
-    const wrapper = mount(<SaveBar {...defaultProps} />);
+    const wrapper = shallow(<SaveBar {...defaultProps} />);
     expect(wrapper.find('button').length).to.equal(3);
     expect(wrapper.find('FontAwesome').length).to.equal(0); //spinner isn't showing
   });
 
   it('can save and keep editing', () => {
-    const wrapper = mount(<SaveBar {...defaultProps} />);
+    const wrapper = shallow(<SaveBar {...defaultProps} />);
 
     const saveAndKeepEditingButton = wrapper.find('button').at(1);
     expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
@@ -36,14 +36,16 @@ describe('SaveBar', () => {
   });
 
   it('shows spinner when isSaving is true', () => {
-    const wrapper = mount(<SaveBar {...defaultProps} isSaving={true} />);
+    const wrapper = shallow(<SaveBar {...defaultProps} isSaving={true} />);
 
     // check the the spinner is showing
     expect(wrapper.find('FontAwesome').length).to.equal(1);
   });
 
   it('shows lastSaved when there is no error', () => {
-    const wrapper = mount(<SaveBar {...defaultProps} lastSaved={Date.now()} />);
+    const wrapper = shallow(
+      <SaveBar {...defaultProps} lastSaved={Date.now()} />
+    );
 
     expect(wrapper.find('.lastSavedMessage').text()).to.include(
       'Last saved at:'
@@ -51,7 +53,7 @@ describe('SaveBar', () => {
   });
 
   it('shows error when props error is set', () => {
-    const wrapper = mount(
+    const wrapper = shallow(
       <SaveBar {...defaultProps} error={'There was an error'} />
     );
     expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(0);
@@ -61,7 +63,7 @@ describe('SaveBar', () => {
   });
 
   it('can save and close', () => {
-    const wrapper = mount(<SaveBar {...defaultProps} />);
+    const wrapper = shallow(<SaveBar {...defaultProps} />);
 
     const saveAndCloseButton = wrapper.find('button').at(2);
     expect(saveAndCloseButton.contains('Save and Close')).to.be.true;
@@ -71,7 +73,7 @@ describe('SaveBar', () => {
   });
 
   it('can go to item with show', () => {
-    const wrapper = mount(<SaveBar {...defaultProps} />);
+    const wrapper = shallow(<SaveBar {...defaultProps} />);
 
     const saveAndCloseButton = wrapper.find('button').at(0);
     expect(saveAndCloseButton.contains('Show')).to.be.true;

--- a/apps/test/unit/lib/levelbuilder/SaveBarTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/SaveBarTest.jsx
@@ -5,27 +5,29 @@ import sinon from 'sinon';
 import SaveBar from '@cdo/apps/lib/levelbuilder/SaveBar';
 
 describe('SaveBar', () => {
-  let defaultProps, handleSave;
+  let defaultProps, handleSave, handleView;
   beforeEach(() => {
     handleSave = sinon.spy();
+    handleView = sinon.spy();
     defaultProps = {
       isSaving: false,
       error: null,
       lastSaved: null,
-      handleSave
+      handleSave,
+      handleView
     };
   });
 
   it('renders default props', () => {
     const wrapper = mount(<SaveBar {...defaultProps} />);
-    expect(wrapper.find('button').length).to.equal(2);
+    expect(wrapper.find('button').length).to.equal(3);
     expect(wrapper.find('FontAwesome').length).to.equal(0); //spinner isn't showing
   });
 
   it('can save and keep editing', () => {
     const wrapper = mount(<SaveBar {...defaultProps} />);
 
-    const saveAndKeepEditingButton = wrapper.find('button').at(0);
+    const saveAndKeepEditingButton = wrapper.find('button').at(1);
     expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
       .true;
     saveAndKeepEditingButton.simulate('click');
@@ -61,10 +63,20 @@ describe('SaveBar', () => {
   it('can save and close', () => {
     const wrapper = mount(<SaveBar {...defaultProps} />);
 
-    const saveAndCloseButton = wrapper.find('button').at(1);
+    const saveAndCloseButton = wrapper.find('button').at(2);
     expect(saveAndCloseButton.contains('Save and Close')).to.be.true;
     saveAndCloseButton.simulate('click');
 
     expect(handleSave).to.have.been.calledOnce;
+  });
+
+  it('can go to item with show', () => {
+    const wrapper = mount(<SaveBar {...defaultProps} />);
+
+    const saveAndCloseButton = wrapper.find('button').at(0);
+    expect(saveAndCloseButton.contains('Show')).to.be.true;
+    saveAndCloseButton.simulate('click');
+
+    expect(handleView).to.have.been.calledOnce;
   });
 });

--- a/apps/test/unit/lib/levelbuilder/course-editor/CourseEditorTest.js
+++ b/apps/test/unit/lib/levelbuilder/course-editor/CourseEditorTest.js
@@ -211,7 +211,7 @@ describe('CourseEditor', () => {
 
       const saveBar = wrapper.find('SaveBar');
 
-      const saveAndKeepEditingButton = saveBar.find('button').at(0);
+      const saveAndKeepEditingButton = saveBar.find('button').at(1);
       expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
         .true;
       saveAndKeepEditingButton.simulate('click');
@@ -248,7 +248,7 @@ describe('CourseEditor', () => {
 
       const saveBar = wrapper.find('SaveBar');
 
-      const saveAndKeepEditingButton = saveBar.find('button').at(0);
+      const saveAndKeepEditingButton = saveBar.find('button').at(1);
       expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
         .true;
       saveAndKeepEditingButton.simulate('click');
@@ -286,7 +286,7 @@ describe('CourseEditor', () => {
 
       const saveBar = wrapper.find('SaveBar');
 
-      const saveAndCloseButton = saveBar.find('button').at(1);
+      const saveAndCloseButton = saveBar.find('button').at(2);
       expect(saveAndCloseButton.contains('Save and Close')).to.be.true;
       saveAndCloseButton.simulate('click');
 
@@ -317,7 +317,7 @@ describe('CourseEditor', () => {
 
       const saveBar = wrapper.find('SaveBar');
 
-      const saveAndCloseButton = saveBar.find('button').at(1);
+      const saveAndCloseButton = saveBar.find('button').at(2);
       expect(saveAndCloseButton.contains('Save and Close')).to.be.true;
       saveAndCloseButton.simulate('click');
 
@@ -349,7 +349,7 @@ describe('CourseEditor', () => {
 
       const saveBar = wrapper.find('SaveBar');
 
-      const saveAndKeepEditingButton = saveBar.find('button').at(0);
+      const saveAndKeepEditingButton = saveBar.find('button').at(1);
       expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
         .true;
       saveAndKeepEditingButton.simulate('click');

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/LessonEditorTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/LessonEditorTest.js
@@ -222,7 +222,7 @@ describe('LessonEditor', () => {
 
     const saveBar = wrapper.find('SaveBar');
 
-    const saveAndKeepEditingButton = saveBar.find('button').at(0);
+    const saveAndKeepEditingButton = saveBar.find('button').at(1);
     expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
       .true;
     saveAndKeepEditingButton.simulate('click');
@@ -259,7 +259,7 @@ describe('LessonEditor', () => {
 
     const saveBar = wrapper.find('SaveBar');
 
-    const saveAndKeepEditingButton = saveBar.find('button').at(0);
+    const saveAndKeepEditingButton = saveBar.find('button').at(1);
     expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
       .true;
     saveAndKeepEditingButton.simulate('click');
@@ -295,7 +295,7 @@ describe('LessonEditor', () => {
 
     const saveBar = wrapper.find('SaveBar');
 
-    const saveAndCloseButton = saveBar.find('button').at(1);
+    const saveAndCloseButton = saveBar.find('button').at(2);
     expect(saveAndCloseButton.contains('Save and Close')).to.be.true;
     saveAndCloseButton.simulate('click');
 
@@ -326,7 +326,7 @@ describe('LessonEditor', () => {
 
     const saveBar = wrapper.find('SaveBar');
 
-    const saveAndCloseButton = saveBar.find('button').at(1);
+    const saveAndCloseButton = saveBar.find('button').at(2);
     expect(saveAndCloseButton.contains('Save and Close')).to.be.true;
     saveAndCloseButton.simulate('click');
 
@@ -358,7 +358,7 @@ describe('LessonEditor', () => {
 
     const saveBar = wrapper.find('SaveBar');
 
-    const saveAndCloseButton = saveBar.find('button').at(1);
+    const saveAndCloseButton = saveBar.find('button').at(2);
     expect(saveAndCloseButton.contains('Save and Close')).to.be.true;
     saveAndCloseButton.simulate('click');
 

--- a/apps/test/unit/lib/levelbuilder/script-editor/ScriptEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/ScriptEditorTest.jsx
@@ -77,6 +77,7 @@ describe('ScriptEditor', () => {
       initialIsStable: false,
       initialHidden: true,
       hasCourse: false,
+      scriptPath: '/s/test-script',
       initialLessonLevelData:
         "lesson_group 'lesson group', display_name: 'lesson group display name'\nlesson 'new lesson', display_name: 'lesson display name', has_lesson_plan: true\n"
     };
@@ -309,7 +310,7 @@ describe('ScriptEditor', () => {
 
       const saveBar = wrapper.find('SaveBar');
 
-      const saveAndKeepEditingButton = saveBar.find('button').at(0);
+      const saveAndKeepEditingButton = saveBar.find('button').at(1);
       expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
         .true;
       saveAndKeepEditingButton.simulate('click');
@@ -346,7 +347,7 @@ describe('ScriptEditor', () => {
 
       const saveBar = wrapper.find('SaveBar');
 
-      const saveAndKeepEditingButton = saveBar.find('button').at(0);
+      const saveAndKeepEditingButton = saveBar.find('button').at(1);
       expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
         .true;
       saveAndKeepEditingButton.simulate('click');
@@ -375,7 +376,7 @@ describe('ScriptEditor', () => {
 
       const saveBar = wrapper.find('SaveBar');
 
-      const saveAndKeepEditingButton = saveBar.find('button').at(0);
+      const saveAndKeepEditingButton = saveBar.find('button').at(1);
       expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
         .true;
       saveAndKeepEditingButton.simulate('click');
@@ -407,7 +408,7 @@ describe('ScriptEditor', () => {
 
       const saveBar = wrapper.find('SaveBar');
 
-      const saveAndKeepEditingButton = saveBar.find('button').at(0);
+      const saveAndKeepEditingButton = saveBar.find('button').at(1);
       expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
         .true;
       saveAndKeepEditingButton.simulate('click');
@@ -438,7 +439,7 @@ describe('ScriptEditor', () => {
 
       const saveBar = wrapper.find('SaveBar');
 
-      const saveAndKeepEditingButton = saveBar.find('button').at(0);
+      const saveAndKeepEditingButton = saveBar.find('button').at(1);
       expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
         .true;
       saveAndKeepEditingButton.simulate('click');
@@ -477,7 +478,7 @@ describe('ScriptEditor', () => {
 
       const saveBar = wrapper.find('SaveBar');
 
-      const saveAndCloseButton = saveBar.find('button').at(1);
+      const saveAndCloseButton = saveBar.find('button').at(2);
       expect(saveAndCloseButton.contains('Save and Close')).to.be.true;
       saveAndCloseButton.simulate('click');
 
@@ -508,7 +509,7 @@ describe('ScriptEditor', () => {
 
       const saveBar = wrapper.find('SaveBar');
 
-      const saveAndCloseButton = saveBar.find('button').at(1);
+      const saveAndCloseButton = saveBar.find('button').at(2);
       expect(saveAndCloseButton.contains('Save and Close')).to.be.true;
       saveAndCloseButton.simulate('click');
 

--- a/apps/test/unit/sites/studio/pages/levelbuilder_edit_script.js
+++ b/apps/test/unit/sites/studio/pages/levelbuilder_edit_script.js
@@ -14,7 +14,8 @@ describe('the level builder page init script', () => {
       script: {
         name: 'Test script',
         stages: [],
-        is_migrated: false
+        is_migrated: false,
+        scriptPath: '/s/test-script'
       },
       i18n: {
         stageDescriptions: [],

--- a/dashboard/app/views/lessons/edit.html.haml
+++ b/dashboard/app/views/lessons/edit.html.haml
@@ -4,5 +4,3 @@
 
 = form_for @lesson, {url: script_lesson_path(@lesson.script, @lesson)} do |f|
   #edit-container
-
-= link_to t('crud.show'), script_lesson_path(@lesson.script, @lesson)

--- a/dashboard/app/views/scripts/edit.html.haml
+++ b/dashboard/app/views/scripts/edit.html.haml
@@ -36,7 +36,3 @@
           - else
             = sl.level.properties['short_instructions']
         %br
-
-= link_to t('crud.show'), @script
-|
-\#{link_to t('crud.back'), script_path(@script)}


### PR DESCRIPTION
There were tiny show links at the bottom of the Script and Lesson edit Pages (as well as back link for script edit which did the same thing as the show link). This PR moves those links into a button the save for easy access. Since we use the save bar on the course, script and lesson edit pages this update will impact all 3.

### Before - Script Edit Page
<img width="165" alt="Screen Shot 2021-05-20 at 2 28 32 PM" src="https://user-images.githubusercontent.com/208083/119030282-aa0a9880-b977-11eb-91b7-649f8555d957.png">

### Before - Lesson Edit Page

<img width="211" alt="Screen Shot 2021-05-20 at 2 29 00 PM" src="https://user-images.githubusercontent.com/208083/119030327-bb53a500-b977-11eb-9b8e-d190c4829974.png">

### After (Course, Script and Lesson Edit)
<img width="1083" alt="Screen Shot 2021-05-19 at 10 06 45 PM" src="https://user-images.githubusercontent.com/208083/118909497-1b533880-b8f1-11eb-88f1-4910705c8359.png">

## Links

https://codedotorg.atlassian.net/browse/PLAT-1015

## Testing story

- Updated Unit tests
- Manually tested an edit page of each type
