### PR TITLE
Levels within levels: BubbleChoice

### DIFF
--- a/bin/cron/create_rollup_tables
+++ b/bin/cron/create_rollup_tables
@@ -128,8 +128,7 @@ def main
   end
 
   Level.where(type: 'BubbleChoice').find_each do |level|
-    level.properties['sublevels']&.each_with_index do |sublevel_name, sublevel_index|
-      sublevel = Level.find_by_name(sublevel_name)
+    level.sublevels&.each_with_index do |sublevel, sublevel_index|
       contained_levels << {
         level_id: level.id,
         contained_level_id: sublevel.id,

--- a/dashboard/app/models/levels/bubble_choice.rb
+++ b/dashboard/app/models/levels/bubble_choice.rb
@@ -48,7 +48,7 @@ class BubbleChoice < DSLDefined
 
   # Returns all of the sublevels for this BubbleChoice level in order.
   def sublevels
-    Level.where(name: properties['sublevels']).sort_by {|l| properties['sublevels'].index(l.name)}
+    child_levels.all.order(:position)
   end
 
   def sublevel_at(index)
@@ -195,7 +195,7 @@ class BubbleChoice < DSLDefined
   # @param [String] level_name. The name of the sublevel.
   # @return [Array<BubbleChoice>] The BubbleChoice parent level(s) of the given sublevel.
   def self.parent_levels(level_name)
-    where("properties -> '$.sublevels' LIKE ?", "%\"#{level_name}\"%")
+    joins(:child_levels).where(child_levels_levels: {name: level_name}).to_a
   end
 
   def supports_markdown?
@@ -208,18 +208,33 @@ class BubbleChoice < DSLDefined
 
   def clone_with_suffix(new_suffix, editor_experiment: nil)
     level = super(new_suffix, editor_experiment: editor_experiment)
-
-    new_sublevel_names = sublevels.map do |sublevel|
-      sublevel.clone_with_suffix(new_suffix, editor_experiment: editor_experiment).name
+    level.levels_child_levels.each do |parent_levels_child_level|
+      sublevel = parent_levels_child_level.child_level
+      cloned_sublevel = sublevel.clone_with_suffix(new_suffix, editor_experiment: editor_experiment)
+      parent_levels_child_level.child_level = cloned_sublevel
+      parent_levels_child_level.save!
     end
 
-    update_params = {
-      properties: {
-        sublevels: new_sublevel_names
-      }
-    }
-    level.update!(update_params)
     level.rewrite_dsl_file(BubbleChoiceDSL.serialize(level))
     level
+  end
+
+  def self.setup(data)
+    sublevel_names = data[:properties].delete(:sublevels)
+    level = super(data)
+    level.setup_sublevels(sublevel_names)
+    level
+  end
+
+  def setup_sublevels(sublevel_names)
+    sublevel_names.each_with_index do |sublevel_name, i|
+      sublevel = Level.find_by_name!(sublevel_name)
+      ParentLevelsChildLevel.find_or_create_by!(
+        parent_level: self,
+        child_level: sublevel,
+        kind: ParentLevelsChildLevel::SUBLEVEL,
+        position: i + 1
+      )
+    end
   end
 end

--- a/dashboard/app/models/levels/bubble_choice.rb
+++ b/dashboard/app/models/levels/bubble_choice.rb
@@ -48,7 +48,11 @@ class BubbleChoice < DSLDefined
 
   # Returns all of the sublevels for this BubbleChoice level in order.
   def sublevels
-    child_levels.all.order(:position)
+    levels_child_levels.
+      includes(:child_level).
+      where(kind: ParentLevelsChildLevel::SUBLEVEL).
+      order('position ASC').
+      map(&:child_level)
   end
 
   def sublevel_at(index)

--- a/dashboard/app/models/levels/bubble_choice.rb
+++ b/dashboard/app/models/levels/bubble_choice.rb
@@ -199,7 +199,7 @@ class BubbleChoice < DSLDefined
   # @param [String] level_name. The name of the sublevel.
   # @return [Array<BubbleChoice>] The BubbleChoice parent level(s) of the given sublevel.
   def self.parent_levels(level_name)
-    joins(:child_levels).where(child_levels_levels: {name: level_name}).to_a
+    includes(:child_levels).where(child_levels_levels: {name: level_name}).to_a
   end
 
   def supports_markdown?

--- a/dashboard/app/models/levels/bubble_choice.rb
+++ b/dashboard/app/models/levels/bubble_choice.rb
@@ -227,6 +227,9 @@ class BubbleChoice < DSLDefined
   end
 
   def setup_sublevels(sublevel_names)
+    reload
+    self.child_levels = []
+
     sublevel_names.each_with_index do |sublevel_name, i|
       sublevel = Level.find_by_name!(sublevel_name)
       ParentLevelsChildLevel.find_or_create_by!(
@@ -236,5 +239,7 @@ class BubbleChoice < DSLDefined
         position: i + 1
       )
     end
+
+    save!
   end
 end

--- a/dashboard/app/models/teacher_feedback.rb
+++ b/dashboard/app/models/teacher_feedback.rb
@@ -50,8 +50,7 @@ class TeacherFeedback < ApplicationRecord
     script_level = level.script_levels.find {|sl| sl.script_id == script_id}
     return script_level if script_level
 
-    # This will be somewhat expensive, but will only be executed for feedbacks
-    # which were are associated with a Bubble Choice sublevel.
+    # accomodate feedbacks associated with a Bubble Choice sublevel
     script_level = BubbleChoice.
       parent_levels(level.name).
       map(&:script_levels).

--- a/dashboard/app/models/teacher_feedback.rb
+++ b/dashboard/app/models/teacher_feedback.rb
@@ -52,10 +52,12 @@ class TeacherFeedback < ApplicationRecord
 
     # This will be somewhat expensive, but will only be executed for feedbacks
     # which were are associated with a Bubble Choice sublevel.
-    bubble_choice_levels = script.levels.where(type: 'BubbleChoice').all
-    parent_level = bubble_choice_levels.find {|bc| bc.sublevels.include?(level)}
+    script_level = BubbleChoice.
+      parent_levels(level.name).
+      map(&:script_levels).
+      flatten.
+      find {|sl| sl.script_id == script_id}
 
-    script_level = parent_level.script_levels.find {|sl| sl.script_id == script_id}
     raise "no script level found for teacher feedback #{id}" unless script_level
     script_level
   end

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -994,22 +994,25 @@ FactoryGirl.define do
     game {create(:game, app: "bubble_choice")}
     sequence(:name) {|n| "Bubble_Choice_Level_#{n}"}
     display_name 'display_name'
-    transient do
-      sublevels []
-    end
     properties do
       {
         display_name: display_name,
-        sublevels: sublevels.pluck(:name)
       }
     end
 
+    # Allow passing a list of levels in the create method to automatically set
+    # up sublevels
+    transient do
+      sublevels []
+    end
+
+    after(:create) do |bubble_choice, evaluator|
+      bubble_choice.setup_sublevels(evaluator.sublevels.pluck(:name)) if evaluator.sublevels.present?
+    end
+
+    # Also allow specifying a trait to automatically create sublevels
     trait :with_sublevels do
-      after(:create) do |bc|
-        sublevels = create_list(:level, 3)
-        bc.properties['sublevels'] = sublevels.pluck(:name)
-        bc.save!
-      end
+      sublevels {create_list(:level, 3)}
     end
   end
 

--- a/dashboard/test/models/levels/bubble_choice_test.rb
+++ b/dashboard/test/models/levels/bubble_choice_test.rb
@@ -360,4 +360,19 @@ DSL
     assert_equal [@bubble_choice, parents[0], parents[1]], BubbleChoice.parent_levels(@sublevel1.name)
     assert_equal [@bubble_choice, parents[0], parents[2]], BubbleChoice.parent_levels(@sublevel2.name)
   end
+
+  test 'only actual sublevels are considered sublevels' do
+    sublevel = create :level
+    contained_level = create :level
+    bubble_choice = create :bubble_choice_level, sublevels: [sublevel]
+    ParentLevelsChildLevel.create(
+      parent_level: bubble_choice,
+      child_level: contained_level,
+      kind: ParentLevelsChildLevel::CONTAINED,
+      position: 2
+    )
+    bubble_choice.reload
+    assert_equal [sublevel, contained_level], bubble_choice.child_levels.to_a
+    assert_equal [sublevel], bubble_choice.sublevels.to_a
+  end
 end

--- a/dashboard/test/models/levels/bubble_choice_test.rb
+++ b/dashboard/test/models/levels/bubble_choice_test.rb
@@ -350,4 +350,14 @@ DSL
     bubble_choice = create :bubble_choice_level, name: 'bubble_choices_level', sublevels: [artist]
     assert_equal [artist.name, template.name], bubble_choice.all_descendant_levels.map(&:name)
   end
+
+  test 'parent_levels will retrieve all parent levels' do
+    parents = []
+    parents << create(:bubble_choice_level, sublevels: [@sublevel1, @sublevel2])
+    parents << create(:bubble_choice_level, sublevels: [@sublevel1])
+    parents << create(:bubble_choice_level, sublevels: [@sublevel2])
+
+    assert_equal [@bubble_choice, parents[0], parents[1]], BubbleChoice.parent_levels(@sublevel1.name)
+    assert_equal [@bubble_choice, parents[0], parents[2]], BubbleChoice.parent_levels(@sublevel2.name)
+  end
 end

--- a/dashboard/test/models/teacher_feedback_test.rb
+++ b/dashboard/test/models/teacher_feedback_test.rb
@@ -282,7 +282,7 @@ class TeacherFeedbackTest < ActiveSupport::TestCase
     script_level = create :script_level, script: script, lesson: lesson, levels: [parent_level]
 
     feedback = create :teacher_feedback, script: script, level: child_level
-    assert_queries(7) do
+    assert_queries(3) do
       assert_equal script_level, feedback.get_script_level
     end
   end


### PR DESCRIPTION
Updates BubbleChoice levels to use the new many-to-many table for referencing sublevels. In the vein of https://github.com/code-dot-org/code-dot-org/pull/35827

Note that we did have to update the `create_rollup_tables` script as part of this work; thanks to Dave for pointing that out, because it was _not_ caught by any tests. I spent some time trying to find a good place to add some, but came up short. So FYI that rollup tables remains an area of the codebase with poor test coverage.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
