### PR TITLE
Fix sinon memory leaks

### DIFF
--- a/apps/test/unit/SoundsTest.js
+++ b/apps/test/unit/SoundsTest.js
@@ -4,18 +4,18 @@ import sinon from 'sinon';
 import winMp3 from '!!file-loader!../audio/assets/win.mp3';
 
 describe('Sounds', () => {
-  let sounds, sourceURL, sound, spy;
+  let sounds, sourceURL, sound;
 
   beforeEach(() => {
     sounds = new Sounds();
     sourceURL = winMp3;
     sounds.register({id: sourceURL, mp3: sourceURL});
     sound = sounds.soundsById[sourceURL];
-    spy = sinon.stub(sound, 'playAfterLoad');
+    sinon.stub(sound, 'playAfterLoad');
   });
 
   afterEach(() => {
-    spy.restore();
+    sinon.restore();
     sounds.unmuteURLs();
   });
 
@@ -41,7 +41,7 @@ describe('Sounds', () => {
     sounds.muteURLs();
 
     let soundFromId = sounds.soundsById['testSound'];
-    spy = sinon.stub(soundFromId, 'play');
+    sinon.stub(soundFromId, 'play');
     sounds.play(soundId);
     expect(soundFromId.play).to.have.been.calledOnce;
   });

--- a/apps/test/unit/code-studio/pd/application_dashboard/detail_view_contentsTest.js
+++ b/apps/test/unit/code-studio/pd/application_dashboard/detail_view_contentsTest.js
@@ -16,7 +16,14 @@ describe('DetailViewContents', () => {
 
   // We aren't testing any of the responses of the workshop selector control, so just
   // have a fake server to handle calls and suppress warnings
-  sinon.fakeServer.create();
+  let server;
+  before(() => {
+    server = sinon.fakeServer.create();
+  });
+
+  after(() => {
+    server.restore();
+  });
 
   let context;
 

--- a/apps/test/unit/code-studio/pd/application_dashboard/summaryTest.js
+++ b/apps/test/unit/code-studio/pd/application_dashboard/summaryTest.js
@@ -67,5 +67,7 @@ describe('Summary', () => {
     expect(rows.at(0).children()).to.have.length(2);
 
     expect(summary.find('Spinner')).to.have.length(0);
+
+    server.restore();
   });
 });

--- a/apps/test/unit/code-studio/pd/foorm/FoormEntityEditorFormModeTest.js
+++ b/apps/test/unit/code-studio/pd/foorm/FoormEntityEditorFormModeTest.js
@@ -62,6 +62,7 @@ describe('FoormEntityEditor in Form editing mode', () => {
 
   afterEach(() => {
     restoreRedux();
+    server.restore();
   });
 
   const createWrapper = overrideProps => {

--- a/apps/test/unit/code-studio/pd/foorm/FoormEntityEditorLibraryModeTest.js
+++ b/apps/test/unit/code-studio/pd/foorm/FoormEntityEditorLibraryModeTest.js
@@ -66,6 +66,7 @@ describe('FoormEntityEditor in Library editing mode', () => {
 
   afterEach(() => {
     restoreRedux();
+    server.restore();
   });
 
   const sampleExistingLibraryQuestionData = {

--- a/apps/test/unit/code-studio/pd/foorm/FoormLibraryEditorManagerTest.js
+++ b/apps/test/unit/code-studio/pd/foorm/FoormLibraryEditorManagerTest.js
@@ -51,6 +51,7 @@ describe('FoormLibraryEditorManager', () => {
 
   afterEach(() => {
     restoreRedux();
+    server.restore();
   });
 
   const sampleExistingLibraryQuestionData = {

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/components/local_summer_workshop_survey_resultsTest.js
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/components/local_summer_workshop_survey_resultsTest.js
@@ -119,6 +119,8 @@ describe('Local Summer Workshop Management', () => {
       expect(localSummerWorkshopSurveyResults.find('.well li')).to.have.length(
         2
       );
+
+      server.restore();
     });
 
     it('Displays table after loading is completed for workshop organizer', () => {
@@ -157,6 +159,8 @@ describe('Local Summer Workshop Management', () => {
       expect(
         localSummerWorkshopSurveyResults.find('.well li ul li')
       ).to.have.length(2);
+
+      server.restore();
     });
   });
 });

--- a/apps/test/unit/code-studio/pd/workshop_enrollment/enroll_formTest.js
+++ b/apps/test/unit/code-studio/pd/workshop_enrollment/enroll_formTest.js
@@ -10,7 +10,13 @@ const refute = p => assert.isNotOk(p);
 
 describe('Enroll Form', () => {
   // We aren't testing server responses, but have a fake server to handle calls and suppress warnings
-  sinon.fakeServer.create();
+  let server;
+  before(() => {
+    server = sinon.fakeServer.create();
+  });
+  after(() => {
+    server.restore();
+  });
 
   const props = {
     workshop_id: 1,

--- a/apps/test/unit/code-studio/peer_reviews/PeerReviewSubmissionsTest.jsx
+++ b/apps/test/unit/code-studio/peer_reviews/PeerReviewSubmissionsTest.jsx
@@ -106,7 +106,7 @@ describe('PeerReviewSubmissions', () => {
   });
 
   it('Changing the course makes a new call and enables the button when a course is selected', () => {
-    server = sinon.fakeServer.create();
+    server.reset();
 
     peerReviewSubmissions
       .find('select#PlcCourseSelect')
@@ -162,7 +162,7 @@ describe('PeerReviewSubmissions', () => {
   });
 
   it('Changing the email filter triggers a new call with email filter applied', () => {
-    server = sinon.fakeServer.create();
+    server.reset();
 
     peerReviewSubmissions
       .find('input#NameEmailFilter')

--- a/apps/test/unit/craft/code-connection/ccTest.js
+++ b/apps/test/unit/craft/code-connection/ccTest.js
@@ -4,9 +4,13 @@ import {singleton as studioApp} from '@cdo/apps/StudioApp';
 import {executeUserCode} from '@cdo/apps/craft/code-connection/craft';
 
 describe('Code Connection extension', () => {
-  it('move forward block to verify single key-value parsing', done => {
+  beforeEach(() => {
     sinon.stub(studioApp(), 'highlight');
-
+  });
+  afterEach(() => {
+    sinon.restore();
+  });
+  it('move forward block to verify single key-value parsing', done => {
     const mockClient = {
       async_command: command => {
         expect(command).to.eql('move?direction=forward');

--- a/apps/test/unit/craft/craftTest.js
+++ b/apps/test/unit/craft/craftTest.js
@@ -37,5 +37,6 @@ describe('Craft', () => {
     Craft.init(config);
     server.respond();
     assert(getStore().getState().pageConstants.isMinecraft);
+    server.restore();
   });
 });

--- a/apps/test/unit/javalab/javalabTest.js
+++ b/apps/test/unit/javalab/javalabTest.js
@@ -37,8 +37,7 @@ describe('Javalab', () => {
   });
 
   afterEach(() => {
-    project.autosave.restore();
-    ReactDOM.render.restore();
+    sinon.restore();
     restoreRedux();
     restoreStudioApp();
   });

--- a/apps/test/unit/lib/kits/maker/boards/microBit/AccelerometerTest.js
+++ b/apps/test/unit/lib/kits/maker/boards/microBit/AccelerometerTest.js
@@ -13,6 +13,10 @@ describe('MicroBitAccelerometer', function() {
     accelerometer = new Accelerometer({mb: boardClient});
   });
 
+  afterEach(() => {
+    sinon.restore();
+  });
+
   it(`attributes are readonly`, () => {
     let attributes = [
       'roll',

--- a/apps/test/unit/lib/kits/maker/boards/microBit/CapacitiveTouchSensorTest.js
+++ b/apps/test/unit/lib/kits/maker/boards/microBit/CapacitiveTouchSensorTest.js
@@ -11,6 +11,9 @@ describe('CapacitiveTouchSensor', function() {
     boardClient = new MicrobitStubBoard();
     sensor = new CapacitiveTouchSensor({mb: boardClient, pin: testPin});
   });
+  afterEach(() => {
+    sinon.restore();
+  });
 
   it(`attributes are readonly`, () => {
     let isPressedDescriptor = Object.getOwnPropertyDescriptor(

--- a/apps/test/unit/lib/kits/maker/boards/microBit/CompassTest.js
+++ b/apps/test/unit/lib/kits/maker/boards/microBit/CompassTest.js
@@ -12,6 +12,9 @@ describe('MicroBit Compass', function() {
     boardClient = new MicrobitStubBoard();
     compass = new Compass({mb: boardClient});
   });
+  afterEach(() => {
+    sinon.restore();
+  });
 
   it(`attributes are readonly`, () => {
     let desc = Object.getOwnPropertyDescriptor(compass, 'heading');

--- a/apps/test/unit/lib/kits/maker/boards/microBit/LedScreenTest.js
+++ b/apps/test/unit/lib/kits/maker/boards/microBit/LedScreenTest.js
@@ -18,6 +18,9 @@ describe('LedScreen', function() {
       displaySpy = sinon.spy(boardClient, 'displayPlot');
       displayClearSpy = sinon.spy(boardClient, 'displayClear');
     });
+    after(() => {
+      sinon.restore();
+    });
 
     it(`calls the parent on() implementation`, () => {
       led.on(1, 2, 155);
@@ -47,6 +50,9 @@ describe('LedScreen', function() {
         mb: boardClient
       });
       displaySpy = sinon.spy(boardClient, 'displayPlot');
+    });
+    after(() => {
+      sinon.restore();
     });
 
     it(`if LED is off, toggle triggers the parent on`, () => {
@@ -83,6 +89,9 @@ describe('LedScreen', function() {
       });
       displaySpy = sinon.spy(boardClient, 'displayShow');
     });
+    after(() => {
+      sinon.restore();
+    });
 
     it('calls the parent displayShow', () => {
       let pixelArray = [
@@ -110,6 +119,9 @@ describe('LedScreen', function() {
       });
       scrollStringSpy = sinon.spy(boardClient, 'scrollString');
       scrollNumSpy = sinon.spy(boardClient, 'scrollInteger');
+    });
+    after(() => {
+      sinon.restore();
     });
 
     it(`calls the parent scrollString`, () => {

--- a/apps/test/unit/lib/kits/maker/boards/microBit/LightSensorTest.js
+++ b/apps/test/unit/lib/kits/maker/boards/microBit/LightSensorTest.js
@@ -16,6 +16,9 @@ describe('LightSensor', function() {
     boardClient = new MicrobitStubBoard();
     lightSensor = new LightSensor({mb: boardClient});
   });
+  afterEach(() => {
+    sinon.restore();
+  });
 
   it(`value attribute is readonly`, () => {
     let descriptor = Object.getOwnPropertyDescriptor(lightSensor, 'value');

--- a/apps/test/unit/lib/kits/maker/boards/microBit/MicroBitBoardTest.js
+++ b/apps/test/unit/lib/kits/maker/boards/microBit/MicroBitBoardTest.js
@@ -40,6 +40,7 @@ describe('MicroBitBoard', () => {
 
   afterEach(() => {
     board = undefined;
+    sinon.restore();
   });
 
   describe('Maker Board Interface', () => {

--- a/apps/test/unit/lib/kits/maker/boards/microBit/MicroBitButtonTest.js
+++ b/apps/test/unit/lib/kits/maker/boards/microBit/MicroBitButtonTest.js
@@ -50,6 +50,9 @@ describe('MicroBitButton', function() {
         pin: 0
       });
     });
+    after(() => {
+      sinon.restore();
+    });
 
     it('is a readonly property', () => {
       const descriptor = Object.getOwnPropertyDescriptor(button, 'holdtime');

--- a/apps/test/unit/lib/kits/maker/boards/microBit/MicroBitComponentsTest.js
+++ b/apps/test/unit/lib/kits/maker/boards/microBit/MicroBitComponentsTest.js
@@ -174,6 +174,9 @@ describe('MicroBit Components', () => {
     beforeEach(() => {
       return createMicroBitComponents(board).then(c => (components = c));
     });
+    afterEach(() => {
+      sinon.restore();
+    });
 
     it('can be safely called on empty object', () => {
       expect(() => {

--- a/apps/test/unit/lib/kits/maker/boards/microBit/MicroBitThermometerTest.js
+++ b/apps/test/unit/lib/kits/maker/boards/microBit/MicroBitThermometerTest.js
@@ -11,6 +11,9 @@ describe('MicroBitThermometer', function() {
     boardClient = new MicrobitStubBoard();
     thermometer = new MicroBitThermometer({mb: boardClient});
   });
+  afterEach(() => {
+    sinon.restore();
+  });
 
   it(`attributes are readonly`, () => {
     let attributes = ['raw', 'celsius', 'fahrenheit', 'C', 'F'];

--- a/apps/test/unit/lib/levelbuilder/course-editor/CourseEditorTest.js
+++ b/apps/test/unit/lib/levelbuilder/course-editor/CourseEditorTest.js
@@ -162,13 +162,18 @@ describe('CourseEditor', () => {
   });
 
   describe('Saving Course Editor', () => {
-    let clock;
+    let clock, server;
+
+    beforeEach(() => {
+      server = sinon.fakeServer.create();
+    });
 
     afterEach(() => {
       if (clock) {
         clock.restore();
         clock = undefined;
       }
+      server.restore();
     });
 
     it('can save and keep editing', () => {
@@ -178,7 +183,6 @@ describe('CourseEditor', () => {
       let returnData = {
         coursePath: '/courses/test-course'
       };
-      let server = sinon.fakeServer.create();
       server.respondWith('PUT', `/courses/test-course`, [
         200,
         {'Content-Type': 'application/json'},
@@ -215,7 +219,6 @@ describe('CourseEditor', () => {
       const courseEditor = wrapper.find('CourseEditor');
 
       let returnData = 'There was an error';
-      let server = sinon.fakeServer.create();
       server.respondWith('PUT', `/courses/test-course`, [
         404,
         {'Content-Type': 'application/json'},
@@ -253,7 +256,6 @@ describe('CourseEditor', () => {
       let returnData = {
         coursePath: '/courses/test-course'
       };
-      let server = sinon.fakeServer.create();
       server.respondWith('PUT', `/courses/test-course`, [
         200,
         {'Content-Type': 'application/json'},
@@ -284,7 +286,6 @@ describe('CourseEditor', () => {
       const courseEditor = wrapper.find('CourseEditor');
 
       let returnData = 'There was an error';
-      let server = sinon.fakeServer.create();
       server.respondWith('PUT', `/courses/test-course`, [
         404,
         {'Content-Type': 'application/json'},

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/AddVocabularyDialogTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/AddVocabularyDialogTest.jsx
@@ -65,6 +65,7 @@ describe('AddVocabularyDialog', () => {
 
     expect(handleCloseSpy.calledOnce).to.be.true;
     expect(afterSaveSpy.calledOnce).to.be.true;
+    server.restore();
   });
 
   it('renders an existing vocabulary for edit', () => {
@@ -112,6 +113,7 @@ describe('AddVocabularyDialog', () => {
     server.respond();
     wrapper.update();
     expect(wrapper.find('h3').contains('There was an error'));
+    server.restore();
   });
 
   it('renders default props', () => {

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/FindProgrammingExpressionDialogTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/FindProgrammingExpressionDialogTest.js
@@ -118,6 +118,7 @@ describe('FindProgrammingExpressionDialog', () => {
     expect(searchStub.callCount).to.equal(2);
     wrapper.instance().setCurrentPage(2);
     expect(searchStub.callCount).to.equal(3);
+    searchStub.restore();
   });
 
   it('searches the programming_expressions endpoint', () => {

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/LessonEditorTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/LessonEditorTest.js
@@ -248,6 +248,7 @@ describe('LessonEditor', () => {
     expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(0);
     //check that last saved message is showing
     expect(wrapper.find('.lastSavedMessage').length).to.equal(1);
+    server.restore();
   });
 
   it('shows error when save and keep editing has error saving', () => {

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/ResourceEditorTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/ResourceEditorTest.js
@@ -122,5 +122,6 @@ describe('ResourcesEditor', () => {
       .calledOnce;
     expect(addResource.withArgs(defaultResourceContext, vocabRollup)).to.be
       .calledOnce;
+    server.restore();
   });
 });

--- a/apps/test/unit/lib/levelbuilder/script-editor/LessonDescriptionsTest.js
+++ b/apps/test/unit/lib/levelbuilder/script-editor/LessonDescriptionsTest.js
@@ -33,6 +33,10 @@ describe('LessonDescriptions', () => {
     };
   });
 
+  afterEach(() => {
+    sinon.restore();
+  });
+
   it('begins collapsed', () => {
     const wrapper = shallow(
       <LessonDescriptions

--- a/apps/test/unit/lib/levelbuilder/script-editor/UnitEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/UnitEditorTest.jsx
@@ -282,6 +282,7 @@ describe('UnitEditor', () => {
       expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(0);
       //check that last saved message is showing
       expect(wrapper.find('.lastSavedMessage').length).to.equal(1);
+      server.restore();
     });
 
     it('shows error when save and keep editing has error saving', () => {

--- a/apps/test/unit/lib/tools/jsinterpreter/JSInterpreterTest.js
+++ b/apps/test/unit/lib/tools/jsinterpreter/JSInterpreterTest.js
@@ -334,6 +334,9 @@ setCallback(function(message) {
               sinon.spy(jsInterpreter, 'executeInterpreter');
               jsInterpreter.executeInterpreter(true);
             });
+            afterEach(() => {
+              sinon.restore();
+            });
 
             it("will be created from the interpreter's callback function", () => {
               expect(lastCallback).to.be.a('function');
@@ -487,6 +490,9 @@ myCallback("this message is coming from inside the interpreter");
       onPauseObserver = sinon.spy();
       jsInterpreter.onPause.register(onPauseObserver);
       sinon.spy(jsInterpreter, 'handleError');
+    });
+    afterEach(() => {
+      sinon.restore();
     });
 
     function getCurrentLine() {

--- a/apps/test/unit/lib/util/urlHelpersTest.js
+++ b/apps/test/unit/lib/util/urlHelpersTest.js
@@ -79,7 +79,7 @@ describe('metaTagDescription() for valid urls', () => {
   </html>`;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
   });
 
   afterEach(() => {

--- a/apps/test/unit/templates/instructions/InlineAudioTest.js
+++ b/apps/test/unit/templates/instructions/InlineAudioTest.js
@@ -164,6 +164,7 @@ describe('InlineAudio', function() {
     expect(window.Audio).to.have.been.calledOnce;
     component.instance().playAudio();
     expect(window.Audio).to.have.been.calledOnce;
+    sinon.restore();
   });
 
   it('handles source update gracefully, stopping audio', async function() {

--- a/apps/test/unit/templates/instructions/ResourceLinkTest.jsx
+++ b/apps/test/unit/templates/instructions/ResourceLinkTest.jsx
@@ -17,5 +17,6 @@ describe('ResourceLink', () => {
     const windowOpenStub = sinon.stub(window, 'open');
     wrapper.instance().selectResource({preventDefault: () => {}});
     expect(windowOpenStub.callCount).to.equal(1);
+    sinon.restore();
   });
 });

--- a/apps/test/unit/templates/teacherDashboard/PrintCertificatesTest.js
+++ b/apps/test/unit/templates/teacherDashboard/PrintCertificatesTest.js
@@ -68,5 +68,6 @@ describe('PrintCertificates', () => {
       .find('div')
       .last()
       .simulate('click');
+    sinon.restore();
   });
 });

--- a/apps/test/unit/weblab/CdoBrambleTest.js
+++ b/apps/test/unit/weblab/CdoBrambleTest.js
@@ -72,8 +72,7 @@ describe('CdoBramble', () => {
   });
 
   afterEach(() => {
-    console.error.restore();
-    console.warn.restore();
+    sinon.restore();
   });
 
   describe('initProject', () => {
@@ -85,6 +84,9 @@ describe('CdoBramble', () => {
         sinon
           .stub(cdoBramble.api, 'getCurrentFilesVersionId')
           .returns('a1b2c3');
+      });
+      afterEach(() => {
+        sinon.restore();
       });
 
       it('syncs files after creating root directory', () => {
@@ -131,6 +133,9 @@ describe('CdoBramble', () => {
 
         cdoBramble.syncFiles([{name: 'index.html'}], projectVersion, () => {});
       });
+      afterEach(() => {
+        sinon.restore();
+      });
 
       it('resets version and local changes', () => {
         expect(cdoBramble.lastSyncedVersionId).to.equal(projectVersion);
@@ -148,6 +153,9 @@ describe('CdoBramble', () => {
         cdoBramble.lastSyncedVersionId = 'd4e5f6';
         cdoBramble.recentChanges = [{operation: 'change', file: 'index.html'}];
         sinon.stub(cdoBramble, 'overwriteProject');
+      });
+      afterEach(() => {
+        sinon.restore();
       });
 
       it('warns that changes will be overwritten if there are any', () => {
@@ -221,6 +229,9 @@ describe('CdoBramble', () => {
     beforeEach(() => {
       cdoBramble.disallowedHtmlTags = DISALLOWED_HTML_TAGS;
     });
+    afterEach(() => {
+      sinon.restore();
+    });
 
     it('no-ops if reading file errored', () => {
       const error = new Error('oh no');
@@ -266,6 +277,9 @@ describe('CdoBramble', () => {
   });
 
   describe('preprocessHtml', () => {
+    afterEach(() => {
+      sinon.restore();
+    });
     it('no-ops if detecting disallowed content errored', () => {
       sinon
         .stub(cdoBramble, 'detectDisallowedHtml')
@@ -560,6 +574,9 @@ describe('CdoBramble', () => {
         .stub(cdoBramble, 'writeFileData')
         .callsFake((path, data, callback) => callback(null));
     });
+    afterEach(() => {
+      sinon.restore();
+    });
 
     it('downloads file data and writes it to bramble', done => {
       const files = [
@@ -639,6 +656,9 @@ describe('CdoBramble', () => {
         .stub(cdoBramble, 'writeFileData')
         .callsFake((path, data, callback) => callback(null));
     });
+    afterEach(() => {
+      sinon.restore();
+    });
 
     it('invokes the callback if there are no source files', done => {
       cdoBramble.recursivelyWriteSourceFiles([], 0, () => {
@@ -711,6 +731,9 @@ describe('CdoBramble', () => {
     beforeEach(() => {
       const startSources = {files: [{name: 'index.html', data: '<div></div>'}]};
       sinon.stub(cdoBramble.api, 'getStartSources').returns(startSources);
+    });
+    afterEach(() => {
+      sinon.restore();
     });
 
     it('is true if source files and user files have different lengths', done => {

--- a/apps/test/util/testUtils.js
+++ b/apps/test/util/testUtils.js
@@ -17,31 +17,23 @@ export function setExternalGlobals(beforeFunc = before, afterFunc = after) {
   window.React = React;
   window.dashboard = {...window.dashboard, assets, project};
 
-  beforeFunc(() => {
-    sinon.stub(project, 'clearHtml');
-    sinon.stub(project, 'exceedsAbuseThreshold').returns(false);
-    sinon.stub(project, 'hasPrivacyProfanityViolation').returns(false);
-    sinon.stub(project, 'getCurrentId').returns('fake_id');
-    sinon.stub(project, 'isEditing').returns(true);
-    sinon.stub(project, 'getMakerAPIs').returns(false);
+  const sandbox = sinon.createSandbox();
 
-    sinon.stub(assets.listStore, 'reset');
-    sinon.stub(assets.listStore, 'add').returns([]);
-    sinon.stub(assets.listStore, 'remove').returns([]);
-    sinon.stub(assets.listStore, 'list').returns([]);
+  beforeFunc(() => {
+    sandbox.stub(project, 'clearHtml');
+    sandbox.stub(project, 'exceedsAbuseThreshold').returns(false);
+    sandbox.stub(project, 'hasPrivacyProfanityViolation').returns(false);
+    sandbox.stub(project, 'getCurrentId').returns('fake_id');
+    sandbox.stub(project, 'isEditing').returns(true);
+    sandbox.stub(project, 'getMakerAPIs').returns(false);
+
+    sandbox.stub(assets.listStore, 'reset');
+    sandbox.stub(assets.listStore, 'add').returns([]);
+    sandbox.stub(assets.listStore, 'remove').returns([]);
+    sandbox.stub(assets.listStore, 'list').returns([]);
   });
   afterFunc(() => {
-    project.clearHtml.restore();
-    project.exceedsAbuseThreshold.restore();
-    project.hasPrivacyProfanityViolation.restore();
-    project.getCurrentId.restore();
-    project.isEditing.restore();
-    project.getMakerAPIs.restore();
-
-    assets.listStore.reset.restore();
-    assets.listStore.add.restore();
-    assets.listStore.remove.restore();
-    assets.listStore.list.restore();
+    sandbox.restore();
   });
 
   window.trackEvent = () => {};


### PR DESCRIPTION
According to the sinon documentation, failing to restore a server/xhr or other stubs will cause memory leaks in tests. We're currently hitting our current memory limits, so this should help a little bit, as well as prevent any test errors caused by global objects being stubbed accidentally.

I went down the list of all the locations where we use sinon in our codebase, and I think I caught all the places that should need fixing. (empty stubs that don't replace methods on objects don't need to be restored)

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- sinon [docs](https://sinonjs.org/releases/v11.1.2/general-setup/)

## Testing story

Full test suite passes

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->
