### PR TITLE
Accept locale in ProfanityFilter. find_potential_profanities

### DIFF
--- a/lib/cdo/profanity_filter.rb
+++ b/lib/cdo/profanity_filter.rb
@@ -10,8 +10,8 @@ class ProfanityFilter
   #
   # Words in this list will be blocked for all languages _except_ for those
   # listed along with the word.
-  # Words in this list should be _unblocked_ on WebPurify, since we are
-  # handling them with our custom code, here.
+  # Words in this list should be added to the allowlist on WebPurify, since we are
+  # handling them with our custom code, here. Webpurify credentials are in LastPass.
   LANGUAGE_SPECIFIC_ALLOWLIST = {
     fu: %w(it), # past-tense "to be" in Italian
     fick: %w(sv) # "got" in Swedish

--- a/lib/cdo/profanity_filter.rb
+++ b/lib/cdo/profanity_filter.rb
@@ -21,7 +21,8 @@ class ProfanityFilter
   # or nil if no profanity is found.
   #
   # @param [String] text to check for profanity
-  # @param [String] language_code a two-character ISO 639-1 language code
+  # @param [String] language_code a two-character ISO 639-1 language code ('en').
+  #   Will also convert a four-character locale code ('en-US').
   # @return [String, nil] The first instance of profanity (if any) or nil (if none)
   def self.find_potential_profanity(text, language_code)
     expletive = find_potential_profanities(text, language_code)
@@ -32,14 +33,24 @@ class ProfanityFilter
   # or nil if no profanities are found.
   #
   # @param [String] text to check for profanity
-  # @param [String] language_code a two-character ISO 639-1 language code
+  # @param [String] language_code a two-character ISO 639-1 language code ('en').
+  #   Will also convert a four-character locale code ('en-US').
   # @return [Array<String>, nil] The profanities (if any) or nil (if none)
   def self.find_potential_profanities(text, language_code)
+    language_code = language(language_code)
     LANGUAGE_SPECIFIC_ALLOWLIST.each do |word, languages|
       next if languages.include? language_code
       r = Regexp.new "\\b#{word}\\b", Regexp::IGNORECASE
       return [word.to_s] if r =~ text
     end
     WebPurify.find_potential_profanities(text, ['en', language_code])
+  end
+
+  # Converts a locale ('en-US') to its language ('en').
+  #
+  # Copied from LocaleHelper (dashboard/app/helpers/locale_helper.rb) as we don't
+  # have access to that module in lib/.
+  def self.language(code)
+    code.to_s.split('-').first
   end
 end

--- a/lib/cdo/profanity_filter.rb
+++ b/lib/cdo/profanity_filter.rb
@@ -38,7 +38,7 @@ class ProfanityFilter
     LANGUAGE_SPECIFIC_ALLOWLIST.each do |word, languages|
       next if languages.include? language_code
       r = Regexp.new "\\b#{word}\\b", Regexp::IGNORECASE
-      return word.to_s if r =~ text
+      return [word.to_s] if r =~ text
     end
     WebPurify.find_potential_profanities(text, ['en', language_code])
   end

--- a/lib/test/cdo/test_profanity_filter.rb
+++ b/lib/test/cdo/test_profanity_filter.rb
@@ -2,27 +2,61 @@ require_relative '../test_helper'
 require 'cdo/profanity_filter'
 
 class ProfanityFilterTest < Minitest::Test
-  def test_find_potential_profanities
-    # webpurify returns an array
-    WebPurify.stubs(:find_potential_profanities).returns(['shit', 'sh1t'])
-    assert_equal 'shit', ProfanityFilter.find_potential_profanity('holy shit, sh1t', 'en')
+  def setup
+    @expletive1 = 'badword'
+    @expletive2 = 'realbadword'
+  end
 
-    # webpurify throws an error
+  def test_find_potential_profanity
+    WebPurify.stubs(:find_potential_profanities).returns([@expletive1, @expletive2])
+    assert_equal @expletive1, ProfanityFilter.find_potential_profanity("holy #{@expletive1}, #{@expletive2}", 'en')
+
+    # WebPurify throws an error
     WebPurify.stubs(:find_potential_profanities).raises(OpenURI::HTTPError.new('something broke', 'fake io'))
     assert_raises(OpenURI::HTTPError) do
-      ProfanityFilter.find_potential_profanity('holy shit, sh1t', 'en')
+      ProfanityFilter.find_potential_profanity("holy #{@expletive1}, #{@expletive2}", 'en')
     end
+
+    WebPurify.unstub(:find_potential_profanities)
   end
 
   def test_find_potential_profanities
-    # webpurify returns an array
-    WebPurify.stubs(:find_potential_profanities).returns(['shit'])
-    assert_equal ['shit'], ProfanityFilter.find_potential_profanities('holy shit', 'en')
+    WebPurify.stubs(:find_potential_profanities).returns([@expletive1])
+    assert_equal [@expletive1], ProfanityFilter.find_potential_profanities("holy #{@expletive1}", 'en')
 
-    # webpurify throws an error
+    # WebPurify throws an error
     WebPurify.stubs(:find_potential_profanities).raises(OpenURI::HTTPError.new('something broke', 'fake io'))
     assert_raises(OpenURI::HTTPError) do
-      ProfanityFilter.find_potential_profanities('holy shit', 'en')
+      ProfanityFilter.find_potential_profanities("holy #{@expletive1}", 'en')
     end
+
+    WebPurify.unstub(:find_potential_profanities)
+  end
+
+  def test_find_potential_profanities_allowlist
+    WebPurify.stubs(:find_potential_profanities).returns(nil)
+
+    # 'fu' is blocked for all languages except Italian.
+    assert_equal ['fu'], ProfanityFilter.find_potential_profanities('oh fu', 'en')
+    assert_nil ProfanityFilter.find_potential_profanities('tofu', 'en') # Superset of 'fu' should be allowed.
+    assert_nil ProfanityFilter.find_potential_profanities('fu', 'it')
+
+    # 'fick' is blocked for all languages except Swedish.
+    assert_equal ['fick'], ProfanityFilter.find_potential_profanities('oh fick', 'en')
+    assert_nil ProfanityFilter.find_potential_profanities('fickle', 'en') # Superset of 'fick' should be allowed.
+    assert_nil ProfanityFilter.find_potential_profanities('fick', 'sv')
+
+    WebPurify.unstub(:find_potential_profanities)
+  end
+
+  def test_find_potential_profanities_locale
+    spanish_expletive = 'uhoh'
+    WebPurify.stubs(:find_potential_profanities).with(spanish_expletive, ['en', 'es']).returns([spanish_expletive])
+
+    assert_equal [spanish_expletive], ProfanityFilter.find_potential_profanities(spanish_expletive, 'es')
+    assert_equal [spanish_expletive], ProfanityFilter.find_potential_profanities(spanish_expletive, 'es-MX')
+    assert_equal [spanish_expletive], ProfanityFilter.find_potential_profanities(spanish_expletive, 'es-ES')
+
+    WebPurify.unstub(:find_potential_profanities)
   end
 end


### PR DESCRIPTION
A few small changes to the ProfanityFilter class.

1. Accept a 4-character locale (en-US) instead of assuming a language (en). This doesn't affect WebPurify's response, but would circumvent our custom LANGUAGE_SPECIFIC_ALLOWLIST logic:
https://github.com/code-dot-org/code-dot-org/blob/7c1846c71d602f24f3551152571db752b0c36958/lib/cdo/profanity_filter.rb#L38-L42

2. Always return `Array<string>|nil` from `ProfanityFilter. find_potential_profanities`. A match for the LANGUAGE_SPECIFIC_ALLOWLIST logic would return a string; it now returns an Array<string>.

3. Unit test the LANGUAGE_SPECIFIC_ALLOWLIST logic. There is test coverage in [test_share_filtering.rb](https://github.com/code-dot-org/code-dot-org/blob/7c1846c71d602f24f3551152571db752b0c36958/lib/test/cdo/test_share_filtering.rb#L64-L128), but it should be in this class. I'm going to leave the existing tests because they're still useful.

## Links

- Related to [STAR-1694](https://codedotorg.atlassian.net/browse/STAR-1694). However, the fix for that was just to add the word to the allowlist in the WebPurify UI. I've updated our [StarLabs Zendesk Process Guide](https://docs.google.com/document/d/1jBy1nj-rTwwIcMBBJbCmjvWQSiqkwwpNG-4th4PCAt8/edit?q=zendesk+labs#heading=h.gtv6gbzbp9bj) with those steps.

## Testing story

Tests added/updated.