### PR TITLE
change to show free test fields for Chile when the facilitator is Centro de Innovación - Mineduc

### DIFF
--- a/apps/src/code-studio/pd/international_opt_in/InternationalOptIn.jsx
+++ b/apps/src/code-studio/pd/international_opt_in/InternationalOptIn.jsx
@@ -72,11 +72,7 @@ class InternationalOptInComponent extends FormComponent {
    * @returns {boolean}
    */
   isColombiaSelected() {
-    return (
-      this.props.data &&
-      this.props.data.schoolCountry &&
-      this.props.data.schoolCountry.toLowerCase() === 'colombia'
-    );
+    return this.props.data?.schoolCountry?.toLowerCase() === 'colombia';
   }
 
   /**
@@ -87,11 +83,7 @@ class InternationalOptInComponent extends FormComponent {
    * @returns {boolean}
    */
   isChileSelected() {
-    return (
-      this.props.data &&
-      this.props.data.schoolCountry &&
-      this.props.data.schoolCountry.toLowerCase() === 'chile'
-    );
+    return this.props.data?.schoolCountry?.toLowerCase() === 'chile';
   }
 
   /**

--- a/apps/src/code-studio/pd/international_opt_in/InternationalOptIn.jsx
+++ b/apps/src/code-studio/pd/international_opt_in/InternationalOptIn.jsx
@@ -297,13 +297,13 @@ class InternationalOptInComponent extends FormComponent {
       schoolDataFieldGroup = this.renderColombianSchoolDataFieldGroup();
     } else if (
       this.isChileSelected() &&
-      this.props.data.workshopOrganizer === 'Fundacion Kodea'
+      this.props.data.workshopFacilitator !== 'Centro de Innovación - Mineduc' //we want the free text fields in this case
     ) {
       schoolDataFieldGroup = this.renderChileanSchoolDataFieldGroup();
     } else {
       // If no country has been selected, display the inputs disabled with a
       // placeholder text asking the user to select their country first.
-      // Otherwise, if they've selected a non-Colombian country, just render
+      // Otherwise, if they've selected a non-Colombian/Chilean country, just render
       // the inputs normally.
       const selectedCountry = this.props.data && this.props.data.schoolCountry;
       const placeholder = selectedCountry

--- a/apps/src/code-studio/pd/international_opt_in/InternationalOptIn.jsx
+++ b/apps/src/code-studio/pd/international_opt_in/InternationalOptIn.jsx
@@ -72,7 +72,11 @@ class InternationalOptInComponent extends FormComponent {
    * @returns {boolean}
    */
   isColombiaSelected() {
-    return this.props.data && this.props.data.schoolCountry === 'colombia';
+    return (
+      this.props.data &&
+      this.props.data.schoolCountry &&
+      this.props.data.schoolCountry.toLowerCase() === 'colombia'
+    );
   }
 
   /**
@@ -83,7 +87,11 @@ class InternationalOptInComponent extends FormComponent {
    * @returns {boolean}
    */
   isChileSelected() {
-    return this.props.data && this.props.data.schoolCountry === 'chile';
+    return (
+      this.props.data &&
+      this.props.data.schoolCountry &&
+      this.props.data.schoolCountry.toLowerCase() === 'chile'
+    );
   }
 
   /**
@@ -215,7 +223,7 @@ class InternationalOptInComponent extends FormComponent {
   }
 
   /**
-   * Similarly, if they have seleced Chile as their country, we want to display dropdowns
+   * Similarly, if they have selected Chile as their country, we want to display dropdowns
    * for city and name.
    *
    * @returns {Component}
@@ -285,10 +293,12 @@ class InternationalOptInComponent extends FormComponent {
 
   renderSchoolFieldGroups() {
     let schoolDataFieldGroup;
-
     if (this.isColombiaSelected()) {
       schoolDataFieldGroup = this.renderColombianSchoolDataFieldGroup();
-    } else if (this.isChileSelected()) {
+    } else if (
+      this.isChileSelected() &&
+      this.props.data.workshopOrganizer === 'Fundacion Kodea'
+    ) {
       schoolDataFieldGroup = this.renderChileanSchoolDataFieldGroup();
     } else {
       // If no country has been selected, display the inputs disabled with a
@@ -392,38 +402,6 @@ class InternationalOptInComponent extends FormComponent {
           required: true
         })}
 
-        {/* School */}
-        {this.renderSchoolFieldGroups()}
-
-        {/* Teaching */}
-        {this.buildButtonsFromOptions({
-          name: 'ages',
-          label: labels.ages,
-          type: 'check',
-          required: true
-        })}
-        {this.buildButtonsWithAdditionalTextFieldsFromOptions({
-          name: 'subjects',
-          label: labels.subjects,
-          type: 'check',
-          required: true,
-          textFieldMap: textFieldMapSubjects
-        })}
-        {this.buildButtonsWithAdditionalTextFieldsFromOptions({
-          name: 'resources',
-          label: labels.resources,
-          type: 'check',
-          required: false,
-          textFieldMap: textFieldMapResources
-        })}
-        {this.buildButtonsWithAdditionalTextFieldsFromOptions({
-          name: 'robotics',
-          label: labels.robotics,
-          type: 'check',
-          required: false,
-          textFieldMap: textFieldMapRobotics
-        })}
-
         {/* Workshop */}
         <FormGroup
           id="date"
@@ -468,6 +446,38 @@ class InternationalOptInComponent extends FormComponent {
           label: labels.workshopCourse,
           required: true,
           placeholder: i18n.selectAnOption()
+        })}
+
+        {/* School */}
+        {this.renderSchoolFieldGroups()}
+
+        {/* Teaching */}
+        {this.buildButtonsFromOptions({
+          name: 'ages',
+          label: labels.ages,
+          type: 'check',
+          required: true
+        })}
+        {this.buildButtonsWithAdditionalTextFieldsFromOptions({
+          name: 'subjects',
+          label: labels.subjects,
+          type: 'check',
+          required: true,
+          textFieldMap: textFieldMapSubjects
+        })}
+        {this.buildButtonsWithAdditionalTextFieldsFromOptions({
+          name: 'resources',
+          label: labels.resources,
+          type: 'check',
+          required: false,
+          textFieldMap: textFieldMapResources
+        })}
+        {this.buildButtonsWithAdditionalTextFieldsFromOptions({
+          name: 'robotics',
+          label: labels.robotics,
+          type: 'check',
+          required: false,
+          textFieldMap: textFieldMapRobotics
         })}
 
         {/* Opt-Ins */}


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Jira: https://codedotorg.atlassian.net/browse/FND-1695

We want to allow the Chile Ministry of Education to use the generic free text fields in our PD form, instead of the custom options we built out previously. Additionally, this PR contains a fix to make school country checks case insensitive.


https://user-images.githubusercontent.com/16494556/131412998-8d791aa7-b118-4fb6-b0dd-73211c680303.mov



## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
