### PR TITLE
stable sort of lesson-resource relationships

### DIFF
--- a/dashboard/lib/services/script_seed.rb
+++ b/dashboard/lib/services/script_seed.rb
@@ -46,7 +46,12 @@ module Services
       activities = script.lessons.map(&:lesson_activities).flatten
       sections = activities.map(&:activity_sections).flatten
       resources = script.lessons.map(&:resources).flatten.concat(script.resources).concat(script.student_resources).uniq.sort_by(&:key)
-      lessons_resources = script.lessons.map(&:lessons_resources).flatten
+
+      # Use the existing seeding_key code to efficiently sort LessonResource
+      # objects in a manner that will be stable across environments.
+      lr_seed_context = SeedContext.new(lessons: script.lessons, resources: resources)
+      lessons_resources = script.lessons.map(&:lessons_resources).flatten.sort_by {|lr| lr.seeding_key(lr_seed_context).to_json}
+
       vocabularies = script.lessons.map(&:vocabularies).flatten
       lessons_vocabularies = script.lessons.map(&:lessons_vocabularies).flatten
       lessons_programming_expressions = script.lessons.map(&:lessons_programming_expressions).flatten

--- a/dashboard/lib/services/script_seed.rb
+++ b/dashboard/lib/services/script_seed.rb
@@ -47,7 +47,7 @@ module Services
       sections = activities.map(&:activity_sections).flatten
       resources = script.lessons.map(&:resources).flatten.concat(script.resources).concat(script.student_resources).uniq.sort_by(&:key)
 
-      # Use the existing seeding_key code to efficiently sort LessonResource
+      # Use the existing seeding_key code to efficiently sort LessonsResource
       # objects in a manner that will be stable across environments.
       lr_seed_context = SeedContext.new(lessons: script.lessons, resources: resources)
       lessons_resources = script.lessons.map(&:lessons_resources).flatten.sort_by {|lr| lr.seeding_key(lr_seed_context).to_json}


### PR DESCRIPTION
makes incremental progress on https://codedotorg.atlassian.net/browse/PLAT-1049. When I run `rake seed:scripts` and then edit a script, I see a reordering of the lesson_resources section of the .script_json file. this PR establishes a stable sort for lesson_resources, so that edits made in any environment will always end up in the same order. 

## Testing story

existing unit test coverage ; also verified manually that the sort is stable after re-seeding and re-saving the script.

## Deployment strategy

Once this reaches levelbuilder, I'll re-serialize all script_json there to get us into a consistent state. EDIT: reserialized in https://github.com/code-dot-org/code-dot-org/commit/64ac9ddb4b6adcd836858837685e92572da3a365

## Follow-up work

there are many more fields that could be sorted (still tracked by  https://codedotorg.atlassian.net/browse/PLAT-1049), but my current plan was just to keep fixing the ones that are showing up in diffs in practice. I don't have a great reason for this, but I'm not 100% sure of the performance impact so this seemed like the most conservative strategy.