### PR TITLE
Fix "Create New Section" dialog scroll bug

### DIFF
--- a/apps/src/templates/teacherDashboard/AddSectionDialog.jsx
+++ b/apps/src/templates/teacherDashboard/AddSectionDialog.jsx
@@ -40,7 +40,7 @@ class AddSectionDialog extends Component {
       handleCancel
     } = this.props;
     const {loginType} = section || {};
-    const title = i18n.newSection();
+    const title = i18n.newSectionUpdated();
     return (
       <BaseDialog
         useUpdatedStyles

--- a/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
+++ b/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
@@ -5,48 +5,16 @@
  * external service like Microsoft Classroom or Clever.
  */
 import PropTypes from 'prop-types';
-
 import React, {Component} from 'react';
 import {connect} from 'react-redux';
 import i18n from '@cdo/locale';
 import {Heading1, Heading2} from '../../lib/ui/Headings';
 import CardContainer from './CardContainer';
+import DialogFooter from './DialogFooter';
 import LoginTypeCard from './LoginTypeCard';
 import Button from '../Button';
 import {OAuthSectionTypes} from '@cdo/apps/lib/ui/accounts/constants';
 import styleConstants from '../../styleConstants';
-
-const style = {
-  root: {
-    width: styleConstants['content-width'],
-    height: '80vh',
-    left: 20,
-    right: 20
-  },
-  scroll: {
-    overflowX: 'hidden',
-    overflowY: 'auto',
-    height: 'calc(80vh - 200px)'
-  },
-  thirdPartyProviderUpsell: {
-    marginBottom: '10px'
-  },
-  footer: {
-    position: 'absolute',
-    width: styleConstants['content-width'],
-    height: '100px',
-    left: 0,
-    bottom: '-65px',
-    padding: '0px 20px 20px 20px',
-    backgroundColor: '#fff',
-    borderRadius: '5px'
-  },
-  emailPolicyNote: {
-    marginBottom: '20px',
-    paddingTop: '20px',
-    borderTop: '1px solid #000'
-  }
-};
 
 /**
  * UI for selecting the login type of a class section:
@@ -63,13 +31,11 @@ class LoginTypePicker extends Component {
     // Provided by Redux
     providers: PropTypes.arrayOf(PropTypes.string)
   };
-
   openImportDialog = provider => {
     this.props.setRosterProvider(provider);
     this.props.handleCancel(); // close this dialog
     this.props.handleImportOpen(); // open the roster dialog
   };
-
   render() {
     const {title, providers, setLoginType, handleCancel, disabled} = this.props;
     const withGoogle =
@@ -79,15 +45,25 @@ class LoginTypePicker extends Component {
     const withClever =
       providers && providers.includes(OAuthSectionTypes.clever);
     const hasThirdParty = withGoogle | withMicrosoft | withClever;
-    // Adjust max height of the scrolling body of the dialog based on number of
-    // LoginCard types available to the user.
-    style.root.maxHeight = hasThirdParty ? '500px' : '360px';
+
+    // explicitly constrain the container as a whole to the width of the
+    // content. We expect that differing length of translations versus english
+    // source text can cause unexpected layout changes, and this constraint
+    // should help mitigate some of them.
+    const containerStyle = {maxWidth: styleConstants['content-width']};
+
+    // anchor email address policy note to footer just above 'Cancel' button
+    const emailPolicyNoteStyle = {
+      position: 'absolute',
+      top: '0px',
+      zIndex: '600'
+    };
 
     return (
-      <div style={style.root}>
-        <Heading1>{i18n.newSectionUpdated()}</Heading1>
+      <div style={containerStyle}>
+        <Heading1>{title}</Heading1>
         <Heading2>{i18n.addStudentsToSectionInstructionsUpdated()}</Heading2>
-        <div style={style.scroll}>
+        <div>
           <CardContainer>
             {withGoogle && (
               <GoogleClassroomCard onClick={this.openImportDialog} />
@@ -100,18 +76,18 @@ class LoginTypePicker extends Component {
             <WordLoginCard onClick={setLoginType} />
             <EmailLoginCard onClick={setLoginType} />
           </CardContainer>
-          {!hasThirdParty && (
-            <div>
-              {i18n.thirdPartyProviderUpsell() + ' '}
-              <a href="https://support.code.org/hc/en-us/articles/115001319312-Setting-up-sections-with-Google-Classroom-or-Clever">
-                {i18n.learnHow()}
-              </a>
-              {' ' + i18n.connectAccountThirdPartyProviders()}
-            </div>
-          )}
         </div>
-        <div style={style.footer}>
-          <div style={style.emailPolicyNote}>
+        {!hasThirdParty && (
+          <div>
+            {i18n.thirdPartyProviderUpsell() + ' '}
+            <a href="https://support.code.org/hc/en-us/articles/115001319312-Setting-up-sections-with-Google-Classroom-or-Clever">
+              {i18n.learnHow()}
+            </a>
+            {' ' + i18n.connectAccountThirdPartyProviders()}
+          </div>
+        )}
+        <DialogFooter>
+          <div style={emailPolicyNoteStyle}>
             <b>{i18n.note()}</b>
             {' ' + i18n.emailAddressPolicy() + ' '}
             <a href="http://blog.code.org/post/147756946588/codeorgs-new-login-approach-to-student-privacy">
@@ -126,7 +102,7 @@ class LoginTypePicker extends Component {
             color={Button.ButtonColor.gray}
             disabled={disabled}
           />
-        </div>
+        </DialogFooter>
       </div>
     );
   }
@@ -135,7 +111,6 @@ export const UnconnectedLoginTypePicker = LoginTypePicker;
 export default connect(state => ({
   providers: state.teacherSections.providers
 }))(LoginTypePicker);
-
 const PictureLoginCard = props => (
   <LoginTypeCard
     className="uitest-pictureLogin"
@@ -149,7 +124,6 @@ PictureLoginCard.propTypes = {
   onClick: PropTypes.func.isRequired,
   disabled: PropTypes.bool
 };
-
 const WordLoginCard = props => (
   <LoginTypeCard
     className="uitest-wordLogin"
@@ -160,7 +134,6 @@ const WordLoginCard = props => (
   />
 );
 WordLoginCard.propTypes = PictureLoginCard.propTypes;
-
 const EmailLoginCard = props => (
   <LoginTypeCard
     className="uitest-emailLogin"
@@ -171,7 +144,6 @@ const EmailLoginCard = props => (
   />
 );
 EmailLoginCard.propTypes = PictureLoginCard.propTypes;
-
 const GoogleClassroomCard = props => (
   <LoginTypeCard
     title={i18n.loginTypeGoogleClassroom()}
@@ -180,7 +152,6 @@ const GoogleClassroomCard = props => (
   />
 );
 GoogleClassroomCard.propTypes = PictureLoginCard.propTypes;
-
 const MicrosoftClassroomCard = props => (
   <LoginTypeCard
     title={i18n.loginTypeMicrosoftClassroom()}
@@ -189,7 +160,6 @@ const MicrosoftClassroomCard = props => (
   />
 );
 MicrosoftClassroomCard.propTypes = PictureLoginCard.propTypes;
-
 const CleverCard = props => (
   <LoginTypeCard
     title={i18n.loginTypeClever()}

--- a/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
+++ b/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
@@ -10,11 +10,42 @@ import {connect} from 'react-redux';
 import i18n from '@cdo/locale';
 import {Heading1, Heading2} from '../../lib/ui/Headings';
 import CardContainer from './CardContainer';
-import DialogFooter from './DialogFooter';
 import LoginTypeCard from './LoginTypeCard';
 import Button from '../Button';
 import {OAuthSectionTypes} from '@cdo/apps/lib/ui/accounts/constants';
 import styleConstants from '../../styleConstants';
+
+const style = {
+  root: {
+    width: styleConstants['content-width'],
+    height: '80vh',
+    left: 20,
+    right: 20
+  },
+  scroll: {
+    overflowX: 'hidden',
+    overflowY: 'auto',
+    height: 'calc(80vh - 200px)'
+  },
+  thirdPartyProviderUpsell: {
+    marginBottom: '10px'
+  },
+  footer: {
+    position: 'absolute',
+    width: styleConstants['content-width'],
+    height: '100px',
+    left: 0,
+    bottom: '-65px',
+    padding: '0px 20px 20px 20px',
+    backgroundColor: '#fff',
+    borderRadius: '5px'
+  },
+  emailPolicyNote: {
+    marginBottom: '20px',
+    paddingTop: '20px',
+    borderTop: '1px solid #000'
+  }
+};
 
 /**
  * UI for selecting the login type of a class section:
@@ -31,11 +62,13 @@ class LoginTypePicker extends Component {
     // Provided by Redux
     providers: PropTypes.arrayOf(PropTypes.string)
   };
+
   openImportDialog = provider => {
     this.props.setRosterProvider(provider);
     this.props.handleCancel(); // close this dialog
     this.props.handleImportOpen(); // open the roster dialog
   };
+
   render() {
     const {title, providers, setLoginType, handleCancel, disabled} = this.props;
     const withGoogle =
@@ -45,25 +78,15 @@ class LoginTypePicker extends Component {
     const withClever =
       providers && providers.includes(OAuthSectionTypes.clever);
     const hasThirdParty = withGoogle | withMicrosoft | withClever;
-
-    // explicitly constrain the container as a whole to the width of the
-    // content. We expect that differing length of translations versus english
-    // source text can cause unexpected layout changes, and this constraint
-    // should help mitigate some of them.
-    const containerStyle = {maxWidth: styleConstants['content-width']};
-
-    // anchor email address policy note to footer just above 'Cancel' button
-    const emailPolicyNoteStyle = {
-      position: 'absolute',
-      top: '0px',
-      zIndex: '600'
-    };
+    // Adjust max height of the scrolling body of the dialog based on number of
+    // LoginCard types available to the user.
+    style.root.maxHeight = hasThirdParty ? '500px' : '360px';
 
     return (
-      <div style={containerStyle}>
+      <div style={style.root}>
         <Heading1>{title}</Heading1>
         <Heading2>{i18n.addStudentsToSectionInstructionsUpdated()}</Heading2>
-        <div>
+        <div style={style.scroll}>
           <CardContainer>
             {withGoogle && (
               <GoogleClassroomCard onClick={this.openImportDialog} />
@@ -76,18 +99,18 @@ class LoginTypePicker extends Component {
             <WordLoginCard onClick={setLoginType} />
             <EmailLoginCard onClick={setLoginType} />
           </CardContainer>
+          {!hasThirdParty && (
+            <div>
+              {i18n.thirdPartyProviderUpsell() + ' '}
+              <a href="https://support.code.org/hc/en-us/articles/115001319312-Setting-up-sections-with-Google-Classroom-or-Clever">
+                {i18n.learnHow()}
+              </a>
+              {' ' + i18n.connectAccountThirdPartyProviders()}
+            </div>
+          )}
         </div>
-        {!hasThirdParty && (
-          <div>
-            {i18n.thirdPartyProviderUpsell() + ' '}
-            <a href="https://support.code.org/hc/en-us/articles/115001319312-Setting-up-sections-with-Google-Classroom-or-Clever">
-              {i18n.learnHow()}
-            </a>
-            {' ' + i18n.connectAccountThirdPartyProviders()}
-          </div>
-        )}
-        <DialogFooter>
-          <div style={emailPolicyNoteStyle}>
+        <div style={style.footer}>
+          <div style={style.emailPolicyNote}>
             <b>{i18n.note()}</b>
             {' ' + i18n.emailAddressPolicy() + ' '}
             <a href="http://blog.code.org/post/147756946588/codeorgs-new-login-approach-to-student-privacy">
@@ -102,7 +125,7 @@ class LoginTypePicker extends Component {
             color={Button.ButtonColor.gray}
             disabled={disabled}
           />
-        </DialogFooter>
+        </div>
       </div>
     );
   }
@@ -111,6 +134,7 @@ export const UnconnectedLoginTypePicker = LoginTypePicker;
 export default connect(state => ({
   providers: state.teacherSections.providers
 }))(LoginTypePicker);
+
 const PictureLoginCard = props => (
   <LoginTypeCard
     className="uitest-pictureLogin"
@@ -124,6 +148,7 @@ PictureLoginCard.propTypes = {
   onClick: PropTypes.func.isRequired,
   disabled: PropTypes.bool
 };
+
 const WordLoginCard = props => (
   <LoginTypeCard
     className="uitest-wordLogin"
@@ -134,6 +159,7 @@ const WordLoginCard = props => (
   />
 );
 WordLoginCard.propTypes = PictureLoginCard.propTypes;
+
 const EmailLoginCard = props => (
   <LoginTypeCard
     className="uitest-emailLogin"
@@ -144,6 +170,7 @@ const EmailLoginCard = props => (
   />
 );
 EmailLoginCard.propTypes = PictureLoginCard.propTypes;
+
 const GoogleClassroomCard = props => (
   <LoginTypeCard
     title={i18n.loginTypeGoogleClassroom()}
@@ -152,6 +179,7 @@ const GoogleClassroomCard = props => (
   />
 );
 GoogleClassroomCard.propTypes = PictureLoginCard.propTypes;
+
 const MicrosoftClassroomCard = props => (
   <LoginTypeCard
     title={i18n.loginTypeMicrosoftClassroom()}
@@ -160,6 +188,7 @@ const MicrosoftClassroomCard = props => (
   />
 );
 MicrosoftClassroomCard.propTypes = PictureLoginCard.propTypes;
+
 const CleverCard = props => (
   <LoginTypeCard
     title={i18n.loginTypeClever()}

--- a/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
+++ b/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
@@ -11,11 +11,42 @@ import {connect} from 'react-redux';
 import i18n from '@cdo/locale';
 import {Heading1, Heading2} from '../../lib/ui/Headings';
 import CardContainer from './CardContainer';
-import DialogFooter from './DialogFooter';
 import LoginTypeCard from './LoginTypeCard';
 import Button from '../Button';
 import {OAuthSectionTypes} from '@cdo/apps/lib/ui/accounts/constants';
 import styleConstants from '../../styleConstants';
+
+const style = {
+  root: {
+    width: styleConstants['content-width'],
+    height: '80vh',
+    left: 20,
+    right: 20
+  },
+  scroll: {
+    overflowX: 'hidden',
+    overflowY: 'auto',
+    height: 'calc(80vh - 200px)'
+  },
+  thirdPartyProviderUpsell: {
+    marginBottom: '10px'
+  },
+  footer: {
+    position: 'absolute',
+    width: styleConstants['content-width'],
+    height: '100px',
+    left: 0,
+    bottom: '-65px',
+    padding: '0px 20px 20px 20px',
+    backgroundColor: '#fff',
+    borderRadius: '5px'
+  },
+  emailPolicyNote: {
+    marginBottom: '20px',
+    paddingTop: '20px',
+    borderTop: '1px solid #000'
+  }
+};
 
 /**
  * UI for selecting the login type of a class section:
@@ -40,7 +71,7 @@ class LoginTypePicker extends Component {
   };
 
   render() {
-    const {title, providers, setLoginType, handleCancel, disabled} = this.props;
+    const {providers, setLoginType, handleCancel, disabled} = this.props;
     const withGoogle =
       providers && providers.includes(OAuthSectionTypes.google_classroom);
     const withMicrosoft =
@@ -49,24 +80,11 @@ class LoginTypePicker extends Component {
       providers && providers.includes(OAuthSectionTypes.clever);
     const hasThirdParty = withGoogle | withMicrosoft | withClever;
 
-    // explicitly constrain the container as a whole to the width of the
-    // content. We expect that differing length of translations versus english
-    // source text can cause unexpected layout changes, and this constraint
-    // should help mitigate some of them.
-    const containerStyle = {maxWidth: styleConstants['content-width']};
-
-    // anchor email address policy note to footer just above 'Cancel' button
-    const emailPolicyNoteStyle = {
-      position: 'absolute',
-      top: '0px',
-      zIndex: '600'
-    };
-
     return (
-      <div style={containerStyle}>
-        <Heading1>{title}</Heading1>
+      <div style={style.root}>
+        <Heading1>{i18n.newSectionUpdated()}</Heading1>
         <Heading2>{i18n.addStudentsToSectionInstructionsUpdated()}</Heading2>
-        <div>
+        <div style={style.scroll}>
           <CardContainer>
             {withGoogle && (
               <GoogleClassroomCard onClick={this.openImportDialog} />
@@ -89,8 +107,8 @@ class LoginTypePicker extends Component {
             {' ' + i18n.connectAccountThirdPartyProviders()}
           </div>
         )}
-        <DialogFooter>
-          <div style={emailPolicyNoteStyle}>
+        <div style={style.footer}>
+          <div style={style.emailPolicyNote}>
             <b>{i18n.note()}</b>
             {' ' + i18n.emailAddressPolicy() + ' '}
             <a href="http://blog.code.org/post/147756946588/codeorgs-new-login-approach-to-student-privacy">
@@ -105,7 +123,7 @@ class LoginTypePicker extends Component {
             color={Button.ButtonColor.gray}
             disabled={disabled}
           />
-        </DialogFooter>
+        </div>
       </div>
     );
   }

--- a/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
+++ b/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
@@ -79,6 +79,9 @@ class LoginTypePicker extends Component {
     const withClever =
       providers && providers.includes(OAuthSectionTypes.clever);
     const hasThirdParty = withGoogle | withMicrosoft | withClever;
+    // Adjust max height of the scrolling body of the dialog based on number of
+    // LoginCard types available to the user.
+    style.root.maxHeight = hasThirdParty ? '500px' : '360px';
 
     return (
       <div style={style.root}>

--- a/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
+++ b/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
@@ -71,7 +71,7 @@ class LoginTypePicker extends Component {
   };
 
   render() {
-    const {providers, setLoginType, handleCancel, disabled} = this.props;
+    const {title, providers, setLoginType, handleCancel, disabled} = this.props;
     const withGoogle =
       providers && providers.includes(OAuthSectionTypes.google_classroom);
     const withMicrosoft =

--- a/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
+++ b/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
@@ -18,32 +18,32 @@ import styleConstants from '../../styleConstants';
 const style = {
   root: {
     width: styleConstants['content-width'],
-    // height: '80vh',
-    // left: 20,
-    // right: 20
+    height: '80vh',
+    left: 20,
+    right: 20
   },
   scroll: {
-    // overflowX: 'hidden',
-    // overflowY: 'auto',
-    // height: 'calc(80vh - 200px)'
+    overflowX: 'hidden',
+    overflowY: 'auto',
+    height: 'calc(80vh - 200px)'
   },
   thirdPartyProviderUpsell: {
-    // marginBottom: '10px'
+    marginBottom: '10px'
   },
   footer: {
-    // position: 'absolute',
-    // width: styleConstants['content-width'],
-    // height: '100px',
-    // left: 0,
-    // bottom: '-65px',
-    // padding: '0px 20px 20px 20px',
-    // backgroundColor: '#fff',
-    // borderRadius: '5px'
+    position: 'absolute',
+    width: styleConstants['content-width'],
+    height: '100px',
+    left: 0,
+    bottom: '-65px',
+    padding: '0px 20px 20px 20px',
+    backgroundColor: '#fff',
+    borderRadius: '5px'
   },
   emailPolicyNote: {
-    // marginBottom: '20px',
-    // paddingTop: '20px',
-    // borderTop: '1px solid #000'
+    marginBottom: '20px',
+    paddingTop: '20px',
+    borderTop: '1px solid #000'
   }
 };
 

--- a/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
+++ b/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
@@ -18,32 +18,32 @@ import styleConstants from '../../styleConstants';
 const style = {
   root: {
     width: styleConstants['content-width'],
-    height: '80vh',
-    left: 20,
-    right: 20
+    // height: '80vh',
+    // left: 20,
+    // right: 20
   },
   scroll: {
-    overflowX: 'hidden',
-    overflowY: 'auto',
-    height: 'calc(80vh - 200px)'
+    // overflowX: 'hidden',
+    // overflowY: 'auto',
+    // height: 'calc(80vh - 200px)'
   },
   thirdPartyProviderUpsell: {
-    marginBottom: '10px'
+    // marginBottom: '10px'
   },
   footer: {
-    position: 'absolute',
-    width: styleConstants['content-width'],
-    height: '100px',
-    left: 0,
-    bottom: '-65px',
-    padding: '0px 20px 20px 20px',
-    backgroundColor: '#fff',
-    borderRadius: '5px'
+    // position: 'absolute',
+    // width: styleConstants['content-width'],
+    // height: '100px',
+    // left: 0,
+    // bottom: '-65px',
+    // padding: '0px 20px 20px 20px',
+    // backgroundColor: '#fff',
+    // borderRadius: '5px'
   },
   emailPolicyNote: {
-    marginBottom: '20px',
-    paddingTop: '20px',
-    borderTop: '1px solid #000'
+    // marginBottom: '20px',
+    // paddingTop: '20px',
+    // borderTop: '1px solid #000'
   }
 };
 
@@ -80,7 +80,7 @@ class LoginTypePicker extends Component {
     const hasThirdParty = withGoogle | withMicrosoft | withClever;
     // Adjust max height of the scrolling body of the dialog based on number of
     // LoginCard types available to the user.
-    style.root.maxHeight = hasThirdParty ? '500px' : '360px';
+    // style.root.maxHeight = hasThirdParty ? '500px' : '360px';
 
     return (
       <div style={style.root}>

--- a/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
+++ b/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
@@ -97,16 +97,16 @@ class LoginTypePicker extends Component {
             <WordLoginCard onClick={setLoginType} />
             <EmailLoginCard onClick={setLoginType} />
           </CardContainer>
+          {!hasThirdParty && (
+            <div>
+              {i18n.thirdPartyProviderUpsell() + ' '}
+              <a href="https://support.code.org/hc/en-us/articles/115001319312-Setting-up-sections-with-Google-Classroom-or-Clever">
+                {i18n.learnHow()}
+              </a>
+              {' ' + i18n.connectAccountThirdPartyProviders()}
+            </div>
+          )}
         </div>
-        {!hasThirdParty && (
-          <div>
-            {i18n.thirdPartyProviderUpsell() + ' '}
-            <a href="https://support.code.org/hc/en-us/articles/115001319312-Setting-up-sections-with-Google-Classroom-or-Clever">
-              {i18n.learnHow()}
-            </a>
-            {' ' + i18n.connectAccountThirdPartyProviders()}
-          </div>
-        )}
         <div style={style.footer}>
           <div style={style.emailPolicyNote}>
             <b>{i18n.note()}</b>


### PR DESCRIPTION
Fixes a scrolling bug in the New Section dialog window where LoginTypeCards were getting cut off since it wasn't scrolling. The original problem was spotted when [this PR](https://github.com/code-dot-org/code-dot-org/pull/40384) was merged. 

## Screenshots of correct behavior for scrolling
### Case when the user does not have a 3rd party provider connected to their account (e.g. Google Classroom) so they only have access to Picture Password, Secret Words, and Personal Login types (only 1 row of 3 LoginTypeCards):
![Fix scroll bug 1](https://user-images.githubusercontent.com/56283563/125521742-edc7a897-d930-4ae4-bb47-f1aecf73b2a6.JPG)
### Case when the user has at least one 3rd party provider connected to their account (e.g. Google Classroom) so they have at least 4 types of login cards (causing 2 rows of cards):
![Fix scroll bug 2](https://user-images.githubusercontent.com/56283563/125521743-fd5394d4-fa7f-4932-8541-b0be19139275.JPG)

## Screenshots of what the dialog normally looks like when no scrolling is needed (i.e. if the window is large enough)
### Case when the user does not have a 3rd party provider connected to their account (e.g. Google Classroom) so they only have access to Picture Password, Secret Words, and Personal Login types (only 1 row of 3 LoginTypeCards):
![Fix scroll bug 3](https://user-images.githubusercontent.com/56283563/125522587-9c9c1b91-6839-466e-bb94-e2cb2ea9f74b.JPG)
### Case when the user has at least one 3rd party provider connected to their account (e.g. Google Classroom) so they have at least 4 types of login cards (causing 2 rows of cards):
![Fix scroll bug 4](https://user-images.githubusercontent.com/56283563/125522588-29c9c777-b173-4814-9483-b00f9af9c141.JPG)