### PR TITLE
Update CB redirection rules to point at code.org and code studio for core courses

### DIFF
--- a/aws/s3/cdo-curriculum/redirection_rules.rb
+++ b/aws/s3/cdo-curriculum/redirection_rules.rb
@@ -2,6 +2,8 @@ require_relative '../../../deployment'
 require 'aws-sdk-s3'
 
 HOST_NAME = "curriculum.code.org"
+CODE_STUDIO_HOST_NAME = "studio.code.org"
+CODE_ORG_HOST_NAME = "code.org"
 BUCKET_NAME = "cdo-curriculum"
 
 routing_rules = [
@@ -10,8 +12,8 @@ routing_rules = [
       key_prefix_equals: "csp/"
     },
     redirect: {
-      host_name: HOST_NAME,
-      replace_key_prefix_with: "csp-current/"
+      host_name: CODE_STUDIO_HOST_NAME,
+      replace_key_prefix_with: "s/csp-2021/"
     }
   },
   {
@@ -19,8 +21,8 @@ routing_rules = [
       key_prefix_equals: "csp-current/"
     },
     redirect: {
-      host_name: HOST_NAME,
-      replace_key_prefix_with: "csp-20/",
+      host_name: CODE_STUDIO_HOST_NAME,
+      replace_key_prefix_with: "s/csp-2021/",
       http_redirect_code: "302"
     }
   },
@@ -29,8 +31,8 @@ routing_rules = [
       key_prefix_equals: "csd/"
     },
     redirect: {
-      host_name: HOST_NAME,
-      replace_key_prefix_with: "csd-current/"
+      host_name: CODE_STUDIO_HOST_NAME,
+      replace_key_prefix_with: "s/csd-2021/"
     }
   },
   {
@@ -38,8 +40,8 @@ routing_rules = [
       key_prefix_equals: "csd-current/"
     },
     redirect: {
-      host_name: HOST_NAME,
-      replace_key_prefix_with: "csd-20/",
+      host_name: CODE_STUDIO_HOST_NAME,
+      replace_key_prefix_with: "s/csd-2021/",
       http_redirect_code: "302"
     }
   },
@@ -48,8 +50,8 @@ routing_rules = [
       key_prefix_equals: "csf/"
     },
     redirect: {
-      host_name: HOST_NAME,
-      replace_key_prefix_with: "csf-current/"
+      host_name: CODE_ORG_HOST_NAME,
+      replace_key_prefix_with: "educate/curriculum/elementary-school"
     }
   },
   {
@@ -57,8 +59,8 @@ routing_rules = [
       key_prefix_equals: "csf-current/"
     },
     redirect: {
-      host_name: HOST_NAME,
-      replace_key_prefix_with: "csf-20/",
+      host_name: CODE_ORG_HOST_NAME,
+      replace_key_prefix_with: "educate/curriculum/elementary-school",
       http_redirect_code: "302"
     }
   },


### PR DESCRIPTION
# DONT MERGE UNITL HARD LAUNCH!

Redirects CB no year links to Code Studio and Code.org

curriculum.code.org/csp and curriculum.code.org/csp-current go to studio.code.org/courses/csp-2021

curriculum.code.org/csd and curriculum.code.org/csd-current go to studio.code.org/courses/csd-2021

curriculum.code.org/csf and curriculum.code.org/csf-current go to code.org/educate/curriculum/elementary-school

## Links

https://codedotorg.atlassian.net/browse/PLAT-871

## Testing story

Not sure how to test this.