### PR TITLE
Revert "Cache associated models for Script#all_scripts"

### DIFF
--- a/dashboard/app/models/lesson_group.rb
+++ b/dashboard/app/models/lesson_group.rb
@@ -20,10 +20,6 @@ class LessonGroup < ApplicationRecord
   include SerializedProperties
 
   belongs_to :script
-  def script
-    Script.get_from_cache(script_id)
-  end
-
   has_many :lessons, -> {order(:absolute_position)}, dependent: :destroy
   has_many :script_levels, through: :lessons
   has_many :levels, through: :script_levels

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -72,21 +72,10 @@ class Script < ApplicationRecord
             :callouts
           ]
         },
-        :lesson_groups,
-        :resources,
-        :student_resources,
         {
-          lessons: [
-            :lesson_activities,
-            {script_levels: [:levels]}
-          ]
+          lessons: [{script_levels: [:levels]}]
         },
-        {
-          unit_group_units: {
-            unit_group: :course_version
-          }
-        },
-        :course_version
+        :unit_group_units
       ]
     )
   end
@@ -272,7 +261,7 @@ class Script < ApplicationRecord
   end
 
   def self.lesson_extras_script_ids
-    @@lesson_extras_scripts ||= all_scripts.select(&:lesson_extras_available?).pluck(:id)
+    @@lesson_extras_scripts ||= Script.all.select(&:lesson_extras_available?).pluck(:id)
   end
 
   def self.maker_units
@@ -316,8 +305,10 @@ class Script < ApplicationRecord
 
   class << self
     def all_scripts
-      return all.to_a unless should_cache?
-      @@all_scripts ||= script_cache.values.uniq.freeze
+      all_scripts = Rails.cache.fetch('valid_scripts/all') do
+        Script.all.to_a
+      end
+      all_scripts.freeze
     end
 
     def family_names
@@ -329,7 +320,10 @@ class Script < ApplicationRecord
     private
 
     def visible_units
-      all_scripts.select(&:launched?).to_a.freeze
+      visible_units = Rails.cache.fetch('valid_scripts/valid') do
+        Script.all.select(&:launched?).to_a
+      end
+      visible_units.freeze
     end
   end
 
@@ -398,7 +392,7 @@ class Script < ApplicationRecord
   end
 
   def self.unit_cache_to_cache
-    Rails.cache.write(UNIT_CACHE_KEY, (@@unit_cache = unit_cache_from_db))
+    Rails.cache.write(UNIT_CACHE_KEY, unit_cache_from_db)
   end
 
   def self.unit_cache_from_cache
@@ -1694,7 +1688,6 @@ class Script < ApplicationRecord
     @@unit_cache = nil
     @@unit_family_cache = nil
     @@level_cache = nil
-    @@all_scripts = nil
     Rails.cache.delete UNIT_CACHE_KEY
   end
 

--- a/dashboard/config/initializers/script_preload.rb
+++ b/dashboard/config/initializers/script_preload.rb
@@ -7,11 +7,11 @@ if File.basename($0) != 'rake' &&
     Script.should_cache? &&
     !Rails.application.config.skip_script_preload
   # Populate the shared in-memory cache from the database.
-  Script.unit_cache_to_cache unless Rails.cache.is_a?(ActiveSupport::Cache::MemoryStore)
+  Script.unit_cache_to_cache
   Script.script_cache
   Script.script_level_cache
   Script.level_cache
   Script.unit_family_cache
-  UnitGroup.course_cache_to_cache unless Rails.cache.is_a?(ActiveSupport::Cache::MemoryStore)
+  UnitGroup.course_cache_to_cache
   UnitGroup.course_cache
 end

--- a/dashboard/test/controllers/courses_controller_test.rb
+++ b/dashboard/test/controllers/courses_controller_test.rb
@@ -34,7 +34,6 @@ class CoursesControllerTest < ActionController::TestCase
     setup do
       Script.stubs(:should_cache?).returns true
       Script.clear_cache
-      UnitGroup.clear_cache
 
       @unit_group_regular = create :unit_group, name: 'non-plc-course', published_state: SharedConstants::PUBLISHED_STATE.beta
     end
@@ -45,53 +44,9 @@ class CoursesControllerTest < ActionController::TestCase
 
     test_user_gets_response_for :index, response: :success, user: :user, queries: 4
 
-    test_user_gets_response_for :show, response: :success, user: :teacher, params: -> {{course_name: @unit_group_regular.name}}, queries: 10
+    test_user_gets_response_for :show, response: :success, user: :teacher, params: -> {{course_name: @unit_group_regular.name}}, queries: 15
 
     test_user_gets_response_for :show, response: :forbidden, user: :admin, params: -> {{course_name: @unit_group_regular.name}}, queries: 3
-  end
-
-  class CachedQueryCounts < ActionController::TestCase
-    setup do
-      Script.stubs(:should_cache?).returns true
-      Script.clear_cache
-      UnitGroup.clear_cache
-
-      offering = create :course_offering, key: 'csx'
-
-      @unit_group = create :unit_group, name: 'csx-3001', published_state: SharedConstants::PUBLISHED_STATE.stable, family_name: 'csx', version_year: '3001'
-      create :course_version, course_offering: offering, content_root: @unit_group, key: '3001'
-      unit1 = create :unit, name: 'csx1-3001', published_state: SharedConstants::PUBLISHED_STATE.stable
-      create :unit_group_unit, unit_group: @unit_group, script: unit1, position: 1
-      unit2 = create :unit, name: 'csx2-3001', published_state: SharedConstants::PUBLISHED_STATE.stable
-      create :unit_group_unit, unit_group: @unit_group, script: unit2, position: 2
-
-      older_unit_group = create :unit_group, name: 'csx-3000', published_state: SharedConstants::PUBLISHED_STATE.stable, family_name: 'csx', version_year: '3000'
-      create :course_version, course_offering: offering, content_root: older_unit_group, key: '3000'
-      unit1 = create :unit, name: 'csx1-3000', published_state: SharedConstants::PUBLISHED_STATE.stable
-      create :unit_group_unit, unit_group: older_unit_group, script: unit1, position: 1
-      unit2 = create :unit, name: 'csx2-3000', published_state: SharedConstants::PUBLISHED_STATE.stable
-      create :unit_group_unit, unit_group: older_unit_group, script: unit2, position: 2
-    end
-
-    test 'signed out user views course overview with caching enabled' do
-      assert_cached_queries(0) do
-        get :show, params: {course_name: @unit_group.name}
-      end
-    end
-
-    test 'student views course overview with caching enabled' do
-      sign_in create(:student)
-      assert_cached_queries(6) do
-        get :show, params: {course_name: @unit_group.name}
-      end
-    end
-
-    test 'teacher views course overview with caching enabled' do
-      sign_in create(:teacher)
-      assert_cached_queries(9) do
-        get :show, params: {course_name: @unit_group.name}
-      end
-    end
   end
 
   test "show: regular courses get sent to show" do

--- a/dashboard/test/controllers/home_controller_test.rb
+++ b/dashboard/test/controllers/home_controller_test.rb
@@ -7,6 +7,10 @@ class HomeControllerTest < ActionController::TestCase
   setup do
     # stub properties so we don't try to hit pegasus db
     Properties.stubs(:get).returns nil
+
+    # ensure consistent query counts by calling Scripts.all_scripts to populate
+    # the script cache here
+    _ = Script.all_scripts
   end
 
   test "teacher without progress or assigned course/script redirected to index" do

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -801,7 +801,7 @@ class LessonTest < ActiveSupport::TestCase
     # of related_lessons, so that the count is not artificially reduced by
     # anything being cached from the call to related_lessons.
     summaries = nil
-    assert_queries(10) do
+    assert_queries(11) do
       summaries = lesson1.summarize_related_lessons
     end
 

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -2067,25 +2067,25 @@ class ScriptTest < ActiveSupport::TestCase
   end
 
   test "self.valid_scripts: returns alternate unit if user has a course experiment with an alternate unit" do
-    Script.destroy_all
     user = create(:user)
-    create(:script, published_state: SharedConstants::PUBLISHED_STATE.stable, name: 'original-unit')
-    alternate_unit = build(:script, published_state: SharedConstants::PUBLISHED_STATE.stable, name: 'alternate-unit')
+    unit = create(:script)
+    alternate_unit = build(:script)
 
     UnitGroup.stubs(:has_any_course_experiments?).returns(true)
-    Script.any_instance.stubs(:alternate_script).returns(alternate_unit)
+    Rails.cache.stubs(:fetch).returns([unit])
+    unit.stubs(:alternate_script).returns(alternate_unit)
 
     units = Script.valid_scripts(user)
     assert_equal [alternate_unit], units
   end
 
   test "self.valid_scripts: returns original unit if user has a course experiment with no alternate unit" do
-    Script.destroy_all
     user = create(:user)
-    unit = create(:script, published_state: SharedConstants::PUBLISHED_STATE.stable)
+    unit = create(:script)
 
     UnitGroup.stubs(:has_any_course_experiments?).returns(true)
-    Script.any_instance.stubs(:alternate_script).returns(nil)
+    Rails.cache.stubs(:fetch).returns([unit])
+    unit.stubs(:alternate_script).returns(nil)
 
     units = Script.valid_scripts(user)
     assert_equal [unit], units

--- a/dashboard/test/testing/capture_queries.rb
+++ b/dashboard/test/testing/capture_queries.rb
@@ -37,8 +37,7 @@ module CaptureQueries
 
   IGNORE_FILTERS = [
     # Script/course-cache related queries don't count.
-    /(script|unit_group)\.rb.*get_from_cache/,
-    /(script|unit_group)\.rb.*all_(scripts|courses)/,
+    /(script|course)\.rb.*get_from_cache/,
     # Level-cache queries don't count.
     /script\.rb.*cache_find_(script_level|level)/,
     # Ignore cached script id lookup


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#41909.

Observed a steady stream of intermittent `NoMethodError` errors in production ([example](https://app.honeybadger.io/projects/3240/faults/81106128)).
