### PR TITLE
Restore "preserve level variants when saving script editor" again

### DIFF
--- a/apps/src/lib/levelbuilder/unit-editor/unitEditorRedux.js
+++ b/apps/src/lib/levelbuilder/unit-editor/unitEditorRedux.js
@@ -360,7 +360,17 @@ const serializeLesson = (lesson, levelKeyList) => {
   s.push(t);
   if (lesson.levels) {
     lesson.levels.forEach(level => {
-      s = s.concat(serializeLevel(levelKeyList, level.ids[0], level));
+      if (level.ids.length > 1) {
+        s.push('variants');
+        level.ids.forEach(id => {
+          const active = id === level.activeId;
+          const lines = serializeLevel(levelKeyList, id, level, active);
+          s = s.concat(lines.map(line => `  ${line}`));
+        });
+        s.push('endvariants');
+      } else {
+        s = s.concat(serializeLevel(levelKeyList, level.ids[0], level));
+      }
     });
   }
   s.push('');
@@ -376,9 +386,9 @@ const serializeLesson = (lesson, levelKeyList) => {
  * to move on to our future system.
  * @param id
  * @param level
- * @return {string}
+ * @return {Array.<string>}
  */
-const serializeLevel = (levelKeyList, id, level) => {
+const serializeLevel = (levelKeyList, id, level, active = true) => {
   const s = [];
   const key = levelKeyList[id];
   if (/^blockly:/.test(key)) {
@@ -398,6 +408,9 @@ const serializeLevel = (levelKeyList, id, level) => {
     }
   }
   let l = level.bonus ? `bonus '${escape(key)}'` : `level '${escape(key)}'`;
+  if (!active) {
+    l += ', active: false';
+  }
   if (level.progression) {
     l += `, progression: '${escape(level.progression)}'`;
   }

--- a/apps/src/lib/levelbuilder/unit-editor/unitEditorRedux.js
+++ b/apps/src/lib/levelbuilder/unit-editor/unitEditorRedux.js
@@ -282,6 +282,7 @@ export const mapLessonGroupDataForEditor = rawLessonGroups => {
             .map(level => ({
               position: level.position,
               activeId: level.activeId,
+              inactiveIds: level.inactiveIds,
               ids: level.ids.slice(),
               kind: level.kind,
               skin: level.skin,

--- a/apps/src/lib/levelbuilder/unit-editor/unitEditorRedux.js
+++ b/apps/src/lib/levelbuilder/unit-editor/unitEditorRedux.js
@@ -361,11 +361,12 @@ const serializeLesson = (lesson, levelKeyList) => {
   s.push(t);
   if (lesson.levels) {
     lesson.levels.forEach(level => {
-      if (level.ids.length > 1) {
+      if (level.inactiveIds && level.inactiveIds.length > 0) {
         s.push('variants');
-        level.ids.forEach(id => {
-          const active = id === level.activeId;
-          const lines = serializeLevel(levelKeyList, id, level, active);
+        let lines = serializeLevel(levelKeyList, level.activeId, level);
+        s = s.concat(lines.map(line => `  ${line}`));
+        level.inactiveIds.forEach(id => {
+          lines = serializeLevel(levelKeyList, id, level, false);
           s = s.concat(lines.map(line => `  ${line}`));
         });
         s.push('endvariants');

--- a/apps/test/unit/code-studio/unitEditorReduxTest.js
+++ b/apps/test/unit/code-studio/unitEditorReduxTest.js
@@ -187,6 +187,30 @@ describe('unitEditorRedux reducer tests', () => {
       );
     });
 
+    it('ignores contained level ids when serializing level variants', () => {
+      const scriptLevel = initialState.lessonGroups[0].lessons[0].levels[1];
+      scriptLevel.ids = ['2002', '2003'];
+      scriptLevel.activeId = '2003';
+      let serializedLessonGroups = getSerializedLessonGroups(
+        initialState.lessonGroups,
+        initialState.levelKeyList
+      );
+
+      expect(serializedLessonGroups).to.equal(
+        "lesson_group 'lg-key', display_name: 'Display Name'\n" +
+          "lesson_group_description 'My Description'\n" +
+          "lesson 'a', display_name: 'A', has_lesson_plan: true, unplugged: true\n" +
+          "level 'Level One'\n" +
+          "level 'Level Two'\n\n" +
+          "lesson 'b', display_name: 'B', has_lesson_plan: false\n\n" +
+          "lesson 'c', display_name: 'C', has_lesson_plan: true\n\n" +
+          "lesson_group 'lg-key-2', display_name: 'Display Name 2'\n" +
+          "lesson 'd', display_name: 'D', has_lesson_plan: true\n\n" +
+          "lesson 'e', display_name: 'E', has_lesson_plan: true\n\n" +
+          "lesson 'f', display_name: 'F', has_lesson_plan: false\n\n"
+      );
+    });
+
     it('serializes legacy level settings', () => {
       const scriptLevel = {
         activeId: '2004',

--- a/apps/test/unit/code-studio/unitEditorReduxTest.js
+++ b/apps/test/unit/code-studio/unitEditorReduxTest.js
@@ -38,12 +38,14 @@ const getInitialState = () => ({
           levels: [
             {
               activeId: '2001',
+              inactiveIds: [],
               ids: ['2001'],
               kind: 'puzzle',
               position: 1
             },
             {
               activeId: '2002',
+              inactiveIds: [],
               ids: ['2002'],
               kind: 'puzzle',
               position: 2
@@ -161,6 +163,7 @@ describe('unitEditorRedux reducer tests', () => {
       const scriptLevel = initialState.lessonGroups[0].lessons[0].levels[1];
       scriptLevel.ids = ['2002', '2003'];
       scriptLevel.activeId = '2003';
+      scriptLevel.inactiveIds = ['2002'];
       let serializedLessonGroups = getSerializedLessonGroups(
         initialState.lessonGroups,
         initialState.levelKeyList
@@ -172,8 +175,8 @@ describe('unitEditorRedux reducer tests', () => {
           "lesson 'a', display_name: 'A', has_lesson_plan: true, unplugged: true\n" +
           "level 'Level One'\n" +
           'variants\n' +
-          "  level 'Level Two', active: false\n" +
           "  level 'Level Three'\n" +
+          "  level 'Level Two', active: false\n" +
           'endvariants\n\n' +
           "lesson 'b', display_name: 'B', has_lesson_plan: false\n\n" +
           "lesson 'c', display_name: 'C', has_lesson_plan: true\n\n" +

--- a/apps/test/unit/code-studio/unitEditorReduxTest.js
+++ b/apps/test/unit/code-studio/unitEditorReduxTest.js
@@ -14,7 +14,12 @@ import reducers, {
 import _ from 'lodash';
 
 const getInitialState = () => ({
-  levelKeyList: {},
+  levelKeyList: {
+    2001: 'Level One',
+    2002: 'Level Two',
+    2003: 'Level Three',
+    2004: 'blockly:Maze:2_3'
+  },
   lessonGroups: [
     {
       id: 1,
@@ -30,7 +35,20 @@ const getInitialState = () => ({
           name: 'A',
           position: 1,
           unplugged: true,
-          levels: [],
+          levels: [
+            {
+              activeId: '2001',
+              ids: ['2001'],
+              kind: 'puzzle',
+              position: 1
+            },
+            {
+              activeId: '2002',
+              ids: ['2002'],
+              kind: 'puzzle',
+              position: 2
+            }
+          ],
           hasLessonPlan: true
         },
         {
@@ -104,7 +122,9 @@ describe('unitEditorRedux reducer tests', () => {
       expect(serializedLessonGroups).to.equal(
         "lesson_group 'lg-key', display_name: 'Display Name'\n" +
           "lesson_group_description 'My Description'\n" +
-          "lesson 'a', display_name: 'A', has_lesson_plan: true, unplugged: true\n\n" +
+          "lesson 'a', display_name: 'A', has_lesson_plan: true, unplugged: true\n" +
+          "level 'Level One'\n" +
+          "level 'Level Two'\n\n" +
           "lesson 'b', display_name: 'B', has_lesson_plan: false\n\n" +
           "lesson 'c', display_name: 'C', has_lesson_plan: true\n\n" +
           "lesson_group 'lg-key-2', display_name: 'Display Name 2'\n" +
@@ -125,7 +145,72 @@ describe('unitEditorRedux reducer tests', () => {
       expect(serializedLessonGroups).to.equal(
         "lesson_group 'lg-key', display_name: 'Display Name'\n" +
           "lesson_group_description 'a\\'b\\'c\\'d'\n" +
-          "lesson 'a', display_name: 'A', has_lesson_plan: true, unplugged: true\n\n" +
+          "lesson 'a', display_name: 'A', has_lesson_plan: true, unplugged: true\n" +
+          "level 'Level One'\n" +
+          "level 'Level Two'\n\n" +
+          "lesson 'b', display_name: 'B', has_lesson_plan: false\n\n" +
+          "lesson 'c', display_name: 'C', has_lesson_plan: true\n\n" +
+          "lesson_group 'lg-key-2', display_name: 'Display Name 2'\n" +
+          "lesson 'd', display_name: 'D', has_lesson_plan: true\n\n" +
+          "lesson 'e', display_name: 'E', has_lesson_plan: true\n\n" +
+          "lesson 'f', display_name: 'F', has_lesson_plan: false\n\n"
+      );
+    });
+
+    it('serializes lessons containing level variants', () => {
+      const scriptLevel = initialState.lessonGroups[0].lessons[0].levels[1];
+      scriptLevel.ids = ['2002', '2003'];
+      scriptLevel.activeId = '2003';
+      let serializedLessonGroups = getSerializedLessonGroups(
+        initialState.lessonGroups,
+        initialState.levelKeyList
+      );
+
+      expect(serializedLessonGroups).to.equal(
+        "lesson_group 'lg-key', display_name: 'Display Name'\n" +
+          "lesson_group_description 'My Description'\n" +
+          "lesson 'a', display_name: 'A', has_lesson_plan: true, unplugged: true\n" +
+          "level 'Level One'\n" +
+          'variants\n' +
+          "  level 'Level Two', active: false\n" +
+          "  level 'Level Three'\n" +
+          'endvariants\n\n' +
+          "lesson 'b', display_name: 'B', has_lesson_plan: false\n\n" +
+          "lesson 'c', display_name: 'C', has_lesson_plan: true\n\n" +
+          "lesson_group 'lg-key-2', display_name: 'Display Name 2'\n" +
+          "lesson 'd', display_name: 'D', has_lesson_plan: true\n\n" +
+          "lesson 'e', display_name: 'E', has_lesson_plan: true\n\n" +
+          "lesson 'f', display_name: 'F', has_lesson_plan: false\n\n"
+      );
+    });
+
+    it('serializes legacy level settings', () => {
+      const scriptLevel = {
+        activeId: '2004',
+        ids: ['2004'],
+        kind: 'puzzle',
+        position: 3,
+        skin: 'birds',
+        concepts: "'sequence'",
+        conceptDifficulty: '{"sequencing":2}'
+      };
+      initialState.lessonGroups[0].lessons[0].levels.push(scriptLevel);
+
+      let serializedLessonGroups = getSerializedLessonGroups(
+        initialState.lessonGroups,
+        initialState.levelKeyList
+      );
+
+      expect(serializedLessonGroups).to.equal(
+        "lesson_group 'lg-key', display_name: 'Display Name'\n" +
+          "lesson_group_description 'My Description'\n" +
+          "lesson 'a', display_name: 'A', has_lesson_plan: true, unplugged: true\n" +
+          "level 'Level One'\n" +
+          "level 'Level Two'\n" +
+          "skin 'birds'\n" +
+          "concepts 'sequence'\n" +
+          'level_concept_difficulty \'{"sequencing":2}\'\n' +
+          "level 'blockly:Maze:2_3'\n\n" +
           "lesson 'b', display_name: 'B', has_lesson_plan: false\n\n" +
           "lesson 'c', display_name: 'C', has_lesson_plan: true\n\n" +
           "lesson_group 'lg-key-2', display_name: 'Display Name 2'\n" +
@@ -143,7 +228,7 @@ describe('unitEditorRedux reducer tests', () => {
 
     expect(mappedLessonGroups.length).to.equal(2);
     expect(mappedLessonGroups[0].lessons.length).to.equal(3);
-    expect(mappedLessonGroups[0].lessons[0].levels.length).to.equal(0);
+    expect(mappedLessonGroups[0].lessons[0].levels.length).to.equal(2);
   });
 
   it('add group', () => {

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -380,6 +380,8 @@ class ScriptLevel < ApplicationRecord
       end
 
     ids = level_ids
+    active_id = oldest_active_level.id
+    inactive_ids = ids - [active_id]
 
     levels.each do |l|
       ids.concat(l.contained_levels.map(&:id))
@@ -387,7 +389,8 @@ class ScriptLevel < ApplicationRecord
 
     summary = {
       ids: ids.map(&:to_s),
-      activeId: oldest_active_level.id.to_s,
+      activeId: active_id.to_s,
+      inactiveIds: inactive_ids.map(&:to_s),
       position: position,
       kind: kind,
       icon: level.icon,


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#41199, restoring #40872, finishing https://codedotorg.atlassian.net/browse/PLAT-1116 . This brings us back into a state where if we need to add a level variant using `ScriptLevel.add_variant`, those changes will survive past the next time someone saves the script edit page.

The problem with the previous attempt was that the script level summarize method sends down contained levels in addition to level variants in the ids field: https://github.com/code-dot-org/code-dot-org/blob/f310793aa82f65825339585eaff1aa1c33016193/dashboard/app/models/script_level.rb#L382-L386 The code in the previous attempt assumed that `ids` represented only level variants.

The solution I'm proposing is to add an `inactiveIds` field which contains only inactive level variants. A more complete solution might be to pick apart why the `ids` field needs to have contained levels in it in the first place and get rid of it now if possible. However, a lot of this code will be going away soon (including all of the client-side code for serializing lessons/levels into DSL syntax), so I thought it would be better to defer that cleanup. that cleanup work is tracked in https://codedotorg.atlassian.net/browse/PLAT-858 . 

## Testing story

* added / updated js unit tests
* manually verified that I can save edits to coursef-2021, which contains at least one contained level
* manually verified that saving the script edit page preserves script level variants