### PR TITLE
Standardize underscore to dash

### DIFF
--- a/apps/src/code-studio/assets/SpriteUpload.jsx
+++ b/apps/src/code-studio/assets/SpriteUpload.jsx
@@ -46,7 +46,7 @@ export default class SpriteUpload extends React.Component {
 
     switch (spriteAvailability) {
       case SpriteLocation.level:
-        destination = `/level_animations/${filename}`;
+        destination = `/level-animations/${filename}`;
         break;
       case SpriteLocation.library:
         destination = `/spritelab/category_${category}/${filename}`;

--- a/shared/middleware/animation_library_api.rb
+++ b/shared/middleware/animation_library_api.rb
@@ -20,10 +20,10 @@ class AnimationLibraryApi < Sinatra::Base
   end
 
   #
-  # GET /api/v1/animation-library/level_animations/<version-id>/<filename>
+  # GET /api/v1/animation-library/level-animations/<version-id>/<filename>
   # Retrieve an animation that was uploaded by a levelbuilder (for use in level start_animations)
   #
-  get %r{/api/v1/animation-library/level_animations/([^/]+)/(.+)} do |version_id, animation_name|
+  get %r{/api/v1/animation-library/level-animations/([^/]+)/(.+)} do |version_id, animation_name|
     not_found if version_id.empty? || animation_name.empty?
 
     begin
@@ -40,10 +40,10 @@ class AnimationLibraryApi < Sinatra::Base
   end
 
   #
-  # POST /api/v1/animation-library/level_animations/<filename>
+  # POST /api/v1/animation-library/level-animations/<filename>
   # Create Sprite in Level Animations folder
   #
-  post %r{/api/v1/animation-library/level_animations/(.+)} do |animation_name|
+  post %r{/api/v1/animation-library/level-animations/(.+)} do |animation_name|
     dont_cache
     if request.content_type == 'image/png' || request.content_type == 'application/json'
       body = request.body


### PR DESCRIPTION
Stems from feedback on: https://github.com/code-dot-org/code-dot-org/pull/41649

Moving underscore to dash to standardize to dashes in URLs.
## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
