### PR TITLE
Foorm easy versioning UI

### DIFF
--- a/apps/src/code-studio/pd/foorm/editor/components/FoormEntityLoadButtons.jsx
+++ b/apps/src/code-studio/pd/foorm/editor/components/FoormEntityLoadButtons.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
 import {Button, DropdownButton, MenuItem} from 'react-bootstrap';
+import SingleCheckbox from '../../../form_components/SingleCheckbox';
 import {
   setLastSaved,
   setSaveError,
@@ -28,14 +29,33 @@ class FoormEntityLoadButtons extends React.Component {
     setLastSavedQuestions: PropTypes.func
   };
 
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      latestVersionsOnly: false
+    };
+  }
+
   getDropdownOptions() {
-    return this.props.foormEntities.map((entity, i) => {
-      return this.renderMenuItem(
-        () => this.props.onSelect(entity['metadata']),
-        entity['text'],
-        i
-      );
-    });
+    return (
+      this.props.foormEntities
+        // sort entities alphabetically by name and version
+        .sort((a, b) => a['text'].localeCompare(b['text']))
+        // optionally filter out entities so that only the last unique version of a name remains
+        .filter((entity, i, array) =>
+          this.state.latestVersionsOnly && array[i + 1]
+            ? array[i + 1]['metadata']['name'] !== entity['metadata']['name']
+            : true
+        )
+        .map((entity, i) => {
+          return this.renderMenuItem(
+            () => this.props.onSelect(entity['metadata']),
+            entity['text'],
+            i
+          );
+        })
+    );
   }
 
   renderMenuItem(clickHandler, textToDisplay, key) {
@@ -77,6 +97,16 @@ class FoormEntityLoadButtons extends React.Component {
         >
           {`New ${this.props.foormEntityName}`}
         </Button>
+        <SingleCheckbox
+          name="latestVersionsOnly"
+          label="Only show latest version"
+          onChange={() =>
+            this.setState({
+              latestVersionsOnly: !this.state.latestVersionsOnly
+            })
+          }
+          value={this.state.latestVersionsOnly}
+        />
       </div>
     );
   }

--- a/apps/src/code-studio/pd/foorm/editor/components/FoormEntityLoadButtons.jsx
+++ b/apps/src/code-studio/pd/foorm/editor/components/FoormEntityLoadButtons.jsx
@@ -20,6 +20,7 @@ class FoormEntityLoadButtons extends React.Component {
     foormEntityName: PropTypes.string,
     showCodeMirror: PropTypes.func,
     isDisabled: PropTypes.bool,
+    showVersionFilterToggle: PropTypes.bool,
 
     // populated by redux
     setLastSaved: PropTypes.func,
@@ -29,14 +30,19 @@ class FoormEntityLoadButtons extends React.Component {
     setLastSavedQuestions: PropTypes.func
   };
 
-  constructor(props) {
-    super(props);
+  state = {
+    latestVersionsOnly: true
+  };
 
-    this.state = {
-      latestVersionsOnly: false
-    };
+  shouldShowLatestVersionsOnly() {
+    return this.props.showVersionFilterToggle && this.state.latestVersionsOnly;
   }
 
+  /**
+   * Takes props.foormEntities in the form of {metatadata: {name: string, version: number}, text: string}
+   * and optionally sorts and filters (based on version filter toggle) and renders them as MenuItems.
+   * @returns Array<MenuItem>
+   */
   getDropdownOptions() {
     return (
       this.props.foormEntities
@@ -44,7 +50,7 @@ class FoormEntityLoadButtons extends React.Component {
         .sort((a, b) => a['text'].localeCompare(b['text']))
         // optionally filter out entities so that only the last unique version of a name remains
         .filter((entity, i, array) =>
-          this.state.latestVersionsOnly && array[i + 1]
+          this.shouldShowLatestVersionsOnly() && array[i + 1]
             ? array[i + 1]['metadata']['name'] !== entity['metadata']['name']
             : true
         )
@@ -97,16 +103,18 @@ class FoormEntityLoadButtons extends React.Component {
         >
           {`New ${this.props.foormEntityName}`}
         </Button>
-        <SingleCheckbox
-          name="latestVersionsOnly"
-          label="Only show latest version"
-          onChange={() =>
-            this.setState({
-              latestVersionsOnly: !this.state.latestVersionsOnly
-            })
-          }
-          value={this.state.latestVersionsOnly}
-        />
+        {this.props.showVersionFilterToggle && (
+          <SingleCheckbox
+            name="latestVersionsOnly"
+            label="Only show latest version"
+            onChange={() =>
+              this.setState({
+                latestVersionsOnly: !this.state.latestVersionsOnly
+              })
+            }
+            value={this.state.latestVersionsOnly}
+          />
+        )}
       </div>
     );
   }

--- a/apps/src/code-studio/pd/foorm/editor/components/FoormEntityLoadButtons.jsx
+++ b/apps/src/code-studio/pd/foorm/editor/components/FoormEntityLoadButtons.jsx
@@ -10,6 +10,7 @@ import {
   setHasLintError,
   setLastSavedQuestions
 } from '../foormEditorRedux';
+import {getLatestVersionMap} from '../../foormHelpers';
 
 class FoormEntityLoadButtons extends React.Component {
   static propTypes = {
@@ -44,15 +45,22 @@ class FoormEntityLoadButtons extends React.Component {
    * @returns Array<MenuItem>
    */
   getDropdownOptions() {
+    const latestVersionMap = getLatestVersionMap(this.props.foormEntities);
+
     return (
       this.props.foormEntities
-        // sort entities alphabetically by name and version
-        .sort((a, b) => a['text'].localeCompare(b['text']))
-        // optionally filter out entities so that only the last unique version of a name remains
-        .filter((entity, i, array) =>
-          this.shouldShowLatestVersionsOnly() && array[i + 1]
-            ? array[i + 1]['metadata']['name'] !== entity['metadata']['name']
+        // optionally filter out entities without the latest version of a name
+        .filter(entity =>
+          this.shouldShowLatestVersionsOnly()
+            ? latestVersionMap[entity['metadata']['name']] ===
+              entity['metadata']['version']
             : true
+        )
+        // sort entities alphabetically by name and version (sort numerically when names are the same)
+        .sort(
+          (a, b) =>
+            a['text'].localeCompare(b['text']) ||
+            a['metadata']['version'] - b['metadata']['version']
         )
         .map((entity, i) => {
           return this.renderMenuItem(

--- a/apps/src/code-studio/pd/foorm/editor/form/FoormFormEditorManager.jsx
+++ b/apps/src/code-studio/pd/foorm/editor/form/FoormFormEditorManager.jsx
@@ -213,6 +213,7 @@ class FoormFormEditorManager extends React.Component {
           onSelect={formMetadata => this.loadFormData(formMetadata)}
           foormEntities={this.getFetchableForms()}
           foormEntityName="Form"
+          showVersionFilterToggle={true}
         />
         {this.state.hasLoadError && (
           <div style={styles.loadError}>Could not load the selected form.</div>

--- a/apps/src/code-studio/pd/foorm/editor/form/FoormFormEditorManager.jsx
+++ b/apps/src/code-studio/pd/foorm/editor/form/FoormFormEditorManager.jsx
@@ -12,6 +12,7 @@ import {
   setLastSavedQuestions
 } from '../foormEditorRedux';
 import FoormFormSaveBar from '@cdo/apps/code-studio/pd/foorm/editor/form/FoormFormSaveBar';
+import {getLatestVersionMap} from '../../foormHelpers';
 
 /*
 Parent component for editing Foorm forms. Will initially show a choice
@@ -182,10 +183,14 @@ class FoormFormEditorManager extends React.Component {
   }
 
   renderSaveBar() {
+    const latestVersionMap = getLatestVersionMap(this.getFetchableForms());
     return (
       <FoormFormSaveBar
         formCategories={this.props.categories}
         resetCodeMirror={this.props.resetCodeMirror}
+        isLatestVersion={
+          latestVersionMap[this.props.formName] === this.props.formVersion
+        }
       />
     );
   }

--- a/apps/src/code-studio/pd/foorm/editor/form/FoormFormSaveBar.jsx
+++ b/apps/src/code-studio/pd/foorm/editor/form/FoormFormSaveBar.jsx
@@ -35,6 +35,7 @@ class FoormFormSaveBar extends Component {
     hasJSONError: PropTypes.bool,
     hasLintError: PropTypes.bool,
     isFormPublished: PropTypes.bool,
+    isLatestVersion: PropTypes.bool,
     formId: PropTypes.number,
     formName: PropTypes.string,
     formVersion: PropTypes.number,
@@ -317,7 +318,7 @@ class FoormFormSaveBar extends Component {
               Publish
             </button>
           )}
-          {this.props.isFormPublished && (
+          {this.props.isFormPublished && this.props.isLatestVersion && (
             <button
               className="btn btn-primary"
               type="button"

--- a/apps/src/code-studio/pd/foorm/editor/form/FoormFormSaveBar.jsx
+++ b/apps/src/code-studio/pd/foorm/editor/form/FoormFormSaveBar.jsx
@@ -54,7 +54,7 @@ class FoormFormSaveBar extends Component {
       confirmationDialogBeingShownName: null,
       isSaving: false,
       showNewFormSave: false,
-      formName: null,
+      formShortName: null, // just the second part of the name without the category
       formCategory: null
     };
   }
@@ -132,12 +132,16 @@ class FoormFormSaveBar extends Component {
       });
   };
 
-  isFormNameValid = () => {
-    return this.state.formName && this.state.formName.match('^[a-z0-9_]+$');
+  isFormShortNameValid = () => {
+    return (
+      this.state.formShortName && this.state.formShortName.match('^[a-z0-9_]+$')
+    );
   };
 
   saveNewForm = (saveAsNewVersion = false) => {
-    const newFormName = `${this.state.formCategory}/${this.state.formName}`;
+    const newFormName = `${this.state.formCategory}/${
+      this.state.formShortName
+    }`;
     $.ajax({
       url: `/foorm/forms`,
       type: 'post',
@@ -203,7 +207,8 @@ class FoormFormSaveBar extends Component {
   }
 
   renderNewFormSaveModal = () => {
-    const showFormNameError = this.state.formName && !this.isFormNameValid();
+    const showFormNameError =
+      this.state.formShortName && !this.isFormShortNameValid();
     return (
       <Modal
         show={this.state.showNewFormSave}
@@ -244,7 +249,7 @@ class FoormFormSaveBar extends Component {
               id="formName"
               type="text"
               required={true}
-              onChange={e => this.setState({formName: e.target.value})}
+              onChange={e => this.setState({formShortName: e.target.value})}
             />
           </FormGroup>
           {showFormNameError && (
@@ -260,7 +265,7 @@ class FoormFormSaveBar extends Component {
             bsStyle="primary"
             onClick={() => this.saveNewForm(false)}
             disabled={
-              !(this.state.formName && this.state.formCategory) ||
+              !(this.state.formShortName && this.state.formCategory) ||
               showFormNameError
             }
           >

--- a/apps/src/code-studio/pd/foorm/editor/form/FoormFormSaveBar.jsx
+++ b/apps/src/code-studio/pd/foorm/editor/form/FoormFormSaveBar.jsx
@@ -424,7 +424,15 @@ const styles = {
 const saveNewVersionWarning = version => (
   <div>
     <span style={styles.warning}>Warning: </span>You are about to save version{' '}
-    {version} of this form. This version will need to be deployed separately.
+    {version} of this form. Read more about versioning{' '}
+    <a
+      href="https://github.com/code-dot-org/code-dot-org/wiki/%5BLevelbuilder%5d-The-Foorm-Editor#when-to-version"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      here
+    </a>
+    . Check with an engineer if you are unsure this needs a new version.
     <br />
     <br />
     Are you sure you want to save your changes?

--- a/apps/src/code-studio/pd/foorm/editor/form/FoormFormSaveBar.jsx
+++ b/apps/src/code-studio/pd/foorm/editor/form/FoormFormSaveBar.jsx
@@ -318,7 +318,7 @@ class FoormFormSaveBar extends Component {
               Publish
             </button>
           )}
-          {this.props.isFormPublished && this.props.isLatestVersion && (
+          {this.props.isLatestVersion && (
             <button
               className="btn btn-primary"
               type="button"

--- a/apps/src/code-studio/pd/foorm/editor/form/FoormFormSaveBar.jsx
+++ b/apps/src/code-studio/pd/foorm/editor/form/FoormFormSaveBar.jsx
@@ -343,19 +343,6 @@ class FoormFormSaveBar extends Component {
         <ConfirmationDialog
           show={
             this.state.confirmationDialogBeingShownName ===
-            confirmationDialogNames.saveNewVersion
-          }
-          onOk={() => {
-            this.handleSave(true);
-          }}
-          okText={'Yes, save the form'}
-          onCancel={this.handleSaveCancel}
-          headerText="Save Form as New Version"
-          bodyText={saveNewVersionWarning(this.props.formVersion + 1)}
-        />
-        <ConfirmationDialog
-          show={
-            this.state.confirmationDialogBeingShownName ===
             confirmationDialogNames.save
           }
           onOk={() => {
@@ -378,6 +365,19 @@ class FoormFormSaveBar extends Component {
           onCancel={this.handleSaveCancel}
           headerText="Publish Form"
           bodyText={aboutToPublishWarning}
+        />
+        <ConfirmationDialog
+          show={
+            this.state.confirmationDialogBeingShownName ===
+            confirmationDialogNames.saveNewVersion
+          }
+          onOk={() => {
+            this.handleSave(true);
+          }}
+          okText={'Yes, save the form'}
+          onCancel={this.handleSaveCancel}
+          headerText="Save Form as New Version"
+          bodyText={saveNewVersionWarning(this.props.formVersion + 1)}
         />
       </div>
     );

--- a/apps/src/code-studio/pd/foorm/editor/form/FoormFormSaveBar.jsx
+++ b/apps/src/code-studio/pd/foorm/editor/form/FoormFormSaveBar.jsx
@@ -84,6 +84,14 @@ class FoormFormSaveBar extends Component {
     }
   };
 
+  handleSaveNewVersion = () => {
+    this.setState({
+      isSaving: true,
+      confirmationDialogBeingShownName: confirmationDialogNames.saveNewVersion
+    });
+    this.props.setSaveError(null);
+  };
+
   handlePublish = () => {
     this.setState({
       isSaving: true,
@@ -144,7 +152,8 @@ class FoormFormSaveBar extends Component {
       .done(result => {
         this.handleSaveSuccess(result);
         this.setState({
-          showNewFormSave: false
+          showNewFormSave: false,
+          confirmationDialogBeingShownName: null
         });
         // adds new form to form dropdown
         this.props.addFetchableForm({
@@ -156,7 +165,8 @@ class FoormFormSaveBar extends Component {
       .fail(result => {
         this.handleSaveError(result);
         this.setState({
-          showNewFormSave: false
+          showNewFormSave: false,
+          confirmationDialogBeingShownName: null
         });
       });
   };
@@ -307,7 +317,7 @@ class FoormFormSaveBar extends Component {
               className="btn btn-primary"
               type="button"
               style={styles.button}
-              onClick={() => this.handleSave(true)}
+              onClick={() => this.handleSaveNewVersion()}
               disabled={this.state.isSaving || this.props.hasJSONError}
             >
               Save as New Version
@@ -324,6 +334,19 @@ class FoormFormSaveBar extends Component {
           </button>
         </div>
         {this.renderNewFormSaveModal()}
+        <ConfirmationDialog
+          show={
+            this.state.confirmationDialogBeingShownName ===
+            confirmationDialogNames.saveNewVersion
+          }
+          onOk={() => {
+            this.handleSave(true);
+          }}
+          okText={'Yes, save the form'}
+          onCancel={this.handleSaveCancel}
+          headerText="Save Form as New Version"
+          bodyText={saveNewVersionWarning(this.props.formVersion + 1)}
+        />
         <ConfirmationDialog
           show={
             this.state.confirmationDialogBeingShownName ===
@@ -392,6 +415,16 @@ const styles = {
   }
 };
 
+const saveNewVersionWarning = version => (
+  <div>
+    <span style={styles.warning}>Warning: </span>You are about to save version{' '}
+    {version} of this form. This version will need to be deployed separately.
+    <br />
+    <br />
+    Are you sure you want to save your changes?
+  </div>
+);
+
 const publishedSaveWarning = (
   <div>
     <span style={styles.warning}>Warning: </span>You are editing a published
@@ -425,7 +458,8 @@ const aboutToPublishWarning = (
 
 const confirmationDialogNames = {
   save: 'save',
-  publish: 'publish'
+  publish: 'publish',
+  saveNewVersion: 'saveNewVersion'
 };
 
 export const UnconnectedFoormFormSaveBar = FoormFormSaveBar;

--- a/apps/src/code-studio/pd/foorm/editor/library/FoormLibraryEditorManager.jsx
+++ b/apps/src/code-studio/pd/foorm/editor/library/FoormLibraryEditorManager.jsx
@@ -249,7 +249,6 @@ class FoormLibraryEditorManager extends React.Component {
           }
           foormEntities={this.getLibraryChoices()}
           foormEntityName="Library"
-          showVersionFilterToggle={true}
         />
         <FoormEntityLoadButtons
           resetCodeMirror={this.props.resetCodeMirror}

--- a/apps/src/code-studio/pd/foorm/editor/library/FoormLibraryEditorManager.jsx
+++ b/apps/src/code-studio/pd/foorm/editor/library/FoormLibraryEditorManager.jsx
@@ -249,6 +249,7 @@ class FoormLibraryEditorManager extends React.Component {
           }
           foormEntities={this.getLibraryChoices()}
           foormEntityName="Library"
+          showVersionFilterToggle={true}
         />
         <FoormEntityLoadButtons
           resetCodeMirror={this.props.resetCodeMirror}

--- a/apps/src/code-studio/pd/foorm/editor/library/FoormLibrarySaveBar.jsx
+++ b/apps/src/code-studio/pd/foorm/editor/library/FoormLibrarySaveBar.jsx
@@ -59,7 +59,7 @@ class FoormLibrarySaveBar extends Component {
     isSaving: false,
     showNewLibraryQuestionSave: false,
     libraryQuestionName: null,
-    libraryName: null,
+    libraryShortName: null,
     formsAppearedIn: [],
     libraryCategory: null
   };
@@ -140,7 +140,7 @@ class FoormLibrarySaveBar extends Component {
     let fullLibraryName = '';
     if (!this.props.libraryId) {
       fullLibraryName = `${this.state.libraryCategory}/${
-        this.state.libraryName
+        this.state.libraryShortName
       }`;
     }
 
@@ -222,7 +222,8 @@ class FoormLibrarySaveBar extends Component {
     return (
       (this.state.libraryQuestionName &&
         !this.isNameValid(this.state.libraryQuestionName)) ||
-      (this.state.libraryName && !this.isNameValid(this.state.libraryName))
+      (this.state.libraryShortName &&
+        !this.isNameValid(this.state.libraryShortName))
     );
   }
 
@@ -241,7 +242,7 @@ class FoormLibrarySaveBar extends Component {
     if (
       !this.props.libraryId &&
       !(
-        this.state.libraryName &&
+        this.state.libraryShortName &&
         this.state.libraryCategory &&
         this.state.libraryQuestionName
       )
@@ -320,7 +321,9 @@ class FoormLibrarySaveBar extends Component {
                   id="libraryName"
                   type="text"
                   required={true}
-                  onChange={e => this.setState({libraryName: e.target.value})}
+                  onChange={e =>
+                    this.setState({libraryShortName: e.target.value})
+                  }
                 />
               </div>
             )}

--- a/apps/src/code-studio/pd/foorm/foormHelpers.js
+++ b/apps/src/code-studio/pd/foorm/foormHelpers.js
@@ -1,0 +1,16 @@
+/**
+ * Creates a map of entity name to entity version where the version is the highest for that name
+ * @param {Array<{metadata: {name: string, version: number}}>} foormEntities foorm entities (forms or libraries)
+ * @returns map from name to latest version for that name
+ */
+export const getLatestVersionMap = foormEntities => {
+  const getName = entity => entity['metadata']['name'];
+  const getVersion = entity => Number(entity['metadata']['version']);
+  const latestVersionMap = foormEntities.reduce((map, entity) => {
+    if (!map[getName(entity)] || getVersion(entity) > map[getName(entity)]) {
+      map[getName(entity)] = getVersion(entity);
+    }
+    return map;
+  }, {});
+  return latestVersionMap;
+};

--- a/apps/test/unit/code-studio/pd/foorm/FoormEntityEditorFormModeTest.js
+++ b/apps/test/unit/code-studio/pd/foorm/FoormEntityEditorFormModeTest.js
@@ -264,11 +264,11 @@ describe('FoormEntityEditor in Form editing mode', () => {
     const saveBarButtons = wrapper
       .find(UnconnectedFoormFormSaveBar)
       .find('button');
-    const saveButton1 = saveBarButtons.at(0);
-    const saveButton2 = saveBarButtons.at(1);
+    const saveNewVersionButton = saveBarButtons.at(0);
+    const saveButton = saveBarButtons.at(1);
 
-    expect(saveButton1.contains('Save as New Version')).to.be.true;
-    expect(saveButton2.contains('Save')).to.be.true;
+    expect(saveNewVersionButton.contains('Save as New Version')).to.be.true;
+    expect(saveButton.contains('Save')).to.be.true;
     expect(saveBarButtons.length).to.equal(2);
   });
 
@@ -281,11 +281,11 @@ describe('FoormEntityEditor in Form editing mode', () => {
     const saveBarButtons = wrapper
       .find(UnconnectedFoormFormSaveBar)
       .find('button');
-    const saveButton1 = saveBarButtons.at(0);
-    const saveButton2 = saveBarButtons.at(1);
+    const saveNewVersionButton = saveBarButtons.at(0);
+    const saveButton = saveBarButtons.at(1);
 
-    expect(saveButton1.contains('Publish')).to.be.false;
-    expect(saveButton2.contains('Save')).to.be.true;
+    expect(saveNewVersionButton.contains('Publish')).to.be.false;
+    expect(saveButton.contains('Save')).to.be.true;
     expect(saveBarButtons.length).to.equal(2);
   });
 

--- a/apps/test/unit/code-studio/pd/foorm/FoormEntityEditorFormModeTest.js
+++ b/apps/test/unit/code-studio/pd/foorm/FoormEntityEditorFormModeTest.js
@@ -38,7 +38,8 @@ describe('FoormEntityEditor in Form editing mode', () => {
     const HeaderTitle = React.createElement('h1', null, 'A title');
     const SaveBar = React.createElement(FoormFormSaveBar, {
       resetCodeMirror: () => {},
-      formCategories: ['surveys/pd', 'surveys/teacher']
+      formCategories: ['surveys/pd', 'surveys/teacher'],
+      isLatestVersion: true
     });
 
     defaultProps = {

--- a/apps/test/unit/code-studio/pd/foorm/FoormEntityEditorFormModeTest.js
+++ b/apps/test/unit/code-studio/pd/foorm/FoormEntityEditorFormModeTest.js
@@ -113,7 +113,7 @@ describe('FoormEntityEditor in Form editing mode', () => {
 
     const saveBar = wrapper.find(UnconnectedFoormFormSaveBar);
 
-    const saveButton = saveBar.find('button').at(1);
+    const saveButton = saveBar.find('button').at(2);
     expect(saveButton.contains('Save')).to.be.true;
     saveButton.simulate('click');
 
@@ -189,7 +189,7 @@ describe('FoormEntityEditor in Form editing mode', () => {
 
     const saveBar = wrapper.find(UnconnectedFoormFormSaveBar);
 
-    const saveButton = saveBar.find('button').at(1);
+    const saveButton = saveBar.find('button').at(2);
     expect(saveButton.contains('Save')).to.be.true;
     saveButton.simulate('click');
 
@@ -256,7 +256,7 @@ describe('FoormEntityEditor in Form editing mode', () => {
     expect(wrapper.find('.lastSavedMessage').length).to.equal(1);
   });
 
-  it('shows save as new version button for published survey', () => {
+  it('shows save as new version button for latest version', () => {
     const wrapper = createWrapper();
 
     store.dispatch(setFormData(samplePublishedFormData));
@@ -271,6 +271,26 @@ describe('FoormEntityEditor in Form editing mode', () => {
     expect(saveNewVersionButton.contains('Save as New Version')).to.be.true;
     expect(saveButton.contains('Save')).to.be.true;
     expect(saveBarButtons.length).to.equal(2);
+  });
+
+  it('hides save as new version button for not latest version', () => {
+    const SaveBarNotLatestVersion = React.createElement(FoormFormSaveBar, {
+      resetCodeMirror: () => {},
+      formCategories: ['surveys/pd', 'surveys/teacher'],
+      isLatestVersion: false
+    });
+    const wrapper = createWrapper({saveBar: SaveBarNotLatestVersion});
+
+    store.dispatch(setFormData(samplePublishedFormData));
+    wrapper.update();
+
+    const saveBarButtons = wrapper
+      .find(UnconnectedFoormFormSaveBar)
+      .find('button');
+    const saveButton = saveBarButtons.at(0);
+
+    expect(saveButton.contains('Save')).to.be.true;
+    expect(saveBarButtons.length).to.equal(1);
   });
 
   it('hides publish button for published survey', () => {
@@ -382,7 +402,7 @@ describe('FoormEntityEditor in Form editing mode', () => {
     const saveBar = wrapper.find(UnconnectedFoormFormSaveBar);
 
     // click save button
-    const saveButton = saveBar.find('button').at(1);
+    const saveButton = saveBar.find('button').at(2);
     expect(saveButton.contains('Save')).to.be.true;
     saveButton.simulate('click');
 
@@ -432,7 +452,7 @@ describe('FoormEntityEditor in Form editing mode', () => {
     const saveBar = wrapper.find(UnconnectedFoormFormSaveBar);
 
     // click save button
-    const saveButton = saveBar.find('button').at(1);
+    const saveButton = saveBar.find('button').at(2);
     expect(saveButton.contains('Save')).to.be.true;
     saveButton.simulate('click');
 

--- a/apps/test/unit/code-studio/pd/foorm/FoormEntityEditorFormModeTest.js
+++ b/apps/test/unit/code-studio/pd/foorm/FoormEntityEditorFormModeTest.js
@@ -224,7 +224,7 @@ describe('FoormEntityEditor in Form editing mode', () => {
 
     const saveBar = wrapper.find(UnconnectedFoormFormSaveBar);
 
-    const saveButton = saveBar.find('button').at(0);
+    const saveButton = saveBar.find('button').at(1);
     expect(saveButton.contains('Save')).to.be.true;
     saveButton.simulate('click');
 
@@ -255,6 +255,23 @@ describe('FoormEntityEditor in Form editing mode', () => {
     expect(wrapper.find('.lastSavedMessage').length).to.equal(1);
   });
 
+  it('shows save as new version button for published survey', () => {
+    const wrapper = createWrapper();
+
+    store.dispatch(setFormData(samplePublishedFormData));
+    wrapper.update();
+
+    const saveBarButtons = wrapper
+      .find(UnconnectedFoormFormSaveBar)
+      .find('button');
+    const saveButton1 = saveBarButtons.at(0);
+    const saveButton2 = saveBarButtons.at(1);
+
+    expect(saveButton1.contains('Save as New Version')).to.be.true;
+    expect(saveButton2.contains('Save')).to.be.true;
+    expect(saveBarButtons.length).to.equal(2);
+  });
+
   it('hides publish button for published survey', () => {
     const wrapper = createWrapper();
 
@@ -264,11 +281,12 @@ describe('FoormEntityEditor in Form editing mode', () => {
     const saveBarButtons = wrapper
       .find(UnconnectedFoormFormSaveBar)
       .find('button');
-    const saveButton = saveBarButtons.at(0);
+    const saveButton1 = saveBarButtons.at(0);
+    const saveButton2 = saveBarButtons.at(1);
 
-    expect(saveButton.contains('Publish')).to.be.false;
-    expect(saveButton.contains('Save')).to.be.true;
-    expect(saveBarButtons.length).to.equal(1);
+    expect(saveButton1.contains('Publish')).to.be.false;
+    expect(saveButton2.contains('Save')).to.be.true;
+    expect(saveBarButtons.length).to.equal(2);
   });
 
   it('can cancel save published form', () => {
@@ -279,7 +297,7 @@ describe('FoormEntityEditor in Form editing mode', () => {
 
     const saveBar = wrapper.find(UnconnectedFoormFormSaveBar);
 
-    const saveButton = saveBar.find('button').at(0);
+    const saveButton = saveBar.find('button').at(1);
     expect(saveButton.contains('Save')).to.be.true;
     saveButton.simulate('click');
 

--- a/apps/test/unit/code-studio/pd/foorm/FoormEntityLoadButtonsTest.js
+++ b/apps/test/unit/code-studio/pd/foorm/FoormEntityLoadButtonsTest.js
@@ -1,0 +1,148 @@
+import React from 'react';
+import {mount} from 'enzyme';
+import {assert} from 'chai';
+
+import {
+  stubRedux,
+  restoreRedux,
+  getStore,
+  registerReducers
+} from '@cdo/apps/redux';
+import {Provider} from 'react-redux';
+import foorm from '../../../../../src/code-studio/pd/foorm/editor/foormEditorRedux';
+import {DropdownButton, MenuItem} from 'react-bootstrap';
+import FoormEntityLoadButtons from '../../../../../src/code-studio/pd/foorm/editor/components/FoormEntityLoadButtons';
+import SingleCheckbox from '../../../../../src/code-studio/pd/form_components/SingleCheckbox';
+
+describe('FoormEntityLoadButtons', () => {
+  let defaultProps, store, wrapper;
+  beforeEach(() => {
+    stubRedux();
+    registerReducers({foorm});
+
+    store = getStore();
+
+    defaultProps = {
+      foormEntities: [
+        {
+          metadata: {name: 'b_library', version: 0},
+          text: 'b_library, version 0'
+        },
+        {
+          metadata: {name: 'a_library', version: 0},
+          text: 'a_library, version 0'
+        },
+        {
+          metadata: {name: 'a_library', version: 1},
+          text: 'a_library, version 1'
+        },
+        {
+          metadata: {name: 'c_library', version: 0},
+          text: 'c_library, version 0'
+        }
+      ]
+    };
+  });
+
+  afterEach(() => {
+    restoreRedux();
+  });
+
+  it('filters and sorts menu items by default with toggle', () => {
+    wrapper = mount(
+      <Provider store={store}>
+        <FoormEntityLoadButtons
+          {...defaultProps}
+          showVersionFilterToggle={true}
+        />
+      </Provider>
+    );
+
+    const expectedOrder = [
+      'a_library, version 1',
+      'b_library, version 0',
+      'c_library, version 0'
+    ];
+
+    assert.equal(
+      wrapper
+        .find(DropdownButton)
+        .at(0)
+        .find(MenuItem).length,
+      3
+    );
+    wrapper
+      .find(DropdownButton)
+      .at(0)
+      .find(MenuItem)
+      .every((menuItem, i) => assert.equal(menuItem.text(), expectedOrder[i]));
+  });
+
+  it("doesn't filter and sort menu items when toggled off", () => {
+    wrapper = mount(
+      <Provider store={store}>
+        <FoormEntityLoadButtons
+          {...defaultProps}
+          showVersionFilterToggle={true}
+        />
+      </Provider>
+    );
+
+    wrapper
+      .find(SingleCheckbox)
+      .at(0)
+      .prop('onChange')();
+    wrapper.update();
+
+    const expectedOrder = [
+      'a_library, version 0',
+      'a_library, version 1',
+      'b_library, version 0',
+      'c_library, version 0'
+    ];
+
+    assert.equal(
+      wrapper
+        .find(DropdownButton)
+        .at(0)
+        .find(MenuItem).length,
+      4
+    );
+    wrapper
+      .find(DropdownButton)
+      .at(0)
+      .find(MenuItem)
+      .every((menuItem, i) => assert.equal(menuItem.text(), expectedOrder[i]));
+  });
+
+  it("doesn't filter and sort menu items with no toggle", () => {
+    wrapper = mount(
+      <Provider store={store}>
+        <FoormEntityLoadButtons
+          {...defaultProps}
+          showVersionFilterToggle={false}
+        />
+      </Provider>
+    );
+
+    const expectedOrder = [
+      'a_library, version 0',
+      'a_library, version 1',
+      'b_library, version 0',
+      'c_library, version 0'
+    ];
+
+    assert.equal(
+      wrapper
+        .find(DropdownButton)
+        .at(0)
+        .find(MenuItem).length,
+      4
+    );
+    wrapper
+      .find(DropdownButton)
+      .at(0)
+      .find(MenuItem)
+      .every((menuItem, i) => assert.equal(menuItem.text(), expectedOrder[i]));
+  });
+});

--- a/apps/test/unit/code-studio/pd/foorm/FoormEntityLoadButtonsTest.js
+++ b/apps/test/unit/code-studio/pd/foorm/FoormEntityLoadButtonsTest.js
@@ -78,7 +78,7 @@ describe('FoormEntityLoadButtons', () => {
       .every((menuItem, i) => assert.equal(menuItem.text(), expectedOrder[i]));
   });
 
-  it("doesn't filter and sort menu items when toggled off", () => {
+  it("sorts, but doesn't filter menu items when toggled off", () => {
     wrapper = mount(
       <Provider store={store}>
         <FoormEntityLoadButtons
@@ -115,7 +115,7 @@ describe('FoormEntityLoadButtons', () => {
       .every((menuItem, i) => assert.equal(menuItem.text(), expectedOrder[i]));
   });
 
-  it("doesn't filter and sort menu items with no toggle", () => {
+  it("sorts, but doesn't filter menu items with no toggle", () => {
     wrapper = mount(
       <Provider store={store}>
         <FoormEntityLoadButtons

--- a/dashboard/app/models/foorm/form.rb
+++ b/dashboard/app/models/foorm/form.rb
@@ -91,12 +91,12 @@ class Foorm::Form < ApplicationRecord
   end
 
   def self.get_questions_and_latest_version_for_name(form_name)
-    latest_version = Foorm::Form.where(name: form_name).maximum(:version)
-    return nil if latest_version.nil?
+    latest_published_version = Foorm::Form.where(name: form_name, published: true).maximum(:version)
+    return nil if latest_published_version.nil?
 
-    questions = get_questions_for_name_and_version(form_name, latest_version)
+    questions = get_questions_for_name_and_version(form_name, latest_published_version)
 
-    return questions, latest_version
+    return questions, latest_published_version
   end
 
   def self.get_questions_for_name_and_version(form_name, form_version)

--- a/dashboard/test/models/foorm/form_test.rb
+++ b/dashboard/test/models/foorm/form_test.rb
@@ -10,6 +10,15 @@ class Foorm::FormTest < ActiveSupport::TestCase
     assert_equal form2.version, version
   end
 
+  test 'get latest form and version gets correct form with latest version unpublished' do
+    form1 = create :foorm_form
+    create :foorm_form, name: form1.name, version: form1.version + 1, published: false
+
+    questions, version = Foorm::Form.get_questions_and_latest_version_for_name(form1.name)
+    assert_equal JSON.parse(form1.questions), questions
+    assert_equal form1.version, version
+  end
+
   test 'readable_questions formats matrix questions for general workshop question' do
     form = build :foorm_form_csf_intro_post_survey
     readable_questions = form.readable_questions


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Adds a new button "Save as New Version" to published foorm forms which will increment the version of the currently edited form. Also sorts and filters the list of forms to choose from, and allows you to toggle viewing all versions or just the latest version.

![filtered-surveys](https://user-images.githubusercontent.com/82416901/119408016-e6046d00-bc99-11eb-8682-6d8dbc071492.png)
![unfiltered-surveys](https://user-images.githubusercontent.com/82416901/119408017-e69d0380-bc99-11eb-98d1-6f256856ffdf.png)


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [PLC-1050](https://codedotorg.atlassian.net/browse/PLC-1050)

## Testing story

Added unit tests, tested locally
