### PR TITLE
JavaLab: Force LTR layout

### DIFF
--- a/apps/src/javalab/JavalabView.jsx
+++ b/apps/src/javalab/JavalabView.jsx
@@ -457,7 +457,8 @@ const styles = {
   },
   javalab: {
     display: 'flex',
-    flexWrap: 'wrap'
+    flexWrap: 'wrap',
+    direction: 'ltr'
   },
   clear: {
     clear: 'both'

--- a/apps/style/javalab/style.scss
+++ b/apps/style/javalab/style.scss
@@ -116,3 +116,12 @@ div#visualizationResizeBar {
   left: 10px;
   right: 10px;
 }
+
+// Override regular behavior while we are forcing JavaLab to be LTR only.
+#visualization.responsive > * {
+  html[dir="RTL"] & {
+    -webkit-transform-origin: 0 0;
+    -ms-transform-origin: 0 0;
+    transform-origin: 0 0;
+  }
+}


### PR DESCRIPTION
Although the RTL layout isn't too far from basically working, JavaLab is intended for english only for now, so for users with an RTL language, we'll force the JavaLab portion of the screen to be LTR for now.

#### before in RTL
<img width="1280" alt="Screen Shot 2021-08-11 at 1 17 03 PM" src="https://user-images.githubusercontent.com/2205926/128971913-b630b370-9156-40ea-9a7b-bf2cf98595f4.png">

#### after in RTL
<img width="1280" alt="Screen Shot 2021-08-11 at 2 51 50 PM" src="https://user-images.githubusercontent.com/2205926/128971926-96991424-a2c6-4d13-b76f-e6623f527d0c.png">
