### PR TITLE
[React upgrade] fix errors in Storybook tests

### DIFF
--- a/apps/src/code-studio/components/GridEditor.story.jsx
+++ b/apps/src/code-studio/components/GridEditor.story.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import GridEditor from './GridEditor';
 import {withInfo} from '@storybook/addon-info';
+import {allowConsoleWarnings} from '../../../test/util/testUtils';
 
 export default storybook => {
+  allowConsoleWarnings();
   const starWarsGrid = [
     [16908288, 16908288, 0, 0, 0, 0, 0, 0],
     [16908288, 16908288, 0, 65536, 131072, 1048576, 0, 0],

--- a/apps/src/code-studio/components/ShareAllowedDialog.jsx
+++ b/apps/src/code-studio/components/ShareAllowedDialog.jsx
@@ -282,7 +282,7 @@ class ShareAllowedDialog extends React.Component {
                       type="text"
                       id="sharing-input"
                       onClick={select}
-                      readOnly={true}
+                      readOnly
                       value={this.props.shareUrl}
                       style={{cursor: 'copy', width: 500}}
                     />

--- a/apps/src/code-studio/components/ShareAllowedDialog.jsx
+++ b/apps/src/code-studio/components/ShareAllowedDialog.jsx
@@ -282,7 +282,7 @@ class ShareAllowedDialog extends React.Component {
                       type="text"
                       id="sharing-input"
                       onClick={select}
-                      readOnly="true"
+                      readOnly={true}
                       value={this.props.shareUrl}
                       style={{cursor: 'copy', width: 500}}
                     />

--- a/apps/src/code-studio/components/progress/ResourcesDropdown.story.jsx
+++ b/apps/src/code-studio/components/progress/ResourcesDropdown.story.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ResourcesDropdown from './ResourcesDropdown';
 import ResourceType from '@cdo/apps/templates/courseOverview/resourceType';
+import {allowConsoleWarnings} from '../../../../test/util/testUtils';
 
 const legacySampleResources = [
   {
@@ -26,7 +27,8 @@ const migratedSampleResources = [
   }
 ];
 
-export default storybook =>
+export default storybook => {
+  allowConsoleWarnings();
   storybook.storiesOf('ResourcesDropdown', module).addStoryTable([
     {
       name: 'unmigrated teacher resources',
@@ -63,3 +65,4 @@ export default storybook =>
       )
     }
   ]);
+};

--- a/apps/src/code-studio/pd/application_dashboard/workshop_assignment_select.story.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/workshop_assignment_select.story.jsx
@@ -2,8 +2,10 @@ import React from 'react';
 import {action} from '@storybook/addon-actions';
 import WorkshopAssignmentSelect from './workshop_assignment_select';
 import reactBootstrapStoryDecorator from '../reactBootstrapStoryDecorator';
+import {allowConsoleWarnings} from '../../../../test/util/testUtils';
 
 export default storybook => {
+  allowConsoleWarnings();
   storybook
     .storiesOf('WorkshopAssignmentSelect', module)
     .addDecorator(reactBootstrapStoryDecorator)

--- a/apps/src/lib/levelbuilder/lesson-editor/ActivitiesEditor.story.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivitiesEditor.story.jsx
@@ -16,6 +16,7 @@ import {
   sampleActivityForLessonWithoutLessonPlan,
   searchOptions
 } from '../../../../test/unit/lib/levelbuilder/lesson-editor/activitiesTestData';
+import {allowConsoleWarnings} from '../../../../test/util/testUtils';
 
 const resourcesEditor = createResourcesReducer('lessonResource');
 
@@ -47,6 +48,7 @@ const createStoreWithoutLessonPlan = () => {
   return store;
 };
 export default storybook => {
+  allowConsoleWarnings();
   storybook.storiesOf('ActivitiesEditor', module).addStoryTable([
     {
       name: 'ActivitiesEditor For Lesson With Lesson Plan',

--- a/apps/src/lib/tools/jsdebugger/JsDebugger.story.jsx
+++ b/apps/src/lib/tools/jsdebugger/JsDebugger.story.jsx
@@ -5,6 +5,7 @@ import commonReducers from '../../../redux/commonReducers';
 import {reducers as applabReducers} from '../../../applab/redux/applab';
 import {setPageConstants} from '../../../redux/pageConstants';
 import JsDebugger from './JsDebugger';
+import {allowConsoleWarnings} from '../../../../test/util/testUtils';
 
 function createApplabStore() {
   return createStore(
@@ -16,6 +17,7 @@ function createApplabStore() {
 }
 
 export default storybook => {
+  allowConsoleWarnings();
   const storyTable = [];
 
   const storybookStyle = {

--- a/apps/src/templates/NavigationBar.story.jsx
+++ b/apps/src/templates/NavigationBar.story.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import {BrowserRouter as Router} from 'react-router-dom';
 import TeacherDashboardNavigation from './teacherDashboard/TeacherDashboardNavigation';
+import {allowConsoleWarnings} from '../../test/util/testUtils';
 
 export default storybook => {
+  allowConsoleWarnings();
   return storybook.storiesOf('NavigationBar', module).addStoryTable([
     {
       name: 'Navigation Bar',

--- a/apps/src/templates/instructions/InstructionsCSF.jsx
+++ b/apps/src/templates/instructions/InstructionsCSF.jsx
@@ -328,8 +328,7 @@ class InstructionsCSF extends React.Component {
           />
           <InstructionsCsfMiddleCol
             ref={instructions =>
-              (this.instructions =
-                instructions && instructions.getWrappedInstance().instructions)
+              (this.instructions = instructions && instructions.instructions)
             }
             dismissHintPrompt={this.dismissHintPrompt}
             shouldDisplayHintPrompt={this.shouldDisplayHintPrompt}

--- a/apps/src/templates/instructions/InstructionsCSF.jsx
+++ b/apps/src/templates/instructions/InstructionsCSF.jsx
@@ -328,7 +328,7 @@ class InstructionsCSF extends React.Component {
           />
           <InstructionsCsfMiddleCol
             ref={instructions =>
-              (this.instructions = instructions && instructions.instructions)
+              (this.instructions = instructions?.instructions)
             }
             dismissHintPrompt={this.dismissHintPrompt}
             shouldDisplayHintPrompt={this.shouldDisplayHintPrompt}

--- a/apps/src/templates/progress/ProgressDetailToggle.jsx
+++ b/apps/src/templates/progress/ProgressDetailToggle.jsx
@@ -109,6 +109,8 @@ const styles = {
   }
 };
 
+export const UnconnectedProgressDetailToggle = ProgressDetailToggle;
+
 export default connect(
   state => ({
     isPlc: !!state.progress.professionalLearningCourse,

--- a/apps/src/templates/progress/ProgressDetailToggle.story.jsx
+++ b/apps/src/templates/progress/ProgressDetailToggle.story.jsx
@@ -1,113 +1,59 @@
 import React from 'react';
-import ProgressDetailToggle from './ProgressDetailToggle';
-import {Provider} from 'react-redux';
-import {combineReducers, createStore} from 'redux';
+import {
+  UnconnectedProgressDetailToggle as ProgressDetailToggle
+} from './ProgressDetailToggle';
 import progress, {setIsSummaryView} from '@cdo/apps/code-studio/progressRedux';
 
 export default storybook => {
-  const initialState = {
-    progress: {
-      lessonGroups: [],
-      lessons: [
-        {
-          levels: []
-        }
-      ],
-      focusAreaLessonIds: [],
-      professionalLearningCourse: false
-    }
-  };
-
-  const initialStateGrouped = {
-    progress: {
-      lessonGroups: [
-        {
-          display_name: 'cat1',
-          id: 1,
-          description: 'This is a description',
-          big_questions: 'What?'
-        },
-        {
-          display_name: 'cat2',
-          id: 2,
-          description: 'This is another description',
-          big_questions: 'Why?'
-        }
-      ],
-      lessons: [
-        {
-          lesson_group_display_name: 'cat1',
-          levels: []
-        },
-        {
-          lesson_group_display_name: 'cat2',
-          levels: []
-        }
-      ],
-      focusAreaLessonIds: [],
-      professionalLearningCourse: false
-    }
-  };
-
-  function isSummaryTrue() {
-    const store = createStore(combineReducers({progress}), initialState);
-    store.dispatch(setIsSummaryView(true));
-    return {
-      name: 'isSummary is true',
-      story: () => (
-        <Provider store={store}>
-          <ProgressDetailToggle />
-        </Provider>
-      )
-    };
-  }
-
-  function isSummaryFalse() {
-    const store = createStore(combineReducers({progress}), initialState);
-    store.dispatch(setIsSummaryView(false));
-    return {
-      name: 'isSummary is false',
-      story: () => (
-        <Provider store={store}>
-          <ProgressDetailToggle />
-        </Provider>
-      )
-    };
-  }
-
-  function isSummaryTrueGrouped() {
-    const store = createStore(combineReducers({progress}), initialStateGrouped);
-    store.dispatch(setIsSummaryView(true));
-    return {
-      name: 'isSummary is true with groups',
-      story: () => (
-        <Provider store={store}>
-          <ProgressDetailToggle />
-        </Provider>
-      )
-    };
-  }
-
-  function isSummaryFalseGrouped() {
-    const store = createStore(combineReducers({progress}), initialStateGrouped);
-    store.dispatch(setIsSummaryView(false));
-    return {
-      name: 'isSummary is false with groups',
-      story: () => (
-        <Provider store={store}>
-          <ProgressDetailToggle />
-        </Provider>
-      )
-    };
-  }
-
   storybook
     .storiesOf('Progress/ProgressDetailToggle', module)
-    .withReduxStore()
+    .withReduxStore({progress})
     .addStoryTable([
-      isSummaryTrue(),
-      isSummaryFalse(),
-      isSummaryTrueGrouped(),
-      isSummaryFalseGrouped()
+      {
+        name: 'isSummary is true',
+        story: () => {
+          return (
+            <ProgressDetailToggle
+              isPlc={false}
+              isSummaryView
+              hasGroups={false}
+              setIsSummaryView={setIsSummaryView}
+            />
+          );
+        }
+      },
+      {
+        name: 'isSummary is false',
+        story: () => (
+          <ProgressDetailToggle
+            isPlc={false}
+            isSummaryView={false}
+            hasGroups={false}
+            setIsSummaryView={setIsSummaryView}
+          />
+        )
+      },
+      {
+        name: 'isSummary is true with groups',
+        story: () => (
+          <ProgressDetailToggle
+            isPlc={false}
+            isSummaryView
+            hasGroups
+            setIsSummaryView={setIsSummaryView}
+          />
+        )
+      },
+      {
+        name: 'isSummary is false with groups',
+        story: () => (
+          <ProgressDetailToggle
+            isPlc={false}
+            isSummaryView={false}
+            hasGroups
+            setIsSummaryView={setIsSummaryView}
+          />
+        )
+      }
     ]);
 };

--- a/apps/src/templates/progress/ProgressDetailToggle.story.jsx
+++ b/apps/src/templates/progress/ProgressDetailToggle.story.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
-import {
-  UnconnectedProgressDetailToggle as ProgressDetailToggle
-} from './ProgressDetailToggle';
+import {UnconnectedProgressDetailToggle as ProgressDetailToggle} from './ProgressDetailToggle';
 import progress, {setIsSummaryView} from '@cdo/apps/code-studio/progressRedux';
 
 export default storybook => {

--- a/apps/src/templates/progress/ProgressDetailToggle.story.jsx
+++ b/apps/src/templates/progress/ProgressDetailToggle.story.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ProgressDetailToggle from './ProgressDetailToggle';
+import {Provider} from 'react-redux';
 import {combineReducers, createStore} from 'redux';
 import progress, {setIsSummaryView} from '@cdo/apps/code-studio/progressRedux';
 
@@ -53,7 +54,11 @@ export default storybook => {
     store.dispatch(setIsSummaryView(true));
     return {
       name: 'isSummary is true',
-      story: () => <ProgressDetailToggle store={store} />
+      story: () => (
+        <Provider store={store}>
+          <ProgressDetailToggle />
+        </Provider>
+      )
     };
   }
 
@@ -62,7 +67,11 @@ export default storybook => {
     store.dispatch(setIsSummaryView(false));
     return {
       name: 'isSummary is false',
-      story: () => <ProgressDetailToggle store={store} />
+      story: () => (
+        <Provider store={store}>
+          <ProgressDetailToggle />
+        </Provider>
+      )
     };
   }
 
@@ -71,7 +80,11 @@ export default storybook => {
     store.dispatch(setIsSummaryView(true));
     return {
       name: 'isSummary is true with groups',
-      story: () => <ProgressDetailToggle store={store} />
+      story: () => (
+        <Provider store={store}>
+          <ProgressDetailToggle />
+        </Provider>
+      )
     };
   }
 
@@ -80,7 +93,11 @@ export default storybook => {
     store.dispatch(setIsSummaryView(false));
     return {
       name: 'isSummary is false with groups',
-      story: () => <ProgressDetailToggle store={store} />
+      story: () => (
+        <Provider store={store}>
+          <ProgressDetailToggle />
+        </Provider>
+      )
     };
   }
 

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableView.story.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableView.story.jsx
@@ -5,6 +5,7 @@ import ProgressTableView from '@cdo/apps/templates/sectionProgress/progressTable
 import SectionProgressToggle from '@cdo/apps/templates/sectionProgress/SectionProgressToggle';
 import {ViewType} from '@cdo/apps/templates/sectionProgress/sectionProgressConstants';
 import {createStore} from '../sectionProgressTestHelpers';
+import {allowConsoleWarnings} from '../../../../test/util/testUtils';
 
 /**
  * The variety of stories here can be useful during development, but add
@@ -41,6 +42,7 @@ const TableWrapper = connect(state => ({
 }))(_TableWrapper);
 
 function buildSmallStories() {
+  allowConsoleWarnings();
   return [
     {
       name: `Small section, small script`,

--- a/apps/src/templates/teacherDashboard/LoginTypeCard.jsx
+++ b/apps/src/templates/teacherDashboard/LoginTypeCard.jsx
@@ -21,35 +21,31 @@ class LoginTypeCard extends Component {
 
   render() {
     const {title, subtitle, description, onClick} = this.props;
-    const cardStyles = {...styles.card};
-    const titleStyles = {...styles.title};
-    const subtitleStyles = {...styles.subtitle};
-    const descriptionStyles = {...styles.description};
 
     if (this.state.hover) {
-      cardStyles.borderColor = color.dark_charcoal;
-      titleStyles.color = color.dark_charcoal;
-      subtitleStyles.color = color.dark_charcoal;
-      descriptionStyles.color = color.dark_charcoal;
+      styles.card.borderColor = color.dark_charcoal;
+      styles.title.color = color.dark_charcoal;
+      styles.subtitle.color = color.dark_charcoal;
+      styles.description.color = color.dark_charcoal;
     } else {
-      cardStyles.borderColor = color.border_gray;
-      titleStyles.color = color.charcoal;
-      subtitleStyles.color = color.charcoal;
-      descriptionStyles.color = color.charcoal;
+      styles.card.borderColor = color.border_gray;
+      styles.title.color = color.charcoal;
+      styles.subtitle.color = color.charcoal;
+      styles.description.color = color.charcoal;
     }
 
     return (
       <div
-        style={cardStyles}
+        style={styles.card}
         onClick={onClick}
         onMouseEnter={this.toggleHover}
         onMouseLeave={this.toggleHover}
         className={this.props.className}
       >
         <div>
-          <div style={titleStyles}>{title}</div>
-          {subtitle && <div style={subtitleStyles}>{subtitle}</div>}
-          <div style={descriptionStyles}>{description}</div>
+          <div style={styles.title}>{title}</div>
+          {subtitle && <div style={styles.subtitle}>{subtitle}</div>}
+          <div style={styles.description}>{description}</div>
         </div>
       </div>
     );

--- a/apps/src/templates/teacherDashboard/LoginTypeCard.jsx
+++ b/apps/src/templates/teacherDashboard/LoginTypeCard.jsx
@@ -21,31 +21,35 @@ class LoginTypeCard extends Component {
 
   render() {
     const {title, subtitle, description, onClick} = this.props;
+    const cardStyles = {...styles.card};
+    const titleStyles = {...styles.title};
+    const subtitleStyles = {...styles.subtitle};
+    const descriptionStyles = {...styles.description};
 
     if (this.state.hover) {
-      styles.card.borderColor = color.dark_charcoal;
-      styles.title.color = color.dark_charcoal;
-      styles.subtitle.color = color.dark_charcoal;
-      styles.description.color = color.dark_charcoal;
+      cardStyles.borderColor = color.dark_charcoal;
+      titleStyles.color = color.dark_charcoal;
+      subtitleStyles.color = color.dark_charcoal;
+      descriptionStyles.color = color.dark_charcoal;
     } else {
-      styles.card.borderColor = color.border_gray;
-      styles.title.color = color.charcoal;
-      styles.subtitle.color = color.charcoal;
-      styles.description.color = color.charcoal;
+      cardStyles.borderColor = color.border_gray;
+      titleStyles.color = color.charcoal;
+      subtitleStyles.color = color.charcoal;
+      descriptionStyles.color = color.charcoal;
     }
 
     return (
       <div
-        style={styles.card}
+        style={cardStyles}
         onClick={onClick}
         onMouseEnter={this.toggleHover}
         onMouseLeave={this.toggleHover}
         className={this.props.className}
       >
         <div>
-          <div style={styles.title}>{title}</div>
-          {subtitle && <div style={styles.subtitle}>{subtitle}</div>}
-          <div style={styles.description}>{description}</div>
+          <div style={titleStyles}>{title}</div>
+          {subtitle && <div style={subtitleStyles}>{subtitle}</div>}
+          <div style={descriptionStyles}>{description}</div>
         </div>
       </div>
     );


### PR DESCRIPTION
**InstructionsCSF**
`If {forwardRef : true} has been passed to connect, adding a ref to the connected wrapper component will actually return the instance of the wrapped component.` ([react-redux docs](https://react-redux.js.org/api/connect#forwardref-boolean)) which means we don't need `getWrappedInstance` because it is no longer a function. 

**ProgressDetailToggle**
Fixed the error: `Passing redux store in props has been removed and does not do anything. 
To use a custom Redux store for specific components, create a custom React context with React.createContext(), and pass the context object to React-Redux's Provider and specific components like: 
<Provider context={MyContext}><ConnectedComponent context={MyContext} /></Provider>. 
You may also pass a {context : MyContext} option to connect`


- allow console warnings in Stories because some components currently use UNSAFE lifecycle methods