### PR TITLE
Add start_direction and serialized_maze to Javalab levelbuilder edit …

### DIFF
--- a/dashboard/app/models/levels/javalab.rb
+++ b/dashboard/app/models/levels/javalab.rb
@@ -39,13 +39,16 @@ class Javalab < Level
 
   before_save :fix_examples, :parse_maze
 
+  def self.start_directions
+    [['North', 0], ['East', 1], ['South', 2], ['West', 3]]
+  end
+
   def self.create_from_level_builder(params, level_params)
     create!(
       level_params.merge(
         user: params[:user],
         game: Game.javalab,
-        level_num: 'custom',
-        properties: {}
+        level_num: 'custom'
       )
     )
   end

--- a/dashboard/app/models/levels/javalab.rb
+++ b/dashboard/app/models/levels/javalab.rb
@@ -40,7 +40,11 @@ class Javalab < Level
   before_save :fix_examples, :parse_maze
 
   def self.start_directions
-    [['North', 0], ['East', 1], ['South', 2], ['West', 3]]
+    [['None', nil], ['North', 0], ['East', 1], ['South', 2], ['West', 3]]
+  end
+
+  def self.csa_view_modes
+    [['Console', 'console'], ['Neighborhood', 'neighborhood'], ['Theater', 'theater']]
   end
 
   def self.create_from_level_builder(params, level_params)

--- a/dashboard/app/views/levels/editors/fields/_csa_fields.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_csa_fields.html.haml
@@ -3,5 +3,13 @@
 
 #csa_features.in.collapse
   .field
-    Select the desired CSA view:
-    = f.select :csa_view_mode, options_for_select([['Console', 'console'], ['Neighborhood', 'neighborhood'], ['Theater', 'theater']])
+    = f.label :csa_view_mode, 'CSA view mode'
+    = f.select :csa_view_mode, options_for_select([['Console', 'console'], ['Neighborhood', 'neighborhood'], ['Theater', 'theater']], @level.csa_view_mode)
+
+  .field
+    = f.label :start_direction
+    = f.select :start_direction, options_for_select(@level.class.start_directions, @level.start_direction)
+
+  .field
+    = f.label :serialized_maze
+    = f.text_area :serialized_maze, value: JSON.pretty_generate(@level.serialized_maze), rows: 20, class: 'input-block-level'

--- a/dashboard/app/views/levels/editors/fields/_csa_fields.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_csa_fields.html.haml
@@ -6,7 +6,7 @@
     = f.label :csa_view_mode, 'CSA view mode'
     = f.select :csa_view_mode, options_for_select(@level.class.csa_view_modes, @level.csa_view_mode), {}, onchange: 'toggleFields(this.value);'
 
-  #neighborhood.collapse
+  #neighborhood{class: ('collapse' if @level.csa_view_mode != 'neighborhood')}
     .field
       = f.label :start_direction
       = f.select :start_direction, options_for_select(@level.class.start_directions, @level.start_direction)

--- a/dashboard/app/views/levels/editors/fields/_csa_fields.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_csa_fields.html.haml
@@ -4,13 +4,24 @@
 #csa_features.in.collapse
   .field
     = f.label :csa_view_mode, 'CSA view mode'
-    = f.select :csa_view_mode, options_for_select([['Console', 'console'], ['Neighborhood', 'neighborhood'], ['Theater', 'theater']], @level.csa_view_mode)
+    = f.select :csa_view_mode, options_for_select(@level.class.csa_view_modes, @level.csa_view_mode), {}, onchange: 'toggleFields(this.value);'
 
-  .field
-    = f.label :start_direction
-    = f.select :start_direction, options_for_select(@level.class.start_directions, @level.start_direction)
+  #neighborhood.collapse
+    .field
+      = f.label :start_direction
+      = f.select :start_direction, options_for_select(@level.class.start_directions, @level.start_direction)
 
   .field
     = f.label :serialized_maze
     - maze_value = @level.serialized_maze ? JSON.pretty_generate(@level.serialized_maze) : ''
     = f.text_area :serialized_maze, value: maze_value, rows: 20, class: 'input-block-level'
+
+:javascript
+  function toggleFields(val) {
+    const neighborhoodFields = document.getElementById('neighborhood');
+    if (val.toLowerCase() === 'neighborhood') {
+      neighborhoodFields.classList.remove('collapse');
+    } else {
+      neighborhoodFields.classList.add('collapse');
+    }
+  }

--- a/dashboard/app/views/levels/editors/fields/_csa_fields.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_csa_fields.html.haml
@@ -12,4 +12,5 @@
 
   .field
     = f.label :serialized_maze
-    = f.text_area :serialized_maze, value: JSON.pretty_generate(@level.serialized_maze), rows: 20, class: 'input-block-level'
+    - maze_value = @level.serialized_maze ? JSON.pretty_generate(@level.serialized_maze) : ''
+    = f.text_area :serialized_maze, value: maze_value, rows: 20, class: 'input-block-level'


### PR DESCRIPTION
…page

Adds `start_direction` and `serialized_maze` fields to the levelbuilder edit page for Javalab levels, which looks as follows:
<img width="1002" alt="Screen Shot 2021-06-02 at 4 32 18 PM" src="https://user-images.githubusercontent.com/9812299/120564658-3d07f180-c3c0-11eb-8ee8-eb2713eeb9bb.png">

## Links

- [CSA-351](https://codedotorg.atlassian.net/browse/CSA-351)