### PR TITLE
Prevent AYW emails from referencing the virtual order form

### DIFF
--- a/dashboard/app/mailers/pd/workshop_mailer.rb
+++ b/dashboard/app/mailers/pd/workshop_mailer.rb
@@ -242,7 +242,7 @@ class Pd::WorkshopMailer < ActionMailer::Base
     @workshop = enrollment.workshop
     course = @workshop.course
 
-    return unless @workshop.virtual? && (course == Pd::Workshop::COURSE_CSP || course == Pd::Workshop::COURSE_CSD)
+    return unless @workshop.virtual? && @workshop.local_summer? && (course == Pd::Workshop::COURSE_CSP || course == Pd::Workshop::COURSE_CSD)
 
     # Pre-workshop virtual order form reminder
     mail content_type: 'text/html',

--- a/dashboard/app/views/pd/workshop_mailer/_teacher_enrollment_details.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/_teacher_enrollment_details.html.haml
@@ -13,7 +13,7 @@
 - unless @workshop.virtual? || !@is_reminder
   = render partial: 'supply_list'
 
-- if @workshop.virtual? && (@workshop.course == Pd::Workshop::COURSE_CSD || @workshop.course == Pd::Workshop::COURSE_CSP)
+- if @workshop.virtual? && @workshop.local_summer? && (@workshop.course == Pd::Workshop::COURSE_CSD || @workshop.course == Pd::Workshop::COURSE_CSP)
   = render partial: 'pre_order_materials'
 
 - if @workshop.virtual?

--- a/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
+++ b/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
@@ -56,6 +56,24 @@ class Pd::WorkshopMailerPreview < ActionMailer::Preview
     mail :teacher_enrollment_receipt, Pd::Workshop::COURSE_CSD, Pd::Workshop::SUBJECT_CSD_WORKSHOP_1
   end
 
+  def teacher_enrollment_receipt__csp_1_virtual
+    mail :teacher_enrollment_receipt, Pd::Workshop::COURSE_CSP, Pd::Workshop::SUBJECT_CSP_WORKSHOP_1,
+      workshop_params: {
+        virtual: true,
+        location_name: 'zoom_link',
+        location_address: nil
+      }
+  end
+
+  def teacher_enrollment_receipt_csd_1_virtual
+    mail :teacher_enrollment_receipt, Pd::Workshop::COURSE_CSD, Pd::Workshop::SUBJECT_CSD_WORKSHOP_1,
+      workshop_params: {
+        virtual: true,
+        location_name: 'zoom_link',
+        location_address: nil
+      }
+  end
+
   def teacher_enrollment_receipt__admin
     mail :teacher_enrollment_receipt, Pd::Workshop::COURSE_ADMIN
   end


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
The link to the virtual workshop order form was mistakenly being added to all-year workshop emails.
Removed the section on the order form from emails and stopped the virtual order form reminder email from going to out for those workshops.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [PLC-1267](https://codedotorg.atlassian.net/browse/PLC-1267)

## Testing story

Tested in rails mailer previews
