### PR TITLE
Remove runButton step from star wars test

### DIFF
--- a/dashboard/test/ui/features/learning_platform/projects/starwars_project.feature
+++ b/dashboard/test/ui/features/learning_platform/projects/starwars_project.feature
@@ -1,6 +1,5 @@
 Feature: Starwars Project
 
-@skip
 @as_student @no_mobile
 Scenario: Starwars Flow
   Given I am on "http://studio.code.org/projects/starwars"
@@ -15,7 +14,6 @@ Scenario: Starwars Flow
   And I click selector ".project_save"
   And I wait until element ".project_edit" is visible
   Then I should see title "Code Ninja III: Revenge of the Semicolon - Play Lab"
-  And I press "runButton"
 
   When I open the project share dialog
   Then the project is unpublished


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Removing the `And I press "runButton"` step because it causes the test to hang on Chrome for reasons unknown (LP-1958). This step is not important to the scenario and the functionality is separately covered in hour_of_code/starwars.feature so we decided to just remove the step.



## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [LP-1958](https://codedotorg.atlassian.net/browse/LP-1958)
- slack thread: https://codedotorg.slack.com/archives/C1B3PNDL7/p1624560950105200

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
