### PR TITLE
Fix yarn version installation

### DIFF
--- a/cookbooks/cdo-nodejs/.kitchen.yml
+++ b/cookbooks/cdo-nodejs/.kitchen.yml
@@ -1,34 +1,20 @@
 ---
-transport:
-  name: sftp
 driver:
-  name: docker
-  use_sudo: false
-  privileged: true
-
+  name: dokken
+  chef_version: 15.2.20
+verifier:
+  name: inspec
+transport:
+  name: dokken
 provisioner:
-  name: chef_zero
-  data_path: test/shared
-  require_chef_omnibus: 15.2.20
-
+  name: dokken
 platforms:
   - name: ubuntu-18.04
+    driver:
+      image: dokken/ubuntu-18.04
     run_list:
       - recipe[apt]
-
 suites:
   - name: default
     run_list:
       - recipe[cdo-nodejs]
-  - name: upgrade
-    steps:
-      - run_list:
-        - recipe[cdo-nodejs]
-        attributes:
-          cdo-nodejs:
-            version: '0.12'
-      - run_list:
-        - recipe[cdo-nodejs]
-        attributes:
-          cdo-nodejs:
-            version: '6.x'

--- a/cookbooks/cdo-nodejs/attributes/default.rb
+++ b/cookbooks/cdo-nodejs/attributes/default.rb
@@ -1,2 +1,2 @@
 default['cdo-nodejs']['version'] = '14.x'
-default['cdo-nodejs']['yarn_version'] = '1.22.10'
+default['cdo-nodejs']['yarn_version'] = '1.22.5-1'

--- a/cookbooks/cdo-nodejs/test/integration/default/inspec/node_spec.rb
+++ b/cookbooks/cdo-nodejs/test/integration/default/inspec/node_spec.rb
@@ -1,7 +1,7 @@
-require_relative '../../../kitchen/data/helper_spec'
+require_relative '../../../shared/helper_spec'
 
 file_exist '/usr/bin/node'
 cmd 'node -v', 'v14.'
 
 cmd 'which yarn', '/usr/bin/yarn'
-cmd 'yarn --version', '1.22.10'
+cmd 'yarn --version', '1.22.5'

--- a/cookbooks/cdo-nodejs/test/integration/upgrade_step_2/serverspec/node_spec.rb
+++ b/cookbooks/cdo-nodejs/test/integration/upgrade_step_2/serverspec/node_spec.rb
@@ -1,7 +1,0 @@
-require_relative '../../../kitchen/data/helper_spec'
-
-file_exist '/usr/bin/node'
-cmd 'node -v', 'v14.'
-
-cmd 'which yarn', '/usr/bin/yarn'
-cmd 'yarn --version', '1.22.10'

--- a/cookbooks/cdo-nodejs/test/shared/helper_spec.rb
+++ b/cookbooks/cdo-nodejs/test/shared/helper_spec.rb
@@ -1,6 +1,3 @@
-require 'serverspec'
-set :backend, :exec
-
 def file_not_exist(file)
   describe file(file) do
     it {should_not exist}


### PR DESCRIPTION
Followup to #41259, fixing the yarn installation to install a version available in the apt repo.
Also update test-kitchen configuration to verify the installation works properly.

## Testing story

Manually verified the install works properly using Test Kitchen on the `cdo-nodejs` cookbook.