### PR TITLE
Revert "make staging commit schema_cache.yml when the schema changes"

### DIFF
--- a/lib/rake/build.rake
+++ b/lib/rake/build.rake
@@ -52,7 +52,7 @@ namespace :build do
 
         # Update the schema cache file, except for production which always uses the cache.
         unless rack_env?(:production)
-          schema_cache_file = dashboard_dir('db/schema_cache.yml')
+          schema_cache_file = dashboard_dir('db/schema_cache.dump')
           RakeUtils.rake 'db:schema:cache:dump'
           if GitUtils.file_changed_from_git?(schema_cache_file)
             # Staging is responsible for committing the authoritative schema cache dump.


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#38596.

After a successful staging build this morning, a schema_cache.dump file was created but not committed.

It appears that the staging build currently generates `schema_cache.dump`, not `schema_cache.yml`, but the code for committing the result looks for the `.yml` file. Looking through git history, I see 2 ways that schema_cache.dump eventually gets committed:
1. DOTD manually commits it
2. the noon staging content scoop

I don't understand the whole history here, but I'm proposing that we change our system back to look for schema_cache.dump since that's what it looks like it's been using. 