### PR TITLE
Migration to include level information with code review comment

### DIFF
--- a/dashboard/app/models/code_review_comment.rb
+++ b/dashboard/app/models/code_review_comment.rb
@@ -5,6 +5,8 @@
 #  id               :bigint           not null, primary key
 #  storage_app_id   :integer          not null
 #  project_version  :string(255)
+#  script_id        :integer
+#  level_id         :integer
 #  commenter_id     :integer          not null
 #  comment          :text(16777215)
 #  project_owner_id :integer

--- a/dashboard/db/migrate/20210811223210_add_level_and_script_id_to_code_review_comments.rb
+++ b/dashboard/db/migrate/20210811223210_add_level_and_script_id_to_code_review_comments.rb
@@ -1,0 +1,6 @@
+class AddLevelAndScriptIdToCodeReviewComments < ActiveRecord::Migration[5.2]
+  def change
+    add_column :code_review_comments, :script_id, :integer, after: :project_version
+    add_column :code_review_comments, :level_id, :integer, after: :script_id
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_10_172702) do
+ActiveRecord::Schema.define(version: 2021_08_11_223210) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -278,6 +278,8 @@ ActiveRecord::Schema.define(version: 2021_08_10_172702) do
   create_table "code_review_comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin", force: :cascade do |t|
     t.integer "storage_app_id", null: false
     t.string "project_version"
+    t.integer "script_id"
+    t.integer "level_id"
     t.integer "commenter_id", null: false
     t.text "comment", limit: 16777215
     t.integer "project_owner_id"


### PR DESCRIPTION
Add columns to log level ID and script ID when writing new code review comments. This will give us flexibility to decide whether to show comments on a per-level basis for levels that share a single project (or, show all comments across all levels that are backed by the same project, which is the existing behavior).

## Testing story

Ran migration up and down locally.