### PR TITLE
Handle blank foorm submissions

### DIFF
--- a/dashboard/app/controllers/api/v1/foorm_simple_survey_submissions_controller.rb
+++ b/dashboard/app/controllers/api/v1/foorm_simple_survey_submissions_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::FoormSimpleSurveySubmissionsController < ApplicationController
   def create
-    answers = params[:answers]
+    answers = params[:answers] || {}
 
     submission = ::Foorm::SimpleSurveySubmission.new(
       user_id: params[:user_id],

--- a/dashboard/app/controllers/api/v1/foorm_simple_survey_submissions_controller.rb
+++ b/dashboard/app/controllers/api/v1/foorm_simple_survey_submissions_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::FoormSimpleSurveySubmissionsController < ApplicationController
   def create
-    answers = params[:answers] || {}
+    answers = params[:answers]
 
     submission = ::Foorm::SimpleSurveySubmission.new(
       user_id: params[:user_id],

--- a/dashboard/app/controllers/api/v1/pd/workshop_survey_foorm_submissions_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshop_survey_foorm_submissions_controller.rb
@@ -1,12 +1,14 @@
 class Api::V1::Pd::WorkshopSurveyFoormSubmissionsController < ApplicationController
   include Pd::WorkshopSurveyFoormConstants
   def create
-    answers = params[:answers] || {}
+    answers = params[:answers]
 
     # save facilitator answers as separate survey submissions
     # for ease of querying per-facilitator data
-    facilitator_answers = answers[Pd::WorkshopSurveyFoormConstants::FACILITATORS]
-    answers.delete(Pd::WorkshopSurveyFoormConstants::FACILITATORS)
+    if answers
+      facilitator_answers = answers[Pd::WorkshopSurveyFoormConstants::FACILITATORS]
+      answers.delete(Pd::WorkshopSurveyFoormConstants::FACILITATORS)
+    end
 
     pd_session_id = params[:pd_session_id].blank? ? nil : params[:pd_session_id].to_i
     day = params[:day].blank? ? nil : params[:day].to_i

--- a/dashboard/app/controllers/api/v1/pd/workshop_survey_foorm_submissions_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshop_survey_foorm_submissions_controller.rb
@@ -1,7 +1,7 @@
 class Api::V1::Pd::WorkshopSurveyFoormSubmissionsController < ApplicationController
   include Pd::WorkshopSurveyFoormConstants
   def create
-    answers = params[:answers]
+    answers = params[:answers] || {}
 
     # save facilitator answers as separate survey submissions
     # for ease of querying per-facilitator data

--- a/dashboard/app/models/foorm/submission.rb
+++ b/dashboard/app/models/foorm/submission.rb
@@ -18,6 +18,8 @@ class Foorm::Submission < ApplicationRecord
 
   belongs_to :form, foreign_key: [:form_name, :form_version], primary_key: [:name, :version]
 
+  before_save :handle_empty_answers
+
   # Returns a hash similar to a submission's answer, with the following changes:
   #   - flattens matrix questions
   #   - returns readable answer, instead of a key representing a user's answer.
@@ -126,5 +128,11 @@ class Foorm::Submission < ApplicationRecord
         [question_id + "_#{number}", answer_text]
       end
     ]
+  end
+
+  # Store the JSON parsable "{}" if we attempt to store a blank submission,
+  # which is typically stored as the string "null", which is the result of nil.to_json
+  def handle_empty_answers
+    self.answers = '{}' if answers == 'null'
   end
 end

--- a/dashboard/test/controllers/api/v1/foorm_simple_survey_submissions_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/foorm_simple_survey_submissions_controller_test.rb
@@ -29,4 +29,19 @@ class Api::V1::FoormSimpleSurveySubmissionsControllerTest < ::ActionController::
     assert_not_nil response_body['simple_survey_submission_id']
     assert_equal @simple_survey_form.id, response_body['simple_survey_form_id']
   end
+
+  test 'blank survey submission can be created and saved' do
+    response = post :create, params: @params.except(:answers)
+
+    assert_response :created
+
+    response_body = JSON.parse(response.body)
+
+    assert_not_nil response_body['foorm_submission_id']
+    assert_not_nil response_body['simple_survey_submission_id']
+    assert_equal @simple_survey_form.id, response_body['simple_survey_form_id']
+
+    # A submission's answers cannot be null, so we store a blank JSON object string if a submission has no answers
+    assert_equal "{}", Foorm::SimpleSurveySubmission.find(response_body['foorm_submission_id']).foorm_submission.answers
+  end
 end

--- a/dashboard/test/controllers/api/v1/foorm_simple_survey_submissions_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/foorm_simple_survey_submissions_controller_test.rb
@@ -42,6 +42,6 @@ class Api::V1::FoormSimpleSurveySubmissionsControllerTest < ::ActionController::
     assert_equal @simple_survey_form.id, response_body['simple_survey_form_id']
 
     # A submission's answers cannot be null, so we store a blank JSON object string if a submission has no answers
-    assert_equal "{}", Foorm::SimpleSurveySubmission.find(response_body['foorm_submission_id']).foorm_submission.answers
+    assert_equal "{}", Foorm::SimpleSurveySubmission.find(response_body['simple_survey_submission_id']).foorm_submission.answers
   end
 end

--- a/dashboard/test/controllers/api/v1/pd/workshop_survey_foorm_submissions_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_survey_foorm_submissions_controller_test.rb
@@ -6,10 +6,7 @@ class Api::V1::Pd::WorkshopSurveyFoormSubmissionsControllerTest < ::ActionContro
     @user = create :user
     @pd_summer_workshop = create :csp_summer_workshop
     @foorm_form = create :foorm_form
-  end
-
-  test 'can create and save survey submission' do
-    params = {
+    @default_params = {
       answers: {
         question1: 'answer1'
       },
@@ -20,8 +17,10 @@ class Api::V1::Pd::WorkshopSurveyFoormSubmissionsControllerTest < ::ActionContro
       form_name: @foorm_form.name,
       form_version: @foorm_form.version
     }
+  end
 
-    response = post :create, params: params
+  test 'can create and save survey submission' do
+    response = post :create, params: @default_params
     assert_response :created
     response_body = JSON.parse(response.body)
     assert_not_nil response_body['submission_id']
@@ -40,17 +39,7 @@ class Api::V1::Pd::WorkshopSurveyFoormSubmissionsControllerTest < ::ActionContro
   end
 
   test 'return conflict if user had already submitted a response' do
-    params = {
-      answers: {
-        question1: 'answer1'
-      },
-      user_id: @user.id,
-      pd_workshop_id: @pd_summer_workshop.id,
-      pd_session_id: nil,
-      day: nil,
-      form_name: nil,
-      form_version: @foorm_form.version
-    }
+    params = @default_params.merge({day: nil, form_name: nil})
 
     response = post :create, params: params
     assert_response :created
@@ -63,17 +52,7 @@ class Api::V1::Pd::WorkshopSurveyFoormSubmissionsControllerTest < ::ActionContro
   end
 
   test 'return conflict if user had already submitted a response, using all params' do
-    params = {
-      answers: {
-        question1: 'answer1'
-      },
-      user_id: @user.id,
-      pd_workshop_id: @pd_summer_workshop.id,
-      pd_session_id: 123,
-      day: 0,
-      form_name: @foorm_form.name,
-      form_version: @foorm_form.version
-    }
+    params = @default_params.merge({pd_session_id: 123})
 
     response = post :create, params: params
     assert_response :created

--- a/dashboard/test/controllers/api/v1/pd/workshop_survey_foorm_submissions_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_survey_foorm_submissions_controller_test.rb
@@ -28,6 +28,17 @@ class Api::V1::Pd::WorkshopSurveyFoormSubmissionsControllerTest < ::ActionContro
     assert_not_nil response_body['survey_submission_id']
   end
 
+  test 'can create and save blank survey submission' do
+    response = post :create, params: @default_params.except(:answers)
+    assert_response :created
+    response_body = JSON.parse(response.body)
+    assert_not_nil response_body['submission_id']
+    assert_not_nil response_body['survey_submission_id']
+
+    # A submission's answers cannot be null, so we store a blank JSON object string if a submission has no answers
+    assert_equal "{}", Pd::WorkshopSurveyFoormSubmission.find(response_body['survey_submission_id']).foorm_submission.answers
+  end
+
   test 'return conflict if user had already submitted a response' do
     params = {
       answers: {


### PR DESCRIPTION
We have a honeybadger error (linked below) where we're trying to process foorm submissions for our analytics (RED) team, but fail when submissions are not parsable JSON.

Identified that submissions where the user did not answer any questions and hit submit are being stored as the string "null", which is not valid JSON. Fixing such that the JSON parsable "{}" is stored in this case going forward.

Tangentially, I deduped some repetitive test fixtures.

## Links

- honeybadger error for cronjob: https://app.honeybadger.io/projects/45435/faults/80897052
- honeybadger error for CSV export: https://app.honeybadger.io/projects/3240/faults/81044781

## Testing story

Added unit tests to cover this case, and manually inspected a simple survey submission I created where I had answered no questions.

## Follow-up work

Take existing submissions (2 at this time) where `answers` field is "null" and save as "{}", which is what will happen in the future.