### PR TITLE
Incorporating Maze minor update that fixes scrapePaint()

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -56,7 +56,7 @@
     "@code-dot-org/johnny-five": "0.11.1-cdo.2",
     "@code-dot-org/js-interpreter-tyrant": "0.2.2",
     "@code-dot-org/js-numbers": "0.1.0-cdo.0",
-    "@code-dot-org/maze": "2.13.0",
+    "@code-dot-org/maze": "2.14.0",
     "@code-dot-org/ml-activities": "0.0.26",
     "@code-dot-org/ml-playground": "0.0.39",
     "@code-dot-org/p5.play": "^1.3.17-cdo",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1622,10 +1622,10 @@
   version "0.1.0-cdo.0"
   resolved "https://registry.yarnpkg.com/@code-dot-org/js-numbers/-/js-numbers-0.1.0-cdo.0.tgz#810092a993c3c75441f2e5a3282f1257d9670715"
 
-"@code-dot-org/maze@2.13.0":
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/maze/-/maze-2.13.0.tgz#27bdc2b76de59d67df78b9b1d2737fe104a349f4"
-  integrity sha512-fVQxq6ys+84Dzt2QnZJzOaxdkxE3kckAw4i8gC+1YMQ8yvkHX8xoFfwknOou3lu8SoAQm+cBIii8a7palesUPQ==
+"@code-dot-org/maze@2.14.0":
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/maze/-/maze-2.14.0.tgz#a4cbaf3305e3b1746e84339c1668fbfbf1f6be30"
+  integrity sha512-u7h8QuzsAfyiUzaVhMHzPPQKwmyw7R3k2NhTVlCag4i1woEdaUqyCP5HURcFN66RI1D1QydvWi0SaO0ayphNIQ==
 
 "@code-dot-org/ml-activities@0.0.26":
   version "0.0.26"


### PR DESCRIPTION
This maze version fixes a bug in the Painter scrapePaint() method by fixing resetTile() in the drawer file. For history/context: the resetTile() function was written during the first paint glomming iteration, when updateItemImage() would redraw the entire grid each time. 

The maze PR: https://github.com/code-dot-org/maze/pull/70

## Links

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/CSA-604


## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
