### PR TITLE
Adding close websocket functionality to Javalab run/stop button

### DIFF
--- a/apps/src/javalab/JavabuilderConnection.js
+++ b/apps/src/javalab/JavabuilderConnection.js
@@ -104,11 +104,19 @@ export default class JavabuilderConnection {
 
   // Send a message across the websocket connection to Javabuilder
   sendMessage(message) {
-    this.socket.send(message);
+    if (!this.socket) {
+      console.error(`[error] The connection has closed.`);
+    } else {
+      this.socket.send(message);
+    }
   }
 
   // Closes web socket connection
   closeConnection() {
-    this.socket.close();
+    if (!this.socket) {
+      console.error(`[error] There is no web socket connection.`);
+    } else {
+      this.socket.close();
+    }
   }
 }

--- a/apps/src/javalab/JavabuilderConnection.js
+++ b/apps/src/javalab/JavabuilderConnection.js
@@ -106,4 +106,9 @@ export default class JavabuilderConnection {
   sendMessage(message) {
     this.socket.send(message);
   }
+
+  // Closes web socket connection
+  closeConnection() {
+    this.socket.close();
+  }
 }

--- a/apps/src/javalab/JavabuilderConnection.js
+++ b/apps/src/javalab/JavabuilderConnection.js
@@ -104,18 +104,14 @@ export default class JavabuilderConnection {
 
   // Send a message across the websocket connection to Javabuilder
   sendMessage(message) {
-    if (!this.socket) {
-      // Do nothing
-    } else {
+    if (this.socket) {
       this.socket.send(message);
     }
   }
 
   // Closes web socket connection
   closeConnection() {
-    if (!this.socket) {
-      // Do nothing - there is no socket to close
-    } else {
+    if (this.socket) {
       this.socket.close();
     }
   }

--- a/apps/src/javalab/JavabuilderConnection.js
+++ b/apps/src/javalab/JavabuilderConnection.js
@@ -105,7 +105,7 @@ export default class JavabuilderConnection {
   // Send a message across the websocket connection to Javabuilder
   sendMessage(message) {
     if (!this.socket) {
-      console.error(`[error] The connection has closed.`);
+      // Do nothing
     } else {
       this.socket.send(message);
     }
@@ -114,7 +114,7 @@ export default class JavabuilderConnection {
   // Closes web socket connection
   closeConnection() {
     if (!this.socket) {
-      console.error(`[error] There is no web socket connection.`);
+      // Do nothing - there is no socket to close
     } else {
       this.socket.close();
     }

--- a/apps/src/javalab/Javalab.js
+++ b/apps/src/javalab/Javalab.js
@@ -88,6 +88,7 @@ Javalab.prototype.init = function(config) {
   config.getCode = this.getCode.bind(this);
   config.afterClearPuzzle = this.afterClearPuzzle.bind(this);
   const onRun = this.onRun.bind(this);
+  const onStop = this.onStop.bind(this);
   const onContinue = this.onContinue.bind(this);
   const onCommitCode = this.onCommitCode.bind(this);
   const onInputMessage = this.onInputMessage.bind(this);
@@ -210,6 +211,7 @@ Javalab.prototype.init = function(config) {
       <JavalabView
         onMount={onMount}
         onRun={onRun}
+        onStop={onStop}
         onContinue={onContinue}
         onCommitCode={onCommitCode}
         onInputMessage={onInputMessage}
@@ -253,6 +255,11 @@ Javalab.prototype.onRun = function() {
   project.autosave(() => {
     this.javabuilderConnection.connectJavabuilder();
   });
+};
+
+// Called by the Javalab app when it wants to stop student code execution
+Javalab.prototype.onStop = function() {
+  this.JavabuilderConnection.closeConnection();
 };
 
 // Called by Javalab console to send a message to Javabuilder.

--- a/apps/src/javalab/Javalab.js
+++ b/apps/src/javalab/Javalab.js
@@ -259,7 +259,7 @@ Javalab.prototype.onRun = function() {
 
 // Called by the Javalab app when it wants to stop student code execution
 Javalab.prototype.onStop = function() {
-  this.JavabuilderConnection.closeConnection();
+  this.javabuilderConnection.closeConnection();
 };
 
 // Called by Javalab console to send a message to Javabuilder.

--- a/apps/src/javalab/JavalabView.jsx
+++ b/apps/src/javalab/JavalabView.jsx
@@ -20,6 +20,7 @@ class JavalabView extends React.Component {
     handleVersionHistory: PropTypes.func.isRequired,
     onMount: PropTypes.func.isRequired,
     onRun: PropTypes.func.isRequired,
+    onStop: PropTypes.func.isRequired,
     onContinue: PropTypes.func.isRequired,
     onCommitCode: PropTypes.func.isRequired,
     onInputMessage: PropTypes.func.isRequired,
@@ -64,15 +65,14 @@ class JavalabView extends React.Component {
     ];
   };
 
-  // This controls the 'run' button state, but stopping program execution is not yet
-  // implemented and will need to be added here.
+  // This controls the 'run' button state
   toggleRun = () => {
     const toggledIsRunning = !this.props.isRunning;
     this.props.setIsRunning(toggledIsRunning);
     if (toggledIsRunning) {
       this.props.onRun();
     } else {
-      // TODO: Stop program execution.
+      this.props.onStop();
     }
   };
 

--- a/apps/test/unit/javalab/JavabuilderConnectionTest.js
+++ b/apps/test/unit/javalab/JavabuilderConnectionTest.js
@@ -43,5 +43,14 @@ describe('JavabuilderConnection', () => {
       connection.onMessage(event);
       expect(onOutputMessage).to.have.been.calledWith(data.value);
     });
+
+    it('closes web socket on closeConnection', () => {
+      const mySocket = new window.WebSocket('ws://example.com');
+      const socketSpy = sinon.spy(window, 'mySocket');
+      const javabuilderConnection = new JavabuilderConnection();
+      javabuilderConnection.socket = mySocket;
+      javabuilderConnection.closeConnection();
+      expect(socketSpy.CLOSED === true);
+    });
   });
 });

--- a/apps/test/unit/javalab/JavabuilderConnectionTest.js
+++ b/apps/test/unit/javalab/JavabuilderConnectionTest.js
@@ -43,14 +43,43 @@ describe('JavabuilderConnection', () => {
       connection.onMessage(event);
       expect(onOutputMessage).to.have.been.calledWith(data.value);
     });
+  });
 
+  describe('sendMessage', () => {
+    it('errors when called on a connection with no socket', () => {
+      const javabuilderConnection = new JavabuilderConnection(null, () => {});
+      sinon.stub(console, 'error');
+      javabuilderConnection.sendMessage('');
+      expect(console.error).to.have.been.calledOnce;
+      expect(console.error.getCall(0).args[0]).to.contain(
+        '[error] The connection has closed.'
+      );
+      console.error.restore();
+    });
+  });
+
+  describe('onClose', () => {
     it('closes web socket on closeConnection', () => {
-      const mySocket = new window.WebSocket('ws://example.com');
-      const socketSpy = sinon.spy(window, 'mySocket');
-      const javabuilderConnection = new JavabuilderConnection();
-      javabuilderConnection.socket = mySocket;
+      const closeStub = sinon.stub();
+      sinon.stub(window, 'WebSocket').returns({
+        close: closeStub
+      });
+      const javabuilderConnection = new JavabuilderConnection(null, () => {});
+      javabuilderConnection.establishWebsocketConnection('fake-token');
       javabuilderConnection.closeConnection();
-      expect(socketSpy.CLOSED === true);
+      expect(closeStub).to.have.been.calledOnce;
+      window.WebSocket.restore();
+    });
+
+    it('errors on a close without a socket', () => {
+      const javabuilderConnection = new JavabuilderConnection(null, () => {});
+      sinon.stub(console, 'error');
+      javabuilderConnection.closeConnection();
+      expect(console.error).to.have.been.calledOnce;
+      expect(console.error.getCall(0).args[0]).to.contain(
+        '[error] There is no web socket connection.'
+      );
+      console.error.restore();
     });
   });
 });

--- a/apps/test/unit/javalab/JavabuilderConnectionTest.js
+++ b/apps/test/unit/javalab/JavabuilderConnectionTest.js
@@ -45,19 +45,6 @@ describe('JavabuilderConnection', () => {
     });
   });
 
-  describe('sendMessage', () => {
-    it('errors when called on a connection with no socket', () => {
-      const javabuilderConnection = new JavabuilderConnection(null, () => {});
-      sinon.stub(console, 'error');
-      javabuilderConnection.sendMessage('');
-      expect(console.error).to.have.been.calledOnce;
-      expect(console.error.getCall(0).args[0]).to.contain(
-        '[error] The connection has closed.'
-      );
-      console.error.restore();
-    });
-  });
-
   describe('onClose', () => {
     it('closes web socket on closeConnection', () => {
       const closeStub = sinon.stub();
@@ -69,17 +56,6 @@ describe('JavabuilderConnection', () => {
       javabuilderConnection.closeConnection();
       expect(closeStub).to.have.been.calledOnce;
       window.WebSocket.restore();
-    });
-
-    it('errors on a close without a socket', () => {
-      const javabuilderConnection = new JavabuilderConnection(null, () => {});
-      sinon.stub(console, 'error');
-      javabuilderConnection.closeConnection();
-      expect(console.error).to.have.been.calledOnce;
-      expect(console.error.getCall(0).args[0]).to.contain(
-        '[error] There is no web socket connection.'
-      );
-      console.error.restore();
     });
   });
 });


### PR DESCRIPTION
This adds Stop functionality to Javalab. That is, by pressing Stop when code is running, a user can close the socket. This provides a way to quit the compilation early, and exit from infinite loops or otherwise lengthy programs without a full page refresh.

The gif below shows an example of an infinite loop, interrupted by clicking stop. 

![InfiniteGif](https://user-images.githubusercontent.com/37230822/127696701-41335c16-c102-4fc0-bd87-c21883fb724a.gif)



- jira ticket: https://codedotorg.atlassian.net/browse/CSA-443

## Testing story

This PR adds a test which checks that closeConnection() does close a web socket connection. 

Worth noting- this pr also builds in a check for the existence of a socket, and does nothing if the socket doesn't exist. 

## Deployment strategy

## Follow-up work

Track down the orphaned lambda function and stop that as well.

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
