### PR TITLE
Student sections shown split between live and archived

### DIFF
--- a/apps/src/templates/studioHomepages/StudentSections.jsx
+++ b/apps/src/templates/studioHomepages/StudentSections.jsx
@@ -98,12 +98,14 @@ export default class StudentSections extends Component {
         />
         {enrolledInASection && (
           <div>
-            <SectionsAsStudentTable
-              sections={liveSections}
-              canLeave={!!isTeacher}
-              updateSections={this.updateSections}
-              updateSectionsResult={this.updateSectionsResult}
-            />
+            {liveSections.length > 0 && (
+              <SectionsAsStudentTable
+                sections={liveSections}
+                canLeave={!!isTeacher}
+                updateSections={this.updateSections}
+                updateSectionsResult={this.updateSectionsResult}
+              />
+            )}
             <div style={styles.buttonContainer}>
               {archivedSections.length > 0 && (
                 <Button

--- a/apps/src/templates/studioHomepages/StudentSections.jsx
+++ b/apps/src/templates/studioHomepages/StudentSections.jsx
@@ -58,7 +58,6 @@ export default class StudentSections extends Component {
       sectionCapacity,
       viewHidden
     } = this.state;
-    const enrolledInASection = sections.length > 0;
     const heading = isTeacher ? i18n.sectionsJoined() : i18n.sectionsTitle();
     const description = isTeacher ? '' : i18n.enrollmentDescription();
 
@@ -96,33 +95,31 @@ export default class StudentSections extends Component {
           id={resultId}
           sectionCapacity={sectionCapacity}
         />
-        {enrolledInASection && (
+        {liveSections.length > 0 && (
+          <SectionsAsStudentTable
+            sections={liveSections}
+            canLeave={!!isTeacher}
+            updateSections={this.updateSections}
+            updateSectionsResult={this.updateSectionsResult}
+          />
+        )}
+        {archivedSections.length > 0 && (
           <div>
-            {liveSections.length > 0 && (
-              <SectionsAsStudentTable
-                sections={liveSections}
-                canLeave={!!isTeacher}
-                updateSections={this.updateSections}
-                updateSectionsResult={this.updateSectionsResult}
-              />
-            )}
             <div style={styles.buttonContainer}>
-              {archivedSections.length > 0 && (
-                <Button
-                  __useDeprecatedTag
-                  className="ui-test-show-hide"
-                  onClick={this.toggleViewHidden}
-                  icon={viewHidden ? 'caret-up' : 'caret-down'}
-                  text={
-                    viewHidden
-                      ? i18n.hideArchivedSections()
-                      : i18n.viewArchivedSections()
-                  }
-                  color={Button.ButtonColor.gray}
-                />
-              )}
+              <Button
+                __useDeprecatedTag
+                className="ui-test-show-hide"
+                onClick={this.toggleViewHidden}
+                icon={viewHidden ? 'caret-up' : 'caret-down'}
+                text={
+                  viewHidden
+                    ? i18n.hideArchivedSections()
+                    : i18n.viewArchivedSections()
+                }
+                color={Button.ButtonColor.gray}
+              />
             </div>
-            {viewHidden && archivedSections.length > 0 && (
+            {viewHidden && (
               <div>
                 <div style={styles.hiddenSectionLabel}>
                   {i18n.archivedSections()}
@@ -138,7 +135,7 @@ export default class StudentSections extends Component {
           </div>
         )}
         <JoinSection
-          enrolledInASection={enrolledInASection}
+          enrolledInASection={liveSections.length > 0}
           updateSections={this.updateSections}
           updateSectionsResult={this.updateSectionsResult}
         />

--- a/apps/src/templates/studioHomepages/StudentSections.jsx
+++ b/apps/src/templates/studioHomepages/StudentSections.jsx
@@ -2,9 +2,12 @@ import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import i18n from '@cdo/locale';
 import ContentContainer from '../ContentContainer';
+import Button from '@cdo/apps/templates/Button';
 import JoinSection from './JoinSection';
 import JoinSectionNotifications from './JoinSectionNotifications';
 import SectionsAsStudentTable from './SectionsAsStudentTable';
+import color from '@cdo/apps/util/color';
+import styleConstants from '@cdo/apps/styleConstants';
 
 export default class StudentSections extends Component {
   // isTeacher will be set false for teachers who are seeing this as a student in another teacher's section.
@@ -21,7 +24,8 @@ export default class StudentSections extends Component {
       result: null,
       resultName: null,
       resultId: null,
-      sectionCapacity: null
+      sectionCapacity: null,
+      viewHidden: false
     };
   }
 
@@ -37,6 +41,12 @@ export default class StudentSections extends Component {
     });
   };
 
+  toggleViewHidden = () => {
+    this.setState({
+      viewHidden: !this.state.viewHidden
+    });
+  };
+
   render() {
     const {isTeacher} = this.props;
     const {
@@ -45,11 +55,37 @@ export default class StudentSections extends Component {
       result,
       resultName,
       resultId,
-      sectionCapacity
+      sectionCapacity,
+      viewHidden
     } = this.state;
     const enrolledInASection = sections.length > 0;
     const heading = isTeacher ? i18n.sectionsJoined() : i18n.sectionsTitle();
     const description = isTeacher ? '' : i18n.enrollmentDescription();
+
+    const styles = {
+      buttonContainer: {
+        width: styleConstants['content-width'],
+        textAlign: 'right',
+        paddingTop: 10,
+        paddingBottom: 10
+      },
+      hiddenSectionLabel: {
+        fontSize: 14,
+        paddingBottom: 5,
+        color: color.charcoal
+      }
+    };
+
+    // Sort student's sections based on whether they are live or archived
+    let liveSections = [];
+    let archivedSections = [];
+    for (const currSection of sections) {
+      if (currSection.hidden) {
+        archivedSections.push(currSection);
+      } else {
+        liveSections.push(currSection);
+      }
+    }
 
     return (
       <ContentContainer heading={heading} description={description}>
@@ -61,12 +97,43 @@ export default class StudentSections extends Component {
           sectionCapacity={sectionCapacity}
         />
         {enrolledInASection && (
-          <SectionsAsStudentTable
-            sections={sections}
-            canLeave={!!isTeacher}
-            updateSections={this.updateSections}
-            updateSectionsResult={this.updateSectionsResult}
-          />
+          <div>
+            <SectionsAsStudentTable
+              sections={liveSections}
+              canLeave={!!isTeacher}
+              updateSections={this.updateSections}
+              updateSectionsResult={this.updateSectionsResult}
+            />
+            <div style={styles.buttonContainer}>
+              {archivedSections.length > 0 && (
+                <Button
+                  __useDeprecatedTag
+                  className="ui-test-show-hide"
+                  onClick={this.toggleViewHidden}
+                  icon={viewHidden ? 'caret-up' : 'caret-down'}
+                  text={
+                    viewHidden
+                      ? i18n.hideArchivedSections()
+                      : i18n.viewArchivedSections()
+                  }
+                  color={Button.ButtonColor.gray}
+                />
+              )}
+            </div>
+            {viewHidden && archivedSections.length > 0 && (
+              <div>
+                <div style={styles.hiddenSectionLabel}>
+                  {i18n.archivedSections()}
+                </div>
+                <SectionsAsStudentTable
+                  sections={archivedSections}
+                  canLeave={!!isTeacher}
+                  updateSections={this.updateSections}
+                  updateSectionsResult={this.updateSectionsResult}
+                />
+              </div>
+            )}
+          </div>
         )}
         <JoinSection
           enrolledInASection={enrolledInASection}

--- a/apps/test/unit/templates/studioHomepages/StudentSectionsTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/StudentSectionsTest.jsx
@@ -45,12 +45,15 @@ describe('StudentSections', () => {
         description={i18n.enrollmentDescription()}
       >
         <JoinSectionNotifications />
-        <SectionsAsStudentTable
-          sections={sections}
-          canLeave={false}
-          updateSections={instance.updateSections}
-          updateSectionsResult={instance.updateSectionsResult}
-        />
+        <div>
+          <SectionsAsStudentTable
+            sections={sections}
+            canLeave={false}
+            updateSections={instance.updateSections}
+            updateSectionsResult={instance.updateSectionsResult}
+          />
+          <div />
+        </div>
         <JoinSection
           enrolledInASection={true}
           updateSections={instance.updateSections}

--- a/apps/test/unit/templates/studioHomepages/StudentSectionsTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/StudentSectionsTest.jsx
@@ -45,15 +45,12 @@ describe('StudentSections', () => {
         description={i18n.enrollmentDescription()}
       >
         <JoinSectionNotifications />
-        <div>
-          <SectionsAsStudentTable
-            sections={sections}
-            canLeave={false}
-            updateSections={instance.updateSections}
-            updateSectionsResult={instance.updateSectionsResult}
-          />
-          <div />
-        </div>
+        <SectionsAsStudentTable
+          sections={sections}
+          canLeave={false}
+          updateSections={instance.updateSections}
+          updateSectionsResult={instance.updateSectionsResult}
+        />
         <JoinSection
           enrolledInASection={true}
           updateSections={instance.updateSections}


### PR DESCRIPTION
In a student's dashboard, their sections are now split up by live sections and archived ones (paralleling how teachers see it). Previously, all student sections (regardless of whether they are live or archived) were listed all together in one long list. Now, the archived sections default to being hidden, but they can be listed when a button below the live sections is clicked to show the archived ones.

Note: Most of the code added is identical or nearly identical to the code found in the Teacher Dashboard since this is how teachers view sections.

## Comparisons of teacher section views and student section views in different scenarios to show parallel behavior:
### Display multiple live sections with existing but not displayed archived sections:
Teacher view:
![Teacher archived not shown](https://user-images.githubusercontent.com/56283563/131568821-f43148fd-a3a0-4be3-9206-53bdc0dc0383.JPG)
Student view:
![Student archived not shown](https://user-images.githubusercontent.com/56283563/131570344-433c797e-923d-41ee-8484-c11258dedcb0.JPG)

### Display multiple live sections and archived sections:
Teacher view:
![Teacher archived shown](https://user-images.githubusercontent.com/56283563/131568834-6c5c8a9e-377c-4c0d-ba72-5722f9967706.JPG)
Student view:
![Student archived shown](https://user-images.githubusercontent.com/56283563/131570367-d109ff03-bdd1-463a-8cc1-df68282817f4.JPG)

### Display 1 live section and 1 archived section:
Teacher view:
![Teacher 1 each](https://user-images.githubusercontent.com/56283563/131568864-132a3b8f-5190-4dde-842c-dec84192150d.JPG)
Student view:
![Student 1 each](https://user-images.githubusercontent.com/56283563/131570402-3b616a3e-e037-4c2e-9a76-e0a651ca0922.JPG)

### Display only live section(s) (i.e. student is not in any archived sections):
Teacher view:
![Teacher 1 live](https://user-images.githubusercontent.com/56283563/131568877-a0991b14-1d92-4dd4-bdca-e3bf6766069c.JPG)
Student view:
![Student 1 live](https://user-images.githubusercontent.com/56283563/131570441-9b75769d-e9f9-47be-80b8-e7f76ba5d331.JPG)

### Display only archived section(s) (i.e. all of the student's sections have been archived):
Teacher view:
![Teacher 1 archived](https://user-images.githubusercontent.com/56283563/131568881-e7a385db-a391-4ac8-b61f-5b00630c2b75.JPG)
Student view:
![Student 1 archived section](https://user-images.githubusercontent.com/56283563/132753348-759664d1-d319-4483-8082-8ab7bb415d13.PNG)

### Display no sections (i.e. the student is not assigned to any sections):
Teacher view:
![Teacher none](https://user-images.githubusercontent.com/56283563/131568899-ee39ab05-68c1-493c-a822-dde7b46dec8f.JPG)
Student view:
![Student none](https://user-images.githubusercontent.com/56283563/131570462-89d4b305-3654-4e64-bc42-6d051a6f5d8c.JPG)

## Links
Item 1 from [this spec](https://docs.google.com/document/d/1bSG8FV6OpBZBQPLA63tTN9oJ9gCk7vkC_S-neQ7Dnws/edit#heading=h.djp86hgtvror).

## Testing story
Manual testing in multiple browsers to check that the sections are properly sorted mirroring the behavior of a teacher's view of their sections. I also checked that live updates to sections are reflecting in student's view so that if a section is archived by a teacher, it is immediatley moved to a student's "Archived sections" list.
- Archive a section that was previously live: [Test video](https://user-images.githubusercontent.com/56283563/131572656-53557e43-2c37-4dc3-ae8d-c95c51497057.mp4)
- Un-archive a section that was previously archived: [Test video](https://user-images.githubusercontent.com/56283563/131572674-8207741a-1e55-4165-9238-3c7a1c2be744.mp4)
- Archive the only section a student is in: [Test video](https://user-images.githubusercontent.com/56283563/131572724-040f7089-8fb4-4c74-b42b-077bf63e28ff.mp4)
- Un-archive the only section a student is in: [Test video](https://user-images.githubusercontent.com/56283563/131572739-45945407-c193-4c64-bb2d-8f5b5acf76c0.mp4)

## Follow-up work
The remaining tasks from [the spec](https://docs.google.com/document/d/1bSG8FV6OpBZBQPLA63tTN9oJ9gCk7vkC_S-neQ7Dnws/edit#heading=h.djp86hgtvror) to improve clarity and ease-of-use of sections for both students and teachers.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
