### PR TITLE
include lesson url when bug is reported on teacher lesson plan

### DIFF
--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -814,6 +814,11 @@ class Lesson < ApplicationRecord
     end
   end
 
+  def report_bug_url(request)
+    message = "Bug in Lesson #{name}\n#{request.url}\n#{request.user_agent}\n"
+    "https://support.code.org/hc/en-us/requests/new?&description=#{CGI.escape(message)}"
+  end
+
   private
 
   # Finds the LessonActivity by id, or creates a new one if id is not specified.

--- a/dashboard/app/views/layouts/_header.html.haml
+++ b/dashboard/app/views/layouts/_header.html.haml
@@ -4,6 +4,7 @@
   script = local_assigns[:script] || Script.twenty_hour_script
   script_level = local_assigns[:script_level]
   level = local_assigns[:level]
+  lesson = local_assigns[:lesson]
   full_width = local_assigns[:full_width]
 
   show_bug_links = script_level || (level && level.try(:is_project_level))
@@ -31,6 +32,7 @@
   hamburger_options = {}
   hamburger_options[:level] = level
   hamburger_options[:script_level] = script_level
+  hamburger_options[:lesson] = lesson
   hamburger_options[:user_type] = user_type
   hamburger_options[:language] = request.language
   hamburger_options[:show_gallery] = true

--- a/dashboard/app/views/layouts/application.html.haml
+++ b/dashboard/app/views/layouts/application.html.haml
@@ -65,7 +65,7 @@
 
     .wrapper{style: ('background-color: #ffffff' if view_options[:white_background])}
       - unless view_options[:no_header]
-        = render partial: 'layouts/header', locals: {script: @script, script_level: @script_level, level: @level, full_width: view_options[:full_width]}
+        = render partial: 'layouts/header', locals: {script: @script, script_level: @script_level, level: @level, lesson: @lesson, full_width: view_options[:full_width]}
       - if view_options[:code_studio_logo]
         = render partial: 'layouts/logo'
       - page = yield

--- a/lib/cdo/help_header.rb
+++ b/lib/cdo/help_header.rb
@@ -79,6 +79,13 @@ class HelpHeader
         url: "/report_abuse",
         id: "report-abuse"
       }
+    elsif options[:lesson]
+      report_url = options[:lesson].report_bug_url(options[:request])
+      entries << {
+        title: I18n.t("#{loc_prefix}report_bug"),
+        url: report_url,
+        id: "report-bug"
+      }
     else
       entries << {
         title: I18n.t("#{loc_prefix}report_bug"),

--- a/pegasus/sites.v3/code.org/views/header.haml
+++ b/pegasus/sites.v3/code.org/views/header.haml
@@ -6,6 +6,7 @@
   hamburger_options = {}
   hamburger_options[:level] = nil
   hamburger_options[:script_level] = nil
+  hamburger_options[:lesson] = nil
   hamburger_options[:user_type] = user_type
   hamburger_options[:language] = request.language
   hamburger_options[:show_gallery] = true

--- a/shared/haml/help_button.haml
+++ b/shared/haml/help_button.haml
@@ -1,7 +1,7 @@
 :ruby
   require 'cdo/help_header'
 
-  options = { level: level, script_level: script_level, language: language, user_type: user_type, loc_prefix: loc_prefix, request: request }
+  options = { level: level, script_level: script_level, lesson: lesson, language: language, user_type: user_type, loc_prefix: loc_prefix, request: request }
 
   help_items = HelpHeader.get_help_contents(options)
 


### PR DESCRIPTION
Finishes https://codedotorg.atlassian.net/browse/PLAT-1071.

### before

when reporting bug from https://studio.code.org/s/coursea-2021/lessons/4

![Screen Shot 2021-06-02 at 4 50 31 PM](https://user-images.githubusercontent.com/8001765/120566717-b0136700-c3c4-11eb-808a-0c339f97a757.png)

![Screen Shot 2021-06-02 at 5 01 35 PM](https://user-images.githubusercontent.com/8001765/120566499-3a0f0000-c3c4-11eb-9abe-9accf91f7a44.png)

### after

when reporting a bug from http://localhost-studio.code.org:3000/s/csp1-2021/lessons/4

![Screen Shot 2021-06-02 at 4 57 54 PM](https://user-images.githubusercontent.com/8001765/120566568-6034a000-c3c4-11eb-953b-c0c01c7dfdd3.png)

### script level bug report

when reporting a bug from http://localhost-studio.code.org:3000/s/csp1-2021/lessons/1/levels/1

![Screen Shot 2021-06-02 at 4 58 33 PM](https://user-images.githubusercontent.com/8001765/120566653-8c502100-c3c4-11eb-8f2f-9d0665ab65c5.png)

## Testing story

Manually verified new behavior shown in screenshots above. manually verified that the bug report link on pages which do not have the lesson param set (such as the script level page shown above) still work.
