### PR TITLE
Embed Share Width

### DIFF
--- a/apps/src/code-studio/components/ShareAllowedDialog.jsx
+++ b/apps/src/code-studio/components/ShareAllowedDialog.jsx
@@ -210,7 +210,8 @@ class ShareAllowedDialog extends React.Component {
       embedOptions = {
         // If you change this width and height, make sure to update the
         // #visualizationColumn.wireframeShare css
-        iframeHeight: applabConstants.APP_HEIGHT + 140,
+        // Extra 40 pixels added to account for left and right padding divs (20 px each side)
+        iframeHeight: applabConstants.APP_HEIGHT + 140 + 40,
         iframeWidth: applabConstants.APP_WIDTH + 32
       };
     } else if (this.props.appType === 'gamelab') {

--- a/apps/src/code-studio/components/ShareAllowedDialog.jsx
+++ b/apps/src/code-studio/components/ShareAllowedDialog.jsx
@@ -211,6 +211,7 @@ class ShareAllowedDialog extends React.Component {
         // If you change this width and height, make sure to update the
         // #visualizationColumn.wireframeShare css
         iframeHeight: applabConstants.APP_HEIGHT + 140,
+        // Extra 32 pixels added to account for phone frame
         // Extra 40 pixels added to account for left and right padding divs (20 px each side)
         iframeWidth: applabConstants.APP_WIDTH + 32 + 40
       };
@@ -219,7 +220,8 @@ class ShareAllowedDialog extends React.Component {
         // If you change this width and height, make sure to update the
         // #visualizationColumn.wireframeShare css
         iframeHeight: p5labConstants.APP_HEIGHT + 357,
-        iframeWidth: p5labConstants.APP_WIDTH + 32
+        // Extra 40 pixels added to account for left and right padding divs (20 px each side)
+        iframeWidth: p5labConstants.APP_WIDTH + 40
       };
     }
     const {canPrint, canPublish, isPublished} = this.props;

--- a/apps/src/code-studio/components/ShareAllowedDialog.jsx
+++ b/apps/src/code-studio/components/ShareAllowedDialog.jsx
@@ -210,9 +210,9 @@ class ShareAllowedDialog extends React.Component {
       embedOptions = {
         // If you change this width and height, make sure to update the
         // #visualizationColumn.wireframeShare css
+        iframeHeight: applabConstants.APP_HEIGHT + 140,
         // Extra 40 pixels added to account for left and right padding divs (20 px each side)
-        iframeHeight: applabConstants.APP_HEIGHT + 140 + 40,
-        iframeWidth: applabConstants.APP_WIDTH + 32
+        iframeWidth: applabConstants.APP_WIDTH + 32 + 40
       };
     } else if (this.props.appType === 'gamelab') {
       embedOptions = {


### PR DESCRIPTION
After fighting with relative and fixed positioning in CSS for this PR chain: https://github.com/code-dot-org/code-dot-org/pull/41136, I decided to just go with the simple solution. This means we are still using divs for spacing, but there are so many factors at play in the spacing, I think it just makes sense to let that exist (if it works, it works). This adds the 40 pixel offset to the calculation of embeded app, which takes into account the 20 pixel spacing for the left and right container. Because this is scoped to the embedded share view, I can ignore the comment that says changes in width should also be added to visualizationColumn.wireframeShare. 

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
