### PR TITLE
Update script breadcrumb to look like lesson breadcrumb

### DIFF
--- a/apps/src/code-studio/components/progress/ScriptOverview.jsx
+++ b/apps/src/code-studio/components/progress/ScriptOverview.jsx
@@ -28,6 +28,7 @@ import {
 import {unitCalendarLesson} from '@cdo/apps/templates/progress/unitCalendarLessonShapes';
 import GoogleClassroomAttributionLabel from '@cdo/apps/templates/progress/GoogleClassroomAttributionLabel';
 import UnitCalendar from './UnitCalendar';
+import color from '@cdo/apps/util/color';
 
 /**
  * Lesson progress component used in level header and script overview.
@@ -36,6 +37,8 @@ class ScriptOverview extends React.Component {
   static propTypes = {
     id: PropTypes.number,
     courseId: PropTypes.number,
+    courseTitle: PropTypes.string,
+    courseLink: PropTypes.string,
     onOverviewPage: PropTypes.bool.isRequired,
     excludeCsfColumnInLegend: PropTypes.bool.isRequired,
     teacherResources: PropTypes.arrayOf(resourceShape),
@@ -145,6 +148,13 @@ class ScriptOverview extends React.Component {
       <div>
         {onOverviewPage && (
           <div>
+            {this.props.courseLink && (
+              <div className="script-breadcrumb" style={styles.navArea}>
+                <a href={this.props.courseLink} style={styles.navLink}>{`< ${
+                  this.props.courseTitle
+                }`}</a>
+              </div>
+            )}
             {displayRedirectDialog && (
               <RedirectDialog
                 isOpen={this.state.showRedirectDialog}
@@ -206,6 +216,17 @@ class ScriptOverview extends React.Component {
     );
   }
 }
+
+const styles = {
+  navLink: {
+    fontSize: 14,
+    lineHeight: '22px',
+    color: color.purple
+  },
+  navArea: {
+    padding: '10px 0px'
+  }
+};
 
 export const UnconnectedScriptOverview = Radium(ScriptOverview);
 export default connect((state, ownProps) => ({

--- a/apps/src/code-studio/progress.js
+++ b/apps/src/code-studio/progress.js
@@ -277,6 +277,8 @@ progress.renderCourseProgress = function(scriptData) {
       <ScriptOverview
         id={scriptData.id}
         courseId={scriptData.course_id}
+        courseTitle={scriptData.course_title}
+        courseLink={scriptData.course_link}
         onOverviewPage={true}
         excludeCsfColumnInLegend={!scriptData.csf}
         teacherResources={teacherResources}

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -3297,24 +3297,6 @@ code {
   }
 }
 
-#script-breadcrumb {
-  padding-bottom: 10px;
-  a:hover {
-    // Don't underline despite the fact that we're technically a link
-    text-decoration: none;
-  }
-  i {
-    color: $teal;
-    font-size: 18px;
-    margin-right: 15px;
-  }
-  span {
-    color: $teal;
-    font-size: 20px;
-    font-family: "Gotham 4r", sans-serif;
-  }
-}
-
 .breadcrumb-header {
   margin-top: 10px;
 }

--- a/dashboard/app/views/scripts/show.html.haml
+++ b/dashboard/app/views/scripts/show.html.haml
@@ -12,6 +12,8 @@
                             user_providers: current_user&.providers,
                             is_verified_teacher: current_user&.authorized_teacher?,
                             locale: Script.locale_english_name_map[request.locale],
+                            course_link: @script.course_link(params[:section_id]),
+                            course_title: @script.course_title || I18n.t('view_all_units'),
                             sections: @sections_with_assigned_info}
 - scriptOverviewData = {scriptData: script_data.merge(additional_script_data)}
 - if @script.professional_learning_course? && @current_user && Plc::UserCourseEnrollment.exists?(user: @current_user, plc_course: @script.plc_course_unit.plc_course)
@@ -28,14 +30,6 @@
 - if @current_user.try(:script_hidden?, @script)
   = render partial: 'hidden_script'
 - else
-  - course_link = @script.course_link(params[:section_id])
-  - if course_link
-    - course_title = @script.course_title || I18n.t('view_all_units')
-    #script-breadcrumb
-      %a{href: course_link}
-        %i.fa.fa-chevron-left
-        %span
-          = course_title
   #landingpage
     #notification
     -# This div ends up being owned by ScriptOverviewHeader in react


### PR DESCRIPTION
Moves the breadcrumb on the ScriptOverview page which points to the CourseOverview page if a script is in a unit_group into React. This allows us to standardize the look of the breadcrumb with the one on the LessonOverview more easily. 

Shows on a script with a unit group
<img width="1078" alt="Screen Shot 2021-06-15 at 1 57 35 PM" src="https://user-images.githubusercontent.com/208083/122100859-a71d8f00-cde1-11eb-895d-381021dd2b2a.png">

Does not show on a standalone script
<img width="1723" alt="Screen Shot 2021-06-15 at 1 58 02 PM" src="https://user-images.githubusercontent.com/208083/122100909-b56bab00-cde1-11eb-9971-7044af13d7e4.png">



## Links

https://codedotorg.atlassian.net/browse/PLAT-657

## Testing story

Tested manually on a couple of scripts.
