### PR TITLE
Add BootUp as a new curriculum offering, and three more states to v2 2018

### DIFF
--- a/dashboard/app/models/census/other_curriculum_offering.rb
+++ b/dashboard/app/models/census/other_curriculum_offering.rb
@@ -23,6 +23,7 @@ class Census::OtherCurriculumOffering < ApplicationRecord
   validates :school_year, presence: true, numericality: {greater_than_or_equal_to: 2015, less_than_or_equal_to: 2030}
 
   SUPPORTED_PROVIDERS = %w(
+    BootUp
     TEALS
     PLTW
   ).freeze

--- a/dashboard/app/models/census/state_cs_offering.rb
+++ b/dashboard/app/models/census/state_cs_offering.rb
@@ -112,6 +112,7 @@ class Census::StateCsOffering < ApplicationRecord
     IL
     IN
     KS
+    KY
     LA
     MA
     MD
@@ -119,12 +120,14 @@ class Census::StateCsOffering < ApplicationRecord
     MO
     MS
     MT
+    NC
     ND
     NE
     NJ
     NM
     NY
     OH
+    OK
     OR
     PA
     RI


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Some more small updates to enable access reporting. The dry runs already run on any files in the other_curriculum folder, but we need to manually enable a new category.