### PR TITLE
Speed up `Lesson#unplugged_lesson?`

### DIFF
--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -172,15 +172,15 @@ class Lesson < ApplicationRecord
   end
 
   def unplugged_lesson?
-    script_levels = script.script_levels.select {|sl| sl.stage_id == id}
-    return false unless script_levels.first
-    script_levels.first.oldest_active_level.unplugged?
+    script_level = script.script_levels.find_by(stage_id: id)
+    return false unless script_level.present?
+    script_level.oldest_active_level.unplugged?
   end
 
   def spelling_bee?
-    script_levels = script.script_levels.select {|sl| sl.stage_id == id}
-    return false unless script_levels.first
-    script_levels.first.oldest_active_level.spelling_bee?
+    script_level = script.script_levels.find_by(stage_id: id)
+    return false unless script_level.present?
+    script_level.oldest_active_level.spelling_bee?
   end
 
   # We number lessons that either have lesson plans or are not lockable

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -179,7 +179,7 @@ class Lesson < ApplicationRecord
       script_levels = script.script_levels.select {|sl| sl.stage_id == id}
       return script_levels.first
     else
-      return script_levels.find_by(stage_id: id)
+      return script.script_levels.find_by(stage_id: id)
     end
   end
 


### PR DESCRIPTION
Currently, this method is implemented by querying for all ScriptLevels in the Lesson's Script, and manually filtering them down to just the one ScriptLevel we actually care about. We should instead query directly for the ScriptLevel we care about.

Right now, calling `Script#summarize_for_unit_edit` invokes this method quite a lot. Specifically:

- `Script#summarize_for_unit_edit` invokes `LessonGroup#summarize_for_unit_edit` for each LessonGroup in the Script
- `LessonGroup#summarize_for_unit_edit` invokes `Lesson#summarize_for_unit_edit` for each Lesson in the LessonGroup
- `Lesson#summarize_for_unit_edit` invokes `Lesson#summarize`
- `Lesson#summarize` invokes `ScriptLevel#summarize` for each ScriptLevel in the Lesson
- `ScriptLevel#summarize` invokes `ScriptLevel#level_display_text`
- `ScriptLevel#level_display_text` invokes `Lesson#unplugged_lesson?` for the Lesson associated with the ScriptLevel

What this means is that when we call `Script#summarize_for_unit_edit`, we are querying for _all_ ScriptLevels in the entire Script not just once, but _once for every ScriptLevel in the entire Script_.

Also fix `Lesson#spelling_bee?` in the same way, while I'm in the area.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
