### PR TITLE
Add some text to email links so they can still be accessed if the email provider strips links

### DIFF
--- a/dashboard/app/views/pd/workshop_mailer/_how_to_cancel.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/_how_to_cancel.html.haml
@@ -12,6 +12,7 @@
   - else
     We know things come up and you may no longer be able to attend. Please click this link to
     = link_to 'cancel your registration', @cancel_url, target: "_blank", rel: "noopener noreferrer"
+    = '(' + @cancel_url + ')'
     if you aren't going to be able to make it.
     - unless @workshop.virtual?
       Workshop materials and food are ordered based on enrollment numbers.

--- a/dashboard/app/views/pd/workshop_mailer/_pre_course_survey.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/_pre_course_survey.html.haml
@@ -4,6 +4,7 @@
 %p
   Before starting your summer workshop,
   = link_to "please take this survey", @pre_workshop_survey_url, target: "_blank", rel: "noopener noreferrer"
+  = '(' + @pre_workshop_survey_url + ')'
   about your thoughts on computer science, teaching, and learning.
 
 %p

--- a/dashboard/app/views/pd/workshop_mailer/_pre_order_materials.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/_pre_order_materials.html.haml
@@ -18,6 +18,6 @@
       The materials are available at no cost to you and include the Code.org curriculum guide and swag.
 %p
   = link_to 'Click here', 'https://studio.code.org/form/virtual_order_form', target: "_blank", rel: "noopener noreferrer"
-  to provide Code.org with your shipping address
+  (https://studio.code.org/form/virtual_order_form) to provide Code.org with your shipping address
   %strong (NOTE: we're unable to deliver to PO boxes).
   If you prefer to reference digital versions of the materials, you can skip this step!


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Links in some emails have been getting stripped out due to spam detection, so we want to add a text version of the link to allow the recipient to copy and paste it into their browser as an alternative. I've only added this text for the essential links that aren't easily accessible elsewhere on the website.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [PLC-1255](https://codedotorg.atlassian.net/browse/PLC-1255)

## Testing story

Previewed in rails mailer previewer

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->
