### PR TITLE
[Spritelab] Play speech block

### DIFF
--- a/apps/src/p5lab/spritelab/commands/worldCommands.js
+++ b/apps/src/p5lab/spritelab/commands/worldCommands.js
@@ -40,6 +40,14 @@ export const commands = {
     audioCommands.playSound({url, loop: false});
   },
 
+  playSpeech(speech) {
+    audioCommands.playSpeech({
+      text: speech,
+      gender: 'female',
+      language: 'English'
+    });
+  },
+
   printText(text) {
     this.printLog.push(text);
     getStore().dispatch(addConsoleMessage({text: text}));

--- a/dashboard/config/blocks/GamelabJr/gamelab_playSpeech.json
+++ b/dashboard/config/blocks/GamelabJr/gamelab_playSpeech.json
@@ -1,0 +1,15 @@
+{
+  "category": "World",
+  "config": {
+    "func": "playSpeech",
+    "docFunc": "gamelab_playSpeech",
+    "blockText": "play speech {SOUND}",
+    "args": [
+      {
+        "name": "SOUND",
+        "type": "String",
+        "field": true
+      }
+    ]
+  }
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8787187/131924052-873d7519-9b3c-4e7e-b016-a04b9959c1b0.png)

Works with the existing audioApi for gamelab, so there's not really any new logic here. Just creating the block and the spritelab command to pass through to the audio api.