### PR TITLE
add aiml-2021 to the assignment selector dropdown

### DIFF
--- a/dashboard/config/locales/scripts.en.yml
+++ b/dashboard/config/locales/scripts.en.yml
@@ -24,6 +24,7 @@ en:
         csp_2021_category_name: CS Principles ('21-'22)
         cspexams_category_name: CS Principles Practice Test
         csp17_category_name: CS Principles ('17-'18)
+        aiml_2021_category_name: AI / ML
         full_course_category_name: Full Courses
         hoc_category_name: Hour of Code
         math_category_name: Math

--- a/lib/cdo/script_constants.rb
+++ b/lib/cdo/script_constants.rb
@@ -69,6 +69,9 @@ module ScriptConstants
       EXPRESS_2021_NAME = 'express-2021'.freeze,
       PRE_READER_EXPRESS_2021_NAME = 'pre-express-2021'.freeze,
     ],
+    aiml_2021: [
+      AIML_2021_NAME = 'aiml-2021'.freeze,
+    ],
     hoc: [
       # Note that now multiple scripts can be an 'hour of code' script.
       # If adding a script here,

--- a/lib/test/test_script_constants.rb
+++ b/lib/test/test_script_constants.rb
@@ -62,8 +62,8 @@ class ScriptConstantsTest < Minitest::Test
   end
 
   def test_category_priority
-    assert_equal 6, ScriptConstants.category_priority(:csf_international)
-    assert_equal 8, ScriptConstants.category_priority(:research_studies)
+    assert_equal 7, ScriptConstants.category_priority(:csf_international)
+    assert_equal 9, ScriptConstants.category_priority(:research_studies)
   end
 
   def test_assignable_info


### PR DESCRIPTION
Finishes https://codedotorg.atlassian.net/browse/PLAT-1120. Depends on https://github.com/code-dot-org/code-dot-org/pull/41362. 

## Screenshots

if I mark aiml-2021 'stable' on my local machine, then it shows up in the dropdown like this:

![Screen Shot 2021-07-09 at 10 17 48 PM](https://user-images.githubusercontent.com/8001765/125152748-9d96f680-e103-11eb-8b46-f60f5d9b4cbf.png)

## Testing story

manual testing as shown in screenshot