### PR TITLE
Fix New Section dialog scrolling bug

### DIFF
--- a/apps/src/templates/teacherDashboard/CardContainer.jsx
+++ b/apps/src/templates/teacherDashboard/CardContainer.jsx
@@ -7,7 +7,8 @@ const style = {
   display: 'flex',
   flexDirection: 'row',
   flexWrap: 'wrap',
-  justifyContent: 'flexStart'
+  justifyContent: 'flexStart',
+  paddingTop: '110px'
 };
 
 /** Uses flexbox to arrange content cards into nice rows with wrapping. */

--- a/apps/src/templates/teacherDashboard/CardContainer.jsx
+++ b/apps/src/templates/teacherDashboard/CardContainer.jsx
@@ -7,8 +7,7 @@ const style = {
   display: 'flex',
   flexDirection: 'row',
   flexWrap: 'wrap',
-  justifyContent: 'flexStart',
-  paddingTop: '110px'
+  justifyContent: 'flexStart'
 };
 
 /** Uses flexbox to arrange content cards into nice rows with wrapping. */

--- a/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
+++ b/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
@@ -41,7 +41,7 @@ class LoginTypePicker extends Component {
   };
 
   render() {
-    const {title, providers, setLoginType, handleCancel, disabled} = this.props;
+    const {providers, setLoginType, handleCancel, disabled} = this.props;
     const withGoogle = true;
     //providers && providers.includes(OAuthSectionTypes.google_classroom);
     const withMicrosoft =
@@ -50,11 +50,11 @@ class LoginTypePicker extends Component {
       providers && providers.includes(OAuthSectionTypes.clever);
     const hasThirdParty = withGoogle | withMicrosoft | withClever;
 
-    // explicitly constrain the dialog as a whole to the width of the
-    // content. We expect that differing length of translations versus english
-    // source text can cause unexpected layout changes, and this constraint
-    // should help mitigate some of them.
-    const dialogStyle = {maxWidth: styleConstants['content-width']};
+    // update dialog style to remain consistent with other dialogs in the user flow
+    // for creating a section.
+    const dialogStyle = {
+      padding: '20px'
+    };
 
     // anchor email address policy note to footer just above 'Cancel' button
     const emailPolicyNoteStyle = {
@@ -62,10 +62,29 @@ class LoginTypePicker extends Component {
       zIndex: '600'
     };
 
+    //AAAAAAAAAA
+    const testStyle = {
+      position: 'absolute',
+      top: '20px',
+      width: '90%',
+      backgroundColor: '#ffffff',
+      zIndex: 5
+    };
+
     return (
-      <BaseDialog isOpen={true} style={dialogStyle}>
-        <Heading1>{title}</Heading1>
-        <Heading2>{i18n.addStudentsToSectionInstructionsUpdated()}</Heading2>
+      <BaseDialog
+        isOpen={true}
+        style={dialogStyle}
+        uncloseable={true}
+        hideCloseButton={true}
+        useUpdatedStyles={true}
+        fixedWidth={styleConstants['content-width']}
+        hideBackdrop={false}
+      >
+        <div style={testStyle}>
+          <Heading1>{i18n.newSectionUpdated()}</Heading1>
+          <Heading2>{i18n.addStudentsToSectionInstructionsUpdated()}</Heading2>
+        </div>
         <CardContainer>
           {withGoogle && (
             <GoogleClassroomCard onClick={this.openImportDialog} />
@@ -87,14 +106,14 @@ class LoginTypePicker extends Component {
             {' ' + i18n.connectAccountThirdPartyProviders()}
           </div>
         )}
+        <div style={emailPolicyNoteStyle}>
+          <b>{i18n.note()}</b>
+          {' ' + i18n.emailAddressPolicy() + ' '}
+          <a href="http://blog.code.org/post/147756946588/codeorgs-new-login-approach-to-student-privacy">
+            {i18n.moreInfo()}
+          </a>
+        </div>
         <DialogFooter>
-          <div style={emailPolicyNoteStyle}>
-            <b>{i18n.note()}</b>
-            {' ' + i18n.emailAddressPolicy() + ' '}
-            <a href="http://blog.code.org/post/147756946588/codeorgs-new-login-approach-to-student-privacy">
-              {i18n.moreInfo()}
-            </a>
-          </div>
           <Button
             __useDeprecatedTag
             onClick={handleCancel}

--- a/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
+++ b/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
@@ -10,7 +10,9 @@ import React, {Component} from 'react';
 import {connect} from 'react-redux';
 import i18n from '@cdo/locale';
 import {Heading1, Heading2} from '../../lib/ui/Headings';
+import BaseDialog from '../BaseDialog.jsx';
 import DialogFooter from './DialogFooter';
+import CardContainer from './CardContainer';
 import LoginTypeCard from './LoginTypeCard';
 import Button from '../Button';
 import {OAuthSectionTypes} from '@cdo/apps/lib/ui/accounts/constants';
@@ -40,43 +42,31 @@ class LoginTypePicker extends Component {
 
   render() {
     const {title, providers, setLoginType, handleCancel, disabled} = this.props;
-    const withGoogle =
-      providers && providers.includes(OAuthSectionTypes.google_classroom);
+    const withGoogle = true;
+    //providers && providers.includes(OAuthSectionTypes.google_classroom);
     const withMicrosoft =
       providers && providers.includes(OAuthSectionTypes.microsoft_classroom);
     const withClever =
       providers && providers.includes(OAuthSectionTypes.clever);
     const hasThirdParty = withGoogle | withMicrosoft | withClever;
-    const gridLayoutHeight = hasThirdParty ? '275px' : '160px';
 
-    // explicitly constrain the container as a whole to the width of the
+    // explicitly constrain the dialog as a whole to the width of the
     // content. We expect that differing length of translations versus english
     // source text can cause unexpected layout changes, and this constraint
     // should help mitigate some of them.
-    const containerStyle = {maxWidth: styleConstants['content-width']};
+    const dialogStyle = {maxWidth: styleConstants['content-width']};
 
     // anchor email address policy note to footer just above 'Cancel' button
     const emailPolicyNoteStyle = {
-      position: 'absolute',
       top: '0px',
       zIndex: '600'
     };
 
-    // style grid container for Login Type Cards
-    const loginTypeCardGridContainerStyle = {
-      height: gridLayoutHeight,
-      display: 'grid',
-      gridTemplateColumns: 'repeat(3, 1fr)',
-      gridAutoRows: '150px',
-      gridGap: '5px',
-      overflow: 'auto'
-    };
-
     return (
-      <div style={containerStyle}>
+      <BaseDialog isOpen={true} style={dialogStyle}>
         <Heading1>{title}</Heading1>
         <Heading2>{i18n.addStudentsToSectionInstructionsUpdated()}</Heading2>
-        <div style={loginTypeCardGridContainerStyle}>
+        <CardContainer>
           {withGoogle && (
             <GoogleClassroomCard onClick={this.openImportDialog} />
           )}
@@ -87,7 +77,7 @@ class LoginTypePicker extends Component {
           <PictureLoginCard onClick={setLoginType} />
           <WordLoginCard onClick={setLoginType} />
           <EmailLoginCard onClick={setLoginType} />
-        </div>
+        </CardContainer>
         {!hasThirdParty && (
           <div>
             {i18n.thirdPartyProviderUpsell() + ' '}
@@ -114,7 +104,7 @@ class LoginTypePicker extends Component {
             disabled={disabled}
           />
         </DialogFooter>
-      </div>
+      </BaseDialog>
     );
   }
 }

--- a/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
+++ b/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
@@ -48,6 +48,7 @@ class LoginTypePicker extends Component {
     const withClever =
       providers && providers.includes(OAuthSectionTypes.clever);
     const hasThirdParty = withGoogle | withMicrosoft | withClever;
+    const gridLayoutHeight = hasThirdParty ? '275px' : '160px';
 
     // explicitly constrain the container as a whole to the width of the
     // content. We expect that differing length of translations versus english
@@ -62,23 +63,30 @@ class LoginTypePicker extends Component {
       zIndex: '600'
     };
 
+    // style grid container for Login Type Cards
+    const loginTypeCardGridContainerStyle = {
+      height: gridLayoutHeight,
+      display: 'grid',
+      gridTemplateColumns: 'repeat(3, 1fr)',
+      gridAutoRows: '150px',
+      gridGap: '5px'
+    };
+
     return (
       <div style={containerStyle}>
         <Heading1>{title}</Heading1>
         <Heading2>{i18n.addStudentsToSectionInstructionsUpdated()}</Heading2>
-        <div>
-          <CardContainer>
-            {withGoogle && (
-              <GoogleClassroomCard onClick={this.openImportDialog} />
-            )}
-            {withMicrosoft && (
-              <MicrosoftClassroomCard onClick={this.openImportDialog} />
-            )}
-            {withClever && <CleverCard onClick={this.openImportDialog} />}
-            <PictureLoginCard onClick={setLoginType} />
-            <WordLoginCard onClick={setLoginType} />
-            <EmailLoginCard onClick={setLoginType} />
-          </CardContainer>
+        <div style={loginTypeCardGridContainerStyle}>
+          {withGoogle && (
+            <GoogleClassroomCard onClick={this.openImportDialog} />
+          )}
+          {withMicrosoft && (
+            <MicrosoftClassroomCard onClick={this.openImportDialog} />
+          )}
+          {withClever && <CleverCard onClick={this.openImportDialog} />}
+          <PictureLoginCard onClick={setLoginType} />
+          <WordLoginCard onClick={setLoginType} />
+          <EmailLoginCard onClick={setLoginType} />
         </div>
         {!hasThirdParty && (
           <div>

--- a/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
+++ b/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
@@ -11,7 +11,6 @@ import {connect} from 'react-redux';
 import i18n from '@cdo/locale';
 import {Heading1, Heading2} from '../../lib/ui/Headings';
 import BaseDialog from '../BaseDialog.jsx';
-import DialogFooter from './DialogFooter';
 import CardContainer from './CardContainer';
 import LoginTypeCard from './LoginTypeCard';
 import Button from '../Button';
@@ -42,33 +41,37 @@ class LoginTypePicker extends Component {
 
   render() {
     const {providers, setLoginType, handleCancel, disabled} = this.props;
-    const withGoogle = true;
-    //providers && providers.includes(OAuthSectionTypes.google_classroom);
+    const withGoogle =
+      providers && providers.includes(OAuthSectionTypes.google_classroom);
     const withMicrosoft =
       providers && providers.includes(OAuthSectionTypes.microsoft_classroom);
     const withClever =
       providers && providers.includes(OAuthSectionTypes.clever);
     const hasThirdParty = withGoogle | withMicrosoft | withClever;
 
-    // update dialog style to remain consistent with other dialogs in the user flow
-    // for creating a section.
+    // Dialog styles listed below.
     const dialogStyle = {
-      padding: '20px'
+      padding: '20px',
+      overflowY: 'hidden'
     };
-
-    // anchor email address policy note to footer just above 'Cancel' button
-    const emailPolicyNoteStyle = {
-      top: '0px',
-      zIndex: '600'
+    const dialogHeaderStyle = {
+      position: 'sticky',
+      top: 0,
+      backgroundColor: '#fff',
+      overflowY: 'hidden'
     };
-
-    //AAAAAAAAAA
-    const testStyle = {
-      position: 'absolute',
-      top: '20px',
-      width: '90%',
-      backgroundColor: '#ffffff',
-      zIndex: 5
+    const thirdPartyProviderUpsellStyle = {
+      marginBottom: '10px'
+    };
+    const dialogFooterStyle = {
+      position: 'sticky',
+      bottom: 0,
+      backgroundColor: '#fff'
+    };
+    const dialogFooterEmailPolicyNoteStyle = {
+      marginBottom: '20px',
+      paddingTop: '20px',
+      borderBottom: '1px solid #000'
     };
 
     return (
@@ -81,24 +84,26 @@ class LoginTypePicker extends Component {
         fixedWidth={styleConstants['content-width']}
         hideBackdrop={false}
       >
-        <div style={testStyle}>
+        <div style={dialogHeaderStyle}>
           <Heading1>{i18n.newSectionUpdated()}</Heading1>
           <Heading2>{i18n.addStudentsToSectionInstructionsUpdated()}</Heading2>
         </div>
-        <CardContainer>
-          {withGoogle && (
-            <GoogleClassroomCard onClick={this.openImportDialog} />
-          )}
-          {withMicrosoft && (
-            <MicrosoftClassroomCard onClick={this.openImportDialog} />
-          )}
-          {withClever && <CleverCard onClick={this.openImportDialog} />}
-          <PictureLoginCard onClick={setLoginType} />
-          <WordLoginCard onClick={setLoginType} />
-          <EmailLoginCard onClick={setLoginType} />
-        </CardContainer>
+        <div>
+          <CardContainer>
+            {withGoogle && (
+              <GoogleClassroomCard onClick={this.openImportDialog} />
+            )}
+            {withMicrosoft && (
+              <MicrosoftClassroomCard onClick={this.openImportDialog} />
+            )}
+            {withClever && <CleverCard onClick={this.openImportDialog} />}
+            <PictureLoginCard onClick={setLoginType} />
+            <WordLoginCard onClick={setLoginType} />
+            <EmailLoginCard onClick={setLoginType} />
+          </CardContainer>
+        </div>
         {!hasThirdParty && (
-          <div>
+          <div style={thirdPartyProviderUpsellStyle}>
             {i18n.thirdPartyProviderUpsell() + ' '}
             <a href="https://support.code.org/hc/en-us/articles/115001319312-Setting-up-sections-with-Google-Classroom-or-Clever">
               {i18n.learnHow()}
@@ -106,14 +111,14 @@ class LoginTypePicker extends Component {
             {' ' + i18n.connectAccountThirdPartyProviders()}
           </div>
         )}
-        <div style={emailPolicyNoteStyle}>
-          <b>{i18n.note()}</b>
-          {' ' + i18n.emailAddressPolicy() + ' '}
-          <a href="http://blog.code.org/post/147756946588/codeorgs-new-login-approach-to-student-privacy">
-            {i18n.moreInfo()}
-          </a>
-        </div>
-        <DialogFooter>
+        <div style={dialogFooterStyle}>
+          <div style={dialogFooterEmailPolicyNoteStyle}>
+            <b>{i18n.note()}</b>
+            {' ' + i18n.emailAddressPolicy() + ' '}
+            <a href="http://blog.code.org/post/147756946588/codeorgs-new-login-approach-to-student-privacy">
+              {i18n.moreInfo()}
+            </a>
+          </div>
           <Button
             __useDeprecatedTag
             onClick={handleCancel}
@@ -122,7 +127,7 @@ class LoginTypePicker extends Component {
             color={Button.ButtonColor.gray}
             disabled={disabled}
           />
-        </DialogFooter>
+        </div>
       </BaseDialog>
     );
   }

--- a/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
+++ b/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
@@ -19,14 +19,14 @@ import styleConstants from '../../styleConstants';
 const style = {
   root: {
     width: styleConstants['content-width'],
-    height: '80vh',
+    height: '50vh',
     left: 20,
     right: 20
   },
   scroll: {
     overflowX: 'hidden',
     overflowY: 'auto',
-    height: 'calc(80vh - 200px)'
+    height: 'calc(60vh - 250px)'
   },
   thirdPartyProviderUpsell: {
     marginBottom: '10px'
@@ -36,7 +36,6 @@ const style = {
     width: styleConstants['content-width'],
     height: '100px',
     left: 0,
-    bottom: '-65px',
     padding: '0px 20px 20px 20px',
     backgroundColor: '#fff',
     borderRadius: '5px'
@@ -79,8 +78,6 @@ class LoginTypePicker extends Component {
     const withClever =
       providers && providers.includes(OAuthSectionTypes.clever);
     const hasThirdParty = withGoogle | withMicrosoft | withClever;
-    // Adjust max height of the dialog based on number of LoginCard types available to the user
-    style.root.maxHeight = hasThirdParty ? '500px' : '360px';
 
     return (
       <div style={style.root}>

--- a/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
+++ b/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
@@ -10,12 +10,43 @@ import React, {Component} from 'react';
 import {connect} from 'react-redux';
 import i18n from '@cdo/locale';
 import {Heading1, Heading2} from '../../lib/ui/Headings';
-import BaseDialog from '../BaseDialog.jsx';
 import CardContainer from './CardContainer';
 import LoginTypeCard from './LoginTypeCard';
 import Button from '../Button';
 import {OAuthSectionTypes} from '@cdo/apps/lib/ui/accounts/constants';
 import styleConstants from '../../styleConstants';
+
+const style = {
+  root: {
+    width: styleConstants['content-width'],
+    height: '80vh',
+    left: 20,
+    right: 20
+  },
+  scroll: {
+    overflowX: 'hidden',
+    overflowY: 'auto',
+    height: 'calc(80vh - 200px)'
+  },
+  thirdPartyProviderUpsell: {
+    marginBottom: '10px'
+  },
+  footer: {
+    position: 'absolute',
+    width: styleConstants['content-width'],
+    height: '100px',
+    left: 0,
+    bottom: '-65px',
+    padding: '0px 20px 20px 20px',
+    backgroundColor: '#fff',
+    borderRadius: '5px'
+  },
+  emailPolicyNote: {
+    marginBottom: '20px',
+    paddingTop: '20px',
+    borderTop: '1px solid #000'
+  }
+};
 
 /**
  * UI for selecting the login type of a class section:
@@ -48,47 +79,14 @@ class LoginTypePicker extends Component {
     const withClever =
       providers && providers.includes(OAuthSectionTypes.clever);
     const hasThirdParty = withGoogle | withMicrosoft | withClever;
-
-    // Dialog styles listed below.
-    const dialogStyle = {
-      padding: '20px',
-      overflowY: 'hidden'
-    };
-    const dialogHeaderStyle = {
-      position: 'sticky',
-      top: 0,
-      backgroundColor: '#fff',
-      overflowY: 'hidden'
-    };
-    const thirdPartyProviderUpsellStyle = {
-      marginBottom: '10px'
-    };
-    const dialogFooterStyle = {
-      position: 'sticky',
-      bottom: 0,
-      backgroundColor: '#fff'
-    };
-    const dialogFooterEmailPolicyNoteStyle = {
-      marginBottom: '20px',
-      paddingTop: '20px',
-      borderBottom: '1px solid #000'
-    };
+    // Adjust max height of the dialog based on number of LoginCard types available to the user
+    style.root.maxHeight = hasThirdParty ? '500px' : '360px';
 
     return (
-      <BaseDialog
-        isOpen={true}
-        style={dialogStyle}
-        uncloseable={true}
-        hideCloseButton={true}
-        useUpdatedStyles={true}
-        fixedWidth={styleConstants['content-width']}
-        hideBackdrop={false}
-      >
-        <div style={dialogHeaderStyle}>
-          <Heading1>{i18n.newSectionUpdated()}</Heading1>
-          <Heading2>{i18n.addStudentsToSectionInstructionsUpdated()}</Heading2>
-        </div>
-        <div>
+      <div style={style.root}>
+        <Heading1>{i18n.newSectionUpdated()}</Heading1>
+        <Heading2>{i18n.addStudentsToSectionInstructionsUpdated()}</Heading2>
+        <div style={style.scroll}>
           <CardContainer>
             {withGoogle && (
               <GoogleClassroomCard onClick={this.openImportDialog} />
@@ -101,18 +99,18 @@ class LoginTypePicker extends Component {
             <WordLoginCard onClick={setLoginType} />
             <EmailLoginCard onClick={setLoginType} />
           </CardContainer>
+          {!hasThirdParty && (
+            <div style={style.thirdPartyProviderUpsell}>
+              {i18n.thirdPartyProviderUpsell() + ' '}
+              <a href="https://support.code.org/hc/en-us/articles/115001319312-Setting-up-sections-with-Google-Classroom-or-Clever">
+                {i18n.learnHow()}
+              </a>
+              {' ' + i18n.connectAccountThirdPartyProviders()}
+            </div>
+          )}
         </div>
-        {!hasThirdParty && (
-          <div style={thirdPartyProviderUpsellStyle}>
-            {i18n.thirdPartyProviderUpsell() + ' '}
-            <a href="https://support.code.org/hc/en-us/articles/115001319312-Setting-up-sections-with-Google-Classroom-or-Clever">
-              {i18n.learnHow()}
-            </a>
-            {' ' + i18n.connectAccountThirdPartyProviders()}
-          </div>
-        )}
-        <div style={dialogFooterStyle}>
-          <div style={dialogFooterEmailPolicyNoteStyle}>
+        <div style={style.footer}>
+          <div style={style.emailPolicyNote}>
             <b>{i18n.note()}</b>
             {' ' + i18n.emailAddressPolicy() + ' '}
             <a href="http://blog.code.org/post/147756946588/codeorgs-new-login-approach-to-student-privacy">
@@ -128,7 +126,7 @@ class LoginTypePicker extends Component {
             disabled={disabled}
           />
         </div>
-      </BaseDialog>
+      </div>
     );
   }
 }

--- a/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
+++ b/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
@@ -68,7 +68,8 @@ class LoginTypePicker extends Component {
       display: 'grid',
       gridTemplateColumns: 'repeat(3, 1fr)',
       gridAutoRows: '150px',
-      gridGap: '5px'
+      gridGap: '5px',
+      overflow: 'auto'
     };
 
     return (

--- a/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
+++ b/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
@@ -10,7 +10,6 @@ import React, {Component} from 'react';
 import {connect} from 'react-redux';
 import i18n from '@cdo/locale';
 import {Heading1, Heading2} from '../../lib/ui/Headings';
-import CardContainer from './CardContainer';
 import DialogFooter from './DialogFooter';
 import LoginTypeCard from './LoginTypeCard';
 import Button from '../Button';

--- a/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
+++ b/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
@@ -19,14 +19,14 @@ import styleConstants from '../../styleConstants';
 const style = {
   root: {
     width: styleConstants['content-width'],
-    height: '50vh',
+    height: '80vh',
     left: 20,
     right: 20
   },
   scroll: {
     overflowX: 'hidden',
     overflowY: 'auto',
-    height: 'calc(60vh - 250px)'
+    height: 'calc(80vh - 200px)'
   },
   thirdPartyProviderUpsell: {
     marginBottom: '10px'
@@ -36,6 +36,7 @@ const style = {
     width: styleConstants['content-width'],
     height: '100px',
     left: 0,
+    bottom: '-65px',
     padding: '0px 20px 20px 20px',
     backgroundColor: '#fff',
     borderRadius: '5px'
@@ -78,6 +79,12 @@ class LoginTypePicker extends Component {
     const withClever =
       providers && providers.includes(OAuthSectionTypes.clever);
     const hasThirdParty = withGoogle | withMicrosoft | withClever;
+    /// Determine maxHeight of dialog based on number of LoginTypeCards
+    style.root.maxHeight = getDialogMaxHeight(
+      withGoogle,
+      withMicrosoft,
+      withClever
+    );
 
     return (
       <div style={style.root}>
@@ -131,6 +138,28 @@ export const UnconnectedLoginTypePicker = LoginTypePicker;
 export default connect(state => ({
   providers: state.teacherSections.providers
 }))(LoginTypePicker);
+
+function getDialogMaxHeight(withGoogle, withMicrosoft, withClever) {
+  const headerAndFooterHeight = 200; // Height of header + height of footer (in px)
+  const numCardsPerRow = 3; // LoginTypeCard.jsx defines 3-column layout
+  const cardHeight = 150; // Card height defined in LoginTypeCard (in px)
+  let numLoginTypeCards = 3; // Number of non-third-party login types
+  if (withGoogle) {
+    numLoginTypeCards++;
+  }
+  if (withMicrosoft) {
+    numLoginTypeCards++;
+  }
+  if (withClever) {
+    numLoginTypeCards++;
+  }
+  // Get height by adding the 'headerAndFooterHeight' to the product of 'cardHeight'
+  // and the number of rows of LoginTypeCards.
+  const dialogMaxHeight =
+    headerAndFooterHeight +
+    cardHeight * Math.ceil(numLoginTypeCards / numCardsPerRow);
+  return dialogMaxHeight + 'px';
+}
 
 const PictureLoginCard = props => (
   <LoginTypeCard


### PR DESCRIPTION
Fixes a scrolling bug in the New Section dialog window where LoginTypeCards were getting cut off since it wasn't scrolling. The original problem was spotted when [this PR](https://github.com/code-dot-org/code-dot-org/pull/40384) was merged. 

## Screenshots of correct behavior for scrolling
### Case when the user does not have a 3rd party provider connected to their account (e.g. Google Classroom) so they only have access to Picture Password, Secret Words, and Personal Login types (only 1 row of 3 LoginTypeCards):
![Fix scroll bug 1](https://user-images.githubusercontent.com/56283563/125521742-edc7a897-d930-4ae4-bb47-f1aecf73b2a6.JPG)
### Case when the user has at least one 3rd party provider connected to their account (e.g. Google Classroom) so they have at least 4 types of login cards (causing 2 rows of cards):
![Fix scroll bug 2](https://user-images.githubusercontent.com/56283563/125521743-fd5394d4-fa7f-4932-8541-b0be19139275.JPG)

## Screenshots of what the dialog normally looks like when no scrolling is needed (i.e. if the window is large enough)
### Case when the user does not have a 3rd party provider connected to their account (e.g. Google Classroom) so they only have access to Picture Password, Secret Words, and Personal Login types (only 1 row of 3 LoginTypeCards):
![Fix scroll bug 3](https://user-images.githubusercontent.com/56283563/125522587-9c9c1b91-6839-466e-bb94-e2cb2ea9f74b.JPG)
### Case when the user has at least one 3rd party provider connected to their account (e.g. Google Classroom) so they have at least 4 types of login cards (causing 2 rows of cards):
![Fix scroll bug 4](https://user-images.githubusercontent.com/56283563/125522588-29c9c777-b173-4814-9483-b00f9af9c141.JPG)

