### PR TITLE
Revert "Fix Dropbox content reversion bug"

### DIFF
--- a/aws/ci_build
+++ b/aws/ci_build
@@ -40,7 +40,6 @@ require 'aws-sdk-cloudwatch'
 STARTED = 'build-started'.freeze
 S3_LOGS_BUCKET = 'cdo-build-logs'.freeze
 S3_LOGS_PREFIX = CDO.name.freeze
-GIT_PULL_STARTED_PATH = deploy_dir('git-pull-started').freeze
 
 # Upload the given log to the logs s3 bucket.
 # @param [String] key where uploaded log should be located
@@ -61,31 +60,6 @@ rescue Exception => msg
   return ''
 end
 
-def protected_git_pull
-  # Use a lock file to prevent git-pull and unison, which both modify files in
-  # local repo, to run at the same time on the staging environment.
-  #
-  # Context: On the staging environment, we use the unison tool to sync content
-  # between local Dropbox and git repo. It works most of the time. However, we've
-  # seen half-dozen cases of Dropbox content being reverted. Those cases happened
-  # a few hours or even a few days after content editors had made file changes.
-  # They mostly coincided with the starts of new builds.
-  # This change is a speculative fix to prevent any potential conflicts between
-  # git-pull and unison.
-  #
-  if rack_env?(:staging)
-    FileUtils.touch GIT_PULL_STARTED_PATH
-    # Wait a few seconds to give the unison tool time to finish.
-    # Unison is fast and usually finishes in less than 1 second.
-    sleep 2
-  end
-  RakeUtils.git_pull
-ensure
-  if rack_env?(:staging) && File.exist?(GIT_PULL_STARTED_PATH)
-    FileUtils.rm GIT_PULL_STARTED_PATH
-  end
-end
-
 def build
   Dir.chdir(deploy_dir) do
     return 0 unless RakeUtils.git_updates_available? || File.file?(STARTED) || !CDO.daemon
@@ -93,7 +67,7 @@ def build
 
     RakeUtils.git_fetch
     count = RakeUtils.git_update_count
-    protected_git_pull if count > 0
+    RakeUtils.git_pull if count > 0
     count = [1, count].max
 
     log = `git log --pretty=format:"%h %s (%an)" -n #{count}`

--- a/bin/cron/sync_dropbox
+++ b/bin/cron/sync_dropbox
@@ -36,8 +36,6 @@ FOLDERS = {
   "hourofcode.com" => "sites.v3/hourofcode.com"
 }.freeze
 
-GIT_PULL_STARTED_PATH = deploy_dir('git-pull-started').freeze
-
 INTERVAL_SECONDS = 5
 TOTAL_SECONDS = 55 - INTERVAL_SECONDS
 
@@ -47,28 +45,24 @@ logger.load # load errors from most recent sync
 while (Time.now - SCRIPT_START) < TOTAL_SECONDS
   attempt_start = Time.now
   logger.reset_new_events # reset new events such that they represent one run through all FOLDERS
-  # To prevent any potential conflict between git-pull and unison on the staging
-  # environment, only run unison when git-pull is not running.
-  unless File.file?(GIT_PULL_STARTED_PATH)
-    FOLDERS.each do |key, value|
-      # 'unison' will sync the two folders. It will return true on success and false on failure.
-      # For full details, see unison's man page. Docs are also here: https://www.cis.upenn.edu/~bcpierce/unison/download/releases/stable/unison-manual.html
-      command = "unison /home/ubuntu/Dropbox/Shared/#{key} /home/ubuntu/staging/pegasus/#{value} -silent -ignore \"Name .dropbox\" -auto -perms 0 -dontchmod -log -logfile /home/ubuntu/unison.log"
-      stdout, stderr, _ = Open3.capture3(command)
-      if stdout == "" && stderr == ""
-        HooksUtils.get_unstaged_files.each do |filename|
-          ChatClient.log("<@#{DevelopersTopic.dotd}> INVALID FILENAME: #{filename}", color: 'red') if HooksUtils.prohibited?(filename) && Time.now.sec % 59 == 0
-        end
-      else
-        error_message = <<~ERROR_MSG
-                          <!here> Error syncing Dropbox and staging
-                          Dropbox directory: #{key}
-                          pegasus directory: #{value}
-                          stdout: #{stdout}
-                          stderr: #{stderr}
-                        ERROR_MSG
-        logger.record error_message
+  FOLDERS.each do |key, value|
+    # 'unison' will sync the two folders. It will return true on success and false on failure.
+    # For full details, see unison's man page. Docs are also here: https://www.cis.upenn.edu/~bcpierce/unison/download/releases/stable/unison-manual.html
+    command = "unison /home/ubuntu/Dropbox/Shared/#{key} /home/ubuntu/staging/pegasus/#{value} -silent -ignore \"Name .dropbox\" -auto -perms 0 -dontchmod -log -logfile /home/ubuntu/unison.log"
+    stdout, stderr, _ = Open3.capture3(command)
+    if stdout == "" && stderr == ""
+      HooksUtils.get_unstaged_files.each do |filename|
+        ChatClient.log("<@#{DevelopersTopic.dotd}> INVALID FILENAME: #{filename}", color: 'red') if HooksUtils.prohibited?(filename) && Time.now.sec % 59 == 0
       end
+    else
+      error_message = <<~ERROR_MSG
+                        <!here> Error syncing Dropbox and staging
+                        Dropbox directory: #{key}
+                        pegasus directory: #{value}
+                        stdout: #{stdout}
+                        stderr: #{stderr}
+                      ERROR_MSG
+      logger.record error_message
     end
   end
   current_time = Time.now


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#40184

This was a speculative fix. The problem continued occurring after this fix was implemented and Will diagnosed and resolved a separate cause for content being undone on staging (#40685 ). Consider reverting this change, since it likely is not needed.