### PR TITLE
Add read-only RDS Proxy endpoint

### DIFF
--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -76,3 +76,13 @@
       TargetGroupName: default
       ConnectionPoolConfigurationInfo:
         ConnectionBorrowTimeout: 10
+        MaxIdleConnectionsPercent: 0
+        SessionPinningFilters: [EXCLUDE_VARIABLE_SETS]
+  DBProxyReadOnlyEndpoint:
+    Type: AWS::RDS::DBProxyEndpoint
+    Properties:
+      DBProxyEndpointName: !Sub "${DBProxy}-ReadOnly"
+      DBProxyName: !Ref DBProxy
+      VpcSubnetIds: <%=subnets.to_json%>
+      VpcSecurityGroupIds: [!ImportValue VPC-DBSecurityGroup]
+      TargetRole: READ_ONLY


### PR DESCRIPTION
Adds a read-only RDS Proxy endpoint to our CloudFormation database-cluster component. RDS Proxy read-only endpoints is a [new feature](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/rds-proxy.html#rds-proxy-endpoints-reader) added to RDS Proxy in [March 2021](https://aws.amazon.com/about-aws/whats-new/2021/03/amazon-rds-proxy-adds-read-only-endpoints-for-amazon-aurora-replicas/).

Also, update configuration on Proxy Target group:
- Lower idle-connections percent to `0` (close all idle connections to minimize number of open connections to the database).
- Exclude variable `SET` statements from triggering session-pinning (Rails sets `SQL_AUTO_IS_NULL=0` by default which is a no-op, so we want to continue allow connection multiplexing)