### PR TITLE
Check redux state in StudioApp.prototype.toggleRunReset

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -61,7 +61,7 @@ import {parseElement as parseXmlElement} from './xml';
 import {resetAniGif} from '@cdo/apps/utils';
 import {setIsRunning, setIsEditWhileRun, setStepSpeed} from './redux/runState';
 import {isEditWhileRun} from './lib/tools/jsdebugger/redux';
-import {setPageConstants} from './redux/pageConstants';
+import * as pageConstantsRedux from '@cdo/apps/redux/pageConstants';
 import {setVisualizationScale} from './redux/layout';
 import {createLibraryClosure} from '@cdo/apps/code-studio/components/libraries/libraryParser';
 import {
@@ -1041,16 +1041,17 @@ StudioApp.prototype.toggleRunReset = function(button) {
 
   var run = document.getElementById('runButton');
   if (run) {
-    // Note: Checking alwaysHideRunButton is necessary because are some levels where we never
-    // want to show the "run" button (e.g., maze levels that are "stepOnly").
     run.style.display =
-      showRun && !this.config.alwaysHideRunButton ? 'inline-block' : 'none';
+      showRun && !pageConstantsRedux.hideRunButton() ? 'inline-block' : 'none';
     run.disabled = !showRun;
   }
 
   var reset = document.getElementById('resetButton');
   if (reset) {
-    reset.style.display = !showRun ? 'inline-block' : 'none';
+    reset.style.display =
+      !showRun && !pageConstantsRedux.hideResetButton()
+        ? 'inline-block'
+        : 'none';
     reset.disabled = showRun;
   }
 
@@ -3474,7 +3475,7 @@ StudioApp.prototype.setPageConstants = function(config, appSpecificConstants) {
     appSpecificConstants
   );
 
-  getStore().dispatch(setPageConstants(combined));
+  getStore().dispatch(pageConstantsRedux.setPageConstants(combined));
 
   const instructionsConstants = determineInstructionsConstants(config);
   getStore().dispatch(setInstructionsConstants(instructionsConstants));

--- a/apps/src/maze/maze.js
+++ b/apps/src/maze/maze.js
@@ -181,17 +181,11 @@ module.exports = class Maze {
       });
     };
 
-    // Note: Setting alwaysHideRunButton in our config is necessary because
-    // StudioApp.js will manipulate the run/reset buttons, displaying the run
-    // button when "Reset" is clicked. We do not want this behavior on stepOnly levels.
-    const alwaysHideRunButton = !!(
-      this.controller.level.stepOnly && !this.controller.level.edit_blocks
-    );
-    config.alwaysHideRunButton = alwaysHideRunButton;
-
     // Push initial level properties into the Redux store
     studioApp().setPageConstants(config, {
-      hideRunButton: alwaysHideRunButton
+      hideRunButton: !!(
+        this.controller.level.stepOnly && !this.controller.level.edit_blocks
+      )
     });
 
     var visualizationColumn = (

--- a/apps/src/redux/pageConstants.js
+++ b/apps/src/redux/pageConstants.js
@@ -1,4 +1,5 @@
-var _ = require('lodash');
+import _ from 'lodash';
+import {getStore} from '@cdo/apps/redux';
 
 var SET_PAGE_CONSTANTS = 'pageConstants/SET_PAGE_CONSTANTS';
 
@@ -130,4 +131,20 @@ export function setPageConstants(props) {
     type: SET_PAGE_CONSTANTS,
     props: props
   };
+}
+
+/**
+ * Helpers
+ */
+
+function rootState() {
+  return getStore().getState()?.pageConstants;
+}
+
+export function hideRunButton() {
+  return rootState()?.hideRunButton;
+}
+
+export function hideResetButton() {
+  return rootState()?.hideResetButton;
 }

--- a/apps/test/unit/StudioAppTest.js
+++ b/apps/test/unit/StudioAppTest.js
@@ -21,6 +21,7 @@ import {
 import sampleLibrary from './code-studio/components/libraries/sampleLibrary.json';
 import {createLibraryClosure} from '@cdo/apps/code-studio/components/libraries/libraryParser';
 import * as utils from '@cdo/apps/utils';
+import * as pageConstantsRedux from '@cdo/apps/redux/pageConstants';
 
 describe('StudioApp', () => {
   sandboxDocumentBody();
@@ -57,7 +58,7 @@ describe('StudioApp', () => {
       document.body.removeChild(containerDiv);
     });
 
-    describe('the init() method', () => {
+    describe('init', () => {
       let files;
       beforeEach(() => {
         files = [];
@@ -112,7 +113,7 @@ describe('StudioApp', () => {
       });
     });
 
-    describe('StudioApp.editDuringRunAlertHandler()', () => {
+    describe('editDuringRunAlertHandler', () => {
       const mockCode = '<xml></xml>';
       let studio;
 
@@ -194,7 +195,76 @@ describe('StudioApp', () => {
       });
     });
 
-    describe('The StudioApp.resetButtonClick function', () => {
+    describe('toggleRunReset', () => {
+      let studio;
+
+      beforeEach(() => {
+        studio = studioApp();
+        studio.getCode = () => '<xml></xml>';
+        studio.config = {
+          readonlyWorkspace: false
+        };
+
+        sinon.stub(pageConstantsRedux, 'hideRunButton').returns(false);
+        sinon.stub(pageConstantsRedux, 'hideResetButton').returns(false);
+      });
+
+      afterEach(() => {
+        sinon.restore();
+      });
+
+      describe('run', () => {
+        it('displays the run button', () => {
+          studio.toggleRunReset('run');
+          expect(runButton().style.display).to.equal('inline-block');
+        });
+
+        it('does not display the run button if hideRunButton is true in redux', () => {
+          pageConstantsRedux.hideRunButton.restore();
+          sinon.stub(pageConstantsRedux, 'hideRunButton').returns(true);
+          studio.toggleRunReset('run');
+          expect(runButton().style.display).to.equal('none');
+        });
+
+        it('enables the run button', () => {
+          studio.toggleRunReset('run');
+          expect(runButton().disabled).to.be.false;
+        });
+
+        it('hides and disables the reset button', () => {
+          studio.toggleRunReset('run');
+          expect(resetButton().style.display).to.equal('none');
+          expect(resetButton().disabled).to.be.true;
+        });
+      });
+
+      describe('reset', () => {
+        it('displays the reset button', () => {
+          studio.toggleRunReset('reset');
+          expect(resetButton().style.display).to.equal('inline-block');
+        });
+
+        it('does not display the reset button if hideResetButton is true in redux', () => {
+          pageConstantsRedux.hideResetButton.restore();
+          sinon.stub(pageConstantsRedux, 'hideResetButton').returns(true);
+          studio.toggleRunReset('reset');
+          expect(resetButton().style.display).to.equal('none');
+        });
+
+        it('enables the reset button', () => {
+          studio.toggleRunReset('reset');
+          expect(resetButton().disabled).to.be.false;
+        });
+
+        it('hides and disables the run button', () => {
+          studio.toggleRunReset('reset');
+          expect(runButton().style.display).to.equal('none');
+          expect(runButton().disabled).to.be.true;
+        });
+      });
+    });
+
+    describe('resetButtonClick', () => {
       let studio, reportSpy;
       beforeEach(() => {
         studio = studioApp();
@@ -227,7 +297,7 @@ describe('StudioApp', () => {
       });
     });
 
-    describe('The StudioApp.report function', () => {
+    describe('report', () => {
       let clock, studio, onAttemptSpy;
       beforeEach(() => {
         clock = sinon.useFakeTimers();
@@ -278,7 +348,7 @@ describe('StudioApp', () => {
     });
   });
 
-  describe('The StudioApp.makeFooterMenuItems function', () => {
+  describe('makeFooterMenuItems', () => {
     beforeEach(() => {
       sinon.stub(project, 'getUrl');
       sinon.stub(project, 'getStandaloneApp');
@@ -531,7 +601,7 @@ describe('StudioApp', () => {
     });
   });
 
-  describe('The StudioApp.validateCodeChanged function', () => {
+  describe('validateCodeChanged', () => {
     let studio, codeDifferentStub;
     beforeEach(() => {
       codeDifferentStub = sinon.stub(project, 'isCurrentCodeDifferent');
@@ -562,3 +632,11 @@ describe('StudioApp', () => {
     });
   });
 });
+
+function runButton() {
+  return document.getElementById('runButton');
+}
+
+function resetButton() {
+  return document.getElementById('resetButton');
+}


### PR DESCRIPTION
Fixes a small regression introduced in #41118 where the run/reset buttons are shown to users on Applab widget levels. This regression happened because the `StudioApp.prototype.toggleRunReset` method manipulates the run/reset buttons directly and wasn't using the hideRunButton/hideResetButton redux state when deciding whether to hide/show the run/reset buttons.

Test URLs:
- http://localhost-studio.code.org:3000/s/csp3-2017/lessons/5/levels/4?no_redirect=true
- http://localhost-studio.code.org:3000/projects/applab/4xJIABqU5BS9yBVXQCniIg
- http://localhost-studio.code.org:3000/projects/applab/4FhnL8VfTfP3ncK3Sld0bg/view
- http://localhost-studio.code.org:3000/s/allthethings/lessons/2/levels/6

## Testing story

Added unit tests.