### PR TITLE
KeepWorking badges on header bubbles and script overview

### DIFF
--- a/apps/src/code-studio/components/SublevelCard.jsx
+++ b/apps/src/code-studio/components/SublevelCard.jsx
@@ -8,6 +8,8 @@ import LessonExtrasFlagIcon from '@cdo/apps/templates/progress/LessonExtrasFlagI
 import MazeThumbnail from '@cdo/apps/code-studio/components/lessonExtras/MazeThumbnail';
 import queryString from 'query-string';
 import {levelType} from '@cdo/apps/templates/progress/progressTypes';
+import _ from 'lodash';
+
 export default class SublevelCard extends React.Component {
   static propTypes = {
     isLessonExtra: PropTypes.bool,
@@ -90,8 +92,17 @@ export default class SublevelCard extends React.Component {
       );
     }
 
+    let mappedSublevel = sublevel;
+    if (mappedSublevel) {
+      mappedSublevel = _.mapKeys(sublevel, (value, key) => _.camelCase(key));
+    }
+
     return (
-      <ProgressBubble level={sublevel} disabled={false} hideToolTips={true} />
+      <ProgressBubble
+        level={mappedSublevel}
+        disabled={false}
+        hideToolTips={true}
+      />
     );
   };
 

--- a/apps/src/code-studio/progressRedux.js
+++ b/apps/src/code-studio/progressRedux.js
@@ -589,6 +589,7 @@ const levelWithProgress = (
   // default values
   let status = LevelStatus.not_tried;
   let locked = isLockable;
+  let teacherFeedbackReviewState = null;
 
   let levelProgress = unitProgress[normalizedLevel.id];
   if (levelProgress?.pages) {
@@ -598,6 +599,7 @@ const levelWithProgress = (
     // if we have levelProgress, overwrite default values
     status = levelProgress.status;
     locked = levelProgress.locked;
+    teacherFeedbackReviewState = levelProgress.teacherFeedbackReviewState;
   } else if (level.kind !== LevelKind.assessment) {
     // if we don't have levelProgress, get the status from `levelResults`.
     // however, `levelResults` doesn't track per-page results for multi-page
@@ -615,7 +617,8 @@ const levelWithProgress = (
     status: status,
     isCurrentLevel: isCurrent,
     paired: levelPairing[level.activeId],
-    isLocked: locked
+    isLocked: locked,
+    teacherFeedbackReviewState: teacherFeedbackReviewState
   };
 };
 

--- a/apps/src/templates/progress/ProgressBubble.jsx
+++ b/apps/src/templates/progress/ProgressBubble.jsx
@@ -17,7 +17,7 @@ import {
   BubbleBadgeWrapper,
   AssessmentBadge,
   KeepWorkingBadge
-} from './BubbleBadge';
+} from '@cdo/apps/templates/progress/BubbleBadge';
 import {ReviewStates} from '@cdo/apps/templates/feedback/types';
 
 /**

--- a/apps/src/templates/progress/ProgressBubble.jsx
+++ b/apps/src/templates/progress/ProgressBubble.jsx
@@ -18,6 +18,7 @@ import {
   AssessmentBadge,
   KeepWorkingBadge
 } from './BubbleBadge';
+import {ReviewStates} from '@cdo/apps/templates/feedback/types';
 
 /**
  * A ProgressBubble represents progress for a specific level. It can be a circle
@@ -81,10 +82,11 @@ export default class ProgressBubble extends React.Component {
       level.isConceptLevel
     );
 
+    const hasKeepWorkingFeedback =
+      level.teacherFeedbackReviewState === ReviewStates.keepWorking;
+
     const displayBubbleBadge =
-      (isLevelAssessment(level) ||
-        level.teacherFeedbackReviewState === 'keepWorking') &&
-      !smallBubble;
+      (isLevelAssessment(level) || hasKeepWorkingFeedback) && !smallBubble;
 
     const bubble = (
       <BasicBubble
@@ -96,7 +98,7 @@ export default class ProgressBubble extends React.Component {
         {content}
         {displayBubbleBadge && (
           <BubbleBadgeWrapper isDiamond={level.isConceptLevel}>
-            {level.teacherFeedbackReviewState === 'keepWorking' ? (
+            {hasKeepWorkingFeedback ? (
               <KeepWorkingBadge />
             ) : (
               <AssessmentBadge />

--- a/apps/src/templates/progress/ProgressBubble.jsx
+++ b/apps/src/templates/progress/ProgressBubble.jsx
@@ -13,7 +13,11 @@ import {
   getBubbleUrl
 } from './BubbleFactory';
 import {levelProgressStyle} from './progressStyles';
-import {BubbleBadgeWrapper, AssessmentBadge} from './BubbleBadge';
+import {
+  BubbleBadgeWrapper,
+  AssessmentBadge,
+  KeepWorkingBadge
+} from './BubbleBadge';
 
 /**
  * A ProgressBubble represents progress for a specific level. It can be a circle
@@ -70,11 +74,17 @@ export default class ProgressBubble extends React.Component {
       level.bubbleText || level.letter || level.levelNumber,
       bubbleSize
     );
+
     const shape = getBubbleShape(
       // override pill shape for small bubbles
       level.isUnplugged && !smallBubble,
       level.isConceptLevel
     );
+
+    const displayBubbleBadge =
+      (isLevelAssessment(level) ||
+        level.teacherFeedbackReviewState === 'keepWorking') &&
+      !smallBubble;
 
     const bubble = (
       <BasicBubble
@@ -84,9 +94,13 @@ export default class ProgressBubble extends React.Component {
         classNames={getBubbleClassNames(this.isClickable())}
       >
         {content}
-        {isLevelAssessment(level) && !smallBubble && (
+        {displayBubbleBadge && (
           <BubbleBadgeWrapper isDiamond={level.isConceptLevel}>
-            <AssessmentBadge />
+            {level.teacherFeedbackReviewState === 'keepWorking' ? (
+              <KeepWorkingBadge />
+            ) : (
+              <AssessmentBadge />
+            )}
           </BubbleBadgeWrapper>
         )}
       </BasicBubble>

--- a/apps/src/templates/progress/ProgressPill.jsx
+++ b/apps/src/templates/progress/ProgressPill.jsx
@@ -42,7 +42,10 @@ class ProgressPill extends React.Component {
       onSingleLevelClick
     } = this.props;
 
-    if (levels.length > 1 || disabled || onSingleLevelClick) {
+    const pillLinksToLevel =
+      !disabled && !onSingleLevelClick && levels.length === 1;
+
+    if (!pillLinksToLevel) {
       return;
     }
 

--- a/apps/src/templates/progress/ProgressPill.jsx
+++ b/apps/src/templates/progress/ProgressPill.jsx
@@ -7,7 +7,11 @@ import {levelWithProgressType} from './progressTypes';
 import {levelProgressStyle, hoverStyle} from './progressStyles';
 import {stringifyQueryParams} from '../../utils';
 import {isLevelAssessment} from './progressHelpers';
-import {BubbleBadgeWrapper, AssessmentBadge} from './BubbleBadge';
+import {
+  BubbleBadgeWrapper,
+  AssessmentBadge,
+  KeepWorkingBadge
+} from './BubbleBadge';
 import {connect} from 'react-redux';
 
 /**
@@ -29,43 +33,31 @@ class ProgressPill extends React.Component {
     isRtl: PropTypes.bool
   };
 
-  render() {
+  getUrl() {
     const {
       levels,
-      icon,
-      text,
-      tooltip,
       disabled,
       selectedSectionId,
-      progressStyle,
-      isRtl
+      onSingleLevelClick
     } = this.props;
 
-    const multiLevelStep = levels.length > 1;
-    let url =
-      multiLevelStep || disabled || this.props.onSingleLevelClick
-        ? undefined
-        : levels[0].url;
-    if (url && selectedSectionId) {
+    if (levels.length > 1 || disabled || onSingleLevelClick) {
+      return;
+    }
+
+    let url = levels[0].url;
+
+    if (selectedSectionId) {
       url += stringifyQueryParams({section_id: selectedSectionId});
     }
-    let onClick =
-      !multiLevelStep && !disabled && !url
-        ? () => this.props.onSingleLevelClick(levels[0])
-        : undefined;
 
-    let style = {
-      ...styles.levelPill,
-      ...((url || onClick) && hoverStyle),
-      ...(!multiLevelStep &&
-        levelProgressStyle(levels[0].status, levels[0].kind))
-    };
+    return url;
+  }
 
-    // Adjust icon margins if locale is RTL
-    const iconMarginStyle = isRtl ? styles.iconMarginRTL : styles.iconMargin;
+  getTooltipProps() {
+    const {tooltip} = this.props;
 
-    // If we're passed a tooltip, we also need to reference it from our div
-    let tooltipProps = {};
+    const tooltipProps = {};
     if (tooltip) {
       const id = tooltip.props.tooltipId;
       tooltipProps['data-tip'] = true;
@@ -73,9 +65,49 @@ class ProgressPill extends React.Component {
       tooltipProps['aria-describedby'] = id;
     }
 
-    // Only put the assessment icon on if its a single assessment level (not set)
-    const levelIsAssessment =
-      isLevelAssessment(levels[0]) && levels.length === 1;
+    return tooltipProps;
+  }
+
+  render() {
+    const {
+      levels,
+      icon,
+      text,
+      tooltip,
+      disabled,
+      progressStyle,
+      isRtl,
+      onSingleLevelClick
+    } = this.props;
+
+    const firstLevel = levels[0];
+
+    const multiLevelStep = levels.length > 1;
+
+    const url = this.getUrl();
+
+    let onClick =
+      !multiLevelStep && !disabled && !url
+        ? () => onSingleLevelClick(firstLevel)
+        : undefined;
+
+    let style = {
+      ...styles.levelPill,
+      ...((url || onClick) && hoverStyle),
+      ...(!multiLevelStep &&
+        levelProgressStyle(firstLevel.status, firstLevel.kind))
+    };
+
+    // Adjust icon margins if locale is RTL
+    const iconMarginStyle = isRtl ? styles.iconMarginRTL : styles.iconMargin;
+
+    const tooltipProps = this.getTooltipProps();
+
+    // Only put the bubble badge on if its a single assessment level (not set)
+    const displayBadge =
+      !multiLevelStep &&
+      (firstLevel['teacherFeedbackReviewState'] === 'keepWorking' ||
+        isLevelAssessment(firstLevel));
 
     const textStyle = progressStyle ? styles.textProgressStyle : styles.text;
 
@@ -100,9 +132,13 @@ class ProgressPill extends React.Component {
             </div>
           )}
           {tooltip}
-          {levelIsAssessment && (
+          {displayBadge && (
             <BubbleBadgeWrapper>
-              <AssessmentBadge />
+              {firstLevel['teacherFeedbackReviewState'] === 'keepWorking' ? (
+                <KeepWorkingBadge />
+              ) : (
+                <AssessmentBadge />
+              )}
             </BubbleBadgeWrapper>
           )}
         </div>

--- a/apps/src/templates/progress/ProgressPill.jsx
+++ b/apps/src/templates/progress/ProgressPill.jsx
@@ -11,7 +11,7 @@ import {
   BubbleBadgeWrapper,
   AssessmentBadge,
   KeepWorkingBadge
-} from './BubbleBadge';
+} from '@cdo/apps/templates/progress/BubbleBadge';
 import {connect} from 'react-redux';
 import {ReviewStates} from '@cdo/apps/templates/feedback/types';
 

--- a/apps/src/templates/progress/ProgressPill.jsx
+++ b/apps/src/templates/progress/ProgressPill.jsx
@@ -13,6 +13,7 @@ import {
   KeepWorkingBadge
 } from './BubbleBadge';
 import {connect} from 'react-redux';
+import {ReviewStates} from '@cdo/apps/templates/feedback/types';
 
 /**
  * This component is similar to our ProgressBubble, except that instead of being
@@ -103,11 +104,13 @@ class ProgressPill extends React.Component {
 
     const tooltipProps = this.getTooltipProps();
 
+    const hasKeepWorkingFeedback =
+      firstLevel['teacherFeedbackReviewState'] === ReviewStates.keepWorking;
+
     // Only put the bubble badge on if its a single assessment level (not set)
     const displayBadge =
       !multiLevelStep &&
-      (firstLevel['teacherFeedbackReviewState'] === 'keepWorking' ||
-        isLevelAssessment(firstLevel));
+      (hasKeepWorkingFeedback || isLevelAssessment(firstLevel));
 
     const textStyle = progressStyle ? styles.textProgressStyle : styles.text;
 
@@ -134,7 +137,7 @@ class ProgressPill extends React.Component {
           {tooltip}
           {displayBadge && (
             <BubbleBadgeWrapper>
-              {firstLevel['teacherFeedbackReviewState'] === 'keepWorking' ? (
+              {hasKeepWorkingFeedback ? (
                 <KeepWorkingBadge />
               ) : (
                 <AssessmentBadge />

--- a/apps/src/templates/progress/progressHelpers.js
+++ b/apps/src/templates/progress/progressHelpers.js
@@ -331,6 +331,7 @@ export const levelProgressFromServer = serverProgress => {
     locked: serverProgress.locked || false,
     paired: serverProgress.paired || false,
     timeSpent: serverProgress.time_spent,
+    teacherFeedbackReviewState: serverProgress.teacher_feedback_review_state,
     lastTimestamp: serverProgress.last_progress_at,
     pages: getPagesProgress(serverProgress)
   };

--- a/apps/src/templates/progress/progressTypes.js
+++ b/apps/src/templates/progress/progressTypes.js
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import {ReviewStates} from '@cdo/apps/templates/feedback/types';
 
 /**
  * See ApplicationHelper::PUZZLE_PAGE_NONE.
@@ -88,6 +89,8 @@ export const levelWithProgressType = PropTypes.shape({
  * The number of seconds a student spent on a level.
  * @property {number} lastTimestamp
  * A timestamp of the last time a student made progress on a level.
+ * @property {ReviewStates} teacherFeedbackReviewState
+ * An optional enum indicating a teacher feedback review state.
  * @property {array} pages
  * An optional array of recursive progress objects representing progress on
  * individual pages of a multi-page assessment
@@ -98,7 +101,8 @@ const studentLevelProgressShape = {
   locked: PropTypes.bool.isRequired,
   paired: PropTypes.bool.isRequired,
   timeSpent: PropTypes.number,
-  lastTimestamp: PropTypes.number
+  lastTimestamp: PropTypes.number,
+  teacherFeedbackReviewState: PropTypes.oneOf(Object.keys(ReviewStates))
   /** pages: PropTypes.array */ // See below
 };
 // Avoid recursive definition

--- a/apps/src/templates/sectionProgress/sectionProgressLoader.js
+++ b/apps/src/templates/sectionProgress/sectionProgressLoader.js
@@ -105,8 +105,6 @@ export function loadScriptProgress(scriptId, sectionId) {
         sectionProgress.unitDataByUnit[scriptId].lessons
       )
     };
-    console.log('maureen actual param');
-    console.log(JSON.stringify(sectionProgress));
     getStore().dispatch(addDataByUnit(sectionProgress));
     getStore().dispatch(finishLoadingProgress());
     getStore().dispatch(finishRefreshingProgress());

--- a/apps/src/templates/sectionProgress/sectionProgressLoader.js
+++ b/apps/src/templates/sectionProgress/sectionProgressLoader.js
@@ -105,6 +105,8 @@ export function loadScriptProgress(scriptId, sectionId) {
         sectionProgress.unitDataByUnit[scriptId].lessons
       )
     };
+    console.log('maureen actual param');
+    console.log(JSON.stringify(sectionProgress));
     getStore().dispatch(addDataByUnit(sectionProgress));
     getStore().dispatch(finishLoadingProgress());
     getStore().dispatch(finishRefreshingProgress());

--- a/apps/test/unit/code-studio/components/SublevelCardTest.js
+++ b/apps/test/unit/code-studio/components/SublevelCardTest.js
@@ -1,98 +1,87 @@
 import React from 'react';
 import {mount} from 'enzyme';
-import {assert} from '../../../util/reconfiguredChai';
+import {assert, expect} from '../../../util/reconfiguredChai';
 import SublevelCard from '@cdo/apps/code-studio/components/SublevelCard';
+import {ReviewStates} from '@cdo/apps/templates/feedback/types';
+import ProgressBubble from '@cdo/apps/templates/progress/ProgressBubble';
 
-const DEFAULT_PROPS = {
-  isLessonExtra: false,
-  sublevel: {
-    id: '1',
-    display_name: 'Choice 1',
-    description: 'Sublevel 1 is lots of fun',
-    thumbnail_url: 'some-fake.url/kittens.png',
-    url: '/s/script/lessons/1/levels/2/sublevel/1',
-    position: 1,
-    letter: 'a',
-    perfect: true,
-    status: 'perfect'
-  }
-};
-
-const LESSON_EXTRAS_DEFAULT_PROPS = {
-  isLessonExtra: true,
-  sublevel: {
-    id: '1',
-    display_name: 'Choice 1',
-    description: 'Sublevel 1 is lots of fun',
-    thumbnail_url: 'some-fake.url/kittens.png',
-    url:
-      'http://studio.code.org:3000/s/coursef-2019/lessons/4/extras?level_name=courseC_artist_prog_challenge1_2019',
-    perfect: false
-  }
-};
-
-const sublevel_no_thumbnail = {
+const DEFAULT_SUBLEVEL = {
   id: '1',
   display_name: 'Choice 1',
   description: 'Sublevel 1 is lots of fun',
-  thumbnail_url: null,
+  thumbnail_url: 'some-fake.url/kittens.png',
   url: '/s/script/lessons/1/levels/2/sublevel/1',
   position: 1,
   letter: 'a',
   perfect: true,
-  status: 'perfect'
+  status: 'perfect',
+  teacher_feedback_review_state: ReviewStates.keepWorking
+};
+
+const setUp = (isLessonExtra = false, overrideSublevel = {}) => {
+  const props = {
+    isLessonExtra: isLessonExtra,
+    sublevel: {...DEFAULT_SUBLEVEL, ...overrideSublevel}
+  };
+  return mount(<SublevelCard {...props} />);
 };
 
 describe('SublevelCard', () => {
   it('renders level information', () => {
-    const wrapper = mount(<SublevelCard {...DEFAULT_PROPS} />);
+    const wrapper = setUp();
     assert.equal(
-      DEFAULT_PROPS.sublevel.display_name,
+      DEFAULT_SUBLEVEL.display_name,
       wrapper.find('.sublevel-card-title-uitest').text()
     );
     assert.equal(
-      DEFAULT_PROPS.sublevel.description,
+      DEFAULT_SUBLEVEL.description,
       wrapper.find('.sublevel-card-description-uitest').text()
     );
   });
 
   it('renders sublevel thumbnail if present', () => {
-    const wrapper = mount(<SublevelCard {...DEFAULT_PROPS} />);
+    const wrapper = setUp();
     const thumbnails = wrapper.find('img');
     assert.equal(1, thumbnails.length);
     assert(
       thumbnails
         .at(0)
         .getDOMNode()
-        .src.includes(DEFAULT_PROPS.sublevel.thumbnail_url)
+        .src.includes(DEFAULT_SUBLEVEL.thumbnail_url)
     );
   });
 
   it('renders progress bubbles for sublevels', () => {
-    const wrapper = mount(<SublevelCard {...DEFAULT_PROPS} />);
+    const wrapper = setUp();
     const bubbles = wrapper.find('ProgressBubble');
     assert.equal(1, bubbles.length);
     assert.equal('perfect', bubbles.at(0).props().level.status);
   });
 
   it('renders a placeholder div if sublevel thumbnail is not present', () => {
-    const wrapper = mount(
-      <SublevelCard {...DEFAULT_PROPS} sublevel={sublevel_no_thumbnail} />
-    );
+    const wrapper = setUp(false, {thumbnail_url: null});
     const placeholderThumbnails = wrapper.find('.placeholder');
     assert.equal(1, placeholderThumbnails.length);
   });
 
   it('renders flag bubble for lesson extras level', () => {
-    const wrapper = mount(<SublevelCard {...LESSON_EXTRAS_DEFAULT_PROPS} />);
+    const wrapper = setUp(true);
     assert.equal(1, wrapper.find('LessonExtrasFlagIcon').length);
     assert.equal(
-      LESSON_EXTRAS_DEFAULT_PROPS.sublevel.display_name,
+      DEFAULT_SUBLEVEL.display_name,
       wrapper.find('.sublevel-card-title-uitest').text()
     );
     assert.equal(
-      LESSON_EXTRAS_DEFAULT_PROPS.sublevel.description,
+      DEFAULT_SUBLEVEL.description,
       wrapper.find('.sublevel-card-description-uitest').text()
+    );
+  });
+
+  it('mapps sublevel keys to camelcase before passing to ProgressBubble', () => {
+    const wrapper = setUp();
+    const progressBubbleLevel = wrapper.find(ProgressBubble).props().level;
+    expect(progressBubbleLevel.teacherFeedbackReviewState).to.equal(
+      ReviewStates.keepWorking
     );
   });
 });

--- a/apps/test/unit/code-studio/components/SublevelCardTest.js
+++ b/apps/test/unit/code-studio/components/SublevelCardTest.js
@@ -77,7 +77,7 @@ describe('SublevelCard', () => {
     );
   });
 
-  it('mapps sublevel keys to camelcase before passing to ProgressBubble', () => {
+  it('maps sublevel keys to camelcase before passing to ProgressBubble', () => {
     const wrapper = setUp();
     const progressBubbleLevel = wrapper.find(ProgressBubble).props().level;
     expect(progressBubbleLevel.teacherFeedbackReviewState).to.equal(

--- a/apps/test/unit/code-studio/progressReduxTest.js
+++ b/apps/test/unit/code-studio/progressReduxTest.js
@@ -604,7 +604,8 @@ describe('progressReduxTest', () => {
             paired: undefined,
             isLocked: false,
             bonus: false,
-            sublevels: []
+            sublevels: [],
+            teacherFeedbackReviewState: null
           },
           {
             id: '323',
@@ -625,7 +626,8 @@ describe('progressReduxTest', () => {
             paired: undefined,
             isLocked: false,
             bonus: false,
-            sublevels: []
+            sublevels: [],
+            teacherFeedbackReviewState: null
           },
           {
             id: '322',
@@ -646,7 +648,8 @@ describe('progressReduxTest', () => {
             paired: undefined,
             isLocked: false,
             bonus: true,
-            sublevels: []
+            sublevels: [],
+            teacherFeedbackReviewState: null
           }
         ],
         [
@@ -669,7 +672,8 @@ describe('progressReduxTest', () => {
             paired: undefined,
             isLocked: false,
             bonus: false,
-            sublevels: []
+            sublevels: [],
+            teacherFeedbackReviewState: null
           },
           {
             id: '339',
@@ -690,7 +694,8 @@ describe('progressReduxTest', () => {
             paired: undefined,
             isLocked: false,
             bonus: false,
-            sublevels: []
+            sublevels: [],
+            teacherFeedbackReviewState: null
           },
           {
             id: '341',
@@ -711,7 +716,8 @@ describe('progressReduxTest', () => {
             paired: undefined,
             isLocked: false,
             bonus: false,
-            sublevels: []
+            sublevels: [],
+            teacherFeedbackReviewState: null
           }
         ]
       ];

--- a/apps/test/unit/templates/progress/ProgressBubbleTest.js
+++ b/apps/test/unit/templates/progress/ProgressBubbleTest.js
@@ -12,6 +12,11 @@ import {
   BubbleShape
 } from '@cdo/apps/templates/progress/BubbleFactory';
 import * as utils from '@cdo/apps/utils';
+import {ReviewStates} from '@cdo/apps/templates/feedback/types';
+import {
+  AssessmentBadge,
+  KeepWorkingBadge
+} from '@cdo/apps/templates/progress/BubbleBadge';
 
 const defaultProps = {
   level: {
@@ -217,6 +222,52 @@ describe('ProgressBubble', () => {
     expect(wrapper.props().size).to.equal(BubbleSize.dot);
   });
 
+  it('shows KeepWorkingBadge if a level has teacher feedback keepWorking and not smallBubble', () => {
+    const wrapper = shallow(
+      <ProgressBubble
+        {...defaultProps}
+        smallBubble={false}
+        level={{
+          ...defaultProps.level,
+          teacherFeedbackReviewState: ReviewStates.keepWorking
+        }}
+      />
+    );
+
+    expect(wrapper.find(KeepWorkingBadge)).to.have.lengthOf(1);
+  });
+
+  it('hides KeepWorkingBadge if a level has teacher feedback keepWorking and is smallBubble', () => {
+    const wrapper = shallow(
+      <ProgressBubble
+        {...defaultProps}
+        smallBubble={true}
+        level={{
+          ...defaultProps.level,
+          teacherFeedbackReviewState: ReviewStates.keepWorking
+        }}
+      />
+    );
+
+    expect(wrapper.find(KeepWorkingBadge)).to.have.lengthOf(0);
+  });
+
+  it('shows KeepWorkingBadge instead of AssessmentBadge on assessment level if feedback is keepWorking', () => {
+    const wrapper = shallow(
+      <ProgressBubble
+        {...defaultProps}
+        level={{
+          ...defaultProps.level,
+          kind: LevelKind.assessment,
+          teacherFeedbackReviewState: ReviewStates.keepWorking
+        }}
+      />
+    );
+
+    expect(wrapper.find(KeepWorkingBadge)).to.have.lengthOf(1);
+    expect(wrapper.find(AssessmentBadge)).to.have.lengthOf(0);
+  });
+
   it('shows AssessmentBadge on assessment level', () => {
     const wrapper = shallow(
       <ProgressBubble
@@ -228,7 +279,7 @@ describe('ProgressBubble', () => {
       />
     );
 
-    expect(wrapper.find('AssessmentBadge')).to.have.lengthOf(1);
+    expect(wrapper.find(AssessmentBadge)).to.have.lengthOf(1);
   });
 
   it('does not show AssessmentBadge on bubble on assessment level, if smallBubble is true', () => {
@@ -243,7 +294,7 @@ describe('ProgressBubble', () => {
       />
     );
 
-    expect(wrapper.find('AssessmentBadge')).to.have.lengthOf(0);
+    expect(wrapper.find(AssessmentBadge)).to.have.lengthOf(0);
   });
 
   it('renders a pill shape for unplugged lessons', () => {

--- a/apps/test/unit/templates/progress/ProgressPillTest.js
+++ b/apps/test/unit/templates/progress/ProgressPillTest.js
@@ -4,13 +4,19 @@ import {shallow} from 'enzyme';
 import {UnconnectedProgressPill as ProgressPill} from '@cdo/apps/templates/progress/ProgressPill';
 import {LevelStatus, LevelKind} from '@cdo/apps/util/sharedConstants';
 import ReactTooltip from 'react-tooltip';
+import {ReviewStates} from '@cdo/apps/templates/feedback/types';
+import {
+  AssessmentBadge,
+  KeepWorkingBadge
+} from '@cdo/apps/templates/progress/BubbleBadge';
 
 const unpluggedLevel = {
   id: '1',
   kind: LevelKind.unplugged,
   isUnplugged: true,
   status: LevelStatus.perfect,
-  isLocked: false
+  isLocked: false,
+  teacherFeedbackReviewState: undefined
 };
 
 const assessmentLevel = {
@@ -18,7 +24,13 @@ const assessmentLevel = {
   kind: LevelKind.assessment,
   isUnplugged: false,
   status: LevelStatus.perfect,
-  isLocked: false
+  isLocked: false,
+  teacherFeedbackReviewState: undefined
+};
+
+const keepWorkingLevel = {
+  ...unpluggedLevel,
+  teacherFeedbackReviewState: ReviewStates.keepWorking
 };
 
 const levelWithUrl = {
@@ -86,18 +98,46 @@ describe('ProgressPill', () => {
     assert.equal(wrapper.find('a').props().href, undefined);
   });
 
+  it('has an keep working icon when single level has keepWorking feedback', () => {
+    const wrapper = shallow(
+      <ProgressPill {...DEFAULT_PROPS} levels={[keepWorkingLevel]} />
+    );
+    expect(wrapper.find(KeepWorkingBadge)).to.have.lengthOf(1);
+  });
+
+  it('does not have an keep working icon when pill represents multiple levels', () => {
+    const wrapper = shallow(
+      <ProgressPill
+        {...DEFAULT_PROPS}
+        levels={[keepWorkingLevel, keepWorkingLevel, keepWorkingLevel]}
+      />
+    );
+    expect(wrapper.find(KeepWorkingBadge)).to.have.lengthOf(0);
+  });
+
+  it('has an keep working icon when single level is assessment and has keepWorking feedback', () => {
+    const level = {
+      ...assessmentLevel,
+      teacherFeedbackReviewState: ReviewStates.keepWorking
+    };
+    const wrapper = shallow(
+      <ProgressPill {...DEFAULT_PROPS} levels={[level]} />
+    );
+    expect(wrapper.find(KeepWorkingBadge)).to.have.lengthOf(1);
+  });
+
   it('has an assessment icon when single level is assessment', () => {
     const wrapper = shallow(
       <ProgressPill {...DEFAULT_PROPS} levels={[assessmentLevel]} />
     );
-    expect(wrapper.find('AssessmentBadge')).to.have.lengthOf(1);
+    expect(wrapper.find(AssessmentBadge)).to.have.lengthOf(1);
   });
 
   it('does not have an assessment icon when single level is not assessment', () => {
     const wrapper = shallow(
       <ProgressPill {...DEFAULT_PROPS} levels={[unpluggedLevel]} />
     );
-    expect(wrapper.find('AssessmentBadge')).to.have.lengthOf(0);
+    expect(wrapper.find(AssessmentBadge)).to.have.lengthOf(0);
   });
 
   it('does not have an assessment icon when multiple assessment levels', () => {
@@ -107,6 +147,6 @@ describe('ProgressPill', () => {
         levels={[assessmentLevel, assessmentLevel]}
       />
     );
-    expect(wrapper.find('BubbleBadge')).to.have.lengthOf(0);
+    expect(wrapper.find(AssessmentBadge)).to.have.lengthOf(0);
   });
 });

--- a/apps/test/unit/templates/sectionProgress/sectionProgressLoaderTest.js
+++ b/apps/test/unit/templates/sectionProgress/sectionProgressLoaderTest.js
@@ -39,6 +39,7 @@ const serverProgressResponse = {
         result: -1,
         paired: false,
         time_spent: undefined,
+        teacher_feedback_review_state: undefined,
         last_progress_at: 12345
       },
       '2001': {
@@ -46,6 +47,7 @@ const serverProgressResponse = {
         result: 30,
         paired: true,
         time_spent: 12345,
+        teacher_feedback_review_state: undefined,
         last_progress_at: 12345
       }
     },
@@ -55,6 +57,7 @@ const serverProgressResponse = {
         result: 100,
         paired: false,
         time_spent: 6789,
+        teacher_feedback_review_state: undefined,
         last_progress_at: 6789
       }
     }
@@ -80,6 +83,7 @@ const firstServerProgressResponse = {
         result: -1,
         paired: false,
         time_spent: undefined,
+        teacher_feedback_review_state: undefined,
         last_progress_at: 12345
       },
       '2001': {
@@ -87,6 +91,7 @@ const firstServerProgressResponse = {
         result: 30,
         paired: true,
         time_spent: 12345,
+        teacher_feedback_review_state: undefined,
         last_progress_at: 12345
       }
     }
@@ -109,6 +114,7 @@ const secondServerProgressResponse = {
         result: 100,
         paired: false,
         time_spent: 6789,
+        teacher_feedback_review_state: undefined,
         last_progress_at: 6789
       }
     }
@@ -140,6 +146,7 @@ const fullExpectedResult = {
           result: -1,
           paired: false,
           timeSpent: undefined,
+          teacherFeedbackReviewState: undefined,
           lastTimestamp: 12345
         },
         '2001': {
@@ -149,6 +156,7 @@ const fullExpectedResult = {
           result: 30,
           paired: true,
           timeSpent: 12345,
+          teacherFeedbackReviewState: undefined,
           lastTimestamp: 12345
         }
       },
@@ -160,6 +168,7 @@ const fullExpectedResult = {
           result: 100,
           paired: false,
           timeSpent: 6789,
+          teacherFeedbackReviewState: undefined,
           lastTimestamp: 6789
         }
       }

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -80,9 +80,6 @@ class ScriptLevelsController < ApplicationController
     authorize! :read, ScriptLevel
     @script = ScriptLevelsController.get_script(request)
 
-    # will be true if the user is in any unarchived section where tts autoplay is enabled
-    @tts_autoplay_enabled = current_user&.sections_as_student&.where({hidden: false})&.map(&:tts_autoplay_enabled)&.reduce(false, :|)
-
     # @view_as_user is used to determine redirect path for bubble choice levels
     view_as_other = params[:user_id] && current_user && params[:user_id] != current_user.id
     @view_as_user = view_as_other ? User.find(params[:user_id]) : current_user
@@ -107,6 +104,9 @@ class ScriptLevelsController < ApplicationController
       redirect_to new_path
       return
     end
+
+    # will be true if the user is in any unarchived section where tts autoplay is enabled
+    @tts_autoplay_enabled = current_user&.sections_as_student&.where({hidden: false})&.map(&:tts_autoplay_enabled)&.reduce(false, :|)
 
     configure_caching(@script)
 

--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -262,7 +262,7 @@ module UsersHelper
           if bubble_choice_progress.present?
             progress.merge!(bubble_choice_progress.compact)
 
-            sum_time_spent = bubble_choice_progress&.values&.reduce(0) do |sum, sublevel_progress|
+            sum_time_spent = bubble_choice_progress.values.reduce(0) do |sum, sublevel_progress|
               sublevel_progress[:time_spent] ? sum + sublevel_progress[:time_spent] : sum
             end
             level_progress[:time_spent] = sum_time_spent if sum_time_spent > 0

--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -220,12 +220,11 @@ module UsersHelper
           level_id_for_feedback, user.id, ul, sl, paired_user_levels, include_timestamp
         )
 
-        # maureen come back to review state for bubble choice
         if level.is_a?(BubbleChoice) # we have a parent level
           bubble_choice_progress = get_bubble_choice_progress(
             level, user, user_levels_by_level, sl, paired_user_levels, include_timestamp
           )
-          if bubble_choice_progress
+          if bubble_choice_progress.present?
             progress.merge!(bubble_choice_progress.compact)
 
             sum_time_spent = bubble_choice_progress&.values&.reduce(0) do |sum, sublevel_progress|
@@ -302,7 +301,6 @@ module UsersHelper
     include_timestamp
   )
     progress = {}
-    best_progress = nil
 
     # get progress for sublevels to save in levels hash
     level.sublevels.each do |sublevel|
@@ -311,13 +309,7 @@ module UsersHelper
       next unless sublevel_progress
 
       progress[sublevel.id] = sublevel_progress
-      if !best_progress || sublevel_progress[:result] > best_progress[:result]
-        best_progress = sublevel_progress
-      end
     end
-
-    # if we don't have a best progress, we don't have any progress
-    return nil if best_progress.nil?
 
     progress
   end

--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -213,8 +213,8 @@ module UsersHelper
         level_for_progress = level.get_level_for_progress(user, script)
         ul = user_levels_by_level.try(:[], level_for_progress.id)
 
-        # feedback for contained level is stored with the level ID not the contained level ID
-        # which is why we pass level_id here - maureen make this better
+        # For contained levels, progress is stored with the contained level id but feedback is stored with
+        # the level id, which is why we need a different level id to get feedback for contained levels.
         level_id_for_feedback =  level.contained_levels.any? ? level.id : level_for_progress.id
         level_progress = get_level_progress(
           level_id_for_feedback, user.id, ul, sl, paired_user_levels, include_timestamp
@@ -259,7 +259,6 @@ module UsersHelper
     paired_user_levels,
     include_timestamp
   )
-    # maureen figure out what to do here if there's no progress but feedback exists
     feedback = TeacherFeedback.get_latest_feedbacks_received(user_id, level_id_for_feedback, script_level.script.id).first
 
     # if we don't have a user level, that means the user doesn't have any

--- a/dashboard/app/models/levels/bubble_choice.rb
+++ b/dashboard/app/models/levels/bubble_choice.rb
@@ -195,6 +195,14 @@ class BubbleChoice < DSLDefined
     end
   end
 
+  # gets the sublevel which will represent the overall progress for the level
+  # (displayed in the progress bubble)
+  def get_sublevel_for_progress(student, script)
+    keep_working_level = keep_working_sublevel(student, script)
+    best_result_level = best_result_sublevel(student, script)
+    return keep_working_level || best_result_level
+  end
+
   # Returns an array of BubbleChoice parent levels for any given sublevel name.
   # @param [String] level_name. The name of the sublevel.
   # @return [Array<BubbleChoice>] The BubbleChoice parent level(s) of the given sublevel.

--- a/dashboard/app/models/levels/bubble_choice.rb
+++ b/dashboard/app/models/levels/bubble_choice.rb
@@ -156,6 +156,9 @@ class BubbleChoice < DSLDefined
                               else
                                 SharedConstants::LEVEL_STATUS.not_tried
                               end
+
+        level_feedback = TeacherFeedback.get_latest_feedbacks_received(user_id, level.id, script_level.try(:script)).first
+        level_info[:teacher_feedback_review_state] = level_feedback&.review_state
       else
         # Pass an empty status if the user is not logged in so the ProgressBubble
         # in the sublevel display can render correctly.
@@ -195,8 +198,9 @@ class BubbleChoice < DSLDefined
     end
   end
 
-  # gets the sublevel which will represent the overall progress for the level
-  # (displayed in the progress bubble)
+  # Determine which sublevel's status to display in our progress bubble.
+  # If there is a sublevel marked with feedback "keep working", display that one. Otherwise display the
+  # progress for sublevel that has the best result
   def get_sublevel_for_progress(student, script)
     keep_working_level = keep_working_sublevel(student, script)
     best_result_level = best_result_sublevel(student, script)

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -807,6 +807,19 @@ class Level < ApplicationRecord
     }
   end
 
+  def get_level_for_progress(student, script)
+    if is_a?(BubbleChoice)
+      sublevel_for_progress = try(:get_sublevel_for_progress, student, script)
+      return sublevel_for_progress || self
+    elsif contained_levels.any?
+      # https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/views/levels/_contained_levels.html.haml#L1
+      # We only display our first contained level, display progress for that level.
+      return contained_levels.first
+    else
+      return self
+    end
+  end
+
   def summarize_for_lesson_show(can_view_teacher_markdown)
     teacher_markdown_for_display = localized_teacher_markdown if can_view_teacher_markdown
     {

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -36,7 +36,6 @@ require 'cdo/shared_constants'
 class ScriptLevel < ApplicationRecord
   include SerializedProperties
   include LevelsHelper
-  include UsersHelper
   include SharedConstants
   include Rails.application.routes.url_helpers
 
@@ -553,7 +552,7 @@ class ScriptLevel < ApplicationRecord
 
   # Bring together all the information needed to show the teacher panel on a level
   def summarize_for_teacher_panel(student, teacher = nil)
-    level_for_progress = get_level_for_progress(student, oldest_active_level, script)
+    level_for_progress = oldest_active_level.get_level_for_progress(student, script)
     user_level = student.last_attempt_for_any([level_for_progress], script_id: script_id)
 
     status = activity_css_class(user_level)

--- a/dashboard/app/models/teacher_feedback.rb
+++ b/dashboard/app/models/teacher_feedback.rb
@@ -71,7 +71,7 @@ class TeacherFeedback < ApplicationRecord
       student_id: student_id,
       level_id: level_id,
       script_id: script_id
-    }
+    }.compact
 
     where(query).
       latest_per_teacher.

--- a/dashboard/test/controllers/api_controller_queries_test.rb
+++ b/dashboard/test/controllers/api_controller_queries_test.rb
@@ -14,11 +14,12 @@ class ApiControllerQueriesTest < ActionDispatch::IntegrationTest
       students.each do |student|
         create :user_level, user: student, level: script_level.level, script: script
       end
+      create :teacher_feedback, student: students.first, teacher: section.teacher, level: script_level.level, script: script
     end
 
     sign_in_as section.teacher
 
-    assert_queries 8 do
+    assert_queries 10 do
       get '/dashboardapi/section_level_progress', params: {
         section_id: section.id,
         script_id: script.id

--- a/dashboard/test/integration/db_query_test.rb
+++ b/dashboard/test/integration/db_query_test.rb
@@ -20,7 +20,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
       level: level,
       level_source: create(:level_source, level: level)
 
-    assert_cached_queries(13) do
+    assert_cached_queries(18) do
       get script_lesson_script_level_path(
         script_id: script.name,
         lesson_position: 1,
@@ -51,7 +51,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
       level: level.id
     )
 
-    assert_cached_queries(10) do
+    assert_cached_queries(12) do
       get user_progress_path,
         headers: {'HTTP_USER_AGENT': 'test'}
       assert_response :success

--- a/dashboard/test/models/levels/bubble_choice_test.rb
+++ b/dashboard/test/models/levels/bubble_choice_test.rb
@@ -243,15 +243,16 @@ DSL
     refute sublevel_summary.last[:perfect]
   end
 
-  test 'best_result_sublevel returns sublevel with highest best_result for user' do
+  test 'get_sublevel_for_progress returns sublevel with highest best_result for user when there is no teacher feedback' do
     student = create :student
-    create :user_level, user: student, level: @sublevel2, best_result: 100
-    create :user_level, user: student, level: @sublevel1, best_result: 20
+    script = @script_level.script
+    create :user_level, user: student, level: @sublevel2, script: script, best_result: 100
+    create :user_level, user: student, level: @sublevel1, script: script, best_result: 20
 
-    assert_equal @sublevel2, @bubble_choice.best_result_sublevel(student, nil)
+    assert_equal @sublevel2, @bubble_choice.get_sublevel_for_progress(student, script)
   end
 
-  test 'keep_working_sublevel returns sublevel where the latest feedback has keepWorking review state' do
+  test 'get_sublevel_for_progress returns sublevel where the latest feedback has keepWorking review state' do
     teacher = create :teacher
     student = create :student
     section = create :section, teacher: teacher
@@ -262,14 +263,12 @@ DSL
     create :user_level, user: student, level: @sublevel1, script: script, best_result: 20
     create :teacher_feedback, student: student, teacher: teacher, level: @sublevel1, script: script, review_state: TeacherFeedback::REVIEW_STATES.keepWorking
 
-    assert_equal @sublevel1, @bubble_choice.keep_working_sublevel(student, script)
+    assert_equal @sublevel1, @bubble_choice.get_sublevel_for_progress(student, script)
   end
 
-  test 'keep_working_sublevel returns nil if no sublevels latest feedback have keepWorking review state' do
+  test 'get_sublevel_for_progress returns nil if no sublevels have progress or feedback' do
     student = create :student
-    create :user_level, user: student, level: @sublevel1, script: @script_level.script, best_result: 100
-
-    assert_nil @bubble_choice.keep_working_sublevel(student, @script_level.script)
+    assert_nil @bubble_choice.get_sublevel_for_progress(student, @script_level.script)
   end
 
   test 'self.parent_levels returns BubbleChoice parent levels for given sublevel name' do


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
The changes in this PR add "keep working" badges to the progress bubbles in the header, script overview pages and to the progress bubbles on the sublevel and bonus level cards. These badges should show if the teacher has given `keepWorking` feedback to the student for the level.

There's a lot to review here, if it's too much to give a good review let me know and I'll figure out a way to split it up into multiple PRs.

![Screen Shot 2021-07-01 at 4 22 40 PM](https://user-images.githubusercontent.com/24235215/124199923-f540bc80-da88-11eb-9ca0-14e096ace251.png)

![Screen Shot 2021-07-02 at 1 31 53 PM](https://user-images.githubusercontent.com/24235215/124325663-e82fd600-db39-11eb-91ce-15fc5271e6a8.png)


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
- jira ticket: [LP-1900](https://codedotorg.atlassian.net/browse/LP-1900)
<!--
- spec: []()

-->

## Testing story
Tested locally for several levels: regular, bubble choice, assessment, also added unit tests.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
