### PR TITLE
Javalab Backpack: add import warning/error tests

### DIFF
--- a/apps/test/unit/javalab/BackpackTest.js
+++ b/apps/test/unit/javalab/BackpackTest.js
@@ -88,4 +88,40 @@ describe('Java Lab Backpack Test', () => {
     const state = wrapper.instance().state;
     expect(state.openDialog).to.equal('IMPORT_WARNING');
   });
+
+  it('import shows error if hidden file name is used', () => {
+    const otherProps = {
+      sources: {file1: {isVisible: true}, file2: {isVisible: false}}
+    };
+    const wrapper = shallow(<Backpack {...{...defaultProps, ...otherProps}} />);
+    // set state to something that should be cleared by expandDropdown
+    wrapper.instance().setState({
+      dropdownOpen: true,
+      backpackFilenames: ['file1', 'file2', 'file3'],
+      selectedFiles: ['file2', 'file3']
+    });
+
+    wrapper.instance().handleImport();
+
+    const state = wrapper.instance().state;
+    expect(state.openDialog).to.equal('IMPORT_ERROR');
+  });
+
+  it('no dialog shown if there are no duplicate file names', () => {
+    const otherProps = {
+      sources: {}
+    };
+    const wrapper = shallow(<Backpack {...{...defaultProps, ...otherProps}} />);
+    // set state to something that should be cleared by expandDropdown
+    wrapper.instance().setState({
+      dropdownOpen: true,
+      backpackFilenames: ['file1', 'file2', 'file3'],
+      selectedFiles: ['file2', 'file3']
+    });
+
+    wrapper.instance().handleImport();
+
+    const state = wrapper.instance().state;
+    expect(state.openDialog).to.equal(null);
+  });
 });

--- a/apps/test/unit/javalab/BackpackTest.js
+++ b/apps/test/unit/javalab/BackpackTest.js
@@ -70,4 +70,22 @@ describe('Java Lab Backpack Test', () => {
     expect(state.selectedFiles.length).to.equal(0);
     expect(state.backpackFilenames.length).to.equal(0);
   });
+
+  it('import shows warning before overwriting files', () => {
+    const otherProps = {
+      sources: {file1: {isVisible: true}, file2: {isVisible: true}}
+    };
+    const wrapper = shallow(<Backpack {...{...defaultProps, ...otherProps}} />);
+    // set state to something that should be cleared by expandDropdown
+    wrapper.instance().setState({
+      dropdownOpen: true,
+      backpackFilenames: ['file1', 'file2', 'file3'],
+      selectedFiles: ['file1', 'file3']
+    });
+
+    wrapper.instance().handleImport();
+
+    const state = wrapper.instance().state;
+    expect(state.openDialog).to.equal('IMPORT_WARNING');
+  });
 });

--- a/apps/test/unit/javalab/BackpackTest.js
+++ b/apps/test/unit/javalab/BackpackTest.js
@@ -91,14 +91,14 @@ describe('Java Lab Backpack Test', () => {
 
   it('import shows error if hidden file name is used', () => {
     const otherProps = {
-      sources: {file1: {isVisible: true}, file2: {isVisible: false}}
+      sources: {visibleFile: {isVisible: true}, hiddenFile: {isVisible: false}}
     };
     const wrapper = shallow(<Backpack {...{...defaultProps, ...otherProps}} />);
     // set state to something that should be cleared by expandDropdown
     wrapper.instance().setState({
       dropdownOpen: true,
-      backpackFilenames: ['file1', 'file2', 'file3'],
-      selectedFiles: ['file2', 'file3']
+      backpackFilenames: ['visibleFile', 'hiddenFile', 'file3'],
+      selectedFiles: ['hiddenFile', 'file3']
     });
 
     wrapper.instance().handleImport();


### PR DESCRIPTION
Follow up to #41917. This adds test coverage for the import warning, error and success cases.

## Links

- jira ticket: [CSA-629](CSA-629)

## PR Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
