### PR TITLE
Fix console error when navigating to pdfs from script overview page

### DIFF
--- a/apps/src/code-studio/components/progress/ScriptOverviewTopRow.jsx
+++ b/apps/src/code-studio/components/progress/ScriptOverviewTopRow.jsx
@@ -177,8 +177,8 @@ class ScriptOverviewTopRow extends React.Component {
                   <a
                     key={option.key}
                     href={option.url}
-                    onClick={() =>
-                      this.recordAndNavigateToPdf(option.key, option.url)
+                    onClick={e =>
+                      this.recordAndNavigateToPdf(e, option.key, option.url)
                     }
                   >
                     {option.name}


### PR DESCRIPTION
When poking around after soft launch, I noticed a console error when clicking on the script pdfs. There's no impact to the user, just a bit of noise.

![Screen Shot 2021-05-26 at 3 56 12 PM](https://user-images.githubusercontent.com/46464143/119741662-07508f00-be3b-11eb-9d29-8acd75a92a8e.png)


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
