### PR TITLE
[Spritelab] Make instructions icon configurable

### DIFF
--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -212,12 +212,12 @@ P5Lab.prototype.init = function(config) {
 
   this.skin = config.skin;
   if (this.isSpritelab) {
-    const MEDIA_URL = '/blockly/media/spritelab/';
-    const avatar = config.level.instructionsIcon || 'avatar';
-    this.skin.smallStaticAvatar = `${MEDIA_URL}${avatar}.png`;
-    this.skin.staticAvatar = `${MEDIA_URL}${avatar}.png`;
-    this.skin.winAvatar = `${MEDIA_URL}${avatar}.png`;
-    this.skin.failureAvatar = `${MEDIA_URL}${avatar}.png`;
+    const mediaUrl = `/blockly/media/spritelab/${config.level
+      .instructionsIcon || 'avatar'}.png`;
+    this.skin.smallStaticAvatar = mediaUrl;
+    this.skin.staticAvatar = mediaUrl;
+    this.skin.winAvatar = mediaUrl;
+    this.skin.failureAvatar = mediaUrl;
 
     injectErrorHandler(
       new BlocklyModeErrorHandler(() => this.JSInterpreter, null)

--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -213,10 +213,11 @@ P5Lab.prototype.init = function(config) {
   this.skin = config.skin;
   if (this.isSpritelab) {
     const MEDIA_URL = '/blockly/media/spritelab/';
-    this.skin.smallStaticAvatar = MEDIA_URL + 'avatar.png';
-    this.skin.staticAvatar = MEDIA_URL + 'avatar.png';
-    this.skin.winAvatar = MEDIA_URL + 'avatar.png';
-    this.skin.failureAvatar = MEDIA_URL + 'avatar.png';
+    const avatar = config.level.instructionsIcon || 'avatar';
+    this.skin.smallStaticAvatar = `${MEDIA_URL}${avatar}.png`;
+    this.skin.staticAvatar = `${MEDIA_URL}${avatar}.png`;
+    this.skin.winAvatar = `${MEDIA_URL}${avatar}.png`;
+    this.skin.failureAvatar = `${MEDIA_URL}${avatar}.png`;
 
     injectErrorHandler(
       new BlocklyModeErrorHandler(() => this.JSInterpreter, null)

--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -845,6 +845,7 @@ input[type="radio"] {
 
 .prompt-icon-cell {
   vertical-align: top;
+  text-align: center;
   width: 50px;
   padding-right: 10px;
   height: auto;

--- a/dashboard/app/models/levels/gamelab_jr.rb
+++ b/dashboard/app/models/levels/gamelab_jr.rb
@@ -34,6 +34,7 @@ class GamelabJr < Gamelab
     mini_toolbox
     hide_pause_button
     blockly_variables
+    instructions_icon
   )
 
   def shared_blocks

--- a/dashboard/app/views/levels/editors/fields/_long_instructions.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_long_instructions.html.haml
@@ -15,7 +15,7 @@
 
 - if @level.is_a? GamelabJr
   = f.label :instructions_icon,'Instructions Icon'
-  %p Please refer to #{link_to 'Sprite Lab Static Assets', 'https://github.com/code-dot-org/code-dot-org/tree/staging/apps/static/spritelab'} for available assets, then enter the name of the image to use as the instructions icon for this level.
+  %p Please refer to #{link_to 'Sprite Lab Static Assets', 'https://github.com/code-dot-org/code-dot-org/tree/levelbuilder/apps/static/spritelab'} for available assets, then enter the name of the image to use as the instructions icon for this level.
   = f.text_field :instructions_icon, value: @level.instructions_icon
   %p Preview:
   %img.instructions-icon-preview{style: 'height: 64px;'}
@@ -23,12 +23,8 @@
 :javascript
   $(document).ready(function() {
     function updateIconPreview() {
-      var iconName = $('#level_instructions_icon')[0].value;
-      if (iconName) {
-        $('.instructions-icon-preview').attr('src', 'https://studio.code.org/blockly/media/spritelab/' + iconName + '.png');
-      } else {
-        $('.instructions-icon-preview').attr('src', 'https://studio.code.org/blockly/media/spritelab/avatar.png');
-      }
+      var iconName = $('#level_instructions_icon')[0].value || 'avatar';
+      $('.instructions-icon-preview').attr('src', 'https://studio.code.org/blockly/media/spritelab/' + iconName + '.png');
     }
     $('#level_instructions_icon').change(updateIconPreview);
     updateIconPreview();

--- a/dashboard/app/views/levels/editors/fields/_long_instructions.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_long_instructions.html.haml
@@ -13,7 +13,26 @@
     %div{ style: 'background-color: rgb(239, 239, 239); padding-top: 12px' }
       ~ f.text_area :long_instructions, rows: 4
 
+- if @level.is_a? GamelabJr
+  = f.label :instructions_icon,'Instructions Icon'
+  %p Please refer to #{link_to 'Sprite Lab Static Assets', 'https://github.com/code-dot-org/code-dot-org/tree/staging/apps/static/spritelab'} for available assets, then enter the name of the image to use as the instructions icon for this level.
+  = f.text_field :instructions_icon, value: @level.instructions_icon
+  %p Preview:
+  %img.instructions-icon-preview{style: 'height: 64px;'}
+
 :javascript
+  $(document).ready(function() {
+    function updateIconPreview() {
+      var iconName = $('#level_instructions_icon')[0].value;
+      if (iconName) {
+        $('.instructions-icon-preview').attr('src', 'https://studio.code.org/blockly/media/spritelab/' + iconName + '.png');
+      } else {
+        $('.instructions-icon-preview').attr('src', 'https://studio.code.org/blockly/media/spritelab/avatar.png');
+      }
+    }
+    $('#level_instructions_icon').change(updateIconPreview);
+    updateIconPreview();
+  })
   var mdEditor = levelbuilder.initializeCodeMirror('level_long_instructions', 'markdown', {
     callback: function (editor, change) {
       convertXmlToBlockly(document.getElementById('level_long_instructions_preview'));


### PR DESCRIPTION
Make the instructions icon configurable per level. This will only work for assets in https://github.com/code-dot-org/code-dot-org/tree/staging/apps/static/spritelab but it's easy enough to add new assets there as needed. Having all the assets served from there seems preferable over using any URL for two reasons:
1. More consistent with how other labs control the instructions avatar
2. It would allow us to easily find/change all usages of an image if needed.

Edit page:
![image](https://user-images.githubusercontent.com/8787187/127238391-3c555315-031e-4d99-9b95-e1f9fda436c9.png)

Before (always turtle)
![image](https://user-images.githubusercontent.com/8787187/127238262-c273b234-1850-4d0e-99b2-ab1d898cbd2a.png)

After (configurable per level)
![image](https://user-images.githubusercontent.com/8787187/127238312-cfe17b33-283c-4bd9-a3f2-dc7df3cda896.png)


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
[jira](https://codedotorg.atlassian.net/browse/STAR-1629)
<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
