### PR TITLE
rename back to ui-test-versioned-script in ScriptsControllerTest

### DIFF
--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -1043,22 +1043,22 @@ class ScriptsControllerTest < ActionController::TestCase
   test 'should redirect to latest stable version in unit family for student without progress or assignment' do
     sign_in create(:student)
 
-    dogs1 = create :script, name: 'dogs1', family_name: 'ui-test-versioned-unit', version_year: '1901'
+    dogs1 = create :script, name: 'dogs1', family_name: 'ui-test-versioned-script', version_year: '1901'
 
     assert_raises ActiveRecord::RecordNotFound do
-      get :show, params: {id: 'ui-test-versioned-unit'}
+      get :show, params: {id: 'ui-test-versioned-script'}
     end
 
     dogs1.update!(published_state: SharedConstants::PUBLISHED_STATE.stable)
-    get :show, params: {id: 'ui-test-versioned-unit'}
+    get :show, params: {id: 'ui-test-versioned-script'}
     assert_redirected_to "/s/dogs1"
 
-    create :script, name: 'dogs2', family_name: 'ui-test-versioned-unit', version_year: '1902', published_state: SharedConstants::PUBLISHED_STATE.stable
-    get :show, params: {id: 'ui-test-versioned-unit'}
+    create :script, name: 'dogs2', family_name: 'ui-test-versioned-script', version_year: '1902', published_state: SharedConstants::PUBLISHED_STATE.stable
+    get :show, params: {id: 'ui-test-versioned-script'}
     assert_redirected_to "/s/dogs2"
 
-    create :script, name: 'dogs3', family_name: 'ui-test-versioned-unit', version_year: '1899', published_state: SharedConstants::PUBLISHED_STATE.stable
-    get :show, params: {id: 'ui-test-versioned-unit'}
+    create :script, name: 'dogs3', family_name: 'ui-test-versioned-script', version_year: '1899', published_state: SharedConstants::PUBLISHED_STATE.stable
+    get :show, params: {id: 'ui-test-versioned-script'}
     assert_redirected_to "/s/dogs2"
   end
 


### PR DESCRIPTION
Follow-on to https://github.com/code-dot-org/code-dot-org/pull/41383, which fixed the seeding problem but broke ScriptsControllerTest.

## Testing story
* I am not planning to wait for a drone run, in hopes of unblocking the build soonest
* I verified manually that scripts_controller_test.rb is passing locally now
* verified there are no other instances of `ui-test-versioned-script` remaining in the codebase
* verified there are no other failures or errors in https://s3.console.aws.amazon.com/s3/object/cdo-build-logs?region=us-east-1&prefix=test/20210630T181904%2B0000