### PR TITLE
JavaLab: Layout management improvements for right side

### DIFF
--- a/apps/src/javalab/JavalabEditor.jsx
+++ b/apps/src/javalab/JavalabEditor.jsx
@@ -32,13 +32,11 @@ import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import _ from 'lodash';
 import msg from '@cdo/locale';
 import javalabMsg from '@cdo/javalab/locale';
-import HeightResizer from '@cdo/apps/templates/instructions/HeightResizer';
 import {CompileStatus} from './constants';
 import {makeEnum} from '@cdo/apps/utils';
 import ProjectTemplateWorkspaceIcon from '../templates/ProjectTemplateWorkspaceIcon';
 
 const MIN_HEIGHT = 100;
-const CONSOLE_BUFFER = 270;
 // This is the height of the "editor" header and the file tabs combined
 const HEADER_OFFSET = 63;
 const Dialog = makeEnum(
@@ -68,10 +66,6 @@ class JavalabEditor extends React.Component {
     isEditingStartSources: PropTypes.bool,
     handleVersionHistory: PropTypes.func.isRequired,
     isReadOnlyWorkspace: PropTypes.bool.isRequired
-  };
-
-  static defaultProps = {
-    height: 400
   };
 
   constructor(props) {
@@ -135,20 +129,6 @@ class JavalabEditor extends React.Component {
     orderedTabKeys.forEach(tabKey => {
       this.createEditor(tabKey, sources[fileMetadata[tabKey]].text);
     });
-
-    this.handleHeightResize(this.props.height);
-    this.props.setEditorColumnHeight(window.innerHeight - HEADER_OFFSET);
-
-    window.addEventListener('resize', () => {
-      this.handleHeightResizeThrottled(this.props.height);
-      this.props.setEditorColumnHeight(window.innerHeight - HEADER_OFFSET);
-    });
-    if (window.visualViewport) {
-      window.visualViewport.addEventListener('resize', () => {
-        this.handleHeightResizeThrottled(this.props.height);
-        this.props.setEditorColumnHeight(window.innerHeight - HEADER_OFFSET);
-      });
-    }
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -475,36 +455,6 @@ class JavalabEditor extends React.Component {
     });
   }
 
-  /**
-   * Returns the top Y coordinate of the instructions that are being resized
-   * via a call to handleHeightResize from HeightResizer.
-   */
-  getItemTop = () => {
-    return this.tabContainer.getBoundingClientRect().top + HEADER_OFFSET;
-  };
-
-  /**
-   * Returns the height of the container with the header incorporated.
-   */
-  getPosition = () => {
-    return this.props.height + HEADER_OFFSET;
-  };
-
-  /**
-   * Given a desired height, determines how much we can actually change the
-   * height (account for min/max) and changes the height to that.
-   * @param {number} desired height
-   */
-  handleHeightResize = desiredHeight => {
-    let maxHeight = window.innerHeight - HEADER_OFFSET - CONSOLE_BUFFER;
-    let newHeight = Math.max(MIN_HEIGHT, desiredHeight);
-    newHeight = Math.min(maxHeight, newHeight);
-
-    this.props.setRenderedHeight(newHeight);
-  };
-
-  handleHeightResizeThrottled = _.throttle(this.handleHeightResize, 33);
-
   onOpenCommitDialog() {
     // When the dialog opens, we will compile the user's files and notify them of success/errors.
     // For now, this is mocked out to successfully compile after a set amount of time.
@@ -541,7 +491,8 @@ class JavalabEditor extends React.Component {
       sources,
       isEditingStartSources,
       isReadOnlyWorkspace,
-      showProjectTemplateWorkspaceIcon
+      showProjectTemplateWorkspaceIcon,
+      height
     } = this.props;
 
     let menuStyle = {
@@ -665,19 +616,13 @@ class JavalabEditor extends React.Component {
                       style={{
                         ...styles.editor,
                         ...(isDarkMode && styles.darkBackground),
-                        ...{height: this.props.height}
+                        ...{height: height - HEADER_OFFSET}
                       }}
                     />
                   </Tab.Pane>
                 );
               })}
             </Tab.Content>
-            <HeightResizer
-              resizeItemTop={this.getItemTop}
-              position={this.getPosition()}
-              onResize={this.handleHeightResizeThrottled}
-              style={styles.resizer}
-            />
           </div>
         </Tab.Container>
         <div style={menuStyle}>
@@ -786,9 +731,6 @@ const styles = {
     float: 'left',
     overflow: 'visible',
     marginLeft: 3
-  },
-  resizer: {
-    position: 'static'
   }
 };
 
@@ -797,7 +739,6 @@ export default connect(
     sources: state.javalab.sources,
     validation: state.javalab.validation,
     isDarkMode: state.javalab.isDarkMode,
-    height: state.javalab.renderedEditorHeight,
     isEditingStartSources: state.pageConstants.isEditingStartSources,
     isReadOnlyWorkspace: state.pageConstants.isReadOnlyWorkspace
   }),

--- a/apps/src/javalab/JavalabView.jsx
+++ b/apps/src/javalab/JavalabView.jsx
@@ -346,10 +346,7 @@ class JavalabView extends React.Component {
             ...styles.javalab
           }}
         >
-          <div
-            ref={ref => (this.editorAndVisualization = ref)}
-            style={styles.editorAndVisualization}
-          >
+          <div style={styles.editorAndVisualization}>
             <div
               id="visualizationColumn"
               className="responsive"

--- a/apps/src/javalab/JavalabView.jsx
+++ b/apps/src/javalab/JavalabView.jsx
@@ -28,8 +28,6 @@ import styleConstants from '../styleConstants';
 import _ from 'lodash';
 import {queryParams} from '@cdo/apps/code-studio/utils';
 
-const FOOTER_BUFFER = 10;
-
 // The top Y coordinate of the JavaLab panels.  Above them is just the common site
 // header and then a bit of empty space.
 const PANELS_TOP_COORDINATE = 60;
@@ -78,13 +76,11 @@ class JavalabView extends React.Component {
   };
 
   state = {
-    isTesting: false,
-    rightContainerHeight: 800
+    isTesting: false
   };
 
   componentDidMount() {
     this.props.onMount();
-    this.setRightContainerHeight();
     this.updateLayout(this.props.leftWidth);
     window.addEventListener('resize', () =>
       this.updateLayoutThrottled(this.props.leftWidth)
@@ -156,15 +152,6 @@ class JavalabView extends React.Component {
         &nbsp;
       </div>
     );
-  };
-
-  setRightContainerHeight = () => {
-    let rightContainerHeight = this.editorAndVisualization.getBoundingClientRect()
-      .top;
-    let topPos = window.innerHeight - rightContainerHeight - FOOTER_BUFFER;
-    this.setState({
-      rightContainerHeight: topPos
-    });
   };
 
   handleWidthResize = desiredWidth => {
@@ -344,7 +331,7 @@ class JavalabView extends React.Component {
       rightWidth,
       awaitingContainedResponse
     } = this.props;
-    const {isTesting, rightContainerHeight} = this.state;
+    const {isTesting} = this.state;
 
     if (isDarkMode) {
       document.body.style.backgroundColor = '#1b1c17';
@@ -356,8 +343,7 @@ class JavalabView extends React.Component {
       <StudioAppWrapper>
         <div
           style={{
-            ...styles.javalab,
-            ...{height: rightContainerHeight}
+            ...styles.javalab
           }}
         >
           <div

--- a/apps/src/javalab/javalabRedux.js
+++ b/apps/src/javalab/javalabRedux.js
@@ -17,6 +17,7 @@ const SET_INSTRUCTIONS_HEIGHT = 'javalab/SET_INSTRUCTIONS_HEIGHT';
 const SET_INSTRUCTIONS_FULL_HEIGHT = 'javalab/SET_INSTRUCTIONS_FULL_HEIGHT';
 const REMOVE_FILE = 'javalab/REMOVE_FILE';
 const SET_IS_RUNNING = 'javalab/SET_IS_RUNNING';
+const SET_CONSOLE_HEIGHT = 'javalab/SET_CONSOLE_HEIGHT';
 const EDITOR_COLUMN_HEIGHT = 'javalab/EDITOR_COLUMN_HEIGHT';
 const SET_BACKPACK_API = 'javalab/SET_BACKPACK_API';
 const SET_IS_START_MODE = 'javalab/SET_IS_START_MODE';
@@ -35,6 +36,7 @@ const initialState = {
   instructionsHeight: 200,
   instructionsFullHeight: 200,
   isRunning: false,
+  consoleHeight: 200,
   editorColumnHeight: 600,
   backpackApi: null,
   isStartMode: false,
@@ -206,6 +208,11 @@ export const setInstructionsFullHeight = height => ({
   height
 });
 
+export const setConsoleHeight = height => ({
+  type: SET_CONSOLE_HEIGHT,
+  height
+});
+
 export const setEditorColumnHeight = editorColumnHeight => ({
   type: EDITOR_COLUMN_HEIGHT,
   editorColumnHeight
@@ -328,6 +335,12 @@ export default function reducer(state = initialState, action) {
     return {
       ...state,
       isRunning: action.isRunning
+    };
+  }
+  if (action.type === SET_CONSOLE_HEIGHT) {
+    return {
+      ...state,
+      consoleHeight: action.height
     };
   }
   if (action.type === EDITOR_COLUMN_HEIGHT) {

--- a/apps/test/unit/javalab/JavalabEditorTest.js
+++ b/apps/test/unit/javalab/JavalabEditorTest.js
@@ -38,7 +38,8 @@ describe('Java Lab Editor Test', () => {
     defaultProps = {
       onCommitCode: () => {},
       handleVersionHistory: () => {},
-      showProjectTemplateWorkspaceIcon: false
+      showProjectTemplateWorkspaceIcon: false,
+      height: 400
     };
     appOptions = window.appOptions;
     window.appOptions = {level: {}};


### PR DESCRIPTION
The horizontal resizer used on the right side of JavaLab, which controls the height of the editor and the console below it, has now been hoisted out of `JavalabEditor` up to the parent `JavalabView`.

This improves over https://github.com/code-dot-org/code-dot-org/pull/41898 in particular, because the user is now actually controlling the height of the console, not the editor, and if they resize the window, then the console will maintain its height, which feels more natural.

It is also a step closer to the ideal architecture described in https://github.com/code-dot-org/code-dot-org/pull/41688, in which we centralize the panel management.  One obvious improvement here is that `JavalabEditor` no longer needs to monitor for window resize and visual viewport resize events; rather, the logic can be rolled into the existing `updateLayout` handler in `JavalabView`.