### PR TITLE
Enforce consistency in the /pd/international_workshop country field stored values

### DIFF
--- a/dashboard/app/models/pd/international_opt_in.rb
+++ b/dashboard/app/models/pd/international_opt_in.rb
@@ -98,6 +98,7 @@ class Pd::InternationalOptIn < ApplicationRecord
     # apps/src/code-studio/pd/form_components/utils.js
     entries = Hash[entry_keys.map do |key, values|
       [key, values.map do |value|
+        # Capitalize country values to be consistent with other country strings in our database
         answer = key.to_s == 'schoolCountry' ? value.titleize : value
         {
           answerText: I18n.t("pd.form_entries.#{key.to_s.underscore}.#{value.underscore}"),

--- a/dashboard/app/models/pd/international_opt_in.rb
+++ b/dashboard/app/models/pd/international_opt_in.rb
@@ -98,9 +98,10 @@ class Pd::InternationalOptIn < ApplicationRecord
     # apps/src/code-studio/pd/form_components/utils.js
     entries = Hash[entry_keys.map do |key, values|
       [key, values.map do |value|
+        answer = key.to_s == 'schoolCountry' ? value.titleize : value
         {
           answerText: I18n.t("pd.form_entries.#{key.to_s.underscore}.#{value.underscore}"),
-          answerValue: value
+          answerValue: answer
         }
       end]
     end]


### PR DESCRIPTION
**What**
Country values within the PD InternationalOptIn form are titleized during form creation.

**Why**
To have the values stored in a capitalized format and be consistent with other stored country values across our database (ex. `user_geos`,`form_geos`).

## Links

- jira ticket: [FND-1232](https://codedotorg.atlassian.net/browse/FND-1232)

## Testing story

- Tested locally
Completed local form with no changes and one with these changes. The stored country value was successfully capitalized as intended.


https://user-images.githubusercontent.com/48133820/129109188-4f3d34c6-4159-4ae4-a585-bbd40fa4da98.mov


## Follow-up work

As mentioned in [this ticket](https://codedotorg.atlassian.net/browse/FND-1232) we need to clean up old country values from being in other languages/translated incorrectly.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
