### PR TITLE
Updates for facilitator reminder emails

### DIFF
--- a/dashboard/app/views/pd/workshop_mailer/_teacher_enrollment_details_facilitator.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/_teacher_enrollment_details_facilitator.html.haml
@@ -18,50 +18,9 @@
     Laptop and charger, as well as any adapters. Review
     = link_to 'this page', Pd::WorkshopMailer::SUPPORTED_TECH_URL
     for more information regarding compatible operating systems and browsers.
-    We do not recommend bringing a tablet as your primary device.
-  %li Download the Zoom app. (more information below)
+    We do not recommend using a tablet as your primary device.
   %li Headphones or earphones. (optional)
   %li Your curiosity and readiness to learn!
-
-%h3 Complete your pre-work and download Zoom
-
-%p
-  To prepare for our time together, we ask that you engage with your pre-work
-  materials (linked below), which should take about
-  %strong 90 minutes
-  to complete. We’ve designed these resources to help you prepare for summer
-  workshops given your region’s chosen delivery modality.
-
-%p
-  = link_to 'Click here', pre_work_url
-  to access pre-work. Pre-work will be added as ready.
-
-%p
-  All of our sessions will be taking place via Zoom, so we strongly recommend
-  that you
-  %strong
-    download the Zoom app
-    = surround '(', ' for download options)' do
-      = link_to 'click here', zoom_download_url
-  because it offers a more reliable connection than the standard browser AND
-  will allow you to fully participate in the activities we’ve planned. Be sure
-  to also check out our
-  = link_to 'Tips for Having a Great Virtual Learning Experience', learning_tips_url
-  for more information about steps you can take to prepare for our time together.
-
-%h3 Visit and bookmark the Digital Digest
-
-%p
-  We also ask that you take a few moments to check out and bookmark the
-  = link_to 'Digital Digest', digital_digest_url
-  = surround '(', ').' do
-    = link_to(digital_digest_url, digital_digest_url)
-  It will serve as your one-stop-shop for a ton of important information, such
-  as your pre-work, session join links, notes doc, and more!
-
-%p
-  Keep an eye out for a calendar invite with the meeting link that will be sent
-  out roughly the week prior to the session.
 
 %h3 Did something come up? If you can’t make it, let us know
 

--- a/dashboard/app/views/pd/workshop_mailer/teacher_enrollment_receipt.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/teacher_enrollment_receipt.html.haml
@@ -16,7 +16,7 @@
     curriculum.
 - elsif Pd::Workshop::COURSE_FACILITATOR == @workshop.course
   %p
-    Thanks for enrolling in Code.org’s summer workshop prep session. We look
+    Thanks for enrolling in your Facilitator workshop. We look
     forward to seeing you there!
 - else
   %p

--- a/dashboard/app/views/pd/workshop_mailer/teacher_enrollment_reminder.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/teacher_enrollment_reminder.html.haml
@@ -14,8 +14,7 @@
     curriculum.
 - elsif @workshop.course == Pd::Workshop::COURSE_FACILITATOR
   %p
-    I wanted to remind you about your upcoming Code.org summer workshop prep
-    session.
+    I wanted to remind you about your upcoming Facilitator workshop.
 - elsif @workshop.course == Pd::Workshop::COURSE_CSF
   %p
     I wanted to remind you about your upcoming Code.org
@@ -52,8 +51,6 @@
   %p
     - if @workshop.course == Pd::Workshop::COURSE_CSF
       This is a great step towards bringing computer science to your classroom!
-    - unless @workshop.subject == Pd::Workshop::SUBJECT_CSP_FOR_RETURNING_TEACHERS
-      We’re excited to continue to work together to bring computer science to your classroom.
     If you have any questions, reach out to your workshop organizer directly:
     = "#{@organizer.name} at "
     = mail_to @organizer.email, "#{@organizer.email}."


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Some small text changes to the facilitator workshop enrollment and reminder emails.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- spec: [email content](https://docs.google.com/document/d/1-6Eb9sHRMvJaAT3k6sWrHXZvV3mAaKTZEburP9UDVOM/edit?usp=sharing)
- jira ticket: [PLC-1184](https://codedotorg.atlassian.net/browse/PLC-1184)

## Testing story

Tested manually through rails previews.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
