### PR TITLE
Update links in pegasus to point to 2021 courses

### DIFF
--- a/pegasus/sites.v3/code.org/public/administrators-alt.erb
+++ b/pegasus/sites.v3/code.org/public/administrators-alt.erb
@@ -249,7 +249,7 @@ Did you know the best way to encourage students to try CS is to tell them theyâ€
 	<summary style="font-size: 18px">Are Code.orgâ€™s courses aligned to any standards?</summary>
 	<p>
 	<br>
-<p>Yes! Specifically, our courses were written using both the K-12 Framework for Computer Science and the 2017 CSTA standards. Additionally, CS Principles was written to AP standards. View standards alignment for each of our courses here: <a href="https://curriculum.code.org/csf-20/standards/" target="_blank">CSF</a>, <a href="https://curriculum.code.org/csd-20/standards/" target="_blank">CSD</a>, <a href="https://curriculum.code.org/csp-20/standards/" target="_blank">CSP</a>.</p>
+<p>Yes! Specifically, our courses were written using both the K-12 Framework for Computer Science and the 2017 CSTA standards. Additionally, CS Principles was written to AP standards. View standards alignment for each of our courses here: <a href="https://curriculum.code.org/csf-20/standards/" target="_blank">CSF</a>, <a href="https://studio.code.org/courses/csd-2021/standards/" target="_blank">CSD</a>, <a href="https://studio.code.org/courses/csp-2021/standards/" target="_blank">CSP</a>.</p>
 <br>
 </details>
 

--- a/pegasus/sites.v3/code.org/public/administrators.erb
+++ b/pegasus/sites.v3/code.org/public/administrators.erb
@@ -242,7 +242,7 @@ Did you know the best way to encourage students to try CS is to tell them theyâ€
 	<summary style="font-size: 18px">Are Code.orgâ€™s courses aligned to any standards?</summary>
 	<p>
 	<br>
-<p>Yes! Specifically, our courses were written using both the K-12 Framework for Computer Science and the 2017 CSTA standards. Additionally, CS Principles was written to AP standards. View standards alignment for each of our courses here: <a href="https://curriculum.code.org/csf-20/standards/" target="_blank">CSF</a>, <a href="https://curriculum.code.org/csd-20/standards/" target="_blank">CSD</a>, <a href="https://curriculum.code.org/csp-20/standards/" target="_blank">CSP</a>.</p>
+<p>Yes! Specifically, our courses were written using both the K-12 Framework for Computer Science and the 2017 CSTA standards. Additionally, CS Principles was written to AP standards. View standards alignment for each of our courses here: <a href="https://curriculum.code.org/csf-20/standards/" target="_blank">CSF</a>, <a href="https://studio.code.org/courses/csd-2021/standards/" target="_blank">CSD</a>, <a href="https://studio.code.org/courses/csp-2021/standards/" target="_blank">CSP</a>.</p>
 <br>
 </details>
 

--- a/pegasus/sites.v3/code.org/public/admins-alt.erb
+++ b/pegasus/sites.v3/code.org/public/admins-alt.erb
@@ -237,7 +237,7 @@ Did you know the best way to encourage students to try CS is to tell them theyâ€
 	<summary style="font-size: 18px">Are Code.orgâ€™s courses aligned to any standards?</summary>
 	<p>
 	<br>
-<p>Yes! Specifically, our courses were written using both the K-12 Framework for Computer Science and the 2017 CSTA standards. Additionally, CS Principles was written to AP standards. View standards alignment for each of our courses here: <a href="https://curriculum.code.org/csf-20/standards/" target="_blank">CSF</a>, <a href="https://curriculum.code.org/csd-20/standards/" target="_blank">CSD</a>, <a href="https://curriculum.code.org/csp-20/standards/" target="_blank">CSP</a>.</p>
+<p>Yes! Specifically, our courses were written using both the K-12 Framework for Computer Science and the 2017 CSTA standards. Additionally, CS Principles was written to AP standards. View standards alignment for each of our courses here: <a href="https://curriculum.code.org/csf-20/standards/" target="_blank">CSF</a>, <a href="https://studio.code.org/courses/csd-2021/standards/" target="_blank">CSD</a>, <a href="https://studio.code.org/courses/csp-2021/standards/" target="_blank">CSP</a>.</p>
 <br>
 </details>
 

--- a/pegasus/sites.v3/code.org/public/admins-alt2.erb
+++ b/pegasus/sites.v3/code.org/public/admins-alt2.erb
@@ -284,7 +284,7 @@ Did you know the best way to encourage students to try CS is to tell them theyâ€
 	<summary style="font-size: 18px">Are Code.orgâ€™s courses aligned to any standards?</summary>
 	<p>
 	<br>
-<p>Yes! Specifically, our courses were written using both the K-12 Framework for Computer Science and the 2017 CSTA standards. Additionally, CS Principles was written to AP standards. View standards alignment for each of our courses here: <a href="https://curriculum.code.org/csf-20/standards/" target="_blank">CSF</a>, <a href="https://curriculum.code.org/csd-20/standards/" target="_blank">CSD</a>, <a href="https://curriculum.code.org/csp-20/standards/" target="_blank">CSP</a>.</p>
+<p>Yes! Specifically, our courses were written using both the K-12 Framework for Computer Science and the 2017 CSTA standards. Additionally, CS Principles was written to AP standards. View standards alignment for each of our courses here: <a href="https://curriculum.code.org/csf-20/standards/" target="_blank">CSF</a>, <a href="https://studio.code.org/courses/csd-2021/standards/" target="_blank">CSD</a>, <a href="https://studio.code.org/courses/csp-2021/standards/" target="_blank">CSP</a>.</p>
 <br>
 </details>
 

--- a/pegasus/sites.v3/code.org/public/admins.erb
+++ b/pegasus/sites.v3/code.org/public/admins.erb
@@ -246,7 +246,7 @@ Did you know the best way to encourage students to try CS is to tell them theyâ€
 	<summary style="font-size: 18px">Are Code.orgâ€™s courses aligned to any standards?</summary>
 	<p>
 	<br>
-<p>Yes! Specifically, our courses were written using both the K-12 Framework for Computer Science and the 2017 CSTA standards. Additionally, CS Principles was written to AP standards. View standards alignment for each of our courses here: <a href="https://curriculum.code.org/csf-20/standards/" target="_blank">CSF</a>, <a href="https://curriculum.code.org/csd-20/standards/" target="_blank">CSD</a>, <a href="https://curriculum.code.org/csp-20/standards/" target="_blank">CSP</a>.</p>
+<p>Yes! Specifically, our courses were written using both the K-12 Framework for Computer Science and the 2017 CSTA standards. Additionally, CS Principles was written to AP standards. View standards alignment for each of our courses here: <a href="https://curriculum.code.org/csf-20/standards/" target="_blank">CSF</a>, <a href="https://studio.code.org/courses/csd-2021/standards/" target="_blank">CSD</a>, <a href="https://studio.code.org/courses/csp-2021/standards/" target="_blank">CSP</a>.</p>
 <br>
 </details>
 

--- a/pegasus/sites.v3/code.org/public/afe/index.md.erb
+++ b/pegasus/sites.v3/code.org/public/afe/index.md.erb
@@ -87,7 +87,7 @@ You don’t have to be a software developer to teach CS. Our program is uniquely
 
 [col-33]
 
-[<center><img src="/images/animated-examples/lessonplans.png" style="width:300px">](https://curriculum.code.org/csp-20)</center>
+[<center><img src="/images/animated-examples/lessonplans.png" style="width:300px">](https://studio.code.org/courses/csp-2021)</center>
 
 <div style="margin-left: 15px; margin-top: 5px;">Teachers have access to daily lesson plans for each course. Along with integrated discussion goals, teaching tips, and assessment opportunities, our lesson plans come with detailed pacing instructions, activity guides, exemplar projects, sample marked rubrics, and more!</div>
 

--- a/pegasus/sites.v3/code.org/public/afe/start-codeorg.md.erb
+++ b/pegasus/sites.v3/code.org/public/afe/start-codeorg.md.erb
@@ -78,7 +78,7 @@ You don’t have to be a software developer to teach CS. Our program is uniquely
 
 [col-33]
 
-[<center><img src="/images/animated-examples/lessonplans.png" style="width:300px">](https://curriculum.code.org/csp-20)</center>
+[<center><img src="/images/animated-examples/lessonplans.png" style="width:300px">](https://studio.code.org/courses/csp-2021)</center>
 
 <div style="margin-left: 15px; margin-top: 5px;">Teachers have access to daily lesson plans for each course. Along with integrated discussion goals, teaching tips, and assessment opportunities, our lesson plans come with detailed pacing instructions, activity guides, exemplar projects, sample marked rubrics, and more!</div>
 

--- a/pegasus/sites.v3/code.org/public/educate/applab.haml
+++ b/pegasus/sites.v3/code.org/public/educate/applab.haml
@@ -94,7 +94,7 @@ video_player: true
       %th Unit description
     %tr
       %td
-        %a{href: CDO.studio_url("/s/csp3-2020")}
+        %a{href: CDO.studio_url("/s/csp3-2021")}
           %img{src: "/educate/csp/images/unit3.png"}
           Unit 3
       %td
@@ -102,7 +102,7 @@ video_player: true
         %p Students design their first app while learning both fundamental programming concepts and collaborative software development processes. Students work with partners to develop a simple app that teaches classmates about a topic of personal interest. Throughout the unit, they learn how to use Code.org’s programming environment, App Lab, to design user interfaces and write simple event-driven programs. Along the way, students learn practices like debugging, pair programming, and collecting and responding to feedback, which they will be able to use throughout the course as they build ever more complex projects. The unit concludes with students sharing the apps they develop with their classmates.
     %tr
       %td
-        %a{href: CDO.studio_url("/s/csp4-2020")}
+        %a{href: CDO.studio_url("/s/csp4-2021")}
           %img{src: "/educate/csp/images/unit4.png"}
           Unit 4
       %td
@@ -110,7 +110,7 @@ video_player: true
         %p Students expand the types of apps they can create as they learn how to store information (variables), make decisions (conditionals), and better organize code (functions). Each programming topic is covered in a specific sequence of lessons that ask students to ‘Explore’ ideas through hands-on activities, ‘Investigate’ these ideas through guided code reading, ‘Practice’ with sample problems, and apply their understanding as they ‘Make’ a one-day scoped project. The entire unit concludes with a three-day open-ended project in which students must build an app that makes a recommendation about any topic they wish.
     %tr
       %td
-        %a{href: CDO.studio_url("/s/csp5-2020")}
+        %a{href: CDO.studio_url("/s/csp5-2021")}
           %img{src: "/educate/csp/images/unit5.png"}
           Unit 5
       %td
@@ -118,7 +118,7 @@ video_player: true
         %p Students learn to build apps that use and process lists of information. Like the previous unit, students learn the core concepts of lists, loops, and traversals through a series of EIPM lesson sequences. Later in the unit, students are introduced to tools that allow them to import tables of real-world data to help further power the types of apps they can make. At the conclusion of the unit, students complete a week-long project in which they must design an app around a goal of their choosing that uses one of these data sets.
     %tr
       %td
-        %a{href: CDO.studio_url("/s/csp7-2020")}
+        %a{href: CDO.studio_url("/s/csp7-2021")}
           %img{src: "/educate/csp/images/unit7.png"}
           Unit 7
       %td
@@ -126,7 +126,7 @@ video_player: true
         %p Students learn how to design clean and reusable code that can be shared with a single classmate or the entire world. In the beginning of the unit, students are introduced to the concepts of parameters and return, which allow for students to design functions that implement an algorithm. In the second half of the unit, students learn how to design libraries of functions that can be packaged up and shared with others. The unit concludes with students designing their own small library of functions that can be used by a classmate.
     %tr
       %td
-        %a{href: CDO.studio_url("/s/csp9-2020")}
+        %a{href: CDO.studio_url("/s/csp9-2021")}
           %img{src: "/educate/csp/images/unit9.png"}
           Unit 9
       %td
@@ -143,7 +143,7 @@ video_player: true
       %th Unit description
     %tr
       %td
-        %a{href: CDO.studio_url("/s/csd4-2020")}
+        %a{href: CDO.studio_url("/s/csd4-2021")}
           %img{src: "/educate/csp/images/thumb_app.png"}
           Unit 4
       %td

--- a/pegasus/sites.v3/code.org/public/educate/csd.md.erb
+++ b/pegasus/sites.v3/code.org/public/educate/csd.md.erb
@@ -25,7 +25,7 @@ theme: responsive
 <p>CS Discoveries can be flexibly taught as a single semester, two semesters over multiple years, or as a full-year course. Options are even available for less than one semester. Our curriculum is available at <a href="/commitment", target=_"blank">no cost</a> for anyone, anywhere to teach. And, <a href="/educate/professional-learning/middle-high">professional learning opportunities</a> are available!</p>
 
 <p>
-<a href="https://curriculum.code.org/csd-20", target=_"blank"><button>Check out the course!</button></a>
+<a href="https://studio.code.org/courses/csd-2021", target=_"blank"><button>Check out the course!</button></a>
 <p>
 
 </div>
@@ -109,15 +109,15 @@ The CS Discoveries curriculum features a unit on artificial intelligence (AI) an
 
 <center><a href="https://docs.google.com/document/d/1-O6o5yQ4I1dk0n4Qzh86quXGBtzDDtyJ3Skr6RpcpO4/preview", target=_"blank"><img src="/images/csd/csd-crop-cover-20-21.png" style="width:300px"></a></center>
 
-<div style="margin-left: 15px; margin-top: 10px;">Check out the <a href="https://curriculum.code.org/csd-20/", target=_"blank">CS Discoveries curriculum page</a> for our series of guides designed to help support new and veteran teachers. These include the Getting Started Guide and the latest Curriculum Guide, where you'll learn about the classroom and student practices that flow throughout the course and how to navigate course tools. Also available are the Implementation Guide, the Assessment Guide, and the Debugging Guide.</div>
+<div style="margin-left: 15px; margin-top: 10px;">Check out the <a href="https://studio.code.org/courses/csd-2021", target=_"blank">CS Discoveries curriculum page</a> for our series of guides designed to help support new and veteran teachers. These include the Getting Started Guide and the latest Curriculum Guide, where you'll learn about the classroom and student practices that flow throughout the course and how to navigate course tools. Also available are the Implementation Guide, the Assessment Guide, and the Debugging Guide.</div>
 
 [/col-33]
 
 [col-33]
 
-[<center><img src="/images/animated-examples/lessonplans_csd.png" style="width:300px">](https://curriculum.code.org/csd-20)</center>
+[<center><img src="/images/animated-examples/lessonplans_csd.png" style="width:300px">](https://studio.code.org/courses/csd-2021)</center>
 
-<div style="margin-left: 15px; margin-top: 10px;">The CS Discoveries curriculum page is also where teachers can access to <a href="https://curriculum.code.org/csd-20">daily lesson plans</a>. Along with integrated discussion goals, teaching tips, and assessment opportunities, our lesson plans come with detailed pacing instructions, activity guides, exemplar projects, sample marked rubrics, and more!</div>
+<div style="margin-left: 15px; margin-top: 10px;">The CS Discoveries curriculum page is also where teachers can access to <a href="https://studio.code.org/courses/csd-2021">daily lesson plans</a>. Along with integrated discussion goals, teaching tips, and assessment opportunities, our lesson plans come with detailed pacing instructions, activity guides, exemplar projects, sample marked rubrics, and more!</div>
 
 [/col-33]
 
@@ -266,10 +266,10 @@ In addition to computer access, you'll need:
 * Worksheet Printing (There are worksheets with some lessons. We also provide Google Docs of our activity guides, which some teachers use to help reduce printing.)
 * A few decks of cards (we recommend one deck per 8 students)
 * Choose from one of the following sets of materials for collaborative activities:
-  * Option 1 - [Aluminum Boats](https://curriculum.code.org/csd-20/unit1/1/): Aluminum foil and containers that can hold water
-  * Option 2 - [Newspaper Tower](https://curriculum.code.org/csd-20/unit1/9/): A set of newspapers and several tape dispensers
-  * Option 3 - [Spaghetti Bridge](https://curriculum.code.org/csd-20/unit1/10/): Several boxes of spaghetti and several glue guns 
-  * Option 4 - [Paper Tower](https://curriculum.code.org/csd-20/unit1/11/): a ream of printer paper
+  * Option 1 - [Aluminum Boats](https://studio.code.org/s/csd1-2021/lessons/1): Aluminum foil and containers that can hold water
+  * Option 2 - [Newspaper Tower](https://studio.code.org/s/csd1-2021/lessons/9): A set of newspapers and several tape dispensers
+  * Option 3 - [Spaghetti Bridge](https://studio.code.org/s/csd1-2021/lessons/10): Several boxes of spaghetti and several glue guns
+  * Option 4 - [Paper Tower](https://studio.code.org/s/csd1-2021/lessons/11): a ream of printer paper
 * [Adafruit's Circuit Playground Boards](/circuitplayground), Micro USB cables, and alligator clip wires & LEDs included in classroom kits. The curriculum is designed for a ratio of 2 students to 1 board & 1 usb cable.
 
 To learn more about getting Adafruit Circuit Playground Boards for your classroom and their software requirements, please visit <a href="/circuitplayground">code.org/circuitplayground</a>

--- a/pegasus/sites.v3/code.org/public/educate/csp.md.erb
+++ b/pegasus/sites.v3/code.org/public/educate/csp.md.erb
@@ -34,7 +34,7 @@ style_min: true
 
 <p>This year-long course can be taught as an introductory course and as an AP course - no prerequisites required for students or for teachers new to computer science! In addition, our curriculum is available at <strong>no cost</strong> for anyone, anywhere to teach. And, <a href="https://code.org/educate/professional-learning/middle-high">professional learning opportunities</a> are available!
 <p>
-<a href="https://curriculum.code.org/csp-20", target=_"blank"><button>Check out the course!</button></a>
+<a href="https://studio.code.org/courses/csp-2021", target=_"blank"><button>Check out the course!</button></a>
 <p>
 
 </div>
@@ -97,9 +97,9 @@ Every lesson plan and activity is tested by a diverse mix of classrooms around t
 
 [col-33]
 
-[<center><img src="/images/animated-examples/lessonplans.png" style="width:300px">](https://curriculum.code.org/csp-20)</center>
+[<center><img src="/images/animated-examples/lessonplans.png" style="width:300px">](https://studio.code.org/courses/csp-2021)</center>
 
-<div style="margin-left: 15px; margin-top: 5px;">The CS Principles curriculum page is where teachers can access <a href="https://curriculum.code.org/csp-20">daily lesson plans</a>. Along with integrated discussion goals, teaching tips, and assessment opportunities, our lesson plans come with detailed pacing instructions, activity guides, required resources, and more!</div>
+<div style="margin-left: 15px; margin-top: 5px;">The CS Principles curriculum page is where teachers can access <a href="https://studio.code.org/courses/csp-2021">daily lesson plans</a>. Along with integrated discussion goals, teaching tips, and assessment opportunities, our lesson plans come with detailed pacing instructions, activity guides, required resources, and more!</div>
 
 [/col-33]
 
@@ -270,7 +270,7 @@ While our course is intented to be taught in-person to build a collaborative and
 	<summary style="font-size: 18px">Is CS Principles mapped to standards?</summary>
 	<p>
 	<br/>
-CS Principles was written using the AP CS Principles Framework and prepares students for the AP CS Principles exam. The course has also been aligned to the newly revised 2017 CSTA standards. A summary of standards mappings can be found at [curriculum.code.org/csp/standards](https://curriculum.code.org/csp/standards)
+CS Principles was written using the AP CS Principles Framework and prepares students for the AP CS Principles exam. The course has also been aligned to the newly revised 2017 CSTA standards. A summary of standards mappings can be found at [studio.code.org/courses/csp-2021/standards](https://studio.code.org/courses/csp-2021/standards)
 </details>
 
 <details style="margin-left: 20px">

--- a/pegasus/sites.v3/code.org/public/educate/gamelab.haml
+++ b/pegasus/sites.v3/code.org/public/educate/gamelab.haml
@@ -28,7 +28,7 @@ video_player: true
   %h3= I18n.t("csd3_name")
   %h4 Grades 7 - 9
   .smalltext In Unit 3, students build on their coding experience as they create programmatic images, animations, interactive art, and games. Starting off with simple, primitive shapes and building up to more sophisticated sprite-based games, students become familiar with the programming concepts and the design process computer scientists use daily. They then learn how these simpler constructs can be combined to create more complex programs. In the final project, students develop a personalized, interactive program. Along the way, they practice design, testing, and iteration, as they come to see that failure and debugging are an expected and valuable part of the programming process.
-  %a{:href=>CDO.studio_url("/s/csd3-2019")}
+  %a{:href=>CDO.studio_url("/s/csd3-2021")}
     %button{style: "margin-top: 20px;"}= I18n.t(:view_unit)
 .clear
 

--- a/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/curriculum.md
+++ b/pegasus/sites.v3/code.org/public/educate/regional-partner/playbook/curriculum.md
@@ -27,7 +27,7 @@ Use the links below to find our program curriculum guides, course information, a
 
 ### [CS Principles](/educate/csp#lessons) (9-12)
 
-- [CS Principles Teacher Resources](http://curriculum.code.org/csp)
+- [CS Principles Teacher Resources](https://studio.code.org/courses/csp-2021)
   - [AP CS Principles One-Pager - 2020-21](https://code.org/files/2020-21_CSPrinciples_1-pager.pdf)
   - [AP CS Principles Curriculum Guide - 2019-20](https://docs.google.com/document/d/1ZVzF_-cON8pjDVUOZjVk32y4flCMXugcrA6gFeWDHzE/preview)
 

--- a/pegasus/sites.v3/code.org/public/educate/weblab.haml
+++ b/pegasus/sites.v3/code.org/public/educate/weblab.haml
@@ -15,6 +15,6 @@ video_player: true
   %h3= I18n.t("csd2_name")
   %h4 Grades 7 - 9
   .smalltext In Unit 2, students are empowered to create and share the content on their own web pages. They begin by thinking about the role of the web, and how it can be used as a medium for creative expression. As students develop their pages and begin to see themselves as programmers, they are encouraged think critically about the impact of sharing information online and how to be more critical content consumers. They are also introduced to problem solving as it relates to programming, as they learn valuable skills such as debugging, commenting, and structure of language. At the conclusion of the unit, students compile their work to create a personal website they can publish and share.
-  %a{:href=>CDO.studio_url("/s/csd2-2019")}
+  %a{:href=>CDO.studio_url("/s/csd2-2021")}
     %button{style: "margin-top: 20px;"}= I18n.t(:view_unit)
 .clear

--- a/pegasus/sites.v3/code.org/public/lesson_plans.haml
+++ b/pegasus/sites.v3/code.org/public/lesson_plans.haml
@@ -27,10 +27,10 @@ theme: responsive
   %h2= I18n.t :dashboard_curriculum_middle_title
   %p
     = I18n.t :dashboard_curriculum_csd
-    %a{href: "https://curriculum.code.org/csd", target: '_blank'}
+    %a{href: "https://studio.code.org/courses/csd-2021", target: '_blank'}
       = I18n.t :dashboard_lesson_plans
     |
-    %a{href: "https://curriculum.code.org/csd/standards", target: '_blank'}
+    %a{href: "https://studio.code.org/courses/csd-2021/standards", target: '_blank'}
       = I18n.t :dashboard_standards
 
   = view :course_curriculum, course: "express", series: "2.0"
@@ -56,10 +56,10 @@ theme: responsive
   %h2= I18n.t :dashboard_curriculum_high_title
   %p
     = I18n.t :dashboard_curriculum_csd
-    %a{href: "https://curriculum.code.org/csd", target: '_blank'}
+    %a{href: "https://studio.code.org/courses/csd-2021", target: '_blank'}
       = I18n.t :dashboard_lesson_plans
     |
-    %a{href: "https://curriculum.code.org/csd/standards", target: '_blank'}
+    %a{href: "https://studio.code.org/courses/csd-2021/standards", target: '_blank'}
       = I18n.t :dashboard_standards
 
   %p

--- a/pegasus/sites.v3/code.org/public/slp-administrators.md.erb
+++ b/pegasus/sites.v3/code.org/public/slp-administrators.md.erb
@@ -60,7 +60,7 @@ A primary source of funding for CS is through a school or a district’s general
 <h2>Step 2: Make computer science courses count</h2>
 
 <h3>Is Code.org’s AP CS Principles course aligned to any standards?</h3>
-Yes! Specifically, our course was written using both the K-12 Framework for Computer Science and the 2017 CSTA standards. Additionally, CS Principles was written to AP standards. View standards alignment for the course <a href="https://curriculum.code.org/csp-20/standards/", target=_"blank">here</a>. 
+Yes! Specifically, our course was written using both the K-12 Framework for Computer Science and the 2017 CSTA standards. Additionally, CS Principles was written to AP standards. View standards alignment for the course <a href="https://studio.code.org/courses/csp-2021/standards/", target=_"blank">here</a>.
 
 <h3>Does computer science count toward a graduation requirement in my state?</h3>
 

--- a/pegasus/sites.v3/code.org/views/course_curriculum.haml
+++ b/pegasus/sites.v3/code.org/views/course_curriculum.haml
@@ -18,8 +18,8 @@
 - elsif series == "2.0"
   %p
     = I18n.t("dashboard_#{course}")
-    %a{href: "https://curriculum.code.org/csf/#{course}", target: '_blank'}
+    %a{href: "https://studio.code.org/s/#{course}-2021", target: '_blank'}
       = I18n.t :dashboard_lesson_plans
     |
-    %a{href: "https://curriculum.code.org/csf/#{course}/standards", target: '_blank'}
+    %a{href: "https://studio.code.org/s/#{course}-2021/standards", target: '_blank'}
       = I18n.t :dashboard_standards


### PR DESCRIPTION
starts https://codedotorg.atlassian.net/browse/PLAT-599 . there are some more instances to change as well, which will come in subsequent PRs, or be made directly on the staging machine. since we are past the last deploy before hard launch, it seems better to merge these now and then follow up separately on the other items.

## Testing story

We will test this manually on staging once all PRs are merged. 

## Deployment strategy

The last planned deploy of today Thursday July 1 has already gone out. oncall engineers have been asked not to do any additional deploys between now and Tuesday (full launch day).

