### PR TITLE
Script to automatically dry run seed access report test files on staging environment

### DIFF
--- a/bin/cron/test_access_report_import
+++ b/bin/cron/test_access_report_import
@@ -4,12 +4,12 @@ abort 'Script already running' unless only_one_running?(__FILE__)
 
 require_relative '../../dashboard/config/environment'
 require 'cdo/chat_client'
+require 'time'
 
 CENSUS_BUCKET = 'cdo-census'.freeze
 
-def update_object_key(object_key, valid)
-  key_without_extension = object_key.chomp(".test")
-  AWS::S3.rename_object(CENSUS_BUCKET, object_key, key_without_extension + ".#{valid ? 'valid' : 'invalid'}")
+def resolved_object_key(object_key, valid)
+  object_key.chomp(".test") + ".#{Time.now.utc.iso8601}" + ".#{valid ? 'valid' : 'invalid'}"
 end
 
 def main
@@ -18,14 +18,17 @@ def main
     Census::StateCsOffering.dry_run_new_test_file(object_key)
 
     # update object key to reflect valid file
-    update_object_key(object_key, true)
+    new_key = resolved_object_key(object_key, true)
+    AWS::S3.rename_object(CENSUS_BUCKET, object_key, new_key)
+    ChatClient.log("Dry run seeding of state cs offering file succeeded: #{new_key}", color: 'green')
   rescue => e
-    ChatClient.log("Dry run seeding of state cs offering file failed: #{object_key}", color: 'red')
+    new_key = resolved_object_key(object_key, false)
+    ChatClient.log("Dry run seeding of state cs offering file failed: #{new_key}", color: 'red')
     ChatClient.log(e, color: 'red')
 
     # update object key to reflect invalid file
-    update_object_key(object_key, false)
-    raise e
+    AWS::S3.rename_object(CENSUS_BUCKET, object_key, new_key)
+    puts e
   end
 end
 

--- a/bin/cron/test_access_report_import
+++ b/bin/cron/test_access_report_import
@@ -25,6 +25,7 @@ def main
 
     # update object key to reflect invalid file
     update_object_key(object_key, false)
+    raise e
   end
 end
 

--- a/bin/cron/test_access_report_import
+++ b/bin/cron/test_access_report_import
@@ -5,10 +5,27 @@ abort 'Script already running' unless only_one_running?(__FILE__)
 require_relative '../../dashboard/config/environment'
 require 'cdo/chat_client'
 
+CENSUS_BUCKET = 'cdo-census'.freeze
+
+def update_object_key(object_key, valid)
+  key_without_extension = object_key.chomp(".test")
+  AWS::S3.rename_object(CENSUS_BUCKET, object_key, key_without_extension + ".#{valid ? 'valid' : 'invalid'}")
+end
+
 def main
-  Census::StateCsOffering.dry_run_new_test_files
-rescue => e
-  ChatClient.log("<@#{DevelopersTopic.dotd}> dry run seeding of state cs offerings failed: #{e}", color: 'yellow')
+  AWS::S3.find_objects_with_ext(CENSUS_BUCKET, 'test', 'state_cs_offerings').each do |object_key|
+    ChatClient.log("Attempting dry run seed of state cs offering file: #{object_key}")
+    Census::StateCsOffering.dry_run_new_test_file(object_key)
+
+    # update object key to reflect valid file
+    update_object_key(object_key, true)
+  rescue => e
+    ChatClient.log("Dry run seeding of state cs offering file failed: #{object_key}", color: 'red')
+    ChatClient.log(e, color: 'red')
+
+    # update object key to reflect invalid file
+    update_object_key(object_key, false)
+  end
 end
 
 main

--- a/bin/cron/test_access_report_import
+++ b/bin/cron/test_access_report_import
@@ -24,11 +24,10 @@ def main
   rescue => e
     new_key = resolved_object_key(object_key, false)
     ChatClient.log("Dry run seeding of state cs offering file failed: #{new_key}", color: 'red')
-    ChatClient.log(e, color: 'red')
+    ChatClient.log(e.message, color: 'red')
 
     # update object key to reflect invalid file
     AWS::S3.rename_object(CENSUS_BUCKET, object_key, new_key)
-    puts e
   end
 end
 

--- a/bin/cron/test_access_report_import
+++ b/bin/cron/test_access_report_import
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+require_relative 'only_one'
+abort 'Script already running' unless only_one_running?(__FILE__)
+
+require_relative '../../dashboard/config/environment'
+require 'cdo/chat_client'
+
+def main
+  Census::StateCsOffering.dry_run_new_test_files
+rescue => e
+  ChatClient.log("<@#{DevelopersTopic.dotd}> dry run seeding of state cs offerings failed: #{e}", color: 'yellow')
+end
+
+main

--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -50,6 +50,7 @@
     if node.chef_environment == 'staging' && node.name == 'staging' # 'real' staging only
       cronjob at:'@reboot', do:home_dir('.dropbox-dist', 'dropboxd')
       cronjob at:'*/5 * * * *', do:deploy_dir('bin', 'cron', 'import_google_sheets')
+      cronjob at:'*/5 * * * *', do:deploy_dir('bin', 'cron', 'test_access_report_import')
       cronjob at:'* * * * *', do:deploy_dir('bin', 'cron', 'sync_dropbox')
       cronjob at:'*/2 * * * *', do:deploy_dir('bin', 'cron', 'run_server_generate_pdfs')
       cronjob at:'*/2 * * * *', do:pegasus_dir('sites','virtual','run_server_generate_curriculum_pdfs')

--- a/dashboard/app/models/census/state_cs_offering.rb
+++ b/dashboard/app/models/census/state_cs_offering.rb
@@ -1511,15 +1511,14 @@ class Census::StateCsOffering < ApplicationRecord
   # @return [array] [state_code, school_year, update, extension]
   def self.deconstruct_object_key(object_key)
     # "state_cs_offerings/<state_code>/<school_year>-<school_year_end>(.<update>).<file_extension>"
-    _, state_code, name = object_key.split('/')
-    years, update_or_extension, extension = name.split('.')
+    _, state_code, filename = object_key.split('/')
+    name, _, extension = filename.rpartition('.')
+    years, update = name.split('.')
     start_year, _ = years.split('-').map(&:to_i)
-    update = extension ? update_or_extension : 1
-    extension ||= update_or_extension
     [
       state_code,
       start_year,
-      update,
+      update || 1,
       extension
     ]
   end

--- a/dashboard/app/models/census/state_cs_offering.rb
+++ b/dashboard/app/models/census/state_cs_offering.rb
@@ -1513,7 +1513,7 @@ class Census::StateCsOffering < ApplicationRecord
     # "state_cs_offerings/<state_code>/<school_year>-<school_year_end>(.<update>).<file_extension>"
     _, state_code, name = object_key.split('/')
     years, update_or_extension, extension = name.split('.')
-    start_year, _ = years.split('-')
+    start_year, _ = years.split('-').map(&:to_i)
     update = extension ? update_or_extension : 1
     extension ||= update_or_extension
     [

--- a/dashboard/app/models/census/state_cs_offering.rb
+++ b/dashboard/app/models/census/state_cs_offering.rb
@@ -1494,6 +1494,7 @@ class Census::StateCsOffering < ApplicationRecord
   end
 
   CENSUS_BUCKET_NAME = "cdo-census".freeze
+  STATE_CS_FOLDER = "state_cs_offerings".freeze
 
   # Construct a path to the CSV.
   # @param [string] state_code - Something like "CA".
@@ -1502,7 +1503,35 @@ class Census::StateCsOffering < ApplicationRecord
   # @param [string] file_extension
   def self.construct_object_key(state_code, school_year, update = 1, file_extension = 'csv')
     update_string = update == 1 ? "" : ".#{update}"
-    "state_cs_offerings/#{state_code}/#{school_year}-#{school_year + 1}#{update_string}.#{file_extension}"
+    "#{STATE_CS_FOLDER}/#{state_code}/#{school_year}-#{school_year + 1}#{update_string}.#{file_extension}"
+  end
+
+  # Deconstructs an object key into multiple variables.
+  # @param [string] object_key - the AWS object name
+  # @return [array] [state_code, school_year, update, extension]
+  def self.deconstruct_object_key(object_key)
+    # "state_cs_offerings/<state_code>/<school_year>-<school_year_end>(.<update>).<file_extension>"
+    _, state_code, name = object_key.split('/')
+    years, update_or_extension, extension = name.split('.')
+    start_year, _ = years.split('-')
+    update = extension ? update_or_extension : 1
+    extension ||= update_or_extension
+    [
+      state_code,
+      start_year,
+      update,
+      extension
+    ]
+  end
+
+  # Searches the state_cs_offering folder for files with the .test extension and attempts to dry run seed them
+  def self.dry_run_new_test_files
+    AWS::S3.find_files_with_ext(CENSUS_BUCKET_NAME, 'test', STATE_CS_FOLDER) do |object_key|
+      state_code, school_year, update = deconstruct_object_key(object_key)
+      AWS::S3.process_file(CENSUS_BUCKET_NAME, object_key) do |filename|
+        seed_from_csv(state_code, school_year, update, filename, true)
+      end
+    end
   end
 
   def self.seed_from_s3(file_extension: 'csv', dry_run: false)

--- a/dashboard/app/models/census/state_cs_offering.rb
+++ b/dashboard/app/models/census/state_cs_offering.rb
@@ -1525,12 +1525,10 @@ class Census::StateCsOffering < ApplicationRecord
   end
 
   # Searches the state_cs_offering folder for files with the .test extension and attempts to dry run seed them
-  def self.dry_run_new_test_files
-    AWS::S3.find_files_with_ext(CENSUS_BUCKET_NAME, 'test', STATE_CS_FOLDER) do |object_key|
-      state_code, school_year, update = deconstruct_object_key(object_key)
-      AWS::S3.process_file(CENSUS_BUCKET_NAME, object_key) do |filename|
-        seed_from_csv(state_code, school_year, update, filename, true)
-      end
+  def self.dry_run_new_test_file(object_key)
+    state_code, school_year, update = deconstruct_object_key(object_key)
+    AWS::S3.process_file(CENSUS_BUCKET_NAME, object_key) do |filename|
+      seed_from_csv(state_code, school_year, update, filename, true)
     end
   end
 

--- a/lib/cdo/aws/s3.rb
+++ b/lib/cdo/aws/s3.rb
@@ -219,10 +219,19 @@ module AWS
       create_client.list_objects_v2(bucket: bucket, prefix: prefix).each do |response|
         object_keys.concat(
           response.contents.map(&:key).
-            filter {|key| key.ends_with?(ext)}
+            select {|key| key.ends_with?(ext)}
         )
       end
       object_keys
+    end
+
+    # Renames an object by copying it and then deleting the old copy (S3 objects are immutable)
+    # @params bucket [String] The S3 bucket name.
+    # @params object_key [String] The object key to rename.
+    # @params new_key [String] The new key the object should have.
+    def self.rename_object(bucket, object_key, new_key)
+      create_client.copy_object({bucket: bucket, copy_source: "/#{bucket}/#{object_key}", key: new_key})
+      create_client.delete_object({bucket: bucket, key: object_key})
     end
 
     # Processes an S3 file, requires a block to be executed after the data has

--- a/lib/cdo/aws/s3.rb
+++ b/lib/cdo/aws/s3.rb
@@ -209,6 +209,22 @@ module AWS
       end
     end
 
+    # Finds all objects with a given extension in the given bucket
+    # @param bucket [String] The S3 bucket name.
+    # @param ext [String] An extension to search for.
+    # @param prefix [String] An optional prefix to filter objects by.
+    def self.find_objects_with_ext(bucket, ext, prefix)
+      object_keys = []
+      # list_objects is paginated and each response is up to 1000 objects
+      create_client.list_objects_v2(bucket: bucket, prefix: prefix).each do |response|
+        object_keys.concat(
+          response.contents.map(&:key).
+            filter {|key| key.ends_with?(ext)}
+        )
+      end
+      object_keys
+    end
+
     # Processes an S3 file, requires a block to be executed after the data has
     # been downloaded to the temporary file (passed as argument to the block).
     # The block will not be called if the exact version of the S3 object has

--- a/lib/cdo/aws/s3.rb
+++ b/lib/cdo/aws/s3.rb
@@ -219,7 +219,7 @@ module AWS
       create_client.list_objects_v2(bucket: bucket, prefix: prefix).each do |response|
         object_keys.concat(
           response.contents.map(&:key).
-            select {|key| key.ends_with?(ext)}
+            select {|key| key.end_with?(ext)}
         )
       end
       object_keys

--- a/shared/test/fixtures/vcr/awss3integration/s3_find_objects_with_ext.yml
+++ b/shared/test/fixtures/vcr/awss3integration/s3_find_objects_with_ext.yml
@@ -1,0 +1,127 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://cdo-temp.s3.amazonaws.com/find_objects/1.test
+    body:
+      encoding: UTF-8
+      string: hello
+    headers:
+      Expect:
+      - 100-continue
+      Content-Md5:
+      - XUFAKrxLKna5cZ2REBfFkg==
+      Content-Length:
+      - '5'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 11 Jun 2021 18:08:48 GMT
+      Etag:
+      - '"5d41402abc4b2a76b9719d911017c592"'
+      Content-Length:
+      - '0'
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 11 Jun 2021 18:08:47 GMT
+- request:
+    method: put
+    uri: https://cdo-temp.s3.amazonaws.com/find_objects/2.test
+    body:
+      encoding: UTF-8
+      string: world
+    headers:
+      Expect:
+      - 100-continue
+      Content-Md5:
+      - fXkwN6B2AYZXSwKC8vQ15w==
+      Content-Length:
+      - '5'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 11 Jun 2021 18:08:49 GMT
+      Etag:
+      - '"7d793037a0760186574b0282f2f435e7"'
+      Content-Length:
+      - '0'
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 11 Jun 2021 18:08:47 GMT
+- request:
+    method: put
+    uri: https://cdo-temp.s3.amazonaws.com/find_objects/3.bad
+    body:
+      encoding: UTF-8
+      string: third value
+    headers:
+      Expect:
+      - 100-continue
+      Content-Md5:
+      - JMy63MKK75+yFkpJPLyswg==
+      Content-Length:
+      - '11'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 11 Jun 2021 18:08:49 GMT
+      Etag:
+      - '"24ccbadcc28aef9fb2164a493cbcacc2"'
+      Server:
+      - AmazonS3
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 11 Jun 2021 18:08:48 GMT
+- request:
+    method: get
+    uri: https://cdo-temp.s3.amazonaws.com/?list-type=2&prefix=find_objects
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Length:
+      - '0'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 11 Jun 2021 18:08:49 GMT
+      X-Amz-Bucket-Region:
+      - us-east-1
+      Content-Type:
+      - application/xml
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="UTF-8"?>
+        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>cdo-temp</Name><Prefix>find_objects</Prefix><KeyCount>3</KeyCount><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated><Contents><Key>find_objects/1.test</Key><LastModified>2021-06-11T18:08:48.000Z</LastModified><ETag>&quot;5d41402abc4b2a76b9719d911017c592&quot;</ETag><Size>5</Size><StorageClass>STANDARD</StorageClass></Contents><Contents><Key>find_objects/2.test</Key><LastModified>2021-06-11T18:08:49.000Z</LastModified><ETag>&quot;7d793037a0760186574b0282f2f435e7&quot;</ETag><Size>5</Size><StorageClass>STANDARD</StorageClass></Contents><Contents><Key>find_objects/3.bad</Key><LastModified>2021-06-11T18:08:49.000Z</LastModified><ETag>&quot;24ccbadcc28aef9fb2164a493cbcacc2&quot;</ETag><Size>11</Size><StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>
+    http_version: 
+  recorded_at: Fri, 11 Jun 2021 18:08:48 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
We want to have a way to test seed certain access report files without manual work on a production environment. This script automatically looks for files in the cdo-census bucket with the state_cs_offerings prefix and a .test file extension. It then attempts to seed those files as a dry run, and reports any errors to the slack log (in this case #infra-staging). After a success or failure, the object key's extension is updated from .test to .valid or .invalid.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- Access report context: [spec](https://docs.google.com/document/d/1Y9Wiz1pZ08OtweMrBJy6QuOfYZ8PM102KqiZax3u6O4/edit#)
- Slack discussion: [slack](https://codedotorg.slack.com/archives/C03CK49G9/p1623260142100700)
- Previous seeding process: [PR](https://github.com/code-dot-org/code-dot-org/pull/34925)

## Testing story

Tested all individual parts through dashboard-console

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

After deployment, the crontab file will be updated, and the process will automatically start checking S3 every 5 minutes. Will monitor the #infra-staging for any errors.

## Follow-up work
This should unblock liz for performing the access report uploads for the state_cs_offerings.
Eventually we will probably want to do this same process for the AP CS offerings and IB offerings.

## Privacy

Could potentially disclose teacher/school data through errors, so we're only logging to our internal slack channel.

![image](https://user-images.githubusercontent.com/82416901/121731791-3fe0a180-caa6-11eb-8c91-511cc8d52b2d.png)
->
![image](https://user-images.githubusercontent.com/82416901/121731849-4f5fea80-caa6-11eb-9faf-e735e8423f78.png)
