### PR TITLE
Destroy parent-child relationship when parent destroyed

### DIFF
--- a/dashboard/app/models/concerns/levels/levels_within_levels.rb
+++ b/dashboard/app/models/concerns/levels/levels_within_levels.rb
@@ -35,6 +35,7 @@ module Levels
 
       has_many :levels_child_levels,
         class_name: 'ParentLevelsChildLevel',
+        dependent: :destroy,
         foreign_key: :parent_level_id
       has_many :child_levels,
         -> {extending ByKindExtension},


### PR DESCRIPTION
So we don't leave invalid many-to-many entries lying around.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
