### PR TITLE
[Spritelab] Fix Pause Button

### DIFF
--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -515,7 +515,7 @@ P5Lab.prototype.init = function(config) {
           <P5LabView
             showFinishButton={finishButtonFirstLine && showFinishButton}
             onMount={onMount}
-            pauseHandler={this.onPause}
+            pauseHandler={this.onPause?.bind(this)}
             hidePauseButton={!!this.level.hidePauseButton}
             onPromptAnswer={this.onPromptAnswer?.bind(this)}
           />


### PR DESCRIPTION
Quick fix to the pause button. I think this regressed with https://github.com/code-dot-org/code-dot-org/pull/41673
The solution is just to make sure the `pauseHandler` function is bound to the `Spritelab` instance before passing it through to the `PauseButton` component