### PR TITLE
Upgrade eslint-plugin-prettier

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -99,7 +99,7 @@
     "eslint-plugin-babel": "^4.1.2",
     "eslint-plugin-cdo-custom-rules": "file:./eslint",
     "eslint-plugin-mocha": "^4.12.1",
-    "eslint-plugin-prettier": "^3.0.1",
+    "eslint-plugin-prettier": "^3.3.1",
     "eslint-plugin-react": "^7.11.0",
     "fast-memoize": "2.0.2",
     "file-loader": "^3.0.1",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -6348,9 +6348,10 @@ eslint-plugin-mocha@^4.12.1:
   dependencies:
     ramda "^0.25.0"
 
-eslint-plugin-prettier@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.0.1.tgz#19d521e3981f69dd6d14f64aec8c6a6ac6eb0b0d"
+eslint-plugin-prettier@^3.3.1:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.0.tgz#cdbad3bf1dbd2b177e9825737fe63b476a08f0c7"
+  integrity sha512-UDK6rJT6INSfcOo545jiaOwB701uAIt2/dR7WnFQoGCVl1/EMqdANBmwUaqqQ45aXprsTGzSa39LI1PyuRBxxw==
   dependencies:
     prettier-linter-helpers "^1.0.0"
 


### PR DESCRIPTION
Taken from #41582. Upgrading our eslint-plugin-prettier package to stay somewhat up-to-date (most recent version at the time of writing is [3.4](https://www.npmjs.com/package/eslint-plugin-prettier)).