### PR TITLE
Fix only_one_running to support git content updates

### DIFF
--- a/lib/cdo/only_one.rb
+++ b/lib/cdo/only_one.rb
@@ -1,8 +1,12 @@
+require 'digest/md5'
+require 'tmpdir'
+
 # Ensure only one instance of a Ruby script is running at a time,
-# using `File#flock` (advisory lock) on the provided script path.
+# using `File#flock` (advisory lock) on a temp file based on the provided script path.
 # @return [Boolean] true if this is the only instance running.
 def only_one_running?(path)
-  !!File.new(path).
+  lock = File.join(Dir.tmpdir, Digest::MD5.hexdigest(File.absolute_path(path)))
+  !!File.new(lock, File::CREAT).
     # Prevent locked Files from being auto-closed by garbage-collector.
     tap {|f| f.autoclose = false}.
     flock(File::LOCK_NB | File::LOCK_EX)

--- a/lib/test/cdo/test_only_one.rb
+++ b/lib/test/cdo/test_only_one.rb
@@ -32,4 +32,14 @@ class OnlyOneTest < Minitest::Test
     refute only_one_running?(tmp1)
     refute only_one_running?(tmp2)
   end
+
+  # Return false even when a file (inode) is replaced by a different file sharing the same path.
+  def test_replaced_file
+    tmp = Tempfile.new
+    tmp_path = tmp.path
+    assert only_one_running?(tmp)
+    tmp.unlink
+    tmp2 = File.new(tmp_path, File::CREAT)
+    refute only_one_running?(tmp2)
+  end
 end


### PR DESCRIPTION
Sometimes, `git pull` will replace a file with a new inode at the same path when updating file contents. This isn't compatible
with `flock` (which locks against the inode directly and not the filesystem path more generally). As a workaround, this PR updates `only_one_running?` to lock against a separate temporary file (derived from an MD5 hash of the filesystem path) instead.

## Links

- [`INF-454`](https://codedotorg.atlassian.net/browse/INF-454)

## Testing story

Added `test_replaced_file` as a unit test that fails without this PR and passes with the fix.