### PR TITLE
[Sprite Lab] Hide widgetdiv when you switch to the costume tab

### DIFF
--- a/apps/src/p5lab/P5LabVisualizationHeader.jsx
+++ b/apps/src/p5lab/P5LabVisualizationHeader.jsx
@@ -36,6 +36,7 @@ class P5LabVisualizationHeader extends React.Component {
         setTimeout(() => utils.fireResizeEvent(), 0);
       }
     } else if (mode === P5LabInterfaceMode.ANIMATION) {
+      Blockly.WidgetDiv.hide();
       firehoseClient.putRecord({
         study: 'animation-library',
         study_group: 'control-2020',

--- a/apps/src/p5lab/P5LabVisualizationHeader.jsx
+++ b/apps/src/p5lab/P5LabVisualizationHeader.jsx
@@ -36,7 +36,10 @@ class P5LabVisualizationHeader extends React.Component {
         setTimeout(() => utils.fireResizeEvent(), 0);
       }
     } else if (mode === P5LabInterfaceMode.ANIMATION) {
-      Blockly.WidgetDiv.hide();
+      if (this.props.spriteLab) {
+        Blockly.WidgetDiv.hide();
+      }
+
       firehoseClient.putRecord({
         study: 'animation-library',
         study_group: 'control-2020',

--- a/apps/src/sites/studio/pages/cdoBlocklyWrapper.js
+++ b/apps/src/sites/studio/pages/cdoBlocklyWrapper.js
@@ -133,6 +133,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.wrapReadOnlyProperty('useContractEditor');
   blocklyWrapper.wrapReadOnlyProperty('useModalFunctionEditor');
   blocklyWrapper.wrapReadOnlyProperty('Variables');
+  blocklyWrapper.wrapReadOnlyProperty('WidgetDiv');
   blocklyWrapper.wrapReadOnlyProperty('weblab_locale');
   blocklyWrapper.wrapReadOnlyProperty('Xml');
 

--- a/apps/src/sites/studio/pages/googleBlocklyWrapper.js
+++ b/apps/src/sites/studio/pages/googleBlocklyWrapper.js
@@ -137,6 +137,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.wrapReadOnlyProperty('Trashcan');
   blocklyWrapper.wrapReadOnlyProperty('Variables');
   blocklyWrapper.wrapReadOnlyProperty('weblab_locale');
+  blocklyWrapper.wrapReadOnlyProperty('WidgetDiv');
   blocklyWrapper.wrapReadOnlyProperty('Workspace');
   blocklyWrapper.wrapReadOnlyProperty('WorkspaceSvg');
   blocklyWrapper.wrapReadOnlyProperty('Xml');


### PR DESCRIPTION
Quick fix to a small polish bug where blockly dropdowns stayed open when you switch to the costume tab

Before
![image](https://user-images.githubusercontent.com/8787187/125362085-250e8080-e323-11eb-8277-9a62ec1487d1.png)
![image](https://user-images.githubusercontent.com/8787187/125362135-39eb1400-e323-11eb-8683-980d81437047.png)

After
![image](https://user-images.githubusercontent.com/8787187/125362041-16c06480-e323-11eb-8e58-e8a130a2a2e0.png)


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
