### PR TITLE
[React upgrade] allow console warnings in anticipation of React upgrade

### DIFF
--- a/apps/src/code-studio/components/progress/ResourcesDropdown.story.jsx
+++ b/apps/src/code-studio/components/progress/ResourcesDropdown.story.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ResourcesDropdown from './ResourcesDropdown';
 import ResourceType from '@cdo/apps/templates/courseOverview/resourceType';
+import {allowConsoleWarnings} from '../../../../test/util/testUtils';
 
 const legacySampleResources = [
   {
@@ -26,7 +27,11 @@ const migratedSampleResources = [
   }
 ];
 
-export default storybook =>
+export default storybook => {
+  if (IN_UNIT_TEST) {
+    allowConsoleWarnings();
+  }
+
   storybook.storiesOf('ResourcesDropdown', module).addStoryTable([
     {
       name: 'unmigrated teacher resources',
@@ -63,3 +68,4 @@ export default storybook =>
       )
     }
   ]);
+};

--- a/apps/src/code-studio/pd/application_dashboard/workshop_assignment_select.story.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/workshop_assignment_select.story.jsx
@@ -2,8 +2,13 @@ import React from 'react';
 import {action} from '@storybook/addon-actions';
 import WorkshopAssignmentSelect from './workshop_assignment_select';
 import reactBootstrapStoryDecorator from '../reactBootstrapStoryDecorator';
+import {allowConsoleWarnings} from '../../../../test/util/testUtils';
 
 export default storybook => {
+  if (IN_UNIT_TEST) {
+    allowConsoleWarnings();
+  }
+
   storybook
     .storiesOf('WorkshopAssignmentSelect', module)
     .addDecorator(reactBootstrapStoryDecorator)

--- a/apps/src/lib/levelbuilder/lesson-editor/ActivitiesEditor.story.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivitiesEditor.story.jsx
@@ -16,6 +16,7 @@ import {
   sampleActivityForLessonWithoutLessonPlan,
   searchOptions
 } from '../../../../test/unit/lib/levelbuilder/lesson-editor/activitiesTestData';
+import {allowConsoleWarnings} from '../../../../test/util/testUtils';
 
 const resourcesEditor = createResourcesReducer('lessonResource');
 
@@ -46,7 +47,12 @@ const createStoreWithoutLessonPlan = () => {
   store.dispatch(initVocabularies([]));
   return store;
 };
+
 export default storybook => {
+  if (IN_UNIT_TEST) {
+    allowConsoleWarnings();
+  }
+
   storybook.storiesOf('ActivitiesEditor', module).addStoryTable([
     {
       name: 'ActivitiesEditor For Lesson With Lesson Plan',

--- a/apps/src/lib/tools/jsdebugger/JsDebugger.story.jsx
+++ b/apps/src/lib/tools/jsdebugger/JsDebugger.story.jsx
@@ -5,6 +5,7 @@ import commonReducers from '../../../redux/commonReducers';
 import {reducers as applabReducers} from '../../../applab/redux/applab';
 import {setPageConstants} from '../../../redux/pageConstants';
 import JsDebugger from './JsDebugger';
+import {allowConsoleWarnings} from '../../../../test/util/testUtils';
 
 function createApplabStore() {
   return createStore(
@@ -16,6 +17,10 @@ function createApplabStore() {
 }
 
 export default storybook => {
+  if (IN_UNIT_TEST) {
+    allowConsoleWarnings();
+  }
+
   const storyTable = [];
 
   const storybookStyle = {

--- a/apps/src/templates/NavigationBar.story.jsx
+++ b/apps/src/templates/NavigationBar.story.jsx
@@ -1,8 +1,13 @@
 import React from 'react';
 import {BrowserRouter as Router} from 'react-router-dom';
 import TeacherDashboardNavigation from './teacherDashboard/TeacherDashboardNavigation';
+import {allowConsoleWarnings} from '../../test/util/testUtils';
 
 export default storybook => {
+  if (IN_UNIT_TEST) {
+    allowConsoleWarnings();
+  }
+
   return storybook.storiesOf('NavigationBar', module).addStoryTable([
     {
       name: 'Navigation Bar',

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableView.story.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableView.story.jsx
@@ -5,6 +5,7 @@ import ProgressTableView from '@cdo/apps/templates/sectionProgress/progressTable
 import SectionProgressToggle from '@cdo/apps/templates/sectionProgress/SectionProgressToggle';
 import {ViewType} from '@cdo/apps/templates/sectionProgress/sectionProgressConstants';
 import {createStore} from '../sectionProgressTestHelpers';
+import {allowConsoleWarnings} from '../../../../test/util/testUtils';
 
 /**
  * The variety of stories here can be useful during development, but add
@@ -41,6 +42,10 @@ const TableWrapper = connect(state => ({
 }))(_TableWrapper);
 
 function buildSmallStories() {
+  if (IN_UNIT_TEST) {
+    allowConsoleWarnings();
+  }
+
   return [
     {
       name: `Small section, small script`,

--- a/apps/src/templates/watchers/AutocompleteSelector.story.jsx
+++ b/apps/src/templates/watchers/AutocompleteSelector.story.jsx
@@ -1,8 +1,13 @@
 import React from 'react';
 import AutocompleteSelector from './AutocompleteSelector';
 import {action} from '@storybook/addon-actions';
+import {allowConsoleWarnings} from '../../../test/util/testUtils';
 
 export default storybook => {
+  if (IN_UNIT_TEST) {
+    allowConsoleWarnings();
+  }
+
   storybook.storiesOf('AutocompleteSelector', module).addStoryTable([
     {
       name: 'with no selection',

--- a/apps/test/unit/code-studio/pd/application_dashboard/detail_view_contentsTest.js
+++ b/apps/test/unit/code-studio/pd/application_dashboard/detail_view_contentsTest.js
@@ -9,8 +9,11 @@ import _ from 'lodash';
 import sinon from 'sinon';
 import {expect} from '../../../../util/reconfiguredChai';
 import {mount} from 'enzyme';
+import {allowConsoleWarnings} from '../../../../util/testUtils';
 
 describe('DetailViewContents', () => {
+  allowConsoleWarnings();
+
   // We aren't testing any of the responses of the workshop selector control, so just
   // have a fake server to handle calls and suppress warnings
   sinon.fakeServer.create();

--- a/apps/test/unit/code-studio/pd/foorm/FoormEntityEditorFormModeTest.js
+++ b/apps/test/unit/code-studio/pd/foorm/FoormEntityEditorFormModeTest.js
@@ -17,12 +17,17 @@ import foorm, {
   setFormData
 } from '../../../../../src/code-studio/pd/foorm/editor/foormEditorRedux';
 import sinon from 'sinon';
+import {allowConsoleWarnings} from '../../../../util/throwOnConsole';
 
 global.$ = require('jquery');
 
 describe('FoormEntityEditor in Form editing mode', () => {
   let defaultProps, store, server;
   beforeEach(() => {
+    // Warnings allowed due to usage of deprecated componentWillMount
+    // lifecycle method.
+    allowConsoleWarnings();
+
     stubRedux();
     registerReducers({foorm});
 

--- a/apps/test/unit/javalab/JavalabEditorTest.js
+++ b/apps/test/unit/javalab/JavalabEditorTest.js
@@ -21,8 +21,13 @@ import javalab, {
 import {setAllSources} from '../../../src/javalab/javalabRedux';
 import commonReducers from '@cdo/apps/redux/commonReducers';
 import {setPageConstants} from '@cdo/apps/redux/pageConstants';
+import {allowConsoleWarnings} from '../../util/throwOnConsole';
 
 describe('Java Lab Editor Test', () => {
+  // Warnings allowed due to usage of deprecated componentWillReceiveProps
+  // lifecycle method.
+  allowConsoleWarnings();
+
   let defaultProps, store, appOptions;
 
   beforeEach(() => {

--- a/apps/test/unit/lib/levelbuilder/course-editor/CourseEditorTest.js
+++ b/apps/test/unit/lib/levelbuilder/course-editor/CourseEditorTest.js
@@ -16,6 +16,7 @@ import sinon from 'sinon';
 import * as utils from '@cdo/apps/utils';
 import $ from 'jquery';
 import {PublishedState} from '@cdo/apps/util/sharedConstants';
+import {allowConsoleWarnings} from '../../../../util/throwOnConsole';
 
 const defaultProps = {
   name: 'test-course',
@@ -41,6 +42,10 @@ const defaultProps = {
 };
 
 describe('CourseEditor', () => {
+  // Warnings allowed due to usage of deprecated componentWillReceiveProps
+  // lifecycle method.
+  allowConsoleWarnings();
+
   beforeEach(() => {
     sinon.stub(utils, 'navigateToHref');
     stubRedux();

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/ActivitySectionCardTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/ActivitySectionCardTest.jsx
@@ -21,8 +21,13 @@ import createResourcesReducer, {
 import vocabulariesEditor, {
   initVocabularies
 } from '@cdo/apps/lib/levelbuilder/lesson-editor/vocabulariesEditorRedux';
+import {allowConsoleWarnings} from '../../../../util/throwOnConsole';
 
 describe('ActivitySectionCard', () => {
+  // Warnings allowed due to usage of deprecated componentWillReceiveProps
+  // lifecycle method.
+  allowConsoleWarnings();
+
   let defaultProps,
     store,
     setTargetActivitySection,

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/AddVocabularyDialogTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/AddVocabularyDialogTest.jsx
@@ -3,8 +3,13 @@ import {shallow, mount} from 'enzyme';
 import {expect} from '../../../../util/reconfiguredChai';
 import AddVocabularyDialog from '@cdo/apps/lib/levelbuilder/lesson-editor/AddVocabularyDialog';
 import sinon from 'sinon';
+import {allowConsoleWarnings} from '../../../../util/throwOnConsole';
 
 describe('AddVocabularyDialog', () => {
+  // Warnings allowed due to usage of deprecated componentWillMount
+  // lifecycle method.
+  allowConsoleWarnings();
+
   let defaultProps, afterSaveSpy, handleCloseSpy;
   beforeEach(() => {
     afterSaveSpy = sinon.spy();

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/LessonEditorTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/LessonEditorTest.js
@@ -29,8 +29,13 @@ import {Provider} from 'react-redux';
 import sinon from 'sinon';
 import * as utils from '@cdo/apps/utils';
 import _ from 'lodash';
+import {allowConsoleWarnings} from '../../../../util/throwOnConsole';
 
 describe('LessonEditor', () => {
+  // Warnings allowed due to usage of deprecated  componentWillReceiveProps
+  // lifecycle method.
+  allowConsoleWarnings();
+
   let defaultProps, store, clock;
   beforeEach(() => {
     sinon.stub(utils, 'navigateToHref');

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/ObjectivesEditorTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/ObjectivesEditorTest.js
@@ -3,8 +3,13 @@ import {mount} from 'enzyme';
 import {expect} from '../../../../util/reconfiguredChai';
 import ObjectivesEditor from '@cdo/apps/lib/levelbuilder/lesson-editor/ObjectivesEditor';
 import sinon from 'sinon';
+import {allowConsoleWarnings} from '../../../../util/throwOnConsole';
 
 describe('ObjectivesEditor', () => {
+  // Warnings allowed due to usage of deprecated componentWillReceiveProps
+  // lifecycle method.
+  allowConsoleWarnings();
+
   let defaultProps, updateObjectives;
   beforeEach(() => {
     updateObjectives = sinon.spy();

--- a/apps/test/unit/lib/tools/jsdebugger/JsDebuggerTest.js
+++ b/apps/test/unit/lib/tools/jsdebugger/JsDebuggerTest.js
@@ -5,7 +5,10 @@ import {mount} from 'enzyme';
 import {expect} from '../../../../util/deprecatedChai';
 import JsDebugger from '@cdo/apps/lib/tools/jsdebugger/JsDebugger';
 import {actions, reducers} from '@cdo/apps/lib/tools/jsdebugger/redux';
-import {createMouseEvent} from '../../../../util/testUtils.js';
+import {
+  allowConsoleWarnings,
+  createMouseEvent
+} from '../../../../util/testUtils.js';
 import {
   getStore,
   registerReducers,
@@ -18,6 +21,10 @@ import {sandboxDocumentBody} from '../../../../util/testUtils';
 import dom from '@cdo/apps/dom';
 
 describe('The JSDebugger component', () => {
+  // TODO: (madelynkasula) Silences componentWillUpdate deprecation warning due to React 16 upgrade.
+  // This warning should be addressed after we've upgraded React.
+  allowConsoleWarnings();
+
   let root, jsDebugger, addEventSpy, removeEventSpy, codeApp;
   const getBodyEventSpies = spyOnBodyEventMethods();
   sandboxDocumentBody();

--- a/apps/test/unit/sites/studio/pages/levelbuilder_edit_script.js
+++ b/apps/test/unit/sites/studio/pages/levelbuilder_edit_script.js
@@ -2,8 +2,13 @@ import sinon from 'sinon';
 import ReactDOM from 'react-dom';
 import {expect} from '../../../../util/deprecatedChai';
 import initPage from '@cdo/apps/sites/studio/pages/scripts/edit';
+import {allowConsoleWarnings} from '../../../../util/throwOnConsole';
 
 describe('the level builder page init script', () => {
+  // Warnings allowed due to usage of deprecated componentWillReceiveProps
+  // lifecycle method.
+  allowConsoleWarnings();
+
   let container;
   beforeEach(() => {
     sinon.spy(ReactDOM, 'render');

--- a/apps/test/unit/templates/SchoolAutocompleteDropdownTest.js
+++ b/apps/test/unit/templates/SchoolAutocompleteDropdownTest.js
@@ -4,8 +4,11 @@ import {assert, expect} from 'chai';
 import sinon from 'sinon';
 import SchoolAutocompleteDropdown from '@cdo/apps/templates/SchoolAutocompleteDropdown';
 import _ from 'lodash';
+import {allowConsoleWarnings} from '../../util/throwOnConsole';
 
 describe('SchoolAutocompleteDropdown', () => {
+  allowConsoleWarnings();
+
   let fetchStub;
   let schoolAutocompleteDropdown;
   let handleChange;

--- a/apps/test/unit/templates/manageStudents/ManageStudentsTableTest.js
+++ b/apps/test/unit/templates/manageStudents/ManageStudentsTableTest.js
@@ -38,8 +38,11 @@ import unitSelection from '@cdo/apps/redux/unitSelectionRedux';
 import isRtl from '@cdo/apps/code-studio/isRtlRedux';
 import NoSectionCodeDialog from '@cdo/apps/templates/manageStudents/NoSectionCodeDialog';
 import {ManageStudentsNotificationFull} from '../../../../src/templates/manageStudents/ManageStudentsTable';
+import {allowConsoleWarnings} from '../../../util/throwOnConsole';
 
 describe('ManageStudentsTable', () => {
+  allowConsoleWarnings();
+
   it('sortRows orders table in the following order: add, newStudent, student', () => {
     const rowData = [
       {id: 1, name: 'studentb', rowType: RowType.STUDENT},

--- a/apps/test/unit/templates/manageStudents/SharingControlActionsHeaderCellTest.js
+++ b/apps/test/unit/templates/manageStudents/SharingControlActionsHeaderCellTest.js
@@ -6,8 +6,11 @@ import i18n from '@cdo/locale';
 import {combineReducers, createStore} from 'redux';
 import reducer from '@cdo/apps/templates/manageStudents/manageStudentsRedux';
 import SharingControlActionsHeaderCell from '@cdo/apps/templates/manageStudents/SharingControlActionsHeaderCell';
+import {allowConsoleWarnings} from '../../../util/throwOnConsole';
 
 describe('SharingControlActionsHeaderCell', () => {
+  allowConsoleWarnings();
+
   const store = createStore(combineReducers({manageStudents: reducer}));
 
   it('renders enable all, disable all and learn more options', () => {

--- a/apps/test/unit/templates/projects/PersonalProjectsTableTest.js
+++ b/apps/test/unit/templates/projects/PersonalProjectsTableTest.js
@@ -12,8 +12,11 @@ import publishDialog from '@cdo/apps/templates/projects/publishDialog/publishDia
 import deleteDialog from '@cdo/apps/templates/projects/deleteDialog/deleteProjectDialogRedux';
 import {UnconnectedPersonalProjectsTable as PersonalProjectsTable} from '@cdo/apps/templates/projects/PersonalProjectsTable';
 import {stubFakePersonalProjectData} from '@cdo/apps/templates/projects/generateFakeProjects';
+import {allowConsoleWarnings} from '../../../util/throwOnConsole';
 
 describe('PersonalProjectsTable', () => {
+  allowConsoleWarnings();
+
   beforeEach(() => {
     stubRedux();
     registerReducers({publishDialog, deleteDialog});

--- a/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableContentViewTest.jsx
+++ b/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableContentViewTest.jsx
@@ -16,6 +16,7 @@ import {
   fakeDetailRowsForStudent
 } from '@cdo/apps/templates/sectionProgress/sectionProgressTestHelpers';
 import sinon from 'sinon';
+import {allowConsoleWarnings} from '../../../../util/testUtils';
 
 const STUDENTS = fakeStudents(3);
 const LESSON_1 = fakeLessonWithLevels({position: 1});
@@ -57,6 +58,8 @@ const setUp = (overrideProps = {}) => {
 };
 
 describe('ProgressTableContentView', () => {
+  allowConsoleWarnings();
+
   afterEach(() => {
     FORMATTERS.forEach(formatter => {
       formatter.resetHistory();

--- a/apps/test/unit/tutorialExplorer/filterHeaderTest.jsx
+++ b/apps/test/unit/tutorialExplorer/filterHeaderTest.jsx
@@ -5,6 +5,7 @@ import {expect} from '../../util/deprecatedChai';
 import FilterHeader from '@cdo/apps/tutorialExplorer/filterHeader';
 import BackButton from '@cdo/apps/tutorialExplorer/backButton';
 import i18n from '@cdo/tutorialExplorer/locale';
+import {allowConsoleWarnings} from '../../util/testUtils';
 
 const FAKE_ON_USER_INPUT = () => {};
 const FAKE_ON_ORG_NAME = () => {};
@@ -24,6 +25,10 @@ const DEFAULT_PROPS = {
 };
 
 describe('FilterHeader', () => {
+  // TODO: (madelynkasula) Silences componentWillMount deprecation warning due to React 16 upgrade.
+  // This warning should be addressed after we've upgraded React.
+  allowConsoleWarnings();
+
   it('renders simplest mobile view', () => {
     const wrapper = mount(
       <StickyContainer>

--- a/apps/test/unit/watchers/AutocompleteSelectorTest.js
+++ b/apps/test/unit/watchers/AutocompleteSelectorTest.js
@@ -3,8 +3,13 @@ import sinon from 'sinon';
 import React from 'react';
 import {mount} from 'enzyme';
 import AutocompleteSelector from '@cdo/apps/templates/watchers/AutocompleteSelector';
+import {allowConsoleWarnings} from '../../util/testUtils';
 
 describe('AutocompleteSelector', () => {
+  // TODO: (madelynkasula) Silences componentWillReceiveProps deprecation warning due to React 16 upgrade.
+  // This warning should be addressed after we've upgraded React.
+  allowConsoleWarnings();
+
   let component, componentInstance, clicked, mousedOver, clickOutside;
 
   const FIRST_OPTION_TEXT = 'option1';


### PR DESCRIPTION
Reducing the diff in #41582

In newer versions of React some of the lifecycle methods we use will be unsafe and throw a warning.  This allows tests to pass for some of those components while we re-write the components to no longer use the unsafe methods. 
