### PR TITLE
Webpack: Always use eval devtool in CI

### DIFF
--- a/apps/webpack.js
+++ b/apps/webpack.js
@@ -195,10 +195,20 @@ if (envConstants.COVERAGE) {
   });
 }
 
-var devtool = process.env.DEV ? 'cheap-inline-source-map' : 'inline-source-map';
+function devtool(options) {
+  if (process.env.CI) {
+    return 'eval';
+  } else if (options && options.minify) {
+    return 'source-map';
+  } else if (process.env.DEV) {
+    return 'cheap-inline-source-map';
+  } else {
+    return 'inline-source-map';
+  }
+}
 
 var storybookConfig = _.extend({}, baseConfig, {
-  devtool: devtool,
+  devtool: devtool(),
   resolve: _.extend({}, baseConfig.resolve, {
     alias: _.extend({}, baseConfig.resolve.alias, {
       '@cdo/apps/lib/util/firehose': path.resolve(__dirname, 'test', 'util')
@@ -224,7 +234,7 @@ var storybookConfig = _.extend({}, baseConfig, {
 
 // config for our test runner
 var karmaConfig = _.extend({}, baseConfig, {
-  devtool: devtool,
+  devtool: devtool(),
   resolve: _.extend({}, baseConfig.resolve, {
     alias: _.extend({}, baseConfig.resolve.alias, {
       '@cdo/locale': path.resolve(
@@ -353,7 +363,7 @@ function create(options) {
       publicPath: '/assets/js/',
       filename: `[name]${suffix}`
     },
-    devtool: !process.env.CI && options.minify ? 'source-map' : devtool,
+    devtool: devtool(options),
     entry: entries,
     externals: externals,
     optimization: optimization,


### PR DESCRIPTION
This change unblocks the React upgrade. Currently, when we attempt to upgrade React, our apps/ unit test process runs out of memory on Drone. The memory limit is 4G, which is set in various [package.json scripts](https://github.com/code-dot-org/code-dot-org/blob/42c7692f1367f8e535f241ba1f60b30ed3085631/apps/package.json#L10-L35) and in [test-low-memory.sh](https://github.com/code-dot-org/code-dot-org/blob/42c7692f1367f8e535f241ba1f60b30ed3085631/apps/test-low-memory.sh#L4). We've been approaching this limit for a while, and it appears upgrading React pushes us over this limit.

While testing this issue on Drone, I realized that while `DEV=1 npm run test-low-memory` fails with an out-of-memory error, `npm run test-low-memory` does not. As you can see in this change, `process.env.DEV` is what configures our webpack devtool ([docs](https://v4.webpack.js.org/configuration/devtool/)). Previously, Drone was using `cheap-inline-source-map` -- with this change, it will use `eval`, which fixes the out-of-memory error and unblocks the React upgrade.

**Important note:** While `eval` is faster than our previous devtool, there is one downside (from the webpack docs): "The main disadvantage is that it doesn’t display line numbers correctly since it gets mapped to transpiled code instead of the original code (No Source Maps from Loaders)."

This obviously doesn't fix the fact that our unit tests consume a lot of memory -- it unblocks the React upgrade and likely just buys us some time. However, I think this is the right change to make right now because we're also upgrading from webpack 4 to 5, so the devtool(s) that make sense may change with that upgrade anyways.

More context in [this Slack thread](https://codedotorg.slack.com/archives/C0T0PNR0D/p1629483625016500).

### Follow-up tasks
- [XTEAM-374](https://codedotorg.atlassian.net/browse/XTEAM-374)