### PR TITLE
Remove redux details from ProgressDetailToggle storybook

### DIFF
--- a/apps/src/templates/progress/ProgressDetailToggle.jsx
+++ b/apps/src/templates/progress/ProgressDetailToggle.jsx
@@ -109,6 +109,8 @@ const styles = {
   }
 };
 
+export const UnconnectedProgressDetailToggle = ProgressDetailToggle;
+
 export default connect(
   state => ({
     isPlc: !!state.progress.professionalLearningCourse,

--- a/apps/src/templates/progress/ProgressDetailToggle.story.jsx
+++ b/apps/src/templates/progress/ProgressDetailToggle.story.jsx
@@ -1,96 +1,58 @@
 import React from 'react';
-import ProgressDetailToggle from './ProgressDetailToggle';
-import {combineReducers, createStore} from 'redux';
-import progress, {setIsSummaryView} from '@cdo/apps/code-studio/progressRedux';
+import {action} from '@storybook/addon-actions';
+import {UnconnectedProgressDetailToggle as ProgressDetailToggle} from './ProgressDetailToggle';
+import progress from '@cdo/apps/code-studio/progressRedux';
 
 export default storybook => {
-  const initialState = {
-    progress: {
-      lessonGroups: [],
-      lessons: [
-        {
-          levels: []
-        }
-      ],
-      focusAreaLessonIds: [],
-      professionalLearningCourse: false
-    }
-  };
-
-  const initialStateGrouped = {
-    progress: {
-      lessonGroups: [
-        {
-          display_name: 'cat1',
-          id: 1,
-          description: 'This is a description',
-          big_questions: 'What?'
-        },
-        {
-          display_name: 'cat2',
-          id: 2,
-          description: 'This is another description',
-          big_questions: 'Why?'
-        }
-      ],
-      lessons: [
-        {
-          lesson_group_display_name: 'cat1',
-          levels: []
-        },
-        {
-          lesson_group_display_name: 'cat2',
-          levels: []
-        }
-      ],
-      focusAreaLessonIds: [],
-      professionalLearningCourse: false
-    }
-  };
-
-  function isSummaryTrue() {
-    const store = createStore(combineReducers({progress}), initialState);
-    store.dispatch(setIsSummaryView(true));
-    return {
-      name: 'isSummary is true',
-      story: () => <ProgressDetailToggle store={store} />
-    };
-  }
-
-  function isSummaryFalse() {
-    const store = createStore(combineReducers({progress}), initialState);
-    store.dispatch(setIsSummaryView(false));
-    return {
-      name: 'isSummary is false',
-      story: () => <ProgressDetailToggle store={store} />
-    };
-  }
-
-  function isSummaryTrueGrouped() {
-    const store = createStore(combineReducers({progress}), initialStateGrouped);
-    store.dispatch(setIsSummaryView(true));
-    return {
-      name: 'isSummary is true with groups',
-      story: () => <ProgressDetailToggle store={store} />
-    };
-  }
-
-  function isSummaryFalseGrouped() {
-    const store = createStore(combineReducers({progress}), initialStateGrouped);
-    store.dispatch(setIsSummaryView(false));
-    return {
-      name: 'isSummary is false with groups',
-      story: () => <ProgressDetailToggle store={store} />
-    };
-  }
-
   storybook
     .storiesOf('Progress/ProgressDetailToggle', module)
-    .withReduxStore()
+    .withReduxStore({progress})
     .addStoryTable([
-      isSummaryTrue(),
-      isSummaryFalse(),
-      isSummaryTrueGrouped(),
-      isSummaryFalseGrouped()
+      {
+        name: 'isSummary is true',
+        story: () => {
+          return (
+            <ProgressDetailToggle
+              isPlc={false}
+              isSummaryView
+              hasGroups={false}
+              setIsSummaryView={action('setIsSummaryView')}
+            />
+          );
+        }
+      },
+      {
+        name: 'isSummary is false',
+        story: () => (
+          <ProgressDetailToggle
+            isPlc={false}
+            isSummaryView={false}
+            hasGroups={false}
+            setIsSummaryView={action('setIsSummaryView')}
+          />
+        )
+      },
+      {
+        name: 'isSummary is true with groups',
+        story: () => (
+          <ProgressDetailToggle
+            isPlc={false}
+            isSummaryView
+            hasGroups
+            setIsSummaryView={action('setIsSummaryView')}
+          />
+        )
+      },
+      {
+        name: 'isSummary is false with groups',
+        story: () => (
+          <ProgressDetailToggle
+            isPlc={false}
+            isSummaryView={false}
+            hasGroups
+            setIsSummaryView={action('setIsSummaryView')}
+          />
+        )
+      }
     ]);
 };


### PR DESCRIPTION
Pulled directly from #41582. We'll be upgrading redux with react; without this change, this storybook entry would fail due to redux Provider changes. This can be deployed before any upgrades.