### PR TITLE
Increase database transaction log durability

### DIFF
--- a/aws/cloudformation/db_parameters.yml.erb
+++ b/aws/cloudformation/db_parameters.yml.erb
@@ -172,10 +172,9 @@ AuroraCluster: &aurora
   # Improve insert/update concurrency for autoincrement tables.
   innodb_autoinc_lock_mode: 2 # not dynamic
 
-  # With a setting of 0, logs are written and flushed to disk once per second.
-  # Transactions for which logs have not been flushed can be lost in a crash.
-  # Reduces durability for better performance.
-  innodb_flush_log_at_trx_commit: 0
+  # Favor durability over transaction write performance.
+  # https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_flush_log_at_trx_commit
+  innodb_flush_log_at_trx_commit: 1
 
   # IAM role ARN used to select data into AWS S3.
   aurora_select_into_s3_role: {'Fn::GetAtt': [AuroraS3Role, Arn]}


### PR DESCRIPTION
Prior to migrating from RDS MySQL to Aurora MySQL we set `innodb_flush_log_at_trx_commit=0` to improve write performance while reducing durability. Write performance has improved significantly (5-10x faster DML latency) since transitioning to Aurora, and it's not clear what this setting does with Aurora's unique storage system, so return to the default and most durable setting.

## Testing story

```
$ bundle exec rake stack:data:validate RAILS_ENV=production

Pending update for stack `DATA-production`:
Modify AuroraClusterDBParameters [AWS::RDS::DBClusterParameterGroup] Properties (Parameters)
Modify AuroraReportingClusterDBParameters [AWS::RDS::DBClusterParameterGroup] Properties (Parameters)
```

## Deployment strategy

Update Stack during low/moderate usage time period after daily production release has completed and monitor DML Latency metrics afterwords. No restart needed. Proactively monitor performance the next school day at ~6AM PDT and have revert prepared, if needed.

`$ bundle exec rake stack:data:start RAILS_ENV=production`

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
