### PR TITLE
Fix storybook console warning for text styled button

### DIFF
--- a/apps/src/templates/Button.jsx
+++ b/apps/src/templates/Button.jsx
@@ -317,7 +317,7 @@ const styles = {
   },
   textButton: {
     color: color.teal,
-    border: 'none',
+    borderWidth: 0,
     backgroundColor: 'unset',
     fontFamily: '"Gotham 5r", sans-serif',
     boxShadow: 'none',


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
I caused a staging build failure because the Button storybook was throwing a warning related to using border to override more specific border styles.

## Testing story
Tested locally that warning no longer shows in console in storybook.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->
## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
