### PR TITLE
hide csa units 4 through 9

### DIFF
--- a/dashboard/config/scripts_json/csa4-pilot.script_json
+++ b/dashboard/config/scripts_json/csa4-pilot.script_json
@@ -14,8 +14,8 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2021-07-30 20:28:29 UTC",
-    "published_state": "pilot",
+    "serialized_at": "2021-08-10 04:49:31 UTC",
+    "published_state": "in_development",
     "seeding_key": {
       "script.name": "csa4-pilot"
     }

--- a/dashboard/config/scripts_json/csa5-pilot.script_json
+++ b/dashboard/config/scripts_json/csa5-pilot.script_json
@@ -14,8 +14,8 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2021-07-30 20:28:29 UTC",
-    "published_state": "pilot",
+    "serialized_at": "2021-08-10 04:49:31 UTC",
+    "published_state": "in_development",
     "seeding_key": {
       "script.name": "csa5-pilot"
     }

--- a/dashboard/config/scripts_json/csa6-pilot.script_json
+++ b/dashboard/config/scripts_json/csa6-pilot.script_json
@@ -10,8 +10,8 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2021-07-30 20:28:30 UTC",
-    "published_state": "pilot",
+    "serialized_at": "2021-08-10 04:49:31 UTC",
+    "published_state": "in_development",
     "seeding_key": {
       "script.name": "csa6-pilot"
     }

--- a/dashboard/config/scripts_json/csa7-pilot.script_json
+++ b/dashboard/config/scripts_json/csa7-pilot.script_json
@@ -10,8 +10,8 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2021-07-30 20:28:30 UTC",
-    "published_state": "pilot",
+    "serialized_at": "2021-08-10 04:49:31 UTC",
+    "published_state": "in_development",
     "seeding_key": {
       "script.name": "csa7-pilot"
     }

--- a/dashboard/config/scripts_json/csa8-pilot.script_json
+++ b/dashboard/config/scripts_json/csa8-pilot.script_json
@@ -10,8 +10,8 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2021-07-30 20:28:30 UTC",
-    "published_state": "pilot",
+    "serialized_at": "2021-08-10 04:49:31 UTC",
+    "published_state": "in_development",
     "seeding_key": {
       "script.name": "csa8-pilot"
     }

--- a/dashboard/config/scripts_json/csa9-pilot.script_json
+++ b/dashboard/config/scripts_json/csa9-pilot.script_json
@@ -10,8 +10,8 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2021-07-30 20:28:30 UTC",
-    "published_state": "pilot",
+    "serialized_at": "2021-08-10 04:49:31 UTC",
+    "published_state": "in_development",
     "seeding_key": {
       "script.name": "csa9-pilot"
     }


### PR DESCRIPTION
CSA units 4 through 9 need to be hidden in Tuesday's deploy so that teachers can be added to the pilot on Wednesday. Since the PR to let levelbuilders control this setting won't reach levelbuilder until tuesday afternoon, I'm using a pull request to hide these units instead. here is how it looks to a pilot teacher:

![Screen Shot 2021-08-09 at 9 53 11 PM](https://user-images.githubusercontent.com/8001765/128810192-af841e69-d8a1-431a-8baa-058228668481.png)
