### PR TITLE
Javalab: automatically toggle stop to run on program completion

### DIFF
--- a/apps/src/javalab/JavabuilderConnection.js
+++ b/apps/src/javalab/JavabuilderConnection.js
@@ -1,6 +1,8 @@
 /* globals dashboard */
 import {WebSocketMessageType} from './constants';
 import {handleException} from './javabuilderExceptionHandler';
+import {getStore} from '../redux';
+import {setIsRunning} from './javalabRedux';
 const queryString = require('query-string');
 
 // Creates and maintains a websocket connection with javabuilder while a user's code is running.
@@ -102,7 +104,14 @@ export default class JavabuilderConnection {
       // event.code is usually 1006 in this case
       console.log(`[close] Connection died. code=${event.code}`);
     }
-    this.miniApp?.onClose?.();
+    if (this.miniApp && this.miniApp.onClose) {
+      // miniApp on close should handle setting isRunning state as it
+      // may not align with actual program execution
+      this.miniApp.onClose();
+    } else {
+      // Set isRunning to false
+      getStore().dispatch(setIsRunning(false));
+    }
   }
 
   onError(error) {

--- a/apps/src/javalab/JavabuilderConnection.js
+++ b/apps/src/javalab/JavabuilderConnection.js
@@ -104,10 +104,11 @@ export default class JavabuilderConnection {
       // event.code is usually 1006 in this case
       console.log(`[close] Connection died. code=${event.code}`);
     }
-    if (this.miniApp && this.miniApp.onClose) {
+    if (this.miniApp) {
       // miniApp on close should handle setting isRunning state as it
-      // may not align with actual program execution
-      this.miniApp.onClose();
+      // may not align with actual program execution. If mini app does
+      // not have on close we won't toggle back automatically.
+      this.miniApp.onClose?.();
     } else {
       // Set isRunning to false
       getStore().dispatch(setIsRunning(false));

--- a/apps/src/javalab/JavalabView.jsx
+++ b/apps/src/javalab/JavalabView.jsx
@@ -6,7 +6,7 @@ import color from '@cdo/apps/util/color';
 import JavalabConsole from './JavalabConsole';
 import JavalabEditor from './JavalabEditor';
 import JavalabSettings from './JavalabSettings';
-import {appendOutputLog, setIsDarkMode} from './javalabRedux';
+import {appendOutputLog, setIsDarkMode, setIsRunning} from './javalabRedux';
 import StudioAppWrapper from '@cdo/apps/templates/StudioAppWrapper';
 import TopInstructions from '@cdo/apps/templates/instructions/TopInstructions';
 import VisualizationResizeBar from '@cdo/apps/lib/ui/VisualizationResizeBar';
@@ -33,11 +33,12 @@ class JavalabView extends React.Component {
     appendOutputLog: PropTypes.func,
     setIsDarkMode: PropTypes.func,
     channelId: PropTypes.string,
-    isEditingStartSources: PropTypes.bool
+    isEditingStartSources: PropTypes.bool,
+    isRunning: PropTypes.bool,
+    setIsRunning: PropTypes.func
   };
 
   state = {
-    isRunning: false,
     isTesting: false,
     rightContainerHeight: 800
   };
@@ -65,16 +66,13 @@ class JavalabView extends React.Component {
   // This controls the 'run' button state, but stopping program execution is not yet
   // implemented and will need to be added here.
   toggleRun = () => {
-    this.setState(
-      state => ({isRunning: !state.isRunning}),
-      () => {
-        if (this.state.isRunning) {
-          this.props.onRun();
-        } else {
-          // TODO: Stop program execution.
-        }
-      }
-    );
+    const toggledIsRunning = !this.props.isRunning;
+    this.props.setIsRunning(toggledIsRunning);
+    if (toggledIsRunning) {
+      this.props.onRun();
+    } else {
+      // TODO: Stop program execution.
+    }
   };
 
   // This controls the 'test' button state, but running/stopping tests
@@ -115,9 +113,10 @@ class JavalabView extends React.Component {
       onInputMessage,
       onContinue,
       handleVersionHistory,
-      isEditingStartSources
+      isEditingStartSources,
+      isRunning
     } = this.props;
-    const {isRunning, isTesting, rightContainerHeight} = this.state;
+    const {isTesting, rightContainerHeight} = this.state;
 
     if (isDarkMode) {
       document.body.style.backgroundColor = '#1b1c17';
@@ -178,8 +177,8 @@ class JavalabView extends React.Component {
                 style={styles.consoleParent}
                 leftColumn={
                   <ControlButtons
-                    isDarkMode={isDarkMode}
                     isRunning={isRunning}
+                    isDarkMode={isDarkMode}
                     isTesting={isTesting}
                     toggleRun={this.toggleRun}
                     toggleTest={this.toggleTest}
@@ -266,10 +265,12 @@ export default connect(
     isReadOnlyWorkspace: state.pageConstants.isReadOnlyWorkspace,
     channelId: state.pageConstants.channelId,
     isDarkMode: state.javalab.isDarkMode,
-    isEditingStartSources: state.pageConstants.isEditingStartSources
+    isEditingStartSources: state.pageConstants.isEditingStartSources,
+    isRunning: state.javalab.isRunning
   }),
   dispatch => ({
     appendOutputLog: log => dispatch(appendOutputLog(log)),
-    setIsDarkMode: isDarkMode => dispatch(setIsDarkMode(isDarkMode))
+    setIsDarkMode: isDarkMode => dispatch(setIsDarkMode(isDarkMode)),
+    setIsRunning: isRunning => dispatch(setIsRunning(isRunning))
   })
 )(UnconnectedJavalabView);

--- a/apps/src/javalab/Neighborhood.js
+++ b/apps/src/javalab/Neighborhood.js
@@ -2,6 +2,8 @@ import {tiles, MazeController} from '@code-dot-org/maze';
 const Slider = require('@cdo/apps/slider');
 const Direction = tiles.Direction;
 import {NeighborhoodSignalType} from './constants';
+import {getStore} from '../redux';
+import {setIsRunning} from './javalabRedux';
 const timeoutList = require('@cdo/apps/lib/util/timeoutList');
 
 const PAUSE_BETWEEN_SIGNALS = 200;
@@ -53,7 +55,9 @@ export default class Neighborhood {
     if (this.signals.length > this.nextSignalIndex) {
       const signal = this.signals[this.nextSignalIndex];
       if (signal.value === NeighborhoodSignalType.DONE) {
-        // we are done processing commands and can stop checking for signals
+        // we are done processing commands and can stop checking for signals.
+        // Set isRunning to false and return
+        getStore().dispatch(setIsRunning(false));
         return;
       }
       const timeForSignal =

--- a/apps/src/javalab/javalabRedux.js
+++ b/apps/src/javalab/javalabRedux.js
@@ -12,13 +12,15 @@ const SET_ALL_VALIDATION = 'javalab/SET_ALL_VALIDATION';
 const COLOR_PREFERENCE_UPDATED = 'javalab/COLOR_PREFERENCE_UPDATED';
 const EDITOR_HEIGHT_UPDATED = 'javalab/EDITOR_HEIGHT_UPDATED';
 const REMOVE_FILE = 'javalab/REMOVE_FILE';
+const SET_IS_RUNNING = 'javalab/SET_IS_RUNNING';
 
 const initialState = {
   consoleLogs: [],
   sources: {'MyClass.java': {text: '', isVisible: true, isValidation: false}},
   isDarkMode: false,
   validation: {},
-  renderedEditorHeight: 400
+  renderedEditorHeight: 400,
+  isRunning: false
 };
 
 // Action Creators
@@ -91,6 +93,11 @@ export const setIsDarkMode = isDarkMode => {
 export const removeFile = filename => ({
   type: REMOVE_FILE,
   filename
+});
+
+export const setIsRunning = isRunning => ({
+  type: SET_IS_RUNNING,
+  isRunning
 });
 
 // Selectors
@@ -209,6 +216,12 @@ export default function reducer(state = initialState, action) {
     return {
       ...state,
       renderedEditorHeight: action.height
+    };
+  }
+  if (action.type === SET_IS_RUNNING) {
+    return {
+      ...state,
+      isRunning: action.isRunning
     };
   }
   return state;


### PR DESCRIPTION
After a Javalab program has completed execution, automatically toggle the 'stop' button back to 'run'. This works as expected for console and neighborhood levels, and for theater we never toggle back to run as we cannot determine the stop time of the gif/audio. This is desired behavior from product/curriculum.

## Links

- jira ticket: [CSA-442](https://codedotorg.atlassian.net/browse/CSA-442)


## Testing story
Tested locally

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
