### PR TITLE
Ensure that all user_level queries pass script_id

### DIFF
--- a/dashboard/app/controllers/api/v1/peer_review_submissions_controller.rb
+++ b/dashboard/app/controllers/api/v1/peer_review_submissions_controller.rb
@@ -101,7 +101,7 @@ class Api::V1::PeerReviewSubmissionsController < ApplicationController
     enrollments.each do |enrollment|
       peer_review_submissions = Hash.new
 
-      UserLevel.where(user: enrollment.user, level: peer_reviewable_levels).each do |user_level|
+      UserLevel.where(user: enrollment.user, level: peer_reviewable_levels, script: script).each do |user_level|
         submission_times = submission_times_by_user_script_level[[user_level.user_id, user_level.script_id, user_level.level_id]]
         peer_review_submissions[user_level.level.name] = {
           status: result_to_status(user_level.best_result),

--- a/dashboard/lib/policies/inline_answer.rb
+++ b/dashboard/lib/policies/inline_answer.rb
@@ -22,7 +22,7 @@ class Policies::InlineAnswer
 
     # Teachers can also put lessons into a readonly mode in which students are
     # able to view the answers
-    user_level = UserLevel.find_by(user: user, level: script_level.level)
+    user_level = UserLevel.find_by(user: user, level: script_level.level, script: script_level.script)
     return true if user_level.try(:readonly_answers)
 
     false

--- a/dashboard/test/lib/policies/inline_answer_test.rb
+++ b/dashboard/test/lib/policies/inline_answer_test.rb
@@ -33,7 +33,7 @@ class Policies::InlineAnswerTest < ActiveSupport::TestCase
 
   test 'visible? returns true for all kinds of users if the lesson is in readonly mode for that user' do
     script_level = create(:script_level)
-    create(:user_level, user: @student, level: script_level.level, submitted: true, readonly_answers: true)
+    create(:user_level, user: @student, level: script_level.level, script: script_level.script, submitted: true, readonly_answers: true)
     assert Policies::InlineAnswer.visible?(@student, script_level)
   end
 end


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

As preparation for switching the order the `level_id` and `script_id` fields in the index of the `user_levels` table, I audited all of the queries for user_levels to check that they are all passing both `level_id` and `script_id`.  These are the only two instances I found that were not doing this.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [LP-1970](https://codedotorg.atlassian.net/browse/LP-1970)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
