### PR TITLE
Foorm validation follow up (blocks saving for lint errors)

### DIFF
--- a/apps/src/code-studio/pd/foorm/editor/components/FoormEntityLoadButtons.jsx
+++ b/apps/src/code-studio/pd/foorm/editor/components/FoormEntityLoadButtons.jsx
@@ -6,6 +6,7 @@ import {
   setLastSaved,
   setSaveError,
   setHasJSONError,
+  setHasLintError,
   setLastSavedQuestions
 } from '../foormEditorRedux';
 
@@ -23,6 +24,7 @@ class FoormEntityLoadButtons extends React.Component {
     setLastSaved: PropTypes.func,
     setSaveError: PropTypes.func,
     setHasJSONError: PropTypes.func,
+    setHasLintError: PropTypes.func,
     setLastSavedQuestions: PropTypes.func
   };
 
@@ -53,6 +55,7 @@ class FoormEntityLoadButtons extends React.Component {
     this.props.setLastSaved(null);
     this.props.setSaveError(null);
     this.props.setHasJSONError(false);
+    this.props.setHasLintError(false);
     this.props.setLastSavedQuestions({});
   }
 
@@ -87,6 +90,7 @@ export default connect(
     setLastSaved: lastSaved => dispatch(setLastSaved(lastSaved)),
     setSaveError: saveError => dispatch(setSaveError(saveError)),
     setHasJSONError: hasJSONError => dispatch(setHasJSONError(hasJSONError)),
+    setHasLintError: hasLintError => dispatch(setHasLintError(hasLintError)),
     setLastSavedQuestions: questions =>
       dispatch(setLastSavedQuestions(questions))
   })

--- a/apps/src/code-studio/pd/foorm/editor/foormEditorRedux.js
+++ b/apps/src/code-studio/pd/foorm/editor/foormEditorRedux.js
@@ -1,5 +1,6 @@
 const SET_QUESTIONS = 'foormEditor/SET_QUESTIONS';
 const SET_HAS_JSON_ERROR = 'foormEditor/SET_HAS_JSON_ERROR';
+const SET_HAS_LINT_ERROR = 'foormEditor/SET_HAS_LINT_ERROR';
 const SET_FORM_DATA = 'foormEditor/SET_FORM_DATA';
 const SET_LIBRARY_QUESTION_DATA = 'foormEditor/SET_LIBRARY_QUESTION_DATA';
 const SET_LIBRARY_DATA = 'foormEditor/SET_LIBRARY_DATA';
@@ -45,6 +46,11 @@ export const setLibraryData = libraryData => ({
 export const setHasJSONError = hasJSONError => ({
   type: SET_HAS_JSON_ERROR,
   hasJSONError
+});
+
+export const setHasLintError = hasLintError => ({
+  type: SET_HAS_LINT_ERROR,
+  hasLintError
 });
 
 // "Entities" represent metadata (ID, name, etc.) about the forms or libraries
@@ -93,6 +99,7 @@ const initialState = {
   // State relevant for both Form and Library editors
   questions: '',
   hasJSONError: false,
+  hasLintError: false,
   fetchableEntities: [],
   saveError: null,
   lastSaved: null,
@@ -122,6 +129,12 @@ export default function foormEditorRedux(state = initialState, action) {
     return {
       ...state,
       hasJSONError: action.hasJSONError
+    };
+  }
+  if (action.type === SET_HAS_LINT_ERROR) {
+    return {
+      ...state,
+      hasLintError: action.hasLintError
     };
   }
   if (action.type === SET_FORM_DATA) {

--- a/apps/src/code-studio/pd/foorm/editor/form/FoormFormEditorManager.jsx
+++ b/apps/src/code-studio/pd/foorm/editor/form/FoormFormEditorManager.jsx
@@ -8,6 +8,7 @@ import {
   setSaveError,
   setFormData,
   setHasJSONError,
+  setHasLintError,
   setLastSavedQuestions
 } from '../foormEditorRedux';
 import FoormFormSaveBar from '@cdo/apps/code-studio/pd/foorm/editor/form/FoormFormSaveBar';
@@ -34,6 +35,7 @@ class FoormFormEditorManager extends React.Component {
     setSaveError: PropTypes.func,
     setFormData: PropTypes.func,
     setHasJSONError: PropTypes.func,
+    setHasLintError: PropTypes.func,
     setLastSavedFormQuestions: PropTypes.func
   };
 
@@ -108,6 +110,7 @@ class FoormFormEditorManager extends React.Component {
   updateFormData(formData) {
     this.props.setFormData(formData);
     this.props.setHasJSONError(false);
+    this.props.setHasLintError(false);
     this.props.setLastSavedFormQuestions(formData['questions']);
     this.props.resetCodeMirror(formData['questions']);
   }
@@ -261,6 +264,7 @@ export default connect(
     setSaveError: saveError => dispatch(setSaveError(saveError)),
     setFormData: formData => dispatch(setFormData(formData)),
     setHasJSONError: hasJSONError => dispatch(setHasJSONError(hasJSONError)),
+    setHasLintError: hasLintError => dispatch(setHasLintError(hasLintError)),
     setLastSavedFormQuestions: formQuestions =>
       dispatch(setLastSavedQuestions(formQuestions))
   })

--- a/apps/src/code-studio/pd/foorm/editor/form/FoormFormSaveBar.jsx
+++ b/apps/src/code-studio/pd/foorm/editor/form/FoormFormSaveBar.jsx
@@ -57,6 +57,8 @@ class FoormFormSaveBar extends Component {
     };
   }
 
+  hasCodeMirrorError = () => this.props.hasLintError || this.props.hasJSONError;
+
   updateQuestionsUrl = () =>
     `/foorm/forms/${this.props.formId}/update_questions`;
 
@@ -261,27 +263,24 @@ class FoormFormSaveBar extends Component {
         <div style={styles.saveButtonBackground} className="saveBar">
           {this.props.lastSaved &&
             !this.props.saveError &&
-            !this.props.hasJSONError &&
-            !this.props.hasLintError && (
+            !this.hasCodeMirrorError() && (
               <div style={styles.lastSaved} className="lastSavedMessage">
                 {`Last saved at: ${new Date(
                   this.props.lastSaved
                 ).toLocaleString()}`}
               </div>
             )}
-          {(this.props.hasJSONError || this.props.hasLintError) && (
+          {this.hasCodeMirrorError() && (
             <div style={styles.error}>
               {`Please fix parsing error before saving. See the errors noted on the left side of the editor.`}
             </div>
           )}
-          {this.props.saveError &&
-            !this.props.hasJSONError &&
-            !this.props.hasLintError && (
-              <div
-                style={styles.error}
-                className="saveErrorMessage"
-              >{`Error Saving: ${this.props.saveError}`}</div>
-            )}
+          {this.props.saveError && !this.hasCodeMirrorError() && (
+            <div
+              style={styles.error}
+              className="saveErrorMessage"
+            >{`Error Saving: ${this.props.saveError}`}</div>
+          )}
           {this.state.isSaving && (
             <div style={styles.spinner}>
               <FontAwesome icon="spinner" className="fa-spin" />
@@ -293,11 +292,7 @@ class FoormFormSaveBar extends Component {
               type="button"
               style={styles.button}
               onClick={this.handlePublish}
-              disabled={
-                this.state.isSaving ||
-                this.props.hasJSONError ||
-                this.props.hasLintError
-              }
+              disabled={this.state.isSaving || this.hasCodeMirrorError()}
             >
               Publish
             </button>
@@ -307,11 +302,7 @@ class FoormFormSaveBar extends Component {
             type="button"
             style={styles.button}
             onClick={this.handleSave}
-            disabled={
-              this.state.isSaving ||
-              this.props.hasJSONError ||
-              this.props.hasLintError
-            }
+            disabled={this.state.isSaving || this.hasCodeMirrorError()}
           >
             Save
           </button>

--- a/apps/src/code-studio/pd/foorm/editor/form/FoormFormSaveBar.jsx
+++ b/apps/src/code-studio/pd/foorm/editor/form/FoormFormSaveBar.jsx
@@ -33,6 +33,7 @@ class FoormFormSaveBar extends Component {
     // Populated by Redux
     formQuestions: PropTypes.object,
     hasJSONError: PropTypes.bool,
+    hasLintError: PropTypes.bool,
     isFormPublished: PropTypes.bool,
     formId: PropTypes.number,
     lastSaved: PropTypes.number,
@@ -260,24 +261,27 @@ class FoormFormSaveBar extends Component {
         <div style={styles.saveButtonBackground} className="saveBar">
           {this.props.lastSaved &&
             !this.props.saveError &&
-            !this.props.hasJSONError && (
+            !this.props.hasJSONError &&
+            !this.props.hasLintError && (
               <div style={styles.lastSaved} className="lastSavedMessage">
                 {`Last saved at: ${new Date(
                   this.props.lastSaved
                 ).toLocaleString()}`}
               </div>
             )}
-          {this.props.hasJSONError && (
+          {(this.props.hasJSONError || this.props.hasLintError) && (
             <div style={styles.error}>
               {`Please fix parsing error before saving. See the errors noted on the left side of the editor.`}
             </div>
           )}
-          {this.props.saveError && !this.props.hasJSONError && (
-            <div
-              style={styles.error}
-              className="saveErrorMessage"
-            >{`Error Saving: ${this.props.saveError}`}</div>
-          )}
+          {this.props.saveError &&
+            !this.props.hasJSONError &&
+            !this.props.hasLintError && (
+              <div
+                style={styles.error}
+                className="saveErrorMessage"
+              >{`Error Saving: ${this.props.saveError}`}</div>
+            )}
           {this.state.isSaving && (
             <div style={styles.spinner}>
               <FontAwesome icon="spinner" className="fa-spin" />
@@ -289,7 +293,11 @@ class FoormFormSaveBar extends Component {
               type="button"
               style={styles.button}
               onClick={this.handlePublish}
-              disabled={this.state.isSaving || this.props.hasJSONError}
+              disabled={
+                this.state.isSaving ||
+                this.props.hasJSONError ||
+                this.props.hasLintError
+              }
             >
               Publish
             </button>
@@ -299,7 +307,11 @@ class FoormFormSaveBar extends Component {
             type="button"
             style={styles.button}
             onClick={this.handleSave}
-            disabled={this.state.isSaving || this.props.hasJSONError}
+            disabled={
+              this.state.isSaving ||
+              this.props.hasJSONError ||
+              this.props.hasLintError
+            }
           >
             Save
           </button>
@@ -415,6 +427,7 @@ export default connect(
   state => ({
     formQuestions: state.foorm.questions || {},
     isFormPublished: state.foorm.isFormPublished,
+    hasLintError: state.foorm.hasLintError,
     hasJSONError: state.foorm.hasJSONError,
     formId: state.foorm.formId,
     lastSaved: state.foorm.lastSaved,

--- a/apps/src/code-studio/pd/foorm/editor/library/FoormLibraryEditorManager.jsx
+++ b/apps/src/code-studio/pd/foorm/editor/library/FoormLibraryEditorManager.jsx
@@ -9,6 +9,7 @@ import {
   setSaveError,
   setLibraryQuestionData,
   setHasJSONError,
+  setHasLintError,
   setLastSavedQuestions,
   setLibraryData
 } from '../foormEditorRedux';
@@ -46,6 +47,7 @@ class FoormLibraryEditorManager extends React.Component {
     setSaveError: PropTypes.func,
     setLibraryQuestionData: PropTypes.func,
     setHasJSONError: PropTypes.func,
+    setHasLintError: PropTypes.func,
     setLastSavedQuestions: PropTypes.func,
     setLibraryData: PropTypes.func
   };
@@ -183,6 +185,7 @@ class FoormLibraryEditorManager extends React.Component {
   updateLibraryQuestionData(libraryQuestionData) {
     this.props.setLibraryQuestionData(libraryQuestionData);
     this.props.setHasJSONError(false);
+    this.props.setHasLintError(false);
     this.props.setLastSavedQuestions(libraryQuestionData['question']);
     this.props.resetCodeMirror(libraryQuestionData['question']);
   }
@@ -316,6 +319,7 @@ export default connect(
     setLibraryQuestionData: libraryQuestionData =>
       dispatch(setLibraryQuestionData(libraryQuestionData)),
     setHasJSONError: hasJSONError => dispatch(setHasJSONError(hasJSONError)),
+    setHasLintError: hasLintError => dispatch(setHasLintError(hasLintError)),
     setLastSavedQuestions: libraryQuestion =>
       dispatch(setLastSavedQuestions(libraryQuestion)),
     setLibraryData: libraryData => dispatch(setLibraryData(libraryData))

--- a/apps/src/code-studio/pd/foorm/editor/library/FoormLibrarySaveBar.jsx
+++ b/apps/src/code-studio/pd/foorm/editor/library/FoormLibrarySaveBar.jsx
@@ -64,6 +64,8 @@ class FoormLibrarySaveBar extends Component {
     libraryCategory: null
   };
 
+  hasCodeMirrorError = () => this.props.hasLintError || this.props.hasJSONError;
+
   updateQuestionUrl = () =>
     `/foorm/library_questions/${this.props.libraryQuestionId}`;
 
@@ -370,27 +372,24 @@ class FoormLibrarySaveBar extends Component {
         <div style={styles.saveButtonBackground} className="saveBar">
           {this.props.lastSaved &&
             !this.props.saveError &&
-            !this.props.hasJSONError &&
-            !this.props.hasLintError && (
+            !this.hasCodeMirrorError() && (
               <div style={styles.lastSaved} className="lastSavedMessage">
                 {`Last saved at: ${new Date(
                   this.props.lastSaved
                 ).toLocaleString()}`}
               </div>
             )}
-          {(this.props.hasJSONError || this.props.hasLintError) && (
+          {this.hasCodeMirrorError() && (
             <div style={styles.error}>
               {`Please fix parsing error before saving. See the errors noted on the left side of the editor.`}
             </div>
           )}
-          {this.props.saveError &&
-            !this.props.hasJSONError &&
-            !this.props.hasLintError && (
-              <div
-                style={styles.error}
-                className="saveErrorMessage"
-              >{`Error Saving: ${this.props.saveError}`}</div>
-            )}
+          {this.props.saveError && !this.hasCodeMirrorError() && (
+            <div
+              style={styles.error}
+              className="saveErrorMessage"
+            >{`Error Saving: ${this.props.saveError}`}</div>
+          )}
           {this.state.isSaving && (
             <div style={styles.spinner}>
               <FontAwesome icon="spinner" className="fa-spin" />
@@ -401,11 +400,7 @@ class FoormLibrarySaveBar extends Component {
             type="button"
             style={styles.button}
             onClick={this.handleSave}
-            disabled={
-              this.state.isSaving ||
-              this.props.hasJSONError ||
-              this.props.hasLintError
-            }
+            disabled={this.state.isSaving || this.hasCodeMirrorError()}
           >
             Save
           </button>

--- a/apps/src/code-studio/pd/foorm/editor/library/FoormLibrarySaveBar.jsx
+++ b/apps/src/code-studio/pd/foorm/editor/library/FoormLibrarySaveBar.jsx
@@ -41,6 +41,7 @@ class FoormLibrarySaveBar extends Component {
     libraryId: PropTypes.number,
     libraryQuestionId: PropTypes.number,
     questions: PropTypes.object,
+    hasLintError: PropTypes.bool,
     hasJSONError: PropTypes.bool,
     lastSaved: PropTypes.number,
     saveError: PropTypes.string,
@@ -369,24 +370,27 @@ class FoormLibrarySaveBar extends Component {
         <div style={styles.saveButtonBackground} className="saveBar">
           {this.props.lastSaved &&
             !this.props.saveError &&
-            !this.props.hasJSONError && (
+            !this.props.hasJSONError &&
+            !this.props.hasLintError && (
               <div style={styles.lastSaved} className="lastSavedMessage">
                 {`Last saved at: ${new Date(
                   this.props.lastSaved
                 ).toLocaleString()}`}
               </div>
             )}
-          {this.props.hasJSONError && (
+          {(this.props.hasJSONError || this.props.hasLintError) && (
             <div style={styles.error}>
               {`Please fix parsing error before saving. See the errors noted on the left side of the editor.`}
             </div>
           )}
-          {this.props.saveError && !this.props.hasJSONError && (
-            <div
-              style={styles.error}
-              className="saveErrorMessage"
-            >{`Error Saving: ${this.props.saveError}`}</div>
-          )}
+          {this.props.saveError &&
+            !this.props.hasJSONError &&
+            !this.props.hasLintError && (
+              <div
+                style={styles.error}
+                className="saveErrorMessage"
+              >{`Error Saving: ${this.props.saveError}`}</div>
+            )}
           {this.state.isSaving && (
             <div style={styles.spinner}>
               <FontAwesome icon="spinner" className="fa-spin" />
@@ -397,7 +401,11 @@ class FoormLibrarySaveBar extends Component {
             type="button"
             style={styles.button}
             onClick={this.handleSave}
-            disabled={this.state.isSaving || this.props.hasJSONError}
+            disabled={
+              this.state.isSaving ||
+              this.props.hasJSONError ||
+              this.props.hasLintError
+            }
           >
             Save
           </button>
@@ -463,6 +471,7 @@ export const UnconnectedFoormLibrarySaveBar = FoormLibrarySaveBar;
 export default connect(
   state => ({
     questions: state.foorm.questions || {},
+    hasLintError: state.foorm.hasLintError,
     hasJSONError: state.foorm.hasJSONError,
     libraryId: state.foorm.libraryId,
     libraryQuestionId: state.foorm.libraryQuestionId,


### PR DESCRIPTION
- Adds a parallel hasLintError prop (because the linting happens asynchronously through different callbacks, reusing hasJSONError for the same thing doesn't work correctly)
- Intentionally not using hasLintError for some messages (i.e. preview error message) because we can still render with a lint error.
- Should properly prevent saving.
- Works in survey and library mode.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- original pr: [40557](https://github.com/code-dot-org/code-dot-org/pull/40557)
- jira ticket: [PLC-1202](https://codedotorg.atlassian.net/browse/PLC-1202)


## Testing story

Tested locally:
verified adding spaces / brackets to names prevented displayed error and prevented saving
