### PR TITLE
Revert "Display run/reset on Applab widgets in start mode"

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -1039,17 +1039,13 @@ StudioApp.prototype.toggleRunReset = function(button) {
   }
 
   var run = document.getElementById('runButton');
-  if (run) {
+  var reset = document.getElementById('resetButton');
+  if (run || reset) {
     run.style.display = showRun ? 'inline-block' : 'none';
     run.disabled = !showRun;
-  }
-
-  var reset = document.getElementById('resetButton');
-  if (reset) {
     reset.style.display = !showRun ? 'inline-block' : 'none';
     reset.disabled = showRun;
   }
-
   if (this.isUsingBlockly() && !this.config.readonlyWorkspace) {
     // craft has a darker color scheme than other blockly labs. It needs to
     // toggle between different colors on run/reset or else, on run, the workspace

--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -472,8 +472,6 @@ Applab.init = function(config) {
   const hasDataMode = !(
     config.level.hideViewDataButton || config.level.widgetMode
   );
-  const playspacePhoneFrame = !(config.share || config.level.widgetMode);
-  const hideRunResetButtons = playspacePhoneFrame || nonLevelbuilderWidgetMode;
 
   // Construct a logging observer for interpreter events
   if (!config.hideSource) {
@@ -658,9 +656,7 @@ Applab.init = function(config) {
 
   // Push initial level properties into the Redux store
   studioApp().setPageConstants(config, {
-    playspacePhoneFrame,
-    hideRunButton: hideRunResetButtons,
-    hideResetButton: hideRunResetButtons,
+    playspacePhoneFrame: !(config.share || config.level.widgetMode),
     channelId: config.channel,
     allowExportExpo: experiments.isEnabled('exportExpo'),
     exportApp: Applab.exportApp,

--- a/apps/src/redux/pageConstants.js
+++ b/apps/src/redux/pageConstants.js
@@ -42,7 +42,6 @@ var ALLOWED_KEYS = new Set([
   'hideCoordinateOverlay',
   'hideSource',
   'hideRunButton',
-  'hideResetButton',
   'playspacePhoneFrame',
   'noVisualization',
   'pinWorkspaceToBottom',

--- a/apps/src/templates/GameButtons.jsx
+++ b/apps/src/templates/GameButtons.jsx
@@ -79,11 +79,13 @@ ResetButton.displayName = 'ResetButton';
 export const UnconnectedGameButtons = props => (
   <div>
     <ProtectedStatefulDiv id="gameButtons" style={styles.main}>
-      <RunButton
-        hidden={props.hideRunButton}
-        runButtonText={props.runButtonText}
-      />
-      {!props.hideResetButton && <ResetButton />}
+      {!(props.playspacePhoneFrame || props.widgetMode) && (
+        <RunButton
+          hidden={props.hideRunButton}
+          runButtonText={props.runButtonText}
+        />
+      )}
+      {!(props.playspacePhoneFrame || props.widgetMode) && <ResetButton />}
       {
         ' ' /* Explicitly insert whitespace so that this behaves like our ejs file*/
       }
@@ -97,7 +99,6 @@ export const UnconnectedGameButtons = props => (
 );
 UnconnectedGameButtons.propTypes = {
   hideRunButton: PropTypes.bool,
-  hideResetButton: PropTypes.bool,
   runButtonText: PropTypes.string,
   playspacePhoneFrame: PropTypes.bool,
   nextLevelUrl: PropTypes.string,
@@ -110,7 +111,6 @@ UnconnectedGameButtons.displayName = 'GameButtons';
 
 export default connect(state => ({
   hideRunButton: state.pageConstants.hideRunButton,
-  hideResetButton: state.pageConstants.hideResetButton,
   runButtonText: state.pageConstants.runButtonText,
   playspacePhoneFrame: state.pageConstants.playspacePhoneFrame,
   nextLevelUrl: state.pageConstants.nextLevelUrl,


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#40992

Reverting because this caused an unexpected diff in an eyes test: https://codedotorg.slack.com/archives/C0T0PNTM3/p1623696174309200