### PR TITLE
do not seed unplugged levels from locale files

### DIFF
--- a/dashboard/config/scripts/levels/DigitalCitizenship.level
+++ b/dashboard/config/scripts/levels/DigitalCitizenship.level
@@ -1,0 +1,15 @@
+<Unplugged>
+  <config><![CDATA[{
+  "properties": {
+    "hint_prompt_attempts_threshold": 2,
+    "encrypted": "false"
+  },
+  "game_id": 31,
+  "published": true,
+  "created_at": "2014-09-20T02:48:43.000Z",
+  "user_id": 18,
+  "audit_log": "[{\"changed_at\":\"2021-06-10 19:37:28 +0000\",\"changed\":[\"published\"],\"changed_by_id\":18,\"changed_by_email\":\"dave@code.org\"}]",
+  "level_concept_difficulty": {
+  }
+}]]></config>
+</Unplugged>

--- a/dashboard/lib/level_loader.rb
+++ b/dashboard/lib/level_loader.rb
@@ -130,18 +130,6 @@ class LevelLoader
     level
   end
 
-  def self.update_unplugged
-    # Unplugged level data is specified in 'unplugged.en.yml' file
-    unplugged = YAML.load_file(Rails.root.join('config/locales/unplugged.en.yml'))['en']['data']['unplugged'].keys
-    unplugged_game = Game.find_by(name: 'Unplugged')
-    unplugged.map do |name, _|
-      Level.where(name: name).first_or_create.update(
-        type: 'Unplugged',
-        game: unplugged_game
-      )
-    end
-  end
-
   private_class_method def self.level_name_from_path(path)
     File.basename(path, File.extname(path))
   end

--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -171,7 +171,6 @@ namespace :seed do
     script_files = opts[:script_files] || SCRIPTS_GLOB
     begin
       custom_scripts = script_files.select {|script| File.mtime(script) > scripts_seeded_mtime}
-      LevelLoader.update_unplugged if File.mtime('config/locales/unplugged.en.yml') > scripts_seeded_mtime
       _, custom_i18n = Script.setup(custom_scripts, show_progress: Rake.application.options.trace)
       Script.merge_and_write_i18n(custom_i18n)
     rescue


### PR DESCRIPTION
## Background

Finishes https://codedotorg.atlassian.net/browse/PLAT-1099. This is a preflight step for [removing duplicate level keys](https://docs.google.com/document/d/10dfZpsKadjYDEyqvYNoqpWIbWxZwj3rK58k2kLVSdeo/edit#).

Originally, unplugged levels were generated from unplugged.en.yml, by the code which is being removed in this PR. At some point, curriculum writers gained the ability to create unplugged levels via the levelbuilder UI. Only those created on levelbuilder are editable on levelbuilder:
![Screen Shot 2021-06-10 at 4 13 52 PM](https://user-images.githubusercontent.com/8001765/121608455-e07f8480-ca06-11eb-8ed2-88e26bb8cc81.png)

Creating an unplugged level on levelbuilder still adds an entry to unplugged.en.yml, but deleting that level doesn't remove that entry. Therefore, if a curriculum writer deletes an unplugged level they created, it will get re-created as a non-editable unplugged level the next time the database is seeded. Meanwhile, if a different level type with the same name has been created in the interim, we'll end up with two levels with the same name.

## Description

The solution is as follows:
1. remove some unneeded contents from unplugged.en.yml (done via levelbuilder content scoops)
2. remove the original codepath for generating unplugged levels (this PR)
3. make sure there is a .level file for any unplugged levels which is actually used in our product (this PR)

## Testing story

Here's how I verified locally that the seed process will still generate any unplugged levels that are shown to our users:

* check out this branch
* set levelbuilder_mode to false (so that .level files do not get deleted in the next step)
* `Unplugged.destroy_all`
* `rake seed:custom_levels`

* obtain a list of all unplugged levels that this PR will stop creating as part of the seed process:
```
unplugged_yml = File.expand_path('config/locales/unplugged.en.yml')
i18n = YAML.load_file(unplugged_yml)
i18n['en']['data']['unplugged'].keys.reject{|k| Unplugged.find_by_name(k)}
=> ["Unplug1", "Unplug2", "Unplug3", "Unplug4", "Unplug5", "Unplug6", "Unplug7", "Unplug8", "Unplug9", "Unplug10", "Unplug11", "deeper learning description"]
```

* verified that none of these levels are being used in our product because they are:
  * not in any scripts
  * not contained or used as a sublevel of any other level
  * not needed for anything else according to the curriculum team (see [slack](https://codedotorg.slack.com/archives/CFGAVL2CA/p1623340217053400))
  