### PR TITLE
Allow adhocs to access Javabuilder secrets

### DIFF
--- a/config/adhoc.yml.erb
+++ b/config/adhoc.yml.erb
@@ -12,3 +12,6 @@ poste_secret: not a real secret
 
 # Engineers need to be able to see raw HTTP error pages so they can debug their feature branch on an adhoc.
 custom_error_response: false
+
+javabuilder_private_key: !Secret
+javabuilder_key_password: !Secret


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Allows adhocs to access Javabuilder secrets so that Javabuilder can authenticate requests from Javalab on adhocs without developers needing to provide their own public/private keys to Javalab and Javabuilder.

## Links
https://codedotorg.atlassian.net/browse/CSA-767
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Tested on adhoc (https://adhoc-playground-backend-prototype-studio.cdn-code.org/) against development Javabuilder instance (wss://javabuilder-sanchit.dev-code.org)

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
