### PR TITLE
Dependabot for apps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/apps"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 1
+    labels:
+      - "npm"
+      - "dependencies"
+    ignore:
+      - dependency-name: "react*"


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This creates our `dependabot.yml` which will allow dependabot to start automatically opening PRs. To start, we will only be using dependabot to upgrade our npm packages. There is a pull request limit of 1, so only 1 dependabot PR can be open at a time. We will be ignoring react dependencies for now, since there is a larger effort already happening to upgrade React. Dependabot upgrades dependencies to the latest version, I looked to see if there was a way to update versions incrementally (for versions that are far behind) and didn't find anything so this may be painful initially.

For more information about configuration see https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates.

## Open questions
- Are there other dependencies we should be ignoring besides React?

## Follow-ups
- Put in place a process for who reviews dependabot PRs so we can stay on top of them. (DoTD?)
- Add documentation that provides guidance on how to review dependency upgrade PRs. Ex: what to look for in patch, minor and major version upgrades. (I'd love help/guidance with this part)

