### PR TITLE
[Sprite Lab] Only one button in sprite dropdown

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -50,7 +50,7 @@
     "@babel/preset-react": "^7.0.0",
     "@cdo/interpreted": "link:../dashboard/config/libraries",
     "@code-dot-org/artist": "0.2.1",
-    "@code-dot-org/blockly": "3.5.35",
+    "@code-dot-org/blockly": "3.5.36",
     "@code-dot-org/craft": "0.2.2",
     "@code-dot-org/dance-party": "1.0.3",
     "@code-dot-org/johnny-five": "0.11.1-cdo.2",

--- a/apps/src/p5lab/actions.js
+++ b/apps/src/p5lab/actions.js
@@ -1,7 +1,6 @@
 /** @file Redux action-creators for Game Lab.
  *  @see http://redux.js.org/docs/basics/Actions.html */
 import $ from 'jquery';
-import {pickNewAnimation, show, Goal} from './redux/animationPicker';
 import {setAllowInstructionsResize} from '../redux/instructions';
 import {P5LabInterfaceMode} from './constants';
 
@@ -24,20 +23,15 @@ export const ADD_MESSAGE = 'spritelab/ADD_MESSAGE';
 /**
  * Change the interface mode between Code Mode and the Animation Tab
  * @param {!P5LabInterfaceMode} interfaceMode
- * @param {boolean} spritelabDraw - If true, opens the animation tab to a new animation
  * @returns {function}
  */
-export function changeInterfaceMode(interfaceMode, spritelabDraw) {
+export function changeInterfaceMode(interfaceMode) {
   return function(dispatch) {
     $(window).trigger('appModeChanged');
     dispatch({
       type: CHANGE_INTERFACE_MODE,
       interfaceMode: interfaceMode
     });
-    if (interfaceMode === P5LabInterfaceMode.ANIMATION && spritelabDraw) {
-      dispatch(show(Goal.NEW_ANIMATION));
-      dispatch(pickNewAnimation());
-    }
     dispatch(
       setAllowInstructionsResize(interfaceMode === P5LabInterfaceMode.CODE)
     );

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -8,7 +8,7 @@ import {APP_HEIGHT, P5LabInterfaceMode} from '../constants';
 import {TOOLBOX_EDIT_MODE} from '../../constants';
 import {animationSourceUrl} from '../redux/animationList';
 import {changeInterfaceMode} from '../actions';
-import {Goal, show, showBackground} from '../redux/animationPicker';
+import {Goal, showBackground} from '../redux/animationPicker';
 import i18n from '@cdo/locale';
 import spritelabMsg from '@cdo/spritelab/locale';
 function animations(areBackgrounds) {
@@ -183,20 +183,11 @@ const customInputTypes = {
       ) {
         buttons = [
           {
-            text: i18n.draw(),
+            text: i18n.costumeMode(),
             action: () => {
               getStore().dispatch(
-                changeInterfaceMode(
-                  P5LabInterfaceMode.ANIMATION,
-                  true /* spritelabDraw */
-                )
+                changeInterfaceMode(P5LabInterfaceMode.ANIMATION)
               );
-            }
-          },
-          {
-            text: i18n.more(),
-            action: () => {
-              getStore().dispatch(show(Goal.NEW_ANIMATION, true));
             }
           }
         ];

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1561,16 +1561,17 @@
     to-fast-properties "^2.0.0"
 
 "@cdo/interpreted@link:../dashboard/config/libraries":
-  version "0.1.0"
+  version "0.0.0"
+  uid ""
 
 "@code-dot-org/artist@0.2.1":
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@code-dot-org/artist/-/artist-0.2.1.tgz#fcfe7ea5cfb3f19ddb6b912e70e922ba4b7ef0b1"
 
-"@code-dot-org/blockly@3.5.35":
-  version "3.5.35"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/blockly/-/blockly-3.5.35.tgz#6afae54e8b4d61e4aa23209639cdbd066881306b"
-  integrity sha512-f+cEBjyMGslVf0qliRm1JJO9MHFswXpLvRklWPYLwlCgjSS9655YlS8e6g1h7UMFHT8uG2c+jlDtRN38r0RPmg==
+"@code-dot-org/blockly@3.5.36":
+  version "3.5.36"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/blockly/-/blockly-3.5.36.tgz#ee3f4493c3511f5d7719a8848e2511735267246e"
+  integrity sha512-6/Q4FFrBtTY2MScm0gOquL39Ah3wgsXMZG+uGuxC95iO88AXG5t+x7gdCkMNRDYFJA8uE7uAXbKA2CRt/tK7Nw==
 
 "@code-dot-org/craft@0.2.2":
   version "0.2.2"


### PR DESCRIPTION
This PR bumps Blockly to `3.5.36` to pull in https://github.com/code-dot-org/blockly/pull/279

Instead of two action buttons on the sprite dropdown, just one button that navigates to the Costumes tab.
Before
![image](https://user-images.githubusercontent.com/8787187/125827123-325ee7dd-1449-4bb5-937f-0cf5841728be.png)

After
![image](https://user-images.githubusercontent.com/8787187/125827058-722f924e-c291-4c43-ab98-7d34fa399145.png)


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
