### PR TITLE
Add awaiting review to review states in feedback CSV

### DIFF
--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1929,8 +1929,8 @@ class Script < ApplicationRecord
     end
 
     script_levels.each do |script_level|
-      next unless script_level.oldest_active_level.can_have_feedback?
       current_level = script_level.oldest_active_level
+      next unless current_level.can_have_feedback?
 
       section.students.each do |student|
         next unless feedback_hash[student.id]

--- a/dashboard/test/controllers/api/v1/assessments_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/assessments_controller_test.rb
@@ -689,4 +689,23 @@ class Api::V1::AssessmentsControllerTest < ActionController::TestCase
     assert_equal expected_response[level1.id.to_s]['levelgroup_results'],
       actual_response[level1.id.to_s]['levelgroup_results']
   end
+
+  test "section_feedback assert query count" do
+    sign_in @teacher
+    script = create :script
+    lesson_group = create :lesson_group, script: script
+    lesson = create :lesson, script: script, lesson_group: lesson_group
+    weblab_level = create :weblab
+    create :script_level, script: script, levels: [weblab_level], lesson: lesson
+
+    [@student_1, @student_2, @student_3, @student_4].each do |student|
+      create :teacher_feedback, script: script, level: weblab_level, student: student, teacher: @teacher
+    end
+
+    assert_queries 13 do
+      get :section_feedback, params: {section_id: @section.id, script_id: script.id}
+    end
+
+    assert_response :success
+  end
 end

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1988,17 +1988,24 @@ class ScriptTest < ActiveSupport::TestCase
     section.add_student(student2)
 
     feedback1 = create(:teacher_feedback, script: script, level: weblab_level, teacher: teacher, student: student1, comment: "Testing", performance: 'performanceLevel1')
-    create(:teacher_feedback, script: script, level: weblab_level, teacher: teacher, student: student2)
+    feedback2 = create(:teacher_feedback, script: script, level: weblab_level, teacher: teacher, student: student2, review_state: TeacherFeedback::REVIEW_STATES.keepWorking)
+    create :user_level, user: student2, level: weblab_level, script: script, updated_at: 1.week.from_now
     create(:teacher_feedback, script: script, level: gamelab_level, teacher: teacher, student: student2)
 
     feedback_for_section = script.get_feedback_for_section(section)
 
     assert_equal(3, feedback_for_section.keys.length) # expect 3 feedbacks
+
+    # feedback1 assertions
     feedback1_result = feedback_for_section[feedback1.id]
     assert_equal(student1.name, feedback1_result[:studentName])
     assert_equal("Testing", feedback1_result[:comment])
     assert_equal("Extensive Evidence", feedback1_result[:performance])
     assert_equal("Never reviewed", feedback1_result[:reviewStateLabel])
+
+    # feedback2 assertions
+    feedback2_result = feedback_for_section[feedback2.id]
+    assert_equal("Waiting for review", feedback2_result[:reviewStateLabel])
   end
 
   # This test checks that all categories that may show up in the UI have


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Update endpoint that powers teacher feedback CSV to include "Waiting for review" as a review state
<img width="366" alt="Screen Shot 2021-08-17 at 7 07 13 PM" src="https://user-images.githubusercontent.com/24235215/129945781-d11bbdb6-1e89-4097-b61f-5211ff8442dd.png">

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
- jira ticket: [LP-2006](https://codedotorg.atlassian.net/browse/LP-2006)
<!--
- spec: []()
-->

## Testing story
Added a couple of dashboard tests, tested CSV download locally
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
