### PR TITLE
Javalab: fix editor resize ellipsis location and add asset manager button to Theater

### DIFF
--- a/apps/src/javalab/Javalab.js
+++ b/apps/src/javalab/Javalab.js
@@ -18,7 +18,7 @@ import {showLevelBuilderSaveButton} from '@cdo/apps/code-studio/header';
 import {RESIZE_VISUALIZATION_EVENT} from '@cdo/apps/lib/ui/VisualizationResizeBar';
 import Neighborhood from './Neighborhood';
 import NeighborhoodVisualizationColumn from './NeighborhoodVisualizationColumn';
-import TheaterVisualization from './TheaterVisualization';
+import TheaterVisualizationColumn from './TheaterVisualizationColumn';
 import Theater from './Theater';
 import {CsaViewMode} from './constants';
 
@@ -95,7 +95,7 @@ Javalab.prototype.init = function(config) {
   } else if (this.level.csaViewMode === CsaViewMode.THEATER) {
     this.miniApp = new Theater();
     config.afterInject = () => this.miniApp.afterInject();
-    this.visualization = <TheaterVisualization />;
+    this.visualization = <TheaterVisualizationColumn />;
   }
 
   const onMount = () => {

--- a/apps/src/javalab/JavalabEditor.jsx
+++ b/apps/src/javalab/JavalabEditor.jsx
@@ -37,8 +37,8 @@ import {makeEnum} from '@cdo/apps/utils';
 
 const MIN_HEIGHT = 100;
 const MAX_HEIGHT = 500;
-// This is the height of the content between the top banner and the editor box
-const HEADER_OFFSET = 80;
+// This is the height of the "editor" header and the file tabs combined
+const HEADER_OFFSET = 63;
 const Dialog = makeEnum(
   'RENAME_FILE',
   'DELETE_FILE',
@@ -597,6 +597,7 @@ class JavalabEditor extends React.Component {
               resizeItemTop={this.getItemTop}
               position={this.getPosition()}
               onResize={this.handleHeightResize}
+              style={styles.resizer}
             />
           </div>
         </Tab.Container>
@@ -704,6 +705,9 @@ const styles = {
     float: 'left',
     overflow: 'visible',
     marginLeft: 3
+  },
+  resizer: {
+    position: 'static'
   }
 };
 

--- a/apps/src/javalab/JavalabView.jsx
+++ b/apps/src/javalab/JavalabView.jsx
@@ -158,7 +158,6 @@ class JavalabView extends React.Component {
                     toggleTest={this.toggleTest}
                   />
                 }
-                style={styles.console}
               />
             </div>
           </div>
@@ -197,9 +196,6 @@ const styles = {
   javalab: {
     display: 'flex',
     flexWrap: 'wrap'
-  },
-  console: {
-    marginTop: 15
   },
   clear: {
     clear: 'both'

--- a/apps/src/javalab/JavalabView.jsx
+++ b/apps/src/javalab/JavalabView.jsx
@@ -169,7 +169,6 @@ class JavalabView extends React.Component {
 
 const styles = {
   instructionsAndPreview: {
-    width: '100%',
     color: color.black,
     right: '15px'
   },

--- a/apps/src/javalab/PreviewPaneHeader.jsx
+++ b/apps/src/javalab/PreviewPaneHeader.jsx
@@ -1,12 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import i18n from '@cdo/locale';
 import PaneHeader, {
   PaneSection,
   PaneButton
 } from '@cdo/apps/templates/PaneHeader';
 import CollapserIcon from '@cdo/apps/templates/CollapserIcon';
 
-export default function PreviewPaneHeader({isCollapsed, isFullscreen}) {
+export default function PreviewPaneHeader({
+  isCollapsed,
+  isFullscreen,
+  showAssetManagerButton = false,
+  headerTitle = i18n.preview()
+}) {
   return (
     <PaneHeader hasFocus>
       <PaneButton
@@ -18,25 +24,37 @@ export default function PreviewPaneHeader({isCollapsed, isFullscreen}) {
         style={styles.transparent}
         leftJustified
       />
-      {/* TODO: Uncomment iconClass and remove icon prop when we are ready to implement fullscreen. */}
-      {/* The empty icon element keeps everything centered in the header pane. */}
+      {headerTitle && (
+        <PaneSection style={styles.headerTitle}>{headerTitle}</PaneSection>
+      )}
+      {/* TODO: Uncomment fullscreen button when we are ready to implement fullscreen.
       <PaneButton
         headerHasFocus
-        // iconClass={isFullscreen ? 'fa fa-compress' : 'fa fa-arrows-alt'}
-        icon={<span style={{width: 13}} />}
+        iconClass={isFullscreen ? 'fa fa-compress' : 'fa fa-arrows-alt'}
         onClick={() => {}}
         label=""
         isRtl={false}
         style={styles.transparent}
       />
-      <PaneSection>Preview</PaneSection>
+       */}
+      {showAssetManagerButton && (
+        <PaneButton
+          headerHasFocus
+          onClick={() => {}}
+          iconClass="fa fa-upload"
+          label="Manage Assets"
+          isRtl={false}
+        />
+      )}
     </PaneHeader>
   );
 }
 
 PreviewPaneHeader.propTypes = {
   isCollapsed: PropTypes.bool.isRequired,
-  isFullscreen: PropTypes.bool.isRequired
+  isFullscreen: PropTypes.bool.isRequired,
+  showAssetManagerButton: PropTypes.bool,
+  headerTitle: PropTypes.string
 };
 
 const styles = {

--- a/apps/src/javalab/PreviewPaneHeader.jsx
+++ b/apps/src/javalab/PreviewPaneHeader.jsx
@@ -11,7 +11,7 @@ export default function PreviewPaneHeader({
   isCollapsed,
   isFullscreen,
   showAssetManagerButton = false,
-  headerTitle = i18n.preview()
+  showPreviewTitle = true
 }) {
   return (
     <PaneHeader hasFocus>
@@ -24,8 +24,8 @@ export default function PreviewPaneHeader({
         style={styles.transparent}
         leftJustified
       />
-      {headerTitle && (
-        <PaneSection style={styles.headerTitle}>{headerTitle}</PaneSection>
+      {showPreviewTitle && (
+        <PaneSection style={styles.headerTitle}>{i18n.preview()}</PaneSection>
       )}
       {/* TODO: Uncomment fullscreen button when we are ready to implement fullscreen.
       <PaneButton
@@ -42,7 +42,7 @@ export default function PreviewPaneHeader({
           headerHasFocus
           onClick={() => {}}
           iconClass="fa fa-upload"
-          label="Manage Assets"
+          label={i18n.manageAssets()}
           isRtl={false}
         />
       )}
@@ -54,7 +54,7 @@ PreviewPaneHeader.propTypes = {
   isCollapsed: PropTypes.bool.isRequired,
   isFullscreen: PropTypes.bool.isRequired,
   showAssetManagerButton: PropTypes.bool,
-  headerTitle: PropTypes.string
+  showPreviewTitle: PropTypes.bool
 };
 
 const styles = {

--- a/apps/src/javalab/TheaterVisualizationColumn.jsx
+++ b/apps/src/javalab/TheaterVisualizationColumn.jsx
@@ -17,8 +17,8 @@ export default class TheaterVisualizationColumn extends React.Component {
         <PreviewPaneHeader
           isCollapsed={isCollapsed}
           isFullscreen={isFullscreen}
-          showAssetManagerButton={true}
-          headerTitle={''}
+          showAssetManagerButton
+          showPreviewTitle={false}
         />
         <ProtectedVisualizationDiv>
           <canvas id="theater" width="400" height="400" />

--- a/apps/src/javalab/TheaterVisualizationColumn.jsx
+++ b/apps/src/javalab/TheaterVisualizationColumn.jsx
@@ -17,6 +17,8 @@ export default class TheaterVisualizationColumn extends React.Component {
         <PreviewPaneHeader
           isCollapsed={isCollapsed}
           isFullscreen={isFullscreen}
+          showAssetManagerButton={true}
+          headerTitle={''}
         />
         <ProtectedVisualizationDiv>
           <canvas id="theater" width="400" height="400" />

--- a/apps/src/javalab/TheaterVisualizationColumn.jsx
+++ b/apps/src/javalab/TheaterVisualizationColumn.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PreviewPaneHeader from './PreviewPaneHeader';
 import ProtectedVisualizationDiv from '@cdo/apps/templates/ProtectedVisualizationDiv';
 
-export default class TheaterVisualization extends React.Component {
+export default class TheaterVisualizationColumn extends React.Component {
   static propTypes = {};
 
   state = {


### PR DESCRIPTION
1. Fix editor resizer ellipsis to appear in correct place.
2. Add asset manager button to visualization area in Theater. Hide "Preview" button here (per input from Moneppo).
3. Renames `TheaterVisualization` to `TheaterVisualizationColumn` to be consistent with Neighborhood.

**Before (Theater)**

![image](https://user-images.githubusercontent.com/25372625/121558488-ba94b880-c9e3-11eb-8b18-359758b4cb8e.png)

**After (Theater)**

![image](https://user-images.githubusercontent.com/25372625/121558606-cda78880-c9e3-11eb-9708-8d7f78d4762f.png)

**Before (Neighborhood)**

![image](https://user-images.githubusercontent.com/25372625/121559751-dfd5f680-c9e4-11eb-9c0b-327d4d9173fe.png)

**After (Neighborhood)**

![image](https://user-images.githubusercontent.com/25372625/121559661-c8970900-c9e4-11eb-8e0f-76650d3b7cde.png)

## Testing story

Tested manually locally.

## Follow-up work

1. There are some issues with centering of headers (made a little worse in this PR for the Preview panel by removing a placeholder span for a future "full size" feature)  -- should "Console", "Preview", and "Editor" headers be centered across the entire width of the header, or in the space between any buttons that appear on the left and right sides of the header? It looks like we use the latter currently, but I think the former maybe makes more sense?
2. There's a few pixel "jump" when you use the editor resizer now that I couldn't quite figure out. We have a [Jira task to make the Console also resize when resizing the Editor](https://codedotorg.atlassian.net/browse/CSA-446), so I thought we could resolve that issue there.