### PR TITLE
ui test unversioned course and script redirects

### DIFF
--- a/dashboard/test/ui/features/learning_platform/course_versions.feature
+++ b/dashboard/test/ui/features/learning_platform/course_versions.feature
@@ -130,3 +130,17 @@ Scenario: Switch versions using dropdown on script overview page
 Scenario: Course unit family names redirect to 2019 version
   When I am on "http://studio.code.org/s/csp3"
   And I get redirected to "/s/csp3-2019" via "dashboard"
+
+@as_student
+@no_mobile
+Scenario: Unversioned course url redirects to latest course version
+  When I am on "http://studio.code.org/courses/ui-test-course"
+  And I get redirected to "/courses/ui-test-course-2019" via "dashboard"
+  Then I wait to see ".uitest-CourseScript"
+
+@as_student
+@no_mobile
+Scenario: Unversioned script url redirects to latest script version
+  When I am on "http://studio.code.org/s/ui-test-versioned-script"
+  And I get redirected to "/s/ui-test-versioned-script-2019" via "dashboard"
+  Then I wait to see ".uitest-toggle-detail"


### PR DESCRIPTION
attempts to fill in a testing blind spot for the HB errors linked in https://github.com/code-dot-org/code-dot-org/pull/42221.

the production regression was tied to script/course caching being enabled. drone does not have script caching enabled, but the test machine does: https://github.com/code-dot-org/code-dot-org/blob/b8da6aaee125be27fa0b548849676ea392dbe80f/dashboard/app/models/script.rb#L387-L390

## Testing story

I ran this cross-browser and with caching enabled here: https://github.com/code-dot-org/code-dot-org/pull/42230
