### PR TITLE
Restore "preserve level variants when saving script editor"

### DIFF
--- a/apps/src/lib/levelbuilder/script-editor/scriptEditorRedux.js
+++ b/apps/src/lib/levelbuilder/script-editor/scriptEditorRedux.js
@@ -360,7 +360,16 @@ const serializeLesson = (lesson, levelKeyList) => {
   s.push(t);
   if (lesson.levels) {
     lesson.levels.forEach(level => {
-      s = s.concat(serializeLevel(levelKeyList, level.ids[0], level));
+      if (level.ids.length > 1) {
+        s.push('variants');
+        level.ids.forEach(id => {
+          const active = id === level.activeId;
+          s.push(`  ${serializeLevel(levelKeyList, id, level, active)}`);
+        });
+        s.push('endvariants');
+      } else {
+        s.push(serializeLevel(levelKeyList, level.ids[0], level));
+      }
     });
   }
   s.push('');
@@ -378,7 +387,7 @@ const serializeLesson = (lesson, levelKeyList) => {
  * @param level
  * @return {string}
  */
-const serializeLevel = (levelKeyList, id, level) => {
+const serializeLevel = (levelKeyList, id, level, active = true) => {
   const s = [];
   const key = levelKeyList[id];
   if (/^blockly:/.test(key)) {
@@ -398,6 +407,9 @@ const serializeLevel = (levelKeyList, id, level) => {
     }
   }
   let l = level.bonus ? `bonus '${escape(key)}'` : `level '${escape(key)}'`;
+  if (!active) {
+    l += ', active: false';
+  }
   if (level.progression) {
     l += `, progression: '${escape(level.progression)}'`;
   }

--- a/apps/src/lib/levelbuilder/script-editor/scriptEditorRedux.js
+++ b/apps/src/lib/levelbuilder/script-editor/scriptEditorRedux.js
@@ -364,11 +364,12 @@ const serializeLesson = (lesson, levelKeyList) => {
         s.push('variants');
         level.ids.forEach(id => {
           const active = id === level.activeId;
-          s.push(`  ${serializeLevel(levelKeyList, id, level, active)}`);
+          const lines = serializeLevel(levelKeyList, id, level, active);
+          s = s.concat(lines.map(line => `  ${line}`));
         });
         s.push('endvariants');
       } else {
-        s.push(serializeLevel(levelKeyList, level.ids[0], level));
+        s = s.concat(serializeLevel(levelKeyList, level.ids[0], level));
       }
     });
   }
@@ -385,7 +386,7 @@ const serializeLesson = (lesson, levelKeyList) => {
  * to move on to our future system.
  * @param id
  * @param level
- * @return {string}
+ * @return {Array.<string>}
  */
 const serializeLevel = (levelKeyList, id, level, active = true) => {
   const s = [];

--- a/apps/test/unit/code-studio/scriptEditorReduxTest.js
+++ b/apps/test/unit/code-studio/scriptEditorReduxTest.js
@@ -17,7 +17,8 @@ const getInitialState = () => ({
   levelKeyList: {
     2001: 'Level One',
     2002: 'Level Two',
-    2003: 'Level Three'
+    2003: 'Level Three',
+    2004: 'blockly:Maze:2_3'
   },
   lessonGroups: [
     {
@@ -174,6 +175,42 @@ describe('scriptEditorRedux reducer tests', () => {
           "  level 'Level Two', active: false\n" +
           "  level 'Level Three'\n" +
           'endvariants\n\n' +
+          "lesson 'b', display_name: 'B', has_lesson_plan: false\n\n" +
+          "lesson 'c', display_name: 'C', has_lesson_plan: true\n\n" +
+          "lesson_group 'lg-key-2', display_name: 'Display Name 2'\n" +
+          "lesson 'd', display_name: 'D', has_lesson_plan: true\n\n" +
+          "lesson 'e', display_name: 'E', has_lesson_plan: true\n\n" +
+          "lesson 'f', display_name: 'F', has_lesson_plan: false\n\n"
+      );
+    });
+
+    it('serializes legacy level settings', () => {
+      const scriptLevel = {
+        activeId: '2004',
+        ids: ['2004'],
+        kind: 'puzzle',
+        position: 3,
+        skin: 'birds',
+        concepts: "'sequence'",
+        conceptDifficulty: '{"sequencing":2}'
+      };
+      initialState.lessonGroups[0].lessons[0].levels.push(scriptLevel);
+
+      let serializedLessonGroups = getSerializedLessonGroups(
+        initialState.lessonGroups,
+        initialState.levelKeyList
+      );
+
+      expect(serializedLessonGroups).to.equal(
+        "lesson_group 'lg-key', display_name: 'Display Name'\n" +
+          "lesson_group_description 'My Description'\n" +
+          "lesson 'a', display_name: 'A', has_lesson_plan: true, unplugged: true\n" +
+          "level 'Level One'\n" +
+          "level 'Level Two'\n" +
+          "skin 'birds'\n" +
+          "concepts 'sequence'\n" +
+          'level_concept_difficulty \'{"sequencing":2}\'\n' +
+          "level 'blockly:Maze:2_3'\n\n" +
           "lesson 'b', display_name: 'B', has_lesson_plan: false\n\n" +
           "lesson 'c', display_name: 'C', has_lesson_plan: true\n\n" +
           "lesson_group 'lg-key-2', display_name: 'Display Name 2'\n" +

--- a/apps/test/unit/code-studio/scriptEditorReduxTest.js
+++ b/apps/test/unit/code-studio/scriptEditorReduxTest.js
@@ -14,7 +14,11 @@ import reducers, {
 import _ from 'lodash';
 
 const getInitialState = () => ({
-  levelKeyList: {},
+  levelKeyList: {
+    2001: 'Level One',
+    2002: 'Level Two',
+    2003: 'Level Three'
+  },
   lessonGroups: [
     {
       id: 1,
@@ -30,7 +34,20 @@ const getInitialState = () => ({
           name: 'A',
           position: 1,
           unplugged: true,
-          levels: [],
+          levels: [
+            {
+              activeId: '2001',
+              ids: ['2001'],
+              kind: 'puzzle',
+              position: 1
+            },
+            {
+              activeId: '2002',
+              ids: ['2002'],
+              kind: 'puzzle',
+              position: 2
+            }
+          ],
           hasLessonPlan: true
         },
         {
@@ -104,7 +121,9 @@ describe('scriptEditorRedux reducer tests', () => {
       expect(serializedLessonGroups).to.equal(
         "lesson_group 'lg-key', display_name: 'Display Name'\n" +
           "lesson_group_description 'My Description'\n" +
-          "lesson 'a', display_name: 'A', has_lesson_plan: true, unplugged: true\n\n" +
+          "lesson 'a', display_name: 'A', has_lesson_plan: true, unplugged: true\n" +
+          "level 'Level One'\n" +
+          "level 'Level Two'\n\n" +
           "lesson 'b', display_name: 'B', has_lesson_plan: false\n\n" +
           "lesson 'c', display_name: 'C', has_lesson_plan: true\n\n" +
           "lesson_group 'lg-key-2', display_name: 'Display Name 2'\n" +
@@ -125,7 +144,36 @@ describe('scriptEditorRedux reducer tests', () => {
       expect(serializedLessonGroups).to.equal(
         "lesson_group 'lg-key', display_name: 'Display Name'\n" +
           "lesson_group_description 'a\\'b\\'c\\'d'\n" +
-          "lesson 'a', display_name: 'A', has_lesson_plan: true, unplugged: true\n\n" +
+          "lesson 'a', display_name: 'A', has_lesson_plan: true, unplugged: true\n" +
+          "level 'Level One'\n" +
+          "level 'Level Two'\n\n" +
+          "lesson 'b', display_name: 'B', has_lesson_plan: false\n\n" +
+          "lesson 'c', display_name: 'C', has_lesson_plan: true\n\n" +
+          "lesson_group 'lg-key-2', display_name: 'Display Name 2'\n" +
+          "lesson 'd', display_name: 'D', has_lesson_plan: true\n\n" +
+          "lesson 'e', display_name: 'E', has_lesson_plan: true\n\n" +
+          "lesson 'f', display_name: 'F', has_lesson_plan: false\n\n"
+      );
+    });
+
+    it('serializes lessons containing level variants', () => {
+      const scriptLevel = initialState.lessonGroups[0].lessons[0].levels[1];
+      scriptLevel.ids = ['2002', '2003'];
+      scriptLevel.activeId = '2003';
+      let serializedLessonGroups = getSerializedLessonGroups(
+        initialState.lessonGroups,
+        initialState.levelKeyList
+      );
+
+      expect(serializedLessonGroups).to.equal(
+        "lesson_group 'lg-key', display_name: 'Display Name'\n" +
+          "lesson_group_description 'My Description'\n" +
+          "lesson 'a', display_name: 'A', has_lesson_plan: true, unplugged: true\n" +
+          "level 'Level One'\n" +
+          'variants\n' +
+          "  level 'Level Two', active: false\n" +
+          "  level 'Level Three'\n" +
+          'endvariants\n\n' +
           "lesson 'b', display_name: 'B', has_lesson_plan: false\n\n" +
           "lesson 'c', display_name: 'C', has_lesson_plan: true\n\n" +
           "lesson_group 'lg-key-2', display_name: 'Display Name 2'\n" +
@@ -143,7 +191,7 @@ describe('scriptEditorRedux reducer tests', () => {
 
     expect(mappedLessonGroups.length).to.equal(2);
     expect(mappedLessonGroups[0].lessons.length).to.equal(3);
-    expect(mappedLessonGroups[0].lessons[0].levels.length).to.equal(0);
+    expect(mappedLessonGroups[0].lessons[0].levels.length).to.equal(2);
   });
 
   it('add group', () => {


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#40868, restoring  #40807 . The problem was that I accidentally changed `.concat` to `.push`, because I thought the thing being passed in was a string rather than an array. 

## Testing story

* manually verified that courses A and D save properly now
* manually verified there were no changes to the stage dsl being sent to the server
* new unit test

The new unit test is a bit contrived, but will do the job of preventing a similar regression if this code changes again before it is removed.