### PR TITLE
Fix cdo-repository.sync default in Chef bootstrap

### DIFF
--- a/aws/cloudformation/bootstrap_chef_stack.sh.erb
+++ b/aws/cloudformation/bootstrap_chef_stack.sh.erb
@@ -95,7 +95,7 @@ cat <<JSON > $FIRST_BOOT
       "revision": "<%=commit%>",
     <% end -%>
     "branch": "${Branch}",
-    "sync": true
+    "sync": <%=!daemon%>
   },
   "cdo-secrets": {
 <% if frontends -%>


### PR DESCRIPTION
As noted in a comment in the `cdo-repository::default` recipe, the 'sync' attribute is only intended for special, non-CI-managed (ie, non-daemon) instances, which use `chef-client` runs instead of the `ci_build` script to update the git repository to the specified commit.

This PR fixes an oversight where the `sync` attribute was being set to true on all instances provisioned via the `bootstrap_chef_stack` user-data script, including daemon instances. This attribute had been un-set (default `false`) on manually-created daemon instances until this last year when they were imported into the CloudFormation stacks (#36514) and their user-data re-applied through this script.