### PR TITLE
Fixing error handling in sync-in

### DIFF
--- a/bin/i18n/i18n_script_utils.rb
+++ b/bin/i18n/i18n_script_utils.rb
@@ -259,7 +259,7 @@ class I18nScriptUtils
     relative_new = Pathname.new(script_i18n_filename).relative_path_from(base)
     Honeybadger.notify(
       error_class: 'Destination directory for script is attempting to change',
-      error_message: "Script #{script.name.inspect} wants to output strings to #{relative_new}, but #{relative_matching.join(' and ')} already exists"
+      error_message: "Script #{script_i18n_name} wants to output strings to #{relative_new}, but #{relative_matching.join(' and ')} already exists"
     )
     return true
   end


### PR DESCRIPTION
When messing around with the sync-in on my local machine, I got an error saying `script` is not defined. This might have been a missed in a refactor.

Error message:
```
Sync in failed from the error: undefined local variable or method `script' for I18nScriptUtils:Class
```

[Original refactoring](https://github.com/code-dot-org/code-dot-org/commit/74cf6d0ae765fbc6dc60ffa72a0e6b4d2a4a8cad)

## Testing story
* Ran the sync-in locally.