### PR TITLE
Revert "Revert "Display run/reset on Applab widgets in start mode""

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -1039,13 +1039,17 @@ StudioApp.prototype.toggleRunReset = function(button) {
   }
 
   var run = document.getElementById('runButton');
-  var reset = document.getElementById('resetButton');
-  if (run || reset) {
+  if (run) {
     run.style.display = showRun ? 'inline-block' : 'none';
     run.disabled = !showRun;
+  }
+
+  var reset = document.getElementById('resetButton');
+  if (reset) {
     reset.style.display = !showRun ? 'inline-block' : 'none';
     reset.disabled = showRun;
   }
+
   if (this.isUsingBlockly() && !this.config.readonlyWorkspace) {
     // craft has a darker color scheme than other blockly labs. It needs to
     // toggle between different colors on run/reset or else, on run, the workspace

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -1040,7 +1040,10 @@ StudioApp.prototype.toggleRunReset = function(button) {
 
   var run = document.getElementById('runButton');
   if (run) {
-    run.style.display = showRun ? 'inline-block' : 'none';
+    // Note: Checking alwaysHideRunButton is necessary because are some levels where we never
+    // want to show the "run" button (e.g., maze levels that are "stepOnly").
+    run.style.display =
+      showRun && !this.config.alwaysHideRunButton ? 'inline-block' : 'none';
     run.disabled = !showRun;
   }
 

--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -472,6 +472,8 @@ Applab.init = function(config) {
   const hasDataMode = !(
     config.level.hideViewDataButton || config.level.widgetMode
   );
+  const playspacePhoneFrame = !(config.share || config.level.widgetMode);
+  const hideRunResetButtons = playspacePhoneFrame || nonLevelbuilderWidgetMode;
 
   // Construct a logging observer for interpreter events
   if (!config.hideSource) {
@@ -656,7 +658,9 @@ Applab.init = function(config) {
 
   // Push initial level properties into the Redux store
   studioApp().setPageConstants(config, {
-    playspacePhoneFrame: !(config.share || config.level.widgetMode),
+    playspacePhoneFrame,
+    hideRunButton: hideRunResetButtons,
+    hideResetButton: hideRunResetButtons,
     channelId: config.channel,
     allowExportExpo: experiments.isEnabled('exportExpo'),
     exportApp: Applab.exportApp,

--- a/apps/src/maze/maze.js
+++ b/apps/src/maze/maze.js
@@ -181,11 +181,17 @@ module.exports = class Maze {
       });
     };
 
+    // Note: Setting alwaysHideRunButton in our config is necessary because
+    // StudioApp.js will manipulate the run/reset buttons, displaying the run
+    // button when "Reset" is clicked. We do not want this behavior on stepOnly levels.
+    const alwaysHideRunButton = !!(
+      this.controller.level.stepOnly && !this.controller.level.edit_blocks
+    );
+    config.alwaysHideRunButton = alwaysHideRunButton;
+
     // Push initial level properties into the Redux store
     studioApp().setPageConstants(config, {
-      hideRunButton: !!(
-        this.controller.level.stepOnly && !this.controller.level.edit_blocks
-      )
+      hideRunButton: alwaysHideRunButton
     });
 
     var visualizationColumn = (

--- a/apps/src/redux/pageConstants.js
+++ b/apps/src/redux/pageConstants.js
@@ -42,6 +42,7 @@ var ALLOWED_KEYS = new Set([
   'hideCoordinateOverlay',
   'hideSource',
   'hideRunButton',
+  'hideResetButton',
   'playspacePhoneFrame',
   'noVisualization',
   'pinWorkspaceToBottom',

--- a/apps/src/templates/GameButtons.jsx
+++ b/apps/src/templates/GameButtons.jsx
@@ -34,7 +34,7 @@ export const RunButton = Radium(props => (
       className={classNames([
         'launch',
         'blocklyLaunch',
-        props.hidden && 'invisible'
+        props.hidden && 'hide'
       ])}
       style={props.style}
     >

--- a/apps/src/templates/GameButtons.jsx
+++ b/apps/src/templates/GameButtons.jsx
@@ -58,7 +58,8 @@ export const ResetButton = Radium(props => (
     className={classNames([
       'launch',
       'blocklyLaunch',
-      props.hideText && 'hideText'
+      props.hideText && 'hideText',
+      props.hidden && 'hide'
     ])}
     style={[commonStyles.hidden, props.style]}
   >
@@ -67,6 +68,7 @@ export const ResetButton = Radium(props => (
   </button>
 ));
 ResetButton.propTypes = {
+  hidden: PropTypes.bool,
   style: PropTypes.object,
   hideText: PropTypes.bool
 };
@@ -83,7 +85,7 @@ export const UnconnectedGameButtons = props => (
         hidden={props.hideRunButton}
         runButtonText={props.runButtonText}
       />
-      {!props.hideResetButton && <ResetButton />}
+      <ResetButton hidden={props.hideResetButton} />
       {
         ' ' /* Explicitly insert whitespace so that this behaves like our ejs file*/
       }

--- a/apps/src/templates/GameButtons.jsx
+++ b/apps/src/templates/GameButtons.jsx
@@ -79,13 +79,11 @@ ResetButton.displayName = 'ResetButton';
 export const UnconnectedGameButtons = props => (
   <div>
     <ProtectedStatefulDiv id="gameButtons" style={styles.main}>
-      {!(props.playspacePhoneFrame || props.widgetMode) && (
-        <RunButton
-          hidden={props.hideRunButton}
-          runButtonText={props.runButtonText}
-        />
-      )}
-      {!(props.playspacePhoneFrame || props.widgetMode) && <ResetButton />}
+      <RunButton
+        hidden={props.hideRunButton}
+        runButtonText={props.runButtonText}
+      />
+      {!props.hideResetButton && <ResetButton />}
       {
         ' ' /* Explicitly insert whitespace so that this behaves like our ejs file*/
       }
@@ -99,6 +97,7 @@ export const UnconnectedGameButtons = props => (
 );
 UnconnectedGameButtons.propTypes = {
   hideRunButton: PropTypes.bool,
+  hideResetButton: PropTypes.bool,
   runButtonText: PropTypes.string,
   playspacePhoneFrame: PropTypes.bool,
   nextLevelUrl: PropTypes.string,
@@ -111,6 +110,7 @@ UnconnectedGameButtons.displayName = 'GameButtons';
 
 export default connect(state => ({
   hideRunButton: state.pageConstants.hideRunButton,
+  hideResetButton: state.pageConstants.hideResetButton,
   runButtonText: state.pageConstants.runButtonText,
   playspacePhoneFrame: state.pageConstants.playspacePhoneFrame,
   nextLevelUrl: state.pageConstants.nextLevelUrl,

--- a/dashboard/test/ui/features/star_labs/step_mode.feature
+++ b/dashboard/test/ui/features/star_labs/step_mode.feature
@@ -29,7 +29,7 @@ Scenario: Step Only - Failure
     And block "6" has class "blocklySelected"
 
   When I press "resetButton"
-  Then element "#runButton" is hidden
+  Then element "#runButton" is not displayed
     And element "#resetButton" is hidden
     And element "#stepButton" is visible
     And element "#stepButton" is not disabled
@@ -72,7 +72,7 @@ Scenario: Step Only - Reset while stepping
     And element "#stepButton" is not disabled
 
   When I press "resetButton"
-  Then element "#runButton" is hidden
+  Then element "#runButton" is not displayed
     And element "#resetButton" is hidden
     And element "#stepButton" is visible
     And element "#stepButton" is not disabled

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -202,6 +202,10 @@ def jquery_is_element_visible(selector)
   "return $(#{selector.dump}).is(':visible') && $(#{selector.dump}).css('visibility') !== 'hidden';"
 end
 
+def jquery_is_element_displayed(selector)
+  "return $(#{selector.dump}).css('display') !== 'none';"
+end
+
 When /^I wait until element "([^"]*)" is (not )?visible$/ do |selector, negation|
   wait_for_jquery
   wait_until {@browser.execute_script(jquery_is_element_visible(selector)) == negation.nil?}
@@ -756,6 +760,10 @@ def element_visible?(selector)
   @browser.execute_script(jquery_is_element_visible(selector))
 end
 
+def element_displayed?(selector)
+  @browser.execute_script(jquery_is_element_displayed(selector))
+end
+
 Then /^element "([^"]*)" is (not )?visible$/ do |selector, negation|
   expect(element_visible?(selector)).to eq(negation.nil?)
 end
@@ -766,6 +774,10 @@ end
 
 Then /^element "([^"]*)" is hidden$/ do |selector|
   expect(element_visible?(selector)).to eq(false)
+end
+
+Then /^element "([^"]*)" is (not )?displayed$/ do |selector, negation|
+  expect(element_displayed?(selector)).to eq(negation.nil?)
 end
 
 And (/^I select age (\d+) in the age dialog/) do |age|


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#41100, reintroducing #40992.

The original PR caused a bug that was caught by an eyes test (hence the need to merge, revert, and reintroduce) where the hidden "Run" button was still taking up space in the DOM:
![image (2)](https://user-images.githubusercontent.com/9812299/122108033-9f092380-cdd0-11eb-8207-e955fdb69883.png)

This happened because we previously had 2 ways of hiding `<RunButton/>` (displayed in the diff screenshot below):
1. the `hidden` prop
2. conditional rendering
<img width="466" alt="Screen Shot 2021-06-15 at 11 57 18 AM" src="https://user-images.githubusercontent.com/9812299/122108330-ec859080-cdd0-11eb-866d-c0e255a5404f.png">

...and I combined these to _only_ use the `hidden` prop in my original PR. However, that prop set the visibility to hidden, so the button still took up space, causing the eyes failure above. I have fixed this issue by using `display: none;` (via an already-existing `hide` class) rather than `visibility: hidden;` for the `hidden` prop.

Now, that same level looks as expected:
<img width="1280" alt="Screen Shot 2021-06-15 at 11 52 35 AM" src="https://user-images.githubusercontent.com/9812299/122108075-a6303180-cdd0-11eb-8e7a-d3cb060f214a.png">

## Follow-up Work
[STAR-1609](https://codedotorg.atlassian.net/browse/STAR-1609). I ran into a lot of trouble (unexpected eyes diffs, failed UI tests, etc) because we imperatively control the run/reset buttons from many places in our codebase. This ticket will refactor those places to shift control onto the React component, where it should be.