### PR TITLE
Javalab: Handle arbitrary message types in Javabuilder

### DIFF
--- a/apps/src/javalab/Javalab.js
+++ b/apps/src/javalab/Javalab.js
@@ -25,7 +25,7 @@ import Neighborhood from './Neighborhood';
 import NeighborhoodVisualizationColumn from './NeighborhoodVisualizationColumn';
 import TheaterVisualizationColumn from './TheaterVisualizationColumn';
 import Theater from './Theater';
-import {CsaViewMode} from './constants';
+import {CsaViewMode, InputMessageType} from './constants';
 import {DisplayTheme, getDisplayThemeFromString} from './DisplayTheme';
 import BackpackClientApi from '../code-studio/components/backpack/BackpackClientApi';
 import {
@@ -315,7 +315,17 @@ Javalab.prototype.onStop = function() {
 
 // Called by Javalab console to send a message to Javabuilder.
 Javalab.prototype.onInputMessage = function(message) {
-  this.javabuilderConnection.sendMessage(message);
+  this.onJavabuilderMessage(InputMessageType.SYSTEM_IN, message);
+};
+
+// Called by the console or mini apps to send a message to Javabuilder.
+Javalab.prototype.onJavabuilderMessage = function(messageType, message) {
+  this.javabuilderConnection.sendMessage(
+    JSON.stringify({
+      messageType,
+      message
+    })
+  );
 };
 
 // Called by the Javalab app when it wants to go to the next level.

--- a/apps/src/javalab/constants.js
+++ b/apps/src/javalab/constants.js
@@ -80,6 +80,11 @@ export const StatusMessageType = {
   EXITED: 'EXITED'
 };
 
+export const InputMessageType = {
+  SYSTEM_IN: 'SYSTEM_IN',
+  PLAYGROUND: 'PLAYGROUND'
+};
+
 export const SoundExceptionType = makeEnum(
   'INVALID_AUDIO_FILE_FORMAT',
   'MISSING_AUDIO_DATA'


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Updates Javalab to send JSON payloads when sending messages to Javabuilder, which enables Javalab to send various types of messages to Javabuilder down the road (such as Playground messages), rather than only System.in messages. 

NOTE: this should not be merged until https://github.com/code-dot-org/javabuilder/pull/97 has been merged and deployed. Additionally, after this PR is merged and the change is deployed to production, there is additional follow-up work to remove backwards-compatible fallback code from Javabuilder (see Javabuilder PR for details).

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

https://codedotorg.atlassian.net/browse/CSA-730
https://github.com/code-dot-org/javabuilder/pull/97

## Testing story

Tested locally.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
