### PR TITLE
Allow channel creation for start sources in javalab

### DIFF
--- a/apps/src/javalab/JavalabView.jsx
+++ b/apps/src/javalab/JavalabView.jsx
@@ -30,7 +30,8 @@ class JavalabView extends React.Component {
     isDarkMode: PropTypes.bool.isRequired,
     appendOutputLog: PropTypes.func,
     setIsDarkMode: PropTypes.func,
-    channelId: PropTypes.string
+    channelId: PropTypes.string,
+    isEditingStartSources: PropTypes.bool
   };
 
   state = {
@@ -100,7 +101,8 @@ class JavalabView extends React.Component {
       onCommitCode,
       onInputMessage,
       onContinue,
-      handleVersionHistory
+      handleVersionHistory,
+      isEditingStartSources
     } = this.props;
     const {isRunning, isTesting} = this.state;
 
@@ -115,11 +117,13 @@ class JavalabView extends React.Component {
         <div style={styles.javalab}>
           <div style={styles.buttons}>
             <JavalabSettings>{this.renderSettings()}</JavalabSettings>
-            <JavalabButton
-              text={i18n.finish()}
-              onClick={onContinue}
-              style={styles.finish}
-            />
+            {!isEditingStartSources && (
+              <JavalabButton
+                text={i18n.finish()}
+                onClick={onContinue}
+                style={styles.finish}
+              />
+            )}
           </div>
           <div style={styles.editorAndVisualization}>
             <div
@@ -225,7 +229,8 @@ export default connect(
     isProjectLevel: state.pageConstants.isProjectLevel,
     isReadOnlyWorkspace: state.pageConstants.isReadOnlyWorkspace,
     channelId: state.pageConstants.channelId,
-    isDarkMode: state.javalab.isDarkMode
+    isDarkMode: state.javalab.isDarkMode,
+    isEditingStartSources: state.pageConstants.isEditingStartSources
   }),
   dispatch => ({
     appendOutputLog: log => dispatch(appendOutputLog(log)),

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -176,7 +176,7 @@ module LevelsHelper
     # Unsafe to generate these twice, so use the cached version if it exists.
     return @app_options unless @app_options.nil?
 
-    if @level.channel_backed? && params[:action] != 'edit_blocks'
+    if @level.channel_backed? && params[:action] != 'edit_blocks' && !@level.is_a?(Javalab)
       view_options(
         channel: get_channel_for(@level, @user),
         server_project_level_id: @level.project_template_level.try(:id),

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -176,7 +176,7 @@ module LevelsHelper
     # Unsafe to generate these twice, so use the cached version if it exists.
     return @app_options unless @app_options.nil?
 
-    if @level.channel_backed? && params[:action] != 'edit_blocks' && !@level.is_a?(Javalab)
+    if (@level.channel_backed? && params[:action] != 'edit_blocks') || @level.is_a?(Javalab)
       view_options(
         channel: get_channel_for(@level, @user),
         server_project_level_id: @level.project_template_level.try(:id),


### PR DESCRIPTION
This PR allows code to run in startSources mode while a user is editing the level in levelbuilder. Additionally, this PR fixes a bug where the "finish" button in startSources mode cleared out the start code on the level. The preferred path forward re: a conversation with Hannah W. determined that we shouldn't have a finish button at all on this page. See the images below for visuals.

## Links

- jira ticket: https://codedotorg.atlassian.net/browse/CSA-314


## Testing story

Tested locally

## Images

![image](https://user-images.githubusercontent.com/37230822/122259153-b1de2f80-ce86-11eb-88bf-c349d438b06d.png)

Changes to note: The code is now in start sources mode, but can run against javabuilder (the main task). The Finish button has also been removed in startSources mode.
![image](https://user-images.githubusercontent.com/37230822/122259696-46e12880-ce87-11eb-9a9f-4ce489855f4e.png)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
