### PR TITLE
Javalab: autosave before code is run

### DIFF
--- a/apps/src/javalab/Javalab.js
+++ b/apps/src/javalab/Javalab.js
@@ -242,7 +242,12 @@ Javalab.prototype.onRun = function() {
     getStore().getState().pageConstants.serverLevelId,
     options
   );
-  this.javabuilderConnection.connectJavabuilder();
+  // ensure autosave is called on first run by manually setting
+  // projectChanged to true.
+  project.projectChanged();
+  project.autosave(() => {
+    this.javabuilderConnection.connectJavabuilder();
+  });
 };
 
 // Called by Javalab console to send a message to Javabuilder.

--- a/apps/src/javalab/Javalab.js
+++ b/apps/src/javalab/Javalab.js
@@ -182,6 +182,10 @@ Javalab.prototype.init = function(config) {
   // Dispatches a redux update of isDarkMode
   getStore().dispatch(setIsDarkMode(this.isDarkMode));
 
+  // ensure autosave is executed on first run by manually setting
+  // projectChanged to true.
+  project.projectChanged();
+
   ReactDOM.render(
     <Provider store={getStore()}>
       <JavalabView
@@ -242,9 +246,6 @@ Javalab.prototype.onRun = function() {
     getStore().getState().pageConstants.serverLevelId,
     options
   );
-  // ensure autosave is called on first run by manually setting
-  // projectChanged to true.
-  project.projectChanged();
   project.autosave(() => {
     this.javabuilderConnection.connectJavabuilder();
   });


### PR DESCRIPTION
Call autosave every time we run code in Javalab to ensure we are running the latest version of the code. This fixes a couple bugs for us:
- If you were running start sources code and had made no edits, you would get a server error because we never saved the code to S3.
- If you made changes to your code but didn't commit or the code didn't autosave between your changes and clicking run, you would get unexpected results as the backend would run different code than what you saw on the frontend.

## Links


- jira ticket: [CSA-435](https://codedotorg.atlassian.net/browse/CSA-435), [CSA-299](https://codedotorg.atlassian.net/browse/CSA-299)


## Testing story
Tested locally

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
