### PR TITLE
Updated levels to reflect standalone plan

### DIFF
--- a/dashboard/config/scripts/allthethings.script
+++ b/dashboard/config/scripts/allthethings.script
@@ -1,6 +1,5 @@
 hideable_lessons true
 lesson_extras_available true
-published_state 'beta'
 
 lesson 'Jigsaw', display_name: 'Jigsaw', has_lesson_plan: false
 level 'blockly:Jigsaw:3'
@@ -201,8 +200,8 @@ variants
   level '4-5 Maze 6', active: false
 endvariants
 variants
-  level 'csp_socialBelonging_control'
   level 'csp_socialBelonging_intervention', experiments: ["socialBelongingTest"]
+  level 'csp_socialBelonging_control'
 endvariants
 
 lesson 'Anonymous student survey', display_name: 'Anonymous student survey', has_lesson_plan: false

--- a/dashboard/config/scripts/allthethings.script
+++ b/dashboard/config/scripts/allthethings.script
@@ -1,5 +1,6 @@
 hideable_lessons true
 lesson_extras_available true
+published_state 'beta'
 
 lesson 'Jigsaw', display_name: 'Jigsaw', has_lesson_plan: false
 level 'blockly:Jigsaw:3'
@@ -200,8 +201,8 @@ variants
   level '4-5 Maze 6', active: false
 endvariants
 variants
-  level 'csp_socialBelonging_intervention', experiments: ["socialBelongingTest"]
   level 'csp_socialBelonging_control'
+  level 'csp_socialBelonging_intervention', experiments: ["socialBelongingTest"]
 endvariants
 
 lesson 'Anonymous student survey', display_name: 'Anonymous student survey', has_lesson_plan: false
@@ -275,4 +276,5 @@ level 'Allthethings Java Lab 4'
 level 'csa widget test2'
 level 'Allthethings Java Lab 6'
 level 'Allthethings Java Lab 7'
+level 'Allthethings Java Lab 8'
 level 'Allthethings Java Lab Playground'

--- a/dashboard/config/scripts/levels/Allthethings Java Lab 2.level
+++ b/dashboard/config/scripts/levels/Allthethings Java Lab 2.level
@@ -1,12 +1,27 @@
 <Javalab>
   <config><![CDATA[{
+  "properties": {
+    "encrypted": "false",
+    "long_instructions": "## Console-only level\r\n\r\nA console-only level should have no visualization space (unlike Theater, Neighborhood, etc). Additionally, the instruction space should take up the entire left column.\r\n\r\nA console-only level will always have instructions. Java Lab standalone levels will be Theater levels.\r\n",
+    "mini_rubric": "false",
+    "hide_share_and_remix": "false",
+    "csa_view_mode": "console",
+    "start_sources": {
+      "MyClass.java": {
+        "text": "import java.util.Scanner;\n\npublic class MyClass {\n  public static void main(String[] args) {\n    Scanner myScanner = new Scanner(System.in);\n    System.out.println(\"What's your name?\");\n    String response = myScanner.nextLine();\n    System.out.println(\"Hello \" + response + \"!\");\n  }\n}\n",
+        "isVisible": true
+      }
+    },
+    "encrypted_examples": [
+
+    ]
+  },
   "game_id": 68,
-  "created_at": "2021-02-15T20:07:34.000Z",
+  "published": true,
+  "created_at": "2021-03-04T21:07:03.000Z",
   "level_num": "custom",
   "user_id": 1,
-  "properties": {
-  },
-  "published": true,
-  "notes": ""
+  "notes": "",
+  "audit_log": "[{\"changed_at\":\"2021-07-29 00:06:02 +0000\",\"changed\":[],\"changed_by_id\":22,\"changed_by_email\":\"jessica+localtest@code.org\"},{\"changed_at\":\"2021-08-12 15:40:48 +0000\",\"changed\":[\"long_instructions\",\"contained_level_names\"],\"changed_by_id\":22,\"changed_by_email\":\"jessica+localtest@code.org\"},{\"changed_at\":\"2021-08-12 15:47:58 +0000\",\"changed\":[],\"changed_by_id\":22,\"changed_by_email\":\"jessica+localtest@code.org\"},{\"changed_at\":\"2021-08-12 15:50:04 +0000\",\"changed\":[\"long_instructions\"],\"changed_by_id\":22,\"changed_by_email\":\"jessica+localtest@code.org\"}]"
 }]]></config>
 </Javalab>

--- a/dashboard/config/scripts/levels/Allthethings Java Lab 8.level
+++ b/dashboard/config/scripts/levels/Allthethings Java Lab 8.level
@@ -1,0 +1,22 @@
+<Javalab>
+  <config><![CDATA[{
+  "properties": {
+    "encrypted": "false",
+    "mini_rubric": "false",
+    "hide_share_and_remix": "false",
+    "csa_view_mode": "theater",
+    "start_sources": {
+      "MyClass.java": {
+        "text": "// This is a sample of what a standalone level could look like \n// for Java Lab. Java Lab standalone levels will be Theater\n// levels without instructions.\n\npublic class MyClass {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\");\n  }\n}\n",
+        "isVisible": true
+      }
+    }
+  },
+  "game_id": 68,
+  "created_at": "2021-08-12T15:53:20.000Z",
+  "level_num": "custom",
+  "user_id": 22,
+  "published": true,
+  "audit_log": "[{\"changed_at\":\"2021-08-12 15:56:03 +0000\",\"changed\":[],\"changed_by_id\":22,\"changed_by_email\":\"jessica+localtest@code.org\"}]"
+}]]></config>
+</Javalab>

--- a/dashboard/config/scripts/levels/New Java Lab Project.level
+++ b/dashboard/config/scripts/levels/New Java Lab Project.level
@@ -1,14 +1,21 @@
 <Javalab>
   <config><![CDATA[{
+  "properties": {
+    "is_project_level": "true",
+    "encrypted": "false",
+    "encrypted_examples": [
+
+    ],
+    "mini_rubric": "false",
+    "hide_share_and_remix": "false",
+    "csa_view_mode": "theater"
+  },
   "game_id": 68,
-  "created_at": "2021-02-15T20:07:34.000Z",
+  "published": true,
+  "created_at": "2021-02-27T00:41:17.000Z",
   "level_num": "custom",
   "user_id": 1,
-  "properties": {
-    "is_project_level": "true"
-  },
-  "published": true,
   "notes": "",
-  "long_instructions": "# Java Lab \r\n This is a new Java Lab project! Write some Java code!"
+  "audit_log": "[{\"changed_at\":\"2021-08-18 18:06:52 +0000\",\"changed\":[\"long_instructions\"],\"changed_by_id\":22,\"changed_by_email\":\"jessica+localtest@code.org\"}]"
 }]]></config>
 </Javalab>

--- a/dashboard/config/scripts_json/allthethings.script_json
+++ b/dashboard/config/scripts_json/allthethings.script_json
@@ -9,7 +9,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2021-08-12 16:15:59 UTC",
+    "serialized_at": "2021-08-18 18:36:12 UTC",
     "published_state": "beta",
     "seeding_key": {
       "script.name": "allthethings"
@@ -5705,7 +5705,7 @@
     },
     {
       "seeding_key": {
-        "level.key": "4-5 Maze 3",
+        "level.key": "4-5 Maze 6",
         "script_level.level_keys": [
           "4-5 Maze 3",
           "4-5 Maze 6"
@@ -5717,7 +5717,7 @@
     },
     {
       "seeding_key": {
-        "level.key": "4-5 Maze 6",
+        "level.key": "4-5 Maze 3",
         "script_level.level_keys": [
           "4-5 Maze 3",
           "4-5 Maze 6"

--- a/dashboard/config/scripts_json/allthethings.script_json
+++ b/dashboard/config/scripts_json/allthethings.script_json
@@ -4,13 +4,13 @@
     "wrapup_video_id": null,
     "login_required": false,
     "properties": {
-      "lesson_extras_available": true,
-      "hideable_lessons": true
+      "hideable_lessons": true,
+      "lesson_extras_available": true
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2021-08-18 18:36:12 UTC",
-    "published_state": "beta",
+    "serialized_at": "2021-08-03 22:46:49 UTC",
+    "published_state": null,
     "seeding_key": {
       "script.name": "allthethings"
     }
@@ -4295,6 +4295,7 @@
           "Allthethings Java Lab 6"
         ]
       },
+      "named_level": false,
       "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
@@ -4318,6 +4319,7 @@
           "Allthethings Java Lab 7"
         ]
       },
+      "named_level": false,
       "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
@@ -4329,29 +4331,6 @@
       },
       "level_keys": [
         "Allthethings Java Lab 7"
-      ]
-    },
-    {
-      "chapter": 154,
-      "position": 8,
-      "activity_section_position": null,
-      "assessment": false,
-      "properties": {
-        "level_keys": [
-          "Allthethings Java Lab 8"
-        ]
-      },
-      "bonus": false,
-      "seeding_key": {
-        "script_level.level_keys": [
-          "Allthethings Java Lab 8"
-        ],
-        "lesson.key": "Java Lab",
-        "lesson_group.key": "",
-        "script.name": "allthethings"
-      },
-      "level_keys": [
-        "Allthethings Java Lab 8"
       ]
     }
   ],
@@ -5585,7 +5564,7 @@
     },
     {
       "seeding_key": {
-        "level.key": "2-3 Artist 1 new",
+        "level.key": "ramp_video_artistIntro",
         "script_level.level_keys": [
           "2-3 Artist 1 new",
           "ramp_video_artistIntro"
@@ -5597,7 +5576,7 @@
     },
     {
       "seeding_key": {
-        "level.key": "ramp_video_artistIntro",
+        "level.key": "2-3 Artist 1 new",
         "script_level.level_keys": [
           "2-3 Artist 1 new",
           "ramp_video_artistIntro"
@@ -5705,7 +5684,7 @@
     },
     {
       "seeding_key": {
-        "level.key": "4-5 Maze 6",
+        "level.key": "4-5 Maze 3",
         "script_level.level_keys": [
           "4-5 Maze 3",
           "4-5 Maze 6"
@@ -5717,7 +5696,7 @@
     },
     {
       "seeding_key": {
-        "level.key": "4-5 Maze 3",
+        "level.key": "4-5 Maze 6",
         "script_level.level_keys": [
           "4-5 Maze 3",
           "4-5 Maze 6"
@@ -6163,17 +6142,6 @@
         "level.key": "Allthethings Java Lab 7",
         "script_level.level_keys": [
           "Allthethings Java Lab 7"
-        ],
-        "lesson.key": "Java Lab",
-        "lesson_group.key": "",
-        "script.name": "allthethings"
-      }
-    },
-    {
-      "seeding_key": {
-        "level.key": "Allthethings Java Lab 8",
-        "script_level.level_keys": [
-          "Allthethings Java Lab 8"
         ],
         "lesson.key": "Java Lab",
         "lesson_group.key": "",

--- a/dashboard/config/scripts_json/allthethings.script_json
+++ b/dashboard/config/scripts_json/allthethings.script_json
@@ -4,13 +4,13 @@
     "wrapup_video_id": null,
     "login_required": false,
     "properties": {
-      "hideable_lessons": true,
-      "lesson_extras_available": true
+      "lesson_extras_available": true,
+      "hideable_lessons": true
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2021-08-03 22:46:49 UTC",
-    "published_state": null,
+    "serialized_at": "2021-08-12 16:15:59 UTC",
+    "published_state": "beta",
     "seeding_key": {
       "script.name": "allthethings"
     }
@@ -4295,7 +4295,6 @@
           "Allthethings Java Lab 6"
         ]
       },
-      "named_level": false,
       "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
@@ -4319,7 +4318,6 @@
           "Allthethings Java Lab 7"
         ]
       },
-      "named_level": false,
       "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
@@ -4331,6 +4329,29 @@
       },
       "level_keys": [
         "Allthethings Java Lab 7"
+      ]
+    },
+    {
+      "chapter": 154,
+      "position": 8,
+      "activity_section_position": null,
+      "assessment": false,
+      "properties": {
+        "level_keys": [
+          "Allthethings Java Lab 8"
+        ]
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Allthethings Java Lab 8"
+        ],
+        "lesson.key": "Java Lab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      },
+      "level_keys": [
+        "Allthethings Java Lab 8"
       ]
     }
   ],
@@ -5564,7 +5585,7 @@
     },
     {
       "seeding_key": {
-        "level.key": "ramp_video_artistIntro",
+        "level.key": "2-3 Artist 1 new",
         "script_level.level_keys": [
           "2-3 Artist 1 new",
           "ramp_video_artistIntro"
@@ -5576,7 +5597,7 @@
     },
     {
       "seeding_key": {
-        "level.key": "2-3 Artist 1 new",
+        "level.key": "ramp_video_artistIntro",
         "script_level.level_keys": [
           "2-3 Artist 1 new",
           "ramp_video_artistIntro"
@@ -6142,6 +6163,17 @@
         "level.key": "Allthethings Java Lab 7",
         "script_level.level_keys": [
           "Allthethings Java Lab 7"
+        ],
+        "lesson.key": "Java Lab",
+        "lesson_group.key": "",
+        "script.name": "allthethings"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "Allthethings Java Lab 8",
+        "script_level.level_keys": [
+          "Allthethings Java Lab 8"
         ],
         "lesson.key": "Java Lab",
         "lesson_group.key": "",


### PR DESCRIPTION
Originally, we were thinking our console levels would be the Java Lab standalone level type. Now, however, we are planning that Theater levels will be the standalone level type. This adds an example allthethings of what that would look like as well as updates our allthethings console level to more accurately display the student experience. This came up because there was confusion about display bugs related to console levels without instructions - for example, a console level without instructions will have the run button covered up by the "extra links" menu. These bugs do not need fixing as console levels should always have instructions.

Sample standalone level
![image](https://user-images.githubusercontent.com/8324574/129232042-fa663a4a-3446-4ee3-b103-f892fcb58edf.png)

Updated console level
![image](https://user-images.githubusercontent.com/8324574/129232121-4727e488-552c-4a03-a66f-8a8807db016f.png)


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
