### PR TITLE
Fix "Create New Section" dialog no-scrolling bug

### DIFF
--- a/apps/src/templates/teacherDashboard/AddSectionDialog.jsx
+++ b/apps/src/templates/teacherDashboard/AddSectionDialog.jsx
@@ -40,7 +40,7 @@ class AddSectionDialog extends Component {
       handleCancel
     } = this.props;
     const {loginType} = section || {};
-    const title = i18n.newSection();
+    const title = i18n.newSectionUpdated();
     return (
       <BaseDialog
         useUpdatedStyles

--- a/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
+++ b/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
@@ -16,6 +16,13 @@ import {OAuthSectionTypes} from '@cdo/apps/lib/ui/accounts/constants';
 import styleConstants from '../../styleConstants';
 
 const style = {
+  container: {
+    width: styleConstants['content-width'],
+    height: '80vh',
+    maxHeight: '360px',
+    left: '20px',
+    right: '20px'
+  },
   scroll: {
     overflowX: 'hidden',
     overflowY: 'auto',
@@ -74,24 +81,24 @@ class LoginTypePicker extends Component {
     const hasThirdParty = withGoogle | withMicrosoft | withClever;
     // Set style of LoginTypePicker container and adjust max height of the scrolling
     // body of the dialog based on number of LoginCard types available to the user.
-    const loginTypePickerContainerStyle = hasThirdParty
-      ? {
-          width: styleConstants['content-width'],
-          height: '80vh',
-          maxHeight: '500px',
-          left: '20px',
-          right: '20px'
-        }
-      : {
-          width: styleConstants['content-width'],
-          height: '80vh',
-          maxHeight: '360px',
-          left: '20px',
-          right: '20px'
-        };
+    // const loginTypePickerContainerStyle = hasThirdParty
+    //   ? {
+    //       width: styleConstants['content-width'],
+    //       height: '80vh',
+    //       maxHeight: '500px',
+    //       left: '20px',
+    //       right: '20px'
+    //     }
+    //   : {
+    //       width: styleConstants['content-width'],
+    //       height: '80vh',
+    //       maxHeight: '360px',
+    //       left: '20px',
+    //       right: '20px'
+    //     };
 
     return (
-      <div style={loginTypePickerContainerStyle}>
+      <div style={style.container}>
         <Heading1>{title}</Heading1>
         <Heading2>{i18n.addStudentsToSectionInstructionsUpdated()}</Heading2>
         <div style={style.scroll}>

--- a/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
+++ b/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
@@ -72,9 +72,26 @@ class LoginTypePicker extends Component {
     const withClever =
       providers && providers.includes(OAuthSectionTypes.clever);
     const hasThirdParty = withGoogle | withMicrosoft | withClever;
+    // Set style of LoginTypePicker container and adjust max height of the scrolling
+    // body of the dialog based on number of LoginCard types available to the user.
+    const loginTypePickerContainerStyle = hasThirdParty
+      ? {
+          width: styleConstants['content-width'],
+          height: '80vh',
+          maxHeight: '500px',
+          left: '20px',
+          right: '20px'
+        }
+      : {
+          width: styleConstants['content-width'],
+          height: '80vh',
+          maxHeight: '360px',
+          left: '20px',
+          right: '20px'
+        };
 
     return (
-      <div>
+      <div style={loginTypePickerContainerStyle}>
         <Heading1>{title}</Heading1>
         <Heading2>{i18n.addStudentsToSectionInstructionsUpdated()}</Heading2>
         <div style={style.scroll}>

--- a/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
+++ b/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
@@ -89,16 +89,16 @@ class LoginTypePicker extends Component {
             <PictureLoginCard onClick={setLoginType} />
             <WordLoginCard onClick={setLoginType} />
             <EmailLoginCard onClick={setLoginType} />
-            {!hasThirdParty && (
-              <div>
-                {i18n.thirdPartyProviderUpsell() + ' '}
-                <a href="https://support.code.org/hc/en-us/articles/115001319312-Setting-up-sections-with-Google-Classroom-or-Clever">
-                  {i18n.learnHow()}
-                </a>
-                {' ' + i18n.connectAccountThirdPartyProviders()}
-              </div>
-            )}
           </CardContainer>
+          {!hasThirdParty && (
+            <div>
+              {i18n.thirdPartyProviderUpsell() + ' '}
+              <a href="https://support.code.org/hc/en-us/articles/115001319312-Setting-up-sections-with-Google-Classroom-or-Clever">
+                {i18n.learnHow()}
+              </a>
+              {' ' + i18n.connectAccountThirdPartyProviders()}
+            </div>
+          )}
         </div>
         <div style={style.footer}>
           <div style={style.emailPolicyNote}>

--- a/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
+++ b/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
@@ -5,17 +5,41 @@
  * external service like Microsoft Classroom or Clever.
  */
 import PropTypes from 'prop-types';
-
 import React, {Component} from 'react';
 import {connect} from 'react-redux';
 import i18n from '@cdo/locale';
 import {Heading1, Heading2} from '../../lib/ui/Headings';
 import CardContainer from './CardContainer';
-import DialogFooter from './DialogFooter';
 import LoginTypeCard from './LoginTypeCard';
 import Button from '../Button';
 import {OAuthSectionTypes} from '@cdo/apps/lib/ui/accounts/constants';
 import styleConstants from '../../styleConstants';
+
+const style = {
+  scroll: {
+    overflowX: 'hidden',
+    overflowY: 'auto',
+    height: 'calc(80vh - 200px)'
+  },
+  thirdPartyProviderUpsell: {
+    marginBottom: '10px'
+  },
+  footer: {
+    position: 'absolute',
+    width: styleConstants['content-width'],
+    height: '100px',
+    left: 0,
+    bottom: '-65px',
+    padding: '0px 20px 20px 20px',
+    backgroundColor: '#fff',
+    borderRadius: '5px'
+  },
+  emailPolicyNote: {
+    marginBottom: '20px',
+    paddingTop: '20px',
+    borderTop: '1px solid #000'
+  }
+};
 
 /**
  * UI for selecting the login type of a class section:
@@ -49,24 +73,11 @@ class LoginTypePicker extends Component {
       providers && providers.includes(OAuthSectionTypes.clever);
     const hasThirdParty = withGoogle | withMicrosoft | withClever;
 
-    // explicitly constrain the container as a whole to the width of the
-    // content. We expect that differing length of translations versus english
-    // source text can cause unexpected layout changes, and this constraint
-    // should help mitigate some of them.
-    const containerStyle = {maxWidth: styleConstants['content-width']};
-
-    // anchor email address policy note to footer just above 'Cancel' button
-    const emailPolicyNoteStyle = {
-      position: 'absolute',
-      top: '0px',
-      zIndex: '600'
-    };
-
     return (
-      <div style={containerStyle}>
+      <div>
         <Heading1>{title}</Heading1>
         <Heading2>{i18n.addStudentsToSectionInstructionsUpdated()}</Heading2>
-        <div>
+        <div style={style.scroll}>
           <CardContainer>
             {withGoogle && (
               <GoogleClassroomCard onClick={this.openImportDialog} />
@@ -78,19 +89,19 @@ class LoginTypePicker extends Component {
             <PictureLoginCard onClick={setLoginType} />
             <WordLoginCard onClick={setLoginType} />
             <EmailLoginCard onClick={setLoginType} />
+            {!hasThirdParty && (
+              <div>
+                {i18n.thirdPartyProviderUpsell() + ' '}
+                <a href="https://support.code.org/hc/en-us/articles/115001319312-Setting-up-sections-with-Google-Classroom-or-Clever">
+                  {i18n.learnHow()}
+                </a>
+                {' ' + i18n.connectAccountThirdPartyProviders()}
+              </div>
+            )}
           </CardContainer>
         </div>
-        {!hasThirdParty && (
-          <div>
-            {i18n.thirdPartyProviderUpsell() + ' '}
-            <a href="https://support.code.org/hc/en-us/articles/115001319312-Setting-up-sections-with-Google-Classroom-or-Clever">
-              {i18n.learnHow()}
-            </a>
-            {' ' + i18n.connectAccountThirdPartyProviders()}
-          </div>
-        )}
-        <DialogFooter>
-          <div style={emailPolicyNoteStyle}>
+        <div style={style.footer}>
+          <div style={style.emailPolicyNote}>
             <b>{i18n.note()}</b>
             {' ' + i18n.emailAddressPolicy() + ' '}
             <a href="http://blog.code.org/post/147756946588/codeorgs-new-login-approach-to-student-privacy">
@@ -105,7 +116,7 @@ class LoginTypePicker extends Component {
             color={Button.ButtonColor.gray}
             disabled={disabled}
           />
-        </DialogFooter>
+        </div>
       </div>
     );
   }

--- a/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
+++ b/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
@@ -19,7 +19,6 @@ const style = {
   container: {
     width: styleConstants['content-width'],
     height: '80vh',
-    maxHeight: '360px',
     left: '20px',
     right: '20px'
   },

--- a/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
+++ b/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
@@ -18,7 +18,7 @@ import styleConstants from '../../styleConstants';
 const style = {
   container: {
     width: styleConstants['content-width'],
-    height: '80vh',
+    height: '360px',
     left: '20px',
     right: '20px'
   },
@@ -78,23 +78,11 @@ class LoginTypePicker extends Component {
     const withClever =
       providers && providers.includes(OAuthSectionTypes.clever);
     const hasThirdParty = withGoogle | withMicrosoft | withClever;
-    // Set style of LoginTypePicker container and adjust max height of the scrolling
-    // body of the dialog based on number of LoginCard types available to the user.
-    // const loginTypePickerContainerStyle = hasThirdParty
-    //   ? {
-    //       width: styleConstants['content-width'],
-    //       height: '80vh',
-    //       maxHeight: '500px',
-    //       left: '20px',
-    //       right: '20px'
-    //     }
-    //   : {
-    //       width: styleConstants['content-width'],
-    //       height: '80vh',
-    //       maxHeight: '360px',
-    //       left: '20px',
-    //       right: '20px'
-    //     };
+    // Adjust max height of the LoginTypePicker container if there are >3 LoginType
+    // cards (thus creating the need for a 2nd row in the CardContainer flexbox).
+    if (hasThirdParty) {
+      style.container.height = '500px';
+    }
 
     return (
       <div style={style.container}>

--- a/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
+++ b/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
@@ -15,38 +15,6 @@ import Button from '../Button';
 import {OAuthSectionTypes} from '@cdo/apps/lib/ui/accounts/constants';
 import styleConstants from '../../styleConstants';
 
-const style = {
-  container: {
-    width: styleConstants['content-width'],
-    height: '360px',
-    left: '20px',
-    right: '20px'
-  },
-  scroll: {
-    overflowX: 'hidden',
-    overflowY: 'auto',
-    height: 'calc(80vh - 200px)'
-  },
-  thirdPartyProviderUpsell: {
-    marginBottom: '10px'
-  },
-  footer: {
-    position: 'absolute',
-    width: styleConstants['content-width'],
-    height: '100px',
-    left: 0,
-    bottom: '-65px',
-    padding: '0px 20px 20px 20px',
-    backgroundColor: '#fff',
-    borderRadius: '5px'
-  },
-  emailPolicyNote: {
-    marginBottom: '20px',
-    paddingTop: '20px',
-    borderTop: '1px solid #000'
-  }
-};
-
 /**
  * UI for selecting the login type of a class section:
  * Word, picture, or email logins, or one of several third-party integrations.
@@ -78,11 +46,41 @@ class LoginTypePicker extends Component {
     const withClever =
       providers && providers.includes(OAuthSectionTypes.clever);
     const hasThirdParty = withGoogle | withMicrosoft | withClever;
-    // Adjust max height of the LoginTypePicker container if there are >3 LoginType
-    // cards (thus creating the need for a 2nd row in the CardContainer flexbox).
-    if (hasThirdParty) {
-      style.container.height = '500px';
-    }
+    // Adjust max height of the LoginTypePicker container based on the number of
+    // LoginType cards (which affects number of rows in the CardContainer flexbox).
+    const containerHeight = hasThirdParty ? '500px' : '360px';
+
+    const style = {
+      container: {
+        width: styleConstants['content-width'],
+        height: containerHeight,
+        left: '20px',
+        right: '20px'
+      },
+      scroll: {
+        overflowX: 'hidden',
+        overflowY: 'auto',
+        height: 'calc(80vh - 200px)'
+      },
+      thirdPartyProviderUpsell: {
+        marginBottom: '10px'
+      },
+      footer: {
+        position: 'absolute',
+        width: styleConstants['content-width'],
+        height: '100px',
+        left: 0,
+        bottom: '-65px',
+        padding: '0px 20px 20px 20px',
+        backgroundColor: '#fff',
+        borderRadius: '5px'
+      },
+      emailPolicyNote: {
+        marginBottom: '20px',
+        paddingTop: '20px',
+        borderTop: '1px solid #000'
+      }
+    };
 
     return (
       <div style={style.container}>


### PR DESCRIPTION
Fixes a scrolling bug in the New Section dialog window where LoginTypeCards were getting cut off since it wasn't scrolling. The original problem was spotted when [this PR](https://github.com/code-dot-org/code-dot-org/pull/40384) was merged. 

## Screenshots of correct behavior for scrolling
### Case when the user does not have a 3rd party provider connected to their account (e.g. Google Classroom) so they only have access to Picture Password, Secret Words, and Personal Login types (only 1 row of 3 LoginTypeCards):
![Fix scroll bug 1](https://user-images.githubusercontent.com/56283563/125521742-edc7a897-d930-4ae4-bb47-f1aecf73b2a6.JPG)
### Case when the user has at least one 3rd party provider connected to their account (e.g. Google Classroom) so they have at least 4 types of login cards (causing 2 rows of cards):
![Fix scroll bug 2](https://user-images.githubusercontent.com/56283563/125521743-fd5394d4-fa7f-4932-8541-b0be19139275.JPG)

## Screenshots of what the dialog normally looks like when no scrolling is needed (i.e. if the window is large enough)
### Case when the user does not have a 3rd party provider connected to their account (e.g. Google Classroom) so they only have access to Picture Password, Secret Words, and Personal Login types (only 1 row of 3 LoginTypeCards):
![Fix scroll bug 3](https://user-images.githubusercontent.com/56283563/125522587-9c9c1b91-6839-466e-bb94-e2cb2ea9f74b.JPG)
### Case when the user has at least one 3rd party provider connected to their account (e.g. Google Classroom) so they have at least 4 types of login cards (causing 2 rows of cards):
![Fix scroll bug 4](https://user-images.githubusercontent.com/56283563/125522588-29c9c777-b173-4814-9483-b00f9af9c141.JPG)

## Testing story
Manual testing with different numbers of LoginTypeCards (by manually toggling whether I have third party options enabled or not such as Google Classrooms) to ensure correct scrolling behavior when there is not enough space to display all of the content at once. This testing was also replicated in multiple browsers while ensuring that the full process of going through the motions of creating a new section still work (from clicking "New section" to the actual creation of a new section). Lastly, I created an ad-hoc environment to triple check its functionality.