### PR TITLE
show seeding error details in drone output

### DIFF
--- a/dashboard/config/scripts/allthethings.script
+++ b/dashboard/config/scripts/allthethings.script
@@ -1,4 +1,3 @@
-bogus
 hideable_lessons true
 lesson_extras_available true
 

--- a/dashboard/config/scripts/allthethings.script
+++ b/dashboard/config/scripts/allthethings.script
@@ -1,3 +1,4 @@
+bogus
 hideable_lessons true
 lesson_extras_available true
 

--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -453,7 +453,7 @@ namespace :seed do
     end
 
     puts 'Cache mismatch, running full ui test seed'
-    Rake::Task['seed:ui_test'].invoke
+    RakeUtils.rake_stream_output 'seed:ui_test'
     File.write(HASH_FILE, current_hash)
     sh('mysqldump -u root -B dashboard_test > db/ui_test_data.sql')
   end


### PR DESCRIPTION
This PR makes the output of seeding scripts appear in the drone output, including any error details, to make it easier to debug seed errors in drone runs. this approach is copied from https://github.com/code-dot-org/code-dot-org/pull/39583.  the screenshots below show before and after output when seeding fails due to problematic syntax within a .script file.

### before

https://drone.cdn-code.org/code-dot-org/code-dot-org/9238/2/4

![Screen Shot 2021-08-09 at 10 35 44 AM](https://user-images.githubusercontent.com/8001765/128749174-3d417e3c-6411-4c7e-9da2-acd716f8c2dc.png)

### after

https://drone.cdn-code.org/code-dot-org/code-dot-org/9240/2/4

![Screen Shot 2021-08-09 at 10 38 02 AM](https://user-images.githubusercontent.com/8001765/128749441-7fcb0978-5529-4881-b926-15911dbfceef.png)

## Testing story

the above screenshots verify the new behavior 