### PR TITLE
Remove hardcoding of counter variable

### DIFF
--- a/apps/src/turtle/blocks.js
+++ b/apps/src/turtle/blocks.js
@@ -653,10 +653,7 @@ exports.install = function(blockly, blockInstallOptions) {
     ].join('\n');
   };
 
-  // This is a modified copy of blockly.Blocks.controls_for with the
-  // variable named "counter" hardcoded.
   blockly.Blocks.controls_for_counter = {
-    // For loop with hardcoded loop variable.
     helpUrl: blockly.Msg.CONTROLS_FOR_HELPURL,
     init: function() {
       this.setHSV(322, 0.9, 0.95);
@@ -683,20 +680,7 @@ exports.install = function(blockly, blockInstallOptions) {
         )
       );
     },
-    getVars: Blockly.Variables.getVars,
-    // serialize the counter variable name to xml so that it can be used across
-    // different locales
-    mutationToDom: function() {
-      var container = document.createElement('mutation');
-      var counter = this.getTitleValue('VAR');
-      container.setAttribute('counter', counter);
-      return container;
-    },
-    // deserialize the counter variable name
-    domToMutation: function(xmlElement) {
-      var counter = xmlElement.getAttribute('counter');
-      this.setTitleValue(counter, 'VAR');
-    }
+    getVars: Blockly.Variables.getVars
   };
 
   generator.controls_for_counter = generator.controls_for;


### PR DESCRIPTION
**What:** Remove mutation methods in `controls_for_counter` block. No matter the language the English "counter" string was used within for blocks.
**Why:** These were used to hardcode the "counter" string within the block. Now the `loopVariable()` method will correctly set the string from the current locale file.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [FND-1681](https://codedotorg.atlassian.net/browse/FND-1681)


## Testing story

Tested several languages locally and the string was translated
<img width="733" alt="Screen Shot 2021-08-30 at 4 43 37 PM" src="https://user-images.githubusercontent.com/48133820/131409721-5f0e579c-d1a8-4bf5-af7c-2d5ce08655c8.png">
<img width="775" alt="Screen Shot 2021-08-30 at 4 43 33 PM" src="https://user-images.githubusercontent.com/48133820/131409725-2c545e92-407a-4049-a0a0-75be25a3379c.png">
<img width="748" alt="Screen Shot 2021-08-30 at 4 43 29 PM" src="https://user-images.githubusercontent.com/48133820/131409727-d3745191-4e5d-4d1c-a4a3-0f3112195726.png">



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
