### PR TITLE
Javabuilder: add levelId to token

### DIFF
--- a/apps/src/javalab/JavabuilderConnection.js
+++ b/apps/src/javalab/JavabuilderConnection.js
@@ -4,11 +4,12 @@ import {handleException} from './javabuilderExceptionHandler';
 
 // Creates and maintains a websocket connection with javabuilder while a user's code is running.
 export default class JavabuilderConnection {
-  constructor(channelId, javabuilderUrl, onMessage, miniApp) {
+  constructor(channelId, javabuilderUrl, onMessage, miniApp, serverLevelId) {
     this.channelId = channelId;
     this.javabuilderUrl = javabuilderUrl;
     this.onOutputMessage = onMessage;
     this.miniApp = miniApp;
+    this.levelId = serverLevelId;
   }
 
   // Get the access token to connect to javabuilder and then open the websocket connection.
@@ -20,7 +21,8 @@ export default class JavabuilderConnection {
       data: {
         projectUrl: dashboard.project.getProjectSourcesUrl(),
         channelId: this.channelId,
-        projectVersion: dashboard.project.getCurrentSourceVersionId()
+        projectVersion: dashboard.project.getCurrentSourceVersionId(),
+        levelId: this.levelId
       }
     })
       .done(result => this.establishWebsocketConnection(result.token))

--- a/apps/src/javalab/JavabuilderConnection.js
+++ b/apps/src/javalab/JavabuilderConnection.js
@@ -37,9 +37,11 @@ export default class JavabuilderConnection {
   establishWebsocketConnection(token) {
     let url = this.javabuilderUrl;
     if (window.location.hostname.includes('localhost')) {
-      // We're hitting the local javabuilder server. Just pass the projectUrl.
+      // We're hitting the local javabuilder server. Just pass the projectUrl and levelId.
       // TODO: Enable token decryption on local javabuilder server.
-      url += `?projectUrl=${dashboard.project.getProjectSourcesUrl()}`;
+      url += `?projectUrl=${dashboard.project.getProjectSourcesUrl()}?levelId=${
+        this.levelId
+      }`;
     } else {
       url += `?Authorization=${token}`;
     }

--- a/apps/src/javalab/Javalab.js
+++ b/apps/src/javalab/Javalab.js
@@ -193,7 +193,8 @@ Javalab.prototype.onRun = function() {
     this.channelId,
     this.level.javabuilderUrl,
     message => getStore().dispatch(appendOutputLog(message)),
-    this.miniApp
+    this.miniApp,
+    getStore().getState().pageConstants.serverLevelId
   );
   this.javabuilderConnection.connectJavabuilder();
 };

--- a/dashboard/app/controllers/javabuilder_sessions_controller.rb
+++ b/dashboard/app/controllers/javabuilder_sessions_controller.rb
@@ -13,6 +13,7 @@ class JavabuilderSessionsController < ApplicationController
     channel_id = params[:channelId]
     project_version = params[:projectVersion]
     project_url = params[:projectUrl]
+    level_id = params[:levelId]
     if !channel_id || !project_version || !project_url
       return render status: :bad_request, json: {}
     end
@@ -37,7 +38,8 @@ class JavabuilderSessionsController < ApplicationController
       storage_app_id: storage_app_id,
       channel_id: channel_id,
       project_version: project_version,
-      project_url: project_url
+      project_url: project_url,
+      level_id: level_id
     }
 
     # log payload to firehose

--- a/dashboard/test/controllers/javabuilder_sessions_controller_test.rb
+++ b/dashboard/test/controllers/javabuilder_sessions_controller_test.rb
@@ -18,7 +18,7 @@ class JavabuilderSessionsControllerTest < ActionController::TestCase
   test 'can decode jwt token' do
     levelbuilder = create :levelbuilder
     sign_in(levelbuilder)
-    get :get_access_token, params: {channelId: @fake_channel_id, projectVersion: 123, projectUrl: "url"}
+    get :get_access_token, params: {channelId: @fake_channel_id, projectVersion: 123, projectUrl: "url", levelId: 261}
 
     response = JSON.parse(@response.body)
     token = response['token']


### PR DESCRIPTION
We need to add the levelId to the javabuilder session token so we can retrieve some level-specific information in Javabuilder (neighborhood grid and validation code).  

## Links

- jira ticket: [CSA-350](https://codedotorg.atlassian.net/browse/CSA-350)


## Testing story
Tested locally and update a unit test to include the new levelId parameter.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
