### PR TITLE
Clean up library questions on seed

### DIFF
--- a/dashboard/app/models/foorm/library.rb
+++ b/dashboard/app/models/foorm/library.rb
@@ -48,6 +48,9 @@ class Foorm::Library < ApplicationRecord
         library.published = published
         library.save! if library.changed?
 
+        # remove existing questions to catch any that were removed in the file
+        library.library_questions.destroy_all
+
         source_questions["pages"].map do |page|
           page["elements"].map do |element|
             question_name = element["name"]


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

We want to clean out an existing library's questions when reseeding in order to catch library questions that were removed. Removing questions in this way (by saving over instead of incrementing the version) means that they should never be used, as they will no longer be accessible by forms attempting to render. Before this change, library questions that got seeded into the db on levelbuilder, but then removed before the content sync, would still show as available and would validate as if they were available, but would cause errors on other environments when trying to render a form using them.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- slack thread: [slack](https://codedotorg.slack.com/archives/CU8HMEE06/p1622753863037000)
- jira ticket: [see comments](https://codedotorg.atlassian.net/browse/PLC-1219)
- ben's PR for enforcing additional rules on library question names: [PR](https://github.com/code-dot-org/code-dot-org/pull/40005)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

Tested locally on staging, tested using dashboard-console on levelbuilder.
