### PR TITLE
Migration: Create backpacks table 

### DIFF
--- a/dashboard/app/models/backpack.rb
+++ b/dashboard/app/models/backpack.rb
@@ -1,0 +1,16 @@
+# == Schema Information
+#
+# Table name: backpacks
+#
+#  id             :bigint           not null, primary key
+#  user_id        :integer          not null
+#  storage_app_id :integer          not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#
+# Indexes
+#
+#  index_backpacks_on_user_id  (user_id)
+#
+class Backpack < ApplicationRecord
+end

--- a/dashboard/app/models/backpack.rb
+++ b/dashboard/app/models/backpack.rb
@@ -2,11 +2,11 @@
 #
 # Table name: backpacks
 #
-#  id             :bigint           not null, primary key
-#  user_id        :integer          not null
-#  storage_app_id :integer          not null
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
+#  id               :bigint           not null, primary key
+#  user_id          :integer          not null
+#  channel_token_id :integer          not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #
 # Indexes
 #

--- a/dashboard/app/models/backpack.rb
+++ b/dashboard/app/models/backpack.rb
@@ -2,11 +2,11 @@
 #
 # Table name: backpacks
 #
-#  id               :bigint           not null, primary key
-#  user_id          :integer          not null
-#  channel_token_id :integer          not null
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
+#  id             :bigint           not null, primary key
+#  user_id        :integer          not null
+#  storage_app_id :integer          not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
 #
 # Indexes
 #

--- a/dashboard/db/migrate/20210719221440_create_backpacks.rb
+++ b/dashboard/db/migrate/20210719221440_create_backpacks.rb
@@ -1,0 +1,10 @@
+class CreateBackpacks < ActiveRecord::Migration[5.2]
+  def change
+    create_table :backpacks do |t|
+      t.integer :user_id, index: true, unique: true, null: false
+      t.integer :storage_app_id, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/dashboard/db/migrate/20210719221440_create_backpacks.rb
+++ b/dashboard/db/migrate/20210719221440_create_backpacks.rb
@@ -2,7 +2,7 @@ class CreateBackpacks < ActiveRecord::Migration[5.2]
   def change
     create_table :backpacks do |t|
       t.integer :user_id, index: true, unique: true, null: false
-      t.integer :channel_token_id, null: false
+      t.integer :storage_app_id, null: false
 
       t.timestamps
     end

--- a/dashboard/db/migrate/20210719221440_create_backpacks.rb
+++ b/dashboard/db/migrate/20210719221440_create_backpacks.rb
@@ -2,7 +2,7 @@ class CreateBackpacks < ActiveRecord::Migration[5.2]
   def change
     create_table :backpacks do |t|
       t.integer :user_id, index: true, unique: true, null: false
-      t.integer :storage_app_id, null: false
+      t.integer :channel_token_id, null: false
 
       t.timestamps
     end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -114,7 +114,7 @@ ActiveRecord::Schema.define(version: 2021_07_19_221440) do
 
   create_table "backpacks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
-    t.integer "channel_token_id", null: false
+    t.integer "storage_app_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_backpacks_on_user_id"

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_15_223451) do
+ActiveRecord::Schema.define(version: 2021_07_19_221440) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -110,6 +110,14 @@ ActiveRecord::Schema.define(version: 2021_07_15_223451) do
     t.index ["level_id"], name: "fk_rails_8f51960e09"
     t.index ["script_id", "level_id"], name: "index_authored_hint_view_requests_on_script_id_and_level_id"
     t.index ["user_id", "script_id", "level_id", "hint_id"], name: "index_authored_hint_view_requests_on_all_related_ids"
+  end
+
+  create_table "backpacks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "storage_app_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_backpacks_on_user_id"
   end
 
   create_table "blocks", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -114,7 +114,7 @@ ActiveRecord::Schema.define(version: 2021_07_19_221440) do
 
   create_table "backpacks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
-    t.integer "storage_app_id", null: false
+    t.integer "channel_token_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_backpacks_on_user_id"


### PR DESCRIPTION
Create the new table needed to store backpack storage_app_ids per user. Each user can have at most one storage_app_id that is defined as their backpack. This will be used to store files that students can use across multiple projects in CSA.

Note: the spec had the `channel_id` as the second column in the table, but I changed that here to be `storage_app_id` instead so we don't store the encrypted token in the table. We can find the encrypted token based on the `user_id` and `storage_app_id`.

## Links

- spec: [Backpack](https://docs.google.com/document/d/1Y01X2_rrVt8f4y8yHpm3BBpq31Ra9CSkOLYycwQ5or8/edit#)
- jira ticket: [CSA-521](https://codedotorg.atlassian.net/browse/CSA-521)

## PR Checklist:


- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
