### PR TITLE
Pardot OAuth Integration

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -145,6 +145,7 @@ pagerduty_token: !Secret
 pardot_password:
 pardot_user_key:
 pardot_username:
+pardot_private_key:
 
 # Honeybadger
 honeybadger_api_token:

--- a/config/development.yml.erb
+++ b/config/development.yml.erb
@@ -41,6 +41,8 @@ enrollments_summer_2020_gsheet_key:
 javabuilder_private_key: !Secret
 javabuilder_key_password: !Secret
 
+pardot_private_key: !Secret
+
 redshift_host: !Secret
 redshift_password: !Secret
 redshift_username: !Secret

--- a/config/production.yml.erb
+++ b/config/production.yml.erb
@@ -4,6 +4,7 @@ level_sources_redis_url: !Secret
 pardot_password: !Secret
 pardot_user_key: !Secret
 pardot_username: !Secret
+pardot_private_key: !Secret
 pd_teacher_application_list_secret_key: !Secret
 pledge_map_table_id: !Secret
 redshift_host: !Secret

--- a/lib/cdo/contact_rollups/v2/pardot_helpers.rb
+++ b/lib/cdo/contact_rollups/v2/pardot_helpers.rb
@@ -1,3 +1,5 @@
+require 'jwt'
+
 module PardotHelpers
   AUTHENTICATION_URL = "https://pi.pardot.com/api/login/version/4".freeze
   SUCCESS_HTTP_CODES = %w(200 201 204).freeze
@@ -38,33 +40,48 @@ module PardotHelpers
 
   private
 
-  # Note: Pardot API key can become invalid and need to be refreshed midstream.
-  @@api_key = nil
+  PRIVATE_KEY = CDO.pardot_private_key
+  PARDOT_BUSINESS_ID = '0Uv5b0000004CHbCAM'
 
-  # Authenticates and requests a new API key.
-  # API keys are valid for one hour while user keys are valid indefinitely.
-  # http://developer.pardot.com/#authentication
-  #
-  # @return [String] API key to use for subsequent requests
-  # @note This method has a side effect (it modifies a class variable) and may raise exception.
-  def request_api_key
-    doc = post_request(
-      AUTHENTICATION_URL,
-      {
-        email: CDO.pardot_username,
-        password: CDO.pardot_password,
-        user_key: CDO.pardot_user_key
-      }
+  OAUTH_ENDPOINT = 'https://login.salesforce.com/services/oauth2/token'
+
+  @@access_token = nil
+
+  # Authenticates and requests an access token
+  # https://help.salesforce.com/articleView?id=sf.remoteaccess_oauth_jwt_flow.htm
+  # https://thespotforpardot.com/2021/02/02/pardot-api-and-getting-ready-with-salesforce-sso-users-part-3b-connecting-to-pardot-api-from-code/
+  def request_api_access_token
+    # build token payload
+    payload = {
+      # connected app client id
+      "iss": "3MVG9fMtCkV6eLhej.9tKBIE6OLmMCsxJAqIfy_eeSC1UaUR4rL0jkzUQOSRAhzfpHmUxUcuBp2JabX1ZOl2p",
+      # always login.salesforce.com
+      "aud": "https://login.salesforce.com",
+      # pardot account email
+      "sub": "plc-emails@code.org",
+      # less than 3 minutes after now
+      "exp": (Time.now + 2.minutes).to_i
+    }
+
+    # encrypt payload with certificate (the certificate is uploaded to the connected app config)
+    encoded_payload = JWT.encode(
+      payload,
+      OpenSSL::PKey::RSA.new(PRIVATE_KEY),
+      'RS256'
     )
 
-    status = get_response_status doc
-    raise "Pardot authentication response failed with status #{status}  #{doc}" unless
-      status == STATUS_OK
+    # request an access token using our jwt token
+    token_request = {
+      'grant_type' => 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+      'assertion' => encoded_payload
+    }
 
-    api_key = doc.xpath('/rsp/api_key').text
-    raise 'Pardot authentication response did not include api_key' if api_key.nil?
+    response = Net::HTTP.post(
+      URI(OAUTH_ENDPOINT),
+      token_request.to_query
+    )
 
-    @@api_key = api_key
+    @@access_token = JSON.parse(response.body)["access_token"]
   end
 
   # Makes an API request with Pardot authentication.
@@ -76,7 +93,7 @@ module PardotHelpers
     post_request_with_auth(url)
   rescue InvalidApiKeyException
     # The API key might have been expired, try again with a new API key
-    request_api_key
+    request_api_access_token
     post_request_with_auth(url)
   end
 
@@ -85,11 +102,8 @@ module PardotHelpers
   # @param url [String] URL to post to. The URL should not contain auth params.
   # @return [Nokogiri::XML] XML response from Pardot
   def post_request_with_auth(url)
-    request_api_key if @@api_key.nil?
-    post_request(
-      url,
-      {api_key: @@api_key, user_key: CDO.pardot_user_key}
-    )
+    request_api_access_token if @@access_token.nil?
+    post_request(url)
   end
 
   # Make an API request. This method may raise exceptions.
@@ -97,9 +111,14 @@ module PardotHelpers
   # @param url [String] URL to post to
   # @param params [Hash] hash of POST params (may be empty hash or contain API and user keys)
   # @return [Nokogiri::XML, nil] XML response from Pardot
-  def post_request(url, params)
+  def post_request(url)
     uri = URI(url)
-    response = Net::HTTP.post_form(uri, params)
+    headers = {
+      'Authorization' => 'Bearer ' + @@access_token,
+      'Pardot-Business-Unit-Id' => PARDOT_BUSINESS_ID,
+      'Content-Type' => 'application/x-www-form-urlencoded'
+    }
+    response = Net::HTTP.post(uri, "", headers)
 
     # TODO: Return a custom exception containing both the HTTP response code and
     #   the (parsed) response body. The detailed error is in the response body.

--- a/lib/cdo/contact_rollups/v2/pardot_helpers.rb
+++ b/lib/cdo/contact_rollups/v2/pardot_helpers.rb
@@ -120,6 +120,8 @@ module PardotHelpers
     }
     response = Net::HTTP.post(uri, "", headers)
 
+    raise InvalidApiKeyException if response.code == '401'
+
     # TODO: Return a custom exception containing both the HTTP response code and
     #   the (parsed) response body. The detailed error is in the response body.
     raise "Pardot request failed with HTTP #{response.code}" unless
@@ -129,9 +131,6 @@ module PardotHelpers
 
     doc = Nokogiri::XML(response.body, &:noblanks)
     raise 'Pardot response did not return parsable XML' if doc.nil?
-
-    error_details = doc.xpath('/rsp/err').text
-    raise InvalidApiKeyException if error_details.include? ERROR_INVALID_API_KEY
 
     status = get_response_status doc
     raise 'Pardot response did not include status' if status.nil?

--- a/lib/cdo/contact_rollups/v2/pardot_helpers.rb
+++ b/lib/cdo/contact_rollups/v2/pardot_helpers.rb
@@ -81,6 +81,9 @@ module PardotHelpers
       token_request.to_query
     )
 
+    raise "Pardot authentication failed with HTTP #{response.code}" unless
+      SUCCESS_HTTP_CODES.include?(response.code)
+
     @@access_token = JSON.parse(response.body)["access_token"]
   end
 


### PR DESCRIPTION
Pardot changed their authentication flow from using an api key obtained through username/password to OAuth, which has multiple authentication flows. We're using the JWT (json web token) flow because it allows non-interactive logins. Setup on the pardot/salesforce config side took a long time, but now our integration allows us to use the new authentication. I added one private key (pardot_private_key) to the secrets manager in development and production environments (this script should only be running in the production daemon environment). The certificate (private key) expires in 100 years, so we'll have to update this then.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- documentation [jwt flow](https://help.salesforce.com/articleView?id=sf.remoteaccess_oauth_jwt_flow.htm)
- helpful [link](https://thespotforpardot.com/2021/02/02/pardot-api-and-getting-ready-with-salesforce-sso-users-part-3b-connecting-to-pardot-api-from-code/)
- jira ticket: [PLC-1240](https://codedotorg.atlassian.net/browse/PLC-1240)

## Testing story
Tested manually that we can access pardot as before:
```
[development] dashboard > require "cdo/contact_rollups/v2/pardot.rb"
GetSecretValue: development/cdo/pardot_private_key
=> true
[development] dashboard > PardotV2.retrieve_pardot_ids_by_email('tim@code.org')
=> ["88970755"]
```
