### PR TITLE
Adding levelbuilder details box dismissal

### DIFF
--- a/dashboard/app/views/shared/_extra_links.html.haml
+++ b/dashboard/app/views/shared/_extra_links.html.haml
@@ -1,7 +1,7 @@
 .extra-links
   %h4
     Extra Links:
-    %a{href: '#', onclick: 'return extraLinksClick()'} [hide/show]
+    %a{id: 'levelbuilder-menu-toggle', href: '#', onclick: 'return extraLinksClick()'} [hide/show]
   .content
     = yield
 

--- a/dashboard/test/ui/features/javalab/neighborhood.feature
+++ b/dashboard/test/ui/features/javalab/neighborhood.feature
@@ -4,7 +4,8 @@ Feature: NeighborhoodPainting
 @no_circle
   Scenario: Paint Glomming Shapes
     When I open my eyes to test "Paint Glomming Shapes"
-    Given I create a levelbuilder named "Simone"
+    Given I create a teacher named "Simone"
+    And I give user "Simone" pilot access to "csa-pilot"
     And I am on "http://studio.code.org/s/allthethings/lessons/44/levels/7"
     And I wait for the page to fully load
     Then I set slider speed to fast
@@ -14,7 +15,8 @@ Feature: NeighborhoodPainting
     Then I close my eyes
 
   #Scenario: Stop Button Closes Connection
-    #Given I create a levelbuilder named "Simone"
+    #Given I create a teacher named "Simone"
+    #And I give user "Simone" pilot access to "csa-pilot"
     #And I am on "http://studio.code.org/s/allthethings/lessons/44/levels/7"
     #And I rotate to landscape
     #And I wait for the page to fully load

--- a/dashboard/test/ui/features/javalab/neighborhood.feature
+++ b/dashboard/test/ui/features/javalab/neighborhood.feature
@@ -4,10 +4,10 @@ Feature: NeighborhoodPainting
 @no_circle
   Scenario: Paint Glomming Shapes
     When I open my eyes to test "Paint Glomming Shapes"
-    Given I create a teacher named "Simone"
-    And I give user "Simone" pilot access to "csa-pilot"
+    Given I create a levelbuilder named "Simone"
     And I am on "http://studio.code.org/s/allthethings/lessons/44/levels/7"
     And I wait for the page to fully load
+    Then I press "#levelbuilder-menu-toggle" using jQuery
     Then I set slider speed to fast
     Then I press "runButton"
     And I wait for 15 seconds
@@ -15,8 +15,7 @@ Feature: NeighborhoodPainting
     Then I close my eyes
 
   #Scenario: Stop Button Closes Connection
-    #Given I create a teacher named "Simone"
-    #And I give user "Simone" pilot access to "csa-pilot"
+    #Given I create a levelbuilder named "Simone"
     #And I am on "http://studio.code.org/s/allthethings/lessons/44/levels/7"
     #And I rotate to landscape
     #And I wait for the page to fully load

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -935,15 +935,6 @@ Then /^the overview page contains ([\d]+) assign (?:button|buttons)$/ do |expect
   expect(actual_num).to eq(expected_num.to_i)
 end
 
-And(/^I give user "([^"]*)" pilot access to "([^"]*)"$/) do |name, pilot|
-  require_rails_env
-  user = User.find_by_email_or_hashed_email(@users[name][:email])
-  SingleUserExperiment.find_or_create_by!(
-    min_user_id: user.id,
-    name: pilot
-  )
-end
-
 And /^I dismiss the language selector$/ do
   steps %Q{
     And I click selector ".close" if I see it

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -935,6 +935,15 @@ Then /^the overview page contains ([\d]+) assign (?:button|buttons)$/ do |expect
   expect(actual_num).to eq(expected_num.to_i)
 end
 
+And(/^I give user "([^"]*)" pilot access to "([^"]*)"$/) do |name, pilot|
+  require_rails_env
+  user = User.find_by_email_or_hashed_email(@users[name][:email])
+  SingleUserExperiment.find_or_create_by!(
+    min_user_id: user.id,
+    name: pilot
+  )
+end
+
 And /^I dismiss the language selector$/ do
   steps %Q{
     And I click selector ".close" if I see it


### PR DESCRIPTION
The UI test is set up with a levelbuilder user because those users automatically have access to the pilot and to javabuilder. This also meant the levelbuilder links showed up, blocking the eyes test. This PR creates a way to dismiss the details box, allowing for the eyes baseline to include all of the paint glomming shapes.

Testing:
I tested this locally on a Saucebuild Connect Tunnel to my localhost to ensure the new click line works to dismiss the box. The only thing I cannot completely check is the actual glomming run via javabuilder because this configuration would require saucelabs hitting my local instance of Javabuilder, which it cannot do. Because this test worked in the test environment/staging otherwise, I trust the javabuilder connection will still work. I will paste below the screenshot of the saucelabs run confirming this new line collapses the levelbuilder box.

What the eyes test looked like:
![image](https://user-images.githubusercontent.com/37230822/129243427-2041bb80-1fe4-433d-a15a-d0c9b7b49cc1.png)

Confirmation of the levelbuilder box collapse:
![image](https://user-images.githubusercontent.com/37230822/129252078-eb8f8a21-c9b0-4e8d-8fac-6e13ecd71859.png)


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
