### PR TITLE
Javalab: fix typo

### DIFF
--- a/apps/i18n/javalab/en_us.json
+++ b/apps/i18n/javalab/en_us.json
@@ -14,7 +14,7 @@
   "commitCode": "Commit Code",
   "commitNotes": "Commit Notes",
   "commitNotesPlaceholder": "Enter notes about this commit here...",
-  "compilationSuccess": "Compliation successful.",
+  "compilationSuccess": "Compilation successful.",
   "compileFailed": "Compile Failed.",
   "compilerError": "We couldn't compile your program. Look for bugs in your program and try again.",
   "compiling": "Compiling...",


### PR DESCRIPTION
We had a typo in one of our console status strings.
