### PR TITLE
Improve verification of progress bubbles in UI tests

### DIFF
--- a/apps/src/templates/progress/DetailProgressTable.jsx
+++ b/apps/src/templates/progress/DetailProgressTable.jsx
@@ -18,7 +18,7 @@ export default class DetailProgressTable extends React.Component {
     }
 
     return (
-      <div>
+      <div className="uitest-detail-progress-table">
         {lessons.map((lesson, index) => (
           <ProgressLesson
             key={index}

--- a/apps/src/templates/progress/ProgressLesson.jsx
+++ b/apps/src/templates/progress/ProgressLesson.jsx
@@ -127,6 +127,7 @@ class ProgressLesson extends React.Component {
     const lessonUrl = levels[0] && levels[0].url;
     return (
       <div
+        className="uitest-progress-lesson"
         style={{
           ...styles.outer,
           ...((hiddenForStudents || showAsLocked) && styles.hiddenOrLocked)

--- a/apps/src/templates/progress/SummaryProgressRow.jsx
+++ b/apps/src/templates/progress/SummaryProgressRow.jsx
@@ -117,6 +117,7 @@ class SummaryProgressRow extends React.Component {
     const lockedTooltipId = _.uniqueId();
     return (
       <tr
+        className="uitest-summary-progress-row"
         style={{
           ...(!dark && styles.lightRow),
           ...(dark && styles.darkRow),

--- a/apps/src/templates/progress/SummaryProgressTable.jsx
+++ b/apps/src/templates/progress/SummaryProgressTable.jsx
@@ -27,7 +27,7 @@ class SummaryProgressTable extends React.Component {
     }
 
     return (
-      <table style={styles.table}>
+      <table className="uitest-summary-progress-table" style={styles.table}>
         {!minimal && (
           <thead>
             <tr style={styles.headerRow}>

--- a/dashboard/test/ui/features/hour_of_code/hour_of_code.feature
+++ b/dashboard/test/ui/features/hour_of_code/hour_of_code.feature
@@ -14,17 +14,13 @@ Scenario: Solving puzzle 1, proceeding to puzzle 2, verifying that puzzle 1 appe
   Then I close the dialog
   And I wait until I am on "http://studio.code.org/hoc/2"
   And I wait for the page to fully load
-  And I wait until jQuery Ajax requests are finished
   And I verify progress in the header of the current page is "perfect" for level 1
   # Course overview should also show progress
   Then I navigate to the course page for "hourofcode"
-  And I wait for 2 seconds
-  And I wait until jQuery Ajax requests are finished
   And I verify progress for lesson 1 level 1 is "perfect"
   # Course overview in a different script shouldn't show progress
   Then I am on "http://studio.code.org/s/20-hour/lessons/2/levels/2?noautoplay=true"
   Then I wait until I am on "http://studio.code.org/s/20-hour/lessons/2/levels/2?noautoplay=true"
-  And I wait until jQuery Ajax requests are finished
   And I verify progress in the header of the current page is "not_tried" for level 1
   # Level source is saved
   Then I am on "http://studio.code.org/hoc/1?noautoplay=true"
@@ -46,12 +42,8 @@ Scenario: Failing at puzzle 1, refreshing puzzle 1, bubble should show up as att
   Then I wait to see ".uitest-topInstructions-inline-feedback"
   Then I reload the page
   And I wait for the page to fully load
-  When element "#runButton" is visible
-  And I wait until jQuery Ajax requests are finished
   And I verify progress in the header of the current page is "attempted" for level 1
   And I navigate to the course page for "hourofcode"
-  And I wait for 2 seconds
-  And I wait until jQuery Ajax requests are finished
   And I verify progress for lesson 1 level 1 is "attempted"
 
 @no_mobile

--- a/dashboard/test/ui/features/hour_of_code/hour_of_code_signed_in.feature
+++ b/dashboard/test/ui/features/hour_of_code/hour_of_code_signed_in.feature
@@ -11,15 +11,12 @@ Scenario:
   Then I close the dialog
   Then I wait until I am on "http://studio.code.org/hoc/2"
   And I wait for the page to fully load
-  When element "#runButton" is visible
   And I verify progress in the header of the current page is "perfect" for level 1
   # Course overview should also show progress
   Then I navigate to the course page for "hourofcode"
-  And I wait until jQuery Ajax requests are finished
   And I verify progress for lesson 1 level 1 is "perfect"
   # Course overview in a different script shouldn't show progress
   Then I am on "http://studio.code.org/s/20-hour/lessons/2/levels/2?noautoplay=true"
-  And I wait until jQuery Ajax requests are finished
   And I verify progress in the header of the current page is "not_tried" for level 1
   # Level source is saved
   Then I am on "http://studio.code.org/hoc/1?noautoplay=true"
@@ -39,35 +36,17 @@ Scenario: Failing at puzzle 6, refreshing puzzle 6, bubble should show up as att
   Then I wait to see ".uitest-topInstructions-inline-feedback"
   Then I reload the page
   And I wait for the page to fully load
-  And I wait until jQuery Ajax requests are finished
-  When element "#runButton" is visible
   Then I verify progress in the header of the current page is "attempted" for level 6
-
-Scenario: Async progress write followed by a stale read
-  Given I am on "http://studio.code.org/hoc/20?noautoplay=true"
-  And I wait for the page to fully load
-  And I wait until jQuery Ajax requests are finished
-  And I verify progress in the header of the current page is "not_tried" for level 20
-  And I reload the page
-  And I wait until jQuery Ajax requests are finished
-  And I verify progress in the header of the current page is "not_tried" for level 20
-  And I wait for 3 seconds
-  And I navigate to the course page for "hourofcode"
-  And I wait until jQuery Ajax requests are finished
-  And I verify progress for lesson 1 level 20 is "not_tried"
 
 Scenario: Progress on the server that is not on the client
   Given I am on "http://studio.code.org/hoc/20?noautoplay=true"
   And I wait for the page to fully load
-  And I wait until jQuery Ajax requests are finished
   And I verify progress in the header of the current page is "not_tried" for level 20
   And I press "runButton"
   Then I am on "http://studio.code.org/hoc/reset"
   Then I am on "http://studio.code.org/hoc/20?noautoplay=true"
-  And I wait until jQuery Ajax requests are finished
   And I verify progress in the header of the current page is "attempted" for level 20
   And I navigate to the course page for "hourofcode"
-  And I wait until jQuery Ajax requests are finished
   And I verify progress for lesson 1 level 20 is "attempted"
 
 @no_mobile

--- a/dashboard/test/ui/features/learning_platform/course_versions.feature
+++ b/dashboard/test/ui/features/learning_platform/course_versions.feature
@@ -116,7 +116,9 @@ Scenario: Switch versions using dropdown on script overview page
   And I click selector ".assignment-version-title:contains(2019)" once I see it
   Then I wait until I am on "http://studio.code.org/s/ui-test-versioned-script-2019"
 
-  When I wait until element "#script-title" is visible
+  # On Safari, the 2017 page may still be visible (even though the url has been changed)
+  # so we need to wait until we are looking at the 2019 page.
+  And I wait until element "#script-title" contains text "2019"
   And element "#uitest-version-selector" is visible
   And I click selector "#assignment-version-year" once I see it
   And element ".assignment-version-title:contains(2018)" is not visible

--- a/dashboard/test/ui/features/learning_platform/lesson_lock.feature
+++ b/dashboard/test/ui/features/learning_platform/lesson_lock.feature
@@ -48,10 +48,10 @@ Scenario: Lock settings for students
   And I wait until element "td:contains(Anonymous student survey 2)" is visible
   And I wait until jQuery Ajax requests are finished
   Then element "td:contains(Anonymous student survey 2) .fa-unlock" is visible
-  Then I verify progress for lesson 31 level 1 is "not_tried"
-  Then I verify progress for lesson 31 level 2 is "not_tried"
-  Then I verify progress for lesson 31 level 3 is "not_tried"
-  Then I verify progress for lesson 31 level 4 is "not_tried"
+  Then I verify progress for lesson 31 level 1 is "not_tried" without waiting
+  Then I verify progress for lesson 31 level 2 is "not_tried" without waiting
+  Then I verify progress for lesson 31 level 3 is "not_tried" without waiting
+  Then I verify progress for lesson 31 level 4 is "not_tried" without waiting
 
   # student submits
 
@@ -85,10 +85,10 @@ Scenario: Lock settings for students
   And I wait until element "td:contains(Anonymous student survey 2)" is visible
   And I wait until jQuery Ajax requests are finished
   Then element "td:contains(Anonymous student survey 2) .fa-unlock" is visible
-  Then I verify progress for lesson 31 level 1 is "not_tried"
-  Then I verify progress for lesson 31 level 2 is "not_tried"
-  Then I verify progress for lesson 31 level 3 is "not_tried"
-  Then I verify progress for lesson 31 level 4 is "not_tried"
+  Then I verify progress for lesson 31 level 1 is "not_tried" without waiting
+  Then I verify progress for lesson 31 level 2 is "not_tried" without waiting
+  Then I verify progress for lesson 31 level 3 is "not_tried" without waiting
+  Then I verify progress for lesson 31 level 4 is "not_tried" without waiting
 
   When I am on "http://studio.code.org/s/allthethings/lockable/1/levels/1/page/4"
   And I wait until element "h2:contains(Pre-survey)" is visible
@@ -126,10 +126,10 @@ Scenario: Lock settings for students who never submit
   And I wait until element "td:contains(Anonymous student survey 2)" is visible
   And I wait until jQuery Ajax requests are finished
   Then element "td:contains(Anonymous student survey 2) .fa-unlock" is visible
-  Then I verify progress for lesson 31 level 1 is "not_tried"
-  Then I verify progress for lesson 31 level 2 is "not_tried"
-  Then I verify progress for lesson 31 level 3 is "not_tried"
-  Then I verify progress for lesson 31 level 4 is "not_tried"
+  Then I verify progress for lesson 31 level 1 is "not_tried" without waiting
+  Then I verify progress for lesson 31 level 2 is "not_tried" without waiting
+  Then I verify progress for lesson 31 level 3 is "not_tried" without waiting
+  Then I verify progress for lesson 31 level 4 is "not_tried" without waiting
 
   # student does not submit assessment before teacher switches to readonly 
 
@@ -148,10 +148,10 @@ Scenario: Lock settings for students who never submit
   And I wait until element "td:contains(Anonymous student survey 2)" is visible
   And I wait until jQuery Ajax requests are finished
   Then element "td:contains(Anonymous student survey 2) .fa-unlock" is visible
-  Then I verify progress for lesson 31 level 1 is "not_tried"
-  Then I verify progress for lesson 31 level 2 is "not_tried"
-  Then I verify progress for lesson 31 level 3 is "not_tried"
-  Then I verify progress for lesson 31 level 4 is "not_tried"
+  Then I verify progress for lesson 31 level 1 is "not_tried" without waiting
+  Then I verify progress for lesson 31 level 2 is "not_tried" without waiting
+  Then I verify progress for lesson 31 level 3 is "not_tried" without waiting
+  Then I verify progress for lesson 31 level 4 is "not_tried" without waiting
 
 Scenario: Lock settings for retake not submit scenario
   # initially locked for student in summary view
@@ -182,10 +182,10 @@ Scenario: Lock settings for retake not submit scenario
   And I wait until element "td:contains(Anonymous student survey 2)" is visible
   And I wait until jQuery Ajax requests are finished
   Then element "td:contains(Anonymous student survey 2) .fa-unlock" is visible
-  Then I verify progress for lesson 31 level 1 is "not_tried"
-  Then I verify progress for lesson 31 level 2 is "not_tried"
-  Then I verify progress for lesson 31 level 3 is "not_tried"
-  Then I verify progress for lesson 31 level 4 is "not_tried"
+  Then I verify progress for lesson 31 level 1 is "not_tried" without waiting
+  Then I verify progress for lesson 31 level 2 is "not_tried" without waiting
+  Then I verify progress for lesson 31 level 3 is "not_tried" without waiting
+  Then I verify progress for lesson 31 level 4 is "not_tried" without waiting
 
   # student does not submit assessment before teacher switches to locked 
 
@@ -264,10 +264,10 @@ Scenario: Lock settings for retake after submit scenario
   And I wait until element "td:contains(Anonymous student survey 2)" is visible
   And I wait until jQuery Ajax requests are finished
   Then element "td:contains(Anonymous student survey 2) .fa-unlock" is visible
-  Then I verify progress for lesson 31 level 1 is "not_tried"
-  Then I verify progress for lesson 31 level 2 is "not_tried"
-  Then I verify progress for lesson 31 level 3 is "not_tried"
-  Then I verify progress for lesson 31 level 4 is "not_tried"
+  Then I verify progress for lesson 31 level 1 is "not_tried" without waiting
+  Then I verify progress for lesson 31 level 2 is "not_tried" without waiting
+  Then I verify progress for lesson 31 level 3 is "not_tried" without waiting
+  Then I verify progress for lesson 31 level 4 is "not_tried" without waiting
   When I am on "http://studio.code.org/s/allthethings/lockable/1/levels/1/page/4"
   And I click selector ".submitButton" once I see it
   And I wait to see a dialog titled "Submit your survey"

--- a/dashboard/test/ui/features/learning_platform/level_types/bubble_choice.feature
+++ b/dashboard/test/ui/features/learning_platform/level_types/bubble_choice.feature
@@ -14,7 +14,6 @@ Feature: BubbleChoice
     And I wait until element ".uitest-bubble-choice:eq(0)" is visible
     And element ".uitest-bubble-choice:eq(0) .progress-bubble:first" is visible
     And check that the url contains "/s/allthethings/lessons/40/levels/1"
-    And element ".uitest-bubble-choice:eq(0) .progress-bubble:first" is visible
     Then I verify progress for the sublevel with selector ".uitest-bubble-choice:eq(0) .progress-bubble" is "perfect"
 
     And I sign out
@@ -37,6 +36,4 @@ Feature: BubbleChoice
     # Teacher has not completed level, so make sure it is not shown as complete
     Then I verify progress for the sublevel with selector ".uitest-bubble-choice:eq(0) .progress-bubble:first" is "not_tried"
     When I click selector ".teacher-panel table td:contains(Alice)" once I see it
-    And I wait until element ".uitest-bubble-choice:eq(0)" is visible
-    And I wait for 4 seconds
     Then I verify progress for the sublevel with selector ".uitest-bubble-choice:eq(0) .progress-bubble:first" is "perfect"

--- a/dashboard/test/ui/features/learning_platform/level_types/level_group_multi_page_dots.feature
+++ b/dashboard/test/ui/features/learning_platform/level_types/level_group_multi_page_dots.feature
@@ -45,7 +45,6 @@ Scenario: Submit three pages as... 1. all, 2. none, 3. some questions answered.
 
   Then I reload the page
   And I wait to see ".react_stage"
-  And I wait until jQuery Ajax requests are finished
 
   # Verify the three dots in the header are 1. all, 2. none, 3. some questions answered.
   And I verify progress in the header of the current page is "perfect_assessment" for level 2
@@ -60,7 +59,6 @@ Scenario: Submit three pages as... 1. all, 2. none, 3. some questions answered.
 
   # Go to the course page and verify the same three dots.
   Then I navigate to the course page for "allthethings"
-  And I wait until jQuery Ajax requests are finished
   And I verify progress for lesson 23 level 2 is "perfect_assessment"
   And I verify progress for lesson 23 level 3 is "not_tried"
   And I verify progress for lesson 23 level 4 is "attempted_assessment"
@@ -72,7 +70,6 @@ Scenario: Submit three pages as... 1. all, 2. none, 3. some questions answered.
   And I press "#ok-button" using jQuery to load a new page
   And I am on "http://studio.code.org/s/allthethings/lessons/23/levels/1?noautoplay=true"
   And I wait to see ".react_stage"
-  And I wait until jQuery Ajax requests are finished
 
   # Verify the three dots in the header all reflect the submission.
   And I verify progress in the header of the current page is "perfect_assessment" for level 2
@@ -87,7 +84,6 @@ Scenario: Submit three pages as... 1. all, 2. none, 3. some questions answered.
 
   # Go to the course page and verify the same three dots.
   Then I navigate to the course page for "allthethings"
-  And I wait until jQuery Ajax requests are finished
   And I verify progress for lesson 23 level 2 is "perfect_assessment"
   And I verify progress for lesson 23 level 3 is "not_tried"
   And I verify progress for lesson 23 level 4 is "attempted_assessment"

--- a/dashboard/test/ui/features/learning_platform/progress.feature
+++ b/dashboard/test/ui/features/learning_platform/progress.feature
@@ -9,13 +9,11 @@ Feature: Level Progress
 
     When I am on "http://studio.code.org/s/allthethings/lessons/2/levels/2"
     And I wait for the page to fully load
-    And I wait for 2 seconds
     Then I verify progress in the header of the current page is "perfect" for level 1
     And I verify progress in the header of the current page is "not_tried" for level 2
 
     When I am on "http://studio.code.org/s/allthethings"
     And I wait until element "td:contains(Maze)" is visible
-    And I wait for 2 seconds
     Then I verify progress for lesson 2 level 1 is "perfect"
     And I verify progress for lesson 2 level 2 is "not_tried"
 
@@ -28,12 +26,10 @@ Feature: Level Progress
 
     When I am on "http://studio.code.org/s/allthethings/lessons/2/levels/2"
     And I wait for the page to fully load
-    And I wait for 2 seconds
     Then I verify progress in the header of the current page is "perfect" for level 1
     And I verify progress in the header of the current page is "not_tried" for level 2
 
     When I am on "http://studio.code.org/s/allthethings"
     And I wait until element "td:contains(Maze)" is visible
-    And I wait for 2 seconds
     Then I verify progress for lesson 2 level 1 is "perfect"
     And I verify progress for lesson 2 level 2 is "not_tried"

--- a/dashboard/test/ui/features/learning_platform/script_overview.feature
+++ b/dashboard/test/ui/features/learning_platform/script_overview.feature
@@ -10,7 +10,6 @@ Feature: Script overview page
     And I am on "http://studio.code.org/s/allthethings"
     And I wait until element "td:contains(Maze)" is visible
     And I wait until element ".teacher-panel" is not visible
-    And I wait for 2 seconds
     Then I verify progress for lesson 2 level 1 is "perfect"
     Then I verify progress for lesson 2 level 2 is "not_tried"
     And I sign out
@@ -20,11 +19,9 @@ Feature: Script overview page
     And I complete the level on "http://studio.code.org/s/allthethings/lessons/29/levels/4?level_name=2-3 Artist 1 new"
     And I am on "http://studio.code.org/s/allthethings"
     And I wait until element ".teacher-panel" is visible
-    And I wait until jQuery Ajax requests are finished
-    Then I verify progress for lesson 29 level 4 is "perfect"
+    Then I verify progress for lesson 29 level 4 in detail view is "perfect"
     When I click selector ".teacher-panel table td:contains(Sally)" once I see it
     And I wait until element "td:contains(Maze)" is visible
-    And I wait for 2 seconds
     Then I verify progress for lesson 2 level 1 is "perfect"
     Then I verify progress for lesson 2 level 2 is "not_tried"
 

--- a/dashboard/test/ui/features/step_definitions/progress.rb
+++ b/dashboard/test/ui/features/step_definitions/progress.rb
@@ -9,7 +9,12 @@ def color_string(key)
   }[key.to_sym]
 end
 
-def verify_progress(selector, test_result)
+# Verifies that the given selector (which should be a progress bubble) is visible
+# and displays the expected test_result. This function accounts for the asynchronous
+# nature of progress bubbles and can be slow, especially when verifying that a bubble
+# displays 'not_tried'. Passing no_wait=true skips all waits and immediately verifies
+# the bubble.
+def verify_progress(selector, test_result, no_wait=false)
   if test_result == 'perfect'
     background_color = color_string('perfect')
     border_color = color_string('perfect')
@@ -26,12 +31,39 @@ def verify_progress(selector, test_result)
     background_color = color_string('not_tried')
     border_color = color_string('assessment')
   end
-  steps %{
-    And I wait until element "#{selector}" is in the DOM
-    And I wait until jQuery Ajax requests are finished
-    And element "#{selector}" has css property "background-color" equal to "#{background_color}"
-    And element "#{selector}" has css property "border-top-color" equal to "#{border_color}"
-  }
+
+  if no_wait
+    steps %{
+      And element "#{selector}" is visible
+      And element "#{selector}" has css property "background-color" equal to "#{background_color}"
+      And element "#{selector}" has css property "border-top-color" equal to "#{border_color}"
+    }
+  else
+    # The data for progress bubbles can be loaded synchronously or asynchronously.
+    # For 'not_tried', it is difficult to tell whether the bubble is just in its
+    # default state or if progress data was loaded and the bubble was explicitly
+    # set to 'not_tried'. In this case, we'll just wait a bit before checking to
+    # reduce the likelihood of false positives.
+    # For all other test_result values, we know that progress has been loaded if
+    # the bubble changes color so we can just poll for the expected color.
+    if test_result == 'not_tried'
+      steps %{
+        And I wait for 2 seconds
+        And I wait until jQuery Ajax requests are finished
+        And I wait until element "#{selector}" is visible
+        And element "#{selector}" has css property "background-color" equal to "#{background_color}"
+        And element "#{selector}" has css property "border-top-color" equal to "#{border_color}"
+      }
+    else
+      steps %{ And I wait until element "#{selector}" is visible }
+      wait_short_until do
+        steps %{
+          And element "#{selector}" has css property "background-color" equal to "#{background_color}"
+          And element "#{selector}" has css property "border-top-color" equal to "#{border_color}"
+        }
+      end
+    end
+  end
 end
 
 def verify_bubble_type(selector, type)
@@ -52,12 +84,6 @@ def header_bubble_selector(level_num)
   ".header_level .react_stage a:nth(#{level_num - 1}) .progress-bubble"
 end
 
-Then /^I verify progress in the header of the current page is "([^"]*)" for level (\d+)/ do |test_result, level|
-  wait_short_until do
-    verify_progress(header_bubble_selector(level.to_i), test_result)
-  end
-end
-
 Then /^I verify the bubble for level (\d+) is an? (concept|activity) bubble/ do |level, type|
   wait_short_until do
     verify_bubble_type(header_bubble_selector(level.to_i), type)
@@ -71,20 +97,25 @@ Then /^I open the progress drop down of the current page$/ do
   }
 end
 
+Then /^I verify progress in the header of the current page is "([^"]*)" for level (\d+)/ do |test_result, level|
+  selector = header_bubble_selector(level.to_i)
+  verify_progress(selector, test_result)
+end
+
 Then /^I verify progress in the drop down of the current page is "([^"]*)" for lesson (\d+) level (\d+)/ do |test_result, lesson, level|
   selector = "tbody tr:nth(#{lesson.to_i - 1}) a:contains(#{level.to_i}) .progress-bubble"
   verify_progress(selector, test_result)
 end
 
-Then /^I verify progress for lesson (\d+) level (\d+) is "([^"]*)"/ do |lesson, level, test_result|
-  selector = "tbody tr:nth(#{lesson.to_i - 1}) a:contains(#{level.to_i}) .progress-bubble"
-  verify_progress(selector, test_result)
+Then /^I verify progress for lesson (\d+) level (\d+)( in detail view)? is "([^"]*)"( without waiting)?/ do |lesson, level, detail_view, test_result, without_waiting|
+  selector = detail_view.nil? ?
+    ".uitest-summary-progress-table .uitest-summary-progress-row:nth(#{lesson.to_i - 1}) .progress-bubble:nth(#{level.to_i - 1})" :
+    ".uitest-detail-progress-table .uitest-progress-lesson:nth(#{lesson.to_i - 1}) .progress-bubble:nth(#{level.to_i - 1})"
+  verify_progress(selector, test_result, !!without_waiting)
 end
 
 Then /^I verify progress for the sublevel with selector "([^"]*)" is "([^"]*)"/ do |selector, test_result|
-  wait_short_until do
-    verify_progress(selector, test_result)
-  end
+  verify_progress(selector, test_result)
 end
 
 # PLC Progress


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

This task started as a general investigation into flaky LP UI tests.  I ended up fixing two issues:
- Specific fix in a test in course_versions.feature (commit #1).
- General fix to improve robustness of tests that check the state of progress bubbles across different parts of the site (commit #2 + #3).

This does not address all flaky tests but I think this is a good stopping point for now.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [LP-1834](https://codedotorg.atlassian.net/browse/LP-1834)
- jira ticket: [LP-1863](https://codedotorg.atlassian.net/browse/LP-1863)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
