### PR TITLE
Javalab - fix the tab dropdown menu

### DIFF
--- a/apps/src/javalab/JavalabEditor.jsx
+++ b/apps/src/javalab/JavalabEditor.jsx
@@ -544,7 +544,7 @@ class JavalabEditor extends React.Component {
                       }}
                       onClick={e => this.toggleTabMenu(tabKey, e)}
                       className="no-focus-outline"
-                      disabled={activeTabKey === tabKey}
+                      disabled={activeTabKey !== tabKey}
                     >
                       <FontAwesome
                         icon={


### PR DESCRIPTION
I broke the tab dropdown menu in [this PR](https://github.com/code-dot-org/code-dot-org/pull/40762) by making it permanently disabled on the selected tab and hidden on the unselected tabs.

It works now:
<img width="1435" alt="Screen Shot 2021-05-27 at 4 30 47 PM" src="https://user-images.githubusercontent.com/17147070/119909333-71376a00-bf09-11eb-8aaf-22cdabea357a.png">


## Links

- PR that I broke this in: [here](https://github.com/code-dot-org/code-dot-org/pull/40762)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
