### PR TITLE
[React upgrade] update test expectations 

### DIFF
--- a/apps/test/unit/p5lab/spritelab/SpritelabTest.js
+++ b/apps/test/unit/p5lab/spritelab/SpritelabTest.js
@@ -225,7 +225,7 @@ describe('SpriteLab', () => {
         it('does not dispatch event when animations do not change', () => {
           // Dispatch an action so the subscriber gets called
           store.dispatch(setIsRunning(true));
-          expect(eventSpy).not.to.have.beenCalled;
+          expect(eventSpy).not.to.have.been.called;
         });
       });
     });

--- a/apps/test/unit/templates/studioHomepages/NpsSurveyBlockTest.js
+++ b/apps/test/unit/templates/studioHomepages/NpsSurveyBlockTest.js
@@ -27,13 +27,13 @@ describe('npsSurveyBlock', () => {
   it('displays nothing on initial mount', () => {
     ajaxStub.returns({done: sinon.stub()});
     const wrapper = shallow(<NpsSurveyBlock />);
-    expect(wrapper).to.deep.equal({});
+    expect(wrapper).to.be.empty;
   });
 
   it('displays nothing when no result is received from the server', () => {
     ajaxStub.returns({done: sinon.stub().callsArgWith(0, undefined)});
     const wrapper = shallow(<NpsSurveyBlock />);
-    expect(wrapper).to.deep.equal({});
+    expect(wrapper).to.be.empty;
   });
 
   it('displays a foorm when a result is received from the server', () => {
@@ -59,6 +59,6 @@ describe('npsSurveyBlock', () => {
     wrapper.update();
     expect(wrapper.find('Foorm').length).to.equal(0);
     expect(wrapper.find('Button').length).to.equal(0);
-    expect(wrapper).to.deep.equal({});
+    expect(wrapper).to.be.empty;
   });
 });


### PR DESCRIPTION
Continuing to reduce the diff in #41582 

These updates are non-breaking changes for the current version of React so making an incremental change in anticipation of the React upgrade. 