### PR TITLE
Include wait time in more cases when UI testing progress bubble color

### DIFF
--- a/dashboard/test/ui/features/step_definitions/progress.rb
+++ b/dashboard/test/ui/features/step_definitions/progress.rb
@@ -32,38 +32,26 @@ def verify_progress(selector, test_result, no_wait=false)
     border_color = color_string('assessment')
   end
 
-  if no_wait
+  # The data for progress bubbles can be loaded synchronously or
+  # asynchronously, therefore unless we know the colors are set (such as when
+  # we're checking multiple not_tried bubbles in a row) we wait a bit before
+  # checking to ensure progress is loaded and the bubble is the correct color.
+  unless no_wait
     steps %{
-      And element "#{selector}" is visible
-      And element "#{selector}" has css property "background-color" equal to "#{background_color}"
-      And element "#{selector}" has css property "border-top-color" equal to "#{border_color}"
+      And I wait for 2 seconds
+      And I wait until jQuery Ajax requests are finished
     }
-  else
-    # The data for progress bubbles can be loaded synchronously or asynchronously.
-    # For 'not_tried', it is difficult to tell whether the bubble is just in its
-    # default state or if progress data was loaded and the bubble was explicitly
-    # set to 'not_tried'. In this case, we'll just wait a bit before checking to
-    # reduce the likelihood of false positives.
-    # For all other test_result values, we know that progress has been loaded if
-    # the bubble changes color so we can just poll for the expected color.
-    if test_result == 'not_tried'
-      steps %{
-        And I wait for 2 seconds
-        And I wait until jQuery Ajax requests are finished
-        And I wait until element "#{selector}" is visible
-        And element "#{selector}" has css property "background-color" equal to "#{background_color}"
-        And element "#{selector}" has css property "border-top-color" equal to "#{border_color}"
-      }
-    else
-      steps %{ And I wait until element "#{selector}" is visible }
-      wait_short_until do
-        steps %{
-          And element "#{selector}" has css property "background-color" equal to "#{background_color}"
-          And element "#{selector}" has css property "border-top-color" equal to "#{border_color}"
-        }
-      end
-    end
   end
+
+  verify_bubble_color(selector, background_color, border_color)
+end
+
+def verify_bubble_color(selector, background_color, border_color)
+  steps %{
+    And I wait until element "#{selector}" is visible
+    And element "#{selector}" has css property "background-color" equal to "#{background_color}"
+    And element "#{selector}" has css property "border-top-color" equal to "#{border_color}"
+  }
 end
 
 def verify_bubble_type(selector, type)


### PR DESCRIPTION
Related to [X-TEAM 366](https://codedotorg.atlassian.net/browse/XTEAM-366)

While investigating UI test failures on a Drone run I stumbled on what appears to be some flakiness in the tests covering multi page assessments. In the Drone run and then occasionally locally on a fresh pull of staging there was an error where we expected a bubble to be purple (perfect), but it was showing as white (not tried). 

<img width="1348" alt="Screen Shot 2021-07-21 at 5 09 38 PM" src="https://user-images.githubusercontent.com/12300669/126560619-648bb959-a207-4c77-8a65-5d2228e8e48d.png">

There was a time-saving optimization in place to only add additional wait time if the status of the bubble was not_tried, but I think the additional wait time is needed in other cases as well to reduce flakiness in this test. These tests consistently pass for me locally when the additional wait time and completion of Ajax requests are added in as steps. 