### PR TITLE
make the file rename error style change with dark and light mode

### DIFF
--- a/apps/src/javalab/NameFileDialog.jsx
+++ b/apps/src/javalab/NameFileDialog.jsx
@@ -90,7 +90,13 @@ export default class NameFileDialog extends Component {
             </button>
           </div>
         </div>
-        {errorMessage && <div style={styles.errorMessage}>{errorMessage}</div>}
+        {errorMessage && (
+          <div
+            style={isDarkMode ? styles.darkErrorMessage : styles.errorMessage}
+          >
+            {errorMessage}
+          </div>
+        )}
       </BaseDialog>
     );
   }
@@ -137,5 +143,9 @@ const styles = {
   },
   errorMessage: {
     color: color.red
+  },
+  darkErrorMessage: {
+    backgroundColor: color.dark_slate_gray,
+    color: color.lightest_red
   }
 };


### PR DESCRIPTION
Dark mode:
<img width="1440" alt="Screen Shot 2021-05-21 at 12 38 42 PM" src="https://user-images.githubusercontent.com/17147070/119190226-ec90ab80-ba31-11eb-9a17-560c2c4e3c48.png">

Light mode: 
<img width="1440" alt="Screen Shot 2021-05-21 at 12 38 56 PM" src="https://user-images.githubusercontent.com/17147070/119190218-ea2e5180-ba31-11eb-9005-d6c1d5da4be5.png">

## Links

- jira ticket: [CSA-353](https://codedotorg.atlassian.net/browse/CSA-353?atlOrigin=eyJpIjoiNDRkYTU1ODRjNGJlNDhiZTlhYzE3MjkzN2JlN2VkNGMiLCJwIjoiaiJ9)


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
