### PR TITLE
stop generating leftover course and script files in dashboard unit tests

### DIFF
--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -31,6 +31,7 @@ class ScriptsControllerTest < ActionController::TestCase
     @unmigrated_unit = create :script
 
     Rails.application.config.stubs(:levelbuilder_mode).returns false
+    File.stubs(:write)
   end
 
   test "should get index" do

--- a/dashboard/test/controllers/vocabularies_controller_test.rb
+++ b/dashboard/test/controllers/vocabularies_controller_test.rb
@@ -5,6 +5,7 @@ class VocabulariesControllerTest < ActionController::TestCase
 
   setup do
     Rails.application.config.stubs(:levelbuilder_mode).returns true
+    File.stubs(:write)
     @levelbuilder = create :levelbuilder
     # We don't want to actually write to the file system here
     Vocabulary.any_instance.stubs(:serialize_scripts)

--- a/dashboard/test/models/resource_test.rb
+++ b/dashboard/test/models/resource_test.rb
@@ -111,6 +111,7 @@ class ResourceTest < ActiveSupport::TestCase
 
   test 'serialize scripts that resource is in' do
     Rails.application.config.stubs(:levelbuilder_mode).returns true
+    File.stubs(:write)
     @levelbuilder = create :levelbuilder
 
     course_version = create :course_version, :with_unit_group

--- a/dashboard/test/models/vocabulary_test.rb
+++ b/dashboard/test/models/vocabulary_test.rb
@@ -79,6 +79,7 @@ class VocabularyTest < ActiveSupport::TestCase
 
   test 'serialize scripts that vocabulary is in' do
     Rails.application.config.stubs(:levelbuilder_mode).returns true
+    File.stubs(:write)
     @levelbuilder = create :levelbuilder
 
     course_version = create :course_version, :with_unit_group


### PR DESCRIPTION
Addresses https://codedotorg.atlassian.net/browse/PLAT-741 . It's not practical to run the entire dashboard test suite locally, so we'll have to wait until this goes through DTT to know if the problem is resolved.

## Testing story

* I manually verified that all of the test files in 430986f were causing leftover course or script files to be generated beforehand and are no longer doing so after. 
* scripts_controller_test.rb didn't seem to be generating any leftover files, perhaps because it creates all of its script objects before enabling levelbuilder mode. However, there are so many test cases in that file with levelbuilder_mode enabled that I thought this would be a good time to fix it anyway.