### PR TITLE
Fix custom styles block linter

### DIFF
--- a/apps/eslint/index.js
+++ b/apps/eslint/index.js
@@ -16,7 +16,9 @@ module.exports = {
           return (
             item.type === 'ClassDeclaration' ||
             (item.type === 'ExportDefaultDeclaration' &&
-              item.declaration.type === 'ClassDeclaration')
+              item.declaration.type === 'ClassDeclaration') ||
+            (item.type === 'ExportNamedDeclaration' &&
+              item.declaration?.type === 'ClassDeclaration')
           );
         }
 

--- a/apps/src/applab/ImportProjectDialog.jsx
+++ b/apps/src/applab/ImportProjectDialog.jsx
@@ -6,25 +6,6 @@ import Dialog, {Body, Buttons, Confirm} from '../templates/Dialog';
 import color from '../util/color';
 import {fetchProject, toggleImportScreen} from './redux/screens';
 
-const styles = {
-  urlInputWrapper: {
-    display: 'flex',
-    alignItems: 'stretch',
-    width: '100%'
-  },
-  urlInput: {
-    width: 'inherit'
-  },
-  // TODO: ditch these styles in favor of standardized typography components
-  // once they exist
-  instructions: {
-    color: color.black
-  },
-  errorText: {
-    color: color.red
-  }
-};
-
 const initialState = {url: ''};
 
 export class ImportProjectDialog extends React.Component {
@@ -84,6 +65,25 @@ export class ImportProjectDialog extends React.Component {
     );
   }
 }
+
+const styles = {
+  urlInputWrapper: {
+    display: 'flex',
+    alignItems: 'stretch',
+    width: '100%'
+  },
+  urlInput: {
+    width: 'inherit'
+  },
+  // TODO: ditch these styles in favor of standardized typography components
+  // once they exist
+  instructions: {
+    color: color.black
+  },
+  errorText: {
+    color: color.red
+  }
+};
 
 export default connect(
   state => ({

--- a/apps/src/code-studio/components/header/RetryProjectSaveDialog.jsx
+++ b/apps/src/code-studio/components/header/RetryProjectSaveDialog.jsx
@@ -11,16 +11,6 @@ import BaseDialog from '../../../templates/BaseDialog';
 import DialogFooter from '../../../templates/teacherDashboard/DialogFooter';
 import Button from '../../../templates/Button';
 
-const styles = {
-  dialog: {
-    color: color.default_text,
-    fontSize: 15,
-    paddingLeft: 20,
-    paddingRight: 20,
-    paddingBottom: 20
-  }
-};
-
 export class UnconnectedRetryProjectSaveDialog extends Component {
   static propTypes = {
     projectUpdatedStatus: PropTypes.oneOf(Object.values(statuses)),
@@ -66,6 +56,16 @@ export class UnconnectedRetryProjectSaveDialog extends Component {
     );
   }
 }
+
+const styles = {
+  dialog: {
+    color: color.default_text,
+    fontSize: 15,
+    paddingLeft: 20,
+    paddingRight: 20,
+    paddingBottom: 20
+  }
+};
 
 export default connect(
   state => ({

--- a/apps/src/code-studio/components/libraries/LibraryCreationDialog.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryCreationDialog.jsx
@@ -239,31 +239,6 @@ class LibraryCreationDialog extends React.Component {
   }
 }
 
-const styles = {
-  libraryBoundary: {
-    padding: 10,
-    width: '90%'
-  },
-  centerContent: {
-    display: 'flex',
-    justifyContent: 'center'
-  },
-  info: {
-    fontSize: 12,
-    fontStyle: 'italic',
-    lineHeight: 1.2
-  },
-  idInfo: {
-    marginBottom: 10
-  },
-  copyBtn: {
-    margin: '0 15px',
-    ':hover': {
-      cursor: 'copy'
-    }
-  }
-};
-
 export class ErrorDisplay extends React.Component {
   static propTypes = {message: PropTypes.string.isRequired};
 
@@ -295,6 +270,31 @@ export class UnpublishSuccessDisplay extends React.Component {
     );
   }
 }
+
+const styles = {
+  libraryBoundary: {
+    padding: 10,
+    width: '90%'
+  },
+  centerContent: {
+    display: 'flex',
+    justifyContent: 'center'
+  },
+  info: {
+    fontSize: 12,
+    fontStyle: 'italic',
+    lineHeight: 1.2
+  },
+  idInfo: {
+    marginBottom: 10
+  },
+  copyBtn: {
+    margin: '0 15px',
+    ':hover': {
+      cursor: 'copy'
+    }
+  }
+};
 
 export const UnconnectedLibraryCreationDialog = LibraryCreationDialog;
 

--- a/apps/src/code-studio/components/libraries/LibraryListItem.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryListItem.jsx
@@ -7,86 +7,6 @@ import i18n from '@cdo/locale';
 import InlineMarkdown from '@cdo/apps/templates/InlineMarkdown';
 import Tooltip from '@cdo/apps/templates/Tooltip';
 
-const styles = {
-  overflowEllipsis: {
-    textOverflow: 'ellipsis',
-    overflow: 'hidden'
-  },
-  listItem: {
-    padding: 8,
-    margin: 2,
-    color: color.dark_charcoal,
-    textAlign: 'left',
-    display: 'flex',
-    borderBottom: `1px solid ${color.lightest_gray}`,
-    lineHeight: 1.5
-  },
-  libraryTitle: {
-    fontFamily: "'Gotham 5r', sans-serif",
-    fontSize: 16,
-    cursor: 'pointer',
-    color: color.link_color,
-    ':hover': {
-      color: color.link_color
-    }
-  },
-  description: {
-    marginRight: 25,
-    flexShrink: 2
-  },
-  actions: {
-    display: 'flex',
-    flexGrow: 1,
-    justifyContent: 'flex-end'
-  },
-  actionBtn: {
-    padding: 8,
-    fontSize: 18,
-    backgroundColor: color.white,
-    ':hover': {
-      boxShadow: 'none'
-    }
-  },
-  iconPadding: {
-    padding: '0 2px'
-  },
-  addBtn: {
-    color: color.link_color,
-    borderColor: color.link_color,
-    ':hover': {
-      color: color.white,
-      backgroundColor: color.link_color
-    }
-  },
-  updateBtn: {
-    color: color.orange,
-    borderColor: color.orange,
-    ':hover': {
-      color: color.white,
-      backgroundColor: color.orange
-    }
-  },
-  updateText: {
-    fontFamily: "'Gotham 5r', sans-serif",
-    paddingLeft: 5,
-    fontSize: 16
-  },
-  removeBtn: {
-    color: color.dark_red,
-    borderColor: color.dark_red,
-    ':hover': {
-      color: color.white,
-      backgroundColor: color.dark_red
-    },
-    ':disabled': {
-      color: color.light_gray,
-      borderColor: color.light_gray,
-      backgroundColor: color.lightest_gray,
-      cursor: 'default'
-    }
-  }
-};
-
 export class LibraryListItem extends React.Component {
   static propTypes = {
     library: PropTypes.object.isRequired,
@@ -173,5 +93,85 @@ export class LibraryListItem extends React.Component {
     );
   }
 }
+
+const styles = {
+  overflowEllipsis: {
+    textOverflow: 'ellipsis',
+    overflow: 'hidden'
+  },
+  listItem: {
+    padding: 8,
+    margin: 2,
+    color: color.dark_charcoal,
+    textAlign: 'left',
+    display: 'flex',
+    borderBottom: `1px solid ${color.lightest_gray}`,
+    lineHeight: 1.5
+  },
+  libraryTitle: {
+    fontFamily: "'Gotham 5r', sans-serif",
+    fontSize: 16,
+    cursor: 'pointer',
+    color: color.link_color,
+    ':hover': {
+      color: color.link_color
+    }
+  },
+  description: {
+    marginRight: 25,
+    flexShrink: 2
+  },
+  actions: {
+    display: 'flex',
+    flexGrow: 1,
+    justifyContent: 'flex-end'
+  },
+  actionBtn: {
+    padding: 8,
+    fontSize: 18,
+    backgroundColor: color.white,
+    ':hover': {
+      boxShadow: 'none'
+    }
+  },
+  iconPadding: {
+    padding: '0 2px'
+  },
+  addBtn: {
+    color: color.link_color,
+    borderColor: color.link_color,
+    ':hover': {
+      color: color.white,
+      backgroundColor: color.link_color
+    }
+  },
+  updateBtn: {
+    color: color.orange,
+    borderColor: color.orange,
+    ':hover': {
+      color: color.white,
+      backgroundColor: color.orange
+    }
+  },
+  updateText: {
+    fontFamily: "'Gotham 5r', sans-serif",
+    paddingLeft: 5,
+    fontSize: 16
+  },
+  removeBtn: {
+    color: color.dark_red,
+    borderColor: color.dark_red,
+    ':hover': {
+      color: color.white,
+      backgroundColor: color.dark_red
+    },
+    ':disabled': {
+      color: color.light_gray,
+      borderColor: color.light_gray,
+      backgroundColor: color.lightest_gray,
+      cursor: 'default'
+    }
+  }
+};
 
 export default Radium(LibraryListItem);

--- a/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
@@ -15,67 +15,6 @@ import color from '@cdo/apps/util/color';
 
 const DEFAULT_MARGIN = 7;
 
-const styles = {
-  dialog: {
-    padding: '0 15px',
-    cursor: 'default'
-  },
-  linkBox: {
-    cursor: 'auto',
-    height: '32px',
-    marginBottom: 0,
-    flex: 1,
-    maxWidth: 400
-  },
-  header: {
-    textAlign: 'left',
-    fontSize: 24,
-    marginTop: 20
-  },
-  libraryList: {
-    maxHeight: '140px',
-    overflowY: 'auto',
-    borderBottom: `2px solid ${color.purple}`
-  },
-  message: {
-    color: color.dark_charcoal,
-    textAlign: 'left',
-    margin: DEFAULT_MARGIN,
-    overflow: 'hidden',
-    lineHeight: '15px',
-    whiteSpace: 'pre-wrap'
-  },
-  inputParent: {
-    display: 'flex',
-    alignItems: 'baseline'
-  },
-  add: {
-    margin: DEFAULT_MARGIN,
-    color: color.dark_charcoal,
-    borderColor: color.dark_charcoal,
-    ':disabled': {
-      color: color.light_gray,
-      borderColor: color.light_gray,
-      backgroundColor: color.lightest_gray
-    }
-  },
-  hidden: {
-    visibility: 'hidden'
-  },
-  error: {
-    color: color.red,
-    textAlign: 'left',
-    margin: DEFAULT_MARGIN,
-    minHeight: 30,
-    whiteSpace: 'pre-wrap',
-    lineHeight: 1
-  },
-  updateButtons: {
-    display: 'flex',
-    justifyContent: 'space-between'
-  }
-};
-
 // Map userName from class libraries to project libraries so the author is displayed in the UI.
 // We only want users to see the author name for libraries from their classmates.
 export const mapUserNameToProjectLibraries = (
@@ -461,5 +400,66 @@ export class LibraryManagerDialog extends React.Component {
     );
   }
 }
+
+const styles = {
+  dialog: {
+    padding: '0 15px',
+    cursor: 'default'
+  },
+  linkBox: {
+    cursor: 'auto',
+    height: '32px',
+    marginBottom: 0,
+    flex: 1,
+    maxWidth: 400
+  },
+  header: {
+    textAlign: 'left',
+    fontSize: 24,
+    marginTop: 20
+  },
+  libraryList: {
+    maxHeight: '140px',
+    overflowY: 'auto',
+    borderBottom: `2px solid ${color.purple}`
+  },
+  message: {
+    color: color.dark_charcoal,
+    textAlign: 'left',
+    margin: DEFAULT_MARGIN,
+    overflow: 'hidden',
+    lineHeight: '15px',
+    whiteSpace: 'pre-wrap'
+  },
+  inputParent: {
+    display: 'flex',
+    alignItems: 'baseline'
+  },
+  add: {
+    margin: DEFAULT_MARGIN,
+    color: color.dark_charcoal,
+    borderColor: color.dark_charcoal,
+    ':disabled': {
+      color: color.light_gray,
+      borderColor: color.light_gray,
+      backgroundColor: color.lightest_gray
+    }
+  },
+  hidden: {
+    visibility: 'hidden'
+  },
+  error: {
+    color: color.red,
+    textAlign: 'left',
+    margin: DEFAULT_MARGIN,
+    minHeight: 30,
+    whiteSpace: 'pre-wrap',
+    lineHeight: 1
+  },
+  updateButtons: {
+    display: 'flex',
+    justifyContent: 'space-between'
+  }
+};
 
 export default Radium(LibraryManagerDialog);

--- a/apps/src/code-studio/components/libraries/ShareTeacherLibraries.jsx
+++ b/apps/src/code-studio/components/libraries/ShareTeacherLibraries.jsx
@@ -16,26 +16,6 @@ import {
   updateProjectLibrary
 } from '@cdo/apps/templates/projects/projectsRedux';
 
-const styles = {
-  container: {
-    fontSize: 13,
-    lineHeight: '18px',
-    color: color.dark_charcoal
-  },
-  footer: {
-    display: 'flex',
-    flexFlow: 'row',
-    justifyContent: 'space-between',
-    margin: 2,
-    paddingTop: 10
-  },
-  libraryCopierLabel: {
-    color: color.purple,
-    marginBottom: 10,
-    fontStyle: 'italic'
-  }
-};
-
 export class ShareTeacherLibraries extends React.Component {
   static propTypes = {
     onCancel: PropTypes.func.isRequired,
@@ -202,6 +182,26 @@ export class ShareTeacherLibraries extends React.Component {
     );
   }
 }
+
+const styles = {
+  container: {
+    fontSize: 13,
+    lineHeight: '18px',
+    color: color.dark_charcoal
+  },
+  footer: {
+    display: 'flex',
+    flexFlow: 'row',
+    justifyContent: 'space-between',
+    margin: 2,
+    paddingTop: 10
+  },
+  libraryCopierLabel: {
+    color: color.purple,
+    marginBottom: 10,
+    fontStyle: 'italic'
+  }
+};
 
 export default connect(
   state => ({

--- a/apps/src/code-studio/components/progress/SelectedStudentInfo.jsx
+++ b/apps/src/code-studio/components/progress/SelectedStudentInfo.jsx
@@ -10,39 +10,6 @@ import {studentShape} from './StudentTable';
 
 const RadiumFontAwesome = Radium(FontAwesome);
 
-const styles = {
-  main: {
-    display: 'flex',
-    justifyContent: 'center',
-    flexDirection: 'row'
-  },
-  studentInfo: {
-    width: 150,
-    textAlign: 'center',
-    display: 'flex',
-    justifyContent: 'center',
-    flexDirection: 'column'
-  },
-  bubble: {
-    marginLeft: 0
-  },
-  name: {
-    fontFamily: '"Gotham 5r", sans-serif',
-    fontWeight: 'bold',
-    fontSize: 15
-  },
-  timeHeader: {
-    fontFamily: '"Gotham 5r", sans-serif',
-    fontWeight: 'bold'
-  },
-  arrow: {
-    fontSize: 40,
-    cursor: 'pointer',
-    position: 'relative',
-    top: 30
-  }
-};
-
 export class SelectedStudentInfo extends React.Component {
   static propTypes = {
     students: PropTypes.arrayOf(studentShape).isRequired,
@@ -182,3 +149,36 @@ export class SelectedStudentInfo extends React.Component {
     );
   }
 }
+
+const styles = {
+  main: {
+    display: 'flex',
+    justifyContent: 'center',
+    flexDirection: 'row'
+  },
+  studentInfo: {
+    width: 150,
+    textAlign: 'center',
+    display: 'flex',
+    justifyContent: 'center',
+    flexDirection: 'column'
+  },
+  bubble: {
+    marginLeft: 0
+  },
+  name: {
+    fontFamily: '"Gotham 5r", sans-serif',
+    fontWeight: 'bold',
+    fontSize: 15
+  },
+  timeHeader: {
+    fontFamily: '"Gotham 5r", sans-serif',
+    fontWeight: 'bold'
+  },
+  arrow: {
+    fontSize: 40,
+    cursor: 'pointer',
+    position: 'relative',
+    top: 30
+  }
+};

--- a/apps/src/code-studio/pd/application_dashboard/cohort_view_table.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/cohort_view_table.jsx
@@ -17,28 +17,6 @@ import {
   RegionalPartnerPropType
 } from '../components/regional_partner_dropdown';
 
-const styles = {
-  container: {
-    overflowX: 'auto'
-  },
-  table: {
-    width: '100%'
-  },
-  statusCellCommon: {
-    padding: '5px'
-  },
-  statusCell: StatusColors,
-  notesCell: {
-    maxWidth: '200px'
-  },
-  notesCellContent: {
-    whiteSpace: 'nowrap',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    paddingLeft: '2px'
-  }
-};
-
 export class CohortViewTable extends React.Component {
   static propTypes = {
     data: PropTypes.array.isRequired,
@@ -368,6 +346,28 @@ export class CohortViewTable extends React.Component {
     );
   }
 }
+
+const styles = {
+  container: {
+    overflowX: 'auto'
+  },
+  table: {
+    width: '100%'
+  },
+  statusCellCommon: {
+    padding: '5px'
+  },
+  statusCell: StatusColors,
+  notesCell: {
+    maxWidth: '200px'
+  },
+  notesCellContent: {
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    paddingLeft: '2px'
+  }
+};
 
 export default connect(state => ({
   regionalPartnerGroup: state.regionalPartners.regionalPartnerGroup,

--- a/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
@@ -51,69 +51,6 @@ import DetailViewWorkshopAssignmentResponse from './detail_view_workshop_assignm
 import ChangeLog from './detail_view/change_log';
 import InlineMarkdown from '@cdo/apps/templates/InlineMarkdown';
 
-const styles = {
-  notes: {
-    height: '95px'
-  },
-  statusSelect: {
-    width: 250 // wide enough for the widest status
-  },
-  editMenuContainer: {
-    display: 'inline-block' // fit contents
-  },
-  editMenu: {
-    display: 'flex'
-  },
-  // React-Bootstrap components don't play well inside a flex box,
-  // so this is required to get the contained split button to stay together.
-  flexSplitButtonContainer: {
-    flex: '0 0 auto'
-  },
-  detailViewHeader: {
-    marginLeft: 'auto'
-  },
-  headerWrapper: {
-    display: 'flex',
-    alignItems: 'baseline'
-  },
-  saveButton: {
-    marginRight: '5px'
-  },
-  statusSelectGroup: {
-    marginRight: 5,
-    marginLeft: 5
-  },
-  editButton: {
-    width: 'auto'
-  },
-  lockedStatus: {
-    fontFamily: '"Gotham 7r"',
-    marginTop: 10
-  },
-  caption: {
-    color: 'black'
-  },
-  detailViewTable: {
-    width: '80%'
-  },
-  questionColumn: {
-    width: '50%'
-  },
-  answerColumn: {
-    width: '30%'
-  },
-  scoringColumn: {
-    width: '20%'
-  },
-  scoringDropdown: {
-    marginTop: '10px',
-    marginBottom: '10px'
-  },
-  scoreBreakdown: {
-    marginLeft: '30px'
-  }
-};
-
 const NA = 'N/A';
 
 const DEFAULT_NOTES =
@@ -1330,6 +1267,69 @@ export class DetailViewContents extends React.Component {
     );
   }
 }
+
+const styles = {
+  notes: {
+    height: '95px'
+  },
+  statusSelect: {
+    width: 250 // wide enough for the widest status
+  },
+  editMenuContainer: {
+    display: 'inline-block' // fit contents
+  },
+  editMenu: {
+    display: 'flex'
+  },
+  // React-Bootstrap components don't play well inside a flex box,
+  // so this is required to get the contained split button to stay together.
+  flexSplitButtonContainer: {
+    flex: '0 0 auto'
+  },
+  detailViewHeader: {
+    marginLeft: 'auto'
+  },
+  headerWrapper: {
+    display: 'flex',
+    alignItems: 'baseline'
+  },
+  saveButton: {
+    marginRight: '5px'
+  },
+  statusSelectGroup: {
+    marginRight: 5,
+    marginLeft: 5
+  },
+  editButton: {
+    width: 'auto'
+  },
+  lockedStatus: {
+    fontFamily: '"Gotham 7r"',
+    marginTop: 10
+  },
+  caption: {
+    color: 'black'
+  },
+  detailViewTable: {
+    width: '80%'
+  },
+  questionColumn: {
+    width: '50%'
+  },
+  answerColumn: {
+    width: '30%'
+  },
+  scoringColumn: {
+    width: '20%'
+  },
+  scoringDropdown: {
+    marginTop: '10px',
+    marginBottom: '10px'
+  },
+  scoreBreakdown: {
+    marginLeft: '30px'
+  }
+};
 
 export default connect(state => ({
   regionalPartnerGroup: state.regionalPartners.regionalPartnerGroup,

--- a/apps/src/code-studio/pd/application_dashboard/quick_view.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/quick_view.jsx
@@ -22,15 +22,6 @@ import $ from 'jquery';
 import {getApplicationStatuses} from './constants';
 import {Button, FormGroup, ControlLabel, Row, Col} from 'react-bootstrap';
 
-const styles = {
-  button: {
-    margin: '20px 20px 20px auto'
-  },
-  select: {
-    width: 250
-  }
-};
-
 export class QuickView extends React.Component {
   static propTypes = {
     regionalPartnerFilter: RegionalPartnerPropType,
@@ -182,6 +173,15 @@ export class QuickView extends React.Component {
     );
   }
 }
+
+const styles = {
+  button: {
+    margin: '20px 20px 20px auto'
+  },
+  select: {
+    width: 250
+  }
+};
 
 export default connect(state => ({
   regionalPartnerFilter: state.regionalPartners.regionalPartnerFilter,

--- a/apps/src/code-studio/pd/application_dashboard/quick_view_table.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/quick_view_table.jsx
@@ -11,28 +11,6 @@ import {StatusColors, getApplicationStatuses} from './constants';
 import wrappedSortable from '@cdo/apps/templates/tables/wrapped_sortable';
 import PrincipalApprovalButtons from './principal_approval_buttons';
 
-const styles = {
-  container: {
-    overflowX: 'auto'
-  },
-  table: {
-    width: '100%'
-  },
-  statusCellCommon: {
-    padding: '5px'
-  },
-  statusCell: StatusColors,
-  notesCell: {
-    maxWidth: '200px'
-  },
-  notesCellContent: {
-    whiteSpace: 'nowrap',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    paddingLeft: '2px'
-  }
-};
-
 export class QuickViewTable extends React.Component {
   static propTypes = {
     path: PropTypes.string.isRequired,
@@ -373,6 +351,28 @@ export class QuickViewTable extends React.Component {
     );
   }
 }
+
+const styles = {
+  container: {
+    overflowX: 'auto'
+  },
+  table: {
+    width: '100%'
+  },
+  statusCellCommon: {
+    padding: '5px'
+  },
+  statusCell: StatusColors,
+  notesCell: {
+    maxWidth: '200px'
+  },
+  notesCellContent: {
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    paddingLeft: '2px'
+  }
+};
 
 export default connect(state => ({
   regionalPartnerGroup: state.regionalPartners.regionalPartnerGroup,

--- a/apps/src/code-studio/pd/application_dashboard/summary_table.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/summary_table.jsx
@@ -9,26 +9,6 @@ import {StatusColors, getApplicationStatuses} from './constants';
 import _ from 'lodash';
 import color from '@cdo/apps/util/color';
 
-const styles = {
-  table: {
-    paddingLeft: '15px',
-    paddingRight: '15px'
-  },
-  tableWrapper: {
-    paddingBottom: '30px'
-  },
-  totalsRow: {
-    fontWeight: 'bold',
-    borderTopStyle: 'solid',
-    borderTopWidth: 2,
-    borderTopColor: color.charcoal
-  },
-  statusCell: StatusColors,
-  viewApplicationsButton: {
-    marginRight: '10px'
-  }
-};
-
 const ApplicationDataPropType = PropTypes.shape({
   total: PropTypes.number.isRequired,
   locked: PropTypes.number
@@ -128,6 +108,26 @@ export class SummaryTable extends React.Component {
     );
   }
 }
+
+const styles = {
+  table: {
+    paddingLeft: '15px',
+    paddingRight: '15px'
+  },
+  tableWrapper: {
+    paddingBottom: '30px'
+  },
+  totalsRow: {
+    fontWeight: 'bold',
+    borderTopStyle: 'solid',
+    borderTopWidth: 2,
+    borderTopColor: color.charcoal
+  },
+  statusCell: StatusColors,
+  viewApplicationsButton: {
+    marginRight: '10px'
+  }
+};
 
 export default connect(state => ({
   canSeeLocked: state.applicationDashboard.permissions.lockApplication

--- a/apps/src/code-studio/pd/components/regional_partner_dropdown.jsx
+++ b/apps/src/code-studio/pd/components/regional_partner_dropdown.jsx
@@ -12,12 +12,6 @@ import {SelectStyleProps} from '../constants';
 import {setRegionalPartnerFilter} from './regional_partners_reducers';
 import {WorkshopAdmin} from '../workshop_dashboard/permission';
 
-const styles = {
-  select: {
-    maxWidth: '500px'
-  }
-};
-
 export const ALL_PARTNERS_LABEL = 'All Regional Partners';
 export const ALL_PARTNERS_VALUE = 'all';
 export const UNMATCHED_PARTNER_LABEL = 'No Partner/Unmatched';
@@ -98,6 +92,12 @@ export class RegionalPartnerDropdown extends React.Component {
     );
   }
 }
+
+const styles = {
+  select: {
+    maxWidth: '500px'
+  }
+};
 
 export default connect(
   state => ({

--- a/apps/src/code-studio/pd/regional_partner_mini_contact/RegionalPartnerMiniContact.jsx
+++ b/apps/src/code-studio/pd/regional_partner_mini_contact/RegionalPartnerMiniContact.jsx
@@ -8,34 +8,6 @@ import FieldGroup from '../form_components/FieldGroup';
 import ButtonList from '../form_components/ButtonList';
 import color from '@cdo/apps/util/color';
 
-const styles = {
-  error: {
-    color: color.red
-  },
-  miniContactContainer: {
-    backgroundColor: color.lightest_cyan,
-    padding: 20,
-    borderRadius: 10,
-    textAlign: 'left'
-  },
-  modalHeader: {
-    padding: '0 15px 0 0',
-    height: 30,
-    borderBottom: 'none'
-  },
-  modalBody: {
-    padding: '0 15px 15px 15px',
-    fontSize: 14,
-    lineHeight: '22px'
-  },
-  intro: {
-    paddingBottom: 10
-  },
-  select: {
-    maxWidth: 500
-  }
-};
-
 const ROLES = [
   'Teacher',
   'Librarian',
@@ -306,3 +278,31 @@ export class RegionalPartnerMiniContactPopupLink extends React.Component {
     );
   }
 }
+
+const styles = {
+  error: {
+    color: color.red
+  },
+  miniContactContainer: {
+    backgroundColor: color.lightest_cyan,
+    padding: 20,
+    borderRadius: 10,
+    textAlign: 'left'
+  },
+  modalHeader: {
+    padding: '0 15px 0 0',
+    height: 30,
+    borderBottom: 'none'
+  },
+  modalBody: {
+    padding: '0 15px 15px 15px',
+    fontSize: 14,
+    lineHeight: '22px'
+  },
+  intro: {
+    paddingBottom: 10
+  },
+  select: {
+    maxWidth: 500
+  }
+};

--- a/apps/src/code-studio/pd/workshop_dashboard/attendance/session_attendance.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/attendance/session_attendance.jsx
@@ -18,17 +18,6 @@ import {PermissionPropType, WorkshopAdmin, ProgramManager} from '../permission';
 const REFRESH_DELAY = 5000;
 const IDLE_TIMEOUT = 60000;
 
-const styles = {
-  idle: {
-    opacity: 0.5
-  },
-  attendanceSummary: {
-    fontFamily: 'Gotham 4r',
-    fontSize: 16,
-    margin: 15
-  }
-};
-
 export class SessionAttendance extends React.Component {
   static propTypes = {
     permission: PermissionPropType.isRequired,
@@ -207,6 +196,17 @@ export class SessionAttendance extends React.Component {
     );
   }
 }
+
+const styles = {
+  idle: {
+    opacity: 0.5
+  },
+  attendanceSummary: {
+    fontFamily: 'Gotham 4r',
+    fontSize: 16,
+    margin: 15
+  }
+};
 
 export default connect(state => ({
   permission: state.workshopDashboard.permission

--- a/apps/src/code-studio/pd/workshop_dashboard/attendance/workshop_attendance.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/attendance/workshop_attendance.jsx
@@ -14,14 +14,6 @@ import {PermissionPropType, WorkshopAdmin, Organizer} from '../permission';
 import color from '@cdo/apps/util/color';
 import {Row, Col, ButtonToolbar, Button, Tabs, Tab} from 'react-bootstrap';
 
-const styles = {
-  saveStatus: {
-    error: {
-      color: color.red
-    }
-  }
-};
-
 export class WorkshopAttendance extends React.Component {
   static contextTypes = {
     router: PropTypes.object.isRequired
@@ -242,6 +234,14 @@ export class WorkshopAttendance extends React.Component {
     );
   }
 }
+
+const styles = {
+  saveStatus: {
+    error: {
+      color: color.red
+    }
+  }
+};
 
 export default connect(state => ({
   permission: state.workshopDashboard.permission

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
@@ -44,20 +44,6 @@ import CourseSelect from './CourseSelect';
 import SubjectSelect from './SubjectSelect';
 import MapboxLocationSearchField from '../../../../templates/MapboxLocationSearchField';
 
-const styles = {
-  readOnlyInput: {
-    backgroundColor: 'inherit',
-    cursor: 'default',
-    border: 'none'
-  },
-  noFeeContainer: {
-    paddingBottom: 7
-  },
-  yesFeeRadio: {
-    width: '100%'
-  }
-};
-
 // Default to today, 9am-5pm.
 const placeholderSession = {
   placeholderId: '_0',
@@ -1088,6 +1074,20 @@ export class WorkshopForm extends React.Component {
     );
   }
 }
+
+const styles = {
+  readOnlyInput: {
+    backgroundColor: 'inherit',
+    cursor: 'default',
+    border: 'none'
+  },
+  noFeeContainer: {
+    paddingBottom: 7
+  },
+  yesFeeRadio: {
+    width: '100%'
+  }
+};
 
 export default connect(state => ({
   permission: state.workshopDashboard.permission,

--- a/apps/src/code-studio/pd/workshop_dashboard/reports/foorm/results_loader.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/reports/foorm/results_loader.jsx
@@ -9,22 +9,6 @@ import {Button} from 'react-bootstrap';
 import {PermissionPropType, WorkshopAdmin} from '../../permission';
 import {connect} from 'react-redux';
 
-const styles = {
-  errorContainer: {
-    marginTop: 15,
-    marginLeft: 15
-  },
-  errorDetailsBox: {
-    backgroundColor: color.lightest_gray,
-    padding: 20,
-    maxWidth: 550,
-    marginTop: 20
-  },
-  csvExportButton: {
-    float: 'right'
-  }
-};
-
 export class ResultsLoader extends React.Component {
   static propTypes = {
     params: PropTypes.shape({
@@ -105,6 +89,22 @@ export class ResultsLoader extends React.Component {
     }
   }
 }
+
+const styles = {
+  errorContainer: {
+    marginTop: 15,
+    marginLeft: 15
+  },
+  errorDetailsBox: {
+    backgroundColor: color.lightest_gray,
+    padding: 20,
+    maxWidth: 550,
+    marginTop: 20
+  },
+  csvExportButton: {
+    float: 'right'
+  }
+};
 
 export default connect(state => ({
   permission: state.workshopDashboard.permission

--- a/apps/src/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/results_loader.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/reports/local_summer_workshop_daily_survey/results_loader.jsx
@@ -5,19 +5,6 @@ import Spinner from '../../../components/spinner';
 import Results from './results';
 import color from '@cdo/apps/util/color';
 
-const styles = {
-  errorContainer: {
-    marginTop: 15,
-    marginLeft: 15
-  },
-  errorDetailsBox: {
-    backgroundColor: color.lightest_gray,
-    padding: 20,
-    maxWidth: 550,
-    marginTop: 20
-  }
-};
-
 export class ResultsLoader extends React.Component {
   static propTypes = {
     params: PropTypes.shape({
@@ -96,3 +83,16 @@ export class ResultsLoader extends React.Component {
     }
   }
 }
+
+const styles = {
+  errorContainer: {
+    marginTop: 15,
+    marginLeft: 15
+  },
+  errorDetailsBox: {
+    backgroundColor: color.lightest_gray,
+    padding: 20,
+    maxWidth: 550,
+    marginTop: 20
+  }
+};

--- a/apps/src/code-studio/pd/workshop_dashboard/reports/teacher_attendance_report.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/reports/teacher_attendance_report.jsx
@@ -13,10 +13,6 @@ import Spinner from '../../components/spinner';
 
 const QUERY_URL = '/api/v1/pd/teacher_attendance_report';
 
-const styles = {
-  link: {cursor: 'pointer'}
-};
-
 export class TeacherAttendanceReport extends React.Component {
   static propTypes = {
     permission: PermissionPropType.isRequired,
@@ -247,6 +243,10 @@ export class TeacherAttendanceReport extends React.Component {
     );
   }
 }
+
+const styles = {
+  link: {cursor: 'pointer'}
+};
 
 export default connect(state => ({
   permission: state.workshopDashboard.permission

--- a/apps/src/code-studio/pd/workshop_dashboard/reports/workshop_summary_report.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/reports/workshop_summary_report.jsx
@@ -15,10 +15,6 @@ const FACILITATOR_DETAILS_COUNT = 6;
 const ATTENDANCE_DAYS_COUNT = 5;
 const QUERY_URL = '/api/v1/pd/workshop_summary_report';
 
-const styles = {
-  link: {cursor: 'pointer'}
-};
-
 export class WorkshopSummaryReport extends React.Component {
   static propTypes = {
     permission: PermissionPropType.isRequired,
@@ -304,6 +300,10 @@ export class WorkshopSummaryReport extends React.Component {
     );
   }
 }
+
+const styles = {
+  link: {cursor: 'pointer'}
+};
 
 export default connect(state => ({
   permission: state.workshopDashboard.permission

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop_index.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop_index.jsx
@@ -38,11 +38,6 @@ const filterParams = {
     state: 'Ended'
   }
 };
-const styles = {
-  surveySubmissionsButton: {
-    marginLeft: 5
-  }
-};
 
 export class WorkshopIndex extends React.Component {
   static propTypes = {
@@ -166,6 +161,12 @@ export class WorkshopIndex extends React.Component {
     );
   }
 }
+
+const styles = {
+  surveySubmissionsButton: {
+    marginLeft: 5
+  }
+};
 
 export default connect(state => ({
   permission: state.workshopDashboard.permission

--- a/apps/src/maze/CollectorGemCounter.jsx
+++ b/apps/src/maze/CollectorGemCounter.jsx
@@ -6,6 +6,40 @@ import msg from './locale';
 
 import assetUrl from '@cdo/apps/code-studio/assetUrl';
 
+export class CollectorGemCounter extends React.Component {
+  static propTypes = {
+    currentCollected: PropTypes.number.isRequired,
+    minRequired: PropTypes.number
+  };
+
+  static defaultProps = {
+    minRequired: 1
+  };
+
+  render() {
+    const showCheckmark = this.props.currentCollected >= this.props.minRequired;
+
+    return (
+      <div style={styles.container}>
+        <div style={styles.label}>{msg.goal()}</div>
+        <div style={styles.gemImage}>
+          <i
+            style={{
+              ...styles.checkmark,
+              visibility: showCheckmark ? 'visible' : 'hidden'
+            }}
+            className="fa fa-check"
+            aria-hidden="true"
+          />
+        </div>
+        <span style={styles.gemCount}>
+          {this.props.currentCollected}/{this.props.minRequired}
+        </span>
+      </div>
+    );
+  }
+}
+
 const styles = {
   container: {
     display: 'inline-block',
@@ -51,40 +85,6 @@ const styles = {
     color: color.charcoal
   }
 };
-
-export class CollectorGemCounter extends React.Component {
-  static propTypes = {
-    currentCollected: PropTypes.number.isRequired,
-    minRequired: PropTypes.number
-  };
-
-  static defaultProps = {
-    minRequired: 1
-  };
-
-  render() {
-    const showCheckmark = this.props.currentCollected >= this.props.minRequired;
-
-    return (
-      <div style={styles.container}>
-        <div style={styles.label}>{msg.goal()}</div>
-        <div style={styles.gemImage}>
-          <i
-            style={{
-              ...styles.checkmark,
-              visibility: showCheckmark ? 'visible' : 'hidden'
-            }}
-            className="fa fa-check"
-            aria-hidden="true"
-          />
-        </div>
-        <span style={styles.gemCount}>
-          {this.props.currentCollected}/{this.props.minRequired}
-        </span>
-      </div>
-    );
-  }
-}
 
 export default connect(state => ({
   currentCollected: state.maze.collectorCurrentCollected,

--- a/apps/src/templates/SwipePrompt.jsx
+++ b/apps/src/templates/SwipePrompt.jsx
@@ -6,18 +6,6 @@ import cookies from 'js-cookie';
 import {dismissSwipeOverlay} from '@cdo/apps/templates/arrowDisplayRedux';
 import trackEvent from '@cdo/apps/util/trackEvent';
 
-const styles = {
-  overlay: {
-    position: 'absolute',
-    zIndex: 1,
-    opacity: '90%'
-  },
-  minecraft: {
-    top: '62px',
-    left: '17px'
-  }
-};
-
 const HideSwipeOverlayCookieName = 'hide_swipe_overlay';
 
 export class SwipePrompt extends React.Component {
@@ -124,6 +112,18 @@ export class SwipePrompt extends React.Component {
     );
   }
 }
+
+const styles = {
+  overlay: {
+    position: 'absolute',
+    zIndex: 1,
+    opacity: '90%'
+  },
+  minecraft: {
+    top: '62px',
+    left: '17px'
+  }
+};
 
 export const UnconnectedSwipePrompt = SwipePrompt;
 

--- a/apps/src/templates/sectionProgress/standards/CreateStandardsReportDialog.jsx
+++ b/apps/src/templates/sectionProgress/standards/CreateStandardsReportDialog.jsx
@@ -6,21 +6,6 @@ import BaseDialog from '../../BaseDialog';
 import CreateStandardsReportStep1 from './CreateStandardsReportStep1';
 import CreateStandardsReportStep2 from './CreateStandardsReportStep2';
 
-const styles = {
-  description: {
-    color: color.dark_charcoal
-  },
-  boldText: {
-    fontFamily: '"Gotham 7r", sans-serif'
-  },
-  dialog: {
-    paddingLeft: 20,
-    paddingRight: 20,
-    paddingBottom: 20,
-    fontFamily: '"Gotham 4r", sans-serif, sans-serif'
-  }
-};
-
 export class CreateStandardsReportDialog extends Component {
   static propTypes = {
     sectionId: PropTypes.number,
@@ -78,5 +63,20 @@ export class CreateStandardsReportDialog extends Component {
     );
   }
 }
+
+const styles = {
+  description: {
+    color: color.dark_charcoal
+  },
+  boldText: {
+    fontFamily: '"Gotham 7r", sans-serif'
+  },
+  dialog: {
+    paddingLeft: 20,
+    paddingRight: 20,
+    paddingBottom: 20,
+    fontFamily: '"Gotham 4r", sans-serif, sans-serif'
+  }
+};
 
 export const UnconnectedCreateStandardsReportDialog = CreateStandardsReportDialog;

--- a/apps/src/templates/studioHomepages/TeacherHomepage.jsx
+++ b/apps/src/templates/studioHomepages/TeacherHomepage.jsx
@@ -20,13 +20,6 @@ import CensusTeacherBanner from '../census2017/CensusTeacherBanner';
 import DonorTeacherBanner from '@cdo/apps/templates/DonorTeacherBanner';
 import {beginGoogleImportRosterFlow} from '../teacherDashboard/teacherSectionsRedux';
 
-const styles = {
-  clear: {
-    clear: 'both',
-    height: 30
-  }
-};
-
 export class UnconnectedTeacherHomepage extends Component {
   static propTypes = {
     joinedSections: shapes.sections,
@@ -288,6 +281,13 @@ export class UnconnectedTeacherHomepage extends Component {
     );
   }
 }
+
+const styles = {
+  clear: {
+    clear: 'both',
+    height: 30
+  }
+};
 
 export default connect(
   state => ({}),

--- a/apps/src/templates/studioHomepages/TwoColumnActionBlock.jsx
+++ b/apps/src/templates/studioHomepages/TwoColumnActionBlock.jsx
@@ -7,60 +7,6 @@ import i18n from '@cdo/locale';
 import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
 import shapes from './shapes';
 
-const styles = {
-  heading: {
-    paddingRight: 5,
-    paddingTop: 10,
-    paddingBottom: 20,
-    fontSize: 24,
-    lineHeight: '26px',
-    fontFamily: 'Gotham 3r',
-    color: color.charcoal
-  },
-  textItem: {
-    backgroundColor: color.teal,
-    padding: 25,
-    minHeight: 281,
-    boxSizing: 'border-box'
-  },
-  subHeading: {
-    paddingRight: 0,
-    paddingBottom: 20,
-    fontSize: 27,
-    lineHeight: 1.2,
-    fontFamily: '"Gotham 7r", sans-serif',
-    color: color.white
-  },
-  subHeadingSmallFont: {
-    paddingRight: 0,
-    paddingBottom: 20,
-    fontSize: 25,
-    lineHeight: 1.2,
-    fontFamily: '"Gotham 7r", sans-serif',
-    color: color.white
-  },
-  image: {
-    width: 485,
-    minHeight: 260,
-    height: 281
-  },
-  description: {
-    paddingRight: 10,
-    paddingBottom: 20,
-    fontSize: 14,
-    fontFamily: 'Gotham 4r',
-    lineHeight: '22px',
-    color: color.white
-  },
-  clear: {
-    clear: 'both'
-  },
-  container: {
-    width: '100%',
-    position: 'relative'
-  }
-};
-
 export class UnconnectedTwoColumnActionBlock extends Component {
   static propTypes = {
     id: PropTypes.string,
@@ -258,3 +204,57 @@ export class SpecialAnnouncementActionBlock extends Component {
     );
   }
 }
+
+const styles = {
+  heading: {
+    paddingRight: 5,
+    paddingTop: 10,
+    paddingBottom: 20,
+    fontSize: 24,
+    lineHeight: '26px',
+    fontFamily: 'Gotham 3r',
+    color: color.charcoal
+  },
+  textItem: {
+    backgroundColor: color.teal,
+    padding: 25,
+    minHeight: 281,
+    boxSizing: 'border-box'
+  },
+  subHeading: {
+    paddingRight: 0,
+    paddingBottom: 20,
+    fontSize: 27,
+    lineHeight: 1.2,
+    fontFamily: '"Gotham 7r", sans-serif',
+    color: color.white
+  },
+  subHeadingSmallFont: {
+    paddingRight: 0,
+    paddingBottom: 20,
+    fontSize: 25,
+    lineHeight: 1.2,
+    fontFamily: '"Gotham 7r", sans-serif',
+    color: color.white
+  },
+  image: {
+    width: 485,
+    minHeight: 260,
+    height: 281
+  },
+  description: {
+    paddingRight: 10,
+    paddingBottom: 20,
+    fontSize: 14,
+    fontFamily: 'Gotham 4r',
+    lineHeight: '22px',
+    color: color.white
+  },
+  clear: {
+    clear: 'both'
+  },
+  container: {
+    width: '100%',
+    position: 'relative'
+  }
+};


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Several months ago I wrote a [custom lint rule](https://github.com/code-dot-org/code-dot-org/pull/40311) to move styles to bottom of components, I've noticed that some blocks didn't get moved, this PR fixes this for components with `export` in front of their class declarations. 

Helpful links:
- I referenced [this guide](https://www.webiny.com/blog/create-custom-eslint-rules-in-2-minutes-e3d41cb6a9a0), which I used to set up the lint rule initially.
- I used the [AST Explorer](https://astexplorer.net/) to recognize types of blocks
- To run the linter on one file (for debugging) I ran `yarn run eslint --format ./.eslintCustomMessagesFormatter.js src/code-studio/pd/workshop_dashboard/attendance/session_attendance.jsx`

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
-  jira ticket: [LP-1915](https://codedotorg.atlassian.net/browse/LP-1915)

<!--
- spec: []()
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
