### PR TITLE
Add some 2018 v2 states to enable old data uploads

### DIFF
--- a/dashboard/app/models/census/state_cs_offering.rb
+++ b/dashboard/app/models/census/state_cs_offering.rb
@@ -100,15 +100,18 @@ class Census::StateCsOffering < ApplicationRecord
   # The following states use the "V2" format for CSV files in 2018-2019.
   STATES_USING_FORMAT_V2_IN_2018_19 = %w(
     AK
+    AL
     AR
     CA
     CT
     FL
     GA
+    HI
     IA
     ID
     IL
     IN
+    KS
     LA
     MA
     MD


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Responding to a quick ask from Liz to enable v2 format files in 2018 for AL, HI, and KS