### PR TITLE
Check level being rendered when deciding whether to enable code review

### DIFF
--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -114,10 +114,6 @@ class ScriptLevelsController < ApplicationController
     raise ActiveRecord::RecordNotFound unless @script_level
     authorize! :read, @script_level, params.slice(:login_required)
 
-    @code_review_enabled = @script_level.level.is_a?(Javalab) &&
-      current_user.present? &&
-      (current_user.teacher? || current_user&.sections_as_student&.all?(&:code_review_enabled?))
-
     if current_user && current_user.script_level_hidden?(@script_level)
       view_options(full_width: true)
       render 'levels/_hidden_lesson'
@@ -504,6 +500,10 @@ class ScriptLevelsController < ApplicationController
         level_id: ''
       )
     end
+
+    @code_review_enabled = @level.is_a?(Javalab) &&
+      current_user.present? &&
+      (current_user.teacher? || current_user&.sections_as_student&.all?(&:code_review_enabled?))
 
     view_options(
       full_width: true,


### PR DESCRIPTION
We have a bug where the "Enable Code Review?" checkbox does not show up on "bubble choice" levels, for example:

studio.code.org/s/csa1-pilot/lessons/18/levels/1
studio.code.org/s/csa1-pilot/lessons/18/levels/1/sublevel/1 (example choice)

This is because we check to see whether the level where you choose the level you'd like to do is a Javalab level (which it is not, it is a `BubbleChoice` level). With this change, we check the actual level that is eventually being rendered to see whether it is a Javalab level.

## Testing story

Manually tested that the "Enable Peer Review" button now appears on bubble choice levels, as well as in two other basic level types used throughout the curriculum ([standalone](https://studio.code.org/s/csa1-pilot/lessons/8/levels/1) and [project-backed](https://studio.code.org/s/csa1-pilot/lessons/9/levels/3)). I also confirmed that I was able to leave feedback on a bubble choice level, and that feedback persisted (when viewing the page again, and to other levels that shared the same project).