### PR TITLE
Revert "Fix some multiple choice levels showing the question twice in the level details dialog"

### DIFF
--- a/apps/src/templates/lessonOverview/activities/LevelDetailsDialog.jsx
+++ b/apps/src/templates/lessonOverview/activities/LevelDetailsDialog.jsx
@@ -100,9 +100,7 @@ class LevelDetailsDialog extends Component {
     } else if (level.type === 'Match' || level.type === 'Multi') {
       return (
         <div style={styles.scrollContainer}>
-          {level.content.map((content, i) => (
-            <SafeMarkdown key={i} markdown={content} />
-          ))}
+          {level.question && <SafeMarkdown markdown={level.question} />}
           {level.questionText && <SafeMarkdown markdown={level.questionText} />}
           {this.getTeacherOnlyMarkdownComponent(level)}
         </div>

--- a/apps/test/unit/templates/lessonOverview/activities/LevelDetailsDialogTest.jsx
+++ b/apps/test/unit/templates/lessonOverview/activities/LevelDetailsDialogTest.jsx
@@ -311,9 +311,8 @@ describe('LevelDetailsDialogTest', () => {
           level: {
             type: 'Multi',
             id: 'level',
-            content: [
-              'Look at the code below and predict how the headings will be displayed.'
-            ],
+            question:
+              'Look at the code below and predict how the headings will be displayed.',
             questionText: 'Eggs, Bacon, Waffles',
             teacherMarkdown: 'This is a multiple choice level.'
           }

--- a/dashboard/app/models/levels/match.rb
+++ b/dashboard/app/models/levels/match.rb
@@ -78,16 +78,9 @@ class Match < DSLDefined
   end
 
   def summarize_for_lesson_show(can_view_teacher_markdown)
-    content = [
-      localized_property('content1'),
-      localized_property('content2'),
-      localized_property('content3'),
-      localized_property('content4'),
-      localized_property('markdown')
-    ].compact
     super.merge(
       {
-        content: content
+        question: question
       }
     )
   end

--- a/dashboard/app/models/levels/multi.rb
+++ b/dashboard/app/models/levels/multi.rb
@@ -67,11 +67,9 @@ class Multi < Match
   end
 
   def summarize_for_lesson_show(can_view_teacher_markdown)
-    localized_questions = localized_property(:questions)
-    question_text = localized_questions.any? ? '' : localized_questions[0]['text']
     super.merge(
       {
-        questionText: question_text
+        questionText: get_question_text
       }
     )
   end

--- a/dashboard/test/models/match_test.rb
+++ b/dashboard/test/models/match_test.rb
@@ -19,16 +19,4 @@ class MatchLevelTest < ActiveSupport::TestCase
       refute_equal shuffle, original_order
     end
   end
-
-  test 'summarize_for_lesson_show includes all set content' do
-    @level = create :match, properties: {
-      content1: 'content 1',
-      content2: nil,
-      content3: 'content 3',
-      content4: nil
-    }
-
-    summary = @level.summarize_for_lesson_show(false)
-    assert_equal ['content 1', 'content 3'], summary[:content]
-  end
 end


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#40864. Breaks lessons like https://staging-studio.code.org/s/csd2-2021/lessons/3 which I believe has a multi level without question text. Already working on a fix but would rather not have to rush one before the DTP.