### PR TITLE
Adding extra HoC certificates for Korean students

### DIFF
--- a/apps/src/templates/Congrats.jsx
+++ b/apps/src/templates/Congrats.jsx
@@ -4,6 +4,8 @@ import Certificate from './Certificate';
 import StudentsBeyondHoc from './StudentsBeyondHoc';
 import TeachersBeyondHoc from './TeachersBeyondHoc';
 import styleConstants from '../styleConstants';
+import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
+import color from '../util/color';
 
 export default class Congrats extends Component {
   static propTypes = {
@@ -17,6 +19,59 @@ export default class Congrats extends Component {
     hideDancePartyFollowUp: PropTypes.bool
   };
 
+  /**
+   * @param tutorial The specific tutorial the student completed i.e. 'dance', 'dance-2019', etc
+   * @returns {string} The category type the specific tutorial belongs to i.e. 'dance', 'applab', etc
+   */
+  getTutorialType = tutorial =>
+    ({
+      dance: 'dance',
+      'dance-2019': 'dance',
+      'applab-intro': 'applab',
+      aquatic: '2018Minecraft',
+      hero: '2017Minecraft',
+      minecraft: 'pre2017Minecraft',
+      mc: 'pre2017Minecraft',
+      oceans: 'oceans'
+    }[tutorial] || 'other');
+
+  /**
+   * Renders links to certificate alternatives when there is a special event going on.
+   * @param {string} language The language code related to the special event i.e. 'en', 'es', 'ko', etc
+   * @param {string} tutorialType The type of lesson the student completed i.e. 'dance', '2018Minecraft', etc
+   * @returns {HTMLElement} HTML for rendering the extra certificate links.
+   */
+  renderExtraCertificateLinks = (language, tutorialType) => {
+    let extraLinkUrl, extraLinkText;
+    // https://codedotorg.atlassian.net/browse/FND-1604
+    // these can be removed after July 25 2021
+    if (language === 'ko') {
+      switch (tutorialType) {
+        case 'oceans':
+          extraLinkUrl = pegasus('/files/online-coding-party-2021-oceans.pdf');
+          extraLinkText =
+            '온라인 코딩 파티 인증서 받으러 가기! (과학기술정보통신부 인증)';
+          break;
+        case 'dance':
+          extraLinkUrl = pegasus('/files/online-coding-party-2021-dance.pdf');
+          extraLinkText =
+            '온라인 코딩 파티 인증서 받으러 가기! (과학기술정보통신부 인증)';
+          break;
+      }
+    }
+    if (!extraLinkUrl || !extraLinkText) {
+      // There are no extra links to render.
+      return;
+    }
+    return (
+      <div style={styles.extraLinkContainer}>
+        <a href={extraLinkUrl} target={'_blank'} style={styles.extraLink}>
+          {extraLinkText}
+        </a>
+      </div>
+    );
+  };
+
   render() {
     const {
       tutorial,
@@ -28,19 +83,8 @@ export default class Congrats extends Component {
       randomDonorTwitter,
       hideDancePartyFollowUp
     } = this.props;
-
     const isEnglish = language === 'en';
-
-    const tutorialType =
-      {
-        dance: 'dance',
-        'dance-2019': 'dance',
-        'applab-intro': 'applab',
-        aquatic: '2018Minecraft',
-        hero: '2017Minecraft',
-        minecraft: 'pre2017Minecraft',
-        mc: 'pre2017Minecraft'
-      }[tutorial] || 'other';
+    const tutorialType = this.getTutorialType(tutorial);
 
     return (
       <div style={styles.container}>
@@ -49,7 +93,9 @@ export default class Congrats extends Component {
           certificateId={certificateId}
           randomDonorTwitter={randomDonorTwitter}
           under13={under13}
-        />
+        >
+          {this.renderExtraCertificateLinks(language, tutorialType)}
+        </Certificate>
         {userType === 'teacher' && isEnglish && <TeachersBeyondHoc />}
         <StudentsBeyondHoc
           completedTutorialType={tutorialType}
@@ -71,5 +117,13 @@ const styles = {
     maxWidth: styleConstants['content-width'],
     marginLeft: 'auto',
     marginRight: 'auto'
+  },
+  extraLinkContainer: {
+    clear: 'both',
+    paddingTop: 20
+  },
+  extraLink: {
+    color: color.teal,
+    fontSize: 14
   }
 };


### PR DESCRIPTION
The government agency in South Korea that's running their nationwide Online Coding Party campaign that kicks off next week. The campaign will run from June 14th (Monday!) to July 25th. They'll include Dance Party and AI for Oceans as official tutorials students can use to participate in the campaign and they need us to link to their official certificate on our certificate page.

This change adds a link to custom certificates on the Congrats! page for Korean students who complete the AI for Oceans or the Dance Party tutorials.

## Links
* [JIRA](https://codedotorg.atlassian.net/browse/FND-1604)
* [PR for similar request made in 2018](https://github.com/code-dot-org/code-dot-org/pull/24799)

## Testing story
* Completed dance party, oceans, and Minecraft tutorials. Verified link is on dance and oceans pages in Korean only. Verified link is not present for Minecraft.
* Clicked the custom certificate links and verified the correct PDF was opened in a new tab.

### Screenshots

---

#### Dance Party
Note the link below the certificate image.
![image](https://user-images.githubusercontent.com/1372238/121276028-65f71d80-c8bd-11eb-94a2-16ec9a39180c.png)

---

#### AI for Oceans
Note the link below the certificate image.
![image](https://user-images.githubusercontent.com/1372238/121276056-75766680-c8bd-11eb-978b-39abef2f66d2.png)

---

#### Minecraft
Note there is NO link below the certificate image.
![image](https://user-images.githubusercontent.com/1372238/121276079-8030fb80-c8bd-11eb-9bba-73de6c67531f.png)

---

## Deployment strategy
Normal DTP

## Follow-up work
Remove these special links after July 25th

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
