### PR TITLE
Javalab: Existing asset manager in place in Theater

### DIFF
--- a/apps/src/javalab/PreviewPaneHeader.jsx
+++ b/apps/src/javalab/PreviewPaneHeader.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import i18n from '@cdo/locale';
+import * as assets from '../code-studio/assets';
 import PaneHeader, {
   PaneSection,
   PaneButton
@@ -40,7 +41,7 @@ export default function PreviewPaneHeader({
       {showAssetManagerButton && (
         <PaneButton
           headerHasFocus
-          onClick={() => {}}
+          onClick={() => assets.showAssetManager()}
           iconClass="fa fa-upload"
           label={i18n.manageAssets()}
           isRtl={false}

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -342,6 +342,7 @@ module LevelsHelper
         use_google_blockly: use_google_blockly,
         use_blockly: use_blockly,
         use_applab: use_applab,
+        use_javalab: use_javalab,
         use_gamelab: use_gamelab,
         use_weblab: use_weblab,
         use_phaser: use_phaser,

--- a/dashboard/app/views/levels/_apps_dependencies.html.haml
+++ b/dashboard/app/views/levels/_apps_dependencies.html.haml
@@ -1,5 +1,5 @@
 -#
-  Expected locals: app, use_blockly, use_droplet, use_p5, use_applab, hide_source, static_asset_base_path
+  Expected locals: app, use_blockly, use_droplet, use_p5, use_applab, use_javalab, hide_source, static_asset_base_path
   Provide default values for some of these
 - use_blockly ||= false
 - use_droplet ||= false
@@ -40,7 +40,7 @@
   %script{src: webpack_asset_path('js/droplet/droplet-full.js')}
   %script{src: webpack_asset_path('js/tooltipster/jquery.tooltipster.js')}
 -# Asset uploader script dependencies (not in share mode)
-- if (use_applab || use_gamelab || use_weblab) && !hide_source
+- if (use_applab || use_gamelab || use_weblab || use_javalab) && !hide_source
   %script{src: webpack_asset_path('js/fileupload/jquery.iframe-transport.js')}
   %script{src: webpack_asset_path('js/fileupload/jquery.fileupload.js')}
 


### PR DESCRIPTION
Adds existing Asset Manager Dialog from Applab to Theater levels in Javalab -- visible when clicking "Manage Assets" button in visualization column.

![image](https://user-images.githubusercontent.com/25372625/122970214-9ded6e80-d35b-11eb-820d-39912574acce.png)

## Testing story

Tested manually.

## Deployment strategy

## Follow-up work

We use our legacy dialog as a quick solution here, and leave style updates (and moving this dialog to our new generic `StyledBaseDialog` as a tech debt item that can be addressed while updating all of our Asset Manager Dialogs.