### PR TITLE
Add get serialized_maze route to levels_controller

### DIFF
--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -161,7 +161,7 @@ class LevelsController < ApplicationController
   # GET /levels/:id/get_serialized_maze
   # Get the serialized_maze for the level, if it exists.
   def get_serialized_maze
-    return head :no_content unless @level.serialized_maze
+    return head :no_content unless @level.properties['serialized_maze'].presence && @level.serialized_maze
     render json: @level.serialized_maze
   end
 

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -7,8 +7,8 @@ EMPTY_XML = '<xml></xml>'.freeze
 class LevelsController < ApplicationController
   include LevelsHelper
   include ActiveSupport::Inflector
-  before_action :authenticate_user!, except: [:show, :embed_level, :get_rubric]
-  before_action :require_levelbuilder_mode_or_test_env, except: [:show, :embed_level, :get_rubric]
+  before_action :authenticate_user!, except: [:show, :embed_level, :get_rubric, :get_serialized_maze]
+  before_action :require_levelbuilder_mode_or_test_env, except: [:show, :embed_level, :get_rubric, :get_serialized_maze]
   load_and_authorize_resource except: [:create]
 
   before_action :set_level, only: [:show, :edit, :update, :destroy]
@@ -156,6 +156,13 @@ class LevelsController < ApplicationController
       performanceLevel3: @level.rubric_performance_level_3,
       performanceLevel4: @level.rubric_performance_level_4
     }
+  end
+
+  # GET /levels/:id/get_serialized_maze
+  # Get the serialized_maze for the level, if it exists.
+  def get_serialized_maze
+    return head :no_content unless @level.serialized_maze
+    render json: @level.serialized_maze
   end
 
   # GET /levels/:id/edit_blocks/:type

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -61,7 +61,7 @@ class Ability
     cannot :index, Level
 
     # If you can see a level, you can also do these things:
-    can [:embed_level, :get_rubric], Level do |level|
+    can [:embed_level, :get_rubric, :get_serialized_maze], Level do |level|
       can? :read, level
     end
 

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -255,6 +255,7 @@ Dashboard::Application.routes.draw do
       get 'get_rubric'
       get 'embed_level'
       get 'edit_blocks/:type', to: 'levels#edit_blocks', as: 'edit_blocks'
+      get 'get_serialized_maze'
       post 'update_properties'
       post 'update_blocks/:type', to: 'levels#update_blocks', as: 'update_blocks'
       post 'clone'

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -1031,6 +1031,34 @@ DSL
     assert_equal 'platformization-partners', level.editor_experiment
   end
 
+  test "should get serialized_maze" do
+    level = create_level_with_serialized_maze
+    get :get_serialized_maze, params: {id: level.id}
+    expected_maze = [[{"tileType" => 1, "value" => 0}], [{"tileType" => 0, "assetId" => 5, "value" => 0}]]
+    assert_equal expected_maze, JSON.parse(@response.body)
+  end
+
+  test "anonymous user can get_serialized_maze" do
+    sign_out @levelbuilder
+    level = create_level_with_serialized_maze
+    get :get_serialized_maze, params: {id: level.id}
+    expected_maze = [[{"tileType" => 1, "value" => 0}], [{"tileType" => 0, "assetId" => 5, "value" => 0}]]
+    assert_equal expected_maze, JSON.parse(@response.body)
+  end
+
+  test "empty success response for get_serialized_maze on level without maze" do
+    level = create :level
+    get :get_serialized_maze, params: {id: level.id}
+    assert_response :no_content
+    assert_equal '', @response.body
+  end
+
+  def create_level_with_serialized_maze
+    create(:javalab,
+      serialized_maze: [[{tileType: 1, value: 0}], [{tileType: 0, assetId: 5, value: 0}]]
+    )
+  end
+
   test_user_gets_response_for(
     :edit,
     response: :forbidden,

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -642,6 +642,10 @@ FactoryGirl.define do
     game {Game.curriculum_reference}
   end
 
+  factory :javalab, parent: :level, class: Javalab do
+    game {Game.javalab}
+  end
+
   factory :block do
     transient do
       sequence(:index)


### PR DESCRIPTION
For Javalab neighborhood levels, we need Javabuilder to be able to access the serialized_maze on the level in order to set up the grid on the backend. This PR adds a new route `/levels/:id/serialized_maze` which returns the serialized maze as json if it exists. The route does not have any auth, similar to the existing get rubric route on the level controller. The lack of auth makes it possible for Javabuilder to access the route, and the serialized maze is not private information, as it is publicly checked into our repo.

## Links
- jira ticket: [CSA-349](https://codedotorg.atlassian.net/browse/CSA-349)

## Testing story
Added unit tests to cover this new route.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
