### PR TITLE
[AiLab] Fixed spacing and text overflow issues in model card

### DIFF
--- a/apps/src/code-studio/components/ModelCard.jsx
+++ b/apps/src/code-studio/components/ModelCard.jsx
@@ -114,7 +114,7 @@ const styles = {
     borderColor: color.gray,
     marginBottom: 10,
     padding: 10,
-    overflowWrap: 'breakWord'
+    overflowWrap: 'break-word'
   },
   bold: {
     fontFamily: "'Gotham 7r', sans-serif"

--- a/apps/src/code-studio/components/ModelCard.jsx
+++ b/apps/src/code-studio/components/ModelCard.jsx
@@ -55,7 +55,7 @@ export default class ModelCard extends React.Component {
               <div style={styles.heading}>Summary</div>
               <p style={styles.details}>
                 Predict {metadata.label.id} based on{' '}
-                {selectedFeatures.join(',')} with {metadata.summaryStat?.stat}%
+                {selectedFeatures.join(', ')} with {metadata.summaryStat?.stat}%
                 accuracy.
               </p>
             </div>
@@ -113,7 +113,8 @@ const styles = {
     borderRadius: 5,
     borderColor: color.gray,
     marginBottom: 10,
-    padding: 10
+    padding: 10,
+    overflowWrap: 'breakWord'
   },
   bold: {
     fontFamily: "'Gotham 7r', sans-serif"


### PR DESCRIPTION
This PR addresses the following:
* There were no spaces between the feature names in the Summary section of the model card.
* The text overflowed past a subsection of the model card.

Before:
![Screen Shot 2021-06-01 at 1 44 28 PM](https://user-images.githubusercontent.com/40412372/120389071-cb0cab00-c2e0-11eb-8612-89e86bc1ecfc.png)

After:
![Screen Shot 2021-06-01 at 1 47 17 PM](https://user-images.githubusercontent.com/40412372/120389080-ce079b80-c2e0-11eb-97f4-0653c3645b29.png)

