### PR TITLE
move migrated script update api off of script dsl syntax

### DIFF
--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -19,7 +19,8 @@ import {connect} from 'react-redux';
 import {
   getSerializedLessonGroups,
   init,
-  mapLessonGroupDataForEditor
+  mapLessonGroupDataForEditor,
+  mapLessonGroupDataForUpdate
 } from '@cdo/apps/lib/levelbuilder/unit-editor/unitEditorRedux';
 import {
   lessonGroupShape,
@@ -286,6 +287,9 @@ class UnitEditor extends React.Component {
       project_widget_visible: this.state.projectWidgetVisible,
       project_widget_types: this.state.projectWidgetTypes,
       lesson_extras_available: this.state.lessonExtrasAvailable,
+      lesson_groups:
+        this.props.isMigrated &&
+        JSON.stringify(mapLessonGroupDataForUpdate(this.props.lessonGroups)),
       script_text: this.props.isMigrated
         ? getSerializedLessonGroups(
             this.props.lessonGroups,

--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -18,8 +18,7 @@ import {linkWithQueryParams, navigateToHref} from '@cdo/apps/utils';
 import {connect} from 'react-redux';
 import {
   init,
-  mapLessonGroupDataForEditor,
-  mapLessonGroupDataForUpdate
+  mapLessonGroupDataForEditor
 } from '@cdo/apps/lib/levelbuilder/unit-editor/unitEditorRedux';
 import {
   lessonGroupShape,
@@ -287,8 +286,7 @@ class UnitEditor extends React.Component {
       project_widget_types: this.state.projectWidgetTypes,
       lesson_extras_available: this.state.lessonExtrasAvailable,
       lesson_groups:
-        this.props.isMigrated &&
-        JSON.stringify(mapLessonGroupDataForUpdate(this.props.lessonGroups)),
+        this.props.isMigrated && JSON.stringify(this.props.lessonGroups),
       script_text: !this.props.isMigrated && this.state.lessonLevelData,
       last_updated_at: this.state.lastUpdatedAt,
       old_unit_text: this.state.oldScriptText,

--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -17,7 +17,6 @@ import $ from 'jquery';
 import {linkWithQueryParams, navigateToHref} from '@cdo/apps/utils';
 import {connect} from 'react-redux';
 import {
-  getSerializedLessonGroups,
   init,
   mapLessonGroupDataForEditor,
   mapLessonGroupDataForUpdate
@@ -290,12 +289,7 @@ class UnitEditor extends React.Component {
       lesson_groups:
         this.props.isMigrated &&
         JSON.stringify(mapLessonGroupDataForUpdate(this.props.lessonGroups)),
-      script_text: this.props.isMigrated
-        ? getSerializedLessonGroups(
-            this.props.lessonGroups,
-            this.props.levelKeyList
-          )
-        : this.state.lessonLevelData,
+      script_text: !this.props.isMigrated && this.state.lessonLevelData,
       last_updated_at: this.state.lastUpdatedAt,
       old_unit_text: this.state.oldScriptText,
       has_verified_resources: this.state.hasVerifiedResources,

--- a/apps/src/lib/levelbuilder/unit-editor/unitEditorRedux.js
+++ b/apps/src/lib/levelbuilder/unit-editor/unitEditorRedux.js
@@ -304,22 +304,6 @@ export const mapLessonGroupDataForEditor = rawLessonGroups => {
   return lessonGroups;
 };
 
-export const mapLessonGroupDataForUpdate = lessonGroups =>
-  lessonGroups.map(lessonGroup => ({
-    key: lessonGroup.key,
-    display_name: lessonGroup.displayName,
-    user_facing: lessonGroup.userFacing,
-    position: lessonGroup.position,
-    description: lessonGroup.description || '',
-    big_questions: lessonGroup.bigQuestions || '',
-    lessons: lessonGroup.lessons.map(lesson => ({
-      id: lesson.id,
-      key: lesson.key,
-      name: lesson.name,
-      position: lesson.position
-    }))
-  }));
-
 // Replace ' with \'
 const escape = str => str.replace(/'/g, "\\'");
 

--- a/apps/src/lib/levelbuilder/unit-editor/unitEditorRedux.js
+++ b/apps/src/lib/levelbuilder/unit-editor/unitEditorRedux.js
@@ -304,6 +304,22 @@ export const mapLessonGroupDataForEditor = rawLessonGroups => {
   return lessonGroups;
 };
 
+export const mapLessonGroupDataForUpdate = lessonGroups =>
+  lessonGroups.map(lessonGroup => ({
+    key: lessonGroup.key,
+    display_name: lessonGroup.displayName,
+    user_facing: lessonGroup.userFacing,
+    position: lessonGroup.position,
+    description: lessonGroup.description || '',
+    big_questions: lessonGroup.bigQuestions || '',
+    lessons: lessonGroup.lessons.map(lesson => ({
+      id: lesson.id,
+      key: lesson.key,
+      name: lesson.name,
+      position: lesson.position
+    }))
+  }));
+
 // Replace ' with \'
 const escape = str => str.replace(/'/g, "\\'");
 

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -295,6 +295,7 @@ class ScriptsController < ApplicationController
       :pilot_experiment,
       :editor_experiment,
       :include_student_lesson_plans,
+      :lesson_groups,
       resourceTypes: [],
       resourceLinks: [],
       resourceIds: [],
@@ -304,6 +305,7 @@ class ScriptsController < ApplicationController
     ).to_h
     h[:peer_reviews_to_complete] = h[:peer_reviews_to_complete].to_i > 0 ? h[:peer_reviews_to_complete].to_i : nil
     h[:announcements] = JSON.parse(h[:announcements]) if h[:announcements]
+    h[:lesson_groups] = JSON.parse(h[:lesson_groups]) if h[:lesson_groups]
 
     h
   end

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -305,7 +305,7 @@ class ScriptsController < ApplicationController
     ).to_h
     h[:peer_reviews_to_complete] = h[:peer_reviews_to_complete].to_i > 0 ? h[:peer_reviews_to_complete].to_i : nil
     h[:announcements] = JSON.parse(h[:announcements]) if h[:announcements]
-    h[:lesson_groups] = JSON.parse(h[:lesson_groups]) if h[:lesson_groups]
+    h[:lesson_groups] = JSON.parse(h[:lesson_groups]).map {|lg| lg.transform_keys(&:underscore)} if h[:lesson_groups]
 
     h
   end

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -93,7 +93,6 @@ class Lesson < ApplicationRecord
     unit.lessons.reload
     raw_lessons.map do |raw_lesson|
       Lesson.prevent_blank_display_name(raw_lesson)
-      Lesson.prevent_changing_stable_i18n_key(unit, raw_lesson)
 
       lesson = unit.lessons.detect {|l| l.key == raw_lesson[:key]} ||
         Lesson.find_or_create_by(

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -93,12 +93,10 @@ class Lesson < ApplicationRecord
     raw_lessons.map do |raw_lesson|
       lesson = fetch_lesson(raw_lesson, unit)
 
-      numbered_lesson = !!raw_lesson[:has_lesson_plan] || !raw_lesson[:lockable]
-
       lesson.assign_attributes(
         lesson_group: lesson_group,
         absolute_position: (counters.lesson_position += 1),
-        relative_position: numbered_lesson ? (counters.numbered_lesson_count += 1) : (counters.unnumbered_lesson_count += 1)
+        relative_position: lesson.numbered_lesson? ? (counters.numbered_lesson_count += 1) : (counters.unnumbered_lesson_count += 1)
       )
       lesson.save! if lesson.changed?
       lesson

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -90,7 +90,6 @@ class Lesson < ApplicationRecord
   include CodespanOnlyMarkdownHelper
 
   def self.update_lessons_in_migrated_unit(unit, lesson_group, raw_lessons, counters)
-    unit.lessons.reload
     raw_lessons.map do |raw_lesson|
       lesson = fetch_lesson(raw_lesson, unit)
 

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -94,15 +94,7 @@ class Lesson < ApplicationRecord
     raw_lessons.map do |raw_lesson|
       Lesson.prevent_blank_display_name(raw_lesson)
 
-      lesson = unit.lessons.detect {|l| l.key == raw_lesson[:key]} ||
-        Lesson.find_or_create_by(
-          key: raw_lesson[:key],
-          script: unit
-        ) do |l|
-          l.name = raw_lesson[:name]
-          l.relative_position = 0 # will be updated below, but cant be null
-          l.has_lesson_plan = true # will be reset below if specified
-        end
+      lesson = fetch_lesson(raw_lesson, unit)
 
       numbered_lesson = !!raw_lesson[:has_lesson_plan] || !raw_lesson[:lockable]
 
@@ -115,6 +107,18 @@ class Lesson < ApplicationRecord
       lesson.reload
       lesson
     end
+  end
+
+  def self.fetch_lesson(raw_lesson, unit)
+    unit.lessons.detect {|l| l.key == raw_lesson[:key]} ||
+      Lesson.find_or_create_by(
+        key: raw_lesson[:key],
+        script: unit
+      ) do |l|
+        l.name = raw_lesson[:name]
+        l.relative_position = 0 # will be updated below, but cant be null
+        l.has_lesson_plan = true # will be reset below if specified
+      end
   end
 
   def self.add_lessons(unit, lesson_group, raw_lessons, counters, new_suffix, editor_experiment)

--- a/dashboard/app/models/lesson_group.rb
+++ b/dashboard/app/models/lesson_group.rb
@@ -92,7 +92,10 @@ class LessonGroup < ApplicationRecord
         lesson_group.save! if lesson_group.changed?
       end
 
-      new_lessons = Lesson.add_lessons(script, lesson_group, raw_lesson_group[:lessons], counters, new_suffix, editor_experiment)
+      new_lessons =
+        script.is_migrated ?
+          Lesson.update_lessons_in_migrated_unit(script, lesson_group, raw_lesson_group[:lessons], counters) :
+          Lesson.add_lessons(script, lesson_group, raw_lesson_group[:lessons], counters, new_suffix, editor_experiment)
       lesson_group.lessons = new_lessons
       lesson_group.save!
 

--- a/dashboard/app/models/lesson_group.rb
+++ b/dashboard/app/models/lesson_group.rb
@@ -146,6 +146,7 @@ class LessonGroup < ApplicationRecord
 
   def summarize_for_unit_edit
     summary = summarize
+    summary[:display_name] = display_name
     summary[:description] = description
     summary[:big_questions] = big_questions
     summary[:lessons] = lessons.map(&:summarize_for_unit_edit)

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1322,6 +1322,7 @@ class Script < ApplicationRecord
       unit_data, i18n =
         if general_params[:is_migrated]
           lesson_groups = general_params[:lesson_groups]
+          raise 'lesson_groups param is required for migrated scripts' unless lesson_groups
           [{lesson_groups: lesson_groups}, get_lesson_groups_i18n(lesson_groups)]
         else
           ScriptDSL.parse(unit_text, 'input', unit_name)

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -380,6 +380,7 @@ class ScriptsControllerTest < ActionController::TestCase
 
     post :create, params: {
       script: {name: unit_name},
+      lesson_groups: '[]',
       is_migrated: true
     }
     assert_redirected_to edit_script_path id: unit_name
@@ -656,7 +657,7 @@ class ScriptsControllerTest < ActionController::TestCase
       stub_file_writes(unit.name)
 
       unit.reload
-      old_unit_dsl = ScriptDSL.serialize_lesson_groups(unit)
+      lesson_groups_json = unit.lesson_groups.map(&:summarize_for_unit_edit).to_json
       updated_at = unit.updated_at
 
       Timecop.travel 1.minute
@@ -666,8 +667,7 @@ class ScriptsControllerTest < ActionController::TestCase
         script: {name: unit.name},
         is_migrated: true,
         last_updated_at: updated_at.to_s,
-        script_text: old_unit_dsl,
-        old_unit_text: old_unit_dsl
+        lesson_groups: lesson_groups_json
       }
       assert_response :success
       unit.reload
@@ -723,11 +723,12 @@ class ScriptsControllerTest < ActionController::TestCase
 
     stub_file_writes(unit.name)
     unit.reload
+    lesson_groups_json = unit.lesson_groups.map(&:summarize_for_unit_edit).to_json
     post :update, params: {
       id: unit.id,
       script: {name: unit.name},
       is_migrated: true,
-      script_text: ScriptDSL.serialize_lesson_groups(unit),
+      lesson_groups: lesson_groups_json,
       last_updated_at: unit.updated_at.to_s,
     }
     assert_response :success
@@ -753,11 +754,12 @@ class ScriptsControllerTest < ActionController::TestCase
 
     stub_file_writes(unit.name)
     unit.reload
+    lesson_groups_json = unit.lesson_groups.map(&:summarize_for_unit_edit).to_json
     post :update, params: {
       id: unit.id,
       script: {name: unit.name},
       is_migrated: true,
-      script_text: ScriptDSL.serialize_lesson_groups(unit),
+      lesson_groups: lesson_groups_json,
       last_updated_at: unit.updated_at.to_s,
     }
 
@@ -803,7 +805,7 @@ class ScriptsControllerTest < ActionController::TestCase
     post :update, params: {
       id: unit.id,
       script: {name: unit.name},
-      script_text: '',
+      lesson_groups: '[]',
       resourceIds: teacher_resources.map(&:id),
       is_migrated: true,
       last_updated_at: unit.updated_at.to_s,
@@ -828,7 +830,7 @@ class ScriptsControllerTest < ActionController::TestCase
     post :update, params: {
       id: unit.id,
       script: {name: unit.name},
-      script_text: '',
+      lesson_groups: '[]',
       studentResourceIds: student_resources.map(&:id),
       is_migrated: true,
       last_updated_at: unit.updated_at.to_s,

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -1065,7 +1065,7 @@ class ScriptsControllerTest < ActionController::TestCase
       {
         key: "",
         display_name: "Content",
-        user_facing: false,
+        userFacing: false,
         lessons: [
           {
             key: "lesson-1",
@@ -1107,11 +1107,11 @@ class ScriptsControllerTest < ActionController::TestCase
     lesson_groups_json = [
       {
         key: "lesson-group-1",
-        display_name: "lesson group 1",
-        user_facing: true,
+        displayName: "lesson group 1",
+        userFacing: true,
         lessons: [],
         description: 'Description',
-        big_questions: 'Big Questions',
+        bigQuestions: 'Big Questions',
       }
     ].to_json
 
@@ -1157,8 +1157,8 @@ class ScriptsControllerTest < ActionController::TestCase
     lesson_groups_json = [
       {
         key: 'lesson-group-1',
-        display_name: 'updated name',
-        user_facing: true,
+        displayName: 'updated name',
+        userFacing: true,
         lessons: [
           {
             id: lesson.id,
@@ -1166,7 +1166,7 @@ class ScriptsControllerTest < ActionController::TestCase
           },
         ],
         description: 'updated description',
-        big_questions: 'updated questions',
+        bigQuestions: 'updated questions',
       }
     ].to_json
 
@@ -1209,8 +1209,8 @@ class ScriptsControllerTest < ActionController::TestCase
     lesson_groups_json = [
       {
         key: 'lesson-group-1',
-        display_name: 'lesson group 1',
-        user_facing: true,
+        displayName: 'lesson group 1',
+        userFacing: true,
         lessons: [
           {
             id: lesson.id,
@@ -1252,8 +1252,8 @@ class ScriptsControllerTest < ActionController::TestCase
     lesson_groups_json = [
       {
         key: 'lesson-group-1',
-        display_name: 'lesson group 1',
-        user_facing: true,
+        displayName: 'lesson group 1',
+        userFacing: true,
         lessons: [
           {
             id: lesson_1.id,
@@ -1267,8 +1267,8 @@ class ScriptsControllerTest < ActionController::TestCase
       },
       {
         key: 'lesson-group-2',
-        display_name: 'lesson group 2',
-        user_facing: true,
+        displayName: 'lesson group 2',
+        userFacing: true,
         lessons: [],
       }
     ].to_json
@@ -1302,14 +1302,14 @@ class ScriptsControllerTest < ActionController::TestCase
     lesson_groups_json = [
       {
         key: 'lesson-group-1',
-        display_name: 'lesson group 1',
-        user_facing: true,
+        displayName: 'lesson group 1',
+        userFacing: true,
         lessons: [],
       },
       {
         key: 'lesson-group-2',
-        display_name: 'lesson group 2',
-        user_facing: true,
+        displayName: 'lesson group 2',
+        userFacing: true,
         lessons: [
           {
             id: lesson_2.id,
@@ -1354,8 +1354,8 @@ class ScriptsControllerTest < ActionController::TestCase
     lesson_groups_json = [
       {
         key: 'lesson-group-1',
-        display_name: 'lesson group 1',
-        user_facing: true,
+        displayName: 'lesson group 1',
+        userFacing: true,
         lessons: [
           {
             id: lesson_2.id,
@@ -1401,8 +1401,8 @@ class ScriptsControllerTest < ActionController::TestCase
     lesson_groups_json = [
       {
         key: 'lesson-group-2',
-        display_name: 'lesson group 2',
-        user_facing: true,
+        displayName: 'lesson group 2',
+        userFacing: true,
         lessons: [
           {
             id: lesson_2.id,
@@ -1412,8 +1412,8 @@ class ScriptsControllerTest < ActionController::TestCase
       },
       {
         key: 'lesson-group-1',
-        display_name: 'lesson group 1',
-        user_facing: true,
+        displayName: 'lesson group 1',
+        userFacing: true,
         lessons: [
           {
             id: lesson_1.id,

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -1163,7 +1163,6 @@ class ScriptsControllerTest < ActionController::TestCase
           {
             id: lesson.id,
             key: 'lesson-1',
-            name: 'lesson 1'
           },
         ],
         description: 'updated description',
@@ -1259,12 +1258,10 @@ class ScriptsControllerTest < ActionController::TestCase
           {
             id: lesson_1.id,
             key: 'lesson-1',
-            name: 'lesson 1'
           },
           {
             id: lesson_2.id,
             key: 'lesson-2',
-            name: 'lesson 2'
           },
         ],
       },
@@ -1317,12 +1314,10 @@ class ScriptsControllerTest < ActionController::TestCase
           {
             id: lesson_2.id,
             key: 'lesson-2',
-            name: 'lesson 2'
           },
           {
             id: lesson_1.id,
             key: 'lesson-1',
-            name: 'lesson 1'
           },
         ],
       }
@@ -1365,17 +1360,14 @@ class ScriptsControllerTest < ActionController::TestCase
           {
             id: lesson_2.id,
             key: 'lesson-2',
-            name: 'lesson 2'
           },
           {
             id: lesson_1.id,
             key: 'lesson-1',
-            name: 'lesson 1'
           },
           {
             id: lesson_3.id,
             key: 'lesson-3',
-            name: 'lesson 3'
           },
         ],
       },
@@ -1415,7 +1407,6 @@ class ScriptsControllerTest < ActionController::TestCase
           {
             id: lesson_2.id,
             key: 'lesson-2',
-            name: 'lesson 2'
           },
         ],
       },
@@ -1427,7 +1418,6 @@ class ScriptsControllerTest < ActionController::TestCase
           {
             id: lesson_1.id,
             key: 'lesson-1',
-            name: 'lesson 1'
           },
         ],
       },

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -1193,6 +1193,51 @@ class ScriptsControllerTest < ActionController::TestCase
     assert_equal 'lesson 1', lesson_group.lessons.first.name
   end
 
+  test 'update to migrated unit does not update lesson name' do
+    sign_in create(:levelbuilder)
+    Rails.application.config.stubs(:levelbuilder_mode).returns true
+
+    unit = create :script, is_migrated: true
+    lesson_group = create :lesson_group, script: unit, key: 'lesson-group-1', display_name: 'lesson group 1', user_facing: true
+    lesson = create :lesson, script: unit, lesson_group: lesson_group, key: 'lesson-1', name: 'lesson 1'
+    stub_file_writes(unit.name)
+
+    Script.stubs(:merge_and_write_i18n).with do |i18n, _, _|
+      i18n[unit.name]['lessons'].empty? &&
+        i18n[unit.name]['lesson_groups']['lesson-group-1']['display_name'] == 'lesson group 1'
+    end.once
+
+    lesson_groups_json = [
+      {
+        key: 'lesson-group-1',
+        display_name: 'lesson group 1',
+        user_facing: true,
+        lessons: [
+          {
+            id: lesson.id,
+            key: 'lesson-1',
+            name: 'bogus lesson name'
+          },
+        ],
+      }
+    ].to_json
+
+    unit.reload
+    post :update, params: {
+      id: unit.id,
+      script: {name: unit.name},
+      is_migrated: true,
+      lesson_groups: lesson_groups_json,
+      last_updated_at: unit.updated_at.to_s
+    }
+    assert_response :success
+    lesson_group_data = JSON.parse(@response.body)['lesson_groups'][0]
+    assert_equal 'lesson 1', lesson_group_data['lessons'][0]['name']
+
+    lesson_group.reload
+    assert_equal 'lesson 1', lesson_group.lessons.first.name
+  end
+
   class CoursePilotTests < ActionController::TestCase
     setup do
       @pilot_teacher = create :teacher, pilot_experiment: 'my-experiment'


### PR DESCRIPTION
## Background

Finishes https://codedotorg.atlassian.net/browse/PLAT-460. Depends on https://github.com/code-dot-org/code-dot-org/pull/42391. 

The existing codepath for script update looks like this:
* https://github.com/code-dot-org/code-dot-org/blob/7acdcb4a42491084872762fce05f430b69e23e0d/dashboard/app/controllers/scripts_controller.rb#L142
* https://github.com/code-dot-org/code-dot-org/blob/112d3e8d22d82b1131db37881525a09a2de36bb9/dashboard/app/models/script.rb#L1301
* https://github.com/code-dot-org/code-dot-org/blob/112d3e8d22d82b1131db37881525a09a2de36bb9/dashboard/app/models/script.rb#L1071
* https://github.com/code-dot-org/code-dot-org/blob/36021987d318088b1bd1ef75e93d9c7a45710226/dashboard/app/models/lesson_group.rb#L95

To complicate things a bit, the seed process for unmigrated scripts also hooks into the same codepath here: 
* https://github.com/code-dot-org/code-dot-org/blob/0e3be2bc9f856401e5528ecec427d39357e1479b/dashboard/lib/tasks/seed.rake#L179
* https://github.com/code-dot-org/code-dot-org/blob/112d3e8d22d82b1131db37881525a09a2de36bb9/dashboard/app/models/script.rb#L1038

## Description

Moves migrated script update onto a new codepath which does not use script dsl, which has the following benefits:
1. unblocks migrating old scripts
2. allows us to send less data down to the script edit page
3. does not use script dsl syntax or parsing logic, allowing us to remove this logic soon
4. completely isolates data ownership between the script edit page and the lesson edit page. 
    * the script edit page owns creating lessons, setting initial lesson name, and updating lesson positions. it cannot update lesson names. new lessons have `has_lesson_plans` enabled by default.
    * the lesson edit page owns updating existing lesson names, and all other lesson attributes besides positions.

In case its helpful for reviewing, here's the approach I took:
1. preflight as much as I could in #42391
1. made minimum possible change to existing codepath to get things working (1617ec421c0f18dfa70cb7769f6b740602677aa5, e77c4ddd28e78b463d21d845306d473e677b00fc)
1. added a bunch of tests
1. refactor a bit to make the new codepath more separate and customized (6ca2955d1654b147f6cfc7d3f1b536612371725b, 187f86229530465fc6e5502de2d4bcf098818f7f, 95f72a76b6ddd3e6578d828273e560c2dcb0bb88)
1. defer everything else into subsequent PRs (see below)

## Testing story

* existing tests cover updates of script attributes as well as manipulation of lessons and script levels in unmigrated scripts
* new unit tests cover manipulating lesson groups and lessons within migrated scripts using the new codepath
* manually verified that lesson groups and lessons can be manipulated and that results are serialized to script json and scripts.en.yml

## Deployment strategy

test coverage seems sufficient that I'm comfortable with having this go live once this PR reaches levelbuilder, without an experiment flag.

## Follow-up work
* https://github.com/code-dot-org/code-dot-org/pull/42438
* https://github.com/code-dot-org/code-dot-org/pull/42442
* See Jira epic: https://codedotorg.atlassian.net/secure/RapidBoard.jspa?rapidView=45&projectKey=PLAT&view=planning.nodetail&epics=visible&selectedEpic=PLAT-789