### PR TITLE
Move settings button and build out JavalabButton component

### DIFF
--- a/apps/src/javalab/JavalabButton.jsx
+++ b/apps/src/javalab/JavalabButton.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import color from '@cdo/apps/util/color';
+
+export default function JavalabButton({icon, text, style, onClick}) {
+  return (
+    <button
+      type="button"
+      style={{...styles.button, ...style}}
+      onClick={onClick}
+    >
+      {icon}
+      {text && <div style={styles.text}>{text}</div>}
+    </button>
+  );
+}
+JavalabButton.propTypes = {
+  icon: PropTypes.node,
+  text: PropTypes.string,
+  style: PropTypes.object,
+  onClick: PropTypes.func.isRequired
+};
+
+const styles = {
+  button: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    color: color.white
+  },
+  text: {
+    paddingTop: 5
+  }
+};

--- a/apps/src/javalab/JavalabButton.jsx
+++ b/apps/src/javalab/JavalabButton.jsx
@@ -2,6 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import color from '@cdo/apps/util/color';
 
+// TODO: This component should be refactored to use <Button/> (apps/src/templates/Button.jsx).
+// In order for that to work, we will need to refactor <Button/> to allow a button's icon and
+// text to be vertically stacked.
 export default function JavalabButton({icon, text, style, onClick}) {
   return (
     <button

--- a/apps/src/javalab/JavalabButton.jsx
+++ b/apps/src/javalab/JavalabButton.jsx
@@ -10,7 +10,7 @@ export default function JavalabButton({icon, text, style, onClick}) {
       onClick={onClick}
     >
       {icon}
-      {text && <div style={styles.text}>{text}</div>}
+      {text && <div style={icon && styles.padding}>{text}</div>}
     </button>
   );
 }
@@ -28,7 +28,7 @@ const styles = {
     alignItems: 'center',
     color: color.white
   },
-  text: {
+  padding: {
     paddingTop: 5
   }
 };

--- a/apps/src/javalab/JavalabSettings.jsx
+++ b/apps/src/javalab/JavalabSettings.jsx
@@ -4,39 +4,13 @@ import Radium from 'radium';
 import color from '@cdo/apps/util/color';
 import onClickOutside from 'react-onclickoutside';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
-
-const styles = {
-  main: {
-    display: 'inline-block'
-  },
-  dropdown: {
-    border: `1px solid ${color.charcoal}`,
-    position: 'absolute'
-  },
-  anchor: {
-    padding: 10,
-    color: color.charcoal,
-    backgroundColor: color.white,
-    fontFamily: '"Gotham 5r", sans-serif',
-    display: 'block',
-    textDecoration: 'none',
-    lineHeight: '20px',
-    transition: 'background-color .2s ease-out',
-    ':hover': {
-      backgroundColor: color.lightest_gray,
-      cursor: 'pointer'
-    }
-  },
-  nonFirstAnchor: {
-    borderTop: `1px solid ${color.charcoal}`
-  }
-};
+import JavalabButton from './JavalabButton';
 
 /**
  * A button that drops down to a set of clickable links, and closes itself if
  * you click on the button, or outside of the dropdown.
  */
-export const JavalabSettings = class JavalabSettingsComponent extends Component {
+export class JavalabSettings extends Component {
   static propTypes = {
     style: PropTypes.object,
     children: props => {
@@ -85,14 +59,19 @@ export const JavalabSettings = class JavalabSettingsComponent extends Component 
   render() {
     const {style} = this.props;
     const {dropdownOpen} = this.state;
+    const btnStyle = {
+      ...styles.button,
+      ...(dropdownOpen && styles.button.selected),
+      ...style
+    };
 
     return (
       <div style={styles.main}>
-        <button type="button" style={style} onClick={this.toggleDropdown}>
-          <FontAwesome icon="cog" className="fa-2x" />
-          <br />
-          Settings
-        </button>
+        <JavalabButton
+          icon={<FontAwesome icon="cog" />}
+          style={btnStyle}
+          onClick={this.toggleDropdown}
+        />
 
         {dropdownOpen && (
           <div style={styles.dropdown} ref={ref => (this.dropdownList = ref)}>
@@ -113,6 +92,47 @@ export const JavalabSettings = class JavalabSettingsComponent extends Component 
       </div>
     );
   }
-};
+}
 
 export default onClickOutside(Radium(JavalabSettings));
+
+const styles = {
+  main: {
+    display: 'inline-block'
+  },
+  button: {
+    color: color.darkest_gray,
+    borderColor: color.darkest_gray,
+    padding: 5,
+    margin: '0 0 10px 0',
+    selected: {
+      backgroundColor: color.cyan,
+      color: color.white,
+      borderColor: color.cyan
+    }
+  },
+  dropdown: {
+    border: `1px solid ${color.charcoal}`,
+    position: 'absolute',
+    // A hack to make sure this renders in front of later absolutely-positioned elements
+    // (e.g., the instructions panel).
+    zIndex: 100
+  },
+  anchor: {
+    padding: 10,
+    color: color.charcoal,
+    backgroundColor: color.white,
+    fontFamily: '"Gotham 5r", sans-serif',
+    display: 'block',
+    textDecoration: 'none',
+    lineHeight: '20px',
+    transition: 'background-color .2s ease-out',
+    ':hover': {
+      backgroundColor: color.lightest_gray,
+      cursor: 'pointer'
+    }
+  },
+  nonFirstAnchor: {
+    borderTop: `1px solid ${color.charcoal}`
+  }
+};

--- a/apps/src/javalab/JavalabView.jsx
+++ b/apps/src/javalab/JavalabView.jsx
@@ -54,6 +54,13 @@ class JavalabView extends React.Component {
     ];
   };
 
+  getButtonStyles = () => {
+    return {
+      ...styles.button.all,
+      ...(this.props.isDarkMode ? styles.button.dark : styles.button.light)
+    };
+  };
+
   render() {
     const {
       isDarkMode,
@@ -65,13 +72,10 @@ class JavalabView extends React.Component {
       visualization
     } = this.props;
 
-    let btnStyle = styles.button.all;
     if (isDarkMode) {
       document.body.style.backgroundColor = '#1b1c17';
-      btnStyle = {...btnStyle, ...styles.button.dark};
     } else {
       document.body.style.backgroundColor = color.background_gray;
-      btnStyle = {...btnStyle, ...styles.button.light};
     }
 
     return (
@@ -103,13 +107,13 @@ class JavalabView extends React.Component {
                 <JavalabButton
                   icon={<FontAwesome icon="stop" className="fa-2x" />}
                   text="Stop"
-                  style={btnStyle}
+                  style={this.getButtonStyles()}
                   onClick={() => {}}
                 />
                 <JavalabButton
                   icon={<FontAwesome icon="check" className="fa-2x" />}
                   text="Continue"
-                  style={btnStyle}
+                  style={this.getButtonStyles()}
                   onClick={onContinue}
                 />
               </div>
@@ -117,7 +121,7 @@ class JavalabView extends React.Component {
                 <JavalabButton
                   icon={<FontAwesome icon="play" className="fa-2x" />}
                   text="Run"
-                  style={btnStyle}
+                  style={this.getButtonStyles()}
                   onClick={onRun}
                 />
               </div>

--- a/apps/src/javalab/JavalabView.jsx
+++ b/apps/src/javalab/JavalabView.jsx
@@ -3,6 +3,7 @@ import JavalabConsole from './JavalabConsole';
 import {connect} from 'react-redux';
 import JavalabEditor from './JavalabEditor';
 import JavalabSettings from './JavalabSettings';
+import JavalabButton from './JavalabButton';
 import {appendOutputLog, setIsDarkMode} from './javalabRedux';
 import PropTypes from 'prop-types';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
@@ -53,17 +54,6 @@ class JavalabView extends React.Component {
     ];
   };
 
-  getButtonStyles = isSettingsButton => {
-    const {isDarkMode} = this.props;
-    if (isDarkMode) {
-      return styles.singleButton;
-    } else if (isSettingsButton) {
-      return {...styles.singleButton, backgroundColor: color.orange};
-    } else {
-      return {...styles.singleButton, backgroundColor: color.cyan};
-    }
-  };
-
   render() {
     const {
       isDarkMode,
@@ -74,11 +64,16 @@ class JavalabView extends React.Component {
       handleVersionHistory,
       visualization
     } = this.props;
+
+    let btnStyle = styles.button.all;
     if (isDarkMode) {
       document.body.style.backgroundColor = '#1b1c17';
+      btnStyle = {...btnStyle, ...styles.button.dark};
     } else {
       document.body.style.backgroundColor = color.background_gray;
+      btnStyle = {...btnStyle, ...styles.button.light};
     }
+
     return (
       <StudioAppWrapper>
         <div style={styles.javalab}>
@@ -87,6 +82,7 @@ class JavalabView extends React.Component {
             className="responsive"
             style={styles.instructionsAndPreview}
           >
+            <JavalabSettings>{this.renderSettings()}</JavalabSettings>
             <TopInstructions mainStyle={styles.instructions} standalone />
             <div style={styles.preview}>{visualization}</div>
           </div>
@@ -104,40 +100,26 @@ class JavalabView extends React.Component {
             />
             <div style={styles.consoleAndButtons}>
               <div style={styles.buttons}>
-                <button
-                  type="button"
-                  style={this.getButtonStyles(false)}
+                <JavalabButton
+                  icon={<FontAwesome icon="stop" className="fa-2x" />}
+                  text="Stop"
+                  style={btnStyle}
                   onClick={() => {}}
-                >
-                  <FontAwesome icon="stop" className="fa-2x" />
-                  <br />
-                  Stop
-                </button>
-                <button
-                  type="button"
-                  style={this.getButtonStyles(false)}
+                />
+                <JavalabButton
+                  icon={<FontAwesome icon="check" className="fa-2x" />}
+                  text="Continue"
+                  style={btnStyle}
                   onClick={onContinue}
-                >
-                  <FontAwesome icon="check" className="fa-2x" />
-                  <br />
-                  Continue
-                </button>
+                />
               </div>
               <div style={styles.buttons}>
-                <JavalabSettings
-                  style={this.getButtonStyles(true /* isSettingsButton */)}
-                >
-                  {this.renderSettings()}
-                </JavalabSettings>
-                <button
-                  type="button"
-                  style={this.getButtonStyles(false)}
+                <JavalabButton
+                  icon={<FontAwesome icon="play" className="fa-2x" />}
+                  text="Run"
+                  style={btnStyle}
                   onClick={onRun}
-                >
-                  <FontAwesome icon="play" className="fa-2x" />
-                  <br />
-                  Run
-                </button>
+                />
               </div>
               <div style={styles.consoleStyle}>
                 <JavalabConsole onInputMessage={onInputMessage} />
@@ -193,14 +175,10 @@ const styles = {
     display: 'flex',
     flexDirection: 'column'
   },
-  singleButton: {
-    // this matches the current code mirror theme we are using
-    // TODO: either add to color.scss or use a color from there depending
-    // on final theme choice.
-    backgroundColor: color.darkest_gray,
-    color: color.white,
-    width: 95,
-    textAlign: 'center'
+  button: {
+    all: {width: 95},
+    light: {backgroundColor: color.cyan},
+    dark: {backgroundColor: color.darkest_gray}
   },
   clear: {
     clear: 'both'

--- a/apps/test/unit/javalab/JavalabSettingsTest.js
+++ b/apps/test/unit/javalab/JavalabSettingsTest.js
@@ -20,7 +20,7 @@ describe('JavalabSettings', () => {
   it('is initially just a button', () => {
     const wrapper = shallow(<JavalabSettings {...defaultProps} />);
     assert.strictEqual(wrapper.children().length, 1);
-    assert.strictEqual(wrapper.childAt(0).name(), 'button');
+    assert.strictEqual(wrapper.childAt(0).name(), 'JavalabButton');
   });
 
   it('shows children when clicked', () => {

--- a/apps/test/unit/javalab/JavalabViewTest.js
+++ b/apps/test/unit/javalab/JavalabViewTest.js
@@ -6,9 +6,8 @@ import {shallow} from 'enzyme';
 // We think this has to do with the version of reac-redux we're using (4.4.9).
 import {UnconnectedJavalabView as JavalabView} from '@cdo/apps/javalab/JavalabView';
 import color from '@cdo/apps/util/color';
-global.$ = require('jquery');
 
-describe('Java Lab View Test', () => {
+describe('JavalabView', () => {
   let defaultProps;
 
   beforeEach(() => {
@@ -27,23 +26,16 @@ describe('Java Lab View Test', () => {
   });
 
   describe('getButtonStyles', () => {
-    it('Is cyan or orange in light mode', () => {
-      // We use shallow instead of mount because mount loads many
-      // shared DOM components which cause collisions with other tests.
-      let editor = shallow(<JavalabView {...defaultProps} />);
-      const notSettings = editor.instance().getButtonStyles(false);
-      expect(notSettings.backgroundColor).to.equal(color.cyan);
-      const settings = editor.instance().getButtonStyles(true);
-      expect(settings.backgroundColor).to.equal(color.orange);
+    it('is cyan in light mode', () => {
+      const editor = shallow(<JavalabView {...defaultProps} />);
+      const btnStyles = editor.instance().getButtonStyles();
+      expect(btnStyles.backgroundColor).to.equal(color.cyan);
     });
 
-    it('Is grey in dark mode', () => {
-      let props = {...defaultProps, isDarkMode: true};
-      let editor = shallow(<JavalabView {...props} />);
-      const notSettings = editor.instance().getButtonStyles(false);
-      expect(notSettings.backgroundColor).to.equal(color.darkest_gray);
-      const settings = editor.instance().getButtonStyles(false);
-      expect(settings.backgroundColor).to.equal(color.darkest_gray);
+    it('is gray in dark mode', () => {
+      const editor = shallow(<JavalabView {...defaultProps} isDarkMode />);
+      const btnStyles = editor.instance().getButtonStyles();
+      expect(btnStyles.backgroundColor).to.equal(color.darkest_gray);
     });
   });
 });


### PR DESCRIPTION
A refactor with a small UI change:
- Refactor buttons with same look/behavior into a new `<JavalabButton/>` component
- Update position and styling for the "settings" button

**Wireframes:**
Also viewable from the Figma link below.
<img width="1202" alt="Screen Shot 2021-05-25 at 10 23 09 AM" src="https://user-images.githubusercontent.com/9812299/119541499-54513a00-bd43-11eb-9133-9344d608020c.png">

<img width="1202" alt="Screen Shot 2021-05-25 at 10 23 23 AM" src="https://user-images.githubusercontent.com/9812299/119541494-52877680-bd43-11eb-8ba1-14eded32ab34.png">

**Screenshots:**
<img width="1278" alt="Screen Shot 2021-05-25 at 10 25 17 AM" src="https://user-images.githubusercontent.com/9812299/119541693-91b5c780-bd43-11eb-94da-40e7102e2b38.png">

<img width="1278" alt="Screen Shot 2021-05-25 at 10 25 23 AM" src="https://user-images.githubusercontent.com/9812299/119541690-90849a80-bd43-11eb-8050-e21e7e445449.png">

## Links

- [CSA-361](https://codedotorg.atlassian.net/browse/CSA-361)
- [Figma](https://www.figma.com/file/fZo4fcZmDUioOCaz04Gza4/Javalab-Design-Spec?node-id=0%3A1)

## Testing story

Updates unit tests.