### PR TITLE
relax constraints for modifying updated_at during script seed

### DIFF
--- a/dashboard/test/lib/services/script_seed_test.rb
+++ b/dashboard/test/lib/services/script_seed_test.rb
@@ -101,11 +101,11 @@ module Services
       Timecop.freeze do
         script = create_script_tree
         updated_at = script.updated_at
-        Timecop.travel 1
+        Timecop.travel 1.minute
         json = ScriptSeed.serialize_seeding_json(script)
         ScriptSeed.seed_from_json(json)
         script.reload
-        assert_equal updated_at + 1, script.updated_at
+        refute_equal updated_at, script.updated_at
       end
     end
 


### PR DESCRIPTION
I saw what looked like a flaky failure of this test: https://drone.cdn-code.org/code-dot-org/code-dot-org/9837/1/3 this is a speculative fix to make the test less likely to fail.
