### PR TITLE
From the level details dialog, open help and tips links in new tab

### DIFF
--- a/apps/src/templates/VideoThumbnail.jsx
+++ b/apps/src/templates/VideoThumbnail.jsx
@@ -6,30 +6,35 @@ import {videoDataShape} from './types';
 export default class VideoThumbnail extends Component {
   static propTypes = {
     video: videoDataShape,
-    onClick: PropTypes.func
+    onClick: PropTypes.func,
+    openInNewTab: PropTypes.bool
+  };
+
+  onThumbnailClick = () => {
+    const video = this.props.video;
+    this.props.onClick && this.props.onClick();
+    if (this.props.openInNewTab) {
+      window.open(video.src, '_blank', 'noopener,noreferrer');
+    } else {
+      showVideoDialog(
+        {
+          src: video.src,
+          name: video.name,
+          key: video.key,
+          download: video.download,
+          thumbnail: video.thumbnail,
+          enable_fallback: video.enable_fallback,
+          autoplay: video.autoplay
+        },
+        true
+      );
+    }
   };
 
   render() {
     const video = this.props.video;
     return (
-      <a
-        style={styles.videoLink}
-        onClick={() => {
-          this.props.onClick && this.props.onClick();
-          showVideoDialog(
-            {
-              src: video.src,
-              name: video.name,
-              key: video.key,
-              download: video.download,
-              thumbnail: video.thumbnail,
-              enable_fallback: video.enable_fallback,
-              autoplay: video.autoplay
-            },
-            true
-          );
-        }}
-      >
+      <a style={styles.videoLink} onClick={this.onThumbnailClick}>
         <img
           style={styles.videoThumbnail}
           src={video.thumbnail}

--- a/apps/src/templates/instructions/HelpTabContents.jsx
+++ b/apps/src/templates/instructions/HelpTabContents.jsx
@@ -8,7 +8,8 @@ export default class HelpTabContents extends Component {
   static propTypes = {
     videoData: videoDataShape,
     mapReference: PropTypes.string,
-    referenceLinks: PropTypes.array
+    referenceLinks: PropTypes.array,
+    openReferenceLinksInNewTab: PropTypes.bool
   };
 
   render() {
@@ -22,11 +23,17 @@ export default class HelpTabContents extends Component {
             highlight
             icon="map"
             reference={this.props.mapReference}
+            openReferenceInNewTab={this.props.openReferenceLinksInNewTab}
           />
         )}
         {this.props.referenceLinks &&
           this.props.referenceLinks.map((link, index) => (
-            <NetworkResourceLink key={index} icon="book" reference={link} />
+            <NetworkResourceLink
+              key={index}
+              icon="book"
+              reference={link}
+              openReferenceInNewTab={this.props.openReferenceLinksInNewTab}
+            />
           ))}
       </div>
     );

--- a/apps/src/templates/instructions/HelpTabContents.jsx
+++ b/apps/src/templates/instructions/HelpTabContents.jsx
@@ -16,7 +16,10 @@ export default class HelpTabContents extends Component {
     return (
       <div style={styles.referenceArea}>
         {this.props.videoData && (
-          <VideoThumbnail video={this.props.videoData} />
+          <VideoThumbnail
+            video={this.props.videoData}
+            openInNewTab={this.props.openReferenceLinksInNewTab}
+          />
         )}
         {this.props.mapReference && (
           <NetworkResourceLink

--- a/apps/src/templates/instructions/NetworkResourceLink.js
+++ b/apps/src/templates/instructions/NetworkResourceLink.js
@@ -7,7 +7,8 @@ export default class NetworkResourceLink extends React.Component {
   static propTypes = {
     highlight: PropTypes.bool,
     icon: PropTypes.string.isRequired,
-    reference: PropTypes.string.isRequired
+    reference: PropTypes.string.isRequired,
+    openReferenceInNewTab: PropTypes.bool
   };
 
   state = {
@@ -27,6 +28,7 @@ export default class NetworkResourceLink extends React.Component {
         icon={this.props.icon}
         text={this.state.title ? this.state.title : this.props.reference}
         reference={this.props.reference}
+        openReferenceInNewTab={this.props.openReferenceInNewTab}
       />
     );
   }

--- a/apps/src/templates/instructions/ResourceLink.jsx
+++ b/apps/src/templates/instructions/ResourceLink.jsx
@@ -10,7 +10,8 @@ class ResourceLink extends React.Component {
     highlight: PropTypes.bool,
     icon: PropTypes.string.isRequired,
     text: PropTypes.string.isRequired,
-    reference: PropTypes.string.isRequired
+    reference: PropTypes.string.isRequired,
+    openReferenceInNewTab: PropTypes.bool
   };
 
   state = {
@@ -22,8 +23,12 @@ class ResourceLink extends React.Component {
       // Don't open modal, just open link in new tab/window
       return;
     }
-    // Don't open link, just open modal.
     e.preventDefault();
+    if (this.props.openReferenceInNewTab) {
+      window.open(this.props.reference, 'noopener', 'noreferrer');
+      return;
+    }
+    // Don't open link, just open modal.
     var dialog = new LegacyDialog({
       body: $('<iframe>')
         .addClass('instructions-container')
@@ -59,7 +64,7 @@ class ResourceLink extends React.Component {
 
     return (
       <div>
-        <div style={styles.resourceStyle} onClick={this.selectResource}>
+        <div style={styles.resourceStyle}>
           <span style={thumbnailStyle}>
             <FontAwesome icon={icon} style={iconStyle} title={text} />
           </span>

--- a/apps/src/templates/instructions/ResourceLink.jsx
+++ b/apps/src/templates/instructions/ResourceLink.jsx
@@ -25,7 +25,7 @@ class ResourceLink extends React.Component {
     }
     e.preventDefault();
     if (!!this.props.openReferenceInNewTab) {
-      window.open(this.props.reference, 'noopener', 'noreferrer');
+      window.open(this.props.reference, '_blank', 'noopener,noreferrer');
       return;
     }
     // Don't open link, just open modal.

--- a/apps/src/templates/instructions/ResourceLink.jsx
+++ b/apps/src/templates/instructions/ResourceLink.jsx
@@ -24,7 +24,7 @@ class ResourceLink extends React.Component {
       return;
     }
     e.preventDefault();
-    if (this.props.openReferenceInNewTab) {
+    if (!!this.props.openReferenceInNewTab) {
       window.open(this.props.reference, 'noopener', 'noreferrer');
       return;
     }
@@ -64,7 +64,7 @@ class ResourceLink extends React.Component {
 
     return (
       <div>
-        <div style={styles.resourceStyle}>
+        <div style={styles.resourceStyle} onClick={this.selectResource}>
           <span style={thumbnailStyle}>
             <FontAwesome icon={icon} style={iconStyle} title={text} />
           </span>

--- a/apps/src/templates/instructions/TopInstructions.jsx
+++ b/apps/src/templates/instructions/TopInstructions.jsx
@@ -82,6 +82,7 @@ class TopInstructions extends Component {
     levelVideos: PropTypes.array,
     mapReference: PropTypes.string,
     referenceLinks: PropTypes.array,
+    openReferenceLinksInNewTab: PropTypes.bool,
     viewAs: PropTypes.oneOf(Object.keys(ViewType)),
     readOnlyWorkspace: PropTypes.bool,
     serverLevelId: PropTypes.number,
@@ -674,6 +675,9 @@ class TopInstructions extends Component {
                 videoData={levelVideos ? levelVideos[0] : []}
                 mapReference={mapReference}
                 referenceLinks={referenceLinks}
+                openReferenceLinksInNewTab={
+                  this.props.openReferenceLinksInNewTab
+                }
               />
             )}
             {displayFeedback && !fetchingData && (

--- a/apps/src/templates/lessonOverview/activities/LevelDetailsDialog.jsx
+++ b/apps/src/templates/lessonOverview/activities/LevelDetailsDialog.jsx
@@ -140,6 +140,7 @@ class LevelDetailsDialog extends Component {
           levelVideos={level.videos}
           mapReference={level.mapReference}
           referenceLinks={level.referenceLinks}
+          openReferenceLinksInNewTab
           teacherMarkdown={level.teacherMarkdown}
           viewAs={this.props.viewAs}
           height={this.state.height}

--- a/apps/src/utils.js
+++ b/apps/src/utils.js
@@ -710,7 +710,7 @@ export function currentLocation() {
  * Helper that wraps window.open, for stubbing in unit tests.
  */
 export function windowOpen(...args) {
-  return window.open(...args);
+  return window.open(...args, 'noopener', 'noreferrer');
 }
 
 /**

--- a/apps/src/utils.js
+++ b/apps/src/utils.js
@@ -710,7 +710,7 @@ export function currentLocation() {
  * Helper that wraps window.open, for stubbing in unit tests.
  */
 export function windowOpen(...args) {
-  return window.open(...args, 'noopener', 'noreferrer');
+  return window.open(...args);
 }
 
 /**

--- a/apps/test/unit/templates/VideoThumbnailTest.jsx
+++ b/apps/test/unit/templates/VideoThumbnailTest.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import {expect} from '../../util/deprecatedChai';
+import sinon from 'sinon';
+import VideoThumbnail from '@cdo/apps/templates/VideoThumbnail';
+
+describe('VideoThumbnail', () => {
+  it('renders a link on the video thumbnail', () => {
+    const wrapper = shallow(
+      <VideoThumbnail
+        video={{
+          name: 'name',
+          src: 'video.url',
+          key: 'key',
+          thumbnail: 'video.url/thumbnail'
+        }}
+      />
+    );
+    expect(wrapper.find('a').length).equals(1);
+    expect(wrapper.find('img').length).equals(1);
+    expect(wrapper.find('img').props().src).equals('video.url/thumbnail');
+  });
+
+  it('opens video in new tab if openInNewTab is set', () => {
+    const wrapper = shallow(
+      <VideoThumbnail
+        video={{
+          name: 'name',
+          src: 'video.url',
+          key: 'key',
+          thumbnail: 'video.url/thumbnail'
+        }}
+        openInNewTab
+      />
+    );
+    const windowOpenStub = sinon.stub(window, 'open');
+    wrapper.instance().onThumbnailClick();
+    expect(windowOpenStub.callCount).to.equal(1);
+  });
+});

--- a/apps/test/unit/templates/VideoThumbnailTest.jsx
+++ b/apps/test/unit/templates/VideoThumbnailTest.jsx
@@ -36,5 +36,6 @@ describe('VideoThumbnail', () => {
     const windowOpenStub = sinon.stub(window, 'open');
     wrapper.instance().onThumbnailClick();
     expect(windowOpenStub.callCount).to.equal(1);
+    windowOpenStub.restore();
   });
 });

--- a/apps/test/unit/templates/instructions/ResourceLinkTest.jsx
+++ b/apps/test/unit/templates/instructions/ResourceLinkTest.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import {expect} from '../../../util/deprecatedChai';
+import ResourceLink from '@cdo/apps/templates/instructions/ResourceLink';
+import sinon from 'sinon';
+
+describe('ResourceLink', () => {
+  it('opens reference in new tab if openReferenceInNewTab is set', () => {
+    const wrapper = shallow(
+      <ResourceLink
+        icon={'map'}
+        reference={'/link/to/reference'}
+        text={'Reference'}
+        openReferenceInNewTab
+      />
+    );
+    const windowOpenStub = sinon.stub(window, 'open');
+    wrapper.instance().selectResource({preventDefault: () => {}});
+    expect(windowOpenStub.callCount).to.equal(1);
+  });
+});


### PR DESCRIPTION
Resolves [PLAT-928](https://codedotorg.atlassian.net/browse/PLAT-928) (at least for now).

Currently the links in the help and tip tab open in a dialog over the screen. This is done using an iframe loading the content from curriculum builder. While the ideal behavior here is to open these links in the level details dialog itself, I don't want to deal with an iframe in this dialog, especially as we're going to be working on concept maps in the near future. We should look into a better solution when we do that work.




- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
