### PR TITLE
Mini-rubric updates

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1574,7 +1574,7 @@
   "rollupTitleStandards": "{title} Standards",
   "rollupTitleVocab": "{title} Vocabulary",
   "rotateText": "Rotate your device.",
-  "rubricHeader": "Evaluation Rubric",
+  "rubric": "Rubric",
   "rubricLevelThreeHeader": "Limited Evidence",
   "rubricLevelOneHeader": "Extensive Evidence",
   "rubricKeyConceptHeader": "Key Concept",

--- a/apps/src/templates/instructions/TopInstructions.jsx
+++ b/apps/src/templates/instructions/TopInstructions.jsx
@@ -677,9 +677,7 @@ class TopInstructions extends Component {
               <TeacherFeedback
                 user={user}
                 visible={tabSelected === TabType.COMMENTS}
-                isReadonly={
-                  this.isViewingAsStudent || !teacherViewingStudentWork
-                }
+                isEditable={teacherViewingStudentWork}
                 rubric={rubric}
                 ref={ref => (this.commentTab = ref)}
                 latestFeedback={feedbacks.length ? feedbacks[0] : null}

--- a/apps/src/templates/instructions/TopInstructions.jsx
+++ b/apps/src/templates/instructions/TopInstructions.jsx
@@ -594,20 +594,8 @@ class TopInstructions extends Component {
 
     const studentHasFeedback = this.isViewingAsStudent && feedbacks.length > 0;
 
-    /*
-     * The feedback tab will be the Key Concept tab if there is a mini rubric and:
-     * 1) Teacher is viewing the level but not giving feedback to the student
-     * 2) Student does not have any feedback for that level
-     * The Key Concept tab shows the Key Concept and Rubric for the level in a view
-     * only form
-     */
-    const displayReadonlyRubric =
-      rubric &&
-      ((this.isViewingAsStudent && !studentHasFeedback) ||
-        (this.isViewingAsTeacher && !teacherViewingStudentWork));
-
     const displayFeedback =
-      displayReadonlyRubric || teacherViewingStudentWork || studentHasFeedback;
+      !!rubric || teacherViewingStudentWork || studentHasFeedback;
 
     // Teacher is viewing students work and in the Feedback Tab
     const teacherOnly =
@@ -649,7 +637,7 @@ class TopInstructions extends Component {
           isCSDorCSP={isCSDorCSP}
           displayHelpTab={displayHelpTab}
           displayFeedback={displayFeedback}
-          displayKeyConcept={displayReadonlyRubric} // Key Concept tab displays a readonly rubric
+          levelHasRubric={!!rubric}
           displayDocumentationTab={displayDocumentationTab}
           displayReviewTab={displayReviewTab}
           isViewingAsTeacher={this.isViewingAsTeacher}
@@ -689,8 +677,7 @@ class TopInstructions extends Component {
               <TeacherFeedback
                 user={user}
                 visible={tabSelected === TabType.COMMENTS}
-                displayReadonlyRubric={displayReadonlyRubric}
-                disabledMode={
+                isReadonly={
                   this.isViewingAsStudent || !teacherViewingStudentWork
                 }
                 rubric={rubric}

--- a/apps/src/templates/instructions/TopInstructionsHeader.jsx
+++ b/apps/src/templates/instructions/TopInstructionsHeader.jsx
@@ -82,7 +82,7 @@ function TopInstructionsHeader(props) {
     isCSDorCSP,
     displayHelpTab,
     displayFeedback,
-    displayKeyConcept,
+    levelHasRubric,
     displayDocumentationTab,
     displayReviewTab,
     isViewingAsTeacher,
@@ -179,7 +179,7 @@ function TopInstructionsHeader(props) {
               className="uitest-feedback"
               onClick={handleCommentTabClick}
               selected={tabSelected === TabType.COMMENTS}
-              text={displayKeyConcept ? i18n.keyConcept() : i18n.feedback()}
+              text={levelHasRubric ? i18n.rubric() : i18n.feedback()}
               teacherOnly={teacherOnly}
               isMinecraft={isMinecraft}
               isRtl={isRtl}
@@ -239,7 +239,7 @@ TopInstructionsHeader.propTypes = {
   isCSDorCSP: PropTypes.bool,
   displayHelpTab: PropTypes.bool,
   displayFeedback: PropTypes.bool,
-  displayKeyConcept: PropTypes.bool,
+  levelHasRubric: PropTypes.bool,
   displayDocumentationTab: PropTypes.bool,
   displayReviewTab: PropTypes.bool,
   isViewingAsTeacher: PropTypes.bool,

--- a/apps/src/templates/instructions/teacherFeedback/Comment.jsx
+++ b/apps/src/templates/instructions/teacherFeedback/Comment.jsx
@@ -4,7 +4,7 @@ import color from '@cdo/apps/util/color';
 
 class Comment extends React.Component {
   static propTypes = {
-    isReadonly: PropTypes.bool,
+    isEditable: PropTypes.bool,
     comment: PropTypes.string,
     placeholderText: PropTypes.string,
     onCommentChange: PropTypes.func.isRequired
@@ -15,7 +15,7 @@ class Comment extends React.Component {
   };
 
   render() {
-    const readOnlyStyle = this.props.isReadonly && styles.readOnly;
+    const readOnlyStyle = !this.props.isEditable && styles.readOnly;
 
     return (
       <textarea
@@ -24,7 +24,7 @@ class Comment extends React.Component {
         onChange={this.commentChanged}
         placeholder={this.props.placeholderText}
         value={this.props.comment}
-        readOnly={this.props.isReadonly}
+        readOnly={!this.props.isEditable}
       />
     );
   }

--- a/apps/src/templates/instructions/teacherFeedback/Rubric.jsx
+++ b/apps/src/templates/instructions/teacherFeedback/Rubric.jsx
@@ -31,12 +31,27 @@ class TeacherFeedbackRubric extends Component {
       viewAs
     } = this.props;
 
-    let showFeedbackInputAreas, expandByDefault;
+    // RubricFields are used to display and update performance levels. When expanded,
+    // the RubricField displays detailed information about the performance level. The RubricFields also
+    // have input areas for the teacher to select a performance level or for the student
+    // to view the selection.
+
+    let showFeedbackInputAreas, expandAllRubricFields;
     if (viewAs === ViewType.Student) {
-      expandByDefault = !performance;
+      // If the student has not been evaluated by the rubric (!performance),
+      // the rubric fields are expanded to display details. If the student has
+      // been evaluated the rubric, fields are collapsed by default. Except for the
+      // selected performance level (see RubricField implementation below).
+      expandAllRubricFields = !performance;
+
+      // Input areas are only displayed if a student has been evalutated with the rubric.
       showFeedbackInputAreas = !!performance;
     } else if (viewAs === ViewType.Teacher) {
-      expandByDefault = !isEditable;
+      // Rubric fields are all expanded if teacher is viewing but not editing the rubric (this
+      // will happen when the teacher is viewing the level and not viewing a student's work).
+      // Rubric fields are all collapsed by default if the teacher is evaluating a student.
+      expandAllRubricFields = !isEditable;
+
       showFeedbackInputAreas = isEditable;
     }
 
@@ -54,7 +69,7 @@ class TeacherFeedbackRubric extends Component {
                 key={level}
                 showFeedbackInputAreas={showFeedbackInputAreas}
                 expandByDefault={
-                  expandByDefault ||
+                  expandAllRubricFields ||
                   (viewAs === ViewType.Student && performance === level)
                 }
                 rubricLevel={level}

--- a/apps/src/templates/instructions/teacherFeedback/Rubric.jsx
+++ b/apps/src/templates/instructions/teacherFeedback/Rubric.jsx
@@ -17,7 +17,7 @@ class TeacherFeedbackRubric extends Component {
   static propTypes = {
     rubric: rubricShape,
     performance: PropTypes.string,
-    isReadonly: PropTypes.bool,
+    isEditable: PropTypes.bool,
     onRubricChange: PropTypes.func.isRequired,
     viewAs: PropTypes.oneOf(['Teacher', 'Student']).isRequired
   };
@@ -26,7 +26,7 @@ class TeacherFeedbackRubric extends Component {
     const {
       rubric,
       performance,
-      isReadonly,
+      isEditable,
       onRubricChange,
       viewAs
     } = this.props;
@@ -36,8 +36,8 @@ class TeacherFeedbackRubric extends Component {
       expandByDefault = !performance;
       showFeedbackInputAreas = !!performance;
     } else if (viewAs === ViewType.Teacher) {
-      expandByDefault = isReadonly;
-      showFeedbackInputAreas = !isReadonly;
+      expandByDefault = !isEditable;
+      showFeedbackInputAreas = isEditable;
     }
 
     return (
@@ -59,7 +59,7 @@ class TeacherFeedbackRubric extends Component {
                 }
                 rubricLevel={level}
                 rubricValue={rubric[level]}
-                disabledMode={isReadonly}
+                disabledMode={!isEditable}
                 onChange={onRubricChange}
                 currentlyChecked={performance === level}
               />

--- a/apps/src/templates/instructions/teacherFeedback/Rubric.jsx
+++ b/apps/src/templates/instructions/teacherFeedback/Rubric.jsx
@@ -18,7 +18,6 @@ class TeacherFeedbackRubric extends Component {
     rubric: rubricShape,
     performance: PropTypes.string,
     isReadonly: PropTypes.bool,
-    disabledMode: PropTypes.bool.isRequired,
     onRubricChange: PropTypes.func.isRequired,
     viewAs: PropTypes.oneOf(['Teacher', 'Student']).isRequired
   };
@@ -28,13 +27,16 @@ class TeacherFeedbackRubric extends Component {
       rubric,
       performance,
       isReadonly,
-      disabledMode,
       onRubricChange,
       viewAs
     } = this.props;
 
-    const showFeedbackInputAreas =
-      !isReadonly && (!!performance || viewAs === ViewType.Teacher);
+    const studentViewingPerfFeedback =
+      !!performance && viewAs === ViewType.Student;
+
+    const showFeedbackInputAreas = !isReadonly || studentViewingPerfFeedback;
+
+    const expandByDefault = isReadonly && !studentViewingPerfFeedback;
 
     return (
       <div style={styles.performanceArea}>
@@ -43,19 +45,19 @@ class TeacherFeedbackRubric extends Component {
           <p style={styles.keyConcepts}>{rubric.keyConcept}</p>
         </div>
         <div style={styles.rubricArea}>
-          <h1 style={styles.h1}> {i18n.rubricHeader()} </h1>
+          <h1 style={styles.h1}> {i18n.rubric()} </h1>
           <form style={styles.form}>
             {rubricLevels.map(level => (
               <RubricField
                 key={level}
                 showFeedbackInputAreas={showFeedbackInputAreas}
                 expandByDefault={
-                  isReadonly ||
-                  (viewAs === ViewType.Student && performance === level)
+                  expandByDefault ||
+                  (studentViewingPerfFeedback && performance === level)
                 }
                 rubricLevel={level}
                 rubricValue={rubric[level]}
-                disabledMode={disabledMode}
+                disabledMode={isReadonly}
                 onChange={onRubricChange}
                 currentlyChecked={performance === level}
               />

--- a/apps/src/templates/instructions/teacherFeedback/Rubric.jsx
+++ b/apps/src/templates/instructions/teacherFeedback/Rubric.jsx
@@ -31,12 +31,14 @@ class TeacherFeedbackRubric extends Component {
       viewAs
     } = this.props;
 
-    const studentViewingPerfFeedback =
-      !!performance && viewAs === ViewType.Student;
-
-    const showFeedbackInputAreas = !isReadonly || studentViewingPerfFeedback;
-
-    const expandByDefault = isReadonly && !studentViewingPerfFeedback;
+    let showFeedbackInputAreas, expandByDefault;
+    if (viewAs === ViewType.Student) {
+      expandByDefault = !performance;
+      showFeedbackInputAreas = !!performance;
+    } else if (viewAs === ViewType.Teacher) {
+      expandByDefault = isReadonly;
+      showFeedbackInputAreas = !isReadonly;
+    }
 
     return (
       <div style={styles.performanceArea}>
@@ -53,7 +55,7 @@ class TeacherFeedbackRubric extends Component {
                 showFeedbackInputAreas={showFeedbackInputAreas}
                 expandByDefault={
                   expandByDefault ||
-                  (studentViewingPerfFeedback && performance === level)
+                  (viewAs === ViewType.Student && performance === level)
                 }
                 rubricLevel={level}
                 rubricValue={rubric[level]}

--- a/apps/src/templates/instructions/teacherFeedback/TeacherFeedback.jsx
+++ b/apps/src/templates/instructions/teacherFeedback/TeacherFeedback.jsx
@@ -246,7 +246,7 @@ export class TeacherFeedback extends Component {
       : placeholderWarning;
 
     // The comment section (reivew state, comment and status) is only displayed
-    // if it's being edited (not readonly) or if the student is viewing their feedback.
+    // if it's editable or if the student is viewing their feedback.
     const displayCommentSection =
       isEditable || (viewAs === ViewType.Student && !!latestFeedback);
 

--- a/apps/src/templates/instructions/teacherFeedback/TeacherFeedback.jsx
+++ b/apps/src/templates/instructions/teacherFeedback/TeacherFeedback.jsx
@@ -30,13 +30,12 @@ const keepWorkingExperiment = 'teacher-feedback-review-state';
 export class TeacherFeedback extends Component {
   static propTypes = {
     user: PropTypes.number,
-    disabledMode: PropTypes.bool.isRequired,
+    isReadonly: PropTypes.bool.isRequired,
     rubric: rubricShape,
     visible: PropTypes.bool.isRequired,
     serverScriptId: PropTypes.number,
     serverLevelId: PropTypes.number,
     teacher: PropTypes.number,
-    displayReadonlyRubric: PropTypes.bool,
     latestFeedback: teacherFeedbackShape,
     token: PropTypes.string,
     //Provided by Redux
@@ -234,14 +233,7 @@ export class TeacherFeedback extends Component {
   }
 
   render() {
-    const {
-      verifiedTeacher,
-      viewAs,
-      rubric,
-      visible,
-      displayReadonlyRubric,
-      disabledMode
-    } = this.props;
+    const {verifiedTeacher, viewAs, rubric, visible, isReadonly} = this.props;
 
     const {comment, performance, latestFeedback, errorState} = this.state;
 
@@ -255,6 +247,9 @@ export class TeacherFeedback extends Component {
 
     const displayComment = !!comment || viewAs === ViewType.Teacher;
 
+    const displayCommentSection =
+      !isReadonly || (viewAs === ViewType.Student && !!latestFeedback);
+
     if (!visible) {
       return null;
     }
@@ -267,13 +262,12 @@ export class TeacherFeedback extends Component {
           <Rubric
             rubric={rubric}
             performance={performance}
-            isReadonly={displayReadonlyRubric}
-            disabledMode={disabledMode}
+            isReadonly={isReadonly}
             onRubricChange={this.onRubricChange}
             viewAs={viewAs}
           />
         )}
-        {!displayReadonlyRubric && (
+        {displayCommentSection && (
           <div style={styles.commentAndFooter}>
             {viewAs === ViewType.Teacher &&
               this.renderCommentAreaHeaderForTeacher()}
@@ -281,7 +275,7 @@ export class TeacherFeedback extends Component {
               this.renderCommentAreaHeaderForStudent()}
             {displayComment && (
               <Comment
-                isReadonly={disabledMode}
+                isReadonly={isReadonly}
                 comment={comment}
                 placeholderText={placeholderText}
                 onCommentChange={this.onCommentChange}

--- a/apps/src/templates/instructions/teacherFeedback/TeacherFeedback.jsx
+++ b/apps/src/templates/instructions/teacherFeedback/TeacherFeedback.jsx
@@ -245,10 +245,12 @@ export class TeacherFeedback extends Component {
       ? latestFeedback.comment
       : placeholderWarning;
 
-    const displayComment = !!comment || viewAs === ViewType.Teacher;
-
+    // The comment section (reivew state, comment and status) is only displayed
+    // if it's being edited (not readonly) or if the student is viewing their feedback.
     const displayCommentSection =
       !isReadonly || (viewAs === ViewType.Student && !!latestFeedback);
+
+    const displayComment = !!comment || viewAs === ViewType.Teacher;
 
     if (!visible) {
       return null;

--- a/apps/src/templates/instructions/teacherFeedback/TeacherFeedback.jsx
+++ b/apps/src/templates/instructions/teacherFeedback/TeacherFeedback.jsx
@@ -30,7 +30,7 @@ const keepWorkingExperiment = 'teacher-feedback-review-state';
 export class TeacherFeedback extends Component {
   static propTypes = {
     user: PropTypes.number,
-    isReadonly: PropTypes.bool.isRequired,
+    isEditable: PropTypes.bool.isRequired,
     rubric: rubricShape,
     visible: PropTypes.bool.isRequired,
     serverScriptId: PropTypes.number,
@@ -233,7 +233,7 @@ export class TeacherFeedback extends Component {
   }
 
   render() {
-    const {verifiedTeacher, viewAs, rubric, visible, isReadonly} = this.props;
+    const {verifiedTeacher, viewAs, rubric, visible, isEditable} = this.props;
 
     const {comment, performance, latestFeedback, errorState} = this.state;
 
@@ -248,7 +248,7 @@ export class TeacherFeedback extends Component {
     // The comment section (reivew state, comment and status) is only displayed
     // if it's being edited (not readonly) or if the student is viewing their feedback.
     const displayCommentSection =
-      !isReadonly || (viewAs === ViewType.Student && !!latestFeedback);
+      isEditable || (viewAs === ViewType.Student && !!latestFeedback);
 
     const displayComment = !!comment || viewAs === ViewType.Teacher;
 
@@ -264,7 +264,7 @@ export class TeacherFeedback extends Component {
           <Rubric
             rubric={rubric}
             performance={performance}
-            isReadonly={isReadonly}
+            isEditable={isEditable}
             onRubricChange={this.onRubricChange}
             viewAs={viewAs}
           />
@@ -277,7 +277,7 @@ export class TeacherFeedback extends Component {
               this.renderCommentAreaHeaderForStudent()}
             {displayComment && (
               <Comment
-                isReadonly={isReadonly}
+                isEditable={isEditable}
                 comment={comment}
                 placeholderText={placeholderText}
                 onCommentChange={this.onCommentChange}

--- a/apps/test/unit/templates/instructions/TopInstructionsHeaderTest.jsx
+++ b/apps/test/unit/templates/instructions/TopInstructionsHeaderTest.jsx
@@ -6,6 +6,7 @@ import {TabType} from '@cdo/apps/templates/instructions/TopInstructions';
 import InlineAudio from '@cdo/apps/templates/instructions/InlineAudio';
 import {PaneButton} from '@cdo/apps/templates/PaneHeader';
 import CollapserIcon from '@cdo/apps/templates/CollapserIcon';
+import i18n from '@cdo/locale';
 
 const DEFAULT_PROPS = {
   teacherOnly: false,
@@ -13,7 +14,7 @@ const DEFAULT_PROPS = {
   isCSDorCSP: true,
   displayHelpTab: true,
   displayFeedback: true,
-  displayKeyConcept: false,
+  levelHasRubric: false,
   isViewingAsTeacher: false,
   fetchingData: false,
   handleDocumentationClick: () => {},
@@ -72,6 +73,26 @@ describe('TopInstructionsHeader', () => {
     });
     const commentTab = wrapper.find('.uitest-feedback');
     expect(commentTab.props().selected).to.be.true;
+  });
+
+  it('on the comments tab selects when displayFeedback and levelHasRubric text is rubric', () => {
+    const wrapper = setUp({
+      levelHasRubric: true,
+      displayFeedback: true,
+      tabSelected: TabType.COMMENTS
+    });
+    const commentTab = wrapper.find('.uitest-feedback');
+    expect(commentTab.props().text).to.equal(i18n.rubric());
+  });
+
+  it('on the comments tab selects when displayFeedback and levelHasRubric = false text is feedback', () => {
+    const wrapper = setUp({
+      levelHasRubric: false,
+      displayFeedback: true,
+      tabSelected: TabType.COMMENTS
+    });
+    const commentTab = wrapper.find('.uitest-feedback');
+    expect(commentTab.props().text).to.equal(i18n.feedback());
   });
 
   it('hides comment tab when displayFeedback is false', () => {

--- a/apps/test/unit/templates/instructions/teacherFeedback/CommentTest.jsx
+++ b/apps/test/unit/templates/instructions/teacherFeedback/CommentTest.jsx
@@ -5,15 +5,15 @@ import Comment from '@cdo/apps/templates/instructions/teacherFeedback/Comment';
 import sinon from 'sinon';
 
 const DEFAULT_PROPS = {
-  isReadonly: false,
+  isEditable: true,
   onCommentChange: () => {},
   comment: 'Good Work!',
   placeholderText: 'Add your comment here'
 };
 
 describe('Comment', () => {
-  it('has a display only textarea if in isReadonly', () => {
-    const wrapper = shallow(<Comment {...DEFAULT_PROPS} isReadonly={true} />);
+  it('has a display only textarea isEditable is false', () => {
+    const wrapper = shallow(<Comment {...DEFAULT_PROPS} isEditable={false} />);
 
     const confirmTextArea = wrapper.find('textarea').first();
     expect(confirmTextArea.props().readOnly).to.equal(true);

--- a/apps/test/unit/templates/instructions/teacherFeedback/RubricTest.jsx
+++ b/apps/test/unit/templates/instructions/teacherFeedback/RubricTest.jsx
@@ -14,7 +14,7 @@ const DEFAULT_PROPS = {
     performanceLevel4: 'no evidence of trying'
   },
   performance: null,
-  isReadonly: false,
+  isEditable: true,
   onRubricChange: () => {},
   viewAs: ViewType.Teacher
 };
@@ -79,40 +79,40 @@ describe('Rubric', () => {
   });
 
   describe('view as teacher', () => {
-    it('RubricField prop showFeedbackInputAreas is true if isReadonly = false', () => {
+    it('RubricField prop showFeedbackInputAreas is true if isEditable = true', () => {
       const wrapper = setUp({
         viewAs: ViewType.Teacher,
-        isReadonly: false
+        isEditable: true
       });
 
       const firstRubricField = wrapper.find('RubricField').first();
       expect(firstRubricField.props().showFeedbackInputAreas).to.be.true;
     });
 
-    it('RubricField prop showFeedbackInputAreas is false if isReadonly = true', () => {
+    it('RubricField prop showFeedbackInputAreas is false if isEditable = false', () => {
       const wrapper = setUp({
         viewAs: ViewType.Teacher,
-        isReadonly: true
+        isEditable: false
       });
 
       const firstRubricField = wrapper.find('RubricField').first();
       expect(firstRubricField.props().showFeedbackInputAreas).to.be.false;
     });
 
-    it('RubricField prop expandByDefault is false isReadonly = false', () => {
+    it('RubricField prop expandByDefault is false isEditable = true', () => {
       const wrapper = setUp({
         viewAs: ViewType.Teacher,
-        isReadonly: false
+        isEditable: true
       });
 
       const firstRubricField = wrapper.find('RubricField').first();
       expect(firstRubricField.props().expandByDefault).to.be.false;
     });
 
-    it('RubricField prop expandByDefault is true isReadonly = true', () => {
+    it('RubricField prop expandByDefault is true isEditable = false', () => {
       const wrapper = setUp({
         viewAs: ViewType.Teacher,
-        isReadonly: true
+        isEditable: false
       });
 
       const firstRubricField = wrapper.find('RubricField').first();
@@ -124,7 +124,7 @@ describe('Rubric', () => {
     it('expands rubric value with feedback', () => {
       const wrapper = setUp({
         viewAs: ViewType.Student,
-        isReadonly: false,
+        isEditable: false,
         performance: 'performanceLevel2'
       });
 

--- a/apps/test/unit/templates/instructions/teacherFeedback/RubricTest.jsx
+++ b/apps/test/unit/templates/instructions/teacherFeedback/RubricTest.jsx
@@ -14,7 +14,6 @@ const DEFAULT_PROPS = {
   },
   performance: null,
   isReadonly: false,
-  disabledMode: false,
   onRubricChange: () => {},
   viewAs: ViewType.Teacher
 };

--- a/apps/test/unit/templates/instructions/teacherFeedback/RubricTest.jsx
+++ b/apps/test/unit/templates/instructions/teacherFeedback/RubricTest.jsx
@@ -3,6 +3,7 @@ import {shallow} from 'enzyme';
 import {expect} from '../../../../util/reconfiguredChai';
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import Rubric from '@cdo/apps/templates/instructions/teacherFeedback/Rubric';
+import i18n from '@cdo/locale';
 
 const DEFAULT_PROPS = {
   rubric: {
@@ -26,8 +27,13 @@ const setUp = overrideProps => {
 describe('Rubric', () => {
   it('displays key concept', () => {
     const wrapper = setUp();
-    expect(wrapper.contains('Key Concept')).to.equal(true);
+    expect(wrapper.contains(i18n.rubricKeyConceptHeader())).to.equal(true);
     expect(wrapper.contains('This is the Key Concept')).to.equal(true);
+  });
+
+  it('displays rubric header', () => {
+    const wrapper = setUp();
+    expect(wrapper.contains(i18n.rubric())).to.equal(true);
   });
 
   it('has 4 rubric fields', () => {

--- a/apps/test/unit/templates/instructions/teacherFeedback/TeacherFeedbackTest.jsx
+++ b/apps/test/unit/templates/instructions/teacherFeedback/TeacherFeedbackTest.jsx
@@ -13,19 +13,18 @@ import Rubric from '@cdo/apps/templates/instructions/teacherFeedback/Rubric';
 
 const TEACHER_FEEDBACK_NO_RUBRIC_PROPS = {
   user: 5,
-  isReadonly: false,
+  isEditable: true,
   rubric: null,
   visible: true,
   viewAs: 'Teacher',
   serverLevelId: 123,
   teacher: 5,
-  displayReadonlyRubric: false,
   latestFeedback: null
 };
 
 const TEACHER_NO_FEEDBACK_RUBRIC_PROPS = {
   user: 5,
-  isReadonly: true,
+  isEditable: false,
   rubric: {
     keyConcept: 'This is the Key Concept',
     performanceLevel1: 'exceeded expectations',
@@ -37,13 +36,12 @@ const TEACHER_NO_FEEDBACK_RUBRIC_PROPS = {
   viewAs: 'Teacher',
   serverLevelId: 123,
   teacher: 5,
-  displayReadonlyRubric: true,
   latestFeedback: null
 };
 
 const TEACHER_FEEDBACK_RUBRIC_PROPS = {
   user: 5,
-  isReadonly: false,
+  isEditable: true,
   rubric: {
     keyConcept: 'This is the Key Concept',
     performanceLevel1: 'exceeded expectations',
@@ -55,25 +53,23 @@ const TEACHER_FEEDBACK_RUBRIC_PROPS = {
   viewAs: 'Teacher',
   serverLevelId: 123,
   teacher: 5,
-  displayReadonlyRubric: false,
   latestFeedback: null
 };
 
 const STUDENT_FEEDBACK_NO_RUBRIC_PROPS = {
   user: 1,
-  isReadonly: true,
+  isEditable: false,
   rubric: null,
   visible: true,
   viewAs: 'Student',
   serverLevelId: 123,
   teacher: 5,
-  displayReadonlyRubric: false,
   latestFeedback: []
 };
 
 const STUDENT_NO_FEEDBACK_RUBRIC_PROPS = {
   user: 1,
-  isReadonly: true,
+  isEditable: false,
   rubric: {
     keyConcept: 'This is the Key Concept',
     performanceLevel1: 'exceeded expectations',
@@ -85,13 +81,12 @@ const STUDENT_NO_FEEDBACK_RUBRIC_PROPS = {
   viewAs: 'Student',
   serverLevelId: 123,
   teacher: 5,
-  displayReadonlyRubric: true,
   latestFeedback: null
 };
 
 const STUDENT_FEEDBACK_RUBRIC_PROPS = {
   user: 1,
-  isReadonly: true,
+  isEditable: false,
   rubric: {
     keyConcept: 'This is the Key Concept',
     performanceLevel1: 'exceeded expectations',
@@ -103,7 +98,6 @@ const STUDENT_FEEDBACK_RUBRIC_PROPS = {
   viewAs: 'Student',
   serverLevelId: 123,
   teacher: 5,
-  displayReadonlyRubric: false,
   latestFeedback: null
 };
 
@@ -138,8 +132,8 @@ describe('TeacherFeedback', () => {
         expect(rubric.props().rubric).to.equal(
           TEACHER_FEEDBACK_RUBRIC_PROPS.rubric
         );
-        expect(rubric.props().isReadonly).to.equal(false);
-        expect(rubric.props().isReadonly).to.equal(false);
+        expect(rubric.props().isEditable).to.equal(true);
+        expect(rubric.props().isEditable).to.equal(true);
         expect(rubric.props().viewAs).to.equal(ViewType.Teacher);
       });
 
@@ -157,7 +151,7 @@ describe('TeacherFeedback', () => {
         );
 
         const confirmCommentArea = wrapper.find(Comment).first();
-        expect(confirmCommentArea.props().isReadonly).to.equal(false);
+        expect(confirmCommentArea.props().isEditable).to.equal(true);
         expect(confirmCommentArea.props().comment).to.equal('');
       });
 
@@ -242,7 +236,7 @@ describe('TeacherFeedback', () => {
         );
 
         const confirmCommentArea = wrapper.find(Comment).first();
-        expect(confirmCommentArea.props().isReadonly).to.equal(false);
+        expect(confirmCommentArea.props().isEditable).to.equal(true);
         expect(confirmCommentArea.props().comment).to.equal('Good work!');
       });
 
@@ -293,8 +287,8 @@ describe('TeacherFeedback', () => {
       expect(rubric.props().rubric).to.equal(
         TEACHER_NO_FEEDBACK_RUBRIC_PROPS.rubric
       );
-      expect(rubric.props().isReadonly).to.equal(true);
-      expect(rubric.props().isReadonly).to.equal(true);
+      expect(rubric.props().isEditable).to.equal(false);
+      expect(rubric.props().isEditable).to.equal(false);
     });
 
     it('does not display comment area', () => {
@@ -336,8 +330,8 @@ describe('TeacherFeedback', () => {
         expect(rubric.props().rubric).to.equal(
           STUDENT_NO_FEEDBACK_RUBRIC_PROPS.rubric
         );
-        expect(rubric.props().isReadonly).to.equal(true);
-        expect(rubric.props().isReadonly).to.equal(true);
+        expect(rubric.props().isEditable).to.equal(false);
+        expect(rubric.props().isEditable).to.equal(false);
         expect(rubric.props().viewAs).to.equal(ViewType.Student);
       });
 
@@ -429,7 +423,7 @@ describe('TeacherFeedback', () => {
           STUDENT_FEEDBACK_RUBRIC_PROPS.rubric
         );
         expect(rubric.props().performance).to.equal('performanceLevel2');
-        expect(rubric.props().isReadonly).to.equal(true);
+        expect(rubric.props().isEditable).to.equal(false);
         expect(rubric.props().viewAs).to.equal(ViewType.Student);
       });
 
@@ -442,7 +436,7 @@ describe('TeacherFeedback', () => {
         );
 
         const confirmCommentArea = wrapper.find(Comment).first();
-        expect(confirmCommentArea.props().isReadonly).to.equal(true);
+        expect(confirmCommentArea.props().isEditable).to.equal(false);
         expect(confirmCommentArea.props().comment).to.equal('Good work!');
       });
 

--- a/apps/test/unit/templates/instructions/teacherFeedback/TeacherFeedbackTest.jsx
+++ b/apps/test/unit/templates/instructions/teacherFeedback/TeacherFeedbackTest.jsx
@@ -13,7 +13,7 @@ import Rubric from '@cdo/apps/templates/instructions/teacherFeedback/Rubric';
 
 const TEACHER_FEEDBACK_NO_RUBRIC_PROPS = {
   user: 5,
-  disabledMode: false,
+  isReadonly: false,
   rubric: null,
   visible: true,
   viewAs: 'Teacher',
@@ -25,7 +25,7 @@ const TEACHER_FEEDBACK_NO_RUBRIC_PROPS = {
 
 const TEACHER_NO_FEEDBACK_RUBRIC_PROPS = {
   user: 5,
-  disabledMode: true,
+  isReadonly: true,
   rubric: {
     keyConcept: 'This is the Key Concept',
     performanceLevel1: 'exceeded expectations',
@@ -43,7 +43,7 @@ const TEACHER_NO_FEEDBACK_RUBRIC_PROPS = {
 
 const TEACHER_FEEDBACK_RUBRIC_PROPS = {
   user: 5,
-  disabledMode: false,
+  isReadonly: false,
   rubric: {
     keyConcept: 'This is the Key Concept',
     performanceLevel1: 'exceeded expectations',
@@ -61,7 +61,7 @@ const TEACHER_FEEDBACK_RUBRIC_PROPS = {
 
 const STUDENT_FEEDBACK_NO_RUBRIC_PROPS = {
   user: 1,
-  disabledMode: true,
+  isReadonly: true,
   rubric: null,
   visible: true,
   viewAs: 'Student',
@@ -73,7 +73,7 @@ const STUDENT_FEEDBACK_NO_RUBRIC_PROPS = {
 
 const STUDENT_NO_FEEDBACK_RUBRIC_PROPS = {
   user: 1,
-  disabledMode: true,
+  isReadonly: true,
   rubric: {
     keyConcept: 'This is the Key Concept',
     performanceLevel1: 'exceeded expectations',
@@ -91,7 +91,7 @@ const STUDENT_NO_FEEDBACK_RUBRIC_PROPS = {
 
 const STUDENT_FEEDBACK_RUBRIC_PROPS = {
   user: 1,
-  disabledMode: true,
+  isReadonly: true,
   rubric: {
     keyConcept: 'This is the Key Concept',
     performanceLevel1: 'exceeded expectations',
@@ -139,7 +139,7 @@ describe('TeacherFeedback', () => {
           TEACHER_FEEDBACK_RUBRIC_PROPS.rubric
         );
         expect(rubric.props().isReadonly).to.equal(false);
-        expect(rubric.props().disabledMode).to.equal(false);
+        expect(rubric.props().isReadonly).to.equal(false);
         expect(rubric.props().viewAs).to.equal(ViewType.Teacher);
       });
 
@@ -294,7 +294,7 @@ describe('TeacherFeedback', () => {
         TEACHER_NO_FEEDBACK_RUBRIC_PROPS.rubric
       );
       expect(rubric.props().isReadonly).to.equal(true);
-      expect(rubric.props().disabledMode).to.equal(true);
+      expect(rubric.props().isReadonly).to.equal(true);
     });
 
     it('does not display comment area', () => {
@@ -337,7 +337,7 @@ describe('TeacherFeedback', () => {
           STUDENT_NO_FEEDBACK_RUBRIC_PROPS.rubric
         );
         expect(rubric.props().isReadonly).to.equal(true);
-        expect(rubric.props().disabledMode).to.equal(true);
+        expect(rubric.props().isReadonly).to.equal(true);
         expect(rubric.props().viewAs).to.equal(ViewType.Student);
       });
 
@@ -429,8 +429,7 @@ describe('TeacherFeedback', () => {
           STUDENT_FEEDBACK_RUBRIC_PROPS.rubric
         );
         expect(rubric.props().performance).to.equal('performanceLevel2');
-        expect(rubric.props().isReadonly).to.equal(false);
-        expect(rubric.props().disabledMode).to.equal(true);
+        expect(rubric.props().isReadonly).to.equal(true);
         expect(rubric.props().viewAs).to.equal(ViewType.Student);
       });
 

--- a/apps/test/unit/templates/instructions/teacherFeedback/TeacherFeedbackTest.jsx
+++ b/apps/test/unit/templates/instructions/teacherFeedback/TeacherFeedbackTest.jsx
@@ -133,7 +133,6 @@ describe('TeacherFeedback', () => {
           TEACHER_FEEDBACK_RUBRIC_PROPS.rubric
         );
         expect(rubric.props().isEditable).to.equal(true);
-        expect(rubric.props().isEditable).to.equal(true);
         expect(rubric.props().viewAs).to.equal(ViewType.Teacher);
       });
 
@@ -288,7 +287,6 @@ describe('TeacherFeedback', () => {
         TEACHER_NO_FEEDBACK_RUBRIC_PROPS.rubric
       );
       expect(rubric.props().isEditable).to.equal(false);
-      expect(rubric.props().isEditable).to.equal(false);
     });
 
     it('does not display comment area', () => {
@@ -330,7 +328,6 @@ describe('TeacherFeedback', () => {
         expect(rubric.props().rubric).to.equal(
           STUDENT_NO_FEEDBACK_RUBRIC_PROPS.rubric
         );
-        expect(rubric.props().isEditable).to.equal(false);
         expect(rubric.props().isEditable).to.equal(false);
         expect(rubric.props().viewAs).to.equal(ViewType.Student);
       });

--- a/dashboard/test/ui/features/learning_platform/instructions/feedback_tab.feature
+++ b/dashboard/test/ui/features/learning_platform/instructions/feedback_tab.feature
@@ -12,10 +12,10 @@ Background:
   And I press "finishButton"
 
 Scenario: As student 'Feedback' tab is not visible if no feedback
-  #As student, with no feedback, can see Key Concept tab on rubric level
+  #As student, with no feedback, can see Rubric tab on rubric level
   And I am on "http://studio.code.org/s/allthethings/lessons/38/levels/1"
   And I wait to see ".uitest-feedback"
-  And element ".editor-column" contains text "Key Concept"
+  And element ".editor-column" contains text "Rubric"
   Then I click selector ".uitest-feedback"
   And I wait to see ".editor-column"
   And element ".editor-column" contains text "This is the key concept for this mini rubric."
@@ -48,7 +48,7 @@ Otherwise don't show feedback tab
   And I am on "http://studio.code.org/s/allthethings/lessons/38/levels/1"
   And I wait for the page to fully load
   And I wait to see ".uitest-feedback"
-  And element ".editor-column" contains text "Key Concept"
+  And element ".editor-column" contains text "Rubric"
   Then I click selector ".uitest-feedback"
   And I wait to see ".editor-column"
   And element ".editor-column" contains text "This is the key concept for this mini rubric."


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
- Updates name of tab in TopInstructions to Rubric if there's a rubric
- Updates name of header of rubric to Rubric
- Refactors rubric props for clarity

![Screen Shot 2021-06-16 at 2 37 57 PM](https://user-images.githubusercontent.com/24235215/122298359-83c21500-ceb1-11eb-8f65-1a1bf4c6d5fa.png)

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
