### PR TITLE
JavaLab: Fix instructions collapse

### DIFF
--- a/apps/src/javalab/JavalabView.jsx
+++ b/apps/src/javalab/JavalabView.jsx
@@ -64,7 +64,8 @@ class JavalabView extends React.Component {
     instructionsRenderedHeight: PropTypes.number.isRequired,
     longInstructions: PropTypes.string,
     awaitingContainedResponse: PropTypes.bool,
-    isVisualizationCollapsed: PropTypes.bool
+    isVisualizationCollapsed: PropTypes.bool,
+    isInstructionsCollapsed: PropTypes.bool
   };
 
   state = {
@@ -182,7 +183,12 @@ class JavalabView extends React.Component {
   };
 
   getInstructionsHeight = () => {
-    if (this.props.isVisualizationCollapsed || !this.props.visualization) {
+    if (this.props.isInstructionsCollapsed) {
+      return 30;
+    } else if (
+      this.props.isVisualizationCollapsed ||
+      !this.props.visualization
+    ) {
       return this.props.instructionsFullHeight;
     } else {
       return Math.min(
@@ -193,7 +199,11 @@ class JavalabView extends React.Component {
   };
 
   shouldShowInstructionsHeightResizer = () => {
-    return !this.props.isVisualizationCollapsed && this.props.visualization;
+    return (
+      !this.props.isInstructionsCollapsed &&
+      !this.props.isVisualizationCollapsed &&
+      this.props.visualization
+    );
   };
 
   isLeftSideVisible = () => {
@@ -494,7 +504,8 @@ export default connect(
     instructionsRenderedHeight: state.instructions.renderedHeight,
     longInstructions: state.instructions.longInstructions,
     awaitingContainedResponse: state.runState.awaitingContainedResponse,
-    isVisualizationCollapsed: state.javalab.isVisualizationCollapsed
+    isVisualizationCollapsed: state.javalab.isVisualizationCollapsed,
+    isInstructionsCollapsed: state.instructions.isCollapsed
   }),
   dispatch => ({
     appendOutputLog: log => dispatch(appendOutputLog(log)),

--- a/apps/src/javalab/PreviewPaneHeader.jsx
+++ b/apps/src/javalab/PreviewPaneHeader.jsx
@@ -69,6 +69,7 @@ PreviewPaneHeader.propTypes = {
 
 const styles = {
   transparent: {
+    marginLeft: -4, // Adjust icon position to align with instructions collapser icon.
     backgroundColor: 'transparent',
     ':hover': {
       backgroundColor: 'transparent'

--- a/apps/src/templates/CollapserIcon.jsx
+++ b/apps/src/templates/CollapserIcon.jsx
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types';
 
 const styles = {
   icon: {
-    fontSize: 18
+    fontSize: 18,
+    fontWeight: 400
   }
 };
 
@@ -23,7 +24,7 @@ function CollapserIcon({
       onClick={onClick}
       role="button"
       className={iconClass + ' fa'}
-      style={{...styles.icon, ...style}}
+      style={{...style, ...styles.icon}}
     />
   );
 }

--- a/apps/src/templates/instructions/TopInstructionsHeader.jsx
+++ b/apps/src/templates/instructions/TopInstructionsHeader.jsx
@@ -52,6 +52,7 @@ const styles = {
       position: 'absolute',
       top: 0,
       margin: 0,
+      cursor: 'pointer',
       lineHeight: styleConstants['workspace-headers-height'] + 'px',
       fontSize: 18,
       ':hover': {


### PR DESCRIPTION
Instructions can now be collapsed again.  Fix for https://github.com/code-dot-org/code-dot-org/pull/41936.

Also fixes icon size and alignment in the visualization header, and mouse cursor in the instructions header.

#### both panels showing
<img width="421" alt="Screen Shot 2021-08-11 at 12 56 09 PM" src="https://user-images.githubusercontent.com/2205926/128963118-7b5a9271-aec3-4024-a4a7-c20a9c1727d3.png">

#### instructions collapsed
<img width="423" alt="Screen Shot 2021-08-11 at 12 55 27 PM" src="https://user-images.githubusercontent.com/2205926/128963104-95eeb377-eff9-45d4-99e6-5b74a489556c.png">

#### visualization collapsed
<img width="429" alt="Screen Shot 2021-08-11 at 12 55 35 PM" src="https://user-images.githubusercontent.com/2205926/128963113-91760a6f-10fe-4554-9c81-117f8eef42c8.png">

#### both panels collapsed
<img width="419" alt="Screen Shot 2021-08-11 at 12 55 45 PM" src="https://user-images.githubusercontent.com/2205926/128963116-6fea6689-d19a-4e5c-ac30-2d76d1a0b5b9.png">

 