### PR TITLE
show all course units on course edit page

### DIFF
--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -194,10 +194,8 @@ class UnitGroup < ApplicationRecord
     units_to_remove = default_unit_group_units.map(&:script) - new_units_objects
     units_to_remove -= alternate_units.map {|hash| Script.find_by_name!(hash['alternate_script'])}
 
-    if units_to_remove.any?(&:prevent_course_version_change?)
-      unit_names = units_to_remove.select(&:prevent_course_version_change?).map(&:name)
-      raise "Cannot remove units that have resources or vocabulary: #{unit_names}"
-    end
+    unremovable_unit_names = units_to_remove.select(&:prevent_course_version_change?).map(&:name)
+    raise "Cannot remove units that have resources or vocabulary: #{unremovable_unit_names}" if unremovable_unit_names.any?
 
     if new_units_objects.any? do |s|
       s.unit_group != self && s.prevent_course_version_change?

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -195,7 +195,8 @@ class UnitGroup < ApplicationRecord
     units_to_remove -= alternate_units.map {|hash| Script.find_by_name!(hash['alternate_script'])}
 
     if units_to_remove.any?(&:prevent_course_version_change?)
-      raise 'Cannot remove units that have resources or vocabulary'
+      unit_names = units_to_remove.select(&:prevent_course_version_change?).map(&:name)
+      raise "Cannot remove units that have resources or vocabulary: #{unit_names}"
     end
 
     if new_units_objects.any? do |s|

--- a/dashboard/app/views/courses/edit.html.haml
+++ b/dashboard/app/views/courses/edit.html.haml
@@ -1,5 +1,5 @@
 - unit_group = local_assigns[:unit_group]
-- course_editor_data = {course_summary: unit_group.summarize(for_edit: true),
+- course_editor_data = {course_summary: unit_group.summarize(current_user, for_edit: true),
                         script_names: Script.all.map(&:name),
                         course_families: UnitGroup.family_names,
                         version_year_options: UnitGroup.get_version_year_options}


### PR DESCRIPTION
https://github.com/code-dot-org/code-dot-org/pull/41896 introduced a regression where `in_development` units would not appear on the course edit page. saving the course page would then either remove these units, or fail to save because the units could not be removed. See [slack](https://codedotorg.slack.com/archives/CNZP84FJ5/p1628696801045100) for more details and screenshots.

## Testing story

* manually verified that all CSA units appear on http://localhost-studio.code.org:3000/courses/csa-pilot/edit
* courses controller tests are passing locally
* i'll wait for a successful drone run before merging