### PR TITLE
Seed csd-2019 in test

### DIFF
--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -93,7 +93,12 @@ namespace :seed do
     'coursec-2019',
     'coursee-2019',
     'coursea-2020',
+    'csd1-2019',
+    'csd2-2019',
     'csd3-2019',
+    'csd4-2019',
+    'csd5-2019',
+    'csd6-2019',
     'csp1-2017',
     'csp2-2017',
     'csp3-2017',
@@ -224,7 +229,7 @@ namespace :seed do
 
   timed_task courses_ui_tests: :environment do
     # seed those courses that are needed for UI tests
-    %w(allthethingscourse csp-2017 csp-2018 csp-2019 csp-2020).each do |course_name|
+    %w(allthethingscourse csp-2017 csp-2018 csd-2019 csp-2019 csp-2020).each do |course_name|
       UnitGroup.load_from_path("config/courses/#{course_name}.course")
     end
     %w(ui-test-course-2017 ui-test-course-2019).each do |course_name|


### PR DESCRIPTION
In test, we seed a subset of scripts/courses for performance reasons. Soon, scripts will look to their unit group (if they have one) for their published state, which means that we are more strictly enforcing the assumption that the unit group of a script is also present in the database. This PR adds a few scripts/courses, particularly csd-2019, to the UI seed list. This is needed for the UI test `features/star_labs/can_see_finish.feature`.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
