### PR TITLE
Relax course offering version keys

### DIFF
--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -17,11 +17,11 @@
 class CourseOffering < ApplicationRecord
   has_many :course_versions
 
-  KEY_CHAR_RE = /[a-z\-]/
+  KEY_CHAR_RE = /[a-z0-9\-]/
   KEY_RE = /\A#{KEY_CHAR_RE}+\Z/
   validates_format_of :key,
     with: KEY_RE,
-    message: "must contain only lowercase alphabetic characters and dashes; got \"%{value}\"."
+    message: "must contain only lowercase alphabetic characters, numbers, and dashes; got \"%{value}\"."
 
   # Seeding method for creating / updating / deleting a CourseOffering and CourseVersion for the given
   # potential content root, i.e. a Script or UnitGroup.

--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -26,11 +26,11 @@ class CourseVersion < ApplicationRecord
   has_many :resources
   has_many :vocabularies
 
-  KEY_CHAR_RE = /\d/
+  KEY_CHAR_RE = /[a-z0-9\-]/
   KEY_RE = /\A#{KEY_CHAR_RE}+\Z/
   validates_format_of :key,
     with: KEY_RE,
-    message: "must contain only digits; got \"%{value}\"."
+    message: "must contain only digits, letters, or dashes; got \"%{value}\"."
 
   def units
     content_root_type == 'UnitGroup' ? content_root.default_scripts : [content_root]

--- a/dashboard/test/models/course_offering_test.rb
+++ b/dashboard/test/models/course_offering_test.rb
@@ -144,7 +144,7 @@ class CourseOfferingTest < ActiveSupport::TestCase
   test "enforces key format" do
     course_offering = build :course_offering, key: 'invalid key'
     refute course_offering.valid?
-    course_offering.key = 'abcdefghijklmnopqrstuvwxyz-'
+    course_offering.key = '0123456789abcdefghijklmnopqrstuvwxyz-'
     assert course_offering.valid?
   end
 

--- a/dashboard/test/models/course_version_test.rb
+++ b/dashboard/test/models/course_version_test.rb
@@ -89,7 +89,7 @@ class CourseVersionTest < ActiveSupport::TestCase
   test "enforces key format" do
     course_version = build :course_version, key: 'invalid key'
     refute course_version.valid?
-    course_version.key = '0123456789'
+    course_version.key = '0123456789abcdefghijklmnopqrstuvwxyz-'
     assert course_version.valid?
   end
 end


### PR DESCRIPTION
A small PR to prepare for all of our assignable scripts to have a course offering and version. My plan is to create course offerings with the same name as the script, such as `20-hour`. As this has a number, it fails the course offering key validation. These scripts also don't have a year associated with them so I'm planning on having the course version key either be their name or "unversioned" (I'm still deciding on this), so I relaxing that validation in this PR as well.

I modeled both of these on the resource key validation, so I don't think it will break any markdown syntax but definitely let me know if there's something I should check for.





## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
