### PR TITLE
Update to P5Play version 20

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -59,7 +59,7 @@
     "@code-dot-org/maze": "2.14.0",
     "@code-dot-org/ml-activities": "0.0.26",
     "@code-dot-org/ml-playground": "0.0.39",
-    "@code-dot-org/p5.play": "^1.3.17-cdo",
+    "@code-dot-org/p5.play": "^1.3.18-cdo",
     "@code-dot-org/piskel": "0.13.0-cdo.6",
     "@code-dot-org/redactable-markdown": "0.4.0",
     "@react-bootstrap/pagination": "^1.0.0",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1657,17 +1657,17 @@
     react-chartjs-2 "^2.11.1"
     reselect "^4.0.0"
 
-"@code-dot-org/p5.play@^1.3.17-cdo":
-  version "1.3.17-cdo"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/p5.play/-/p5.play-1.3.17-cdo.tgz#c7d3dd3744c626dd2d2b90bda735fe64f64be662"
-  integrity sha512-0H423zbBWym1EyuJ7HfaCb68W4bGQd0E6DD5ENjmLBPZq/PXyf6Rn/agBnlKPZ1OGMStEVwlgRbg8IhpYRhWZA==
+"@code-dot-org/p5.play@^1.3.18-cdo":
+  version "1.3.18-cdo"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/p5.play/-/p5.play-1.3.18-cdo.tgz#5ff3e155cb019a1b9e81e3cfe1f71ed2d11e7aa4"
+  integrity sha512-lcJp8a8exbUOLaZ29KIpmEN6wvckSi5vURxb6ZewlO5ASpz3GONMLvHoWU3RSd6ON9ippWRuWp9kzi7mHBDX+Q==
   dependencies:
-    "@code-dot-org/p5" "0.5.4-cdo.9"
+    "@code-dot-org/p5" "0.5.4-cdo.10"
 
-"@code-dot-org/p5@0.5.4-cdo.9":
-  version "0.5.4-cdo.9"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/p5/-/p5-0.5.4-cdo.9.tgz#8d5e7a75130bf3b4ee21678a7601fabed9858c7d"
-  integrity sha512-spJZkp8f2Hfqq6Xg8aiZlFSEtoPLln01e/MCX0ak4/7uX+NpgN0SkPKfzREp+NaLCOEZG0u+45XkSWYaFAGXvA==
+"@code-dot-org/p5@0.5.4-cdo.10":
+  version "0.5.4-cdo.10"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/p5/-/p5-0.5.4-cdo.10.tgz#4a915c4af0a762e59606bf3582dbb22a4c625139"
+  integrity sha512-UnlIasrM4YOULFhWLnnvx2DFznQEuEtSwL9JGD1zWfpEWoQ5hnfJcDuTKvmy7wUlt5hrE2M5aF2aMwxBfEYGTQ==
   dependencies:
     opentype.js "^0.4.9"
     reqwest "^1.1.5"


### PR DESCRIPTION
cc: @ajpal - this will release your latest P5Play changes.

Includes this PR: https://github.com/code-dot-org/p5.play/pull/65 which fixes a regression that was shipped in version 18 of p5play.

The regression (version 18)
![reproWith18](https://user-images.githubusercontent.com/2959170/131008824-4dad31c3-2523-4acb-b769-7c0c1e0b3142.gif)

With fix (version 20)
![reproWith20](https://user-images.githubusercontent.com/2959170/131008879-436e9797-d92c-4713-86df-34093b6940f6.gif)


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
