### PR TITLE
removeBehavior -> removeBehaviorSimple

### DIFF
--- a/apps/src/p5lab/spritelab/commands/behaviorCommands.js
+++ b/apps/src/p5lab/spritelab/commands/behaviorCommands.js
@@ -112,7 +112,7 @@ export const commands = {
     sprites.forEach(sprite => this.removeAllBehaviors(sprite));
   },
 
-  removeBehavior(spriteArg, behavior) {
+  removeBehaviorSimple(spriteArg, behavior) {
     let sprites = this.getSpriteArray(spriteArg);
     sprites.forEach(sprite => this.removeBehavior(sprite, behavior));
   }


### PR DESCRIPTION
This was just an oversight in https://github.com/code-dot-org/code-dot-org/pull/41673

The spritelab generated code is `removeBehaviorSimple` but the behaviorCommands function was named `renameBehavior`
Previously this was handled in `spritelab/commands`:
```
removeBehaviorSimple(spriteArg, behavior) {
    behaviorCommands.removeBehavior(spriteArg, behavior);
  }
```

The fix is just to rename the behaviorCommands function to match the generated code