### PR TITLE
Grant JavaLab permission to connect to Javabuilder beta service

### DIFF
--- a/lib/cdo/rack/upgrade_insecure_requests.rb
+++ b/lib/cdo/rack/upgrade_insecure_requests.rb
@@ -50,7 +50,7 @@ module Rack
             "style-src 'self' https: 'unsafe-inline'",
             "img-src 'self' https: data: blob:",
             "font-src 'self' https: data:",
-            "connect-src 'self' https: https://api.pusherapp.com wss://ws.pusherapp.com wss://*.firebaseio.com http://localhost:8080 https://curriculum.code.org/ wss://*.code.org",
+            "connect-src 'self' https: https://api.pusherapp.com wss://ws.pusherapp.com wss://*.firebaseio.com http://localhost:8080 https://curriculum.code.org/ wss://*.code.org wss://javabuilderbeta.dev-code.org",
             "media-src 'self' https: http://vaas.acapela-group.com",
             "report-uri #{CDO.code_org_url('https/mixed-content')}"
           ]


### PR DESCRIPTION
Configure Content Security Policy to permit client scripts (such as JavaLab) permission to open web socket connections to the beta deployment of the Javabuilder service.

## Follow-up work

Remove this permission when staging and production instances of the Javabuilder service are deployed.

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
