### PR TITLE
[PoemBot][HOC] Set alpha on stroke for fade effect

### DIFF
--- a/apps/src/p5lab/spritelab/libraries/PoemBotLibrary.js
+++ b/apps/src/p5lab/spritelab/libraries/PoemBotLibrary.js
@@ -320,8 +320,10 @@ export default class PoemBotLibrary extends CoreLibrary {
     }
     this.p5.textSize(renderInfo.lineSize);
     renderInfo.lines.forEach(item => {
-      let color = this.getP5Color(renderInfo.font.fill, item.alpha);
-      this.p5.fill(color);
+      let fillColor = this.getP5Color(renderInfo.font.fill, item.alpha);
+      this.p5.fill(fillColor);
+      let strokeColor = this.getP5Color(renderInfo.font.stroke, item.alpha);
+      this.p5.stroke(strokeColor);
       this.p5.text(item.text, item.x, item.y);
     });
   }


### PR DESCRIPTION
Now that text also has an outline color (see https://github.com/code-dot-org/code-dot-org/pull/42215), we also need to set the alpha on the stroke for each line for the fade effect.
Before
![Aug-30-2021 09-24-56](https://user-images.githubusercontent.com/8787187/131372081-5607294f-7833-4f00-a325-7b12d93d80b2.gif)


After
![Aug-30-2021 09-25-52](https://user-images.githubusercontent.com/8787187/131372094-d0451e97-d9cf-41fd-b448-9a492c88b429.gif)
