### PR TITLE
Adds error to levelbuilder if javalab neighborhood with gridsize over 16 adds paint bucket

### DIFF
--- a/dashboard/app/models/levels/javalab.rb
+++ b/dashboard/app/models/levels/javalab.rb
@@ -73,7 +73,10 @@ class Javalab < Level
         end
       end
     end
-
+    # paint bucket asset id is 303
+    if serialized_maze.include?("303") && (maze.length > 16)
+      raise ArgumentError.new("Large mazes cannot have paint buckets")
+    end
     self.serialized_maze = maze
   end
 


### PR DESCRIPTION
Accompanies Javabuilder update to treat painters on large (>=16) grid sizes as having infinite paint. Because of this, we no longer allow paint buckets on those grid sizes. This PR makes levelbuilder throw an error if an editor tries to insert the asset for a paint bucket (303) into a level with a large enough grid size.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
