### PR TITLE
Add roblox.com and io.adafruit.com

### DIFF
--- a/dashboard/app/controllers/xhr_proxy_controller.rb
+++ b/dashboard/app/controllers/xhr_proxy_controller.rb
@@ -72,6 +72,7 @@ class XhrProxyController < ApplicationController
     herokuapp.com
     hubblesite.org
     images-api.nasa.gov
+    io.adafruit.com
     isenseproject.org
     lakeside-cs.org
     maker.ifttt.com
@@ -87,6 +88,7 @@ class XhrProxyController < ApplicationController
     random.org
     rejseplanen.dk
     restcountries.eu
+    roblox.com
     runescape.com
     sessionserver.mojang.com
     spreadsheets.google.com


### PR DESCRIPTION
Both Zendesk requests https://codeorg.zendesk.com/agent/tickets/342855 and https://codeorg.zendesk.com/agent/tickets/341076

Note that roblox.com has multiple api endpoints: api.roblox.com, avatar.roblox.com, badges.roblox.com, etc. which you can look at here https://api.roblox.com/docs?useConsolidatedPage=true
