### PR TITLE
[Sprite Lab] Allow levelbuilders to set initial Blockly variables

### DIFF
--- a/apps/src/blocklyAddons/cdoVariableMap.js
+++ b/apps/src/blocklyAddons/cdoVariableMap.js
@@ -1,0 +1,7 @@
+import GoogleBlockly from 'blockly/core';
+
+export default class CdoVariableMap extends GoogleBlockly.VariableMap {
+  addVariables(variableList) {
+    variableList.forEach(varName => this.createVariable(varName));
+  }
+}

--- a/apps/src/blocklyAddons/cdoWorkspaceSvg.js
+++ b/apps/src/blocklyAddons/cdoWorkspaceSvg.js
@@ -1,6 +1,21 @@
 import GoogleBlockly from 'blockly/core';
 
 export default class WorkspaceSvg extends GoogleBlockly.WorkspaceSvg {
+  registerGlobalVariables(variableList) {
+    this.globalVariables = variableList;
+    this.getVariableMap().addVariables(variableList);
+  }
+
+  clear() {
+    super.clear();
+
+    // After clearing the workspace, we need to reinitialize global variables
+    // if there are any.
+    if (this.globalVariables) {
+      this.getVariableMap().addVariables(this.globalVariables);
+    }
+  }
+
   /** Add trashcan to flyout instead of block canvas
    * @override
    */

--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -740,11 +740,6 @@ P5Lab.prototype.afterInject_ = function(config) {
   );
 
   if (this.isSpritelab) {
-    if (this.level.blocklyVariables) {
-      Blockly.addGlobalVariables(
-        this.level.blocklyVariables.split(',').map(varName => varName.trim())
-      );
-    }
     // Add to reserved word list: API, local variables in execution evironment
     // (execute) and the infinite loop detection function.
     Blockly.JavaScript.addReservedWords(
@@ -762,6 +757,12 @@ P5Lab.prototype.afterInject_ = function(config) {
 
     // Don't add infinite loop protection
     Blockly.clearInfiniteLoopTrap();
+  }
+
+  if (this.level.blocklyVariables) {
+    Blockly.mainBlockSpace.registerGlobalVariables(
+      this.level.blocklyVariables.split(',').map(varName => varName.trim())
+    );
   }
 
   // Update p5Wrapper's scale and keep it updated with future resizes:

--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -740,6 +740,11 @@ P5Lab.prototype.afterInject_ = function(config) {
   );
 
   if (this.isSpritelab) {
+    if (this.level.blocklyVariables) {
+      Blockly.addGlobalVariables(
+        this.level.blocklyVariables.split(',').map(varName => varName.trim())
+      );
+    }
     // Add to reserved word list: API, local variables in execution evironment
     // (execute) and the infinite loop detection function.
     Blockly.JavaScript.addReservedWords(

--- a/apps/src/sites/studio/pages/cdoBlocklyWrapper.js
+++ b/apps/src/sites/studio/pages/cdoBlocklyWrapper.js
@@ -148,7 +148,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.wrapSettableProperty('typeHints');
   blocklyWrapper.wrapSettableProperty('valueTypeTabShapeMap');
 
-  blocklyWrapper.addGlobalVariables = function() {}; // Not implemented
+  blocklyWrapper.BlockSpace.prototype.registerGlobalVariables = function() {}; // Not implemented.
 
   blocklyWrapper.getGenerator = function() {
     return blocklyWrapper.Generator.get('JavaScript');

--- a/apps/src/sites/studio/pages/cdoBlocklyWrapper.js
+++ b/apps/src/sites/studio/pages/cdoBlocklyWrapper.js
@@ -148,6 +148,8 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.wrapSettableProperty('typeHints');
   blocklyWrapper.wrapSettableProperty('valueTypeTabShapeMap');
 
+  blocklyWrapper.addGlobalVariables = function() {}; // Not implemented
+
   blocklyWrapper.getGenerator = function() {
     return blocklyWrapper.Generator.get('JavaScript');
   };

--- a/apps/src/sites/studio/pages/googleBlocklyWrapper.js
+++ b/apps/src/sites/studio/pages/googleBlocklyWrapper.js
@@ -13,6 +13,7 @@ import CdoTheme from '@cdo/apps/blocklyAddons/cdoTheme';
 import initializeTouch from '@cdo/apps/blocklyAddons/cdoTouch';
 import CdoTrashcan from '@cdo/apps/blocklyAddons/cdoTrashcan';
 import initializeVariables from '@cdo/apps/blocklyAddons/cdoVariables';
+import CdoVariableMap from '@cdo/apps/blocklyAddons/cdoVariableMap';
 import CdoWorkspaceSvg from '@cdo/apps/blocklyAddons/cdoWorkspaceSvg';
 import initializeBlocklyXml from '@cdo/apps/blocklyAddons/cdoXml';
 
@@ -136,6 +137,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.wrapReadOnlyProperty('Touch');
   blocklyWrapper.wrapReadOnlyProperty('Trashcan');
   blocklyWrapper.wrapReadOnlyProperty('Variables');
+  blocklyWrapper.wrapReadOnlyProperty('VariableMap');
   blocklyWrapper.wrapReadOnlyProperty('weblab_locale');
   blocklyWrapper.wrapReadOnlyProperty('Workspace');
   blocklyWrapper.wrapReadOnlyProperty('WorkspaceSvg');
@@ -150,6 +152,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.blockly_.MetricsManager = CdoMetricsManager;
   blocklyWrapper.geras.PathObject = CdoPathObject;
   blocklyWrapper.blockly_.Trashcan = CdoTrashcan;
+  blocklyWrapper.blockly_.VariableMap = CdoVariableMap;
   blocklyWrapper.blockly_.WorkspaceSvg = CdoWorkspaceSvg;
 
   blocklyWrapper.blockly_.registry.register(
@@ -199,12 +202,6 @@ function initializeBlocklyWrapper(blocklyInstance) {
       this.blockly_.CONNECTING_SNAP_RADIUS = snapRadius;
     }
   });
-
-  blocklyWrapper.addGlobalVariables = function(variableList) {
-    variableList.forEach(varName =>
-      Blockly.mainBlockSpace.getVariableMap().createVariable(varName)
-    );
-  };
 
   blocklyWrapper.addChangeListener = function(blockspace, handler) {
     blockspace.addChangeListener(handler);

--- a/apps/src/sites/studio/pages/googleBlocklyWrapper.js
+++ b/apps/src/sites/studio/pages/googleBlocklyWrapper.js
@@ -200,6 +200,12 @@ function initializeBlocklyWrapper(blocklyInstance) {
     }
   });
 
+  blocklyWrapper.addGlobalVariables = function(variableList) {
+    variableList.forEach(varName =>
+      Blockly.mainBlockSpace.getVariableMap().createVariable(varName)
+    );
+  };
+
   blocklyWrapper.addChangeListener = function(blockspace, handler) {
     blockspace.addChangeListener(handler);
   };

--- a/dashboard/app/models/levels/gamelab_jr.rb
+++ b/dashboard/app/models/levels/gamelab_jr.rb
@@ -33,6 +33,7 @@ class GamelabJr < Gamelab
     block_pools
     mini_toolbox
     hide_pause_button
+    blockly_variables
   )
 
   def shared_blocks

--- a/dashboard/app/views/levels/editors/fields/_blockly_variables.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_blockly_variables.html.haml
@@ -1,0 +1,8 @@
+%h1.control-legend{data: {toggle: "collapse", target: "#variables"}}
+  Blockly Variables
+
+#variables.in.collapse
+  = f.label :blockly_variables,'Pre-initialized Blockly Variables'
+  %p Enter a comma-separated list of variables that will be pre-populated in the variable dropdown blocks.
+  %p NOTE: Only works with Google Blockly.
+  = f.text_area :blockly_variables, value: @level.blockly_variables

--- a/dashboard/app/views/levels/editors/fields/_blockly_variables.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_blockly_variables.html.haml
@@ -4,5 +4,5 @@
 #variables.in.collapse
   = f.label :blockly_variables,'Pre-initialized Blockly Variables'
   %p Enter a comma-separated list of variables that will be pre-populated in the variable dropdown blocks.
-  %p NOTE: Only works with Google Blockly.
+  %p{style: 'color: red; font-size: larger' } NOTE: Only works with Google Blockly.
   = f.text_area :blockly_variables, value: @level.blockly_variables

--- a/dashboard/app/views/levels/editors/fields/_code_area.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_code_area.html.haml
@@ -5,6 +5,7 @@
   = render partial: 'levels/editors/fields/droplet', locals: {f: f} if @level.uses_droplet?
   = render partial: 'levels/editors/fields/blockly', locals: {f: f} if !(@level.uses_droplet?) && @level.is_a?(Blockly)
   = render partial: 'levels/editors/fields/weblab_code_area', locals: {f: f} if @level.is_a?(Weblab)
+  = render partial: 'levels/editors/fields/blockly_variables', locals: {f: f} if @level.is_a?(GamelabJr)
   = render partial: 'levels/editors/fields/block_pools', locals: {f: f} if @level.is_a?(GamelabJr) || @level.is_a?(Dancelab)
   = render partial: 'levels/editors/fields/helper_libraries', locals: {f: f} if @level.is_a?(GamelabJr) || @level.is_a?(Dancelab)
   = render partial: 'levels/editors/fields/validation_code', locals: {f: f}


### PR DESCRIPTION
This PR makes it so that levelbuilders can specify a list of variable names that will be pre-initialized in the Blockly variable map so that they show up in the Blockly variables dropdown.

Note: This feature only works with Google Blockly. I have no plans at this time to implement in on our fork of Blockly. The reason for that is that our fork of Blockly does not keep track of variables at a global level (it traverses all the blocks every time it needs to know all the variables in scope). Adding global variable tracking to our fork seems like a lot of work compared to value at this time, so this feature should be considered a Google Blockly only feature.

![image](https://user-images.githubusercontent.com/8787187/125693954-006c111c-e2de-4a02-8577-2a338462bd90.png)

![image](https://user-images.githubusercontent.com/8787187/125693966-2f122eb0-eb12-4bc5-b406-1753ceed9428.png)


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
[jira](https://codedotorg.atlassian.net/browse/STAR-1556)
<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work
Translations

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
