### PR TITLE
Purge user PII data

### DIFF
--- a/dashboard/test/helpers/delete_accounts_helper_test.rb
+++ b/dashboard/test/helpers/delete_accounts_helper_test.rb
@@ -2052,6 +2052,26 @@ class DeleteAccountsHelperTest < ActionView::TestCase
     assert teacher_old.purged_at
   end
 
+  test 'deletes contact rollups final data' do
+    teacher = create :teacher
+    teacher_email = teacher.email
+    create :contact_rollups_final, email: teacher_email
+
+    assert ContactRollupsFinal.find_by_email(teacher_email)
+    purge_user teacher
+    assert_nil ContactRollupsFinal.find_by_email(teacher_email)
+  end
+
+  test 'marks contact rollups pardot memory for deletion' do
+    teacher = create :teacher
+    teacher_email = teacher.email
+    create :contact_rollups_pardot_memory, email: teacher_email
+
+    assert_nil ContactRollupsPardotMemory.find_by_email(teacher_email).marked_for_deletion_at
+    purge_user teacher
+    refute_nil ContactRollupsPardotMemory.find_by_email(teacher_email).marked_for_deletion_at
+  end
+
   private
 
   def assert_logged(expected_message)

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -919,7 +919,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
 
     # Fully purge the user account's PD records,
     # which removes their user ID from attendances.
-    DeleteAccountsHelper.new.clean_and_destroy_pd_content workshop_participant.id
+    DeleteAccountsHelper.new.clean_and_destroy_pd_content workshop_participant.id, workshop_participant.email
     workshop.reload
 
     # Should still return 0 once we've fully purged the teacher user ID from the attendance

--- a/lib/cdo/delete_accounts_helper.rb
+++ b/lib/cdo/delete_accounts_helper.rb
@@ -131,7 +131,7 @@ class DeleteAccountsHelper
     end
 
     # Delete email history
-    Pd::Application::Email.where(to: user_email).destroy_all
+    Pd::Application::Email.where(to: user_email).destroy_all if user_email.present?
 
     unless application_ids.empty?
       # Pd::FitWeekend1819Registration does not inherit from Pd::FitWeekendRegistrationBase so both are needed here

--- a/lib/cdo/delete_accounts_helper.rb
+++ b/lib/cdo/delete_accounts_helper.rb
@@ -93,7 +93,7 @@ class DeleteAccountsHelper
   # Remove all user generated content associated with any PD the user has been through, as well as
   # all PII associated with any PD records.
   # @param [Integer] The ID of the user to clean the PD content.
-  def clean_and_destroy_pd_content(user_id)
+  def clean_and_destroy_pd_content(user_id, user_email)
     @log.puts "Cleaning PD content"
     application_ids = Pd::Application::ApplicationBase.with_deleted.where(user_id: user_id).pluck(:id)
     pd_enrollment_ids = Pd::Enrollment.with_deleted.where(user_id: user_id).pluck(:id)
@@ -122,7 +122,16 @@ class DeleteAccountsHelper
     PeerReview.where(submitter_id: user_id).update_all(submitter_id: nil, audit_trail: nil)
     PeerReview.where(reviewer_id: user_id).update_all(reviewer_id: nil, data: nil, audit_trail: nil)
 
+    # Delete survey submissions
     SurveyResult.where(user_id: user_id).destroy_all
+    Pd::MiscSurvey.where(user_id: user_id).destroy_all
+    Foorm::SimpleSurveySubmission.where(user_id: user_id).each do |simple_submission|
+      simple_submission.foorm_submission.destroy
+      simple_submission.destroy
+    end
+
+    # Delete email history
+    Pd::Application::Email.where(to: user_email).destroy
 
     unless application_ids.empty?
       # Pd::FitWeekend1819Registration does not inherit from Pd::FitWeekendRegistrationBase so both are needed here
@@ -340,7 +349,7 @@ class DeleteAccountsHelper
     clean_level_source_backed_progress(user.id)
     clean_pegasus_forms_for_user(user)
     delete_project_backed_progress(user)
-    clean_and_destroy_pd_content(user.id)
+    clean_and_destroy_pd_content(user.id, user_email)
     clean_user_sections(user.id)
     remove_user_from_sections_as_student(user)
     remove_poste_data(user_email) if user_email&.present?

--- a/lib/cdo/delete_accounts_helper.rb
+++ b/lib/cdo/delete_accounts_helper.rb
@@ -295,8 +295,8 @@ class DeleteAccountsHelper
     # are dropped, records marked for deletion in ContactRollupsPardotMemory are
     # also purged. In addition, records in Pardot server are also deleted.
     # Thus, only need to delete ContactRollupsFinal record here.
-    ContactRollupsFinal.find_by_email(email).delete
-    set_pardot_deletion_via_contact_rollups(user_email) if user_email&.present?
+    ContactRollupsFinal.find_by_email(email)&.delete
+    set_pardot_deletion_via_contact_rollups(email)
   end
 
   # Purges (deletes and cleans) various pieces of information owned by the user in our system.

--- a/lib/cdo/delete_accounts_helper.rb
+++ b/lib/cdo/delete_accounts_helper.rb
@@ -131,7 +131,7 @@ class DeleteAccountsHelper
     end
 
     # Delete email history
-    Pd::Application::Email.where(to: user_email).destroy
+    Pd::Application::Email.where(to: user_email).destroy_all
 
     unless application_ids.empty?
       # Pd::FitWeekend1819Registration does not inherit from Pd::FitWeekendRegistrationBase so both are needed here
@@ -290,6 +290,7 @@ class DeleteAccountsHelper
   end
 
   def purge_user_authentications(user)
+    @log.puts "Deleting user authentication options"
     # Delete most recently destroyed (soft-deleted) record first
     user.authentication_options.with_deleted.order(deleted_at: :desc).each(&:really_destroy!)
   end
@@ -304,7 +305,7 @@ class DeleteAccountsHelper
     # are dropped, records marked for deletion in ContactRollupsPardotMemory are
     # also purged. In addition, records in Pardot server are also deleted.
     # Thus, only need to delete ContactRollupsFinal record here.
-    ContactRollupsFinal.find_by_email(email)&.delete
+    ContactRollupsFinal.find_by_email(email)&.destroy
     set_pardot_deletion_via_contact_rollups(email)
   end
 


### PR DESCRIPTION
[FND-1417](https://codedotorg.atlassian.net/browse/FND-1417)

Data to purge
- Contact rollups data in `ContactRollupsFinal`.
- Survey data in `Pd::MiscSurvey`, `Foorm::Submission`, and `Foorm::SimpleSurveySubmission`.
- Professional development email history in `Pd::Application::Email`.

No action needed
- The current process already purges `TeacherFeedback` and `ContactRollupsPardotMemory`.
- `ContactRollupsRaw` and `ContactRollupsProcessed` are just intermediate tables. They are dropped and rebuilt everyday by the contact rollups process.. 
- `contact_rollups_comparison` table was dropped long ago.
- `Pd::Application::Tag` model doesn't contain PII data. The `name` field is just tag name. In addition, the `pd_application_tags` table is currently empty.
- `Donor` model doesn't contain PII data. It has organization/donor names, URLs and Twitter links; all can be considered public information. Moreover, the `donors` table has only 166 records. They can be manually deleted upon request.


## Links
- [PLC PII data](https://docs.google.com/spreadsheets/d/1s_AoB4UnwKfyOLyJD2Oozg_m6NizIL15JJb9BTbPo0M/edit#gid=1738712892)
- [LP PII data](https://docs.google.com/spreadsheets/d/12UY_ye1UAxnYRG4e2mytdgBx_AxK3BFS4U7jsD8G0pY/edit#gid=0)


## Testing story
- Run unit tests `bundle exec rails test test/helpers/delete_accounts_helper_test.rb`

## Follow-up work
- [x] Drop `survey_answers` table. Last created row was from 2019-10-22. We have migrated previous survey data to the new `foorm` system.
- [x] Back-purging data in `ContactRollupsFinal`, `ContactRollupsPardotMemory`, `Pd::MiscSurvey`, `Foorm::Submission`, `Foorm::SimpleSurveySubmission`, and `Pd::Application::Email`.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
