### PR TITLE
Add .rb extension to cronjob script

### DIFF
--- a/experimental/i18n-dev.crontab
+++ b/experimental/i18n-dev.crontab
@@ -40,7 +40,7 @@ HOME=/home/ubuntu
 # - Run it every day except Monday. This is done so we don't conflict with the
 #   full sync, and also because we expect to spend Monday verifiying the
 #   results of the full sync.
-30 */2 * * SUN,TUE-SAT cd /home/ubuntu/code-dot-org && ((bundle exec ./bin/i18n/sync-all -c down && bundle exec ./bin/i18n/sync-all -c out) | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error
+30 */2 * * SUN,TUE-SAT cd /home/ubuntu/code-dot-org && ((bundle exec ./bin/i18n/sync-all.rb -c down && bundle exec ./bin/i18n/sync-all.rb -c out) | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error
 
 # Periodically check to see if the I18n Sync PRs have been merged and attempt
 # to return to staging.


### PR DESCRIPTION
For unknown reasons we suddenly get a lot of this error on the i18n-dev server ([Slack](https://codedotorg.slack.com/archives/C99KAHFK9/p1621499403143000)). 
<img width="370" alt="Screen Shot 2021-05-20 at 12 55 09 PM" src="https://user-images.githubusercontent.com/46507039/119040715-9c9ae180-b96a-11eb-8260-2ad516792830.png">
This is a quick fix by adding `.rb` extension to script name.

## Follow up
- [ ] Update conrjob settings on the i18n-dev machine `crontab ./experimental/i18n-dev.crontab`
