### PR TITLE
Fix failing Foorm processing cronjob

### DIFF
--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -87,7 +87,7 @@
       cronjob at:'*/3 * * * *', do:dashboard_dir('bin', 'process_pd_workshop_ends')
       cronjob at:'*/5 * * * *', do:dashboard_dir('bin', 'fill_jotform_placeholders')
       cronjob at:'*/30 * * * *', do:dashboard_dir('bin', 'sync_jotforms')
-      cronjob at:'0 6 * * *', do:dashboard_dir('bin', 'process_foorm_data')
+      cronjob at:'0 6 * * *', do:deploy_dir('bin', 'cron', 'process_foorm_data')
       cronjob at:'25 7 * * *', do:deploy_dir('bin', 'cron', 'update_hoc_map')
       cronjob at:'49 5 * * *', do:deploy_dir('bin', 'cron', 'update_census_mapbox')
       cronjob at:'0 9 * * 1-5', do:deploy_dir('bin', 'cron', 'check_for_census_inaccuracy_reports')

--- a/dashboard/lib/pd/foorm/foorm_parser.rb
+++ b/dashboard/lib/pd/foorm/foorm_parser.rb
@@ -60,8 +60,8 @@ module Pd::Foorm
 
       filled_in_form_questions = ::Foorm::Form.fill_in_library_items(form_questions_parsed_from_json)
       filled_in_form_questions.deep_symbolize_keys!
-      filled_in_form_questions[:pages].each do |page|
-        page[:elements].each do |question_data|
+      filled_in_form_questions[:pages]&.each do |page|
+        page[:elements]&.each do |question_data|
           parsed_form_questions.deep_merge!(parse_element(question_data, false))
         end
       end


### PR DESCRIPTION
The cronjob I added last week hasn't been working because of a lazy copy-paste. Fixing that. [HB error here](https://app.honeybadger.io/projects/45435/faults/44710818).

I tried to run the job manually, and ran into an error relating to not handling Forms that do not have pages. Fixing that as well.

## Testing story

Was able to run manually with this fix on production daemon (I removed those changes after this successful run).