### PR TITLE
Removed extra code that will no longer be needed due to Javabuilder HTTP server.

### DIFF
--- a/apps/src/javalab/Theater.js
+++ b/apps/src/javalab/Theater.js
@@ -19,18 +19,6 @@ export default class Theater {
         this.getImgElement().src = data.detail.url;
         break;
       }
-      // TODO: Remove these message types once javabuilder is updated to
-      // no longer use them.
-      case TheaterSignalType.VISUAL: {
-        const imageString = 'data:image/gif;base64,' + data.detail.image;
-        this.getImgElement().src = imageString;
-        break;
-      }
-      case TheaterSignalType.AUDIO: {
-        const audioString = 'data:audio/wav;base64,' + data.detail.audio;
-        this.getAudioElement().src = audioString;
-        break;
-      }
       default:
         break;
     }

--- a/apps/src/javalab/constants.js
+++ b/apps/src/javalab/constants.js
@@ -67,9 +67,7 @@ export const NeighborhoodExceptionType = makeEnum(
 
 export const TheaterSignalType = {
   AUDIO_URL: 'AUDIO_URL',
-  VISUAL_URL: 'VISUAL_URL',
-  AUDIO: 'AUDIO',
-  VISUAL: 'VISUAL'
+  VISUAL_URL: 'VISUAL_URL'
 };
 
 export const StatusMessageType = {


### PR DESCRIPTION
This removes code made obsolete by a recent change in the Javabuilder repo to set up a HTTP server to mimic S3 functionality.
https://github.com/code-dot-org/javabuilder/pull/90 

Now, Java Lab can interact with Javabuilder-created-files in the same way on localhost as on production.

This should not be merged until after https://github.com/code-dot-org/javabuilder/pull/90 is merged.
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
