### PR TITLE
Skip IE for Oceans UI tests

### DIFF
--- a/dashboard/test/ui/features/hour_of_code/ml/ml_hoc.feature
+++ b/dashboard/test/ui/features/hour_of_code/ml/ml_hoc.feature
@@ -1,6 +1,10 @@
+@no_circle
+@no_mobile
+@no_safari
+@no_ie
+
 Feature: Oceans ML HoC
 
-  @no_circle @no_mobile @no_safari @no_ie
   Scenario: Fish vs. Trash
     # Training Screen
     Given I am on "http://studio.code.org/s/oceans/lessons/1/levels/2?guide=off"
@@ -17,7 +21,6 @@ Feature: Oceans ML HoC
     And I wait until element "button:contains(Continue)" is visible
     And I wait for 3 seconds
 
-  @no_circle @no_mobile @no_safari @no_ie
   Scenario: Sea Creatures
     # Initial Screen
     Given I am on "http://studio.code.org/s/oceans/lessons/1/levels/3?guide=off"
@@ -40,7 +43,6 @@ Feature: Oceans ML HoC
     And I wait until element "button:contains(Continue)" is visible
     And I wait for 3 seconds
 
-  @no_circle @no_mobile @no_safari @no_ie
   Scenario: Short Word List
     # Training Screen
     Given I am on "http://studio.code.org/s/oceans/lessons/1/levels/6?guide=off"
@@ -58,7 +60,6 @@ Feature: Oceans ML HoC
     And I wait until element "button:contains(Continue)" is visible
     And I wait for 3 seconds
 
-  @no_circle @no_mobile @no_safari @no_ie
   Scenario: Long Word List
     # Training Screen
     Given I am on "http://studio.code.org/s/oceans/lessons/1/levels/8?guide=off"

--- a/dashboard/test/ui/features/hour_of_code/ml/ml_hoc.feature
+++ b/dashboard/test/ui/features/hour_of_code/ml/ml_hoc.feature
@@ -1,6 +1,6 @@
 Feature: Oceans ML HoC
 
-  @no_circle @no_mobile @no_safari
+  @no_circle @no_mobile @no_safari @no_ie
   Scenario: Fish vs. Trash
     # Training Screen
     Given I am on "http://studio.code.org/s/oceans/lessons/1/levels/2?guide=off"
@@ -17,7 +17,7 @@ Feature: Oceans ML HoC
     And I wait until element "button:contains(Continue)" is visible
     And I wait for 3 seconds
 
-  @no_circle @no_mobile @no_safari
+  @no_circle @no_mobile @no_safari @no_ie
   Scenario: Sea Creatures
     # Initial Screen
     Given I am on "http://studio.code.org/s/oceans/lessons/1/levels/3?guide=off"
@@ -40,7 +40,7 @@ Feature: Oceans ML HoC
     And I wait until element "button:contains(Continue)" is visible
     And I wait for 3 seconds
 
-  @no_circle @no_mobile @no_safari
+  @no_circle @no_mobile @no_safari @no_ie
   Scenario: Short Word List
     # Training Screen
     Given I am on "http://studio.code.org/s/oceans/lessons/1/levels/6?guide=off"
@@ -58,7 +58,7 @@ Feature: Oceans ML HoC
     And I wait until element "button:contains(Continue)" is visible
     And I wait for 3 seconds
 
-  @no_circle @no_mobile @no_safari
+  @no_circle @no_mobile @no_safari @no_ie
   Scenario: Long Word List
     # Training Screen
     Given I am on "http://studio.code.org/s/oceans/lessons/1/levels/8?guide=off"


### PR DESCRIPTION
We don't support Oceans in IE so disabling that browser for the hoc_ml UI test, which was recently flaky. 
