### PR TITLE
Localize Resource URLs

### DIFF
--- a/dashboard/app/models/resource.rb
+++ b/dashboard/app/models/resource.rb
@@ -92,7 +92,7 @@ class Resource < ApplicationRecord
       id: id,
       key: key,
       name: get_localized_property(:name),
-      url: url,
+      url: get_localized_property(:url),
       download_url: download_url,
       audience: audience || 'All',
       type: type
@@ -121,7 +121,7 @@ class Resource < ApplicationRecord
       key: key,
       markdownKey: Services::GloballyUniqueIdentifiers.build_resource_key(self),
       name: get_localized_property(:name),
-      url: url
+      url: get_localized_property(:url)
     }
   end
 

--- a/dashboard/lib/services/i18n/curriculum_sync_utils/serializers.rb
+++ b/dashboard/lib/services/i18n/curriculum_sync_utils/serializers.rb
@@ -60,7 +60,7 @@ module Services
       end
 
       class ResourceCrowdinSerializer < CrowdinSerializer
-        attribute :name
+        attributes :name, :url
 
         # override
         def crowdin_key

--- a/dashboard/lib/services/i18n/curriculum_sync_utils/sync_out.rb
+++ b/dashboard/lib/services/i18n/curriculum_sync_utils/sync_out.rb
@@ -37,26 +37,7 @@ module Services
             result = flatten(script_objects, ScriptCrowdinSerializer, :scripts)
 
             # Then we apply some postprocessing.
-            # We use URLs as keys for lessons in Crowdin, to make things easier for
-            # translators. For the actual translation files, though, we'd like to use
-            # more-standard keys.
-            if result.key?(:lessons)
-              rekeyed_lessons = result[:lessons].map do |lesson_url, lesson_data|
-                route_params = Rails.application.routes.recognize_path(lesson_url)
-                lesson = Lesson.joins(:script).
-                  find_by(
-                    "scripts.name": route_params[:script_id],
-                    relative_position: route_params[:position].to_i,
-                    has_lesson_plan: true
-                  )
-                unless lesson.present?
-                  STDERR.puts "could not find lesson for url #{lesson_url.inspect}"
-                  next
-                end
-                [Services::GloballyUniqueIdentifiers.build_lesson_key(lesson), lesson_data]
-              end
-              result[:lessons] = rekeyed_lessons.compact.to_h
-            end
+            postprocess(result)
 
             # Finally, write each resulting collection of strings out to a rails i18n
             # config file.
@@ -64,6 +45,44 @@ module Services
               dest = File.join(Rails.root, 'config/locales', "#{type}.#{locale}.json")
               data = {locale => {data: {type => strings}}}
               File.write(dest, JSON.pretty_generate(data))
+            end
+          end
+        end
+
+        # Perform any necessary postprocessing to the final translated strings,
+        # before writing them out to config files
+        def self.postprocess(result)
+          # We use URLs as keys for lessons in Crowdin, to make things easier for
+          # translators. For the actual translation files, though, we'd like to use
+          # more-standard keys.
+          if result.key?(:lessons)
+            rekeyed_lessons = result[:lessons].map do |lesson_url, lesson_data|
+              route_params = Rails.application.routes.recognize_path(lesson_url)
+              lesson = Lesson.joins(:script).
+                find_by(
+                  "scripts.name": route_params[:script_id],
+                  relative_position: route_params[:position].to_i,
+                  has_lesson_plan: true
+                )
+              unless lesson.present?
+                STDERR.puts "could not find lesson for url #{lesson_url.inspect}"
+                next
+              end
+              [Services::GloballyUniqueIdentifiers.build_lesson_key(lesson), lesson_data]
+            end
+            result[:lessons] = rekeyed_lessons.compact.to_h
+          end
+
+          # We also provide URLs to the translators for Resources only; because
+          # the sync has a side effect of applying Markdown formatting to
+          # everything it encounters, we want to make sure to un-Markdownify
+          # these URLs
+          if result.key?(:resources)
+            result[:resources].each do |_key, resource|
+              next unless resource[:url].present?
+              resource[:url].strip!
+              resource[:url].delete_prefix!('<')
+              resource[:url].delete_suffix!('>')
             end
           end
         end


### PR DESCRIPTION
Usually we want to avoid allowing translators to edit url values, but for Resources this is actually the system we plan to use to allow international partners to create translated versions of resource content. The international team plans to own the work to make sure these fields are secured in Crowdin against malicious translator activity.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
