### PR TITLE
add some new states to the list of allowed V2 2017 data

### DIFF
--- a/dashboard/app/models/census/state_cs_offering.rb
+++ b/dashboard/app/models/census/state_cs_offering.rb
@@ -84,13 +84,16 @@ class Census::StateCsOffering < ApplicationRecord
     CA
     HI
     IL
+    ID
     MA
     MD
     NE
     NY
+    SD
     OR
     PA
     VA
+    WA
   ).freeze
 
   # The following states use the "V2" format for CSV files in 2018-2019.


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Liz wants to be able to upload some historical data from 2017 for these states that did not previously have data. The dry run fails because they're not in the list of allowed states for the V2 format.

[dry-run failure](https://codedotorg.slack.com/archives/C03CK8E51/p1623876346039700)
