### PR TITLE
updating file extensions to include .wav files

### DIFF
--- a/apps/src/code-studio/components/ImagePicker.jsx
+++ b/apps/src/code-studio/components/ImagePicker.jsx
@@ -10,10 +10,10 @@ import {ICON_PREFIX} from '@cdo/apps/applab/constants';
 const extensionFilter = {
   // Note: .jfif files will be converted to .jpg by the server.
   image: '.jpg, .jpeg, .jfif, .gif, .png',
-  audio: '.mp3',
+  audio: '.mp3, .wav',
   document: '.jpg, .jpeg, .gif, .png, .pdf, .doc, .docx',
   // Default set of valid extensions (used if type filter is not specified)
-  default: '.jpg, .jpeg, .jfif, .gif, .png, .mp3, .pdf, .doc, .docx'
+  default: '.jpg, .jpeg, .jfif, .gif, .png, .mp3, .wav, .pdf, .doc, .docx'
 };
 
 /**

--- a/dashboard/app/controllers/level_starter_assets_controller.rb
+++ b/dashboard/app/controllers/level_starter_assets_controller.rb
@@ -6,7 +6,7 @@ class LevelStarterAssetsController < ApplicationController
 
   S3_BUCKET = 'cdo-v3-assets'.freeze
   S3_PREFIX = 'starter_assets/'.freeze
-  VALID_FILE_EXTENSIONS = %w(.jpg .jpeg .gif .png .mp3)
+  VALID_FILE_EXTENSIONS = %w(.jpg .jpeg .gif .png .mp3 .wav)
 
   # GET /level_starter_assets/:level_name
   def show


### PR DESCRIPTION
Attempting to upload .wav files in start_sources produced a 422 error. It was unclear whether size impacted the ability to upload, so for local testing I used a file >1mb. Adding the .wav extensions to the imagePicker and starter_assets_controller list has allowed for successful uploads in start_sources locally.

![image](https://user-images.githubusercontent.com/37230822/128552370-52a050de-f85c-46f4-ad5d-0c45320edec1.png)

Error message from prior attempts:
![image](https://user-images.githubusercontent.com/37230822/128563468-24c10962-4dbe-4c84-a6bf-9eb3cd74a2aa.png)


- jira ticket: https://codedotorg.atlassian.net/browse/CSA-614


## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
