### PR TITLE
Only show keep working for CSD CSP progress legend

### DIFF
--- a/apps/src/templates/instructions/TopInstructionsHeader.jsx
+++ b/apps/src/templates/instructions/TopInstructionsHeader.jsx
@@ -10,72 +10,6 @@ import i18n from '@cdo/locale';
 import color from '../../util/color';
 import styleConstants from '../../styleConstants';
 
-const styles = {
-  paneHeaderOverride: {
-    color: color.default_text
-  },
-  audioRTL: {
-    wrapper: {
-      float: 'left'
-    }
-  },
-  audio: {
-    button: {
-      height: 24,
-      marginTop: '3px',
-      marginBottom: '3px'
-    },
-    buttonImg: {
-      lineHeight: '24px',
-      fontSize: 15,
-      paddingLeft: 12
-    }
-  },
-  audioLTR: {
-    wrapper: {
-      float: 'right'
-    }
-  },
-  helpTabs: {
-    paddingTop: 6
-  },
-  helpTabsLtr: {
-    float: 'left',
-    paddingLeft: 30
-  },
-  helpTabsRtl: {
-    float: 'right',
-    paddingRight: 30
-  },
-  collapserIcon: {
-    showHideButton: {
-      position: 'absolute',
-      top: 0,
-      margin: 0,
-      cursor: 'pointer',
-      lineHeight: styleConstants['workspace-headers-height'] + 'px',
-      fontSize: 18,
-      ':hover': {
-        cursor: 'pointer',
-        color: color.white
-      }
-    },
-    showHideButtonLtr: {
-      left: 8
-    },
-    showHideButtonRtl: {
-      right: 8
-    },
-    teacherOnlyColor: {
-      color: color.lightest_cyan,
-      ':hover': {
-        cursor: 'pointer',
-        color: color.default_text
-      }
-    }
-  }
-};
-
 function TopInstructionsHeader(props) {
   const {
     teacherOnly,
@@ -233,6 +167,72 @@ function TopInstructionsHeader(props) {
     </PaneHeader>
   );
 }
+
+const styles = {
+  paneHeaderOverride: {
+    color: color.default_text
+  },
+  audioRTL: {
+    wrapper: {
+      float: 'left'
+    }
+  },
+  audio: {
+    button: {
+      height: 24,
+      marginTop: '3px',
+      marginBottom: '3px'
+    },
+    buttonImg: {
+      lineHeight: '24px',
+      fontSize: 15,
+      paddingLeft: 12
+    }
+  },
+  audioLTR: {
+    wrapper: {
+      float: 'right'
+    }
+  },
+  helpTabs: {
+    paddingTop: 6
+  },
+  helpTabsLtr: {
+    float: 'left',
+    paddingLeft: 30
+  },
+  helpTabsRtl: {
+    float: 'right',
+    paddingRight: 30
+  },
+  collapserIcon: {
+    showHideButton: {
+      position: 'absolute',
+      top: 0,
+      margin: 0,
+      cursor: 'pointer',
+      lineHeight: styleConstants['workspace-headers-height'] + 'px',
+      fontSize: 18,
+      ':hover': {
+        cursor: 'pointer',
+        color: color.white
+      }
+    },
+    showHideButtonLtr: {
+      left: 8
+    },
+    showHideButtonRtl: {
+      right: 8
+    },
+    teacherOnlyColor: {
+      color: color.lightest_cyan,
+      ':hover': {
+        cursor: 'pointer',
+        color: color.default_text
+      }
+    }
+  }
+};
 
 TopInstructionsHeader.propTypes = {
   teacherOnly: PropTypes.bool,

--- a/apps/src/templates/progress/progressHelpers.js
+++ b/apps/src/templates/progress/progressHelpers.js
@@ -160,17 +160,13 @@ export function lessonHasLevels(lesson) {
 /**
  * Determines if we should show "Keep working" and "Needs review" states for
  * progress in a unit. User must be enrolled in the relevant pilot and unit
- * must be either CSF or CSD.
+ * must be either CSD or CSP.
  */
 export function shouldShowReviewStates(unit) {
   return (
     experiments.isEnabled(experiments.KEEP_WORKING) &&
-    (unit.csf || isUnitCsd(unit))
+    (unit.isCsd || unit.isCsp)
   );
-}
-
-function isUnitCsd(unit) {
-  return unit.name?.startsWith('csd');
 }
 
 /**

--- a/apps/src/templates/progress/progressTestHelpers.js
+++ b/apps/src/templates/progress/progressTestHelpers.js
@@ -177,6 +177,8 @@ export const fakeScriptData = (overrideFields = {}) => {
     name: 'csd1-2020',
     title: 'CSD Unit 1 - Problem Solving and Computing (20-21)',
     csf: false,
+    isCsd: true,
+    isCsp: false,
     lessons: [],
     ...overrideFields
   };

--- a/apps/test/unit/code-studio/components/progress/UnitOverviewTest.js
+++ b/apps/test/unit/code-studio/components/progress/UnitOverviewTest.js
@@ -17,7 +17,7 @@ const defaultProps = {
   hasVerifiedResources: true,
   perLevelResults: {},
   unitCompleted: false,
-  unitData: {csf: true},
+  unitData: {csf: false, isCsp: true, isCsd: false},
   scriptId: 123,
   scriptName: 'csp1',
   unitTitle: 'CSP 1',

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1494,6 +1494,8 @@ class Script < ApplicationRecord
       disablePostMilestone: disable_post_milestone?,
       isHocScript: hoc?,
       csf: csf?,
+      isCsd: csd?,
+      isCsp: csp?,
       only_instructor_review_required: only_instructor_review_required?,
       peerReviewsRequired: peer_reviews_to_complete || 0,
       peerReviewLessonInfo: peer_review_lesson_info,


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
- Updates legend to only show keep working state if the script is CSD or CSP
Express course:
![Screen Shot 2021-08-16 at 1 28 51 PM](https://user-images.githubusercontent.com/24235215/129625579-56ea21a9-abf9-46d2-a8bb-9e76fea2abb6.png)
- CSD:
![Screen Shot 2021-08-16 at 2 21 14 PM](https://user-images.githubusercontent.com/24235215/129631059-e0ed09c1-3468-41b1-8791-93af18a240f4.png)


- We found another bug where student is not seeing the updated legend because they're not enrolled directly into the pilot. I'm going to leave this for now, since we're going to be removing the pilot code anyway before launch.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
- jira ticket: [LP-1997](https://codedotorg.atlassian.net/browse/LP-1997)
<!--
- spec: []()
-->

## Testing story
Tested locally that progress legend looks right for different units
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
