### PR TITLE
Refactor lesson token test to use shallow rendering

### DIFF
--- a/apps/src/lib/levelbuilder/script-editor/LessonGroupCard.jsx
+++ b/apps/src/lib/levelbuilder/script-editor/LessonGroupCard.jsx
@@ -293,7 +293,6 @@ class LessonGroupCard extends Component {
               }
             }}
             key={lesson.key}
-            lessonGroupPosition={this.props.lessonGroup.position}
             lesson={lesson}
             dragging={!!draggedLessonPos}
             draggedLessonPos={lesson.position === draggedLessonPos}

--- a/apps/src/lib/levelbuilder/script-editor/LessonToken.jsx
+++ b/apps/src/lib/levelbuilder/script-editor/LessonToken.jsx
@@ -61,7 +61,7 @@ export default class LessonToken extends Component {
   }
 }
 
-class LessonTokenContents extends Component {
+export class LessonTokenContents extends Component {
   static propTypes = {
     y: PropTypes.number.isRequired,
     scale: PropTypes.number.isRequired,

--- a/apps/src/lib/levelbuilder/script-editor/LessonToken.jsx
+++ b/apps/src/lib/levelbuilder/script-editor/LessonToken.jsx
@@ -10,7 +10,6 @@ import {lessonShape} from '@cdo/apps/lib/levelbuilder/shapes';
  */
 export default class LessonToken extends Component {
   static propTypes = {
-    lessonGroupPosition: PropTypes.number.isRequired,
     lesson: lessonShape.isRequired,
     dragging: PropTypes.bool,
     draggedLessonPos: PropTypes.bool,

--- a/apps/src/lib/levelbuilder/script-editor/LessonToken.jsx
+++ b/apps/src/lib/levelbuilder/script-editor/LessonToken.jsx
@@ -20,18 +20,6 @@ export default class LessonToken extends Component {
     cloneLesson: PropTypes.func.isRequired
   };
 
-  handleDragStart = e => {
-    this.props.handleDragStart(this.props.lesson.position, e);
-  };
-
-  handleRemove = () => {
-    this.props.removeLesson(this.props.lesson.position);
-  };
-
-  handleClone = () => {
-    this.props.cloneLesson(this.props.lesson.position);
-  };
-
   render() {
     const {draggedLessonPos} = this.props;
     const springConfig = {stiffness: 1000, damping: 80};
@@ -57,61 +45,102 @@ export default class LessonToken extends Component {
         {// Use react-motion to interpolate the following values and create
         // smooth transitions.
         ({y, scale, shadow}) => (
-          <div
-            style={Object.assign({}, styles.lessonToken, {
-              transform: `translate3d(0, ${y}px, 0) scale(${scale})`,
-              boxShadow: `${color.shadow} 0 ${shadow}px ${shadow * 3}px`,
-              zIndex: draggedLessonPos ? 1000 : 500 - this.props.lesson.position
-            })}
-          >
-            <div style={styles.reorder} onMouseDown={this.handleDragStart}>
-              <i className="fa fa-arrows-v" />
-            </div>
-            <span style={styles.lessonTokenName}>
-              <span style={styles.lessonArea}>
-                <span style={styles.lessonTitle}>{this.props.lesson.name}</span>
-                <span style={styles.lessonDetails}>
-                  {this.props.lesson.unplugged && (
-                    <span style={styles.tag}>unplugged</span>
-                  )}
-                  {this.props.lesson.assessment && (
-                    <span style={styles.tag}>assessment</span>
-                  )}
-                  {!this.props.lesson.hasLessonPlan && (
-                    <span style={styles.tag}>no lesson plan</span>
-                  )}
-                  {this.props.lesson.lockable && (
-                    <span style={styles.tag}>lockable</span>
-                  )}
-                </span>
-              </span>
-            </span>
-            {this.props.lesson.id && (
-              <div
-                style={styles.edit}
-                onClick={() => {
-                  window.lessonEditorOpened = true;
-                  const win = window.open(
-                    `${this.props.lesson.lessonEditPath}`,
-                    '_blank'
-                  );
-                  win.focus();
-                }}
-              >
-                <i className="fa fa-pencil" />
-              </div>
-            )}
-            {this.props.lesson.id && (
-              <div style={styles.clone} onMouseDown={this.handleClone}>
-                <i className="fa fa-clone" />
-              </div>
-            )}
-            <div style={styles.remove} onMouseDown={this.handleRemove}>
-              <i className="fa fa-times" />
-            </div>
-          </div>
+          <LessonTokenContents
+            y={y}
+            scale={scale}
+            shadow={shadow}
+            draggedLessonPos={draggedLessonPos}
+            lesson={this.props.lesson}
+            handleDragStart={this.props.handleDragStart}
+            removeLesson={this.props.removeLesson}
+            cloneLesson={this.props.cloneLesson}
+          />
         )}
       </Motion>
+    );
+  }
+}
+
+class LessonTokenContents extends Component {
+  static propTypes = {
+    y: PropTypes.number.isRequired,
+    scale: PropTypes.number.isRequired,
+    shadow: PropTypes.number.isRequired,
+    draggedLessonPos: PropTypes.bool,
+    lesson: lessonShape.isRequired,
+    handleDragStart: PropTypes.func.isRequired,
+    removeLesson: PropTypes.func.isRequired,
+    cloneLesson: PropTypes.func.isRequired
+  };
+
+  handleEditLesson = () => {
+    window.lessonEditorOpened = true;
+    const win = window.open(`${this.props.lesson.lessonEditPath}`, '_blank');
+    win.focus();
+  };
+
+  handleDragStart = e => {
+    this.props.handleDragStart(this.props.lesson.position, e);
+  };
+
+  handleRemove = () => {
+    this.props.removeLesson(this.props.lesson.position);
+  };
+
+  handleClone = () => {
+    this.props.cloneLesson(this.props.lesson.position);
+  };
+
+  render() {
+    return (
+      <div
+        style={Object.assign({}, styles.lessonToken, {
+          transform: `translate3d(0, ${this.props.y}px, 0) scale(${
+            this.props.scale
+          })`,
+          boxShadow: `${color.shadow} 0 ${this.props.shadow}px ${this.props
+            .shadow * 3}px`,
+          zIndex: this.props.draggedLessonPos
+            ? 1000
+            : 500 - this.props.lesson.position
+        })}
+      >
+        <div style={styles.reorder} onMouseDown={this.handleDragStart}>
+          <i className="fa fa-arrows-v" />
+        </div>
+        <span style={styles.lessonTokenName}>
+          <span style={styles.lessonArea}>
+            <span style={styles.lessonTitle}>{this.props.lesson.name}</span>
+            <span style={styles.lessonDetails}>
+              {this.props.lesson.unplugged && (
+                <span style={styles.tag}>unplugged</span>
+              )}
+              {this.props.lesson.assessment && (
+                <span style={styles.tag}>assessment</span>
+              )}
+              {!this.props.lesson.hasLessonPlan && (
+                <span style={styles.tag}>no lesson plan</span>
+              )}
+              {this.props.lesson.lockable && (
+                <span style={styles.tag}>lockable</span>
+              )}
+            </span>
+          </span>
+        </span>
+        {this.props.lesson.id && (
+          <div style={styles.edit} onClick={this.handleEditLesson}>
+            <i className="fa fa-pencil" />
+          </div>
+        )}
+        {this.props.lesson.id && (
+          <div style={styles.clone} onMouseDown={this.handleClone}>
+            <i className="fa fa-clone" />
+          </div>
+        )}
+        <div style={styles.remove} onMouseDown={this.handleRemove}>
+          <i className="fa fa-times" />
+        </div>
+      </div>
     );
   }
 }

--- a/apps/src/lib/levelbuilder/script-editor/LessonToken.jsx
+++ b/apps/src/lib/levelbuilder/script-editor/LessonToken.jsx
@@ -75,7 +75,8 @@ class LessonTokenContents extends Component {
 
   handleEditLesson = () => {
     window.lessonEditorOpened = true;
-    const win = window.open(`${this.props.lesson.lessonEditPath}`, '_blank');
+    const url = this.props.lesson.lessonEditPath;
+    const win = window.open(url, 'noopener', 'noreferrer');
     win.focus();
   };
 

--- a/apps/test/unit/lib/levelbuilder/script-editor/LessonTokenTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/LessonTokenTest.jsx
@@ -38,7 +38,7 @@ describe('LessonToken', () => {
       };
     });
 
-    it('renders default props', () => {
+    it('renders a Motion component', () => {
       const wrapper = shallow(<LessonToken {...defaultProps} />);
       expect(wrapper.find('Motion').length).to.equal(1);
     });
@@ -61,7 +61,7 @@ describe('LessonToken', () => {
       };
     });
 
-    it('renders default props', () => {
+    it('renders existing lesson with edit and clone buttons', () => {
       const wrapper = shallow(<LessonTokenContents {...defaultProps} />);
       expect(wrapper.contains('Lesson 1')).to.be.true;
       expect(wrapper.find('.fa-pencil').length).to.equal(1);
@@ -69,7 +69,7 @@ describe('LessonToken', () => {
       expect(wrapper.contains('assessment')).to.be.true;
     });
 
-    it('renders newly added lesson without edit button', () => {
+    it('renders newly added lesson without edit and clone buttons', () => {
       let wrapper = shallow(
         <LessonTokenContents
           {...defaultProps}

--- a/apps/test/unit/lib/levelbuilder/script-editor/LessonTokenTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/LessonTokenTest.jsx
@@ -4,6 +4,19 @@ import {expect} from '../../../../util/reconfiguredChai';
 import sinon from 'sinon';
 import LessonToken from '@cdo/apps/lib/levelbuilder/script-editor/LessonToken';
 
+const defaultLesson = {
+  id: 10,
+  key: 'lesson-1',
+  name: 'Lesson 1',
+  levels: [],
+  position: 1,
+  relative_position: 1,
+  lockable: false,
+  unplugged: false,
+  assessment: true,
+  hasLessonPlan: true
+};
+
 describe('LessonToken', () => {
   let handleDragStart, cloneLesson, removeLesson, defaultProps;
 
@@ -18,18 +31,7 @@ describe('LessonToken', () => {
       handleDragStart,
       cloneLesson,
       removeLesson,
-      lesson: {
-        id: 10,
-        key: 'lesson-1',
-        name: 'Lesson 1',
-        levels: [],
-        position: 1,
-        relative_position: 1,
-        lockable: false,
-        unplugged: false,
-        assessment: true,
-        hasLessonPlan: true
-      },
+      lesson: defaultLesson,
       lessonGroupPosition: 1
     };
   });

--- a/apps/test/unit/lib/levelbuilder/script-editor/LessonTokenTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/LessonTokenTest.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
-import {mount} from 'enzyme';
+import {shallow} from 'enzyme';
 import {expect} from '../../../../util/reconfiguredChai';
 import sinon from 'sinon';
-import LessonToken from '@cdo/apps/lib/levelbuilder/script-editor/LessonToken';
+import LessonToken, {
+  LessonTokenContents
+} from '@cdo/apps/lib/levelbuilder/script-editor/LessonToken';
 
 const defaultLesson = {
   id: 10,
@@ -20,48 +22,70 @@ const defaultLesson = {
 describe('LessonToken', () => {
   let handleDragStart, cloneLesson, removeLesson, defaultProps;
 
-  beforeEach(() => {
-    handleDragStart = sinon.spy();
-    cloneLesson = sinon.spy();
-    removeLesson = sinon.spy();
-    defaultProps = {
-      dragging: false,
-      draggedLessonPos: false,
-      delta: 0,
-      handleDragStart,
-      cloneLesson,
-      removeLesson,
-      lesson: defaultLesson,
-      lessonGroupPosition: 1
-    };
+  describe('LessonToken', () => {
+    beforeEach(() => {
+      handleDragStart = sinon.spy();
+      cloneLesson = sinon.spy();
+      removeLesson = sinon.spy();
+      defaultProps = {
+        dragging: false,
+        draggedLessonPos: false,
+        delta: 0,
+        handleDragStart,
+        cloneLesson,
+        removeLesson,
+        lesson: defaultLesson,
+        lessonGroupPosition: 1
+      };
+    });
+
+    it('renders default props', () => {
+      const wrapper = shallow(<LessonToken {...defaultProps} />);
+      expect(wrapper.find('Motion').length).to.equal(1);
+    });
   });
 
-  it('renders default props', () => {
-    let wrapper = mount(<LessonToken {...defaultProps} />);
-    expect(wrapper.find('Motion').length).to.equal(1);
-    expect(wrapper.contains('Lesson 1')).to.be.true;
-    expect(wrapper.find('i').length).to.equal(4);
-    expect(wrapper.find('.fa-pencil').length).to.equal(1);
-    expect(wrapper.find('.fa-clone').length).to.equal(1);
-    expect(wrapper.contains('assessment')).to.be.true;
-  });
+  describe('LessonTokenContents', () => {
+    beforeEach(() => {
+      handleDragStart = sinon.spy();
+      cloneLesson = sinon.spy();
+      removeLesson = sinon.spy();
+      defaultProps = {
+        y: 0,
+        scale: 0,
+        shadow: 0,
+        draggedLessonPos: false,
+        handleDragStart,
+        cloneLesson,
+        removeLesson,
+        lesson: defaultLesson,
+        lessonGroupPosition: 1
+      };
+    });
 
-  it('renders newly added lesson without edit button', () => {
-    let wrapper = mount(
-      <LessonToken
-        {...defaultProps}
-        lesson={{
-          key: 'new-lesson',
-          name: 'New Lesson',
-          levels: [],
-          position: 1
-        }}
-      />
-    );
-    expect(wrapper.find('Motion').length).to.equal(1);
-    expect(wrapper.contains('New Lesson')).to.be.true;
-    expect(wrapper.find('i').length).to.equal(2);
-    expect(wrapper.find('.fa-pencil').length).to.equal(0);
-    expect(wrapper.find('.fa-clone').length).to.equal(0);
+    it('renders default props', () => {
+      const wrapper = shallow(<LessonTokenContents {...defaultProps} />);
+      expect(wrapper.contains('Lesson 1')).to.be.true;
+      expect(wrapper.find('.fa-pencil').length).to.equal(1);
+      expect(wrapper.find('.fa-clone').length).to.equal(1);
+      expect(wrapper.contains('assessment')).to.be.true;
+    });
+
+    it('renders newly added lesson without edit button', () => {
+      let wrapper = shallow(
+        <LessonTokenContents
+          {...defaultProps}
+          lesson={{
+            key: 'new-lesson',
+            name: 'New Lesson',
+            levels: [],
+            position: 1
+          }}
+        />
+      );
+      expect(wrapper.contains('New Lesson'), 'New Lesson').to.be.true;
+      expect(wrapper.find('.fa-pencil').length, 'fa-pencil').to.equal(0);
+      expect(wrapper.find('.fa-clone').length, 'fa-clone').to.equal(0);
+    });
   });
 });

--- a/apps/test/unit/lib/levelbuilder/script-editor/LessonTokenTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/LessonTokenTest.jsx
@@ -34,8 +34,7 @@ describe('LessonToken', () => {
         handleDragStart,
         cloneLesson,
         removeLesson,
-        lesson: defaultLesson,
-        lessonGroupPosition: 1
+        lesson: defaultLesson
       };
     });
 
@@ -58,8 +57,7 @@ describe('LessonToken', () => {
         handleDragStart,
         cloneLesson,
         removeLesson,
-        lesson: defaultLesson,
-        lessonGroupPosition: 1
+        lesson: defaultLesson
       };
     });
 


### PR DESCRIPTION
The goal of this PR is to eliminate the use of `mount` in a unit test, replacing it with `shallow`. In this case, the strategy is to extract a subcomponent. See [react testing practical guide](https://docs.google.com/document/d/1cLcTvqh-F65IhEMlI6wVEQVDImUwoKhYhEv_O71EML8/edit) for context.