### PR TITLE
fix dot bubble margin

### DIFF
--- a/apps/src/templates/progress/BubbleFactory.jsx
+++ b/apps/src/templates/progress/BubbleFactory.jsx
@@ -229,7 +229,7 @@ const bubbleSizes = {
 };
 
 const circleMargins = {
-  [BubbleSize.dot]: 3,
+  [BubbleSize.dot]: 2,
   [BubbleSize.letter]: 3,
   [BubbleSize.full]: 2
 };


### PR DESCRIPTION
eyes tests revealed that refactored small header bubbles were two pixels wider than previously. resolved by reducing their margins.