### PR TITLE
Fix level creation problems on spritelab and other level types

### DIFF
--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -288,7 +288,9 @@ class LevelsController < ApplicationController
     params[:level][:maze_data] = params[:level][:maze_data].to_json if type_class <= Grid
     params[:user] = current_user
 
-    create_level_params = level_params
+    # safely convert params to hash now so that if they are modified later, it
+    # will not result in a ActionController::UnfilteredParameters error.
+    create_level_params = level_params.to_h
 
     # Give platformization partners permission to edit any levels they create.
     editor_experiment = Experiment.get_editor_experiment(current_user)

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -386,6 +386,45 @@ class LevelsControllerTest < ActionController::TestCase
     assert_equal edit_level_path(assigns(:level)), JSON.parse(@response.body)["redirect"]
   end
 
+  test "should create applab level" do
+    game = Game.find_by_name("Applab")
+    assert_creates(Level) do
+      post :create, params: {
+        level: {name: "NewCustomLevel", type: 'Applab'},
+        game_id: game.id,
+        program: @program
+      }
+    end
+
+    assert_equal edit_level_path(assigns(:level)), JSON.parse(@response.body)["redirect"]
+  end
+
+  test "should create gamelab level" do
+    game = Game.find_by_name("Gamelab")
+    assert_creates(Level) do
+      post :create, params: {
+        level: {name: "NewCustomLevel", type: 'Gamelab'},
+        game_id: game.id,
+        program: @program
+      }
+    end
+
+    assert_equal edit_level_path(assigns(:level)), JSON.parse(@response.body)["redirect"]
+  end
+
+  test "should create dance level" do
+    game = Game.find_by_name("Dance")
+    assert_creates(Level) do
+      post :create, params: {
+        level: {name: "NewCustomLevel", type: 'Dancelab'},
+        game_id: game.id,
+        program: @program
+      }
+    end
+
+    assert_equal edit_level_path(assigns(:level)), JSON.parse(@response.body)["redirect"]
+  end
+
   test "should create and destroy custom level with level file" do
     # Enable writing custom level to file for this specific test only
     Level.any_instance.stubs(:write_to_file?).returns(true)

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -373,6 +373,19 @@ class LevelsControllerTest < ActionController::TestCase
     assert_equal edit_level_path(assigns(:level)), JSON.parse(@response.body)["redirect"]
   end
 
+  test "should create spritelab level" do
+    game = Game.find_by_name("Spritelab")
+    assert_creates(Level) do
+      post :create, params: {
+        level: {name: "NewCustomLevel", type: 'GamelabJr'},
+        game_id: game.id,
+        program: @program
+      }
+    end
+
+    assert_equal edit_level_path(assigns(:level)), JSON.parse(@response.body)["redirect"]
+  end
+
   test "should create and destroy custom level with level file" do
     # Enable writing custom level to file for this specific test only
     Level.any_instance.stubs(:write_to_file?).returns(true)


### PR DESCRIPTION
Fixes https://codedotorg.atlassian.net/browse/PLAT-649

It appears that the problem is that we do something like this:
1. permit/filter params to accept only those we need. at this point all params are "permitted"
2. modify the params object to add new things to it. after this the params become "unpermitted"
3. try to serialize the params object to a hash. this results in an `ActionController::UnfilteredParameters` error 

the solution is to convert the params to a hash after step 1, so that the hash can later be modified without triggering the error.

## Testing story

all new unit tests pass with code change and fail without it. 

## Security

the .to_h method is safe. the .to_unsafe_h method is not. see https://edgeapi.rubyonrails.org/classes/ActionController/Parameters.html for details.

