### PR TITLE
[Dance] Fix visualization overflow on initial page load for small screens

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -83,20 +83,21 @@ import {userAlreadyReportedAbuse} from '@cdo/apps/reportAbuse';
 import {setArrowButtonDisabled} from '@cdo/apps/templates/arrowDisplayRedux';
 import {workspace_running_background, white} from '@cdo/apps/util/color';
 import WorkspaceAlert from '@cdo/apps/code-studio/components/WorkspaceAlert';
+
 var copyrightStrings;
 
 /**
  * The minimum width of a playable whole blockly game.
  */
-var MIN_WIDTH = 1200;
-var DEFAULT_MOBILE_NO_PADDING_SHARE_WIDTH = 400;
-var MAX_VISUALIZATION_WIDTH = 400;
-var MIN_VISUALIZATION_WIDTH = 200;
+const MIN_WIDTH = 1200;
+const DEFAULT_MOBILE_NO_PADDING_SHARE_WIDTH = 400;
+export const MAX_VISUALIZATION_WIDTH = 400;
+const MIN_VISUALIZATION_WIDTH = 200;
 
 /**
  * Treat mobile devices with screen.width less than the value below as phones.
  */
-var MAX_PHONE_WIDTH = 500;
+const MAX_PHONE_WIDTH = 500;
 
 class StudioApp extends EventEmitter {
   constructor() {

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -92,7 +92,7 @@ var copyrightStrings;
 const MIN_WIDTH = 1200;
 const DEFAULT_MOBILE_NO_PADDING_SHARE_WIDTH = 400;
 export const MAX_VISUALIZATION_WIDTH = 400;
-const MIN_VISUALIZATION_WIDTH = 200;
+export const MIN_VISUALIZATION_WIDTH = 200;
 
 /**
  * Treat mobile devices with screen.width less than the value below as phones.

--- a/apps/src/dance/Dance.js
+++ b/apps/src/dance/Dance.js
@@ -131,11 +131,6 @@ Dance.prototype.init = function(config) {
     this.studioApp_.init(config);
     this.studioAppInitPromiseResolve();
 
-    // Manually trigger a 'resize' after the relevant React components have mounted
-    // to ensure consistent sizing/scaling and prevent overflow after instructions
-    // have rendered.
-    this.studioApp_.resizeVisualization();
-
     const finishButton = document.getElementById('finishButton');
     if (finishButton) {
       dom.addClickTouchEvent(finishButton, () => this.onPuzzleComplete(true));

--- a/apps/src/dance/Dance.js
+++ b/apps/src/dance/Dance.js
@@ -131,6 +131,11 @@ Dance.prototype.init = function(config) {
     this.studioApp_.init(config);
     this.studioAppInitPromiseResolve();
 
+    // Manually trigger a 'resize' after the relevant React components have mounted
+    // to ensure consistent sizing/scaling and prevent overflow after instructions
+    // have rendered.
+    this.studioApp_.resizeVisualization();
+
     const finishButton = document.getElementById('finishButton');
     if (finishButton) {
       dom.addClickTouchEvent(finishButton, () => this.onPuzzleComplete(true));

--- a/apps/src/dance/Dance.js
+++ b/apps/src/dance/Dance.js
@@ -56,7 +56,7 @@ const ArrowIds = {
 };
 
 /**
- * An instantiable GameLab class
+ * An instantiable Dance class
  * @constructor
  * @implements LogTarget
  */
@@ -94,13 +94,13 @@ Dance.prototype.injectStudioApp = function(studioApp) {
 };
 
 /**
- * Initialize Blockly and this GameLab instance.  Called on page load.
+ * Initialize Blockly and this Dance instance.  Called on page load.
  * @param {!AppOptionsConfig} config
- * @param {!GameLabLevel} config.level
+ * @param {!Dancelab} config.level
  */
 Dance.prototype.init = function(config) {
   if (!this.studioApp_) {
-    throw new Error('GameLab requires a StudioApp');
+    throw new Error('Dance requires a StudioApp');
   }
 
   this.level = config.level;

--- a/apps/src/dance/DanceVisualizationColumn.jsx
+++ b/apps/src/dance/DanceVisualizationColumn.jsx
@@ -103,7 +103,7 @@ class DanceVisualizationColumn extends React.Component {
         {!this.props.isShareView && (
           <AgeDialog turnOffFilter={this.turnFilterOff} />
         )}
-        <span>
+        <div style={{maxWidth: MAX_GAME_WIDTH}}>
           {!this.props.isShareView && (
             <SongSelector
               enableSongSelection={enableSongSelection}
@@ -136,7 +136,7 @@ class DanceVisualizationColumn extends React.Component {
             <ArrowButtons />
           </GameButtons>
           <BelowVisualization />
-        </span>
+        </div>
       </div>
     );
   }

--- a/apps/src/dance/DanceVisualizationColumn.jsx
+++ b/apps/src/dance/DanceVisualizationColumn.jsx
@@ -154,7 +154,7 @@ const styles = {
     overflow: 'hidden'
   },
   loadingContainer: {
-    // The value of display will be controlled externally by StudioApp.
+    // The value of display is controlled by StudioApp.
     display: 'none',
     alignItems: 'center',
     justifyContent: 'center'

--- a/apps/src/dance/DanceVisualizationColumn.jsx
+++ b/apps/src/dance/DanceVisualizationColumn.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import GameButtons from '../templates/GameButtons';
 import ArrowButtons from '../templates/ArrowButtons';
 import BelowVisualization from '../templates/BelowVisualization';
-import * as gameLabConstants from './constants';
+import * as dancelabConstants from './constants';
 import ProtectedVisualizationDiv from '../templates/ProtectedVisualizationDiv';
 import PropTypes from 'prop-types';
 import Radium from 'radium';
@@ -10,8 +10,7 @@ import {connect} from 'react-redux';
 import i18n from '@cdo/locale';
 import AgeDialog, {signedOutOver13} from '../templates/AgeDialog';
 
-const GAME_WIDTH = gameLabConstants.GAME_WIDTH;
-const GAME_HEIGHT = gameLabConstants.GAME_HEIGHT;
+const {MAX_GAME_WIDTH, GAME_HEIGHT} = dancelabConstants;
 
 const SongSelector = Radium(
   class extends React.Component {
@@ -92,28 +91,6 @@ class DanceVisualizationColumn extends React.Component {
   }
 
   render() {
-    const divDanceStyle = {
-      touchAction: 'none',
-      width: GAME_WIDTH,
-      height: GAME_HEIGHT,
-      background: '#fff',
-      position: 'relative',
-      overflow: 'hidden'
-    };
-
-    const p5LoadingStyle = {
-      width: 400,
-      height: 400,
-      display: 'none',
-      alignItems: 'center',
-      justifyContent: 'center'
-    };
-
-    const p5LoadingGifStyle = {
-      width: 100,
-      height: 100
-    };
-
     const filenameToImgUrl = {
       'click-to-run': require('@cdo/static/dance/click-to-run.png')
     };
@@ -139,11 +116,17 @@ class DanceVisualizationColumn extends React.Component {
             />
           )}
           <ProtectedVisualizationDiv>
-            <div id="divDance" style={divDanceStyle}>
-              <div id="divDanceLoading" style={p5LoadingStyle}>
+            <div
+              id="divDance"
+              style={{...styles.visualization, ...styles.container}}
+            >
+              <div
+                id="divDanceLoading"
+                style={{...styles.visualization, ...styles.loadingContainer}}
+              >
                 <img
                   src="//curriculum.code.org/images/DancePartyLoading.gif"
-                  style={p5LoadingGifStyle}
+                  style={styles.loadingGif}
                 />
               </div>
               {this.props.isShareView && (
@@ -162,6 +145,26 @@ class DanceVisualizationColumn extends React.Component {
 }
 
 const styles = {
+  visualization: {
+    width: MAX_GAME_WIDTH,
+    height: GAME_HEIGHT
+  },
+  container: {
+    touchAction: 'none',
+    background: '#fff',
+    position: 'relative',
+    overflow: 'hidden'
+  },
+  loadingContainer: {
+    // The value of display will be controlled externally by StudioApp.
+    display: 'none',
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
+  loadingGif: {
+    width: 100,
+    height: 100
+  },
   selectStyle: {
     width: '100%'
   }

--- a/apps/src/dance/DanceVisualizationColumn.jsx
+++ b/apps/src/dance/DanceVisualizationColumn.jsx
@@ -2,15 +2,13 @@ import React from 'react';
 import GameButtons from '../templates/GameButtons';
 import ArrowButtons from '../templates/ArrowButtons';
 import BelowVisualization from '../templates/BelowVisualization';
-import * as dancelabConstants from './constants';
+import {MAX_GAME_WIDTH, GAME_HEIGHT} from './constants';
 import ProtectedVisualizationDiv from '../templates/ProtectedVisualizationDiv';
 import PropTypes from 'prop-types';
 import Radium from 'radium';
 import {connect} from 'react-redux';
 import i18n from '@cdo/locale';
 import AgeDialog, {signedOutOver13} from '../templates/AgeDialog';
-
-const {MAX_GAME_WIDTH, GAME_HEIGHT} = dancelabConstants;
 
 const SongSelector = Radium(
   class extends React.Component {

--- a/apps/src/dance/constants.js
+++ b/apps/src/dance/constants.js
@@ -1,10 +1,13 @@
-import {MAX_VISUALIZATION_WIDTH} from '@cdo/apps/StudioApp';
+import {
+  MAX_VISUALIZATION_WIDTH,
+  MIN_VISUALIZATION_WIDTH
+} from '@cdo/apps/StudioApp';
 
 /** @const {number} */
 export const MAX_GAME_WIDTH = MAX_VISUALIZATION_WIDTH;
 
 /** @const {number} */
-export const MIN_GAME_WIDTH = 200;
+export const MIN_GAME_WIDTH = MIN_VISUALIZATION_WIDTH;
 
 /** @const {number} */
 export const GAME_HEIGHT = 400;

--- a/apps/src/dance/constants.js
+++ b/apps/src/dance/constants.js
@@ -1,5 +1,10 @@
+import {MAX_VISUALIZATION_WIDTH} from '@cdo/apps/StudioApp';
+
 /** @const {number} */
-export const GAME_WIDTH = 400;
+export const MAX_GAME_WIDTH = MAX_VISUALIZATION_WIDTH;
+
+/** @const {number} */
+export const MIN_GAME_WIDTH = 200;
 
 /** @const {number} */
 export const GAME_HEIGHT = 400;

--- a/apps/src/sites/studio/pages/init/loadDance.js
+++ b/apps/src/sites/studio/pages/init/loadDance.js
@@ -1,13 +1,13 @@
 import appMain from '@cdo/apps/appMain';
 import {singleton as studioApp} from '@cdo/apps/StudioApp';
 import Dance from '@cdo/apps/dance/Dance';
-import * as dancelabConstants from '@cdo/apps/dance/constants';
+import {MAX_GAME_WIDTH, MIN_GAME_WIDTH} from '@cdo/apps/dance/constants';
 import blocks from '@cdo/apps/dance/blocks';
 
 export default function loadDancelab(options) {
   options.blocksModule = blocks;
-  options.maxVisualizationWidth = dancelabConstants.MAX_GAME_WIDTH;
-  options.minVisualizationWidth = dancelabConstants.MIN_GAME_WIDTH;
+  options.maxVisualizationWidth = MAX_GAME_WIDTH;
+  options.minVisualizationWidth = MIN_GAME_WIDTH;
   const dance = new Dance();
 
   dance.injectStudioApp(studioApp());

--- a/apps/src/sites/studio/pages/init/loadDance.js
+++ b/apps/src/sites/studio/pages/init/loadDance.js
@@ -1,10 +1,13 @@
 import appMain from '@cdo/apps/appMain';
 import {singleton as studioApp} from '@cdo/apps/StudioApp';
 import Dance from '@cdo/apps/dance/Dance';
+import * as dancelabConstants from '@cdo/apps/dance/constants';
 import blocks from '@cdo/apps/dance/blocks';
 
-export default function loadGamelab(options) {
+export default function loadDancelab(options) {
   options.blocksModule = blocks;
+  options.maxVisualizationWidth = dancelabConstants.MAX_GAME_WIDTH;
+  options.minVisualizationWidth = dancelabConstants.MIN_GAME_WIDTH;
   const dance = new Dance();
 
   dance.injectStudioApp(studioApp());

--- a/apps/src/templates/ProtectedVisualizationDiv.jsx
+++ b/apps/src/templates/ProtectedVisualizationDiv.jsx
@@ -18,6 +18,8 @@ export function isResponsiveFromState(state) {
 /**
  * Protected div with ID "visualization" that depends on Redux state to render
  * with the "responsive" class or not.
+ *
+ * Note: This component is controlled externally by StudioApp.resizeVisualization.
  */
 class ProtectedVisualizationDiv extends React.Component {
   static propTypes = {


### PR DESCRIPTION
Fixes a bug where the song selector and game buttons horizontally-overflowed in Dance Party on certain screen sizes (browser width > 1150 && height > 900).

There is also some clean-up in this PR. The actual (short-term) fix for this bug is in commit [531826d](https://github.com/code-dot-org/code-dot-org/pull/41454/commits/531826dc2390478d2819b6cb2b6a25b10a40b26c). The long-term fix is logged as follow-up work.

**Before:**
![Screen Shot 2021-06-15 at 1 46 43 PM](https://user-images.githubusercontent.com/9812299/124681370-3700a700-de7d-11eb-825b-8eca06bb480b.png)

**After:**

https://user-images.githubusercontent.com/9812299/124681454-6d3e2680-de7d-11eb-9f5c-d77d4600c55c.mov


## Links

- [STAR-1606](https://codedotorg.atlassian.net/browse/STAR-1606)

## Testing story

Relies on existing UI/eyes tests.

## Follow-up work

Right now, StudioApp controls resizing logic imperatively via [StudioApp.resizeVisualization](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/StudioApp.js#L1524-L1596). I've logged a follow-up task to refactor our approach to resizing as [STAR-1621](https://codedotorg.atlassian.net/browse/STAR-1621).