### PR TITLE
AiLab: Set viewport scale

### DIFF
--- a/apps/src/ailab/Ailab.js
+++ b/apps/src/ailab/Ailab.js
@@ -15,14 +15,12 @@ import {
 } from '../redux/instructions';
 
 /**
- * On small mobile devices, when in portrait orientation, we show an overlay
- * image telling the user to rotate their device to landscape mode.  Because
- * the ailab app is able to render at a minimum width of 480px, we set this
- * width to be somewhat larger.  We will use this width to set the viewport
- * on the mobile device, and correspondingly to scale up the overlay image to
- * properly fit on the mobile device for that viewport.
+ * This is used to set the viewport width in portrait mode, and will become
+ * the viewport height in landscape mode.  On a 1024x768 screen in landscape
+ * it will set the same viewport scale as Applab (which does it by requesting
+ * 1200 pixels' width), which is roughly 0.85, since 1200 / 1024 * 768 = 900.
  */
-const MOBILE_PORTRAIT_WIDTH = 600;
+const MOBILE_PORTRAIT_WIDTH = 900;
 
 function getInstructionsDefaults() {
   var instructions = {


### PR DESCRIPTION
Set the "mobile portrait height" to 900 pixels.  This is used to set the viewport width [in portrait mode](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/StudioApp.js#L2021-L2022), and will become the viewport height in landscape mode.  On a 1024x768 screen in landscape it will set the same viewport scale as Applab (which does it by [requesting 1200 pixels' width](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/StudioApp.js#L1987-L1988)), which is roughly 0.85, since `1200 / 1024 * 768 = 900`.

Here are examples using Chrome's device mode in 1024x768:

### before
![image](https://user-images.githubusercontent.com/2205926/119408639-e3eede00-bc9a-11eb-93f9-9e55f2085b57.png)

### after
![image](https://user-images.githubusercontent.com/2205926/119408685-f49f5400-bc9a-11eb-84c0-a88d5ac89895.png)
