### PR TITLE
Button variant styled as text

### DIFF
--- a/apps/src/templates/Button.jsx
+++ b/apps/src/templates/Button.jsx
@@ -39,6 +39,7 @@ class Button extends React.Component {
     text: PropTypes.string.isRequired,
     size: PropTypes.oneOf(Object.keys(ButtonSize)),
     color: PropTypes.oneOf(Object.keys(ButtonColor)),
+    displayAsText: PropTypes.bool,
     icon: PropTypes.string,
     iconClassName: PropTypes.string,
     iconStyle: PropTypes.object,
@@ -65,9 +66,9 @@ class Button extends React.Component {
 
   render() {
     const {
-      className,
       href,
       text,
+      displayAsText,
       icon,
       iconClassName,
       iconStyle,
@@ -114,10 +115,19 @@ class Button extends React.Component {
     // potential exploits. Therefore, we do so here.
     const rel = target === '_blank' ? 'noopener noreferrer' : undefined;
 
+    let tagStyle;
+    let className = this.props.className || '';
+    if (displayAsText) {
+      tagStyle = [styles.main, styles.textButton, style];
+      className += 'button-active-no-border';
+    } else {
+      tagStyle = [styles.main, styles.colors[color], sizeStyle, style];
+    }
+
     return (
       <Tag
         className={className}
-        style={[styles.main, styles.colors[color], sizeStyle, style]}
+        style={tagStyle}
         href={disabled ? '#' : href}
         target={target}
         rel={rel}
@@ -302,6 +312,18 @@ const styles = {
       paddingLeft: 10,
       paddingRight: 10,
       lineHeight: '40px'
+    }
+  },
+  textButton: {
+    color: color.teal,
+    border: 'none',
+    backgroundColor: 'unset',
+    fontWeight: 'bold',
+    boxShadow: 'none',
+    padding: 0,
+    margin: 0,
+    ':hover': {
+      backgroundColor: 'unset'
     }
   }
 };

--- a/apps/src/templates/Button.jsx
+++ b/apps/src/templates/Button.jsx
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types';
 import Radium from 'radium';
 import color from '@cdo/apps/util/color';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
+import classNames from 'classnames';
 
 const ButtonColor = {
   orange: 'orange',
@@ -39,7 +40,7 @@ class Button extends React.Component {
     text: PropTypes.string.isRequired,
     size: PropTypes.oneOf(Object.keys(ButtonSize)),
     color: PropTypes.oneOf(Object.keys(ButtonColor)),
-    displayAsText: PropTypes.bool,
+    styleAsText: PropTypes.bool,
     icon: PropTypes.string,
     iconClassName: PropTypes.string,
     iconStyle: PropTypes.object,
@@ -68,7 +69,7 @@ class Button extends React.Component {
     const {
       href,
       text,
-      displayAsText,
+      styleAsText,
       icon,
       iconClassName,
       iconStyle,
@@ -115,13 +116,13 @@ class Button extends React.Component {
     // potential exploits. Therefore, we do so here.
     const rel = target === '_blank' ? 'noopener noreferrer' : undefined;
 
-    let tagStyle;
-    let className = this.props.className || '';
-    if (displayAsText) {
+    let tagStyle, className;
+    if (styleAsText) {
       tagStyle = [styles.main, styles.textButton, style];
-      className += 'button-active-no-border';
+      className = classNames(this.props.className, 'button-active-no-border');
     } else {
       tagStyle = [styles.main, styles.colors[color], sizeStyle, style];
+      className = this.props.className;
     }
 
     return (
@@ -318,7 +319,7 @@ const styles = {
     color: color.teal,
     border: 'none',
     backgroundColor: 'unset',
-    fontWeight: 'bold',
+    fontFamily: '"Gotham 5r", sans-serif',
     boxShadow: 'none',
     padding: 0,
     margin: 0,

--- a/apps/src/templates/Button.story.jsx
+++ b/apps/src/templates/Button.story.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Button from './Button';
+import {action} from '@storybook/addon-actions';
 
 export default storybook => {
   storybook.storiesOf('Buttons/Button', module).addStoryTable([
@@ -89,9 +90,9 @@ export default storybook => {
       name: 'Button styled as text',
       story: () => (
         <Button
-          displayAsText={true}
+          styleAsText={true}
           text="Batman & Robin"
-          onClick={() => console.log('click')}
+          onClick={action('click')}
         />
       )
     },
@@ -100,7 +101,7 @@ export default storybook => {
       story: () => (
         <Button
           __useDeprecatedTag
-          onClick={() => console.log('click')}
+          onClick={action('click')}
           text="Batman & Robin"
         />
       )

--- a/apps/src/templates/Button.story.jsx
+++ b/apps/src/templates/Button.story.jsx
@@ -86,6 +86,16 @@ export default storybook => {
       )
     },
     {
+      name: 'Button styled as text',
+      story: () => (
+        <Button
+          displayAsText={true}
+          text="Batman & Robin"
+          onClick={() => console.log('click')}
+        />
+      )
+    },
+    {
       name: 'Button with onClick',
       story: () => (
         <Button

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -3073,6 +3073,9 @@ button:hover>img {
 button:active {
   border: 1px solid $light_gray !important;
 }
+button.button-active-no-border:active {
+  border: none !important;
+}
 button:hover {
   @include box-shadow(2px 2px 5px $shadow);
 }

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -3074,6 +3074,7 @@ button:active {
   border: 1px solid $light_gray !important;
 }
 button.button-active-no-border:active {
+  // Needed to override the border with !important defined for button:active
   border: none !important;
 }
 button:hover {

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -3074,7 +3074,8 @@ button:active {
   border: 1px solid $light_gray !important;
 }
 button.button-active-no-border:active {
-  // Needed to override the border with !important defined for button:active
+  // This class is needed for when we want to hide the border on
+  // an active button. (overriding button:active rule above)
   border: none !important;
 }
 button:hover {


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
I came across a use-case where I needed a button that didn't have a button style but rather looks like text
![Screen Shot 2021-08-31 at 4 09 16 PM](https://user-images.githubusercontent.com/24235215/131587333-10b9804d-efff-4380-b1c4-5b7bd9886706.png)

I've added a prop to the existing Button component `styleAsText` which will style the button as text rather than a button.

![Screen Shot 2021-08-31 at 4 08 15 PM](https://user-images.githubusercontent.com/24235215/131587392-db9fc475-4ea6-45b5-9203-c59a4c9a1fd4.png)

## Testing story
Since these are just visual changes, I've added the variant to storybook and verified test are passing.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
