### PR TITLE
Add extra database-user secrets to stack template

### DIFF
--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -30,16 +30,18 @@
       Family: aurora-mysql5.7
       Parameters: {'innodb_monitor_enable': 'all'}
 
-  DatabaseSecret:
+<% db_secrets = [nil, 'application-writer', 'readonly'].map do |user| -%>
+  DatabaseSecret<%=secret = user&.underscore&.camelcase%>:
     Type: AWS::SecretsManager::Secret
     Properties:
-      Description: !Sub "Secrets for accessing database from ${AWS::StackName} CloudFormation stack"
+      Description: !Sub "Secrets for accessing database<%user ? " user #{user}" : ''%> from ${AWS::StackName} CloudFormation stack"
       GenerateSecretString:
-        SecretStringTemplate: !Sub '{"username": "${DatabaseUsername}"}'
+        SecretStringTemplate: !Sub '{"username": "<%=user || '${DatabaseUsername}'%>"}'
         GenerateStringKey: password
         PasswordLength: 10
         ExcludePunctuation: True
-      Name: !Sub "CfnStack/${AWS::StackName}/database-secret"
+      Name: !Sub "CfnStack/${AWS::StackName}/database-<%=user || 'secret'%>"
+<% secret; end -%>
 
   DBProxy:
     Type: AWS::RDS::DBProxy
@@ -47,7 +49,10 @@
       DBProxyName: !Ref AWS::StackName
       EngineFamily: MYSQL
       RoleArn: !GetAtt DBProxyRole.Arn
-      Auth: [{AuthScheme: SECRETS, SecretArn: !Ref DatabaseSecret, IAMAuth: DISABLED}]
+      Auth:
+<% db_secrets.each do |secret| -%>
+        - {AuthScheme: SECRETS, SecretARN: !Ref DatabaseSecret<%=secret%>, IAMAuth: DISABLED}
+<%end -%>
       VpcSubnetIds: <%=subnets.to_json%>
       VpcSecurityGroupIds: [!ImportValue VPC-DBSecurityGroup]
   DBProxyRole:
@@ -58,7 +63,9 @@
         - PolicyName: RDSProxy
           PolicyDocument:
             Statement:
-              - {Effect: Allow, Action: 'secretsmanager:GetSecretValue', Resource: !Ref DatabaseSecret}
+<% db_secrets.each do |secret| -%>
+              - {Effect: Allow, Action: 'secretsmanager:GetSecretValue', Resource: !Ref DatabaseSecret<%=secret%>}
+<%end -%>
       PermissionsBoundary: !ImportValue IAM-DevPermissions
   DBProxyTargetGroup:
     Type: AWS::RDS::DBProxyTargetGroup


### PR DESCRIPTION
Adds `application-writer` and `readonly` db-user secrets to the 'database' component of our application CloudFormation stack-template. This creates extra secrets (containing generated passwords) for these users and configures them as `Auth` items for the `DBProxy` resource in the stack.

The following steps still need to be manually performed to activate these users for new environments (e.g., adhoc with `DATABASE=1`):
- Add database users with a MYSQL statement from the [RDS master user](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.MasterAccounts.html) (e.g., [`CREATE USER [user] IDENTIFIED BY [password]`](https://dev.mysql.com/doc/refman/5.7/en/create-user.html)).
- Update the application config variables (e.g., `db_writer` and `db_reader`) to reference the new user credentials.

## Links

- [Database Users and Privileges](https://docs.google.com/document/d/12IE9_U9I07WxAbtc9WqGzlvVBQpkpNxaUoV_Xsi5wGo/edit#) (Google Doc)
- [INF-414](https://codedotorg.atlassian.net/browse/INF-414) 'RDS Proxy'
- [INF-128](https://codedotorg.atlassian.net/browse/INF-128) 'Restrict privileges of application database users' (resolved 6/2019)


## Testing story

Manual testing, output of `stack:validate` for `staging`:
```
Pending update for stack `staging`:
Modify ALBTargetGroup [AWS::ElasticLoadBalancingV2::TargetGroup] Properties (Targets)
Modify DBProxyRole [AWS::IAM::Role] Properties (Policies, Policies, Policies)
Modify DBProxy [AWS::RDS::DBProxy] Properties (Auth, RoleArn, Auth, Auth)
Modify DaemonMemoryUtilizationAlarm [AWS::CloudWatch::Alarm] Properties (Dimensions)
Modify Daemon [AWS::EC2::Instance] Properties Replacement: Conditional (UserData)
Add DatabaseSecretApplicationWriter [AWS::SecretsManager::Secret] 
Add DatabaseSecretReadonly [AWS::SecretsManager::Secret] 
```

## Deployment strategy

Secrets will be added automatically in managed-database environments (`production` has a manually-managed database, so secrets will be added manually there), then manually updated to reflect the existing database credentials.

## Follow-up work

- Consider more thorough code-driven automation of mysql user credentials (e.g., something like [`cfn-mysql-user-provider`](https://github.com/binxio/cfn-mysql-user-provider) to control mysql users directly from the CloudFormation template)
- Adopt [IAM database authentication](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html) for RDS / RDS Proxy