### PR TITLE
Add firehose logging to animation library

### DIFF
--- a/apps/src/p5lab/AnimationTab/PiskelEditor.jsx
+++ b/apps/src/p5lab/AnimationTab/PiskelEditor.jsx
@@ -63,7 +63,7 @@ class PiskelEditor extends React.Component {
      * - The Piskel editor saves continuously, so we only want to log the first
      * event to Firehose.
      */
-    this.hasLoggedFirehoseEvent = false;
+    this.hasLoggedFirehoseEvent_ = false;
 
     this.piskel = new PiskelApi();
     this.piskel.attachToPiskel(this.iframe);
@@ -207,14 +207,14 @@ class PiskelEditor extends React.Component {
       return;
     }
 
-    if (!this.hasLoggedFirehoseEvent) {
+    if (!this.hasLoggedFirehoseEvent_) {
       firehoseClient.putRecord({
         study: 'animation-library',
         study_group: 'control-2020',
         event: 'asset-editing',
         data_string: this.props.isBlockly ? 'spritelab' : 'gamelab'
       });
-      this.hasLoggedFirehoseEvent = true;
+      this.hasLoggedFirehoseEvent_ = true;
     }
 
     this.props.editAnimation(this.loadedAnimation_, {

--- a/apps/src/p5lab/P5LabVisualizationHeader.jsx
+++ b/apps/src/p5lab/P5LabVisualizationHeader.jsx
@@ -5,6 +5,7 @@ import {changeInterfaceMode} from './actions';
 import {connect} from 'react-redux';
 import {P5LabInterfaceMode} from './constants';
 import msg from '@cdo/locale';
+import firehoseClient from '@cdo/apps/lib/util/firehose';
 import ToggleGroup from '@cdo/apps/templates/ToggleGroup';
 import styleConstants from '@cdo/apps/styleConstants';
 import {allowAnimationMode} from './stateQueries';
@@ -34,6 +35,13 @@ class P5LabVisualizationHeader extends React.Component {
         // Fire a window resize event to tell Game Lab (Droplet) to rerender.
         setTimeout(() => utils.fireResizeEvent(), 0);
       }
+    } else if (mode === 'ANIMATION') {
+      firehoseClient.putRecord({
+        study: 'animation-library',
+        study_group: 'control-2020',
+        event: 'tab-click',
+        data_string: this.props.spriteLab ? 'spritelab' : 'gamelab'
+      });
     }
 
     this.props.onInterfaceModeChange(mode);

--- a/apps/src/p5lab/P5LabVisualizationHeader.jsx
+++ b/apps/src/p5lab/P5LabVisualizationHeader.jsx
@@ -27,7 +27,7 @@ class P5LabVisualizationHeader extends React.Component {
 
   changeInterfaceMode = mode => {
     // Make sure code workspace is rendered properly after switching from the Animation Tab.
-    if (mode === 'CODE') {
+    if (mode === P5LabInterfaceMode.CODE) {
       if (this.props.spriteLab) {
         // Sprite Lab (Blockly) doesn't need a window resize event, but it does need to rerender.
         setTimeout(() => Blockly.mainBlockSpace.render(), 0);
@@ -35,7 +35,7 @@ class P5LabVisualizationHeader extends React.Component {
         // Fire a window resize event to tell Game Lab (Droplet) to rerender.
         setTimeout(() => utils.fireResizeEvent(), 0);
       }
-    } else if (mode === 'ANIMATION') {
+    } else if (mode === P5LabInterfaceMode.ANIMATION) {
       firehoseClient.putRecord({
         study: 'animation-library',
         study_group: 'control-2020',

--- a/apps/src/p5lab/redux/animationPicker.js
+++ b/apps/src/p5lab/redux/animationPicker.js
@@ -132,6 +132,15 @@ export function beginUpload(filename) {
  * @returns {function}
  */
 export function handleUploadComplete(result) {
+  firehoseClient.putRecord({
+    study: 'animation-library',
+    study_group: 'control-2020',
+    event: 'upload',
+    data_json: JSON.stringify({
+      size: result.size
+    })
+  });
+
   return function(dispatch, getState) {
     const {goal, uploadFilename} = getState().animationPicker;
     const key = result.filename.replace(/\.png$/i, '');


### PR DESCRIPTION
Details are in this [jira ticket](https://codedotorg.atlassian.net/browse/STAR-1597)
Adds firehose logs for:
- on click costume/animation tab
- on animation edit (once per session)
- on animation upload