### PR TITLE
show lesson name in lesson plan web page title

### DIFF
--- a/dashboard/app/views/lessons/show.html.haml
+++ b/dashboard/app/views/lessons/show.html.haml
@@ -1,3 +1,5 @@
+- @page_title = @lesson_data[:displayName]
+
 %link{href: asset_path('css/lessons.css'), rel: 'stylesheet', type: 'text/css'}
 %script{src: webpack_asset_path('js/lessons/show.js'),
         data: {lesson: @lesson_data.to_json}}


### PR DESCRIPTION
feature request from curriculum team for parity with old CB behavior.

before:

![Screen Shot 2021-07-21 at 11 11 30 AM](https://user-images.githubusercontent.com/8001765/126538647-de4290b0-ee44-4ef7-aa69-db4ff2521606.png)

after:

![Screen Shot 2021-07-21 at 11 10 02 AM](https://user-images.githubusercontent.com/8001765/126538552-a22166d7-6022-4213-baa5-126a3540ec41.png)

the `[development]` and `[levelbuilder]` parts of the title will not be visible in production.