### PR TITLE
Display run/reset on Applab widgets in start mode

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -1039,13 +1039,17 @@ StudioApp.prototype.toggleRunReset = function(button) {
   }
 
   var run = document.getElementById('runButton');
-  var reset = document.getElementById('resetButton');
-  if (run || reset) {
+  if (run) {
     run.style.display = showRun ? 'inline-block' : 'none';
     run.disabled = !showRun;
+  }
+
+  var reset = document.getElementById('resetButton');
+  if (reset) {
     reset.style.display = !showRun ? 'inline-block' : 'none';
     reset.disabled = showRun;
   }
+
   if (this.isUsingBlockly() && !this.config.readonlyWorkspace) {
     // craft has a darker color scheme than other blockly labs. It needs to
     // toggle between different colors on run/reset or else, on run, the workspace

--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -472,6 +472,8 @@ Applab.init = function(config) {
   const hasDataMode = !(
     config.level.hideViewDataButton || config.level.widgetMode
   );
+  const playspacePhoneFrame = !(config.share || config.level.widgetMode);
+  const hideRunResetButtons = playspacePhoneFrame || nonLevelbuilderWidgetMode;
 
   // Construct a logging observer for interpreter events
   if (!config.hideSource) {
@@ -656,7 +658,9 @@ Applab.init = function(config) {
 
   // Push initial level properties into the Redux store
   studioApp().setPageConstants(config, {
-    playspacePhoneFrame: !(config.share || config.level.widgetMode),
+    playspacePhoneFrame,
+    hideRunButton: hideRunResetButtons,
+    hideResetButton: hideRunResetButtons,
     channelId: config.channel,
     allowExportExpo: experiments.isEnabled('exportExpo'),
     exportApp: Applab.exportApp,

--- a/apps/src/redux/pageConstants.js
+++ b/apps/src/redux/pageConstants.js
@@ -42,6 +42,7 @@ var ALLOWED_KEYS = new Set([
   'hideCoordinateOverlay',
   'hideSource',
   'hideRunButton',
+  'hideResetButton',
   'playspacePhoneFrame',
   'noVisualization',
   'pinWorkspaceToBottom',

--- a/apps/src/templates/GameButtons.jsx
+++ b/apps/src/templates/GameButtons.jsx
@@ -79,13 +79,11 @@ ResetButton.displayName = 'ResetButton';
 export const UnconnectedGameButtons = props => (
   <div>
     <ProtectedStatefulDiv id="gameButtons" style={styles.main}>
-      {!(props.playspacePhoneFrame || props.widgetMode) && (
-        <RunButton
-          hidden={props.hideRunButton}
-          runButtonText={props.runButtonText}
-        />
-      )}
-      {!(props.playspacePhoneFrame || props.widgetMode) && <ResetButton />}
+      <RunButton
+        hidden={props.hideRunButton}
+        runButtonText={props.runButtonText}
+      />
+      {!props.hideResetButton && <ResetButton />}
       {
         ' ' /* Explicitly insert whitespace so that this behaves like our ejs file*/
       }
@@ -99,6 +97,7 @@ export const UnconnectedGameButtons = props => (
 );
 UnconnectedGameButtons.propTypes = {
   hideRunButton: PropTypes.bool,
+  hideResetButton: PropTypes.bool,
   runButtonText: PropTypes.string,
   playspacePhoneFrame: PropTypes.bool,
   nextLevelUrl: PropTypes.string,
@@ -111,6 +110,7 @@ UnconnectedGameButtons.displayName = 'GameButtons';
 
 export default connect(state => ({
   hideRunButton: state.pageConstants.hideRunButton,
+  hideResetButton: state.pageConstants.hideResetButton,
   runButtonText: state.pageConstants.runButtonText,
   playspacePhoneFrame: state.pageConstants.playspacePhoneFrame,
   nextLevelUrl: state.pageConstants.nextLevelUrl,


### PR DESCRIPTION
Currently, the run/reset buttons are hidden for Applab widget levels. This makes it so that the buttons are shown for levelbuilders in start mode.

**Applab visualization column for a levelbuilder in start mode:**
<img width="626" alt="Screen Shot 2021-06-08 at 9 47 36 AM" src="https://user-images.githubusercontent.com/9812299/121225656-96e43d80-c83e-11eb-944a-84d785b93130.png">
<img width="636" alt="Screen Shot 2021-06-08 at 9 47 25 AM" src="https://user-images.githubusercontent.com/9812299/121225660-977cd400-c83e-11eb-97cf-7c5a8e0b7035.png">

**Applab visualization column for a user viewing that widget level:**
<img width="629" alt="Screen Shot 2021-06-08 at 9 48 23 AM" src="https://user-images.githubusercontent.com/9812299/121225819-c430eb80-c83e-11eb-8862-b747e9ae2a61.png">


## Links

- [STAR-1594](https://codedotorg.atlassian.net/browse/STAR-1594)

## Testing story

Relies on existing UI/eyes tests.