### PR TITLE
Removing extra HoC certificates for Korean students

### DIFF
--- a/apps/src/templates/Congrats.jsx
+++ b/apps/src/templates/Congrats.jsx
@@ -4,7 +4,6 @@ import Certificate from './Certificate';
 import StudentsBeyondHoc from './StudentsBeyondHoc';
 import TeachersBeyondHoc from './TeachersBeyondHoc';
 import styleConstants from '../styleConstants';
-import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
 import color from '../util/color';
 
 export default class Congrats extends Component {
@@ -43,19 +42,8 @@ export default class Congrats extends Component {
    */
   renderExtraCertificateLinks = (language, tutorial) => {
     let extraLinkUrl, extraLinkText;
-    // https://codedotorg.atlassian.net/browse/FND-1604
-    // these can be removed after July 25 2021
-    if (language === 'ko') {
-      if (/oceans/.test(tutorial)) {
-        extraLinkUrl = pegasus('/files/online-coding-party-2021-oceans.pdf');
-        extraLinkText =
-          '온라인 코딩 파티 인증서 받으러 가기! (과학기술정보통신부 인증)';
-      } else if (/dance/.test(tutorial)) {
-        extraLinkUrl = pegasus('/files/online-coding-party-2021-dance.pdf');
-        extraLinkText =
-          '온라인 코딩 파티 인증서 받으러 가기! (과학기술정보통신부 인증)';
-      }
-    }
+    // Add extra links here
+
     if (!extraLinkUrl || !extraLinkText) {
       // There are no extra links to render.
       return;


### PR DESCRIPTION
There was a special Hour of Code campaign in Korea last month which has now ended. During that campaign, we added a download link for a special Korean certificate. The campaign is now over, so we need to remove the special links. We will leave the framework for adding special links because this is a common request.

[PR adding special Korean HoC certificate](https://github.com/code-dot-org/code-dot-org/pull/41025)

## Links
* [JIRA](https://codedotorg.atlassian.net/browse/FND-1607)

## Testing story
* Verified on localhost

## Screenshot
Note there is no link below the certificate image
![Screen Shot 2021-07-27 at 2 55 40 PM](https://user-images.githubusercontent.com/1372238/127232798-3e57c747-f5a9-4f8f-a0ab-9105d0849027.png)

