### PR TITLE
Javalab: Code doesn't run for users under 13

### DIFF
--- a/shared/middleware/files_api.rb
+++ b/shared/middleware/files_api.rb
@@ -275,7 +275,11 @@ class FilesApi < Sinatra::Base
     end
 
     return body_string unless parsed_json.key?('source')
-    blockly_xml = Nokogiri::XML(parsed_json['source'])
+    source_json = parsed_json['source']
+    if source_json.is_a?(Hash)
+      source_json = source_json.to_s
+    end
+    blockly_xml = Nokogiri::XML(source_json)
     return body_string unless blockly_xml.errors.empty?
 
     # first, remove all comment blocks by replacing them with the next block in


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Root cause here is that the XML parser used by for blockly projects in `sanitize_for_under_13` expects a string but Javalab sources were being stored as un-stringified JSON. This fix just converts the source JSON to a string if it's a hash.

## Links

https://codedotorg.atlassian.net/browse/CSA-593
Slack discussion thread: https://codedotorg.slack.com/archives/C01EF4GJ9GE/p1627500338261700

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Tested locally.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
