### PR TITLE
Update In Development to Preview in the version selector

### DIFF
--- a/apps/src/templates/teacherDashboard/AssignmentVersionMenuItem.jsx
+++ b/apps/src/templates/teacherDashboard/AssignmentVersionMenuItem.jsx
@@ -95,7 +95,7 @@ export default class AssignmentVersionMenuItem extends Component {
                   style={{color: color.light_orange}}
                 />
                 &nbsp;
-                {i18n.inDevelopment()}
+                {i18n.preview()}
               </span>
             )}
           </span>


### PR DESCRIPTION
Updates the warning we put next to the new courses during the time between soft launch and hard launch. It now says 'Preview' instead of 'In Development' which matches the new publish states.

<img width="456" alt="Screen Shot 2021-05-19 at 10 42 19 PM" src="https://user-images.githubusercontent.com/208083/118911163-c107a700-b8f3-11eb-8475-05f4efeb04b0.png">
