### PR TITLE
Javalab: Increase grid size warning in levelbuilder on Neighborhood levels

### DIFF
--- a/dashboard/app/models/levels/javalab.rb
+++ b/dashboard/app/models/levels/javalab.rb
@@ -76,7 +76,7 @@ class Javalab < Level
       end
     end
     # paint bucket asset id is 303
-    if serialized_maze.include?("303") && (maze.length > 16)
+    if serialized_maze.include?("303") && (maze.length >= 20)
       raise ArgumentError.new("Large mazes cannot have paint buckets")
     end
     self.serialized_maze = maze


### PR DESCRIPTION
Accompanies https://github.com/code-dot-org/javabuilder/pull/99, which sets our "large grid" size to 20 instead of 16.

## Testing story

I didn't test this at all :)