### PR TITLE
preserve level variants when saving script editor

### DIFF
--- a/apps/src/lib/levelbuilder/script-editor/scriptEditorRedux.js
+++ b/apps/src/lib/levelbuilder/script-editor/scriptEditorRedux.js
@@ -360,7 +360,16 @@ const serializeLesson = (lesson, levelKeyList) => {
   s.push(t);
   if (lesson.levels) {
     lesson.levels.forEach(level => {
-      s = s.concat(serializeLevel(levelKeyList, level.ids[0], level));
+      if (level.ids.length > 1) {
+        s.push('variants');
+        level.ids.forEach(id => {
+          const active = id === level.activeId;
+          s.push(`  ${serializeLevel(levelKeyList, id, level, active)}`);
+        });
+        s.push('endvariants');
+      } else {
+        s.push(serializeLevel(levelKeyList, level.ids[0], level));
+      }
     });
   }
   s.push('');
@@ -378,7 +387,7 @@ const serializeLesson = (lesson, levelKeyList) => {
  * @param level
  * @return {string}
  */
-const serializeLevel = (levelKeyList, id, level) => {
+const serializeLevel = (levelKeyList, id, level, active = true) => {
   const s = [];
   const key = levelKeyList[id];
   if (/^blockly:/.test(key)) {
@@ -398,6 +407,9 @@ const serializeLevel = (levelKeyList, id, level) => {
     }
   }
   let l = level.bonus ? `bonus '${escape(key)}'` : `level '${escape(key)}'`;
+  if (!active) {
+    l += ', active: false';
+  }
   if (level.progression) {
     l += `, progression: '${escape(level.progression)}'`;
   }

--- a/apps/test/unit/code-studio/scriptEditorReduxTest.js
+++ b/apps/test/unit/code-studio/scriptEditorReduxTest.js
@@ -14,7 +14,11 @@ import reducers, {
 import _ from 'lodash';
 
 const getInitialState = () => ({
-  levelKeyList: {},
+  levelKeyList: {
+    2001: 'Level One',
+    2002: 'Level Two',
+    2003: 'Level Three'
+  },
   lessonGroups: [
     {
       id: 1,
@@ -30,7 +34,20 @@ const getInitialState = () => ({
           name: 'A',
           position: 1,
           unplugged: true,
-          levels: [],
+          levels: [
+            {
+              activeId: '2001',
+              ids: ['2001'],
+              kind: 'puzzle',
+              position: 1
+            },
+            {
+              activeId: '2002',
+              ids: ['2002'],
+              kind: 'puzzle',
+              position: 2
+            }
+          ],
           hasLessonPlan: true
         },
         {
@@ -104,7 +121,9 @@ describe('scriptEditorRedux reducer tests', () => {
       expect(serializedLessonGroups).to.equal(
         "lesson_group 'lg-key', display_name: 'Display Name'\n" +
           "lesson_group_description 'My Description'\n" +
-          "lesson 'a', display_name: 'A', has_lesson_plan: true, unplugged: true\n\n" +
+          "lesson 'a', display_name: 'A', has_lesson_plan: true, unplugged: true\n" +
+          "level 'Level One'\n" +
+          "level 'Level Two'\n\n" +
           "lesson 'b', display_name: 'B', has_lesson_plan: false\n\n" +
           "lesson 'c', display_name: 'C', has_lesson_plan: true\n\n" +
           "lesson_group 'lg-key-2', display_name: 'Display Name 2'\n" +
@@ -125,7 +144,9 @@ describe('scriptEditorRedux reducer tests', () => {
       expect(serializedLessonGroups).to.equal(
         "lesson_group 'lg-key', display_name: 'Display Name'\n" +
           "lesson_group_description 'a\\'b\\'c\\'d'\n" +
-          "lesson 'a', display_name: 'A', has_lesson_plan: true, unplugged: true\n\n" +
+          "lesson 'a', display_name: 'A', has_lesson_plan: true, unplugged: true\n" +
+          "level 'Level One'\n" +
+          "level 'Level Two'\n\n" +
           "lesson 'b', display_name: 'B', has_lesson_plan: false\n\n" +
           "lesson 'c', display_name: 'C', has_lesson_plan: true\n\n" +
           "lesson_group 'lg-key-2', display_name: 'Display Name 2'\n" +
@@ -143,7 +164,7 @@ describe('scriptEditorRedux reducer tests', () => {
 
     expect(mappedLessonGroups.length).to.equal(2);
     expect(mappedLessonGroups[0].lessons.length).to.equal(3);
-    expect(mappedLessonGroups[0].lessons[0].levels.length).to.equal(0);
+    expect(mappedLessonGroups[0].lessons[0].levels.length).to.equal(2);
   });
 
   it('add group', () => {

--- a/apps/test/unit/code-studio/scriptEditorReduxTest.js
+++ b/apps/test/unit/code-studio/scriptEditorReduxTest.js
@@ -155,6 +155,33 @@ describe('scriptEditorRedux reducer tests', () => {
           "lesson 'f', display_name: 'F', has_lesson_plan: false\n\n"
       );
     });
+
+    it('serializes lessons containing level variants', () => {
+      const scriptLevel = initialState.lessonGroups[0].lessons[0].levels[1];
+      scriptLevel.ids = ['2002', '2003'];
+      scriptLevel.activeId = '2003';
+      let serializedLessonGroups = getSerializedLessonGroups(
+        initialState.lessonGroups,
+        initialState.levelKeyList
+      );
+
+      expect(serializedLessonGroups).to.equal(
+        "lesson_group 'lg-key', display_name: 'Display Name'\n" +
+          "lesson_group_description 'My Description'\n" +
+          "lesson 'a', display_name: 'A', has_lesson_plan: true, unplugged: true\n" +
+          "level 'Level One'\n" +
+          'variants\n' +
+          "  level 'Level Two', active: false\n" +
+          "  level 'Level Three'\n" +
+          'endvariants\n\n' +
+          "lesson 'b', display_name: 'B', has_lesson_plan: false\n\n" +
+          "lesson 'c', display_name: 'C', has_lesson_plan: true\n\n" +
+          "lesson_group 'lg-key-2', display_name: 'Display Name 2'\n" +
+          "lesson 'd', display_name: 'D', has_lesson_plan: true\n\n" +
+          "lesson 'e', display_name: 'E', has_lesson_plan: true\n\n" +
+          "lesson 'f', display_name: 'F', has_lesson_plan: false\n\n"
+      );
+    });
   });
 
   it('mapLessonGroupDataForEditor', () => {


### PR DESCRIPTION
Finishes https://codedotorg.atlassian.net/browse/PLAT-371. 

Without this change, running ScriptLevel.add_variant and then trying to load and save the script edit page results in an error:
* ![Screen Shot 2021-05-27 at 5 16 15 AM](https://user-images.githubusercontent.com/8001765/119824387-b5dfe880-beaa-11eb-8ab0-b3c6a4172f3a.png)

Unfortunately, everything in this PR will soon be removed as part of the Migrate Old Scripts work. However, we need this to be in place ASAP in case we need to add a level variant to a soft-launched 2021 course.

the logic I've added in this PR is mostly copied from here: https://github.com/code-dot-org/code-dot-org/blob/2ff2e329a62171e76d14a6b138734f11184e226d/dashboard/app/dsl/script_dsl.rb#L405-L404 however its worth noting that we do not plan to support experiments in level variants ([example](https://github.com/code-dot-org/code-dot-org/blob/7434ccd0002d20d392001244d024e5b2171f1bf4/dashboard/config/scripts/allthethings.script#L219-L222)). this is ok because this code will be going away before we migrate any scripts that have level variants with experiments.

## Testing story

Added unit tests for script editor redux to generate the correct script DSL. Manually verified that saving the script now succeeds, and accurately preserves level variants in the script json as well as in the database.
