### PR TITLE
Update <g> to <svg> to fix test

### DIFF
--- a/apps/src/templates/TooltipOverlay.jsx
+++ b/apps/src/templates/TooltipOverlay.jsx
@@ -137,7 +137,7 @@ export default class TooltipOverlay extends React.Component {
     ) {
       return null;
     }
-    return <g className="tooltip-overlay">{this.renderTooltips()}</g>;
+    return <svg className="tooltip-overlay">{this.renderTooltips()}</svg>;
   }
 }
 


### PR DESCRIPTION
A small test update to prepare for the React upgrade. A test was failing because `<g>` was an unrecognized element -- `<svg>` works fine in this context.