### PR TITLE
Added test and documentation for template level starter_assets

### DIFF
--- a/dashboard/app/views/levels/editors/fields/_special_level_types.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_special_level_types.html.haml
@@ -34,6 +34,7 @@
         %li if start_blocks are defined in the project template level, use those instead of the start blocks for this level
         %li if toolbox_blocks are defined in the project template level, use those instead of the toolbox blocks for this level
         %li For Weblab - if Starting Sources are defined in the project template level, use those instead of the Starting Sources for this level
+        %li if starter_assets are defined in the project template level, use those instead of the starter_assets for this level
         %li autocreate a project that is shared with all levels with the same project template level
       %p
         (Leave blank if you do not want all of this)

--- a/dashboard/test/controllers/level_starter_assets_controller_test.rb
+++ b/dashboard/test/controllers/level_starter_assets_controller_test.rb
@@ -54,10 +54,8 @@ class LevelStarterAssetsControllerTest < ActionController::TestCase
     uuid_name_1 = "#{SecureRandom.uuid}.png"
     key_1 = "starter_assets/#{uuid_name_1}"
     uuid_name_2 = "#{SecureRandom.uuid}.jpg"
-    key_2 = "starter_assets/#{uuid_name_2}"
     file_objs = [
-      MockS3ObjectSummary.new(key_1, 123, 1.day.ago),
-      MockS3ObjectSummary.new(key_2, 321, 2.days.ago)
+      MockS3ObjectSummary.new(key_1, 123, 1.day.ago)
     ]
     LevelStarterAssetsController.any_instance.
       expects(:get_object).once.

--- a/dashboard/test/controllers/level_starter_assets_controller_test.rb
+++ b/dashboard/test/controllers/level_starter_assets_controller_test.rb
@@ -50,6 +50,40 @@ class LevelStarterAssetsControllerTest < ActionController::TestCase
     assert_equal file_objs[1].size, starter_assets[1]['size']
   end
 
+  test 'show: returns template level starter_assets when defined' do
+    uuid_name_1 = "#{SecureRandom.uuid}.png"
+    key_1 = "starter_assets/#{uuid_name_1}"
+    uuid_name_2 = "#{SecureRandom.uuid}.jpg"
+    key_2 = "starter_assets/#{uuid_name_2}"
+    file_objs = [
+      MockS3ObjectSummary.new(key_1, 123, 1.day.ago),
+      MockS3ObjectSummary.new(key_2, 321, 2.days.ago)
+    ]
+    LevelStarterAssetsController.any_instance.
+      expects(:get_object).once.
+      returns(file_objs[0])
+    level_starter_asset_1 = {
+      'ty.png' => uuid_name_1
+    }
+    level_starter_asset_2 = {
+      'welcome.jpg' => uuid_name_2
+    }
+    template_level = create(:applab, starter_assets: level_starter_asset_1)
+
+    child_level = create(:applab)
+    child_level.project_template_level_name = template_level.name
+    child_level.starter_assets = level_starter_asset_2
+    child_level.save!
+
+    # start assets comes from template_level not child_level
+    get :show, params: {level_name: child_level.name}
+    assert_response :success
+    starter_assets = JSON.parse(response.body)['starter_assets']
+    assert_equal 'ty.png', starter_assets[0]['filename']
+    assert_equal 'image', starter_assets[0]['category']
+    assert_equal file_objs[0].size, starter_assets[0]['size']
+  end
+
   test 'file: returns requested file' do
     LevelStarterAssetsController.any_instance.
       expects(:get_object).


### PR DESCRIPTION
This is a follow-up to a PR that was merged without tests: https://github.com/code-dot-org/code-dot-org/pull/41958 

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
