### PR TITLE
International workshop form: Add header to school info form group

### DIFF
--- a/apps/src/code-studio/pd/international_opt_in/InternationalOptIn.jsx
+++ b/apps/src/code-studio/pd/international_opt_in/InternationalOptIn.jsx
@@ -325,6 +325,7 @@ class InternationalOptInComponent extends FormComponent {
 
     return (
       <FormGroup>
+        <br />
         <h4>{i18n.yourSchoolTellUs()}</h4>
         {this.buildSelectFieldGroupFromOptions({
           name: 'schoolCountry',

--- a/apps/src/code-studio/pd/international_opt_in/InternationalOptIn.jsx
+++ b/apps/src/code-studio/pd/international_opt_in/InternationalOptIn.jsx
@@ -325,9 +325,7 @@ class InternationalOptInComponent extends FormComponent {
 
     return (
       <FormGroup>
-        <h4>
-          {i18n.yourSchoolTellUs()}
-        </h4>
+        <h4>{i18n.yourSchoolTellUs()}</h4>
         {this.buildSelectFieldGroupFromOptions({
           name: 'schoolCountry',
           label: this.props.labels.schoolCountry,

--- a/apps/src/code-studio/pd/international_opt_in/InternationalOptIn.jsx
+++ b/apps/src/code-studio/pd/international_opt_in/InternationalOptIn.jsx
@@ -325,6 +325,9 @@ class InternationalOptInComponent extends FormComponent {
 
     return (
       <FormGroup>
+        <h4>
+          {i18n.yourSchoolTellUs()}
+        </h4>
         {this.buildSelectFieldGroupFromOptions({
           name: 'schoolCountry',
           label: this.props.labels.schoolCountry,


### PR DESCRIPTION
Currently, on the [international workshop form](https://studio.code.org/pd/international_workshop), workshop fields and school info fields are adjacent, making it potentially confusing for teachers ("is it the workshop's school info or my school info?"). Adding a header helps clarify what school we're referring to.

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
Tested on localhost
**Before**
<img width="739" alt="no-heading" src="https://user-images.githubusercontent.com/2933346/131556350-1d3a78a7-95c2-4a38-a6ca-205a4fb1632d.png">

**After**
<img width="743" alt="Screenshot 2021-08-31 130910" src="https://user-images.githubusercontent.com/2933346/131569319-9c7df023-dff4-48a0-9c96-dd7cc6f151a5.png">

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
