### PR TITLE
Migration for user_scripts table for reset progress

### DIFF
--- a/dashboard/app/models/user_script.rb
+++ b/dashboard/app/models/user_script.rb
@@ -12,11 +12,12 @@
 #  created_at       :datetime
 #  updated_at       :datetime
 #  properties       :text(65535)
+#  deleted_at       :datetime
 #
 # Indexes
 #
-#  index_user_scripts_on_script_id              (script_id)
-#  index_user_scripts_on_user_id_and_script_id  (user_id,script_id) UNIQUE
+#  index_user_scripts_on_script_id                             (script_id)
+#  index_user_scripts_on_user_id_and_script_id_and_deleted_at  (user_id,script_id,deleted_at) UNIQUE
 #
 
 class UserScript < ApplicationRecord

--- a/dashboard/db/migrate/20210809205147_add_deleted_at_to_user_scripts.rb
+++ b/dashboard/db/migrate/20210809205147_add_deleted_at_to_user_scripts.rb
@@ -1,0 +1,10 @@
+class AddDeletedAtToUserScripts < ActiveRecord::Migration[5.2]
+  def change
+    # This change will be implemented on production using the MySQL gh-ost tool.
+    return if Rails.env.production?
+
+    add_column :user_scripts, :deleted_at, :datetime
+    add_index :user_scripts, [:user_id, :script_id, :deleted_at], unique: true
+    remove_index :user_scripts, column: [:user_id, :script_id], unique: true
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_03_222704) do
+ActiveRecord::Schema.define(version: 2021_08_09_205147) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -1927,8 +1927,9 @@ ActiveRecord::Schema.define(version: 2021_08_03_222704) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.text "properties"
+    t.datetime "deleted_at"
     t.index ["script_id"], name: "index_user_scripts_on_script_id"
-    t.index ["user_id", "script_id"], name: "index_user_scripts_on_user_id_and_script_id", unique: true
+    t.index ["user_id", "script_id", "deleted_at"], name: "index_user_scripts_on_user_id_and_script_id_and_deleted_at", unique: true
   end
 
   create_table "users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

This migration adds a `deleted_at` column to the `user_scripts` table in preparation for implementing reset progress.

@sureshc , please advise on whether this migration should be done via ghost or whether it can be run as usual.  Thanks!

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- tech spec: [doc](https://docs.google.com/document/d/1iiExH1ZHHGEJKeca3vQ8zpLZx3LPK5SW00qpN6GdgxA/edit)
- jira ticket: [LP-1970](https://codedotorg.atlassian.net/browse/LP-1970)
- analogous migration for `user_levels` table: #41694

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
