### PR TITLE
Fix AppLab Embed Width

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -2271,14 +2271,9 @@ StudioApp.prototype.handleHideSource_ = function(options) {
         // Set the document to use flex.
         document.body.className += ' WireframeButtons_container';
 
-        // Create an empty div on the left for padding
-        var div = document.createElement('div');
-        div.className = 'WireframeButtons_containerLeft';
-        document.body.insertBefore(div, document.body.firstChild);
-
         // Add 'withWireframeButtons' class to top level div that wraps app.
         // This will add necessary styles.
-        div = document.getElementsByClassName('wrapper')[0];
+        var div = document.getElementsByClassName('wrapper')[0];
         if (div) {
           div.className = 'wrapper withWireframeButtons';
         }

--- a/apps/style/applab/style.scss
+++ b/apps/style/applab/style.scss
@@ -242,7 +242,8 @@ div#visualizationResizeBar {
   padding: 20px 0;
   position: fixed;
   left: 50%;
-  margin-left: -178px;
+  // Offset by half the width of the app with phone frame to center the applab visualization
+  margin-left: -(($applab-content-width + $applab-phoneframe-width) / 2);
   background-size: initial;
 
   #playSpaceHeader, #gameButtons {

--- a/apps/style/applab/style.scss
+++ b/apps/style/applab/style.scss
@@ -239,9 +239,10 @@ div#visualizationResizeBar {
   // make sure to update the AdvancedShareOptions.jsx iframe code.
   width: 352px;
   height: 612px;
-  margin: 0 auto;
   padding: 20px 0;
-
+  position: fixed;
+  left: 50%;
+  margin-left: -178px;
   background-size: initial;
 
   #playSpaceHeader, #gameButtons {

--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -1573,13 +1573,6 @@ $see-examples-thick-underline-color: $yellow;
   display: flex;
 }
 
-.WireframeButtons_containerLeft {
-  flex: 1 1 372px;
-  overflow: hidden;
-  padding-top: 20px;
-  padding-right: 20px;
-}
-
 .wrapper.withWireframeButtons {
   flex: 0 0 auto;
   margin-bottom: 0;
@@ -1596,10 +1589,6 @@ $see-examples-thick-underline-color: $yellow;
 @media (max-width: 845px) {
   .WireframeButtons_containerRight {
     flex: 1 1 372px;
-  }
-
-  .WireframeButtons_containerLeft {
-    flex: 1 1 auto;
   }
 }
 

--- a/shared/css/style-constants.scss
+++ b/shared/css/style-constants.scss
@@ -12,3 +12,9 @@ $delete-opacity: 0.5;
 
 // Width of pegasus content as of 2017 redesign
 $content-width: 970px;
+
+// Width of Applab content
+$applab-content-width: 320px;
+
+// Width of Applab 'phone' frame
+$applab-phoneframe-width: 32px;


### PR DESCRIPTION
Remove wireframeButtons_containerLeft, which was used only for padding. Adding css to the visualization column to equate the styling that was on wireframeButtons_containerLeft. No visual changes expected. 

This should fix the bug here: https://codedotorg.atlassian.net/secure/RapidBoard.jspa?rapidView=26&projectKey=STAR&modal=detail&selectedIssue=STAR-1548. The embedded app was pushed 20-pixels to the right because of the padding on wireframeButtons_containerLeft, so removing that padding should move the app so it's not getting cut off.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
