### PR TITLE
Remove @storybook/addon-info

### DIFF
--- a/apps/.storybook/config.js
+++ b/apps/.storybook/config.js
@@ -1,10 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import * as storybook from '@storybook/react';
-import { setOptions } from '@storybook/addon-options';
-import Node from '@storybook/addon-info/dist/components/Node';
-import Props from '@storybook/addon-info/dist/components/Props';
-import {Pre} from '@storybook/addon-info/dist/components/markdown/code';
+import {setOptions} from '@storybook/addon-options';
 import experiments from '@cdo/apps/util/experiments';
 import withReduxStore from '../test/util/withReduxStore';
 
@@ -13,23 +10,6 @@ import '../style/netsim/style.scss';
 import '../style/applab/style.scss';
 import '../src/templates/GameButtons.story.scss';
 
-// Workaround for missing required prop in addon-info components.
-Props.propTypes = {
-  ...Props.propTypes,
-  maxPropsIntoLine: PropTypes.number,
-  maxPropObjectKeys: PropTypes.number,
-  maxPropArrayLength: PropTypes.number,
-  maxPropStringLength: PropTypes.number,
-};
-
-Node.propTypes = {
-  ...Node.propTypes,
-  maxPropsIntoLine: PropTypes.number,
-  maxPropObjectKeys: PropTypes.number,
-  maxPropArrayLength: PropTypes.number,
-  maxPropStringLength: PropTypes.number,
-};
-
 const styles = {
   centeredStory: {
     position: 'absolute',
@@ -37,26 +17,26 @@ const styles = {
     right: 0,
     display: 'flex',
     alignItems: 'center',
-    justifyContent: 'center',
+    justifyContent: 'center'
   },
   storyTable: {
     table: {backgroundColor: 'white', tableLayout: 'fixed', width: '100%'},
     row: {border: '1px solid #ccc'},
-    cell: {width:'50%', padding: 20},
+    cell: {width: '50%', padding: 20}
   },
   deprecatedStory: {
     width: '100%',
     height: '100vh',
     paddingLeft: 50,
-    paddingRight: 50,
+    paddingRight: 50
   },
   deprecatedStoryHeader: {
     color: 'red',
-    textAlign: 'center',
+    textAlign: 'center'
   },
   deprecatedImg: {
-    float: 'right',
-  },
+    float: 'right'
+  }
 };
 
 const storybookWrapper = Object.create(storybook);
@@ -75,14 +55,19 @@ storybookWrapper.deprecatedStoriesOf = (name, module, options) => {
           src="https://cdn.meme.am/instances/500x/62160477.jpg"
         />
         <dl>
-          <dt><strong>reason:</strong></dt>
-          <dd>{options && options.reason || defaultDeprecationReason}</dd>
-          <dt><strong>replacement:</strong></dt>
+          <dt>
+            <strong>reason:</strong>
+          </dt>
+          <dd>{(options && options.reason) || defaultDeprecationReason}</dd>
+          <dt>
+            <strong>replacement:</strong>
+          </dt>
           <dd>
-            {options && options.replacement &&
-             <a href="#" onClick={storybook.linkTo(options.replacement)}>
-               {`<${options.replacement}>`}
-             </a>}
+            {options && options.replacement && (
+              <a href="#" onClick={storybook.linkTo(options.replacement)}>
+                {`<${options.replacement}>`}
+              </a>
+            )}
           </dd>
         </dl>
       </div>
@@ -93,14 +78,14 @@ function loadStories() {
   require('./about');
   require('./colors');
 
-  var sidecarContext = require.context("../src/", true, /\.story\.jsx?$/);
+  var sidecarContext = require.context('../src/', true, /\.story\.jsx?$/);
   sidecarContext.keys().forEach(key => {
     var module;
     try {
       module = sidecarContext(key);
       module(storybookWrapper);
     } catch (e) {
-      console.error("failed to load", key, e);
+      console.error('failed to load', key, e);
       console.error(e.stack);
       return;
     }
@@ -115,7 +100,7 @@ function Centered({children}) {
   return <div style={styles.centeredStory}>{children}</div>;
 }
 Centered.propTypes = {
-  children: PropTypes.node,
+  children: PropTypes.node
 };
 
 storybook.setAddon({
@@ -128,60 +113,48 @@ storybook.setAddon(withReduxStore);
 
 storybook.setAddon({
   addStoryTable(items) {
-    this.add(
-      'Overview',
-      () => {
-        // Make sure that the only experiments enabled are those that we explicitly
-        // added via withExperiments
-        localStorage.removeItem('experimentsList');
-        if (this.experiments) {
-          this.experiments.forEach(key => experiments.setEnabled(key, true));
-        }
-        return (
-          <div>
-            <table style={styles.storyTable.table}>
-              <thead>
-                <tr>
-                  <th>Version</th>
-                  <th>Rendered</th>
-                </tr>
-              </thead>
-              <tbody>
-                {items.map((item, index) => (
-                   <tr style={styles.storyTable.row} key={index}>
-                     <td style={styles.storyTable.cell}>
-                       <strong>
-                         {item.name}
-                       </strong>
-                       <p>
-                         {item.description || ''}
-                       </p>
-                       <Pre>
-                         <Node depth={0} node={item.story()}/>
-                       </Pre>
-                     </td>
-                     <td
-                       className={item.storyCellClass}
-                       style={styles.storyTable.cell}
-                     >
-                       {item.story()}
-                     </td>
-                   </tr>
-                 ))}
-              </tbody>
-            </table>
-          </div>
-        );
+    this.add('Overview', () => {
+      // Make sure that the only experiments enabled are those that we explicitly
+      // added via withExperiments
+      localStorage.removeItem('experimentsList');
+      if (this.experiments) {
+        this.experiments.forEach(key => experiments.setEnabled(key, true));
       }
-    );
+      return (
+        <div>
+          <table style={styles.storyTable.table}>
+            <thead>
+              <tr>
+                <th>Version</th>
+                <th>Rendered</th>
+              </tr>
+            </thead>
+            <tbody>
+              {items.map((item, index) => (
+                <tr style={styles.storyTable.row} key={index}>
+                  <td style={styles.storyTable.cell}>
+                    <strong>{item.name}</strong>
+                    <p>{item.description || ''}</p>
+                  </td>
+                  <td
+                    className={item.storyCellClass}
+                    style={styles.storyTable.cell}
+                  >
+                    {item.story()}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      );
+    });
     items.forEach(item => this.add(item.name, item.story));
   }
 });
 
 storybook.addDecorator(story => {
   var rendered = story();
-  return (
-    <Centered>{rendered}</Centered>
-  );
+  return <Centered>{rendered}</Centered>;
 });
 storybook.configure(loadStories, module);

--- a/apps/package.json
+++ b/apps/package.json
@@ -64,7 +64,6 @@
     "@code-dot-org/redactable-markdown": "0.4.0",
     "@react-bootstrap/pagination": "^1.0.0",
     "@storybook/addon-actions": "^4.1.16",
-    "@storybook/addon-info": "^3.3.15",
     "@storybook/addon-options": "^4.1.16",
     "@storybook/react": "^4.1.16",
     "aws-sdk": "2.28.0",

--- a/apps/src/code-studio/components/GridEditor.story.jsx
+++ b/apps/src/code-studio/components/GridEditor.story.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import GridEditor from './GridEditor';
-import {withInfo} from '@storybook/addon-info';
 
 export default storybook => {
   const starWarsGrid = [
@@ -19,11 +18,10 @@ export default storybook => {
     });
   });
 
-  storybook
-    .storiesOf('GridEditor', module)
-    .add(
-      'karel',
-      withInfo('This is the farmer / bee / collector editor.')(() => (
+  storybook.storiesOf('GridEditor', module).addStoryTable([
+    {
+      name: 'Karel: Farmer/Bee/Collector editor',
+      story: () => (
         <div id="grid">
           <GridEditor
             skin="bee"
@@ -50,11 +48,11 @@ export default storybook => {
             onUpdate={() => {}}
           />
         </div>
-      ))
-    )
-    .add(
-      'star wars grid',
-      withInfo('This is the Star Wars BB-8 editor.')(() => (
+      )
+    },
+    {
+      name: 'Star Wars: BB-8 editor',
+      story: () => (
         <div id="grid">
           <GridEditor
             skin="starwarsgrid"
@@ -62,6 +60,7 @@ export default storybook => {
             onUpdate={() => {}}
           />
         </div>
-      ))
-    );
+      )
+    }
+  ]);
 };

--- a/apps/src/code-studio/components/lessonExtras/LessonExtras.story.jsx
+++ b/apps/src/code-studio/components/lessonExtras/LessonExtras.story.jsx
@@ -3,7 +3,6 @@ import LessonExtras from './LessonExtras';
 import progress, {mergeResults} from '@cdo/apps/code-studio/progressRedux';
 import {Provider} from 'react-redux';
 import {createStore, combineReducers} from 'redux';
-import {withInfo} from '@storybook/addon-info';
 
 function configureStore() {
   const store = createStore(
@@ -21,147 +20,151 @@ function configureStore() {
   return store;
 }
 
+const bonusLevels = [
+  {
+    lessonNumber: 1,
+    levels: [
+      {
+        id: '23222',
+        display_name: 'courseB_maze_seq_challenge1',
+        url:
+          'http://studio.code.org:3000/s/coursef-2019/lessons/1/extras?level_name=courseC_artist_prog_challenge1',
+        perfect: false,
+        type: 'Maze',
+        maze_summary: {
+          map: [
+            [0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 1, 1, 1, 1, 2, 0],
+            [0, 0, 1, 1, 1, 1, 1, 0],
+            [0, 0, 1, 1, 1, 1, 1, 0],
+            [0, 0, 1, 4, 4, 1, 1, 0],
+            [0, 0, 1, 1, 3, 4, 1, 0],
+            [0, 0, 1, 1, 1, 1, 1, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0]
+          ],
+          skin: 'birds',
+          level: {
+            startDirection: 2
+          }
+        }
+      },
+      {
+        id: '23223',
+        display_name: 'courseB_maze_seq_challenge1',
+        url:
+          'http://studio.code.org:3000/s/coursef-2019/lessons/1/extras?level_name=courseC_artist_prog_challenge1',
+        perfect: false,
+        type: 'Maze',
+        maze_summary: {
+          map: [
+            [0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 1, 1, 1, 4, 1, 3, 0],
+            [0, 1, 1, 0, 1, 1, 4, 0],
+            [0, 1, 0, 1, 1, 0, 1, 0],
+            [0, 1, 1, 1, 0, 1, 1, 0],
+            [0, 1, 1, 0, 1, 1, 1, 0],
+            [0, 2, 1, 1, 1, 1, 1, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0]
+          ],
+          skin: 'birds',
+          level: {
+            startDirection: 2
+          }
+        }
+      }
+    ]
+  },
+  {
+    lessonNumber: 2,
+    levels: [
+      {
+        id: '23224',
+        display_name: 'courseC_artist_prog_challenge1',
+        url:
+          'http://studio.code.org:3000/s/coursef-2019/lessons/1/extras?level_name=courseC_artist_prog_challenge1',
+        type: 'Artist',
+        thumbnail_url:
+          'https://d3p74s6bwmy6t9.cloudfront.net/80cc9bbdbd9a05c1a0cf03500b4eb38c=development/2091.png',
+        perfect: false
+      },
+      {
+        id: '23225',
+        display_name: 'courseC_PlayLab_events_challenge1',
+        url:
+          'http://studio.code.org:3000/s/coursef-2019/lessons/1/extras?level_name=courseC_artist_prog_challenge1',
+        type: 'Studio',
+        thumbnail_url:
+          'https://d3p74s6bwmy6t9.cloudfront.net/0b5d06628b7510904ee392a94065352a=development/2069.png',
+        perfect: false
+      }
+    ]
+  },
+  {
+    lessonNumber: 3,
+    levels: [
+      {
+        id: '23226',
+        display_name: 'courseC_artist_prog_challenge1',
+        url:
+          'http://studio.code.org:3000/s/coursef-2019/lessons/1/extras?level_name=courseC_artist_prog_challenge1',
+        type: 'Artist',
+        thumbnail_url:
+          'https://d3p74s6bwmy6t9.cloudfront.net/80cc9bbdbd9a05c1a0cf03500b4eb38c=development/2091.png',
+        perfect: false
+      },
+      {
+        id: '23227',
+        display_name: 'courseB_maze_seq_challenge2',
+        url:
+          'http://studio.code.org:3000/s/coursef-2019/lessons/1/extras?level_name=courseC_artist_prog_challenge1',
+        type: 'Maze',
+        perfect: false,
+        maze_summary: {
+          map: [
+            [0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 1, 1, 1, 4, 1, 3, 0],
+            [0, 1, 1, 0, 1, 1, 4, 0],
+            [0, 1, 0, 1, 1, 0, 1, 0],
+            [0, 1, 1, 1, 0, 1, 1, 0],
+            [0, 1, 1, 0, 1, 1, 1, 0],
+            [0, 2, 1, 1, 1, 1, 1, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0]
+          ],
+          skin: 'birds',
+          level: {
+            startDirection: 2
+          }
+        }
+      },
+      {
+        id: '23228',
+        display_name: 'courseC_PlayLab_events_challenge1',
+        url:
+          'http://studio.code.org:3000/s/coursef-2019/lessons/1/extras?level_name=courseC_artist_prog_challenge1',
+        type: 'Studio',
+        thumbnail_url:
+          'https://d3p74s6bwmy6t9.cloudfront.net/0b5d06628b7510904ee392a94065352a=development/2069.png',
+        perfect: false
+      }
+    ]
+  }
+];
+
 export default storybook => {
   const store = configureStore();
-  storybook.storiesOf('LessonExtras', module).add(
-    'default',
-    withInfo('This is the LessonExtras component.')(() => (
-      <Provider store={store}>
-        <LessonExtras
-          lessonNumber={1}
-          nextLevelPath="#"
-          bonusLevels={[
-            {
-              lessonNumber: 1,
-              levels: [
-                {
-                  id: '23222',
-                  display_name: 'courseB_maze_seq_challenge1',
-                  url:
-                    'http://studio.code.org:3000/s/coursef-2019/lessons/1/extras?level_name=courseC_artist_prog_challenge1',
-                  perfect: false,
-                  type: 'Maze',
-                  maze_summary: {
-                    map: [
-                      [0, 0, 0, 0, 0, 0, 0, 0],
-                      [0, 0, 1, 1, 1, 1, 2, 0],
-                      [0, 0, 1, 1, 1, 1, 1, 0],
-                      [0, 0, 1, 1, 1, 1, 1, 0],
-                      [0, 0, 1, 4, 4, 1, 1, 0],
-                      [0, 0, 1, 1, 3, 4, 1, 0],
-                      [0, 0, 1, 1, 1, 1, 1, 0],
-                      [0, 0, 0, 0, 0, 0, 0, 0]
-                    ],
-                    skin: 'birds',
-                    level: {
-                      startDirection: 2
-                    }
-                  }
-                },
-                {
-                  id: '23223',
-                  display_name: 'courseB_maze_seq_challenge1',
-                  url:
-                    'http://studio.code.org:3000/s/coursef-2019/lessons/1/extras?level_name=courseC_artist_prog_challenge1',
-                  perfect: false,
-                  type: 'Maze',
-                  maze_summary: {
-                    map: [
-                      [0, 0, 0, 0, 0, 0, 0, 0],
-                      [0, 1, 1, 1, 4, 1, 3, 0],
-                      [0, 1, 1, 0, 1, 1, 4, 0],
-                      [0, 1, 0, 1, 1, 0, 1, 0],
-                      [0, 1, 1, 1, 0, 1, 1, 0],
-                      [0, 1, 1, 0, 1, 1, 1, 0],
-                      [0, 2, 1, 1, 1, 1, 1, 0],
-                      [0, 0, 0, 0, 0, 0, 0, 0]
-                    ],
-                    skin: 'birds',
-                    level: {
-                      startDirection: 2
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              lessonNumber: 2,
-              levels: [
-                {
-                  id: '23224',
-                  display_name: 'courseC_artist_prog_challenge1',
-                  url:
-                    'http://studio.code.org:3000/s/coursef-2019/lessons/1/extras?level_name=courseC_artist_prog_challenge1',
-                  type: 'Artist',
-                  thumbnail_url:
-                    'https://d3p74s6bwmy6t9.cloudfront.net/80cc9bbdbd9a05c1a0cf03500b4eb38c=development/2091.png',
-                  perfect: false
-                },
-                {
-                  id: '23225',
-                  display_name: 'courseC_PlayLab_events_challenge1',
-                  url:
-                    'http://studio.code.org:3000/s/coursef-2019/lessons/1/extras?level_name=courseC_artist_prog_challenge1',
-                  type: 'Studio',
-                  thumbnail_url:
-                    'https://d3p74s6bwmy6t9.cloudfront.net/0b5d06628b7510904ee392a94065352a=development/2069.png',
-                  perfect: false
-                }
-              ]
-            },
-            {
-              lessonNumber: 3,
-              levels: [
-                {
-                  id: '23226',
-                  display_name: 'courseC_artist_prog_challenge1',
-                  url:
-                    'http://studio.code.org:3000/s/coursef-2019/lessons/1/extras?level_name=courseC_artist_prog_challenge1',
-                  type: 'Artist',
-                  thumbnail_url:
-                    'https://d3p74s6bwmy6t9.cloudfront.net/80cc9bbdbd9a05c1a0cf03500b4eb38c=development/2091.png',
-                  perfect: false
-                },
-                {
-                  id: '23227',
-                  display_name: 'courseB_maze_seq_challenge2',
-                  url:
-                    'http://studio.code.org:3000/s/coursef-2019/lessons/1/extras?level_name=courseC_artist_prog_challenge1',
-                  type: 'Maze',
-                  perfect: false,
-                  maze_summary: {
-                    map: [
-                      [0, 0, 0, 0, 0, 0, 0, 0],
-                      [0, 1, 1, 1, 4, 1, 3, 0],
-                      [0, 1, 1, 0, 1, 1, 4, 0],
-                      [0, 1, 0, 1, 1, 0, 1, 0],
-                      [0, 1, 1, 1, 0, 1, 1, 0],
-                      [0, 1, 1, 0, 1, 1, 1, 0],
-                      [0, 2, 1, 1, 1, 1, 1, 0],
-                      [0, 0, 0, 0, 0, 0, 0, 0]
-                    ],
-                    skin: 'birds',
-                    level: {
-                      startDirection: 2
-                    }
-                  }
-                },
-                {
-                  id: '23228',
-                  display_name: 'courseC_PlayLab_events_challenge1',
-                  url:
-                    'http://studio.code.org:3000/s/coursef-2019/lessons/1/extras?level_name=courseC_artist_prog_challenge1',
-                  type: 'Studio',
-                  thumbnail_url:
-                    'https://d3p74s6bwmy6t9.cloudfront.net/0b5d06628b7510904ee392a94065352a=development/2069.png',
-                  perfect: false
-                }
-              ]
-            }
-          ]}
-          showProjectWidget={false}
-        />
-      </Provider>
-    ))
-  );
+  storybook.storiesOf('LessonExtras', module).addStoryTable([
+    {
+      name: 'Default',
+      story: () => (
+        <Provider store={store}>
+          <LessonExtras
+            lessonNumber={1}
+            nextLevelPath="#"
+            bonusLevels={bonusLevels}
+            showProjectWidget={false}
+          />
+        </Provider>
+      )
+    }
+  ]);
 };

--- a/apps/src/code-studio/components/playzone.story.jsx
+++ b/apps/src/code-studio/components/playzone.story.jsx
@@ -1,21 +1,16 @@
 import React from 'react';
 import PlayZone from './playzone';
 import CreateSomething from './lessonExtras/CreateSomething';
-import {withInfo} from '@storybook/addon-info';
 
 export default storybook => {
-  storybook
-    .storiesOf('PlayZone', module)
-    .add(
-      'default',
-      withInfo('This is the PlayZone component.')(() => (
-        <PlayZone lessonName="Test Lesson" onContinue={() => {}} />
-      ))
-    )
-    .add(
-      'create something',
-      withInfo('This is the CreateSomething component.')(() => (
-        <CreateSomething />
-      ))
-    );
+  storybook.storiesOf('PlayZone', module).addStoryTable([
+    {
+      name: 'Default',
+      story: () => <PlayZone lessonName="Test Lesson" onContinue={() => {}} />
+    },
+    {
+      name: 'Create something',
+      story: () => <CreateSomething />
+    }
+  ]);
 };

--- a/apps/src/netsim/NetSimLogBrowser.story.jsx
+++ b/apps/src/netsim/NetSimLogBrowser.story.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import NetSimLogBrowser from './NetSimLogBrowser';
 import Packet from './Packet';
 import {createUuid} from '@cdo/apps/utils';
-import {withInfo} from '@storybook/addon-info';
 
 const range = function(i) {
   return new Array(i).fill().map((_, i) => i);
@@ -71,31 +70,28 @@ export default storybook => {
 
   const senderNames = _.uniq(sampleData.map(row => row['sent-by']));
 
-  return storybook
-    .storiesOf('NetSimLogBrowser', module)
-    .add(
-      'No filtering allowed',
-      withInfo(`Here's what the dialog looks like with minimum settings.`)(
-        () => (
-          <div id="netsim">
-            <NetSimLogBrowser
-              isOpen
-              i18n={i18n}
-              setRouterLogMode={() => null}
-              setTrafficFilter={() => null}
-              headerFields={simplePacket}
-              logRows={sampleData}
-              senderNames={senderNames}
-            />
-          </div>
-        )
+  return storybook.storiesOf('NetSimLogBrowser', module).addStoryTable([
+    {
+      name: 'No filtering allowed',
+      description: 'What the dialog looks like with minimum settings.',
+      story: () => (
+        <div id="netsim">
+          <NetSimLogBrowser
+            isOpen
+            i18n={i18n}
+            setRouterLogMode={() => null}
+            setTrafficFilter={() => null}
+            headerFields={simplePacket}
+            logRows={sampleData}
+            senderNames={senderNames}
+          />
+        </div>
       )
-    )
-    .add(
-      'Student filters',
-      withInfo(
-        `Here's what the dialog looks like with filters and more columns.`
-      )(() => (
+    },
+    {
+      name: 'Student filters',
+      description: 'What the dialog looks like with filters and more columns.',
+      story: () => (
         <div id="netsim">
           <NetSimLogBrowser
             isOpen
@@ -111,11 +107,12 @@ export default storybook => {
             senderNames={senderNames}
           />
         </div>
-      ))
-    )
-    .add(
-      `Teacher's View`,
-      withInfo(`Here's what the teacher (or shard owner) gets to see`)(() => (
+      )
+    },
+    {
+      name: 'Teacher view',
+      description: 'What the teacher (or shared owner) gets to see.',
+      story: () => (
         <div id="netsim">
           <NetSimLogBrowser
             isOpen
@@ -130,6 +127,7 @@ export default storybook => {
             teacherView
           />
         </div>
-      ))
-    );
+      )
+    }
+  ]);
 };

--- a/apps/src/templates/LegacyButton.story.jsx
+++ b/apps/src/templates/LegacyButton.story.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import LegacyButton, {BUTTON_TYPES, style} from './LegacyButton';
-import {withInfo} from '@storybook/addon-info';
 
 const docs = {
   default: "Use for actions that don't need to be the focus of the page",
@@ -12,62 +11,64 @@ const docs = {
 };
 
 export default storybook => {
-  storybook.storiesOf('Buttons/LegacyButton', module).add(
-    'overview',
-    withInfo('')(() => (
-      <div>
-        <h1>Intro</h1>
-        <p>
-          LegacyButtons come in many different shapes and sizes! Some aspects of
-          buttons that are worth mentioning:
-        </p>
-        <ul>
-          <li>They have a min width of {`${style.base.minWidth}px`}</li>
-          <li>
-            They come in a number of different semantic styles:{' '}
-            {Object.keys(BUTTON_TYPES).join(', ')}
-          </li>
-        </ul>
-        <h1>Types</h1>
-        <table style={{backgroundColor: 'white', textAlign: 'center'}}>
-          <thead>
-            <tr>
-              <th>Type</th>
-              <th style={{width: 300}}>Usage</th>
-              <th>Appearance</th>
-              <th>Large Size</th>
-              <th>Left arrow</th>
-              <th>Right arrow</th>
-            </tr>
-          </thead>
-          <tbody>
-            {Object.keys(BUTTON_TYPES).map(type => (
-              <tr key={type}>
-                <td>{type}</td>
-                <td style={{textAlign: 'left'}}>{docs[type]}</td>
-                <td>
-                  <LegacyButton type={type}>{type}</LegacyButton>
-                </td>
-                <td>
-                  <LegacyButton type={type} size="large">
-                    {type}
-                  </LegacyButton>
-                </td>
-                <td>
-                  <LegacyButton type={type} size="large" arrow="left">
-                    {type}
-                  </LegacyButton>
-                </td>
-                <td>
-                  <LegacyButton type={type} size="large" arrow="right">
-                    {type}
-                  </LegacyButton>
-                </td>
+  storybook.storiesOf('Buttons/LegacyButton', module).addStoryTable([
+    {
+      name: 'Overview',
+      story: () => (
+        <div>
+          <h1>Intro</h1>
+          <p>
+            LegacyButtons come in many different shapes and sizes! Some aspects
+            of buttons that are worth mentioning:
+          </p>
+          <ul>
+            <li>They have a min width of {`${style.base.minWidth}px`}</li>
+            <li>
+              They come in a number of different semantic styles:{' '}
+              {Object.keys(BUTTON_TYPES).join(', ')}
+            </li>
+          </ul>
+          <h1>Types</h1>
+          <table style={{backgroundColor: 'white', textAlign: 'center'}}>
+            <thead>
+              <tr>
+                <th>Type</th>
+                <th style={{width: 300}}>Usage</th>
+                <th>Appearance</th>
+                <th>Large Size</th>
+                <th>Left arrow</th>
+                <th>Right arrow</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-    ))
-  );
+            </thead>
+            <tbody>
+              {Object.keys(BUTTON_TYPES).map(type => (
+                <tr key={type}>
+                  <td>{type}</td>
+                  <td style={{textAlign: 'left'}}>{docs[type]}</td>
+                  <td>
+                    <LegacyButton type={type}>{type}</LegacyButton>
+                  </td>
+                  <td>
+                    <LegacyButton type={type} size="large">
+                      {type}
+                    </LegacyButton>
+                  </td>
+                  <td>
+                    <LegacyButton type={type} size="large" arrow="left">
+                      {type}
+                    </LegacyButton>
+                  </td>
+                  <td>
+                    <LegacyButton type={type} size="large" arrow="right">
+                      {type}
+                    </LegacyButton>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )
+    }
+  ]);
 };

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -2059,22 +2059,6 @@
     react-inspector "^2.3.0"
     uuid "^3.3.2"
 
-"@storybook/addon-info@^3.3.15":
-  version "3.4.12"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-info/-/addon-info-3.4.12.tgz#3e867ed347997823a5389369aa018231e9416b8e"
-  dependencies:
-    "@storybook/client-logger" "3.4.12"
-    "@storybook/components" "3.4.12"
-    babel-runtime "^6.26.0"
-    glamor "^2.20.40"
-    glamorous "^4.12.1"
-    global "^4.3.2"
-    marksy "^6.0.3"
-    nested-object-assign "^1.0.1"
-    prop-types "^15.6.1"
-    react-addons-create-fragment "^15.5.3"
-    util-deprecate "^1.0.2"
-
 "@storybook/addon-options@^4.1.16":
   version "4.1.16"
   resolved "https://registry.yarnpkg.com/@storybook/addon-options/-/addon-options-4.1.16.tgz#07957ec2c43eedfe7c3524dd6275c662adcaa0d6"
@@ -2104,21 +2088,9 @@
   version "4.1.16"
   resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-4.1.16.tgz#b935a5e5b762ba0f7ebb6d833e35a57dbfc02858"
 
-"@storybook/client-logger@3.4.12":
-  version "3.4.12"
-  resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-3.4.12.tgz#060a335cb560e4f0a0b61b358bac95a7529ef3d3"
-
 "@storybook/client-logger@4.1.16":
   version "4.1.16"
   resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-4.1.16.tgz#be9ffda433fdbf6a3cfe6b99ec62bcea35966140"
-
-"@storybook/components@3.4.12":
-  version "3.4.12"
-  resolved "https://registry.yarnpkg.com/@storybook/components/-/components-3.4.12.tgz#07499c43aca1f8543211202f3d142764bdd4c807"
-  dependencies:
-    glamor "^2.20.40"
-    glamorous "^4.12.1"
-    prop-types "^15.6.1"
 
 "@storybook/components@4.1.16":
   version "4.1.16"
@@ -3575,10 +3547,6 @@ babel-runtime@^6.0.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0, babel-runtim
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
-babel-standalone@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-standalone/-/babel-standalone-6.26.0.tgz#15fb3d35f2c456695815ebf1ed96fe7f015b6886"
-
 babel-template@^6.16.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
@@ -3954,10 +3922,6 @@ braces@^2.3.1, braces@^2.3.2:
     snapdragon-node "^2.0.1"
     split-string "^3.0.2"
     to-regex "^3.0.1"
-
-brcast@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/brcast/-/brcast-3.0.1.tgz#6256a8349b20de9eed44257a9b24d71493cd48dd"
 
 brorand@^1.0.1:
   version "1.1.0"
@@ -6842,10 +6806,6 @@ fast-memoize@2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/fast-memoize/-/fast-memoize-2.0.2.tgz#18227721734e1bb97b4fa308abccb3ffb71e9bf8"
 
-fast-memoize@^2.2.7:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/fast-memoize/-/fast-memoize-2.5.1.tgz#c3519241e80552ce395e1a32dcdde8d1fd680f5d"
-
 fastparse@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.1.tgz#d1e2643b38a94d7583b479060e6c4affc94071f8"
@@ -6874,7 +6834,7 @@ faye-websocket@~0.11.0, faye-websocket@~0.11.1:
   dependencies:
     websocket-driver ">=0.5.1"
 
-fbjs@^0.8.1, fbjs@^0.8.12, fbjs@^0.8.16, fbjs@^0.8.4, fbjs@^0.8.9:
+fbjs@^0.8.1, fbjs@^0.8.16, fbjs@^0.8.4, fbjs@^0.8.9:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   dependencies:
@@ -7427,29 +7387,6 @@ getpass@^0.1.1:
   resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.6.tgz#283ffd9fc1256840875311c1b60e8c40187110e6"
   dependencies:
     assert-plus "^1.0.0"
-
-glamor@^2.20.40:
-  version "2.20.40"
-  resolved "https://registry.yarnpkg.com/glamor/-/glamor-2.20.40.tgz#f606660357b7cf18dface731ad1a2cfa93817f05"
-  dependencies:
-    fbjs "^0.8.12"
-    inline-style-prefixer "^3.0.6"
-    object-assign "^4.1.1"
-    prop-types "^15.5.10"
-    through "^2.3.8"
-
-glamorous@^4.12.1:
-  version "4.13.1"
-  resolved "https://registry.yarnpkg.com/glamorous/-/glamorous-4.13.1.tgz#8909afcbc7f09133c6eb26bedcc1250c1f774312"
-  dependencies:
-    brcast "^3.0.0"
-    csstype "^2.2.0"
-    fast-memoize "^2.2.7"
-    html-tag-names "^1.1.1"
-    is-function "^1.0.1"
-    is-plain-object "^2.0.4"
-    react-html-attributes "^1.4.2"
-    svg-tag-names "^1.1.0"
 
 glob-base@^0.3.0:
   version "0.3.0"
@@ -8140,7 +8077,7 @@ he@1.1.1:
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
   integrity sha1-k0EP0hsAlzUVH4howvJx80J+I/0=
 
-he@1.2.x, he@^1.1.1:
+he@1.2.x:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
 
@@ -8236,10 +8173,6 @@ html-comment-regex@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/html-comment-regex/-/html-comment-regex-1.1.1.tgz#668b93776eaae55ebde8f3ad464b307a4963625e"
 
-html-element-attributes@^1.0.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/html-element-attributes/-/html-element-attributes-1.3.1.tgz#9fa6a2e37e6b61790a303e87ddbbb9746e8c035f"
-
 html-element-map@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/html-element-map/-/html-element-map-1.0.1.tgz#3c4fcb4874ebddfe4283b51c8994e7713782b592"
@@ -8268,10 +8201,6 @@ html-minifier@^3, html-minifier@^3.5.20:
     param-case "2.1.x"
     relateurl "0.2.x"
     uglify-js "3.4.x"
-
-html-tag-names@^1.1.1:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/html-tag-names/-/html-tag-names-1.1.3.tgz#f81f75e59d626cb8a958a19e58f90c1d69707b82"
 
 html-void-elements@^1.0.0, html-void-elements@^1.0.1:
   version "1.0.3"
@@ -8617,13 +8546,6 @@ ini@^1.3.4:
 ini@~1.3.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
-
-inline-style-prefixer@^3.0.6:
-  version "3.0.8"
-  resolved "https://registry.yarnpkg.com/inline-style-prefixer/-/inline-style-prefixer-3.0.8.tgz#8551b8e5b4d573244e66a34b04f7d32076a2b534"
-  dependencies:
-    bowser "^1.7.3"
-    css-in-js-utils "^2.0.0"
 
 inline-style-prefixer@^4.0.0:
   version "4.0.2"
@@ -10167,21 +10089,9 @@ marked-terminal@^1.6.2:
     lodash.assign "^4.2.0"
     node-emoji "^1.4.1"
 
-marked@^0.3.12:
-  version "0.3.19"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.19.tgz#5d47f709c4c9fc3c216b6d46127280f40b39d790"
-
 marked@^0.3.6:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.6.tgz#b2c6c618fccece4ef86c4fc6cb8a7cbf5aeda8d7"
-
-marksy@^6.0.3:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/marksy/-/marksy-6.1.0.tgz#36482148a1115cc78570855f7ebd744bb453d5cc"
-  dependencies:
-    babel-standalone "^6.26.0"
-    he "^1.1.1"
-    marked "^0.3.12"
 
 material-colors@^1.2.1:
   version "1.2.5"
@@ -10809,10 +10719,6 @@ neo-async@^2.6.0, neo-async@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
   integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
-
-nested-object-assign@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/nested-object-assign/-/nested-object-assign-1.0.3.tgz#5aca69390d9affe5a612152b5f0843ae399ac597"
 
 netmask@^1.0.6:
   version "1.0.6"
@@ -12751,14 +12657,6 @@ react-ace@^9.2.1:
     lodash.isequal "^4.5.0"
     prop-types "^15.7.2"
 
-react-addons-create-fragment@^15.5.3:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/react-addons-create-fragment/-/react-addons-create-fragment-15.6.2.tgz#a394de7c2c7becd6b5475ba1b97ac472ce7c74f8"
-  dependencies:
-    fbjs "^0.8.4"
-    loose-envify "^1.3.1"
-    object-assign "^4.1.0"
-
 react-addons-test-utils@~15.4.0:
   version "15.4.2"
   resolved "https://registry.yarnpkg.com/react-addons-test-utils/-/react-addons-test-utils-15.4.2.tgz#93bcaa718fcae7360d42e8fb1c09756cc36302a2"
@@ -12920,12 +12818,6 @@ react-hot-loader:
   dependencies:
     react-hot-api "^0.4.5"
     source-map "^0.4.4"
-
-react-html-attributes@^1.4.2:
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/react-html-attributes/-/react-html-attributes-1.4.3.tgz#8c36c35fce6b750938d286af428ed1da7625186e"
-  dependencies:
-    html-element-attributes "^1.0.0"
 
 react-idle-timer@^4.2.7:
   version "4.2.7"
@@ -15191,10 +15083,6 @@ survey-react@1.7.4:
   resolved "https://registry.yarnpkg.com/survey-react/-/survey-react-1.7.4.tgz#41194f0c4c4a96a88676a19f812ff362aa62f243"
   integrity sha512-s6MsZvHUbp9YYoMsmpxcGEL3hz0iWLUQQ3aR+C1V6EBQrHwnhUN0nl7llpQsTc5pn0l4r0kwlGpKMFArVVInIA==
 
-svg-tag-names@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/svg-tag-names/-/svg-tag-names-1.1.1.tgz#9641b29ef71025ee094c7043f7cdde7d99fbd50a"
-
 svg-url-loader@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/svg-url-loader/-/svg-url-loader-2.3.2.tgz#dd86b26c19fe3b914f04ea10ef39594eade04464"
@@ -15382,7 +15270,7 @@ through2@^2.0.0:
     readable-stream "~2.3.6"
     xtend "~4.0.1"
 
-through@^2.3.4, through@^2.3.6, through@^2.3.8:
+through@^2.3.4, through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 


### PR DESCRIPTION
Pulled out of #41582 so we can ship unrelated work before upgrading React.

This refactors storybook entries that used the addon-info storybook plugin because it uses deprecated React features and doesn't give us any value that default storybook doesn't already have. It also removes this dependency from our storybook config and package.json.