### PR TITLE
Form configuration for pre- and daily summer workshop surveys

### DIFF
--- a/dashboard/config/foorm/forms/surveys/pd/summer_workshop_daily_survey.1.json
+++ b/dashboard/config/foorm/forms/surveys/pd/summer_workshop_daily_survey.1.json
@@ -1,0 +1,90 @@
+{
+  "published": true,
+  "pages": [
+    {
+      "name": "page_1",
+      "elements": [
+        {
+          "type": "library_item",
+          "library_name": "surveys/pd/workshop_elements",
+          "library_version": 0,
+          "name": "summer_workshop_daily_preamble"
+        },
+        {
+          "type": "library_item",
+          "library_name": "surveys/pd/workshop_elements",
+          "library_version": 0,
+          "name": "feel_prepared"
+        },
+        {
+          "type": "library_item",
+          "library_name": "surveys/pd/workshop_elements",
+          "library_version": 0,
+          "name": "teacher_comfort"
+        },
+
+        {
+          "type": "library_item",
+          "library_name": "surveys/pd/workshop_elements",
+          "library_version": 0,
+          "name": "teacher_community"
+        },
+
+        {
+          "type": "library_item",
+          "library_name": "surveys/pd/workshop_elements",
+          "library_version": 0,
+          "name": "excited_about_tomorrow"
+        },
+
+        {
+          "type": "library_item",
+          "library_name": "surveys/pd/workshop_elements",
+          "library_version": 0,
+          "name": "what_supported"
+        },
+
+        {
+          "type": "library_item",
+          "library_name": "surveys/pd/workshop_elements",
+          "library_version": 0,
+          "name": "what_detracted"
+        },
+
+        {
+          "type": "library_item",
+          "library_name": "surveys/pd/workshop_elements",
+          "library_version": 0,
+          "name": "discuss_tomorrow"
+        },
+
+        {
+          "type": "html",
+          "name": "question2",
+          "html": "<h2>Facilitator Feedback</h2>\n<p>Please be thoughtful in your responses for each individual.</p>"
+        },
+        {
+          "type": "paneldynamic",
+          "name": "facilitators",
+          "title": "Facilitators",
+          "templateElements": [
+            {
+              "type": "comment",
+              "name": "facilitator_feedback_FR",
+              "title": "Do you have any feedback about today for {panel.facilitator_name}?",
+              "rows": 2
+            }
+          ],
+          "templateTitle": "Facilitator {panel.facilitator_position} - {panel.facilitator_name}",
+          "allowAddPanel": false,
+          "allowRemovePanel": false
+        },
+        {
+          "type": "html",
+          "name": "question1",
+          "html": "<p> Thank you for the feedback and for participating today!</p>"
+        }
+      ]
+    }
+  ]
+}

--- a/dashboard/config/foorm/forms/surveys/pd/summer_workshop_pre_survey.1.json
+++ b/dashboard/config/foorm/forms/surveys/pd/summer_workshop_pre_survey.1.json
@@ -1,0 +1,507 @@
+{
+  "published": true,
+  "pages": [
+    {
+      "name": "preamble_page",
+      "elements": [
+
+        {
+          "type": "library_item",
+          "library_name": "surveys/pd/workshop_elements",
+          "library_version": 0,
+          "name": "pd_survey_preamble"
+        }
+      ]
+    },
+    {
+      "name": "page_teaching_context",
+      "elements": [
+        {
+          "type": "html",
+          "name": "question1",
+          "html": "<h2>Teaching Context</h2>\nFirst, we have some questions about the context in which you are teaching {workshop_course}. Your responses help us understand issues that may be unique to your local context and allow us to develop programming to provide you with support."
+        },
+        {
+          "type": "radiogroup",
+          "name": "required_course_status",
+          "title": "Is {workshop_course} a required or elective course at your school?",
+          "choices": [
+            {
+              "value": "required",
+              "text": "Required"
+            },
+            {
+              "value": "elective",
+              "text": "Elective"
+            }
+          ]
+        },
+        {
+          "type": "radiogroup",
+          "name": "course_length_weeks",
+          "title": " For a typical section of {workshop_course} that you will teach, approximately how many WEEKS will the class run? ",
+          "choices": [
+            {
+              "value": "5_fewer",
+              "text": "5 or fewer"
+            },
+            {
+              "value": "6_10",
+              "text": "6 - 10"
+            },
+            {
+              "value": "11_15",
+              "text": "11 - 15"
+            },
+            {
+              "value": "16_20",
+              "text": "16 - 20"
+            },
+            {
+              "value": "21_30",
+              "text": "21 - 30"
+            },
+            {
+              "value": "30_more",
+              "text": "30 or more (full year)"
+            }
+          ]
+        },
+        {
+          "type": "radiogroup",
+          "name": "section_time_minutes",
+          "title": "At your school, on average, how many MINUTES PER WEEK will a typical section of {workshop_course} meet?",
+          "choices": [
+            {
+              "value": "50_less",
+              "text": "50 or less"
+            },
+            {
+              "value": "51_100",
+              "text": "51 - 100"
+            },
+            {
+              "value": "101_150",
+              "text": "101 - 150"
+            },
+            {
+              "value": "151_200",
+              "text": "151 - 200"
+            },
+            {
+              "value": "201_250",
+              "text": "201 - 250"
+            },
+            {
+              "value": "251_300",
+              "text": "251 - 300"
+            },
+            {
+              "value": "301_more",
+              "text": "301 or more"
+            }
+          ]
+        },
+        {
+          "type": "panel",
+          "name": "csp_panel_ap",
+          "elements": [
+            {
+              "type": "html",
+              "name": "question6",
+              "visible": false,
+              "html": "<p><span style=\"background-color: #ffff00;\">&gt;&gt;IF CS PRINCIPLES&lt;&lt;</span></p>"
+            },
+            {
+              "type": "checkbox",
+              "name": "teaching_csp_as",
+              "title": " I plan to teach {workshop_course} as...",
+              "description": "Check all that apply.",
+              "hasOther": true,
+              "otherPlaceHolder": "Other",
+              "choices": [
+                {
+                  "value": "AP",
+                  "text": "An AP Course"
+                },
+                {
+                  "value": "honors",
+                  "text": "An honors course (non-AP) "
+                },
+                {
+                  "value": "regular",
+                  "text": "A regular course (non-AP) "
+                }
+              ],
+              "otherText": "Other"
+            },
+            {
+              "type": "radiogroup",
+              "name": "taught_ap_before",
+              "title": "Have you taught an AP class before?",
+              "choices": [
+                {
+                  "value": "yes",
+                  "text": "Yes"
+                },
+                {
+                  "value": "no",
+                  "text": "No"
+                }
+              ]
+            },
+            {
+              "type": "checkbox",
+              "name": "other_aps_taught",
+              "visibleIf": "{taught_ap_before} = 'yes'",
+              "title": "What other AP course(s) have you taught? ",
+              "description": "Check all that apply.",
+              "choices": [
+                {
+                  "value": "ap_csa",
+                  "text": "AP Computer Science A"
+                },
+                {
+                  "value": "ap_calc",
+                  "text": "AP Calculus (AB or BC)"
+                },
+                {
+                  "value": "ap_stats",
+                  "text": "AP Statistics"
+                },
+                {
+                  "value": "ap_sciences",
+                  "text": "AP Sciences"
+                },
+                {
+                  "value": "ap_english",
+                  "text": "AP English"
+                },
+                {
+                  "value": "ap_world_lang",
+                  "text": "AP World Languages"
+                },
+                {
+                  "value": "ap_hist_and_soc_sci",
+                  "text": "AP History and Social Sciences"
+                },
+                {
+                  "value": "ap_arts",
+                  "text": "AP Arts"
+                },
+                {
+                  "value": "ap_capstone",
+                  "text": "AP Capstone"
+                }
+              ],
+              "colCount": 2
+            },
+            {
+              "type": "checkbox",
+              "name": "grade_levels_csp",
+              "title": "I plan to teach CS Principles to students in the following grade levels. (check all that apply)",
+              "choices": [
+                {
+                  "value": "8",
+                  "text": "8th"
+                },
+                {
+                  "value": "9",
+                  "text": "9th"
+                },
+                {
+                  "value": "10",
+                  "text": "10th"
+                },
+                {
+                  "value": "11",
+                  "text": "11th"
+                },
+                {
+                  "value": "12",
+                  "text": "12th"
+                },
+                {
+                  "value": "not_sure",
+                  "text": "not sure"
+                }
+              ]
+            }
+          ],
+          "visibleIf": "{workshop_course} = 'CS Principles'"
+        },
+        {
+          "type": "panel",
+          "name": "csd_panel_teaching_context",
+          "elements": [
+            {
+              "type": "html",
+              "name": "question7",
+              "visible": false,
+              "html": "<p><span style=\"background-color: #ffff00;\">&gt;&gt;IF CS DISCOVERIES&lt;&lt;</span></p>"
+            },
+            {
+              "type": "checkbox",
+              "name": "grade_levels_csd",
+              "title": "I plan to teach CS Discoveries to students in the following grade levels. (check all that apply)",
+              "choices": [
+                {
+                  "value": "4",
+                  "text": "4th"
+                },
+                {
+                  "value": "5",
+                  "text": "5th"
+                },
+                {
+                  "value": "6",
+                  "text": "6th"
+                },
+                {
+                  "value": "7",
+                  "text": "7th"
+                },
+                {
+                  "value": "8",
+                  "text": "8th"
+                },
+                {
+                  "value": "9",
+                  "text": "9th"
+                },
+                {
+                  "value": "10",
+                  "text": "10th"
+                },
+                {
+                  "value": "11",
+                  "text": "11th"
+                },
+                {
+                  "value": "12",
+                  "text": "12th"
+                },
+                {
+                  "value": "not_sure",
+                  "text": "not sure"
+                }
+              ]
+            }
+          ],
+          "visibleIf": "{workshop_course} = 'CS Discoveries'"
+        },
+        {
+          "type": "library_item",
+          "library_name": "surveys/pd/demographic_items",
+          "library_version": 0,
+          "name": "years_teaching"
+        },
+
+        {
+          "type": "library_item",
+          "library_name": "surveys/pd/demographic_items",
+          "library_version": 0,
+          "name": "years_teaching_cs"
+        },
+        {
+          "type": "radiogroup",
+          "name": "total_pd_time",
+          "title": "What is the TOTAL amount of time you have spent on professional development related to computer science or computer science teaching in the last 2 years? (reference: a typical weeklong summer workshop is about 35 hours) ",
+          "choices": [
+            {
+              "value": "none",
+              "text": "None"
+            },
+            {
+              "value": "less_6",
+              "text": "Less than 6 hours"
+            },
+            {
+              "value": "6_15",
+              "text": "6-15 hours"
+            },
+            {
+              "value": "16_35",
+              "text": "16-35 hours"
+            },
+            {
+              "value": "36_80",
+              "text": "36-80 hours"
+            },
+            {
+              "value": "more_80",
+              "text": "More than 80 hours"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "page_teaching_computer_science",
+      "elements": [
+        {
+          "type": "html",
+          "name": "question5",
+          "html": "<h2>Teaching Computer Science</h2>"
+        },
+        {
+          "type": "library_item",
+          "library_name": "surveys/pd/workshop_elements",
+          "library_version": 0,
+          "name": "cs_community"
+        },
+        {
+          "type": "library_item",
+          "library_name": "surveys/pd/workshop_elements",
+          "library_version": 0,
+          "name": "true_of_me_now_scale_expl"
+        },
+        {
+          "type": "library_item",
+          "library_name": "surveys/pd/workshop_elements",
+          "library_version": 0,
+          "name": "codedotorg_teaching_strategies_csd"
+
+        },
+        {
+          "type": "library_item",
+          "library_name": "surveys/pd/workshop_elements",
+          "library_version": 0,
+          "name": "codedotorg_teaching_strategies_csp"
+        }
+      ]
+    },
+
+
+
+
+    {
+      "name": "page_teaching_philosophy",
+      "elements": [
+        {
+          "type": "library_item",
+          "library_name": "surveys/pd/workshop_elements",
+          "library_version": 0,
+          "name": "pairs_of_statements_instructions"
+        },
+
+        {
+          "type": "library_item",
+          "library_name": "surveys/pd/workshop_elements",
+          "library_version": 0,
+          "name": "lead_learner_panel"
+        },
+        {
+          "type": "library_item",
+          "library_name": "surveys/pd/workshop_elements",
+          "library_version": 0,
+          "name": "recruit_responsibility_panel"
+        },
+        {
+          "type": "library_item",
+          "library_name": "surveys/pd/workshop_elements",
+          "library_version": 0,
+          "name": "prioritize_time_panel"
+        },
+        {
+          "type": "library_item",
+          "library_name": "surveys/pd/workshop_elements",
+          "library_version": 0,
+          "name": "instructional_focus_panel"
+        }
+      ]
+    },
+    {
+      "name": "page_wrap_up_submit",
+      "elements": [
+        {
+          "type": "html",
+          "name": "question2",
+          "html": "<h2>Wrap Up and Submit</h2>\n<p>As a reminder this survey is <strong>confidential</strong>. We collect this information for program improvement. None of your responses will ever be tied back to you personally.</p>"
+        },
+        {
+          "type": "radiogroup",
+          "name": "highest_level_cs_education",
+          "title": "Which most accurately describes the highest level of formal computer science education you have completed? ",
+          "hasOther": true,
+          "otherPlaceHolder": "Other CS Education",
+          "choices": [
+            {
+              "value": "little_no",
+              "text": "At this time, I have little to no formal education in computer science."
+            },
+            {
+              "value": "online_courses",
+              "text": "I have taken one or more courses online for credit."
+            },
+            {
+              "value": "college_courses",
+              "text": "I took one or more courses in college."
+            },
+            {
+              "value": "earning_degree",
+              "text": "I am currently in the process of earning a computer science degree."
+            },
+            {
+              "value": "bachelors_degree",
+              "text": "I have a Bachelor's degree in computer science."
+            },
+            {
+              "value": "masters_degree",
+              "text": "I have a Master's degree in computer science."
+            },
+            {
+              "value": "phd",
+              "text": "I have a PhD in computer science."
+            }
+          ],
+          "otherText": "Other CS Education"
+        },
+        {
+          "type": "radiogroup",
+          "name": "assigned_or_chose_to_teach",
+          "title": "Which of the following most closely applies to you about teaching {workshop_course} next school year: ",
+          "choices": [
+            {
+              "value": "assigned",
+              "text": "I was assigned to teach the course."
+            },
+            {
+              "value": "chose",
+              "text": "I chose to teach the course."
+            },
+            {
+              "value": "not_planning",
+              "text": "I am not currently planning to teach the course next year."
+            }
+          ]
+        },
+        {
+          "type": "library_item",
+          "library_name": "surveys/pd/demographic_items",
+          "library_version": 0,
+          "name": "birth_year"
+        },
+
+        {
+          "type": "library_item",
+          "library_name": "surveys/pd/demographic_items",
+          "library_version": 0,
+          "name": "gender_identity"
+        },
+
+        {
+          "type": "library_item",
+          "library_name": "surveys/pd/demographic_items",
+          "library_version": 0,
+          "name": "racial_ethnic_identity"
+        },
+        {
+          "type": "html",
+          "name": "thank_you",
+          "html": "<h2>Thank you!</h2>\n<p>Thank you so much for taking the time to complete this survey. Your input and feedback is vital for our programs.</p>\n"
+        }
+      ]
+    }
+  ]
+}

--- a/dashboard/config/foorm/library/surveys/pd/workshop_elements.0.json
+++ b/dashboard/config/foorm/library/surveys/pd/workshop_elements.0.json
@@ -281,6 +281,11 @@
           ]
         },
         {
+          "type": "html",
+          "name": "instructional_focus_statements",
+          "html": "<table style=\"width: 600px; margin-left: auto; margin-right: auto;\" cellpadding=\"5\">\n<tbody>\n                <tr>\n                  <td style=\"padding-top: 10px; text-align: center;\">\n                    <span style=\"font-family: arial, helvetica, sans-serif; font-size: 12pt;\">\n                      <strong>Statement A</strong>\n                    </span>\n                  </td>\n                  <td style=\"padding-top: 10px; text-align: center;\">\n                    <span style=\"font-family: arial, helvetica, sans-serif; font-size: 12pt;\">\n                      <strong>      </strong>\n                    </span>\n                  </td>\n                  <td style=\"padding-top: 10px; text-align: center;\">\n                    <span style=\"font-family: arial, helvetica, sans-serif; font-size: 12pt;\">\n                      <strong>Statement B</strong>\n                    </span>\n                  </td>\n                </tr>\n                <tr>\n                  <td style=\"border: 1px solid black; width: 250px; vertical-align: top; text-align: left;\">\n                    <span style=\"color: black;\">Instruction and class activities should focus on maintaining high standards and rigor so that students reach the highest level of achievement, even if some students struggle with the material. </span>\n                  </td>\n                  <td style=\"text-align: center;\">\n                    <em><span style=\"color: #999999;\"> </span></em>\n                  </td>\n                  <td style=\"border: 1px solid black; width: 250px; vertical-align: top; text-align: left;\"> \t\n<span style=\"color: black;\">Instruction and class activities should focus on ensuring that students with the least prior knowledge and preparation are not left behind, even if that means that less material can be covered. </span>\n                  </td>\n                </tr>\n              </tbody>\n</table>"
+        },
+        {
           "type": "panel",
           "name": "lead_learner_panel",
           "elements": [
@@ -298,6 +303,11 @@
               "maxRateDescription": "Strongly aligned with B"
             }
           ]
+        },
+        {
+          "type": "html",
+          "name": "lead_learner_statements",
+          "html": "<table style=\"width: 600px; margin-left: auto; margin-right: auto;\" cellpadding=\"5\">\n<tbody>\n                <tr>\n                  <td style=\"padding-top: 10px; text-align: center;\">\n                    <span style=\"font-family: arial, helvetica, sans-serif; font-size: 12pt;\">\n                      <strong>Statement A</strong>\n                    </span>\n                  </td>\n                  <td style=\"padding-top: 10px; text-align: center;\">\n                    <span style=\"font-family: arial, helvetica, sans-serif; font-size: 12pt;\">\n                      <strong>      </strong>\n                    </span>\n                  </td>\n                  <td style=\"padding-top: 10px; text-align: center;\">\n                    <span style=\"font-family: arial, helvetica, sans-serif; font-size: 12pt;\">\n                      <strong>Statement B</strong>\n                    </span>\n                  </td>\n                </tr>\n                <tr>\n                  <td style=\"border: 1px solid black; width: 250px; vertical-align: top; text-align: left;\">\n                    <span style=\"color: black;\">\"I do not need to have deep expertise in computer science in order to successfully teach it. I have expertise in how to learn, and I can model that for my students as we learn the content together.\" </span>\n                  </td>\n                  <td style=\"text-align: center;\">\n                    <em><span style=\"color: #999999;\"> </span></em>\n                  </td>\n                  <td style=\"border: 1px solid black; width: 250px; vertical-align: top; text-align: left;\"> \t\n<span style=\"color: black;\">\"As the teacher, I need to have deep content expertise so that I can properly answer students’ questions and guide instruction appropriately.\"</span>\n                    \n                  </td>\n                </tr>\n              </tbody>\n</table>"
         },
         {
           "type": "matrix",
@@ -399,6 +409,11 @@
               "maxRateDescription": "Strongly aligned with B"
             }
           ]
+        },
+        {
+          "type": "html",
+          "name": "prioritize_time_statements",
+          "html": "<table style=\"width: 600px; margin-left: auto; margin-right: auto;\" cellpadding=\"5\">\n<tbody>\n                <tr>\n                  <td style=\"padding-top: 10px; text-align: center;\">\n                    <span style=\"font-family: arial, helvetica, sans-serif; font-size: 12pt;\">\n                      <strong>Statement A</strong>\n                    </span>\n                  </td>\n                  <td style=\"padding-top: 10px; text-align: center;\">\n                    <span style=\"font-family: arial, helvetica, sans-serif; font-size: 12pt;\">\n                      <strong>      </strong>\n                    </span>\n                  </td>\n                  <td style=\"padding-top: 10px; text-align: center;\">\n                    <span style=\"font-family: arial, helvetica, sans-serif; font-size: 12pt;\">\n                      <strong>Statement B</strong>\n                    </span>\n                  </td>\n                </tr>\n                <tr>\n                  <td style=\"border: 1px solid black; width: 250px; vertical-align: top; text-align: left;\">\n                    <span style=\"color: black;\">It’s important that the teacher prioritize their time and resources for students who have the most need. </span>\n                  </td>\n                  <td style=\"text-align: center;\">\n                    <em><span style=\"color: #999999;\"> </span></em>\n                  </td>\n                  <td style=\"border: 1px solid black; width: 250px; vertical-align: top; text-align: left;\"> \t\n<span style=\"color: black;\">  \tThe teacher should ensure that their time, and students’ access to resources are distributed equally for all. </span>\n                  </td>\n                </tr>\n              </tbody>\n</table>"
         },
         {
           "type": "html",

--- a/dashboard/config/foorm/library/surveys/pd/workshop_elements.0.json
+++ b/dashboard/config/foorm/library/surveys/pd/workshop_elements.0.json
@@ -281,11 +281,6 @@
           ]
         },
         {
-          "type": "html",
-          "name": "instructional_focus_statements",
-          "html": "<table style=\"width: 600px; margin-left: auto; margin-right: auto;\" cellpadding=\"5\">\n<tbody>\n                <tr>\n                  <td style=\"padding-top: 10px; text-align: center;\">\n                    <span style=\"font-family: arial, helvetica, sans-serif; font-size: 12pt;\">\n                      <strong>Statement A</strong>\n                    </span>\n                  </td>\n                  <td style=\"padding-top: 10px; text-align: center;\">\n                    <span style=\"font-family: arial, helvetica, sans-serif; font-size: 12pt;\">\n                      <strong>      </strong>\n                    </span>\n                  </td>\n                  <td style=\"padding-top: 10px; text-align: center;\">\n                    <span style=\"font-family: arial, helvetica, sans-serif; font-size: 12pt;\">\n                      <strong>Statement B</strong>\n                    </span>\n                  </td>\n                </tr>\n                <tr>\n                  <td style=\"border: 1px solid black; width: 250px; vertical-align: top; text-align: left;\">\n                    <span style=\"color: black;\">Instruction and class activities should focus on maintaining high standards and rigor so that students reach the highest level of achievement, even if some students struggle with the material. </span>\n                  </td>\n                  <td style=\"text-align: center;\">\n                    <em><span style=\"color: #999999;\"> </span></em>\n                  </td>\n                  <td style=\"border: 1px solid black; width: 250px; vertical-align: top; text-align: left;\"> \t\n<span style=\"color: black;\">Instruction and class activities should focus on ensuring that students with the least prior knowledge and preparation are not left behind, even if that means that less material can be covered. </span>\n                  </td>\n                </tr>\n              </tbody>\n</table>"
-        },
-        {
           "type": "panel",
           "name": "lead_learner_panel",
           "elements": [
@@ -303,11 +298,6 @@
               "maxRateDescription": "Strongly aligned with B"
             }
           ]
-        },
-        {
-          "type": "html",
-          "name": "lead_learner_statements",
-          "html": "<table style=\"width: 600px; margin-left: auto; margin-right: auto;\" cellpadding=\"5\">\n<tbody>\n                <tr>\n                  <td style=\"padding-top: 10px; text-align: center;\">\n                    <span style=\"font-family: arial, helvetica, sans-serif; font-size: 12pt;\">\n                      <strong>Statement A</strong>\n                    </span>\n                  </td>\n                  <td style=\"padding-top: 10px; text-align: center;\">\n                    <span style=\"font-family: arial, helvetica, sans-serif; font-size: 12pt;\">\n                      <strong>      </strong>\n                    </span>\n                  </td>\n                  <td style=\"padding-top: 10px; text-align: center;\">\n                    <span style=\"font-family: arial, helvetica, sans-serif; font-size: 12pt;\">\n                      <strong>Statement B</strong>\n                    </span>\n                  </td>\n                </tr>\n                <tr>\n                  <td style=\"border: 1px solid black; width: 250px; vertical-align: top; text-align: left;\">\n                    <span style=\"color: black;\">\"I do not need to have deep expertise in computer science in order to successfully teach it. I have expertise in how to learn, and I can model that for my students as we learn the content together.\" </span>\n                  </td>\n                  <td style=\"text-align: center;\">\n                    <em><span style=\"color: #999999;\"> </span></em>\n                  </td>\n                  <td style=\"border: 1px solid black; width: 250px; vertical-align: top; text-align: left;\"> \t\n<span style=\"color: black;\">\"As the teacher, I need to have deep content expertise so that I can properly answer students’ questions and guide instruction appropriately.\"</span>\n                    \n                  </td>\n                </tr>\n              </tbody>\n</table>"
         },
         {
           "type": "matrix",
@@ -409,11 +399,6 @@
               "maxRateDescription": "Strongly aligned with B"
             }
           ]
-        },
-        {
-          "type": "html",
-          "name": "prioritize_time_statements",
-          "html": "<table style=\"width: 600px; margin-left: auto; margin-right: auto;\" cellpadding=\"5\">\n<tbody>\n                <tr>\n                  <td style=\"padding-top: 10px; text-align: center;\">\n                    <span style=\"font-family: arial, helvetica, sans-serif; font-size: 12pt;\">\n                      <strong>Statement A</strong>\n                    </span>\n                  </td>\n                  <td style=\"padding-top: 10px; text-align: center;\">\n                    <span style=\"font-family: arial, helvetica, sans-serif; font-size: 12pt;\">\n                      <strong>      </strong>\n                    </span>\n                  </td>\n                  <td style=\"padding-top: 10px; text-align: center;\">\n                    <span style=\"font-family: arial, helvetica, sans-serif; font-size: 12pt;\">\n                      <strong>Statement B</strong>\n                    </span>\n                  </td>\n                </tr>\n                <tr>\n                  <td style=\"border: 1px solid black; width: 250px; vertical-align: top; text-align: left;\">\n                    <span style=\"color: black;\">It’s important that the teacher prioritize their time and resources for students who have the most need. </span>\n                  </td>\n                  <td style=\"text-align: center;\">\n                    <em><span style=\"color: #999999;\"> </span></em>\n                  </td>\n                  <td style=\"border: 1px solid black; width: 250px; vertical-align: top; text-align: left;\"> \t\n<span style=\"color: black;\">  \tThe teacher should ensure that their time, and students’ access to resources are distributed equally for all. </span>\n                  </td>\n                </tr>\n              </tbody>\n</table>"
         },
         {
           "type": "html",


### PR DESCRIPTION
Introduces new versions of Form configuration for pre-workshop and daily surveys for our 5-day summer CS Principles and CS Discoveries workshops.

## Testing story

I created a 5-day summer workshop, enrolled with a teacher account, and (from that account) tested the following:

1. Before the workshop had started, I was able to access and submit the new version of the pre- survey from the /my-professional-learning page.
2. Once I started the workshop, I was able to access and submit the new version of the daily survey at /pd/workshop_daily_survey/day/1.
3. Logged in as the workshop admin, I was able to see the responses that I had submitted in steps 1 and 2.

I did **not** extensively review the content of either survey.