### PR TITLE
Levelbuilder Sprite Management Homepage

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -634,7 +634,9 @@ describe('entry tests', () => {
     'shared_blockly_functions/edit':
       './src/sites/studio/pages/shared_blockly_functions/edit.js',
     'sprite_management/sprite_upload':
-      './src/sites/studio/pages/sprite_management/sprite_upload.js'
+      './src/sites/studio/pages/sprite_management/sprite_upload.js',
+    'sprite_management/sprite_management_directory':
+      './src/sites/studio/pages/sprite_management/sprite_management_directory.js'
   };
 
   var pegasusEntries = {

--- a/apps/src/code-studio/assets/SpriteManagementDirectory.jsx
+++ b/apps/src/code-studio/assets/SpriteManagementDirectory.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export default class SpriteManagementDirectory extends React.Component {
+  render() {
+    return (
+      <div>
+        <h1>Manage Sprite Lab Sprites</h1>
+      </div>
+    );
+  }
+}

--- a/apps/src/code-studio/assets/SpriteManagementDirectory.jsx
+++ b/apps/src/code-studio/assets/SpriteManagementDirectory.jsx
@@ -5,6 +5,9 @@ export default class SpriteManagementDirectory extends React.Component {
     return (
       <div>
         <h1>Manage Sprite Lab Sprites</h1>
+        <h3>
+          <a href="/sprites/sprite_upload">Upload New Sprites</a>
+        </h3>
       </div>
     );
   }

--- a/apps/src/code-studio/assets/SpriteUpload.jsx
+++ b/apps/src/code-studio/assets/SpriteUpload.jsx
@@ -139,6 +139,7 @@ export default class SpriteUpload extends React.Component {
 
     return (
       <div>
+        <a href="/sprites">Back to Sprite Management</a>
         <h1>Sprite Lab Sprite Upload</h1>
         <form onSubmit={this.handleSubmit}>
           <h2 style={styles.spriteUploadStep}>

--- a/apps/src/sites/studio/pages/sprite_management/sprite_management_directory.js
+++ b/apps/src/sites/studio/pages/sprite_management/sprite_management_directory.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import SpriteManagementDirectory from '@cdo/apps/code-studio/assets/SpriteManagementDirectory';
+
+$(document).ready(function() {
+  ReactDOM.render(
+    <SpriteManagementDirectory />,
+    document.getElementById('sprite-management-directory-container')
+  );
+});

--- a/dashboard/app/controllers/sprite_management_controller.rb
+++ b/dashboard/app/controllers/sprite_management_controller.rb
@@ -2,6 +2,9 @@ class SpriteManagementController < ApplicationController
   before_action :require_levelbuilder_mode
   before_action :authenticate_user!
 
+  def sprite_management_directory
+  end
+
   def sprite_upload
   end
 end

--- a/dashboard/app/views/home/_levelbuilder.html.haml
+++ b/dashboard/app/views/home/_levelbuilder.html.haml
@@ -10,4 +10,4 @@
     %li= link_to 'Helper Libraries', libraries_path
     %li= link_to 'Gallery', 'projects/public'
     %li= link_to 'Foorm Surveys (preview)', 'foorm/forms/editor'
-    %li= link_to '(BETA) Sprite Lab Sprite Management', 'sprites/sprite_upload'
+    %li= link_to '(BETA) Sprite Lab Sprite Management', 'sprites'

--- a/dashboard/app/views/sprite_management/sprite_management_directory.haml
+++ b/dashboard/app/views/sprite_management/sprite_management_directory.haml
@@ -1,0 +1,5 @@
+- content_for(:head) do
+  %script{src: webpack_asset_path('js/sprite_management/sprite_management_directory.js')}
+
+#sprite-management-directory-container
+  -# populated by React

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -850,6 +850,8 @@ Dashboard::Application.routes.draw do
 
   get '/javabuilder/access_token', to: 'javabuilder_sessions#get_access_token'
 
+  get '/sprites', to: 'sprite_management#sprite_management_directory'
+
   get '/sprites/sprite_upload', to: 'sprite_management#sprite_upload'
 
   # These really belong in the foorm namespace,


### PR DESCRIPTION
Step 2 of this Tech Plan: https://docs.google.com/document/d/1ceG2upHYXLEUxIr1kSf_DNjzoagmOxI82vhX2D_OXTA/edit

Before - The Sprite Upload was just about uploading sprites, available at /sprites/sprite_upload.
Now - Because we are also going to be editing the animation manifests and making defaults available, I've created the UI for a homepage at /sprites which can serve as a table of contents with links to UI for adding sprites, making sprites default, or deploying sprite changes to production. The PR covers the routing for that page, adding the link for Sprite Upload, which is the only fully fleshed out feature as of yet, and adding a "back" link to the sprite upload page.

Screenshot of /sprites
![Screenshot from 2021-07-12 12-18-10](https://user-images.githubusercontent.com/2959170/125343735-44011880-e30b-11eb-9c5d-3c7378d4b195.png)


Screenshot of 'back' link on 'sprites/sprite_upload':
![Screenshot from 2021-07-12 12-18-19](https://user-images.githubusercontent.com/2959170/125343779-4fecda80-e30b-11eb-98fe-69314e71350c.png)



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
