### PR TITLE
Enable binary logging on production Aurora database cluster.

### DIFF
--- a/aws/cloudformation/db_parameters.yml.erb
+++ b/aws/cloudformation/db_parameters.yml.erb
@@ -147,8 +147,18 @@ Reporting:
 
 # System variables for the Aurora DB cluster.
 AuroraCluster: &aurora
-  # Disable binary logging to improve write performance.
-  binlog_format: 'OFF'
+  # When using row-based logging, the primary database writes events to the binary log that indicate how individual table rows are changed.
+  # Replication of the primary database to a replica works by copying the events representing the changes to the table rows to the replica.
+  # ROW required for DMS Change Data Capture:
+  # https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.MySQL.html#CHAP_Source.MySQL.AmazonManaged
+  # ROW also required to use gh-ost to carry out online schema changes on large tables:
+  # https://github.com/github/gh-ost/blob/master/doc/requirements-and-limitations.md
+  binlog_format: ROW
+  # When enabled, this variable causes the primary database to write a checksum for each event in the binary log.
+  # When disabled (value NONE), write and check the event length (rather than a checksum) for each event.
+  # NONE required for DMS Change Data Capture:
+  # https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.MySQL.html#CHAP_Source.MySQL.AmazonManaged
+  binlog_checksum: NONE
 
   # Enable GTIDs: https://aws.amazon.com/blogs/database/amazon-aurora-for-mysql-compatibility-now-supports-global-transaction-identifiers-gtids-replication/
   gtid-mode: ON_PERMISSIVE


### PR DESCRIPTION
We [disabled binary logging](https://github.com/code-dot-org/code-dot-org/pull/31506) on the production Aurora database cluster in October 2019 because it was degrading write performance (particularly with both a "reporting" Aurora cluster acting as a replica client and the old production RDS MySQL database instance acting as a replica client in case we wanted to rollback). Re-enabling binary logging along with upgrading to Aurora Engineer 2.10.0, [which includes performance improvements](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Updates.2100.html) to binary logging. This will enable us to use [gh-ost](https://github.com/github/gh-ost) to carry out schema changes of large tables.

https://codedotorg.atlassian.net/browse/INF-460

NOTE: Before running a gh-ost migration we must temporarily disable aurora binlog filtering (does not require a restart) and re-enable after.

## Testing story

```
$ bundle exec rake stack:data:validate RAILS_ENV=production
Pending update for stack `DATA-production`:
Modify AuroraClusterDBParameters [AWS::RDS::DBClusterParameterGroup] Properties (Parameters)
Modify AuroraReportingClusterDBParameters [AWS::RDS::DBClusterParameterGroup] Properties (Parameters)
```

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

```
bundle exec rake stack:data:start RAILS_ENV=production
```

Followed by a restart of the writer instance (which will be carried out during upgrade to Aurora 2.10.0

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
