### PR TITLE
Channel token script_id backfill

### DIFF
--- a/bin/oneoff/backfill_data/backfill_script_ids_channel_tokens.rb
+++ b/bin/oneoff/backfill_data/backfill_script_ids_channel_tokens.rb
@@ -65,6 +65,7 @@ $level_to_script_ids = {}
 def update_script_ids
   puts "Backfilling channel token script_ids..."
 
+  # find_each uses find_in_batches with a batch size of 1000 (https://apidock.com/rails/ActiveRecord/Batches/find_each)
   ChannelToken.where(id: $start_id..$end_id).find_each do |channel_token|
     next if channel_token.script_id.present?
 

--- a/bin/oneoff/backfill_data/backfill_script_ids_channel_tokens.rb
+++ b/bin/oneoff/backfill_data/backfill_script_ids_channel_tokens.rb
@@ -21,6 +21,7 @@
 require_relative '../../../dashboard/config/environment'
 require 'cdo/db'
 require 'optparse'
+require 'csv'
 
 # We started writing script_id to the table here: https://github.com/code-dot-org/code-dot-org/pull/39855
 # so we don't need to backfill past that point
@@ -70,11 +71,12 @@ end.parse!
 puts "Options: #{options}"
 options.freeze
 
+# we're storing channel token ids that failed backfill in a csv for easy lookup later
+$csv_filename = "bin/oneoff/backfill_data/channel-token-backfill-failures.csv"
 $start_id = options[:start_id]
 $end_id = options[:end_id]
 $is_dry_run = options[:dry_run]
 
-$backfill_count = 0
 $unable_to_backfill = 0
 
 $level_to_script_ids = {}
@@ -82,57 +84,66 @@ $level_to_script_ids = {}
 def update_script_ids
   puts "Backfilling channel token script_ids..."
   puts "Script started at #{Time.now}"
-  # find_each uses find_in_batches with a batch size of 1000 (https://apidock.com/rails/ActiveRecord/Batches/find_each)
-  ChannelToken.where(id: $start_id..$end_id).find_each do |channel_token|
-    next if channel_token.script_id.present?
 
-    level = channel_token.level
-    user_id = user_id_for_storage_id(channel_token.storage_id)
+  CSV.open($csv_filename, "w") do |csv|
+    csv << ["channel token failed backfill"]
 
-    # get all the possible scripts the channel_token could be associated with
-    associated_script_ids = get_associated_script_ids(level)
+    # find_each uses find_in_batches with a batch size of 1000 (https://apidock.com/rails/ActiveRecord/Batches/find_each)
+    ChannelToken.where(id: $start_id..$end_id).find_each do |channel_token|
+      next if channel_token.script_id.present?
 
-    # if the level is associated with only one script_level, use that script
-    if associated_script_ids.length == 1
-      script_id = associated_script_ids[0]
-      update_channel_token(channel_token, script_id)
-      next
+      begin
+        level = channel_token.level
+        user_id = user_id_for_storage_id(channel_token.storage_id)
+
+        # get all the possible scripts the channel_token could be associated with
+        associated_script_ids = get_associated_script_ids(level)
+
+        # if the level is associated with only one script_level, use that script
+        if associated_script_ids.length == 1
+          script_id = associated_script_ids[0]
+          update_channel_token(channel_token, script_id, csv)
+          next
+        end
+
+        # it's possible the channel token was generated for a logged-out user, in which case no user_id will exist
+        if user_id.present?
+          # get user_scripts for the associated_script_ids, if there is just one user_script, backfill with the
+          # associated script_id
+          script_ids_from_user_scripts = associated_script_ids_by_user_scripts(user_id, associated_script_ids)
+          if script_ids_from_user_scripts.count == 1
+            update_channel_token(channel_token, script_ids_from_user_scripts[0], csv)
+            next
+          end
+
+          # get user_levels for the associated_script_ids, if there is just one user_level, backfill with the
+          # associated script_id
+          script_ids_from_user_levels = associated_script_ids_from_user_levels(user_id, level)
+          if script_ids_from_user_levels.count == 1
+            update_channel_token(channel_token, script_ids_from_user_levels[0], csv)
+            next
+          end
+
+          # if the user has no associated user_levels or user_scripts, it's possible that the user visited a channel backed
+          # level which generated a channel_token and then the user left the page without making any progress. In this case it doesn't
+          # matter which script_id we pick, so backfill with the first associated_script_ids
+          if associated_script_ids.count > 0 && script_ids_from_user_scripts.blank? && script_ids_from_user_levels.blank?
+            update_channel_token(channel_token, associated_script_ids[0], csv)
+            next
+          end
+        end
+      rescue StandardError
+        print "[E]"
+      end
+
+      log_backfill_failed(channel_token.id, csv)
     end
-
-    # it's possible the channel token was generated for a logged-out user, in which case no user_id will exist
-    if user_id.present?
-      # get user_scripts for the associated_script_ids, if there is just one user_script, backfill with the
-      # associated script_id
-      script_ids_from_user_scripts = associated_script_ids_by_user_scripts(user_id, associated_script_ids)
-      if script_ids_from_user_scripts.count == 1
-        update_channel_token(channel_token, script_ids_from_user_scripts[0])
-        next
-      end
-
-      # get user_levels for the associated_script_ids, if there is just one user_level, backfill with the
-      # associated script_id
-      script_ids_from_user_levels = associated_script_ids_from_user_levels(user_id, level)
-      if script_ids_from_user_levels.count == 1
-        update_channel_token(channel_token, script_ids_from_user_levels[0])
-        next
-      end
-
-      # if the user has no associated user_levels or user_scripts, it's possible that the user visited a channel backed
-      # level which generated a channel_token and then the user left the page without making any progress. In this case it doesn't
-      # matter which script_id we pick, so backfill with the first associated_script_ids
-      if associated_script_ids.count > 0 && script_ids_from_user_scripts.blank? && script_ids_from_user_levels.blank?
-        update_channel_token(channel_token, associated_script_ids[0])
-        next
-      end
-    end
-
-    log_backfill_failed(channel_token)
   end
   puts
   puts "Script ended at #{Time.now}"
   puts
-  puts "backfilled #{$backfill_count} script ids"
   puts "unable to backfill script id for #{$unable_to_backfill} channel tokens"
+  puts "Failures exported to: #{$csv_filename}"
   puts
 end
 
@@ -152,23 +163,22 @@ def get_associated_script_ids(level)
   return $level_to_script_ids[level.id]
 end
 
-def update_channel_token(channel_token, script_id)
+def update_channel_token(channel_token, script_id, csv)
   unless $is_dry_run
     did_save = channel_token.update_attributes(script_id: script_id)
 
     unless did_save
-      log_backfill_failed(channel_token.id)
+      log_backfill_failed(channel_token.id, csv)
       return
     end
   end
-  print "."
-  $backfill_count += 1
+  print "#{channel_token.id},"
 end
 
-def log_backfill_failed(channel_token_id)
-  print "F"
-  CDO.log.info("Could not update channel token with ID: #{channel_token_id}")
+def log_backfill_failed(channel_token_id, csv)
+  print "[F] #{channel_token_id},"
   $unable_to_backfill += 1
+  csv << [channel_token_id]
 end
 
 def associated_script_ids_by_user_scripts(user_id, script_ids)

--- a/bin/oneoff/backfill_data/backfill_script_ids_channel_tokens.rb
+++ b/bin/oneoff/backfill_data/backfill_script_ids_channel_tokens.rb
@@ -85,8 +85,8 @@ def update_script_ids
   puts "Backfilling channel token script_ids..."
   puts "Script started at #{Time.now}"
 
-  CSV.open($csv_filename, "w") do |csv|
-    csv << ["channel token failed backfill"]
+  CSV.open($csv_filename, "a") do |csv|
+    csv.sync = true
 
     # find_each uses find_in_batches with a batch size of 1000 (https://apidock.com/rails/ActiveRecord/Batches/find_each)
     ChannelToken.where(id: $start_id..$end_id).find_each do |channel_token|

--- a/bin/oneoff/backfill_data/backfill_script_ids_channel_tokens_1.rb
+++ b/bin/oneoff/backfill_data/backfill_script_ids_channel_tokens_1.rb
@@ -1,0 +1,29 @@
+#!/usr/bin/env ruby
+# Backfill existing ChannelTokens to set script_id if it can easily be inferred because there is only one script associated with the level_id
+
+require_relative '../../../dashboard/config/environment'
+
+def channel_tokens_without_script_ids
+  ChannelToken.where(script_id: nil)
+end
+
+def puts_count
+  puts "There are #{channel_tokens_without_script_ids.count} channel_tokens without a script_id"
+end
+
+def update_script_ids
+  puts "backfilling script_ids..."
+  channel_tokens_without_script_ids.find_each do |channel_token|
+    associated_script_levels = channel_token.level.script_levels
+    if associated_script_levels.length == 1
+      script_id = associated_script_levels[0].script_id
+      channel_token.update_attributes(script_id: script_id)
+    end
+  end
+end
+
+ChannelToken.transaction do
+  puts_count
+  update_script_ids
+  puts_count
+end

--- a/bin/oneoff/backfill_data/backfill_script_ids_channel_tokens_1.rb
+++ b/bin/oneoff/backfill_data/backfill_script_ids_channel_tokens_1.rb
@@ -11,15 +11,92 @@ def puts_count
   puts "There are #{channel_tokens_without_script_ids.count} channel_tokens without a script_id"
 end
 
+# TODO: not filter by script ID run through all, keep track with a counter
+
 def update_script_ids
   puts "backfilling script_ids..."
   channel_tokens_without_script_ids.find_each do |channel_token|
     associated_script_levels = channel_token.level.script_levels
+
+    # if the level is associated with only one script_level, use that script
     if associated_script_levels.length == 1
       script_id = associated_script_levels[0].script_id
       channel_token.update_attributes(script_id: script_id)
+      next
+    end
+
+    potential_associated_scripts = associated_script_levels.map(&:script_id)
+
+    # if the level is associated with only one script_level where the script is visible,
+    # use that script
+    if visible_script_id = script_id_by_visible_scripts(potential_associated_scripts)
+      channel_token.update_attributes(script_id: visible_script_id)
+      next
+    end
+
+    user_id = user_id_for_storage_id(channel_token.storage_id)
+    next unless user_id
+
+    # if the user has only user_level associated with the level, use the script on that user_level
+    if user_level_script_id = script_id_by_user_level(user_id, channel_token.level_id)
+      channel_token.update_attributes(script_id: user_level_script_id)
+      next
+    end
+
+    # if the user is in or owns a section where the script assigned matches a potential script
+    # that could be associated with the level, use that script
+    if section_script_id = script_id_by_section(user_id, potential_associated_scripts)
+      channel_token.update_attributes(script_id: section_script_id)
+      next
     end
   end
+end
+
+# Given the script_levels that a channel token may be associated with, this method
+# returns the script_id for the associated script if there is only one publicly visible script
+def script_id_by_visible_scripts(associated_script_ids)
+  visible_published_states = [
+    SharedConstants::PUBLISHED_STATE.stable,
+    SharedConstants::PUBLISHED_STATE.preview,
+    SharedConstants::PUBLISHED_STATE.beta,
+    SharedConstants::PUBLISHED_STATE.in_development
+  ]
+
+  visible_associated_scripts = Script.where(
+    id: associated_script_ids,
+    published_state: visible_published_states
+  )
+
+  return visible_associated_scripts[0].id if visible_associated_scripts.count == 1
+end
+
+# Given a channel token, this method returns the associated script_id if it can
+# be identified based on user_level
+def script_id_by_user_level(user_id, level_id)
+  associated_user_levels = UserLevel.where(
+    user_id: user_id,
+    level_id: level_id
+  )
+
+  if associated_user_levels.count == 1
+    script_id = associated_user_levels[0].script_id
+    return script_id if script_id.present?
+  end
+end
+
+# Given a user_id and script ids that could be associated with the channel token, this
+# method returns a script id if the user is in a section assigned to a script that matches
+# the potential scripts for the channel token
+def script_id_by_section(user_id, associated_script_ids)
+  user = User.find(user_id)
+
+  user_sections = user.sections_as_student + user.sections
+  return if user_sections.empty?
+
+  user_section_script_ids = user_sections.map(&:script_id)
+  script_id_intersection = associated_script_ids & user_section_script_ids
+
+  return script_id_intersection[0] if script_id_intersection.length == 1
 end
 
 ChannelToken.transaction do

--- a/bin/oneoff/backfill_data/backfill_script_ids_channel_tokens_1.rb
+++ b/bin/oneoff/backfill_data/backfill_script_ids_channel_tokens_1.rb
@@ -2,27 +2,84 @@
 # Backfill existing ChannelTokens to set script_id if it can easily be inferred because there is only one script associated with the level_id
 
 require_relative '../../../dashboard/config/environment'
-
-# TODO: backfill only up to where we start writing script id to DB
+require 'optparse'
 
 # We started writing script_id to the table here: https://github.com/code-dot-org/code-dot-org/pull/39855
 # so we don't need to backfill past that point
 MAX_CHANNEL_TOKEN_ID_FOR_BACKFILL = 303_500_000
 
-def update_script_ids
+# Parse options
+options = {
+  start_id: nil,
+  end_id: nil,
+  dry_run: false,
+}
+
+OptionParser.new do |opts|
+  opts.banner = <<~BANNER
+    Usage: #{File.basename(__FILE__)} [options]
+
+    This script backfills script_id on the Channel Tokens table.
+
+    Options:
+  BANNER
+
+  opts.on('--start-id=1234567',
+    Integer,
+    'Id of first entry to backfill (inclusive).'
+  ) do |start_id|
+    options[:start_id] = start_id
+  end
+
+  opts.on('--end-id=1234567',
+    Integer,
+    'Id of last entry to backfill (exclusive).'
+  ) do |end_id|
+    options[:end_id] = end_id
+  end
+
+  opts.on('--dry-run',
+    'Enables read-only mode where no changes are written to the database'
+  ) do |dry_run|
+    options[:dry_run] = dry_run
+  end
+
+  opts.on('-h', '--help', 'Prints this help message') do
+    puts opts
+    exit
+  end
+end.parse!
+puts "Options: #{options}"
+options.freeze
+
+def update_script_ids(start_id, end_id, is_dry_run)
   puts "backfilling script_ids..."
   backfill_count = 0
   unable_to_backfill = 0
 
-  ChannelToken.where("id < ?", MAX_CHANNEL_TOKEN_ID_FOR_BACKFILL).find_each do |channel_token|
+  ChannelToken.where(id: start_id..end_id).find_each do |channel_token|
     next if channel_token.script_id.present?
 
-    associated_script_levels = channel_token.level.script_levels
+    level = channel_token.level
+    associated_script_levels = level.script_levels
+    user_id = user_id_for_storage_id(channel_token.storage_id)
+
+    # if the level is not in any script_levels, check to see if it's a level
+    # within a level
+    if associated_script_levels.empty?
+      parent_level_ids = get_parent_level_ids(level)
+      next unless parent_level_ids.present? && user_id
+
+      script_id_by_parent_user_levels = get_script_id_by_parent_levels(parent_level_ids, user_id)
+      if script_id_by_parent_user_levels
+        channel_token.update_attributes(script_id: script_id_by_parent_user_levels) unless is_dry_run
+      end
+    end
 
     # if the level is associated with only one script_level, use that script
     if associated_script_levels.length == 1
       script_id = associated_script_levels[0].script_id
-      channel_token.update_attributes(script_id: script_id)
+      channel_token.update_attributes(script_id: script_id) unless is_dry_run
       backfill_count += 1
       next
     end
@@ -32,17 +89,16 @@ def update_script_ids
     # if the level is associated with only one script_level where the script is visible,
     # use that script
     if visible_script_id = script_id_by_visible_scripts(potential_associated_scripts)
-      channel_token.update_attributes(script_id: visible_script_id)
+      channel_token.update_attributes(script_id: visible_script_id) unless is_dry_run
       backfill_count += 1
       next
     end
 
-    user_id = user_id_for_storage_id(channel_token.storage_id)
     next unless user_id
 
     # if the user has only user_level associated with the level, use the script on that user_level
-    if user_level_script_id = script_id_by_user_level(user_id, channel_token.level_id)
-      channel_token.update_attributes(script_id: user_level_script_id)
+    if user_level_script_id = script_id_by_user_level(user_id, level.id)
+      channel_token.update_attributes(script_id: user_level_script_id) unless is_dry_run
       backfill_count += 1
       next
     end
@@ -50,7 +106,7 @@ def update_script_ids
     # if the user is in or owns a section where the script assigned matches a potential script
     # that could be associated with the level, use that script
     if section_script_id = script_id_by_section(user_id, potential_associated_scripts)
-      channel_token.update_attributes(script_id: section_script_id)
+      channel_token.update_attributes(script_id: section_script_id) unless is_dry_run
       backfill_count += 1
       next
     end
@@ -59,6 +115,20 @@ def update_script_ids
   end
 
   puts "backfilled #{backfill_count} script ids, unable to backfill script id for #{unable_to_backfill} channel tokens"
+end
+
+def get_parent_level_ids(level)
+  parent_level_child_levels = level.levels_parent_levels
+  return unless parent_level_child_levels.any?
+
+  parent_level_child_levels.map(&:parent_level_id)
+end
+
+def get_script_id_by_parent_levels(parent_level_ids, user_id)
+  parent_level_ids.each do |level_id|
+    script_id = script_id_by_user_level(user_id, level_id)
+    return script_id if script_id
+  end
 end
 
 # Given the script_levels that a channel token may be associated with, this method
@@ -112,6 +182,9 @@ def script_id_by_section(user_id, associated_script_ids)
   return script_id_intersection[0] if script_id_intersection.length == 1
 end
 
+start_id = options[:start_id] || 1
+end_id = options[:end_id] || MAX_CHANNEL_TOKEN_ID_FOR_BACKFILL
+is_dry_run = options[:dry_run]
 ChannelToken.transaction do
-  update_script_ids
+  update_script_ids(start_id, end_id, is_dry_run)
 end

--- a/bin/oneoff/backfill_data/backfill_script_ids_channel_tokens_1.rb
+++ b/bin/oneoff/backfill_data/backfill_script_ids_channel_tokens_1.rb
@@ -56,6 +56,7 @@ def update_script_ids(start_id, end_id, is_dry_run)
   puts "backfilling script_ids..."
   backfill_count = 0
   unable_to_backfill = 0
+  levels_missing_backfills = []
 
   ChannelToken.where(id: start_id..end_id).find_each do |channel_token|
     next if channel_token.script_id.present?
@@ -78,6 +79,7 @@ def update_script_ids(start_id, end_id, is_dry_run)
       parent_level_ids = get_parent_level_ids(level)
 
       if parent_level_ids.blank? || user_id.blank?
+        levels_missing_backfills.push(level.id)
         unable_to_backfill += 1
         next
       end
@@ -116,10 +118,15 @@ def update_script_ids(start_id, end_id, is_dry_run)
       next
     end
 
+    levels_missing_backfills.push(level.id)
     unable_to_backfill += 1
   end
 
   puts "backfilled #{backfill_count} script ids, unable to backfill script id for #{unable_to_backfill} channel tokens"
+
+  # for investigation purposes
+  puts "unfilled levels:"
+  puts levels_missing_backfills.uniq!
 end
 
 def get_parent_level_ids(level)

--- a/bin/oneoff/backfill_data/backfill_script_ids_channel_tokens_1.rb
+++ b/bin/oneoff/backfill_data/backfill_script_ids_channel_tokens_1.rb
@@ -52,153 +52,136 @@ end.parse!
 puts "Options: #{options}"
 options.freeze
 
-def update_script_ids(start_id, end_id, is_dry_run)
-  puts "backfilling script_ids..."
-  backfill_count = 0
-  unable_to_backfill = 0
-  levels_missing_backfills = []
+$start_id = options[:start_id] || 1
+$end_id = options[:end_id] || MAX_CHANNEL_TOKEN_ID_FOR_BACKFILL
+$is_dry_run = options[:dry_run]
 
-  ChannelToken.where(id: start_id..end_id).find_each do |channel_token|
+$backfill_count = 0
+$unable_to_backfill = 0
+$template_unable_to_backfill = 0
+$levels_missing_backfills = []
+$template_levels_missing_backfills = []
+
+$level_to_script_ids = {}
+
+def update_script_ids
+  puts "backfilling script_ids..."
+
+  ChannelToken.where(id: $start_id..$end_id).find_each do |channel_token|
     next if channel_token.script_id.present?
 
     level = channel_token.level
     user_id = user_id_for_storage_id(channel_token.storage_id)
 
-    # if the user has only user_level associated with the level, use the script on that user_level
-    if user_id.present? && user_level_script_id = script_id_by_user_level(user_id, level.id)
-      channel_token.update_attributes(script_id: user_level_script_id) unless is_dry_run
-      backfill_count += 1
+    # get all the possible scripts the channel token could be associated with
+    # search user scripts, if there's just one result use that script id
+    # see what's left
+    associated_script_ids = get_associated_script_ids(level)
+    if user_id.present? && script_id_from_user_scripts = script_id_by_user_scripts(user_id, associated_script_ids)
+      update_channel_token(channel_token, script_id_from_user_scripts)
       next
     end
 
-    associated_script_levels = level.script_levels
-
-    # if the level is not in any script_levels, check to see if it's a level
-    # within a level
-    if associated_script_levels.empty?
-      parent_level_ids = get_parent_level_ids(level)
-
-      if parent_level_ids.blank? || user_id.blank?
-        levels_missing_backfills.push(level.id)
-        unable_to_backfill += 1
-        next
-      end
-
-      script_id_by_parent_user_levels = get_script_id_by_parent_levels(parent_level_ids, user_id)
-      if script_id_by_parent_user_levels
-        channel_token.update_attributes(script_id: script_id_by_parent_user_levels) unless is_dry_run
-        backfill_count += 1
-        next
-      end
+    # if the user has only user_level associated with the level, use the script on that user_level
+    if user_id.present? && user_level_script_id = script_id_from_user_level(user_id, level)
+      update_channel_token(channel_token, user_level_script_id)
+      next
     end
 
     # if the level is associated with only one script_level, use that script
-    if associated_script_levels.length == 1
-      script_id = associated_script_levels[0].script_id
-      channel_token.update_attributes(script_id: script_id) unless is_dry_run
-      backfill_count += 1
+    if associated_script_ids.length == 1
+      script_id = associated_script_ids[0]
+      update_channel_token(channel_token, script_id)
       next
     end
 
-    potential_associated_scripts = associated_script_levels.map(&:script_id)
+    #----- after this we could potentially just pick a script ID there may be multiple from user scripts
+    # if we had a logged in user and they have no trace of progress
 
-    # if the level is associated with only one script_level where the script is visible,
-    # use that script
-    if visible_script_id = script_id_by_visible_scripts(potential_associated_scripts)
-      channel_token.update_attributes(script_id: visible_script_id) unless is_dry_run
-      backfill_count += 1
-      next
-    end
-
-    # if the user is in or owns a section where the script assigned matches a potential script
-    # that could be associated with the level, use that script
-    if user_id.present? && section_script_id = script_id_by_section(user_id, potential_associated_scripts)
-      channel_token.update_attributes(script_id: section_script_id) unless is_dry_run
-      backfill_count += 1
-      next
-    end
-
-    levels_missing_backfills.push(level.id)
-    unable_to_backfill += 1
+    record_failed_script_id_backfill(level, channel_token, user_id)
   end
 
-  puts "backfilled #{backfill_count} script ids, unable to backfill script id for #{unable_to_backfill} channel tokens"
+  puts
+  puts "backfilled #{$backfill_count} script ids"
+  puts "unable to backfill script id for #{$unable_to_backfill} channel tokens (non-template)"
+  puts "unable to backfill script id for #{$template_unable_to_backfill} channel tokens (template)"
 
   # for investigation purposes
   puts "unfilled levels:"
-  puts levels_missing_backfills.uniq!
+  print $levels_missing_backfills.uniq!
+  puts
+
+  puts "unfilled template levels:"
+  print $template_levels_missing_backfills.uniq!
+
+  puts
 end
 
-def get_parent_level_ids(level)
-  parent_level_child_levels = level.levels_parent_levels
-  return unless parent_level_child_levels.any?
+def get_associated_script_ids(level)
+  if $level_to_script_ids[level.id].present?
+    return $level_to_script_ids[level.id]
+  end
 
-  parent_level_child_levels.map(&:parent_level_id)
+  script_ids = level.script_levels.map(&:script_id)
+  level.parent_levels.map do |parent_level|
+    parent_level_script_ids = parent_level.script_levels.map(&:script_id)
+    script_ids.concat(parent_level_script_ids)
+  end
+  $level_to_script_ids[level.id] = script_ids.uniq
+  return $level_to_script_ids[level.id]
 end
 
-def get_script_id_by_parent_levels(parent_level_ids, user_id)
-  parent_level_ids.each do |level_id|
-    script_id = script_id_by_user_level(user_id, level_id)
-    return script_id if script_id
+def update_channel_token(channel_token, script_id)
+  print "."
+  channel_token.update_attributes(script_id: script_id) unless $is_dry_run
+  $backfill_count += 1
+end
+
+def record_failed_script_id_backfill(level, channel_token, user_id)
+  print "f"
+  if level.name.downcase.include?("template")
+    $template_levels_missing_backfills.push(level.id)
+    $template_unable_to_backfill += 1
+  else
+    if user_id.present?
+      puts
+      print "level_id: #{level.id}, channel_token_id: #{channel_token.id}, level_name: #{level.name}"
+      puts
+    end
+    $levels_missing_backfills.push(level.id)
+    $unable_to_backfill += 1
   end
 end
 
-# Given the script_levels that a channel token may be associated with, this method
-# returns the script_id for the associated script if there is only one publicly visible script
-def script_id_by_visible_scripts(associated_script_ids)
-  visible_published_states = [
-    SharedConstants::PUBLISHED_STATE.stable,
-    SharedConstants::PUBLISHED_STATE.preview,
-    SharedConstants::PUBLISHED_STATE.beta,
-    SharedConstants::PUBLISHED_STATE.in_development
-  ]
-
-  visible_associated_scripts = Script.where(
-    id: associated_script_ids,
-    published_state: visible_published_states
-  )
-
-  return visible_associated_scripts[0].id if visible_associated_scripts.count == 1
+def script_id_by_user_scripts(user_id, script_ids)
+  user_scripts = UserScript.where(user_id: user_id, script_id: script_ids)
+  return user_scripts[0].script_id if user_scripts.count == 1
 end
 
 # Given a channel token, this method returns the associated script_id if it can
 # be identified based on user_level
-def script_id_by_user_level(user_id, level_id)
+def script_id_from_user_level(user_id, level)
   associated_user_levels = UserLevel.where(
     user_id: user_id,
-    level_id: level_id
+    level_id: level.id
   )
 
+  if associated_user_levels.count == 0 && level.contained_levels.any?
+    contained_level_id = level.contained_levels.first
+    associated_user_levels = UserLevel.where(
+      user_id: user_id,
+      level_id: contained_level_id
+    )
+  end
+
   if associated_user_levels.count == 1
-    script_id = associated_user_levels[0].script_id
-    return script_id if script_id.present?
+    return associated_user_levels[0].script_id
   elsif associated_user_levels.count > 1
     recent_user_levels = associated_user_levels.order(updated_at: :desc)
     script_id = recent_user_levels[0].script_id
-    return script_id if script_id.present?
+    # TODO: add logging so we can determine where we might have missing progress
+    return script_id
   end
 end
 
-# Given a user_id and script ids that could be associated with the channel token, this
-# method returns a script id if the user is in a section assigned to a script that matches
-# the potential scripts for the channel token
-def script_id_by_section(user_id, associated_script_ids)
-  user = User.find_by(id: user_id)
-
-  return if user.nil?
-
-  user_sections = user.sections_as_student + user.sections
-  return if user_sections.empty?
-
-  user_section_script_ids = user_sections.map(&:script_id)
-  script_id_intersection = associated_script_ids & user_section_script_ids
-
-  return script_id_intersection[0] if script_id_intersection.length == 1
-end
-
-start_id = options[:start_id] || 1
-end_id = options[:end_id] || MAX_CHANNEL_TOKEN_ID_FOR_BACKFILL
-is_dry_run = options[:dry_run]
-ChannelToken.transaction do
-  update_script_ids(start_id, end_id, is_dry_run)
-end
+update_script_ids


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Backfill script to populate channel_token script_id column using a variety of methods. The backfill will output channel token ids as they are processed. Channel tokens that cannot be backfilled will be written to a CSV.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
- jira ticket: [LP-1840](https://codedotorg.atlassian.net/browse/LP-1840)
<!--
- spec: []()

-->

## Testing story
I chose random samples of channel tokens by ID range and ran the backfill on a clone of the production DB to determine that the backfill was working and to debug which channel tokens are unable to be backfilled.

Example of how to run: `ruby bin/oneoff/backfill_data/backfill_script_ids_channel_tokens.rb --dry-run --start-id=20000000 --end-id=20000100`
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy
1. Let infrastructure team know that the script is going to be run so they can help monitor the impact
2. I'll run the script
3. Regularly check on the script, if there are any issues I'll stop the script and go from there

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
