### PR TITLE
[HOC] Set default_hoc_mode to pre-hoc

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -414,7 +414,7 @@ proxy: false # If true, generated URLs will not include explicit port numbers in
 # Run dashboard-server with the level editing interface enabled (for admins)
 levelbuilder_mode:
 
-default_hoc_mode:   post-hoc # overridden by 'hoc_mode' DCDO param, except in :test
+default_hoc_mode:   pre-hoc # overridden by 'hoc_mode' DCDO param, except in :test
 default_hoc_launch: ''       # overridden by 'hoc_launch' DCDO param, except in :test
 
 # teacher_application_mode values: 'open', 'closing-soon', 'closed'


### PR DESCRIPTION
This change will only affect the test environment. This updates `default_hoc_mode` to `pre-hoc` which we will be switching over to soon.

The relevant changes for 2021 are here: https://github.com/code-dot-org/code-dot-org/pull/41693