### PR TITLE
Check for the user when checking for code_review_enabled

### DIFF
--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -114,7 +114,9 @@ class ScriptLevelsController < ApplicationController
     raise ActiveRecord::RecordNotFound unless @script_level
     authorize! :read, @script_level, params.slice(:login_required)
 
-    @code_review_enabled = @script_level.level.is_a?(Javalab) && (current_user.teacher? || current_user&.sections_as_student&.all?(&:code_review_enabled?))
+    @code_review_enabled = @script_level.level.is_a?(Javalab) &&
+      current_user.present? &&
+      (current_user.teacher? || current_user&.sections_as_student&.all?(&:code_review_enabled?))
 
     if current_user && current_user.script_level_hidden?(@script_level)
       view_options(full_width: true)


### PR DESCRIPTION
Fix for https://app.honeybadger.io/projects/3240/faults/81104741. Tested locally by being a signed out user on http://localhost-studio.code.org:3000/s/allthethings/lessons/44/levels/1.

This is a pretty low-urgency issue as javalab can't actually be run as a signed out user but it's good to fix anyway.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
