### PR TITLE
Foorm Simple Surveys: allow surveys of non-signed in users

### DIFF
--- a/dashboard/app/controllers/foorm/simple_survey_forms_controller.rb
+++ b/dashboard/app/controllers/foorm/simple_survey_forms_controller.rb
@@ -24,6 +24,7 @@ module Foorm
           form_name: form.name,
           form_version: form.version,
           allow_multiple_submissions: params[:allow_multiple_submissions] == '1',
+          allow_signed_out: params[:allow_signed_out] == '1',
           survey_data: survey_data
         )
       # Admin only page, so return any errors in plain text.
@@ -43,32 +44,39 @@ module Foorm
     # If no variables are provided, will use survey variables from the configuration in foorm/simple_survey_forms,
     # or use no variables if there are none in the configuration.
     def show
-      return render :logged_out unless current_user
-      return render :not_teacher unless current_user.teacher?
-      return render :no_teacher_email unless current_user.email.present?
-
+      # First, check if we can find the simple survey form configuration, and that form is not disabled.
+      return render :survey_closed if SimpleSurveyForm.form_path_disabled?(params[:path])
       form_data = SimpleSurveyForm.find_most_recent_form_for_path(params[:path])
       return render_404 unless form_data
 
-      return render :survey_closed if SimpleSurveyForm.form_path_disabled?(params[:path])
+      # Pass simple survey form ID to the form to identify responses
+      # We include user ID as well if the survey is only for signed in users
+      key_params = {simple_survey_form_id: form_data[:id]}
 
+      # Second, add user ID as a key parameter,
+      # unless this form allows user to be signed out or the signed in user is not a teacher or doesn't have an email
+      unless form_data.allow_signed_out
+        return render :logged_out unless current_user
+        return render :not_teacher unless current_user.teacher?
+        return render :no_teacher_email unless current_user.email.present?
+
+        key_params[:user_id] = current_user.id
+      end
+
+      # Third, check that the user hasn't submitted this survey,
+      # unless the survey allows multiple submissions or allows signed out submissions
+      unless form_data.allow_multiple_submissions || form_data.allow_signed_out
+        return render :thanks if response_exists?(key_params)
+      end
+
+      # Fourth, check we can find the Foorm configuration.
       form_questions = ::Foorm::Form.get_questions_for_name_and_version(
         form_data[:form_name],
         form_data[:form_version]
       )
-
       return render_404 unless form_questions
 
-      # Pass these params to the form to identify unique responses
-      key_params = {
-        user_id: current_user.id,
-        simple_survey_form_id: form_data[:id]
-      }
-
-      unless form_data[:allow_multiple_submissions]
-        return render :thanks if response_exists?(key_params)
-      end
-
+      # Finally, return the form data.
       @script_data = {
         props: {
           formQuestions: form_questions,
@@ -87,23 +95,42 @@ module Foorm
     # an existing page. One example of this is the NPS survey which is rendered as part
     # of the teacher homepage. The client will handle the custom rendering of the survey.
     def configuration
-      return render json: {}, status: :no_content unless current_user&.teacher? && current_user.email.present?
-
+      # First, check if we can find the simple survey form configuration, and that form is not disabled.
       form_data = SimpleSurveyForm.find_most_recent_form_for_path(params[:path])
       return render json: {}, status: :no_content if !form_data || SimpleSurveyForm.form_path_disabled?(params[:path])
 
+      # Pass simple survey form ID to the form to identify responses
+      # We include user ID as well if the survey is only for signed in users
+      key_params = {simple_survey_form_id: form_data[:id]}
+
+      # Second, add user ID as a key parameter,
+      # unless this form allows user to be signed out or the signed in user is not a teacher or doesn't have an email
+      unless form_data.allow_signed_out
+        unless current_user&.teacher? && current_user.email.present?
+          return render json: {}, status: :no_content
+        end
+
+        key_params[:user_id] = current_user.id
+      end
+
+      # Third, check that the user hasn't submitted this survey,
+      # unless the survey allows multiple submissions or allows signed out submissions
+      unless form_data.allow_multiple_submissions || form_data.allow_signed_out
+        if response_exists?(key_params)
+          return render json: {}, status: :no_content
+        end
+      end
+
+      # Fourth, check we can find the Foorm configuration.
       form_questions = ::Foorm::Form.get_questions_for_name_and_version(
         form_data[:form_name],
         form_data[:form_version]
       )
+      unless form_questions
+        return render json: {}, status: :no_content
+      end
 
-      key_params = {
-        user_id: current_user.id,
-        simple_survey_form_id: form_data[:id]
-      }
-
-      return render json: {}, status: :no_content if !form_questions || (!form_data[:allow_multiple_submissions] && response_exists?(key_params))
-
+      # Finally, return the form data.
       render json: @script_data = {
         props: {
           formQuestions: form_questions,

--- a/dashboard/app/models/foorm/simple_survey_form.rb
+++ b/dashboard/app/models/foorm/simple_survey_form.rb
@@ -20,7 +20,8 @@ class Foorm::SimpleSurveyForm < ApplicationRecord
 
   serialized_attrs [
     'survey_data',
-    'allow_multiple_submissions'
+    'allow_multiple_submissions',
+    'allow_signed_out'
   ]
 
   belongs_to :form, foreign_key: [:form_name, :form_version], primary_key: [:name, :version]

--- a/dashboard/app/views/foorm/simple_survey_forms/new.haml
+++ b/dashboard/app/views/foorm/simple_survey_forms/new.haml
@@ -25,6 +25,9 @@
   .field
     = f.check_box :allow_multiple_submissions
     = f.label :allow_multiple_submissions, 'Allow multiple submissions by the same user?'
+  .field
+    = f.check_box :allow_signed_out
+    = f.label :allow_signed_out, 'Allow submissions from signed out users? Note we cannot control repeat submissions if survey participants are not signed in.'
   %h2
     Variables (optional)
   %p

--- a/dashboard/test/controllers/foorm/simple_survey_forms_controller_test.rb
+++ b/dashboard/test/controllers/foorm/simple_survey_forms_controller_test.rb
@@ -122,7 +122,7 @@ module Foorm
       assert_nil created_simple_survey_form.kind
       assert_equal @foorm_form.name, created_simple_survey_form.form_name
       assert_equal @foorm_form.version, created_simple_survey_form.form_version
-      assert_equal true, created_simple_survey_form.properties['allow_multiple_submissions']
+      assert_equal true, created_simple_survey_form.allow_multiple_submissions
     end
 
     test 'admin can create new simple survey form that allows anonymous submissions' do
@@ -133,7 +133,7 @@ module Foorm
 
       created_simple_survey_form = Foorm::SimpleSurveyForm.find_by(path: @test_url_path)
       assert created_simple_survey_form
-      assert_equal true, created_simple_survey_form.properties['allow_signed_out']
+      assert_equal true, created_simple_survey_form.allow_signed_out
     end
 
     test 'creating simple survey form with invalid form fails' do
@@ -162,7 +162,7 @@ module Foorm
       expected_survey_data = {'a_key' => 'a_value'}
 
       created_simple_survey_form = Foorm::SimpleSurveyForm.find_by(path: @test_url_path)
-      assert_equal expected_survey_data, created_simple_survey_form.properties['survey_data']
+      assert_equal expected_survey_data, created_simple_survey_form.survey_data
     end
 
     test 'parse_survey_data raises error when key provided with no value' do

--- a/dashboard/test/controllers/foorm/simple_survey_forms_controller_test.rb
+++ b/dashboard/test/controllers/foorm/simple_survey_forms_controller_test.rb
@@ -9,9 +9,10 @@ module Foorm
       @foorm_form = create :foorm_form
       @simple_survey_form = create :foorm_simple_survey_form, form_name: @foorm_form.name
       @disabled_simple_survey_form = create :foorm_simple_survey_form, form_name: @foorm_form.name, path: 'disabled_path'
+      @test_url_path = 'test_url_path'
 
       @base_success_params = {
-        path: 'test_url_path',
+        path: @test_url_path,
         kind: '',
         form_key: @foorm_form.key,
         allow_multiple_submissions: '1'
@@ -24,6 +25,16 @@ module Foorm
       sign_in @teacher
 
       get "/form/#{@simple_survey_form.path}"
+      assert_template :show
+      assert_response :success
+    end
+
+    test 'renders form if user is not signed in and form allows anonymous submissions' do
+      anonymous_form = create :foorm_simple_survey_form,
+        form_name: @foorm_form.name,
+        properties: {allow_signed_out: true}
+
+      get "/form/#{anonymous_form.path}"
       assert_template :show
       assert_response :success
     end
@@ -58,6 +69,27 @@ module Foorm
       assert_response :success
     end
 
+    test 'renders thanks if teacher has already submitted' do
+      create :foorm_simple_survey_submission, simple_survey_form: @simple_survey_form, user: @teacher
+
+      sign_in @teacher
+      get "/form/#{@simple_survey_form.path}"
+      assert_template :thanks
+      assert_response :success
+    end
+
+    test 'renders form if teacher has already submitted but form allows multiple submissions' do
+      multiple_submissions_form = create :foorm_simple_survey_form,
+        form_name: @foorm_form.name,
+        properties: {allow_multiple_submissions: true}
+      create :foorm_simple_survey_submission, simple_survey_form: multiple_submissions_form, user: @teacher
+
+      sign_in @teacher
+      get "/form/#{multiple_submissions_form.path}"
+      assert_template :show
+      assert_response :success
+    end
+
     test 'non-admin cannot access admin only simple survey forms' do
       sign_in @teacher
 
@@ -84,20 +116,31 @@ module Foorm
       post foorm_simple_survey_forms_path, params: @base_success_params
       assert_response :success
 
-      created_simple_survey_form = Foorm::SimpleSurveyForm.find_by(path: 'test_url_path')
+      created_simple_survey_form = Foorm::SimpleSurveyForm.find_by(path: @test_url_path)
       assert created_simple_survey_form
-      assert_equal 'test_url_path', created_simple_survey_form.path
+      assert_equal @test_url_path, created_simple_survey_form.path
       assert_nil created_simple_survey_form.kind
       assert_equal @foorm_form.name, created_simple_survey_form.form_name
       assert_equal @foorm_form.version, created_simple_survey_form.form_version
-      assert_equal({'allow_multiple_submissions' => true}, created_simple_survey_form.properties)
+      assert_equal true, created_simple_survey_form.properties['allow_multiple_submissions']
+    end
+
+    test 'admin can create new simple survey form that allows anonymous submissions' do
+      sign_in @admin
+
+      post foorm_simple_survey_forms_path, params: @base_success_params.merge({allow_signed_out: '1'})
+      assert_response :success
+
+      created_simple_survey_form = Foorm::SimpleSurveyForm.find_by(path: @test_url_path)
+      assert created_simple_survey_form
+      assert_equal true, created_simple_survey_form.properties['allow_signed_out']
     end
 
     test 'creating simple survey form with invalid form fails' do
       sign_in @admin
 
       post foorm_simple_survey_forms_path, params: {
-        path: 'test_url_path',
+        path: @test_url_path,
         form_key: 'a_form_that_does_not_exist.0',
         allow_multiple_submissions: '1'
       }
@@ -118,7 +161,7 @@ module Foorm
 
       expected_survey_data = {'a_key' => 'a_value'}
 
-      created_simple_survey_form = Foorm::SimpleSurveyForm.find_by(path: 'test_url_path')
+      created_simple_survey_form = Foorm::SimpleSurveyForm.find_by(path: @test_url_path)
       assert_equal expected_survey_data, created_simple_survey_form.properties['survey_data']
     end
 

--- a/dashboard/test/factories/foorm_factories.rb
+++ b/dashboard/test/factories/foorm_factories.rb
@@ -1174,4 +1174,9 @@ FactoryGirl.define do
     form_name 'A form that does not actually exist'
     form_version 0
   end
+
+  factory :foorm_simple_survey_submission, class: 'Foorm::SimpleSurveySubmission' do
+    association :foorm_submission, factory: :basic_foorm_submission
+    association :simple_survey_form, factory: :foorm_simple_survey_form
+  end
 end


### PR DESCRIPTION
This change is primarily intended to introduce the ability to conduct simple surveys of logged out users. It adds a checkbox in our admin UI so that admins can create Simple Surveys that can be filled out by a signed out user. 

At the same time, I made a couple of tangential changes:
- The ability to allow multiple submissions (gated by the `allow_multiple_submissions` property) did not work, so we never actually allowed multiple submissions. Syntax was `form_data[:allow_multiple_submissions]`, but should have been `form_data.allow_multiple_submissions`
- Additional tests covering the case that was not working above.
- Reorganized the return conditions of the simple survey controller to be more clearlyl aligned between our data-only route (`configuration`) and our full Foorm UI route (`show`).

## Testing story

Added unit tests and tested manually that I could create a new simple survey with allowing signed out enabled, and was able to submit responses while signed out. Also tested that I was able to render and submit the NPS survey (which we access via the `configuration` route), and was able to submit it multiple times when I configured it to allow multiple submissions from the same user.