### PR TITLE
Revert "Use serialized_maze and start_direction from template level in Javalab levels"

### DIFF
--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -159,9 +159,8 @@ class LevelsController < ApplicationController
   # GET /levels/:id/get_serialized_maze
   # Get the serialized_maze for the level, if it exists.
   def get_serialized_maze
-    serialized_maze = @level.try(:get_serialized_maze)
-    return head :no_content unless serialized_maze
-    render json: serialized_maze
+    return head :no_content unless @level.properties['serialized_maze'].presence && @level.serialized_maze
+    render json: @level.serialized_maze
   end
 
   # GET /levels/:id/edit_blocks/:type

--- a/dashboard/app/models/levels/javalab.rb
+++ b/dashboard/app/models/levels/javalab.rb
@@ -60,7 +60,6 @@ class Javalab < Level
   end
 
   def parse_maze
-    return if serialized_maze.blank? && project_template_level&.try(:serialized_maze).present?
     if serialized_maze.nil? && csa_view_mode == 'neighborhood'
       raise ArgumentError.new('neighborhood must have a serialized_maze')
     end
@@ -95,10 +94,6 @@ class Javalab < Level
     self.examples = all_examples
   end
 
-  def get_serialized_maze
-    serialized_maze || project_template_level&.try(:serialized_maze)
-  end
-
   # Return an 'appOptions' hash derived from the level contents
   def non_blockly_puzzle_level_options
     options = Rails.cache.fetch("#{cache_key}/non_blockly_puzzle_level_options/v2") do
@@ -110,11 +105,6 @@ class Javalab < Level
         # Don't override existing valid (non-nil/empty) values
         value = JSONValue.value(properties[dashboard].presence)
         level_prop[apps_prop_name] = value unless value.nil? # make sure we convert false
-      end
-
-      if csa_view_mode == 'neighborhood'
-        level_prop['serializedMaze'] = get_serialized_maze
-        level_prop['startDirection'] = start_direction || try(:project_template_level).start_direction
       end
 
       level_prop['levelId'] = level_num

--- a/dashboard/test/models/javalab_test.rb
+++ b/dashboard/test/models/javalab_test.rb
@@ -24,22 +24,4 @@ class JavalabTest < ActiveSupport::TestCase
       Javalab.create(neighborhood_data)
     end
   end
-
-  test 'get_serialized_maze returns template level maze if level doesnt have one' do
-    template_data = {game_id: 68, level_num: "custom", name: "template_neighborhood"}
-    serialized_maze = "[[{\"tileType\": 0, \"assetId\": 13, \"value\": 0}],[{\"tileType\":1,\"value\":0}]]"
-    template_data[:properties] = {
-      serialized_maze: serialized_maze,
-      csa_view_mode: "neighborhood"
-    }
-    template_level = Javalab.create(template_data)
-
-    neighborhood_data = {game_id: 68, level_num: "custom", name: "sample_neighborhood"}
-    neighborhood_data[:properties] = {
-      csa_view_mode: "neighborhood",
-      project_template_level_name: template_level.name
-    }
-    neighborhood_level = Javalab.create(neighborhood_data)
-    assert_equal template_level.get_serialized_maze, neighborhood_level.get_serialized_maze
-  end
 end


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#41689

Cause of https://app.honeybadger.io/projects/3240/faults/80612416