### PR TITLE
Cleanup from 2019-20 NCES school import

### DIFF
--- a/bin/oneoff/nces_data/import_school_stats_by_years_2019_2020_ccd
+++ b/bin/oneoff/nces_data/import_school_stats_by_years_2019_2020_ccd
@@ -115,8 +115,6 @@ AWS::S3.process_file('cdo-nces', "#{SURVEY_YEAR}/ccd/schools.csv") do |filename|
   end
 end
 
-# URL where source was found ("Public School File" under 2018-19 tab): https://nces.ed.gov/programs/edge/Geographic/SchoolLocations
-# Download link: https://nces.ed.gov/programs/edge/data/EDGE_GEOCODE_PUBLICSCH_1819.zip
 AWS::S3.process_file('cdo-nces', "#{SURVEY_YEAR}/ccd/locale.csv") do |filename|
   SchoolStatsByYear.merge_from_csv(filename, {col_sep: ",", headers: true, quote_char: "\x00", encoding: 'UTF-8'}, dry_run: DRY_RUN) do |row|
     {

--- a/dashboard/app/models/school_stats_by_year.rb
+++ b/dashboard/app/models/school_stats_by_year.rb
@@ -51,7 +51,7 @@ class SchoolStatsByYear < ApplicationRecord
   # @param filename [String] The CSV file name.
   # @param options [Hash] Optional, the CSV file parsing options.
   # @param dry_run [Boolean] Optional, roll back any db transactions after processing.
-  def self.merge_from_csv(filename, options = {col_sep: "\t", headers: true, quote_char: "\x00"}, dry_run = false)
+  def self.merge_from_csv(filename, options = {col_sep: "\t", headers: true, quote_char: "\x00"}, dry_run: false)
     new_schools = 0
     updated_schools = 0
     unchanged_schools = 0


### PR DESCRIPTION
Cleans up a few items we noticed while importing National Center for Education Statistics data from the 2019-20 school year:
- removes a copy/pasted comment in school stats import file
- uncomment School.seed_al and SchoolDistrict.seed_all methods for future seeding
- rename “new_attributes” parameter to "ignore_attributes"
- fix positional argument in school_stats_by_years import

### Testing Story

I seeded my local database with the new schools, school districts, and school stats after making (most) of these changes (admittedly, there were a couple of variable renames that I did after the seeding).