### PR TITLE
stable sort script-resource relationships in script json

### DIFF
--- a/dashboard/lib/services/script_seed.rb
+++ b/dashboard/lib/services/script_seed.rb
@@ -48,9 +48,11 @@ module Services
       resources = script.lessons.map(&:resources).flatten.concat(script.resources).concat(script.student_resources).uniq.sort_by(&:key)
 
       # Use the existing seeding_key code to efficiently sort LessonsResource
-      # objects in a manner that will be stable across environments.
+      # and ScriptsResource objects in a manner that will be stable across environments.
       lr_seed_context = SeedContext.new(lessons: script.lessons, resources: resources)
       lessons_resources = script.lessons.map(&:lessons_resources).flatten.sort_by {|lr| lr.seeding_key(lr_seed_context).to_json}
+      sr_seed_context = SeedContext.new(script: script, resources: resources)
+      scripts_resources = script.scripts_resources.sort_by {|sr| sr.seeding_key(sr_seed_context).to_json}
 
       vocabularies = script.lessons.map(&:vocabularies).flatten
       lessons_vocabularies = script.lessons.map(&:lessons_vocabularies).flatten
@@ -70,7 +72,7 @@ module Services
         levels: my_levels,
         resources: resources,
         lessons_resources: lessons_resources,
-        scripts_resources: script.scripts_resources,
+        scripts_resources: scripts_resources,
         scripts_student_resources: script.scripts_student_resources,
         vocabularies: vocabularies,
         lessons_vocabularies: lessons_vocabularies,
@@ -95,7 +97,7 @@ module Services
         levels_script_levels: script.levels_script_levels.map {|lsl| ScriptSeed::LevelsScriptLevelSerializer.new(lsl, scope: scope).as_json},
         resources: resources.map {|r| ScriptSeed::ResourceSerializer.new(r, scope: scope).as_json},
         lessons_resources: lessons_resources.map {|lr| ScriptSeed::LessonsResourceSerializer.new(lr, scope: scope).as_json},
-        scripts_resources: script.scripts_resources.map {|sr| ScriptSeed::ScriptsResourceSerializer.new(sr, scope: scope).as_json},
+        scripts_resources: scripts_resources.map {|sr| ScriptSeed::ScriptsResourceSerializer.new(sr, scope: scope).as_json},
         scripts_student_resources: script.scripts_student_resources.map {|sr| ScriptSeed::ScriptsResourceSerializer.new(sr, scope: scope).as_json},
         vocabularies: vocabularies.map {|v| ScriptSeed::VocabularySerializer.new(v, scope: scope).as_json},
         lessons_vocabularies: lessons_vocabularies.map {|lv| ScriptSeed::LessonsVocabularySerializer.new(lv, scope: scope).as_json},


### PR DESCRIPTION
Follow-on to https://github.com/code-dot-org/code-dot-org/pull/41574. I did this because when i went to look back at https://codedotorg.atlassian.net/browse/PLAT-1049, it specifically mentioned scripts_resources being out of order, and the solution is very similar to the one in the previous PR for lessons_resources.

## Testing story

existing unit test coverage ; also verified manually that the sort is stable after re-seeding and re-saving the script.