### PR TITLE
IE11 unsupported banner

### DIFF
--- a/apps/src/util/browser-detector.js
+++ b/apps/src/util/browser-detector.js
@@ -1,5 +1,5 @@
 // We support IE 11+
-export function isUnsupportedIE() {
+function isUnsupportedIE() {
   var isIE = navigator.userAgent.indexOf('MSIE') !== -1;
   var IEVersion = navigator.appVersion.indexOf('Trident/');
   var IEBelow8 = isIE && IEVersion < 8;

--- a/apps/src/util/browser-detector.js
+++ b/apps/src/util/browser-detector.js
@@ -1,5 +1,5 @@
 // We support IE 11+
-function isUnsupportedIE() {
+export function isUnsupportedIE() {
   var isIE = navigator.userAgent.indexOf('MSIE') !== -1;
   var IEVersion = navigator.appVersion.indexOf('Trident/');
   var IEBelow8 = isIE && IEVersion < 8;

--- a/apps/src/util/unsupportedBrowserWarning.js
+++ b/apps/src/util/unsupportedBrowserWarning.js
@@ -1,6 +1,7 @@
 /* global appOptions */
 import {
   isUnsupportedBrowser,
+  isUnsupportedIE,
   isIE11,
   isMobileDevice,
   isStorageAvailable
@@ -11,7 +12,9 @@ export var checkForUnsupportedBrowsersOnLoad = function() {
   $(document).ready(function() {
     let textDivId = null;
 
-    if (isUnsupportedBrowser()) {
+    if (isUnsupportedIE() || isIE11()) {
+      textDivId = '#ie-unsupported-browser';
+    } else if (isUnsupportedBrowser()) {
       textDivId = '#unsupported-browser';
     } else if (typeof appOptions !== 'undefined') {
       if (isMobileDevice()) {

--- a/apps/src/util/unsupportedBrowserWarning.js
+++ b/apps/src/util/unsupportedBrowserWarning.js
@@ -23,10 +23,6 @@ export var checkForUnsupportedBrowsersOnLoad = function() {
         } else if (appOptions.app === 'gamelab') {
           textDivId = '#gamelab-unsupported-tablet';
         }
-      } else if (isIE11() && appOptions.app === 'fish') {
-        textDivId = '#oceans-unsupported-browser';
-      } else if (isIE11() && appOptions.app === 'weblab') {
-        textDivId = '#weblab-unsupported-browser';
       } else if (
         appOptions.app === 'weblab' &&
         !isStorageAvailable('localStorage')

--- a/apps/src/util/unsupportedBrowserWarning.js
+++ b/apps/src/util/unsupportedBrowserWarning.js
@@ -1,7 +1,6 @@
 /* global appOptions */
 import {
   isUnsupportedBrowser,
-  isUnsupportedIE,
   isIE11,
   isMobileDevice,
   isStorageAvailable
@@ -12,9 +11,7 @@ export var checkForUnsupportedBrowsersOnLoad = function() {
   $(document).ready(function() {
     let textDivId = null;
 
-    if (isUnsupportedIE() || isIE11()) {
-      textDivId = '#ie-unsupported-browser';
-    } else if (isUnsupportedBrowser()) {
+    if (isUnsupportedBrowser() || isIE11()) {
       textDivId = '#unsupported-browser';
     } else if (typeof appOptions !== 'undefined') {
       if (isMobileDevice()) {

--- a/dashboard/app/views/layouts/_unsupported_browser.html.haml
+++ b/dashboard/app/views/layouts/_unsupported_browser.html.haml
@@ -3,6 +3,7 @@
   %i.fa.fa-warning.warning-sign.banner-icon#warning-icon{style: 'display: none'}
   &nbsp;
   #unsupported-browser.banner-text{style: 'display: none'}!= t("compatibility.upgrade.unsupported_message", supported_browsers_url: 'https://support.code.org/hc/en-us/articles/202591743', markdown: true)
+  #ie-unsupported-browser.banner-text{style: 'display: none'}= t("compatibility.upgrade.ie_unsupported_message")
   #applab-unsupported-tablet.banner-text{style: 'display: none'}= t("compatibility.upgrade.applab_unsupported_tablet")
   #gamelab-unsupported-tablet.banner-text{style: 'display: none'}= t("compatibility.upgrade.gamelab_unsupported_tablet")
   #oceans-unsupported-browser.banner-text{style: 'display: none'}= t("compatibility.upgrade.oceans_unsupported_browser")

--- a/dashboard/app/views/layouts/_unsupported_browser.html.haml
+++ b/dashboard/app/views/layouts/_unsupported_browser.html.haml
@@ -3,7 +3,6 @@
   %i.fa.fa-warning.warning-sign.banner-icon#warning-icon{style: 'display: none'}
   &nbsp;
   #unsupported-browser.banner-text{style: 'display: none'}!= t("compatibility.upgrade.unsupported_message", supported_browsers_url: 'https://support.code.org/hc/en-us/articles/202591743', markdown: true)
-  #ie-unsupported-browser.banner-text{style: 'display: none'}= t("compatibility.upgrade.ie_unsupported_message")
   #applab-unsupported-tablet.banner-text{style: 'display: none'}= t("compatibility.upgrade.applab_unsupported_tablet")
   #gamelab-unsupported-tablet.banner-text{style: 'display: none'}= t("compatibility.upgrade.gamelab_unsupported_tablet")
   #weblab-unsupported-local-storage.banner-text{style: 'display: none'}= t("compatibility.upgrade.weblab_unsupported_locale_storage")

--- a/dashboard/app/views/layouts/_unsupported_browser.html.haml
+++ b/dashboard/app/views/layouts/_unsupported_browser.html.haml
@@ -6,7 +6,5 @@
   #ie-unsupported-browser.banner-text{style: 'display: none'}= t("compatibility.upgrade.ie_unsupported_message")
   #applab-unsupported-tablet.banner-text{style: 'display: none'}= t("compatibility.upgrade.applab_unsupported_tablet")
   #gamelab-unsupported-tablet.banner-text{style: 'display: none'}= t("compatibility.upgrade.gamelab_unsupported_tablet")
-  #oceans-unsupported-browser.banner-text{style: 'display: none'}= t("compatibility.upgrade.oceans_unsupported_browser")
-  #weblab-unsupported-browser.banner-text{style: 'display: none'}= t("compatibility.upgrade.weblab_unsupported_browser")
   #weblab-unsupported-local-storage.banner-text{style: 'display: none'}= t("compatibility.upgrade.weblab_unsupported_locale_storage")
   %i.fa.fa-close.close-button.banner-icon#dismiss-icon{style: 'display: none; cursor: pointer', onclick: '$("#warning-banner").slideUp();'}

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -620,6 +620,7 @@ en:
   compatibility:
     upgrade:
       unsupported_message: "Your browser is not supported. Please upgrade your browser to [one of our supported browsers](%{supported_browsers_url}). You can try viewing the page, but expect functionality to be broken."
+      ie_unsupported_message: "We no longer support this browser. Please try visiting this page using Edge, Chrome, Firefox, or another modern browser."
       link: "Learn more"
       applab_unsupported_tablet: "App Lab works best on a desktop or laptop computer with a mouse and keyboard. You may experience issues using this tool on your current device."
       gamelab_unsupported_tablet: "Game Lab works best on a desktop or laptop computer with a mouse and keyboard. You may experience issues using this tool on your current device."

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -620,7 +620,6 @@ en:
   compatibility:
     upgrade:
       unsupported_message: "Your browser is not supported. Please upgrade your browser to [one of our supported browsers](%{supported_browsers_url}). You can try viewing the page, but expect functionality to be broken."
-      ie_unsupported_message: "We no longer support this browser. Please try visiting this page using Edge, Chrome, Firefox, or another modern browser."
       link: "Learn more"
       applab_unsupported_tablet: "App Lab works best on a desktop or laptop computer with a mouse and keyboard. You may experience issues using this tool on your current device."
       gamelab_unsupported_tablet: "Game Lab works best on a desktop or laptop computer with a mouse and keyboard. You may experience issues using this tool on your current device."

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -624,8 +624,6 @@ en:
       link: "Learn more"
       applab_unsupported_tablet: "App Lab works best on a desktop or laptop computer with a mouse and keyboard. You may experience issues using this tool on your current device."
       gamelab_unsupported_tablet: "Game Lab works best on a desktop or laptop computer with a mouse and keyboard. You may experience issues using this tool on your current device."
-      oceans_unsupported_browser: "This browser is not supported for this tutorial. Please try visiting this page using Edge, Chrome, Firefox, or another modern browser."
-      weblab_unsupported_browser: "Unfortunately, we're currently experiencing issues with loading Web Lab on this browser. You may want to use a different browser until this is resolved. Sorry for the inconvenience."
       weblab_unsupported_locale_storage: "You may experience issues using Web Lab in Private Browsing mode. Please reload your project in normal mode. Sorry for the inconvenience."
   slow_loading: 'This is taking longer than usual...'
   try_reloading: 'Try reloading the page'


### PR DESCRIPTION
**What**
A new persistent banner across all of dashboard with copy "We no longer support this browser. Please try visiting this page using Edge, Chrome, Firefox, or another modern browser." for all Internet Explorer browsers

**Why**
IE _will_ be deprecated as a whole. Anything previous to IE 11 is already unsupported.

**Note:** IE11 isn't officially unsupported on the platform _yet_

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [FND-1615](https://codedotorg.atlassian.net/browse/FND-1615)

## Testing story

Tested locally using [Microsoft provided VMs](https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/)
1. Tested Chrome
2. Tested IE 11 (on VM)
3. Tested IE 9

## Screenshots
Chrome
<img width="862" alt="Screen Shot 2021-07-29 at 4 46 08 PM" src="https://user-images.githubusercontent.com/48133820/127570976-85df98ab-70bd-4899-a90f-1974e4d42599.png">

IE11
<img width="552" alt="Screen Shot 2021-07-29 at 4 46 13 PM" src="https://user-images.githubusercontent.com/48133820/127570988-c3e6d78c-6e15-4ba2-a01f-dbe3c21ba9df.png">

IE9 (Unsupported by our platform)
<img width="530" alt="Screen Shot 2021-07-29 at 4 46 18 PM" src="https://user-images.githubusercontent.com/48133820/127571014-a8a1b84c-182c-4ebd-9920-50f8b3cc756b.png">


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
