### PR TITLE
Javalab: Code Review - prevent showing teacher comments to peers of project owner

### DIFF
--- a/dashboard/app/controllers/code_review_comments_controller.rb
+++ b/dashboard/app/controllers/code_review_comments_controller.rb
@@ -59,7 +59,7 @@ class CodeReviewCommentsController < ApplicationController
     ).order(:created_at)
 
     # Keep teacher comments private between project owner and teacher.
-    if CodeReviewComment.user_is_peer_of_project_owner?(@project_owner, current_user)
+    unless @project_owner.student_of?(current_user) || @project_owner == current_user
       @project_comments = @project_comments.reject {|comment| comment.commenter.teacher?}
     end
 

--- a/dashboard/app/controllers/code_review_comments_controller.rb
+++ b/dashboard/app/controllers/code_review_comments_controller.rb
@@ -58,6 +58,11 @@ class CodeReviewCommentsController < ApplicationController
       storage_app_id: @storage_app_id
     ).order(:created_at)
 
+    # Keep teacher comments private between project owner and teacher.
+    if CodeReviewComment.user_is_peer_of_project_owner?(@project_owner, current_user)
+      @project_comments = @project_comments.reject {|comment| comment.commenter.teacher?}
+    end
+
     serialized_comments = @project_comments.map {|comment| serialize(comment)}
 
     render json: serialized_comments

--- a/dashboard/app/models/code_review_comment.rb
+++ b/dashboard/app/models/code_review_comment.rb
@@ -28,15 +28,17 @@ class CodeReviewComment < ApplicationRecord
   validates :comment, presence: true
   validates :project_owner_id, presence: true
 
-  # Note: this should be moved to the reviewable_projects model once it exists
-  # Something like reviewable_project.user_can_review?(potential_reviewer)
+  # To do: move to ReviewableProject model
   def self.user_can_review_project?(project_owner, potential_reviewer)
     project_owner == potential_reviewer ||
       project_owner.student_of?(potential_reviewer) ||
       user_is_peer_of_project_owner?(project_owner, potential_reviewer)
   end
 
+  # To do: move to ReviewableProject model
   def self.user_is_peer_of_project_owner?(project_owner, potential_reviewer)
+    return false if project_owner == potential_reviewer
+
     (project_owner.sections_as_student & potential_reviewer.sections_as_student).any?
   end
 end

--- a/dashboard/app/models/code_review_comment.rb
+++ b/dashboard/app/models/code_review_comment.rb
@@ -32,13 +32,6 @@ class CodeReviewComment < ApplicationRecord
   def self.user_can_review_project?(project_owner, potential_reviewer)
     project_owner == potential_reviewer ||
       project_owner.student_of?(potential_reviewer) ||
-      user_is_peer_of_project_owner?(project_owner, potential_reviewer)
-  end
-
-  # To do: move to ReviewableProject model
-  def self.user_is_peer_of_project_owner?(project_owner, potential_reviewer)
-    return false if project_owner == potential_reviewer
-
-    (project_owner.sections_as_student & potential_reviewer.sections_as_student).any?
+      (project_owner.sections_as_student & potential_reviewer.sections_as_student).any?
   end
 end

--- a/dashboard/app/models/code_review_comment.rb
+++ b/dashboard/app/models/code_review_comment.rb
@@ -33,6 +33,10 @@ class CodeReviewComment < ApplicationRecord
   def self.user_can_review_project?(project_owner, potential_reviewer)
     project_owner == potential_reviewer ||
       project_owner.student_of?(potential_reviewer) ||
-      (project_owner.sections_as_student & potential_reviewer.sections_as_student).any?
+      user_is_peer_of_project_owner?(project_owner, potential_reviewer)
+  end
+
+  def self.user_is_peer_of_project_owner?(project_owner, potential_reviewer)
+    (project_owner.sections_as_student & potential_reviewer.sections_as_student).any?
   end
 end

--- a/dashboard/test/controllers/code_review_comments_controller_test.rb
+++ b/dashboard/test/controllers/code_review_comments_controller_test.rb
@@ -239,6 +239,27 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
     assert_equal 2, JSON.parse(response.body).length
   end
 
+  test 'teacher of section project owner is enrolled in can fetch their own comments' do
+    stub_storage_apps_calls
+    setup_project_comments_tests
+
+    create :follower, student_user: @project_owner, section: @section
+    create :code_review_comment,
+      commenter: @teacher,
+      storage_app_id: @project_storage_app_id,
+      project_version: @project_version_string,
+      project_owner_id: @project_owner.id
+
+    sign_in @teacher
+    get :project_comments, params: {
+      channel_id: @project_owner_channel_id,
+      project_version: @project_version_string
+    }
+
+    assert_response :success
+    assert_equal 3, JSON.parse(response.body).length
+  end
+
   test 'student not in same section as project owner cannot fetch project comments' do
     stub_storage_apps_calls
     setup_project_comments_tests

--- a/dashboard/test/controllers/code_review_comments_controller_test.rb
+++ b/dashboard/test/controllers/code_review_comments_controller_test.rb
@@ -149,7 +149,7 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
     assert_response :forbidden
   end
 
-  test 'project owner can fetch project comments for their projects' do
+  test 'project owner can fetch peer project comments for their projects' do
     stub_storage_apps_calls
     setup_project_comments_tests
 
@@ -163,7 +163,27 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
     assert_equal 2, JSON.parse(response.body).length
   end
 
-  test 'student in same section as project owner can fetch non-teacher project comments' do
+  test 'project owner can see teacher comments' do
+    stub_storage_apps_calls
+    setup_project_comments_tests
+
+    create :follower, student_user: @project_owner, section: @section
+
+    teacher_comment = create :code_review_comment,
+      commenter: @teacher,
+      storage_app_id: @project_storage_app_id,
+      project_version: @project_version_string,
+      project_owner_id: @project_owner.id
+
+    sign_in @project_owner
+    get :project_comments, params: {channel_id: @project_owner_channel_id}
+
+    comment_ids = JSON.parse(response.body).map {|comment| comment['id']}
+    assert_equal 3, JSON.parse(response.body).length
+    assert_includes comment_ids, teacher_comment.id
+  end
+
+  test 'student in same section as project owner can see non-teacher project comments' do
     stub_storage_apps_calls
     setup_project_comments_tests
 
@@ -179,6 +199,28 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
 
     assert_response :success
     assert_equal 2, JSON.parse(response.body).length
+  end
+
+  test 'student in same section as project owner cannot see teacher comments' do
+    stub_storage_apps_calls
+    setup_project_comments_tests
+
+    [@project_owner, @another_student].each do |student|
+      create :follower, student_user: student, section: @section
+    end
+
+    teacher_comment = create :code_review_comment,
+      commenter: @teacher,
+      storage_app_id: @project_storage_app_id,
+      project_version: @project_version_string,
+      project_owner_id: @project_owner.id
+
+    sign_in @another_student
+    get :project_comments, params: {channel_id: @project_owner_channel_id}
+
+    comment_ids = JSON.parse(response.body).map {|comment| comment['id']}
+    assert_equal 2, JSON.parse(response.body).length
+    refute_includes comment_ids, teacher_comment.id
   end
 
   test 'teacher of section project owner is enrolled in can fetch project comments' do
@@ -221,28 +263,6 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
     }
 
     assert_response :forbidden
-  end
-
-  test 'peer of project owner sees comments without teacher comments' do
-    stub_storage_apps_calls
-    setup_project_comments_tests
-
-    [@project_owner, @another_student].each do |student|
-      create :follower, student_user: student, section: @section
-    end
-
-    teacher_comment = create :code_review_comment,
-      commenter: @teacher,
-      storage_app_id: @project_storage_app_id,
-      project_version: @project_version_string,
-      project_owner_id: @project_owner.id
-
-    sign_in @another_student
-    get :project_comments, params: {channel_id: @project_owner_channel_id}
-
-    comment_ids = JSON.parse(response.body).map {|comment| comment['id']}
-    assert_equal 2, JSON.parse(response.body).length
-    refute_includes comment_ids, teacher_comment.id
   end
 
   private


### PR DESCRIPTION
When pulling down code review comments, exclude teacher comments when one student in a section is viewing another student's project. This is the requested behavior for this feature, such that students (other than the project owner) cannot see teacher comments on the project owner's project.

## Testing story

Added new controller tests to cover this situation.