### PR TITLE
Javalab: add icon to clear console button

### DIFF
--- a/apps/src/javalab/JavalabConsole.jsx
+++ b/apps/src/javalab/JavalabConsole.jsx
@@ -108,6 +108,7 @@ class JavalabConsole extends React.Component {
             onClick={() => {
               clearConsoleLogs();
             }}
+            iconClass="fa fa-eraser"
             label={javalabMsg.clearConsole()}
           />
           <PaneSection>{javalabMsg.console()}</PaneSection>


### PR DESCRIPTION
Add an eraser icon to the clear console button. This fixes the vertical alignment issue on the button and makes it so all our header buttons have icons.

New button:
<img width="142" alt="Screen Shot 2021-08-02 at 11 47 59 AM" src="https://user-images.githubusercontent.com/33666587/127909198-f59f5d44-ae70-4d51-a73c-4806fb4a2826.png">


## Links

- jira ticket: [CSA-494](https://codedotorg.atlassian.net/browse/CSA-494)


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
