### PR TITLE
Disable react-select filtering

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/SearchBox.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/SearchBox.jsx
@@ -12,13 +12,6 @@ export default class SearchBox extends Component {
     additionalQueryParams: PropTypes.object
   };
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      searchValue: ''
-    };
-  }
-
   /**
    * Debounced function that will request search results from the server.
    * Because this function is debounced it is not guaranteed to execute
@@ -75,9 +68,8 @@ export default class SearchBox extends Component {
     return (
       <Select.Async
         loadOptions={this.getOptions}
-        value={this.state.searchValue}
         onChange={this.props.onSearchSelect}
-        placeholder={''}
+        filterOptions={false}
       />
     );
   }


### PR DESCRIPTION
This PR prevents `react-select` from doing its own filtering as we're doing that on the server-side. This is following the [advice](https://www.npmjs.com/package/react-select/v/1.2.1#note-about-filtering-async-options) from the documentation. This affects all components that use `SearchBox`.

Example: Searching for the CSD Implementation Guide using the search term "csd guide implementation"

Before:

https://user-images.githubusercontent.com/46464143/120834252-9f273a80-c517-11eb-9d7b-8323ff4985e2.mov

After:

https://user-images.githubusercontent.com/46464143/120834271-a51d1b80-c517-11eb-9d4e-cdb08349ab2d.mov



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
