### PR TITLE
Javalab: use new javabuilder URL

### DIFF
--- a/lib/cdo.rb
+++ b/lib/cdo.rb
@@ -128,7 +128,7 @@ module Cdo
       else
         # TODO: Update to use this URL once we have Route53 set up for API Gateway
         # site_url('javabuilder.code.org', '', 'wss')
-        'wss://javabuilderpilot.code.org'
+        'wss://javabuilderbeta.dev-code.org'
       end
     end
 


### PR DESCRIPTION
We have a new Javabuilder dev beta URL until we get our system fully set up.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
