### PR TITLE
Modify user_levels table with gh-ost

### DIFF
--- a/bin/oneoff/gh-ost_migrations/add_deleted_at_properties_columns_to_user_levels.sh
+++ b/bin/oneoff/gh-ost_migrations/add_deleted_at_properties_columns_to_user_levels.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+DB_USER=${DB_USER?Required}
+DB_PASSWORD=${DB_PASSWORD?Required}
+DB_MASTER_HOST=${DB_MASTER_HOST?Required}
+
+# Options reference: https://github.com/github/gh-ost/blob/master/go/cmd/gh-ost/main.go
+args=(
+  # MySQL user
+  --user=${DB_USER}
+
+  # MySQL password
+  --password=${DB_PASSWORD}
+
+  # We don't have a reporting replica anymore, so carry out all operations on primary database
+  --allow-on-master
+
+  # MySQL hostname (preferably a replica, not the master)
+  --host=${DB_MASTER_HOST}
+
+  # (optional) explicitly tell gh-ost the identity of the master.
+  # Format: some.host.com[:port]
+  # This is useful in master-master setups where you wish to pick an explicit master,
+  # or in a tungsten-replicator where gh-ost is unable to determine the master
+  --assume-master-host=${DB_MASTER_HOST}
+
+  # while this file exists, migration will postpone the final stage of swapping tables,
+  # and will keep on syncing the ghost table.
+  # Cut-over/swapping would be ready to perform the moment the file is deleted.
+  --postpone-cut-over-flag-file=/tmp/gh-ost.cutover
+
+  # directory where hook files are found (default: empty, ie. hooks disabled).
+  # Hook files found on this path, and conforming to hook naming conventions will be executed
+  --hooks-path=${PWD}
+
+  # database name (mandatory)
+  --database="dashboard_production"
+
+  # table name (mandatory)
+  --table="user_levels"
+
+  # verbose
+  --verbose
+
+  # alter statement (mandatory)
+  --alter="ADD deleted_at datetime, ADD properties text, ADD UNIQUE  index_user_levels_unique  (`user_id`, `script_id`, `level_id`, `deleted_at`) , DROP INDEX index_user_levels_on_user_id_and_level_id_and_script_id"
+
+  # Drop a possibly existing Ghost table (remains from a previous run?) before beginning operation.
+  # Default is to panic and abort if such table exists
+#  --initially-drop-ghost-table
+
+  # Drop a possibly existing OLD table (remains from a previous run?) before beginning operation.
+  # Default is to panic and abort if such table exists
+#  --initially-drop-old-table
+
+  # Comma delimited status-name=threshold.
+  # e.g: 'Threads_running=100,Threads_connected=500'.
+  # When status exceeds threshold, app throttles writes
+  --max-load=Threads_running=30
+
+  # set to 'true' when you know for certain your server uses 'ROW' binlog_format.
+  # gh-ost is unable to tell, even after reading binlog_format, whether the replication process does indeed use 'ROW',
+  # and restarts replication to be certain RBR setting is applied.
+  # Such operation requires SUPER privileges which you might not have.
+  # Setting this flag avoids restarting replication and you can proceed to use gh-ost without SUPER privileges
+  --assume-rbr
+
+  # amount of rows to handle in each iteration (allowed range: 100-100,000)
+  --chunk-size=1000
+
+  # batch size for DML events to apply in a single transaction (range 1-100)
+  --dml-batch-size=100
+
+  # Default number of retries for various operations before panicking
+  --default-retries=1000
+
+  # choose cut-over type (default|atomic, two-step)
+  --cut-over=default
+
+  # actually count table rows as opposed to estimate them (results in more accurate progress estimation)
+  --exact-rowcount
+
+  # (with --exact-rowcount)
+  # when true (default): count rows after row-copy begins, concurrently, and adjust row estimate later on;
+  # when false: first count rows, then start row copy
+  --concurrent-rowcount
+
+  # when this file is created, gh-ost will immediately terminate, without cleanup
+  --panic-flag-file=/tmp/gh-ost.panic.flag
+
+  # actually execute the alter & migrate the table. Default is noop: do some tests and exit
+#  --execute
+)
+
+/opt/gh-ost "${args[@]}"

--- a/bin/oneoff/gh-ost_migrations/add_deleted_at_properties_columns_to_user_levels.sh
+++ b/bin/oneoff/gh-ost_migrations/add_deleted_at_properties_columns_to_user_levels.sh
@@ -43,7 +43,7 @@ args=(
   --verbose
 
   # alter statement (mandatory)
-  --alter="ADD deleted_at datetime, ADD properties text, ADD UNIQUE  index_user_levels_unique  (`user_id`, `script_id`, `level_id`, `deleted_at`) , DROP INDEX index_user_levels_on_user_id_and_level_id_and_script_id"
+  --alter="ADD deleted_at datetime, ADD properties text, ADD UNIQUE  index_user_levels_unique  (user_id, script_id, level_id, deleted_at) , DROP INDEX index_user_levels_on_user_id_and_level_id_and_script_id"
 
   # Drop a possibly existing Ghost table (remains from a previous run?) before beginning operation.
   # Default is to panic and abort if such table exists


### PR DESCRIPTION
Implement the Rails migration in #41694 on production with the [gh-ost](https://github.com/github/gh-ost) because this table has >3B rows.


## Testing story

I've successfully executed the 4 DDL statements issued by the Rails migration in #41694 as a single `ALTER TABLE` statement on my local development environment:

``` sql
ALTER TABLE user_levels ADD deleted_at datetime, ADD properties text, ADD UNIQUE  index_user_levels_unique  (`user_id`, `script_id`, `level_id`, `deleted_at`) , DROP INDEX index_user_levels_on_user_id_and_level_id_and_script_id;
```



## Deployment strategy

1. Disable Aurora binlog filtering on production database cluster by setting the Parameter Group setting `aurora_enable_repl_bin_log_filtering=0` (this is a dynamic configuration setting).
2. This Pull Request hasn’t been merged yet, so checkout this file on `git checkout origin/modify-user-levels-table-with-gh-ost -- bin/oneoff/gh-ost_migrations/add_deleted_at_properties_columns_to_user_levels.sh`
2. Execute this shell script in a `screen` on `production-daemon`. It will create the empty new table by copying the existing table, and will then apply the schema change to the empty table, and will then delete the new table as a dry-run.
3. Edit the deployed shell script to UN-comment out the `--execute` flag and re-run the script for realz in a `screen`
3. Detach from the `screen` and monitor database and system performance and terminate the gh-ost migration if it is negatively impacting system performance.
4. Tell gh-ost to complete cut-over when it is done copying over all of the rows from the existing table by deleting the cutover flag file `/tmp/gh-ost.cutover`
5. Re-enable Aurora binlog filtering by setting `aurora_enable_repl_bin_log_filtering=1`
6. After we’re certain the new table is working correctly, delete the old table.
7. Delete this shell script file from `production-daemon` so that when this change is merged and released to production it can be deployed.

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
