### PR TITLE
Fix typo in DBProxy database component

### DIFF
--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -51,7 +51,7 @@
       RoleArn: !GetAtt DBProxyRole.Arn
       Auth:
 <% db_secrets.each do |secret| -%>
-        - {AuthScheme: SECRETS, SecretARN: !Ref DatabaseSecret<%=secret%>, IAMAuth: DISABLED}
+        - {AuthScheme: SECRETS, SecretArn: !Ref DatabaseSecret<%=secret%>, IAMAuth: DISABLED}
 <%end -%>
       VpcSubnetIds: <%=subnets.to_json%>
       VpcSecurityGroupIds: [!ImportValue VPC-DBSecurityGroup]


### PR DESCRIPTION
Typo-fix followup to #40905. Template property should be [`SecretArn`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-dbproxy-authformat.html#cfn-rds-dbproxy-authformat-secretarn), not `SecretARN`.
