### PR TITLE
i18n will double-quote YAML strings with '#' in them

### DIFF
--- a/bin/i18n/i18n_script_utils.rb
+++ b/bin/i18n/i18n_script_utils.rb
@@ -55,10 +55,17 @@ class I18nScriptUtils
 
     # Make sure we treat the strings 'y' and 'n' as strings, and not bools
     yaml_bool = /^(?:y|Y|n|N)$/
+    # Make sure we use the right format for strings with '#' in them, otherwise
+    # YAML parsers might treat part of the string as a YAML comment.
+    octothorp = /#/
     ast.grep(Psych::Nodes::Scalar).each do |node|
       if yaml_bool.match node.value
         node.plain = false
         node.quoted = true
+      elsif octothorp.match node.value
+        node.plain = false
+        node.quoted = true
+        node.style = Psych::Nodes::Scalar::DOUBLE_QUOTED
       end
     end
 

--- a/bin/i18n/i18n_script_utils.rb
+++ b/bin/i18n/i18n_script_utils.rb
@@ -57,12 +57,12 @@ class I18nScriptUtils
     yaml_bool = /^(?:y|Y|n|N)$/
     # Make sure we use the right format for strings with '#' in them, otherwise
     # YAML parsers might treat part of the string as a YAML comment.
-    octothorp = /#/
+    octothorpe = /#/
     ast.grep(Psych::Nodes::Scalar).each do |node|
       if yaml_bool.match node.value
         node.plain = false
         node.quoted = true
-      elsif octothorp.match node.value
+      elsif octothorpe.match node.value
         node.plain = false
         node.quoted = true
         node.style = Psych::Nodes::Scalar::DOUBLE_QUOTED


### PR DESCRIPTION
Adds double quotes around strings which have an '#'  in them (markdown formatting); otherwise, YAML parsers might treat the string as a comment.

Ideally we would add double quotes around all Strings, but testing revealed that Crowdin's YAML parser has some bugs and can't parse some specific use cases. Fortunately, none of our markdown strings seem to hit those edge cases.

## Testing story
* Ran a full i18n sync on the `i18n-dev` server

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
