### PR TITLE
Refactor Animation Manifest Path

### DIFF
--- a/bin/animation_assets/manifest_builder.rb
+++ b/bin/animation_assets/manifest_builder.rb
@@ -74,10 +74,10 @@ class ManifestBuilder
     EOS
 
     if @options[:spritelab] && @options[:upload_to_s3]
-      info "Uploading manifests/spritelabCostumeLibrary.json to S3"
+      info "Uploading animation-manifests/manifests/spritelabCostumeLibrary.json to S3"
       AWS::S3.upload_to_bucket(
         DEFAULT_S3_BUCKET,
-        "manifests/spritelabCostumeLibrary.json",
+        "animation-manifests/manifests/spritelabCostumeLibrary.json",
         generate_json(animation_metadata, alias_map, category_map),
         acl: 'public-read',
         no_random: true,
@@ -213,10 +213,10 @@ The animation has been skipped.
       normalized_category_map[key.tr(' ', '_')] = value
     end
 
-    info "Uploading manifests/spritelabCostumeLibrary.#{locale}.json to S3"
+    info "Uploading animation-manifests/manifests/spritelabCostumeLibrary.#{locale}.json to S3"
     AWS::S3.upload_to_bucket(
       DEFAULT_S3_BUCKET,
-      "manifests/spritelabCostumeLibrary.#{locale}.json",
+      "animation-manifests/manifests/spritelabCostumeLibrary.#{locale}.json",
       generate_json(animation_metadata, alias_map, normalized_category_map),
       acl: 'public-read',
       no_random: true,

--- a/bin/animation_assets/manifest_builder.rb
+++ b/bin/animation_assets/manifest_builder.rb
@@ -12,6 +12,7 @@ DEFAULT_S3_BUCKET = 'cdo-animation-library'.freeze
 DEFAULT_OUTPUT_FILE = "#{`git rev-parse --show-toplevel`.strip}/apps/src/p5lab/gamelab/animationLibrary.json".freeze
 SPRITELAB_OUTPUT_FILE = "#{`git rev-parse --show-toplevel`.strip}/apps/src/p5lab/spritelab/spriteCostumeLibrary.json".freeze
 DOWNLOAD_DESTINATION = '~/cdo-animation-library'.freeze
+SPRITELAB_MANIFEST = "animation-manifests/manifests/spritelabCostumeLibrary.json"
 
 class Hash
   # Like Enumerable::map but returns a Hash instead of an Array
@@ -77,7 +78,7 @@ class ManifestBuilder
       info "Uploading animation-manifests/manifests/spritelabCostumeLibrary.json to S3"
       AWS::S3.upload_to_bucket(
         DEFAULT_S3_BUCKET,
-        "animation-manifests/manifests/spritelabCostumeLibrary.json",
+        SPRITELAB_MANIFEST,
         generate_json(animation_metadata, alias_map, category_map),
         acl: 'public-read',
         no_random: true,

--- a/bin/animation_assets/manifest_builder.rb
+++ b/bin/animation_assets/manifest_builder.rb
@@ -78,9 +78,7 @@ class ManifestBuilder
 
     if @options[:spritelab] && @options[:upload_to_s3]
       manifest_filename = generate_spritelab_manifest_filename
-      #info "Uploading #{manifest_filename} to S3"
-      info "Uploading to S3"
-      puts manifest_filename
+      info "Uploading #{manifest_filename} to S3"
       AWS::S3.upload_to_bucket(
         DEFAULT_S3_BUCKET,
         SPRITELAB_MANIFEST_PATH + 'spritelabCostumeLibrary.json',

--- a/bin/animation_assets/manifest_builder.rb
+++ b/bin/animation_assets/manifest_builder.rb
@@ -442,7 +442,7 @@ The animation has been skipped.
   end
 
   def generate_spritelab_manifest_filename(locale = nil)
-    filename = locale ? `spritelabCostumeLibrary.#{locale}.json` : 'spritelabCostumeLibrary.json'
+    filename = locale ? "spritelabCostumeLibrary.#{locale}.json" : 'spritelabCostumeLibrary.json'
     SPRITELAB_MANIFEST_PATH + filename
   end
 

--- a/bin/animation_assets/manifest_builder.rb
+++ b/bin/animation_assets/manifest_builder.rb
@@ -2,11 +2,12 @@ require 'aws-sdk-s3'
 require 'ruby-progressbar'
 require 'optparse'
 require 'parallel'
+require File.expand_path('../../../dashboard/config/environment', __FILE__)
+require_relative '../../lib/cdo/aws/s3'
 require_relative '../../deployment'
 require_relative '../../lib/cdo/cdo_cli'
 require_relative '../../lib/cdo/png_utils'
 require_relative './constants'
-require_relative
 include CdoCli
 
 DEFAULT_S3_BUCKET = 'cdo-animation-library'.freeze

--- a/shared/middleware/animation_library_api.rb
+++ b/shared/middleware/animation_library_api.rb
@@ -101,7 +101,7 @@ class AnimationLibraryApi < Sinatra::Base
     manifest_extension = (app_type == 'spritelab' && locale != 'en_us') ? "#{locale}.json" : 'json'
     result = Aws::S3::Bucket.
       new(ANIMATION_LIBRARY_BUCKET, client: AWS::S3.create_client).
-      object("manifests/#{manifest_filename}.#{manifest_extension}").
+      object("animation-manifests/manifests/#{manifest_filename}.#{manifest_extension}").
       get
     content_type result.content_type
     cache_for 3600

--- a/shared/test/test_animation_library_api.rb
+++ b/shared/test/test_animation_library_api.rb
@@ -52,7 +52,7 @@ class AnimationLibraryTest < Minitest::Test
         get_object: {body: contents, content_type: 'json'}
       }
     )
-    get '/api/v1/animation-library/animation-manifests/manifests/test_manifests.png'
+    get '/api/v1/animation-library/manifest/spritelab/en_us'
     assert last_response.ok?
     assert_equal contents, last_response.body
   ensure

--- a/shared/test/test_animation_library_api.rb
+++ b/shared/test/test_animation_library_api.rb
@@ -44,6 +44,21 @@ class AnimationLibraryTest < Minitest::Test
     AWS::S3.s3 = nil
   end
 
+  def test_get_spritelab_manifest
+    contents = 'TEST_MANIFEST'
+    # Ensure the shared S3 client is used by stubbing the client with the expected response.
+    AWS::S3.s3 = Aws::S3::Client.new(
+      stub_responses: {
+        get_object: {body: contents, content_type: 'json'}
+      }
+    )
+    get '/api/v1/animation-library/animation-manifests/manifests/test_manifests.png'
+    assert last_response.ok?
+    assert_equal contents, last_response.body
+  ensure
+    AWS::S3.s3 = nil
+  end
+
   def test_not_found
     get '/api/v1/animation-library/animation_not_found.png'
     assert last_response.not_found?


### PR DESCRIPTION
Step 0 as outlined in the technical plan: https://docs.google.com/document/d/1ceG2upHYXLEUxIr1kSf_DNjzoagmOxI82vhX2D_OXTA/edit

Context Summary: We are separating manifests from `cdo-animation-library/manifests` to `cdo-animation-library/animation-manifests/manifests` and `cdo-animation-library/animation-manifests/manifests_levelbuilder`. This allows us to make changes to defaults and manifests in an LB environment before they are deployed to production. The pre-work of this PR was duplicating the files in `cdo-animation-library/manifests` to the new `animation-manifests/manifests` folder. This PR updates references to the original path to be references to the new path.

This should result in no changes to the user experience.

This PR should not be merged before getting approval from someone familiar with i18n experience, as one of the main functions that uses this path is how the manifests are translated.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
