### PR TITLE
Fix IE bubble layout

### DIFF
--- a/apps/src/templates/progress/BubbleFactory.jsx
+++ b/apps/src/templates/progress/BubbleFactory.jsx
@@ -8,13 +8,7 @@ import i18n from '@cdo/locale';
 import {currentLocation, makeEnum} from '@cdo/apps/utils';
 import TooltipWithIcon from './TooltipWithIcon';
 import {getIconForLevel, isLevelAssessment} from './progressHelpers';
-import {
-  flex,
-  font,
-  marginLeftRight,
-  marginTopBottom,
-  tightlyConstrainedSizeStyle
-} from './progressStyles';
+import {flex, font, marginLeftRight, marginTopBottom} from './progressStyles';
 import {levelWithProgressType} from './progressTypes';
 import './bubbleStyles.scss';
 
@@ -324,7 +318,10 @@ function shapeSizeStyle(shape, size) {
   const bubbleSize = bubbleSizes[shape][size];
   const fontSize = fontSizes[size];
   return {
-    ...tightlyConstrainedSizeStyle(bubbleSize),
+    width: bubbleSize,
+    height: bubbleSize,
+    maxWidth: bubbleSize,
+    maxHeight: bubbleSize,
     borderRadius: bubbleBorderRadii[shape][size],
     fontSize: fontSize,
     lineHeight: `${fontSize}px`,

--- a/apps/src/templates/progress/progressStyles.js
+++ b/apps/src/templates/progress/progressStyles.js
@@ -26,15 +26,6 @@ export const flexBetween = {...flex, justifyContent: 'space-between'};
 
 export const inlineBlock = {display: 'inline-block'};
 
-export const tightlyConstrainedSizeStyle = size => {
-  return {
-    minWidth: size,
-    maxWidth: size,
-    minHeight: size,
-    maxHeight: size
-  };
-};
-
 export const marginLeftRight = margin => {
   return {
     marginLeft: margin,

--- a/apps/test/unit/templates/progress/BubbleFactoryTest.jsx
+++ b/apps/test/unit/templates/progress/BubbleFactoryTest.jsx
@@ -254,7 +254,7 @@ describe('BubbleFactory', () => {
       expect(bubbleStyle).to.include(unitTestExports.bubbleStyles.diamond);
     });
 
-    it('when shape is a diamond and size is dot has expected border radius, min/max widths and font size', () => {
+    it('when shape is a diamond and size is dot has expected border radius, widths, and font size', () => {
       const bubbleStyle = unitTestExports.mainBubbleStyle(
         BubbleShape.diamond,
         BubbleSize.dot,
@@ -262,11 +262,11 @@ describe('BubbleFactory', () => {
       );
 
       expect(bubbleStyle.borderRadius).to.equal(2);
-      expect(bubbleStyle.minWidth).to.equal(10);
+      expect(bubbleStyle.width).to.equal(10);
       expect(bubbleStyle.maxWidth).to.equal(10);
     });
 
-    it('when shape is a diamond and size is full has expected border radius, min/max widths and font size', () => {
+    it('when shape is a diamond and size is full has expected border radius, widths, and font size', () => {
       const bubbleStyle = unitTestExports.mainBubbleStyle(
         BubbleShape.diamond,
         BubbleSize.full,
@@ -275,11 +275,11 @@ describe('BubbleFactory', () => {
 
       expect(bubbleStyle.borderRadius).to.equal(4);
       expect(bubbleStyle.fontSize).to.equal(16);
-      expect(bubbleStyle.minWidth).to.equal(26);
+      expect(bubbleStyle.width).to.equal(26);
       expect(bubbleStyle.maxWidth).to.equal(26);
     });
 
-    it('when shape is a circle and size is dot has expected border radius, min/max widths and font size', () => {
+    it('when shape is a circle and size is dot has expected border radius, widths, and font size', () => {
       const bubbleStyle = unitTestExports.mainBubbleStyle(
         BubbleShape.circle,
         BubbleSize.dot,
@@ -287,11 +287,11 @@ describe('BubbleFactory', () => {
       );
 
       expect(bubbleStyle.borderRadius).to.equal(13);
-      expect(bubbleStyle.minWidth).to.equal(13);
+      expect(bubbleStyle.width).to.equal(13);
       expect(bubbleStyle.maxWidth).to.equal(13);
     });
 
-    it('when shape is a circle and size is letter has expected border radius, min/max widths and font size', () => {
+    it('when shape is a circle and size is letter has expected border radius, widths, and font size', () => {
       const bubbleStyle = unitTestExports.mainBubbleStyle(
         BubbleShape.circle,
         BubbleSize.letter,
@@ -300,11 +300,11 @@ describe('BubbleFactory', () => {
 
       expect(bubbleStyle.borderRadius).to.equal(20);
       expect(bubbleStyle.fontSize).to.equal(12);
-      expect(bubbleStyle.minWidth).to.equal(20);
+      expect(bubbleStyle.width).to.equal(20);
       expect(bubbleStyle.maxWidth).to.equal(20);
     });
 
-    it('when shape is a circle and size is full has expected border radius, min/max widths and font size', () => {
+    it('when shape is a circle and size is full has expected border radius, widths, and font size', () => {
       const bubbleStyle = unitTestExports.mainBubbleStyle(
         BubbleShape.circle,
         BubbleSize.full,
@@ -313,7 +313,7 @@ describe('BubbleFactory', () => {
 
       expect(bubbleStyle.borderRadius).to.equal(34);
       expect(bubbleStyle.fontSize).to.equal(16);
-      expect(bubbleStyle.minWidth).to.equal(34);
+      expect(bubbleStyle.width).to.equal(34);
       expect(bubbleStyle.maxWidth).to.equal(34);
     });
 


### PR DESCRIPTION
apparently in IE 11, setting `min-height` on a flex box breaks `align-items: center`. this PR works around that by simply using `height` instead of `min-height`