### PR TITLE
Revert "Update ui-test-versioned-script"

### DIFF
--- a/dashboard/config/scripts_json/allthemigratedthings.script_json
+++ b/dashboard/config/scripts_json/allthemigratedthings.script_json
@@ -13,7 +13,7 @@
       "include_student_lesson_plans": true
     },
     "new_name": null,
-    "family_name": "ui-test-versioned-unit",
+    "family_name": "ui-test-versioned-script",
     "serialized_at": "2021-06-16 23:01:32 UTC",
     "published_state": "beta",
     "seeding_key": {

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -1782,22 +1782,22 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   end
 
   test 'should redirect to 2017 version in script family' do
-    cats1 = create :script, name: 'cats1', family_name: 'ui-test-versioned-unit', version_year: '2017'
+    cats1 = create :script, name: 'cats1', family_name: 'ui-test-versioned-script', version_year: '2017'
 
     assert_raises ActiveRecord::RecordNotFound do
-      get :show, params: {script_id: 'ui-test-versioned-unit', lesson_position: 1, id: 1}
+      get :show, params: {script_id: 'ui-test-versioned-script', lesson_position: 1, id: 1}
     end
 
     cats1.update!(published_state: SharedConstants::PUBLISHED_STATE.stable)
-    get :show, params: {script_id: 'ui-test-versioned-unit', lesson_position: 1, id: 1}
+    get :show, params: {script_id: 'ui-test-versioned-script', lesson_position: 1, id: 1}
     assert_redirected_to "/s/cats1/lessons/1/levels/1"
 
-    create :script, name: 'cats2', family_name: 'ui-test-versioned-unit', version_year: '2018', published_state: SharedConstants::PUBLISHED_STATE.stable
-    get :show, params: {script_id: 'ui-test-versioned-unit', lesson_position: 1, id: 1}
+    create :script, name: 'cats2', family_name: 'ui-test-versioned-script', version_year: '2018', published_state: SharedConstants::PUBLISHED_STATE.stable
+    get :show, params: {script_id: 'ui-test-versioned-script', lesson_position: 1, id: 1}
     assert_redirected_to "/s/cats2/lessons/1/levels/1"
 
     # next redirects to latest version in a script family
-    get :next, params: {script_id: 'ui-test-versioned-unit'}
+    get :next, params: {script_id: 'ui-test-versioned-script'}
     assert_redirected_to "/s/cats2/next"
   end
 

--- a/dashboard/test/ui/config/scripts/ui-test-versioned-script-2017.script
+++ b/dashboard/test/ui/config/scripts/ui-test-versioned-script-2017.script
@@ -1,4 +1,4 @@
-family_name 'ui-test-versioned-unit'
+family_name 'ui-test-versioned-script'
 version_year '2017'
 published_state 'stable'
 

--- a/dashboard/test/ui/config/scripts/ui-test-versioned-script-2019.script
+++ b/dashboard/test/ui/config/scripts/ui-test-versioned-script-2019.script
@@ -1,4 +1,4 @@
-family_name 'ui-test-versioned-unit'
+family_name 'ui-test-versioned-script'
 version_year '2019'
 published_state 'stable'
 

--- a/lib/cdo/script_constants.rb
+++ b/lib/cdo/script_constants.rb
@@ -317,7 +317,7 @@ module ScriptConstants
     AIML = "aiml".freeze,
 
     # Testing
-    TEST = 'ui-test-versioned-unit'.freeze
+    TEST = 'ui-test-versioned-script'.freeze
   ].freeze
 
   def self.unit_in_category?(category, script)

--- a/lib/cdo/script_constants.rb
+++ b/lib/cdo/script_constants.rb
@@ -317,6 +317,9 @@ module ScriptConstants
     AIML = "aiml".freeze,
 
     # Testing
+    #
+    # note that this constant is hard to rename from 'script' to 'unit' because
+    # doing so causes the course version to change, causing seeding to fail.
     TEST = 'ui-test-versioned-script'.freeze
   ].freeze
 


### PR DESCRIPTION
This reverts commit 50f4c52b2c0166c2dc95b83acc27efa32772dd3a, reverting part of https://github.com/code-dot-org/code-dot-org/pull/41332. 50f4c52b2c0166c2dc95b83acc27efa32772dd3a resulted in the following error while seeding in development, staging and test:
```
Error adding unit named 'allthemigratedthings': cannot change course version of allthemigratedthings
/Users/dsb/src/cdo/dashboard/app/models/course_version.rb:76:in `add_course_version'
/Users/dsb/src/cdo/dashboard/app/models/course_offering.rb:49:in `add_course_offering'
/Users/dsb/src/cdo/dashboard/lib/services/script_seed.rb:196:in `block in seed_from_hash'
/Users/dsb/src/cdo/dashboard/lib/services/script_seed.rb:184:in `seed_from_hash'
/Users/dsb/src/cdo/dashboard/lib/services/curriculum_pdfs/script_seed.rb:28:in `seed_from_hash'
/Users/dsb/src/cdo/dashboard/lib/services/script_seed.rb:119:in `seed_from_json'
/Users/dsb/src/cdo/dashboard/lib/services/script_seed.rb:111:in `seed_from_json_file'
/Users/dsb/src/cdo/dashboard/app/models/script.rb:1979:in `seed_from_json_file'
/Users/dsb/src/cdo/dashboard/app/models/script.rb:1009:in `block in setup'
/Users/dsb/src/cdo/dashboard/app/models/script.rb:1006:in `map'
/Users/dsb/src/cdo/dashboard/app/models/script.rb:1006:in `setup'
/Users/dsb/src/cdo/dashboard/lib/tasks/seed.rake:174:in `update_scripts'
/Users/dsb/src/cdo/dashboard/lib/tasks/seed.rake:208:in `block (2 levels) in <top (required)>'
/Users/dsb/src/cdo/dashboard/lib/tasks/seed.rake:15:in `block in execute'
/Users/dsb/src/cdo/dashboard/lib/tasks/seed.rake:15:in `execute'
```

The problem was not caught by drone presumably because drone seeds a fresh copy of the database, whereas the error is only raised if the system detects a change between the existing DB contents and the newly seeded data.

For now I am not planning to follow up and try to restore the problematic commit. Once the rest of the script --> unit rename is done, we can decide if we think it's worth it to circle back and change this constant name.

## Testing story

Verified locally that `rake seed:scripts` succeeds