### PR TITLE
Move styles to bottom of AutocompleteSelector file

### DIFF
--- a/apps/src/templates/watchers/AutocompleteSelector.jsx
+++ b/apps/src/templates/watchers/AutocompleteSelector.jsx
@@ -2,31 +2,6 @@ import onClickOutside from 'react-onclickoutside';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const PANEL_MIN_WIDTH = 163;
-
-const styles = {
-  autocompletePanel: {
-    width: '100%',
-    minWidth: PANEL_MIN_WIDTH,
-    height: 'initial',
-    background: 'white',
-    color: '#808080',
-    border: '1px gray solid',
-    padding: 0,
-    marginTop: -2,
-    marginLeft: -1
-  },
-  autocompleteOption: {
-    cursor: 'pointer',
-    margin: 0,
-    padding: 4
-  },
-  selectedStyle: {
-    backgroundColor: '#cad6fa',
-    color: 'black'
-  }
-};
-
 export default onClickOutside(
   class AutocompleteSelector extends React.Component {
     static propTypes = {
@@ -77,3 +52,28 @@ export default onClickOutside(
     }
   }
 );
+
+const PANEL_MIN_WIDTH = 163;
+
+const styles = {
+  autocompletePanel: {
+    width: '100%',
+    minWidth: PANEL_MIN_WIDTH,
+    height: 'initial',
+    background: 'white',
+    color: '#808080',
+    border: '1px gray solid',
+    padding: 0,
+    marginTop: -2,
+    marginLeft: -1
+  },
+  autocompleteOption: {
+    cursor: 'pointer',
+    margin: 0,
+    padding: 4
+  },
+  selectedStyle: {
+    backgroundColor: '#cad6fa',
+    color: 'black'
+  }
+};


### PR DESCRIPTION
Friday tidy! 

The `AutocompleteSelector` component is wrapped in an `onClickOutside` library so wasn't recognized [when the initial change](https://github.com/code-dot-org/code-dot-org/pull/40311) was made to move styles to the bottom of React component files. I moved those styles in this PR for consistency. 
