### PR TITLE
Add family names to other assignable scripts

### DIFF
--- a/dashboard/config/scripts/20-hour.script
+++ b/dashboard/config/scripts/20-hour.script
@@ -1,8 +1,11 @@
 id '1'
 hideable_lessons true
+family_name '20-hour'
+version_year 'unversioned'
 published_state 'preview'
 supported_locales ["de-DE"]
 curriculum_umbrella 'CSF'
+is_course true
 
 lesson 'Introduction to Computer Science', display_name: 'Introduction to Computer Science', has_lesson_plan: false, unplugged: true
 concepts 'sequence'

--- a/dashboard/config/scripts/AlgebraA.script
+++ b/dashboard/config/scripts/AlgebraA.script
@@ -1,7 +1,10 @@
 login_required true
 hideable_lessons true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/algebra/courseA/{LESSON}'
+family_name 'algebraa'
+version_year 'unversioned'
 published_state 'preview'
+is_course true
 
 lesson 'Calc: Evaluation Blocks', display_name: 'Calc: Evaluation Blocks', has_lesson_plan: true
 level 'Calc Circles of Eval .1'

--- a/dashboard/config/scripts/AlgebraB.script
+++ b/dashboard/config/scripts/AlgebraB.script
@@ -1,7 +1,10 @@
 login_required true
 hideable_lessons true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/algebra/courseB/{LESSON}'
+family_name 'algebrab'
+version_year 'unversioned'
 published_state 'preview'
+is_course true
 
 lesson 'Unplugged: Video Games and Coordinate Planes', display_name: 'Unplugged: Video Games and Coordinate Planes', has_lesson_plan: true, unplugged: true
 level 'VideoGamesCoordinatePlanes'

--- a/dashboard/config/scripts/algebra.script
+++ b/dashboard/config/scripts/algebra.script
@@ -1,6 +1,9 @@
 login_required true
 hideable_lessons true
+family_name 'algebra'
+version_year 'unversioned'
 published_state 'preview'
+is_course true
 
 lesson 'Unplugged: Video Games and Coordinate Planes', display_name: 'Unplugged: Video Games and Coordinate Planes', has_lesson_plan: true, unplugged: true
 level 'VideoGamesCoordinatePlanes'

--- a/dashboard/config/scripts/applab-intro.script
+++ b/dashboard/config/scripts/applab-intro.script
@@ -1,6 +1,9 @@
 student_detail_progress_view true
+family_name 'applab-intro'
+version_year 'unversioned'
 published_state 'preview'
 tts true
+is_course true
 
 lesson 'Intro to App Lab', display_name: 'Intro to App Lab', has_lesson_plan: true
 level 'App Lab Intro 8 - Video Getting Started', progression: 'Setting Properties'

--- a/dashboard/config/scripts/aquatic.script
+++ b/dashboard/config/scripts/aquatic.script
@@ -1,4 +1,7 @@
+family_name 'aquatic'
+version_year 'unversioned'
 published_state 'preview'
+is_course true
 
 lesson 'Aquatic', display_name: 'Aquatic', has_lesson_plan: false
 level 'HOC 2018 Level_1'

--- a/dashboard/config/scripts/artist.script
+++ b/dashboard/config/scripts/artist.script
@@ -1,5 +1,8 @@
+family_name 'artist'
+version_year 'unversioned'
 published_state 'preview'
 tts true
+is_course true
 
 lesson 'Artist', display_name: 'Artist', has_lesson_plan: false
 level 'Standalone_Artist_1'

--- a/dashboard/config/scripts/basketball.script
+++ b/dashboard/config/scripts/basketball.script
@@ -1,5 +1,8 @@
+family_name 'basketball'
+version_year 'unversioned'
 published_state 'preview'
 tts true
+is_course true
 
 lesson 'Bounce', display_name: 'Bounce', has_lesson_plan: false
 level 'bounce_1_basketball'

--- a/dashboard/config/scripts/code-break-younger.script
+++ b/dashboard/config/scripts/code-break-younger.script
@@ -1,6 +1,9 @@
 hideable_lessons true
 student_detail_progress_view true
+family_name 'code-break-younger'
+version_year 'unversioned'
 published_state 'preview'
+is_course true
 
 lesson 'Episode 1 - Algorithms with Hill Harper', display_name: 'Episode 1 - Algorithms with Hill Harper', has_lesson_plan: false
 level 'CodeBreak Episode Placeholder', progression: 'Code Break: Episode 1'

--- a/dashboard/config/scripts/code-break.script
+++ b/dashboard/config/scripts/code-break.script
@@ -1,7 +1,10 @@
 login_required true
 hideable_lessons true
 student_detail_progress_view true
+family_name 'code-break'
+version_year 'unversioned'
 published_state 'preview'
+is_course true
 
 lesson 'Episode 1 - Algorithms with Hill Harper', display_name: 'Episode 1 - Algorithms with Hill Harper', has_lesson_plan: false
 level 'CodeBreak Episode Placeholder', progression: 'Code Break: Episode 1'

--- a/dashboard/config/scripts/course1.script
+++ b/dashboard/config/scripts/course1.script
@@ -3,9 +3,12 @@ lesson_extras_available true
 curriculum_path 'https://code.org/curriculum/course1/{LESSON}/Teacher'
 project_widget_visible true
 project_widget_types ["playlab_k1", "artist_k1"]
+family_name 'course1'
+version_year 'unversioned'
 published_state 'preview'
 curriculum_umbrella 'CSF'
 tts true
+is_course true
 
 lesson 'Happy Maps', display_name: 'Happy Maps', has_lesson_plan: true, unplugged: true
 level 'UnplugHappyMaps'

--- a/dashboard/config/scripts/course2.script
+++ b/dashboard/config/scripts/course2.script
@@ -3,9 +3,12 @@ lesson_extras_available true
 curriculum_path 'https://code.org/curriculum/course2/{LESSON}/Teacher'
 project_widget_visible true
 project_widget_types ["playlab", "artist"]
+family_name 'course2'
+version_year 'unversioned'
 published_state 'preview'
 curriculum_umbrella 'CSF'
 tts true
+is_course true
 
 lesson 'Graph Paper Programming', display_name: 'Graph Paper Programming', has_lesson_plan: true, unplugged: true
 level 'GraphPaperProgramming'
@@ -40,8 +43,8 @@ level '2-3 Artist 3.4'
 level '2-3 Artist 4'
 level '2-3 Artist 6'
 variants
-  level '2-3 Artist 9', active: false
   level '2-3 Artist 9 NEW'
+  level '2-3 Artist 9', active: false
 endvariants
 level '2-3 Artist 7'
 level '2-3 Artist 8'

--- a/dashboard/config/scripts/course3.script
+++ b/dashboard/config/scripts/course3.script
@@ -3,9 +3,12 @@ lesson_extras_available true
 curriculum_path 'https://code.org/curriculum/course3/{LESSON}/Teacher'
 project_widget_visible true
 project_widget_types ["playlab", "artist"]
+family_name 'course3'
+version_year 'unversioned'
 published_state 'preview'
 curriculum_umbrella 'CSF'
 tts true
+is_course true
 
 lesson 'Computational Thinking', display_name: 'Computational Thinking', has_lesson_plan: true, unplugged: true
 level 'ComputationalThinking'

--- a/dashboard/config/scripts/course4.script
+++ b/dashboard/config/scripts/course4.script
@@ -1,8 +1,11 @@
 hideable_lessons true
 curriculum_path 'https://code.org/curriculum/course4/{LESSON}/Teacher'
+family_name 'course4'
+version_year 'unversioned'
 published_state 'preview'
 curriculum_umbrella 'CSF'
 tts true
+is_course true
 
 lesson 'Unplugged: Tangrams', display_name: 'Unplugged: Tangrams', has_lesson_plan: true, unplugged: true
 level 'TangramAlgorithms'

--- a/dashboard/config/scripts/csd-post-survey.script
+++ b/dashboard/config/scripts/csd-post-survey.script
@@ -1,6 +1,9 @@
 login_required true
 has_verified_resources true
+family_name 'csd-post-survey'
+version_year 'unversioned'
 published_state 'preview'
+is_course true
 
 lesson_group 'csd_survey', display_name: 'Post-Course Survey'
 lesson 'CSD post-course survey', display_name: 'CSD post-course survey', has_lesson_plan: false

--- a/dashboard/config/scripts/csd3-virtual.script
+++ b/dashboard/config/scripts/csd3-virtual.script
@@ -4,8 +4,11 @@ student_detail_progress_view true
 teacher_resources [["teacherForum", "https://forum.code.org/c/csd3"]]
 has_verified_resources true
 curriculum_path 'https://curriculum.code.org/csd-20/unit3/{LESSON}'
+family_name 'csd3-virtual'
+version_year 'unversioned'
 published_state 'preview'
 project_sharing true
+is_course true
 
 lesson 'Drawing in Game Lab', display_name: 'Drawing in Game Lab', has_lesson_plan: false
 level 'CSD U3 samples_virtual_2020', progression: 'Sample Programs'

--- a/dashboard/config/scripts/csp-mid-survey.script
+++ b/dashboard/config/scripts/csp-mid-survey.script
@@ -1,6 +1,9 @@
 login_required true
 has_verified_resources true
+family_name 'csp-mid-survey'
+version_year 'unversioned'
 published_state 'preview'
+is_course true
 
 lesson_group 'cspSurvey', display_name: 'Survey'
 lesson 'CSP Mid-year survey', display_name: 'CSP Mid-year survey', has_lesson_plan: false

--- a/dashboard/config/scripts/csp3-virtual.script
+++ b/dashboard/config/scripts/csp3-virtual.script
@@ -2,8 +2,11 @@ login_required true
 hideable_lessons true
 student_detail_progress_view true
 has_verified_resources true
+family_name 'csp3-virtual'
+version_year 'unversioned'
 published_state 'preview'
 project_sharing true
+is_course true
 
 lesson_group 'csp3_1_2018', display_name: 'Unit 3: Intro to Programming'
 lesson 'Using Simple Commands', display_name: 'Using Simple Commands', has_lesson_plan: false

--- a/dashboard/config/scripts/csp5-virtual.script
+++ b/dashboard/config/scripts/csp5-virtual.script
@@ -1,8 +1,11 @@
 login_required true
 hideable_lessons true
 student_detail_progress_view true
+family_name 'csp5-virtual'
+version_year 'unversioned'
 published_state 'preview'
 project_sharing true
+is_course true
 
 lesson 'Intro to App Lab', display_name: 'Intro to App Lab', has_lesson_plan: false
 level 'CSPU5_HOC_virtual1', progression: 'Setting Properties'

--- a/dashboard/config/scripts/dance-2019.script
+++ b/dashboard/config/scripts/dance-2019.script
@@ -1,5 +1,8 @@
+family_name 'dance-2019'
+version_year 'unversioned'
 published_state 'preview'
 tts true
+is_course true
 
 lesson 'Dance Party', display_name: 'Dance Party', has_lesson_plan: false
 level 'Dance_2019_01'

--- a/dashboard/config/scripts/dance-extras-2019.script
+++ b/dashboard/config/scripts/dance-extras-2019.script
@@ -1,5 +1,8 @@
+family_name 'dance-extras-2019'
+version_year 'unversioned'
 published_state 'preview'
 tts true
+is_course true
 
 lesson 'Dance Party - Go Further', display_name: 'Dance Party - Go Further', has_lesson_plan: false
 level 'Dance_Party_extras_intro_2019', named: true

--- a/dashboard/config/scripts/dance-extras.script
+++ b/dashboard/config/scripts/dance-extras.script
@@ -1,5 +1,8 @@
+family_name 'dance-extras'
+version_year 'unversioned'
 published_state 'preview'
 tts true
+is_course true
 
 lesson 'Dance Party - Go Further', display_name: 'Dance Party - Go Further', has_lesson_plan: false
 level 'Dance_Party_extras_intro', named: true

--- a/dashboard/config/scripts/dance.script
+++ b/dashboard/config/scripts/dance.script
@@ -1,5 +1,8 @@
+family_name 'dance'
+version_year 'unversioned'
 published_state 'preview'
 tts true
+is_course true
 
 lesson 'Dance Party', display_name: 'Dance Party', has_lesson_plan: true
 level 'Dance_Party_01'

--- a/dashboard/config/scripts/deepdive-debugging.script
+++ b/dashboard/config/scripts/deepdive-debugging.script
@@ -1,4 +1,7 @@
+family_name 'deepdive-debugging'
+version_year 'unversioned'
 published_state 'preview'
+is_course true
 
 lesson 'Debugging for AB Educators', display_name: 'Debugging for AB Educators', has_lesson_plan: false
 level 'AB_debug_Laurel1'

--- a/dashboard/config/scripts/fit2019-apprentice.script
+++ b/dashboard/config/scripts/fit2019-apprentice.script
@@ -1,7 +1,10 @@
 professional_learning_course 'Facilitators in Training Summer Reflections 2019'
 login_required true
 student_detail_progress_view true
+family_name 'fit2019-apprentice'
+version_year 'unversioned'
 published_state 'preview'
+is_course true
 
 lesson_group 'required', display_name: 'Overview'
 lesson 'Apprentice Reflection Overview', display_name: 'Apprentice Reflection Overview', has_lesson_plan: false

--- a/dashboard/config/scripts/flappy.script
+++ b/dashboard/config/scripts/flappy.script
@@ -1,5 +1,8 @@
 id '6'
+family_name 'flappy'
+version_year 'unversioned'
 published_state 'preview'
+is_course true
 
 lesson 'Flappy Code', display_name: 'Flappy Code', has_lesson_plan: false
 level 'flappy_1'

--- a/dashboard/config/scripts/frozen.script
+++ b/dashboard/config/scripts/frozen.script
@@ -1,4 +1,7 @@
+family_name 'frozen'
+version_year 'unversioned'
 published_state 'preview'
+is_course true
 
 lesson 'Artist', display_name: 'Artist', has_lesson_plan: false
 level 'frozen line'

--- a/dashboard/config/scripts/gumball.script
+++ b/dashboard/config/scripts/gumball.script
@@ -1,4 +1,7 @@
+family_name 'gumball'
+version_year 'unversioned'
 published_state 'preview'
+is_course true
 
 lesson 'Gumball Play Lab', display_name: 'Gumball Play Lab', has_lesson_plan: false
 skin 'gumball'

--- a/dashboard/config/scripts/hero.script
+++ b/dashboard/config/scripts/hero.script
@@ -1,4 +1,7 @@
+family_name 'hero'
+version_year 'unversioned'
 published_state 'preview'
+is_course true
 
 lesson 'Minecraft Hour of Code', display_name: 'Minecraft Hour of Code', has_lesson_plan: false
 level 'MC_HOC_2017_01_RETRY'

--- a/dashboard/config/scripts/hoc-encryption.script
+++ b/dashboard/config/scripts/hoc-encryption.script
@@ -1,4 +1,7 @@
+family_name 'hoc-encryption'
+version_year 'unversioned'
 published_state 'preview'
+is_course true
 
 lesson 'Simple Encryption', display_name: 'Simple Encryption', has_lesson_plan: false
 level 'Crack a Caesar Cipher', named: true

--- a/dashboard/config/scripts/hourofcode.script
+++ b/dashboard/config/scripts/hourofcode.script
@@ -1,5 +1,8 @@
 wrapup_video 'hoc_wrapup'
+family_name 'hourofcode'
+version_year 'unversioned'
 published_state 'preview'
+is_course true
 
 lesson 'Maze', display_name: 'Maze', has_lesson_plan: false
 skin 'birds'

--- a/dashboard/config/scripts/iceage.script
+++ b/dashboard/config/scripts/iceage.script
@@ -1,4 +1,7 @@
+family_name 'iceage'
+version_year 'unversioned'
 published_state 'preview'
+is_course true
 
 lesson 'Ice Age Play Lab', display_name: 'Ice Age Play Lab', has_lesson_plan: false
 level 'iceage_hello1'

--- a/dashboard/config/scripts/infinity.script
+++ b/dashboard/config/scripts/infinity.script
@@ -1,4 +1,7 @@
+family_name 'infinity'
+version_year 'unversioned'
 published_state 'preview'
+is_course true
 
 lesson 'Infinity', display_name: 'Infinity', has_lesson_plan: false
 level 'Infinity_move_right'

--- a/dashboard/config/scripts/jigsaw.script
+++ b/dashboard/config/scripts/jigsaw.script
@@ -1,5 +1,8 @@
 id '7'
+family_name 'jigsaw'
+version_year 'unversioned'
 published_state 'preview'
+is_course true
 
 lesson 'Jigsaw', display_name: 'Jigsaw', has_lesson_plan: false
 skin 'jigsaw'

--- a/dashboard/config/scripts/mc.script
+++ b/dashboard/config/scripts/mc.script
@@ -1,4 +1,7 @@
+family_name 'mc'
+version_year 'unversioned'
 published_state 'preview'
+is_course true
 
 lesson 'Hour of Code 2015', display_name: 'Hour of Code 2015', has_lesson_plan: false
 level 'Overworld Move to Sheep'

--- a/dashboard/config/scripts/minecraft.script
+++ b/dashboard/config/scripts/minecraft.script
@@ -1,4 +1,7 @@
+family_name 'minecraft'
+version_year 'unversioned'
 published_state 'preview'
+is_course true
 
 lesson 'Minecraft Hour of Code Designer', display_name: 'Minecraft Hour of Code Designer', has_lesson_plan: false
 level 'MC HOC 2016 Level 2-2'

--- a/dashboard/config/scripts/oceans.script
+++ b/dashboard/config/scripts/oceans.script
@@ -1,4 +1,7 @@
+family_name 'oceans'
+version_year 'unversioned'
 published_state 'preview'
+is_course true
 
 lesson 'Oceans', display_name: 'Oceans', has_lesson_plan: true
 level 'Oceans_Video_Machine_Learning'

--- a/dashboard/config/scripts/outbreak.script
+++ b/dashboard/config/scripts/outbreak.script
@@ -1,4 +1,7 @@
+family_name 'outbreak'
+version_year 'unversioned'
 published_state 'preview'
+is_course true
 
 lesson_group 'outbreak', display_name: 'Outbreak Simulation'
 lesson 'Virus Simulation for Code Bytes', display_name: 'Coding a Simulation', has_lesson_plan: false

--- a/dashboard/config/scripts/pixelation.script
+++ b/dashboard/config/scripts/pixelation.script
@@ -1,4 +1,7 @@
+family_name 'pixelation'
+version_year 'unversioned'
 published_state 'preview'
+is_course true
 
 lesson 'Black & White Pixelation Tutorial', display_name: 'Black & White Pixelation Tutorial', has_lesson_plan: false
 level 'Pixelation 4x4 Empty'

--- a/dashboard/config/scripts/playlab.script
+++ b/dashboard/config/scripts/playlab.script
@@ -1,4 +1,7 @@
+family_name 'playlab'
+version_year 'unversioned'
 published_state 'preview'
+is_course true
 
 lesson 'Play Lab', display_name: 'Play Lab', has_lesson_plan: false
 skin 'studio'

--- a/dashboard/config/scripts/sports.script
+++ b/dashboard/config/scripts/sports.script
@@ -1,5 +1,8 @@
+family_name 'sports'
+version_year 'unversioned'
 published_state 'preview'
 tts true
+is_course true
 
 lesson 'Sports', display_name: 'Sports', has_lesson_plan: false
 level 'bounce_1_sports'

--- a/dashboard/config/scripts/starwars.script
+++ b/dashboard/config/scripts/starwars.script
@@ -1,4 +1,7 @@
+family_name 'starwars'
+version_year 'unversioned'
 published_state 'preview'
+is_course true
 
 lesson 'Hour of Code 2015', display_name: 'Hour of Code 2015', has_lesson_plan: false
 skin 'hoc2015x'

--- a/dashboard/config/scripts/starwarsblocks.script
+++ b/dashboard/config/scripts/starwarsblocks.script
@@ -1,4 +1,7 @@
+family_name 'starwarsblocks'
+version_year 'unversioned'
 published_state 'preview'
+is_course true
 
 lesson 'Hour of Code 2015', display_name: 'Hour of Code 2015', has_lesson_plan: false
 skin 'hoc2015x'

--- a/dashboard/config/scripts/text-compression.script
+++ b/dashboard/config/scripts/text-compression.script
@@ -1,4 +1,7 @@
+family_name 'text-compression'
+version_year 'unversioned'
 published_state 'preview'
+is_course true
 
 lesson 'Text Compression', display_name: 'Text Compression', has_lesson_plan: false
 level 'Text Compression', named: true

--- a/dashboard/config/scripts_json/20-hour.script_json
+++ b/dashboard/config/scripts_json/20-hour.script_json
@@ -8,11 +8,13 @@
       "supported_locales": [
         "de-DE"
       ],
-      "hideable_lessons": true
+      "hideable_lessons": true,
+      "version_year": "unversioned",
+      "is_course": true
     },
     "new_name": null,
-    "family_name": null,
-    "serialized_at": "2021-06-17 22:27:39 UTC",
+    "family_name": "20-hour",
+    "serialized_at": "2021-07-06 22:25:42 UTC",
     "published_state": "preview",
     "seeding_key": {
       "script.name": "20-hour"

--- a/dashboard/config/scripts_json/AlgebraA.script_json
+++ b/dashboard/config/scripts_json/AlgebraA.script_json
@@ -6,11 +6,13 @@
     "properties": {
       "has_lesson_plan": true,
       "curriculum_path": "https://curriculum.code.org/{LOCALE}/algebra/courseA/{LESSON}",
-      "hideable_lessons": true
+      "hideable_lessons": true,
+      "version_year": "unversioned",
+      "is_course": true
     },
     "new_name": null,
-    "family_name": null,
-    "serialized_at": "2021-06-17 22:28:15 UTC",
+    "family_name": "algebraa",
+    "serialized_at": "2021-07-06 22:25:44 UTC",
     "published_state": "preview",
     "seeding_key": {
       "script.name": "AlgebraA"

--- a/dashboard/config/scripts_json/AlgebraB.script_json
+++ b/dashboard/config/scripts_json/AlgebraB.script_json
@@ -6,11 +6,13 @@
     "properties": {
       "has_lesson_plan": true,
       "curriculum_path": "https://curriculum.code.org/{LOCALE}/algebra/courseB/{LESSON}",
-      "hideable_lessons": true
+      "hideable_lessons": true,
+      "version_year": "unversioned",
+      "is_course": true
     },
     "new_name": null,
-    "family_name": null,
-    "serialized_at": "2021-06-17 22:28:16 UTC",
+    "family_name": "algebrab",
+    "serialized_at": "2021-07-06 22:25:45 UTC",
     "published_state": "preview",
     "seeding_key": {
       "script.name": "AlgebraB"

--- a/dashboard/config/scripts_json/algebra.script_json
+++ b/dashboard/config/scripts_json/algebra.script_json
@@ -4,12 +4,13 @@
     "wrapup_video_id": null,
     "login_required": true,
     "properties": {
-      "has_lesson_plan": true,
-      "hideable_lessons": true
+      "hideable_lessons": true,
+      "version_year": "unversioned",
+      "is_course": true
     },
     "new_name": null,
-    "family_name": null,
-    "serialized_at": "2021-06-17 22:27:50 UTC",
+    "family_name": "algebra",
+    "serialized_at": "2021-07-06 22:25:46 UTC",
     "published_state": "preview",
     "seeding_key": {
       "script.name": "algebra"

--- a/dashboard/config/scripts_json/applab-intro.script_json
+++ b/dashboard/config/scripts_json/applab-intro.script_json
@@ -6,11 +6,13 @@
     "properties": {
       "student_detail_progress_view": true,
       "has_lesson_plan": true,
-      "tts": true
+      "tts": true,
+      "version_year": "unversioned",
+      "is_course": true
     },
     "new_name": null,
-    "family_name": null,
-    "serialized_at": "2021-06-17 22:29:06 UTC",
+    "family_name": "applab-intro",
+    "serialized_at": "2021-07-06 22:25:47 UTC",
     "published_state": "preview",
     "seeding_key": {
       "script.name": "applab-intro"

--- a/dashboard/config/scripts_json/aquatic.script_json
+++ b/dashboard/config/scripts_json/aquatic.script_json
@@ -4,10 +4,12 @@
     "wrapup_video_id": null,
     "login_required": false,
     "properties": {
+      "version_year": "unversioned",
+      "is_course": true
     },
     "new_name": null,
-    "family_name": null,
-    "serialized_at": "2021-06-17 22:29:55 UTC",
+    "family_name": "aquatic",
+    "serialized_at": "2021-07-06 22:25:47 UTC",
     "published_state": "preview",
     "seeding_key": {
       "script.name": "aquatic"

--- a/dashboard/config/scripts_json/artist.script_json
+++ b/dashboard/config/scripts_json/artist.script_json
@@ -4,11 +4,13 @@
     "wrapup_video_id": null,
     "login_required": false,
     "properties": {
-      "tts": true
+      "tts": true,
+      "version_year": "unversioned",
+      "is_course": true
     },
     "new_name": null,
-    "family_name": null,
-    "serialized_at": "2021-06-17 22:27:41 UTC",
+    "family_name": "artist",
+    "serialized_at": "2021-07-06 22:25:47 UTC",
     "published_state": "preview",
     "seeding_key": {
       "script.name": "artist"

--- a/dashboard/config/scripts_json/basketball.script_json
+++ b/dashboard/config/scripts_json/basketball.script_json
@@ -4,11 +4,13 @@
     "wrapup_video_id": null,
     "login_required": false,
     "properties": {
-      "tts": true
+      "tts": true,
+      "version_year": "unversioned",
+      "is_course": true
     },
     "new_name": null,
-    "family_name": null,
-    "serialized_at": "2021-06-17 22:28:32 UTC",
+    "family_name": "basketball",
+    "serialized_at": "2021-07-06 22:25:47 UTC",
     "published_state": "preview",
     "seeding_key": {
       "script.name": "basketball"

--- a/dashboard/config/scripts_json/code-break-younger.script_json
+++ b/dashboard/config/scripts_json/code-break-younger.script_json
@@ -5,11 +5,13 @@
     "login_required": false,
     "properties": {
       "student_detail_progress_view": true,
-      "hideable_lessons": true
+      "hideable_lessons": true,
+      "version_year": "unversioned",
+      "is_course": true
     },
     "new_name": null,
-    "family_name": null,
-    "serialized_at": "2021-06-17 22:30:57 UTC",
+    "family_name": "code-break-younger",
+    "serialized_at": "2021-07-06 22:25:48 UTC",
     "published_state": "preview",
     "seeding_key": {
       "script.name": "code-break-younger"

--- a/dashboard/config/scripts_json/code-break.script_json
+++ b/dashboard/config/scripts_json/code-break.script_json
@@ -5,11 +5,13 @@
     "login_required": true,
     "properties": {
       "student_detail_progress_view": true,
-      "hideable_lessons": true
+      "hideable_lessons": true,
+      "version_year": "unversioned",
+      "is_course": true
     },
     "new_name": null,
-    "family_name": null,
-    "serialized_at": "2021-06-17 22:30:55 UTC",
+    "family_name": "code-break",
+    "serialized_at": "2021-07-06 22:25:49 UTC",
     "published_state": "preview",
     "seeding_key": {
       "script.name": "code-break"

--- a/dashboard/config/scripts_json/course1.script_json
+++ b/dashboard/config/scripts_json/course1.script_json
@@ -14,11 +14,13 @@
       "curriculum_umbrella": "CSF",
       "tts": true,
       "lesson_extras_available": true,
-      "hideable_lessons": true
+      "hideable_lessons": true,
+      "version_year": "unversioned",
+      "is_course": true
     },
     "new_name": null,
-    "family_name": null,
-    "serialized_at": "2021-06-17 22:27:42 UTC",
+    "family_name": "course1",
+    "serialized_at": "2021-07-06 22:25:51 UTC",
     "published_state": "preview",
     "seeding_key": {
       "script.name": "course1"

--- a/dashboard/config/scripts_json/course2.script_json
+++ b/dashboard/config/scripts_json/course2.script_json
@@ -14,11 +14,13 @@
       "curriculum_umbrella": "CSF",
       "tts": true,
       "lesson_extras_available": true,
-      "hideable_lessons": true
+      "hideable_lessons": true,
+      "version_year": "unversioned",
+      "is_course": true
     },
     "new_name": null,
-    "family_name": null,
-    "serialized_at": "2021-06-17 22:27:43 UTC",
+    "family_name": "course2",
+    "serialized_at": "2021-07-06 22:25:53 UTC",
     "published_state": "preview",
     "seeding_key": {
       "script.name": "course2"

--- a/dashboard/config/scripts_json/course3.script_json
+++ b/dashboard/config/scripts_json/course3.script_json
@@ -14,11 +14,13 @@
       "curriculum_umbrella": "CSF",
       "tts": true,
       "lesson_extras_available": true,
-      "hideable_lessons": true
+      "hideable_lessons": true,
+      "version_year": "unversioned",
+      "is_course": true
     },
     "new_name": null,
-    "family_name": null,
-    "serialized_at": "2021-06-17 22:27:45 UTC",
+    "family_name": "course3",
+    "serialized_at": "2021-07-06 22:25:56 UTC",
     "published_state": "preview",
     "seeding_key": {
       "script.name": "course3"

--- a/dashboard/config/scripts_json/course4.script_json
+++ b/dashboard/config/scripts_json/course4.script_json
@@ -8,11 +8,13 @@
       "curriculum_path": "https://code.org/curriculum/course4/{LESSON}/Teacher",
       "curriculum_umbrella": "CSF",
       "tts": true,
-      "hideable_lessons": true
+      "hideable_lessons": true,
+      "version_year": "unversioned",
+      "is_course": true
     },
     "new_name": null,
-    "family_name": null,
-    "serialized_at": "2021-06-17 22:27:47 UTC",
+    "family_name": "course4",
+    "serialized_at": "2021-07-06 22:25:58 UTC",
     "published_state": "preview",
     "seeding_key": {
       "script.name": "course4"

--- a/dashboard/config/scripts_json/csd-post-survey.script_json
+++ b/dashboard/config/scripts_json/csd-post-survey.script_json
@@ -5,11 +5,13 @@
     "login_required": true,
     "properties": {
       "exclude_csf_column_in_legend": true,
-      "has_verified_resources": true
+      "has_verified_resources": true,
+      "version_year": "unversioned",
+      "is_course": true
     },
     "new_name": null,
-    "family_name": null,
-    "serialized_at": "2021-06-17 22:29:52 UTC",
+    "family_name": "csd-post-survey",
+    "serialized_at": "2021-07-06 22:25:58 UTC",
     "published_state": "preview",
     "seeding_key": {
       "script.name": "csd-post-survey"

--- a/dashboard/config/scripts_json/csd3-virtual.script_json
+++ b/dashboard/config/scripts_json/csd3-virtual.script_json
@@ -14,11 +14,13 @@
           "teacherForum",
           "https://forum.code.org/c/csd3"
         ]
-      ]
+      ],
+      "version_year": "unversioned",
+      "is_course": true
     },
     "new_name": null,
-    "family_name": null,
-    "serialized_at": "2021-06-17 22:31:00 UTC",
+    "family_name": "csd3-virtual",
+    "serialized_at": "2021-07-06 22:26:00 UTC",
     "published_state": "preview",
     "seeding_key": {
       "script.name": "csd3-virtual"

--- a/dashboard/config/scripts_json/csp-mid-survey.script_json
+++ b/dashboard/config/scripts_json/csp-mid-survey.script_json
@@ -4,11 +4,13 @@
     "wrapup_video_id": null,
     "login_required": true,
     "properties": {
-      "has_verified_resources": true
+      "has_verified_resources": true,
+      "version_year": "unversioned",
+      "is_course": true
     },
     "new_name": null,
-    "family_name": null,
-    "serialized_at": "2021-06-17 22:30:05 UTC",
+    "family_name": "csp-mid-survey",
+    "serialized_at": "2021-07-06 22:26:00 UTC",
     "published_state": "preview",
     "seeding_key": {
       "script.name": "csp-mid-survey"

--- a/dashboard/config/scripts_json/csp3-virtual.script_json
+++ b/dashboard/config/scripts_json/csp3-virtual.script_json
@@ -7,11 +7,13 @@
       "student_detail_progress_view": true,
       "has_verified_resources": true,
       "project_sharing": true,
-      "hideable_lessons": true
+      "hideable_lessons": true,
+      "version_year": "unversioned",
+      "is_course": true
     },
     "new_name": null,
-    "family_name": null,
-    "serialized_at": "2021-06-17 22:30:51 UTC",
+    "family_name": "csp3-virtual",
+    "serialized_at": "2021-07-06 22:26:01 UTC",
     "published_state": "preview",
     "seeding_key": {
       "script.name": "csp3-virtual"

--- a/dashboard/config/scripts_json/csp5-virtual.script_json
+++ b/dashboard/config/scripts_json/csp5-virtual.script_json
@@ -6,11 +6,13 @@
     "properties": {
       "student_detail_progress_view": true,
       "project_sharing": true,
-      "hideable_lessons": true
+      "hideable_lessons": true,
+      "version_year": "unversioned",
+      "is_course": true
     },
     "new_name": null,
-    "family_name": null,
-    "serialized_at": "2021-06-17 22:30:53 UTC",
+    "family_name": "csp5-virtual",
+    "serialized_at": "2021-07-06 22:26:02 UTC",
     "published_state": "preview",
     "seeding_key": {
       "script.name": "csp5-virtual"

--- a/dashboard/config/scripts_json/dance-2019.script_json
+++ b/dashboard/config/scripts_json/dance-2019.script_json
@@ -4,11 +4,13 @@
     "wrapup_video_id": null,
     "login_required": false,
     "properties": {
-      "tts": true
+      "tts": true,
+      "version_year": "unversioned",
+      "is_course": true
     },
     "new_name": null,
-    "family_name": null,
-    "serialized_at": "2021-06-17 22:30:25 UTC",
+    "family_name": "dance-2019",
+    "serialized_at": "2021-07-06 22:26:02 UTC",
     "published_state": "preview",
     "seeding_key": {
       "script.name": "dance-2019"

--- a/dashboard/config/scripts_json/dance-extras-2019.script_json
+++ b/dashboard/config/scripts_json/dance-extras-2019.script_json
@@ -4,11 +4,13 @@
     "wrapup_video_id": null,
     "login_required": false,
     "properties": {
-      "tts": true
+      "tts": true,
+      "version_year": "unversioned",
+      "is_course": true
     },
     "new_name": null,
-    "family_name": null,
-    "serialized_at": "2021-06-17 22:30:26 UTC",
+    "family_name": "dance-extras-2019",
+    "serialized_at": "2021-07-06 22:26:02 UTC",
     "published_state": "preview",
     "seeding_key": {
       "script.name": "dance-extras-2019"

--- a/dashboard/config/scripts_json/dance-extras.script_json
+++ b/dashboard/config/scripts_json/dance-extras.script_json
@@ -4,11 +4,13 @@
     "wrapup_video_id": null,
     "login_required": false,
     "properties": {
-      "tts": true
+      "tts": true,
+      "version_year": "unversioned",
+      "is_course": true
     },
     "new_name": null,
-    "family_name": null,
-    "serialized_at": "2021-06-17 22:29:56 UTC",
+    "family_name": "dance-extras",
+    "serialized_at": "2021-07-06 22:26:03 UTC",
     "published_state": "preview",
     "seeding_key": {
       "script.name": "dance-extras"

--- a/dashboard/config/scripts_json/dance.script_json
+++ b/dashboard/config/scripts_json/dance.script_json
@@ -5,11 +5,13 @@
     "login_required": false,
     "properties": {
       "has_lesson_plan": true,
-      "tts": true
+      "tts": true,
+      "version_year": "unversioned",
+      "is_course": true
     },
     "new_name": null,
-    "family_name": null,
-    "serialized_at": "2021-06-17 22:29:55 UTC",
+    "family_name": "dance",
+    "serialized_at": "2021-07-06 22:26:03 UTC",
     "published_state": "preview",
     "seeding_key": {
       "script.name": "dance"

--- a/dashboard/config/scripts_json/deepdive-debugging.script_json
+++ b/dashboard/config/scripts_json/deepdive-debugging.script_json
@@ -4,10 +4,12 @@
     "wrapup_video_id": null,
     "login_required": false,
     "properties": {
+      "version_year": "unversioned",
+      "is_course": true
     },
     "new_name": null,
-    "family_name": null,
-    "serialized_at": "2021-06-17 22:29:54 UTC",
+    "family_name": "deepdive-debugging",
+    "serialized_at": "2021-07-06 22:26:03 UTC",
     "published_state": "preview",
     "seeding_key": {
       "script.name": "deepdive-debugging"

--- a/dashboard/config/scripts_json/fit2019-apprentice.script_json
+++ b/dashboard/config/scripts_json/fit2019-apprentice.script_json
@@ -5,11 +5,13 @@
     "login_required": true,
     "properties": {
       "student_detail_progress_view": true,
-      "professional_learning_course": "Facilitators in Training Summer Reflections 2019"
+      "professional_learning_course": "Facilitators in Training Summer Reflections 2019",
+      "version_year": "unversioned",
+      "is_course": true
     },
     "new_name": null,
-    "family_name": null,
-    "serialized_at": "2021-06-17 22:30:22 UTC",
+    "family_name": "fit2019-apprentice",
+    "serialized_at": "2021-07-06 22:26:03 UTC",
     "published_state": "preview",
     "seeding_key": {
       "script.name": "fit2019-apprentice"

--- a/dashboard/config/scripts_json/flappy.script_json
+++ b/dashboard/config/scripts_json/flappy.script_json
@@ -4,10 +4,12 @@
     "wrapup_video_id": null,
     "login_required": false,
     "properties": {
+      "version_year": "unversioned",
+      "is_course": true
     },
     "new_name": null,
-    "family_name": null,
-    "serialized_at": "2021-06-17 22:27:40 UTC",
+    "family_name": "flappy",
+    "serialized_at": "2021-07-06 22:25:43 UTC",
     "published_state": "preview",
     "seeding_key": {
       "script.name": "flappy"

--- a/dashboard/config/scripts_json/frozen.script_json
+++ b/dashboard/config/scripts_json/frozen.script_json
@@ -4,10 +4,12 @@
     "wrapup_video_id": null,
     "login_required": false,
     "properties": {
+      "version_year": "unversioned",
+      "is_course": true
     },
     "new_name": null,
-    "family_name": null,
-    "serialized_at": "2021-06-17 22:27:48 UTC",
+    "family_name": "frozen",
+    "serialized_at": "2021-07-06 22:26:04 UTC",
     "published_state": "preview",
     "seeding_key": {
       "script.name": "frozen"

--- a/dashboard/config/scripts_json/gumball.script_json
+++ b/dashboard/config/scripts_json/gumball.script_json
@@ -4,10 +4,12 @@
     "wrapup_video_id": null,
     "login_required": false,
     "properties": {
+      "version_year": "unversioned",
+      "is_course": true
     },
     "new_name": null,
-    "family_name": null,
-    "serialized_at": "2021-06-17 22:28:12 UTC",
+    "family_name": "gumball",
+    "serialized_at": "2021-07-06 22:26:04 UTC",
     "published_state": "preview",
     "seeding_key": {
       "script.name": "gumball"

--- a/dashboard/config/scripts_json/hero.script_json
+++ b/dashboard/config/scripts_json/hero.script_json
@@ -4,10 +4,12 @@
     "wrapup_video_id": null,
     "login_required": false,
     "properties": {
+      "version_year": "unversioned",
+      "is_course": true
     },
     "new_name": null,
-    "family_name": null,
-    "serialized_at": "2021-06-17 22:29:20 UTC",
+    "family_name": "hero",
+    "serialized_at": "2021-07-06 22:26:04 UTC",
     "published_state": "preview",
     "seeding_key": {
       "script.name": "hero"

--- a/dashboard/config/scripts_json/hoc-encryption.script_json
+++ b/dashboard/config/scripts_json/hoc-encryption.script_json
@@ -4,10 +4,12 @@
     "wrapup_video_id": null,
     "login_required": false,
     "properties": {
+      "version_year": "unversioned",
+      "is_course": true
     },
     "new_name": null,
-    "family_name": null,
-    "serialized_at": "2021-06-17 22:28:33 UTC",
+    "family_name": "hoc-encryption",
+    "serialized_at": "2021-07-06 22:26:04 UTC",
     "published_state": "preview",
     "seeding_key": {
       "script.name": "hoc-encryption"

--- a/dashboard/config/scripts_json/hourofcode.script_json
+++ b/dashboard/config/scripts_json/hourofcode.script_json
@@ -4,10 +4,12 @@
     "wrapup_video_id": 13,
     "login_required": false,
     "properties": {
+      "version_year": "unversioned",
+      "is_course": true
     },
     "new_name": null,
-    "family_name": null,
-    "serialized_at": "2021-06-17 22:27:49 UTC",
+    "family_name": "hourofcode",
+    "serialized_at": "2021-07-06 22:26:05 UTC",
     "published_state": "preview",
     "seeding_key": {
       "script.name": "hourofcode"

--- a/dashboard/config/scripts_json/iceage.script_json
+++ b/dashboard/config/scripts_json/iceage.script_json
@@ -4,10 +4,12 @@
     "wrapup_video_id": null,
     "login_required": false,
     "properties": {
+      "version_year": "unversioned",
+      "is_course": true
     },
     "new_name": null,
-    "family_name": null,
-    "serialized_at": "2021-06-17 22:28:11 UTC",
+    "family_name": "iceage",
+    "serialized_at": "2021-07-06 22:26:05 UTC",
     "published_state": "preview",
     "seeding_key": {
       "script.name": "iceage"

--- a/dashboard/config/scripts_json/infinity.script_json
+++ b/dashboard/config/scripts_json/infinity.script_json
@@ -4,10 +4,12 @@
     "wrapup_video_id": null,
     "login_required": false,
     "properties": {
+      "version_year": "unversioned",
+      "is_course": true
     },
     "new_name": null,
-    "family_name": null,
-    "serialized_at": "2021-06-17 22:27:50 UTC",
+    "family_name": "infinity",
+    "serialized_at": "2021-07-06 22:26:05 UTC",
     "published_state": "preview",
     "seeding_key": {
       "script.name": "infinity"

--- a/dashboard/config/scripts_json/jigsaw.script_json
+++ b/dashboard/config/scripts_json/jigsaw.script_json
@@ -4,10 +4,12 @@
     "wrapup_video_id": null,
     "login_required": false,
     "properties": {
+      "version_year": "unversioned",
+      "is_course": true
     },
     "new_name": null,
-    "family_name": null,
-    "serialized_at": "2021-06-17 22:27:41 UTC",
+    "family_name": "jigsaw",
+    "serialized_at": "2021-07-06 22:25:43 UTC",
     "published_state": "preview",
     "seeding_key": {
       "script.name": "jigsaw"

--- a/dashboard/config/scripts_json/mc.script_json
+++ b/dashboard/config/scripts_json/mc.script_json
@@ -4,10 +4,12 @@
     "wrapup_video_id": null,
     "login_required": false,
     "properties": {
+      "version_year": "unversioned",
+      "is_course": true
     },
     "new_name": null,
-    "family_name": null,
-    "serialized_at": "2021-06-17 22:28:12 UTC",
+    "family_name": "mc",
+    "serialized_at": "2021-07-06 22:26:06 UTC",
     "published_state": "preview",
     "seeding_key": {
       "script.name": "mc"

--- a/dashboard/config/scripts_json/minecraft.script_json
+++ b/dashboard/config/scripts_json/minecraft.script_json
@@ -4,10 +4,12 @@
     "wrapup_video_id": null,
     "login_required": false,
     "properties": {
+      "version_year": "unversioned",
+      "is_course": true
     },
     "new_name": null,
-    "family_name": null,
-    "serialized_at": "2021-06-17 22:28:41 UTC",
+    "family_name": "minecraft",
+    "serialized_at": "2021-07-06 22:26:06 UTC",
     "published_state": "preview",
     "seeding_key": {
       "script.name": "minecraft"

--- a/dashboard/config/scripts_json/oceans.script_json
+++ b/dashboard/config/scripts_json/oceans.script_json
@@ -5,11 +5,13 @@
     "login_required": false,
     "properties": {
       "has_lesson_plan": true,
-      "background": "oceans-blue"
+      "background": "oceans-blue",
+      "version_year": "unversioned",
+      "is_course": true
     },
     "new_name": null,
-    "family_name": null,
-    "serialized_at": "2021-06-17 22:30:28 UTC",
+    "family_name": "oceans",
+    "serialized_at": "2021-07-06 22:26:06 UTC",
     "published_state": "preview",
     "seeding_key": {
       "script.name": "oceans"

--- a/dashboard/config/scripts_json/outbreak.script_json
+++ b/dashboard/config/scripts_json/outbreak.script_json
@@ -4,10 +4,12 @@
     "wrapup_video_id": null,
     "login_required": false,
     "properties": {
+      "version_year": "unversioned",
+      "is_course": true
     },
     "new_name": null,
-    "family_name": null,
-    "serialized_at": "2021-06-17 22:31:04 UTC",
+    "family_name": "outbreak",
+    "serialized_at": "2021-07-06 22:26:07 UTC",
     "published_state": "preview",
     "seeding_key": {
       "script.name": "outbreak"

--- a/dashboard/config/scripts_json/pixelation.script_json
+++ b/dashboard/config/scripts_json/pixelation.script_json
@@ -4,10 +4,12 @@
     "wrapup_video_id": null,
     "login_required": false,
     "properties": {
+      "version_year": "unversioned",
+      "is_course": true
     },
     "new_name": null,
-    "family_name": null,
-    "serialized_at": "2021-06-17 22:27:51 UTC",
+    "family_name": "pixelation",
+    "serialized_at": "2021-07-06 22:26:07 UTC",
     "published_state": "preview",
     "seeding_key": {
       "script.name": "pixelation"

--- a/dashboard/config/scripts_json/playlab.script_json
+++ b/dashboard/config/scripts_json/playlab.script_json
@@ -4,10 +4,12 @@
     "wrapup_video_id": null,
     "login_required": false,
     "properties": {
+      "version_year": "unversioned",
+      "is_course": true
     },
     "new_name": null,
-    "family_name": null,
-    "serialized_at": "2021-06-17 22:27:46 UTC",
+    "family_name": "playlab",
+    "serialized_at": "2021-07-06 22:26:07 UTC",
     "published_state": "preview",
     "seeding_key": {
       "script.name": "playlab"

--- a/dashboard/config/scripts_json/sports.script_json
+++ b/dashboard/config/scripts_json/sports.script_json
@@ -4,11 +4,13 @@
     "wrapup_video_id": null,
     "login_required": false,
     "properties": {
-      "tts": true
+      "tts": true,
+      "version_year": "unversioned",
+      "is_course": true
     },
     "new_name": null,
-    "family_name": null,
-    "serialized_at": "2021-06-17 22:28:41 UTC",
+    "family_name": "sports",
+    "serialized_at": "2021-07-06 22:26:07 UTC",
     "published_state": "preview",
     "seeding_key": {
       "script.name": "sports"

--- a/dashboard/config/scripts_json/starwars.script_json
+++ b/dashboard/config/scripts_json/starwars.script_json
@@ -4,10 +4,12 @@
     "wrapup_video_id": null,
     "login_required": false,
     "properties": {
+      "version_year": "unversioned",
+      "is_course": true
     },
     "new_name": null,
-    "family_name": null,
-    "serialized_at": "2021-06-17 22:28:12 UTC",
+    "family_name": "starwars",
+    "serialized_at": "2021-07-06 22:26:08 UTC",
     "published_state": "preview",
     "seeding_key": {
       "script.name": "starwars"

--- a/dashboard/config/scripts_json/starwarsblocks.script_json
+++ b/dashboard/config/scripts_json/starwarsblocks.script_json
@@ -4,10 +4,12 @@
     "wrapup_video_id": null,
     "login_required": false,
     "properties": {
+      "version_year": "unversioned",
+      "is_course": true
     },
     "new_name": null,
-    "family_name": null,
-    "serialized_at": "2021-06-17 22:28:13 UTC",
+    "family_name": "starwarsblocks",
+    "serialized_at": "2021-07-06 22:26:08 UTC",
     "published_state": "preview",
     "seeding_key": {
       "script.name": "starwarsblocks"

--- a/dashboard/config/scripts_json/text-compression.script_json
+++ b/dashboard/config/scripts_json/text-compression.script_json
@@ -4,10 +4,12 @@
     "wrapup_video_id": null,
     "login_required": false,
     "properties": {
+      "version_year": "unversioned",
+      "is_course": true
     },
     "new_name": null,
-    "family_name": null,
-    "serialized_at": "2021-06-17 22:27:52 UTC",
+    "family_name": "text-compression",
+    "serialized_at": "2021-07-06 22:26:08 UTC",
     "published_state": "preview",
     "seeding_key": {
       "script.name": "text-compression"


### PR DESCRIPTION
Adds family names and version years to all scripts that are either in preview or stable.

Updated by running these commands on `dashboard-console`:
```
scripts_to_update = Script.where(published_state: ['stable', 'preview']).select {|s| s.get_course_version.nil? }
scripts_to_update.each {|s| s.family_name = s.name.downcase ; s.version_year = 'unversioned' ; s.is_course = true; s.save!(validate: false) ; s.write_script_dsl ; s.write_script_json }
```


## Testing story

tested seeding, spot checked a couple scripts to make sure they still worked




## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
