### PR TITLE
gitignore piskel and curriculum_content i18n artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,5 @@ npm-debug.log
 /rebuild-code-studio
 /tools/scripts/brokenLinkChecker/node_modules/
 /i18n/locales/*/codeorg-markdown/
+/i18n/locales/*/curriculum_content/
+/i18n/locales/*/piskel/


### PR DESCRIPTION
We have added some new things to the i18n sync which don't need to be tracked by git. Without this change, the `i18n-dev` server shows a lot of untracked files when you run `git status`. This will also provide confidence for future developers that this content doesn't need to be committed.


## Testing story
Ran `git status` on my laptop after running the sync scripts

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
