### PR TITLE
Javalab: remove required project version in code review comments

### DIFF
--- a/dashboard/app/controllers/code_review_comments_controller.rb
+++ b/dashboard/app/controllers/code_review_comments_controller.rb
@@ -8,11 +8,8 @@ class CodeReviewCommentsController < ApplicationController
   # POST /code_review_comments
   def create
     additional_attributes = {
-      # Using temporary placeholder string for currently required project_version.
-      # Immediate to-do to migrate the code_review_comments table to not require project_version.
       commenter_id: current_user.id,
       storage_app_id: @storage_app_id,
-      project_version: 'temporary placeholder',
       project_owner_id: @project_owner.id
     }
     @code_review_comment = CodeReviewComment.new(code_review_comments_params.merge(additional_attributes))
@@ -85,9 +82,8 @@ class CodeReviewCommentsController < ApplicationController
   end
 
   def serialize(comment)
-    # once project versioning is implemented,
-    # we should pass the project_version string to the front end
-    # and calculate isFromOlderVersionOfProject there.
+    # once comments associated with project versions is implemented,
+    # we should calculate isFromOlderVersionOfProject there.
     {
       id: comment.id,
       name: comment.commenter&.name,

--- a/dashboard/app/models/code_review_comment.rb
+++ b/dashboard/app/models/code_review_comment.rb
@@ -4,7 +4,7 @@
 #
 #  id               :bigint           not null, primary key
 #  storage_app_id   :integer          not null
-#  project_version  :string(255)      not null
+#  project_version  :string(255)
 #  commenter_id     :integer          not null
 #  comment          :text(16777215)
 #  project_owner_id :integer

--- a/dashboard/db/migrate/20210721233403_code_review_comments_make_project_version_nullable.rb
+++ b/dashboard/db/migrate/20210721233403_code_review_comments_make_project_version_nullable.rb
@@ -1,0 +1,5 @@
+class CodeReviewCommentsMakeProjectVersionNullable < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :code_review_comments, :project_version, true
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_19_221440) do
+ActiveRecord::Schema.define(version: 2021_07_21_233403) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -274,7 +274,7 @@ ActiveRecord::Schema.define(version: 2021_07_19_221440) do
 
   create_table "code_review_comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
     t.integer "storage_app_id", null: false
-    t.string "project_version", null: false
+    t.string "project_version"
     t.integer "commenter_id", null: false
     t.text "comment", limit: 16777215
     t.integer "project_owner_id"

--- a/dashboard/test/controllers/code_review_comments_controller_test.rb
+++ b/dashboard/test/controllers/code_review_comments_controller_test.rb
@@ -8,7 +8,6 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
     @project_owner_channel_id = 'encrypted_channel_id'
     @project_owner_storage_id = 123
     @project_storage_app_id = 456
-    @project_version_string = 'special_project_version_string'
 
     @teacher = create :teacher
     @section = create :section, user: @teacher
@@ -26,7 +25,6 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
     sign_in @project_owner
     post :create, params: {
       channel_id: @project_owner_channel_id,
-      project_version: 'a_project_version_string',
       comment: 'a comment'
     }
 
@@ -39,7 +37,6 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
     sign_in @another_student
     post :create, params: {
       channel_id: @project_owner_channel_id,
-      project_version: 'a_project_version_string',
       comment: 'a comment'
     }
 
@@ -56,7 +53,6 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
     sign_in @another_student
     post :create, params: {
       channel_id: @project_owner_channel_id,
-      project_version: 'a_project_version_string',
       comment: 'a comment'
     }
 
@@ -71,7 +67,6 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
     sign_in @teacher
     post :create, params: {
       channel_id: @project_owner_channel_id,
-      project_version: 'a_project_version_string',
       comment: 'a comment'
     }
 
@@ -84,7 +79,6 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
     sign_in @teacher
     post :create, params: {
       channel_id: @project_owner_channel_id,
-      project_version: 'a_project_version_string',
       comment: 'a comment'
     }
 
@@ -155,8 +149,7 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
 
     sign_in @project_owner
     get :project_comments, params: {
-      channel_id: @project_owner_channel_id,
-      project_version: @project_version_string
+      channel_id: @project_owner_channel_id
     }
 
     assert_response :success
@@ -172,7 +165,6 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
     teacher_comment = create :code_review_comment,
       commenter: @teacher,
       storage_app_id: @project_storage_app_id,
-      project_version: @project_version_string,
       project_owner_id: @project_owner.id
 
     sign_in @project_owner
@@ -193,8 +185,7 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
 
     sign_in @another_student
     get :project_comments, params: {
-      channel_id: @project_owner_channel_id,
-      project_version: @project_version_string
+      channel_id: @project_owner_channel_id
     }
 
     assert_response :success
@@ -212,7 +203,6 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
     teacher_comment = create :code_review_comment,
       commenter: @teacher,
       storage_app_id: @project_storage_app_id,
-      project_version: @project_version_string,
       project_owner_id: @project_owner.id
 
     sign_in @another_student
@@ -231,8 +221,7 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
 
     sign_in @teacher
     get :project_comments, params: {
-      channel_id: @project_owner_channel_id,
-      project_version: @project_version_string
+      channel_id: @project_owner_channel_id
     }
 
     assert_response :success
@@ -247,13 +236,11 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
     create :code_review_comment,
       commenter: @teacher,
       storage_app_id: @project_storage_app_id,
-      project_version: @project_version_string,
       project_owner_id: @project_owner.id
 
     sign_in @teacher
     get :project_comments, params: {
-      channel_id: @project_owner_channel_id,
-      project_version: @project_version_string
+      channel_id: @project_owner_channel_id
     }
 
     assert_response :success
@@ -266,8 +253,7 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
 
     sign_in @another_student
     get :project_comments, params: {
-      channel_id: @project_owner_channel_id,
-      project_version: @project_version_string
+      channel_id: @project_owner_channel_id
     }
 
     assert_response :forbidden
@@ -279,8 +265,7 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
 
     sign_in @teacher
     get :project_comments, params: {
-      channel_id: @project_owner_channel_id,
-      project_version: @project_version_string
+      channel_id: @project_owner_channel_id
     }
 
     assert_response :forbidden
@@ -305,7 +290,6 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
     2.times do
       create :code_review_comment,
         storage_app_id: @project_storage_app_id,
-        project_version: @project_version_string,
         project_owner_id: @project_owner.id
     end
 

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -1387,7 +1387,6 @@ FactoryGirl.define do
     association :project_owner, factory: :student
 
     storage_app_id 1
-    project_version 'a_project_version_string'
     comment 'a comment about your project'
   end
 


### PR DESCRIPTION
Remove requirement that code review comments be associated with a specific version of a project. This feature (version-specific comments) will be implemented at a later date.

## Testing story

Ran migration locally.