### PR TITLE
Add data_string to sprite upload/selection events

### DIFF
--- a/apps/src/p5lab/redux/animationPicker.js
+++ b/apps/src/p5lab/redux/animationPicker.js
@@ -136,6 +136,7 @@ export function handleUploadComplete(result) {
     study: 'animation-library',
     study_group: 'control-2020',
     event: 'upload',
+    data_string: this.props.spriteLab ? 'spritelab' : 'gamelab',
     data_json: JSON.stringify({
       size: result.size
     })
@@ -236,6 +237,7 @@ export function pickLibraryAnimation(animation) {
     study: 'sprite-use',
     study_group: 'before-update-v2',
     event: 'select-sprite',
+    data_string: this.props.spriteLab ? 'spritelab' : 'gamelab',
     data_json: JSON.stringify({
       name: animation.name,
       sourceUrl: animation.sourceUrl


### PR DESCRIPTION
Firehose events did not specify Game Lab vs Sprite Lab, and adding the "data_string: this.props.spriteLab ? 'spritelab' : 'gamelab'," code adds that functionality.

Based off of Anjali's PR: https://github.com/code-dot-org/code-dot-org/pull/41438 