### PR TITLE
Add AI resource card to courses page

### DIFF
--- a/apps/i18n/common/de_de.json
+++ b/apps/i18n/common/de_de.json
@@ -380,7 +380,7 @@
   "courseBlocksToolsAppLabDescription": "App-Lab ist eine Programmierumgebung, wo man einfache apps machen kann. Entwerfe eine Anwendung/App, Code mit Blöcken oder JavaScript damit es funktioniert, dann teile die App in Sekunden.",
   "courseBlocksToolsGameLab": "Spielelabor",
   "courseBlocksToolsGameLabDescription": "Spielelabor ist eine Programmierumgebung, in der Sie einfache Animationen und Spiele mit Objekten und Charakteren, die miteinander interagieren, erstellen können.",
-  "courseBlocksToolsWebLab": "Weblabor (Beta)",
+  "courseBlocksToolsWebLab": "Weblabor",
   "courseBlocksToolsWebLabDescription": "Web Lab ist eine Programmierumgebung, in der Sie einfache Webseiten mit HTML und CSS erstellen können. Entwerfen Sie Ihre Webseiten und teilen Sie die in Sekunden.",
   "courseBlocksToolsWidgets": "Widgets",
   "courseBlocksToolsWidgetsDescription": "Studenten können mit unseren hands-on digitalen Werkzeugen, Konzepte aus unserem CS Principles Kurs erforschen. Die Widgets auf eigene Faust verwenden, oder eine Ein-Konzept Unterricht für deine Klasse.",

--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -406,6 +406,8 @@
   "courseBlocksToolsTitleTeacher": "Tools and resources for your classroom",
   "courseBlocksToolsTitleNonEn": "Tools for middle and high school (English only)",
   "courseBlocksToolsDescription": "In addition to our courses, teachers can use tools to teach students how to create apps, animations, games, or websites. We also have lessons and widgets to teach encryption, text compression, and other computer science concepts. Browse our other resources to inspire students with posters, videos, or by inviting guest speakers.",
+  "courseBlocksToolsAi": "AI Module",
+  "courseBlocksToolsAiDescription": "Students will learn the fundamentals of artificial intelligence and machine learning and discuss their implications. Suitable for grades 6-12.",
   "courseBlocksToolsAppLab": "App Lab",
   "courseBlocksToolsAppLabDescription": "App Lab is a programming environment where you can make simple apps. Design an app, code with blocks or JavaScript to make it work, then share your app in seconds.",
   "courseBlocksToolsGameLab": "Game Lab",

--- a/apps/i18n/common/es_mx.json
+++ b/apps/i18n/common/es_mx.json
@@ -408,7 +408,7 @@
   "courseBlocksToolsAppLabDescription": "El Laboratorio de aplicaciones es un entorno de programación donde puedes crear aplicaciones sencillas. Diseña una aplicación, programa con bloques o JavaScript para que funcione, y luego comparte tu aplicación en cuestión de segundos.",
   "courseBlocksToolsGameLab": "Laboratorio de juegos",
   "courseBlocksToolsGameLabDescription": "Game Lab es un entorno de programación en donde puedes hacer animaciones simples y juegos con objetos y personajes que interactúan entre ellos.",
-  "courseBlocksToolsWebLab": "Web Lab (beta)",
+  "courseBlocksToolsWebLab": "Web Lab",
   "courseBlocksToolsWebLabDescription": "Web Lab es un entorno de programación dónde usted puede hacer páginas web simples usando HTML y CSS. Diseñe sus páginas web y comparta su sitio en segundos.",
   "courseBlocksToolsWidgets": "Widgets",
   "courseBlocksToolsWidgetsDescription": "Los estudiantes pueden explorar conceptos de nuestro curso CS Principles de manera práctica utilizando estas herramientas digitales. Use los widgets por su cuenta, o cree una lección de concepto único para su clase.",

--- a/apps/i18n/common/fr_fr.json
+++ b/apps/i18n/common/fr_fr.json
@@ -390,7 +390,7 @@
   "courseBlocksToolsAppLabDescription": "App Lab est un environnement de programmation où vous pouvez créer des applications simples. Concevez une application, codez-la avec des blocs ou avec JavaScript, puis partagez-la en quelques secondes.",
   "courseBlocksToolsGameLab": "Labo des Jeux",
   "courseBlocksToolsGameLabDescription": "Game Lab est un environnement de programmation où vous pouvez créer des animations simples et des jeux avec des objets et des personnages qui interagissent entre eux.",
-  "courseBlocksToolsWebLab": "Web Lab (beta)",
+  "courseBlocksToolsWebLab": "Web Lab",
   "courseBlocksToolsWebLabDescription": "Web Lab est un environnement de programmation où vous pouvez créer des pages web simples en utilisant HTML et CSS. Créez vos propres pages web et partagez-les en quelques instants.",
   "courseBlocksToolsWidgets": "Widgets",
   "courseBlocksToolsWidgetsDescription": "Les élèves peuvent explorer des concepts à partir de nos cours pratiques sur CS Principles, en utilisant ces outils numériques. Utilisez les widgets tel quel, ou créez une leçon, sur un seul concept, pour votre classe.",

--- a/apps/i18n/common/nn_no.json
+++ b/apps/i18n/common/nn_no.json
@@ -318,7 +318,7 @@
   "courseBlocksToolsAppLabDescription": "App-lab er eit programmeringsmiljø kor du kan lage enkle appar. Lag ein app, programmer med blokker eller JavaScript for å få det til å virke, deretter kan du dele appen på få sekunder.",
   "courseBlocksToolsGameLab": "Spel-lab",
   "courseBlocksToolsGameLabDescription": "Spel-lab er eit programmeringsmiljø der du kan lage enkle animasjonar og spel med objekter og figurar som samhandlar med kvarandre.",
-  "courseBlocksToolsWebLab": "Nett-lab (beta)",
+  "courseBlocksToolsWebLab": "Nett-lab",
   "courseBlocksToolsWebLabDescription": "Nett-lab er eit programmeringsmiljø der du kan lage nettsider mer HTML og CSS. Lag ei nettside og del han med andre i løpet av sekunder.",
   "courseBlocksToolsWidgets": "Modular",
   "courseBlocksToolsWidgetsDescription": "Studentar kan utforske konsept fra informatikkursa våre sjølv ved å bruke desse digitale verktøya. Bruk modulane for seg sjølv, eller lag ei enkeltkonseptøkt for klassen din.",

--- a/apps/src/sites/studio/pages/courses/index.js
+++ b/apps/src/sites/studio/pages/courses/index.js
@@ -35,6 +35,7 @@ function showCourses() {
         isSignedOut={signedOut}
         modernElementaryCoursesAvailable={modernElementaryCoursesAvailable}
         specialAnnouncement={specialAnnouncement}
+        showAiCard={coursesData.showAiCard}
       />
     </Provider>,
     document.getElementById('courses-container')

--- a/apps/src/templates/studioHomepages/CourseBlocksTools.jsx
+++ b/apps/src/templates/studioHomepages/CourseBlocksTools.jsx
@@ -5,52 +5,63 @@ import ContentContainer from '../ContentContainer';
 import ResourceCard from './ResourceCard';
 import ResourceCardResponsiveContainer from './ResourceCardResponsiveContainer';
 import i18n from '@cdo/locale';
-import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
+import {pegasus, studio} from '@cdo/apps/lib/util/urlHelpers';
 
 class CourseBlocksTools extends Component {
   static propTypes = {
-    isEnglish: PropTypes.bool.isRequired
+    isEnglish: PropTypes.bool.isRequired,
+    showAiCard: PropTypes.bool
   };
 
-  cards = [
-    {
-      heading: i18n.courseBlocksToolsAppLab(),
-      description: i18n.courseBlocksToolsAppLabDescription(),
-      path: 'applab'
-    },
-    {
-      heading: i18n.courseBlocksToolsGameLab(),
-      description: i18n.courseBlocksToolsGameLabDescription(),
-      path: 'gamelab'
-    },
-    {
-      heading: i18n.courseBlocksToolsWebLab(),
-      callout: `(${i18n.beta()})`,
-      description: i18n.courseBlocksToolsWebLabDescription(),
-      path: 'weblab'
-    },
-    {
-      heading: i18n.csJourneys(),
-      callout: i18n.newExclame(),
-      description: i18n.csJourneysDescription(),
-      path: 'csjourneys'
-    },
-    {
-      heading: i18n.courseBlocksToolsVideo(),
-      description: i18n.courseBlocksToolsVideoDescription(),
-      path: 'videos'
-    },
-    {
-      heading: i18n.courseBlocksToolsWidgets(),
-      description: i18n.courseBlocksToolsWidgetsDescription(),
-      path: 'widgets'
+  constructor(props) {
+    super(props);
+    this.cards = [
+      {
+        heading: i18n.courseBlocksToolsAppLab(),
+        description: i18n.courseBlocksToolsAppLabDescription(),
+        link: pegasus('/applab')
+      },
+      {
+        heading: i18n.courseBlocksToolsGameLab(),
+        description: i18n.courseBlocksToolsGameLabDescription(),
+        link: pegasus('/gamelab')
+      },
+      {
+        heading: i18n.courseBlocksToolsWebLab(),
+        callout: `(${i18n.beta()})`,
+        description: i18n.courseBlocksToolsWebLabDescription(),
+        link: pegasus('/weblab')
+      },
+      {
+        heading: i18n.csJourneys(),
+        callout: i18n.newExclame(),
+        description: i18n.csJourneysDescription(),
+        link: pegasus('/csjourneys')
+      },
+      {
+        heading: i18n.courseBlocksToolsVideo(),
+        description: i18n.courseBlocksToolsVideoDescription(),
+        link: pegasus('/videos')
+      }
+    ];
+    if (props.isEnglish && props.showAiCard) {
+      this.cards.push({
+        heading: i18n.courseBlocksToolsAi(),
+        callout: i18n.newExclame(),
+        description: i18n.courseBlocksToolsAiDescription(),
+        link: studio('/s/aiml-2021')
+      });
+    } else {
+      this.cards.push({
+        heading: i18n.courseBlocksToolsWidgets(),
+        description: i18n.courseBlocksToolsWidgetsDescription(),
+        link: pegasus('/widgets')
+      });
     }
-  ];
+  }
 
   render() {
-    const {isEnglish} = this.props;
-
-    const headingText = isEnglish
+    const headingText = this.props.isEnglish
       ? i18n.courseBlocksToolsTitleTeacher()
       : i18n.courseBlocksToolsTitleNonEn();
 
@@ -68,7 +79,7 @@ class CourseBlocksTools extends Component {
                 callout={card.callout}
                 description={card.description}
                 buttonText={i18n.learnMore()}
-                link={pegasus(`/${card.path}`)}
+                link={card.link}
               />
             ))}
           </ResourceCardResponsiveContainer>

--- a/apps/src/templates/studioHomepages/Courses.jsx
+++ b/apps/src/templates/studioHomepages/Courses.jsx
@@ -22,7 +22,8 @@ class Courses extends Component {
     linesCount: PropTypes.string.isRequired,
     studentsCount: PropTypes.string.isRequired,
     modernElementaryCoursesAvailable: PropTypes.bool.isRequired,
-    specialAnnouncement: shapes.specialAnnouncement
+    specialAnnouncement: shapes.specialAnnouncement,
+    showAiCard: PropTypes.bool
   };
 
   componentDidMount() {
@@ -112,7 +113,7 @@ class Courses extends Component {
                     announcement={specialAnnouncement}
                   />
                 )}
-                <CoursesTeacherEnglish />
+                <CoursesTeacherEnglish showAiCard={this.props.showAiCard} />
               </div>
             )}
 

--- a/apps/src/templates/studioHomepages/CoursesTeacherEnglish.jsx
+++ b/apps/src/templates/studioHomepages/CoursesTeacherEnglish.jsx
@@ -1,5 +1,6 @@
 import $ from 'jquery';
 import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import ContentContainer from '../ContentContainer';
 import {AdministratorResourcesActionBlock} from './TwoColumnActionBlock';
@@ -14,6 +15,10 @@ import i18n from '@cdo/locale';
  * though it may also be shown for a signed-out user using English.
  */
 class CoursesTeacherEnglish extends Component {
+  static propTypes = {
+    showAiCard: PropTypes.bool
+  };
+
   componentDidMount() {
     // The components used here are implemented in legacy HAML/CSS rather than React.
     $('.courseexplorer')
@@ -38,7 +43,7 @@ class CoursesTeacherEnglish extends Component {
 
           <CourseBlocksHoc />
 
-          <CourseBlocksTools isEnglish={true} />
+          <CourseBlocksTools isEnglish showAiCard={this.props.showAiCard} />
 
           <AdministratorResourcesActionBlock />
         </div>

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -420,7 +420,7 @@ default_hoc_launch: ''       # overridden by 'hoc_launch' DCDO param, except in 
 # teacher_application_mode values: 'open', 'closing-soon', 'closed'
 default_teacher_application_mode: 'closed' # overridden by 'teacher_application_mode' DCDO param, except in :test
 
-default_courses_show_ai: true # overridden by 'courses_show_ai' DCDO param, except in :test
+default_courses_show_ai: false # overridden by 'courses_show_ai' DCDO param, except in :test
 
 localize_apps: false
 

--- a/dashboard/app/views/courses/index.html.haml
+++ b/dashboard/app/views/courses/index.html.haml
@@ -13,6 +13,7 @@
   courses_data[:codeorgurlprefix] = CDO.code_org_url
   courses_data[:signedout] = @is_signed_out
   courses_data[:modernelementarycoursesavailable] = @modern_elementary_courses_available
+  courses_data[:showAiCard] = DCDO.get('courses_show_ai', CDO.default_courses_show_ai)
 
   @page_title = @is_teacher ? I18n.t('courses_page.title_teacher') : I18n.t('courses_page.title_student')
 

--- a/i18n/locales/de-DE/blockly-mooc/common.json
+++ b/i18n/locales/de-DE/blockly-mooc/common.json
@@ -380,7 +380,7 @@
   "courseBlocksToolsAppLabDescription": "App-Lab ist eine Programmierumgebung, wo man einfache apps machen kann. Entwerfe eine Anwendung/App, Code mit Blöcken oder JavaScript damit es funktioniert, dann teile die App in Sekunden.",
   "courseBlocksToolsGameLab": "Spielelabor",
   "courseBlocksToolsGameLabDescription": "Spielelabor ist eine Programmierumgebung, in der Sie einfache Animationen und Spiele mit Objekten und Charakteren, die miteinander interagieren, erstellen können.",
-  "courseBlocksToolsWebLab": "Weblabor (Beta)",
+  "courseBlocksToolsWebLab": "Weblabor",
   "courseBlocksToolsWebLabDescription": "Web Lab ist eine Programmierumgebung, in der Sie einfache Webseiten mit HTML und CSS erstellen können. Entwerfen Sie Ihre Webseiten und teilen Sie die in Sekunden.",
   "courseBlocksToolsWidgets": "Widgets",
   "courseBlocksToolsWidgetsDescription": "Studenten können mit unseren hands-on digitalen Werkzeugen, Konzepte aus unserem CS Principles Kurs erforschen. Die Widgets auf eigene Faust verwenden, oder eine Ein-Konzept Unterricht für deine Klasse.",

--- a/i18n/locales/es-MX/blockly-mooc/common.json
+++ b/i18n/locales/es-MX/blockly-mooc/common.json
@@ -408,7 +408,7 @@
   "courseBlocksToolsAppLabDescription": "El Laboratorio de aplicaciones es un entorno de programación donde puedes crear aplicaciones sencillas. Diseña una aplicación, programa con bloques o JavaScript para que funcione, y luego comparte tu aplicación en cuestión de segundos.",
   "courseBlocksToolsGameLab": "Laboratorio de juegos",
   "courseBlocksToolsGameLabDescription": "Game Lab es un entorno de programación en donde puedes hacer animaciones simples y juegos con objetos y personajes que interactúan entre ellos.",
-  "courseBlocksToolsWebLab": "Web Lab (beta)",
+  "courseBlocksToolsWebLab": "Web Lab",
   "courseBlocksToolsWebLabDescription": "Web Lab es un entorno de programación dónde usted puede hacer páginas web simples usando HTML y CSS. Diseñe sus páginas web y comparta su sitio en segundos.",
   "courseBlocksToolsWidgets": "Widgets",
   "courseBlocksToolsWidgetsDescription": "Los estudiantes pueden explorar conceptos de nuestro curso CS Principles de manera práctica utilizando estas herramientas digitales. Use los widgets por su cuenta, o cree una lección de concepto único para su clase.",

--- a/i18n/locales/fr-FR/blockly-mooc/common.json
+++ b/i18n/locales/fr-FR/blockly-mooc/common.json
@@ -390,7 +390,7 @@
   "courseBlocksToolsAppLabDescription": "App Lab est un environnement de programmation où vous pouvez créer des applications simples. Concevez une application, codez-la avec des blocs ou avec JavaScript, puis partagez-la en quelques secondes.",
   "courseBlocksToolsGameLab": "Labo des Jeux",
   "courseBlocksToolsGameLabDescription": "Game Lab est un environnement de programmation où vous pouvez créer des animations simples et des jeux avec des objets et des personnages qui interagissent entre eux.",
-  "courseBlocksToolsWebLab": "Web Lab (beta)",
+  "courseBlocksToolsWebLab": "Web Lab",
   "courseBlocksToolsWebLabDescription": "Web Lab est un environnement de programmation où vous pouvez créer des pages web simples en utilisant HTML et CSS. Créez vos propres pages web et partagez-les en quelques instants.",
   "courseBlocksToolsWidgets": "Widgets",
   "courseBlocksToolsWidgetsDescription": "Les élèves peuvent explorer des concepts à partir de nos cours pratiques sur CS Principles, en utilisant ces outils numériques. Utilisez les widgets tel quel, ou créez une leçon, sur un seul concept, pour votre classe.",

--- a/i18n/locales/nn-NO/blockly-mooc/common.json
+++ b/i18n/locales/nn-NO/blockly-mooc/common.json
@@ -318,7 +318,7 @@
   "courseBlocksToolsAppLabDescription": "App-lab er eit programmeringsmiljø kor du kan lage enkle appar. Lag ein app, programmer med blokker eller JavaScript for å få det til å virke, deretter kan du dele appen på få sekunder.",
   "courseBlocksToolsGameLab": "Spel-lab",
   "courseBlocksToolsGameLabDescription": "Spel-lab er eit programmeringsmiljø der du kan lage enkle animasjonar og spel med objekter og figurar som samhandlar med kvarandre.",
-  "courseBlocksToolsWebLab": "Nett-lab (beta)",
+  "courseBlocksToolsWebLab": "Nett-lab",
   "courseBlocksToolsWebLabDescription": "Nett-lab er eit programmeringsmiljø der du kan lage nettsider mer HTML og CSS. Lag ei nettside og del han med andre i løpet av sekunder.",
   "courseBlocksToolsWidgets": "Modular",
   "courseBlocksToolsWidgetsDescription": "Studentar kan utforske konsept fra informatikkursa våre sjølv ved å bruke desse digitale verktøya. Bruk modulane for seg sjølv, eller lag ei enkeltkonseptøkt for klassen din.",


### PR DESCRIPTION
This PR replaces the "Widgets" resource card on the courses page with a card for AI. The replacement is hidden behind a DCDO flag and only applies to the english version of the page.

ENGLISH:
<img width="979" alt="Screen Shot 2021-07-01 at 2 52 28 PM" src="https://user-images.githubusercontent.com/4986878/124194573-ae00fe80-da7d-11eb-8312-f78cb6b7f75f.png">

NOT ENGLISH:
<img width="978" alt="Screen Shot 2021-07-01 at 2 52 11 PM" src="https://user-images.githubusercontent.com/4986878/124194595-b822fd00-da7d-11eb-8d4b-2b2695f82515.png">


## Links
- jira ticket: [LP-1911]

[LP-1911]: https://codedotorg.atlassian.net/browse/LP-1911