### PR TITLE
Revert "Revert "Fix some multiple choice levels showing the question twice in the level details dialog""

### DIFF
--- a/apps/src/templates/lessonOverview/activities/LevelDetailsDialog.jsx
+++ b/apps/src/templates/lessonOverview/activities/LevelDetailsDialog.jsx
@@ -100,7 +100,9 @@ class LevelDetailsDialog extends Component {
     } else if (level.type === 'Match' || level.type === 'Multi') {
       return (
         <div style={styles.scrollContainer}>
-          {level.question && <SafeMarkdown markdown={level.question} />}
+          {level.content.map((content, i) => (
+            <SafeMarkdown key={i} markdown={content} />
+          ))}
           {level.questionText && <SafeMarkdown markdown={level.questionText} />}
           {this.getTeacherOnlyMarkdownComponent(level)}
         </div>

--- a/apps/test/unit/templates/lessonOverview/activities/LevelDetailsDialogTest.jsx
+++ b/apps/test/unit/templates/lessonOverview/activities/LevelDetailsDialogTest.jsx
@@ -311,8 +311,9 @@ describe('LevelDetailsDialogTest', () => {
           level: {
             type: 'Multi',
             id: 'level',
-            question:
-              'Look at the code below and predict how the headings will be displayed.',
+            content: [
+              'Look at the code below and predict how the headings will be displayed.'
+            ],
             questionText: 'Eggs, Bacon, Waffles',
             teacherMarkdown: 'This is a multiple choice level.'
           }

--- a/dashboard/app/models/levels/match.rb
+++ b/dashboard/app/models/levels/match.rb
@@ -78,9 +78,16 @@ class Match < DSLDefined
   end
 
   def summarize_for_lesson_show(can_view_teacher_markdown)
+    content = [
+      localized_property('content1'),
+      localized_property('content2'),
+      localized_property('content3'),
+      localized_property('content4'),
+      localized_property('markdown')
+    ].compact
     super.merge(
       {
-        question: question
+        content: content
       }
     )
   end

--- a/dashboard/app/models/levels/multi.rb
+++ b/dashboard/app/models/levels/multi.rb
@@ -68,7 +68,7 @@ class Multi < Match
 
   def summarize_for_lesson_show(can_view_teacher_markdown)
     localized_questions = localized_property(:questions)
-    question_text = localized_questions.any? ? '' : localized_questions[0]['text']
+    question_text = localized_questions.any? ? localized_questions[0]['text'] : nil
     super.merge(
       {
         questionText: question_text

--- a/dashboard/app/models/levels/multi.rb
+++ b/dashboard/app/models/levels/multi.rb
@@ -67,9 +67,11 @@ class Multi < Match
   end
 
   def summarize_for_lesson_show(can_view_teacher_markdown)
+    localized_questions = localized_property(:questions)
+    question_text = localized_questions.any? ? '' : localized_questions[0]['text']
     super.merge(
       {
-        questionText: get_question_text
+        questionText: question_text
       }
     )
   end

--- a/dashboard/test/models/match_test.rb
+++ b/dashboard/test/models/match_test.rb
@@ -19,4 +19,16 @@ class MatchLevelTest < ActiveSupport::TestCase
       refute_equal shuffle, original_order
     end
   end
+
+  test 'summarize_for_lesson_show includes all set content' do
+    @level = create :match, properties: {
+      content1: 'content 1',
+      content2: nil,
+      content3: 'content 3',
+      content4: nil
+    }
+
+    summary = @level.summarize_for_lesson_show(false)
+    assert_equal ['content 1', 'content 3'], summary[:content]
+  end
 end

--- a/dashboard/test/models/multi_test.rb
+++ b/dashboard/test/models/multi_test.rb
@@ -25,4 +25,22 @@ class MultiLevelTest < ActiveSupport::TestCase
     )
     assert_equal(level.correct_answer_indexes_array, [1, 2])
   end
+
+  test 'summarize_for_lesson_show sets questionText if it exists' do
+    level = create :multi
+    level.properties = {'questions': [{'text': 'Question text'}]}
+    level.save!
+
+    summary = level.summarize_for_lesson_show(false)
+    assert_equal 'Question text', summary[:questionText]
+  end
+
+  test 'summarize_for_lesson_show does not set questionText if it does not exist' do
+    level = create :multi
+    level.properties = {}
+    level.save!
+
+    summary = level.summarize_for_lesson_show(false)
+    assert_nil summary[:questionText]
+  end
 end


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#40901, restoring #40864. I flipped the results of a ternary operator and was trying to get elements from an empty array. I'm not sure how I missed it so I added a couple tests this time.