### PR TITLE
Fnd 1614 sync codeorg markdown pages

### DIFF
--- a/bin/i18n/SETUP.md
+++ b/bin/i18n/SETUP.md
@@ -11,9 +11,10 @@ npm install
 
 You will additionally need to add a `codeorg_credentials.yml` file to this
 directory (`{project root}/bin/i18n/`) containing the API key for the code.org
-project, and an `hourofcode_credentials.yml` file containing the API key for the
-Hour of Code project.  See [the crowdin documentation][2] for more details; the
-API keys themselves can be found on the project settings page
+project, an `hourofcode_credentials.yml` file containing the API key for the
+Hour of Code project, and a `codeorg_markdown_credentials.yml` file containing
+the API key for the Code.org - Markdown project.  See [the crowdin documentation][2]
+for more details; the API keys themselves can be found on the project settings page
 
 [1]: https://support.crowdin.com/cli-tool/
 [2]: https://support.crowdin.com/configuration-file/#split-project-configuration-and-api-credentials

--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -389,13 +389,14 @@ def distribute_translations(upload_manifests)
 
     ### Pegasus markdown
     Dir.glob("#{locale_dir}/codeorg-markdown/**/*.*") do |loc_file|
-      relative_path = loc_file.delete_prefix(locale_dir)
+      relative_path = loc_file.delete_prefix("#{locale_dir}/codeorg-markdown")
       next unless file_changed?(locale, relative_path)
 
       destination_dir = "pegasus/sites.v3/code.org/i18n/public"
-      relative_dir = File.dirname(loc_file.delete_prefix("#{locale_dir}/codeorg-markdown"))
+      relative_dir = File.dirname(relative_path)
       name = File.basename(loc_file, ".*")
       destination = File.join(destination_dir, relative_dir, "#{name}.#{locale}.md.partial")
+      FileUtils.mkdir_p(File.dirname(destination))
       FileUtils.mv(loc_file, destination)
     end
 


### PR DESCRIPTION
Fix for HoC markdown pages not getting translated. There were a couple of issues in the syncout with the markdown path being set incorrectly, and throwing an error if the directory didn't already exist. Also updated the i18n SETUP doc to include the credentials file for the codeorg_markdown crowdin project.

Successfully translated HoC markdown:
<img width="1772" alt="Screen Shot 2021-08-25 at 12 43 25 PM" src="https://user-images.githubusercontent.com/86268316/130857093-91a67692-ecd3-4a57-a4ad-1ba504fb08aa.png">

## Links

- Jira ticket: [Hour of Code markdown pages not syncing Crowdin translations](https://codedotorg.atlassian.net/browse/FND-1614)