### PR TITLE
Make sure that the assign text and buttons show in the right spot

### DIFF
--- a/apps/src/code-studio/components/progress/ScriptOverviewTopRow.jsx
+++ b/apps/src/code-studio/components/progress/ScriptOverviewTopRow.jsx
@@ -221,7 +221,8 @@ const styles = {
     // ensure we have height when we only have our toggle (which is floated)
     minHeight: 50,
     position: 'relative',
-    display: 'flex'
+    display: 'flex',
+    flexDirection: 'column'
   },
   buttonsInRow: {
     display: 'flex',

--- a/apps/src/code-studio/components/progress/ScriptOverviewTopRow.jsx
+++ b/apps/src/code-studio/components/progress/ScriptOverviewTopRow.jsx
@@ -127,7 +127,7 @@ class ScriptOverviewTopRow extends React.Component {
     return (
       <div style={styles.buttonRow} className="script-overview-top-row">
         {!professionalLearningCourse && viewAs === ViewType.Student && (
-          <div>
+          <div style={styles.buttonsInRow}>
             <Button
               __useDeprecatedTag
               href={`/s/${scriptName}/next`}
@@ -220,7 +220,12 @@ const styles = {
   buttonRow: {
     // ensure we have height when we only have our toggle (which is floated)
     minHeight: 50,
-    position: 'relative'
+    position: 'relative',
+    display: 'flex'
+  },
+  buttonsInRow: {
+    display: 'flex',
+    alignItems: 'center'
   },
   right: {
     position: 'absolute',

--- a/apps/src/templates/AssignButton.jsx
+++ b/apps/src/templates/AssignButton.jsx
@@ -104,10 +104,14 @@ class AssignButton extends React.Component {
 
 const styles = {
   buttonMargin: {
-    marginLeft: 10
+    marginLeft: 10,
+    display: 'flex',
+    alignItems: 'center'
   },
   buttonMarginRTL: {
-    marginRight: 10
+    marginRight: 10,
+    display: 'flex',
+    alignItems: 'center'
   }
 };
 

--- a/apps/src/templates/Assigned.jsx
+++ b/apps/src/templates/Assigned.jsx
@@ -7,7 +7,9 @@ export default class Assigned extends Component {
   render() {
     return (
       <span style={styles.assigned} className={'uitest-assigned'}>
-        <FontAwesome icon="check" />
+        <span style={styles.checkmark}>
+          <FontAwesome icon="check" />
+        </span>
         {i18n.assigned()}
       </span>
     );
@@ -15,12 +17,17 @@ export default class Assigned extends Component {
 }
 
 const styles = {
+  checkmark: {
+    padding: 5
+  },
   assigned: {
     color: color.level_perfect,
     fontSize: 16,
     fontFamily: '"Gotham 5r", sans-serif',
     lineHeight: '36px',
     marginLeft: 10,
-    verticalAlign: 'top'
+    verticalAlign: 'top',
+    display: 'flex',
+    alignItems: 'center'
   }
 };

--- a/apps/src/templates/UnassignButton.jsx
+++ b/apps/src/templates/UnassignButton.jsx
@@ -61,10 +61,14 @@ class UnassignButton extends React.Component {
 
 const styles = {
   buttonMargin: {
-    marginLeft: 10
+    marginLeft: 10,
+    display: 'flex',
+    alignItems: 'center'
   },
   buttonMarginRTL: {
-    marginRight: 10
+    marginRight: 10,
+    display: 'flex',
+    alignItems: 'center'
   }
 };
 

--- a/apps/src/templates/courseOverview/CourseScript.js
+++ b/apps/src/templates/courseOverview/CourseScript.js
@@ -175,7 +175,8 @@ const styles = {
     marginRight: 0
   },
   flex: {
-    display: 'flex'
+    display: 'flex',
+    alignItems: 'center'
   }
 };
 export const UnconnectedCourseScript = CourseScript;

--- a/apps/src/templates/teacherDashboard/SectionAssigner.jsx
+++ b/apps/src/templates/teacherDashboard/SectionAssigner.jsx
@@ -40,7 +40,7 @@ class SectionAssigner extends Component {
     );
 
     return (
-      <div>
+      <div style={styles.section}>
         <div style={styles.label}>{i18n.currentSection()}</div>
         <div style={styles.content}>
           <TeacherSectionSelector
@@ -72,8 +72,12 @@ class SectionAssigner extends Component {
 }
 
 const styles = {
+  section: {
+    marginBottom: 10
+  },
   content: {
-    display: 'flex'
+    display: 'flex',
+    alignItems: 'center'
   },
   label: {
     width: '100%',

--- a/apps/src/templates/teacherDashboard/TeacherSectionSelector.jsx
+++ b/apps/src/templates/teacherDashboard/TeacherSectionSelector.jsx
@@ -131,7 +131,8 @@ export default class TeacherSectionSelector extends Component {
 const styles = {
   select: {
     height: 34,
-    width: 300
+    width: 300,
+    marginBottom: 0
   },
   addNewSection: {
     borderTop: `1px solid ${color.charcoal}`,


### PR DESCRIPTION
[Amanda reported](https://codedotorg.slack.com/archives/CNZP84FJ5/p1621549314044000) that the assign text and icon on the student view in Safari looked weird. I went in and updated things so everything aligns nicely now on safari and chrome.

![Screen Shot 2021-05-24 at 5 18 52 PM](https://user-images.githubusercontent.com/208083/119408838-61731800-bcb4-11eb-89e1-101ad6abfb1c.png)
![Screen Shot 2021-05-24 at 5 18 48 PM](https://user-images.githubusercontent.com/208083/119408841-61731800-bcb4-11eb-9edc-4eeca02c3886.png)
![Screen Shot 2021-05-24 at 5 18 59 PM](https://user-images.githubusercontent.com/208083/119408843-620bae80-bcb4-11eb-831c-9d4b90857e52.png)

