### PR TITLE
Javalab: add index for allowing us to search for reviewable projects

### DIFF
--- a/dashboard/app/models/reviewable_project.rb
+++ b/dashboard/app/models/reviewable_project.rb
@@ -12,7 +12,7 @@
 #
 # Indexes
 #
-#  index_reviewable_projects_on_storage_app_id_and_user_id  (storage_app_id,user_id)
+#  index_reviewable_projects_on_user_script_level_storage_app  (user_id,script_id,level_id,storage_app_id)
 #
 class ReviewableProject < ApplicationRecord
   belongs_to :user

--- a/dashboard/db/migrate/20210728222333_index_level_and_script_id_on_reviewable_projects.rb
+++ b/dashboard/db/migrate/20210728222333_index_level_and_script_id_on_reviewable_projects.rb
@@ -1,0 +1,8 @@
+class IndexLevelAndScriptIdOnReviewableProjects < ActiveRecord::Migration[5.2]
+  def change
+    remove_index :reviewable_projects, column: [:storage_app_id, :user_id]
+    add_index :reviewable_projects,
+      [:user_id, :script_id, :level_id, :storage_app_id],
+      name: 'index_reviewable_projects_on_user_script_level_storage_app'
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_22_162824) do
+ActiveRecord::Schema.define(version: 2021_07_28_222333) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -1413,7 +1413,7 @@ ActiveRecord::Schema.define(version: 2021_07_22_162824) do
     t.integer "script_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["storage_app_id", "user_id"], name: "index_reviewable_projects_on_storage_app_id_and_user_id"
+    t.index ["user_id", "script_id", "level_id", "storage_app_id"], name: "index_reviewable_projects_on_user_script_level_storage_app"
   end
 
   create_table "school_districts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|


### PR DESCRIPTION
So far, we search the `reviewable_projects` table either by [user/script/level/storage app IDs](https://github.com/code-dot-org/code-dot-org/blob/ee19018f81cf16072dfee4b6a7d079f8d261a7d5/dashboard/app/controllers/reviewable_projects_controller.rb#L10), or by [user/script/level IDs](https://github.com/code-dot-org/code-dot-org/blob/ee19018f81cf16072dfee4b6a7d079f8d261a7d5/dashboard/app/models/ability.rb#L129). Adding an index that allows us to execute these searches efficiently.

## Testing story

Ran migration up/down locally.