### PR TITLE
add test to show applab level by id

### DIFF
--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -876,6 +876,11 @@ class LevelsControllerTest < ActionController::TestCase
     get :show, params: {id: my_level, game_id: my_level.game}
   end
 
+  test 'should show applab level' do
+    my_level = create :applab, type: 'Applab'
+    get :show, params: {id: my_level, game_id: my_level.game}
+  end
+
   test 'should show legacy unplugged level' do
     level = create :unplugged, name: 'OldUnplugged', type: 'Unplugged'
     get :show, params: {id: level, game_id: level.game}


### PR DESCRIPTION
See https://github.com/code-dot-org/code-dot-org/pull/39855#discussion_r694394247 for context.

## Testing story

Verified via `puts` statement that `LevelsHelper.get_channel_for` is getting called without `@script` being set, which could become a problem when making `channel_tokens.script_id` a required column.
