### PR TITLE
CloudFront real-time access log processor

### DIFF
--- a/aws/cloudformation/access_logs.rb
+++ b/aws/cloudformation/access_logs.rb
@@ -1,0 +1,39 @@
+# Transform CloudFront access logs from CSV to JSON.
+# Use Glue-table schema to determine CSV column headers and format.
+
+require 'base64'
+require 'csv'
+require 'json'
+require 'aws-sdk-glue'
+
+DATABASE = ENV['DATABASE']
+TABLE = ENV['TABLE']
+
+GLUE = Aws::Glue::Client.new
+COLUMNS = GLUE.get_table(database_name: DATABASE, name: TABLE).
+  table.storage_descriptor.columns.map {|c| [c.name, c.type]}.to_h
+
+CONVERTERS = [
+  ->(field, info) {COLUMNS[info.header] == 'int' ? field.to_i : field},
+  ->(field, info) {COLUMNS[info.header] == 'float' ? field.to_f : field}
+]
+
+def handler(event:, context:)
+  {
+    records: event['records'].map do |record|
+      data = Base64.decode64(record['data'])
+      output_data = CSV.parse_line(data, col_sep: "\t", headers: COLUMNS.keys, converters: CONVERTERS).to_h.to_json
+      {
+        recordId: record['recordId'],
+        result: 'Ok',
+        data: Base64.encode64(output_data)
+      }
+    rescue => e
+      {
+        recordId: record['recordId'],
+        result: 'ProcessingFailed',
+        data: Base64.encode64({error: e.full_message}.to_json)
+      }
+    end
+  }
+end

--- a/aws/cloudformation/access_logs.yml
+++ b/aws/cloudformation/access_logs.yml
@@ -82,6 +82,12 @@ Resources:
     DependsOn: AccessLogPartitionPermission
     Properties:
       BucketName: !Ref BucketName
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault: 
+              SSEAlgorithm: aws:kms
+              KMSMasterKeyID: alias/aws/s3
+            BucketKeyEnabled: true
       NotificationConfiguration:
         LambdaConfigurations:
           - Event: 's3:ObjectCreated:*'
@@ -113,6 +119,9 @@ Resources:
     Type: AWS::Kinesis::Stream
     Properties:
       ShardCount: !Ref ShardCount
+      StreamEncryption:
+        EncryptionType: KMS
+        KeyId: alias/aws/kinesis
   AccessLogDeliveryStream:
     Type: AWS::KinesisFirehose::DeliveryStream
     Properties:
@@ -143,7 +152,6 @@ Resources:
             DatabaseName: !Ref AccessLogDatabase
             TableName: !Ref AccessLogTable
             RoleARN: !GetAtt AccessLogDeliveryRole.Arn
-
   AccessLogProcessor:
     Type: AWS::Lambda::Function
     Properties:

--- a/aws/cloudformation/access_logs.yml
+++ b/aws/cloudformation/access_logs.yml
@@ -249,6 +249,7 @@ Resources:
   AccessLogRole:
     Type: AWS::IAM::Role
     Properties:
+      PermissionsBoundary: !ImportValue IAM-DevPermissions
       AssumeRolePolicyDocument:
         Statement:
           - Action: sts:AssumeRole
@@ -273,12 +274,12 @@ Resources:
   AccessLogConfigRole:
     Type: AWS::IAM::Role
     Properties:
+      PermissionsBoundary: !ImportValue IAM-DevPermissions
       AssumeRolePolicyDocument:
         Statement:
           - Action: sts:AssumeRole
             Effect: Allow
             Principal: {Service: cloudfront.amazonaws.com}
-#      PermissionsBoundary: !ImportValue IAM-DevPermissions
       Policies:
         - PolicyName: root
           PolicyDocument:
@@ -294,12 +295,12 @@ Resources:
   AccessLogDeliveryRole:
     Type: AWS::IAM::Role
     Properties:
+      PermissionsBoundary: !ImportValue IAM-DevPermissions
       AssumeRolePolicyDocument:
         Statement:
           - Action: sts:AssumeRole
             Effect: Allow
             Principal: {Service: firehose.amazonaws.com}
-#      PermissionsBoundary: !ImportValue IAM-DevPermissions
       Policies:
         - PolicyName: firehose_delivery_policy
           PolicyDocument:
@@ -343,6 +344,7 @@ Resources:
   AccessLogRedshiftSpectrumRole:
     Type: AWS::IAM::Role
     Properties:
+      PermissionsBoundary: !ImportValue IAM-DevPermissions
       AssumeRolePolicyDocument:
         Statement:
           - Action: sts:AssumeRole

--- a/aws/cloudformation/access_logs.yml
+++ b/aws/cloudformation/access_logs.yml
@@ -88,6 +88,11 @@ Resources:
               SSEAlgorithm: aws:kms
               KMSMasterKeyID: alias/aws/s3
             BucketKeyEnabled: true
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
       NotificationConfiguration:
         LambdaConfigurations:
           - Event: 's3:ObjectCreated:*'

--- a/aws/cloudformation/access_logs.yml
+++ b/aws/cloudformation/access_logs.yml
@@ -1,0 +1,375 @@
+---
+AWSTemplateFormatVersion: 2010-09-09
+Description: |
+  CloudFront real-time log configuration storing all access logs to an S3 bucket.
+  Access logs are stored in compressed Parquet format, partitioned by date-hour (yyyy/MM/dd/HH),
+  and can be efficiently queried using Athena.
+  
+  To store access logs, reference the exported config in a CloudFront distribution, e.g.:
+  `RealtimeLogConfigArn: !ImportValue AccessLogs-Config`
+
+Parameters:
+  BucketName:
+    Type: String
+    Default: cdo-access-logs
+  BucketPrefix:
+    Type: String
+    Default: access-logs/
+  DatabaseName:
+    Type: String
+    Default: cdo_access_logs
+  TableName:
+    Type: String
+    Default: access_logs
+  ShardCount:
+    Type: Number
+    Default: 1
+Resources:
+  AccessLogConfig:
+    Type: AWS::CloudFront::RealtimeLogConfig
+    Properties:
+      Name: !Ref AWS::StackName
+      SamplingRate: 100
+      EndPoints:
+        - StreamType: Kinesis
+          KinesisStreamConfig:
+            RoleArn: !GetAtt AccessLogConfigRole.Arn
+            StreamArn: !GetAtt AccessLogStream.Arn
+      Fields:
+        # From https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/real-time-logs.html#understand-real-time-log-config-fields
+        - timestamp
+        - c-ip
+        - time-to-first-byte
+        - sc-status
+        - sc-bytes
+        - cs-method
+        - cs-protocol
+        - cs-host
+        - cs-uri-stem
+        - cs-bytes
+        - x-edge-location
+        - x-edge-request-id
+        - x-host-header
+        - time-taken
+        - cs-protocol-version
+        - c-ip-version
+        - cs-user-agent
+        - cs-referer
+        - cs-cookie
+        - cs-uri-query
+        - x-edge-response-result-type
+        - x-forwarded-for
+        - ssl-protocol
+        - ssl-cipher
+        - x-edge-result-type
+        - fle-encrypted-fields
+        - fle-status
+        - sc-content-type
+        - sc-content-len
+        - sc-range-start
+        - sc-range-end
+        - c-port
+        - x-edge-detailed-result-type
+        - c-country
+        - cs-accept-encoding
+        - cs-accept
+        - cache-behavior-path-pattern
+        - cs-headers
+        - cs-header-names
+        - cs-headers-count
+  AccessLogBucket:
+    Type: AWS::S3::Bucket
+    DependsOn: AccessLogPartitionPermission
+    Properties:
+      BucketName: !Ref BucketName
+      NotificationConfiguration:
+        LambdaConfigurations:
+          - Event: 's3:ObjectCreated:*'
+            Function: !GetAtt AccessLogPartition.Arn
+            Filter: {S3Key: {Rules: [{Name: prefix, Value: !Ref BucketPrefix}]}}
+  AccessLogPartition:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: AccessLogPartition
+      Code: ./access_logs_partition.rb
+      Handler: access_logs_partition.handler
+      Environment:
+        Variables:
+          DATABASE: !Ref AccessLogDatabase
+          TABLE: !Ref AccessLogTable
+          PREFIX: !Ref BucketPrefix
+      Runtime: ruby2.7
+      Role: !GetAtt AccessLogRole.Arn
+  AccessLogPartitionPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !GetAtt AccessLogPartition.Arn
+      Principal: s3.amazonaws.com
+      SourceAccount: !Ref AWS::AccountId
+      SourceArn: !Sub 'arn:aws:s3:::${BucketName}'
+
+  AccessLogStream:
+    Type: AWS::Kinesis::Stream
+    Properties:
+      ShardCount: !Ref ShardCount
+  AccessLogDeliveryStream:
+    Type: AWS::KinesisFirehose::DeliveryStream
+    Properties:
+      DeliveryStreamName: !Ref AWS::StackName
+      DeliveryStreamType: KinesisStreamAsSource
+      KinesisStreamSourceConfiguration:
+        KinesisStreamARN: !GetAtt AccessLogStream.Arn
+        RoleARN: !GetAtt AccessLogDeliveryRole.Arn
+      ExtendedS3DestinationConfiguration:
+        BufferingHints: 
+          IntervalInSeconds: 60
+          SizeInMBs: 128
+        BucketARN: !GetAtt AccessLogBucket.Arn
+        RoleARN: !GetAtt AccessLogDeliveryRole.Arn
+        Prefix: !Ref BucketPrefix
+        ProcessingConfiguration:
+          Enabled: true
+          Processors:
+            - Type: Lambda
+              Parameters:
+                - {ParameterName: LambdaArn, ParameterValue: !GetAtt AccessLogProcessor.Arn}
+                - {ParameterName: RoleArn, ParameterValue: !GetAtt AccessLogDeliveryRole.Arn}
+        DataFormatConversionConfiguration:
+          Enabled: true
+          InputFormatConfiguration: {Deserializer: {OpenXJsonSerDe: {}}}
+          OutputFormatConfiguration: {Serializer: {ParquetSerDe: {}}}
+          SchemaConfiguration:
+            DatabaseName: !Ref AccessLogDatabase
+            TableName: !Ref AccessLogTable
+            RoleARN: !GetAtt AccessLogDeliveryRole.Arn
+
+  AccessLogProcessor:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: AccessLogProcessor
+      Code: ./access_logs.rb
+      Handler: access_logs.handler
+      Runtime: ruby2.7
+      MemorySize: 1024
+      Environment:
+        Variables:
+          DATABASE: !Ref AccessLogDatabase
+          TABLE: !Ref AccessLogTable
+      Role: !GetAtt AccessLogRole.Arn
+
+  AccessLogDatabase:
+    Type: AWS::Glue::Database
+    Properties:
+      DatabaseInput: {Name: !Ref DatabaseName}
+      CatalogId: !Ref AWS::AccountId
+  AccessLogTable:
+    Type: AWS::Glue::Table
+    Properties:
+      DatabaseName: !Ref AccessLogDatabase
+      CatalogId: !Ref AWS::AccountId
+      TableInput:
+        Name: !Ref TableName
+        TableType: EXTERNAL_TABLE
+        Parameters:
+          classification: parquet
+          parquet.compression: SNAPPY
+          # Athena Partition Projection table properties.
+          # See: https://docs.aws.amazon.com/athena/latest/ug/partition-projection.html
+          projection.datehour.type: date
+          projection.datehour.range: 2021/01/01/00,NOW
+          projection.datehour.format: yyyy/MM/dd/HH
+          projection.datehour.interval: 1
+          projection.datehour.interval.unit: HOURS
+          projection.enabled: true
+          storage.location.template: !Sub 's3://${BucketName}/${BucketPrefix}${!datehour}'
+        PartitionKeys:
+          - {Name: datehour, Type: string}
+        StorageDescriptor:
+          Location: !Sub 's3://${BucketName}/${BucketPrefix}'
+          InputFormat: org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat
+          OutputFormat: org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat
+          SerdeInfo:
+            SerializationLibrary: org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe
+          Columns:
+            - {Name: timestamp,                   Type: timestamp}
+            - {Name: c-ip,                        Type: string}
+            - {Name: time-to-first-byte,          Type: float}
+            - {Name: sc-status,                   Type: int}
+            - {Name: sc-bytes,                    Type: int}
+            - {Name: cs-method,                   Type: string}
+            - {Name: cs-protocol,                 Type: string}
+            - {Name: cs-host,                     Type: string}
+            - {Name: cs-uri-stem,                 Type: string}
+            - {Name: cs-bytes,                    Type: int}
+            - {Name: x-edge-location,             Type: string}
+            - {Name: x-edge-request-id,           Type: string}
+            - {Name: x-host-header,               Type: string}
+            - {Name: time-taken,                  Type: float}
+            - {Name: cs-protocol-version,         Type: string}
+            - {Name: c-ip-version,                Type: string}
+            - {Name: cs-user-agent,               Type: string}
+            - {Name: cs-referer,                  Type: string}
+            - {Name: cs-cookie,                   Type: string}
+            - {Name: cs-uri-query,                Type: string}
+            - {Name: x-edge-response-result-type, Type: string}
+            - {Name: x-forwarded-for,             Type: string}
+            - {Name: ssl-protocol,                Type: string}
+            - {Name: ssl-cipher,                  Type: string}
+            - {Name: x-edge-result-type,          Type: string}
+            - {Name: fle-encrypted-fields,        Type: int}
+            - {Name: fle-status,                  Type: string}
+            - {Name: sc-content-type,             Type: string}
+            - {Name: sc-content-len,              Type: int}
+            - {Name: sc-range-start,              Type: int}
+            - {Name: sc-range-end,                Type: int}
+            - {Name: c-port,                      Type: int}
+            - {Name: x-edge-detailed-result-type, Type: string}
+            - {Name: c-country,                   Type: string}
+            - {Name: cs-accept-encoding,          Type: string}
+            - {Name: cs-accept,                   Type: string}
+            - {Name: cache-behavior-path-pattern, Type: string}
+            - {Name: cs-headers,                  Type: string}
+            - {Name: cs-header-names,             Type: string}
+            - {Name: cs-headers-count,            Type: int}
+
+  AccessLogRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal: { Service: lambda.amazonaws.com }
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: glue
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - glue:GetTable
+                  - glue:GetPartition
+                  - glue:CreatePartition
+                Resource:
+                  - !Sub 'arn:aws:glue:${AWS::Region}:${AWS::AccountId}:catalog'
+                  - !Sub 'arn:aws:glue:${AWS::Region}:${AWS::AccountId}:database/${AccessLogDatabase}'
+                  - !Sub 'arn:aws:glue:${AWS::Region}:${AWS::AccountId}:table/${AccessLogDatabase}/${AccessLogTable}'
+  AccessLogConfigRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal: {Service: cloudfront.amazonaws.com}
+#      PermissionsBoundary: !ImportValue IAM-DevPermissions
+      Policies:
+        - PolicyName: root
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - kinesis:PutRecord
+                  - kinesis:PutRecords
+                  - kinesis:DescribeStreamSummary
+                  - kinesis:DescribeStream
+                Resource: !GetAtt AccessLogStream.Arn
+  AccessLogDeliveryRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal: {Service: firehose.amazonaws.com}
+#      PermissionsBoundary: !ImportValue IAM-DevPermissions
+      Policies:
+        - PolicyName: firehose_delivery_policy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:AbortMultipartUpload
+                  - s3:GetBucketLocation
+                  - s3:GetObject
+                  - s3:ListBucket
+                  - s3:ListBucketMultipartUploads
+                  - s3:PutObject
+                Resource:
+                  - !GetAtt AccessLogBucket.Arn
+                  - !Sub '${AccessLogBucket.Arn}/*'
+              - Effect: Allow
+                Action:
+                  - kinesis:DescribeStream
+                  - kinesis:GetShardIterator
+                  - kinesis:GetRecords
+                  - kinesis:ListShards
+                Resource:
+                  - !GetAtt AccessLogStream.Arn
+              - Effect: Allow
+                Action:
+                  - glue:GetTable
+                  - glue:GetTableVersion
+                  - glue:GetTableVersions
+                Resource:
+                  - !Sub 'arn:aws:glue:${AWS::Region}:${AWS::AccountId}:catalog'
+                  - !Sub 'arn:aws:glue:${AWS::Region}:${AWS::AccountId}:database/${AccessLogDatabase}'
+                  - !Sub 'arn:aws:glue:${AWS::Region}:${AWS::AccountId}:table/${AccessLogDatabase}/${AccessLogTable}'
+                  - !Sub 'arn:aws:glue:${AWS::Region}:${AWS::AccountId}:tableVersion/${AccessLogDatabase}/${AccessLogTable}/*'
+              - Effect: Allow
+                Action:
+                  - lambda:InvokeFunction
+                  - lambda:GetFunctionConfiguration
+                Resource:
+                  - !GetAtt AccessLogProcessor.Arn
+  AccessLogRedshiftSpectrumRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal: { Service: redshift.amazonaws.com }
+      Policies:
+        - PolicyName: s3
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:GetBucketLocation
+                  - s3:GetObject
+                  - s3:ListMultipartUploadParts
+                  - s3:ListBucket
+                  - s3:ListBucketMultipartUploads
+                Resource:
+                  - !GetAtt AccessLogBucket.Arn
+                  - !Sub '${AccessLogBucket.Arn}/*'
+              - Effect: Allow
+                Action:
+                  - glue:GetDatabase
+                  - glue:GetDatabases
+                  - glue:GetTable
+                  - glue:GetTables
+                  - glue:GetPartition
+                  - glue:GetPartitions
+                  - glue:BatchGetPartition
+                Resource:
+                  - !Sub 'arn:aws:glue:${AWS::Region}:${AWS::AccountId}:catalog'
+                  - !Sub 'arn:aws:glue:${AWS::Region}:${AWS::AccountId}:database/${AccessLogDatabase}'
+                  - !Sub 'arn:aws:glue:${AWS::Region}:${AWS::AccountId}:table/${AccessLogDatabase}/${AccessLogTable}'
+
+Outputs:
+  AccessLogConfig:
+    Description: CloudFront real-time log config
+    Value: !Ref AccessLogConfig
+    Export: {Name: !Sub "${AWS::StackName}-Config"}
+  RedshiftSpectrumRoleARN:
+    Description: Redshift Spectrum Role ARN
+    Value: !GetAtt AccessLogRedshiftSpectrumRole.Arn
+    Export: {Name: !Sub "${AWS::StackName}-RedshiftSpectrumRoleARN"}

--- a/aws/cloudformation/access_logs_partition.rb
+++ b/aws/cloudformation/access_logs_partition.rb
@@ -1,0 +1,45 @@
+# Add Glue partition metadata when an S3 object is created.
+# Invoked by a S3 bucket notification configuration for `s3:ObjectCreated:*` events.
+# This function is made redundant by Athena Partition Projection, but
+# adding partitions manually is still currently necessary for Redshift Spectrum.
+
+require 'aws-sdk-glue'
+GLUE = Aws::Glue::Client.new
+
+DATABASE = ENV['DATABASE']
+TABLE = ENV['TABLE']
+PREFIX = ENV['PREFIX']
+
+STORAGE_DESCRIPTOR = GLUE.get_table(
+  database_name: DATABASE,
+  name: TABLE
+).table.storage_descriptor
+
+# Track already-created partitions to avoid unnecessary calls to GetPartition.
+CREATED_PARTITIONS = {}
+
+def handler(event:, context:)
+  partition = event['Records'][0].dig('s3', 'object', 'key').
+    delete_prefix(PREFIX).split('/').tap(&:pop).join('/')
+
+  CREATED_PARTITIONS[partition] ||=
+    begin
+      GLUE.get_partition(
+        database_name: DATABASE,
+        table_name: TABLE,
+        partition_values: [partition]
+      ).partition
+      true
+    rescue Aws::Glue::Errors::EntityNotFoundException
+      GLUE.create_partition(
+        database_name: DATABASE,
+        table_name: TABLE,
+        partition_input: {
+          values: [partition],
+          storage_descriptor: STORAGE_DESCRIPTOR.dup.tap do |storage|
+            storage.location += partition + '/'
+          end
+        }
+      )
+    end
+end

--- a/lib/cdo/aws/cloudfront.rb
+++ b/lib/cdo/aws/cloudfront.rb
@@ -260,6 +260,7 @@ module AWS
         ViewerProtocolPolicy: 'redirect-to-https'
       }.tap do |behavior|
         behavior[:PathPattern] = path if path
+        behavior[:RealtimeLogConfigArn] = {'Fn::ImportValue': 'AccessLogs-Config'}
       end
     end
 


### PR DESCRIPTION
This PR provides a CloudFormation stack that exports CloudFront real-time access logs to Parquet files in an S3 bucket, supporting efficient queries from Athena or Redshift Spectrum.

## Links

CloudFront:
- https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/real-time-logs.html

Kinesis Firehose:
- https://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html
- https://docs.aws.amazon.com/firehose/latest/dev/data-transformation.html
- https://docs.aws.amazon.com/firehose/latest/dev/record-format-conversion.html

Jira:
- [`INF-381`](https://codedotorg.atlassian.net/browse/INF-381) ('Set up Real-time logs for CloudFront distributions')
- [`INF-423`](https://codedotorg.atlassian.net/browse/INF-423) ('Log Pegasus HTTP logs to AWS Athena')

## Testing story

Manually tested, via the following steps:
- Provision CloudFormation stack in dev account
- Attach the exported configuration to an existing CloudFront distribution, and generate some HTTP requests against it
- Query the access logs using Athena (via management console), e.g.: `SELECT * FROM cdo_access_logs.access_logs WHERE datehour > '2021/06/15' ORDER BY timestamp DESC LIMIT 10`
- Create a test Redshift cluster and query against it:
  - Associate the exported Redshift Spectrum IAM role
  - Manually create the external schema using [`CREATE EXTERNAL SCHEMA`](https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_EXTERNAL_SCHEMA.html) query, e.g., `CREATE EXTERNAL SCHEMA cdo_access_logs FROM DATA CATALOG DATABASE 'cdo_access_logs_dev' IAM_ROLE '[role_arn]';`
  - Query the access logs using the external schema, e.g.: `SELECT * FROM cdo_access_logs.access_logs WHERE datehour > '2021/06/15' LIMIT 10`

## Deployment strategy

- Manually create stack in production account
  - NOTE: Packaging and uploading the Lambda functions associated with the stack template requires the use of [`aws cloudformation package`](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/cloudformation/package.html) command.
- Update CloudFront distributions to associate the exported realtime log configuration
- Monitor metrics to make sure everything is working properly

## Follow-up work

- (eventually) disable classic access logs once they're no longer needed

## Privacy

This feature controls the creation of HTTP access logs which contain IP addresses, user-agents and other potentially-sensitive data (depending on the data encoded in paths, query parameters, etc).

## Security

- Access logs are stored in a private S3 bucket with all 'block public access' configuration set, and with at-rest encryption (AWS-managed key)
- Kinesis data stream is stored with at-rest encryption (AWS-managed key)
- IAM roles for the various services invoked by this system (`cloudfront`, `firehose`, `redshift`, `lambda`) grant least privilege to created resources.

## PR Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
