### PR TITLE
Added optimizely events to count user type selections in sign up process

### DIFF
--- a/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
+++ b/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
@@ -70,6 +70,10 @@ $(document).ready(() => {
       return false;
     }
 
+    // Optimizely-related code for new sign-up user-type buttons (start)
+    optimizelyCountUserTypeSelection(getUserType());
+    // Optimizely-related code for new sign-up user-type buttons (end)
+
     alreadySubmitted = true;
     // Clean up school data and set age for teachers.
     if (getUserType() === 'teacher') {
@@ -140,8 +144,14 @@ $(document).ready(() => {
     }
   }
   // Keep if sign-up user type experiment favors variant (end)
-  // Keep if sign-up user type experiment favors original (just the below function))
 
+  // Optimizely-related code for new sign-up user-type buttons
+  function optimizelyCountUserTypeSelection(userType) {
+    window['optimizely'] = window['optimizely'] || [];
+    window['optimizely'].push({type: 'event', eventName: userType});
+  }
+
+  // Keep if sign-up user type experiment favors original (just func. below)
   $('#user_user_type').change(function() {
     var value = $(this).val();
     setUserType(value);


### PR DESCRIPTION
Added Optimizely-related code to keep count of which user type (Teacher or Student) each user is selecting in the sign-up process.

## Links
The updated sign-up process can be found at [this PR](https://github.com/code-dot-org/code-dot-org/pull/41608).
Logic used for Optimizely-related code is similar to the code removed from [this PR](https://github.com/code-dot-org/code-dot-org/pull/41191) which was also used for an Optimizely experiment.

## Testing story
Ran the same manual tests done when I was testing [the original PR](https://github.com/code-dot-org/code-dot-org/pull/41608) this experiment will test. I also checked that the Optimizely counter logs the correct user type selection upon form submission of the sign up page using console logs.