### PR TITLE
Fix contact-rollups record deletion

### DIFF
--- a/lib/cdo/contact_rollups/v2/pardot.rb
+++ b/lib/cdo/contact_rollups/v2/pardot.rb
@@ -270,7 +270,7 @@ class PardotV2
   # @param email [String]
   # @return [Array<String>]
   def self.retrieve_pardot_ids_by_email(email)
-    doc = post_with_auth_retry "#{PROSPECT_READ_URL}/#{email}"
+    doc = post_with_auth_retry "#{PROSPECT_READ_URL}/#{URI.escape(email)}"
     doc.xpath('//prospect/id').map(&:text)
   rescue StandardError => e
     # If the input email does not exist, Pardot will response with


### PR DESCRIPTION
_[FND-1584](https://codedotorg.atlassian.net/browse/FND-1584). This is a follow-up of https://github.com/code-dot-org/code-dot-org/pull/40683._ 

The process to delete contact-rollups records and Pardot prospects has been failing **silently** since 1/2021. There are 6K+ records marked for deletion in `ContactRollupsPardotMemory` that are not deleted. 
```
ContactRollupsPardotMemory.where.not(marked_for_deletion_at: nil).count  #6340
```

This means we still keep data from users who requested us to delete their info in both our system (ContactRollups) and an external system (Pardot). There are 2 reasons:

1. Invalid email address caused the deletion process to fail, as reported in [Honeybadger #79757239](https://app.honeybadger.io/projects/3240/faults/79757239).
2. The error was silent because we save exception in a `LogCollector` instance but did not report it to Honeybadger. (The Honeybadger above is created recently as a result of this fix.)

## Testing story
Manually test the fix in Rails console using the invalid email from the Honeybadger above.
```ruby
require 'cdo/contact_rollups/v2/pardot'
PardotV2.retrieve_pardot_ids_by_email(invalid_email)
PardotV2.delete_prospects_by_email(invalid_email)
```

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
