### PR TITLE
stub course file writes in resources controller test

### DIFF
--- a/dashboard/test/controllers/resources_controller_test.rb
+++ b/dashboard/test/controllers/resources_controller_test.rb
@@ -6,6 +6,7 @@ class ResourcesControllerTest < ActionController::TestCase
   setup do
     Rails.application.config.stubs(:levelbuilder_mode).returns true
     @levelbuilder = create :levelbuilder
+    File.stubs(:write)
     # We don't want to write to the file system here
     Resource.any_instance.stubs(:serialize_scripts)
   end


### PR DESCRIPTION
Follow-on to https://github.com/code-dot-org/code-dot-org/pull/41595 .

## Testing story

manually verified that the resources controller test was producing bogus course files before, but is no longer. also, because it produced exactly 3 course files and that is the number that was being generated by each DTT, I am optimistic that this might be the last instance of stray course/script files being generated during dashboard unit tests.