### PR TITLE
Javalab: code review comments backend basics

### DIFF
--- a/dashboard/app/controllers/code_review_comments_controller.rb
+++ b/dashboard/app/controllers/code_review_comments_controller.rb
@@ -1,10 +1,19 @@
 class CodeReviewCommentsController < ApplicationController
-  # require permit description: https://stackoverflow.com/questions/18424671/what-is-params-requireperson-permitname-age-doing-in-rails-4
-  # require commenter id, project id, project version, comment
+  # TO DO: Permissioning
+
+  # POST /code_review_comments
   def create
+    @code_review_comment = CodeReviewComment.new(code_review_comments_params)
+
+    if @code_review_comment.save
+      render json: @code_review_comment
+    else
+      head :bad_request
+    end
   end
 
   # require code_review_comment_id, permit comment? is_resolved?
+  # no update action in teacher feedback -- maybe this is a better pattern (no updates)?
   def update
   end
 
@@ -14,9 +23,36 @@ class CodeReviewCommentsController < ApplicationController
 
   # require code_review_comment_id
   def destroy
+    @code_review_comment = CodeReviewComment.find_by(params[:id])
+
+    if @code_review_comment.delete
+      head :ok
+    else
+      head :bad_request
+    end
   end
 
   # require project id, project version
   def project_comments
+    @project_comments = CodeReviewComment.where(
+      channel_token_id: params[:channel_token_id],
+      project_version: params[:project_version]
+    )
+
+    render json: @project_comments
+  end
+
+  private
+
+  # TO DO: permit params
+  # require permit description: https://stackoverflow.com/questions/18424671/what-is-params-requireperson-permitname-age-doing-in-rails-4
+  # require commenter id, project id, project version, comment
+  def code_review_comments_params
+    params.require(:code_review_comment).permit(
+      :channel_token_id,
+      :project_version,
+      :commenter_id,
+      :comment
+    )
   end
 end

--- a/dashboard/app/controllers/code_review_comments_controller.rb
+++ b/dashboard/app/controllers/code_review_comments_controller.rb
@@ -1,0 +1,22 @@
+class CodeReviewCommentsController < ApplicationController
+  # require permit description: https://stackoverflow.com/questions/18424671/what-is-params-requireperson-permitname-age-doing-in-rails-4
+  # require commenter id, project id, project version, comment
+  def create
+  end
+
+  # require code_review_comment_id, permit comment? is_resolved?
+  def update
+  end
+
+  # may be able to remove and implement using update
+  def resolve
+  end
+
+  # require code_review_comment_id
+  def destroy
+  end
+
+  # require project id, project version
+  def project_comments
+  end
+end

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -310,6 +310,10 @@ class Ability
     if user.persisted?
       if Experiment.enabled?(user: user, experiment_name: 'csa-pilot')
         can :get_access_token, :javabuilder_session
+
+        # Temporarily allow management of CodeReviewComments by piloters --
+        # more nuanced permissioning up next
+        can :manage, CodeReviewComment
       end
     end
 

--- a/dashboard/app/models/code_review_comment.rb
+++ b/dashboard/app/models/code_review_comment.rb
@@ -22,5 +22,8 @@
 class CodeReviewComment < ApplicationRecord
   acts_as_paranoid
 
+  belongs_to :channel_token
   belongs_to :commenter, class_name: 'User'
+
+  validates :comment, presence: true
 end

--- a/dashboard/app/models/code_review_comment.rb
+++ b/dashboard/app/models/code_review_comment.rb
@@ -21,4 +21,6 @@
 #
 class CodeReviewComment < ApplicationRecord
   acts_as_paranoid
+
+  belongs_to :commenter, class_name: 'User'
 end

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -880,4 +880,8 @@ Dashboard::Application.routes.draw do
       end
     end
   end
+
+  resources :code_review_comments, only: [:create, :update, :destroy] do
+    get :project_comments, on: collection
+  end
 end

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -882,6 +882,7 @@ Dashboard::Application.routes.draw do
   end
 
   resources :code_review_comments, only: [:create, :update, :destroy] do
+    patch :resolve, on: :member
     get :project_comments, on: :collection
   end
 end

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -882,6 +882,6 @@ Dashboard::Application.routes.draw do
   end
 
   resources :code_review_comments, only: [:create, :update, :destroy] do
-    get :project_comments, on: collection
+    get :project_comments, on: :collection
   end
 end

--- a/dashboard/test/controllers/code_review_comments_controller_test.rb
+++ b/dashboard/test/controllers/code_review_comments_controller_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class CodeReviewCommentsControllerTest < ActionController::TestCase
+  test 'can create CodeReviewComment' do
+    channel_token = create :channel_token
+    commenter = create :teacher
+
+    post :create, params: {
+      code_review_comment: {
+        channel_token_id: channel_token.id,
+        project_version: 'a_project_version_string',
+        commenter_id: commenter.id,
+        comment: 'a comment'
+      }
+    }
+
+    assert_response :success
+  end
+end

--- a/dashboard/test/controllers/code_review_comments_controller_test.rb
+++ b/dashboard/test/controllers/code_review_comments_controller_test.rb
@@ -1,19 +1,92 @@
 require 'test_helper'
 
 class CodeReviewCommentsControllerTest < ActionController::TestCase
+  setup_all do
+    @pilot_teacher = create :teacher
+    create(:single_user_experiment, min_user_id: @pilot_teacher.id, name: 'csa-pilot')
+  end
+
   test 'can create CodeReviewComment' do
+    sign_in(@pilot_teacher)
+
     channel_token = create :channel_token
     commenter = create :teacher
 
     post :create, params: {
-      code_review_comment: {
-        channel_token_id: channel_token.id,
-        project_version: 'a_project_version_string',
-        commenter_id: commenter.id,
-        comment: 'a comment'
-      }
+      channel_token_id: channel_token.id,
+      project_version: 'a_project_version_string',
+      commenter_id: commenter.id,
+      comment: 'a comment'
     }
 
     assert_response :success
+  end
+
+  test 'can delete CodeReviewComment' do
+    sign_in(@pilot_teacher)
+
+    code_review_comment = create :code_review_comment
+
+    assert_not_nil CodeReviewComment.find_by(id: code_review_comment.id)
+
+    delete :destroy, params: {
+      id: code_review_comment.id
+    }
+
+    assert_response :success
+    assert_nil CodeReviewComment.find_by(id: code_review_comment.id)
+  end
+
+  test 'can get all comments for a given project and version' do
+    sign_in(@pilot_teacher)
+
+    channel_token = create :channel_token
+
+    2.times do
+      create :code_review_comment,
+        channel_token: channel_token,
+        project_version: 'test_get_project_comments_string'
+    end
+
+    # Create third code review comment from another project
+    # to make sure we only fetch the correct set of comments.
+    create :code_review_comment
+
+    get :project_comments, params: {
+      channel_token_id: channel_token.id,
+      project_version: 'test_get_project_comments_string'
+    }
+
+    assert_response :success
+    assert_equal 2, JSON.parse(response.body).length
+  end
+
+  test 'renders successfully for project with no comments' do
+    sign_in(@pilot_teacher)
+
+    channel_token = create :channel_token
+
+    get :project_comments, params: {
+      channel_token_id: channel_token.id,
+      project_version: 'test_get_project_comments_string'
+    }
+
+    assert_response :success
+    assert_empty JSON.parse(response.body)
+  end
+
+  test 'can mark comment as resolved' do
+    sign_in(@pilot_teacher)
+
+    code_review_comment = create :code_review_comment
+
+    assert_nil code_review_comment.is_resolved
+
+    patch :resolve, params: {
+      id: code_review_comment.id
+    }
+
+    assert_response :success
+    assert code_review_comment.reload.is_resolved
   end
 end

--- a/dashboard/test/controllers/code_review_comments_controller_test.rb
+++ b/dashboard/test/controllers/code_review_comments_controller_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class CodeReviewCommentsControllerTest < ActionController::TestCase
+  self.use_transactional_test_case = true
+
   setup_all do
     @pilot_teacher = create :teacher
     create(:single_user_experiment, min_user_id: @pilot_teacher.id, name: 'csa-pilot')

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -492,7 +492,7 @@ FactoryGirl.define do
     sequence(:name) {|n| "Level_#{n}"}
     sequence(:level_num) {|n| "1_2_#{n}"}
 
-    # User id must be non-nil for custom level
+    # User id must be non -nil for custom level
     user_id '1'
     game
 
@@ -1315,6 +1315,7 @@ FactoryGirl.define do
     # Note: This creates channel_tokens where the channel is NOT an accurately
     # encrypted version of storage_app_id/app_id
     storage_app_id 1
+    association :level
     storage_id {storage_user.try(:id) || 2}
   end
 
@@ -1376,6 +1377,13 @@ FactoryGirl.define do
         create :script_level, script: tf.script, levels: [tf.level]
       end
     end
+  end
+
+  factory :code_review_comment do
+    association :commenter, factory: :teacher
+    association :channel_token
+    project_version 'a_project_version_string'
+    comment 'a comment about your project'
   end
 
   factory :teacher_score do

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -492,7 +492,7 @@ FactoryGirl.define do
     sequence(:name) {|n| "Level_#{n}"}
     sequence(:level_num) {|n| "1_2_#{n}"}
 
-    # User id must be non -nil for custom level
+    # User id must be non-nil for custom level
     user_id '1'
     game
 

--- a/dashboard/test/models/code_review_comment_test.rb
+++ b/dashboard/test/models/code_review_comment_test.rb
@@ -1,0 +1,11 @@
+require 'test_helper'
+
+class CodeReviewCommentTest < ActiveSupport::TestCase
+  test 'CodeReviewComment must have a non-nil comment' do
+    code_review_comment = build :code_review_comment, comment: nil
+    refute code_review_comment.valid?
+
+    code_review_comment.comment = 'a comment'
+    assert code_review_comment.valid?
+  end
+end


### PR DESCRIPTION
Initial pieces of Javalab code review backend, with a lot to still flesh out. This PR includes controller methods to handle (I think) the functionality in the [design doc](https://docs.google.com/document/d/1D5MplHJSoeu6mUFcfd8gfrkDXfWx6F7mkAV9wXT47-o/edit#).

Not 100% done, but looking for any feedback on:
- things that look directionally incorrect,
- functionality we need for code review that wouldn't be possible with the actions that are in this PR,
- anything tricky you think should be watched out for,
- or whatever else is on your mind :)

## Testing story

I've added unit tests for the happy cases here -- I expect that I'll be adding more of the failure cases as I build out permissioning around who can do what with code review comments.

## Follow-up work

1. Build in permissioning for different actions (currently set to allow all of these actions to piloters, just to avoid any possible spam before I build in actual permissioning).
2. More error handling for non-happy cases.