### PR TITLE
Query channel tokens by script ID

### DIFF
--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -91,7 +91,7 @@ module LevelsHelper
       # set_level_source to load answers when looking at another user,
       # we have to load the channel here.
       user_storage_id = storage_id_for_user_id(user.id)
-      channel_token = ChannelToken.find_channel_token(level, user_storage_id)
+      channel_token = ChannelToken.find_channel_token(level, user_storage_id, script_id)
     else
       user_storage_id = get_storage_id
       channel_token = ChannelToken.find_or_create_channel_token(

--- a/dashboard/app/models/channel_token.rb
+++ b/dashboard/app/models/channel_token.rb
@@ -29,6 +29,7 @@ class ChannelToken < ApplicationRecord
   # @param [Level] level The level associated with the channel token request.
   # @param [String] ip The IP address making the channel token request.
   # @param [String] user_storage_id The if of the storage app associated with the channel token request.
+  # @param [Integer] script_id The ID of the script associated with the channel token.
   # @param [Hash] data
   # @return [ChannelToken] The channel token (new or existing).
   def self.find_or_create_channel_token(level, ip, user_storage_id, script_id = nil, data = {})
@@ -39,7 +40,7 @@ class ChannelToken < ApplicationRecord
     SeamlessDatabasePool.use_master_connection do
       Retryable.retryable on: [Mysql2::Error, ActiveRecord::RecordNotUnique], matching: /Duplicate entry/ do
         # your own channel
-        channel_token = find_by(level: level.host_level, storage_id: user_storage_id)
+        channel_token = find_channel_token(level, user_storage_id, script_id)
 
         return channel_token if channel_token
 
@@ -55,8 +56,13 @@ class ChannelToken < ApplicationRecord
     end
   end
 
-  def self.find_channel_token(level, user_storage_id)
-    find_by(level: level.host_level, storage_id: user_storage_id)
+  # Finds the channel token. If a channel token exists for the user and level with and without a script ID,
+  # the channel token with the script_id takes precedence.
+  # @param [Level] level The level associated with the channel token request.
+  # @param [String] user_storage_id The if of the storage app associated with the channel token request.
+  # @param [Integer] script_id The ID of the script associated with the channel token.
+  def self.find_channel_token(level, user_storage_id, script_id)
+    order(script_id: 'desc').find_by(level: level.host_level, storage_id: user_storage_id, script_id: [nil, script_id])
   end
 
   # Create a new channel.

--- a/dashboard/app/models/channel_token.rb
+++ b/dashboard/app/models/channel_token.rb
@@ -28,7 +28,7 @@ class ChannelToken < ApplicationRecord
 
   # @param [Level] level The level associated with the channel token request.
   # @param [String] ip The IP address making the channel token request.
-  # @param [String] user_storage_id The if of the storage app associated with the channel token request.
+  # @param [String] user_storage_id The ID of the storage app associated with the channel token request.
   # @param [Integer] script_id The ID of the script associated with the channel token.
   # @param [Hash] data
   # @return [ChannelToken] The channel token (new or existing).
@@ -59,7 +59,7 @@ class ChannelToken < ApplicationRecord
   # Finds the channel token. If a channel token exists for the user and level with and without a script ID,
   # the channel token with the script_id takes precedence.
   # @param [Level] level The level associated with the channel token request.
-  # @param [String] user_storage_id The if of the storage app associated with the channel token request.
+  # @param [String] user_storage_id The ID of the storage app associated with the channel token request.
   # @param [Integer] script_id The ID of the script associated with the channel token.
   def self.find_channel_token(level, user_storage_id, script_id)
     order(script_id: 'desc').find_by(level: level.host_level, storage_id: user_storage_id, script_id: [nil, script_id])

--- a/dashboard/test/models/channel_token_test.rb
+++ b/dashboard/test/models/channel_token_test.rb
@@ -40,6 +40,21 @@ class ChannelTokenTest < ActiveSupport::TestCase
     assert_equal expected_channel_token.id, channel_token.id
   end
 
+  test 'find_or_create_channel_token returns a channel_token for the script_id if one exists' do
+    storage_id = get_storage_id
+    create :channel_token, level: @level, storage_id: storage_id, script_id: nil
+    expected_channel_token = create :channel_token, level: @level, storage_id: storage_id, script_id: @script.id
+
+    channel_token = ChannelToken.find_or_create_channel_token(
+      @level,
+      @fake_ip,
+      storage_id,
+      @script.id
+    )
+
+    assert_equal expected_channel_token.id, channel_token.id
+  end
+
   test 'find_or_create_channel_token will create a new channel token with script_id if no channel token exists' do
     level = create :level
     channel_token = ChannelToken.find_or_create_channel_token(


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Background: we recently started writing script_ids to the channel tokens table (https://github.com/code-dot-org/code-dot-org/pull/39855). There is an effort to write a backfill for the script_id column for older channel tokens (https://github.com/code-dot-org/code-dot-org/pull/42181), however this backfill has gotten complicated and requires more thought.

In the meantime, to minimize the issue where channel tokens are shared between levels in different scripts, this PR updates the query for the channel token to prioritize a search with script_id and fallback to get the channel token with a missing script_id for the level. 

What this means in practice is that code written on a channel-backed level shared between scripts where script_id is populated (after https://github.com/code-dot-org/code-dot-org/pull/39855 was released), will not show on the same level in another script.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
- jira ticket: [LP-1843](https://codedotorg.atlassian.net/browse/LP-1843)
<!--
- spec: []()
-->

## Testing story
Added a test to ensure correct channel token is being returned if one exists with and without script_id. Also tested manually locally that correct channel is fetched for a level.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Follow-up work
Figure out if/how to run the backfill
<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
