### PR TITLE
Update styles on console logs

### DIFF
--- a/apps/src/javalab/JavalabConsole.jsx
+++ b/apps/src/javalab/JavalabConsole.jsx
@@ -31,11 +31,13 @@ const style = {
     whiteSpace: 'pre-wrap',
     flexGrow: 1
   },
-  consoleInputWrapper: {
+  consoleLineWrapper: {
     flexGrow: 0,
     flexShrink: 0,
     display: 'flex',
-    overflow: 'auto'
+    alignItems: 'center',
+    overflow: 'auto',
+    fontSize: 14
   },
   consoleInputPrompt: {
     display: 'block',
@@ -47,7 +49,8 @@ const style = {
     flexGrow: 1,
     marginBottom: 0,
     boxShadow: 'none',
-    border: 'none'
+    border: 'none',
+    padding: 0
   }
 };
 
@@ -104,14 +107,13 @@ class JavalabConsole extends React.Component {
 
   displayConsoleLogs() {
     return this.props.consoleLogs.map((log, i) => {
-      let prefix = '<';
-      if (log.type === 'input') {
-        prefix = '>';
-      }
       return (
-        <p key={`log_${i}`}>
-          {prefix} {log.text}
-        </p>
+        <div key={`log-${i}`} style={style.consoleLineWrapper}>
+          {log.type === 'input' && (
+            <span style={style.consoleInputPrompt}>&gt;</span>
+          )}
+          {log.text}
+        </div>
       );
     });
   }
@@ -158,7 +160,7 @@ class JavalabConsole extends React.Component {
           className="javalab-console"
         >
           <div style={style.consoleLogs}>{this.displayConsoleLogs()}</div>
-          <div style={style.consoleInputWrapper}>
+          <div style={style.consoleLineWrapper}>
             <span style={style.consoleInputPrompt} onClick={this.focus}>
               &gt;
             </span>


### PR DESCRIPTION
Tweaking the styles in the JavalabConsole to:
- Remove the "<" prefix before console output
- Condense the padding between logs
- Remove shifting after entering input (by making the styles the same between the console input and logs)

**Before:**
<img width="625" alt="Screen Shot 2021-06-02 at 5 59 10 PM" src="https://user-images.githubusercontent.com/9812299/120570130-426b3900-c3cc-11eb-81d0-a9bc1a748abd.png">


**After:**
<img width="624" alt="Screen Shot 2021-06-02 at 5 53 32 PM" src="https://user-images.githubusercontent.com/9812299/120569991-f4eecc00-c3cb-11eb-98a5-729057d49cbe.png">


## Links

- [CSA-361](https://codedotorg.atlassian.net/browse/CSA-361)