### PR TITLE
Fix missing variable name during I18n sync-in

### DIFF
--- a/bin/i18n/i18n_script_utils.rb
+++ b/bin/i18n/i18n_script_utils.rb
@@ -257,10 +257,13 @@ class I18nScriptUtils
     base = Pathname.new(level_content_directory)
     relative_matching = matching_files.map {|filename| Pathname.new(filename).relative_path_from(base)}
     relative_new = Pathname.new(script_i18n_filename).relative_path_from(base)
+    script_name = script_i18n_name.split('.')[0]
+    error_message = "Script #{script_name} wants to output strings to #{relative_new}, but #{relative_matching.join(' and ')} already exists"
     Honeybadger.notify(
       error_class: 'Destination directory for script is attempting to change',
-      error_message: "Script #{script.name.inspect} wants to output strings to #{relative_new}, but #{relative_matching.join(' and ')} already exists"
+      error_message: error_message
     )
+    puts error_message
     return true
   end
 end

--- a/bin/i18n/i18n_script_utils.rb
+++ b/bin/i18n/i18n_script_utils.rb
@@ -257,7 +257,7 @@ class I18nScriptUtils
     base = Pathname.new(level_content_directory)
     relative_matching = matching_files.map {|filename| Pathname.new(filename).relative_path_from(base)}
     relative_new = Pathname.new(script_i18n_filename).relative_path_from(base)
-    script_name = script_i18n_name.split('.')[0]
+    script_name = File.basename(script_i18n_name, '.*')
     error_message = "Script #{script_name} wants to output strings to #{relative_new}, but #{relative_matching.join(' and ')} already exists"
     Honeybadger.notify(
       error_class: 'Destination directory for script is attempting to change',


### PR DESCRIPTION
I18n `sync-in` failed because of the error below ([Slack message](https://codedotorg.slack.com/archives/C99KAHFK9/p1627119258064900)). The fix is to get script's name from the `script_i18n_name`.
```
NameError: undefined local variable or method `script' for I18nScriptUtils:Class
/home/ubuntu/code-dot-org/bin/i18n/i18n_script_utils.rb:262:in `unit_directory_change?'
```

## Follow-up work
While fixing this error, I find 2 more issues that we should address later.
1. The issue that `I18nScriptUtils.unit_directory_change?` detects. It prevents the following scripts from being localized ([related code](https://github.com/code-dot-org/code-dot-org/blob/dea46196e586a13c138e2802afbc290867eabe75/bin/i18n/sync-in.rb#L272)): `20-hour`, `jigsaw`, `course1`, `course2`, `course3`, `course4`, `csd-post-survey`, `deepdive-debugging`, `pixelation`, `outbreak`. Tracked by [FND-1666](https://codedotorg.atlassian.net/browse/FND-1666).

2. Honeybadger doesn't work on the i18n-dev machine. I added Honeybadger's API keys to `locals.yml`. However, Honeybadger detected that it is running in [a development environment](https://docs.honeybadger.io/lib/ruby/getting-started/environments/) and did not send error to its server. Tracked by [FND-1667](https://codedotorg.atlassian.net/browse/FND-1667).


## Links
Related PR: https://github.com/code-dot-org/code-dot-org/pull/41009 

## Testing story
Ran `bin/i18n/sync-in.rb` on the i18n-dev server. This was the output:
```
ubuntu@i18n-dev:~/code-dot-org$ bin/i18n/sync-in.rb
Sync in starting
Preparing level content
Script 20-hour wants to output strings to unversioned/20-hour.json, but other/20-hour.json already exists
Script jigsaw wants to output strings to unversioned/jigsaw.json, but other/jigsaw.json already exists
Script course1 wants to output strings to unversioned/course1.json, but other/course1.json already exists
Script course2 wants to output strings to unversioned/course2.json, but other/course2.json already exists
Script course3 wants to output strings to unversioned/course3.json, but other/course3.json already exists
Script course4 wants to output strings to unversioned/course4.json, but other/course4.json already exists
Script csd-post-survey wants to output strings to unversioned/csd-post-survey.json, but other/csd-post-survey.json already exists
Script deepdive-debugging wants to output strings to unversioned/deepdive-debugging.json, but other/deepdive-debugging.json already exists
Script pixelation wants to output strings to unversioned/pixelation.json, but other/pixelation.json already exists
Script outbreak wants to output strings to unversioned/outbreak.json, but other/outbreak.json already exists
scriPreparing project content
Sync in completed successfully
```

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
