### PR TITLE
Move teacher feedback components into sub-directory

### DIFF
--- a/apps/src/templates/instructions/TopInstructions.jsx
+++ b/apps/src/templates/instructions/TopInstructions.jsx
@@ -7,7 +7,7 @@ import classNames from 'classnames';
 import {connect} from 'react-redux';
 import _ from 'lodash';
 import TeacherOnlyMarkdown from './TeacherOnlyMarkdown';
-import TeacherFeedback from './TeacherFeedback';
+import TeacherFeedback from '@cdo/apps/templates/instructions/teacherFeedback/TeacherFeedback';
 import ContainedLevel from '../ContainedLevel';
 import ContainedLevelAnswer from '../ContainedLevelAnswer';
 import HelpTabContents from './HelpTabContents';

--- a/apps/src/templates/instructions/teacherFeedback/Comment.jsx
+++ b/apps/src/templates/instructions/teacherFeedback/Comment.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import color from '@cdo/apps/util/color';
 
-export class CommentArea extends React.Component {
+class Comment extends React.Component {
   static propTypes = {
     isReadonly: PropTypes.bool,
     comment: PropTypes.string,
@@ -51,3 +51,5 @@ const styles = {
     fontWeight: 'normal'
   }
 };
+
+export default Comment;

--- a/apps/src/templates/instructions/teacherFeedback/EditableReviewState.jsx
+++ b/apps/src/templates/instructions/teacherFeedback/EditableReviewState.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import i18n from '@cdo/locale';
 import color from '@cdo/apps/util/color';
 import ReactTooltip from 'react-tooltip';
-import {ReviewStates} from '@cdo/apps/templates/types';
+import {ReviewStates} from '@cdo/apps/templates/instructions/teacherFeedback/types';
 
 // EditableReviewState displays a checkbox which can be in one of 3 states:
 // 1. Checked - meaning the teacher has requested the student to keep working

--- a/apps/src/templates/instructions/teacherFeedback/EditableReviewState.jsx
+++ b/apps/src/templates/instructions/teacherFeedback/EditableReviewState.jsx
@@ -5,13 +5,13 @@ import color from '@cdo/apps/util/color';
 import ReactTooltip from 'react-tooltip';
 import {ReviewStates} from '@cdo/apps/templates/types';
 
-// TeacherFeedbackKeepWorking displays a checkbox which can be in one of 3 states:
+// EditableReviewState displays a checkbox which can be in one of 3 states:
 // 1. Checked - meaning the teacher has requested the student to keep working
 // 2. Unchecked - meaning the teacher has not requested the student to keep working, or has removed the previous request
 // 3. Indeterminate - meaning the level is awaiting teacher review (the teacher requested
 // the student to keep working and the student has made progress since that feedback was given)
 // This checkbox is displayed to and controlled by the teacher.
-class TeacherFeedbackKeepWorking extends Component {
+class EditableReviewState extends Component {
   static propTypes = {
     latestReviewState: PropTypes.oneOf(Object.keys(ReviewStates)),
     isAwaitingTeacherReview: PropTypes.bool,
@@ -130,4 +130,4 @@ const styles = {
   }
 };
 
-export default TeacherFeedbackKeepWorking;
+export default EditableReviewState;

--- a/apps/src/templates/instructions/teacherFeedback/ReviewState.jsx
+++ b/apps/src/templates/instructions/teacherFeedback/ReviewState.jsx
@@ -5,7 +5,7 @@ import {KeepWorkingBadge} from '@cdo/apps/templates/progress/BubbleBadge';
 import {ReviewStates} from '@cdo/apps/templates/types';
 import color from '@cdo/apps/util/color';
 
-class FeedbackStudentReviewState extends React.Component {
+class ReviewState extends React.Component {
   static propTypes = {
     latestReviewState: PropTypes.oneOf(Object.keys(ReviewStates)),
     isAwaitingTeacherReview: PropTypes.bool
@@ -75,4 +75,4 @@ const styles = {
   }
 };
 
-export default FeedbackStudentReviewState;
+export default ReviewState;

--- a/apps/src/templates/instructions/teacherFeedback/ReviewState.jsx
+++ b/apps/src/templates/instructions/teacherFeedback/ReviewState.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import i18n from '@cdo/locale';
 import {KeepWorkingBadge} from '@cdo/apps/templates/progress/BubbleBadge';
-import {ReviewStates} from '@cdo/apps/templates/types';
+import {ReviewStates} from '@cdo/apps/templates/instructions/teacherFeedback/types';
 import color from '@cdo/apps/util/color';
 
 class ReviewState extends React.Component {

--- a/apps/src/templates/instructions/teacherFeedback/Rubric.jsx
+++ b/apps/src/templates/instructions/teacherFeedback/Rubric.jsx
@@ -2,7 +2,7 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import color from '@cdo/apps/util/color';
 import i18n from '@cdo/locale';
-import RubricField from './RubricField';
+import RubricField from '@cdo/apps/templates/instructions/teacherFeedback/RubricField';
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import {rubricShape} from '@cdo/apps/templates/types';
 

--- a/apps/src/templates/instructions/teacherFeedback/Rubric.jsx
+++ b/apps/src/templates/instructions/teacherFeedback/Rubric.jsx
@@ -4,7 +4,7 @@ import color from '@cdo/apps/util/color';
 import i18n from '@cdo/locale';
 import RubricField from '@cdo/apps/templates/instructions/teacherFeedback/RubricField';
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
-import {rubricShape} from '@cdo/apps/templates/types';
+import {rubricShape} from '@cdo/apps/templates/instructions/teacherFeedback/types';
 
 const rubricLevels = [
   'performanceLevel1',

--- a/apps/src/templates/instructions/teacherFeedback/RubricField.jsx
+++ b/apps/src/templates/instructions/teacherFeedback/RubricField.jsx
@@ -2,7 +2,7 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import color from '@cdo/apps/util/color';
 import Radium from 'radium';
-import {CheckedRadioButton} from '../../lib/ui/CheckedRadioButton';
+import {CheckedRadioButton} from '@cdo/apps/lib/ui/CheckedRadioButton';
 import ReactTooltip from 'react-tooltip';
 import _ from 'lodash';
 import i18n from '@cdo/locale';

--- a/apps/src/templates/instructions/teacherFeedback/Status.jsx
+++ b/apps/src/templates/instructions/teacherFeedback/Status.jsx
@@ -6,7 +6,7 @@ import color from '@cdo/apps/util/color';
 import i18n from '@cdo/locale';
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 
-class TeacherFeedbackStatus extends Component {
+class Status extends Component {
   static propTypes = {
     viewAs: PropTypes.oneOf(['Teacher', 'Student']).isRequired,
     latestFeedback: PropTypes.object.isRequired
@@ -142,4 +142,4 @@ const styles = {
   }
 };
 
-export default TeacherFeedbackStatus;
+export default Status;

--- a/apps/src/templates/instructions/teacherFeedback/TeacherFeedback.jsx
+++ b/apps/src/templates/instructions/teacherFeedback/TeacherFeedback.jsx
@@ -15,7 +15,7 @@ import {
   teacherFeedbackShape,
   rubricShape,
   ReviewStates
-} from '@cdo/apps/templates/types';
+} from '@cdo/apps/templates/instructions/teacherFeedback/types';
 import experiments from '@cdo/apps/util/experiments';
 import ReviewState from '@cdo/apps/templates/instructions/teacherFeedback/ReviewState';
 

--- a/apps/src/templates/instructions/teacherFeedback/TeacherFeedback.jsx
+++ b/apps/src/templates/instructions/teacherFeedback/TeacherFeedback.jsx
@@ -7,17 +7,17 @@ import PropTypes from 'prop-types';
 import queryString from 'query-string';
 import color from '@cdo/apps/util/color';
 import $ from 'jquery';
-import {CommentArea} from './CommentArea';
-import TeacherFeedbackKeepWorking from '@cdo/apps/templates/instructions/TeacherFeedbackKeepWorking';
-import TeacherFeedbackStatus from '@cdo/apps/templates/instructions/TeacherFeedbackStatus';
-import TeacherFeedbackRubric from '@cdo/apps/templates/instructions/TeacherFeedbackRubric';
+import Comment from '@cdo/apps/templates/instructions/teacherFeedback/Comment';
+import EditableReviewState from '@cdo/apps/templates/instructions/teacherFeedback/EditableReviewState';
+import Status from '@cdo/apps/templates/instructions/teacherFeedback/Status';
+import Rubric from '@cdo/apps/templates/instructions/teacherFeedback/Rubric';
 import {
   teacherFeedbackShape,
   rubricShape,
   ReviewStates
 } from '@cdo/apps/templates/types';
 import experiments from '@cdo/apps/util/experiments';
-import FeedbackStudentReviewState from '@cdo/apps/templates/instructions/FeedbackStudentReviewState';
+import ReviewState from '@cdo/apps/templates/instructions/teacherFeedback/ReviewState';
 
 const ErrorType = {
   NoError: 'NoError',
@@ -181,7 +181,7 @@ export class TeacherFeedback extends Component {
       <div style={styles.header}>
         <h1 style={styles.h1}> {i18n.feedbackCommentAreaHeader()} </h1>
         {keepWorkingEnabled && (
-          <TeacherFeedbackKeepWorking
+          <EditableReviewState
             latestReviewState={latestFeedback?.review_state || null}
             isAwaitingTeacherReview={this.isAwaitingTeacherReview}
             setReviewState={this.onReviewStateChange}
@@ -198,7 +198,7 @@ export class TeacherFeedback extends Component {
     return (
       <div style={styles.header}>
         <h1 style={styles.h1}> {i18n.feedbackCommentAreaHeader()} </h1>
-        <FeedbackStudentReviewState
+        <ReviewState
           latestReviewState={latestFeedback?.review_state || null}
           isAwaitingTeacherReview={this.isAwaitingTeacherReview}
         />
@@ -264,7 +264,7 @@ export class TeacherFeedback extends Component {
         {errorState === ErrorType.Load &&
           this.renderError(i18n.feedbackLoadError())}
         {rubric && (
-          <TeacherFeedbackRubric
+          <Rubric
             rubric={rubric}
             performance={performance}
             isReadonly={displayReadonlyRubric}
@@ -280,7 +280,7 @@ export class TeacherFeedback extends Component {
             {viewAs === ViewType.Student &&
               this.renderCommentAreaHeaderForStudent()}
             {displayComment && (
-              <CommentArea
+              <Comment
                 isReadonly={disabledMode}
                 comment={comment}
                 placeholderText={placeholderText}
@@ -293,10 +293,7 @@ export class TeacherFeedback extends Component {
             <div style={styles.footer}>
               {viewAs === ViewType.Teacher && this.renderSubmitFeedbackButton()}
               {!!latestFeedback && (
-                <TeacherFeedbackStatus
-                  viewAs={viewAs}
-                  latestFeedback={latestFeedback}
-                />
+                <Status viewAs={viewAs} latestFeedback={latestFeedback} />
               )}
             </div>
           </div>

--- a/apps/src/templates/instructions/teacherFeedback/types.js
+++ b/apps/src/templates/instructions/teacherFeedback/types.js
@@ -1,0 +1,24 @@
+import PropTypes from 'prop-types';
+import {makeEnum} from '@cdo/apps/utils';
+
+export const teacherFeedbackShape = PropTypes.shape({
+  comment: PropTypes.string,
+  performance: PropTypes.string,
+  student_seen_feedback: PropTypes.date,
+  created_at: PropTypes.date,
+  feedback_provider_id: PropTypes.number
+});
+
+export const rubricShape = PropTypes.shape({
+  keyConcept: PropTypes.string,
+  performanceLevel1: PropTypes.string,
+  performanceLevel2: PropTypes.string,
+  performanceLevel3: PropTypes.string,
+  performanceLevel4: PropTypes.string
+});
+
+export const ReviewStates = makeEnum(
+  'completed',
+  'keepWorking',
+  'awaitingReview'
+);

--- a/apps/src/templates/types.js
+++ b/apps/src/templates/types.js
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import {makeEnum} from '@cdo/apps/utils';
 
 export const videoDataShape = PropTypes.shape({
   src: PropTypes.string.isRequired,
@@ -10,25 +9,3 @@ export const videoDataShape = PropTypes.shape({
   enable_fallback: PropTypes.bool,
   autoplay: PropTypes.bool
 });
-
-export const teacherFeedbackShape = PropTypes.shape({
-  comment: PropTypes.string,
-  performance: PropTypes.string,
-  student_seen_feedback: PropTypes.date,
-  created_at: PropTypes.date,
-  feedback_provider_id: PropTypes.number
-});
-
-export const rubricShape = PropTypes.shape({
-  keyConcept: PropTypes.string,
-  performanceLevel1: PropTypes.string,
-  performanceLevel2: PropTypes.string,
-  performanceLevel3: PropTypes.string,
-  performanceLevel4: PropTypes.string
-});
-
-export const ReviewStates = makeEnum(
-  'completed',
-  'keepWorking',
-  'awaitingReview'
-);

--- a/apps/test/unit/templates/instructions/teacherFeedback/CommentTest.jsx
+++ b/apps/test/unit/templates/instructions/teacherFeedback/CommentTest.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {shallow} from 'enzyme';
-import {expect} from '../../../util/reconfiguredChai';
-import {CommentArea} from '@cdo/apps/templates/instructions/CommentArea';
+import {expect} from '../../../../util/reconfiguredChai';
+import Comment from '@cdo/apps/templates/instructions/teacherFeedback/Comment';
 import sinon from 'sinon';
 
 const DEFAULT_PROPS = {
@@ -11,25 +11,25 @@ const DEFAULT_PROPS = {
   placeholderText: 'Add your comment here'
 };
 
-describe('CommentArea', () => {
+describe('Comment', () => {
   it('has a display only textarea if in isReadonly', () => {
-    const wrapper = shallow(
-      <CommentArea {...DEFAULT_PROPS} isReadonly={true} />
-    );
+    const wrapper = shallow(<Comment {...DEFAULT_PROPS} isReadonly={true} />);
 
     const confirmTextArea = wrapper.find('textarea').first();
     expect(confirmTextArea.props().readOnly).to.equal(true);
   });
+
   it('has a textarea with value of empty string if no comment is given', () => {
-    const wrapper = shallow(<CommentArea {...DEFAULT_PROPS} comment={''} />);
+    const wrapper = shallow(<Comment {...DEFAULT_PROPS} comment={''} />);
 
     const confirmTextArea = wrapper.find('textarea').first();
     expect(confirmTextArea.props().value).to.equal('');
   });
+
   it('updates the text in the comment area', () => {
     const spy = sinon.spy();
     const wrapper = shallow(
-      <CommentArea {...DEFAULT_PROPS} comment={''} onCommentChange={spy} />
+      <Comment {...DEFAULT_PROPS} comment={''} onCommentChange={spy} />
     );
     expect(spy).not.to.have.been.called;
 

--- a/apps/test/unit/templates/instructions/teacherFeedback/EditableReviewStateTest.jsx
+++ b/apps/test/unit/templates/instructions/teacherFeedback/EditableReviewStateTest.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {mount} from 'enzyme';
 import {expect} from '../../../../util/reconfiguredChai';
 import EditableReviewState from '@cdo/apps/templates/instructions/teacherFeedback/EditableReviewState';
-import {ReviewStates} from '@cdo/apps/templates/types';
+import {ReviewStates} from '@cdo/apps/templates/instructions/teacherFeedback/types';
 import i18n from '@cdo/locale';
 import sinon from 'sinon';
 

--- a/apps/test/unit/templates/instructions/teacherFeedback/EditableReviewStateTest.jsx
+++ b/apps/test/unit/templates/instructions/teacherFeedback/EditableReviewStateTest.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {mount} from 'enzyme';
-import {expect} from '../../../util/reconfiguredChai';
-import TeacherFeedbackKeepWorking from '@cdo/apps/templates/instructions/TeacherFeedbackKeepWorking';
+import {expect} from '../../../../util/reconfiguredChai';
+import EditableReviewState from '@cdo/apps/templates/instructions/teacherFeedback/EditableReviewState';
 import {ReviewStates} from '@cdo/apps/templates/types';
 import i18n from '@cdo/locale';
 import sinon from 'sinon';
@@ -16,10 +16,10 @@ const DEFAULT_PROPS = {
 const setUp = overrideProps => {
   const props = {...DEFAULT_PROPS, ...overrideProps};
   // using mount instead of shallow so that refs are set
-  return mount(<TeacherFeedbackKeepWorking {...props} />);
+  return mount(<EditableReviewState {...props} />);
 };
 
-describe('TeacherFeedbackKeepWorking', () => {
+describe('EditableReviewState', () => {
   it('displays keep working text', () => {
     const wrapper = setUp();
     expect(wrapper.contains(i18n.keepWorking())).to.be.true;

--- a/apps/test/unit/templates/instructions/teacherFeedback/ReviewStateTest.jsx
+++ b/apps/test/unit/templates/instructions/teacherFeedback/ReviewStateTest.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {shallow} from 'enzyme';
 import {expect} from '../../../../util/reconfiguredChai';
 import ReviewState from '@cdo/apps/templates/instructions/teacherFeedback/ReviewState';
-import {ReviewStates} from '@cdo/apps/templates/types';
+import {ReviewStates} from '@cdo/apps/templates/instructions/teacherFeedback/types';
 import i18n from '@cdo/locale';
 import color from '@cdo/apps/util/color';
 

--- a/apps/test/unit/templates/instructions/teacherFeedback/ReviewStateTest.jsx
+++ b/apps/test/unit/templates/instructions/teacherFeedback/ReviewStateTest.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {shallow} from 'enzyme';
-import {expect} from '../../../util/reconfiguredChai';
-import FeedbackStudentReviewState from '@cdo/apps/templates/instructions/FeedbackStudentReviewState';
+import {expect} from '../../../../util/reconfiguredChai';
+import ReviewState from '@cdo/apps/templates/instructions/teacherFeedback/ReviewState';
 import {ReviewStates} from '@cdo/apps/templates/types';
 import i18n from '@cdo/locale';
 import color from '@cdo/apps/util/color';
@@ -13,10 +13,10 @@ const DEFAULT_PROPS = {
 
 const setUp = overrideProps => {
   const props = {...DEFAULT_PROPS, ...overrideProps};
-  return shallow(<FeedbackStudentReviewState {...props} />);
+  return shallow(<ReviewState {...props} />);
 };
 
-describe('FeedbackStudentReviewState', () => {
+describe('ReviewState', () => {
   it('renders completed text if review state is completed', () => {
     const wrapper = setUp({latestReviewState: ReviewStates.completed});
     expect(wrapper.contains(i18n.reviewedComplete())).to.be.true;

--- a/apps/test/unit/templates/instructions/teacherFeedback/RubricFieldTest.jsx
+++ b/apps/test/unit/templates/instructions/teacherFeedback/RubricFieldTest.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {shallow} from 'enzyme';
-import {expect} from '../../../util/reconfiguredChai';
-import {UnwrappedRubricField as RubricField} from '@cdo/apps/templates/instructions/RubricField';
+import {expect} from '../../../../util/reconfiguredChai';
+import {UnwrappedRubricField as RubricField} from '@cdo/apps/templates/instructions/teacherFeedback/RubricField';
 
 const DEFAULT_PROPS = {
   showFeedbackInputAreas: true,

--- a/apps/test/unit/templates/instructions/teacherFeedback/RubricTest.jsx
+++ b/apps/test/unit/templates/instructions/teacherFeedback/RubricTest.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import {shallow} from 'enzyme';
-import {expect} from '../../../util/reconfiguredChai';
+import {expect} from '../../../../util/reconfiguredChai';
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
-import TeacherFeedbackRubric from '@cdo/apps/templates/instructions/TeacherFeedbackRubric';
+import Rubric from '@cdo/apps/templates/instructions/teacherFeedback/Rubric';
 
 const DEFAULT_PROPS = {
   rubric: {
@@ -21,10 +21,10 @@ const DEFAULT_PROPS = {
 
 const setUp = overrideProps => {
   const props = {...DEFAULT_PROPS, ...overrideProps};
-  return shallow(<TeacherFeedbackRubric {...props} />);
+  return shallow(<Rubric {...props} />);
 };
 
-describe('TeacherFeedbackRubric', () => {
+describe('Rubric', () => {
   it('displays key concept', () => {
     const wrapper = setUp();
     expect(wrapper.contains('Key Concept')).to.equal(true);

--- a/apps/test/unit/templates/instructions/teacherFeedback/StatusTest.jsx
+++ b/apps/test/unit/templates/instructions/teacherFeedback/StatusTest.jsx
@@ -1,16 +1,16 @@
 import React from 'react';
 import {shallow} from 'enzyme';
-import {expect} from '../../../util/reconfiguredChai';
+import {expect} from '../../../../util/reconfiguredChai';
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
-import TeacherFeedbackStatus from '@cdo/apps/templates/instructions/TeacherFeedbackStatus';
+import Status from '@cdo/apps/templates/instructions/teacherFeedback/Status';
 import moment from 'moment/moment';
 
 const setUp = (latestFeedback, viewAs = ViewType.Teacher) => {
   const props = {latestFeedback, viewAs};
-  return shallow(<TeacherFeedbackStatus {...props} />);
+  return shallow(<Status {...props} />);
 };
 
-describe('TeacherFeedbackStatusText', () => {
+describe('Status', () => {
   describe('viewed as Teacher', () => {
     it('displays nicely formatted date with checkmark icon if student viewed teacher feedback today', () => {
       const today = new Date();

--- a/apps/test/unit/templates/instructions/teacherFeedback/TeacherFeedbackTest.jsx
+++ b/apps/test/unit/templates/instructions/teacherFeedback/TeacherFeedbackTest.jsx
@@ -1,10 +1,15 @@
 import React from 'react';
 import {shallow} from 'enzyme';
-import {expect} from '../../../util/reconfiguredChai';
-import {UnconnectedTeacherFeedback as TeacherFeedback} from '@cdo/apps/templates/instructions/TeacherFeedback';
+import {expect} from '../../../../util/reconfiguredChai';
+import {UnconnectedTeacherFeedback as TeacherFeedback} from '@cdo/apps/templates/instructions/teacherFeedback/TeacherFeedback';
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import experiments from '@cdo/apps/util/experiments';
 import sinon from 'sinon';
+import Comment from '@cdo/apps/templates/instructions/teacherFeedback/Comment';
+import EditableReviewState from '@cdo/apps/templates/instructions/teacherFeedback/EditableReviewState';
+import ReviewState from '@cdo/apps/templates/instructions/teacherFeedback/ReviewState';
+import Status from '@cdo/apps/templates/instructions/teacherFeedback/Status';
+import Rubric from '@cdo/apps/templates/instructions/teacherFeedback/Rubric';
 
 const TEACHER_FEEDBACK_NO_RUBRIC_PROPS = {
   user: 5,
@@ -120,7 +125,7 @@ describe('TeacherFeedback', () => {
         };
 
         const wrapper = shallow(<TeacherFeedback {...props} />);
-        expect(wrapper.find('TeacherFeedbackStatus')).to.have.length(0);
+        expect(wrapper.find(Status)).to.have.length(0);
       });
 
       it('displays a rubric with expected props if there is a rubric', () => {
@@ -128,7 +133,7 @@ describe('TeacherFeedback', () => {
           <TeacherFeedback {...TEACHER_FEEDBACK_RUBRIC_PROPS} />
         );
 
-        const rubric = wrapper.find('TeacherFeedbackRubric');
+        const rubric = wrapper.find(Rubric);
         expect(rubric).to.have.length(1);
         expect(rubric.props().rubric).to.equal(
           TEACHER_FEEDBACK_RUBRIC_PROPS.rubric
@@ -143,7 +148,7 @@ describe('TeacherFeedback', () => {
           <TeacherFeedback {...TEACHER_FEEDBACK_NO_RUBRIC_PROPS} />
         );
 
-        expect(wrapper.find('TeacherFeedbackRubric')).to.have.lengthOf(0);
+        expect(wrapper.find(Rubric)).to.have.lengthOf(0);
       });
 
       it('displays the comment with expected props', () => {
@@ -151,7 +156,7 @@ describe('TeacherFeedback', () => {
           <TeacherFeedback {...TEACHER_FEEDBACK_RUBRIC_PROPS} />
         );
 
-        const confirmCommentArea = wrapper.find('CommentArea').first();
+        const confirmCommentArea = wrapper.find(Comment).first();
         expect(confirmCommentArea.props().isReadonly).to.equal(false);
         expect(confirmCommentArea.props().studentHasFeedback).to.equal(false);
         expect(confirmCommentArea.props().comment).to.equal('');
@@ -174,7 +179,7 @@ describe('TeacherFeedback', () => {
           <TeacherFeedback {...TEACHER_FEEDBACK_NO_RUBRIC_PROPS} />
         );
 
-        const keepWorkingComponent = wrapper.find('TeacherFeedbackKeepWorking');
+        const keepWorkingComponent = wrapper.find(EditableReviewState);
         expect(keepWorkingComponent).to.have.length(1);
         expect(keepWorkingComponent.props().latestReviewState).to.equal(null);
         expect(keepWorkingComponent.props().isAwaitingTeacherReview).to.be
@@ -208,7 +213,7 @@ describe('TeacherFeedback', () => {
 
         const wrapper = shallow(<TeacherFeedback {...props} />);
 
-        const statusComponent = wrapper.find('TeacherFeedbackStatus');
+        const statusComponent = wrapper.find(Status);
         expect(statusComponent).to.have.length(1);
         expect(statusComponent.props().viewAs).to.equal('Teacher');
         expect(statusComponent.props().latestFeedback).to.equal(latestFeedback);
@@ -225,7 +230,7 @@ describe('TeacherFeedback', () => {
           />
         );
 
-        const rubric = wrapper.find('TeacherFeedbackRubric');
+        const rubric = wrapper.find(Rubric);
         expect(rubric).to.have.length(1);
       });
 
@@ -237,7 +242,7 @@ describe('TeacherFeedback', () => {
           />
         );
 
-        const confirmCommentArea = wrapper.find('CommentArea').first();
+        const confirmCommentArea = wrapper.find(Comment).first();
         expect(confirmCommentArea.props().isReadonly).to.equal(false);
         expect(confirmCommentArea.props().studentHasFeedback).to.equal(false);
         expect(confirmCommentArea.props().comment).to.equal('Good work!');
@@ -266,7 +271,7 @@ describe('TeacherFeedback', () => {
           />
         );
 
-        const keepWorkingComponent = wrapper.find('TeacherFeedbackKeepWorking');
+        const keepWorkingComponent = wrapper.find(EditableReviewState);
         expect(keepWorkingComponent).to.have.length(1);
         expect(keepWorkingComponent.props().latestReviewState).to.equal(
           'completed'
@@ -285,7 +290,7 @@ describe('TeacherFeedback', () => {
         <TeacherFeedback {...TEACHER_NO_FEEDBACK_RUBRIC_PROPS} />
       );
 
-      const rubric = wrapper.find('TeacherFeedbackRubric');
+      const rubric = wrapper.find(Rubric);
       expect(rubric).to.have.length(1);
       expect(rubric.props().rubric).to.equal(
         TEACHER_NO_FEEDBACK_RUBRIC_PROPS.rubric
@@ -299,7 +304,7 @@ describe('TeacherFeedback', () => {
         <TeacherFeedback {...TEACHER_NO_FEEDBACK_RUBRIC_PROPS} />
       );
 
-      expect(wrapper.find('CommentArea')).to.have.lengthOf(0);
+      expect(wrapper.find(Comment)).to.have.lengthOf(0);
     });
 
     it('does not display submit button', () => {
@@ -320,7 +325,7 @@ describe('TeacherFeedback', () => {
         };
 
         const wrapper = shallow(<TeacherFeedback {...props} />);
-        expect(wrapper.find('TeacherFeedbackStatus')).to.have.length(0);
+        expect(wrapper.find(Status)).to.have.length(0);
       });
 
       it('displays rubric with expected props if there is a rubric', () => {
@@ -328,7 +333,7 @@ describe('TeacherFeedback', () => {
           <TeacherFeedback {...STUDENT_NO_FEEDBACK_RUBRIC_PROPS} />
         );
 
-        const rubric = wrapper.find('TeacherFeedbackRubric');
+        const rubric = wrapper.find(Rubric);
         expect(rubric).to.have.length(1);
         expect(rubric.props().rubric).to.equal(
           STUDENT_NO_FEEDBACK_RUBRIC_PROPS.rubric
@@ -343,7 +348,7 @@ describe('TeacherFeedback', () => {
           <TeacherFeedback {...STUDENT_NO_FEEDBACK_RUBRIC_PROPS} />
         );
 
-        expect(wrapper.find('CommentArea')).to.have.lengthOf(0);
+        expect(wrapper.find(Comment)).to.have.lengthOf(0);
       });
 
       it('does not display the submit feedback button', () => {
@@ -359,7 +364,7 @@ describe('TeacherFeedback', () => {
           <TeacherFeedback {...STUDENT_NO_FEEDBACK_RUBRIC_PROPS} />
         );
 
-        expect(wrapper.find('FeedbackStudentReviewState')).to.have.lengthOf(0);
+        expect(wrapper.find(ReviewState)).to.have.lengthOf(0);
       });
     });
 
@@ -387,7 +392,7 @@ describe('TeacherFeedback', () => {
 
         const wrapper = shallow(<TeacherFeedback {...props} />);
 
-        const statusComponent = wrapper.find('TeacherFeedbackStatus');
+        const statusComponent = wrapper.find(Status);
         expect(statusComponent).to.have.length(1);
         expect(statusComponent.props().viewAs).to.equal('Student');
         expect(statusComponent.props().latestFeedback).to.equal(latestFeedback);
@@ -401,7 +406,7 @@ describe('TeacherFeedback', () => {
           />
         );
 
-        expect(wrapper.find('TeacherFeedbackRubric')).to.have.lengthOf(0);
+        expect(wrapper.find(Rubric)).to.have.lengthOf(0);
       });
 
       it('renders rubric with expected props if there is a rubric for the level', () => {
@@ -420,7 +425,7 @@ describe('TeacherFeedback', () => {
           />
         );
 
-        const rubric = wrapper.find('TeacherFeedbackRubric');
+        const rubric = wrapper.find(Rubric);
         expect(rubric).to.have.length(1);
         expect(rubric.props().rubric).to.equal(
           STUDENT_FEEDBACK_RUBRIC_PROPS.rubric
@@ -439,7 +444,7 @@ describe('TeacherFeedback', () => {
           />
         );
 
-        const confirmCommentArea = wrapper.find('CommentArea').first();
+        const confirmCommentArea = wrapper.find(Comment).first();
         expect(confirmCommentArea.props().isReadonly).to.equal(true);
         expect(confirmCommentArea.props().studentHasFeedback).to.equal(true);
         expect(confirmCommentArea.props().comment).to.equal('Good work!');
@@ -457,7 +462,7 @@ describe('TeacherFeedback', () => {
           />
         );
 
-        expect(wrapper.find('CommentArea')).to.have.lengthOf(0);
+        expect(wrapper.find(Comment)).to.have.lengthOf(0);
       });
 
       it('does not render submit button', () => {
@@ -479,7 +484,7 @@ describe('TeacherFeedback', () => {
           />
         );
 
-        const reviewState = wrapper.find('FeedbackStudentReviewState');
+        const reviewState = wrapper.find(ReviewState);
         expect(reviewState).to.have.lengthOf(1);
         expect(reviewState.props().latestReviewState).to.equal('keepWorking');
       });


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

- Creates a new directory in `instructions` called `teacherFeedback` which contains all the teacher feedback components for the feedback tab of `TopInstructions`. 
- Renames of components to remove `TeacherFeedback-` and `Feedback-` prefixes which are no longer necessary with the directory context
- Moves types needed for teacher feedback tab into a new file within `teacherFeedback` directory

No functional changes

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
