### PR TITLE
Add Sprite Upload to Extra Links

### DIFF
--- a/apps/src/code-studio/assets/SpriteUpload.jsx
+++ b/apps/src/code-studio/assets/SpriteUpload.jsx
@@ -105,7 +105,7 @@ export default class SpriteUpload extends React.Component {
 
     return (
       <div>
-        <h1>Sprite Upload</h1>
+        <h1>Sprite Lab Sprite Upload</h1>
         <form onSubmit={this.handleSubmit}>
           <label>
             <h3>Sprite Category:</h3>

--- a/dashboard/app/views/home/_levelbuilder.html.haml
+++ b/dashboard/app/views/home/_levelbuilder.html.haml
@@ -10,4 +10,4 @@
     %li= link_to 'Helper Libraries', libraries_path
     %li= link_to 'Gallery', 'projects/public'
     %li= link_to 'Foorm Surveys (preview)', 'foorm/forms/editor'
-    %li= link_to '(BETA) Sprite Management', 'sprites/sprite_upload'
+    %li= link_to '(BETA) Sprite Lab Sprite Management', 'sprites/sprite_upload'

--- a/dashboard/app/views/home/_levelbuilder.html.haml
+++ b/dashboard/app/views/home/_levelbuilder.html.haml
@@ -10,3 +10,4 @@
     %li= link_to 'Helper Libraries', libraries_path
     %li= link_to 'Gallery', 'projects/public'
     %li= link_to 'Foorm Surveys (preview)', 'foorm/forms/editor'
+    %li= link_to '(BETA) Sprite Management', 'sprites/sprite_upload'


### PR DESCRIPTION
Part of the Sprite Upload task. Now that we have a simple sprite upload tool that can upload a sprite and metadata, adding the Beta link to the Levelbuilder Extra Links.

Image of Extra Links Tab with "Sprite Management" link:
![Screenshot from 2021-05-21 09-54-20](https://user-images.githubusercontent.com/2959170/119173048-8bf67400-ba1b-11eb-8ebb-fff37ebe54d3.png)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
