### PR TITLE
[AiLab] re-order model card sections, string updates

### DIFF
--- a/apps/src/code-studio/components/ModelCard.jsx
+++ b/apps/src/code-studio/components/ModelCard.jsx
@@ -52,12 +52,16 @@ export default class ModelCard extends React.Component {
             </div>
             <br />
             <div style={styles.subPanel}>
-              <div style={styles.heading}>Summary</div>
-              <p style={styles.details}>
-                Predict {metadata.label.id} based on{' '}
-                {selectedFeatures.join(', ')} with {metadata.summaryStat?.stat}%
-                accuracy.
-              </p>
+              <div style={styles.heading}>Accuracy</div>
+              <p style={styles.details}>{metadata.summaryStat?.stat}%</p>
+            </div>
+            <div style={styles.subPanel}>
+              <div style={styles.heading}>Intended Use</div>
+              <p style={styles.details}>{metadata.potentialUses}</p>
+            </div>
+            <div style={styles.subPanel}>
+              <div style={styles.heading}>Warnings and Limitations</div>
+              <p style={styles.details}>{metadata.potentialMisuses}</p>
             </div>
             <div style={styles.subPanel}>
               <div style={styles.heading}>About the Data</div>
@@ -72,12 +76,11 @@ export default class ModelCard extends React.Component {
               )}
             </div>
             <div style={styles.subPanel}>
-              <div style={styles.heading}>Intended Use</div>
-              <p style={styles.details}>{metadata.potentialUses}</p>
-            </div>
-            <div style={styles.subPanel}>
-              <div style={styles.heading}>Warnings</div>
-              <p style={styles.details}>{metadata.potentialMisuses}</p>
+              <div style={styles.heading}>Features and Label</div>
+              <p style={styles.details}>
+                Predict {metadata.label.id} based on{' '}
+                {selectedFeatures.join(', ')}.
+              </p>
             </div>
             <div style={styles.subPanel}>
               <div style={styles.heading}>Label</div>


### PR DESCRIPTION
Re-ordered sections of the Save Model form and the Model Card and updated a few strings per[ request](https://docs.google.com/document/d/1GLDEz5Nb6SYqTohXU992fAxS-D0Lg8cQA5ic9dJCNXA/edit) from the Curriculum team. Similar updates were made in ml-playground (https://github.com/code-dot-org/ml-playground/pull/256). 
![Screen Shot 2021-06-29 at 3 33 19 PM](https://user-images.githubusercontent.com/12300669/123857360-2afe6d80-d8f0-11eb-8db8-dd60bda062cb.png)
![Screen Shot 2021-06-29 at 3 33 25 PM](https://user-images.githubusercontent.com/12300669/123857402-3c477a00-d8f0-11eb-9ea5-7ff22413f349.png)
