### PR TITLE
update links in /educate/spritelab-21 to point to 2021 levels

### DIFF
--- a/pegasus/sites.v3/code.org/public/educate/spritelab-21.haml
+++ b/pegasus/sites.v3/code.org/public/educate/spritelab-21.haml
@@ -43,11 +43,11 @@ video_player: true
 
   - spritelab_videos = []
   - spritelab_videos << { id: 'CSF_SpriteLabIntro_CDEF', category_title: 'Making Your First Projects', code: 'l0B0gDuHHC8', download_path: 'https://videos.code.org/levelbuilder/introducingspritelab_sm-mp4.mp4', studio_stage: '/s/coursee-2021/lessons/2/levels/1' }
-  - spritelab_videos << { id: 'CSF_Spritelab_MakeSprite_CDEF', code: 'nHq7_-Kpgc8', download_path: 'https://videos.code.org/levelbuilder/howtomakeasprite_sm-mp4.mp4', studio_stage: ' /s/coursee-2021/lessons/2/levels/6' }
+  - spritelab_videos << { id: 'CSF_Spritelab_MakeSprite_CDEF', code: 'nHq7_-Kpgc8', download_path: 'https://videos.code.org/levelbuilder/howtomakeasprite_sm-mp4.mp4', studio_stage: '/s/coursee-2021/lessons/2/levels/6' }
   - spritelab_videos << { id: 'CDEF_Video_SpritesInAction', code: 'vsjoWjyQLRU', download_path: 'https://videos.code.org/levelbuilder/spritesinaction_sm-mp4.mp4', studio_stage: '/s/coursee-2021/lessons/3/levels/2' }
   - spritelab_videos << { id: '	csf21pilot_events', code: '_RxDeRPwJ-g', download_path: 'https://videos.code.org/levelbuilder/video-1-sprites-in-action_v2_small_20mb-mp4.mp4', studio_stage: '/s/coursef-2021/lessons/3/levels/3' }
   - spritelab_videos << { id: '	csf21pilot_prompts', code: '3TQ6ybjSm6c', download_path: 'https://videos.code.org/levelbuilder/video-2-sprite-lab-text-and-prompts_v2_small_20mb-mp4.mp4', studio_stage: '/s/coursef-2021/lessons/7/levels/3' }
-  - spritelab_videos << { id: 'csf_lots_of_sprites', code: '5yWt5o0zwAM', download_path: 'https://videos.code.org/levelbuilder/video-3-sprite-lab-lots-of-sprites-v2_small_20mb-mp4.mp4', studio_stage: 's/coursef-2021/lessons/20/levels/2/sublevel/1' }
+  - spritelab_videos << { id: 'csf_lots_of_sprites', code: '5yWt5o0zwAM', download_path: 'https://videos.code.org/levelbuilder/video-3-sprite-lab-lots-of-sprites-v2_small_20mb-mp4.mp4', studio_stage: '/s/coursef-2021/lessons/20/levels/2/sublevel/1' }
 
   - spritelab_videos.each do |video|
     // Show the chapter title at the beginning of each video chapter

--- a/pegasus/sites.v3/code.org/public/educate/spritelab-21.haml
+++ b/pegasus/sites.v3/code.org/public/educate/spritelab-21.haml
@@ -36,15 +36,15 @@ video_player: true
 
 #videos
   %h1 Video library
-  These videos appear in 
+  These videos appear in
   %a{href: "/curriculum/csf/"}
     CS Fundamentals
   and are displayed here as a quick introduction to using Sprite Lab. Check out each video to see how you can add new features to your project.
 
   - spritelab_videos = []
-  - spritelab_videos << { id: 'CSF_SpriteLabIntro_CDEF', category_title: 'Making Your First Projects', code: 'l0B0gDuHHC8', download_path: 'https://videos.code.org/levelbuilder/introducingspritelab_sm-mp4.mp4', studio_stage: '/s/coursee-2020/lessons/6/levels/1' }
-  - spritelab_videos << { id: 'CSF_Spritelab_MakeSprite_CDEF', code: 'nHq7_-Kpgc8', download_path: 'https://videos.code.org/levelbuilder/howtomakeasprite_sm-mp4.mp4', studio_stage: '/s/coursee-2020/lessons/6/levels/6' }
-  - spritelab_videos << { id: 'CDEF_Video_SpritesInAction', code: 'vsjoWjyQLRU', download_path: 'https://videos.code.org/levelbuilder/spritesinaction_sm-mp4.mp4', studio_stage: '/s/coursee-2020/lessons/7/levels/2' }
+  - spritelab_videos << { id: 'CSF_SpriteLabIntro_CDEF', category_title: 'Making Your First Projects', code: 'l0B0gDuHHC8', download_path: 'https://videos.code.org/levelbuilder/introducingspritelab_sm-mp4.mp4', studio_stage: '/s/coursee-2021/lessons/2/levels/1' }
+  - spritelab_videos << { id: 'CSF_Spritelab_MakeSprite_CDEF', code: 'nHq7_-Kpgc8', download_path: 'https://videos.code.org/levelbuilder/howtomakeasprite_sm-mp4.mp4', studio_stage: ' /s/coursee-2021/lessons/2/levels/6' }
+  - spritelab_videos << { id: 'CDEF_Video_SpritesInAction', code: 'vsjoWjyQLRU', download_path: 'https://videos.code.org/levelbuilder/spritesinaction_sm-mp4.mp4', studio_stage: '/s/coursee-2021/lessons/3/levels/2' }
   - spritelab_videos << { id: '	csf21pilot_events', code: '_RxDeRPwJ-g', download_path: 'https://videos.code.org/levelbuilder/video-1-sprites-in-action_v2_small_20mb-mp4.mp4', studio_stage: '/s/coursef-2021/lessons/3/levels/3' }
   - spritelab_videos << { id: '	csf21pilot_prompts', code: '3TQ6ybjSm6c', download_path: 'https://videos.code.org/levelbuilder/video-2-sprite-lab-text-and-prompts_v2_small_20mb-mp4.mp4', studio_stage: '/s/coursef-2021/lessons/7/levels/3' }
   - spritelab_videos << { id: 'csf_lots_of_sprites', code: '5yWt5o0zwAM', download_path: 'https://videos.code.org/levelbuilder/video-3-sprite-lab-lots-of-sprites-v2_small_20mb-mp4.mp4', studio_stage: 's/coursef-2021/lessons/20/levels/2/sublevel/1' }


### PR DESCRIPTION
this is part of hard launch, tracked by https://codedotorg.atlassian.net/browse/PLAT-599 . this follows the same pattern as https://github.com/code-dot-org/code-dot-org/pull/41408.