### PR TITLE
JavaLab: Enable project-backed level progressions in levelbuilder

### DIFF
--- a/dashboard/app/views/levels/editors/_javalab.html.haml
+++ b/dashboard/app/views/levels/editors/_javalab.html.haml
@@ -1,6 +1,7 @@
 = render partial: 'levels/editors/fields/instructions_area', locals: {f: f}
 = render partial: 'levels/editors/fields/teacher_only_markdown', locals: {f: f}
 = render partial: 'levels/editors/fields/bubble_choice_sublevel', locals: {f: f}
+= render partial: 'levels/editors/fields/special_level_types', locals: {f: f}
 = render partial: 'levels/editors/fields/csa_fields', locals: {f: f}
 = render partial: 'levels/editors/fields/encrypted_examples', locals: {f: f, level_type: 'javalab'}
 = render partial: 'levels/editors/fields/sharing', locals: {f: f}

--- a/dashboard/app/views/levels/editors/fields/_special_level_types.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_special_level_types.html.haml
@@ -26,7 +26,7 @@
         %li For users: The coding workspace, design mode, data mode, the reset button, and sharing are all disabled.
         %li For levelbuilders: The coding workspace and design mode are available in start mode.
 
-  - if (@level.is_a?(Blockly) || @level.is_a?(Weblab))
+  - if (@level.is_a?(Blockly) || @level.is_a?(Weblab) || @level.is_a?(Javalab))
     .field
       = f.label :project_template_level_name, 'Project Template Level Name'
       %p What this does:


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Enables project-backed level progressions for JavaLab in levelbuilder. Screenshot attached:

![Screen Shot 2021-06-15 at 3 35 53 PM](https://user-images.githubusercontent.com/85528507/122132774-59f4e980-cdf0-11eb-9db7-240698ecad3f.png)


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

[CSA-471](https://codedotorg.atlassian.net/browse/CSA-471)

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
