### PR TITLE
[Blockly] Targeted performance fixes

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -50,7 +50,7 @@
     "@babel/preset-react": "^7.0.0",
     "@cdo/interpreted": "link:../dashboard/config/libraries",
     "@code-dot-org/artist": "0.2.1",
-    "@code-dot-org/blockly": "3.5.36",
+    "@code-dot-org/blockly": "3.5.37",
     "@code-dot-org/craft": "0.2.2",
     "@code-dot-org/dance-party": "1.0.3",
     "@code-dot-org/johnny-five": "0.11.1-cdo.2",

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -609,6 +609,7 @@ export default {
           block.setHSV(136, 0.84, 0.8);
           block.parameterNames_ = [i18n.thisSprite()];
           block.parameterTypes_ = [Blockly.BlockValueType.SPRITE];
+          block.setUserVisible(false);
         },
         overrides: {
           getVars(category) {

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -609,7 +609,6 @@ export default {
           block.setHSV(136, 0.84, 0.8);
           block.parameterNames_ = [i18n.thisSprite()];
           block.parameterTypes_ = [Blockly.BlockValueType.SPRITE];
-          block.setUserVisible(false);
         },
         overrides: {
           getVars(category) {

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1568,10 +1568,10 @@
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@code-dot-org/artist/-/artist-0.2.1.tgz#fcfe7ea5cfb3f19ddb6b912e70e922ba4b7ef0b1"
 
-"@code-dot-org/blockly@3.5.36":
-  version "3.5.36"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/blockly/-/blockly-3.5.36.tgz#ee3f4493c3511f5d7719a8848e2511735267246e"
-  integrity sha512-6/Q4FFrBtTY2MScm0gOquL39Ah3wgsXMZG+uGuxC95iO88AXG5t+x7gdCkMNRDYFJA8uE7uAXbKA2CRt/tK7Nw==
+"@code-dot-org/blockly@3.5.37":
+  version "3.5.37"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/blockly/-/blockly-3.5.37.tgz#183540de0ceb351172546b12310d29e7f0434f62"
+  integrity sha512-WATxgrKVWQApsbi8eOJHQeBIj582lDc2ZuVShKktCwFMJ3V3sl5H+Am4cBmFLuCiMOzsRMpvwpCelHdeSch06A==
 
 "@code-dot-org/craft@0.2.2":
   version "0.2.2"


### PR DESCRIPTION
Pulls in https://github.com/code-dot-org/blockly/pull/280 and https://github.com/code-dot-org/blockly/pull/281
Also sets `behavior_definition` blocks in spritelab to not user visible so we don't have to render them (they're already hidden, we just weren't setting the block property).

Slack threads:
https://codedotorg.slack.com/archives/C0T0PNTM3/p1627571617462700
https://codedotorg.slack.com/archives/C01V27QS9AT/p1627581282013800
