### PR TITLE
Remove requirement that the source script needs to have a course version for cloning

### DIFF
--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -768,7 +768,7 @@ class Lesson < ApplicationRecord
   def copy_to_unit(destination_unit, new_level_suffix = nil)
     return if script == destination_unit
     raise 'Both lesson and unit must be migrated' unless script.is_migrated? && destination_unit.is_migrated?
-    raise 'Destination unit and lesson must be in a course version' if destination_unit.get_course_version.nil? || script.get_course_version.nil?
+    raise 'Destination unit and lesson must be in a course version' if destination_unit.get_course_version.nil?
 
     copied_lesson = dup
     copied_lesson.key = copied_lesson.name

--- a/dashboard/app/models/lesson_group.rb
+++ b/dashboard/app/models/lesson_group.rb
@@ -224,7 +224,7 @@ class LessonGroup < ApplicationRecord
   def copy_to_unit(destination_script, new_level_suffix = nil)
     return if script == destination_script
     raise 'Both lesson group and script must be migrated' unless script.is_migrated? && destination_script.is_migrated?
-    raise 'Destination script and lesson group must be in a course version' if destination_script.get_course_version.nil? || script.get_course_version.nil?
+    raise 'Destination script and lesson group must be in a course version' if destination_script.get_course_version.nil?
 
     copied_lesson_group = dup
     copied_lesson_group.script = destination_script

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -1097,6 +1097,25 @@ class LessonTest < ActiveSupport::TestCase
       assert_equal course_version.vocabularies.count, course_version_vocab_count
     end
 
+    test "can clone lesson without course version to a script with a course version" do
+      original_script = create :script, is_migrated: true, is_course: true
+      original_script.reload
+
+      original_script.expects(:write_script_json).never
+      original_lesson_group = create :lesson_group, script: original_script
+      original_lesson = create :lesson, lesson_group: original_lesson_group, script: original_script, has_lesson_plan: true
+
+      destination_script = create :script, is_migrated: true, is_course: true
+      create :course_version, content_root: destination_script
+      create :lesson_group, script: destination_script
+
+      destination_script.expects(:write_script_json).once
+      Script.expects(:merge_and_write_i18n).once
+      copied_lesson = original_lesson.copy_to_unit(destination_script)
+
+      assert_equal destination_script, copied_lesson.script
+    end
+
     test "can clone lesson into another script with lessons" do
       lesson_activity = create :lesson_activity, lesson: @original_lesson
       activity_section = create :activity_section, lesson_activity: lesson_activity

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -3219,6 +3219,34 @@ class ScriptTest < ActiveSupport::TestCase
       assert_equal @unit_in_course.resources[0], cloned_unit.resources[0]
       assert_equal @unit_in_course.student_resources[0], cloned_unit.student_resources[0]
     end
+
+    test 'can copy a script without a course version' do
+      source_unit = create :script, is_course: true, is_migrated: true
+      lesson = create :lesson, script: source_unit
+      create :lesson_group, script: source_unit, lessons: [lesson]
+
+      cloned_unit = source_unit.clone_migrated_unit('cloned-unit', family_name: 'family-name', version_year: 'unversioned')
+      assert_equal 1, cloned_unit.lesson_groups.count
+      assert_equal 1, cloned_unit.lessons.count
+      refute_nil cloned_unit.get_course_version
+    end
+
+    test 'clone raises exception if destination_unit_group does not have a course version' do
+      versionless_unit_group = create :unit_group
+      assert_nil versionless_unit_group.course_version
+      assert_raises do
+        @standalone_unit.clone_migrated_unit('coursename2-2021', destination_unit_group_name: versionless_unit_group.name)
+      end
+    end
+
+    test 'clone raises exception if cloning as standalone without family name or version year' do
+      assert_raises do
+        @standalone_unit.clone_migrated_unit('standalone-2022', version_year: '2022')
+      end
+      assert_raises do
+        @standalone_unit.clone_migrated_unit('standalone-2022', family_name: 'standalone')
+      end
+    end
   end
 
   private


### PR DESCRIPTION
This removes the requirement that, when cloning a lesson or script, the *source* script needs a course version. This is a slight change from the spec, but I think this is a confusing and unnecessary requirement. The *destination* script must still have a course version. 

Happy for push back if people disagree.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
