### PR TITLE
Attempt fix flaky Safari sign-in UI test

### DIFF
--- a/dashboard/test/ui/features/foundations/signing_in.feature
+++ b/dashboard/test/ui/features/foundations/signing_in.feature
@@ -61,6 +61,7 @@ Scenario: Teacher sign in from studio.code.org
   Then I wait to see ".user_menu"
   And I wait until element ".display_name" is visible
   And element ".display_name" contains text "Casey"
+  Then I sign out
 
 Scenario: Join non-existent section from sign in page shows error
   Given I am on "http://studio.code.org/users/sign_in/"

--- a/dashboard/test/ui/features/foundations/signing_in.feature
+++ b/dashboard/test/ui/features/foundations/signing_in.feature
@@ -50,7 +50,7 @@ Scenario: Student sign in from studio.code.org in the eu
 Scenario: Teacher sign in from studio.code.org
   Given I create a teacher named "Casey"
   And I sign out
-  Given I am on "http://code.org/"
+  Given I am on "http://studio.code.org/"
   And I reload the page
   Then I wait to see ".header_user"
   Then I click ".header_user"
@@ -61,7 +61,6 @@ Scenario: Teacher sign in from studio.code.org
   Then I wait to see ".user_menu"
   And I wait until element ".display_name" is visible
   And element ".display_name" contains text "Casey"
-  Then I sign out
 
 Scenario: Join non-existent section from sign in page shows error
   Given I am on "http://studio.code.org/users/sign_in/"


### PR DESCRIPTION
Fixing a flaky test involving Safari and Firefox having trouble with signing_in tests.

Test scenario: `Teacher sign in from studio.code.org`

Success example in Safari: https://app.saucelabs.com/tests/1940c6d76f7847c68ebc4ab5be462457
Success example in Firefox: https://app.saucelabs.com/tests/ba889e6f49f34e978fe4af099ba13c79#22

## Links
- [Slack message where flakiness was brought up](https://codedotorg.slack.com/archives/CFTFD6BPV/p1622736224091600)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
