### PR TITLE
[AiLab] Put max and min as placeholders in input design elements

### DIFF
--- a/apps/src/applab/ai.js
+++ b/apps/src/applab/ai.js
@@ -4,8 +4,8 @@ import {stripSpaceAndSpecial} from '@cdo/apps/aiUtils';
 
 function generateCodeDesignElements(modelId, modelData) {
   var x = 20;
-  var y = 20;
-  var SPACER_PIXELS = 20;
+  var y = 0;
+  var SPACER_PIXELS = 18;
 
   const modelClass = 'ml_model_' + modelId;
 
@@ -50,14 +50,11 @@ function generateCodeDesignElements(modelId, modelData) {
     } else {
       // Create text input field for each continuous feature.
       label.textContent = feature.id;
-      var labelMinMax = designMode.createElement('LABEL', x, y);
+      var input = designMode.createElement('TEXT_INPUT', x, y);
       var min = feature.min.toFixed(2);
       var max = feature.max.toFixed(2);
-      // Unary plus operator returns a number and truncates trailing zeroes.
-      labelMinMax.textContent = `(min: ${+min}, max: ${+max}):`;
-      labelMinMax.style.width = '300px';
-      y = y + SPACER_PIXELS;
-      var input = designMode.createElement('TEXT_INPUT', x, y);
+      var maxMinPlaceholder = `min: ${+min}, max: ${+max}`;
+      designMode.updateProperty(input, 'placeholder', maxMinPlaceholder);
       fieldId = alphaNumFeature + '_input';
       input.id = 'design_' + fieldId;
       input.className = modelClass;
@@ -73,7 +70,6 @@ function generateCodeDesignElements(modelId, modelData) {
   label.id = 'design_' + alphaNumModelName + '_label';
   label.className = modelClass;
   label.style.width = '300px';
-  y = y + SPACER_PIXELS;
   var predictionId = alphaNumModelName + '_prediction';
   // Button to do the prediction.
   var predictButton = designMode.createElement('BUTTON', x, y);


### PR DESCRIPTION
The additional max and min information elements for continuous features increased the amount of space each feature input took up. To avoid elements running off of the App Lab screen for models with a common number of features (6 or less), we not put the max and min info as a placeholder in the input box. I also tightened the spacing in general slightly. 

BEFORE: 
![Screen Shot 2021-05-28 at 12 57 48 PM](https://user-images.githubusercontent.com/12300669/120017812-53730f00-bfb4-11eb-9a11-5906512af364.png)

AFTER: 
![Screen Shot 2021-05-28 at 12 50 25 PM](https://user-images.githubusercontent.com/12300669/120017725-34747d00-bfb4-11eb-8204-a72b1e8b7e88.png)
