### PR TITLE
Updated error message for "unknown errors"

### DIFF
--- a/apps/src/javalab/constants.js
+++ b/apps/src/javalab/constants.js
@@ -18,6 +18,7 @@ export const WebSocketMessageType = {
 };
 
 export const JavabuilderExceptionType = {
+  CLASS_NOT_FOUND: 'CLASS_NOT_FOUND',
   COMPILER_ERROR: 'COMPILER_ERROR',
   ILLEGAL_METHOD_ACCESS: 'ILLEGAL_METHOD_ACCESS',
   INTERNAL_COMPILER_EXCEPTION: 'INTERNAL_COMPILER_EXCEPTION',
@@ -27,7 +28,7 @@ export const JavabuilderExceptionType = {
   NO_MAIN_METHOD: 'NO_MAIN_METHOD',
   RUNTIME_ERROR: 'RUNTIME_ERROR',
   TWO_MAIN_METHODS: 'TWO_MAIN_METHODS',
-  CLASS_NOT_FOUND: 'CLASS_NOT_FOUND'
+  UNKNOWN_ERROR: 'UNKNOWN_ERROR'
 };
 
 export const NeighborhoodSignalType = {

--- a/apps/src/javalab/javabuilderExceptionHandler.js
+++ b/apps/src/javalab/javabuilderExceptionHandler.js
@@ -43,6 +43,7 @@ export function handleException(exceptionDetails, callback) {
     case JavabuilderExceptionType.INTERNAL_COMPILER_EXCEPTION:
       error = msg.internalCompilerException({connectionId: connectionId});
       break;
+    case JavabuilderExceptionType.UNKNOWN_ERROR:
     case JavabuilderExceptionType.INTERNAL_EXCEPTION:
       error = msg.internalException({connectionId: connectionId});
       break;


### PR DESCRIPTION
This updates the user-facing error message for "UNKNOWN_ERROR" which we throw if Javabuilder throws an error we don't know how to handle on the backend. We now show the same error message as for an internal exception as both have the same next-steps for the user.

OLD:
![image](https://user-images.githubusercontent.com/8324574/131933647-d8b86867-f919-4001-b3c6-1c6c2e1e2e3c.png)


NEW:
![image](https://user-images.githubusercontent.com/8324574/131933460-50b984f8-6759-4db4-b8cb-b2c103960592.png)



## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
