### PR TITLE
Update mini view links from white to blue

### DIFF
--- a/apps/src/code-studio/components/progress/MiniView.jsx
+++ b/apps/src/code-studio/components/progress/MiniView.jsx
@@ -41,6 +41,7 @@ class MiniView extends React.Component {
     } else {
       body = (
         <div
+          className="mini-view"
           style={{
             ...(!hasGroups && !isSummaryView && styles.detailView),
             ...(hasGroups && styles.groupView)

--- a/apps/style/curriculum/levels.scss
+++ b/apps/style/curriculum/levels.scss
@@ -1,1 +1,15 @@
 @import "pdf_printing";
+
+.header-wrapper {
+  .header {
+    .mini-view {
+      a:link {
+       color: #0596CE;
+      }
+
+      a:visited {
+        color: #0596CE;
+      }
+    }
+  }
+}

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -188,6 +188,16 @@ img.video_thumbnail {
       padding: 4px 16px;
       margin-top: 0;
     }
+
+    .mini-view {
+      a:link {
+        color: $blue;
+      }
+
+      a:visited {
+        color: $blue;
+      }
+    }
   }
 
   .project_info {

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -188,16 +188,6 @@ img.video_thumbnail {
       padding: 4px 16px;
       margin-top: 0;
     }
-
-    .mini-view {
-      a:link {
-        color: $blue;
-      }
-
-      a:visited {
-        color: $blue;
-      }
-    }
   }
 
   .project_info {


### PR DESCRIPTION
The links in the lesson descriptions in the mini view were showing up as white. This fixes them to make them blue.

### Before

<img width="859" alt="Screen Shot 2021-06-01 at 5 42 32 PM" src="https://user-images.githubusercontent.com/208083/120393934-c1933b00-c300-11eb-85ae-6a2af0cf1e40.png">


### After 

<img width="805" alt="Screen Shot 2021-06-01 at 5 39 36 PM" src="https://user-images.githubusercontent.com/208083/120393832-97da1400-c300-11eb-95fc-3a43c03926e2.png">
