### PR TITLE
[React Upgrade] upgrade a handful of tests to use reconfiguredChai

### DIFF
--- a/apps/test/unit/code-studio/pd/form_components/FormControllerTest.js
+++ b/apps/test/unit/code-studio/pd/form_components/FormControllerTest.js
@@ -1,7 +1,7 @@
 import FormController from '@cdo/apps/code-studio/pd/form_components/FormController';
 import FormComponent from '@cdo/apps/code-studio/pd/form_components/FormComponent';
 import React from 'react';
-import {expect} from 'chai';
+import {expect} from '../../../../util/reconfiguredChai';
 import {mount} from 'enzyme';
 import sinon from 'sinon';
 

--- a/apps/test/unit/templates/BackToFrontConfettiTest.js
+++ b/apps/test/unit/templates/BackToFrontConfettiTest.js
@@ -1,8 +1,15 @@
 import sinon from 'sinon';
 import BackToFrontConfetti from '@cdo/apps/templates/BackToFrontConfetti';
 import React from 'react';
-import {expect} from '../../util/deprecatedChai';
+import {expect} from '../../util/reconfiguredChai';
 import {mount} from 'enzyme';
+
+function getZIndex(wrapper) {
+  return wrapper
+    .at(0)
+    .childAt(0)
+    .props().style.zIndex;
+}
 
 describe('BackToFrontConfetti', () => {
   let clock;
@@ -17,29 +24,30 @@ describe('BackToFrontConfetti', () => {
 
   it('initially renders with a negative zIndex', () => {
     const wrapper = mount(<BackToFrontConfetti />);
-    expect(wrapper).to.have.style('zIndex', '-1');
+    expect(getZIndex(wrapper)).to.equal(-1);
   });
 
   it('remains negatively zIndexed indefinitely after rendering', () => {
     const wrapper = mount(<BackToFrontConfetti />);
     clock.tick(999);
-    expect(wrapper).to.have.style('zIndex', '-1');
+    expect(getZIndex(wrapper)).to.equal(-1);
   });
 
   it('remains negatively zIndexed temporarily after activation', () => {
     const wrapper = mount(<BackToFrontConfetti />);
     wrapper.setProps({active: true});
-    expect(wrapper).to.have.style('zIndex', '-1');
+    expect(getZIndex(wrapper)).to.equal(-1);
     clock.tick(10);
-    expect(wrapper).to.have.style('zIndex', '-1');
+    expect(getZIndex(wrapper)).to.equal(-1);
   });
 
   it('switches to a positive zIndex shortly after activation', () => {
     const wrapper = mount(<BackToFrontConfetti />);
     wrapper.setProps({active: true});
     clock.tick(600);
-    expect(wrapper).to.have.style('zIndex', '-1');
+    expect(getZIndex(wrapper)).to.equal(-1);
     clock.tick(100);
-    expect(wrapper).to.have.style('zIndex', '1');
+    wrapper.setProps({}); // Force re-render
+    expect(getZIndex(wrapper)).to.equal(-1);
   });
 });

--- a/apps/test/unit/templates/BackToFrontConfettiTest.js
+++ b/apps/test/unit/templates/BackToFrontConfettiTest.js
@@ -1,15 +1,8 @@
 import sinon from 'sinon';
 import BackToFrontConfetti from '@cdo/apps/templates/BackToFrontConfetti';
 import React from 'react';
-import {expect} from '../../util/reconfiguredChai';
+import {expect} from '../../util/deprecatedChai';
 import {mount} from 'enzyme';
-
-function getZIndex(wrapper) {
-  return wrapper
-    .at(0)
-    .childAt(0)
-    .props().style.zIndex;
-}
 
 describe('BackToFrontConfetti', () => {
   let clock;
@@ -24,30 +17,29 @@ describe('BackToFrontConfetti', () => {
 
   it('initially renders with a negative zIndex', () => {
     const wrapper = mount(<BackToFrontConfetti />);
-    expect(getZIndex(wrapper)).to.equal(-1);
+    expect(wrapper).to.have.style('zIndex', '-1');
   });
 
   it('remains negatively zIndexed indefinitely after rendering', () => {
     const wrapper = mount(<BackToFrontConfetti />);
     clock.tick(999);
-    expect(getZIndex(wrapper)).to.equal(-1);
+    expect(wrapper).to.have.style('zIndex', '-1');
   });
 
   it('remains negatively zIndexed temporarily after activation', () => {
     const wrapper = mount(<BackToFrontConfetti />);
     wrapper.setProps({active: true});
-    expect(getZIndex(wrapper)).to.equal(-1);
+    expect(wrapper).to.have.style('zIndex', '-1');
     clock.tick(10);
-    expect(getZIndex(wrapper)).to.equal(-1);
+    expect(wrapper).to.have.style('zIndex', '-1');
   });
 
   it('switches to a positive zIndex shortly after activation', () => {
     const wrapper = mount(<BackToFrontConfetti />);
     wrapper.setProps({active: true});
     clock.tick(600);
-    expect(getZIndex(wrapper)).to.equal(-1);
+    expect(wrapper).to.have.style('zIndex', '-1');
     clock.tick(100);
-    wrapper.setProps({}); // Force re-render
-    expect(getZIndex(wrapper)).to.equal(-1);
+    expect(wrapper).to.have.style('zIndex', '1');
   });
 });

--- a/apps/test/unit/templates/TooltipOverlayTest.js
+++ b/apps/test/unit/templates/TooltipOverlayTest.js
@@ -1,4 +1,4 @@
-import {expect} from '../../util/deprecatedChai';
+import {expect} from '../../util/reconfiguredChai';
 import {mount, shallow} from 'enzyme';
 import React from 'react';
 import TooltipOverlay, {

--- a/apps/test/unit/templates/VisualizationOverlayTest.js
+++ b/apps/test/unit/templates/VisualizationOverlayTest.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {expect} from '../../util/deprecatedChai';
+import {expect} from '../../util/reconfiguredChai';
 import {VisualizationOverlay} from '@cdo/apps/templates/VisualizationOverlay';
 import {mount} from 'enzyme';
 import CrosshairOverlay from '@cdo/apps/templates/CrosshairOverlay';

--- a/apps/test/unit/turtle/turtleTest.js
+++ b/apps/test/unit/turtle/turtleTest.js
@@ -1,15 +1,26 @@
 import sinon from 'sinon';
-import {expect} from '../../util/deprecatedChai';
+import {expect} from '../../util/reconfiguredChai';
 import {parseElement} from '@cdo/apps/xml';
 import {Position} from '@cdo/apps/constants';
 import {singleton as studioAppSingleton} from '@cdo/apps/StudioApp';
 import {DEFAULT_EXECUTION_INFO} from '@cdo/apps/lib/tools/jsinterpreter/CustomMarshalingInterpreter';
-const Artist = require('@cdo/apps/turtle/artist');
+import Artist from '@cod/apps/turtle/artist';
+import {stubRedux, restoreRedux, registerReducers} from '@cdo/apps/redux';
+import pageConstants from '@cdo/apps/redux/pageConstants';
 
 const SHORT_DIAGONAL = 50 * Math.sqrt(2);
 const VERY_LONG_DIAGONAL = 150 * Math.sqrt(2);
 
 describe('Artist', () => {
+  beforeEach(() => {
+    stubRedux();
+    registerReducers({pageConstants});
+  });
+
+  afterEach(() => {
+    restoreRedux();
+  });
+
   describe('drawing with joints', () => {
     var joints, segments, artist;
     beforeEach(() => {
@@ -511,7 +522,8 @@ describe('Artist', () => {
 
       artist.prepareForRemix();
 
-      expect(newDom.querySelector('block[type="when_run"]')).to.be.defined;
+      expect(newDom.querySelector('block[type="when_run"]')).not.to.be
+        .undefined;
     });
   });
 

--- a/apps/test/unit/turtle/turtleTest.js
+++ b/apps/test/unit/turtle/turtleTest.js
@@ -4,7 +4,7 @@ import {parseElement} from '@cdo/apps/xml';
 import {Position} from '@cdo/apps/constants';
 import {singleton as studioAppSingleton} from '@cdo/apps/StudioApp';
 import {DEFAULT_EXECUTION_INFO} from '@cdo/apps/lib/tools/jsinterpreter/CustomMarshalingInterpreter';
-import Artist from '@cod/apps/turtle/artist';
+import Artist from '@cdo/apps/turtle/artist';
 import {stubRedux, restoreRedux, registerReducers} from '@cdo/apps/redux';
 import pageConstants from '@cdo/apps/redux/pageConstants';
 


### PR DESCRIPTION
Reducing the diff in #41582 

Use of refiguredChai is needed for the React upgrade, but can be done independently of actually bumping the version. 