### PR TITLE
Adding setup instructions for seting up i18n

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -306,6 +306,13 @@ If you want to make JavaScript changes and have them take effect locally, you'll
 
 This configures dashboard to rebuild apps whenever you run `bundle exec rake build` and to use the version that you built yourself.  See the documentation in that directory for faster ways to build and iterate.
 
+## Enabling internationalization(i18n) / translations
+If you want to enable the ability to switch Code.org to display different languages:
+1. Edit `locals.yml` and enable the following options:
+   ```
+   # code-dot-org/locals.yml
+   load_locales: true
+   ```
 ## Editor configuration
 
 We enforce linting rules for all our code, and we recommend you set up your editor to integrate with that linting.


### PR DESCRIPTION
Updating the developer setup documentation to include the configuration for displaying the code.org website in other languages.