### PR TITLE
Store unversioned scripts in other directory

### DIFF
--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -259,7 +259,7 @@ def localize_level_content(variable_strings, parameter_strings)
       script_i18n_directory =
         if ScriptConstants.unit_in_category?(:hoc, script.name)
           File.join(level_content_directory, "Hour of Code")
-        elsif script.version_year
+        elsif script.version_year && script.version_year != 'unversioned'
           File.join(level_content_directory, script.version_year)
         else
           File.join(level_content_directory, "other")

--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -259,10 +259,10 @@ def localize_level_content(variable_strings, parameter_strings)
       script_i18n_directory =
         if ScriptConstants.unit_in_category?(:hoc, script.name)
           File.join(level_content_directory, "Hour of Code")
-        elsif script.version_year && script.version_year != 'unversioned'
-          File.join(level_content_directory, script.version_year)
-        else
+        elsif script.unversioned?
           File.join(level_content_directory, "other")
+        else
+          File.join(level_content_directory, script.version_year)
         end
 
       FileUtils.mkdir_p script_i18n_directory

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1813,7 +1813,7 @@ class Script < ApplicationRecord
   end
 
   def unversioned?
-    version_year.blank? || version_year == 'unversioned'
+    version_year.blank? || version_year == CourseVersion::UNVERSIONED
   end
 
   # If there is an alternate version of this unit which the user should be on

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1812,6 +1812,10 @@ class Script < ApplicationRecord
     unit_group.try(:localized_title)
   end
 
+  def unversioned?
+    version_year.blank? || version_year == 'unversioned'
+  end
+
   # If there is an alternate version of this unit which the user should be on
   # due to existing progress or a course experiment, return that unit. Otherwise,
   # return nil.


### PR DESCRIPTION
**What:** The directory that scripts with a `version_year` of `unversioned` are saved in - won't be the same as versioned scripts.

**Why:** Unversioned scripts were being skipped with the existing logic

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [FND-1666](https://codedotorg.atlassian.net/browse/FND-1666)


## Testing story

Ran `sync-in.rb` locally and no scripts were skipped

Before:
<img width="620" alt="Screen Shot 2021-08-18 at 12 56 51 PM" src="https://user-images.githubusercontent.com/48133820/129948353-dcf1d4ff-5fa2-48c5-b777-ab595c29c42e.png">

After:
<img width="890" alt="Screen Shot 2021-08-18 at 1 43 51 PM" src="https://user-images.githubusercontent.com/48133820/129954461-ccaaf891-4398-4841-87f6-abd587533f5d.png">



<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked