### PR TITLE
Update CloudFront access-logs configuration

### DIFF
--- a/aws/cloudformation/access_logs.rb
+++ b/aws/cloudformation/access_logs.rb
@@ -1,13 +1,21 @@
 # Transform CloudFront access logs from CSV to JSON.
-# Use Glue-table schema to determine CSV column headers and format.
+# Use RealtimeLogConfig to determine CSV column headers,
+# and Glue-table schema to determine column formats.
 
 require 'base64'
 require 'csv'
 require 'json'
 require 'aws-sdk-glue'
+require 'aws-sdk-cloudfront'
 
 DATABASE = ENV['DATABASE']
 TABLE = ENV['TABLE']
+CONFIG_ARN = ENV['CONFIG_ARN']
+
+CLOUDFRONT = Aws::CloudFront::Client.new
+
+LOG_FIELDS = ENV['LOG_FIELDS']&.split(',')
+$log_fields = LOG_FIELDS || []
 
 GLUE = Aws::Glue::Client.new
 COLUMNS = GLUE.get_table(database_name: DATABASE, name: TABLE).
@@ -22,13 +30,25 @@ def handler(event:, context:)
   {
     records: event['records'].map do |record|
       data = Base64.decode64(record['data'])
-      output_data = CSV.parse_line(data, col_sep: "\t", headers: COLUMNS.keys, converters: CONVERTERS).to_h.to_json
+
+      tries = 0
+      output = begin
+                 CSV.parse_line(data, col_sep: "\t", headers: $log_fields, converters: CONVERTERS).tap do |out|
+                   raise ArgumentError, "Record data doesn't match log fields" if out.headers[-1].nil? || out[-1].nil?
+                 end
+               rescue ArgumentError
+                 raise if (tries += 1) > 1
+                 # Try again after updating fields from the realtime log config.
+                 $log_fields = CLOUDFRONT.get_realtime_log_config(arn: CONFIG_ARN).realtime_log_config.fields
+                 retry
+               end
       {
         recordId: record['recordId'],
         result: 'Ok',
-        data: Base64.encode64(output_data)
+        data: Base64.encode64(output.to_h.to_json)
       }
     rescue => e
+      puts "Error: #{e.full_message}"
       {
         recordId: record['recordId'],
         result: 'ProcessingFailed',

--- a/aws/cloudformation/access_logs.yml
+++ b/aws/cloudformation/access_logs.yml
@@ -24,6 +24,50 @@ Parameters:
   ShardCount:
     Type: Number
     Default: 1
+  LogFields:
+    Type: CommaDelimitedList
+    # From https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/real-time-logs.html#understand-real-time-log-config-fields
+    Default: >
+      timestamp,
+      c-ip,
+      time-to-first-byte,
+      sc-status,
+      sc-bytes,
+      cs-method,
+      cs-protocol,
+      cs-host,
+      cs-uri-stem,
+      cs-bytes,
+      x-edge-location,
+      x-edge-request-id,
+      x-host-header,
+      time-taken,
+      cs-protocol-version,
+      c-ip-version,
+      cs-user-agent,
+      cs-referer,
+      cs-cookie,
+      cs-uri-query,
+      x-edge-response-result-type,
+      x-forwarded-for,
+      ssl-protocol,
+      ssl-cipher,
+      x-edge-result-type,
+      fle-encrypted-fields,
+      fle-status,
+      sc-content-type,
+      sc-content-len,
+      sc-range-start,
+      sc-range-end,
+      c-port,
+      x-edge-detailed-result-type,
+      c-country,
+      cs-accept-encoding,
+      cs-accept,
+      cache-behavior-path-pattern,
+      cs-headers,
+      cs-header-names,
+      cs-headers-count
 Resources:
   AccessLogConfig:
     Type: AWS::CloudFront::RealtimeLogConfig
@@ -35,48 +79,7 @@ Resources:
           KinesisStreamConfig:
             RoleArn: !GetAtt AccessLogConfigRole.Arn
             StreamArn: !GetAtt AccessLogStream.Arn
-      Fields:
-        # From https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/real-time-logs.html#understand-real-time-log-config-fields
-        - timestamp
-        - c-ip
-        - time-to-first-byte
-        - sc-status
-        - sc-bytes
-        - cs-method
-        - cs-protocol
-        - cs-host
-        - cs-uri-stem
-        - cs-bytes
-        - x-edge-location
-        - x-edge-request-id
-        - x-host-header
-        - time-taken
-        - cs-protocol-version
-        - c-ip-version
-        - cs-user-agent
-        - cs-referer
-        - cs-cookie
-        - cs-uri-query
-        - x-edge-response-result-type
-        - x-forwarded-for
-        - ssl-protocol
-        - ssl-cipher
-        - x-edge-result-type
-        - fle-encrypted-fields
-        - fle-status
-        - sc-content-type
-        - sc-content-len
-        - sc-range-start
-        - sc-range-end
-        - c-port
-        - x-edge-detailed-result-type
-        - c-country
-        - cs-accept-encoding
-        - cs-accept
-        - cache-behavior-path-pattern
-        - cs-headers
-        - cs-header-names
-        - cs-headers-count
+      Fields: !Ref LogFields
   AccessLogBucket:
     Type: AWS::S3::Bucket
     DependsOn: AccessLogPartitionPermission
@@ -169,6 +172,8 @@ Resources:
         Variables:
           DATABASE: !Ref AccessLogDatabase
           TABLE: !Ref AccessLogTable
+          LOG_FIELDS: !Join [',', !Ref LogFields]
+          CONFIG_ARN: !Ref AccessLogConfig
       Role: !GetAtt AccessLogRole.Arn
 
   AccessLogDatabase:
@@ -271,6 +276,14 @@ Resources:
                   - !Sub 'arn:aws:glue:${AWS::Region}:${AWS::AccountId}:catalog'
                   - !Sub 'arn:aws:glue:${AWS::Region}:${AWS::AccountId}:database/${AccessLogDatabase}'
                   - !Sub 'arn:aws:glue:${AWS::Region}:${AWS::AccountId}:table/${AccessLogDatabase}/${AccessLogTable}'
+        - PolicyName: cloudfront
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - cloudfront:GetRealtimeLogConfig
+                Resource: '*'
   AccessLogConfigRole:
     Type: AWS::IAM::Role
     Properties:

--- a/aws/cloudformation/access_logs.yml
+++ b/aws/cloudformation/access_logs.yml
@@ -101,6 +101,19 @@ Resources:
           - Event: 's3:ObjectCreated:*'
             Function: !GetAtt AccessLogPartition.Arn
             Filter: {S3Key: {Rules: [{Name: prefix, Value: !Ref BucketPrefix}]}}
+      IntelligentTieringConfigurations:
+        - Id: AccessLogStorage
+          Prefix: !Ref BucketPrefix
+          Status: Enabled
+          Tierings:
+            - {AccessTier: ARCHIVE_ACCESS, Days: 90}
+            - {AccessTier: DEEP_ARCHIVE_ACCESS, Days: 180}
+      LifecycleConfiguration:
+        Rules:
+          - Prefix: !Ref BucketPrefix
+            Status: Enabled
+            Transitions:
+              - {StorageClass: INTELLIGENT_TIERING, TransitionInDays: 30}
   AccessLogPartition:
     Type: AWS::Lambda::Function
     Properties:


### PR DESCRIPTION
This PR contains a couple updates to tune the CloudFront access-logs configuration (#41119) after reviewing the system operating in production the last couple of weeks.

1. Add logic to the access-log processor Lambda-function script to expect only the fields specified by an ENV variable (which may be less than the full set of columns in the Glue table schema).
The added logic is also flexible enough to deal with dynamic updates to exported fields. When the count of expected fields doesn't match the parsed number of fields in an incoming record, it queries the CloudFront Realtime Log Configuration resource directly (using [`cloudfront:GetRealtimeLogConfig`](https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_GetRealtimeLogConfig.html)) for an updated field list. If the fields still don't match it will then raise an error.

2. Use the [S3 Intelligent-Tiering](https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage-class-intro.html#sc-dynamic-data-access) storage class for the access-logs bucket/prefix, and enable the `Archive Access` (90-day) and `Deep Archive Access` (180-day) tiers for lower-cost longer-term storage.

## Testing story

Manually tested the updated configuration in the dev account.

## Deployment strategy

Manually update the access-logs stack in production, update the `FieldList` parameter to remove several unneeded access-log fields, and monitor/query to ensure access logs are being stored correctly and the overall data volume is adequate.