### PR TITLE
Add back in level concept difficulty editing on CSF level types

### DIFF
--- a/dashboard/app/views/levels/editors/_artist.html.haml
+++ b/dashboard/app/views/levels/editors/_artist.html.haml
@@ -14,4 +14,5 @@
 = render partial: 'levels/editors/fields/sharing', locals: {f: f}
 = render partial: 'levels/editors/fields/callouts', locals: {f: f}
 = render partial: 'levels/editors/fields/audit_log', locals: {f: f}
+= render partial: 'levels/editors/fields/level_concept_difficulty', locals: {f: f}
 

--- a/dashboard/app/views/levels/editors/_bounce.html.haml
+++ b/dashboard/app/views/levels/editors/_bounce.html.haml
@@ -12,3 +12,4 @@
 = render partial: 'levels/editors/fields/sharing', locals: {f: f}
 = render partial: 'levels/editors/fields/callouts', locals: {f: f}
 = render partial: 'levels/editors/fields/audit_log', locals: {f: f}
+= render partial: 'levels/editors/fields/level_concept_difficulty', locals: {f: f}

--- a/dashboard/app/views/levels/editors/_craft.html.haml
+++ b/dashboard/app/views/levels/editors/_craft.html.haml
@@ -13,3 +13,4 @@
 = render partial: 'levels/editors/fields/sharing', locals: {f: f}
 = render partial: 'levels/editors/fields/callouts', locals: {f: f}
 = render partial: 'levels/editors/fields/audit_log', locals: {f: f}
+= render partial: 'levels/editors/fields/level_concept_difficulty', locals: {f: f}

--- a/dashboard/app/views/levels/editors/_dance.html.haml
+++ b/dashboard/app/views/levels/editors/_dance.html.haml
@@ -17,6 +17,7 @@
 = render partial: 'levels/editors/fields/sharing', locals: {f: f}
 = render partial: 'levels/editors/fields/callouts', locals: {f: f}
 = render partial: 'levels/editors/fields/audit_log', locals: {f: f}
+= render partial: 'levels/editors/fields/level_concept_difficulty', locals: {f: f}
 
 :javascript
   window.toggleBlock = function (elementId) {

--- a/dashboard/app/views/levels/editors/_dsl.html.haml
+++ b/dashboard/app/views/levels/editors/_dsl.html.haml
@@ -6,3 +6,4 @@
 = render partial: 'levels/editors/fields/video', locals: {f: f} if @level.is_a?(External)
 = render partial: 'levels/editors/fields/bubble_choice_sublevel', locals: {f: f} if @level.is_a?(LevelGroup) || @level.is_a?(Match)
 = render partial: 'levels/editors/fields/audit_log', locals: {f: f}
+= render partial: 'levels/editors/fields/level_concept_difficulty', locals: {f: f}

--- a/dashboard/app/views/levels/editors/_flappy.html.haml
+++ b/dashboard/app/views/levels/editors/_flappy.html.haml
@@ -10,3 +10,4 @@
 = render partial: 'levels/editors/fields/sharing', locals: {f: f}
 = render partial: 'levels/editors/fields/callouts', locals: {f: f}
 = render partial: 'levels/editors/fields/audit_log', locals: {f: f}
+= render partial: 'levels/editors/fields/level_concept_difficulty', locals: {f: f}

--- a/dashboard/app/views/levels/editors/_free_response.html.haml
+++ b/dashboard/app/views/levels/editors/_free_response.html.haml
@@ -5,3 +5,4 @@
 = render partial: 'levels/editors/fields/special_level_types', locals: {f: f}
 = render partial: 'levels/editors/fields/callouts', locals: {f: f}
 = render partial: 'levels/editors/fields/audit_log', locals: {f: f}
+= render partial: 'levels/editors/fields/level_concept_difficulty', locals: {f: f}

--- a/dashboard/app/views/levels/editors/_maze.html.haml
+++ b/dashboard/app/views/levels/editors/_maze.html.haml
@@ -12,3 +12,4 @@
 = render partial: 'levels/editors/fields/sharing', locals: {f: f}
 = render partial: 'levels/editors/fields/callouts', locals: {f: f}
 = render partial: 'levels/editors/fields/audit_log', locals: {f: f}
+= render partial: 'levels/editors/fields/level_concept_difficulty', locals: {f: f}

--- a/dashboard/app/views/levels/editors/_spritelab.html.haml
+++ b/dashboard/app/views/levels/editors/_spritelab.html.haml
@@ -14,6 +14,7 @@
 = render partial: 'levels/editors/fields/sharing', locals: {f: f}
 = render partial: 'levels/editors/fields/callouts', locals: {f: f}
 = render partial: 'levels/editors/fields/audit_log', locals: {f: f}
+= render partial: 'levels/editors/fields/level_concept_difficulty', locals: {f: f}
 
 :javascript
   window.toggleBlock = function (elementId) {

--- a/dashboard/app/views/levels/editors/_standalone_video.html.haml
+++ b/dashboard/app/views/levels/editors/_standalone_video.html.haml
@@ -3,3 +3,4 @@
 = render partial: 'levels/editors/fields/video', locals: {f: f}
 = render partial: 'levels/editors/fields/callouts', locals: {f: f}
 = render partial: 'levels/editors/fields/audit_log', locals: {f: f}
+= render partial: 'levels/editors/fields/level_concept_difficulty', locals: {f: f}

--- a/dashboard/app/views/levels/editors/_studio.html.haml
+++ b/dashboard/app/views/levels/editors/_studio.html.haml
@@ -17,3 +17,4 @@
 = render partial: 'levels/editors/fields/cs_in_a', locals: {f: f}
 = render partial: 'levels/editors/fields/callouts', locals: {f: f}
 = render partial: 'levels/editors/fields/audit_log', locals: {f: f}
+= render partial: 'levels/editors/fields/level_concept_difficulty', locals: {f: f}

--- a/dashboard/app/views/levels/editors/_unplugged.html.haml
+++ b/dashboard/app/views/levels/editors/_unplugged.html.haml
@@ -12,3 +12,4 @@
 = render partial: 'levels/editors/fields/video', locals: {f: f}
 = render partial: 'levels/editors/fields/callouts', locals: {f: f}
 = render partial: 'levels/editors/fields/audit_log', locals: {f: f}
+= render partial: 'levels/editors/fields/level_concept_difficulty', locals: {f: f}

--- a/dashboard/app/views/levels/editors/fields/_level_concept_difficulty.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_level_concept_difficulty.html.haml
@@ -1,0 +1,33 @@
+%h1.control-legend.collapsed{data: {toggle: "collapse", target: "#lcd"}}
+  Level Concept Difficulty
+#lcd.collapse
+  .field
+    = f.label 'concepts'
+    %p
+      Select
+      %a.select_all{href: '#'} all
+      \/
+      %a.select_none{href: '#'} none
+      (shift-click or cmd-click to select multiple).
+    = f.collection_select :concept_ids, Concept.cached, :id, :name, { :selected => @level.concept_ids }, { :multiple => true, :name => 'level[concept_ids][]', :size => Concept.cached.length }
+
+  -# We can only save a related LevelConceptDifficulty object for a level that's already been created, not for a new level about to be created
+  - if @level && @level.id
+    .field
+      = f.label 'concept difficulties'
+      %a{href: "https://docs.google.com/spreadsheets/d/1jPVTIqsIH6qLUd_WlKtzE7CEiaQG-hqM9n_A1hY-rL0"} Concept Difficulty Tagging guidelines
+      %table{style: 'width: 80%'}
+        %thead
+          %tr
+            %th Concept
+            %th Difficulty
+        %tbody
+          - concept_difficulty = @level.level_concept_difficulty || LevelConceptDifficulty.new(level:@level)
+          %input{type: 'hidden', name: "level[level_concept_difficulty_attributes][id]", value: concept_difficulty.id}
+          - LevelConceptDifficulty::CONCEPTS.each do |concept|
+            - difficulty = concept_difficulty.send(concept)
+            %tr
+              %td
+                = concept
+              %td
+                = select_tag "level[level_concept_difficulty_attributes][#{concept}]", options_for_select((1..LevelConceptDifficulty::MAXIMUM_CONCEPT_DIFFICULTY).to_a, difficulty), include_blank: true


### PR DESCRIPTION
Add back in the ability to edit level concept difficulty from the level edit page of level types used in CSF.

### Started Collapsed
<img width="1724" alt="Screen Shot 2021-05-26 at 10 29 44 PM" src="https://user-images.githubusercontent.com/208083/119756987-4bab5180-be72-11eb-9ef3-96255bd4146f.png">

### When Opened
<img width="997" alt="Screen Shot 2021-05-26 at 10 31 11 PM" src="https://user-images.githubusercontent.com/208083/119756982-4a7a2480-be72-11eb-8680-3d9895c01bca.png">

## Links

https://codedotorg.atlassian.net/browse/PLAT-1076

## Testing story

Checked locally that it loads level concept difficulty correct on edit page for levels that already have it.  Plus updated level concept difficulty information and that worked as well.