### PR TITLE
Use stitch mode none for Javalab contained level eyes test

### DIFF
--- a/dashboard/test/ui/features/learning_platform/level_types/contained_levels.feature
+++ b/dashboard/test/ui/features/learning_platform/level_types/contained_levels.feature
@@ -74,24 +74,23 @@ Scenario: Javalab with free response contained level
   And I rotate to landscape
   And I wait to see ".response"
   And I scroll the ".response" element into view
-  Then I see no difference for "initial load"
+  Then I see no difference for "initial load" using stitch mode "none"
   Then I press keys "This is my answer" for element ".response"
-  And I see no difference for "answer entered"
+  And I see no difference for "answer entered" using stitch mode "none"
   Then I press "javalabRun"
-  And I see no difference for "level run"
+  And I see no difference for "level run" using stitch mode "none"
   # At this point, we should have submitted our result to the server, do
   # a reload and make sure we have the submission
   Then I am on "http://studio.code.org/s/allthethings/lessons/44/levels/6"
   And I rotate to landscape
   And I wait to see ".response"
-  And I see no difference for "reloaded with contained level answered"
+  And I see no difference for "reloaded with contained level answered" using stitch mode "none"
   Then I press "javalabRun"
-  And I see no difference for "finished level with contained level"
+  And I see no difference for "finished level with contained level" using stitch mode "none"
   Then I press "javalabFinish"
   # Make sure continue takes us to next level
   And I wait until current URL contains "/home"
   Then I close my eyes
-
 
 Scenario: Authorized Teacher on Maze with free response contained level
   When I open my eyes to test "maze free response contained level"


### PR DESCRIPTION
This is a possible fix for the flakiness on this test, which saw a large area under the level as part of the image captured. Other tests in this file use stitch mode none and it passed locally when running with it.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
