### PR TITLE
Increasing maze version to integrate Neighborhood turn left and reset paint

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -55,7 +55,7 @@
     "@code-dot-org/johnny-five": "0.11.1-cdo.2",
     "@code-dot-org/js-interpreter-tyrant": "0.2.2",
     "@code-dot-org/js-numbers": "0.1.0-cdo.0",
-    "@code-dot-org/maze": "2.4.0",
+    "@code-dot-org/maze": "2.7.0",
     "@code-dot-org/ml-activities": "0.0.26",
     "@code-dot-org/ml-playground": "0.0.31",
     "@code-dot-org/p5.play": "^1.3.17-cdo",

--- a/apps/package.json
+++ b/apps/package.json
@@ -55,7 +55,7 @@
     "@code-dot-org/johnny-five": "0.11.1-cdo.2",
     "@code-dot-org/js-interpreter-tyrant": "0.2.2",
     "@code-dot-org/js-numbers": "0.1.0-cdo.0",
-    "@code-dot-org/maze": "2.7.0",
+    "@code-dot-org/maze": "2.10.0",
     "@code-dot-org/ml-activities": "0.0.26",
     "@code-dot-org/ml-playground": "0.0.31",
     "@code-dot-org/p5.play": "^1.3.17-cdo",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1622,10 +1622,10 @@
   version "0.1.0-cdo.0"
   resolved "https://registry.yarnpkg.com/@code-dot-org/js-numbers/-/js-numbers-0.1.0-cdo.0.tgz#810092a993c3c75441f2e5a3282f1257d9670715"
 
-"@code-dot-org/maze@2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/maze/-/maze-2.4.0.tgz#59371335c2823d1c6e982cd61d13b05f9ada5922"
-  integrity sha512-kfTUvFpgvFbWSBOXi/C1JasBVNOAmofbRgAMz0nKXweow8jUUvZ7OU6mB6V0bCWaMFEk+vOrE1rcpRhCdRfJmw==
+"@code-dot-org/maze@2.7.0":
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/maze/-/maze-2.7.0.tgz#e2d6f3702250a7122d5cad80e683218c78e2d73e"
+  integrity sha512-ApOTehhUW1M3rCnf1VU03/NKjEKSvJohBc0Jd9HaF53nnc6lIGwsj03c9actNKNbZta+z7/IpA+B9K4C9dflBg==
 
 "@code-dot-org/ml-activities@0.0.26":
   version "0.0.26"

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1622,10 +1622,10 @@
   version "0.1.0-cdo.0"
   resolved "https://registry.yarnpkg.com/@code-dot-org/js-numbers/-/js-numbers-0.1.0-cdo.0.tgz#810092a993c3c75441f2e5a3282f1257d9670715"
 
-"@code-dot-org/maze@2.7.0":
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/maze/-/maze-2.7.0.tgz#e2d6f3702250a7122d5cad80e683218c78e2d73e"
-  integrity sha512-ApOTehhUW1M3rCnf1VU03/NKjEKSvJohBc0Jd9HaF53nnc6lIGwsj03c9actNKNbZta+z7/IpA+B9K4C9dflBg==
+"@code-dot-org/maze@2.10.0":
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/maze/-/maze-2.10.0.tgz#6540b8dfe6b12a1fc1e1dc88b131fb43f19b275d"
+  integrity sha512-aofnfNPy64AzLQeJ8adxtd/tmEdw4IGQVBG7DP1SO9xTZVrGO7WxAxitg/66mloh3D2LH+VPvgRrSeuZi1RfZA==
 
 "@code-dot-org/ml-activities@0.0.26":
   version "0.0.26"


### PR DESCRIPTION
This PR pulls in the most recent Maze version: 2.10.0 to incorporate turnLeft() and reset() commands. 

Reset is called each time the Javalab code is run, clearing out old paint. AddPaint() was already operational, but the new paint was applied on top of whatever had been painted during the last run. The paint was only cleared out on refreshing the page. 

TurnLeft() allows for the pegman to rotate counter-clockwise in place. It required making a custom turn method that took in cardinal directions, as well as a new turn renderer that displays the end direction frame only. We do not currently have spritesheets that include the angles in between each direction.

The PRs with these updates on Maze can be seen here:
https://github.com/code-dot-org/maze/pull/57
https://github.com/code-dot-org/maze/pull/59
