### PR TITLE
Fix JS error on non-Spritelab level edit pages

### DIFF
--- a/dashboard/app/views/levels/editors/fields/_long_instructions.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_long_instructions.html.haml
@@ -22,12 +22,14 @@
 
 :javascript
   $(document).ready(function() {
-    function updateIconPreview() {
-      var iconName = $('#level_instructions_icon')[0].value || 'avatar';
-      $('.instructions-icon-preview').attr('src', 'https://studio.code.org/blockly/media/spritelab/' + iconName + '.png');
+    if ($('#level_instructions_icon').length > 0) {
+      function updateIconPreview() {
+        var iconName = $('#level_instructions_icon')[0].value || 'avatar';
+        $('.instructions-icon-preview').attr('src', 'https://studio.code.org/blockly/media/spritelab/' + iconName + '.png');
+      }
+      $('#level_instructions_icon').change(updateIconPreview);
+      updateIconPreview();
     }
-    $('#level_instructions_icon').change(updateIconPreview);
-    updateIconPreview();
   })
   var mdEditor = levelbuilder.initializeCodeMirror('level_long_instructions', 'markdown', {
     callback: function (editor, change) {


### PR DESCRIPTION
A new field was added for spritelab levels which has some corresponding JS. However, that JS threw an error when the field didn't exist (which it doesn't except for on spritelab levels). Solution is just to check if that field exists before adding the handler.

This fixes an issue where new levels weren't being marked as published and an issue where saving doesn't redirect to the level.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
