### PR TITLE
Add googleapis.com to startWebRequest allowlist

### DIFF
--- a/dashboard/app/controllers/xhr_proxy_controller.rb
+++ b/dashboard/app/controllers/xhr_proxy_controller.rb
@@ -69,6 +69,7 @@ class XhrProxyController < ApplicationController
     distanza.org
     dweet.io
     enclout.com
+    googleapis.com
     herokuapp.com
     hubblesite.org
     images-api.nasa.gov


### PR DESCRIPTION
A student requested access to the [Google Civic Information API](https://developers.google.com/civic-information) in Zendesk. That API is nested under the `googleapis.com` domain (as `https://www.googleapis.com/civicinfo/v2`), so we have to add the entire domain in order to allow access to this API.

## Links

- [Zendesk](https://codeorg.zendesk.com/agent/tickets/348552)