### PR TITLE
Add new virtual order form reminder email 

### DIFF
--- a/dashboard/app/mailers/pd/workshop_mailer.rb
+++ b/dashboard/app/mailers/pd/workshop_mailer.rb
@@ -237,6 +237,21 @@ class Pd::WorkshopMailer < ActionMailer::Base
       reply_to: email_address(@workshop.organizer.name, @workshop.organizer.email)
   end
 
+  def teacher_virtual_order_form_reminder(enrollment)
+    @enrollment = enrollment
+    @workshop = enrollment.workshop
+    course = @workshop.course
+
+    return unless @workshop.virtual? && (course == Pd::Workshop::COURSE_CSP || course == Pd::Workshop::COURSE_CSD)
+
+    # Pre-workshop virtual order form reminder
+    mail content_type: 'text/html',
+      from: from_teacher,
+      subject: 'Tell Code.org where to send materials for your upcoming workshop!',
+      to: email_address(@enrollment.full_name, @enrollment.email),
+      reply_to: email_address(@workshop.organizer.name, @workshop.organizer.email)
+  end
+
   # Exit survey email
   # @param enrollment [Pd::Enrollment]
   def exit_survey(enrollment)

--- a/dashboard/app/views/pd/workshop_mailer/teacher_virtual_order_form_reminder.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/teacher_virtual_order_form_reminder.html.haml
@@ -1,0 +1,42 @@
+:css
+  body {
+    font-family: Gotham, sans-serif;
+  }
+
+%p
+  Hi
+  = @enrollment.first_name + ','
+
+%p
+  Your virtual summer workshop is 4-weeks away!
+  = @workshop.organizer.name
+  is looking forward to welcoming you to the
+  = @workshop.course
+  Professional Learning Program beginning
+  = @workshop.sessions.first.start_date_us_format + "."
+
+%p
+  Code.org would like to ship workshop materials directly to you
+  at an address that’s most convenient. Please complete the form below
+  this week to ensure they arrive in advance of your workshop!
+
+%p
+  Things to note:
+  %ul
+    %li
+      Your order will arrive via FedEx approximately 3-weeks from when you press submit.
+    %li
+      If you submit the form less than 3-weeks prior to your workshop, don’t worry!
+      Digital versions are available for you to reference during your workshop.
+    %li
+      The materials are available at no cost to you and include the Code.org curriculum guide and swag.
+
+%p
+  = link_to 'Click here', 'https://studio.code.org/form/virtual_order_form'
+  (https://studio.code.org/form/virtual_order_form) to provide Code.org with your shipping address.
+  If you prefer to reference digital versions of the materials, you can skip this step!
+
+%p
+  Thank you,
+  %br
+  = @workshop.organizer.name

--- a/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
+++ b/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
@@ -252,8 +252,15 @@ class Pd::WorkshopMailerPreview < ActionMailer::Preview
       options: {days_before: 3}
   end
 
-  def teacher_virtual_order_form_reminder
+  def teacher_virtual_order_form_reminder__csp
     mail :teacher_virtual_order_form_reminder, Pd::Workshop::COURSE_CSP, Pd::Workshop::SUBJECT_CSP_SUMMER_WORKSHOP,
+      workshop_params: {
+        virtual: true
+      }
+  end
+
+  def teacher_virtual_order_form_reminder__csd
+    mail :teacher_virtual_order_form_reminder, Pd::Workshop::COURSE_CSD, Pd::Workshop::SUBJECT_CSD_WORKSHOP_1,
       workshop_params: {
         virtual: true
       }

--- a/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
+++ b/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
@@ -252,6 +252,13 @@ class Pd::WorkshopMailerPreview < ActionMailer::Preview
       options: {days_before: 3}
   end
 
+  def teacher_virtual_order_form_reminder
+    mail :teacher_virtual_order_form_reminder, Pd::Workshop::COURSE_CSP, Pd::Workshop::SUBJECT_CSP_SUMMER_WORKSHOP,
+      workshop_params: {
+        virtual: true
+      }
+  end
+
   def teacher_follow_up__csf_intro_with_rp
     facilitator1 = build :facilitator, name: 'Fiona Facilitator', email: 'fiona_facilitator@example.net'
     facilitator2 = build :facilitator, name: 'Fred Facilitator', email: 'fred_facilitator@example.net'


### PR DESCRIPTION
Add new virtual order form reminder email and schedule for 4 weeks out from start of workshop. We want to show the link to the order form to teachers earlier in the process.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- spec: [email content](https://docs.google.com/document/d/1sr7IaWZtZTM2GDmt12Nq8hk4ThXsGrtH2-1SPcQUbKU/edit#)
- jira ticket: [PLC-1237](https://codedotorg.atlassian.net/browse/PLC-1237)


## Testing story

Manually tested through rails mailer preview
![image](https://user-images.githubusercontent.com/82416901/123334315-c4e0a780-d4f7-11eb-8866-2f7c743eeb21.png)

