### PR TITLE
Switched coordinates so 0,0 is in the top left

### DIFF
--- a/apps/src/javalab/Neighborhood.js
+++ b/apps/src/javalab/Neighborhood.js
@@ -84,7 +84,7 @@ export default class Neighborhood {
         return this.controller.addPegman(
           id,
           parseInt(x),
-          this.convertYCoordinate(parseInt(y)),
+          parseInt(y),
           Direction[direction.toUpperCase()]
         );
       }
@@ -125,13 +125,5 @@ export default class Neighborhood {
     // The slider goes from 0 to 1. We scale the speed slider value to be between -1 and 1 and
     // return 2 to the power of that scaled value to get a multiplier between 0.5 and 2.
     return Math.pow(2, -2 * this.speedSlider.getValue() + 1);
-  }
-
-  // Convert y-coordinate from Neighborhood format to Maze format.
-  // In neighborhood (0,0) is the bottom-left grid square, in Maze
-  // it is the top left.
-  convertYCoordinate(y) {
-    // if we have 8 rows, y = 0 -> y = 7, y = 1 -> y = 6, and so on
-    return this.numRows - 1 - y;
   }
 }


### PR DESCRIPTION
Originally, we wanted to set up Neighborhood with the origin in the bottom left. However, since we are planning to support pixel operations on the curriculum units following Neighborhood, we'll want to use origin in the top left for consistency. This updates the coordinates.

This pairs with a similar change in the Javabuilder repo: https://github.com/code-dot-org/javabuilder/pull/48

![originTopLeft](https://user-images.githubusercontent.com/8324574/120408247-7e869700-c303-11eb-967d-129b08c841fd.gif)


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->


- spec: [Slack discussion](https://codedotorg.slack.com/archives/C01EF4GJ9GE/p1622146181166200)
- jira ticket: [CSA-407](https://codedotorg.atlassian.net/browse/CSA-407)


## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
