### PR TITLE
Fix for state_cs_offering seed error when missing stub files

### DIFF
--- a/dashboard/app/models/census/state_cs_offering.rb
+++ b/dashboard/app/models/census/state_cs_offering.rb
@@ -1493,6 +1493,9 @@ class Census::StateCsOffering < ApplicationRecord
       CDO.log.info "State CS Offering seeding: done processing "\
         "#{state_code}-#{school_year}-#{update} data. "\
         "#{succeeded} rows succeeded, #{skipped} rows skipped."
+
+    rescue Errno::ENOENT
+      CDO.log.warn "State CS Offering seed file #{filename} not found. Skipping..."
     end
   end
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Some of these files are missing because they haven't been pushed to git yet. Added some error handling to just skip these files with a warning.

## Links

- slack: [slack](https://codedotorg.slack.com/archives/C0T0PNTM3/p1624388564443600)
- PR that caused the issue: [PR 41190](https://github.com/code-dot-org/code-dot-org/pull/41190)

## Testing story

did a db:reset and reseeded from staging to repro the issue, then made change and reseeded again successfully.
