### PR TITLE
Add more error logging to PDF generation

### DIFF
--- a/dashboard/lib/services/curriculum_pdfs/resources.rb
+++ b/dashboard/lib/services/curriculum_pdfs/resources.rb
@@ -110,6 +110,25 @@ module Services
           path = File.join(directory, filename)
 
           PDF.generate_from_html(page_content, path)
+
+          # we've been having some issues with these title page PDFs not
+          # existing on the filesystem when it comes time to make the rollup.
+          # It's not yet clear whether that's because this step is failing to
+          # generate or because the file is getting vanished after generation.
+          # Adding some logging here to help diagnose.
+          unless $?.success?
+            ChatClient.log(
+              "PDF generation exited with status code #{$?.exitstatus.inspect}",
+              color: 'red'
+            )
+          end
+          unless File.exist?(path)
+            ChatClient.log(
+              "File #{path.inspect} does not exist after generation",
+              color: 'red'
+            )
+          end
+
           return path
         end
 


### PR DESCRIPTION
We're still getting the intermittent error where some expected files end up missing in the PDF generation. Futhermore, recent data indicates that it's specifically the title pages which are missing, so add some more-specific logging to the title page generation code which should help us identify whether it's a problem with the generation process itself, or with something else messing with the files after generation.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
