### PR TITLE
Prevent react-select from filtering out inexact matches and don't alw…

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/SearchBox.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/SearchBox.jsx
@@ -12,13 +12,6 @@ export default class SearchBox extends Component {
     additionalQueryParams: PropTypes.object
   };
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      searchValue: ''
-    };
-  }
-
   /**
    * Debounced function that will request search results from the server.
    * Because this function is debounced it is not guaranteed to execute
@@ -75,9 +68,8 @@ export default class SearchBox extends Component {
     return (
       <Select.Async
         loadOptions={this.getOptions}
-        value={this.state.searchValue}
         onChange={this.props.onSearchSelect}
-        placeholder={''}
+        filterOptions={false}
       />
     );
   }

--- a/dashboard/lib/autocomplete_helper.rb
+++ b/dashboard/lib/autocomplete_helper.rb
@@ -28,7 +28,7 @@ class AutocompleteHelper
   # @see https://dev.mysql.com/doc/refman/5.6/en/fulltext-boolean.html
   # @param query [String] the user-defined query string
   # @return [String] the formatted query string
-  def self.format_query(query)
+  def self.format_query(query, require_all_terms: true)
     words = get_query_terms query
     # Don't filter the last word if it is short since we will
     # append it with * for a wildcard search.
@@ -36,6 +36,10 @@ class AutocompleteHelper
       i == words.length - 1 || w.length >= MIN_WORD_LENGTH
     end
 
-    return words.empty? ? "" : "+#{words.join(' +')}*"
+    if require_all_terms
+      return words.empty? ? "" : "+#{words.join(' +')}*"
+    else
+      return words.empty? ? "" : "#{words.join(' ')}*"
+    end
   end
 end

--- a/dashboard/lib/resources_autocomplete.rb
+++ b/dashboard/lib/resources_autocomplete.rb
@@ -5,7 +5,7 @@ class ResourcesAutocomplete < AutocompleteHelper
     rows = Resource.limit(limit)
     rows = rows.where(course_version_id: course_version_id)
     return [] if query.length < MIN_WORD_LENGTH
-    query = format_query(query)
+    query = format_query(query, require_all_terms: false)
     rows = rows.
       where("MATCH(name,url) AGAINST(? in BOOLEAN MODE)", query)
     return rows.map(&:summarize_for_lesson_edit)

--- a/dashboard/test/lib/autocomplete_helper_test.rb
+++ b/dashboard/test/lib/autocomplete_helper_test.rb
@@ -5,6 +5,10 @@ class AutocompleteHelperTest < ActiveSupport::TestCase
     assert_equal '+ABC +DEF*', AutocompleteHelper.format_query('abc def')
   end
 
+  test 'to search string with two words with require_all_terms set to false' do
+    assert_equal 'ABC DEF*', AutocompleteHelper.format_query('abc def', require_all_terms: false)
+  end
+
   test 'to search string with special chars before second word' do
     assert_equal '+ABC +DEF*', AutocompleteHelper.format_query('abc +def')
   end


### PR DESCRIPTION
This PR prevents `react-select` from doing its own filtering as we're doing that on the server-side. This is following the [advice](https://www.npmjs.com/package/react-select/v/1.2.1#note-about-filtering-async-options) from the documentation. This affects all components that use `SearchBox`.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
