### PR TITLE
[PoemBot][HOC] Play sound block with dropdown

### DIFF
--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -1151,7 +1151,7 @@ P5Lab.prototype.initInterpreter = function(attachDebugger = true) {
   this.JSInterpreter.parse({
     code,
     projectLibraries: this.level.projectLibraries,
-    blocks: dropletConfig.blocks,
+    blocks: this.isSpritelab ? [] : dropletConfig.blocks,
     blockFilter: this.level.executePaletteApisOnly && this.level.codeFunctions,
     enableEvents: true,
     initGlobals: injectGamelabGlobals,

--- a/apps/src/p5lab/spritelab/commands/worldCommands.js
+++ b/apps/src/p5lab/spritelab/commands/worldCommands.js
@@ -4,6 +4,7 @@ import {
   addTextPrompt,
   addMultipleChoicePrompt
 } from '../../redux/spritelabInput';
+import {commands as audioCommands} from '@cdo/apps/lib/util/audioApi';
 
 export const commands = {
   comment(text) {
@@ -32,6 +33,10 @@ export const commands = {
 
   hideTitleScreen() {
     this.screenText = {};
+  },
+
+  playSound(url) {
+    audioCommands.playSound({url, loop: false});
   },
 
   printText(text) {

--- a/dashboard/config/blocks/PoemBot/PoemBot_playSound.json
+++ b/dashboard/config/blocks/PoemBot/PoemBot_playSound.json
@@ -1,0 +1,62 @@
+{
+  "category": "",
+  "config": {
+    "func": "playSound",
+    "blockText": "play sound {SOUND}",
+    "args": [
+      {
+        "name": "SOUND",
+        "options": [
+          [
+            "Bell",
+            "\"sound://category_bell/bells_win_low.mp3\""
+          ],
+          [
+            "Bright",
+            "\"sound://category_loops/vibrant_game_welcome_to_heaven_loop_1.mp3\""
+          ],
+          [
+            "Fireside",
+            "\"sound://category_background/fire_burning.mp3\""
+          ],
+          [
+            "Forest",
+            "\"sound://category_nature/forest_woodland_ambience_2.mp3\""
+          ],
+          [
+            "Harps",
+            "\"sound://category_loops/vibrant_game_harping_down_forever_loop_2_accent.mp3\""
+          ],
+          [
+            "Night",
+            "\"sound://category_nature/summer_night_loop.mp3\""
+          ],
+          [
+            "Ocean",
+            "\"sound://category_background/ocean_waves.mp3\""
+          ],
+          [
+            "Rainy",
+            "\"sound://category_background/rain_thunderstorm_calm.mp3\""
+          ],
+          [
+            "Rainforest",
+            "\"sound://category_background/rainforest_ambient_sound.mp3\""
+          ],
+          [
+            "Sleepy",
+            "\"sound://category_background/wavering_wind.mp3\""
+          ],
+          [
+            "Typewriter",
+            "\"sound://category_background/typewriter.mp3\""
+          ],
+          [
+            "Waterfall",
+            "\"sound://category_background/waterfall.mp3\""
+          ]
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Play sound block with limited options (curated by Amy for the poembot experience):
![image](https://user-images.githubusercontent.com/8787187/130277532-2f3bb142-e0a8-43d4-bb88-c13ebfa1a355.png)

Also removes Sprite Lab's implicit dependence on Gamelab's droplet config for the play sound block. More explanation of this in [slack thread](https://codedotorg.slack.com/archives/C01V27QS9AT/p1627514753027600)

Testing: Manually verified that sounds continue to work in both poembot and spritelab.