### PR TITLE
Special Korean certificate link available for dance-party-extras

### DIFF
--- a/apps/src/templates/Congrats.jsx
+++ b/apps/src/templates/Congrats.jsx
@@ -38,25 +38,22 @@ export default class Congrats extends Component {
   /**
    * Renders links to certificate alternatives when there is a special event going on.
    * @param {string} language The language code related to the special event i.e. 'en', 'es', 'ko', etc
-   * @param {string} tutorialType The type of lesson the student completed i.e. 'dance', '2018Minecraft', etc
+   * @param {string} tutorial The type of tutorial the student finished i.e. 'dance', 'oceans', etc
    * @returns {HTMLElement} HTML for rendering the extra certificate links.
    */
-  renderExtraCertificateLinks = (language, tutorialType) => {
+  renderExtraCertificateLinks = (language, tutorial) => {
     let extraLinkUrl, extraLinkText;
     // https://codedotorg.atlassian.net/browse/FND-1604
     // these can be removed after July 25 2021
     if (language === 'ko') {
-      switch (tutorialType) {
-        case 'oceans':
-          extraLinkUrl = pegasus('/files/online-coding-party-2021-oceans.pdf');
-          extraLinkText =
-            '온라인 코딩 파티 인증서 받으러 가기! (과학기술정보통신부 인증)';
-          break;
-        case 'dance':
-          extraLinkUrl = pegasus('/files/online-coding-party-2021-dance.pdf');
-          extraLinkText =
-            '온라인 코딩 파티 인증서 받으러 가기! (과학기술정보통신부 인증)';
-          break;
+      if (/oceans/.test(tutorial)) {
+        extraLinkUrl = pegasus('/files/online-coding-party-2021-oceans.pdf');
+        extraLinkText =
+          '온라인 코딩 파티 인증서 받으러 가기! (과학기술정보통신부 인증)';
+      } else if (/dance/.test(tutorial)) {
+        extraLinkUrl = pegasus('/files/online-coding-party-2021-dance.pdf');
+        extraLinkText =
+          '온라인 코딩 파티 인증서 받으러 가기! (과학기술정보통신부 인증)';
       }
     }
     if (!extraLinkUrl || !extraLinkText) {
@@ -94,7 +91,7 @@ export default class Congrats extends Component {
           randomDonorTwitter={randomDonorTwitter}
           under13={under13}
         >
-          {this.renderExtraCertificateLinks(language, tutorialType)}
+          {this.renderExtraCertificateLinks(language, tutorial)}
         </Certificate>
         {userType === 'teacher' && isEnglish && <TeachersBeyondHoc />}
         <StudentsBeyondHoc


### PR DESCRIPTION
There is a Part 2 to Dance Party referred to as `dance-extras-2019` which should also provide the custom dance party certificate for Korean students.

## Links
* [JIRA](https://codedotorg.atlassian.net/browse/FND-1604)
* [Previous PR](https://github.com/code-dot-org/code-dot-org/pull/41025)

## Testing story
Manually tested on localhost
---

### Korean Congrats page for Dance Party Part 2
Note the link below the certificate
![image](https://user-images.githubusercontent.com/1372238/121443216-981b8480-c97c-11eb-9e5b-658328f9ce5d.png)

---

### Korean Congrats page for Ai for Oceans
Note the link below the certificate
![image](https://user-images.githubusercontent.com/1372238/121443737-97cfb900-c97d-11eb-8388-c3bea27157e1.png)

---

### English Congrats page for Dance Party Part 2
Note there is NO link below the certificate
![image](https://user-images.githubusercontent.com/1372238/121443306-c8632300-c97c-11eb-9729-f9d65465ca02.png)

---

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
