### PR TITLE
Remove `parent_level_id` from levels

### DIFF
--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -69,7 +69,6 @@ class Level < ApplicationRecord
     map_reference
     reference_links
     name_suffix
-    parent_level_id
     contained_level_names
     project_template_level_name
     hint_prompt_attempts_threshold
@@ -655,15 +654,14 @@ class Level < ApplicationRecord
     false
   end
 
-  # Create a copy of this level named new_name, and store the id of the original
-  # level in parent_level_id.
+  # Create a copy of this level named new_name
   # @param [String] new_name
   # @param [String] editor_experiment
   # @raise [ActiveRecord::RecordInvalid] if the new name already is taken.
   def clone_with_name(new_name, editor_experiment: nil)
     level = dup
     # specify :published to make should_write_custom_level_file? return true
-    level_params = {name: new_name, parent_level_id: id, published: true}
+    level_params = {name: new_name, published: true}
     level_params[:editor_experiment] = editor_experiment if editor_experiment
     level_params[:audit_log] = [{changed_at: Time.now, changed: ["cloned from #{name.dump}"], cloned_from: name}].to_json
     level.update!(level_params)
@@ -671,9 +669,9 @@ class Level < ApplicationRecord
   end
 
   # Create a copy of this level by appending new_suffix to the name, removing
-  # any previous suffix from the name first. Store the id of the original
-  # level in parent_level_id, and store the suffix in name_suffix. If a level
-  # with the same name already exists, us that instead of creating a new one.
+  # any previous suffix from the name first and storing the suffix in
+  # name_suffix. If a level with the same name already exists, us that instead
+  # of creating a new one.
   #
   # Also, copy over any project template level. If two levels with the same
   # project template level are copied using the same new_suffix, then the new

--- a/dashboard/test/models/level_test.rb
+++ b/dashboard/test/models/level_test.rb
@@ -845,7 +845,6 @@ class LevelTest < ActiveSupport::TestCase
     new_level = old_level.clone_with_suffix(' copy')
     assert_equal 'level copy', new_level.name
     assert_equal '<xml>foo</xml>', new_level.start_blocks
-    assert_equal old_level.id, new_level.parent_level_id
     assert_equal ' copy', new_level.name_suffix
   end
 
@@ -855,13 +854,11 @@ class LevelTest < ActiveSupport::TestCase
     # level_1 has no name suffix, so the new suffix is appended.
     level_2 = level_1.clone_with_suffix('_2')
     assert_equal 'my_level_1_2', level_2.name
-    assert_equal level_1.id, level_2.parent_level_id
     assert_equal '_2', level_2.name_suffix
 
     # level_2 has a name suffix, which the new suffix replaces.
     level_3 = level_2.clone_with_suffix('_3')
     assert_equal 'my_level_1_3', level_3.name
-    assert_equal level_2.id, level_3.parent_level_id
     assert_equal '_3', level_3.name_suffix
   end
 
@@ -902,18 +899,15 @@ class LevelTest < ActiveSupport::TestCase
     level_2_copy = level_2.clone_with_suffix(' copy')
 
     template_level_copy = Level.find_by_name('template level copy')
-    assert_equal template_level.id, template_level_copy.parent_level_id
     assert_equal ' copy', template_level_copy.name_suffix
     assert_equal '<xml>template</xml>', template_level_copy.start_blocks
 
     assert_equal template_level_copy, level_1_copy.project_template_level
     assert_equal 'level 1 copy', level_1_copy.name
-    assert_equal level_1.id, level_1_copy.parent_level_id
     assert_equal ' copy', level_1_copy.name_suffix
 
     assert_equal template_level_copy, level_2_copy.project_template_level
     assert_equal 'level 2 copy', level_2_copy.name
-    assert_equal level_2.id, level_2_copy.parent_level_id
     assert_equal ' copy', level_2_copy.name_suffix
   end
 

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1812,7 +1812,6 @@ class ScriptTest < ActiveSupport::TestCase
       assert_equal "Level #{level_num}_copy", level.name
       old_level = Level.find_by_name("Level #{level_num}")
       assert_equal old_level.level_num, level.level_num
-      assert_equal old_level.id, level.parent_level_id
       assert_equal '_copy', level.name_suffix
     end
 


### PR DESCRIPTION
It's not currently used anywhere, doesn't make sense to persist since ids aren't useful cross-environment, and has the potential to cause confusion with the new ParentLevelsChildLevel many-to-many table.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
