### PR TITLE
Fix ProjectAppTypeAreaTest in preparation for React upgrade

### DIFF
--- a/apps/test/unit/templates/projects/ProjectAppTypeAreaTest.js
+++ b/apps/test/unit/templates/projects/ProjectAppTypeAreaTest.js
@@ -1,7 +1,8 @@
 import $ from 'jquery';
+import {Provider, connect} from 'react-redux';
 import React from 'react';
 import {mount} from 'enzyme';
-import {expect} from '../../../util/deprecatedChai';
+import {expect} from '../../../util/reconfiguredChai';
 import ProjectAppTypeArea from '@cdo/apps/templates/projects/ProjectAppTypeArea';
 import sinon from 'sinon';
 import {
@@ -10,24 +11,50 @@ import {
   stubRedux,
   restoreRedux
 } from '@cdo/apps/redux';
-import projectsReducer from '@cdo/apps/templates/projects/projectsRedux';
+import projectsReducer, {
+  appendProjects
+} from '@cdo/apps/templates/projects/projectsRedux';
+import {
+  allowConsoleErrors,
+  allowConsoleWarnings
+} from '../../../util/throwOnConsole';
+
+function wrapped(element) {
+  return mount(<Provider store={getStore()}>{element}</Provider>);
+}
+
+const ProjectProvider = connect((state, ownProps) => ({
+  projectList: state.projects.projectLists[ownProps.labKey].map(project => {
+    return {
+      projectData: project,
+      currentGallery: 'public'
+    };
+  })
+}))(ProjectAppTypeArea);
 
 function generateFakeProjects(numProjects, projectType) {
-  const startTime = Date.parse('2017-01-01T11:00:00.000-00:00');
-  return [...Array(numProjects).keys()].map(projectNum => ({
-    projectData: {
-      channel: `STUB_CHANNEL_ID_${projectNum}_`,
-      name: `Published Project ${projectNum}.`,
-      type: projectType,
-      publishedAt: new Date(startTime + projectNum).toISOString(),
-      publishedToPublic: true,
-      publishedToClass: true
-    },
+  return generateFakeProjectData(numProjects, projectType).map(data => ({
+    projectData: data,
     currentGallery: 'public'
   }));
 }
 
+function generateFakeProjectData(numProjects, projectType) {
+  const startTime = Date.parse('2017-01-01T11:00:00.000-00:00');
+  return [...Array(numProjects).keys()].map(projectNum => ({
+    channel: `STUB_CHANNEL_ID_${projectNum}_`,
+    name: `Published Project ${projectNum}.`,
+    type: projectType,
+    publishedAt: new Date(startTime + projectNum).toISOString(),
+    publishedToPublic: true,
+    publishedToClass: true
+  }));
+}
+
 describe('ProjectAppTypeArea', () => {
+  allowConsoleErrors();
+  allowConsoleWarnings();
+
   let stubAjax, ajaxDeferred, stubNavigate;
 
   beforeEach(() => {
@@ -46,7 +73,7 @@ describe('ProjectAppTypeArea', () => {
 
   describe('detail view', () => {
     it('shows the right number of projects initially', () => {
-      const wrapper = mount(
+      const wrapper = wrapped(
         <ProjectAppTypeArea
           labKey="applab"
           labName="App Lab"
@@ -56,7 +83,6 @@ describe('ProjectAppTypeArea', () => {
           galleryType="public"
           navigateFunction={stubNavigate}
           isDetailView={true}
-          store={getStore()}
         />
       );
       expect(wrapper.find('ProjectCard')).to.have.length(12);
@@ -71,7 +97,7 @@ describe('ProjectAppTypeArea', () => {
 
     it('renders a working link to view more projects of a specific type', () => {
       var viewMoreLink = 'more App Lab projects';
-      const wrapper = mount(
+      const wrapper = wrapped(
         <ProjectAppTypeArea
           labKey="applab"
           labName="App Lab"
@@ -81,7 +107,6 @@ describe('ProjectAppTypeArea', () => {
           galleryType="public"
           navigateFunction={stubNavigate}
           isDetailView={true}
-          store={getStore()}
         />
       );
       expect(wrapper.find('.viewMoreLink')).to.have.length(1);
@@ -91,21 +116,25 @@ describe('ProjectAppTypeArea', () => {
     });
 
     it('displays more projects when View More is pressed', () => {
+      const store = getStore();
+      store.dispatch(
+        appendProjects(generateFakeProjectData(30, 'applab'), 'applab')
+      );
+      const wrapper = mount(
+        <Provider store={store}>
+          <ProjectProvider
+            labKey="applab"
+            labName="App Lab"
+            labViewMoreString="more App Lab projects"
+            numProjectsToShow={12}
+            galleryType="public"
+            navigateFunction={stubNavigate}
+            isDetailView={true}
+          />
+        </Provider>
+      );
       // some of the most useful selectors like [text="View more"] don't work
       // with mount(). see: https://github.com/airbnb/enzyme/issues/534
-      const wrapper = mount(
-        <ProjectAppTypeArea
-          labKey="applab"
-          labName="App Lab"
-          labViewMoreString="more App Lab projects"
-          projectList={generateFakeProjects(30, 'applab')}
-          numProjectsToShow={12}
-          galleryType="public"
-          navigateFunction={stubNavigate}
-          isDetailView={true}
-          store={getStore()}
-        />
-      );
       expect(wrapper.find('ProjectCard')).to.have.length(12);
       let viewMoreWrapper = wrapper.find('Button').first();
       expect(viewMoreWrapper.text()).to.equal('View more');
@@ -126,10 +155,10 @@ describe('ProjectAppTypeArea', () => {
       expect(stubAjax).to.have.been.calledOnce;
 
       // Simulate the network request completing.
-      ajaxDeferred.resolve({applab: generateFakeProjects(40, 'applab')});
-      wrapper.setProps({
-        projectList: generateFakeProjects(40, 'applab')
+      ajaxDeferred.resolve({
+        applab: generateFakeProjectData(40, 'applab')
       });
+      wrapper.setProps({}); // Force refresh
 
       // Displays additional projects returned from the server.
       expect(wrapper.find('ProjectCard')).to.have.length(36);


### PR DESCRIPTION
Mostly a copy of [this commit](https://github.com/code-dot-org/code-dot-org/commit/8fc68e6d42ac3e37e00c5c2e057f9235c7ab4e33). Removing it from #41582 to reduce the size of that PR and ship whatever we can before upgrading React.