### PR TITLE
reprint drone runner hostname

### DIFF
--- a/docker/ui_tests.sh
+++ b/docker/ui_tests.sh
@@ -73,6 +73,9 @@ RAKE_VERBOSE=true bundle exec rake install --trace
 # name: rake build
 RAKE_VERBOSE=true bundle exec rake build --trace
 
+# reprint the hostname in case the first printing has already been truncated by the drone UI
+hostname=$(curl -s --max-time 3 http://169.254.169.254/latest/meta-data/public-hostname || echo $DRONE_RUNNER_HOSTNAME); echo "Running on $hostname"
+
 # name: seed ui tests
 bundle exec rake circle:seed_ui_test --trace
 


### PR DESCRIPTION
## Background

The first step in [Accessing your drone test run container](https://docs.google.com/document/d/1Qls20xfNN6T_DErOMwVQOFJsxAEAdMWFHzBDIbxyUQQ/edit#heading=h.8lciuf4o4a01) is to obtain the hostname from the output shown in the drone UI. unfortunately, in UI test containers, the test run generates so much output that the hostname is truncated from the scrollback:

https://user-images.githubusercontent.com/8001765/126871296-765ac661-5d17-49ea-bd2c-5cbeb79a6353.mov

this requires you to carefully time when you go look at the drone run, after the UI test container starts, but before the `rake assets:precompile` step runs during `rake build`. if you miss it, you have to restart the drone run, leading  to wasted developer time and drone resources.

## Description

The solution is to print out the hostname again. This point is far enough down in the log output that it remains visible once UI tests have started:

![Screen Shot 2021-07-24 at 7 10 09 AM](https://user-images.githubusercontent.com/8001765/126871161-76985bc4-0c1f-4adc-9940-fecb2ba3fd3e.png)

## Future work

It's not totally clear whether we need the entire multi-thousand-line output of a successful run of `rake assets:precompile` in our drone build logs. we could consider removing it.