### PR TITLE
Javalab neighborhood test: use stitch mode none

### DIFF
--- a/dashboard/test/ui/features/javalab/neighborhood.feature
+++ b/dashboard/test/ui/features/javalab/neighborhood.feature
@@ -11,7 +11,7 @@ Feature: NeighborhoodPainting
     Then I set slider speed to fast
     Then I press "runButton"
     And I wait for 15 seconds
-    And I see no difference for "paint glomming"
+    And I see no difference for "paint glomming" using stitch mode "none"
     Then I close my eyes
 
   #Scenario: Stop Button Closes Connection


### PR DESCRIPTION
This test is currently flaky. Update it to use stitch mode none to hopefully get rid of the flakiness.

Based on [this PR](https://github.com/code-dot-org/code-dot-org/pull/41915) which fixed a similar problem