### PR TITLE
Learn: reenable "scroll to top" when showing/hiding filters on mobile

### DIFF
--- a/apps/src/tutorialExplorer/tutorialExplorer.js
+++ b/apps/src/tutorialExplorer/tutorialExplorer.js
@@ -183,15 +183,9 @@ export default class TutorialExplorer extends React.Component {
    * Set up a smooth scroll to the top of all tutorials once we've re-rendered the
    * relevant changes.
    * Note that if that next render never comes, we won't actually do the scroll.
-   *
-   * Also note that this is currently disabled unless URL parameter "scrolltotop" is
-   * provided, due to flicker and mispositioning of the sticky header after scrolling
-   * on iOS devices.
    */
   scrollToTop() {
-    if (window.location.search.indexOf('scrolltotop') !== -1) {
-      this.shouldScrollToTop = true;
-    }
+    this.shouldScrollToTop = true;
   }
 
   /**


### PR DESCRIPTION
Followup to https://github.com/code-dot-org/code-dot-org/pull/12127 from 2016.  The sticky header no longer appears to have issues on modern iOS, and scrolling to the top feels nice both when showing filters and hiding them, so finally enabling this feature for all.
