### PR TITLE
Learn: fix sticky header for non-en users

### DIFF
--- a/apps/src/tutorialExplorer/tutorialExplorer.js
+++ b/apps/src/tutorialExplorer/tutorialExplorer.js
@@ -537,41 +537,41 @@ export default class TutorialExplorer extends React.Component {
     const grade = this.state.filters.grade[0];
 
     return (
-      <StickyContainer>
-        <div
-          style={{
-            width: getResponsiveContainerWidth(),
-            margin: '0 auto',
-            paddingBottom: 0
-          }}
-        >
-          {this.shouldShowTutorialsForLocale() && (
-            <div>
-              <h1>{i18n.headingTutorialsYourLanguage()}</h1>
-              {this.state.filteredTutorialsForLocale.length === 0 &&
-                i18n.noTutorialsYourLanguage()}
+      <div
+        style={{
+          width: getResponsiveContainerWidth(),
+          margin: '0 auto',
+          paddingBottom: 0
+        }}
+      >
+        {this.shouldShowTutorialsForLocale() && (
+          <div>
+            <h1>{i18n.headingTutorialsYourLanguage()}</h1>
+            {this.state.filteredTutorialsForLocale.length === 0 &&
+              i18n.noTutorialsYourLanguage()}
 
-              {this.state.filteredTutorialsForLocale.length > 0 && (
-                <TutorialSet
-                  tutorials={this.state.filteredTutorialsForLocale}
-                  specificLocale={true}
-                  localeEnglish={false}
-                  disabledTutorials={this.props.disabledTutorials}
-                  grade={grade}
-                />
-              )}
-            </div>
-          )}
+            {this.state.filteredTutorialsForLocale.length > 0 && (
+              <TutorialSet
+                tutorials={this.state.filteredTutorialsForLocale}
+                specificLocale={true}
+                localeEnglish={false}
+                disabledTutorials={this.props.disabledTutorials}
+                grade={grade}
+              />
+            )}
+          </div>
+        )}
 
-          {this.shouldShowAllTutorialsToggleButton() && (
-            <ToggleAllTutorialsButton
-              showAllTutorials={this.showAllTutorials}
-              hideAllTutorials={this.hideAllTutorials}
-              showingAllTutorials={this.state.showingAllTutorials}
-            />
-          )}
+        {this.shouldShowAllTutorialsToggleButton() && (
+          <ToggleAllTutorialsButton
+            showAllTutorials={this.showAllTutorials}
+            hideAllTutorials={this.hideAllTutorials}
+            showingAllTutorials={this.state.showingAllTutorials}
+          />
+        )}
 
-          {this.state.showingAllTutorials && (
+        {this.state.showingAllTutorials && (
+          <StickyContainer>
             <div ref={allTutorials => (this.allTutorials = allTutorials)}>
               <FilterHeader
                 mobileLayout={this.state.mobileLayout}
@@ -645,9 +645,9 @@ export default class TutorialExplorer extends React.Component {
                 </div>
               </div>
             </div>
-          )}
-        </div>
-      </StickyContainer>
+          </StickyContainer>
+        )}
+      </div>
     );
   }
 }


### PR DESCRIPTION
For non-en users, the header for the complete set of tutorials was stuck to the top of the window as soon as the full set of tutorials was being displayed, but before the user had scrolled past it:

<img width="1280" alt="Screen Shot 2021-07-31 at 7 46 27 PM" src="https://user-images.githubusercontent.com/2205926/127736360-a5edf23b-f0b7-4936-ac3e-39457a70199a.png">

By moving the `<StickyContainer>` to the right place, it no longer sticks early:

<img width="1280" alt="Screen Shot 2021-07-31 at 7 47 32 PM" src="https://user-images.githubusercontent.com/2205926/127736358-ccd8a835-b727-4ee6-94d8-356a696c1456.png">

But now sticks at the right time, once the user has scrolled so that it reaches the top of the window:

<img width="1280" alt="Screen Shot 2021-07-31 at 8 00 12 PM" src="https://user-images.githubusercontent.com/2205926/127736352-751c9505-e906-4df7-bb7c-cd72c817e2d8.png">


