### PR TITLE
Grant javabuilder access to csa-pilot-facilitators

### DIFF
--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -3,6 +3,7 @@ class Ability
   include Pd::Application::ActiveApplicationModels
 
   CSA_PILOT = 'csa-pilot'
+  CSA_PILOT_FACILITATORS = 'csa-pilot-facilitators'
 
   # Define abilities for the passed in user here. For more information, see the
   # wiki at https://github.com/ryanb/cancan/wiki/Defining-Abilities.
@@ -361,7 +362,10 @@ class Ability
     if user.persisted?
       if user.has_pilot_experiment?(CSA_PILOT) ||
         (!user.teachers.empty? &&
-          user.teachers.any? {|t| t.has_pilot_experiment?(CSA_PILOT)})
+          user.teachers.any? {|t| t.has_pilot_experiment?(CSA_PILOT)}) ||
+          user.has_pilot_experiment?(CSA_PILOT_FACILITATORS) ||
+        (!user.teachers.empty? &&
+          user.teachers.any? {|t| t.has_pilot_experiment?(CSA_PILOT_FACILITATORS)})
         can :get_access_token, :javabuilder_session
       end
     end

--- a/dashboard/test/controllers/javabuilder_sessions_controller_test.rb
+++ b/dashboard/test/controllers/javabuilder_sessions_controller_test.rb
@@ -3,6 +3,7 @@ require 'test_helper'
 class JavabuilderSessionsControllerTest < ActionController::TestCase
   URL = "url"
   CSA_PILOT = "csa-pilot"
+  CSA_PILOT_FACILITATORS = "csa-pilot-facilitators"
   CSD_PILOT = "csd-piloters"
 
   setup do
@@ -63,6 +64,17 @@ class JavabuilderSessionsControllerTest < ActionController::TestCase
   test 'student of csa pilot participant can get access token' do
     teacher = create(:teacher)
     create(:single_user_experiment, min_user_id: teacher.id, name: CSA_PILOT)
+    section = create(:section, user: teacher, login_type: 'word')
+    student_1 = create(:follower, section: section).student_user
+    sign_in(student_1)
+    get :get_access_token, params: {channelId: @fake_channel_id, projectVersion: 123, projectUrl: URL}
+    assert_response :success
+    section.destroy
+  end
+
+  test 'student of csa pilot facilitators participant can get access token' do
+    teacher = create(:teacher)
+    create(:single_user_experiment, min_user_id: teacher.id, name: CSA_PILOT_FACILITATORS)
     section = create(:section, user: teacher, login_type: 'word')
     student_1 = create(:follower, section: section).student_user
     sign_in(student_1)


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

https://codedotorg.slack.com/archives/C0T0PNTM3/p1628969033169900

Javabuilder access is needed for both the 'csa-pilot' and 'csa-pilot-facilitators' pilots. This fix is needed in time for the CSA Pilot launch Monday 8/16.

Follow up work: allow `has_pilot_experiment?` to handle arrays to simplify logic. 

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
