### PR TITLE
fix rtl image spacing

### DIFF
--- a/apps/src/templates/PaneHeader.jsx
+++ b/apps/src/templates/PaneHeader.jsx
@@ -153,7 +153,7 @@ export const PaneButton = Radium(function(props) {
   let iconStyle = {
     ...styles.headerButtonIcon,
     ...(props.isRtl && styles.headerButtonIconRtl),
-    ...(!props.iconClass && styles.headerButtonIconHidden)
+    ...(!props.iconClass && !props.hiddenImage && styles.headerButtonIconHidden)
   };
 
   const label = props.isPressed ? props.pressedLabel : props.label;


### PR DESCRIPTION
In removing spacing from PaneButtons that don't have icons as part of [this change](https://github.com/code-dot-org/code-dot-org/pull/40762), I removed the spacing between RTL PaneButtons that use the hiddenImage property instead of the iconClass property to set the icon in the button. This adds a check on the hiddenImage property before removing icon padding.

From the eyes test, the show blocks button here is an example of the issue
<img width="617" alt="Screen Shot 2021-05-27 at 12 58 04 PM" src="https://user-images.githubusercontent.com/17147070/119889265-30c8f380-beeb-11eb-8354-44cb11f724eb.png">

Here's the fixed version on show blocks
<img width="1436" alt="Screen Shot 2021-05-27 at 12 52 56 PM" src="https://user-images.githubusercontent.com/17147070/119889509-7eddf700-beeb-11eb-89e9-2b36922f6c4d.png">




## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
