### PR TITLE
Enable asset retrieval in javalab local mode

### DIFF
--- a/apps/src/javalab/JavabuilderConnection.js
+++ b/apps/src/javalab/JavabuilderConnection.js
@@ -52,7 +52,7 @@ export default class JavabuilderConnection {
       // TODO: Enable token decryption on local javabuilder server.
       url += `?projectUrl=${dashboard.project.getProjectSourcesUrl()}&levelId=${
         this.levelId
-      }`;
+      }&channelId=${this.channelId}`;
       if (optionsStr) {
         url += `&${optionsStr}`;
       }

--- a/apps/src/javalab/JavabuilderConnection.js
+++ b/apps/src/javalab/JavabuilderConnection.js
@@ -48,11 +48,9 @@ export default class JavabuilderConnection {
     let url = this.javabuilderUrl;
     const optionsStr = queryString.stringify(this.options);
     if (window.location.hostname.includes('localhost')) {
-      // We're hitting the local javabuilder server. Just pass the projectUrl and levelId.
+      // We're hitting the local javabuilder server. Just pass the required parameters.
       // TODO: Enable token decryption on local javabuilder server.
-      url += `?projectUrl=${dashboard.project.getProjectSourcesUrl()}&levelId=${
-        this.levelId
-      }&channelId=${this.channelId}`;
+      url += `?levelId=${this.levelId}&channelId=${this.channelId}`;
       if (optionsStr) {
         url += `&${optionsStr}`;
       }

--- a/dashboard/app/controllers/javabuilder_sessions_controller.rb
+++ b/dashboard/app/controllers/javabuilder_sessions_controller.rb
@@ -12,6 +12,7 @@ class JavabuilderSessionsController < ApplicationController
   def get_access_token
     channel_id = params[:channelId]
     project_version = params[:projectVersion]
+    # TODO: remove project_url after javabuilder is deployed with update to no longer need it
     project_url = params[:projectUrl]
     level_id = params[:levelId]
     options = params[:options]

--- a/shared/middleware/files_api.rb
+++ b/shared/middleware/files_api.rb
@@ -145,6 +145,8 @@ class FilesApi < Sinatra::Base
   # GET /v3/(animations|assets|sources|files|libraries)/<channel-id>/<filename>?version=<version-id>
   #
   # Read a file. Optionally get a specific version instead of the most recent.
+  # Note: we depend on this URL in Javabuilder
+  # https://github.com/code-dot-org/javabuilder/blob/main/org-code-javabuilder/protocol/src/main/java/org/code/protocol/GlobalProtocol.java
   #
   get %r{/v3/(animations|assets|sources|files|libraries)/([^/]+)/([^/]+)$} do |endpoint, encrypted_channel_id, filename|
     if endpoint == 'libraries'


### PR DESCRIPTION
Javabuilder is being updated to allow for programs to retrieve assets (images, audio) from the assets system (See [this PR](https://github.com/code-dot-org/javabuilder/pull/64). This PR updates the local setup for the Javalab connection to Javabuilder to include the channel id needed to generate the asset urls. The non-local version already has this information. 

The update linked above also removes the need for the projects url to be passed. Removed this on the local side here (and therefore this should be merged after the Javabuilder PR), and put a note to remove it on the session token side once Javabuilder has been deployed with the updates. Removing it from the session token now could cause Javabuilder to break if we do things in the wrong order.

## Links
- jira ticket: [https://codedotorg.atlassian.net/browse/CSA-424](https://codedotorg.atlassian.net/browse/CSA-424)


## Testing story
Tested locally against local Javabuilder with the new updates.

## Deployment strategy
This should be merged after the Javabuilder change is merged to avoid local development errors.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
