### PR TITLE
Revert "Upgrade react-tooltip"

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -180,7 +180,7 @@
     "react-select": "^1.2.1",
     "react-sticky": "^6.0.3",
     "react-tether": "^1.0.4",
-    "react-tooltip": "^4.2.3",
+    "react-tooltip": "^3.2.7",
     "react-virtualized": "^9.18.5",
     "react-virtualized-select": "^3.0.1",
     "react-with-context": "^2.0.0",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -13095,13 +13095,12 @@ react-textarea-autosize@^7.0.4:
     "@babel/runtime" "^7.1.2"
     prop-types "^15.6.0"
 
-react-tooltip@^4.2.3:
-  version "4.2.21"
-  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-4.2.21.tgz#840123ed86cf33d50ddde8ec8813b2960bfded7f"
-  integrity sha512-zSLprMymBDowknr0KVDiJ05IjZn9mQhhg4PRsqln0OZtURAJ1snt1xi5daZfagsh6vfsziZrc9pErPTDY1ACig==
+react-tooltip@^3.2.7:
+  version "3.9.2"
+  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-3.9.2.tgz#df74e6f5fd454bb15132d5d2d506895cf505cb5e"
   dependencies:
-    prop-types "^15.7.2"
-    uuid "^7.0.3"
+    classnames "^2.2.5"
+    prop-types "^15.6.0"
 
 react-transition-group@2.9.0, react-transition-group@^2.2.1:
   version "2.9.0"
@@ -15959,11 +15958,6 @@ uuid@^3.0.1, uuid@^3.1.0:
 uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
-
-uuid@^7.0.3:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
-  integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
 
 validate-npm-package-license@^3.0.1:
   version "3.0.1"

--- a/dashboard/test/ui/features/learning_platform/level_types/level_group_multi_page_dots.feature
+++ b/dashboard/test/ui/features/learning_platform/level_types/level_group_multi_page_dots.feature
@@ -53,11 +53,9 @@ Scenario: Submit three pages as... 1. all, 2. none, 3. some questions answered.
 
   # Open the dropdown and verify the same three dots.
   Then I open the progress drop down of the current page
-  # TODO: Fix steps below after react-tooltip upgrade. Behavior has been verified manually.
-  # Tracked by https://codedotorg.atlassian.net/browse/LP-1988
-  # And I verify progress in the drop down of the current page is "perfect_assessment" for lesson 23 level 2
-  # And I verify progress in the drop down of the current page is "not_tried" for lesson 23 level 3
-  # And I verify progress in the drop down of the current page is "attempted_assessment" for lesson 23 level 4
+  And I verify progress in the drop down of the current page is "perfect_assessment" for lesson 23 level 2
+  And I verify progress in the drop down of the current page is "not_tried" for lesson 23 level 3
+  And I verify progress in the drop down of the current page is "attempted_assessment" for lesson 23 level 4
 
   # Go to the course page and verify the same three dots.
   Then I navigate to the course page for "allthethings"
@@ -80,11 +78,9 @@ Scenario: Submit three pages as... 1. all, 2. none, 3. some questions answered.
 
   # Open the dropdown and verify the same three dots.
   Then I open the progress drop down of the current page
-  # TODO: Fix steps below after react-tooltip upgrade. Behavior has been verified manually.
-  # Tracked by https://codedotorg.atlassian.net/browse/LP-1988
-  # And I verify progress in the drop down of the current page is "perfect_assessment" for lesson 23 level 2
-  # And I verify progress in the drop down of the current page is "not_tried" for lesson 23 level 3
-  # And I verify progress in the drop down of the current page is "attempted_assessment" for lesson 23 level 4
+  And I verify progress in the drop down of the current page is "perfect_assessment" for lesson 23 level 2
+  And I verify progress in the drop down of the current page is "not_tried" for lesson 23 level 3
+  And I verify progress in the drop down of the current page is "attempted_assessment" for lesson 23 level 4
 
   # Go to the course page and verify the same three dots.
   Then I navigate to the course page for "allthethings"


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#41843

We think this caused some teacher-panel-related UI tests to fail in Win10IE11, although I wasn't able to repro (through Saucelabs) on staging. ([Slack thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1628796648132200))