### PR TITLE
Support callback for playSpeech

### DIFF
--- a/apps/src/AzureTextToSpeech.js
+++ b/apps/src/AzureTextToSpeech.js
@@ -11,7 +11,14 @@ import Sounds from '@cdo/apps/Sounds';
  * @param {Error} error Any error that occurs while requesting the sound or checking for profanity.
  */
 class SoundResponse {
-  constructor(id, bytes, profaneWords = [], error = null, onEnded = null) {
+  constructor(
+    id,
+    bytes,
+    profaneWords = [],
+    error = null,
+    onEnded = null,
+    playbackOptions = {}
+  ) {
     this.id = id;
     this.bytes = bytes;
     this.playbackOptions = {
@@ -19,7 +26,8 @@ class SoundResponse {
       loop: false,
       forceHTML5: false,
       allowHTML5Mobile: true,
-      onEnded
+      onEnded,
+      ...playbackOptions
     };
     this.profaneWords = profaneWords;
     this.error = error;
@@ -332,9 +340,7 @@ export default class AzureTextToSpeech {
    */
   createSoundResponse_ = opts => {
     const onEnded = () => {
-      if (opts.onComplete) {
-        opts.onComplete();
-      }
+      opts.onComplete?.();
       this.onSoundComplete_();
     };
     return new SoundResponse(

--- a/apps/src/AzureTextToSpeech.js
+++ b/apps/src/AzureTextToSpeech.js
@@ -10,11 +10,17 @@ import Sounds from '@cdo/apps/Sounds';
  * @param {Array<string>} profaneWords Any profanity in the response. Used to determine whether the response should be cached and played.
  * @param {Error} error Any error that occurs while requesting the sound or checking for profanity.
  */
-export class SoundResponse {
-  constructor(id, bytes, playbackOptions, profaneWords = [], error = null) {
+class SoundResponse {
+  constructor(id, bytes, profaneWords = [], error = null, onEnded = null) {
     this.id = id;
     this.bytes = bytes;
-    this.playbackOptions = playbackOptions;
+    this.playbackOptions = {
+      volume: 1.0,
+      loop: false,
+      forceHTML5: false,
+      allowHTML5Mobile: true,
+      onEnded
+    };
     this.profaneWords = profaneWords;
     this.error = error;
   }
@@ -70,13 +76,6 @@ export default class AzureTextToSpeech {
     this.playing = false;
     this.queue_ = [];
     this.cachedSounds_ = {};
-    this.playbackOptions_ = {
-      volume: 1.0,
-      loop: false,
-      forceHTML5: false,
-      allowHTML5Mobile: true,
-      onEnded: this.onSoundComplete_
-    };
 
     Sounds.getSingleton().onStopAllAudio(this.onAudioEnded_);
   }
@@ -99,12 +98,20 @@ export default class AzureTextToSpeech {
    * @param {string} opts.locale
    * @param {string} opts.authenticityToken Rails authenticity token. Optional.
    * @param {function(string)} opts.onFailure Called with an error message if the sound will not be played.
+   * @param {function()} opts.onComplete Called when the sound is finished playing.
    * @returns {function} A thunk that returns a promise, which resolves to a SoundResponse. Example usage:
    * const soundPromise = createSoundPromise(options);
    * const soundResponse = await soundPromise();
    */
   createSoundPromise = opts => () => {
-    const {text, gender, locale, authenticityToken, onFailure} = opts;
+    const {
+      text,
+      gender,
+      locale,
+      authenticityToken,
+      onFailure,
+      onComplete
+    } = opts;
     const id = this.cacheKey_(locale, gender, text);
     const cachedSound = this.getCachedSound_(locale, gender, text);
     const wrappedSetCachedSound = soundResponse => {
@@ -118,11 +125,14 @@ export default class AzureTextToSpeech {
 
       return new Promise(resolve => {
         if (profaneWords && profaneWords.length > 0) {
-          const soundResponse = wrappedCreateSoundResponse({profaneWords});
+          const soundResponse = wrappedCreateSoundResponse({
+            onComplete,
+            profaneWords
+          });
           onFailure(soundResponse.profanityMessage());
           resolve(soundResponse);
         } else {
-          resolve(wrappedCreateSoundResponse({id, bytes}));
+          resolve(wrappedCreateSoundResponse({onComplete, id, bytes}));
         }
       });
     }
@@ -136,7 +146,10 @@ export default class AzureTextToSpeech {
           authenticityToken
         );
         if (profaneWords && profaneWords.length > 0) {
-          const soundResponse = wrappedCreateSoundResponse({profaneWords});
+          const soundResponse = wrappedCreateSoundResponse({
+            onComplete,
+            profaneWords
+          });
           onFailure(soundResponse.profanityMessage());
           wrappedSetCachedSound(soundResponse);
           resolve(soundResponse);
@@ -149,11 +162,15 @@ export default class AzureTextToSpeech {
           locale,
           authenticityToken
         );
-        const soundResponse = wrappedCreateSoundResponse({id, bytes});
+        const soundResponse = wrappedCreateSoundResponse({
+          onComplete,
+          id,
+          bytes
+        });
         wrappedSetCachedSound(soundResponse);
         resolve(soundResponse);
       } catch (error) {
-        const soundResponse = wrappedCreateSoundResponse({error});
+        const soundResponse = wrappedCreateSoundResponse({onComplete, error});
         onFailure(soundResponse.errorMessage());
         resolve(soundResponse);
       }
@@ -314,12 +331,18 @@ export default class AzureTextToSpeech {
    * @private
    */
   createSoundResponse_ = opts => {
+    const onEnded = () => {
+      if (opts.onComplete) {
+        opts.onComplete();
+      }
+      this.onSoundComplete_();
+    };
     return new SoundResponse(
       opts.id,
       opts.bytes,
-      this.playbackOptions_,
       opts.profaneWords,
-      opts.error
+      opts.error,
+      onEnded
     );
   };
 }

--- a/apps/src/lib/util/audioApi.js
+++ b/apps/src/lib/util/audioApi.js
@@ -201,7 +201,7 @@ export const commands = {
       locale: voices[language].locale,
       authenticityToken,
       onFailure: message => outputWarning(message + '\n'),
-      onComplete: validOnComplete && onComplete
+      onComplete: validOnComplete ? onComplete : null
     });
     azureTTS.enqueueAndPlay(promise);
   }

--- a/apps/src/lib/util/audioApi.js
+++ b/apps/src/lib/util/audioApi.js
@@ -39,9 +39,15 @@ export const commands = {
    * _@param {function} [opts.onEnded] Called back when the sound stops playing
    */
   playSound(opts) {
-    apiValidateType(opts, 'playSound', 'url', opts.url, 'string');
+    const validUrl = apiValidateType(
+      opts,
+      'playSound',
+      'url',
+      opts.url,
+      'string'
+    );
     apiValidateType(opts, 'playSound', 'loop', opts.loop, 'boolean', OPTIONAL);
-    apiValidateType(
+    const validCallback = apiValidateType(
       opts,
       'playSound',
       'callback',
@@ -49,7 +55,7 @@ export const commands = {
       'function',
       OPTIONAL
     );
-    apiValidateType(
+    const validOnEnded = apiValidateType(
       opts,
       'playSound',
       'onEnded',
@@ -58,9 +64,13 @@ export const commands = {
       OPTIONAL
     );
 
+    if (!validUrl) {
+      return;
+    }
+
     const url = assetPrefix.fixPath(opts.url);
     if (Sounds.getSingleton().isPlaying(url)) {
-      if (opts.callback) {
+      if (opts.callback && validCallback) {
         opts.callback(false);
       }
     }
@@ -95,8 +105,8 @@ export const commands = {
       loop: !!opts.loop,
       forceHTML5: forceHTML5,
       allowHTML5Mobile: true,
-      callback: opts.callback,
-      onEnded: opts.onEnded
+      callback: validCallback && opts.callback,
+      onEnded: validOnEnded && opts.onEnded
     });
   },
 
@@ -105,9 +115,16 @@ export const commands = {
    * @param {string} [opts.url] The sound to stop.  Stops all sounds if omitted.
    */
   stopSound(opts) {
-    apiValidateType(opts, 'stopSound', 'url', opts.url, 'string', OPTIONAL);
+    const validUrl = apiValidateType(
+      opts,
+      'stopSound',
+      'url',
+      opts.url,
+      'string',
+      OPTIONAL
+    );
 
-    if (opts.url) {
+    if (opts.url && validUrl) {
       const url = assetPrefix.fixPath(opts.url);
       if (Sounds.getSingleton().isPlaying(url)) {
         Sounds.getSingleton().stopLoopingAudio(url);
@@ -121,6 +138,7 @@ export const commands = {
    * @param {string} opts.text The text to play as speech.
    * @param {string} opts.gender The gender of the voice to play.
    * @param {string} opts.language The language of the text to play.
+   * @param {function()} opts.onComplete Called when the sound is complete.
    */
   async playSpeech(opts) {
     const validText = apiValidateType(
@@ -137,6 +155,15 @@ export const commands = {
       opts.gender,
       'string'
     );
+    const validOnComplete = apiValidateType(
+      opts,
+      'playSpeech',
+      'onComplete',
+      opts.onComplete,
+      'function',
+      OPTIONAL
+    );
+
     if (!validText || opts.text.length === 0 || !validGender) {
       return;
     }
@@ -153,7 +180,7 @@ export const commands = {
     // This is because script_levels remove Rails' authenticity token from the DOM for caching purposes:
     // https://github.com/code-dot-org/code-dot-org/pull/5753
     const {azureSpeechServiceVoices: voices, authenticityToken} = appOptions;
-    let {text, gender, language} = opts;
+    let {text, gender, language, onComplete} = opts;
 
     // Fall back to defaults if requested language/gender combination is not available.
     if (!(voices[language] && voices[language][gender])) {
@@ -173,7 +200,8 @@ export const commands = {
       gender,
       locale: voices[language].locale,
       authenticityToken,
-      onFailure: message => outputWarning(message + '\n')
+      onFailure: message => outputWarning(message + '\n'),
+      onComplete: validOnComplete && onComplete
     });
     azureTTS.enqueueAndPlay(promise);
   }
@@ -187,7 +215,7 @@ export const executors = {
   playSound: (url, loop = false, callback) =>
     executeCmd(null, 'playSound', {url, loop, callback}),
   stopSound: url => executeCmd(null, 'stopSound', {url}),
-  playSpeech: (text, gender, language = 'English') =>
-    executeCmd(null, 'playSpeech', {text, gender, language})
+  playSpeech: (text, gender, language = 'English', onComplete) =>
+    executeCmd(null, 'playSpeech', {text, gender, language, onComplete})
 };
 // Note to self - can we use _.zipObject to map argumentNames to arguments here?

--- a/apps/test/unit/AzureTextToSpeechTest.js
+++ b/apps/test/unit/AzureTextToSpeechTest.js
@@ -4,7 +4,14 @@ import AzureTextToSpeech from '@cdo/apps/AzureTextToSpeech';
 
 const assertSoundResponsesEqual = (expected, actual) => {
   assert.deepEqual(expected.bytes, actual.bytes);
-  assert.deepEqual(expected.playbackOptions, actual.playbackOptions);
+  const playbackOptions = ['volume', 'loop', 'forceHTML5', 'allowHTML5Mobile'];
+  playbackOptions.forEach(opt => {
+    assert.deepEqual(
+      expected.playbackOptions[opt],
+      actual.playbackOptions[opt]
+    );
+  });
+  // assert.deepEqual(expected.playbackOptions, actual.playbackOptions);
   assert.deepEqual(expected.profaneWords, actual.profaneWords);
   assert.equal(expected.error, actual.error);
 };

--- a/apps/test/unit/AzureTextToSpeechTest.js
+++ b/apps/test/unit/AzureTextToSpeechTest.js
@@ -11,7 +11,6 @@ const assertSoundResponsesEqual = (expected, actual) => {
       actual.playbackOptions[opt]
     );
   });
-  // assert.deepEqual(expected.playbackOptions, actual.playbackOptions);
   assert.deepEqual(expected.profaneWords, actual.profaneWords);
   assert.equal(expected.error, actual.error);
 };

--- a/apps/test/unit/lib/util/audioApiTest.js
+++ b/apps/test/unit/lib/util/audioApiTest.js
@@ -83,7 +83,7 @@ describe('Audio API', function() {
   });
 
   describe('playSpeech', function() {
-    it('has three arguments, "text", "gender", and "language"', function() {
+    it('has four arguments, "text", "gender", "language", and "onComplete"', function() {
       const funcName = 'playSpeech';
       // Check droplet config for the 2 documented params
       expect(dropletConfig[funcName].paletteParams).to.deep.equal([
@@ -96,12 +96,20 @@ describe('Audio API', function() {
       // Check that executors map arguments to object correctly
       let spy = sinon.spy();
       injectExecuteCmd(spy);
-      executors[funcName]('this is text', 'female', 'English', 'nothing');
+      const onCompleteCallback = () => console.log('done');
+      executors[funcName](
+        'this is text',
+        'female',
+        'English',
+        onCompleteCallback,
+        'no fifth arg'
+      );
       expect(spy).to.have.been.calledOnce;
       expect(spy.firstCall.args[2]).to.deep.equal({
         text: 'this is text',
         gender: 'female',
-        language: 'English'
+        language: 'English',
+        onComplete: onCompleteCallback
       });
     });
 


### PR DESCRIPTION
This will be needed for the play speech block in sprite lab.
![image](https://user-images.githubusercontent.com/8787187/128939590-5f8b6343-fbfd-4829-9f21-039fb6221ea1.png)


Also adds a few missing guards for invalid parameter types. These shouldn't cause real browser errors (because it just ends up as noise in newrelic):
![image](https://user-images.githubusercontent.com/8787187/128939312-46945e07-20b6-4719-bd45-23fa66b01419.png)
![image](https://user-images.githubusercontent.com/8787187/128939304-bacb5933-0807-403c-8f5c-dcf0c24f3888.png)

After:
![image](https://user-images.githubusercontent.com/8787187/128939485-6c68bec9-db3f-4037-af18-587a858cd172.png)
