### PR TITLE
Fix recommended course

### DIFF
--- a/apps/src/code-studio/components/progress/UnitOverviewHeader.jsx
+++ b/apps/src/code-studio/components/progress/UnitOverviewHeader.jsx
@@ -59,7 +59,7 @@ class UnitOverviewHeader extends Component {
     isSignedIn: PropTypes.bool.isRequired,
     isVerifiedTeacher: PropTypes.bool.isRequired,
     hasVerifiedResources: PropTypes.bool.isRequired,
-    localeEnglishName: PropTypes.string
+    localeCode: PropTypes.string
   };
 
   componentDidMount() {
@@ -133,7 +133,7 @@ class UnitOverviewHeader extends Component {
     );
     setRecommendedAndSelectedVersions(
       filteredVersions,
-      this.props.localeEnglishName,
+      this.props.localeCode,
       selectedVersion && selectedVersion.year
     );
 
@@ -272,5 +272,5 @@ export default connect(state => ({
   viewAs: state.viewAs,
   isVerifiedTeacher: state.verifiedTeacher.isVerified,
   hasVerifiedResources: state.verifiedTeacher.hasVerifiedResources,
-  localeEnglishName: state.locales.localeEnglishName
+  localeCode: state.locales.localeCode
 }))(UnitOverviewHeader);

--- a/apps/src/redux/localesRedux.js
+++ b/apps/src/redux/localesRedux.js
@@ -1,7 +1,6 @@
 // Action type constants
 
 const SET_LOCALE_CODE = 'locale/SET_LOCALE_CODE';
-const SET_LOCALE_ENGLISH_NAME = 'locale/SET_LOCALE_ENGLISH_NAME';
 
 // Action creators
 
@@ -10,18 +9,11 @@ export const setLocaleCode = localeCode => ({
   localeCode
 });
 
-export const setLocaleEnglishName = localeEnglishName => ({
-  type: SET_LOCALE_ENGLISH_NAME,
-  localeEnglishName
-});
-
 // Initial state of localesRedux
 
 const initialState = {
   // locale code like 'en-US', 'es-MX', or null if none is specified.
-  localeCode: null,
-  // The english name for this locale.
-  localeEnglishName: null
+  localeCode: null
 };
 
 export default function reducer(state = initialState, action) {
@@ -29,12 +21,6 @@ export default function reducer(state = initialState, action) {
     return {
       ...state,
       localeCode: action.localeCode
-    };
-  }
-  if (action.type === SET_LOCALE_ENGLISH_NAME) {
-    return {
-      ...state,
-      localeEnglishName: action.localeEnglishName
     };
   }
   return state;

--- a/apps/src/sites/studio/pages/home/_homepage.js
+++ b/apps/src/sites/studio/pages/home/_homepage.js
@@ -23,10 +23,7 @@ import currentUser, {
 } from '@cdo/apps/templates/currentUserRedux';
 import {initializeHiddenScripts} from '@cdo/apps/code-studio/hiddenLessonRedux';
 import {updateQueryParam} from '@cdo/apps/code-studio/utils';
-import locales, {
-  setLocaleCode,
-  setLocaleEnglishName
-} from '@cdo/apps/redux/localesRedux';
+import locales, {setLocaleCode} from '@cdo/apps/redux/localesRedux';
 import mapboxReducer, {setMapboxAccessToken} from '@cdo/apps/redux/mapbox';
 
 $(document).ready(showHomepage);
@@ -49,7 +46,6 @@ function showHomepage() {
   store.dispatch(initializeHiddenScripts(homepageData.hiddenScripts));
   store.dispatch(setPageType(pageTypes.homepage));
   store.dispatch(setLocaleCode(homepageData.localeCode));
-  store.dispatch(setLocaleEnglishName(homepageData.locale));
   store.dispatch(setCurrentUserId(homepageData.currentUserId));
 
   // DCDO Flag - show/hide Lock Section field

--- a/apps/src/sites/studio/pages/scripts/show.js
+++ b/apps/src/sites/studio/pages/scripts/show.js
@@ -16,7 +16,7 @@ import {
 } from '@cdo/apps/code-studio/verifiedTeacherRedux';
 import {tooltipifyVocabulary} from '@cdo/apps/utils';
 
-import locales, {setLocaleEnglishName} from '../../../../redux/localesRedux';
+import locales, {setLocaleCode} from '../../../../redux/localesRedux';
 
 $(document).ready(initPage);
 
@@ -27,7 +27,7 @@ function initPage() {
   const {scriptData, plcBreadcrumb} = config;
   const store = getStore();
   registerReducers({locales});
-  store.dispatch(setLocaleEnglishName(scriptData.locale));
+  store.dispatch(setLocaleCode(scriptData.locale_code));
 
   if (plcBreadcrumb) {
     // Dispatch breadcrumb props so that UnitOverviewHeader can add the breadcrumb

--- a/apps/src/templates/teacherDashboard/AssignmentSelector.jsx
+++ b/apps/src/templates/teacherDashboard/AssignmentSelector.jsx
@@ -40,7 +40,8 @@ const getVersion = assignment => ({
   year: assignment.version_year,
   title: assignment.version_title,
   isStable: assignment.is_stable,
-  locales: assignment.supported_locales || []
+  locales: assignment.supported_locales || [],
+  localeCodes: assignment.supported_locale_codes || []
 });
 
 /**
@@ -56,7 +57,7 @@ export default class AssignmentSelector extends Component {
     dropdownStyle: PropTypes.object,
     onChange: PropTypes.func,
     disabled: PropTypes.bool,
-    localeEnglishName: PropTypes.string,
+    localeCode: PropTypes.string,
     isNewSection: PropTypes.bool
   };
 
@@ -87,7 +88,7 @@ export default class AssignmentSelector extends Component {
 
     return setRecommendedAndSelectedVersions(
       versions,
-      this.props.localeEnglishName,
+      this.props.localeCode,
       selectedVersionYear
     );
   };

--- a/apps/src/templates/teacherDashboard/AssignmentVersionSelector.jsx
+++ b/apps/src/templates/teacherDashboard/AssignmentVersionSelector.jsx
@@ -19,12 +19,12 @@ const menuWidth = menuItemWidth + 2 * STANDARD_PADDING;
  * isRecommended and isSelected properties set on the recommended and selected version(s).
  * Note: This method will change the content of the versions array that is passed to it.
  * @param {Array<AssignmentVersionShape>} versions
- * @param {String} localeEnglishName. English name of user's current locale.
+ * @param {String} localeCode. The user's "??-??" locale code.
  * @param {String} selectedVersionYear. Currently selected version year. Optional.
  */
 export const setRecommendedAndSelectedVersions = (
   versions,
-  localeEnglishName = null,
+  localeCode = null,
   selectedVersionYear = null
 ) => {
   // Sort versions by year descending.
@@ -38,11 +38,11 @@ export const setRecommendedAndSelectedVersions = (
    * Versions are sorted from most to least recent, so the first stable version will be the latest.
    */
   let recommendedVersion;
-  if (localeEnglishName) {
+  if (localeCode) {
     recommendedVersion = versions.find(v => {
       const localeSupported =
-        (v.locales || []).includes(localeEnglishName) ||
-        localeEnglishName.toLowerCase().startsWith('en');
+        (v.localeCodes || []).includes(localeCode) ||
+        localeCode.startsWith('en');
 
       return v.isStable && localeSupported;
     });

--- a/apps/src/templates/teacherDashboard/AssignmentVersionSelector.story.jsx
+++ b/apps/src/templates/teacherDashboard/AssignmentVersionSelector.story.jsx
@@ -13,6 +13,7 @@ const defaultVersions = [
     year: '2019',
     title: "19'-20'",
     isStable: false,
+    localeCodes: [],
     locales: []
   },
   {
@@ -21,6 +22,7 @@ const defaultVersions = [
     isStable: true,
     isRecommended: true,
     isSelected: false,
+    localeCodes: ['en-US'],
     locales: ['English']
   },
   {
@@ -29,7 +31,8 @@ const defaultVersions = [
     isStable: true,
     isRecommended: false,
     isSelected: true,
-    locales: ['English', 'French', 'Spanish']
+    localeCodes: ['en-US', 'fr-FR', 'es-MX'],
+    locales: ['English', 'Français', 'Español (Latinoamérica)']
   }
 ];
 

--- a/apps/src/templates/teacherDashboard/EditSectionForm.jsx
+++ b/apps/src/templates/teacherDashboard/EditSectionForm.jsx
@@ -75,7 +75,6 @@ class EditSectionForm extends Component {
     hiddenLessonState: PropTypes.object.isRequired,
     assignedUnitName: PropTypes.string.isRequired,
     updateHiddenScript: PropTypes.func.isRequired,
-    localeEnglishName: PropTypes.string,
     localeCode: PropTypes.string,
     showLockSectionField: PropTypes.bool // DCDO Flag - show/hide Lock Section field
   };
@@ -167,9 +166,8 @@ class EditSectionForm extends Component {
       lessonExtrasAvailable,
       textToSpeechUnitIds,
       assignedUnitName,
-      localeEnglishName,
-      isNewSection,
       localeCode,
+      isNewSection,
       showLockSectionField // DCDO Flag - show/hide Lock Section field
     } = this.props;
 
@@ -239,7 +237,7 @@ class EditSectionForm extends Component {
             validAssignments={validAssignments}
             assignmentFamilies={assignmentFamilies}
             disabled={isSaveInProgress}
-            localeEnglishName={localeEnglishName}
+            localeCode={localeCode}
             isNewSection={isNewSection}
           />
           {lessonExtrasAvailable(section.scriptId) && (
@@ -403,7 +401,7 @@ const AssignmentField = ({
   validAssignments,
   assignmentFamilies,
   disabled,
-  localeEnglishName,
+  localeCode,
   isNewSection
 }) => (
   <div>
@@ -417,7 +415,7 @@ const AssignmentField = ({
       chooseLaterOption={true}
       dropdownStyle={style.dropdown}
       disabled={disabled}
-      localeEnglishName={localeEnglishName}
+      localeCode={localeCode}
       isNewSection={isNewSection}
     />
   </div>
@@ -428,7 +426,7 @@ AssignmentField.propTypes = {
   validAssignments: PropTypes.objectOf(assignmentShape).isRequired,
   assignmentFamilies: PropTypes.arrayOf(assignmentFamilyShape).isRequired,
   disabled: PropTypes.bool,
-  localeEnglishName: PropTypes.string,
+  localeCode: PropTypes.string,
   isNewSection: PropTypes.bool
 };
 
@@ -580,7 +578,6 @@ let defaultPropsFromState = state => ({
   lessonExtrasAvailable: id => lessonExtrasAvailable(state, id),
   hiddenLessonState: state.hiddenLesson,
   assignedUnitName: assignedUnitName(state),
-  localeEnglishName: state.locales.localeEnglishName,
   localeCode: state.locales.localeCode,
 
   // DCDO Flag - show/hide Lock Section field

--- a/apps/src/templates/teacherDashboard/shapes.jsx
+++ b/apps/src/templates/teacherDashboard/shapes.jsx
@@ -64,7 +64,8 @@ export const assignmentShape = PropTypes.shape({
   version_year: PropTypes.string,
   version_title: PropTypes.string,
   is_stable: PropTypes.bool,
-  supported_locales: PropTypes.arrayOf(PropTypes.string)
+  supported_locales: PropTypes.arrayOf(PropTypes.string),
+  supported_locale_codes: PropTypes.arrayOf(PropTypes.string)
 });
 
 // An assignment family is a collection of versions of a course or script like
@@ -92,6 +93,7 @@ export const assignmentVersionShape = PropTypes.shape({
   isRecommended: PropTypes.bool,
   isSelected: PropTypes.bool,
   locales: PropTypes.arrayOf(PropTypes.string).isRequired,
+  localeCodes: PropTypes.arrayOf(PropTypes.string).isRequired,
   canViewVersion: PropTypes.bool
 });
 
@@ -105,6 +107,7 @@ export const convertAssignmentVersionShapeFromServer = serverVersions => {
       title: v.version_title,
       isStable: v.is_stable,
       locales: v.locales || [],
+      localeCodes: v.locale_codes || [],
       canViewVersion: v.can_view_version
     };
   });

--- a/apps/test/unit/code-studio/components/progress/UnitOverviewHeaderTest.js
+++ b/apps/test/unit/code-studio/components/progress/UnitOverviewHeaderTest.js
@@ -114,6 +114,7 @@ describe('UnitOverviewHeader', () => {
         title: '2017',
         isStable: true,
         locales: ['English', 'Italian'],
+        localeCodes: ['en-US', 'it-IT'],
         canViewVersion: true
       },
       {
@@ -122,6 +123,7 @@ describe('UnitOverviewHeader', () => {
         title: '2018',
         isStable: true,
         locales: ['English'],
+        localeCodes: ['en-US'],
         canViewVersion: true
       },
       {
@@ -130,6 +132,7 @@ describe('UnitOverviewHeader', () => {
         title: '2019',
         isStable: false,
         locales: [],
+        localeCodes: [],
         canViewVersion: false
       }
     ];
@@ -138,7 +141,7 @@ describe('UnitOverviewHeader', () => {
         {...defaultProps}
         scriptName="coursea-2018"
         versions={versions}
-        localeEnglishName="Italian"
+        localeCode="it-IT"
       />,
       {disableLifecycleMethods: true}
     );

--- a/apps/test/unit/templates/courseOverview/CourseOverviewTest.js
+++ b/apps/test/unit/templates/courseOverview/CourseOverviewTest.js
@@ -176,7 +176,8 @@ describe('CourseOverview', () => {
           title: '2017',
           canViewVersion: true,
           isStable: true,
-          locales: []
+          locales: [],
+          localeCodes: []
         },
         {
           name: 'csp-2018',
@@ -184,7 +185,8 @@ describe('CourseOverview', () => {
           title: '2018',
           canViewVersion: true,
           isStable: true,
-          locales: []
+          locales: [],
+          localeCodes: []
         }
       ];
       const wrapper = shallow(
@@ -212,7 +214,8 @@ describe('CourseOverview', () => {
           title: '2017',
           canViewVersion: false,
           isStable: true,
-          locales: []
+          locales: [],
+          localeCodes: []
         },
         {
           name: 'csp-2018',
@@ -220,7 +223,8 @@ describe('CourseOverview', () => {
           title: '2018',
           canViewVersion: true,
           isStable: true,
-          locales: []
+          locales: [],
+          localeCodes: []
         }
       ];
       const wrapper = shallow(

--- a/apps/test/unit/templates/teacherDashboard/AssignmentSelectorTest.js
+++ b/apps/test/unit/templates/teacherDashboard/AssignmentSelectorTest.js
@@ -5,7 +5,7 @@ import {assert, expect} from '../../../util/deprecatedChai';
 import AssignmentSelector from '@cdo/apps/templates/teacherDashboard/AssignmentSelector';
 
 const defaultProps = {
-  localeEnglishName: 'English',
+  localeCode: 'en-US',
   section: {
     id: 11,
     name: 'foo',
@@ -74,7 +74,7 @@ const defaultProps = {
       version_year: '2017',
       version_title: '2017',
       is_stable: true,
-      supported_locales: ['Spanish']
+      supported_locale_codes: ['es-MX']
     },
     // script not in course
     null_7: {
@@ -318,7 +318,7 @@ describe('AssignmentSelector', () => {
       const wrapper = shallow(
         <AssignmentSelector
           {...defaultProps}
-          localeEnglishName="Spanish"
+          localeCode="es-MX"
           section={{
             ...defaultProps.section,
             courseId: null,
@@ -344,7 +344,7 @@ describe('AssignmentSelector', () => {
       const wrapper = shallow(
         <AssignmentSelector
           {...defaultProps}
-          localeEnglishName="Slovak"
+          localeCode="sk-SK"
           section={{
             ...defaultProps.section,
             courseId: null,

--- a/apps/test/unit/templates/teacherDashboard/AssignmentVersionSelectorTest.js
+++ b/apps/test/unit/templates/teacherDashboard/AssignmentVersionSelectorTest.js
@@ -7,21 +7,24 @@ const fakeVersions = [
     year: '2017',
     title: '2017',
     isStable: true,
-    locales: ['English', 'Spanish']
+    locales: ['English', 'Spanish'],
+    localeCodes: ['en-US', 'es-MX']
   },
   {
     name: 'coursea-2018',
     year: '2018',
     title: '2018',
     isStable: true,
-    locales: ['English']
+    locales: ['English'],
+    localeCodes: ['en-US']
   },
   {
     name: 'coursea-2019',
     year: '2019',
     title: '2019',
     isStable: false,
-    locales: ['English']
+    locales: ['English'],
+    localeCodes: ['en-US']
   }
 ];
 
@@ -29,7 +32,7 @@ describe('AssignmentVersionSelector', () => {
   describe('setRecommendedAndSelectedVersions', () => {
     it('sets latest stable version supported in locale to isRecommended if locale provided', () => {
       const versions = JSON.parse(JSON.stringify(fakeVersions));
-      const response = setRecommendedAndSelectedVersions(versions, 'Spanish');
+      const response = setRecommendedAndSelectedVersions(versions, 'es-MX');
       const recommendedVersion = response.find(v => v.isRecommended);
       const selectedVersion = response.find(v => v.isSelected);
 

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1664,7 +1664,8 @@ class Script < ApplicationRecord
           version_title: s.version_year,
           can_view_version: s.can_view_version?(user),
           is_stable: s.stable?,
-          locales: s.supported_locale_names
+          locales: s.supported_locale_names,
+          locale_codes: s.supported_locales
         }
       end
 
@@ -1841,6 +1842,7 @@ class Script < ApplicationRecord
 
     info[:category] = I18n.t("data.script.category.#{info[:category]}_category_name", default: info[:category])
     info[:supported_locales] = supported_locale_names
+    info[:supported_locale_codes] = supported_locale_codes
     info[:lesson_extras_available] = lesson_extras_available
     if has_standards_associations?
       info[:standards] = standards
@@ -1848,11 +1850,14 @@ class Script < ApplicationRecord
     info
   end
 
-  def supported_locale_names
+  def supported_locale_codes
     locales = supported_locales || []
-    locales += ['en-US']
-    locales = locales.sort
-    locales.map {|l| Script.locale_native_name_map[l] || l}.uniq
+    locales += ['en-US'] unless locales.include? 'en-US'
+    locales.sort
+  end
+
+  def supported_locale_names
+    supported_locale_codes.map {|l| Script.locale_native_name_map[l] || l}.uniq
   end
 
   def self.locale_native_name_map

--- a/dashboard/app/views/scripts/show.html.haml
+++ b/dashboard/app/views/scripts/show.html.haml
@@ -12,6 +12,7 @@
                             user_providers: current_user&.providers,
                             is_verified_teacher: current_user&.authorized_teacher?,
                             locale: Script.locale_english_name_map[request.locale],
+                            locale_code: request.locale,
                             course_link: @script.course_link(params[:section_id]),
                             course_title: @script.course_title || I18n.t('view_all_units'),
                             sections: @sections_with_assigned_info}

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -2161,6 +2161,26 @@ class ScriptTest < ActiveSupport::TestCase
     assert_not Script.modern_elementary_courses_available?("fr-fr")
   end
 
+  test 'supported_locale_codes' do
+    unit = create :script
+    assert_equal ['en-US'], unit.supported_locale_codes
+
+    unit.supported_locales = ['en-US']
+    assert_equal ['en-US'], unit.supported_locale_codes
+
+    unit.supported_locales = ['fr-FR']
+    assert_equal ['en-US', 'fr-FR'], unit.supported_locale_codes
+
+    unit.supported_locales = ['fr-FR', 'ar-SA']
+    assert_equal ['ar-SA', 'en-US', 'fr-FR'], unit.supported_locale_codes
+
+    unit.supported_locales = ['en-US', 'fr-FR', 'ar-SA']
+    assert_equal ['ar-SA', 'en-US', 'fr-FR'], unit.supported_locale_codes
+
+    unit.supported_locales = ['fr-fr']
+    assert_equal ['en-US', 'fr-fr'], unit.supported_locale_codes
+  end
+
   test 'supported_locale_names' do
     unit = create :script
     assert_equal ['English'], unit.supported_locale_names


### PR DESCRIPTION
Our courses have been updated every year but translations aren't available for the latest year until much later. Once a course for a particular year has been fully translated into a language, we then mark the course as available in the language. To show this in the UI, we have a little `Recommended` tag next to the version year of the course. So you would see something like `2017 (Recommended)`. However, at some point front end code broke and we stopped recommending the correct year for non-English languages. This PR makes it so the correct year is recommended when a teacher is creating a new section and when a teacher browsing the course overview page.

The root cause of this bug was that the English name of a language was being used to see if it was in the list of available languages. At some point, the list of available languages started using native name for the language, rather than the English version. I could have fixed this by using the native language name instead, but I felt a better solution is to use the 4 letter locale code ??-?? (en-US, es-ES, etc) instead because it wouldn't be affected by translation changes. A lot of this PR is simply passing around the 4 letter locale codes and relying on that instead of the locale names.

## Links
- [JIRA](https://codedotorg.atlassian.net/browse/FND-1592)

## Testing story
* Unit test
* Manual tests

## Screenshots
### Before
Note that 2017 should be the recommended course year.
![image](https://user-images.githubusercontent.com/1372238/126382844-c8257700-8182-44b7-8338-181dfc8851a7.png)

-----

### After
![image](https://user-images.githubusercontent.com/1372238/126382423-062073ca-6bd7-4f47-a21d-5b99c0896e4d.png)

-----

### Before
Note that 2017 should be the recommended course year.
![image](https://user-images.githubusercontent.com/1372238/126382676-05f64dfb-5d51-4154-a450-663bc6137d2d.png)

-----

### After
![image](https://user-images.githubusercontent.com/1372238/126382459-2a9f3307-8596-444f-936d-10c10891600b.png)

-----

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
