### PR TITLE
Javalab: fix channel id logic

### DIFF
--- a/apps/src/javalab/JavabuilderConnection.js
+++ b/apps/src/javalab/JavabuilderConnection.js
@@ -5,15 +5,8 @@ const queryString = require('query-string');
 
 // Creates and maintains a websocket connection with javabuilder while a user's code is running.
 export default class JavabuilderConnection {
-  constructor(
-    channelId,
-    javabuilderUrl,
-    onMessage,
-    miniApp,
-    serverLevelId,
-    options
-  ) {
-    this.channelId = channelId;
+  constructor(javabuilderUrl, onMessage, miniApp, serverLevelId, options) {
+    this.channelId = dashboard.project.getCurrentId();
     this.javabuilderUrl = javabuilderUrl;
     this.onOutputMessage = onMessage;
     this.miniApp = miniApp;

--- a/apps/src/javalab/JavabuilderConnection.js
+++ b/apps/src/javalab/JavabuilderConnection.js
@@ -1,12 +1,12 @@
-/* globals dashboard */
 import {WebSocketMessageType} from './constants';
 import {handleException} from './javabuilderExceptionHandler';
 const queryString = require('query-string');
+import project from '@cdo/apps/code-studio/initApp/project';
 
 // Creates and maintains a websocket connection with javabuilder while a user's code is running.
 export default class JavabuilderConnection {
   constructor(javabuilderUrl, onMessage, miniApp, serverLevelId, options) {
-    this.channelId = dashboard.project.getCurrentId();
+    this.channelId = project.getCurrentId();
     this.javabuilderUrl = javabuilderUrl;
     this.onOutputMessage = onMessage;
     this.miniApp = miniApp;
@@ -21,9 +21,9 @@ export default class JavabuilderConnection {
       url: '/javabuilder/access_token',
       type: 'get',
       data: {
-        projectUrl: dashboard.project.getProjectSourcesUrl(),
+        projectUrl: project.getProjectSourcesUrl(),
         channelId: this.channelId,
-        projectVersion: dashboard.project.getCurrentSourceVersionId(),
+        projectVersion: project.getCurrentSourceVersionId(),
         levelId: this.levelId,
         options: this.options
       }

--- a/apps/src/javalab/Javalab.js
+++ b/apps/src/javalab/Javalab.js
@@ -36,7 +36,6 @@ const MOBILE_PORTRAIT_WIDTH = 600;
 const Javalab = function() {
   this.skin = null;
   this.level = null;
-  this.channelId = null;
 
   /** @type {StudioApp} */
   this.studioApp_ = null;
@@ -61,7 +60,6 @@ Javalab.prototype.init = function(config) {
 
   this.skin = config.skin;
   this.level = config.level;
-  this.channelId = config.channel;
   // Sets dark mode based on displayTheme user preference
   this.isDarkMode =
     getDisplayThemeFromString(config.displayTheme) === DisplayTheme.DARK;
@@ -231,7 +229,6 @@ Javalab.prototype.onRun = function() {
     options.useNeighborhood = true;
   }
   this.javabuilderConnection = new JavabuilderConnection(
-    this.channelId,
     this.level.javabuilderUrl,
     message => getStore().dispatch(appendOutputLog(message)),
     this.miniApp,

--- a/apps/test/unit/javalab/JavabuilderConnectionTest.js
+++ b/apps/test/unit/javalab/JavabuilderConnectionTest.js
@@ -3,8 +3,17 @@ import {expect} from '../../util/reconfiguredChai';
 import JavabuilderConnection from '@cdo/apps/javalab/JavabuilderConnection';
 import {WebSocketMessageType} from '@cdo/apps/javalab/constants';
 import * as ExceptionHandler from '@cdo/apps/javalab/javabuilderExceptionHandler';
+import project from '@cdo/apps/code-studio/initApp/project';
 
 describe('JavabuilderConnection', () => {
+  beforeEach(() => {
+    sinon.stub(project, 'getCurrentId');
+  });
+
+  afterEach(() => {
+    project.getCurrentId.restore();
+  });
+
   describe('onMessage', () => {
     it('passes the parsed event data to the exception handler', () => {
       const data = {
@@ -16,7 +25,7 @@ describe('JavabuilderConnection', () => {
       };
       const onOutputMessage = sinon.stub();
       const handleException = sinon.stub(ExceptionHandler, 'handleException');
-      const connection = new JavabuilderConnection(null, null, onOutputMessage);
+      const connection = new JavabuilderConnection(null, onOutputMessage);
       connection.onMessage(event);
       expect(handleException).to.have.been.calledWith(data, onOutputMessage);
     });
@@ -30,7 +39,7 @@ describe('JavabuilderConnection', () => {
         data: JSON.stringify(data)
       };
       const onOutputMessage = sinon.stub();
-      const connection = new JavabuilderConnection(null, null, onOutputMessage);
+      const connection = new JavabuilderConnection(null, onOutputMessage);
       connection.onMessage(event);
       expect(onOutputMessage).to.have.been.calledWith(data.value);
     });


### PR DESCRIPTION
We were passing the wrong channel id to the Javabuilder backend, which caused issues for standalone projects since we now use the channel id to get the project/asset url. Use the same channel id that projects uses to determine the url, which is `project.getCurrentId()`

## Testing story
Tested locally that the standalone level and the levels within scripts work.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
