### PR TITLE
Fix some multiple choice levels showing the question twice in the level details dialog

### DIFF
--- a/apps/src/templates/lessonOverview/activities/LevelDetailsDialog.jsx
+++ b/apps/src/templates/lessonOverview/activities/LevelDetailsDialog.jsx
@@ -100,8 +100,10 @@ class LevelDetailsDialog extends Component {
     } else if (level.type === 'Match' || level.type === 'Multi') {
       return (
         <div style={styles.scrollContainer}>
+          {level.content.map((content, i) => (
+            <SafeMarkdown key={i} markdown={content} />
+          ))}
           {level.question && <SafeMarkdown markdown={level.question} />}
-          {level.questionText && <SafeMarkdown markdown={level.questionText} />}
           {this.getTeacherOnlyMarkdownComponent(level)}
         </div>
       );

--- a/apps/src/templates/lessonOverview/activities/LevelDetailsDialog.jsx
+++ b/apps/src/templates/lessonOverview/activities/LevelDetailsDialog.jsx
@@ -103,7 +103,7 @@ class LevelDetailsDialog extends Component {
           {level.content.map((content, i) => (
             <SafeMarkdown key={i} markdown={content} />
           ))}
-          {level.question && <SafeMarkdown markdown={level.question} />}
+          {level.questionText && <SafeMarkdown markdown={level.questionText} />}
           {this.getTeacherOnlyMarkdownComponent(level)}
         </div>
       );

--- a/apps/test/unit/templates/lessonOverview/activities/LevelDetailsDialogTest.jsx
+++ b/apps/test/unit/templates/lessonOverview/activities/LevelDetailsDialogTest.jsx
@@ -311,9 +311,10 @@ describe('LevelDetailsDialogTest', () => {
           level: {
             type: 'Multi',
             id: 'level',
-            question:
-              'Look at the code below and predict how the headings will be displayed.',
-            questionText: 'Eggs, Bacon, Waffles',
+            content: [
+              'Look at the code below and predict how the headings will be displayed.'
+            ],
+            question: 'Eggs, Bacon, Waffles',
             teacherMarkdown: 'This is a multiple choice level.'
           }
         }}

--- a/apps/test/unit/templates/lessonOverview/activities/LevelDetailsDialogTest.jsx
+++ b/apps/test/unit/templates/lessonOverview/activities/LevelDetailsDialogTest.jsx
@@ -314,7 +314,7 @@ describe('LevelDetailsDialogTest', () => {
             content: [
               'Look at the code below and predict how the headings will be displayed.'
             ],
-            question: 'Eggs, Bacon, Waffles',
+            questionText: 'Eggs, Bacon, Waffles',
             teacherMarkdown: 'This is a multiple choice level.'
           }
         }}

--- a/dashboard/app/models/levels/match.rb
+++ b/dashboard/app/models/levels/match.rb
@@ -78,9 +78,11 @@ class Match < DSLDefined
   end
 
   def summarize_for_lesson_show(can_view_teacher_markdown)
+    question_text = localized_property(:questions).blank? ? '' : questions[0]['text']
     super.merge(
       {
-        question: question
+        content: [properties['content1'], properties['content2'], properties['content3'], properties['content4'], properties['markdown']].compact,
+        question: question_text
       }
     )
   end

--- a/dashboard/app/models/levels/match.rb
+++ b/dashboard/app/models/levels/match.rb
@@ -79,9 +79,16 @@ class Match < DSLDefined
 
   def summarize_for_lesson_show(can_view_teacher_markdown)
     question_text = localized_property(:questions).blank? ? '' : questions[0]['text']
+    content = [
+      localized_property('content1'),
+      localized_property('content2'),
+      localized_property('content3'),
+      localized_property('content4'),
+      localized_property('markdown')
+    ].compact
     super.merge(
       {
-        content: [properties['content1'], properties['content2'], properties['content3'], properties['content4'], properties['markdown']].compact,
+        content: content,
         question: question_text
       }
     )

--- a/dashboard/app/models/levels/match.rb
+++ b/dashboard/app/models/levels/match.rb
@@ -78,7 +78,6 @@ class Match < DSLDefined
   end
 
   def summarize_for_lesson_show(can_view_teacher_markdown)
-    question_text = localized_property(:questions).blank? ? '' : questions[0]['text']
     content = [
       localized_property('content1'),
       localized_property('content2'),
@@ -88,8 +87,7 @@ class Match < DSLDefined
     ].compact
     super.merge(
       {
-        content: content,
-        question: question_text
+        content: content
       }
     )
   end

--- a/dashboard/app/models/levels/multi.rb
+++ b/dashboard/app/models/levels/multi.rb
@@ -65,4 +65,13 @@ class Multi < Match
     end
     return question_text
   end
+
+  def summarize_for_lesson_show(can_view_teacher_markdown)
+    question_text = localized_property(:questions).blank? ? '' : questions[0]['text']
+    super.merge(
+      {
+        questionText: question_text
+      }
+    )
+  end
 end

--- a/dashboard/app/models/levels/multi.rb
+++ b/dashboard/app/models/levels/multi.rb
@@ -65,12 +65,4 @@ class Multi < Match
     end
     return question_text
   end
-
-  def summarize_for_lesson_show(can_view_teacher_markdown)
-    super.merge(
-      {
-        questionText: get_question_text
-      }
-    )
-  end
 end

--- a/dashboard/app/models/levels/multi.rb
+++ b/dashboard/app/models/levels/multi.rb
@@ -67,7 +67,8 @@ class Multi < Match
   end
 
   def summarize_for_lesson_show(can_view_teacher_markdown)
-    question_text = localized_property(:questions).blank? ? '' : questions[0]['text']
+    localized_questions = localized_property(:questions)
+    question_text = localized_questions.any? ? '' : localized_questions[0]['text']
     super.merge(
       {
         questionText: question_text

--- a/dashboard/test/models/match_test.rb
+++ b/dashboard/test/models/match_test.rb
@@ -19,4 +19,16 @@ class MatchLevelTest < ActiveSupport::TestCase
       refute_equal shuffle, original_order
     end
   end
+
+  test 'summarize_for_lesson_show includes all set content' do
+    @level = create :match, properties: {
+      content1: 'content 1',
+      content2: nil,
+      content3: 'content 3',
+      content4: nil
+    }
+
+    summary = @level.summarize_for_lesson_show(false)
+    assert_equal ['content 1', 'content 3'], summary[:content]
+  end
 end


### PR DESCRIPTION
Fixes some multiple choice levels showing the question multiple times. This was happening because `question` and `get_question_text` were sometimes the same (but sometimes different which is why I didn't catch this initially). This new code models how the haml displays this info, first displaying content in the `content{1-4}` fields, ([here](https://github.com/code-dot-org/code-dot-org/blob/54eddad8217141cfc8f19a18d5bb23aabc87ea69/dashboard/app/views/levels/_content.html.haml#L22) from [here](https://github.com/code-dot-org/code-dot-org/blob/3bb5ebd28aa2e51814ad71e2901224ded2891522/dashboard/app/views/levels/_single_multi.html.haml#L43)) and then displaying `localized_questions[0]["text"]` [here](https://github.com/code-dot-org/code-dot-org/blob/3bb5ebd28aa2e51814ad71e2901224ded2891522/dashboard/app/views/levels/_single_multi.html.haml#L47). Match levels use `localized_questions` for the answers, which is out of scope of this PR.

Multi level before:
![Screen Shot 2021-06-01 at 8 44 03 AM](https://user-images.githubusercontent.com/46464143/120382516-9563c400-c2d8-11eb-9a9c-087efd90c8f3.png)

Multi level after:
![Screen Shot 2021-06-01 at 8 44 28 AM](https://user-images.githubusercontent.com/46464143/120382521-97c61e00-c2d8-11eb-923d-e9c144f15f47.png)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
