### PR TITLE
[Applab] Properly escape properties in start mode

### DIFF
--- a/apps/src/code-studio/components/header/LevelBuilderSaveButton.jsx
+++ b/apps/src/code-studio/components/header/LevelBuilderSaveButton.jsx
@@ -24,7 +24,7 @@ class LevelBuilderSaveButton extends React.Component {
     $.ajax({
       type: 'POST',
       url: '../update_properties',
-      data: JSON.stringify(this.props.getChanges()),
+      data: encodeURIComponent(JSON.stringify(this.props.getChanges())),
       dataType: 'json',
       error: this.props.setProjectUpdatedError,
       success: this.props.setProjectUpdatedSaved

--- a/apps/src/javalab/CommitDialog.jsx
+++ b/apps/src/javalab/CommitDialog.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import i18n from '@cdo/javalab/locale';
 import color from '@cdo/apps/util/color';
 import {CompileStatus} from './constants';
-import StylizedBaseDialog from '@cdo/apps/designSystem/StylizedBaseDialog';
+import StylizedBaseDialog from '@cdo/apps/templates/StylizedBaseDialog';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 
 export default class CommitDialog extends React.Component {

--- a/apps/src/javalab/CommitDialog.jsx
+++ b/apps/src/javalab/CommitDialog.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import i18n from '@cdo/javalab/locale';
 import color from '@cdo/apps/util/color';
 import {CompileStatus} from './constants';
-import StylizedBaseDialog from '@cdo/apps/templates/StylizedBaseDialog';
+import StylizedBaseDialog from '@cdo/apps/designSystem/StylizedBaseDialog';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 
 export default class CommitDialog extends React.Component {

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -229,7 +229,7 @@ class LevelsController < ApplicationController
   end
 
   def update_properties
-    changes = JSON.parse(request.body.read)
+    changes = JSON.parse(URI.unescape(request.body.read))
     changes.each do |key, value|
       @level.properties[key] = value
     end

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -418,15 +418,33 @@ class LevelsControllerTest < ActionController::TestCase
   test "should update App Lab starter code and starter HTML" do
     post :update_properties, params: {
       id: create(:applab).id,
-    }, body: {
-      start_html: '<h1>foo</h1>',
-      start_blocks: 'console.log("hello world");',
-    }.to_json
+    }, body: URI.escape(
+      {
+        start_html: '<h1>foo</h1>',
+        start_blocks: 'console.log("hello world");',
+      }.to_json
+    )
 
     assert_response :success
     level = assigns(:level)
     assert_equal '<h1>foo</h1>', level.properties['start_html']
     assert_equal 'console.log("hello world");', level.properties['start_blocks']
+  end
+
+  test "should update App Lab starter code and starter HTML with special characters" do
+    post :update_properties, params: {
+      id: create(:applab).id,
+    }, body: URI.escape(
+      {
+        start_html: '<h1>Final Grade: 90%</h1><h2>student@code.org</h2>',
+        start_blocks: 'console.log(4 % 2 == 0);',
+      }.to_json
+    )
+
+    assert_response :success
+    level = assigns(:level)
+    assert_equal '<h1>Final Grade: 90%</h1><h2>student@code.org</h2>', level.properties['start_html']
+    assert_equal 'console.log(4 % 2 == 0);', level.properties['start_blocks']
   end
 
   test "non-levelbuilder cannot update_properties" do


### PR DESCRIPTION
This change is required to support `%` characters (and probably other special characters) in the start code in Applab.
See more details in [slack thread](https://codedotorg.slack.com/archives/C1B3PNDL7/p1623101611062300)
Before
![image](https://user-images.githubusercontent.com/8787187/122478934-25636800-cf7f-11eb-8c1d-8775159c81a2.png)

After
![image](https://user-images.githubusercontent.com/8787187/122478735-cbfb3900-cf7e-11eb-851f-44088d327873.png)


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
[jira](https://codedotorg.atlassian.net/browse/STAR-1603)
<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
