### PR TITLE
set is_migrated on new scripts

### DIFF
--- a/apps/src/lib/levelbuilder/script-editor/NewScriptForm.jsx
+++ b/apps/src/lib/levelbuilder/script-editor/NewScriptForm.jsx
@@ -24,6 +24,7 @@ export default function NewScriptForm() {
         </HelpTip>
       </label>
       <input name="script[name]" />
+      <input name="is_migrated" value={true} type="hidden" />
       <br />
       <button className="btn btn-primary" type="submit" style={buttonStyle}>
         Save Changes

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -73,6 +73,7 @@ class ScriptsController < ApplicationController
   end
 
   def create
+    return head :bad_request unless general_params[:is_migrated]
     @script = Script.new(script_params)
     if @script.save && @script.update_text(script_params, params[:script_text], i18n_params, general_params)
       redirect_to edit_script_url(@script), notice: I18n.t('crud.created', model: Script.model_name.human)

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -304,7 +304,8 @@ class ScriptsControllerTest < ActionController::TestCase
     sign_in @platformization_partner
     post :create, params: {
       script: {name: 'test-script-create'},
-      script_text: ''
+      script_text: '',
+      is_migrated: true
     }
     assert_response :forbidden
   end
@@ -379,6 +380,19 @@ class ScriptsControllerTest < ActionController::TestCase
     script = Script.find_by_name(script_name)
     assert_equal script_name, script.name
     assert script.is_migrated
+  end
+
+  test 'cannot create legacy script' do
+    Rails.application.config.stubs(:levelbuilder_mode).returns true
+    sign_in @levelbuilder
+
+    script_name = 'legacy'
+    post :create, params: {
+      script: {name: script_name},
+    }
+
+    assert_response :bad_request
+    refute Script.find_by_name(script_name)
   end
 
   test 'destroy raises exception for evil filenames' do

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -361,10 +361,9 @@ class ScriptsControllerTest < ActionController::TestCase
   end
 
   test 'create' do
-    expected_contents = ''
     script_name = 'test-script-create'
     File.stubs(:write).with {|filename, _| filename.end_with? 'scripts.en.yml'}.once
-    File.stubs(:write).with("#{Rails.root}/config/scripts/#{script_name}.script", expected_contents).once
+    File.stubs(:write).with("#{Rails.root}/config/scripts/#{script_name}.script", "is_migrated true\n").once
     File.stubs(:write).with do |filename, contents|
       filename == "#{Rails.root}/config/scripts_json/#{script_name}.script_json" && JSON.parse(contents)['script']['name'] == script_name
     end
@@ -373,11 +372,13 @@ class ScriptsControllerTest < ActionController::TestCase
 
     post :create, params: {
       script: {name: script_name},
+      is_migrated: true
     }
     assert_redirected_to edit_script_path id: script_name
 
     script = Script.find_by_name(script_name)
     assert_equal script_name, script.name
+    assert script.is_migrated
   end
 
   test 'destroy raises exception for evil filenames' do


### PR DESCRIPTION
Finishes https://codedotorg.atlassian.net/browse/PLAT-826.

## Testing story

New unit tests verify that new scripts are created with the is_migrated param, and that the request to create a script fails without it.