### PR TITLE
Javalab: Mark comments as from teacher in code review

### DIFF
--- a/dashboard/app/controllers/code_review_comments_controller.rb
+++ b/dashboard/app/controllers/code_review_comments_controller.rb
@@ -13,8 +13,7 @@ class CodeReviewCommentsController < ApplicationController
       commenter_id: current_user.id,
       storage_app_id: @storage_app_id,
       project_version: 'temporary placeholder',
-      project_owner_id: @project_owner.id,
-      is_from_teacher: current_user.teacher?
+      project_owner_id: @project_owner.id
     }
     @code_review_comment = CodeReviewComment.new(code_review_comments_params.merge(additional_attributes))
 

--- a/dashboard/app/controllers/code_review_comments_controller.rb
+++ b/dashboard/app/controllers/code_review_comments_controller.rb
@@ -61,7 +61,7 @@ class CodeReviewCommentsController < ApplicationController
 
     # Keep teacher comments private between project owner and teacher.
     unless @project_owner.student_of?(current_user) || @project_owner == current_user
-      @project_comments = @project_comments.reject {|comment| comment.commenter.teacher?}
+      @project_comments = @project_comments.reject {|comment| !!comment.is_from_teacher}
     end
 
     serialized_comments = @project_comments.map {|comment| serialize(comment)}

--- a/dashboard/app/controllers/code_review_comments_controller.rb
+++ b/dashboard/app/controllers/code_review_comments_controller.rb
@@ -13,7 +13,8 @@ class CodeReviewCommentsController < ApplicationController
       commenter_id: current_user.id,
       storage_app_id: @storage_app_id,
       project_version: 'temporary placeholder',
-      project_owner_id: @project_owner.id
+      project_owner_id: @project_owner.id,
+      is_from_teacher: current_user.teacher?
     }
     @code_review_comment = CodeReviewComment.new(code_review_comments_params.merge(additional_attributes))
 

--- a/dashboard/app/models/code_review_comment.rb
+++ b/dashboard/app/models/code_review_comment.rb
@@ -28,10 +28,16 @@ class CodeReviewComment < ApplicationRecord
   validates :comment, presence: true
   validates :project_owner_id, presence: true
 
+  before_save :compute_is_from_teacher
+
   # To do: move to ReviewableProject model
   def self.user_can_review_project?(project_owner, potential_reviewer)
     project_owner == potential_reviewer ||
       project_owner.student_of?(potential_reviewer) ||
       (project_owner.sections_as_student & potential_reviewer.sections_as_student).any?
+  end
+
+  def compute_is_from_teacher
+    self.is_from_teacher = commenter.teacher? ? true : false
   end
 end

--- a/dashboard/test/controllers/code_review_comments_controller_test.rb
+++ b/dashboard/test/controllers/code_review_comments_controller_test.rb
@@ -31,6 +31,7 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
     }
 
     assert_response :success
+    refute JSON.parse(response.body)['isFromTeacher']
   end
 
   test 'student not in same section with project owner cannot comment on project' do
@@ -61,6 +62,7 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
     }
 
     assert_response :success
+    refute JSON.parse(response.body)['isFromTeacher']
   end
 
   test 'teacher can create CodeReviewComment for student in their section' do
@@ -76,6 +78,7 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
     }
 
     assert_response :success
+    assert JSON.parse(response.body)['isFromTeacher']
   end
 
   test 'teacher cannot create CodeReviewComment for student not in their section' do

--- a/dashboard/test/models/code_review_comment_test.rb
+++ b/dashboard/test/models/code_review_comment_test.rb
@@ -1,11 +1,23 @@
 require 'test_helper'
 
 class CodeReviewCommentTest < ActiveSupport::TestCase
-  test 'CodeReviewComment must have a non-nil comment' do
+  test 'must have a non-nil comment' do
     code_review_comment = build :code_review_comment, comment: nil
     refute code_review_comment.valid?
 
     code_review_comment.comment = 'a comment'
     assert code_review_comment.valid?
+  end
+
+  test 'comment from student is marked as not from teacher' do
+    student = create :student
+    code_review_comment = create :code_review_comment, commenter: student
+    assert_equal false, code_review_comment.is_from_teacher?
+  end
+
+  test 'comment from teacher is marked as from teacher' do
+    teacher = create :teacher
+    code_review_comment = create :code_review_comment, commenter: teacher
+    assert_equal true, code_review_comment.is_from_teacher?
   end
 end


### PR DESCRIPTION
When code review comments are submitted, mark comments as from teacher if they are, in fact, from a teacher.

## Testing story

Added unit test cases.