### PR TITLE
Remove ErinB TODOs

### DIFF
--- a/apps/src/templates/progress/ProgressBubbleSet.jsx
+++ b/apps/src/templates/progress/ProgressBubbleSet.jsx
@@ -17,7 +17,6 @@ class ProgressBubbleSet extends React.Component {
     levels: PropTypes.arrayOf(levelWithProgressType).isRequired,
     disabled: PropTypes.bool.isRequired,
     style: PropTypes.object,
-    //TODO: (ErinB) probably change to use just number during post launch clean-up.
     selectedSectionId: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.number

--- a/apps/src/templates/projects/ProjectAppTypeArea.jsx
+++ b/apps/src/templates/projects/ProjectAppTypeArea.jsx
@@ -18,8 +18,6 @@ class ProjectAppTypeArea extends React.Component {
     labName: PropTypes.string.isRequired,
     labViewMoreString: PropTypes.string.isRequired,
     // Ability to hide link for Applab and Gamelab
-    // TODO (Erin B.) remove when we have enough featured projects and a solid profanity filter
-    // that we can ensure there won't be inappropriate projects.
     hideViewMoreLink: PropTypes.bool,
     projectList: PropTypes.arrayOf(projectPropType),
     numProjectsToShow: PropTypes.number.isRequired,


### PR DESCRIPTION
Decluttering some lingering TODO comments based on Chap. 4 of "Clean Code" for Dev Book Club. 

`ProgressBubbleSet` is marked as a deprecated component, and I will realistically never go back to address this TODO item. 

Checked with the Product team and they're interested in keeping the ability to quickly hide the "View more" links for App Lab and Game Lab as a back-up plan in the unlikely but high severity case the gallery is overrun with naughty projects. So, I removed the TODO item in `ProjectAppTypeArea`.