### PR TITLE
Save commit comments in Javalab

### DIFF
--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -1164,7 +1164,7 @@ var projects = (module.exports = {
             firstSaveTimestamp = response.timestamp;
           }
           currentSourceVersionId = response.versionId;
-          replaceCurrentSourceVersion = true;
+          replaceCurrentSourceVersion = !forceNewVersion;
           current.migratedToS3 = true;
 
           this.updateChannels_(callback);

--- a/apps/src/javalab/CommitDialog.jsx
+++ b/apps/src/javalab/CommitDialog.jsx
@@ -7,7 +7,7 @@ import StylizedBaseDialog, {
 } from '@cdo/apps/componentLibrary/StylizedBaseDialog';
 import {connect} from 'react-redux';
 
-class CommitDialog extends React.Component {
+export class UnconnectedCommitDialog extends React.Component {
   state = {
     filesToBackpack: [],
     commitNotes: '',
@@ -167,6 +167,10 @@ class CommitDialog extends React.Component {
     this.setState({filesToBackpack});
   };
 
+  updateNotes = commitNotes => {
+    this.setState({commitNotes});
+  };
+
   render() {
     const {commitNotes, filesToBackpack} = this.state;
     const {isOpen, files} = this.props;
@@ -184,7 +188,7 @@ class CommitDialog extends React.Component {
             }))}
             notes={commitNotes}
             onToggleFile={this.toggleFileToBackpack}
-            onChangeNotes={commitNotes => this.setState({commitNotes})}
+            onChangeNotes={this.updateNotes}
           />
         }
         renderFooter={this.renderFooter}
@@ -195,7 +199,7 @@ class CommitDialog extends React.Component {
   }
 }
 
-CommitDialog.propTypes = {
+UnconnectedCommitDialog.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   files: PropTypes.arrayOf(PropTypes.string).isRequired,
   handleClose: PropTypes.func.isRequired,
@@ -320,4 +324,4 @@ const styles = {
 export default connect(state => ({
   sources: state.javalab.sources,
   backpackApi: state.javalab.backpackApi
-}))(CommitDialog);
+}))(UnconnectedCommitDialog);

--- a/apps/src/javalab/Javalab.js
+++ b/apps/src/javalab/Javalab.js
@@ -325,7 +325,7 @@ Javalab.prototype.afterClearPuzzle = function() {
 };
 
 Javalab.prototype.onCommitCode = function(commitNotes, onSuccessCallback) {
-  project.save(true, false).then(result => {
+  project.save(true, false, true).then(result => {
     fetch('/project_versions', {
       method: 'POST',
       headers: {

--- a/apps/src/javalab/Javalab.js
+++ b/apps/src/javalab/Javalab.js
@@ -331,7 +331,7 @@ Javalab.prototype.afterClearPuzzle = function() {
 };
 
 Javalab.prototype.onCommitCode = function(commitNotes, onSuccessCallback) {
-  project.save(true, false, true).then(result => {
+  project.save(true).then(result => {
     fetch('/project_versions', {
       method: 'POST',
       headers: {

--- a/apps/src/javalab/Javalab.js
+++ b/apps/src/javalab/Javalab.js
@@ -53,6 +53,8 @@ const Javalab = function() {
   this.studioApp_ = null;
   this.miniApp = null;
   this.visualization = null;
+
+  this.csrf_token = null;
 };
 
 /**
@@ -218,6 +220,10 @@ Javalab.prototype.init = function(config) {
 
   getStore().dispatch(setDisableFinishButton(config.readonlyWorkspace));
 
+  fetch('/project_versions/get_token', {
+    method: 'GET'
+  }).then(response => (this.csrf_token = response.headers.get('csrf-token')));
+
   ReactDOM.render(
     <Provider store={getStore()}>
       <JavalabView
@@ -330,7 +336,7 @@ Javalab.prototype.onCommitCode = function(commitNotes, onSuccessCallback) {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content')
+        'X-CSRF-Token': this.csrf_token
       },
       body: JSON.stringify({
         storage_id: project.getCurrentId(),

--- a/apps/src/javalab/Javalab.js
+++ b/apps/src/javalab/Javalab.js
@@ -324,8 +324,21 @@ Javalab.prototype.afterClearPuzzle = function() {
   project.autosave();
 };
 
-Javalab.prototype.onCommitCode = function(commitNotes) {
-  project.autosave();
+Javalab.prototype.onCommitCode = function(commitNotes, onSuccessCallback) {
+  project.save(true, false).then(result => {
+    fetch('/project_versions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content')
+      },
+      body: JSON.stringify({
+        storage_id: project.getCurrentId(),
+        version_id: project.getCurrentSourceVersionId(),
+        comment: commitNotes
+      })
+    }).then(() => onSuccessCallback());
+  });
 };
 
 Javalab.prototype.onOutputMessage = function(message) {

--- a/apps/test/unit/javalab/CommitDialogTest.js
+++ b/apps/test/unit/javalab/CommitDialogTest.js
@@ -1,0 +1,96 @@
+import React from 'react';
+import {expect} from '../../util/reconfiguredChai';
+import {shallow, mount} from 'enzyme';
+import sinon from 'sinon';
+import {UnconnectedCommitDialog as CommitDialog} from '@cdo/apps/javalab/CommitDialog';
+
+describe('CommitDialog test', () => {
+  let defaultProps, handleCommitSpy, backpackSaveFilesSpy;
+
+  beforeEach(() => {
+    handleCommitSpy = sinon.spy();
+    backpackSaveFilesSpy = sinon.spy();
+    defaultProps = {
+      isOpen: true,
+      files: [],
+      handleClose: () => {},
+      handleCommit: handleCommitSpy,
+      sources: {},
+      backpackApi: {saveFiles: backpackSaveFilesSpy}
+    };
+  });
+
+  it('cannot commit with message', () => {
+    const wrapper = mount(<CommitDialog {...defaultProps} />);
+    expect(
+      wrapper
+        .find('#confirmationButton')
+        .find('FooterButton')
+        .props().disabled
+    ).to.be.true;
+    wrapper.instance().updateNotes('commit notes');
+    wrapper.update();
+    expect(
+      wrapper
+        .find('#confirmationButton')
+        .find('FooterButton')
+        .props().disabled
+    ).to.be.false;
+  });
+
+  it('can commit and save', () => {
+    const wrapper = shallow(<CommitDialog {...defaultProps} />);
+    wrapper.instance().updateNotes('commit notes');
+    wrapper.update();
+    wrapper.instance().commitAndSaveToBackpack();
+    expect(handleCommitSpy).to.be.called.once;
+    expect(backpackSaveFilesSpy).to.be.called.once;
+
+    expect(wrapper.instance().state.backpackSaveInProgress).to.be.true;
+    expect(wrapper.instance().state.commitSaveInProgress).to.be.true;
+  });
+
+  it('dialog closes after save then commit succeeds', () => {
+    const handleCloseSpy = sinon.spy();
+    const wrapper = shallow(
+      <CommitDialog {...defaultProps} handleClose={handleCloseSpy} />
+    );
+    wrapper.instance().updateNotes('commit notes');
+    wrapper.update();
+    wrapper.instance().commitAndSaveToBackpack();
+    expect(handleCommitSpy).to.be.called.once;
+    expect(backpackSaveFilesSpy).to.be.called.once;
+
+    expect(wrapper.instance().state.backpackSaveInProgress).to.be.true;
+    expect(wrapper.instance().state.commitSaveInProgress).to.be.true;
+    expect(handleCloseSpy.callCount).to.equal(0);
+
+    wrapper.instance().handleBackpackSaveSuccess();
+    expect(handleCloseSpy.callCount).to.equal(0);
+
+    wrapper.instance().handleCommitSaveSuccess();
+    expect(handleCloseSpy.callCount).to.equal(1);
+  });
+
+  it('dialog closes after commit then save succeeds', () => {
+    const handleCloseSpy = sinon.spy();
+    const wrapper = shallow(
+      <CommitDialog {...defaultProps} handleClose={handleCloseSpy} />
+    );
+    wrapper.instance().updateNotes('commit notes');
+    wrapper.update();
+    wrapper.instance().commitAndSaveToBackpack();
+    expect(handleCommitSpy).to.be.called.once;
+    expect(backpackSaveFilesSpy).to.be.called.once;
+
+    expect(wrapper.instance().state.backpackSaveInProgress).to.be.true;
+    expect(wrapper.instance().state.commitSaveInProgress).to.be.true;
+    expect(handleCloseSpy.callCount).to.equal(0);
+
+    wrapper.instance().handleCommitSaveSuccess();
+    expect(handleCloseSpy.callCount).to.equal(0);
+
+    wrapper.instance().handleBackpackSaveSuccess();
+    expect(handleCloseSpy.callCount).to.equal(1);
+  });
+});

--- a/dashboard/app/controllers/project_versions_controller.rb
+++ b/dashboard/app/controllers/project_versions_controller.rb
@@ -1,0 +1,15 @@
+class ProjectVersionsController < ApplicationController
+  skip_before_action :verify_authenticity_token
+  before_action :authenticate_user!
+  before_action :decrypt_channel_id, only: [:create, :project_comments]
+
+  # POST /project_versions
+  def create
+    project_version = ProjectVersion.new(storage_app_id: @storage_app_id, object_version_id: params[:version_id], comment: params[:comment])
+    if project_version.save
+      return head :ok
+    else
+      return head :bad_request
+    end
+  end
+end

--- a/dashboard/app/controllers/project_versions_controller.rb
+++ b/dashboard/app/controllers/project_versions_controller.rb
@@ -1,11 +1,11 @@
 class ProjectVersionsController < ApplicationController
   skip_before_action :verify_authenticity_token
   before_action :authenticate_user!
-  before_action :decrypt_channel_id, only: [:create, :project_comments]
 
   # POST /project_versions
   def create
-    project_version = ProjectVersion.new(storage_app_id: @storage_app_id, object_version_id: params[:version_id], comment: params[:comment])
+    _, storage_app_id = storage_decrypt_channel_id(params[:storage_id])
+    project_version = ProjectVersion.new(storage_app_id: storage_app_id, object_version_id: params[:version_id], comment: params[:comment])
     if project_version.save
       return head :ok
     else

--- a/dashboard/app/controllers/project_versions_controller.rb
+++ b/dashboard/app/controllers/project_versions_controller.rb
@@ -1,5 +1,4 @@
 class ProjectVersionsController < ApplicationController
-  skip_before_action :verify_authenticity_token
   before_action :authenticate_user!
 
   # POST /project_versions
@@ -11,5 +10,10 @@ class ProjectVersionsController < ApplicationController
     else
       return head :bad_request
     end
+  end
+
+  def get_token
+    headers['csrf-token'] = form_authenticity_token
+    return head :ok
   end
 end

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -894,6 +894,8 @@ Dashboard::Application.routes.draw do
 
   get '/backpacks/channel', to: 'backpacks#get_channel'
 
+  resources :project_versions, only: [:create]
+
   resources :reviewable_projects, only: [:create, :destroy]
   get 'reviewable_projects/for_level', to: 'reviewable_projects#for_level'
   get 'reviewable_projects/reviewable_status', to: 'reviewable_projects#reviewable_status'

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -895,6 +895,7 @@ Dashboard::Application.routes.draw do
   get '/backpacks/channel', to: 'backpacks#get_channel'
 
   resources :project_versions, only: [:create]
+  get 'project_versions/get_token', to: 'project_versions#get_token'
 
   resources :reviewable_projects, only: [:create, :destroy]
   get 'reviewable_projects/for_level', to: 'reviewable_projects#for_level'

--- a/dashboard/test/controllers/project_versions_controller_test.rb
+++ b/dashboard/test/controllers/project_versions_controller_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+
+class ProjectVersionsControllerTest < ActionController::TestCase
+  test "can create project version" do
+    student = create :student
+    sign_in student
+
+    @controller.expects(:storage_decrypt_channel_id).with("abcdef").returns([123, 654])
+    assert_creates(ProjectVersion) do
+      post :create, params: {storage_id: 'abcdef', version_id: 'fghj', comment: 'This is a comment'}
+    end
+    project_version = ProjectVersion.find_by(storage_app_id: 654, object_version_id: 'fghj')
+    assert_not_nil project_version
+    assert_equal 'This is a comment', project_version.comment
+  end
+end


### PR DESCRIPTION
This is a purely behind-the-scenes change that saves the commit message students write into `CommitDialog` to `project_versions`.

This works by calling `project.save(true)` when saving a commit, which in turn forces a new version of the project to be saved to S3. We then grab the version id and the channel id from that save and in turn save that to the database using an API call.

I want to point out that this dialog makes n+1 consecutive API calls, where n is the number of files being saved to the backpack. If any of these fail, the user should see an error in the dialog. This could potentially lead to duplicate commit messages.

Screen capture with the network requests made (my dev machine is generally slower than prod):

https://user-images.githubusercontent.com/46464143/130143740-e8a9085c-689a-404a-8ced-37510808ae08.mov



## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
