### PR TITLE
Remove test for unit family names redirecting to 2019

### DIFF
--- a/dashboard/test/ui/features/learning_platform/course_versions.feature
+++ b/dashboard/test/ui/features/learning_platform/course_versions.feature
@@ -124,9 +124,3 @@ Scenario: Switch versions using dropdown on script overview page
   And element ".assignment-version-title:contains(2018)" is not visible
   And I click selector ".assignment-version-title:contains(2017)" once I see it
   Then I wait until I am on "http://studio.code.org/s/ui-test-versioned-script-2017"
-
-@as_student
-@no_mobile
-Scenario: Course unit family names redirect to 2019 version
-  When I am on "http://studio.code.org/s/csp3"
-  And I get redirected to "/s/csp3-2019" via "dashboard"


### PR DESCRIPTION
We talked about how we didn't want to continue supporting this past 2020, plus we're about to launch 2021 so this feature is clearly outdated :) 

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
