### PR TITLE
`KeepWorkingBadge` in progress table

### DIFF
--- a/apps/src/code-studio/components/SublevelCard.jsx
+++ b/apps/src/code-studio/components/SublevelCard.jsx
@@ -94,6 +94,8 @@ export default class SublevelCard extends React.Component {
 
     let mappedSublevel = sublevel;
     if (mappedSublevel) {
+      // ProgressBubble expects level keys to be camelCase (instead of snake case)
+      // converting keys to the correct casing here
       mappedSublevel = _.mapKeys(sublevel, (value, key) => _.camelCase(key));
     }
 

--- a/apps/src/code-studio/components/progress/TeacherPanelProgressBubble.jsx
+++ b/apps/src/code-studio/components/progress/TeacherPanelProgressBubble.jsx
@@ -8,11 +8,12 @@ import {
   levelProgressStyle
 } from '@cdo/apps/templates/progress/progressStyles';
 import {LevelStatus} from '@cdo/apps/util/sharedConstants';
-import {
-  BubbleBadgeWrapper,
-  KeepWorkingBadge
-} from '@cdo/apps/templates/progress/BubbleBadge';
+import BubbleBadge, {BadgeType} from '@cdo/apps/templates/progress/BubbleBadge';
 import {ReviewStates} from '@cdo/apps/templates/feedback/types';
+import {
+  BubbleShape,
+  BubbleSize
+} from '@cdo/apps/templates/progress/BubbleFactory';
 
 /**
  * A TeacherPanelProgressBubble represents progress for a specific level in the TeacherPanel. It can be a circle
@@ -70,9 +71,15 @@ export class TeacherPanelProgressBubble extends React.Component {
             {!hideNumber && <span>{userLevel.levelNumber}</span>}
           </div>
           {shouldKeepWorking && (
-            <BubbleBadgeWrapper isDiamond={userLevel.isConceptLevel}>
-              <KeepWorkingBadge />
-            </BubbleBadgeWrapper>
+            <BubbleBadge
+              bubbleShape={
+                userLevel.isConceptLevel
+                  ? BubbleShape.diamond
+                  : BubbleShape.circle
+              }
+              bubbleSize={BubbleSize.full}
+              badgeType={BadgeType.keepWorking}
+            />
           )}
         </div>
       </div>

--- a/apps/src/templates/progress/BubbleBadge.jsx
+++ b/apps/src/templates/progress/BubbleBadge.jsx
@@ -2,7 +2,38 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import color from '@cdo/apps/util/color';
 import FontAwesome from '../FontAwesome';
+import {makeEnum} from '@cdo/apps/utils';
+import {BubbleSize, BubbleShape} from './BubbleFactory';
 
+export const BadgeType = makeEnum('assessment', 'keepWorking');
+
+export default function BubbleBadge({badgeType, bubbleSize, bubbleShape}) {
+  const badge = getBadge(badgeType);
+  if (!badge || bubbleSize !== BubbleSize.full) {
+    return null;
+  }
+  return (
+    <BubbleBadgeWrapper isDiamond={bubbleShape === BubbleShape.diamond}>
+      {badge}
+    </BubbleBadgeWrapper>
+  );
+}
+BubbleBadge.propTypes = {
+  badgeType: PropTypes.oneOf(Object.values(BadgeType)).isRequired,
+  bubbleSize: PropTypes.oneOf(Object.values(BubbleSize)).isRequired,
+  bubbleShape: PropTypes.oneOf(Object.values(BubbleShape)).isRequired
+};
+
+function getBadge(badgeType) {
+  switch (badgeType) {
+    case BadgeType.assessment:
+      return <AssessmentBadge />;
+    case BadgeType.keepWorking:
+      return <KeepWorkingBadge />;
+    default:
+      return null;
+  }
+}
 export function BubbleBadgeWrapper({isDiamond, children}) {
   const bubblePositioning = isDiamond
     ? styles.diamondBubblePosition

--- a/apps/src/templates/progress/BubbleBadge.jsx
+++ b/apps/src/templates/progress/BubbleBadge.jsx
@@ -34,7 +34,7 @@ function getBadge(badgeType) {
       return null;
   }
 }
-export function BubbleBadgeWrapper({isDiamond, children}) {
+function BubbleBadgeWrapper({isDiamond, children}) {
   const bubblePositioning = isDiamond
     ? styles.diamondBubblePosition
     : styles.bubblePosition;

--- a/apps/src/templates/progress/ProgressBubble.jsx
+++ b/apps/src/templates/progress/ProgressBubble.jsx
@@ -13,12 +13,8 @@ import {
   getBubbleUrl
 } from './BubbleFactory';
 import {levelProgressStyle} from './progressStyles';
-import {
-  BubbleBadgeWrapper,
-  AssessmentBadge,
-  KeepWorkingBadge
-} from '@cdo/apps/templates/progress/BubbleBadge';
 import {ReviewStates} from '@cdo/apps/templates/feedback/types';
+import BubbleBadge, {BadgeType} from './BubbleBadge';
 
 /**
  * A ProgressBubble represents progress for a specific level. It can be a circle
@@ -97,13 +93,15 @@ export default class ProgressBubble extends React.Component {
       >
         {content}
         {displayBubbleBadge && (
-          <BubbleBadgeWrapper isDiamond={level.isConceptLevel}>
-            {hasKeepWorkingFeedback ? (
-              <KeepWorkingBadge />
-            ) : (
-              <AssessmentBadge />
-            )}
-          </BubbleBadgeWrapper>
+          <BubbleBadge
+            badgeType={
+              hasKeepWorkingFeedback
+                ? BadgeType.keepWorking
+                : BadgeType.assessment
+            }
+            bubbleSize={bubbleSize}
+            bubbleShape={shape}
+          />
         )}
       </BasicBubble>
     );

--- a/apps/src/templates/progress/ProgressLegend.jsx
+++ b/apps/src/templates/progress/ProgressLegend.jsx
@@ -7,7 +7,7 @@ import {
   BasicTooltip,
   BubbleSize
 } from './BubbleFactory';
-import {BubbleBadgeWrapper, KeepWorkingBadge} from './BubbleBadge';
+import BubbleBadge, {BadgeType} from './BubbleBadge';
 import {defaultBubbleIcon} from './progressHelpers';
 import {levelProgressStyle} from './progressStyles';
 import FontAwesome from '../FontAwesome';
@@ -306,17 +306,20 @@ export default class ProgressLegend extends Component {
   }
 
   getBubble(status, isConcept, text, includeKeepWorkingBadge = false) {
+    const shape = isConcept ? BubbleShape.diamond : BubbleShape.circle;
     return (
       <BasicTooltip icon={defaultBubbleIcon} text={text}>
         <BasicBubble
-          shape={isConcept ? BubbleShape.diamond : BubbleShape.circle}
+          shape={shape}
           size={BubbleSize.full}
           progressStyle={levelProgressStyle(status)}
         >
           {includeKeepWorkingBadge && (
-            <BubbleBadgeWrapper isDiamond={isConcept}>
-              <KeepWorkingBadge />
-            </BubbleBadgeWrapper>
+            <BubbleBadge
+              badgeType={BadgeType.keepWorking}
+              bubbleSize={BubbleSize.full}
+              bubbleShape={shape}
+            />
           )}
         </BasicBubble>
       </BasicTooltip>

--- a/apps/src/templates/progress/ProgressPill.jsx
+++ b/apps/src/templates/progress/ProgressPill.jsx
@@ -7,13 +7,13 @@ import {levelWithProgressType} from './progressTypes';
 import {levelProgressStyle, hoverStyle} from './progressStyles';
 import {stringifyQueryParams} from '../../utils';
 import {isLevelAssessment} from './progressHelpers';
-import {
-  BubbleBadgeWrapper,
-  AssessmentBadge,
-  KeepWorkingBadge
-} from '@cdo/apps/templates/progress/BubbleBadge';
 import {connect} from 'react-redux';
 import {ReviewStates} from '@cdo/apps/templates/feedback/types';
+import BubbleBadge, {BadgeType} from '@cdo/apps/templates/progress/BubbleBadge';
+import {
+  BubbleShape,
+  BubbleSize
+} from '@cdo/apps/templates/progress/BubbleFactory';
 
 /**
  * This component is similar to our ProgressBubble, except that instead of being
@@ -139,13 +139,15 @@ class ProgressPill extends React.Component {
           )}
           {tooltip}
           {displayBadge && (
-            <BubbleBadgeWrapper>
-              {hasKeepWorkingFeedback ? (
-                <KeepWorkingBadge />
-              ) : (
-                <AssessmentBadge />
-              )}
-            </BubbleBadgeWrapper>
+            <BubbleBadge
+              badgeType={
+                hasKeepWorkingFeedback
+                  ? BadgeType.keepWorking
+                  : BadgeType.assessment
+              }
+              bubbleSize={BubbleSize.full}
+              bubbleShape={BubbleShape.pill}
+            />
           )}
         </div>
       </a>

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableDetailCell.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableDetailCell.jsx
@@ -95,6 +95,7 @@ export default class ProgressTableDetailCell extends React.Component {
             isConcept={level.isConceptLevel}
             title={level.bubbleText}
             url={url}
+            reviewState={levelProgress?.reviewState}
           />
         </div>
         {level.sublevels && this.renderSublevels(level)}

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableDetailCell.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableDetailCell.jsx
@@ -95,7 +95,7 @@ export default class ProgressTableDetailCell extends React.Component {
             isConcept={level.isConceptLevel}
             title={level.bubbleText}
             url={url}
-            reviewState={levelProgress?.reviewState}
+            reviewState={levelProgress?.teacherFeedbackReviewState}
           />
         </div>
         {level.sublevels && this.renderSublevels(level)}

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableLevelBubble.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableLevelBubble.jsx
@@ -9,6 +9,8 @@ import {
   getBubbleClassNames,
   getBubbleShape
 } from '@cdo/apps/templates/progress/BubbleFactory';
+import BubbleBadge, {BadgeType} from '@cdo/apps/templates/progress/BubbleBadge';
+import {ReviewStates} from '@cdo/apps/templates/feedback/types';
 import CachedElement from '@cdo/apps/util/CachedElement';
 import {levelProgressStyle} from '../../progress/progressStyles';
 
@@ -37,7 +39,8 @@ export default class ProgressTableLevelBubble extends React.PureComponent {
     isPaired: PropTypes.bool,
     bubbleSize: PropTypes.oneOf(Object.values(BubbleSize)).isRequired,
     title: PropTypes.string,
-    url: PropTypes.string
+    url: PropTypes.string,
+    reviewState: PropTypes.oneOf(Object.keys(ReviewStates))
   };
 
   static defaultProps = {
@@ -58,6 +61,12 @@ export default class ProgressTableLevelBubble extends React.PureComponent {
           createElement={this.createBubbleElement}
         />
       </BubbleLink>
+    );
+  }
+
+  shouldShowKeepWorkingBadge() {
+    return [ReviewStates.keepWorking, ReviewStates.awaitingReview].includes(
+      this.props.reviewState
     );
   }
 
@@ -85,7 +94,8 @@ export default class ProgressTableLevelBubble extends React.PureComponent {
       getBubbleShape(isUnplugged, isConcept),
       bubbleSize,
       levelProgressStyle(levelStatus, levelKind),
-      content
+      content,
+      this.shouldShowKeepWorkingBadge()
     );
   }
 
@@ -93,7 +103,7 @@ export default class ProgressTableLevelBubble extends React.PureComponent {
    * We use this helper as a testing hook to intercept the explicit props used
    * to render the `BasicBubble`.
    */
-  renderBasicBubble(shape, size, progressStyle, content) {
+  renderBasicBubble(shape, size, progressStyle, content, showKeepWorkingBadge) {
     return (
       <BasicBubble
         shape={shape}
@@ -102,6 +112,13 @@ export default class ProgressTableLevelBubble extends React.PureComponent {
         classNames={getBubbleClassNames(true)}
       >
         {content}
+        {showKeepWorkingBadge && (
+          <BubbleBadge
+            badgeType={BadgeType.keepWorking}
+            bubbleSize={size}
+            bubbleShape={shape}
+          />
+        )}
       </BasicBubble>
     );
   }
@@ -168,6 +185,10 @@ export default class ProgressTableLevelBubble extends React.PureComponent {
       ? `ttl=${title}`
       : null;
 
-    return `${contentString}&${shapeString}&${statusString}`;
+    const strings = [contentString, shapeString, statusString];
+    if (this.shouldShowKeepWorkingBadge()) {
+      strings.push('bdg');
+    }
+    return strings.join('&');
   }
 }

--- a/apps/src/templates/sectionProgress/sectionProgressTestHelpers.js
+++ b/apps/src/templates/sectionProgress/sectionProgressTestHelpers.js
@@ -12,6 +12,7 @@ import locales from '@cdo/apps/redux/localesRedux';
 import {LevelStatus} from '@cdo/apps/util/sharedConstants';
 import {TestResults} from '@cdo/apps/constants';
 import {lessonProgressForSection} from '@cdo/apps/templates/progress/progressHelpers';
+import {ReviewStates} from '@cdo/apps/templates/feedback/types';
 
 export function fakeRowsForStudents(students) {
   const rows = [];
@@ -96,6 +97,7 @@ function randomProgress(level) {
   const rand = Math.floor(Math.random() * 4);
   const paired = Math.floor(Math.random() * 10) === 0;
   const timeSpent = level.isConceptLevel ? 0 : Math.random() * 60 * 60 + 1;
+  const timestamp = Date.now() / 1000;
   switch (rand) {
     case 0:
       return {
@@ -104,7 +106,8 @@ function randomProgress(level) {
         result: TestResults.MINIMUM_OPTIMAL_RESULT,
         paired: paired,
         timeSpent: timeSpent,
-        lastTimestamp: Date.now()
+        lastTimestamp: timestamp,
+        reviewState: randomReviewState()
       };
     case 1:
       return {
@@ -113,7 +116,8 @@ function randomProgress(level) {
         result: TestResults.LEVEL_STARTED,
         paired: paired,
         timeSpent: timeSpent,
-        lastTimestamp: Date.now()
+        lastTimestamp: timestamp,
+        reviewState: randomReviewState()
       };
     case 2:
       return {
@@ -122,8 +126,21 @@ function randomProgress(level) {
         result: TestResults.TOO_MANY_BLOCKS_FAIL,
         paired: paired,
         timeSpent: timeSpent,
-        lastTimestamp: Date.now()
+        lastTimestamp: timestamp,
+        reviewState: randomReviewState()
       };
+    default:
+      return null;
+  }
+}
+
+function randomReviewState() {
+  const rand = Math.floor(Math.random() * 20);
+  switch (rand) {
+    case 0:
+      return ReviewStates.keepWorking;
+    case 1:
+      return ReviewStates.awaitingReview;
     default:
       return null;
   }

--- a/apps/test/unit/code-studio/components/progress/TeacherPanelProgressBubbleTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/TeacherPanelProgressBubbleTest.jsx
@@ -4,7 +4,7 @@ import {assert, expect} from '../../../../util/reconfiguredChai';
 import {TeacherPanelProgressBubble} from '@cdo/apps/code-studio/components/progress/TeacherPanelProgressBubble';
 import color from '@cdo/apps/util/color';
 import {LevelKind, LevelStatus} from '@cdo/apps/util/sharedConstants';
-import {KeepWorkingBadge} from '@cdo/apps/templates/progress/BubbleBadge';
+import BubbleBadge, {BadgeType} from '@cdo/apps/templates/progress/BubbleBadge';
 import {ReviewStates} from '@cdo/apps/templates/feedback/types';
 
 const defaultUserLevel = {
@@ -120,13 +120,17 @@ describe('TeacherPanelProgressBubbleTest', () => {
       teacherFeedbackReivewState: ReviewStates.completed
     });
 
-    expect(wrapper.find(KeepWorkingBadge)).to.have.length(0);
+    const badge = wrapper.find(BubbleBadge);
+    expect(badge).to.have.lengthOf(0);
   });
 
   it('displays keep working badge if teacherFeedbackReivewState is keepWorking', () => {
     const wrapper = setUp({
       teacherFeedbackReivewState: ReviewStates.keepWorking
     });
-    expect(wrapper.find(KeepWorkingBadge)).to.have.length(1);
+
+    const badge = wrapper.find(BubbleBadge);
+    expect(badge).to.have.lengthOf(1);
+    expect(badge.at(0).props().badgeType).to.equal(BadgeType.keepWorking);
   });
 });

--- a/apps/test/unit/templates/progress/BubbleBadgeTest.jsx
+++ b/apps/test/unit/templates/progress/BubbleBadgeTest.jsx
@@ -1,14 +1,60 @@
 import React from 'react';
 import {mount, shallow} from 'enzyme';
-import {
+import BubbleBadge, {
   BubbleBadgeWrapper,
   KeepWorkingBadge,
-  AssessmentBadge
+  AssessmentBadge,
+  BadgeType
 } from '@cdo/apps/templates/progress/BubbleBadge';
+import {
+  BubbleSize,
+  BubbleShape
+} from '@cdo/apps/templates/progress/BubbleFactory';
 import {expect} from '../../../util/reconfiguredChai';
 import color from '@cdo/apps/util/color';
 
 describe('BubbleBadge', () => {
+  it('renders an AssessmentBadge for BadgeType.assessment', () => {
+    const wrapper = shallow(
+      <BubbleBadge
+        badgeType={BadgeType.assessment}
+        bubbleSize={BubbleSize.full}
+        bubbleShape={BubbleShape.circle}
+      />
+    );
+    expect(wrapper.find(AssessmentBadge)).to.have.lengthOf(1);
+  });
+
+  it('renders a KeepWorkingBadge for BadgeType.keepWorking', () => {
+    const wrapper = shallow(
+      <BubbleBadge
+        badgeType={BadgeType.keepWorking}
+        bubbleSize={BubbleSize.full}
+        bubbleShape={BubbleShape.circle}
+      />
+    );
+    expect(wrapper.find(KeepWorkingBadge)).to.have.lengthOf(1);
+  });
+
+  it('renders nothing for small bubbles', () => {
+    const letter = shallow(
+      <BubbleBadge
+        badgeType={BadgeType.keepWorking}
+        bubbleSize={BubbleSize.letter}
+        bubbleShape={BubbleShape.circle}
+      />
+    );
+    const dot = shallow(
+      <BubbleBadge
+        badgeType={BadgeType.keepWorking}
+        bubbleSize={BubbleSize.dot}
+        bubbleShape={BubbleShape.circle}
+      />
+    );
+    expect(letter).to.be.empty;
+    expect(dot).to.be.empty;
+  });
+
   describe('BubbleBadgeWrapper', () => {
     it('positions the wrapper correctly if isDiamond is false', () => {
       const children = <div />;
@@ -24,7 +70,6 @@ describe('BubbleBadge', () => {
       const wrapper = shallow(
         <BubbleBadgeWrapper isDiamond={true}>{children}</BubbleBadgeWrapper>
       );
-      console.log(wrapper.debug());
       expect(wrapper.props().style.top).to.equal(-13);
       expect(wrapper.props().style.right).to.equal(-17);
     });

--- a/apps/test/unit/templates/progress/BubbleBadgeTest.jsx
+++ b/apps/test/unit/templates/progress/BubbleBadgeTest.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {mount, shallow} from 'enzyme';
 import BubbleBadge, {
-  BubbleBadgeWrapper,
   KeepWorkingBadge,
   AssessmentBadge,
   BadgeType
@@ -55,24 +54,28 @@ describe('BubbleBadge', () => {
     expect(dot).to.be.empty;
   });
 
-  describe('BubbleBadgeWrapper', () => {
-    it('positions the wrapper correctly if isDiamond is false', () => {
-      const children = <div />;
-      const wrapper = shallow(
-        <BubbleBadgeWrapper isDiamond={false}>{children}</BubbleBadgeWrapper>
-      );
-      expect(wrapper.props().style.top).to.equal(-7);
-      expect(wrapper.props().style.right).to.equal(-7);
-    });
+  it('positions the element correctly is bubbleShape is not a diamond', () => {
+    const wrapper = mount(
+      <BubbleBadge
+        badgeType={BadgeType.keepWorking}
+        bubbleShape={BubbleShape.circle}
+        bubbleSize={BubbleSize.full}
+      />
+    );
+    expect(wrapper.find('div').props().style.top).to.equal(-7);
+    expect(wrapper.find('div').props().style.right).to.equal(-7);
+  });
 
-    it('positions the wrapper correctly if isDiamond is true', () => {
-      const children = <div />;
-      const wrapper = shallow(
-        <BubbleBadgeWrapper isDiamond={true}>{children}</BubbleBadgeWrapper>
-      );
-      expect(wrapper.props().style.top).to.equal(-13);
-      expect(wrapper.props().style.right).to.equal(-17);
-    });
+  it('positions the element correctly is bubbleShape is a diamond', () => {
+    const wrapper = mount(
+      <BubbleBadge
+        badgeType={BadgeType.keepWorking}
+        bubbleShape={BubbleShape.diamond}
+        bubbleSize={BubbleSize.full}
+      />
+    );
+    expect(wrapper.find('div').props().style.top).to.equal(-13);
+    expect(wrapper.find('div').props().style.right).to.equal(-17);
   });
 
   describe('KeepWorkingBadge', () => {

--- a/apps/test/unit/templates/progress/ProgressBubbleTest.js
+++ b/apps/test/unit/templates/progress/ProgressBubbleTest.js
@@ -14,10 +14,6 @@ import {
 import BubbleBadge, {BadgeType} from '@cdo/apps/templates/progress/BubbleBadge';
 import * as utils from '@cdo/apps/utils';
 import {ReviewStates} from '@cdo/apps/templates/feedback/types';
-import {
-  AssessmentBadge,
-  KeepWorkingBadge
-} from '@cdo/apps/templates/progress/BubbleBadge';
 
 const defaultProps = {
   level: {
@@ -235,7 +231,9 @@ describe('ProgressBubble', () => {
       />
     );
 
-    expect(wrapper.find(KeepWorkingBadge)).to.have.lengthOf(1);
+    const badge = wrapper.find(BubbleBadge);
+    expect(badge).to.have.lengthOf(1);
+    expect(badge.at(0).props().badgeType).to.equal(BadgeType.keepWorking);
   });
 
   it('hides KeepWorkingBadge if a level has teacher feedback keepWorking and is smallBubble', () => {
@@ -250,7 +248,7 @@ describe('ProgressBubble', () => {
       />
     );
 
-    expect(wrapper.find(KeepWorkingBadge)).to.have.lengthOf(0);
+    expect(wrapper.find(BubbleBadge)).to.have.lengthOf(0);
   });
 
   it('shows KeepWorkingBadge instead of AssessmentBadge on assessment level if feedback is keepWorking', () => {
@@ -265,8 +263,9 @@ describe('ProgressBubble', () => {
       />
     );
 
-    expect(wrapper.find(KeepWorkingBadge)).to.have.lengthOf(1);
-    expect(wrapper.find(AssessmentBadge)).to.have.lengthOf(0);
+    const badge = wrapper.find(BubbleBadge);
+    expect(badge).to.have.lengthOf(1);
+    expect(badge.at(0).props().badgeType).to.equal(BadgeType.keepWorking);
   });
 
   it('shows AssessmentBadge on assessment level', () => {
@@ -296,7 +295,8 @@ describe('ProgressBubble', () => {
       />
     );
 
-    expect(wrapper.find(AssessmentBadge)).to.have.lengthOf(0);
+    const badge = wrapper.find(BubbleBadge);
+    expect(badge).to.have.lengthOf(0);
   });
 
   it('renders a pill shape for unplugged lessons', () => {

--- a/apps/test/unit/templates/progress/ProgressBubbleTest.js
+++ b/apps/test/unit/templates/progress/ProgressBubbleTest.js
@@ -11,6 +11,7 @@ import {
   BubbleSize,
   BubbleShape
 } from '@cdo/apps/templates/progress/BubbleFactory';
+import BubbleBadge, {BadgeType} from '@cdo/apps/templates/progress/BubbleBadge';
 import * as utils from '@cdo/apps/utils';
 import {ReviewStates} from '@cdo/apps/templates/feedback/types';
 import {
@@ -278,8 +279,9 @@ describe('ProgressBubble', () => {
         }}
       />
     );
-
-    expect(wrapper.find(AssessmentBadge)).to.have.lengthOf(1);
+    const badge = wrapper.find(BubbleBadge);
+    expect(badge).to.have.lengthOf(1);
+    expect(badge.at(0).props().badgeType).to.equal(BadgeType.assessment);
   });
 
   it('does not show AssessmentBadge on bubble on assessment level, if smallBubble is true', () => {

--- a/apps/test/unit/templates/progress/ProgressLegendTest.jsx
+++ b/apps/test/unit/templates/progress/ProgressLegendTest.jsx
@@ -2,7 +2,7 @@ import {expect} from '../../../util/reconfiguredChai';
 import React from 'react';
 import {shallow} from 'enzyme';
 import ProgressLegend from '@cdo/apps/templates/progress/ProgressLegend';
-import {KeepWorkingBadge} from '@cdo/apps/templates/progress/BubbleBadge';
+import BubbleBadge, {BadgeType} from '@cdo/apps/templates/progress/BubbleBadge';
 
 describe('ProgressLegend', () => {
   it('renders a single table without extra columns', () => {
@@ -37,6 +37,9 @@ describe('ProgressLegend', () => {
     const wrapper = shallow(
       <ProgressLegend includeReviewStates includeCsfColumn />
     );
-    expect(wrapper.find(KeepWorkingBadge)).to.have.lengthOf(2);
+
+    const badge = wrapper.find(BubbleBadge);
+    expect(badge).to.have.lengthOf(2);
+    expect(badge.at(0).props().badgeType).to.equal(BadgeType.keepWorking);
   });
 });

--- a/apps/test/unit/templates/progress/ProgressPillTest.js
+++ b/apps/test/unit/templates/progress/ProgressPillTest.js
@@ -5,10 +5,7 @@ import {UnconnectedProgressPill as ProgressPill} from '@cdo/apps/templates/progr
 import {LevelStatus, LevelKind} from '@cdo/apps/util/sharedConstants';
 import ReactTooltip from 'react-tooltip';
 import {ReviewStates} from '@cdo/apps/templates/feedback/types';
-import {
-  AssessmentBadge,
-  KeepWorkingBadge
-} from '@cdo/apps/templates/progress/BubbleBadge';
+import BubbleBadge, {BadgeType} from '@cdo/apps/templates/progress/BubbleBadge';
 
 const unpluggedLevel = {
   id: '1',
@@ -102,7 +99,10 @@ describe('ProgressPill', () => {
     const wrapper = shallow(
       <ProgressPill {...DEFAULT_PROPS} levels={[keepWorkingLevel]} />
     );
-    expect(wrapper.find(KeepWorkingBadge)).to.have.lengthOf(1);
+
+    const badge = wrapper.find(BubbleBadge);
+    expect(badge).to.have.lengthOf(1);
+    expect(badge.at(0).props().badgeType).to.equal(BadgeType.keepWorking);
   });
 
   it('does not have an keep working icon when pill represents multiple levels', () => {
@@ -112,7 +112,9 @@ describe('ProgressPill', () => {
         levels={[keepWorkingLevel, keepWorkingLevel, keepWorkingLevel]}
       />
     );
-    expect(wrapper.find(KeepWorkingBadge)).to.have.lengthOf(0);
+
+    const badge = wrapper.find(BubbleBadge);
+    expect(badge).to.have.lengthOf(0);
   });
 
   it('has an keep working icon when single level is assessment and has keepWorking feedback', () => {
@@ -123,21 +125,29 @@ describe('ProgressPill', () => {
     const wrapper = shallow(
       <ProgressPill {...DEFAULT_PROPS} levels={[level]} />
     );
-    expect(wrapper.find(KeepWorkingBadge)).to.have.lengthOf(1);
+
+    const badge = wrapper.find(BubbleBadge);
+    expect(badge).to.have.lengthOf(1);
+    expect(badge.at(0).props().badgeType).to.equal(BadgeType.keepWorking);
   });
 
   it('has an assessment icon when single level is assessment', () => {
     const wrapper = shallow(
       <ProgressPill {...DEFAULT_PROPS} levels={[assessmentLevel]} />
     );
-    expect(wrapper.find(AssessmentBadge)).to.have.lengthOf(1);
+
+    const badge = wrapper.find(BubbleBadge);
+    expect(badge).to.have.lengthOf(1);
+    expect(badge.at(0).props().badgeType).to.equal(BadgeType.assessment);
   });
 
   it('does not have an assessment icon when single level is not assessment', () => {
     const wrapper = shallow(
       <ProgressPill {...DEFAULT_PROPS} levels={[unpluggedLevel]} />
     );
-    expect(wrapper.find(AssessmentBadge)).to.have.lengthOf(0);
+
+    const badge = wrapper.find(BubbleBadge);
+    expect(badge).to.have.lengthOf(0);
   });
 
   it('does not have an assessment icon when multiple assessment levels', () => {
@@ -147,6 +157,8 @@ describe('ProgressPill', () => {
         levels={[assessmentLevel, assessmentLevel]}
       />
     );
-    expect(wrapper.find(AssessmentBadge)).to.have.lengthOf(0);
+
+    const badge = wrapper.find(BubbleBadge);
+    expect(badge).to.have.lengthOf(0);
   });
 });

--- a/apps/test/unit/templates/sectionProgress/ProgressTableLevelBubbleTest.jsx
+++ b/apps/test/unit/templates/sectionProgress/ProgressTableLevelBubbleTest.jsx
@@ -14,6 +14,11 @@ import {
   BubbleSize,
   BubbleShape
 } from '@cdo/apps/templates/progress/BubbleFactory';
+import BubbleBadge, {
+  KeepWorkingBadge,
+  BadgeType
+} from '@cdo/apps/templates/progress/BubbleBadge';
+import {ReviewStates} from '@cdo/apps/templates/feedback/types';
 
 const TITLE = '1';
 
@@ -77,6 +82,7 @@ function getFirstRenderedBasicBubble(propOverrides = {}) {
   const size = renderPropsSpy.args[0][1];
   const progressStyle = renderPropsSpy.args[0][2];
   const content = renderPropsSpy.args[0][3];
+  const showKeepWorkingBadge = renderPropsSpy.args[0][4];
 
   // finally we render the `BasicBubble` itself so we can verifty its props
   // (since the underlying `CachedElement` rendered it as raw HTML when
@@ -84,6 +90,13 @@ function getFirstRenderedBasicBubble(propOverrides = {}) {
   return mount(
     <BasicBubble shape={shape} size={size} progressStyle={progressStyle}>
       {content}
+      {showKeepWorkingBadge && (
+        <BubbleBadge
+          badgeType={BadgeType.keepWorking}
+          bubbleSize={size}
+          bubbleShape={shape}
+        />
+      )}
     </BasicBubble>
   );
 }
@@ -224,6 +237,36 @@ describe('ProgressTableLevelBubble', () => {
         levelKind: LevelKind.assessment
       });
       expect(style.backgroundColor).to.equal(assessmentBackgrounds[status]);
+    });
+  });
+
+  describe('badges', () => {
+    it('shows a badge for ReviewState.keepWorking', () => {
+      const wrapper = getFirstRenderedBasicBubble({
+        reviewState: ReviewStates.keepWorking
+      });
+      expect(wrapper.find(KeepWorkingBadge)).to.have.lengthOf(1);
+    });
+
+    it('shows a badge for ReviewState.awaitingReview', () => {
+      const wrapper = getFirstRenderedBasicBubble({
+        reviewState: ReviewStates.awaitingReview
+      });
+      expect(wrapper.find(KeepWorkingBadge)).to.have.lengthOf(1);
+    });
+
+    it('does not show a badge for ReviewState.completed', () => {
+      const wrapper = getFirstRenderedBasicBubble({
+        reviewState: ReviewStates.completed
+      });
+      expect(wrapper.find(KeepWorkingBadge)).to.be.empty;
+    });
+
+    it('does not show a badge if no review state', () => {
+      const wrapper = getFirstRenderedBasicBubble({
+        reviewState: undefined
+      });
+      expect(wrapper.find(KeepWorkingBadge)).to.be.empty;
     });
   });
 

--- a/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableDetailCellTest.jsx
+++ b/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableDetailCellTest.jsx
@@ -9,6 +9,8 @@ import {
   fakeLevel,
   fakeProgressForLevels
 } from '@cdo/apps/templates/progress/progressTestHelpers';
+import {ReviewStates} from '@cdo/apps/templates/feedback/types';
+import {LevelStatus} from '@cdo/apps/util/sharedConstants';
 
 const level_1 = fakeLevel({
   id: '123',
@@ -24,7 +26,9 @@ const DEFAULT_PROPS = {
   studentId: 1,
   sectionId: 123,
   levels: levels,
-  studentProgress: fakeProgressForLevels(levels)
+  studentProgress: fakeProgressForLevels(levels, LevelStatus.passed, {
+    teacher_feedback_review_state: ReviewStates.keepWorking
+  })
 };
 
 const setUp = (overrideProps = {}) => {
@@ -54,6 +58,19 @@ describe('ProgressTableDetailCell', () => {
     expect(levelBubble1.find(ProgressTableLevelBubble)).to.have.length(1);
     expect(levelBubble2.find(ProgressTableLevelBubble)).to.have.length(2); // 1 for level, 1 for sublevel
     expect(levelBubble3.find(ProgressTableLevelBubble)).to.have.length(1);
+  });
+
+  it('passes expected values to ProgressTableLevelBubble', () => {
+    const wrapper = setUp();
+    const levelBubble3 = wrapper
+      .findWhere(node => node.key() === '999_3')
+      .find(ProgressTableLevelBubble);
+    const levelBubble3Props = levelBubble3.props();
+    expect(levelBubble3Props.levelStatus).to.equal(LevelStatus.passed);
+    expect(levelBubble3Props.isLocked).to.be.false;
+    expect(levelBubble3Props.isUnplugged).to.be.false;
+    expect(levelBubble3Props.isBonus).to.be.true;
+    expect(levelBubble3Props.reviewState).to.equal(ReviewStates.keepWorking);
   });
 
   it('generates the right url for level bubble', () => {


### PR DESCRIPTION
Display bubble badges on the progress table.

<img width="979" alt="Screen Shot 2021-07-02 at 10 22 50 AM" src="https://user-images.githubusercontent.com/4986878/124309864-39cb6700-db20-11eb-8962-0a939bf6d2c7.png">

![Screen Shot 2021-07-09 at 10 42 17 AM](https://user-images.githubusercontent.com/24235215/125116964-5c222f00-e0a2-11eb-9e4c-c52e0110a1cd.png)


Additionally, refactor to use new `BubbleBadge` instead of composing the badge with `BubbleBadgeWrapper`.
## Links

- jira ticket: [LP-1901]

[LP-1901]: https://codedotorg.atlassian.net/browse/LP-1901
[LP-1901]: https://codedotorg.atlassian.net/browse/LP-1901