### PR TITLE
Manually trigger ActiveRecord callbacks in script_seed

### DIFF
--- a/dashboard/lib/services/script_seed.rb
+++ b/dashboard/lib/services/script_seed.rb
@@ -247,7 +247,21 @@ module Services
       # Needed because we already have some Scripts with invalid names
       script_to_import.skip_name_format_validation = true
       Script.import! [script_to_import], on_duplicate_key_update: get_columns(Script)
-      Script.find_by!(name: script_to_import.name)
+
+      # activerecord-import doesn't trigger callbacks for imported models, and
+      # Scripts rely on the after_save hook to invoke `generate_plc_objects`,
+      # so we invoke it manually.
+      #
+      # see https://github.com/zdennis/activerecord-import#callbacks
+      #
+      # Note that we use activerecord-import extensively in the script seeding
+      # process, so we may end up needing to manually invoke these callbacks
+      # for more models than just Script, in which case we should probably
+      # reassess the pattern being used here.
+      imported_script = Script.find_by!(name: script_to_import.name)
+      imported_script.run_callbacks(:save)
+      imported_script.run_callbacks(:create)
+      return imported_script
     end
 
     def self.import_lesson_groups(lesson_groups_data, seed_context)


### PR DESCRIPTION
activerecord-import [doesn't trigger callbacks for imported models](https://github.com/zdennis/activerecord-import#callbacks), but Scripts rely on the after_save hook to invoke `generate_plc_objects`.

Note that we use activerecord-import extensively in the script seeding process, so we may end up needing to manually invoke these callbacks for more models than just Script, in which case we should probably reassess the pattern being used here.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
