### PR TITLE
Enabling unit tests to run in RubyMine

### DIFF
--- a/bin/i18n/test/test_helper.rb
+++ b/bin/i18n/test/test_helper.rb
@@ -5,4 +5,6 @@ reporters = [Minitest::Reporters::SpecReporter.new]
 if ENV['CIRCLECI']
   reporters << Minitest::Reporters::JUnitReporter.new("#{ENV['CIRCLE_TEST_REPORTS']}/bin/i18n")
 end
-Minitest::Reporters.use! reporters
+
+# Skip this if the tests are run in RubyMine
+Minitest::Reporters.use! reporters unless ENV['RM_INFO']

--- a/dashboard/test/test_helper.rb
+++ b/dashboard/test/test_helper.rb
@@ -23,7 +23,8 @@ reporters = [CowReporter.new]
 if ENV['CIRCLECI']
   reporters << Minitest::Reporters::JUnitReporter.new("#{ENV['CIRCLE_TEST_REPORTS']}/dashboard")
 end
-Minitest::Reporters.use! reporters
+# Skip this if the tests are run in RubyMine
+Minitest::Reporters.use! reporters unless ENV['RM_INFO']
 
 ENV["UNIT_TEST"] = 'true'
 ENV["RAILS_ENV"] = "test"

--- a/lib/test/test_helper.rb
+++ b/lib/test/test_helper.rb
@@ -5,7 +5,8 @@ reporters = [Minitest::Reporters::SpecReporter.new]
 if ENV['CIRCLECI']
   reporters << Minitest::Reporters::JUnitReporter.new("#{ENV['CIRCLE_TEST_REPORTS']}/lib")
 end
-Minitest::Reporters.use! reporters
+# Skip this if the tests are run in RubyMine
+Minitest::Reporters.use! reporters unless ENV['RM_INFO']
 
 class Level
   def report_bug_url(request)

--- a/pegasus/test/test_helper.rb
+++ b/pegasus/test/test_helper.rb
@@ -6,7 +6,8 @@ reporters = [Minitest::Reporters::SpecReporter.new]
 if ENV['CIRCLECI']
   reporters << Minitest::Reporters::JUnitReporter.new("#{ENV['CIRCLE_TEST_REPORTS']}/pegasus")
 end
-Minitest::Reporters.use! reporters
+# Skip this if the tests are run in RubyMine
+Minitest::Reporters.use! reporters unless ENV['RM_INFO']
 
 class Minitest::Test
   def before_setup

--- a/shared/test/test_helper.rb
+++ b/shared/test/test_helper.rb
@@ -9,7 +9,8 @@ reporters = [Minitest::Reporters::SpecReporter.new]
 if ENV['CIRCLECI']
   reporters << Minitest::Reporters::JUnitReporter.new("#{ENV['CIRCLE_TEST_REPORTS']}/shared")
 end
-Minitest::Reporters.use! reporters
+# Skip this if the tests are run in RubyMine
+Minitest::Reporters.use! reporters unless ENV['RM_INFO']
 
 WebMock.disable_net_connect!
 


### PR DESCRIPTION
Updated RubyMind and Ruby unit tests started failing. I followed these instruction from JetBrains: https://blog.jetbrains.com/ruby/2021/04/improved-minitest-support-action-required/


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
