### PR TITLE
Update programming expression display in lesson plan to use syntax

### DIFF
--- a/apps/src/templates/courseRollupPages/CourseRollup.story.jsx
+++ b/apps/src/templates/courseRollupPages/CourseRollup.story.jsx
@@ -27,6 +27,7 @@ const defaultProps = {
             ],
             programmingExpressions: [
               {
+                syntax: 'playSound',
                 name: 'playSound',
                 link: 'studio.code.org/docs/applab/playSound'
               }
@@ -78,6 +79,7 @@ const defaultProps = {
             ],
             programmingExpressions: [
               {
+                syntax: 'playSound',
                 name: 'playSound',
                 link: 'studio.code.org/docs/applab/playSound'
               }
@@ -147,6 +149,7 @@ const defaultProps = {
             ],
             programmingExpressions: [
               {
+                syntax: 'playSound',
                 name: 'playSound',
                 link: 'studio.code.org/docs/applab/playSound'
               }

--- a/apps/src/templates/lessonOverview/StyledCodeBlock.jsx
+++ b/apps/src/templates/lessonOverview/StyledCodeBlock.jsx
@@ -5,14 +5,7 @@ import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 export const buildProgrammingExpressionMarkdown = function(
   programmingExpression
 ) {
-  let block = `\`${programmingExpression.name}`;
-  if (
-    programmingExpression.parameters &&
-    programmingExpression.parameters.length > 0
-  ) {
-    block += `(${programmingExpression.parameters.join(', ')})`;
-  }
-  block += `\``;
+  let block = `\`${programmingExpression.syntax}\``;
   if (programmingExpression.color) {
     block += `(${programmingExpression.color})`;
   }
@@ -23,7 +16,7 @@ export default class StyledCodeBlock extends Component {
   static propTypes = {
     programmingExpression: PropTypes.shape({
       color: PropTypes.string,
-      name: PropTypes.string.isRequired,
+      syntax: PropTypes.string.isRequired,
       link: PropTypes.string,
       parameters: PropTypes.array
     }).isRequired

--- a/apps/test/unit/templates/courseRollupPages/rollupTestData.jsx
+++ b/apps/test/unit/templates/courseRollupPages/rollupTestData.jsx
@@ -22,6 +22,7 @@ export const courseData = {
           programmingExpressions: [
             {
               name: 'playSound',
+              syntax: 'playSound',
               link: 'studio.code.org/docs/applab/playSound'
             }
           ],
@@ -73,6 +74,7 @@ export const courseData = {
           programmingExpressions: [
             {
               name: 'playSound',
+              syntax: 'playSound',
               link: 'studio.code.org/docs/applab/playSound'
             }
           ],
@@ -142,6 +144,7 @@ export const courseData = {
           programmingExpressions: [
             {
               name: 'playSound',
+              syntax: 'playSound',
               link: 'studio.code.org/docs/applab/playSound'
             }
           ],

--- a/apps/test/unit/templates/lessonOverview/LessonOverviewTest.js
+++ b/apps/test/unit/templates/lessonOverview/LessonOverviewTest.js
@@ -84,6 +84,7 @@ describe('LessonOverview', () => {
         programmingExpressions: [
           {
             name: 'playSound',
+            syntax: 'playSound',
             link: '/docs/applab/playSound'
           }
         ],

--- a/apps/test/unit/templates/lessonOverview/StudentLessonOverviewTest.jsx
+++ b/apps/test/unit/templates/lessonOverview/StudentLessonOverviewTest.jsx
@@ -72,6 +72,7 @@ describe('StudentLessonOverview', () => {
         programmingExpressions: [
           {
             name: 'playSound',
+            syntax: 'playSound',
             link: '/docs/applab/playSound'
           }
         ],

--- a/apps/test/unit/templates/lessonOverview/StyledCodeBlockTest.jsx
+++ b/apps/test/unit/templates/lessonOverview/StyledCodeBlockTest.jsx
@@ -11,29 +11,18 @@ describe('StyledCodeBlock', () => {
       const input = {
         color: '#c0ffee',
         link: 'https://example.com',
-        name: 'test block'
+        syntax: 'test_block(x,y)'
       };
-      const expected = '[`test block`(#c0ffee)](https://example.com)';
-      expect(buildProgrammingExpressionMarkdown(input)).to.equal(expected);
-    });
-
-    it('builds a full visual code block markdown expression with parameters', () => {
-      const input = {
-        color: '#c0ffee',
-        link: 'https://example.com',
-        name: 'test block',
-        parameters: ['x', 'y']
-      };
-      const expected = '[`test block(x, y)`(#c0ffee)](https://example.com)';
+      const expected = '[`test_block(x,y)`(#c0ffee)](https://example.com)';
       expect(buildProgrammingExpressionMarkdown(input)).to.equal(expected);
     });
 
     it('builds a regular code block when not given a color', () => {
       const input = {
         link: 'https://example.com',
-        name: 'test block'
+        syntax: 'test_block(x,y)'
       };
-      const expected = '[`test block`](https://example.com)';
+      const expected = '[`test_block(x,y)`](https://example.com)';
       expect(buildProgrammingExpressionMarkdown(input)).to.equal(expected);
     });
   });
@@ -42,7 +31,7 @@ describe('StyledCodeBlock', () => {
     const wrapper = shallow(
       <StyledCodeBlock
         programmingExpression={{
-          name: 'playSound',
+          syntax: 'playSound',
           color: '#000000',
           link: '/docs/applab/playSound'
         }}
@@ -58,7 +47,7 @@ describe('StyledCodeBlock', () => {
     const wrapper = shallow(
       <StyledCodeBlock
         programmingExpression={{
-          name: 'playSound',
+          syntax: 'playSound',
           color: null,
           link: '/docs/applab/playSound'
         }}

--- a/dashboard/app/models/programming_expression.rb
+++ b/dashboard/app/models/programming_expression.rb
@@ -66,6 +66,8 @@ class ProgrammingExpression < ApplicationRecord
       syntax += `(#{config['paletteParams'].join(', ')})`
     elsif config['block']
       syntax = config['block']
+    elsif config['syntax']
+      syntax = config['syntax']
     end
 
     syntax

--- a/dashboard/app/models/programming_expression.rb
+++ b/dashboard/app/models/programming_expression.rb
@@ -45,7 +45,8 @@ class ProgrammingExpression < ApplicationRecord
         name: expression_config['config']['func'] || expression_config['config']['name'],
         programming_environment_id: programming_environment.id,
         category: expression_config['category'],
-        color: expression_config['config']['color']
+        color: expression_config['config']['color'],
+        syntax: expression_config['config']['func'] || expression_config['config']['name']
       }
     else
       {

--- a/dashboard/app/models/programming_expression.rb
+++ b/dashboard/app/models/programming_expression.rb
@@ -62,12 +62,12 @@ class ProgrammingExpression < ApplicationRecord
 
   def self.get_syntax(config)
     syntax = config['func']
-    if config['paletteParams']
+    if config['syntax']
+      syntax = config['syntax']
+    elsif config['paletteParams']
       syntax = config['func'] + "(" + config['paletteParams'].join(', ') + ")"
     elsif config['block']
       syntax = config['block']
-    elsif config['syntax']
-      syntax = config['syntax']
     end
 
     syntax

--- a/dashboard/app/models/programming_expression.rb
+++ b/dashboard/app/models/programming_expression.rb
@@ -28,7 +28,7 @@ class ProgrammingExpression < ApplicationRecord
 
   serialized_attrs %w(
     color
-    parameters
+    syntax
   )
 
   def self.properties_from_file(path, content)
@@ -36,6 +36,8 @@ class ProgrammingExpression < ApplicationRecord
 
     environment_name = File.basename(File.dirname(path)) == 'GamelabJr' ? 'spritelab' : File.basename(File.dirname(path))
     programming_environment = ProgrammingEnvironment.find_by(name: environment_name)
+
+    syntax = ProgrammingExpression.get_syntax(expression_config)
 
     if environment_name == 'spritelab'
       {
@@ -52,9 +54,21 @@ class ProgrammingExpression < ApplicationRecord
         programming_environment_id: programming_environment.id,
         category: expression_config['category'],
         color: ProgrammingExpression.get_category_color(expression_config['category']),
-        parameters: expression_config['paletteParams']
+        syntax: syntax
       }
     end
+  end
+
+  def self.get_syntax(config)
+    syntax = config['func']
+    if config['paletteParams']
+      puts
+      syntax += `(#{config['paletteParams'].join(', ')})`
+    elsif config['block']
+      syntax = config['block']
+    end
+
+    syntax
   end
 
   def self.get_category_color(category)
@@ -137,6 +151,6 @@ class ProgrammingExpression < ApplicationRecord
   end
 
   def summarize_for_lesson_show
-    {name: name, color: color, parameters: parameters, link: documentation_path}
+    {name: name, color: color, syntax: syntax, link: documentation_path}
   end
 end

--- a/dashboard/app/models/programming_expression.rb
+++ b/dashboard/app/models/programming_expression.rb
@@ -62,8 +62,7 @@ class ProgrammingExpression < ApplicationRecord
   def self.get_syntax(config)
     syntax = config['func']
     if config['paletteParams']
-      puts
-      syntax += `(#{config['paletteParams'].join(', ')})`
+      syntax = config['func'] + "(" + config['paletteParams'].join(', ') + ")"
     elsif config['block']
       syntax = config['block']
     elsif config['syntax']

--- a/dashboard/config/programming_expressions/weblab/a.json
+++ b/dashboard/config/programming_expressions/weblab/a.json
@@ -1,4 +1,5 @@
 {
   "func": "A",
-  "category": "HTML Tags"
+  "category": "HTML Tags",
+  "syntax": "<a></a>"
 }

--- a/dashboard/config/programming_expressions/weblab/backgroundColor.json
+++ b/dashboard/config/programming_expressions/weblab/backgroundColor.json
@@ -1,4 +1,5 @@
 {
   "func": "background-color",
-  "category": "CSS Properties"
+  "category": "CSS Properties",
+  "syntax": "background-color: value;"
 }

--- a/dashboard/config/programming_expressions/weblab/body.json
+++ b/dashboard/config/programming_expressions/weblab/body.json
@@ -1,4 +1,5 @@
 {
   "func": "body",
-  "category": "HTML Tags"
+  "category": "HTML Tags",
+  "syntax": "<body></body>"
 }

--- a/dashboard/config/programming_expressions/weblab/border.json
+++ b/dashboard/config/programming_expressions/weblab/border.json
@@ -1,4 +1,5 @@
 {
   "func": "border",
-  "category": "CSS Properties"
+  "category": "CSS Properties",
+  "syntax": "border: border-width border-style border-color;"
 }

--- a/dashboard/config/programming_expressions/weblab/borderBottom.json
+++ b/dashboard/config/programming_expressions/weblab/borderBottom.json
@@ -1,4 +1,5 @@
 {
   "func": "border-bottom",
-  "category": "CSS Properties"
+  "category": "CSS Properties",
+  "syntax": "border-bottom: border-width border-style border-color;"
 }

--- a/dashboard/config/programming_expressions/weblab/borderColor.json
+++ b/dashboard/config/programming_expressions/weblab/borderColor.json
@@ -1,4 +1,5 @@
 {
   "func": "border-color",
-  "category": "CSS Properties"
+  "category": "CSS Properties",
+  "syntax": "border-color: value;"
 }

--- a/dashboard/config/programming_expressions/weblab/borderLeft.json
+++ b/dashboard/config/programming_expressions/weblab/borderLeft.json
@@ -1,4 +1,5 @@
 {
   "func": "border-left",
-  "category": "CSS Properties"
+  "category": "CSS Properties",
+  "syntax": "border-left: border-width border-style border-color;"
 }

--- a/dashboard/config/programming_expressions/weblab/borderRadius.json
+++ b/dashboard/config/programming_expressions/weblab/borderRadius.json
@@ -1,4 +1,5 @@
 {
   "func": "border-radius",
-  "category": "CSS Properties"
+  "category": "CSS Properties",
+  "syntax": "border-radius: value;"
 }

--- a/dashboard/config/programming_expressions/weblab/borderRight.json
+++ b/dashboard/config/programming_expressions/weblab/borderRight.json
@@ -1,4 +1,5 @@
 {
   "func": "border-right",
-  "category": "CSS Properties"
+  "category": "CSS Properties",
+  "syntax": "border-right: value;"
 }

--- a/dashboard/config/programming_expressions/weblab/borderStyle.json
+++ b/dashboard/config/programming_expressions/weblab/borderStyle.json
@@ -1,4 +1,5 @@
 {
   "func": "border-style",
-  "category": "CSS Properties"
+  "category": "CSS Properties",
+  "syntax": "border-style: value;"
 }

--- a/dashboard/config/programming_expressions/weblab/borderTop.json
+++ b/dashboard/config/programming_expressions/weblab/borderTop.json
@@ -1,4 +1,5 @@
 {
   "func": "border-top",
-  "category": "CSS Properties"
+  "category": "CSS Properties",
+  "syntax": "border-top: border-width border-style border-color;"
 }

--- a/dashboard/config/programming_expressions/weblab/borderWidth.json
+++ b/dashboard/config/programming_expressions/weblab/borderWidth.json
@@ -1,4 +1,5 @@
 {
   "func": "border-width",
-  "category": "CSS Properties"
+  "category": "CSS Properties",
+  "syntax": "border-width: value;"
 }

--- a/dashboard/config/programming_expressions/weblab/color.json
+++ b/dashboard/config/programming_expressions/weblab/color.json
@@ -1,4 +1,5 @@
 {
   "func": "color",
-  "category": "CSS Properties"
+  "category": "CSS Properties",
+  "syntax": "color: value;"
 }

--- a/dashboard/config/programming_expressions/weblab/comment.json
+++ b/dashboard/config/programming_expressions/weblab/comment.json
@@ -1,4 +1,5 @@
 {
   "func": "comment",
-  "category": "HTML Tags"
+  "category": "HTML Tags",
+  "syntax": "<!-- Your comment here-->"
 }

--- a/dashboard/config/programming_expressions/weblab/div.json
+++ b/dashboard/config/programming_expressions/weblab/div.json
@@ -1,4 +1,5 @@
 {
   "func": "div",
-  "category": "HTML Tags"
+  "category": "HTML Tags",
+  "syntax": "<div></div>"
 }

--- a/dashboard/config/programming_expressions/weblab/doctype.json
+++ b/dashboard/config/programming_expressions/weblab/doctype.json
@@ -1,4 +1,5 @@
 {
   "func": "doctype",
-  "category": "HTML Tags"
+  "category": "HTML Tags",
+  "syntax": "<!DOCTYPE>"
 }

--- a/dashboard/config/programming_expressions/weblab/float.json
+++ b/dashboard/config/programming_expressions/weblab/float.json
@@ -1,4 +1,5 @@
 {
   "func": "float",
-  "category": "CSS Properties"
+  "category": "CSS Properties",
+  "syntax": "float: value;"
 }

--- a/dashboard/config/programming_expressions/weblab/fontFamily.json
+++ b/dashboard/config/programming_expressions/weblab/fontFamily.json
@@ -1,4 +1,5 @@
 {
   "func": "font-family",
-  "category": "CSS Properties"
+  "category": "CSS Properties",
+  "syntax": "font-family: value;"
 }

--- a/dashboard/config/programming_expressions/weblab/fontSize.json
+++ b/dashboard/config/programming_expressions/weblab/fontSize.json
@@ -1,4 +1,5 @@
 {
   "func": "font-size",
-  "category": "CSS Properties"
+  "category": "CSS Properties",
+  "syntax": "font-size: value;"
 }

--- a/dashboard/config/programming_expressions/weblab/h.json
+++ b/dashboard/config/programming_expressions/weblab/h.json
@@ -1,4 +1,5 @@
 {
   "func": "h",
-  "category": "HTML Tags"
+  "category": "HTML Tags",
+  "syntax": "<h1></h1>"
 }

--- a/dashboard/config/programming_expressions/weblab/head.json
+++ b/dashboard/config/programming_expressions/weblab/head.json
@@ -1,4 +1,5 @@
 {
   "func": "head",
-  "category": "HTML Tags"
+  "category": "HTML Tags",
+  "syntax": "<head></head>"
 }

--- a/dashboard/config/programming_expressions/weblab/height.json
+++ b/dashboard/config/programming_expressions/weblab/height.json
@@ -1,4 +1,5 @@
 {
   "func": "height",
-  "category": "CSS Properties"
+  "category": "CSS Properties",
+  "syntax": "height: value;"
 }

--- a/dashboard/config/programming_expressions/weblab/html.json
+++ b/dashboard/config/programming_expressions/weblab/html.json
@@ -1,4 +1,5 @@
 {
   "func": "html",
-  "category": "HTML Tags"
+  "category": "HTML Tags",
+  "syntax": "<html></html>"
 }

--- a/dashboard/config/programming_expressions/weblab/img.json
+++ b/dashboard/config/programming_expressions/weblab/img.json
@@ -1,4 +1,5 @@
 {
   "func": "img",
-  "category": "HTML Tags"
+  "category": "HTML Tags",
+  "syntax": "<img >"
 }

--- a/dashboard/config/programming_expressions/weblab/li.json
+++ b/dashboard/config/programming_expressions/weblab/li.json
@@ -1,4 +1,5 @@
 {
   "func": "li",
-  "category": "HTML Tags"
+  "category": "HTML Tags",
+  "syntax": "<li></li>"
 }

--- a/dashboard/config/programming_expressions/weblab/link.json
+++ b/dashboard/config/programming_expressions/weblab/link.json
@@ -1,4 +1,5 @@
 {
   "func": "link",
-  "category": "HTML Tags"
+  "category": "HTML Tags",
+  "syntax": "<link></link>"
 }

--- a/dashboard/config/programming_expressions/weblab/margin.json
+++ b/dashboard/config/programming_expressions/weblab/margin.json
@@ -1,4 +1,5 @@
 {
   "func": "margin",
-  "category": "CSS Properties"
+  "category": "CSS Properties",
+  "syntax": "margin: value;"
 }

--- a/dashboard/config/programming_expressions/weblab/meta.json
+++ b/dashboard/config/programming_expressions/weblab/meta.json
@@ -1,4 +1,5 @@
 {
   "func": "meta",
-  "category": "HTML Tags"
+  "category": "HTML Tags",
+  "syntax": "<meta>"
 }

--- a/dashboard/config/programming_expressions/weblab/ol.json
+++ b/dashboard/config/programming_expressions/weblab/ol.json
@@ -1,4 +1,5 @@
 {
   "func": "ol",
-  "category": "HTML Tags"
+  "category": "HTML Tags",
+  "syntax": "<ol></ol>"
 }

--- a/dashboard/config/programming_expressions/weblab/p.json
+++ b/dashboard/config/programming_expressions/weblab/p.json
@@ -1,4 +1,5 @@
 {
   "func": "P",
-  "category": "HTML Tags"
+  "category": "HTML Tags",
+  "syntax": "<p></p>"
 }

--- a/dashboard/config/programming_expressions/weblab/padding.json
+++ b/dashboard/config/programming_expressions/weblab/padding.json
@@ -1,4 +1,5 @@
 {
   "func": "pad",
-  "category": "CSS Properties"
+  "category": "CSS Properties",
+  "syntax": "padding: value;"
 }

--- a/dashboard/config/programming_expressions/weblab/pseudoClasses.json
+++ b/dashboard/config/programming_expressions/weblab/pseudoClasses.json
@@ -1,4 +1,5 @@
 {
   "func": "pseudo-classes",
-  "category": "CSS Properties"
+  "category": "CSS Properties",
+  "syntax": "selector:pseudo-class {property: value;}"
 }

--- a/dashboard/config/programming_expressions/weblab/rgbColor.json
+++ b/dashboard/config/programming_expressions/weblab/rgbColor.json
@@ -1,4 +1,5 @@
 {
   "func": "rgb-color",
-  "category": "CSS Properties"
+  "category": "CSS Properties",
+  "syntax": "rgb(red, green, blue);"
 }

--- a/dashboard/config/programming_expressions/weblab/style.json
+++ b/dashboard/config/programming_expressions/weblab/style.json
@@ -1,4 +1,5 @@
 {
   "func": "style",
-  "category": "HTML Tags"
+  "category": "HTML Tags",
+  "syntax": "<style>"
 }

--- a/dashboard/config/programming_expressions/weblab/textAlign.json
+++ b/dashboard/config/programming_expressions/weblab/textAlign.json
@@ -1,4 +1,5 @@
 {
   "func": "text-align",
-  "category": "CSS Properties"
+  "category": "CSS Properties",
+  "syntax": "text-align: value;"
 }

--- a/dashboard/config/programming_expressions/weblab/textDecoration.json
+++ b/dashboard/config/programming_expressions/weblab/textDecoration.json
@@ -1,4 +1,5 @@
 {
   "func": "Text-Dec",
-  "category": "CSS Properties"
+  "category": "CSS Properties",
+  "syntax": "text-decoration: value;"
 }

--- a/dashboard/config/programming_expressions/weblab/title.json
+++ b/dashboard/config/programming_expressions/weblab/title.json
@@ -1,4 +1,5 @@
 {
   "func": "title",
-  "category": "HTML Tags"
+  "category": "HTML Tags",
+  "syntax": "<title></title>"
 }

--- a/dashboard/config/programming_expressions/weblab/ul.json
+++ b/dashboard/config/programming_expressions/weblab/ul.json
@@ -1,4 +1,5 @@
 {
   "func": "ul",
-  "category": "HTML Tags"
+  "category": "HTML Tags",
+  "syntax": "<ul></ul>"
 }

--- a/dashboard/config/programming_expressions/weblab/width.json
+++ b/dashboard/config/programming_expressions/weblab/width.json
@@ -1,4 +1,5 @@
 {
   "func": "width",
-  "category": "CSS Properties"
+  "category": "CSS Properties",
+  "syntax": "width: value;"
 }


### PR DESCRIPTION
[Dan reported](https://codedotorg.slack.com/archives/CNZP84FJ5/p1620749886377300) that some commands were not showing their syntax in the current implementation of programming expressions because of the many different ways we store information for commands. Some blocks use `paletteParams`. Some have something called `block` that defines the syntax. And Web Lab needed a way to set syntax so added `syntax` to the json files. 

This results in commands looking like they did in lesson plans on CB.  For ease of showing a bunch of different blocks at once here are some of the code roll up pages after: 

<img width="981" alt="Screen Shot 2021-06-01 at 11 12 51 PM" src="https://user-images.githubusercontent.com/208083/120418662-f1593780-c32e-11eb-8db7-34def6cc0378.png">
<img width="1043" alt="Screen Shot 2021-06-01 at 11 12 40 PM" src="https://user-images.githubusercontent.com/208083/120418666-f28a6480-c32e-11eb-945b-7b7b6d59f9cd.png">
<img width="1013" alt="Screen Shot 2021-06-01 at 11 12 31 PM" src="https://user-images.githubusercontent.com/208083/120418668-f28a6480-c32e-11eb-98e7-6dbaa34fd0ce.png">


## Links

https://codedotorg.atlassian.net/browse/PLAT-1038

## Testing story

- Updated unit test
- Manually tested a bunch of code roll up pages and lesson plans

