### PR TITLE
Add policy for ml model bucket

### DIFF
--- a/aws/cloudformation/s3_buckets.yml
+++ b/aws/cloudformation/s3_buckets.yml
@@ -107,3 +107,25 @@ Resources:
         RestrictPublicBuckets: true
       VersioningConfiguration:
         Status: "Enabled"
+  MLModelsBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref MLModelsBucket
+      PolicyDocument:
+        Statement:
+          - Sid: Grant Drone permission to objects created by CI tests.
+            Effect: "Allow"
+            Action: "s3:*"
+            Resource: "arn:aws:s3:::cdo-v3-trained-ml-models/*"
+            Principal:
+              {
+                AWS: [!Sub "arn:aws:iam::${DeveloperAccount}:role/DroneWorker"],
+              }
+          - Sid: Grant Drone permission to list objects for CI tests.
+            Effect: "Allow"
+            Action: "s3:ListBucket"
+            Resource: "arn:aws:s3:::cdo-v3-trained-ml-models"
+            Principal:
+              {
+                AWS: [!Sub "arn:aws:iam::${DeveloperAccount}:role/DroneWorker"],
+              }

--- a/aws/cloudformation/s3_buckets.yml
+++ b/aws/cloudformation/s3_buckets.yml
@@ -100,6 +100,10 @@ Resources:
     DeletionPolicy: Retain
     Properties:
       BucketName: "cdo-v3-trained-ml-models"
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: "aws:kms"
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true


### PR DESCRIPTION
We need to be able to write to the trained-ml-models s3 bucket from Drone for [UI tests](https://github.com/code-dot-org/code-dot-org/pull/41527). When I set up the s3 bucket initially I did it through the AWS console. However,  s3 buckets can and should be set up using a CloudFormation template. In #41880 Suresh and I made a bucket template that matched the set up of the initial ml-models s3 bucket.  

In this PR we added an encryption property to the bucket and a policy to allow Drone to write to the ml models bucket. 

In the AWS console, this is the change staged for execution:

```
[
  {
    "resourceChange": {
      "logicalResourceId": "MLModelsBucketPolicy",
      "action": "Add",
      "physicalResourceId": null,
      "resourceType": "AWS::S3::BucketPolicy",
      "replacement": null,
      "moduleInfo": null,
      "details": [],
      "changeSetId": null,
      "scope": []
    },
    "hookInvocationCount": null,
    "type": "Resource"
  },
  {
    "resourceChange": {
      "logicalResourceId": "MLModelsBucket",
      "action": "Modify",
      "physicalResourceId": "cdo-v3-trained-ml-models",
      "resourceType": "AWS::S3::Bucket",
      "replacement": "False",
      "moduleInfo": null,
      "details": [
        {
          "target": {
            "name": "BucketEncryption",
            "requiresRecreation": "Never",
            "attribute": "Properties"
          },
          "causingEntity": null,
          "evaluation": "Static",
          "changeSource": "DirectModification"
        }
      ],
      "changeSetId": null,
      "scope": [
        "Properties"
      ]
    },
    "hookInvocationCount": null,
    "type": "Resource"
  }
]
```