### PR TITLE
Update progress dropdown UI test step

### DIFF
--- a/dashboard/test/ui/features/step_definitions/progress.rb
+++ b/dashboard/test/ui/features/step_definitions/progress.rb
@@ -81,7 +81,7 @@ end
 Then /^I open the progress drop down of the current page$/ do
   steps %{
     Then I click selector ".header_popup_link"
-    And I wait to see ".user-stats-block"
+    And I wait to see ".uitest-summary-progress-table"
   }
 end
 


### PR DESCRIPTION
Taken from #41582. Previously, this step was waiting for the container element, which loads before progress actually loads. Now, we look for the table that contains progress and should only be loaded once the data is available.