### PR TITLE
[PoemBot][HOC] Add font outline color to set font block + small fixes

### DIFF
--- a/apps/src/p5lab/spritelab/libraries/PoemBotLibrary.js
+++ b/apps/src/p5lab/spritelab/libraries/PoemBotLibrary.js
@@ -212,7 +212,7 @@ export default class PoemBotLibrary extends CoreLibrary {
     const numLinesToShow = Math.floor(progress * renderInfo.lines.length);
     return {
       ...renderInfo,
-      lines: newLines.slice(0, numLinesToShow)
+      lines: newLines.slice(0, numLinesToShow + 1) // end index is not inclusive, so + 1
     };
   }
 

--- a/apps/src/p5lab/spritelab/libraries/PoemBotLibrary.js
+++ b/apps/src/p5lab/spritelab/libraries/PoemBotLibrary.js
@@ -17,15 +17,17 @@ export default class PoemBotLibrary extends CoreLibrary {
       title: '',
       author: '',
       lines: [],
-      color: 'black',
-      font: 'Arial',
+      font: {
+        fill: 'black',
+        stroke: 'white',
+        font: 'Arial'
+      },
       isVisible: true,
       effects: []
     };
     this.backgroundEffect = () => this.p5.background('white');
     this.foregroundEffect = () => {};
     this.lineEvents = {};
-    this.p5.noStroke();
     this.p5.textAlign(this.p5.CENTER);
     this.p5.angleMode(this.p5.DEGREES);
 
@@ -77,12 +79,19 @@ export default class PoemBotLibrary extends CoreLibrary {
         this.poemState.lines.push(line || '');
       },
 
-      setFontColor(color) {
-        this.poemState.color = color;
+      setFontColor(fill, stroke) {
+        if (fill) {
+          this.poemState.font.fill = fill;
+        }
+        if (stroke) {
+          this.poemState.font.stroke = stroke;
+        }
       },
 
       setFont(font) {
-        this.poemState.font = font;
+        if (font) {
+          this.poemState.font.font = font;
+        }
       },
 
       setTitle(title) {
@@ -135,6 +144,10 @@ export default class PoemBotLibrary extends CoreLibrary {
   getScaledFontSize(text, font, desiredSize) {
     this.p5.push();
     this.p5.textFont(font);
+    // stroke color doesn't matter here, we just need to set a stroke to get an
+    // accurate width calculation.
+    this.p5.stroke('black');
+    this.p5.strokeWeight(3);
     this.p5.textSize(desiredSize);
     const fullWidth = this.p5.textWidth(text);
     const scaledSize = Math.min(
@@ -224,8 +237,9 @@ export default class PoemBotLibrary extends CoreLibrary {
     }
     let yCursor = OUTER_MARGIN;
     let renderInfo = {
-      color: poemState.color,
-      font: poemState.font,
+      font: {
+        ...poemState.font
+      },
       lines: []
     };
     if (poemState.title) {
@@ -235,7 +249,7 @@ export default class PoemBotLibrary extends CoreLibrary {
         y: yCursor,
         size: this.getScaledFontSize(
           poemState.title,
-          poemState.font,
+          poemState.font.font,
           FONT_SIZE * 2
         )
       };
@@ -247,7 +261,7 @@ export default class PoemBotLibrary extends CoreLibrary {
         text: poemState.author,
         x: PLAYSPACE_SIZE / 2,
         y: yCursor,
-        size: this.getScaledFontSize(poemState.author, poemState.font, 16)
+        size: this.getScaledFontSize(poemState.author, poemState.font.font, 16)
       };
       yCursor += LINE_HEIGHT;
     }
@@ -259,7 +273,7 @@ export default class PoemBotLibrary extends CoreLibrary {
     );
     renderInfo.lineSize = this.getScaledFontSize(
       longestLine,
-      poemState.font,
+      poemState.font.font,
       FONT_SIZE
     );
     poemState.lines.forEach(line => {
@@ -284,8 +298,10 @@ export default class PoemBotLibrary extends CoreLibrary {
   }
 
   drawFromRenderInfo(renderInfo) {
-    this.p5.fill(renderInfo.color || 'black');
-    this.p5.textFont(renderInfo.font || 'Arial');
+    this.p5.fill(renderInfo.font.fill);
+    this.p5.stroke(renderInfo.font.stroke);
+    this.p5.strokeWeight(3);
+    this.p5.textFont(renderInfo.font.font);
     if (renderInfo.title) {
       this.p5.textSize(renderInfo.title.size);
       this.p5.text(
@@ -304,7 +320,7 @@ export default class PoemBotLibrary extends CoreLibrary {
     }
     this.p5.textSize(renderInfo.lineSize);
     renderInfo.lines.forEach(item => {
-      let color = this.getP5Color(renderInfo.color || 'black', item.alpha);
+      let color = this.getP5Color(renderInfo.font.fill, item.alpha);
       this.p5.fill(color);
       this.p5.text(item.text, item.x, item.y);
     });

--- a/apps/src/p5lab/spritelab/poembot/commands/backgroundEffects.js
+++ b/apps/src/p5lab/spritelab/poembot/commands/backgroundEffects.js
@@ -30,7 +30,7 @@ export const commands = {
             color: utils.lerpColorFromPalette(
               this.p5,
               palette,
-              (i / numPoints) * utils.PALETTES[palette].length
+              (i / numPoints) * PALETTES[palette].length
             )
           });
         }

--- a/dashboard/config/blocks/PoemBot/PoemBot_setFontColor.json
+++ b/dashboard/config/blocks/PoemBot/PoemBot_setFontColor.json
@@ -2,10 +2,14 @@
   "category": "",
   "config": {
     "func": "setFontColor",
-    "blockText": "set font color {COLOR}",
+    "blockText": "set font color {FILL} with outline {STROKE}",
     "args": [
       {
-        "name": "COLOR",
+        "name": "FILL",
+        "type": "Colour"
+      },
+      {
+        "name": "STROKE",
         "type": "Colour"
       }
     ]

--- a/dashboard/config/scripts/levels/New PoemBot Project.level
+++ b/dashboard/config/scripts/levels/New PoemBot Project.level
@@ -95,7 +95,12 @@
         <block type="PoemBot_setFont"/>
         <block type="PoemBot_setTitle"/>
         <block type="PoemBot_setFontColor">
-          <value name="COLOR">
+          <value name="FILL">
+            <block type="colour_picker">
+              <title name="COLOUR">#99ff99</title>
+            </block>
+          </value>
+          <value name="STROKE">
             <block type="colour_picker">
               <title name="COLOUR">#99ff99</title>
             </block>

--- a/dashboard/config/scripts/levels/New PoemBot Project.level
+++ b/dashboard/config/scripts/levels/New PoemBot Project.level
@@ -85,11 +85,13 @@
     </start_blocks>
     <toolbox_blocks>
       <xml>
+        <block type="PoemBot_playSound"/>
         <block type="PoemBot_stringValue"/>
         <block type="PoemBot_randomWord"/>
         <block type="PoemBot_textConcat"/>
         <block type="variables_set"/>
         <block type="variables_get"/>
+        <block type="PoemBot_setPoem"/>
         <block type="PoemBot_setFont"/>
         <block type="PoemBot_setTitle"/>
         <block type="PoemBot_setFontColor">


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8787187/131025652-543cfbfa-8e65-482d-950e-37f44ac9d891.png)

`strokeWeight` is hard-coded to be `3`- this matches the Sprite Lab title stroke weight.
![image](https://user-images.githubusercontent.com/8787187/131025939-94209891-3efb-4c06-ab7e-32348954ce8c.png)


Also in this PR:
- fix off-by-one error in line animation that was breaking text effects. 
- fix squiggles background that was still referencing `utils.PALETTES` but `PALETTES` moved to `constants.js`