### PR TITLE
Theater: Fetch output from url

### DIFF
--- a/apps/src/javalab/Theater.js
+++ b/apps/src/javalab/Theater.js
@@ -16,6 +16,18 @@ export default class Theater {
         this.getImgElement().src = data.detail.url;
         break;
       }
+      // TODO: Remove these message types once javabuilder is updated to
+      // no longer use them.
+      case TheaterSignalType.VISUAL: {
+        const imageString = 'data:image/gif;base64,' + data.detail.image;
+        this.getImgElement().src = imageString;
+        break;
+      }
+      case TheaterSignalType.AUDIO: {
+        const audioString = 'data:audio/wav;base64,' + data.detail.audio;
+        this.getAudioElement().src = audioString;
+        break;
+      }
       default:
         break;
     }

--- a/apps/src/javalab/Theater.js
+++ b/apps/src/javalab/Theater.js
@@ -1,3 +1,5 @@
+import {TheaterSignalType} from './constants';
+
 export default class Theater {
   constructor() {
     this.canvas = null;
@@ -5,21 +7,23 @@ export default class Theater {
   }
 
   handleSignal(data) {
-    if (data.detail.image) {
-      const imageString = 'data:image/gif;base64,' + data.detail.image;
-      const imgElement = this.getImgElement();
-      imgElement.src = imageString;
-    }
-    if (data.detail.audio) {
-      const audioString = 'data:audio/wav;base64,' + data.detail.audio;
-      const audioElement = this.getAudioElement();
-      audioElement.src = audioString;
+    switch (data.value) {
+      case TheaterSignalType.AUDIO_URL: {
+        this.getAudioElement().src = data.detail.url;
+        break;
+      }
+      case TheaterSignalType.VISUAL_URL: {
+        this.getImgElement().src = data.detail.url;
+        break;
+      }
+      default:
+        break;
     }
   }
 
   reset() {
-    const imgElement = this.getImgElement();
-    imgElement.src = '';
+    this.getImgElement().src = '';
+    this.getAudioElement().src = '';
   }
 
   getImgElement() {

--- a/apps/src/javalab/constants.js
+++ b/apps/src/javalab/constants.js
@@ -53,7 +53,9 @@ export const NeighborhoodSignalType = {
 
 export const TheaterSignalType = {
   AUDIO_URL: 'AUDIO_URL',
-  VISUAL_URL: 'VISUAL_URL'
+  VISUAL_URL: 'VISUAL_URL',
+  AUDIO: 'AUDIO',
+  VISUAL: 'VISUAL'
 };
 
 export const CompileStatus = makeEnum('NONE', 'LOADING', 'SUCCESS', 'ERROR');

--- a/apps/src/javalab/constants.js
+++ b/apps/src/javalab/constants.js
@@ -51,4 +51,9 @@ export const NeighborhoodSignalType = {
   DONE: 'DONE'
 };
 
+export const TheaterSignalType = {
+  AUDIO_URL: 'AUDIO_URL',
+  VISUAL_URL: 'VISUAL_URL'
+};
+
 export const CompileStatus = makeEnum('NONE', 'LOADING', 'SUCCESS', 'ERROR');


### PR DESCRIPTION
~DO NOT MERGE until Javabuilder has been updated with these changes: [javabuilder 72](https://github.com/code-dot-org/javabuilder/pull/72), [javabuilder 73](https://github.com/code-dot-org/javabuilder/pull/73)~ (no longer applies, I kept the old message type)

Update theater to receive gif and audio data via a url passed over the websocket instead of through binary data passed over the websocket.

## Links

- jira ticket: [CSA-502](https://codedotorg.atlassian.net/browse/CSA-502)


## Testing story
Tested locally.


## Deployment strategy
This needs to be merged after we have merged the relevant Javabuilder changes linked above, as those add the urls we will fetch data from.



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
