### PR TITLE
use country and language in the sample email hoc URL

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/public/promote/resources.md.partial
+++ b/pegasus/sites.v3/hourofcode.com/public/promote/resources.md.partial
@@ -91,7 +91,7 @@ This year, let's make it even bigger. I’m asking you to join the Hour of Code 
 
 Get the word out. Host an event. Ask a local school to sign up. Or try the Hour of Code yourself—everyone can benefit from learning the basics.
 
-Get started at http://hourofcode.com/{{ country }}
+Get started at http://hourofcode.com/{{ country_language }}
 <br>
 
 ***

--- a/pegasus/sites.v3/hourofcode.com/public/promote/resources.md.partial
+++ b/pegasus/sites.v3/hourofcode.com/public/promote/resources.md.partial
@@ -128,7 +128,7 @@ That’s why our entire school is joining in on the largest learning event in hi
 
 This is a chance to change the future of education in [TOWN/CITY NAME].
 
-See http://hourofcode.com/{{ country }} for details, and help spread the word.
+See http://hourofcode.com/{{ country_language }} for details, and help spread the word.
 <br>
 ***
 

--- a/pegasus/sites.v3/hourofcode.com/views/country_language.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/country_language.haml
@@ -1,0 +1,1 @@
+= @country + '/' + @language


### PR DESCRIPTION
International team is preparing for international Hour of Code with [this list](https://docs.google.com/spreadsheets/d/1bjSzPqjQnn6KXCphXPXrLFFUc4xRIF5_oqkHbXKXHiQ/edit#gid=0). This change appends the user's language to the hourofcode.com URL in the sample email template.

## Links
[HOC Webpage Prep doc](https://docs.google.com/spreadsheets/d/1bjSzPqjQnn6KXCphXPXrLFFUc4xRIF5_oqkHbXKXHiQ/edit#gid=0)

## Testing story
Tested on localhost
_Pre_
![image](https://user-images.githubusercontent.com/2933346/125543652-1c958ea7-fefc-4b35-bcb2-a62c875b16af.png)

_Post_
<img width="243" alt="Screenshot 2021-07-13 163443" src="https://user-images.githubusercontent.com/2933346/125543523-aa8f6f4b-9906-4cf2-9694-03e6ee775e27.png">
Note that other languages will not show the language until [this string's translation](https://crowdin.com/translate/hour-of-code/612/en-esmx#2059372) has been updated to use `country_language` instead of `country`.

## Follow-up work
- Update [this string's translation](https://crowdin.com/translate/hour-of-code/612/en-esmx#2059372) to use `country_language` instead of `country`.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
