### PR TITLE
Dedup level keys everywhere but levelbuilder and prod

### DIFF
--- a/dashboard/db/migrate/20210614185722_dedup_level_keys_non_prod.rb
+++ b/dashboard/db/migrate/20210614185722_dedup_level_keys_non_prod.rb
@@ -1,0 +1,20 @@
+class DedupLevelKeysNonProd < ActiveRecord::Migration[5.2]
+  def up
+    # Two levels should never have the same key. Levels with duplicate keys will
+    # be manually removed in levelbuilder and production, since the stakes are
+    # higher for deleting levels there. This PR removes duplicates from all
+    # other environments.
+
+    if [:adhoc, :development, :staging, :test].include? rack_env
+      duplicate_keys = Level.all.map(&:key).sort.group_by {|k| k}.select {|_k, v| v.length > 1}.map(&:first)
+      duplicate_levels = duplicate_keys.map {|key| Level.where(Level.key_to_params(key)).all}.flatten
+      levels_to_destroy = duplicate_levels.reject {|l| l.script_levels.any?}
+      puts "removing the following levels, which have duplicate keys:"
+      puts levels_to_destroy.map {|l| "id: #{l.id} key: #{l.key}"}.join("\n")
+      levels_to_destroy.each(&:destroy)
+    end
+  end
+
+  def down
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_14_182035) do
+ActiveRecord::Schema.define(version: 2021_06_14_185722) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"


### PR DESCRIPTION
See [dedup level keys tech spec](https://docs.google.com/document/d/10dfZpsKadjYDEyqvYNoqpWIbWxZwj3rK58k2kLVSdeo/edit#) for context. 

Depends on https://github.com/code-dot-org/code-dot-org/pull/41097, but this is not an especially interesting dependency -- it's just that I wrote that migration first, and so that PR needs to get merged first to avoid merged conflicts.

Previously, pairs of levels with identical keys in levelbuilder and production were removed manually. Due to the number of development and adhoc environments, this PR uses a migration to clean up development and adhoc environments. The staging and test environments are included in the migration too, so that I do not have to clean them up manually, and because those environments do not require the same special care as levelbuilder or production.

## Testing story

Verified locally that when a pair of legacy blockly levels have the same key, this script keeps the one that's in a script and removes the ones that's not.


