### PR TITLE
Temporarily silence warnings in entry tests

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -41,11 +41,15 @@ import 'whatwg-fetch';
 import Adapter from 'enzyme-adapter-react-16';
 import enzyme from 'enzyme';
 enzyme.configure({adapter: new Adapter()});
-import { throwOnConsoleErrorsEverywhere, throwOnConsoleWarningsEverywhere } from './util/throwOnConsole';
+import { throwOnConsoleErrorsEverywhere } from './util/throwOnConsole';
 ${loadContext}
 describe('entry tests', () => {
   throwOnConsoleErrorsEverywhere();
-  throwOnConsoleWarningsEverywhere();
+
+  // TODO: Add warnings back once we've run the rename-unsafe-lifecycles codemod.
+  // https://codedotorg.atlassian.net/browse/XTEAM-377
+  // throwOnConsoleWarningsEverywhere();
+
   ${runTests}
 });
 `;


### PR DESCRIPTION
I'll undo this change in #42220.

In the [React upgrade](https://github.com/code-dot-org/code-dot-org/pull/42169), I silenced warnings for deprecated lifecycle methods in unit, storybook, and integration tests, but forgot to silence them for entry tests. This silences them until I've merged the change to rename deprecated lifecycle methods, which will also silence them, so we can fail tests on other/real warnings.