### PR TITLE
Upgrade `react-portal`

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -257,7 +257,7 @@
     "react-debounce-input": "^3.2.2",
     "react-dom-confetti": "^0.0.8",
     "react-hot-loader": "^1.3.1",
-    "react-portal": "^3.2.0",
+    "react-portal": "^4.2.1",
     "react-router-dom": "^4.3.1",
     "react-transition-group": "2.9.0",
     "reactabular-sticky": "^8.14.0",

--- a/apps/src/applab/designElements/CopyElementToScreenButton.jsx
+++ b/apps/src/applab/designElements/CopyElementToScreenButton.jsx
@@ -66,8 +66,7 @@ class CopyElementToScreenButton extends React.Component {
     this.state.opened && this.setState({opened: false});
   }
 
-  beforeClose = (_, resetPortalState) => {
-    resetPortalState();
+  onClose = () => {
     this.closeMenu();
   };
 
@@ -98,7 +97,7 @@ class CopyElementToScreenButton extends React.Component {
             isOpen={this.state.opened}
             targetPoint={targetPoint}
             offset={{x: 0, y: 0}}
-            beforeClose={this.beforeClose}
+            onClose={this.onClose}
             style={styles.menu}
           >
             {otherScreens}

--- a/apps/src/lib/ui/ConfirmEnableMakerDialog.jsx
+++ b/apps/src/lib/ui/ConfirmEnableMakerDialog.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
-import Portal from 'react-portal';
+import {Portal} from 'react-portal';
 import msg from '@cdo/locale';
 import color from '../../util/color';
 import Dialog, {
@@ -113,9 +113,11 @@ export default class ConfirmEnableMakerDialogPortal extends Component {
   static propTypes = ConfirmEnableMakerDialog.propTypes;
   render() {
     return (
-      <Portal isOpened={this.props.isOpen}>
-        <ConfirmEnableMakerDialog {...this.props} />
-      </Portal>
+      this.props.isOpen && (
+        <Portal>
+          <ConfirmEnableMakerDialog {...this.props} />
+        </Portal>
+      )
     );
   }
 }

--- a/apps/src/lib/ui/HelpTip.jsx
+++ b/apps/src/lib/ui/HelpTip.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ReactTooltip from 'react-tooltip';
-import Portal from 'react-portal';
+import {Portal} from 'react-portal';
 import FontAwesome from '../../templates/FontAwesome';
 import _ from 'lodash';
 
@@ -14,7 +14,7 @@ export default function HelpTip({children}) {
         icon="question-circle-o"
         style={{cursor: 'pointer', marginLeft: '0.5em', marginRight: '0.5em'}}
       />
-      <Portal isOpened={true}>
+      <Portal>
         <ReactTooltip id={id} role="tooltip" effect="solid">
           <div style={{maxWidth: 400}}>{children}</div>
         </ReactTooltip>

--- a/apps/src/lib/ui/PopUpMenu.jsx
+++ b/apps/src/lib/ui/PopUpMenu.jsx
@@ -3,7 +3,7 @@ import React, {Component, Children} from 'react';
 import PropTypes from 'prop-types';
 
 import Radium from 'radium';
-import Portal from 'react-portal';
+import {PortalWithState} from 'react-portal';
 import msg from '@cdo/locale';
 import color from '../../util/color';
 
@@ -54,29 +54,37 @@ export default class PopUpMenu extends Component {
     children: PropTypes.any,
     className: PropTypes.string,
     isOpen: PropTypes.bool,
-    beforeClose: PropTypes.func,
+    onClose: PropTypes.func,
     showTail: PropTypes.bool,
     style: PropTypes.object
   };
 
   render() {
     return (
-      <Portal
-        closeOnEsc
-        closeOnOutsideClick
-        isOpened={this.props.isOpen}
-        beforeClose={this.props.beforeClose}
-      >
-        <MenuBubble
-          targetPoint={this.props.targetPoint}
-          offset={this.props.offset}
-          className={this.props.className}
-          showTail={this.props.showTail}
-          style={this.props.style}
+      this.props.isOpen && (
+        <PortalWithState
+          closeOnOutsideClick
+          closeOnEsc
+          onClose={this.props.onClose}
+          defaultOpen={this.props.isOpen}
         >
-          {this.props.children}
-        </MenuBubble>
-      </Portal>
+          {({openPortal, closePortal, isOpen, portal}) => (
+            <div>
+              {portal(
+                <MenuBubble
+                  targetPoint={this.props.targetPoint}
+                  offset={this.props.offset}
+                  className={this.props.className}
+                  showTail={this.props.showTail}
+                  style={this.props.style}
+                >
+                  {this.props.children}
+                </MenuBubble>
+              )}
+            </div>
+          )}
+        </PortalWithState>
+      )
     );
   }
 }

--- a/apps/src/lib/ui/PopUpMenu.story.jsx
+++ b/apps/src/lib/ui/PopUpMenu.story.jsx
@@ -7,6 +7,7 @@ export default storybook => {
 
 class Overview extends Component {
   state = {
+    isOpen: true,
     targetPoint: {
       top: 0,
       left: 0
@@ -36,10 +37,15 @@ class Overview extends Component {
             width: '50%'
           }}
           ref={el => (this.target = el)}
+          onClick={() => !this.state.isOpen && this.setState({isOpen: true})}
         >
           It targets the bottom-center of this element.
         </div>
-        <PopUpMenu isOpen targetPoint={this.state.targetPoint}>
+        <PopUpMenu
+          isOpen={this.state.isOpen}
+          onClose={() => this.setState({isOpen: false})}
+          targetPoint={this.state.targetPoint}
+        >
           <PopUpMenu.Item onClick={() => {}}>Option One</PopUpMenu.Item>
           <PopUpMenu.Item onClick={() => {}}>Option Two</PopUpMenu.Item>
           <PopUpMenu.Item onClick={() => {}}>Option Three</PopUpMenu.Item>

--- a/apps/src/lib/ui/SettingsCog.jsx
+++ b/apps/src/lib/ui/SettingsCog.jsx
@@ -16,32 +16,7 @@ import {getStore} from '../../redux';
 import experiments from '@cdo/apps/util/experiments';
 import ModelManagerDialog from '@cdo/apps/code-studio/components/ModelManagerDialog';
 
-const style = {
-  iconContainer: {
-    float: 'right',
-    marginRight: 10,
-    marginLeft: 10,
-    height: '100%',
-    cursor: 'pointer',
-    color: color.lighter_purple,
-    ':hover': {
-      color: color.white
-    }
-  },
-  assetsIcon: {
-    fontSize: 18,
-    verticalAlign: 'middle'
-  }
-};
-
 class SettingsCog extends Component {
-  constructor(props) {
-    super(props);
-
-    // Default icon bounding rect for first render
-    this.targetPoint = {top: 0, left: 0};
-  }
-
   static propTypes = {
     isRunning: PropTypes.bool,
     runModeIndicators: PropTypes.bool,
@@ -49,30 +24,22 @@ class SettingsCog extends Component {
     autogenerateML: PropTypes.func
   };
 
-  componentDidMount() {
-    this.setState({isAIEnabled: experiments.isEnabled(experiments.APPLAB_ML)});
-  }
-  // This ugly two-flag state is a workaround for an event-handling bug in
-  // react-portal that prevents closing the portal by clicking on the icon
-  // that opened it.  For now we're just disabling the cog when the menu is
-  // open, and re-enabling one tick after it closes.
-  // @see https://github.com/tajo/react-portal/issues/140
   state = {
     open: false,
-    canOpen: true,
     confirmingEnableMaker: false,
     managingLibraries: false,
     managingModels: false,
     isAIEnabled: false
   };
 
-  open = () => this.setState({open: true, canOpen: false});
-  close = () => this.setState({open: false});
+  targetPoint = {top: 0, left: 0};
 
-  onClose = () => {
-    this.setState({open: false});
-    window.setTimeout(() => this.setState({canOpen: true}), 0);
-  };
+  componentDidMount() {
+    this.setState({isAIEnabled: experiments.isEnabled(experiments.APPLAB_ML)});
+  }
+
+  open = () => this.setState({open: true});
+  close = () => this.setState({open: false});
 
   manageAssets = () => {
     this.close();
@@ -148,7 +115,7 @@ class SettingsCog extends Component {
     const {isRunning, runModeIndicators} = this.props;
 
     // Adjust icon color when running
-    const rootStyle = {...style.iconContainer};
+    const rootStyle = {...styles.iconContainer};
     if (runModeIndicators && isRunning) {
       rootStyle.color = color.dark_charcoal;
     }
@@ -160,15 +127,15 @@ class SettingsCog extends Component {
         <FontAwesome
           className="settings-cog"
           icon="cog"
-          style={style.assetsIcon}
+          style={styles.assetsIcon}
           title={msg.settings()}
-          onClick={this.state.canOpen ? this.open : undefined}
+          onClick={this.open}
         />
         <PopUpMenu
           className="settings-cog-menu"
           targetPoint={this.targetPoint}
           isOpen={this.state.open}
-          onClose={this.onClose}
+          onClose={this.close}
           showTail={true}
         >
           <ManageAssets onClick={this.manageAssets} />
@@ -234,3 +201,21 @@ export function ToggleMaker(props) {
   );
 }
 ToggleMaker.propTypes = ManageAssets.propTypes;
+
+const styles = {
+  iconContainer: {
+    float: 'right',
+    marginRight: 10,
+    marginLeft: 10,
+    height: '100%',
+    cursor: 'pointer',
+    color: color.lighter_purple,
+    ':hover': {
+      color: color.white
+    }
+  },
+  assetsIcon: {
+    fontSize: 18,
+    verticalAlign: 'middle'
+  }
+};

--- a/apps/src/lib/ui/SettingsCog.jsx
+++ b/apps/src/lib/ui/SettingsCog.jsx
@@ -69,8 +69,7 @@ class SettingsCog extends Component {
   open = () => this.setState({open: true, canOpen: false});
   close = () => this.setState({open: false});
 
-  beforeClose = (_, resetPortalState) => {
-    resetPortalState();
+  onClose = () => {
     this.setState({open: false});
     window.setTimeout(() => this.setState({canOpen: true}), 0);
   };
@@ -169,7 +168,7 @@ class SettingsCog extends Component {
           className="settings-cog-menu"
           targetPoint={this.targetPoint}
           isOpen={this.state.open}
-          beforeClose={this.beforeClose}
+          onClose={this.onClose}
           showTail={true}
         >
           <ManageAssets onClick={this.manageAssets} />

--- a/apps/src/templates/tables/QuickActionsCell.jsx
+++ b/apps/src/templates/tables/QuickActionsCell.jsx
@@ -54,8 +54,7 @@ export default class QuickActionsCell extends Component {
   };
 
   // Menu closed
-  beforeClose = (_, resetPortalState) => {
-    resetPortalState();
+  onClose = () => {
     this.setState({
       open: false,
       canOpen: true
@@ -117,7 +116,7 @@ export default class QuickActionsCell extends Component {
         <PopUpMenu
           targetPoint={targetPoint}
           isOpen={this.state.open}
-          beforeClose={this.beforeClose}
+          onClose={this.onClose}
           showTail={false}
         >
           {this.props.children}

--- a/apps/src/templates/teacherDashboard/AssignmentVersionSelector.jsx
+++ b/apps/src/templates/teacherDashboard/AssignmentVersionSelector.jsx
@@ -74,7 +74,6 @@ export default class AssignmentVersionSelector extends Component {
 
   state = {
     isMenuOpen: false,
-    canMenuOpen: true,
     targetPoint: {top: 0, left: 0}
   };
 
@@ -84,7 +83,7 @@ export default class AssignmentVersionSelector extends Component {
   };
 
   handleClick = () => {
-    if (!this.state.isMenuOpen && this.state.canMenuOpen) {
+    if (!this.state.isMenuOpen) {
       this.openMenu();
     }
   };
@@ -95,20 +94,13 @@ export default class AssignmentVersionSelector extends Component {
       top: rect.bottom + window.pageYOffset,
       left: rect.left + window.pageXOffset
     };
-    this.setState({isMenuOpen: true, canMenuOpen: false, targetPoint});
-  }
-
-  closeMenu() {
-    this.setState({isMenuOpen: false});
-  }
-
-  onClose = () => {
-    this.closeMenu();
-    // Work around a bug in react-portal. see SettingsCog.jsx for details.
-    window.setTimeout(() => {
-      this.setState({canMenuOpen: true});
+    this.setState({
+      isMenuOpen: true,
+      targetPoint
     });
-  };
+  }
+
+  closeMenu = () => this.setState({isMenuOpen: false});
 
   handleNativeDropdownChange = event => {
     const versionYear = event.target.value;
@@ -127,7 +119,10 @@ export default class AssignmentVersionSelector extends Component {
     const popupMenuXOffset = this.props.rightJustifiedPopupMenu
       ? -menuWidth / 2
       : 0;
-    const menuOffset = {x: popupMenuXOffset, y: 0};
+    const menuOffset = {
+      x: popupMenuXOffset,
+      y: 0
+    };
 
     return (
       <span style={styles.version} id="uitest-version-selector">
@@ -157,7 +152,7 @@ export default class AssignmentVersionSelector extends Component {
           targetPoint={this.state.targetPoint}
           offset={menuOffset}
           style={styles.popUpMenuStyle}
-          onClose={this.onClose}
+          onClose={this.closeMenu}
         >
           <AssignmentVersionMenuHeader />
           {versions.map(version => (

--- a/apps/src/templates/teacherDashboard/AssignmentVersionSelector.jsx
+++ b/apps/src/templates/teacherDashboard/AssignmentVersionSelector.jsx
@@ -102,8 +102,7 @@ export default class AssignmentVersionSelector extends Component {
     this.setState({isMenuOpen: false});
   }
 
-  beforeClose = (node, resetPortalState) => {
-    resetPortalState();
+  onClose = () => {
     this.closeMenu();
     // Work around a bug in react-portal. see SettingsCog.jsx for details.
     window.setTimeout(() => {
@@ -158,7 +157,7 @@ export default class AssignmentVersionSelector extends Component {
           targetPoint={this.state.targetPoint}
           offset={menuOffset}
           style={styles.popUpMenuStyle}
-          beforeClose={this.beforeClose}
+          onClose={this.onClose}
         >
           <AssignmentVersionMenuHeader />
           {versions.map(version => (

--- a/apps/src/templates/teacherDashboard/TeacherSectionSelector.jsx
+++ b/apps/src/templates/teacherDashboard/TeacherSectionSelector.jsx
@@ -24,7 +24,6 @@ export default class TeacherSectionSelector extends Component {
 
   state = {
     isMenuOpen: false,
-    canMenuOpen: true,
     targetPoint: {top: 0, left: 0}
   };
 
@@ -34,7 +33,7 @@ export default class TeacherSectionSelector extends Component {
   };
 
   handleClick = () => {
-    if (!this.state.isMenuOpen && this.state.canMenuOpen) {
+    if (!this.state.isMenuOpen) {
       this.openMenu();
     }
   };
@@ -50,20 +49,13 @@ export default class TeacherSectionSelector extends Component {
       top: rect.bottom + window.pageYOffset,
       left: rect.left + window.pageXOffset
     };
-    this.setState({isMenuOpen: true, canMenuOpen: false, targetPoint});
-  }
-
-  onClose = () => {
-    this.closeMenu();
-    // Work around a bug in react-portal. see SettingsCog.jsx for details.
-    window.setTimeout(() => {
-      this.setState({canMenuOpen: true});
+    this.setState({
+      isMenuOpen: true,
+      targetPoint
     });
-  };
-
-  closeMenu() {
-    this.setState({isMenuOpen: false});
   }
+
+  closeMenu = () => this.setState({isMenuOpen: false});
 
   chooseMenuItem = section => {
     this.props.onChangeSection(section.id);
@@ -80,7 +72,10 @@ export default class TeacherSectionSelector extends Component {
     const {sections, selectedSection, courseId, scriptId} = this.props;
     const menuOffset = {x: 0, y: 0};
     const value = selectedSection ? selectedSection.id : '';
-    const queryParams = queryString.stringify({courseId, scriptId});
+    const queryParams = queryString.stringify({
+      courseId,
+      scriptId
+    });
 
     return (
       <div>
@@ -103,7 +98,7 @@ export default class TeacherSectionSelector extends Component {
         <PopUpMenu
           isOpen={this.state.isMenuOpen}
           targetPoint={this.state.targetPoint}
-          onClose={this.onClose}
+          onClose={this.closeMenu}
           offset={menuOffset}
         >
           {sections &&

--- a/apps/src/templates/teacherDashboard/TeacherSectionSelector.jsx
+++ b/apps/src/templates/teacherDashboard/TeacherSectionSelector.jsx
@@ -53,8 +53,7 @@ export default class TeacherSectionSelector extends Component {
     this.setState({isMenuOpen: true, canMenuOpen: false, targetPoint});
   }
 
-  beforeClose = (node, resetPortalState) => {
-    resetPortalState();
+  onClose = () => {
     this.closeMenu();
     // Work around a bug in react-portal. see SettingsCog.jsx for details.
     window.setTimeout(() => {
@@ -104,7 +103,7 @@ export default class TeacherSectionSelector extends Component {
         <PopUpMenu
           isOpen={this.state.isMenuOpen}
           targetPoint={this.state.targetPoint}
-          beforeClose={this.beforeClose}
+          onClose={this.onClose}
           offset={menuOffset}
         >
           {sections &&

--- a/apps/test/unit/lib/ui/SettingsCogTest.js
+++ b/apps/test/unit/lib/ui/SettingsCogTest.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import Portal from 'react-portal';
+import {Portal} from 'react-portal';
 import {mount} from 'enzyme';
 import sinon from 'sinon';
 import msg from '@cdo/locale';
@@ -12,66 +12,25 @@ import * as assets from '@cdo/apps/code-studio/assets';
 describe('SettingsCog', () => {
   it('renders as a FontAwesome icon', () => {
     const wrapper = mount(<SettingsCog />);
-    expect(wrapper.find(FontAwesome)).to.have.length(1);
+    expect(wrapper.find(FontAwesome)).to.have.lengthOf(1);
   });
 
   it('opens the menu when the cog is clicked', () => {
     const wrapper = mount(<SettingsCog />);
-    var portal = wrapper.find(Portal).first();
-    expect(portal).to.have.prop('isOpened', false);
+    expect(wrapper.find(Portal)).to.be.empty;
     wrapper.instance().open();
     wrapper.update();
-    portal = wrapper.find(Portal).first();
-    expect(portal).to.have.prop('isOpened', true);
+    expect(wrapper.find(Portal)).to.have.lengthOf(1);
   });
 
   it('can close the menu', () => {
-    // (It turns out testing the portal auto-close is difficult)
     const wrapper = mount(<SettingsCog />);
     wrapper.instance().open();
     wrapper.update();
-    var menu = wrapper.find(Portal).first();
-    expect(menu).to.have.prop('isOpened', true);
+    expect(wrapper.find(Portal)).to.have.lengthOf(1);
     wrapper.instance().close();
     wrapper.update();
-    menu = wrapper.find(Portal).first();
-    expect(menu).to.have.prop('isOpened', false);
-  });
-
-  it('works around buggy portal behavior', done => {
-    // This fragile test covers a workaround for an event-handling bug in
-    // react-portal that prevents closing the portal by clicking on the icon
-    // that opened it.
-    // @see https://github.com/tajo/react-portal/issues/140
-    // Can probably remove this test if that bug gets fixed and our code
-    // gets simplified.
-    const wrapper = mount(<SettingsCog />);
-    var cog = wrapper.find(FontAwesome).first();
-    var menu = wrapper.find(Portal).first();
-    expect(wrapper).to.have.state('canOpen', true);
-    expect(cog.prop('onClick')).to.be.a.function;
-
-    // Open the menu
-    cog.simulate('click');
-    wrapper.update();
-    cog = wrapper.find(FontAwesome).first();
-    expect(wrapper).to.have.state('canOpen', false);
-    expect(cog.prop('onClick')).to.be.undefined;
-
-    // Close the menu
-    wrapper.instance().close();
-    wrapper.update();
-    cog = wrapper.find(FontAwesome).first();
-    menu = wrapper.find(Portal).first();
-    // This doesn't happen right away - that's our workaround, so we don't
-    // re-open the menu in the same moment.
-    expect(menu).to.have.prop('isOpened', false);
-    expect(cog.prop('onClick')).to.be.undefined;
-    setTimeout(() => {
-      expect(wrapper).to.have.state('canOpen', true);
-      expect(cog.prop('onClick')).to.be.a.function;
-      done();
-    }, 0);
+    expect(wrapper.find(Portal)).to.be.empty;
   });
 
   it('does not show maker toggle when "showMakerToggle" is false', () => {
@@ -80,16 +39,12 @@ describe('SettingsCog', () => {
   });
 
   describe('menu items', () => {
-    let wrapper, portal;
+    let wrapper;
 
     beforeEach(() => {
       wrapper = mount(<SettingsCog showMakerToggle={true} />);
-      portal = wrapper.find(Portal).first();
-      expect(portal).to.have.prop('isOpened', false);
       wrapper.instance().open();
       wrapper.update();
-      portal = wrapper.find(Portal).first();
-      expect(portal).to.have.prop('isOpened', true);
     });
 
     describe('manage assets', () => {
@@ -111,8 +66,7 @@ describe('SettingsCog', () => {
       it('closes the menu when clicked', () => {
         wrapper.instance().manageAssets();
         wrapper.update();
-        portal = wrapper.find(Portal).first();
-        expect(portal).to.have.prop('isOpened', false);
+        expect(wrapper.find(Portal)).to.be.empty;
       });
     });
 

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -13003,10 +13003,10 @@ react-popper@^0.9.1:
     popper.js "^1.14.1"
     prop-types "^15.6.1"
 
-react-portal@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/react-portal/-/react-portal-3.2.0.tgz#4224e19b2b05d5cbe730a7ba0e34ec7585de0043"
-  integrity sha512-avb1FreAZAVCvNNyS2dCpxZiPYPJnAasHYPxdVBTROgNFeI+KSb+OoMHNsC1GbDawESCriPwCX+qKua6WSPIFw==
+react-portal@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/react-portal/-/react-portal-4.2.1.tgz#12c1599238c06fb08a9800f3070bea2a3f78b1a6"
+  integrity sha512-fE9kOBagwmTXZ3YGRYb4gcMy+kSA+yLO0xnPankjRlfBv4uCpFXqKPfkpsGQQR15wkZ9EssnvTOl1yMzbkxhPQ==
   dependencies:
     prop-types "^15.5.8"
 


### PR DESCRIPTION
in preparation for our upgrade to react 16, this PR updates the `react-portal` version to one that is backward-compatible with react 15 but won't log warnings about deprecated lifecycle methods when used in react 16.

## Links
- jira tickets: [XTEAM-323], [LP-1928]



[XTEAM-323]: https://codedotorg.atlassian.net/browse/XTEAM-323
[LP-1928]: https://codedotorg.atlassian.net/browse/LP-1928