### PR TITLE
Don't query for course version change-ability on course show

### DIFF
--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -335,7 +335,7 @@ class UnitGroup < ApplicationRecord
     [SharedConstants::PUBLISHED_STATE.preview, SharedConstants::PUBLISHED_STATE.stable].include?(published_state)
   end
 
-  def summarize(user = nil)
+  def summarize(user = nil, for_edit: false)
     {
       name: name,
       id: id,
@@ -363,7 +363,7 @@ class UnitGroup < ApplicationRecord
       show_assign_button: assignable_for_user?(user),
       announcements: announcements,
       course_version_id: course_version&.id,
-      prevent_course_version_change: prevent_course_version_change?,
+      prevent_course_version_change: for_edit && prevent_course_version_change?,
       course_path: link
     }
   end

--- a/dashboard/app/views/courses/edit.html.haml
+++ b/dashboard/app/views/courses/edit.html.haml
@@ -1,5 +1,5 @@
 - unit_group = local_assigns[:unit_group]
-- course_editor_data = {course_summary: unit_group.summarize,
+- course_editor_data = {course_summary: unit_group.summarize(for_edit: true),
                         script_names: Script.all.map(&:name),
                         course_families: UnitGroup.family_names,
                         version_year_options: UnitGroup.get_version_year_options}

--- a/dashboard/app/views/courses/show.html.haml
+++ b/dashboard/app/views/courses/show.html.haml
@@ -5,7 +5,7 @@
 - unit_group = local_assigns[:unit_group]
 
 - data = {}
-- data[:course_summary] = unit_group.summarize(@current_user)
+- data[:course_summary] = unit_group.summarize(@current_user, for_edit: false)
 - data[:sections] = @sections_with_assigned_info || []
 - data[:is_teacher] = @current_user.try(:teacher?) || false
 - data[:is_verified_teacher] = @current_user.try(:authorized_teacher?) || false


### PR DESCRIPTION
Apparently the course show pages performs some outrageous number of queries. This PR doesn't solve the bulk of those but it does remove some unnecessary queries from that page. `prevent_course_version_change` is a fairly expensive method who's result is only used on the edit page.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
