### PR TITLE
Relax threshold for BufferBench test

### DIFF
--- a/lib/test/cdo/test_buffer.rb
+++ b/lib/test/cdo/test_buffer.rb
@@ -156,7 +156,7 @@ class BufferBench < Minitest::Benchmark
 
   def bench_linear_performance
     buffer = BufferTest::TestBuffer.new(batch_count: 500, min_interval: 0.01)
-    assert_performance_linear do |n|
+    assert_performance_linear(0.95) do |n|
       n.times {buffer.buffer({})}
       buffer.flush!
     end


### PR DESCRIPTION
Reduce the failure threshold from 0.99 (default) to 0.95 to reduce test flakiness in CI builds.

See also #40737 (same adjustment to the similar i18n string url tracker test).