### PR TITLE
Seed unit groups from .course file with published_state information

### DIFF
--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -107,6 +107,7 @@ class UnitGroup < ApplicationRecord
     unit_group = UnitGroup.find_or_create_by!(name: hash['name'])
     unit_group.update_scripts(hash['script_names'], hash['alternate_scripts'])
     unit_group.properties = hash['properties']
+    unit_group.published_state = hash['published_state'] || SharedConstants::PUBLISHED_STATE.beta
 
     # add_course_offering creates the course version
     CourseOffering.add_course_offering(unit_group)

--- a/dashboard/test/models/unit_group_test.rb
+++ b/dashboard/test/models/unit_group_test.rb
@@ -94,17 +94,17 @@ class UnitGroupTest < ActiveSupport::TestCase
   end
 
   test "can seed unit group from hash" do
-    unit_group = create(:unit_group, name: 'my-unit-group', is_stable: true, published_state: SharedConstants::PUBLISHED_STATE.beta)
-    create(:unit_group_unit, unit_group: unit_group, position: 1, script: create(:script, name: "script1", published_state: SharedConstants::PUBLISHED_STATE.beta))
-    create(:unit_group_unit, unit_group: unit_group, position: 2, script: create(:script, name: "script2", published_state: SharedConstants::PUBLISHED_STATE.beta))
-    create(:unit_group_unit, unit_group: unit_group, position: 3, script: create(:script, name: "script3", published_state: SharedConstants::PUBLISHED_STATE.beta))
+    unit_group = create(:unit_group, name: 'my-unit-group', is_stable: true, published_state: SharedConstants::PUBLISHED_STATE.stable)
+    create(:unit_group_unit, unit_group: unit_group, position: 1, script: create(:script, name: "script1", published_state: SharedConstants::PUBLISHED_STATE.stable))
+    create(:unit_group_unit, unit_group: unit_group, position: 2, script: create(:script, name: "script2", published_state: SharedConstants::PUBLISHED_STATE.stable))
+    create(:unit_group_unit, unit_group: unit_group, position: 3, script: create(:script, name: "script3", published_state: SharedConstants::PUBLISHED_STATE.stable))
 
     serialization = unit_group.serialize
     unit_group.destroy
 
     seeded_unit_group = UnitGroup.seed_from_hash(JSON.parse(serialization))
     assert_equal 'my-unit-group', seeded_unit_group.name
-    assert_equal 'beta', seeded_unit_group.published_state
+    assert_equal 'stable', seeded_unit_group.published_state
     assert_equal 3, seeded_unit_group.default_unit_group_units.length
     assert_equal 3, seeded_unit_group.default_scripts.length
   end

--- a/dashboard/test/models/unit_group_test.rb
+++ b/dashboard/test/models/unit_group_test.rb
@@ -94,16 +94,17 @@ class UnitGroupTest < ActiveSupport::TestCase
   end
 
   test "can seed unit group from hash" do
-    unit_group = create(:unit_group, name: 'my-unit-group', is_stable: true)
-    create(:unit_group_unit, unit_group: unit_group, position: 1, script: create(:script, name: "script1"))
-    create(:unit_group_unit, unit_group: unit_group, position: 2, script: create(:script, name: "script2"))
-    create(:unit_group_unit, unit_group: unit_group, position: 3, script: create(:script, name: "script3"))
+    unit_group = create(:unit_group, name: 'my-unit-group', is_stable: true, published_state: SharedConstants::PUBLISHED_STATE.beta)
+    create(:unit_group_unit, unit_group: unit_group, position: 1, script: create(:script, name: "script1", published_state: SharedConstants::PUBLISHED_STATE.beta))
+    create(:unit_group_unit, unit_group: unit_group, position: 2, script: create(:script, name: "script2", published_state: SharedConstants::PUBLISHED_STATE.beta))
+    create(:unit_group_unit, unit_group: unit_group, position: 3, script: create(:script, name: "script3", published_state: SharedConstants::PUBLISHED_STATE.beta))
 
     serialization = unit_group.serialize
     unit_group.destroy
 
     seeded_unit_group = UnitGroup.seed_from_hash(JSON.parse(serialization))
     assert_equal 'my-unit-group', seeded_unit_group.name
+    assert_equal 'beta', seeded_unit_group.published_state
     assert_equal 3, seeded_unit_group.default_unit_group_units.length
     assert_equal 3, seeded_unit_group.default_scripts.length
   end


### PR DESCRIPTION
Looks like in the previous PR when we started saving published_state information on unit_groups and scripts we did not set up seeding published_state that was serialized in the file for unit_groups. This makes it so we seed the published_state information for unit_groups

## Links

https://codedotorg.atlassian.net/browse/PLAT-1059

## Testing story

Added a check to a unit test to make sure we check for this in the future