### PR TITLE
fix kill-tests script to properly kill dashboard unit test rake task

### DIFF
--- a/bin/kill-tests
+++ b/bin/kill-tests
@@ -14,7 +14,7 @@ FAIL_MSG = 'failed to kill all tests'.freeze
 
 # @return [Boolean] Returns whether tests are currently running via pgrep.
 def tests_running?
-  !`pgrep -f runner.rb`.empty? || !`pgrep -f cucumber`.empty? || !`pgrep -f 'rake test'`.empty?
+  !`pgrep -f runner.rb`.empty? || !`pgrep -f cucumber`.empty? || !`pgrep -f 'rake parallel:test'`.empty?
 end
 
 # Prints to the console and logs to ChatClient a message.
@@ -26,7 +26,7 @@ end
 
 def kill_tests
   # Kill dashboard unit tests.
-  `pkill -f 'rake test'`
+  `pkill -f 'rake parallel:test'`
 
   # Kill ui tests.
   `pkill -f runner.rb`


### PR DESCRIPTION
see https://codedotorg.slack.com/archives/C03CM903Y/p1627016109148200

## Testing story

* killing `rake parallel:test` by PID yesterday succeeded in killing the dashboard unit tests, and causing the DTT to end. 
* manually verified this script will kill `rake parallel:test` locally (screenshots show two separate windows):
  * ![Screen Shot 2021-07-23 at 9 57 27 AM](https://user-images.githubusercontent.com/8001765/126816210-de8f103d-62b5-4cf7-a221-193ba03fa888.png)
  * ![Screen Shot 2021-07-23 at 9 57 44 AM](https://user-images.githubusercontent.com/8001765/126816223-e2060a19-b7a0-4b41-b8a2-12430367f2ec.png)
