### PR TITLE
Only postprocess Lesson content if we have translations

### DIFF
--- a/dashboard/lib/services/i18n/curriculum_sync_utils/sync_out.rb
+++ b/dashboard/lib/services/i18n/curriculum_sync_utils/sync_out.rb
@@ -40,21 +40,23 @@ module Services
             # We use URLs as keys for lessons in Crowdin, to make things easier for
             # translators. For the actual translation files, though, we'd like to use
             # more-standard keys.
-            rekeyed_lessons = result[:lessons].map do |lesson_url, lesson_data|
-              route_params = Rails.application.routes.recognize_path(lesson_url)
-              lesson = Lesson.joins(:script).
-                find_by(
-                  "scripts.name": route_params[:script_id],
-                  relative_position: route_params[:position].to_i,
-                  has_lesson_plan: true
-                )
-              unless lesson.present?
-                STDERR.puts "could not find lesson for url #{lesson_url.inspect}"
-                next
+            if result.key?(:lessons)
+              rekeyed_lessons = result[:lessons].map do |lesson_url, lesson_data|
+                route_params = Rails.application.routes.recognize_path(lesson_url)
+                lesson = Lesson.joins(:script).
+                  find_by(
+                    "scripts.name": route_params[:script_id],
+                    relative_position: route_params[:position].to_i,
+                    has_lesson_plan: true
+                  )
+                unless lesson.present?
+                  STDERR.puts "could not find lesson for url #{lesson_url.inspect}"
+                  next
+                end
+                [Services::GloballyUniqueIdentifiers.build_lesson_key(lesson), lesson_data]
               end
-              [Services::GloballyUniqueIdentifiers.build_lesson_key(lesson), lesson_data]
+              result[:lessons] = rekeyed_lessons.compact.to_h
             end
-            result[:lessons] = rekeyed_lessons.compact.to_h
 
             # Finally, write each resulting collection of strings out to a rails i18n
             # config file.


### PR DESCRIPTION
Otherwise, any language that hasn't translated any Lesson content will fail because `result[:lessons]` is expected to be `nil` in that case.

I recommend reviewing with whitespace changes disabled: https://github.com/code-dot-org/code-dot-org/pull/41374/files?w=1

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
