### PR TITLE
Revert "preserve level variants when saving script editor"

### DIFF
--- a/apps/src/lib/levelbuilder/script-editor/scriptEditorRedux.js
+++ b/apps/src/lib/levelbuilder/script-editor/scriptEditorRedux.js
@@ -360,16 +360,7 @@ const serializeLesson = (lesson, levelKeyList) => {
   s.push(t);
   if (lesson.levels) {
     lesson.levels.forEach(level => {
-      if (level.ids.length > 1) {
-        s.push('variants');
-        level.ids.forEach(id => {
-          const active = id === level.activeId;
-          s.push(`  ${serializeLevel(levelKeyList, id, level, active)}`);
-        });
-        s.push('endvariants');
-      } else {
-        s.push(serializeLevel(levelKeyList, level.ids[0], level));
-      }
+      s = s.concat(serializeLevel(levelKeyList, level.ids[0], level));
     });
   }
   s.push('');
@@ -387,7 +378,7 @@ const serializeLesson = (lesson, levelKeyList) => {
  * @param level
  * @return {string}
  */
-const serializeLevel = (levelKeyList, id, level, active = true) => {
+const serializeLevel = (levelKeyList, id, level) => {
   const s = [];
   const key = levelKeyList[id];
   if (/^blockly:/.test(key)) {
@@ -407,9 +398,6 @@ const serializeLevel = (levelKeyList, id, level, active = true) => {
     }
   }
   let l = level.bonus ? `bonus '${escape(key)}'` : `level '${escape(key)}'`;
-  if (!active) {
-    l += ', active: false';
-  }
   if (level.progression) {
     l += `, progression: '${escape(level.progression)}'`;
   }

--- a/apps/test/unit/code-studio/scriptEditorReduxTest.js
+++ b/apps/test/unit/code-studio/scriptEditorReduxTest.js
@@ -14,11 +14,7 @@ import reducers, {
 import _ from 'lodash';
 
 const getInitialState = () => ({
-  levelKeyList: {
-    2001: 'Level One',
-    2002: 'Level Two',
-    2003: 'Level Three'
-  },
+  levelKeyList: {},
   lessonGroups: [
     {
       id: 1,
@@ -34,20 +30,7 @@ const getInitialState = () => ({
           name: 'A',
           position: 1,
           unplugged: true,
-          levels: [
-            {
-              activeId: '2001',
-              ids: ['2001'],
-              kind: 'puzzle',
-              position: 1
-            },
-            {
-              activeId: '2002',
-              ids: ['2002'],
-              kind: 'puzzle',
-              position: 2
-            }
-          ],
+          levels: [],
           hasLessonPlan: true
         },
         {
@@ -121,9 +104,7 @@ describe('scriptEditorRedux reducer tests', () => {
       expect(serializedLessonGroups).to.equal(
         "lesson_group 'lg-key', display_name: 'Display Name'\n" +
           "lesson_group_description 'My Description'\n" +
-          "lesson 'a', display_name: 'A', has_lesson_plan: true, unplugged: true\n" +
-          "level 'Level One'\n" +
-          "level 'Level Two'\n\n" +
+          "lesson 'a', display_name: 'A', has_lesson_plan: true, unplugged: true\n\n" +
           "lesson 'b', display_name: 'B', has_lesson_plan: false\n\n" +
           "lesson 'c', display_name: 'C', has_lesson_plan: true\n\n" +
           "lesson_group 'lg-key-2', display_name: 'Display Name 2'\n" +
@@ -144,36 +125,7 @@ describe('scriptEditorRedux reducer tests', () => {
       expect(serializedLessonGroups).to.equal(
         "lesson_group 'lg-key', display_name: 'Display Name'\n" +
           "lesson_group_description 'a\\'b\\'c\\'d'\n" +
-          "lesson 'a', display_name: 'A', has_lesson_plan: true, unplugged: true\n" +
-          "level 'Level One'\n" +
-          "level 'Level Two'\n\n" +
-          "lesson 'b', display_name: 'B', has_lesson_plan: false\n\n" +
-          "lesson 'c', display_name: 'C', has_lesson_plan: true\n\n" +
-          "lesson_group 'lg-key-2', display_name: 'Display Name 2'\n" +
-          "lesson 'd', display_name: 'D', has_lesson_plan: true\n\n" +
-          "lesson 'e', display_name: 'E', has_lesson_plan: true\n\n" +
-          "lesson 'f', display_name: 'F', has_lesson_plan: false\n\n"
-      );
-    });
-
-    it('serializes lessons containing level variants', () => {
-      const scriptLevel = initialState.lessonGroups[0].lessons[0].levels[1];
-      scriptLevel.ids = ['2002', '2003'];
-      scriptLevel.activeId = '2003';
-      let serializedLessonGroups = getSerializedLessonGroups(
-        initialState.lessonGroups,
-        initialState.levelKeyList
-      );
-
-      expect(serializedLessonGroups).to.equal(
-        "lesson_group 'lg-key', display_name: 'Display Name'\n" +
-          "lesson_group_description 'My Description'\n" +
-          "lesson 'a', display_name: 'A', has_lesson_plan: true, unplugged: true\n" +
-          "level 'Level One'\n" +
-          'variants\n' +
-          "  level 'Level Two', active: false\n" +
-          "  level 'Level Three'\n" +
-          'endvariants\n\n' +
+          "lesson 'a', display_name: 'A', has_lesson_plan: true, unplugged: true\n\n" +
           "lesson 'b', display_name: 'B', has_lesson_plan: false\n\n" +
           "lesson 'c', display_name: 'C', has_lesson_plan: true\n\n" +
           "lesson_group 'lg-key-2', display_name: 'Display Name 2'\n" +
@@ -191,7 +143,7 @@ describe('scriptEditorRedux reducer tests', () => {
 
     expect(mappedLessonGroups.length).to.equal(2);
     expect(mappedLessonGroups[0].lessons.length).to.equal(3);
-    expect(mappedLessonGroups[0].lessons[0].levels.length).to.equal(2);
+    expect(mappedLessonGroups[0].lessons[0].levels.length).to.equal(0);
   });
 
   it('add group', () => {


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#40807, since it broke editing of 2021 CSF scripts.

repro steps:
1. go to  https://levelbuilder-studio.code.org/s/coursed-2021/edit 
2. press "save and keep editing"

EXPECTED: save succeeds
ACTUAL: warning dialog: 
![Screen Shot 2021-06-01 at 10 41 08 AM](https://user-images.githubusercontent.com/8001765/120371684-01d7c680-c2cb-11eb-8d55-d33c76d708d0.png)

if you click ok, the following error appears:
![Screen Shot 2021-06-01 at 11 17 04 AM](https://user-images.githubusercontent.com/8001765/120371622-ecfb3300-c2ca-11eb-922e-6bc76ac55764.png)

I haven't diagnosed the exact cause yet, but want to revert quickly to fix script editing on levelbuilder.

## Testing story

verified locally that reverting this PR restores the expected behavior.