### PR TITLE
Speculative fix for flaky CourseOffering test

### DIFF
--- a/dashboard/test/models/course_offering_test.rb
+++ b/dashboard/test/models/course_offering_test.rb
@@ -6,7 +6,7 @@ class CourseOfferingTest < ActiveSupport::TestCase
     version1 = create :course_version, course_offering: course_offering
     version2 = create :course_version, course_offering: course_offering
 
-    assert_equal [version1, version2], course_offering.course_versions
+    assert_equal [version1, version2].sort_by(&:key), course_offering.course_versions.sort_by(&:key)
     assert_equal course_offering, version1.course_offering
     assert_equal course_offering, version2.course_offering
   end


### PR DESCRIPTION
Dave noticed a test failure in a Drone run that seemed unrelated to the PR itself. The output of that failure was:

```
====[0m[1000D[K FAIL["test_course_offering_associations", "CourseOfferingTest", 886.3625437790001]
 test_course_offering_associations#CourseOfferingTest (886.36s)
        --- expected
        +++ actual
        @@ -1 +1 @@
        -[#<CourseVersion id: 915399323, key: "20299", display_name: "2118-2119", properties: nil, content_root_type: "UnitGroup", content_root_id: 842, created_at: "2021-07-13 18:29:43", updated_at: "2021-07-13 18:29:43", course_offering_id: 87>, #<CourseVersion id: 915399324, key: "202100", display_name: "2119-2120", properties: nil, content_root_type: "UnitGroup", content_root_id: 843, created_at: "2021-07-13 18:29:43", updated_at: "2021-07-13 18:29:43", course_offering_id: 87>]
        +#<ActiveRecord::Associations::CollectionProxy [#<CourseVersion id: 915399324, key: "202100", display_name: "2119-2120", properties: nil, content_root_type: "UnitGroup", content_root_id: 843, created_at: "2021-07-13 18:29:43", updated_at: "2021-07-13 18:29:43", course_offering_id: 87>, #<CourseVersion id: 915399323, key: "20299", display_name: "2118-2119", properties: nil, content_root_type: "UnitGroup", content_root_id: 842, created_at: "2021-07-13 18:29:43", updated_at: "2021-07-13 18:29:43", course_offering_id: 87>]>
        test/models/course_offering_test.rb:9:in `block in <class:CourseOfferingTest>'
        test/testing/setup_all_and_teardown_all.rb:36:in `run'
```

Looking at this output, it looks like the course versions are in the wrong order, probably due to a race condition when creating them. There are 3 options here:
1. remove the test (testing that associations work is only so useful)
2. Enforce an ordering in CourseOffering. This might be something to consider in the future, but I don't know if there would be any implications here or what order we would want
3. Sort the lists in the test

I chose the 3rd option as it's the safest and easiest.

I couldn't get this test to fail locally so this is a speculative fix. If this test fails again, I'll have to look a bit harder.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
