### PR TITLE
Update yarn installation instructions to be simpler.

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -190,9 +190,7 @@ Note: Virtual Machine Users should check the [Alternative note](#alternative-use
     1. `rbenv global 2.5.0`
     1. `rbenv rehash`
 1. Install yarn
-    1. `curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -`
-    1. `echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list`
-    1. `sudo apt-get update && sudo apt-get install yarn=1.22.5-1`
+    1. `npm install -g yarn@1.22.5`.
     1. `yarn --version` Double check the version of yarn is correct.
 1. Make it so that you can run apps tests locally
     1. Add the following to `~/.bash_profile` or your desired shell configuration file:


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Using npm to install yarn instead of apt so that yarn gets installed to the node version specific nvm directory.
This change is a result of testing stuff during the node upgrade, see also: https://codedotorg.slack.com/archives/C0T0PNTM3/p1628114703035800