### PR TITLE
Revert "Fix AppLab Embed Width"

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -2271,9 +2271,14 @@ StudioApp.prototype.handleHideSource_ = function(options) {
         // Set the document to use flex.
         document.body.className += ' WireframeButtons_container';
 
+        // Create an empty div on the left for padding
+        var div = document.createElement('div');
+        div.className = 'WireframeButtons_containerLeft';
+        document.body.insertBefore(div, document.body.firstChild);
+
         // Add 'withWireframeButtons' class to top level div that wraps app.
         // This will add necessary styles.
-        var div = document.getElementsByClassName('wrapper')[0];
+        div = document.getElementsByClassName('wrapper')[0];
         if (div) {
           div.className = 'wrapper withWireframeButtons';
         }

--- a/apps/style/applab/style.scss
+++ b/apps/style/applab/style.scss
@@ -239,11 +239,9 @@ div#visualizationResizeBar {
   // make sure to update the AdvancedShareOptions.jsx iframe code.
   width: 352px;
   height: 612px;
+  margin: 0 auto;
   padding: 20px 0;
-  position: fixed;
-  left: 50%;
-  // Offset by half the width of the app with phone frame to center the applab visualization
-  margin-left: -(($applab-content-width + $applab-phoneframe-width) / 2);
+
   background-size: initial;
 
   #playSpaceHeader, #gameButtons {

--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -1573,6 +1573,13 @@ $see-examples-thick-underline-color: $yellow;
   display: flex;
 }
 
+.WireframeButtons_containerLeft {
+  flex: 1 1 372px;
+  overflow: hidden;
+  padding-top: 20px;
+  padding-right: 20px;
+}
+
 .wrapper.withWireframeButtons {
   flex: 0 0 auto;
   margin-bottom: 0;
@@ -1589,6 +1596,10 @@ $see-examples-thick-underline-color: $yellow;
 @media (max-width: 845px) {
   .WireframeButtons_containerRight {
     flex: 1 1 372px;
+  }
+
+  .WireframeButtons_containerLeft {
+    flex: 1 1 auto;
   }
 }
 

--- a/shared/css/style-constants.scss
+++ b/shared/css/style-constants.scss
@@ -12,9 +12,3 @@ $delete-opacity: 0.5;
 
 // Width of pegasus content as of 2017 redesign
 $content-width: 970px;
-
-// Width of Applab content
-$applab-content-width: 320px;
-
-// Width of Applab 'phone' frame
-$applab-phoneframe-width: 32px;


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#41017

Eyes tests caught some discrepancies in expected behavior.
![Screenshot from 2021-06-09 15-44-45](https://user-images.githubusercontent.com/2959170/121439028-f410e980-c939-11eb-8534-40dc63b608e6.png)
![Screenshot from 2021-06-09 15-44-33](https://user-images.githubusercontent.com/2959170/121439031-f4a98000-c939-11eb-96c7-a5c54e6fd995.png)

Current plan -> address the edge cases caught in eyes test and try to re-merge later in this sprint.