### PR TITLE
Edit course unit published state

### DIFF
--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -347,6 +347,14 @@ class UnitEditor extends React.Component {
       });
   };
 
+  toggleHiddenCourseUnit = () => {
+    const publishedState =
+      this.state.publishedState === PublishedState.in_development
+        ? null
+        : PublishedState.in_development;
+    this.setState({publishedState});
+  };
+
   render() {
     const textAreaRows = this.state.lessonLevelData
       ? this.state.lessonLevelData.split('\n').length + 5
@@ -611,10 +619,31 @@ class UnitEditor extends React.Component {
                 </HelpTip>
               </label>
               {this.props.hasCourse && (
-                <p>
-                  This unit is part of a course. Go to the course edit page to
-                  publish the course and its units.
-                </p>
+                <div>
+                  <p>
+                    This unit is part of a course. Go to the course edit page to
+                    publish the course and its units.
+                  </p>
+                  <label>
+                    Hide this unit within this course
+                    <input
+                      type="checkbox"
+                      checked={
+                        this.state.publishedState ===
+                        PublishedState.in_development
+                      }
+                      style={styles.checkbox}
+                      onChange={this.toggleHiddenCourseUnit}
+                    />
+                    <HelpTip>
+                      <p>
+                        Whether to hide this unit from the list of units in its
+                        course, as viewed on the course overview page, the edit
+                        section dialog, and the teacher dashboard.
+                      </p>
+                    </HelpTip>
+                  </label>
+                </div>
               )}
               {!this.props.hasCourse && (
                 <div>

--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -624,6 +624,16 @@ class UnitEditor extends React.Component {
                     This unit is part of a course. Go to the course edit page to
                     publish the course and its units.
                   </p>
+                  {/*
+                   Just use a checkbox instead of a dropdown to set the
+                   published state for now, because (1) units in unit groups
+                   really only need 2 of the 6 possible states at the moment,
+                   but (2) we haven't nailed down how many of these states we
+                   will need in the long term, and (3) we need these 2 states
+                   working now in order to launch the AP CSA pilot. The work to
+                   clean this up is tracked in:
+                   https://codedotorg.atlassian.net/browse/PLAT-1170
+                   */}
                   <label>
                     Hide this unit within this course
                     <input

--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -639,7 +639,9 @@ class UnitEditor extends React.Component {
                       <p>
                         Whether to hide this unit from the list of units in its
                         course, as viewed on the course overview page, the edit
-                        section dialog, and the teacher dashboard.
+                        section dialog, and the teacher dashboard, as well as
+                        when navigating directly to the unit by its url. Hidden
+                        units will still be visible to levelbuilders.
                       </p>
                     </HelpTip>
                   </label>

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -116,7 +116,9 @@ class Script < ApplicationRecord
   before_validation :hide_pilot_units
 
   def hide_pilot_units
-    self.published_state = SharedConstants::PUBLISHED_STATE.pilot unless get_pilot_experiment.blank?
+    if !unit_group && pilot_experiment.present?
+      self.published_state = SharedConstants::PUBLISHED_STATE.pilot
+    end
   end
 
   # As we read and write to files with the unit name, to prevent directory

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -129,7 +129,7 @@ class Script < ApplicationRecord
       message: 'cannot start with a tilde or dot or contain slashes'
     }
 
-  validates :published_state, acceptance: {accept: SharedConstants::PUBLISHED_STATE.to_h.values, message: 'must be in_development, pilot, beta, preview or stable'}
+  validates :published_state, acceptance: {accept: SharedConstants::PUBLISHED_STATE.to_h.values.push(nil), message: 'must be nil, in_development, pilot, beta, preview or stable'}
 
   def prevent_duplicate_levels
     reload
@@ -1296,7 +1296,7 @@ class Script < ApplicationRecord
           login_required: general_params[:login_required].nil? ? false : general_params[:login_required], # default false
           wrapup_video: general_params[:wrapup_video],
           family_name: general_params[:family_name].presence ? general_params[:family_name] : nil, # default nil
-          published_state: general_params[:published_state].nil? ? SharedConstants::PUBLISHED_STATE.in_development : general_params[:published_state],
+          published_state: general_params[:published_state],
           properties: Script.build_property_hash(general_params)
         },
         unit_data[:lesson_groups]


### PR DESCRIPTION
## Background

Part 3 of 3, finishing https://codedotorg.atlassian.net/browse/PLAT-1060. Previously, it was not possible to edit the published state for a unit in a course via levelbuilder:

![Screen Shot 2021-08-09 at 10 55 38 AM](https://user-images.githubusercontent.com/8001765/128751651-51a141f5-b479-46ed-be5d-be7b9126d240.png)

previous PRs made it so that when a unit is in a course, we let the published state of the unit override the published state of the course when deciding whether to let that unit be visible in certain places:
* when you try to navigate to the unit page `studio.code.org/s/...`
* https://github.com/code-dot-org/code-dot-org/pull/41896 on the course overview page and other places

This leaves a lot of leeway for what the controls on the unit edit page should do in order to be able to hide a unit within a course.

## Description

This PR takes the approach of adding a simple checkbox to control whether the unit should be hidden within the course or not:

![Screen Shot 2021-08-09 at 11 25 52 AM](https://user-images.githubusercontent.com/8001765/128755413-2c82fce7-a10d-4672-9d0e-f55d2d93d018.png)

the behavior is as follows:
* unchecked: the unit is visible to anyone who can view the course
* checked: the unit is hidden everywhere from everyone but levelbuilders

## Testing story

- [x] manually verified the new controls affect whether the unit is visible on the course overview page. 

## Follow-up work

this should be enough to let the curriculum team add hidden units to the CSA course so they can start adding vocab and resources to them. if they end up needing more complex controls, such as making "hidden" units visible only to pilot classrooms, then a more sophisticated approach can be added later.