### PR TITLE
Extract LevelTokenContents component and add unit tests

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/LevelToken.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/LevelToken.jsx
@@ -29,6 +29,67 @@ class LevelToken extends Component {
     toggleExpand: PropTypes.func
   };
 
+  render() {
+    const {draggedLevelPos, scriptLevel} = this.props;
+    const springConfig = {stiffness: 1000, damping: 80};
+
+    return (
+      <Motion
+        style={
+          draggedLevelPos
+            ? {
+                y: this.props.dragging ? this.props.delta : 0,
+                scale: spring(1.02, springConfig),
+                shadow: spring(5, springConfig)
+              }
+            : {
+                y: this.props.dragging
+                  ? spring(this.props.delta, springConfig)
+                  : 0,
+                scale: 1,
+                shadow: 0
+              }
+        }
+        key={scriptLevel.position}
+      >
+        {// Use react-motion to interpolate the following values and create
+        // smooth transitions.
+        ({y, scale, shadow}) => (
+          <LevelTokenContents
+            y={y}
+            scale={scale}
+            shadow={shadow}
+            draggedLevelPos={draggedLevelPos}
+            scriptLevel={scriptLevel}
+            handleDragStart={this.props.handleDragStart}
+            toggleExpand={this.props.toggleExpand}
+            removeLevel={this.props.removeLevel}
+            activitySectionPosition={this.props.activitySectionPosition}
+            activityPosition={this.props.activityPosition}
+          />
+        )}
+      </Motion>
+    );
+  }
+}
+
+// This component renders an uneditable view of the script level object.
+// Editing of script level properties is controlled by LevelTokenDetails,
+// which expands or collapses by clicking this component.
+class LevelTokenContents extends Component {
+  static propTypes = {
+    y: PropTypes.number.isRequired,
+    scale: PropTypes.number.isRequired,
+    shadow: PropTypes.number.isRequired,
+    draggedLevelPos: PropTypes.bool,
+    scriptLevel: scriptLevelShape.isRequired,
+    handleDragStart: PropTypes.func.isRequired,
+    toggleExpand: PropTypes.func.isRequired,
+    removeLevel: PropTypes.func.isRequired,
+    activitySectionPosition: PropTypes.number.isRequired,
+    activityPosition: PropTypes.number.isRequired
+  };
+
   handleDragStart = e => {
     this.props.handleDragStart(this.props.scriptLevel.position, e);
   };
@@ -57,9 +118,7 @@ class LevelToken extends Component {
   };
 
   render() {
-    const {draggedLevelPos, scriptLevel} = this.props;
-    const springConfig = {stiffness: 1000, damping: 80};
-
+    const {scriptLevel} = this.props;
     const hasVariants = scriptLevel.levels.length > 1;
 
     const activeLevel = hasVariants
@@ -70,82 +129,60 @@ class LevelToken extends Component {
 
     const progressBubbleLevel = this.scriptLevelForProgressBubble(activeLevel);
     return (
-      <Motion
-        style={
-          draggedLevelPos
-            ? {
-                y: this.props.dragging ? this.props.delta : 0,
-                scale: spring(1.02, springConfig),
-                shadow: spring(5, springConfig)
-              }
-            : {
-                y: this.props.dragging
-                  ? spring(this.props.delta, springConfig)
-                  : 0,
-                scale: 1,
-                shadow: 0
-              }
-        }
-        key={scriptLevel.position}
+      <div
+        style={Object.assign({}, styles.levelToken, {
+          transform: `translate3d(0, ${this.props.y}px, 0) scale(${
+            this.props.scale
+          })`,
+          boxShadow: `${color.shadow} 0 ${this.props.shadow}px ${this.props
+            .shadow * 3}px`,
+          zIndex: this.props.draggedLevelPos ? 1000 : 500 - scriptLevel.position
+        })}
       >
-        {// Use react-motion to interpolate the following values and create
-        // smooth transitions.
-        ({y, scale, shadow}) => (
-          <div
-            style={Object.assign({}, styles.levelToken, {
-              transform: `translate3d(0, ${y}px, 0) scale(${scale})`,
-              boxShadow: `${color.shadow} 0 ${shadow}px ${shadow * 3}px`,
-              zIndex: draggedLevelPos ? 1000 : 500 - scriptLevel.position
-            })}
-          >
-            <div style={styles.reorder} onMouseDown={this.handleDragStart}>
-              <i className="fa fa-arrows-v" />
-            </div>
-            <span
-              style={styles.levelTokenName}
-              onClick={this.toggleExpand}
-              className="uitest-level-token-name"
-            >
-              <span style={styles.levelArea}>
-                <span style={styles.titleAndBubble}>
-                  <ProgressBubble
-                    hideToolTips={true}
-                    level={progressBubbleLevel}
-                    disabled={true}
-                  />
-                  <span style={styles.levelTitle}>{scriptLevel.key}</span>
-                </span>
-                {activeLevel.assessment && (
-                  <span style={styles.tag}>assessment</span>
-                )}
-                {activeLevel.bonus && <span style={styles.tag}>bonus</span>}
-                {activeLevel.challenge && (
-                  <span style={styles.tag}>challenge</span>
-                )}
-              </span>
-            </span>
-            <div
-              style={styles.edit}
-              onClick={() => {
-                const win = window.open(activeLevel.url, '_blank');
-                win.focus();
-              }}
-            >
-              <i className="fa fa-pencil" />
-            </div>
-            <div style={styles.remove} onMouseDown={this.handleRemove}>
-              <i className="fa fa-times" />
-            </div>
-            {scriptLevel.expand && (
-              <LevelTokenDetails
-                scriptLevel={scriptLevel}
-                activitySectionPosition={this.props.activitySectionPosition}
-                activityPosition={this.props.activityPosition}
+        <div style={styles.reorder} onMouseDown={this.handleDragStart}>
+          <i className="fa fa-arrows-v" />
+        </div>
+        <span
+          style={styles.levelTokenName}
+          onClick={this.toggleExpand}
+          className="uitest-level-token-name"
+        >
+          <span style={styles.levelArea}>
+            <span style={styles.titleAndBubble}>
+              <ProgressBubble
+                hideToolTips={true}
+                level={progressBubbleLevel}
+                disabled={true}
               />
+              <span style={styles.levelTitle}>{scriptLevel.key}</span>
+            </span>
+            {activeLevel.assessment && (
+              <span style={styles.tag}>assessment</span>
             )}
-          </div>
+            {activeLevel.bonus && <span style={styles.tag}>bonus</span>}
+            {activeLevel.challenge && <span style={styles.tag}>challenge</span>}
+          </span>
+        </span>
+        <div
+          style={styles.edit}
+          onClick={() => {
+            const win = window.open(activeLevel.url, '_blank');
+            win.focus();
+          }}
+        >
+          <i className="fa fa-pencil" />
+        </div>
+        <div style={styles.remove} onMouseDown={this.handleRemove}>
+          <i className="fa fa-times" />
+        </div>
+        {scriptLevel.expand && (
+          <LevelTokenDetails
+            scriptLevel={scriptLevel}
+            activitySectionPosition={this.props.activitySectionPosition}
+            activityPosition={this.props.activityPosition}
+          />
         )}
-      </Motion>
+      </div>
     );
   }
 }

--- a/apps/src/lib/levelbuilder/lesson-editor/LevelToken.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/LevelToken.jsx
@@ -166,7 +166,7 @@ export class LevelTokenContents extends Component {
         <div
           style={styles.edit}
           onClick={() => {
-            const win = window.open(activeLevel.url, '_blank');
+            const win = window.open(activeLevel.url, 'noopener', 'noreferrer');
             win.focus();
           }}
         >

--- a/apps/src/lib/levelbuilder/lesson-editor/LevelToken.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/LevelToken.jsx
@@ -14,7 +14,7 @@ import _ from 'lodash';
 /**
  * Component for editing puzzle dots with one or more level variants.
  */
-class LevelToken extends Component {
+export class UnconnectedLevelToken extends Component {
   static propTypes = {
     activitySectionPosition: PropTypes.number.isRequired,
     activityPosition: PropTypes.number.isRequired,
@@ -76,7 +76,7 @@ class LevelToken extends Component {
 // This component renders an uneditable view of the script level object.
 // Editing of script level properties is controlled by LevelTokenDetails,
 // which expands or collapses by clicking this component.
-class LevelTokenContents extends Component {
+export class LevelTokenContents extends Component {
   static propTypes = {
     y: PropTypes.number.isRequired,
     scale: PropTypes.number.isRequired,
@@ -261,9 +261,11 @@ const styles = {
   }
 };
 
-export default connect(
+export const LevelToken = connect(
   state => ({}),
   {
     toggleExpand
   }
-)(LevelToken);
+)(UnconnectedLevelToken);
+
+export default LevelToken;

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/ActivitySectionCardTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/ActivitySectionCardTest.jsx
@@ -107,7 +107,7 @@ describe('ActivitySectionCard', () => {
     expect(wrapper.find('Connect(ActivitySectionCardButtons)').length).to.equal(
       1
     );
-    expect(wrapper.find('Connect(LevelToken)').length).to.equal(2);
+    expect(wrapper.find('Connect(UnconnectedLevelToken)').length).to.equal(2);
     expect(wrapper.find('textarea').length).to.equal(1);
     expect(wrapper.find('OrderControls').length).to.equal(1);
     expect(wrapper.contains('Progression Title:')).to.be.true;
@@ -124,7 +124,7 @@ describe('ActivitySectionCard', () => {
     expect(wrapper.find('Connect(ActivitySectionCardButtons)').length).to.equal(
       1
     );
-    expect(wrapper.find('Connect(LevelToken)').length).to.equal(2);
+    expect(wrapper.find('Connect(UnconnectedLevelToken)').length).to.equal(2);
     expect(wrapper.find('textarea').length).to.equal(0);
     expect(wrapper.find('OrderControls').length).to.equal(1);
     expect(wrapper.contains('Progression Title:')).to.be.true;

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/AddLevelDialogTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/AddLevelDialogTest.jsx
@@ -25,7 +25,7 @@ describe('AddLevelDialog', () => {
     expect(wrapper.contains('Add Levels')).to.be.true;
     expect(wrapper.find('LessonEditorDialog').length).to.equal(1);
     expect(wrapper.find('Connect(AddLevelDialogTop)').length).to.equal(1);
-    expect(wrapper.find('Connect(LevelToken)').length).to.equal(2);
+    expect(wrapper.find('Connect(UnconnectedLevelToken)').length).to.equal(2);
     expect(wrapper.find('FontAwesome').length).to.equal(0); // no spinner
   });
 });

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/LevelTokenTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/LevelTokenTest.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import {expect} from '../../../../util/reconfiguredChai';
+import sinon from 'sinon';
+import {UnconnectedLevelToken as LevelToken} from '@cdo/apps/lib/levelbuilder/lesson-editor/LevelToken';
+
+const defaultScriptLevel = {
+  id: '11',
+  position: 1,
+  activeId: '2001',
+  levels: [],
+  kind: 'puzzle'
+};
+
+describe('LevelToken', () => {
+  let handleDragStart, removeLevel, toggleExpand, defaultProps;
+
+  beforeEach(() => {
+    handleDragStart = sinon.spy();
+    removeLevel = sinon.spy();
+    toggleExpand = sinon.spy();
+    defaultProps = {
+      activitySectionPosition: 1,
+      activityPosition: 1,
+      scriptLevel: defaultScriptLevel,
+      dragging: false,
+      delta: 0,
+      handleDragStart,
+      removeLevel,
+      toggleExpand
+    };
+  });
+
+  it('renders a Motion component', () => {
+    const wrapper = shallow(<LevelToken {...defaultProps} />);
+    expect(wrapper.find('Motion').length).to.equal(1);
+  });
+});

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/LevelTokenTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/LevelTokenTest.js
@@ -2,13 +2,22 @@ import React from 'react';
 import {shallow} from 'enzyme';
 import {expect} from '../../../../util/reconfiguredChai';
 import sinon from 'sinon';
-import {UnconnectedLevelToken as LevelToken} from '@cdo/apps/lib/levelbuilder/lesson-editor/LevelToken';
+import {
+  UnconnectedLevelToken as LevelToken,
+  LevelTokenContents
+} from '@cdo/apps/lib/levelbuilder/lesson-editor/LevelToken';
 
 const defaultScriptLevel = {
   id: '11',
   position: 1,
   activeId: '2001',
-  levels: [],
+  levels: [
+    {
+      id: '11',
+      name: 'My Level',
+      url: '/path/to/edit/url'
+    }
+  ],
   kind: 'puzzle'
 };
 
@@ -34,5 +43,31 @@ describe('LevelToken', () => {
   it('renders a Motion component', () => {
     const wrapper = shallow(<LevelToken {...defaultProps} />);
     expect(wrapper.find('Motion').length).to.equal(1);
+  });
+});
+
+describe('LevelTokenContents', () => {
+  let handleDragStart, removeLevel, toggleExpand, defaultProps;
+
+  beforeEach(() => {
+    handleDragStart = sinon.spy();
+    removeLevel = sinon.spy();
+    toggleExpand = sinon.spy();
+    defaultProps = {
+      y: 0,
+      scale: 0,
+      shadow: 0,
+      activitySectionPosition: 1,
+      activityPosition: 1,
+      scriptLevel: defaultScriptLevel,
+      handleDragStart,
+      removeLevel,
+      toggleExpand
+    };
+  });
+
+  it('renders a ProgressBubble', () => {
+    const wrapper = shallow(<LevelTokenContents {...defaultProps} />);
+    expect(wrapper.find('ProgressBubble').length).to.equal(1);
   });
 });

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/LevelTokenTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/LevelTokenTest.js
@@ -57,8 +57,8 @@ describe('LevelTokenContents', () => {
       y: 0,
       scale: 0,
       shadow: 0,
-      activitySectionPosition: 1,
-      activityPosition: 1,
+      activitySectionPosition: 2,
+      activityPosition: 3,
       scriptLevel: defaultScriptLevel,
       handleDragStart,
       removeLevel,
@@ -69,5 +69,21 @@ describe('LevelTokenContents', () => {
   it('renders a ProgressBubble', () => {
     const wrapper = shallow(<LevelTokenContents {...defaultProps} />);
     expect(wrapper.find('ProgressBubble').length).to.equal(1);
+  });
+
+  it('calls toggleExpand when level name is clicked', () => {
+    const wrapper = shallow(<LevelTokenContents {...defaultProps} />);
+    expect(wrapper.find('LevelTokenDetails').length).to.equal(0);
+    expect(toggleExpand).not.to.have.been.called;
+    const nameWrapper = wrapper.find('.uitest-level-token-name');
+    nameWrapper.simulate('click');
+    expect(toggleExpand).to.have.been.calledWith(3, 2, 1);
+  });
+
+  it('shows LevelTokenDetails when expanded', () => {
+    defaultProps.scriptLevel.expand = true;
+    const wrapper = shallow(<LevelTokenContents {...defaultProps} />);
+    console.log(wrapper.debug());
+    expect(wrapper.find('Connect(LevelTokenDetails)').length).to.equal(1);
   });
 });


### PR DESCRIPTION
Before making some changes to LevelToken, I wanted to add some tests. Before Adding some tests, I wanted to extract a subcomponent so that the unit tests can use shallow rendering. This PR is very similar to https://github.com/code-dot-org/code-dot-org/pull/40866 . 

## Testing story

New Unit tests. Also manually verified the various controls on the level token are still working.