### PR TITLE
[AiLab] prevent save of trained models if they don't pass share filtering

### DIFF
--- a/dashboard/app/controllers/api/v1/ml_models_controller.rb
+++ b/dashboard/app/controllers/api/v1/ml_models_controller.rb
@@ -15,11 +15,7 @@ class Api::V1::MlModelsController < Api::V1::JsonApiController
     return head :bad_request if model_data.nil? || model_data == ""
     profanity_or_pii = ShareFiltering.find_failure(model_data.to_s, request.locale)
     if profanity_or_pii
-      render json: {
-        id: model_id,
-        status: "failure",
-        profanity_pii_type: profanity_or_pii.type
-      }
+      render json: {id: model_id, status: "piiProfanity"}
     else
       metadata = model_data.except(:trainedModel, :featureNumberKey)
       @user_ml_model = UserMlModel.create(

--- a/dashboard/app/controllers/api/v1/ml_models_controller.rb
+++ b/dashboard/app/controllers/api/v1/ml_models_controller.rb
@@ -15,7 +15,11 @@ class Api::V1::MlModelsController < Api::V1::JsonApiController
     return head :bad_request if model_data.nil? || model_data == ""
     profanity_or_pii = ShareFiltering.find_failure(model_data.to_s, request.locale)
     if profanity_or_pii
-      render json: {id: model_id, status: "failure", details: profanity_or_pii.type}
+      render json: {
+        id: model_id,
+        status: "failure",
+        profanity_pii_type: profanity_or_pii.type
+      }
     else
       metadata = model_data.except(:trainedModel, :featureNumberKey)
       @user_ml_model = UserMlModel.create(

--- a/dashboard/test/controllers/api/v1/ml_models_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/ml_models_controller_test.rb
@@ -40,9 +40,7 @@ class Api::V1::MlModelsControllerTest < ::ActionController::TestCase
     sign_in @owner
     ShareFiltering.stubs(:find_failure).returns(ShareFailure.new('profanity', 'damn'))
     post :save, params: {"ml_model" => {"name" => "Naughty Model"}}
-    assert_equal "failure", JSON.parse(@response.body)["status"]
-    assert_equal ShareFiltering::FailureType::PROFANITY,
-      JSON.parse(@response.body)["profanity_pii_type"]
+    assert_equal "piiProfanity", JSON.parse(@response.body)["status"]
   end
 
   test 'returns failure when model saves to database but not S3' do

--- a/dashboard/test/controllers/api/v1/ml_models_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/ml_models_controller_test.rb
@@ -41,7 +41,8 @@ class Api::V1::MlModelsControllerTest < ::ActionController::TestCase
     ShareFiltering.stubs(:find_failure).returns(ShareFailure.new('profanity', 'damn'))
     post :save, params: {"ml_model" => {"name" => "Naughty Model"}}
     assert_equal "failure", JSON.parse(@response.body)["status"]
-    assert_equal "profanity", JSON.parse(@response.body)["details"]
+    assert_equal ShareFiltering::FailureType::PROFANITY,
+      JSON.parse(@response.body)["profanity_pii_type"]
   end
 
   test 'returns failure when model saves to database but not S3' do


### PR DESCRIPTION
We don't want students to be able to save trained machine learning models if they contain profanity or personally identifying information (pii). Saved models can be imported into App Lab apps, which can be published or remixed and we don't want indecent or unsafe information shared. Prior to saving a model, we now run its data through the share filter, which will check for profanity, emails, phone numbers or street addresses and prevent the model from saving if any are found. 

We'll show an alternate fail message if profanity or pii is found:
![Screen Shot 2021-06-07 at 12 17 20 PM](https://user-images.githubusercontent.com/12300669/121055858-a191ca80-c78b-11eb-9a89-1c1ffa56a0a9.png)

https://github.com/code-dot-org/ml-playground/pull/218