### PR TITLE
[AiLab] bump ml-playground version to 0.0.36

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -57,7 +57,7 @@
     "@code-dot-org/js-numbers": "0.1.0-cdo.0",
     "@code-dot-org/maze": "2.10.0",
     "@code-dot-org/ml-activities": "0.0.26",
-    "@code-dot-org/ml-playground": "0.0.35",
+    "@code-dot-org/ml-playground": "0.0.36",
     "@code-dot-org/p5.play": "^1.3.17-cdo",
     "@code-dot-org/piskel": "0.13.0-cdo.6",
     "@code-dot-org/redactable-markdown": "0.4.0",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1638,10 +1638,10 @@
     messageformat "^1.1.0"
     react-typist "^2.0.5"
 
-"@code-dot-org/ml-playground@0.0.35":
-  version "0.0.35"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/ml-playground/-/ml-playground-0.0.35.tgz#edff40d8708213a1d8e145e54aae095f7b129a26"
-  integrity sha512-zOY5nccPzMRQ6QjSfTRSsM3sj0xMXxrS3tli6tRZswT9ZbYAZMDiWEKgDE0TS3Uj41/i6/OtKIB4yDC81g5sUA==
+"@code-dot-org/ml-playground@0.0.36":
+  version "0.0.36"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/ml-playground/-/ml-playground-0.0.36.tgz#b3eb7cb43c02cce058246d2507c05956be8d4c46"
+  integrity sha512-+z/eZOclumQLFa92Pi1S52lP1519EJuDO7TJ/XNVDtXgAyp2WiDfdaPd/RqTAaUSMKodyyOWBEzW8vF5cXVacA==
   dependencies:
     "@fortawesome/fontawesome-svg-core" "^1.2.25"
     "@fortawesome/free-solid-svg-icons" "^5.11.2"


### PR DESCRIPTION
Contains:

- [Fix dynamic instructions with specific dataset](https://github.com/code-dot-org/ml-playground/pull/246)
- [Update background image](https://github.com/code-dot-org/ml-playground/pull/247)
