### PR TITLE
send studentDescription to script edit page in camelCase

### DIFF
--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1637,7 +1637,7 @@ class Script < ApplicationRecord
     end.to_h
 
     data[:description] = Services::MarkdownPreprocessor.process(I18n.t("data.script.name.#{name}.description", default: ''))
-    data[:student_description] = Services::MarkdownPreprocessor.process(I18n.t("data.script.name.#{name}.student_description", default: ''))
+    data[:studentDescription] = Services::MarkdownPreprocessor.process(I18n.t("data.script.name.#{name}.student_description", default: ''))
 
     if include_lessons
       data[:lessonDescriptions] = lessons.map do |lesson|


### PR DESCRIPTION
The student description was showing up on the script overview page, but wasn't showing up on the script edit page. See [slack](https://codedotorg.slack.com/archives/CNZP84FJ5/p1629227982012800) for screenshots and more context.

The problem was a mismatch between snake_case and camelCase in the value being sent down from the server.

## Testing story

manually verified that student overview can now be edited and updated locally.