### PR TITLE
stop serializing named_level to script json

### DIFF
--- a/dashboard/config/scripts_json/allthemigratedthings.script_json
+++ b/dashboard/config/scripts_json/allthemigratedthings.script_json
@@ -14,7 +14,7 @@
     },
     "new_name": null,
     "family_name": "ui-test-versioned-script",
-    "serialized_at": "2021-07-20 22:21:28 UTC",
+    "serialized_at": "2021-07-27 16:15:39 UTC",
     "published_state": "beta",
     "seeding_key": {
       "script.name": "allthemigratedthings"
@@ -389,7 +389,6 @@
         ],
         "progression": "Levels are Cool"
       },
-      "named_level": false,
       "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
@@ -415,7 +414,6 @@
         ],
         "progression": "Bubble Choice"
       },
-      "named_level": false,
       "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
@@ -441,7 +439,6 @@
         ],
         "progression": "Standalone Video"
       },
-      "named_level": false,
       "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
@@ -467,7 +464,6 @@
         ],
         "progression": "Level with Instructions"
       },
-      "named_level": false,
       "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [

--- a/dashboard/lib/services/script_seed.rb
+++ b/dashboard/lib/services/script_seed.rb
@@ -769,7 +769,6 @@ module Services
         :activity_section_position,
         :assessment,
         :properties,
-        :named_level,
         :bonus,
         :seeding_key,
         :level_keys
@@ -782,10 +781,6 @@ module Services
       def properties
         # sort properties hash by key
         object.properties.sort.to_h
-      end
-
-      def named_level
-        !!object.named_level
       end
 
       def bonus

--- a/dashboard/test/fixtures/test-serialize-seeding-json.script_json
+++ b/dashboard/test/fixtures/test-serialize-seeding-json.script_json
@@ -217,7 +217,6 @@
       "assessment": false,
       "properties": {
       },
-      "named_level": false,
       "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
@@ -240,7 +239,6 @@
       "properties": {
         "challenge": true
       },
-      "named_level": false,
       "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
@@ -262,7 +260,6 @@
       "assessment": false,
       "properties": {
       },
-      "named_level": false,
       "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
@@ -285,7 +282,6 @@
       "properties": {
         "challenge": true
       },
-      "named_level": false,
       "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
@@ -307,7 +303,6 @@
       "assessment": false,
       "properties": {
       },
-      "named_level": false,
       "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
@@ -330,7 +325,6 @@
       "properties": {
         "challenge": true
       },
-      "named_level": false,
       "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
@@ -352,7 +346,6 @@
       "assessment": false,
       "properties": {
       },
-      "named_level": false,
       "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
@@ -375,7 +368,6 @@
       "properties": {
         "challenge": true
       },
-      "named_level": false,
       "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
@@ -397,7 +389,6 @@
       "assessment": false,
       "properties": {
       },
-      "named_level": false,
       "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
@@ -420,7 +411,6 @@
       "properties": {
         "challenge": true
       },
-      "named_level": false,
       "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
@@ -442,7 +432,6 @@
       "assessment": false,
       "properties": {
       },
-      "named_level": false,
       "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
@@ -465,7 +454,6 @@
       "properties": {
         "challenge": true
       },
-      "named_level": false,
       "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
@@ -487,7 +475,6 @@
       "assessment": false,
       "properties": {
       },
-      "named_level": false,
       "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
@@ -510,7 +497,6 @@
       "properties": {
         "challenge": true
       },
-      "named_level": false,
       "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
@@ -532,7 +518,6 @@
       "assessment": false,
       "properties": {
       },
-      "named_level": false,
       "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
@@ -555,7 +540,6 @@
       "properties": {
         "challenge": true
       },
-      "named_level": false,
       "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [

--- a/dashboard/test/lib/services/script_seed_test.rb
+++ b/dashboard/test/lib/services/script_seed_test.rb
@@ -278,7 +278,7 @@ module Services
         updated_script_level = script.script_levels.first
         updated_script_level.update!(challenge: 'foo')
         updated_script_level.levels += [new_level]
-        create :script_level, lesson: script.lessons.last, script: script, levels: [new_level], assessment: false, bonus: false, named_level: false
+        create :script_level, lesson: script.lessons.last, script: script, levels: [new_level], assessment: false, bonus: false
       end
 
       ScriptSeed.seed_from_json(json)
@@ -1155,7 +1155,7 @@ module Services
               level = create :level, name: "#{name_prefix}_blockly_#{sl_num}", level_num: "custom", game: game
               create :script_level, activity_section: section, activity_section_position: sl_pos,
                      lesson: lesson, script: script, levels: [level], challenge: sl_num.even?,
-                     assessment: false, bonus: false, named_level: false
+                     assessment: false, bonus: false
               sl_num += 1
             end
           end


### PR DESCRIPTION
Continues work on https://codedotorg.atlassian.net/browse/PLAT-621. Follow-on to https://github.com/code-dot-org/code-dot-org/pull/41714. That PR removed named level syntax from .script files. this PR removes it from .script_json files.

## Testing story

1. I regenerated script json for just `allthemigratedthings` and included that in this PR, so that drone would seed at least one migrated script with this syntax removed.
2. I regenerated script json for migrated scripts, then ran `rake seed:scripts` to make sure we can still seed all migrated scripts
3. after doing the above, I verified that no script levels in my local DB have the named_level property
4. we use .script_json when seeding migrated scripts. to convince myself that this PR will not remove the named_level property from any migrated scripts, I did the following:
  a. I looked at the output of regenerating script_json locally (see c1b9cfd5ff1201a1e5a54fe5e8e11b9723de8003) and verified that we are only removing lines that look like `"named_level": false`, never `"named_level": true`.
  b. I verified that (as a result of #41714) there are no longer any named levels on levelbuilder:
```
[levelbuilder] dashboard > ScriptLevel.where(named_level: true).count
=> 0
```

## Deployment strategy

Once this PR reaches levelbuilder, I will:
- [x] immediately regenerate script json on levelbuilder for non-migrated scripts: `Script.all.reject(&:is_migrated).each(&:write_script_json)`. this shouldn't affect any functionality, because we generate those but don't do anything with them for non-migrated scripts.
- [x] wait a few days for most frequently-edited, migrated scripts to get updated/regenerated
- [ ] open another PR to regenerate script json for any remaining migrated scripts, without touching the `serialized_at` column (used by PDF generation to decide when to regenerate)

this is a bit complicated, but seems best for (a) avoiding merge conflicts and (b) avoiding regenerating all script jsons for migrated scripts at once, since this can result in PDF generation holding up the staging build for > 2 hours.
