### PR TITLE
Filter user script using get_published_state instead of the published_state 

### DIFF
--- a/dashboard/lib/queries/script_activity.rb
+++ b/dashboard/lib/queries/script_activity.rb
@@ -2,7 +2,7 @@ class Queries::ScriptActivity
   # Retrieve all scripts this user has started but not yet completed
   # return [Script]
   def self.working_on_scripts(user)
-    user.scripts.where('user_scripts.completed_at is null').map(&:cached)
+    user.scripts.where('user_scripts.completed_at is null').map(&:cached).select {|s| [SharedConstants::PUBLISHED_STATE.stable, SharedConstants::PUBLISHED_STATE.preview].include?(s.get_published_state)}
   end
 
   # Retrieve all UserScripts for scripts this user has started but not yet

--- a/dashboard/test/lib/queries/script_activity_test.rb
+++ b/dashboard/test/lib/queries/script_activity_test.rb
@@ -24,9 +24,17 @@ class Queries::ScriptActivityTest < ActiveSupport::TestCase
     assert_equal [a.script, s2.script, s1.script], Queries::ScriptActivity.working_on_scripts(@user)
     assert_equal a.script, Queries::ScriptActivity.primary_script(@user)
 
+    unit_group = create :unit_group, published_state: SharedConstants::PUBLISHED_STATE.stable
+    course_script = create :script, published_state: nil
+    create :unit_group_unit, unit_group: unit_group, script: course_script, position: 1
+    course_script.reload
+    create :user_script, user: @user, started_at: Time.now - 12.hours, script: course_script
+    assert_equal [course_script, a.script, s2.script, s1.script], Queries::ScriptActivity.working_on_scripts(@user)
+    assert_equal course_script, Queries::ScriptActivity.primary_script(@user)
+
     # make progress on an older script
     s1.update_attribute(:last_progress_at, Time.now - 3.hours)
-    assert_equal [s1.script, a.script, s2.script], Queries::ScriptActivity.working_on_scripts(@user)
+    assert_equal [s1.script, course_script, a.script, s2.script], Queries::ScriptActivity.working_on_scripts(@user)
     assert_equal s1.script, Queries::ScriptActivity.primary_script(@user)
   end
 


### PR DESCRIPTION
Fixes https://codedotorg.atlassian.net/browse/PLAT-1271. The tiles on the studio homepage were not showing scripts within courses, such as any CSD or CSP scripts. This is due to the fact that we nulled-out the published_state for scripts within courses in order to support per-script publishing.

Here we do filtering as an extra step but I _think_ that because we're using the cached versions of the scripts, this shouldn't add extra queries (or at least not many).

I did my best to replace any uses of `user.scripts` with `user.visible_scripts` but I'm not 100% sure I didn't miss any (just searching `scripts` wouldn't have gotten me very far). The worst that will happen is a user will see a pilot script where they shouldn't, which doesn't seem too problematic.



## Testing story

added a unit test. Also verified locally that the top course can be a script within a course.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
