### PR TITLE
Fix minor state_cs_offering dry run script bug

### DIFF
--- a/dashboard/app/models/census/state_cs_offering.rb
+++ b/dashboard/app/models/census/state_cs_offering.rb
@@ -1525,7 +1525,7 @@ class Census::StateCsOffering < ApplicationRecord
     [
       state_code,
       start_year,
-      update || 1,
+      update&.to_i || 1,
       extension
     ]
   end

--- a/dashboard/test/models/census/state_cs_offering_test.rb
+++ b/dashboard/test/models/census/state_cs_offering_test.rb
@@ -25,4 +25,20 @@ class Census::StateCsOfferingTest < ActiveSupport::TestCase
     offering = build :state_cs_offering, :with_invalid_school_year
     refute offering.valid?
   end
+
+  test "Deconstructing the object key succeeds" do
+    object_key = "state_cs_offerings/DE/2020-2021.test"
+    state_code, school_year, update, extension = Census::StateCsOffering.deconstruct_object_key(object_key)
+    assert state_code == 'DE'
+    assert school_year == 2020
+    assert update == 1
+    assert extension == 'test'
+
+    object_key = "state_cs_offerings/DE/2020-2021.2.test2"
+    state_code, school_year, update, extension = Census::StateCsOffering.deconstruct_object_key(object_key)
+    assert state_code == 'DE'
+    assert school_year == 2020
+    assert update == 2
+    assert extension == 'test2'
+  end
 end


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Fixes a minor bug with the dry run script where version update numbers need to be converted to numbers from strings.

## Links

- error message: [slack](https://codedotorg.slack.com/archives/C03CK8E51/p1626190251410200)
