### PR TITLE
[Sprite Lab] Fix when sprite created event

### DIFF
--- a/apps/src/p5lab/spritelab/commands/eventCommands.js
+++ b/apps/src/p5lab/spritelab/commands/eventCommands.js
@@ -44,12 +44,8 @@ export const commands = {
   },
 
   whenSpriteCreated(spriteArg, callback) {
-    if (spriteArg && spriteArg.costume) {
-      coreLibrary.addEvent(
-        'whenSpriteCreated',
-        {costume: spriteArg.costume},
-        callback
-      );
+    if (spriteArg) {
+      coreLibrary.addEvent('whenSpriteCreated', spriteArg, callback);
     }
   },
 

--- a/apps/src/p5lab/spritelab/coreLibrary.js
+++ b/apps/src/p5lab/spritelab/coreLibrary.js
@@ -158,16 +158,7 @@ export function addSprite(sprite, name, animation) {
 
   // If there are any whenSpriteCreated events, call the callback immediately
   // so that the event happens during the same draw loop frame.
-  const matchingInputEvents = inputEvents.filter(
-    inputEvent =>
-      inputEvent.type === 'whenSpriteCreated' &&
-      (inputEvent.args.name === name ||
-        inputEvent.args.costume === animation ||
-        inputEvent.args.costume === 'all')
-  );
-  matchingInputEvents.forEach(inputEvent =>
-    inputEvent.callback({newSprite: sprite.id})
-  );
+  runSpriteCreatedEvents(sprite);
 
   spriteId++;
   return sprite.id;
@@ -249,6 +240,20 @@ export function addEvent(type, args, callback) {
 
 export function clearCollectDataEvents() {
   inputEvents = inputEvents.filter(e => e.type !== 'collectData');
+}
+
+function runSpriteCreatedEvents(newSprite) {
+  const matchingInputEvents = inputEvents.filter(
+    inputEvent =>
+      inputEvent.type === 'whenSpriteCreated' &&
+      (inputEvent.args.name === newSprite.name ||
+        inputEvent.args.costume === newSprite.getAnimationLabel() ||
+        inputEvent.args.costume === 'all')
+  );
+  matchingInputEvents.forEach(inputEvent => {
+    eventLog.push(`spriteCreated: ${newSprite.id}`);
+    inputEvent.callback({newSprite: newSprite.id});
+  });
 }
 
 function atTimeEvent(inputEvent, p5Inst) {


### PR DESCRIPTION
2 small bugs here:
1. It didn't work with the named sprite block or the all sprites block. This was just an oversight, and a simple fix to handle the case where the sprite block in the event socket is *not* a costume.
2. Make sure the event fires in the same frame that the sprite is created. This was a slightly harder fix, but the solution ended up being to call the callback immediately when the sprite is created, rather than waiting for the event to run on the following frame. The issue is kind of hard to explain, but I think is illustrated pretty well in the gifs. Basically, before we were creating the sprite in one frame, and doing the "when sprite created" event code the following frame, which in this example makes the carrot show up very briefly at full size before being shrunk to size 50. Now, we check for potential "when sprite created" events and fire them immediately when we create the new sprite.
Before:
![Jul-16-2021 14-04-27](https://user-images.githubusercontent.com/8787187/126008393-3b8b2698-5953-4f41-a1bb-4bc344b9be0d.gif)

After
![Jul-16-2021 14-03-22](https://user-images.githubusercontent.com/8787187/126008417-bee56a6e-adf1-4104-9e14-6de740f5afb6.gif)


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
