### PR TITLE
Remove trailing whitespace in bubble_choice.rb

### DIFF
--- a/dashboard/app/models/levels/bubble_choice.rb
+++ b/dashboard/app/models/levels/bubble_choice.rb
@@ -239,7 +239,7 @@ class BubbleChoice < DSLDefined
 
     save!
   end
-  
+
   private
 
   # Returns the sublevel for a user that has the highest best_result.


### PR DESCRIPTION
Staging was failing to build due to a [linter error](https://cdo-build-logs.s3.amazonaws.com/staging/20210713T230909%2B0000?versionId=RGFr8qU_s1Hr5KWm_LPWNHEIj0BIL1gg&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAW5P5EEELJAYEU7HB%2F20210713%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20210713T231213Z&X-Amz-Expires=259200&X-Amz-SignedHeaders=host&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEA8aCXVzLWVhc3QtMSJGMEQCIFbILwzWIYUHdBPkh6oKcUEPRZMxjOefPYO5eDnHZBe1AiALzMCh8xbtB6mEMgIZHm1I%2F%2BzN18Hm6ClZ3BBE37lTviqDBAj3%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F8BEAAaDDQ3NTY2MTYwNzE5MCIMvTGqkh%2Bp6tljTvD7KtcDuzJvnaVki%2F%2B1ocQLa2E2wHp%2BRc0DipYUzZGCDof9bMywO44YFJNYEgL1clK16Obi1riCtRN0zI0xx1ptVvoqTGBwdYKqDnAtDM0uCgfYxaCJse7n5Rv0RTSUxQp7ihUkN44uNkJu372bUA%2F3mlMkyz98q9WCJFdNgSDIN0dqSeSa37lK1WxtMmv81nbIeebJl0nPowvdqNSqE5d5D2VEAprk%2B8MtGsyvvDWAGivudQ281J1KI2qqcpwS0NlxquW%2BP7nV6S8jga8zCKZcbT929EFXAdaKd9RCYiPCGUEdyBMpjXCE54wp6XlYB9FmS%2FL2QJzfKogOIIaiNOuXys%2BpmDX1R9ziI8wVuBHRih%2BHLkmoUQ7mSBatFOPwO7Nww%2FFMTd4OEG1XJaVNsHr73rzcQPXSvoJoUd3Xt3Fcv5lV%2F3r%2F%2BNiCb%2FjRJH08sikLEMVy1kBEl7y9eX6c%2F0WOctw0RtgcMQXba89npONAJgyW%2FQPJOboGfldPaeqyGhryAjb8scQgme5RGgE508nrQPbajGZY6ZO%2B4Rm0iMYxxGfIlsUT%2B2gijzkLfj7g9J%2FEx0ZtHSg4JuDF3D9wnpPkACecyn1NVn9sORT2LB%2BXCtx5RkUQJyA8G28mMKyjuIcGOqYBI%2FGj16hdEtQJs9cOISCnAAx6ACR98cXkY6QVQTtVBSelpTbW7YtlWhPhro32ARtVMFG5Tx2mQDZw0Do7Iu1xrEjDFL4h4Pt8v6ViupmQ%2BL%2FreUcV0SfGzOcw9eVC6MnjFlvmGXNwUvVqN1xINU8%2BtHZ6zyQQ7hprGWX7DnDnicIUXxVNR3vdhwiX6nufd4Gfh%2BuN4QSpom7Vo0o6sB97yfG%2Bmm2d9A%3D%3D&X-Amz-Signature=762bc962419f46f3b3a8bc6a439fbd43df89bd3cc05934324e4da72bc40c109d) after the merge of #41420. This removes the offending whitespace.
