### PR TITLE
[PoemBot][HOC] setFont block

### DIFF
--- a/apps/src/p5lab/spritelab/libraries/PoemBotLibrary.js
+++ b/apps/src/p5lab/spritelab/libraries/PoemBotLibrary.js
@@ -61,6 +61,10 @@ export default class PoemBotLibrary extends CoreLibrary {
         this.poem.lines.push(line || [BLANK_TEXT]);
       },
 
+      setFont(font) {
+        this.p5.textFont(font);
+      },
+
       setTitle(line) {
         if (line) {
           this.poem.title = line[0].value;

--- a/dashboard/config/blocks/PoemBot/PoemBot_setFont.json
+++ b/dashboard/config/blocks/PoemBot/PoemBot_setFont.json
@@ -1,0 +1,50 @@
+{
+  "category": "",
+  "config": {
+    "func": "setFont",
+    "blockText": "set font {FONT}",
+    "args": [
+      {
+        "name": "FONT",
+        "options": [
+          [
+            "Arial",
+            "\"Arial\""
+          ],
+          [
+            "Georgia",
+            "\"Georgia\""
+          ],
+          [
+            "Palatino",
+            "\"Palatino\""
+          ],
+          [
+            "Times",
+            "\"Times\""
+          ],
+          [
+            "Courier",
+            "\"Courier\""
+          ],
+          [
+            "Arial Black",
+            "\"Arial Black\""
+          ],
+          [
+            "Impact",
+            "\"Impact\""
+          ],
+          [
+            "Tahoma",
+            "\"Tahoma\""
+          ],
+          [
+            "Verdana",
+            "\"Verdana\""
+          ]
+        ]
+      }
+    ]
+  }
+}

--- a/dashboard/config/scripts/levels/New PoemBot Project.level
+++ b/dashboard/config/scripts/levels/New PoemBot Project.level
@@ -90,6 +90,7 @@
         <block type="PoemBot_textConcat"/>
         <block type="variables_set"/>
         <block type="variables_get"/>
+        <block type="PoemBot_setFont"/>
         <block type="PoemBot_setTitle"/>
         <block type="PoemBot_setAuthor"/>
         <block type="PoemBot_addLine"/>


### PR DESCRIPTION
Fonts are similar to what we use in applab, which should all be web-safe fonts. We can easily add/remove fonts later just through levelbuilder if needed.
![image](https://user-images.githubusercontent.com/8787187/129398141-7e183929-4c7a-4ed4-806d-8cb661132566.png)

![image](https://user-images.githubusercontent.com/8787187/129398220-3839e3d3-ee54-4bcc-b347-591bb6cd9b5a.png)
