### PR TITLE
Javalab: Code Review uses storage app IDs instead of channel tokens as project identifer

### DIFF
--- a/dashboard/app/controllers/code_review_comments_controller.rb
+++ b/dashboard/app/controllers/code_review_comments_controller.rb
@@ -61,7 +61,6 @@ class CodeReviewCommentsController < ApplicationController
   # GET /code_review_comments/project_comments
   def project_comments
     @project_comments = CodeReviewComment.where(
-      storage_id: params[:storage_id],
       storage_app_id: params[:storage_app_id],
       project_version: params[:project_version]
     )
@@ -74,7 +73,6 @@ class CodeReviewCommentsController < ApplicationController
   # TO DO: modify permit_params to handle other parameters (eg, section ID)
   def code_review_comments_params
     params.permit(
-      :storage_id,
       :storage_app_id,
       :project_version,
       :commenter_id,

--- a/dashboard/app/controllers/code_review_comments_controller.rb
+++ b/dashboard/app/controllers/code_review_comments_controller.rb
@@ -61,7 +61,8 @@ class CodeReviewCommentsController < ApplicationController
   # GET /code_review_comments/project_comments
   def project_comments
     @project_comments = CodeReviewComment.where(
-      channel_token_id: params[:channel_token_id],
+      storage_id: params[:storage_id],
+      storage_app_id: params[:storage_app_id],
       project_version: params[:project_version]
     )
 
@@ -73,7 +74,8 @@ class CodeReviewCommentsController < ApplicationController
   # TO DO: modify permit_params to handle other parameters (eg, section ID)
   def code_review_comments_params
     params.permit(
-      :channel_token_id,
+      :storage_id,
+      :storage_app_id,
       :project_version,
       :commenter_id,
       :comment,

--- a/dashboard/app/models/code_review_comment.rb
+++ b/dashboard/app/models/code_review_comment.rb
@@ -3,7 +3,8 @@
 # Table name: code_review_comments
 #
 #  id               :bigint           not null, primary key
-#  channel_token_id :integer          not null
+#  storage_id       :integer          not null
+#  storage_app_id   :integer          not null
 #  project_version  :string(255)      not null
 #  commenter_id     :integer          not null
 #  comment          :text(16777215)
@@ -17,12 +18,11 @@
 #
 # Indexes
 #
-#  index_code_review_comments_on_project_id_and_version  (channel_token_id,project_version)
+#  index_code_review_comments_on_project_identifier_and_version  (storage_id,storage_app_id,project_version)
 #
 class CodeReviewComment < ApplicationRecord
   acts_as_paranoid
 
-  belongs_to :channel_token
   belongs_to :commenter, class_name: 'User'
 
   validates :comment, presence: true

--- a/dashboard/app/models/code_review_comment.rb
+++ b/dashboard/app/models/code_review_comment.rb
@@ -3,7 +3,6 @@
 # Table name: code_review_comments
 #
 #  id               :bigint           not null, primary key
-#  storage_id       :integer          not null
 #  storage_app_id   :integer          not null
 #  project_version  :string(255)      not null
 #  commenter_id     :integer          not null
@@ -18,7 +17,7 @@
 #
 # Indexes
 #
-#  index_code_review_comments_on_project_identifier_and_version  (storage_id,storage_app_id,project_version)
+#  index_code_review_comments_on_storage_app_id_and_version  (storage_app_id,project_version)
 #
 class CodeReviewComment < ApplicationRecord
   acts_as_paranoid

--- a/dashboard/db/migrate/20210629133900_update_code_review_comments_to_use_storage_app_id.rb
+++ b/dashboard/db/migrate/20210629133900_update_code_review_comments_to_use_storage_app_id.rb
@@ -1,0 +1,13 @@
+class UpdateCodeReviewCommentsToUseStorageAppId < ActiveRecord::Migration[5.2]
+  def change
+    add_column :code_review_comments, :storage_id, :integer, null: false, after: :id
+    add_column :code_review_comments, :storage_app_id, :integer, null: false, after: :storage_id
+    add_index :code_review_comments, [:storage_id, :storage_app_id, :project_version],
+      name: 'index_code_review_comments_on_project_identifier_and_version'
+
+    remove_index :code_review_comments,
+      name: 'index_code_review_comments_on_project_id_and_version',
+      column: [:channel_token_id, :project_version]
+    remove_column :code_review_comments, :channel_token_id, :integer
+  end
+end

--- a/dashboard/db/migrate/20210629133900_update_code_review_comments_to_use_storage_app_id.rb
+++ b/dashboard/db/migrate/20210629133900_update_code_review_comments_to_use_storage_app_id.rb
@@ -1,9 +1,8 @@
 class UpdateCodeReviewCommentsToUseStorageAppId < ActiveRecord::Migration[5.2]
   def change
-    add_column :code_review_comments, :storage_id, :integer, null: false, after: :id
-    add_column :code_review_comments, :storage_app_id, :integer, null: false, after: :storage_id
-    add_index :code_review_comments, [:storage_id, :storage_app_id, :project_version],
-      name: 'index_code_review_comments_on_project_identifier_and_version'
+    add_column :code_review_comments, :storage_app_id, :integer, null: false, after: :id
+    add_index :code_review_comments, [:storage_app_id, :project_version],
+      name: 'index_code_review_comments_on_storage_app_id_and_version'
 
     remove_index :code_review_comments,
       name: 'index_code_review_comments_on_project_id_and_version',

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_24_200622) do
+ActiveRecord::Schema.define(version: 2021_06_29_133900) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -265,7 +265,8 @@ ActiveRecord::Schema.define(version: 2021_06_24_200622) do
   end
 
   create_table "code_review_comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
-    t.integer "channel_token_id", null: false
+    t.integer "storage_id", null: false
+    t.integer "storage_app_id", null: false
     t.string "project_version", null: false
     t.integer "commenter_id", null: false
     t.text "comment", limit: 16777215
@@ -276,7 +277,7 @@ ActiveRecord::Schema.define(version: 2021_06_24_200622) do
     t.timestamp "deleted_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["channel_token_id", "project_version"], name: "index_code_review_comments_on_project_id_and_version"
+    t.index ["storage_id", "storage_app_id", "project_version"], name: "index_code_review_comments_on_project_identifier_and_version"
   end
 
   create_table "concepts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -265,7 +265,6 @@ ActiveRecord::Schema.define(version: 2021_06_29_133900) do
   end
 
   create_table "code_review_comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
-    t.integer "storage_id", null: false
     t.integer "storage_app_id", null: false
     t.string "project_version", null: false
     t.integer "commenter_id", null: false
@@ -277,7 +276,7 @@ ActiveRecord::Schema.define(version: 2021_06_29_133900) do
     t.timestamp "deleted_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["storage_id", "storage_app_id", "project_version"], name: "index_code_review_comments_on_project_identifier_and_version"
+    t.index ["storage_app_id", "project_version"], name: "index_code_review_comments_on_storage_app_id_and_version"
   end
 
   create_table "concepts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|

--- a/dashboard/test/controllers/code_review_comments_controller_test.rb
+++ b/dashboard/test/controllers/code_review_comments_controller_test.rb
@@ -8,16 +8,14 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
     create(:single_user_experiment, min_user_id: @pilot_teacher.id, name: 'csa-pilot')
   end
 
+  setup {sign_in @pilot_teacher}
+
   test 'can create CodeReviewComment' do
-    sign_in(@pilot_teacher)
-
-    channel_token = create :channel_token
-    commenter = create :teacher
-
     post :create, params: {
-      channel_token_id: channel_token.id,
+      storage_id: 1,
+      storage_app_id: 2,
       project_version: 'a_project_version_string',
-      commenter_id: commenter.id,
+      commenter_id: @pilot_teacher.id,
       comment: 'a comment'
     }
 
@@ -25,8 +23,6 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
   end
 
   test 'can delete CodeReviewComment' do
-    sign_in(@pilot_teacher)
-
     code_review_comment = create :code_review_comment
 
     assert_not_nil CodeReviewComment.find_by(id: code_review_comment.id)
@@ -40,32 +36,27 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
   end
 
   test 'can get all comments for a given project and version' do
-    sign_in(@pilot_teacher)
-
-    channel_token = create :channel_token
+    project_identifiers = {
+      storage_id: 1234,
+      storage_app_id: 5678,
+      project_version: 'test_get_project_comments_string'
+    }
 
     2.times do
-      create :code_review_comment,
-        channel_token: channel_token,
-        project_version: 'test_get_project_comments_string'
+      create :code_review_comment, project_identifiers
     end
 
     # Create third code review comment from another project
     # to make sure we only fetch the correct set of comments.
     create :code_review_comment
 
-    get :project_comments, params: {
-      channel_token_id: channel_token.id,
-      project_version: 'test_get_project_comments_string'
-    }
+    get :project_comments, params: project_identifiers
 
     assert_response :success
     assert_equal 2, JSON.parse(response.body).length
   end
 
-  test 'renders successfully for project with no comments' do
-    sign_in(@pilot_teacher)
-
+  test 'responds successfully for project with no comments' do
     channel_token = create :channel_token
 
     get :project_comments, params: {
@@ -78,8 +69,6 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
   end
 
   test 'can mark comment as resolved' do
-    sign_in(@pilot_teacher)
-
     code_review_comment = create :code_review_comment
 
     assert_nil code_review_comment.is_resolved

--- a/dashboard/test/controllers/code_review_comments_controller_test.rb
+++ b/dashboard/test/controllers/code_review_comments_controller_test.rb
@@ -12,8 +12,7 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
 
   test 'can create CodeReviewComment' do
     post :create, params: {
-      storage_id: 1,
-      storage_app_id: 2,
+      storage_app_id: 1,
       project_version: 'a_project_version_string',
       commenter_id: @pilot_teacher.id,
       comment: 'a comment'
@@ -37,8 +36,7 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
 
   test 'can get all comments for a given project and version' do
     project_identifiers = {
-      storage_id: 1234,
-      storage_app_id: 5678,
+      storage_app_id: 1234,
       project_version: 'test_get_project_comments_string'
     }
 

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -1381,7 +1381,9 @@ FactoryGirl.define do
 
   factory :code_review_comment do
     association :commenter, factory: :teacher
-    association :channel_token
+
+    storage_id 1
+    storage_app_id 2
     project_version 'a_project_version_string'
     comment 'a comment about your project'
   end

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -1382,8 +1382,7 @@ FactoryGirl.define do
   factory :code_review_comment do
     association :commenter, factory: :teacher
 
-    storage_id 1
-    storage_app_id 2
+    storage_app_id 1
     project_version 'a_project_version_string'
     comment 'a comment about your project'
   end


### PR DESCRIPTION
Use `storage_app_id` to uniquely identify projects instead of `channel_token_id` when storing code review comments.

## Testing story

Updated existing controller tests to account for the update. Ran migration up and down.