### PR TITLE
Make lesson copy an instance method

### DIFF
--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -132,7 +132,7 @@ class LessonsController < ApplicationController
   def clone
     destination_script = Script.find_by_name(params[:destinationUnitName])
     raise "Cannot find script #{params[:destinationUnitName]}" unless destination_script
-    copied_lesson = Lesson.copy_to_script(@lesson, destination_script)
+    copied_lesson = @lesson.copy_to_script(destination_script)
     render(status: 200, json: {editLessonUrl: edit_lesson_path(id: copied_lesson.id), editScriptUrl: edit_script_path(copied_lesson.script)})
   rescue => err
     render(json: {error: err.message}.to_json, status: :not_acceptable)

--- a/dashboard/test/controllers/lessons_controller_test.rb
+++ b/dashboard/test/controllers/lessons_controller_test.rb
@@ -1281,7 +1281,7 @@ class LessonsControllerTest < ActionController::TestCase
     script = create :script
     lesson = create :lesson
     cloned_lesson = create :lesson, script: script
-    Lesson.stubs(:copy_to_script).returns(cloned_lesson)
+    Lesson.any_instance.stubs(:copy_to_script).returns(cloned_lesson)
     put :clone, params: {id: lesson.id, 'destinationUnitName': script.name}
 
     assert_response 200

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -972,7 +972,7 @@ class LessonTest < ActiveSupport::TestCase
       @original_lesson.programming_expressions = [create(:programming_expression)]
 
       @destination_script.expects(:write_script_json).once
-      copied_lesson = Lesson.copy_to_script(@original_lesson, @destination_script)
+      copied_lesson = @original_lesson.copy_to_script(@destination_script)
       assert_equal @destination_script, copied_lesson.script
       assert_equal 2, copied_lesson.script_levels.length
       assert_equal [level1, level2], copied_lesson.script_levels.map(&:level)
@@ -995,7 +995,7 @@ class LessonTest < ActiveSupport::TestCase
       Script.expects(:merge_and_write_i18n).once
       destination_resource = create :resource, name: 'resource1', course_version: @destination_course_version
       destination_vocab = create :vocabulary, word: 'word one', course_version: @destination_course_version
-      copied_lesson = Lesson.copy_to_script(@original_lesson, @destination_script)
+      copied_lesson = @original_lesson.copy_to_script(@destination_script)
       assert_equal @destination_script, copied_lesson.script
       assert_equal [destination_resource], copied_lesson.resources
       assert_equal [destination_vocab], copied_lesson.vocabularies
@@ -1021,7 +1021,7 @@ class LessonTest < ActiveSupport::TestCase
       course_version_resource_count = course_version.resources.count
       course_version_vocab_count = course_version.vocabularies.count
       Script.expects(:merge_and_write_i18n).once
-      copied_lesson = Lesson.copy_to_script(original_lesson, destination_script)
+      copied_lesson = original_lesson.copy_to_script(destination_script)
       course_version.reload
 
       assert_equal destination_script, copied_lesson.script
@@ -1047,7 +1047,7 @@ class LessonTest < ActiveSupport::TestCase
 
       @destination_script.expects(:write_script_json).once
       Script.expects(:merge_and_write_i18n).once
-      copied_lesson = Lesson.copy_to_script(@original_lesson, @destination_script)
+      copied_lesson = @original_lesson.copy_to_script(@destination_script)
       @destination_script.reload
 
       # Test that the script levels were correctly added to the script
@@ -1075,7 +1075,7 @@ class LessonTest < ActiveSupport::TestCase
       create :lesson, script: @destination_script, lesson_group: @destination_lesson_group, has_lesson_plan: false, lockable: true, absolute_position: 3, relative_position: 1
 
       @destination_script.expects(:write_script_json).once
-      copied_lesson = Lesson.copy_to_script(@original_lesson, @destination_script)
+      copied_lesson = @original_lesson.copy_to_script(@destination_script)
       @destination_script.reload
       assert_equal @destination_script, copied_lesson.script
       assert_equal 4, copied_lesson.absolute_position
@@ -1092,7 +1092,7 @@ class LessonTest < ActiveSupport::TestCase
 
       @destination_script.expects(:write_script_json).once
       Script.expects(:merge_and_write_i18n).once
-      copied_lesson = Lesson.copy_to_script(@original_lesson, @destination_script)
+      copied_lesson = @original_lesson.copy_to_script(@destination_script)
       @destination_script.reload
       assert_equal @destination_script, copied_lesson.script
       assert_equal 4, copied_lesson.absolute_position
@@ -1110,7 +1110,7 @@ class LessonTest < ActiveSupport::TestCase
 
       @destination_script.expects(:write_script_json).once
       Script.expects(:merge_and_write_i18n).once
-      copied_lesson = Lesson.copy_to_script(@original_lesson, @destination_script)
+      copied_lesson = @original_lesson.copy_to_script(@destination_script)
       @destination_script.reload
       assert_equal @destination_script, copied_lesson.script
       assert_equal 4, copied_lesson.absolute_position
@@ -1122,7 +1122,7 @@ class LessonTest < ActiveSupport::TestCase
 
       @destination_script.expects(:write_script_json).once
       Script.expects(:merge_and_write_i18n).twice
-      copied_lesson = Lesson.copy_to_script(@original_lesson, @destination_script)
+      copied_lesson = @original_lesson.copy_to_script(@destination_script)
       assert_equal 1, @destination_script.lesson_groups.count
       assert_equal 1, @destination_script.lessons.count
       assert_equal @destination_script.lesson_groups.first, copied_lesson.lesson_group


### PR DESCRIPTION
This is a non-functional change to make the code more similar to how we currently have script copying working. Also, the first argument is an instance of a lesson, so this just seems like bad style by me. 🙃 

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
