### PR TITLE
Revert "Revert "[Spritelab] Make instructions icon configurable""

### DIFF
--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -213,11 +213,12 @@ P5Lab.prototype.init = function(config) {
 
   this.skin = config.skin;
   if (this.isSpritelab) {
-    const MEDIA_URL = '/blockly/media/spritelab/';
-    this.skin.smallStaticAvatar = MEDIA_URL + 'avatar.png';
-    this.skin.staticAvatar = MEDIA_URL + 'avatar.png';
-    this.skin.winAvatar = MEDIA_URL + 'avatar.png';
-    this.skin.failureAvatar = MEDIA_URL + 'avatar.png';
+    const mediaUrl = `/blockly/media/spritelab/${config.level
+      .instructionsIcon || 'avatar'}.png`;
+    this.skin.smallStaticAvatar = mediaUrl;
+    this.skin.staticAvatar = mediaUrl;
+    this.skin.winAvatar = mediaUrl;
+    this.skin.failureAvatar = mediaUrl;
 
     injectErrorHandler(
       new BlocklyModeErrorHandler(() => this.JSInterpreter, null)

--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -845,6 +845,7 @@ input[type="radio"] {
 
 .prompt-icon-cell {
   vertical-align: top;
+  text-align: center;
   width: 50px;
   padding-right: 10px;
   height: auto;

--- a/dashboard/app/models/levels/gamelab_jr.rb
+++ b/dashboard/app/models/levels/gamelab_jr.rb
@@ -34,6 +34,7 @@ class GamelabJr < Gamelab
     mini_toolbox
     hide_pause_button
     blockly_variables
+    instructions_icon
   )
 
   def shared_blocks

--- a/dashboard/app/views/levels/editors/fields/_long_instructions.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_long_instructions.html.haml
@@ -13,7 +13,22 @@
     %div{ style: 'background-color: rgb(239, 239, 239); padding-top: 12px' }
       ~ f.text_area :long_instructions, rows: 4
 
+- if @level.is_a? GamelabJr
+  = f.label :instructions_icon,'Instructions Icon'
+  %p Please refer to #{link_to 'Sprite Lab Static Assets', 'https://github.com/code-dot-org/code-dot-org/tree/levelbuilder/apps/static/spritelab'} for available assets, then enter the name of the image to use as the instructions icon for this level.
+  = f.text_field :instructions_icon, value: @level.instructions_icon
+  %p Preview:
+  %img.instructions-icon-preview{style: 'height: 64px;'}
+
 :javascript
+  $(document).ready(function() {
+    function updateIconPreview() {
+      var iconName = $('#level_instructions_icon')[0].value || 'avatar';
+      $('.instructions-icon-preview').attr('src', 'https://studio.code.org/blockly/media/spritelab/' + iconName + '.png');
+    }
+    $('#level_instructions_icon').change(updateIconPreview);
+    updateIconPreview();
+  })
   var mdEditor = levelbuilder.initializeCodeMirror('level_long_instructions', 'markdown', {
     callback: function (editor, change) {
       convertXmlToBlockly(document.getElementById('level_long_instructions_preview'));


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#41786 to reapply https://github.com/code-dot-org/code-dot-org/pull/41772

Turns out this PR was not the root cause of the staging problems we had yesterday, so it's safe to re-merge this PR