### PR TITLE
[Sprite Lab] Remove unnecessary calls to createLibrary()

### DIFF
--- a/apps/src/p5lab/spritelab/SpriteLab.js
+++ b/apps/src/p5lab/spritelab/SpriteLab.js
@@ -4,7 +4,6 @@ import Sounds from '@cdo/apps/Sounds';
 import {getStore} from '@cdo/apps/redux';
 import {clearConsole} from '../redux/textConsole';
 import {clearPrompts, popPrompt} from '../redux/spritelabInput';
-import createLibrary from './libraries/libraryFactory';
 
 var SpriteLab = function() {
   P5Lab.call(this);
@@ -25,7 +24,6 @@ SpriteLab.prototype.preview = function() {
     // and, not knowing that preload is still in progress, would attempt to call p5.redraw(), and mess up the preview
     return;
   }
-  this.spritelabLibrary = createLibrary(this.level, {p5: this.p5Wrapper.p5});
   getStore().dispatch(clearConsole());
   Sounds.getSingleton().muteURLs();
   if (this.p5Wrapper.p5 && this.JSInterpreter) {
@@ -45,7 +43,6 @@ SpriteLab.prototype.preview = function() {
 
 SpriteLab.prototype.reset = function() {
   P5Lab.prototype.reset.call(this);
-  this.spritelabLibrary = createLibrary(this.level, {p5: this.p5Wrapper.p5});
   getStore().dispatch(clearPrompts());
   this.preview();
 };


### PR DESCRIPTION
Quick follow up to https://github.com/code-dot-org/code-dot-org/pull/41766

This warning was coming up way more than I had expected:
![image](https://user-images.githubusercontent.com/8787187/128098958-2c5e1b58-7c98-42a5-9917-c7dd6df12576.png)

Turns out, `p5` is always `null` when we are in `Spritelab.reset` and `Spritelab.preview` anyways, so calling `createLibrary()` from there was pointless, and just resulting in lots of those warnings. This PR just removes the unnecessary calls.