### PR TITLE
[Sprite Lab] text-to-speech integrated with sprite lab say block

### DIFF
--- a/apps/src/p5lab/spritelab/commands/actionCommands.js
+++ b/apps/src/p5lab/spritelab/commands/actionCommands.js
@@ -1,4 +1,5 @@
 import {commands as behaviorCommands} from './behaviorCommands';
+import {commands as audioCommands} from '@cdo/apps/lib/util/audioApi';
 
 function move(coreLibrary, spriteArg, distance) {
   let sprites = coreLibrary.getSpriteArray(spriteArg);
@@ -237,6 +238,19 @@ export const commands = {
       } else {
         sprite[prop] = val;
       }
+    });
+  },
+
+  spriteSay(spriteArg, speech) {
+    let sprites = this.getSpriteArray(spriteArg);
+    sprites.forEach(sprite => {
+      const bubbleId = this.addSpeechBubble(sprite, speech);
+      audioCommands.playSpeech({
+        text: speech,
+        gender: 'female',
+        language: 'English',
+        onComplete: () => this.removeSpeechBubble(bubbleId)
+      });
     });
   },
 

--- a/apps/src/p5lab/spritelab/libraries/CoreLibrary.js
+++ b/apps/src/p5lab/spritelab/libraries/CoreLibrary.js
@@ -1,3 +1,4 @@
+import {createUuid} from '@cdo/apps/utils';
 import commands from '../commands/index';
 
 export default class CoreLibrary {
@@ -15,6 +16,7 @@ export default class CoreLibrary {
     this.printLog = [];
     this.promptVars = {};
     this.eventLog = [];
+    this.speechBubbles = [];
 
     this.commands = {
       executeDrawLoopAndCallbacks() {
@@ -22,6 +24,7 @@ export default class CoreLibrary {
         this.runBehaviors();
         this.runEvents();
         this.p5.drawSprites();
+        this.drawSpeechBubbles();
         if (this.screenText.title || this.screenText.subtitle) {
           commands.drawTitle.apply(this);
         }
@@ -48,6 +51,30 @@ export default class CoreLibrary {
       this.background.resize(400, 400);
       this.p5.image(this.background);
     }
+  }
+
+  drawSpeechBubbles() {
+    this.p5.push();
+    this.p5.fill('black');
+    this.p5.stroke('white');
+    this.p5.strokeWeight(2);
+    this.p5.textSize(25);
+    this.speechBubbles.forEach(bubbleInfo => {
+      this.p5.text(bubbleInfo.text, bubbleInfo.sprite.x, bubbleInfo.sprite.y);
+    });
+    this.p5.pop();
+  }
+
+  addSpeechBubble(sprite, text) {
+    const id = createUuid();
+    this.speechBubbles.push({id, sprite, text});
+    return id;
+  }
+
+  removeSpeechBubble(bubbleId) {
+    this.speechBubbles = this.speechBubbles.filter(
+      bubbleInfo => bubbleInfo.id !== bubbleId
+    );
   }
 
   startPause(time) {

--- a/dashboard/app/models/game.rb
+++ b/dashboard/app/models/game.rb
@@ -236,7 +236,7 @@ class Game < ApplicationRecord
   end
 
   def use_azure_speech_service?
-    [APPLAB, GAMELAB].include? app
+    [APPLAB, GAMELAB, SPRITELAB].include? app
   end
 
   def channel_backed?


### PR DESCRIPTION
very basic implementation of sprite lab say block integrated with azure text to speech.
https://user-images.githubusercontent.com/8787187/129294935-0ad39bdf-2090-43c1-851b-0fe3d98d8ba5.mov

Not done yet:
- profanity filtering for the speech bubble (the audio won't play, but the speech bubble still shows until the audio promise marks as complete)
- speech bubble UI including word wrapping, dynamic placement, and bubble shape


Merging this PR won't result in any user-facing changes since the block is currently not used in any externally-available levels. I mostly just want to get it onto levelbuilder so Mike can start playing with it, and we can decide if this is the direction we want to go.