### PR TITLE
Bump blockly

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -50,7 +50,7 @@
     "@babel/preset-react": "^7.0.0",
     "@cdo/interpreted": "link:../dashboard/config/libraries",
     "@code-dot-org/artist": "0.2.1",
-    "@code-dot-org/blockly": "4.0.0",
+    "@code-dot-org/blockly": "4.0.1",
     "@code-dot-org/craft": "0.2.2",
     "@code-dot-org/dance-party": "1.0.3",
     "@code-dot-org/johnny-five": "0.11.1-cdo.2",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1575,10 +1575,10 @@
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@code-dot-org/artist/-/artist-0.2.1.tgz#fcfe7ea5cfb3f19ddb6b912e70e922ba4b7ef0b1"
 
-"@code-dot-org/blockly@4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/blockly/-/blockly-4.0.0.tgz#cd42bebfdeb5fcb1c4615882414347af185429f4"
-  integrity sha512-r4Mg7PnMrlI8bmJHkXrNS1+P1kmdXaQCGNl4yddvanqbIW+smx3HDvB6wdGKWhhIRY3xufV0FbpiMUSeEhZ0Ng==
+"@code-dot-org/blockly@4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/blockly/-/blockly-4.0.1.tgz#77d1f975d75923792b6c72e0aa2ed9cf2bde7841"
+  integrity sha512-gmCY1Lx94chMNxC6ZOdQ/H0MBp+UzJKbJVLQ8JC77DpO5y3+LrFcM3y7DIcyCQEtbKq6qlgfY1nx4lAqdIIalw==
 
 "@code-dot-org/craft@0.2.2":
   version "0.2.2"


### PR DESCRIPTION
It looks like when we bumped to `4.0.0` we reverted the changes in `3.5.36` and `3.5.37`
NPM version history 
![image](https://user-images.githubusercontent.com/8787187/129597784-655e494a-c0ad-4dfa-8401-3a14793c205d.png)
