### PR TITLE
Revert "Sync teacher panel and section list on NetSim"

### DIFF
--- a/apps/src/netsim/NetSimLobby.js
+++ b/apps/src/netsim/NetSimLobby.js
@@ -9,7 +9,6 @@ import $ from 'jquery';
 var utils = require('../utils');
 var _ = require('lodash');
 var i18n = require('@cdo/netsim/locale');
-import {getStore} from '../redux';
 var NetSimNodeFactory = require('./NetSimNodeFactory');
 var NetSimClientNode = require('./NetSimClientNode');
 var NetSimAlert = require('./NetSimAlert');
@@ -561,7 +560,6 @@ NetSimLobby.prototype.buildShardChoiceList_ = function(
     unarchivedSections.map(
       function(section) {
         return {
-          sectionId: section.id,
           shardSeed: section.id,
           shardID: this.makeShardIDFromSeed_(section.id),
           displayName: section.name
@@ -581,20 +579,9 @@ NetSimLobby.prototype.buildShardChoiceList_ = function(
     });
   }
 
-  // Get teacher selected section (selected in TeacherPanel)
-  const teacherSections = getStore().getState().teacherSections;
-  const teacherSelectedSectionId =
-    teacherSections && teacherSections.selectedSectionId;
-
   // If there's only one possible shard, select it by default
   if (this.shardChoices_.length === 1 && !this.selectedShardID_) {
     this.setShardID(this.shardChoices_[0].shardID);
-  } else if (teacherSelectedSectionId && !this.selectedShardID_) {
-    // If teacher has selected a section, select it by default
-    const selectedSectionShardId = this.makeShardIDFromSeed_(
-      teacherSelectedSectionId
-    );
-    this.setShardID(selectedSectionShardId);
   }
 };
 

--- a/apps/src/netsim/NetSimShardSelectionPanel.html.ejs
+++ b/apps/src/netsim/NetSimShardSelectionPanel.html.ejs
@@ -23,7 +23,7 @@
               selectedAnyShard = true;
             }
             %>
-              <option value="<%= shardChoice.shardID %>" section-id="<%= shardChoice.sectionId %>" <%= attributes %>><%= shardChoice.displayName %></option>
+              <option value="<%= shardChoice.shardID %>" <%= attributes %>><%= shardChoice.displayName %></option>
             <%
           });
         %>

--- a/apps/src/netsim/NetSimShardSelectionPanel.js
+++ b/apps/src/netsim/NetSimShardSelectionPanel.js
@@ -10,9 +10,6 @@ var i18n = require('@cdo/netsim/locale');
 var markup = require('./NetSimShardSelectionPanel.html.ejs');
 var NetSimPanel = require('./NetSimPanel');
 import {KeyCodes} from '../constants';
-import {getStore} from '../redux';
-import {updateQueryParam} from '../code-studio/utils';
-import {reload} from '../utils';
 
 /**
  * @type {string}
@@ -152,26 +149,6 @@ NetSimShardSelectionPanel.prototype.setNameButtonClick_ = function() {
 };
 
 /**
- * @param {Node} selectElement
- * @private
- */
-NetSimShardSelectionPanel.prototype.updateTeacherSelectedSection_ = function(
-  selectElement
-) {
-  const shardID = selectElement.value;
-  if (shardID && getStore().getState().currentUser.userType === 'teacher') {
-    const sectionIdSelected = selectElement
-      .querySelector(`option[value=${shardID}]`)
-      .getAttribute('section-id');
-
-    updateQueryParam('section_id', sectionIdSelected || undefined);
-    // If we have a user_id when we switch sections we should get rid of it
-    updateQueryParam('user_id', undefined);
-    reload();
-  }
-};
-
-/**
  * @param {Event} jQueryEvent
  * @private
  */
@@ -181,7 +158,6 @@ NetSimShardSelectionPanel.prototype.onShardSelectChange_ = function(
   var shardID = jQueryEvent.target.value;
   var setShardButton = this.getBody().find('#netsim-shard-confirm-button');
   setShardButton.attr('disabled', !shardID || shardID === SELECTOR_NONE_VALUE);
-  this.updateTeacherSelectedSection_(jQueryEvent.target);
 };
 
 /**
@@ -198,7 +174,6 @@ NetSimShardSelectionPanel.prototype.onShardSelectKeyUp_ = function(
     jQueryEvent.which === KeyCodes.ENTER
   ) {
     this.setShardButtonClick_();
-    this.updateTeacherSelectedSection_(jQueryEvent.target);
   }
 };
 

--- a/apps/test/unit/netsim/NetSimLobbyTest.js
+++ b/apps/test/unit/netsim/NetSimLobbyTest.js
@@ -1,7 +1,6 @@
 import sinon from 'sinon';
 import $ from 'jquery';
 import {expect} from '../../util/reconfiguredChai';
-import * as redux from '@cdo/apps/redux';
 import NetSimLobby from '../../../src/netsim/NetSimLobby.js';
 import * as userSectionClient from '@cdo/apps/util/userSectionClient';
 var NetSimTestUtils = require('../../util/netsimTestUtils');
@@ -56,71 +55,5 @@ describe('NetSimLobby', () => {
     expect(netsimLobby.shardChoices_.map(obj => obj.displayName)).to.include(
       'Course 2'
     );
-  });
-
-  it('when a teacher has a section selected (teacher panel), NetSim lobby selects the selected section', () => {
-    const teacherSelectedSectionId = 3;
-
-    const reduxStub = sinon.stub(redux, 'getStore').returns({
-      getState: sinon.stub().returns({
-        teacherSections: {selectedSectionId: teacherSelectedSectionId}
-      })
-    });
-
-    const netsimLobby = new NetSimLobby(rootDiv, netsim, SIGNED_IN_USER);
-
-    const sectionList = [
-      {
-        id: 1,
-        name: 'Course 1',
-        hidden: false
-      },
-      {
-        id: 2,
-        name: 'Course 2',
-        hidden: false
-      },
-      {
-        id: teacherSelectedSectionId,
-        name: 'Course 3',
-        hidden: false
-      }
-    ];
-
-    netsimLobby.buildShardChoiceList_(sectionList, null);
-    const expectedSelectedShardID = netsimLobby.makeShardIDFromSeed_(
-      teacherSelectedSectionId
-    );
-    expect(netsimLobby.selectedShardID_).to.eq(expectedSelectedShardID);
-
-    reduxStub.restore();
-  });
-
-  it('when a teacher does not have a section selected and multiple sections, NetSim lobby does not auto select section', () => {
-    const reduxStub = sinon.stub(redux, 'getStore').returns({
-      getState: sinon.stub().returns({
-        teacherSections: {selectedSectionId: ''}
-      })
-    });
-
-    const netsimLobby = new NetSimLobby(rootDiv, netsim, SIGNED_IN_USER);
-
-    const sectionList = [
-      {
-        id: 1,
-        name: 'Course 1',
-        hidden: false
-      },
-      {
-        id: 2,
-        name: 'Course 2',
-        hidden: false
-      }
-    ];
-
-    netsimLobby.buildShardChoiceList_(sectionList, null);
-    expect(netsimLobby.selectedShardID_).to.eq(undefined);
-
-    reduxStub.restore();
   });
 });


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#39062

This PR caused the bug discussed here https://codedotorg.slack.com/archives/C0T0PNTM3/p1623265050262700. When a teacher poses as a student, the syncing with the teacher panel does not work correctly. I attempted a fix where syncing with the teacher panel will not happen when the teacher is posing as a student, however this proved to have some issues. I'm going to revert this PR for now and discuss the best way to move forward with product.