### PR TITLE
Remove a couple tests covering "lessonless" scripts

### DIFF
--- a/dashboard/test/models/script_level_test.rb
+++ b/dashboard/test/models/script_level_test.rb
@@ -283,20 +283,6 @@ class ScriptLevelTest < ActiveSupport::TestCase
     assert_equal student.id, summary[:userId]
   end
 
-  test 'calling next_level when next level is unplugged skips the level for script without lessons' do
-    last_20h_maze_1_level = ScriptLevel.joins(:levels).find_by(levels: {level_num: '2_19'}, script_id: 1)
-    first_20h_artist_1_level = ScriptLevel.joins(:levels).find_by(levels: {level_num: '1_1'}, script_id: 1)
-
-    assert_equal first_20h_artist_1_level, last_20h_maze_1_level.next_progression_level
-  end
-
-  test 'calling next_level when next level is not unplugged does not skip the level for script without lessons' do
-    first_20h_artist_1_level = ScriptLevel.joins(:levels).find_by(levels: {level_num: '1_1'}, script_id: 1)
-    second_20h_artist_1_level = ScriptLevel.joins(:levels).find_by(levels: {level_num: '1_2'}, script_id: 1)
-
-    assert_equal second_20h_artist_1_level, first_20h_artist_1_level.next_progression_level
-  end
-
   test 'calling next_level when next level is unplugged skips the level' do
     script = create(:script, name: 's1')
     lesson_group = create(:lesson_group, script: script)


### PR DESCRIPTION
It's not entirely clear to me what edge case these tests are trying to cover, but given that we no longer have scripts without lessons I believe they're no longer needed. Please let me know if you know something I don't about why these might still be necessary.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
