### PR TITLE
Add Origin Shield to CloudFront config

### DIFF
--- a/lib/cdo/aws/cloudfront.rb
+++ b/lib/cdo/aws/cloudfront.rb
@@ -179,6 +179,10 @@ module AWS
             },
             DomainName: origin,
             OriginPath: '',
+            OriginShield: {
+              Enabled: true,
+              OriginShieldRegion: {Ref: 'AWS::Region'}
+            }
           },
           {
             Id: 'cdo-assets',


### PR DESCRIPTION
We have been using instances of Varnish running locally on each frontend server as an ['origin shield'](https://developer.fastly.com/learning/concepts/shielding), which prevents cacheable requests from being fetched more than once from any given frontend.

Last year (Oct 2020), Amazon [added](https://aws.amazon.com/about-aws/whats-new/2020/10/announcing-amazon-cloudfront-origin-shield/) an 'origin shield' feature to CloudFront, which directs all edge traffic through a single region location before being passed to the origin. This feature could potentially replace the 'origin shield' use-case for Varnish in our stack.

This PR enables Origin Shield in CloudFront distribution, though it doesn't adjust the existing Varnish configuration.

## Links

[Announcing Amazon CloudFront Origin Shield](https://aws.amazon.com/about-aws/whats-new/2020/10/announcing-amazon-cloudfront-origin-shield/)
[Using Amazon CloudFront Origin Shield](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/origin-shield.html)

## Testing story

Manual testing on adhoc server: https://adhoc-origin-shield.cdn-code.org/

## Deployment strategy

This change affects the CloudFormation template, and will be rolled out through the normal deployment pipeline.

## Follow-up work

- Remove Varnish caching layer from our stack once the CloudFront origin shield is stable and confirmed Varnish is no longer useful.