### PR TITLE
Synchronize progress table scrolling

### DIFF
--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableContainer.story.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableContainer.story.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
+import {Provider, connect} from 'react-redux';
+import PropTypes from 'prop-types';
 import ProgressTableView from '@cdo/apps/templates/sectionProgress/progressTables/ProgressTableView';
+import SectionProgressToggle from '@cdo/apps/templates/sectionProgress/SectionProgressToggle';
 import {ViewType} from '@cdo/apps/templates/sectionProgress/sectionProgressConstants';
-import {Provider} from 'react-redux';
-import {createStore, wrapTable} from '../sectionProgressTestHelpers';
+import {createStore} from '../sectionProgressTestHelpers';
 
 /**
  * The variety of stories here can be useful during development, but add
@@ -12,86 +14,116 @@ import {createStore, wrapTable} from '../sectionProgressTestHelpers';
  */
 const INCLUDE_LARGE_STORIES = false;
 
-function buildSmallStories(component, currentView) {
+class _TableWrapper extends React.Component {
+  static propTypes = {
+    currentView: PropTypes.oneOf(Object.values(ViewType))
+  };
+  render() {
+    return (
+      <div
+        className="main"
+        style={{
+          marginLeft: 80,
+          width: 970,
+          display: 'block',
+          backgroundColor: '#ffffff'
+        }}
+      >
+        <SectionProgressToggle />
+        <ProgressTableView currentView={this.props.currentView} />
+      </div>
+    );
+  }
+}
+
+const TableWrapper = connect(state => ({
+  currentView: state.sectionProgress.currentView
+}))(_TableWrapper);
+
+function buildSmallStories() {
   return [
     {
-      name: `${currentView} - Tiny section, small script`,
+      name: `Small section, small script`,
       story: () => {
         const store = createStore(3, 10);
-        return wrapTable(<Provider store={store}>{component}</Provider>);
+        return (
+          <Provider store={store}>
+            <TableWrapper />
+          </Provider>
+        );
       }
     },
     {
-      name: `${currentView} - Tiny section, large script`,
+      name: `Small section, large script`,
       story: () => {
         const store = createStore(3, 30);
-        return wrapTable(<Provider store={store}>{component}</Provider>);
+        return (
+          <Provider store={store}>
+            <TableWrapper />
+          </Provider>
+        );
       }
     }
   ];
 }
 
-function buildLargeStories(component, currentView) {
+function buildLargeStories() {
   return [
     {
-      name: `${currentView} - Small section, small script`,
+      name: `Medium section, small script`,
       story: () => {
         const store = createStore(30, 10);
-        return wrapTable(<Provider store={store}>{component}</Provider>);
+        return (
+          <Provider store={store}>
+            <TableWrapper />
+          </Provider>
+        );
       }
     },
     {
-      name: `${currentView} - Small section, large script`,
+      name: `Medium section, large script`,
       story: () => {
         const store = createStore(30, 30);
-        return wrapTable(<Provider store={store}>{component}</Provider>);
+        return (
+          <Provider store={store}>
+            <TableWrapper />
+          </Provider>
+        );
       }
     },
     {
-      name: `${currentView} - Large section, small script`,
+      name: `Large section, small script`,
       story: () => {
         const store = createStore(200, 10);
-        return wrapTable(<Provider store={store}>{component}</Provider>);
+        return (
+          <Provider store={store}>
+            <TableWrapper />
+          </Provider>
+        );
       }
     },
     {
-      name: `${currentView} - Large section, large script`,
+      name: `Large section, large script`,
       story: () => {
         const store = createStore(200, 30);
-        return wrapTable(<Provider store={store}>{component}</Provider>);
+        return (
+          <Provider store={store}>
+            <TableWrapper />
+          </Provider>
+        );
       }
     }
   ];
 }
 
-let summaryViewStories = buildSmallStories(
-  <ProgressTableView currentView={ViewType.SUMMARY} />,
-  ViewType.SUMMARY
-);
-let detailViewStories = buildSmallStories(
-  <ProgressTableView currentView={ViewType.DETAIL} />,
-  ViewType.DETAIL
-);
+let stories = buildSmallStories();
 
 if (INCLUDE_LARGE_STORIES) {
-  summaryViewStories = summaryViewStories.concat(
-    buildLargeStories(
-      <ProgressTableView currentView={ViewType.SUMMARY} />,
-      ViewType.SUMMARY
-    )
-  );
-  detailViewStories = detailViewStories.concat(
-    buildLargeStories(
-      <ProgressTableView currentView={ViewType.DETAIL} />,
-      ViewType.DETAIL
-    )
-  );
+  stories = stories.concat(buildLargeStories());
 }
-
-const progressTableViewStories = summaryViewStories.concat(detailViewStories);
 
 export default storybook => {
   storybook
     .storiesOf('SectionProgress/ProgressTableView', module)
-    .addStoryTable(progressTableViewStories);
+    .addStoryTable(stories);
 };

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableView.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableView.jsx
@@ -125,6 +125,7 @@ class ProgressTableView extends React.Component {
 
   studentList = null;
   contentView = null;
+  scrollTop = 0;
 
   componentDidMount() {
     this.setRowsToRender();
@@ -136,29 +137,72 @@ class ProgressTableView extends React.Component {
     }
   }
 
-  // override the default initial number of rows to render
+  /**
+   * Override the default initial number of rows to render
+   */
   setRowsToRender() {
     const initialRows = parseInt(progressTableStyles.MAX_ROWS);
 
     // amountOfRowsToRender is a reactabular internal
-    this.studentList &&
-      this.studentList.bodyComponent.setState({
-        amountOfRowsToRender: initialRows
-      });
-    this.contentView &&
-      this.contentView.bodyComponent.setState({
-        amountOfRowsToRender: initialRows
-      });
+    this.studentList?.bodyComponent.setState({
+      amountOfRowsToRender: initialRows
+    });
+    this.contentView?.bodyComponent.setState({
+      amountOfRowsToRender: initialRows
+    });
+    this.syncScrollTop();
   }
 
   onScroll(e) {
     this.studentList.body.scrollTop = e.target.scrollTop;
     this.contentView.header.scrollLeft = e.target.scrollLeft;
+    this.scrollTop = e.target.scrollTop;
+    this.syncScrollTop();
   }
 
-  // When the student list is long enough to enable vertical scrolling in the
-  // table body, we need to add a "gutter" to the content view header to
-  // account for the horizontal space used by the vertical scrollbar.
+  /**
+   * This function serves three purposes:
+   * 1) When switching between views, it will restore the vertical scroll
+   *    position of the previous view.
+   * 2) When expanding/collapsing detail rows, the scroll positions of the
+   *    student list and content view sometimes get out of sync, so this is
+   *    used to correct that when it happens.
+   * 3) Making sure the internal states of the content view and student list
+   *    remain in sync after scrolling (see comment on `setScrollState` below)
+   *
+   * A 200ms timeout is used because reactabular has an internal 100ms timeout
+   * it uses to wait before calculating all its measurements, and we need to
+   * make sure to wait until after that completes.
+   */
+  syncScrollTop() {
+    clearTimeout(this.timeout);
+    this.timeout = setTimeout(() => {
+      this.setScrollState(this.contentView.bodyComponent);
+      this.setScrollState(this.studentList.bodyComponent);
+    }, 200);
+  }
+
+  /**
+   * Simply setting the `scrollTop` value on each of our table components
+   * sometimes leads to the internal state of the components (and resulting
+   * vertical scroll positions) getting out of sync.
+   *
+   * To work around this, we copy the implementation of reactabular's internal
+   * `VirtualizedBody.getRef().scrollTo()` to make sure the state gets updated
+   * appropriately. However, `scrollTo` accepts a row index, whereas we need to
+   * set the `scrollTop` value directly, hence this custom implementation.
+   */
+  setScrollState(table) {
+    table.scrollTop = this.scrollTop;
+    table.ref.scrollTop = this.scrollTop;
+    table.setState(table.calculateRows(table.props));
+  }
+
+  /**
+   * When the student list is long enough to enable vertical scrolling in the
+   * table body, we need to add a "gutter" to the content view header to
+   * account for the horizontal space used by the vertical scrollbar.
+   */
   needsContentHeaderGutter() {
     return (
       this.props.section.students.length >
@@ -177,6 +221,7 @@ class ProgressTableView extends React.Component {
       this.collapseDetailRows(rowData, rowIndex);
     }
     this.recordToggleRow(!rowData.isExpanded, rowData.student.id);
+    this.syncScrollTop();
   }
 
   recordToggleRow(expanding, studentId) {
@@ -271,12 +316,17 @@ class ProgressTableView extends React.Component {
       ? this.detailContentViewProps()
       : this.summaryContentViewProps();
 
+    // we use the view type as a key to force a full re-instantiation of the
+    // table components when the view changes
+    const key = this.props.currentView;
+
     return (
       // outer div contains both table and legend
       <div>
         <div style={styles.container} className="progress-table">
           <div style={styles.studentList} className="student-list">
             <ProgressTableStudentList
+              key={key}
               ref={r => (this.studentList = r)}
               headers={studentListHeaders}
               rows={this.state.rows}
@@ -291,7 +341,7 @@ class ProgressTableView extends React.Component {
           </div>
           <div style={styles.contentView} className="content-view">
             <ProgressTableContentView
-              key={this.props.currentView} //force a full re-instantiation of the component when view changes
+              key={key}
               ref={r => (this.contentView = r)}
               rows={this.state.rows}
               onRow={this.onRow}

--- a/apps/src/templates/sectionProgress/sectionProgressTestHelpers.js
+++ b/apps/src/templates/sectionProgress/sectionProgressTestHelpers.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import {registerReducers, createStoreWithReducers} from '@cdo/apps/redux';
 import sectionData, {setSection} from '@cdo/apps/redux/sectionDataRedux';
 import sectionProgress, {
@@ -32,22 +31,6 @@ export function fakeDetailRowsForStudent(student) {
     {id: `${student.id}.1`, student: student, expansionIndex: 1},
     {id: `${student.id}.2`, student: student, expansionIndex: 2}
   ];
-}
-
-export function wrapTable(table) {
-  return (
-    <div
-      className="main"
-      style={{
-        marginLeft: 80,
-        width: 970,
-        display: 'block',
-        backgroundColor: '#ffffff'
-      }}
-    >
-      {table}
-    </div>
-  );
 }
 
 export function createStore(numStudents, numLessons) {


### PR DESCRIPTION
while investigating [LP-1933] i discovered a number of bugs around vertical scrolling when switching between lesson and level table views with detail rows expanded. the solution required overriding more of reactabular's internal functionality and therefore is definitely on the hacky side. let this serve as another +1 for upgrading react and getting off reactabular ASAP.

BEFORE:
<img width="682" alt="Screen Shot 2021-06-01 at 5 08 56 PM" src="https://user-images.githubusercontent.com/4986878/120406526-e9ce6a00-c2ff-11eb-97f1-5785904b8278.png">

one feature that fell out of this work is that we are now able to preserve the vertical scroll position when switching view types (or more accurately, we restore it after the new instance renders, which is not ideal, but seemed like a better solution than simply resetting it to 0 for both student list and content view).

details of the change are in the comments.

[LP-1933]: https://codedotorg.atlassian.net/browse/LP-1933