### PR TITLE
Revert "[Google Blockly][Spritelab] Implement Preview"

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -1004,7 +1004,8 @@ StudioApp.prototype.runChangeHandlers = function() {
 StudioApp.prototype.setupChangeHandlers = function() {
   const runAllHandlers = this.runChangeHandlers.bind(this);
   if (this.isUsingBlockly()) {
-    Blockly.addChangeListener(runAllHandlers);
+    const blocklyCanvas = Blockly.mainBlockSpace.getCanvas();
+    blocklyCanvas.addEventListener('blocklyBlockSpaceChange', runAllHandlers);
   } else {
     this.editor.on('change', runAllHandlers);
     // Droplet doesn't automatically bubble up aceEditor changes

--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -389,15 +389,10 @@ P5Lab.prototype.init = function(config) {
     this.setCrosshairCursorForPlaySpace();
 
     if (this.isSpritelab) {
-      this.currentCode = Blockly.getWorkspaceCode();
       this.studioApp_.addChangeHandler(() => {
-        const newCode = Blockly.getWorkspaceCode();
-        if (newCode !== this.currentCode) {
-          this.currentCode = newCode;
-          if (!getStore().getState().runState.isRunning) {
-            this.reset();
-            this.preview.apply(this);
-          }
+        if (!getStore().getState().runState.isRunning) {
+          this.reset();
+          this.preview.apply(this);
         }
       });
     }

--- a/apps/src/sites/studio/pages/blocks/edit.js
+++ b/apps/src/sites/studio/pages/blocks/edit.js
@@ -127,7 +127,9 @@ function updateBlockPreview() {
   const blocksDom = parseElement(`<block type="${blockName}" />`);
   Blockly.mainBlockSpace.clear();
   Blockly.Xml.domToBlockSpace(Blockly.mainBlockSpace, blocksDom);
-  Blockly.addChangeListener(onBlockSpaceChange);
+  Blockly.mainBlockSpace
+    .getCanvas()
+    .addEventListener('blocklyBlockSpaceChange', onBlockSpaceChange);
 }
 
 function onBlockSpaceChange() {

--- a/apps/src/sites/studio/pages/cdoBlocklyWrapper.js
+++ b/apps/src/sites/studio/pages/cdoBlocklyWrapper.js
@@ -152,11 +152,6 @@ function initializeBlocklyWrapper(blocklyInstance) {
     return blocklyWrapper.Generator.get('JavaScript');
   };
 
-  blocklyWrapper.addChangeListener = function(handler) {
-    const blocklyCanvas = Blockly.mainBlockSpace.getCanvas();
-    blocklyCanvas.addEventListener('blocklyBlockSpaceChange', handler);
-  };
-
   blocklyWrapper.setInfiniteLoopTrap = function() {
     Blockly.JavaScript.INFINITE_LOOP_TRAP = INFINITE_LOOP_TRAP;
   };

--- a/apps/src/sites/studio/pages/googleBlocklyWrapper.js
+++ b/apps/src/sites/studio/pages/googleBlocklyWrapper.js
@@ -200,14 +200,6 @@ function initializeBlocklyWrapper(blocklyInstance) {
     }
   });
 
-  blocklyWrapper.addChangeListener = function(handler) {
-    Blockly.mainBlockSpace.addChangeListener(handler);
-  };
-
-  blocklyWrapper.getWorkspaceCode = function() {
-    return Blockly.JavaScript.workspaceToCode(Blockly.mainBlockSpace);
-  };
-
   // TODO - used for spritelab behavior blocks
   blocklyWrapper.Block.createProcedureDefinitionBlock = function(config) {};
 

--- a/apps/src/templates/instructions/utils.js
+++ b/apps/src/templates/instructions/utils.js
@@ -157,19 +157,21 @@ export function convertXmlToBlockly(xmlContainer) {
     // resize after initial render, so we also want to resize the container
     // whenever a blockSpaceChange results in the content size changing.
     let metrics = blockSpace.getMetrics();
-    Blockly.addChangeListener(function() {
-      const oldHeight = metrics.contentHeight;
-      const oldWidth = metrics.contentWidth;
-      const newHeight = blockSpace.getMetrics().contentHeight;
-      const newWidth = blockSpace.getMetrics().contentWidth;
+    blockSpace
+      .getCanvas()
+      .addEventListener('blocklyBlockSpaceChange', function() {
+        const oldHeight = metrics.contentHeight;
+        const oldWidth = metrics.contentWidth;
+        const newHeight = blockSpace.getMetrics().contentHeight;
+        const newWidth = blockSpace.getMetrics().contentWidth;
 
-      // if the blockspace's content size has changed, kick off another sync and
-      // save the new metrics as the old ones
-      if (newHeight !== oldHeight || newWidth !== oldWidth) {
-        shrinkBlockSpaceContainer(blockSpace, withPadding);
-        metrics = blockSpace.getMetrics();
-      }
-    });
+        // if the blockspace's content size has changed, kick off another sync and
+        // save the new metrics as the old ones
+        if (newHeight !== oldHeight || newWidth !== oldWidth) {
+          shrinkBlockSpaceContainer(blockSpace, withPadding);
+          metrics = blockSpace.getMetrics();
+        }
+      });
 
     shrinkBlockSpaceContainer(blockSpace, withPadding);
   });


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#41245 as it caused unexpected Eyes diffs ([Slack](https://codedotorg.slack.com/archives/C1B3PNDL7/p1625093007110000)).

Verified the diff is gone on an affected CSinA level:
<img width="835" alt="Screen Shot 2021-06-30 at 4 20 56 PM" src="https://user-images.githubusercontent.com/9812299/124043138-44221f80-d9bf-11eb-9695-92d837399541.png">
