### PR TITLE
duplicating middle-high.js to avoid entry point check failures

### DIFF
--- a/apps/src/sites/code.org/pages/public/student/middle-high-alt.js
+++ b/apps/src/sites/code.org/pages/public/student/middle-high-alt.js
@@ -1,0 +1,7 @@
+import initResponsive from '@cdo/apps/code-studio/responsive';
+
+$(document).ready(function() {
+  initResponsive();
+
+  $('.hoc-tiles-container').load('/dashboardapi/middle_high_student_labs');
+});

--- a/pegasus/sites.v3/code.org/public/student/middle-high-alt.haml
+++ b/pegasus/sites.v3/code.org/public/student/middle-high-alt.haml
@@ -10,7 +10,7 @@ theme: responsive
 
 - js_locale = request.locale.to_s.downcase.tr('-', '_')
 %script{src: webpack_asset_path("js/#{js_locale}/common_locale.js")}
-%script{src: webpack_asset_path('js/code.org/public/student/middle-high.js')}
+%script{src: webpack_asset_path('js/code.org/public/student/middle-high-alt.js')}
 %link{href: "/shared/css/course-blocks.css", rel: "stylesheet", type: "text/css"}
 = view 'mobilecheck.js'
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

To unblock staging, we are duplicating `middle-high.js` in order to circumvent the following entry point check error:

```
âœ˜ code.org/public/student/middle-high âžœ ./src/sites/code.org/pages/public/student/middle-high.js
  âœ˜ Entry points should only be used by one template but this one is used by 2!
  this entry point is referenced by the following templates:
    ../pegasus/sites.v3/code.org/public/student/middle-high-alt.haml
                                 public/student/middle-high.haml
```

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
