### PR TITLE
Set code_review_enabled default to true

### DIFF
--- a/dashboard/app/models/sections/clever_section.rb
+++ b/dashboard/app/models/sections/clever_section.rb
@@ -21,7 +21,7 @@
 #  hidden               :boolean          default(FALSE), not null
 #  tts_autoplay_enabled :boolean          default(FALSE), not null
 #  restrict_section     :boolean          default(FALSE)
-#  code_review_enabled  :boolean
+#  code_review_enabled  :boolean          default(TRUE)
 #
 # Indexes
 #

--- a/dashboard/app/models/sections/email_section.rb
+++ b/dashboard/app/models/sections/email_section.rb
@@ -21,7 +21,7 @@
 #  hidden               :boolean          default(FALSE), not null
 #  tts_autoplay_enabled :boolean          default(FALSE), not null
 #  restrict_section     :boolean          default(FALSE)
-#  code_review_enabled  :boolean
+#  code_review_enabled  :boolean          default(TRUE)
 #
 # Indexes
 #

--- a/dashboard/app/models/sections/google_classroom_section.rb
+++ b/dashboard/app/models/sections/google_classroom_section.rb
@@ -21,7 +21,7 @@
 #  hidden               :boolean          default(FALSE), not null
 #  tts_autoplay_enabled :boolean          default(FALSE), not null
 #  restrict_section     :boolean          default(FALSE)
-#  code_review_enabled  :boolean
+#  code_review_enabled  :boolean          default(TRUE)
 #
 # Indexes
 #

--- a/dashboard/app/models/sections/omni_auth_section.rb
+++ b/dashboard/app/models/sections/omni_auth_section.rb
@@ -21,7 +21,7 @@
 #  hidden               :boolean          default(FALSE), not null
 #  tts_autoplay_enabled :boolean          default(FALSE), not null
 #  restrict_section     :boolean          default(FALSE)
-#  code_review_enabled  :boolean
+#  code_review_enabled  :boolean          default(TRUE)
 #
 # Indexes
 #

--- a/dashboard/app/models/sections/picture_section.rb
+++ b/dashboard/app/models/sections/picture_section.rb
@@ -21,7 +21,7 @@
 #  hidden               :boolean          default(FALSE), not null
 #  tts_autoplay_enabled :boolean          default(FALSE), not null
 #  restrict_section     :boolean          default(FALSE)
-#  code_review_enabled  :boolean
+#  code_review_enabled  :boolean          default(TRUE)
 #
 # Indexes
 #

--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -21,7 +21,7 @@
 #  hidden               :boolean          default(FALSE), not null
 #  tts_autoplay_enabled :boolean          default(FALSE), not null
 #  restrict_section     :boolean          default(FALSE)
-#  code_review_enabled  :boolean
+#  code_review_enabled  :boolean          default(TRUE)
 #
 # Indexes
 #

--- a/dashboard/app/models/sections/word_section.rb
+++ b/dashboard/app/models/sections/word_section.rb
@@ -21,7 +21,7 @@
 #  hidden               :boolean          default(FALSE), not null
 #  tts_autoplay_enabled :boolean          default(FALSE), not null
 #  restrict_section     :boolean          default(FALSE)
-#  code_review_enabled  :boolean
+#  code_review_enabled  :boolean          default(TRUE)
 #
 # Indexes
 #

--- a/dashboard/db/migrate/20210820182004_set_code_review_enabled_default_to_true.rb
+++ b/dashboard/db/migrate/20210820182004_set_code_review_enabled_default_to_true.rb
@@ -1,0 +1,5 @@
+class SetCodeReviewEnabledDefaultToTrue < ActiveRecord::Migration[5.2]
+  def change
+    change_column_default :sections, :code_review_enabled, to: true
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_16_222729) do
+ActiveRecord::Schema.define(version: 2021_08_20_182004) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -1625,7 +1625,7 @@ ActiveRecord::Schema.define(version: 2021_08_16_222729) do
     t.boolean "hidden", default: false, null: false
     t.boolean "tts_autoplay_enabled", default: false, null: false
     t.boolean "restrict_section", default: false
-    t.boolean "code_review_enabled"
+    t.boolean "code_review_enabled", default: true
     t.index ["code"], name: "index_sections_on_code", unique: true
     t.index ["course_id"], name: "fk_rails_20b1e5de46"
     t.index ["user_id"], name: "index_sections_on_user_id"


### PR DESCRIPTION
We realized that communicating the code review enabled/disabled setting to teachers would be a challenge now that the pilot has already begun, so we're defaulting this setting to on. Hopefully, in the future, we can default to false.

I did ask infra and this is a safe change but won't update any existing columns. I can either do that by bulk updating the handful of sections that have a nil value in this column or adjusting the logic in #42082 to account for nil values.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
