### PR TITLE
Escape PDF URLs

### DIFF
--- a/dashboard/lib/services/curriculum_pdfs/lesson_plans.rb
+++ b/dashboard/lib/services/curriculum_pdfs/lesson_plans.rb
@@ -15,16 +15,17 @@ module Services
         # <Pathname:csp1-2021/20210216001309/teacher-lesson-plans/Welcome to CSP.pdf>
         # and this for student lesson plans
         # <Pathname:csp1-2021/20210216001309/student-lesson-plans/Welcome to CSP.pdf>
-        def get_lesson_plan_pathname(lesson, student_facing = false)
+        def get_lesson_plan_pathname(lesson, student_facing = false, as_url = false)
           return nil unless lesson&.script&.seeded_from
           version_number = Time.parse(lesson.script.seeded_from).to_s(:number)
           filename = ActiveStorage::Filename.new(lesson.key + ".pdf").sanitized
+          filename = CGI.escape(filename) if as_url
           subdir = student_facing ? "student-lesson-plans" : "teacher-lesson-plans"
           return Pathname.new(File.join(lesson.script.name, version_number, subdir, filename))
         end
 
         def get_lesson_plan_url(lesson, student_facing=false)
-          pathname = get_lesson_plan_pathname(lesson, student_facing)
+          pathname = get_lesson_plan_pathname(lesson, student_facing, true)
           return nil unless pathname.present?
 
           File.join(get_base_url, pathname)

--- a/dashboard/lib/services/curriculum_pdfs/resources.rb
+++ b/dashboard/lib/services/curriculum_pdfs/resources.rb
@@ -10,8 +10,9 @@ module Services
     module Resources
       extend ActiveSupport::Concern
       class_methods do
-        def get_script_resources_pathname(script)
+        def get_script_resources_pathname(script, as_url = false)
           filename = ActiveStorage::Filename.new(script.localized_title + " - Resources.pdf").sanitized
+          filename = CGI.escape(filename) if as_url
           script_overview_pathname = get_script_overview_pathname(script)
           return nil unless script_overview_pathname
           subdirectory = File.dirname(script_overview_pathname)
@@ -19,7 +20,7 @@ module Services
         end
 
         def get_script_resources_url(script)
-          pathname = get_script_resources_pathname(script)
+          pathname = get_script_resources_pathname(script, true)
           return nil unless pathname.present?
           File.join(get_base_url, pathname)
         end

--- a/dashboard/lib/services/curriculum_pdfs/script_overview.rb
+++ b/dashboard/lib/services/curriculum_pdfs/script_overview.rb
@@ -8,15 +8,16 @@ module Services
     module ScriptOverview
       extend ActiveSupport::Concern
       class_methods do
-        def get_script_overview_pathname(script)
+        def get_script_overview_pathname(script, as_url = false)
           return nil unless script&.seeded_from
           version_number = Time.parse(script.seeded_from).to_s(:number)
           filename = ActiveStorage::Filename.new(script.localized_title + ".pdf").sanitized
+          filename = CGI.escape(filename) if as_url
           return Pathname.new(File.join(script.name, version_number, filename))
         end
 
         def get_script_overview_url(script)
-          pathname = get_script_overview_pathname(script)
+          pathname = get_script_overview_pathname(script, true)
           return nil unless pathname.present?
           File.join(get_base_url, pathname)
         end

--- a/dashboard/test/lib/services/curriculum_pdfs/lesson_plans_test.rb
+++ b/dashboard/test/lib/services/curriculum_pdfs/lesson_plans_test.rb
@@ -18,6 +18,15 @@ class Services::CurriculumPdfs::LessonPlansTest < ActiveSupport::TestCase
     refute_equal original_pathname, new_pathname
   end
 
+  test 'urls are escaped' do
+    script = create(:script, name: "test-escapes-script", seeded_from: Time.at(0))
+    lesson = create(:lesson, script: script, key: "Some!key_with?special/characters")
+    assert_equal Pathname.new("test-escapes-script/19700101000000/teacher-lesson-plans/Some%21key_with%3Fspecial-characters.pdf"),
+      Services::CurriculumPdfs.get_lesson_plan_pathname(lesson, false, true)
+    assert_equal "https://lesson-plans.code.org/test-escapes-script/19700101000000/teacher-lesson-plans/Some%21key_with%3Fspecial-characters.pdf",
+      Services::CurriculumPdfs.get_lesson_plan_url(lesson, false)
+  end
+
   test 'pathnames are differentiated by audience' do
     script = create(:script, name: "test-pathnames-script", seeded_from: Time.at(0))
     lesson = create(:lesson, script: script, key: "test-pathnames-lesson")

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -824,7 +824,7 @@ class LessonTest < ActiveSupport::TestCase
     script.seeded_from = Time.now.to_s
     assert_equal(
       new_lesson.lesson_plan_pdf_url,
-      "https://lesson-plans.code.org/#{script.name}/#{Time.parse(script.seeded_from).to_s(:number)}/teacher-lesson-plans/Some Verbose Lesson Name.pdf"
+      "https://lesson-plans.code.org/#{script.name}/#{Time.parse(script.seeded_from).to_s(:number)}/teacher-lesson-plans/Some+Verbose+Lesson+Name.pdf"
     )
   end
 
@@ -836,7 +836,7 @@ class LessonTest < ActiveSupport::TestCase
     script.seeded_from = Time.now.to_s
     assert_equal(
       new_lesson.student_lesson_plan_pdf_url,
-      "https://lesson-plans.code.org/#{script.name}/#{Time.parse(script.seeded_from).to_s(:number)}/student-lesson-plans/Some Verbose Lesson Name.pdf"
+      "https://lesson-plans.code.org/#{script.name}/#{Time.parse(script.seeded_from).to_s(:number)}/student-lesson-plans/Some+Verbose+Lesson+Name.pdf"
     )
   end
 
@@ -846,7 +846,7 @@ class LessonTest < ActiveSupport::TestCase
     lesson = create :lesson, lesson_group: lesson_group, script: script, has_lesson_plan: true
 
     assert_equal(
-      "https://lesson-plans.code.org/#{script.name}/#{Time.parse(script.seeded_from).to_s(:number)}/#{script.name} - Resources.pdf",
+      "https://lesson-plans.code.org/#{script.name}/#{Time.parse(script.seeded_from).to_s(:number)}/#{script.name}+-+Resources.pdf",
       lesson.script_resource_pdf_url
     )
   end


### PR DESCRIPTION
We've got some lessons with special characters in their names (ie, https://studio.code.org/s/csd1-2021/lessons/4, which has a question mark), so we gotta make sure to escape those names when constructing the URLs.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
