### PR TITLE
Remove APPLAB_ML experiment

### DIFF
--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -705,7 +705,7 @@ Applab.init = function(config) {
 
   config.dropletConfig = dropletConfig;
 
-  if (config.level.aiEnabled && experiments.isEnabled(experiments.APPLAB_ML)) {
+  if (config.level.aiEnabled) {
     config.dropletConfig = utils.deepMergeConcatArrays(
       config.dropletConfig,
       aiConfig

--- a/apps/src/applab/dropletConfig.js
+++ b/apps/src/applab/dropletConfig.js
@@ -19,7 +19,6 @@ import {
 } from './setPropertyDropdown';
 import {getStore} from '../redux';
 import * as applabConstants from './constants';
-import experiments from '../util/experiments';
 
 var DEFAULT_WIDTH = applabConstants.APP_WIDTH.toString();
 var DEFAULT_HEIGHT = (

--- a/apps/src/applab/dropletConfig.js
+++ b/apps/src/applab/dropletConfig.js
@@ -1049,42 +1049,37 @@ export var blocks = [
     docFunc: 'comment',
     category: 'Goals',
     noAutocomplete: true
+  },
+  {
+    func: 'getPrediction',
+    parent: api,
+    category: 'Data',
+    paletteParams: ['name', 'id', 'data', 'callback'],
+    params: ['"name"', '"id"', 'data', 'function (value) {\n \n}']
+  },
+  {
+    func: 'declareAssign_object',
+    block: `var object = {"key": "value"};`,
+    category: 'Variables',
+    noAutocomplete: true
+  },
+  {
+    func: 'getValue',
+    parent: dontMarshalApi,
+    category: 'Variables',
+    paletteParams: ['object', '"key"'],
+    params: ['{"key": "value"}', '"key"'],
+    dontMarshal: true
+  },
+  {
+    func: 'addPair',
+    parent: dontMarshalApi,
+    category: 'Variables',
+    paletteParams: ['object', '"key"', '"value"'],
+    params: ['object', '"key"', '"value"'],
+    dontMarshal: true
   }
 ];
-
-if (experiments.isEnabled(experiments.APPLAB_ML)) {
-  blocks.push(
-    {
-      func: 'getPrediction',
-      parent: api,
-      category: 'Data',
-      paletteParams: ['name', 'id', 'data', 'callback'],
-      params: ['"name"', '"id"', 'data', 'function (value) {\n \n}']
-    },
-    {
-      func: 'declareAssign_object',
-      block: `var object = {"key": "value"};`,
-      category: 'Variables',
-      noAutocomplete: true
-    },
-    {
-      func: 'getValue',
-      parent: dontMarshalApi,
-      category: 'Variables',
-      paletteParams: ['object', '"key"'],
-      params: ['{"key": "value"}', '"key"'],
-      dontMarshal: true
-    },
-    {
-      func: 'addPair',
-      parent: dontMarshalApi,
-      category: 'Variables',
-      paletteParams: ['object', '"key"', '"value"'],
-      params: ['object', '"key"', '"value"'],
-      dontMarshal: true
-    }
-  );
-}
 
 export const categories = {
   'UI controls': {

--- a/apps/src/lib/ui/SettingsCog.jsx
+++ b/apps/src/lib/ui/SettingsCog.jsx
@@ -134,12 +134,14 @@ class SettingsCog extends Component {
           {this.areLibrariesEnabled() && (
             <ManageLibraries onClick={this.manageLibraries} />
           )}
-          {this.areAIToolsEnabled() && <ManageModels onClick={this.manageModels} />}
+          {this.areAIToolsEnabled() && (
+            <ManageModels onClick={this.manageModels} />
+          )}
           {this.props.showMakerToggle && (
             <ToggleMaker onClick={this.toggleMakerToolkit} />
           )}
         </PopUpMenu>
-        {aiEnabled && (
+        {this.areAIToolsEnabled() && (
           <ModelManagerDialog
             isOpen={this.state.managingModels}
             onClose={this.closeModelManager}

--- a/apps/src/lib/ui/SettingsCog.jsx
+++ b/apps/src/lib/ui/SettingsCog.jsx
@@ -13,7 +13,6 @@ import PopUpMenu from './PopUpMenu';
 import ConfirmEnableMakerDialog from './ConfirmEnableMakerDialog';
 import LibraryManagerDialog from '@cdo/apps/code-studio/components/libraries/LibraryManagerDialog';
 import {getStore} from '../../redux';
-import experiments from '@cdo/apps/util/experiments';
 import ModelManagerDialog from '@cdo/apps/code-studio/components/ModelManagerDialog';
 
 class SettingsCog extends Component {
@@ -28,15 +27,10 @@ class SettingsCog extends Component {
     open: false,
     confirmingEnableMaker: false,
     managingLibraries: false,
-    managingModels: false,
-    isAIEnabled: false
+    managingModels: false
   };
 
   targetPoint = {top: 0, left: 0};
-
-  componentDidMount() {
-    this.setState({isAIEnabled: experiments.isEnabled(experiments.APPLAB_ML)});
-  }
 
   open = () => this.setState({open: true});
   close = () => this.setState({open: false});
@@ -120,8 +114,6 @@ class SettingsCog extends Component {
       rootStyle.color = color.dark_charcoal;
     }
 
-    const aiEnabled = this.state.isAIEnabled && this.areAIToolsEnabled();
-
     return (
       <span style={rootStyle} ref={icon => this.setTargetPoint(icon)}>
         <FontAwesome
@@ -142,7 +134,7 @@ class SettingsCog extends Component {
           {this.areLibrariesEnabled() && (
             <ManageLibraries onClick={this.manageLibraries} />
           )}
-          {aiEnabled && <ManageModels onClick={this.manageModels} />}
+          {this.areAIToolsEnabled() && <ManageModels onClick={this.manageModels} />}
           {this.props.showMakerToggle && (
             <ToggleMaker onClick={this.toggleMakerToolkit} />
           )}

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -30,7 +30,6 @@ experiments.TEACHER_DASHBOARD_SECTION_BUTTONS_ALTERNATE_TEXT =
 experiments.FINISH_DIALOG_METRICS = 'finish-dialog-metrics';
 experiments.I18N_TRACKING = 'i18n-tracking';
 experiments.TIME_SPENT = 'time-spent';
-experiments.APPLAB_ML = 'applab-ml';
 experiments.BYPASS_DIALOG_POPUP = 'bypass-dialog-popup';
 experiments.SPECIAL_TOPIC = 'special-topic';
 experiments.POEM_BOT = 'poemBot';

--- a/apps/test/integration/levelSolutions/applab1/ec_data_blocks.js
+++ b/apps/test/integration/levelSolutions/applab1/ec_data_blocks.js
@@ -280,7 +280,8 @@ export default {
           'onRecordEvent',
           'getUserId',
           'drawChart',
-          'drawChartFromRecords'
+          'drawChartFromRecords',
+          'getPrediction'
         ];
         assert.deepEqual(actualBlocks, expectedBlocks);
         Applab.onPuzzleComplete();


### PR DESCRIPTION
This enables the "Manage AI Models" option under the App Lab settings cog for users not in the experiment.

Tested: successfully imported an AI model in an incognito browser window.