### PR TITLE
[Salvador Villalon] Add i18n change iframe locale

### DIFF
--- a/apps/src/p5lab/AnimationTab/PiskelEditor.jsx
+++ b/apps/src/p5lab/AnimationTab/PiskelEditor.jsx
@@ -63,7 +63,7 @@ class PiskelEditor extends React.Component {
     this.piskel.onStateSaved(this.onAnimationSaved);
     this.piskel.onAddFrame(this.onAddFrame);
 
-    this.iframe.contentWindow.locale = this.props.localeCode;
+    this.iframe.contentWindow.piskel_locale = this.props.localeCode;
   }
 
   componentWillUnmount() {

--- a/config/development.yml.erb
+++ b/config/development.yml.erb
@@ -5,8 +5,8 @@ dashboard_enable_pegasus: true
 
 firebase_name: cdo-v3-dev
 # provide a unique path for firebase channels data for development, to avoid conflicts in channel ids.
-firebase_secret: !Secret
-firebase_shared_secret: !Secret
+#firebase_secret: !Secret
+#firebase_shared_secret: !Secret
 firebase_channel_id_suffix: -DEVELOPMENT-<%=ENV['USER']%>
 
 lint: true
@@ -21,7 +21,7 @@ disable_s3_image_uploads: true
 
 chef_local_mode: true
 
-devinternal_db_writer: !Secret
+#devinternal_db_writer: !Secret
 dashboard_honeybadger_api_key: '00000000'
 pegasus_honeybadger_api_key:   '00000000'
 google_safe_browsing_key: fake_api_key

--- a/config/development.yml.erb
+++ b/config/development.yml.erb
@@ -5,8 +5,8 @@ dashboard_enable_pegasus: true
 
 firebase_name: cdo-v3-dev
 # provide a unique path for firebase channels data for development, to avoid conflicts in channel ids.
-#firebase_secret: !Secret
-#firebase_shared_secret: !Secret
+firebase_secret: !Secret
+firebase_shared_secret: !Secret
 firebase_channel_id_suffix: -DEVELOPMENT-<%=ENV['USER']%>
 
 lint: true
@@ -21,7 +21,7 @@ disable_s3_image_uploads: true
 
 chef_local_mode: true
 
-#devinternal_db_writer: !Secret
+devinternal_db_writer: !Secret
 dashboard_honeybadger_api_key: '00000000'
 pegasus_honeybadger_api_key:   '00000000'
 google_safe_browsing_key: fake_api_key


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
## Overview
This changes the iframe.contentWindow.locale to iframe.contentWindow.piskel_locale so that it can match what we are using in the Piskel Repo

## Testing story
In PiskelEditor.jsx I changed the piskel_locale to es_mx. Then in the browser console, I change the JavaScript context to refer to the Piskel Iframe. I then searched for piskel_locale and find that it has es_mx.

## Follow-up work
Need to update the Piskel Repo Version to match the one that has the changes

## PR Checklist:

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
