### PR TITLE
[Spritelab] Fixes for validation code

### DIFF
--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -1151,7 +1151,7 @@ P5Lab.prototype.initInterpreter = function(attachDebugger = true) {
   this.JSInterpreter.parse({
     code,
     projectLibraries: this.level.projectLibraries,
-    blocks: this.isSpritelab ? [] : dropletConfig.blocks,
+    blocks: dropletConfig.blocks,
     blockFilter: this.level.executePaletteApisOnly && this.level.codeFunctions,
     enableEvents: true,
     initGlobals: injectGamelabGlobals,

--- a/apps/src/p5lab/spritelab/commands/validationCommands.js
+++ b/apps/src/p5lab/spritelab/commands/validationCommands.js
@@ -5,7 +5,9 @@ export const commands = {
 
   getBackground() {
     const background = this.getBackground();
-    if (typeof background === 'string') {
+    if (background === undefined) {
+      return undefined;
+    } else if (typeof background === 'string') {
       return background;
     } else {
       return background.name;


### PR DESCRIPTION
Reports came in that `console.log` was not working in validation code anymore, it turns out this was a regression from https://github.com/code-dot-org/code-dot-org/pull/42141. Along the way, I also found that the `getBackground` function needed an additional guard for the case where the background is undefined.

Slack threads:
https://codedotorg.slack.com/archives/C1B3PNDL7/p1629820166079300