### PR TITLE
optimize scripts controller tests

### DIFF
--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -178,7 +178,7 @@ class Section < ApplicationRecord
     # added_by is passed only from the sections_students_controller, used by teachers to
     # manager their rosters.
     unless added_by&.id == user_id || (LOGIN_TYPES_OAUTH.include? login_type)
-      return ADD_STUDENT_RESTRICTED if restrict_section == TRUE && (!follower || follower.deleted?)
+      return ADD_STUDENT_RESTRICTED if restrict_section == true && (!follower || follower.deleted?)
     end
 
     # Unless the sections login type is Google or Clever

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -11,11 +11,6 @@ class ScriptsControllerTest < ActionController::TestCase
 
     @in_development_unit = create :script, published_state: SharedConstants::PUBLISHED_STATE.in_development
 
-    @pilot_teacher = create :teacher, pilot_experiment: 'my-experiment'
-    @pilot_unit = create :script, pilot_experiment: 'my-experiment', published_state: SharedConstants::PUBLISHED_STATE.pilot
-    @pilot_section = create :section, user: @pilot_teacher, script: @pilot_unit
-    @pilot_student = create(:follower, section: @pilot_section).student_user
-
     @no_progress_or_assignment_student = create :student
 
     @coursez_2017 = create :script, name: 'coursez-2017', family_name: 'coursez', version_year: '2017', published_state: SharedConstants::PUBLISHED_STATE.stable
@@ -1053,40 +1048,51 @@ class ScriptsControllerTest < ActionController::TestCase
 
   no_access_msg = "You don&#39;t have access to this unit."
 
-  test_user_gets_response_for :show, response: :redirect, user: nil,
-    params: -> {{id: @pilot_unit.name}},
-    name: 'signed out user cannot view pilot unit'
+  class CoursePilotTests < ActionController::TestCase
+    setup do
+      @pilot_teacher = create :teacher, pilot_experiment: 'my-experiment'
+      @pilot_unit = create :script, pilot_experiment: 'my-experiment', published_state: SharedConstants::PUBLISHED_STATE.pilot
+      @pilot_section = create :section, user: @pilot_teacher, script: @pilot_unit
+      @pilot_student = create(:follower, section: @pilot_section).student_user
+    end
 
-  test_user_gets_response_for(:show, response: :success, user: :student,
-    params: -> {{id: @pilot_unit.name}}, name: 'student cannot view pilot unit'
-  ) do
-    assert response.body.include? no_access_msg
-  end
+    no_access_msg = "You don&#39;t have access to this unit."
 
-  test_user_gets_response_for(:show, response: :success, user: :teacher,
-    params: -> {{id: @pilot_unit.name}},
-    name: 'teacher without pilot access cannot view pilot unit'
-  ) do
-    assert response.body.include? no_access_msg
-  end
+    test_user_gets_response_for :show, response: :redirect, user: nil,
+      params: -> {{id: @pilot_unit.name}},
+      name: 'signed out user cannot view pilot unit'
 
-  test_user_gets_response_for(:show, response: :success, user: -> {@pilot_teacher},
-    params: -> {{id: @pilot_unit.name, section_id: @pilot_section.id}},
-    name: 'pilot teacher can view pilot unit'
-  ) do
-    refute response.body.include? no_access_msg
-  end
+    test_user_gets_response_for(:show, response: :success, user: :student,
+      params: -> {{id: @pilot_unit.name}}, name: 'student cannot view pilot unit'
+    ) do
+      assert response.body.include? no_access_msg
+    end
 
-  test_user_gets_response_for(:show, response: :success, user: -> {@pilot_student},
-    params: -> {{id: @pilot_unit.name}}, name: 'pilot student can view pilot unit'
-  ) do
-    refute response.body.include? no_access_msg
-  end
+    test_user_gets_response_for(:show, response: :success, user: :teacher,
+      params: -> {{id: @pilot_unit.name}},
+      name: 'teacher without pilot access cannot view pilot unit'
+    ) do
+      assert response.body.include? no_access_msg
+    end
 
-  test_user_gets_response_for(:show, response: :success, user: :levelbuilder,
-    params: -> {{id: @pilot_unit.name}}, name: 'levelbuilder can view pilot unit'
-  ) do
-    refute response.body.include? no_access_msg
+    test_user_gets_response_for(:show, response: :success, user: -> {@pilot_teacher},
+      params: -> {{id: @pilot_unit.name, section_id: @pilot_section.id}},
+      name: 'pilot teacher can view pilot unit'
+    ) do
+      refute response.body.include? no_access_msg
+    end
+
+    test_user_gets_response_for(:show, response: :success, user: -> {@pilot_student},
+      params: -> {{id: @pilot_unit.name}}, name: 'pilot student can view pilot unit'
+    ) do
+      refute response.body.include? no_access_msg
+    end
+
+    test_user_gets_response_for(:show, response: :success, user: :levelbuilder,
+      params: -> {{id: @pilot_unit.name}}, name: 'levelbuilder can view pilot unit'
+    ) do
+      refute response.body.include? no_access_msg
+    end
   end
 
   test_user_gets_response_for :show, response: :redirect, user: nil,

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -7,7 +7,6 @@ class ScriptsControllerTest < ActionController::TestCase
     @admin = create(:admin)
     @not_admin = create(:user)
     @platformization_partner = create(:platformization_partner)
-    @levelbuilder = create(:levelbuilder)
 
     @in_development_unit = create :script, published_state: SharedConstants::PUBLISHED_STATE.in_development
 
@@ -32,7 +31,7 @@ class ScriptsControllerTest < ActionController::TestCase
   test "should get index" do
     Rails.application.config.stubs(:levelbuilder_mode).returns true
 
-    sign_in(@levelbuilder)
+    sign_in(create(:levelbuilder))
     get :index
     assert_response :success
     assert_not_nil assigns(:scripts)
@@ -245,21 +244,21 @@ class ScriptsControllerTest < ActionController::TestCase
   test "should not get edit on production" do
     CDO.stubs(:rack_env).returns(:production)
     Rails.application.config.stubs(:levelbuilder_mode).returns false
-    sign_in @levelbuilder
+    sign_in create(:levelbuilder)
     get :edit, params: {id: 'course1'}
     assert_response :forbidden
   end
 
   test "should get edit on levelbuilder" do
     Rails.application.config.stubs(:levelbuilder_mode).returns true
-    sign_in @levelbuilder
+    sign_in create(:levelbuilder)
     get :edit, params: {id: 'course1'}
     assert_response :ok
   end
 
   test "should not be able to edit on levelbuilder in locale besides en-US" do
     Rails.application.config.stubs(:levelbuilder_mode).returns true
-    sign_in @levelbuilder
+    sign_in create(:levelbuilder)
     with_default_locale(:de) do
       get :edit, params: {id: 'course1'}
     end
@@ -269,7 +268,7 @@ class ScriptsControllerTest < ActionController::TestCase
   test "should get edit on test" do
     CDO.stubs(:rack_env).returns(:test)
     Rails.application.config.stubs(:levelbuilder_mode).returns false
-    sign_in @levelbuilder
+    sign_in create(:levelbuilder)
     get :edit, params: {id: 'course1'}
     assert_response :ok
   end
@@ -277,7 +276,7 @@ class ScriptsControllerTest < ActionController::TestCase
   test "should not get edit on staging" do
     CDO.stubs(:rack_env).returns(:staging)
     Rails.application.config.stubs(:levelbuilder_mode).returns false
-    sign_in @levelbuilder
+    sign_in create(:levelbuilder)
     get :edit, params: {id: 'course1'}
     assert_response :forbidden
   end
@@ -301,7 +300,7 @@ class ScriptsControllerTest < ActionController::TestCase
 
   test "edit" do
     Rails.application.config.stubs(:levelbuilder_mode).returns true
-    sign_in @levelbuilder
+    sign_in create(:levelbuilder)
     unit = Script.find_by_name('course1')
     get :edit, params: {id: unit.name}
 
@@ -378,7 +377,7 @@ class ScriptsControllerTest < ActionController::TestCase
       filename == "#{Rails.root}/config/scripts_json/#{unit_name}.script_json" && JSON.parse(contents)['script']['name'] == unit_name
     end
     Rails.application.config.stubs(:levelbuilder_mode).returns true
-    sign_in @levelbuilder
+    sign_in create(:levelbuilder)
 
     post :create, params: {
       script: {name: unit_name},
@@ -393,7 +392,7 @@ class ScriptsControllerTest < ActionController::TestCase
 
   test 'cannot create legacy unit' do
     Rails.application.config.stubs(:levelbuilder_mode).returns true
-    sign_in @levelbuilder
+    sign_in create(:levelbuilder)
 
     unit_name = 'legacy'
     post :create, params: {
@@ -406,7 +405,7 @@ class ScriptsControllerTest < ActionController::TestCase
 
   test 'destroy raises exception for evil filenames' do
     Rails.application.config.stubs(:levelbuilder_mode).returns true
-    sign_in @levelbuilder
+    sign_in create(:levelbuilder)
 
     # Note that these unit names (intentionally) fail model validation.
     [
@@ -425,7 +424,7 @@ class ScriptsControllerTest < ActionController::TestCase
   test "cannot update on production" do
     CDO.stubs(:rack_env).returns(:production)
     Rails.application.config.stubs(:levelbuilder_mode).returns false
-    sign_in @levelbuilder
+    sign_in create(:levelbuilder)
 
     unit = create :script, published_state: SharedConstants::PUBLISHED_STATE.beta
     File.stubs(:write).raises('must not modify filesystem')
@@ -442,7 +441,7 @@ class ScriptsControllerTest < ActionController::TestCase
 
   test "can update on levelbuilder" do
     Rails.application.config.stubs(:levelbuilder_mode).returns true
-    sign_in @levelbuilder
+    sign_in create(:levelbuilder)
 
     unit = create :script, published_state: SharedConstants::PUBLISHED_STATE.beta
     File.stubs(:write).with {|filename, _| filename.end_with? 'scripts.en.yml'}.once
@@ -463,7 +462,7 @@ class ScriptsControllerTest < ActionController::TestCase
 
   test "update published state to in_development" do
     Rails.application.config.stubs(:levelbuilder_mode).returns true
-    sign_in @levelbuilder
+    sign_in create(:levelbuilder)
 
     unit = create :script, published_state: SharedConstants::PUBLISHED_STATE.beta
     File.stubs(:write).with {|filename, _| filename.end_with? 'scripts.en.yml'}.once
@@ -484,7 +483,7 @@ class ScriptsControllerTest < ActionController::TestCase
 
   test "update published state to pilot" do
     Rails.application.config.stubs(:levelbuilder_mode).returns true
-    sign_in @levelbuilder
+    sign_in create(:levelbuilder)
 
     unit = create :script, published_state: SharedConstants::PUBLISHED_STATE.preview
     File.stubs(:write).with {|filename, _| filename.end_with? 'scripts.en.yml'}.once
@@ -506,7 +505,7 @@ class ScriptsControllerTest < ActionController::TestCase
 
   test "update published state to beta" do
     Rails.application.config.stubs(:levelbuilder_mode).returns true
-    sign_in @levelbuilder
+    sign_in create(:levelbuilder)
 
     unit = create :script, published_state: SharedConstants::PUBLISHED_STATE.preview
     File.stubs(:write).with {|filename, _| filename.end_with? 'scripts.en.yml'}.once
@@ -527,7 +526,7 @@ class ScriptsControllerTest < ActionController::TestCase
 
   test "update published state to preview" do
     Rails.application.config.stubs(:levelbuilder_mode).returns true
-    sign_in @levelbuilder
+    sign_in create(:levelbuilder)
 
     unit = create :script, published_state: SharedConstants::PUBLISHED_STATE.beta
     File.stubs(:write).with {|filename, _| filename.end_with? 'scripts.en.yml'}.once
@@ -548,7 +547,7 @@ class ScriptsControllerTest < ActionController::TestCase
 
   test "update published state to stable" do
     Rails.application.config.stubs(:levelbuilder_mode).returns true
-    sign_in @levelbuilder
+    sign_in create(:levelbuilder)
 
     unit = create :script, published_state: SharedConstants::PUBLISHED_STATE.beta
     File.stubs(:write).with {|filename, _| filename.end_with? 'scripts.en.yml'}.once
@@ -570,7 +569,7 @@ class ScriptsControllerTest < ActionController::TestCase
   test "can update on test without modifying filesystem" do
     CDO.stubs(:rack_env).returns(:test)
     Rails.application.config.stubs(:levelbuilder_mode).returns false
-    sign_in @levelbuilder
+    sign_in create(:levelbuilder)
 
     unit = create :script, published_state: SharedConstants::PUBLISHED_STATE.beta
     File.stubs(:write).raises('must not modify filesystem')
@@ -588,7 +587,7 @@ class ScriptsControllerTest < ActionController::TestCase
   test "cannot update on staging" do
     CDO.stubs(:rack_env).returns(:staging)
     Rails.application.config.stubs(:levelbuilder_mode).returns false
-    sign_in @levelbuilder
+    sign_in create(:levelbuilder)
 
     unit = create :script, published_state: SharedConstants::PUBLISHED_STATE.beta
     File.stubs(:write).raises('must not modify filesystem')
@@ -604,7 +603,7 @@ class ScriptsControllerTest < ActionController::TestCase
   end
 
   test 'cannot update if changes have been made to the database which are not reflected in the current edit page' do
-    sign_in @levelbuilder
+    sign_in create(:levelbuilder)
     Rails.application.config.stubs(:levelbuilder_mode).returns true
 
     unit = create :script
@@ -623,7 +622,7 @@ class ScriptsControllerTest < ActionController::TestCase
   end
 
   test 'can update if database matches starting content for current edit page' do
-    sign_in @levelbuilder
+    sign_in create(:levelbuilder)
     Rails.application.config.stubs(:levelbuilder_mode).returns true
 
     unit = create :script
@@ -648,7 +647,7 @@ class ScriptsControllerTest < ActionController::TestCase
   end
 
   test 'updating migrated unit without differences updates timestamp' do
-    sign_in @levelbuilder
+    sign_in create(:levelbuilder)
     Rails.application.config.stubs(:levelbuilder_mode).returns true
 
     Timecop.freeze do
@@ -678,7 +677,7 @@ class ScriptsControllerTest < ActionController::TestCase
   end
 
   test 'cannot update migrated unit with outdated timestamp' do
-    sign_in @levelbuilder
+    sign_in create(:levelbuilder)
     Rails.application.config.stubs(:levelbuilder_mode).returns true
 
     unit = create :script, is_migrated: true
@@ -704,7 +703,7 @@ class ScriptsControllerTest < ActionController::TestCase
   end
 
   test 'can update migrated unit containing migrated script levels' do
-    sign_in @levelbuilder
+    sign_in create(:levelbuilder)
     Rails.application.config.stubs(:levelbuilder_mode).returns true
 
     unit = create :script, name: 'migrated', is_migrated: true
@@ -738,7 +737,7 @@ class ScriptsControllerTest < ActionController::TestCase
   end
 
   test 'cannot update migrated unit containing legacy script levels' do
-    sign_in @levelbuilder
+    sign_in create(:levelbuilder)
     Rails.application.config.stubs(:levelbuilder_mode).returns true
 
     unit = create :script, name: 'migrated', is_migrated: true
@@ -771,7 +770,7 @@ class ScriptsControllerTest < ActionController::TestCase
   end
 
   test 'updates teacher resources' do
-    sign_in @levelbuilder
+    sign_in create(:levelbuilder)
     Rails.application.config.stubs(:levelbuilder_mode).returns true
 
     unit = create :script
@@ -788,7 +787,7 @@ class ScriptsControllerTest < ActionController::TestCase
   end
 
   test 'updates migrated teacher resources' do
-    sign_in @levelbuilder
+    sign_in create(:levelbuilder)
     Rails.application.config.stubs(:levelbuilder_mode).returns true
 
     unit = create :script, published_state: SharedConstants::PUBLISHED_STATE.beta, is_migrated: true
@@ -814,7 +813,7 @@ class ScriptsControllerTest < ActionController::TestCase
   end
 
   test 'updates migrated student resources' do
-    sign_in @levelbuilder
+    sign_in create(:levelbuilder)
     Rails.application.config.stubs(:levelbuilder_mode).returns true
 
     unit = create :script, published_state: SharedConstants::PUBLISHED_STATE.beta, is_migrated: true
@@ -839,7 +838,7 @@ class ScriptsControllerTest < ActionController::TestCase
   end
 
   test 'updates pilot_experiment' do
-    sign_in @levelbuilder
+    sign_in create(:levelbuilder)
     Rails.application.config.stubs(:levelbuilder_mode).returns true
 
     unit = create :script
@@ -861,7 +860,7 @@ class ScriptsControllerTest < ActionController::TestCase
   end
 
   test 'does not hide unit with blank pilot_experiment' do
-    sign_in @levelbuilder
+    sign_in create(:levelbuilder)
     Rails.application.config.stubs(:levelbuilder_mode).returns true
 
     unit = create :script
@@ -883,7 +882,7 @@ class ScriptsControllerTest < ActionController::TestCase
   end
 
   test 'update: can update general_params' do
-    sign_in @levelbuilder
+    sign_in create(:levelbuilder)
     Rails.application.config.stubs(:levelbuilder_mode).returns true
 
     unit = create :script
@@ -914,7 +913,7 @@ class ScriptsControllerTest < ActionController::TestCase
   end
 
   test 'set_and_unset_teacher_resources' do
-    sign_in @levelbuilder
+    sign_in create(:levelbuilder)
     Rails.application.config.stubs(:levelbuilder_mode).returns true
 
     unit = create :script
@@ -952,7 +951,7 @@ class ScriptsControllerTest < ActionController::TestCase
   end
 
   test 'set and unset all general_params' do
-    sign_in @levelbuilder
+    sign_in create(:levelbuilder)
     Rails.application.config.stubs(:levelbuilder_mode).returns true
 
     unit = create :script
@@ -1019,7 +1018,7 @@ class ScriptsControllerTest < ActionController::TestCase
   end
 
   test 'add lesson to unit' do
-    sign_in @levelbuilder
+    sign_in create(:levelbuilder)
     Rails.application.config.stubs(:levelbuilder_mode).returns true
 
     level = create :level
@@ -1142,7 +1141,7 @@ class ScriptsControllerTest < ActionController::TestCase
   end
 
   test "levelbuilder does not see visible after warning if lesson does not have visible_after property" do
-    sign_in @levelbuilder
+    sign_in create(:levelbuilder)
 
     get :show, params: {id: 'course1'}
     assert_response :success
@@ -1151,7 +1150,7 @@ class ScriptsControllerTest < ActionController::TestCase
 
   test "levelbuilder does not see visible after warning if lesson has visible_after property that is in the past" do
     Timecop.freeze(Time.new(2020, 4, 2))
-    sign_in @levelbuilder
+    sign_in create(:levelbuilder)
 
     create(:level, name: "Level 1")
     unit_file = File.join(self.class.fixture_path, "test-fixture-visible-after.script")
@@ -1165,7 +1164,7 @@ class ScriptsControllerTest < ActionController::TestCase
 
   test "levelbuilder sees visible after warning if lesson has visible_after property that is in the future" do
     Timecop.freeze(Time.new(2020, 3, 27))
-    sign_in @levelbuilder
+    sign_in create(:levelbuilder)
 
     create(:level, name: "Level 1")
     unit_file = File.join(self.class.fixture_path, "test-fixture-visible-after.script")
@@ -1219,7 +1218,7 @@ class ScriptsControllerTest < ActionController::TestCase
 
   test "view all instructions page for migrated unit" do
     Rails.application.config.stubs(:levelbuilder_mode).returns true
-    sign_in(@levelbuilder)
+    sign_in(create(:levelbuilder))
 
     get :instructions, params: {id: @migrated_unit.name}
     assert_response :success
@@ -1227,7 +1226,7 @@ class ScriptsControllerTest < ActionController::TestCase
 
   test "view all instructions page for unmigrated unit" do
     Rails.application.config.stubs(:levelbuilder_mode).returns true
-    sign_in(@levelbuilder)
+    sign_in(create(:levelbuilder))
 
     get :instructions, params: {id: @unmigrated_unit.name}
     assert_response :success
@@ -1235,7 +1234,7 @@ class ScriptsControllerTest < ActionController::TestCase
 
   test "get_rollup_resources return rollups for a unit with code, resources, standards, and vocab" do
     Rails.application.config.stubs(:levelbuilder_mode).returns true
-    sign_in(@levelbuilder)
+    sign_in(create(:levelbuilder))
 
     course_version = create :course_version, content_root: @migrated_unit
     lesson_group = create :lesson_group, script: @migrated_unit
@@ -1254,7 +1253,7 @@ class ScriptsControllerTest < ActionController::TestCase
 
   test "get_rollup_resources doesn't return rollups if no lesson in a unit has the associated object" do
     Rails.application.config.stubs(:levelbuilder_mode).returns true
-    sign_in(@levelbuilder)
+    sign_in(create(:levelbuilder))
 
     course_version = create :course_version, content_root: @migrated_unit
     lesson_group = create :lesson_group, script: @migrated_unit
@@ -1272,7 +1271,7 @@ class ScriptsControllerTest < ActionController::TestCase
 
   test "get_unit bypasses cache for edit route" do
     Rails.application.config.stubs(:levelbuilder_mode).returns true
-    sign_in(@levelbuilder)
+    sign_in(create(:levelbuilder))
 
     Script.expects(:get_from_cache).never
     Script.expects(:get_without_cache).with(@migrated_unit.name, with_associated_models: true).returns(@migrated_unit).once

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -9,10 +9,6 @@ class ScriptsControllerTest < ActionController::TestCase
     @coursez_2019 = create :script, name: 'coursez-2019', family_name: 'coursez', version_year: '2019', published_state: SharedConstants::PUBLISHED_STATE.beta
     @partner_unit = create :script, editor_experiment: 'platformization-partners', published_state: SharedConstants::PUBLISHED_STATE.beta
 
-    @student_coursez_2017 = create :student
-    @section_coursez_2017 = create :section, script: @coursez_2017
-    @section_coursez_2017.add_student(@student_coursez_2017)
-
     @migrated_unit = create :script, is_migrated: true
     @unmigrated_unit = create :script
 
@@ -217,7 +213,11 @@ class ScriptsControllerTest < ActionController::TestCase
   end
 
   test "show: redirect from new unstable version to assigned version for student" do
-    sign_in @student_coursez_2017
+    student_coursez_2017 = create :student
+    section_coursez_2017 = create :section, script: @coursez_2017
+    section_coursez_2017.add_student(student_coursez_2017)
+
+    sign_in student_coursez_2017
     get :show, params: {id: @coursez_2019.name}
     assert_redirected_to "/s/#{@coursez_2017.name}?redirect_warning=true"
   end

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -10,8 +10,6 @@ class ScriptsControllerTest < ActionController::TestCase
 
     @in_development_unit = create :script, published_state: SharedConstants::PUBLISHED_STATE.in_development
 
-    @no_progress_or_assignment_student = create :student
-
     @coursez_2017 = create :script, name: 'coursez-2017', family_name: 'coursez', version_year: '2017', published_state: SharedConstants::PUBLISHED_STATE.stable
     @coursez_2018 = create :script, name: 'coursez-2018', family_name: 'coursez', version_year: '2018', published_state: SharedConstants::PUBLISHED_STATE.stable
     @coursez_2019 = create :script, name: 'coursez-2019', family_name: 'coursez', version_year: '2019', published_state: SharedConstants::PUBLISHED_STATE.beta
@@ -192,13 +190,13 @@ class ScriptsControllerTest < ActionController::TestCase
   end
 
   test "show: do not redirect when showing latest stable version in family for student" do
-    sign_in @no_progress_or_assignment_student
+    sign_in create(:student)
     get :show, params: {id: @coursez_2018.name}
     assert_response :success
   end
 
   test "show: redirect from older version to latest stable version in family for student" do
-    sign_in @no_progress_or_assignment_student
+    sign_in create(:student)
     get :show, params: {id: @coursez_2017.name}
     assert_redirected_to "/s/#{@coursez_2018.name}?redirect_warning=true"
   end
@@ -209,7 +207,7 @@ class ScriptsControllerTest < ActionController::TestCase
   end
 
   test "show: redirect from new unstable version to latest stable version in family for student" do
-    sign_in @no_progress_or_assignment_student
+    sign_in create(:student)
     get :show, params: {id: @coursez_2019.name}
     assert_redirected_to "/s/#{@coursez_2018.name}?redirect_warning=true"
   end
@@ -230,7 +228,7 @@ class ScriptsControllerTest < ActionController::TestCase
   # the student is not redirected if true is returned.
   test "show: do not redirect student to latest stable version in family if they can view the unit version" do
     Script.any_instance.stubs(:can_view_version?).returns(true)
-    sign_in @no_progress_or_assignment_student
+    sign_in create(:student)
     get :show, params: {id: @coursez_2017.name}
     assert_response :ok
   end

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -4,8 +4,6 @@ class ScriptsControllerTest < ActionController::TestCase
   include Devise::Test::ControllerHelpers
 
   setup do
-    @in_development_unit = create :script, published_state: SharedConstants::PUBLISHED_STATE.in_development
-
     @coursez_2017 = create :script, name: 'coursez-2017', family_name: 'coursez', version_year: '2017', published_state: SharedConstants::PUBLISHED_STATE.stable
     @coursez_2018 = create :script, name: 'coursez-2018', family_name: 'coursez', version_year: '2018', published_state: SharedConstants::PUBLISHED_STATE.stable
     @coursez_2019 = create :script, name: 'coursez-2019', family_name: 'coursez', version_year: '2019', published_state: SharedConstants::PUBLISHED_STATE.beta
@@ -1046,8 +1044,6 @@ class ScriptsControllerTest < ActionController::TestCase
     assert_not_nil JSON.parse(@response.body)['lesson_groups'][0]['lessons'][0]['id']
   end
 
-  no_access_msg = "You don&#39;t have access to this unit."
-
   class CoursePilotTests < ActionController::TestCase
     setup do
       @pilot_teacher = create :teacher, pilot_experiment: 'my-experiment'
@@ -1095,27 +1091,35 @@ class ScriptsControllerTest < ActionController::TestCase
     end
   end
 
-  test_user_gets_response_for :show, response: :redirect, user: nil,
-                              params: -> {{id: @in_development_unit.name}},
-                              name: 'signed out user cannot view in-development unit'
+  class CourseInDevelopmentTests < ActionController::TestCase
+    setup do
+      @in_development_unit = create :script, published_state: SharedConstants::PUBLISHED_STATE.in_development
+    end
 
-  test_user_gets_response_for(:show, response: :success, user: :student,
-                              params: -> {{id: @in_development_unit.name}}, name: 'student cannot view in-development unit'
-  ) do
-    assert response.body.include? no_access_msg
-  end
+    no_access_msg = "You don&#39;t have access to this unit."
 
-  test_user_gets_response_for(:show, response: :success, user: :teacher,
-                              params: -> {{id: @in_development_unit.name}},
-                              name: 'teacher cannot view in-development unit'
-  ) do
-    assert response.body.include? no_access_msg
-  end
+    test_user_gets_response_for :show, response: :redirect, user: nil,
+      params: -> {{id: @in_development_unit.name}},
+      name: 'signed out user cannot view in-development unit'
 
-  test_user_gets_response_for(:show, response: :success, user: :levelbuilder,
-                              params: -> {{id: @in_development_unit.name}}, name: 'levelbuilder can view in-development unit'
-  ) do
-    refute response.body.include? no_access_msg
+    test_user_gets_response_for(:show, response: :success, user: :student,
+      params: -> {{id: @in_development_unit.name}}, name: 'student cannot view in-development unit'
+    ) do
+      assert response.body.include? no_access_msg
+    end
+
+    test_user_gets_response_for(:show, response: :success, user: :teacher,
+      params: -> {{id: @in_development_unit.name}},
+      name: 'teacher cannot view in-development unit'
+    ) do
+      assert response.body.include? no_access_msg
+    end
+
+    test_user_gets_response_for(:show, response: :success, user: :levelbuilder,
+      params: -> {{id: @in_development_unit.name}}, name: 'levelbuilder can view in-development unit'
+    ) do
+      refute response.body.include? no_access_msg
+    end
   end
 
   test 'should redirect to latest stable version in unit family for student without progress or assignment' do

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -4,8 +4,6 @@ class ScriptsControllerTest < ActionController::TestCase
   include Devise::Test::ControllerHelpers
 
   setup do
-    @platformization_partner = create(:platformization_partner)
-
     @in_development_unit = create :script, published_state: SharedConstants::PUBLISHED_STATE.in_development
 
     @coursez_2017 = create :script, name: 'coursez-2017', family_name: 'coursez', version_year: '2017', published_state: SharedConstants::PUBLISHED_STATE.stable
@@ -312,7 +310,7 @@ class ScriptsControllerTest < ActionController::TestCase
 
   test 'platformization partner cannot create unit' do
     Rails.application.config.stubs(:levelbuilder_mode).returns true
-    sign_in @platformization_partner
+    sign_in create(:platformization_partner)
     post :create, params: {
       script: {name: 'test-unit-create'},
       script_text: '',
@@ -323,21 +321,21 @@ class ScriptsControllerTest < ActionController::TestCase
 
   test "platformization partner cannot edit our units" do
     Rails.application.config.stubs(:levelbuilder_mode).returns true
-    sign_in @platformization_partner
+    sign_in create(:platformization_partner)
     get :edit, params: {id: @coursez_2019.id}
     assert_response :forbidden
   end
 
   test "platformization partner can edit their units" do
     Rails.application.config.stubs(:levelbuilder_mode).returns true
-    sign_in @platformization_partner
+    sign_in create(:platformization_partner)
     get :edit, params: {id: @partner_unit.id}
     assert_response :success
   end
 
   test "platformization partner cannot update our units" do
     Rails.application.config.stubs(:levelbuilder_mode).returns true
-    sign_in @platformization_partner
+    sign_in create(:platformization_partner)
     patch :update, params: {
       id: @coursez_2019.id,
       script: {name: @coursez_2019.name},
@@ -350,7 +348,7 @@ class ScriptsControllerTest < ActionController::TestCase
     Rails.application.config.stubs(:levelbuilder_mode).returns true
     stub_file_writes(@partner_unit.name)
 
-    sign_in @platformization_partner
+    sign_in create(:platformization_partner)
     patch :update, params: {
       id: @partner_unit.id,
       script: {name: @partner_unit.name},

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -4,8 +4,6 @@ class ScriptsControllerTest < ActionController::TestCase
   include Devise::Test::ControllerHelpers
 
   setup do
-    @admin = create(:admin)
-    @not_admin = create(:user)
     @platformization_partner = create(:platformization_partner)
 
     @in_development_unit = create :script, published_state: SharedConstants::PUBLISHED_STATE.in_development
@@ -52,7 +50,9 @@ class ScriptsControllerTest < ActionController::TestCase
   end
 
   test "should not get index if not levelbuilder" do
-    [@admin, @not_admin].each do |user|
+    admin = create(:admin)
+    not_admin = create(:user)
+    [admin, not_admin].each do |user|
       sign_in user
 
       get :index
@@ -77,7 +77,8 @@ class ScriptsControllerTest < ActionController::TestCase
   end
 
   test "should get show of ECSPD if signed in" do
-    sign_in @not_admin
+    not_admin = create(:user)
+    sign_in not_admin
     get :show, params: {id: 'ECSPD'}
     assert_response :success
   end
@@ -130,13 +131,15 @@ class ScriptsControllerTest < ActionController::TestCase
   end
 
   test "should get show if not admin" do
-    sign_in @not_admin
+    not_admin = create(:user)
+    sign_in not_admin
     get :show, params: {id: Script::FLAPPY_NAME}
     assert_response :success
   end
 
   test 'should not get show if admin' do
-    sign_in @admin
+    admin = create(:admin)
+    sign_in admin
     get :show, params: {id: Script::FLAPPY_NAME}
     assert_response :forbidden
   end
@@ -288,7 +291,9 @@ class ScriptsControllerTest < ActionController::TestCase
 
   test "should not get edit if not levelbuilder" do
     Rails.application.config.stubs(:levelbuilder_mode).returns true
-    [@not_admin, @admin].each do |user|
+    admin = create(:admin)
+    not_admin = create(:user)
+    [not_admin, admin].each do |user|
       sign_in user
       get :edit, params: {id: 'course1'}
 


### PR DESCRIPTION
Speeds up the scripts controller tests by about 33%, mostly by moving object creation out of the setup method and into the test cases which need them. I did this because I was having to run these tests a lot while working on the new script update api.

## Before

```
Dave-MBP:~/src/cdo/dashboard (staging)$ time bundle exec spring testunit ./test/controllers/scripts_controller_test.rb
Running via Spring preloader in process 24873
Started with run options --seed 20219

/Users/dsb/src/cdo/dashboard/app/models/sections/section.rb:181: warning: constant ::TRUE is deprecated=---=---=---=---=--] 0% Time: 00:00:00,  ETA: ??:??:??
/Users/dsb/src/cdo/dashboard/app/models/sections/section.rb:181: warning: constant ::TRUE is deprecated                   ] 0% Time: 00:00:19,  ETA: 00:37:26
/Users/dsb/src/cdo/dashboard/app/models/sections/section.rb:181: warning: constant ::TRUE is deprecated                   ] 1% Time: 00:00:21,  ETA: 00:19:23
/Users/dsb/src/cdo/dashboard/app/models/sections/section.rb:181: warning: constant ::TRUE is deprecated                   ] 2% Time: 00:00:23,  ETA: 00:13:51
/Users/dsb/src/cdo/dashboard/app/models/sections/section.rb:181: warning: constant ::TRUE is deprecated                  ] 14% Time: 00:00:46,  ETA: 00:04:32
Resource object "all_resources" is missing course version and/or offering
Resource object "all_standards" is missing course version and/or offering
/Users/dsb/src/cdo/dashboard/app/models/sections/section.rb:181: warning: constant ::TRUE is deprecated                  ] 15% Time: 00:00:47,  ETA: 00:04:20
Resource object "all_code" is missing course version and/or offering
Resource object "all_resources" is missing course version and/or offering
Resource object "all_standards" is missing course version and/or offering
Resource object "all_vocabulary" is missing course version and/or offering
/Users/dsb/src/cdo/dashboard/app/models/sections/section.rb:181: warning: constant ::TRUE is deprecated                  ] 16% Time: 00:00:48,  ETA: 00:04:09
/Users/dsb/src/cdo/dashboard/app/models/sections/section.rb:181: warning: constant ::TRUE is deprecated                  ] 17% Time: 00:00:55,  ETA: 00:04:26
/Users/dsb/src/cdo/dashboard/app/models/sections/section.rb:181: warning: constant ::TRUE is deprecated                  ] 18% Time: 00:00:57,  ETA: 00:04:16
...
/Users/dsb/src/cdo/dashboard/app/models/sections/section.rb:181: warning: constant ::TRUE is deprecated=                 ] 85% Time: 00:03:27,  ETA: 00:00:36
/Users/dsb/src/cdo/dashboard/app/models/sections/section.rb:181: warning: constant ::TRUE is deprecated==                ] 86% Time: 00:03:29,  ETA: 00:00:33
/Users/dsb/src/cdo/dashboard/app/models/sections/section.rb:181: warning: constant ::TRUE is deprecated===               ] 87% Time: 00:03:30,  ETA: 00:00:31
Resource object "fake_name" is missing course version and/or offering============================================        ] 93% Time: 00:03:40,  ETA: 00:00:16
Resource object "fake_name" is missing course version and/or offering
Resource object "fake_name" is missing course version and/or offering
Resource object "fake_name_1" is missing course version and/or offering
Resource object "fake_name_1" is missing course version and/or offering
Resource object "fake_name_1" is missing course version and/or offering
/Users/dsb/src/cdo/dashboard/app/models/sections/section.rb:181: warning: constant ::TRUE is deprecated===========       ] 94% Time: 00:03:42,  ETA: 00:00:14
Resource object "fake_name" is missing course version and/or offering
Resource object "fake_name" is missing course version and/or offering
Resource object "fake_name" is missing course version and/or offering
Resource object "fake_name_1" is missing course version and/or offering
Resource object "fake_name_1" is missing course version and/or offering
Resource object "fake_name_1" is missing course version and/or offering
Resource object "fake_name_2" is missing course version and/or offering
Resource object "fake_name_2" is missing course version and/or offering
Resource object "fake_name_2" is missing course version and/or offering
/Users/dsb/src/cdo/dashboard/app/models/sections/section.rb:181: warning: constant ::TRUE is deprecated================  ] 99% Time: 00:03:50,  ETA: 00:00:03
  103/103: [============================================================================================================] 100% Time: 00:03:52, Time: 00:03:52

Finished in 232.07734s
103 tests, 255 assertions, 0 failures, 0 errors, 0 skips
bundle exec spring testunit ./test/controllers/scripts_controller_test.rb  0.34s user 0.15s system 0% cpu 3:57.41 total
```

## after

```
Dave-MBP:~/src/cdo/dashboard (optimize-scripts-controller-tests)$ time bundle exec spring testunit ./test/controllers/scripts_controller_test.rb
Running via Spring preloader in process 23947
Started with run options --seed 44890

Resource object "all_resources" is missing course version and/or offering                                                ] 24% Time: 00:00:36,  ETA: 00:01:53
Resource object "all_standards" is missing course version and/or offering
Resource object "all_code" is missing course version and/or offering                                                     ] 25% Time: 00:00:36,  ETA: 00:01:49
Resource object "all_resources" is missing course version and/or offering
Resource object "all_standards" is missing course version and/or offering
Resource object "all_vocabulary" is missing course version and/or offering
Resource object "fake_name" is missing course version and/or offering============================================        ] 93% Time: 00:02:24,  ETA: 00:00:11
Resource object "fake_name" is missing course version and/or offering
Resource object "fake_name" is missing course version and/or offering
Resource object "fake_name_1" is missing course version and/or offering
Resource object "fake_name_1" is missing course version and/or offering
Resource object "fake_name_1" is missing course version and/or offering
Resource object "fake_name" is missing course version and/or offering=============================================       ] 94% Time: 00:02:25,  ETA: 00:00:09
Resource object "fake_name" is missing course version and/or offering
Resource object "fake_name" is missing course version and/or offering
Resource object "fake_name_1" is missing course version and/or offering
Resource object "fake_name_1" is missing course version and/or offering
Resource object "fake_name_1" is missing course version and/or offering
Resource object "fake_name_2" is missing course version and/or offering
Resource object "fake_name_2" is missing course version and/or offering
Resource object "fake_name_2" is missing course version and/or offering
  103/103: [============================================================================================================] 100% Time: 00:02:31, Time: 00:02:31

Finished in 151.07421s
103 tests, 255 assertions, 0 failures, 0 errors, 0 skips
bundle exec spring testunit ./test/controllers/scripts_controller_test.rb  0.34s user 0.16s system 0% cpu 2:34.50 total
```