### PR TITLE
[Spritelab] Make sure sprite name is valid variable

### DIFF
--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -448,7 +448,9 @@ export default {
     };
     generator.sprite_variables_get = function() {
       return [
-        `{name: '${this.getTitleValue('VAR')}'}`,
+        `{name: '${Blockly.JavaScript.translateVarName(
+          this.getTitleValue('VAR')
+        )}'}`,
         Blockly.JavaScript.ORDER_ATOMIC
       ];
     };


### PR DESCRIPTION
Quick follow up to https://github.com/code-dot-org/code-dot-org/pull/40531
Very similar change, just for the sprite getter block as well.
Before
![image](https://user-images.githubusercontent.com/8787187/124649066-dce7ed80-de4c-11eb-8702-a841d838955c.png)

After
![image](https://user-images.githubusercontent.com/8787187/124649084-e5402880-de4c-11eb-9893-a43fb256bbe4.png)
