### PR TITLE
Fix design element tests for React upgrade

### DIFF
--- a/apps/src/applab/designElements/library.js
+++ b/apps/src/applab/designElements/library.js
@@ -46,10 +46,10 @@ elements[ElementType.CHART] = require('./chart');
 elements[ElementType.SLIDER] = require('./slider');
 elements[ElementType.PHOTO_SELECT] = require('./photoSelect');
 
-export {ElementType, elements};
-
 export default {
-  ElementType: ElementType,
+  ElementType,
+  elements,
+
   /**
    * Returns an element id with the given prefix which is unused within
    * the applab app's DOM.

--- a/apps/src/applab/designElements/library.js
+++ b/apps/src/applab/designElements/library.js
@@ -3,6 +3,7 @@ import * as utils from '../../utils';
 import * as elementUtils from './elementUtils';
 import designMode from '../designMode';
 import {themeOptions, DEFAULT_THEME_INDEX} from '../constants';
+
 /**
  * A map from prefix to the next numerical suffix to try to
  * use as an id in the applab app's DOM.
@@ -14,7 +15,7 @@ var nextElementIdMap = {};
  * @readonly
  * @enum {string}
  */
-var ElementType = utils.makeEnum(
+const ElementType = utils.makeEnum(
   'BUTTON',
   'LABEL',
   'TEXT_INPUT',
@@ -30,7 +31,7 @@ var ElementType = utils.makeEnum(
   'PHOTO_SELECT'
 );
 
-var elements = {};
+let elements = {};
 elements[ElementType.BUTTON] = require('./button');
 elements[ElementType.LABEL] = require('./label');
 elements[ElementType.TEXT_INPUT] = require('./textInput');
@@ -44,6 +45,8 @@ elements[ElementType.SCREEN] = require('./screen');
 elements[ElementType.CHART] = require('./chart');
 elements[ElementType.SLIDER] = require('./slider');
 elements[ElementType.PHOTO_SELECT] = require('./photoSelect');
+
+export {ElementType, elements};
 
 export default {
   ElementType: ElementType,

--- a/apps/test/unit/applab/designElements/dropdownTest.js
+++ b/apps/test/unit/applab/designElements/dropdownTest.js
@@ -1,9 +1,7 @@
 import {expect} from '../../../util/deprecatedChai';
-import library, {
-  ElementType,
-  elements
-} from '@cdo/apps/applab/designElements/library';
+import library from '@cdo/apps/applab/designElements/library';
 
+const {elements, ElementType} = library;
 const dropdown = elements[ElementType.DROPDOWN];
 
 function setIndex(e, newIndex) {

--- a/apps/test/unit/applab/designElements/dropdownTest.js
+++ b/apps/test/unit/applab/designElements/dropdownTest.js
@@ -1,6 +1,10 @@
 import {expect} from '../../../util/deprecatedChai';
-import dropdown from '@cdo/apps/applab/designElements/dropdown';
-import library from '@cdo/apps/applab/designElements/library';
+import library, {
+  ElementType,
+  elements
+} from '@cdo/apps/applab/designElements/library';
+
+const dropdown = elements[ElementType.DROPDOWN];
 
 function setIndex(e, newIndex) {
   dropdown.onPropertyChange(e, 'index', newIndex);

--- a/apps/test/unit/applab/designElements/labelTest.js
+++ b/apps/test/unit/applab/designElements/labelTest.js
@@ -1,11 +1,9 @@
 import $ from 'jquery';
 import {expect} from '../../../util/deprecatedChai';
-import library, {
-  ElementType,
-  elements
-} from '@cdo/apps/applab/designElements/library';
+import library from '@cdo/apps/applab/designElements/library';
 import * as applabConstants from '@cdo/apps/applab/constants';
 
+const {elements, ElementType} = library;
 const label = elements[ElementType.LABEL];
 
 function getRect(e) {

--- a/apps/test/unit/applab/designElements/labelTest.js
+++ b/apps/test/unit/applab/designElements/labelTest.js
@@ -1,8 +1,12 @@
 import $ from 'jquery';
 import {expect} from '../../../util/deprecatedChai';
-import label from '@cdo/apps/applab/designElements/label';
-import library from '@cdo/apps/applab/designElements/library';
+import library, {
+  ElementType,
+  elements
+} from '@cdo/apps/applab/designElements/library';
 import * as applabConstants from '@cdo/apps/applab/constants';
+
+const label = elements[ElementType.LABEL];
 
 function getRect(e) {
   return {


### PR DESCRIPTION
Unit tests for specific design elements were failing with the error `TypeError: elementClass.create is not a function`. This was happening because the test file was importing the design element separately from the way [library.js](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/applab/designElements/library.js) (the "library" of design elements) imports/instantiates those same design elements.

The fix for this was to export `elements` (all library elements) and `ElementType` (all element types; was already being exported) from library.js and import that in the test file instead of importing the element directly.

## Links

- [XTEAM-316](https://codedotorg.atlassian.net/browse/XTEAM-316)
