### PR TITLE
Varnish simplify

### DIFF
--- a/aws/cloudformation/accept-language.js.erb
+++ b/aws/cloudformation/accept-language.js.erb
@@ -27,6 +27,7 @@ function handler(event) {
  */
 function lookup(acceptLanguage, tags, defaultTag) {
     // 'Language tags and thus language ranges are to be treated as case-insensitive' (RFC4647 Section 2)
+    // Normalize header and tags to lowercase.
     acceptLanguage = acceptLanguage.toLowerCase();
 
     /*
@@ -40,7 +41,7 @@ function lookup(acceptLanguage, tags, defaultTag) {
       qvalue          = ( "0" [ "." 0*3DIGIT ] )
                       / ( "1" [ "." 0*3("0") ] )
      */
-    var regex = /(?<range>([a-z]{1,8})(-([a-z0-9]{1,8}))*|\*)(\s*;\s*q=(?<qvalue>0(\.[0-9]{0,3})?|1(\.0{0,3})?))?(\s*,\s*)?/gi
+    var regex = /(?<range>([a-z]{1,8})(-([a-z0-9]{1,8}))*|\*)(\s*;\s*q=(?<qvalue>0(\.[0-9]{0,3})?|1(\.0{0,3})?))?(\s*,\s*)?/g
 
     var match,
       /* 'Each application, protocol, or specification that uses lookup MUST
@@ -65,7 +66,7 @@ function lookup(acceptLanguage, tags, defaultTag) {
                     break;
                 }
                 oldRange = range;
-                range = oldRange.replace(/-([A-Z0-9]{1,8})$/, '');
+                range = oldRange.replace(/-([a-z0-9]{1,8})$/, '');
             }
         }
     }

--- a/aws/cloudformation/accept-language.js.erb
+++ b/aws/cloudformation/accept-language.js.erb
@@ -1,0 +1,73 @@
+// CloudFront Functions handler to normalize Accept-Language header for optimized caching.
+<% require 'cdo/languages' -%>
+var tags = <%= Languages.table.select(:locale_s, :code_s).map {|x| x.values.values}.flatten.uniq.map(&:downcase).to_json %>;
+var defaultTag = 'en';
+
+function handler(event) {
+    var headers = event.request.headers;
+    var languageCookie = event.request.cookies.language_;
+    var languageHeader = headers['accept-language'] ? headers['accept-language'].value : '';
+    headers['accept-language'] = {value: languageCookie && languageCookie.value || lookup(languageHeader, tags, defaultTag)};
+    return event.request;
+}
+
+/*
+  Parse an Accept-Language request header field,
+  performing a "lookup" of a matching language tag for the given request.
+
+  References:
+
+  HTTP/1.1 Semantics and Content, RFC 7231
+  Section 5.3, Request Header Fields: Content Negotiation
+  Quality Values, Section 5.3.1 (https://datatracker.ietf.org/doc/html/rfc7231#section-5.3.1)
+  Accept-Language, Section 5.3.5 (https://datatracker.ietf.org/doc/html/rfc7231#section-5.3.5)
+  
+  Matching of Language Tags, RFC 4647
+  Types of Matching: Lookup, Section 3.4 (https://datatracker.ietf.org/doc/html/rfc4647#section-3.4)
+ */
+function lookup(acceptLanguage, tags, defaultTag) {
+    // 'Language tags and thus language ranges are to be treated as case-insensitive' (RFC4647 Section 2)
+    acceptLanguage = acceptLanguage.toLowerCase();
+
+    /*
+      JavaScript regex translation of Accept-Language ABNF syntax:
+
+      Accept-Language = 1#( language-range [ weight ] )
+      1#element       => element *( OWS "," OWS element )
+      language-range  = (1*8ALPHA *("-" 1*8alphanum)) / "*"
+      alphanum        = ALPHA / DIGIT
+      weight          = OWS ";" OWS "q=" qvalue
+      qvalue          = ( "0" [ "." 0*3DIGIT ] )
+                      / ( "1" [ "." 0*3("0") ] )
+     */
+    var regex = /(?<range>([a-z]{1,8})(-([a-z0-9]{1,8}))*|\*)(\s*;\s*q=(?<qvalue>0(\.[0-9]{0,3})?|1(\.0{0,3})?))?(\s*,\s*)?/gi
+
+    var match,
+      /* 'Each application, protocol, or specification that uses lookup MUST
+      define the defaulting behavior when no tag matches the language
+      priority list.' (RFC4647 Section 3.4.1) */
+      bestTag = defaultTag,
+      // 'a value of 0 means "not acceptable".' (RFC7231 Section 5.3.1)
+      bestWeight = 0;
+
+      while ((match = regex.exec(acceptLanguage)) !== null) {
+        // 'If no "q" parameter is present, the default weight is 1.' (RFC7231 Section 5.3.1)
+        var weight = match.groups.qvalue ? parseFloat(match.groups.qvalue) : 1.0
+        if (weight > bestWeight) {
+            /* 'In the lookup scheme, the language range is progressively truncated
+            from the end until a matching language tag is located.' (RFC4647 Section 3.4) */
+            var range = match.groups.range;
+            var oldRange = null;
+            while(range !== oldRange) {
+                if (tags.includes(range)) {
+                    bestWeight = weight;
+                    bestTag = range;
+                    break;
+                }
+                oldRange = range;
+                range = oldRange.replace(/-([A-Z0-9]{1,8})$/, '');
+            }
+        }
+    }
+    return bestTag;
+}

--- a/aws/cloudformation/lambda.yml.erb
+++ b/aws/cloudformation/lambda.yml.erb
@@ -333,6 +333,14 @@ Resources:
       Action: 'lambda:InvokeFunction'
       Principal: events.amazonaws.com
       SourceArn: !GetAtt SessionEvent.Arn
+  AcceptLanguageFunction:
+    Type: AWS::CloudFront::Function
+    Properties:
+      Name: AcceptLanguage
+      FunctionCode: <%=js_erb 'accept-language.js.erb', max: FUNCTION_MAX %>
+      FunctionConfig:
+        Comment: "Normalizes Accept-Language header from viewer requests"
+        Runtime: cloudfront-js-1.0
 Outputs:
   AMIManager:
     Value: !GetAtt AMIManager.Arn

--- a/cookbooks/cdo-nginx/templates/default/nginx.conf.erb
+++ b/cookbooks/cdo-nginx/templates/default/nginx.conf.erb
@@ -27,15 +27,17 @@ http {
   keepalive_timeout 30;
 
   server {
-    listen <%= node['cdo-apps']['dashboard']['port'] %> default deferred;
-    server_name dashboard_proxy;
+    listen 80 deferred;
+    listen <%= node['cdo-apps']['dashboard']['port'] %> deferred;
+    server_name ~(dashboard|studio);
     location / {
       proxy_pass http://unix:<%= @run_dir %>/dashboard.sock;
       proxy_set_header Host $http_host;
     }
   }
   server {
-    listen <%= node['cdo-apps']['pegasus']['port'] %> default deferred;
+    listen 80 default_server deferred;
+    listen <%= node['cdo-apps']['pegasus']['port'] %> deferred;
     server_name pegasus_proxy;
     location / {
       proxy_pass http://unix:<%= @run_dir %>/pegasus.sock;
@@ -47,10 +49,17 @@ http {
     listen 443 ssl;
     <%= render 'nginx.erb', cookbook: 'ssl_certificate' %>
     location / {
-      # Pass the request on to Varnish.
+      # Pass the request on to port 80.
       proxy_pass  http://127.0.0.1;
       proxy_set_header Host $http_host;
       proxy_set_header X-Forwarded-Proto https;
     }
   }
+<% node['cdo-varnish']['redirects'].dup.each_pair do |domain, site| -%>
+  server {
+    listen 80 deferred;
+    server_name <%=domain%>;
+    return 301 https://<%=site%>$request_uri;
+  }
+<% end -%>
 }

--- a/cookbooks/cdo-nginx/templates/default/nginx.conf.erb
+++ b/cookbooks/cdo-nginx/templates/default/nginx.conf.erb
@@ -79,8 +79,11 @@ http {
     listen 443 ssl;
     <%= render 'nginx.erb', cookbook: 'ssl_certificate' %>
     location / {
-      # Pass the request on to port 80.
+<% if node['cdo-varnish']['enabled'] -%>
       proxy_pass  http://127.0.0.1;
+<% else -%>
+      proxy_pass http://unix:<%= @run_dir %>/$upstream.sock;
+<% end -%>
       proxy_set_header X-Forwarded-Proto https;
     }
   }

--- a/cookbooks/cdo-nginx/templates/default/nginx.conf.erb
+++ b/cookbooks/cdo-nginx/templates/default/nginx.conf.erb
@@ -22,9 +22,11 @@ http {
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   proxy_set_header X-Request-Start "t=${msec}";
   proxy_set_header Host $http_host;
+<% unless node['cdo-varnish']['enabled'] -%>
   # Copy Accept-Language header to X-Varnish-Accept-Language.
   # TODO: Update application code to read Accept-Language instead of X-Varnish-Accept-Language.
   proxy_set_header X-Varnish-Accept-Language $http_accept_language;
+<% end -%>
   proxy_buffer_size 8k;
 
   client_max_body_size 4G;
@@ -32,7 +34,7 @@ http {
 
   server {
 <% unless node['cdo-varnish']['enabled'] -%>
-    listen 80 deferred;
+    listen 80;
 <% end -%>
     listen <%= node['cdo-apps']['dashboard']['port'] %> deferred;
     server_name ~(dashboard|studio);
@@ -61,10 +63,11 @@ http {
     }
   }
 <% unless node['cdo-varnish']['enabled'] -%>
-<%   node['cdo-varnish']['redirects'].dup.each_pair do |domain, site| -%>
+<%   redirects = node['cdo-varnish']['redirects'].group_by(&:last).transform_values {|v| v.to_h.keys}
+     redirects.each do |site, domains| -%>
   server {
-    listen 80 deferred;
-    server_name <%=domain%>;
+    listen 80;
+    server_name <%=domains.join(' ')%>;
     return 301 https://<%=site%>$request_uri;
   }
 <%   end -%>

--- a/cookbooks/cdo-nginx/templates/default/nginx.conf.erb
+++ b/cookbooks/cdo-nginx/templates/default/nginx.conf.erb
@@ -21,27 +21,33 @@ http {
   proxy_redirect off;
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   proxy_set_header X-Request-Start "t=${msec}";
+  proxy_set_header Host $http_host;
+  # Copy Accept-Language header to X-Varnish-Accept-Language.
+  # TODO: Update application code to read Accept-Language instead of X-Varnish-Accept-Language.
+  proxy_set_header X-Varnish-Accept-Language $http_accept_language;
   proxy_buffer_size 8k;
 
   client_max_body_size 4G;
   keepalive_timeout 30;
 
   server {
+<% unless node['cdo-varnish']['enabled'] -%>
     listen 80 deferred;
+<% end -%>
     listen <%= node['cdo-apps']['dashboard']['port'] %> deferred;
     server_name ~(dashboard|studio);
     location / {
       proxy_pass http://unix:<%= @run_dir %>/dashboard.sock;
-      proxy_set_header Host $http_host;
     }
   }
   server {
+<% unless node['cdo-varnish']['enabled'] -%>
     listen 80 default_server deferred;
+<% end -%>
     listen <%= node['cdo-apps']['pegasus']['port'] %> deferred;
     server_name pegasus_proxy;
     location / {
       proxy_pass http://unix:<%= @run_dir %>/pegasus.sock;
-      proxy_set_header Host $http_host;
     }
   }
   server {
@@ -51,15 +57,16 @@ http {
     location / {
       # Pass the request on to port 80.
       proxy_pass  http://127.0.0.1;
-      proxy_set_header Host $http_host;
       proxy_set_header X-Forwarded-Proto https;
     }
   }
-<% node['cdo-varnish']['redirects'].dup.each_pair do |domain, site| -%>
+<% unless node['cdo-varnish']['enabled'] -%>
+<%   node['cdo-varnish']['redirects'].dup.each_pair do |domain, site| -%>
   server {
     listen 80 deferred;
     server_name <%=domain%>;
     return 301 https://<%=site%>$request_uri;
   }
+<%   end -%>
 <% end -%>
 }

--- a/cookbooks/cdo-nginx/templates/default/nginx.conf.erb
+++ b/cookbooks/cdo-nginx/templates/default/nginx.conf.erb
@@ -22,30 +22,52 @@ http {
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   proxy_set_header X-Request-Start "t=${msec}";
   proxy_set_header Host $http_host;
-<% unless node['cdo-varnish']['enabled'] -%>
-  # Copy Accept-Language header to X-Varnish-Accept-Language.
-  # TODO: Update application code to read Accept-Language instead of X-Varnish-Accept-Language.
-  proxy_set_header X-Varnish-Accept-Language $http_accept_language;
-<% end -%>
   proxy_buffer_size 8k;
 
   client_max_body_size 4G;
   keepalive_timeout 30;
 
-  server {
 <% unless node['cdo-varnish']['enabled'] -%>
+  # Copy Accept-Language header to X-Varnish-Accept-Language.
+  # TODO: Update application code to read Accept-Language instead of X-Varnish-Accept-Language.
+  proxy_set_header X-Varnish-Accept-Language $http_accept_language;
+
+  # Select port 80 backend based on Host and/or X-Cdo-Backend headers.
+  map "$host:$http_x_cdo_backend" $upstream {
+    # Override backend using X-Cdo-Backend header.
+    ~:dashboard$ "dashboard";
+    ~:pegasus$ "pegasus";
+    # Select dashboard if 'dashboard' or 'studio' appear anywhere in the host.
+    ~(dashboard|studio).*: "dashboard";
+    # Default to pegasus.
+    default "pegasus";
+  }
+
+  server {
+    listen 80 default_server deferred;
+    server_name _;
+    location / {
+      proxy_pass http://unix:<%= @run_dir %>/$upstream.sock;
+    }
+  }
+<%   redirects = node['cdo-varnish']['redirects'].group_by(&:last).transform_values {|v| v.to_h.keys}
+     redirects.each do |site, domains| -%>
+  server {
     listen 80;
+    server_name <%=domains.join(' ')%>;
+    return 301 https://<%=site%>$request_uri;
+  }
+<%   end -%>
 <% end -%>
+
+  server {
     listen <%= node['cdo-apps']['dashboard']['port'] %> deferred;
-    server_name ~(dashboard|studio);
+    server_name dashboard_proxy;
     location / {
       proxy_pass http://unix:<%= @run_dir %>/dashboard.sock;
     }
   }
   server {
-<% unless node['cdo-varnish']['enabled'] -%>
-    listen 80 default_server deferred;
-<% end -%>
     listen <%= node['cdo-apps']['pegasus']['port'] %> deferred;
     server_name pegasus_proxy;
     location / {
@@ -62,14 +84,4 @@ http {
       proxy_set_header X-Forwarded-Proto https;
     }
   }
-<% unless node['cdo-varnish']['enabled'] -%>
-<%   redirects = node['cdo-varnish']['redirects'].group_by(&:last).transform_values {|v| v.to_h.keys}
-     redirects.each do |site, domains| -%>
-  server {
-    listen 80;
-    server_name <%=domains.join(' ')%>;
-    return 301 https://<%=site%>$request_uri;
-  }
-<%   end -%>
-<% end -%>
 }

--- a/cookbooks/cdo-varnish/attributes/default.rb
+++ b/cookbooks/cdo-varnish/attributes/default.rb
@@ -1,5 +1,5 @@
 default['cdo-varnish'] = {
-  enabled: true,
+  enabled: false,
   'secret' => '00000000-0000-0000-0000-000000000000',
   redirects: {
     'forums.code.org'   => 'support.code.org',

--- a/cookbooks/cdo-varnish/attributes/default.rb
+++ b/cookbooks/cdo-varnish/attributes/default.rb
@@ -1,7 +1,4 @@
 default['cdo-varnish'] = {
-  'backends' => {
-    'localhost' => '127.0.0.1',
-  },
   'secret' => '00000000-0000-0000-0000-000000000000',
   redirects: {
     'forums.code.org'   => 'support.code.org',

--- a/cookbooks/cdo-varnish/attributes/default.rb
+++ b/cookbooks/cdo-varnish/attributes/default.rb
@@ -1,4 +1,5 @@
 default['cdo-varnish'] = {
+  enabled: true,
   'secret' => '00000000-0000-0000-0000-000000000000',
   redirects: {
     'forums.code.org'   => 'support.code.org',

--- a/cookbooks/cdo-varnish/attributes/default.rb
+++ b/cookbooks/cdo-varnish/attributes/default.rb
@@ -1,5 +1,8 @@
 default['cdo-varnish'] = {
-  enabled: false,
+  enabled: true,
+  'backends' => {
+    'localhost' => '127.0.0.1',
+  },
   'secret' => '00000000-0000-0000-0000-000000000000',
   redirects: {
     'forums.code.org'   => 'support.code.org',

--- a/cookbooks/cdo-varnish/recipes/default.rb
+++ b/cookbooks/cdo-varnish/recipes/default.rb
@@ -83,5 +83,9 @@ end
 
 service "varnish" do
   supports restart: true, reload: true, status: true
-  action [:enable, :start]
+  if node['cdo-varnish']['enabled']
+    action [:enable, :start]
+  else
+    action [:disable, :stop]
+  end
 end

--- a/cookbooks/cdo-varnish/templates/default/default.vcl.erb
+++ b/cookbooks/cdo-varnish/templates/default/default.vcl.erb
@@ -59,33 +59,6 @@ sub vcl_recv
 ###
 
 ### REDIRECTS
-  # TODO: Move to ELBv2 Listener Rules "redirect" action.
-
-  if(req.http.host ~ "\.$")
-  {
-    /* Don't allow domain names that end in "." */
-    return(synth(751, "https://" + regsub(req.http.host, "\.$","") + req.url));
-  }
-  else if(req.http.host ~ "^www\.")
-  {
-    /* Normalize domain names to the short (non www.) form. */
-    return(synth(751, "https://" + regsub(req.http.host, "^www\.","") + req.url));
-  }
-<%
-  node['cdo-varnish']['redirects'].dup.each_pair do |domain, site|
-    site = "https://#{site}" unless site =~ %r[^https?://]
--%>
-  else if(req.http.Host == "<%= domain %>")
-  {
-    return(synth(751, "<%= site %>" + req.url));
-  }
-<% end -%>
-  # Redirect http to https
-  if(req.http.X-Forwarded-Proto !~ "(?i)https") {
-    return(synth(751, "https://" + req.http.host + req.url));
-  }
-###
-
 # Copy Accept-Language header to X-Varnish-Accept-Language.
 # TODO: Update application code to read Accept-Language instead of X-Varnish-Accept-Language.
 
@@ -106,15 +79,4 @@ if (req.http.Accept-Language) {
 
   # Disable caching, just proxy requests to backend.
   return (pass);
-}
-
-# Handle redirects
-sub vcl_synth {
-  if(resp.status == 751) {
-    # We use this special error status 751 to force redirects with 301 (permanent) redirects
-    # To use this, call the following from anywhere in vcl_recv: return (synth(751, "http://host/new.html"));
-    set resp.http.Location = resp.reason;
-    set resp.status = 301;
-    return(deliver);
-  }
 }

--- a/cookbooks/cdo-varnish/templates/default/default.vcl.erb
+++ b/cookbooks/cdo-varnish/templates/default/default.vcl.erb
@@ -6,12 +6,10 @@ import std;
 import accept;
 
 <%
-  config = node['cdo-varnish']['config']
   backends = node['cdo-varnish']['backends'].to_hash
   redirects = node['cdo-varnish']['redirects'].dup
-%>
-
-<% backends.each_pair do |id, ip| %>
+-%>
+<% backends.each_pair do |id, ip| -%>
 probe backend_healthcheck {
   .url = "/health_check";
   .window = 4;
@@ -20,76 +18,60 @@ probe backend_healthcheck {
   .interval = 15s;
   .timeout = 10s;
 }
-
-backend pegasus_<%= id %> {
+<%   %w[pegasus dashboard].each do |app| -%>
+backend <%=app%>_<%=id%> {
   .host = "<%= ip %>";
-  .port = "<%= node['cdo-apps']['pegasus']['port'] %>";
+  .port = "<%= node['cdo-apps'][app]['port'] %>";
   .connect_timeout = 600s;
   .first_byte_timeout = 600s;
   .between_bytes_timeout = 600s;
   .probe = backend_healthcheck;
 }
-
-backend dashboard_<%= id %> {
-  .host = "<%= ip %>";
-  .port = "<%= node['cdo-apps']['dashboard']['port'] %>";
-  .connect_timeout = 600s;
-  .first_byte_timeout = 600s;
-  .between_bytes_timeout = 600s;
-  .probe = backend_healthcheck;
-}
-<% end %>
+<%   end -%>
+<% end -%>
 
 sub vcl_init {
-  new pegasus = directors.round_robin();
   new dashboard = directors.round_robin();
-<% backends.keys.each do |id| %>
-  pegasus.add_backend(pegasus_<%= id %>);
-  dashboard.add_backend(dashboard_<%= id %>);
-<% end %>
-
-  # Default unsupported Accept-Language languages to en
-  new al_rule = accept.rule("en");
-  # Add supported Accept-Language languages
-<% node['cdo-apps']['i18n']['languages'].to_hash.keys.map {|k| k.to_s }.each do |lang| %>
-  al_rule.add("<%= lang %>");
-<% end %>
+<% %w[pegasus dashboard].each do |app| -%>
+  new <%=app%> = directors.round_robin();
+<%   backends.keys.each do |id| -%>
+  <%=app%>.add_backend(<%=app%>_<%= id %>);
+<%   end -%>
+<% end -%>
 }
 
 # Respond to incoming requests.
 sub vcl_recv
 {
+### HEALTH CHECKS
+# TODO: Move to ELBv2 Target Group health checks.
+
   # Use "/varnishcheck" to determine if you are hitting a Varnish instance.
   if (req.method == "GET" && req.url ~ "^/varnishcheck$") {
     return(synth(200, "Varnish is ready."));
   }
 
-  # Use "/health_check.php" to keep this instance in the load balancer.
-  if (req.method == "GET" && (req.url ~ "^/health_check.php$" || req.url ~ "^/health_check$")) {
+  # Use "/health_check" to keep this instance in the load balancer.
+  if (req.method == "GET" && req.url ~ "^/health_check$") {
     if (std.healthy(dashboard_<%=backends.keys.first%>) && std.healthy(pegasus_<%=backends.keys.first%>)) {
       return(synth(200, "Webapps are healthy."));
     } else {
       return(synth(503, "Webapps are not healthy."));
     }
   }
-
-  if (req.method == "GET" && req.url ~ "^/health_check.dashboard$") {
-    if (std.healthy(dashboard_<%=backends.keys.first%>)) {
-      return(synth(200, "Dashboard is healthy."));
+<% %w[pegasus dashboard].each do |app| -%>
+  if (req.method == "GET" && req.url ~ "^/health_check.<%=app%>$") {
+    if (std.healthy(<%=app%>_<%=backends.keys.first%>)) {
+      return(synth(200, "<%=app%> is healthy."));
     } else {
-      return(synth(503, "Dashboard is not healthy."));
+      return(synth(503, "<%=app%> is not healthy."));
     }
   }
-
-  if (req.method == "GET" && req.url ~ "^/health_check.pegasus$") {
-    if (std.healthy(pegasus_<%=backends.keys.first%>)) {
-      return(synth(200, "Pegasus is healthy."));
-    } else {
-      return(synth(503, "Pegasus is not healthy."));
-    }
-  }
+<% end -%>
+###
 
 ### REDIRECTS
+  # TODO: Move to ELBv2 Listener Rules "redirect" action.
 
   if(req.http.host ~ "\.$")
   {
@@ -116,124 +98,26 @@ sub vcl_recv
   }
 ###
 
-### REQUEST COOKIE+HEADER FILTER
-if(req.http.Cookie) {
-  cookie.parse(req.http.Cookie);
-}
-<%= setup_behavior(config, 'req', &method(:process_request)) %>
-if(req.http.Cookie) {
-  set req.http.Cookie = cookie.get_string();
-  if (req.http.Cookie == "") {
-    unset req.http.Cookie;
-  }
-}
-###
+# Copy Accept-Language header to X-Varnish-Accept-Language.
+# TODO: Update application code to read Accept-Language instead of X-Varnish-Accept-Language.
 
-# Normalize Accept-Language header into X-Varnish-Accept-Language for better cache hit rates.
 if (req.http.Accept-Language) {
-  set req.http.X-Varnish-Accept-Language = al_rule.filter(req.http.Accept-Language);
-}
-
-# Collapse cookie-extracted language setting into X-Varnish-Accept-Language header if present.
-if (req.http.X-Cookie-language_) {
-  set req.http.X-Varnish-Accept-Language = req.http.X-Cookie-language_;
-  unset req.http.X-Cookie-language_;
+  set req.http.X-Varnish-Accept-Language = req.http.Accept-Language;
 }
 
 ### PROXIES
-<%= setup_behavior(config, 'req', &method(:process_proxy)) %>
+  # Host-based backend selection.
+  # TODO: Move to ELBv2 Listener Rules "forward" action, to select among multiple Target Groups.
+
+  if(req.http.host ~ "(dashboard|studio)") {
+    set req.backend_hint = dashboard.backend();
+  } else {
+    set req.backend_hint = pegasus.backend();
+  }
 ###
 
-# Override builtin VCL with customizations:
-# 1. Allow caching whitelisted cookies.
-# 2. Return 403 instead of (pipe) on unsupported HTTP request methods.
-if (req.method != "GET" &&
-  req.method != "HEAD" &&
-  req.method != "PUT" &&
-  req.method != "POST" &&
-  req.method != "TRACE" &&
-  req.method != "OPTIONS" &&
-  req.method != "DELETE" &&
-  req.method != "PATCH") {
-  /* Non-RFC2616 or CONNECT which is weird. */
-  # return (pipe);
-  return(synth(403, "Unsupported HTTP request method."));
-}
-if (req.method != "GET" && req.method != "HEAD") {
-  /* We only deal with GET and HEAD by default */
+  # Disable caching, just proxy requests to backend.
   return (pass);
-}
-if (req.http.Authorization /* || req.http.Cookie */) {
-  /* Not cacheable by default */
-  return (pass);
-}
-
-return (hash);
-}
-
-# Handle the HTTP response coming from our backend
-# beresp == Back-end response from the web server.
-sub vcl_backend_response {
-
-### RESPONSE COOKIE FILTER
-# Only apply cookie filter to cached HTTP methods.
-if(bereq.method == "GET" || bereq.method == "HEAD") {
-<%= setup_behavior(config, 'bereq', &method(:process_response)) %>
-}
-###
-
-  if (beresp.http.Cache-Control) {
-    # Cache-Control: max-age directive overrides the Expires header.
-    # This line is not strictly necessary, but appropriate for a default http-cache config.
-    unset beresp.http.Expires;
-  }
-
-  # Keep all objects for 1h longer in the cache than their TTL specifies.
-  # So even if HTTP objects are expired (they've passed their TTL), we can still use them in case all backends go down.
-  # Old content to show is better than no content at all (or an error page).
-  # Ref: https://www.varnish-cache.org/docs/4.0/users-guide/vcl-grace.html
-  set beresp.grace = 1h;
-
-  # Workaround for https://www.varnish-cache.org/trac/ticket/1643
-  # Fixed in Varnish 4.1 (TODO: Remove workaround after upgrade)
-  if (bereq.http.range) {
-    set beresp.do_stream = false;
-  }
-
-### UPSTREAM VARY HEADER
-<%= setup_behavior(config, 'bereq', &method(:process_vary)) %>
-###
-
-  if (beresp.http.Vary) {
-    # Transform 'Accept-Language' Vary header field to 'X-Varnish-Accept-Language'.
-    set beresp.http.Vary = regsub(beresp.http.Vary, "(?<=\s|,|^)Accept-Language", "X-Varnish-Accept-Language");
-  }
-  # Pass-through to builtin.
-}
-
-sub vcl_deliver {
-  # Downstream Vary header.
-  if (resp.http.Vary) {
-    # Transform 'X-Varnish-Accept-Language' Vary header field back to 'Accept-Language'.
-    set resp.http.Vary = regsub(resp.http.Vary, "(?<=\s|,|^)X-Varnish-Accept-Language", "Accept-Language");
-
-    # Strip all "X-COOKIE-*" Vary header fields appearing anywhere in the comma-delimited header.
-    <% reg = '\s*X-COOKIE-[^,\s]+\s*' %>
-    if (resp.http.Vary ~ "<%= reg %>") {
-      set resp.http.Vary = regsuball(resp.http.Vary, "<%= "^#{reg},?\\s*|,#{reg}" %>", "");
-      <%= set_vary('Cookie', 'resp') %>
-    }
-  }
-  # Set a header to track a cache HIT/MISS.
-  if (obj.hits > 0) {
-    set resp.http.X-Varnish-Cache = "HIT";
-  }
-  else {
-    set resp.http.X-Varnish-Cache = "MISS";
-  }
-
-  set resp.http.X-Varnish-Node = server.hostname;
-  # Pass-through to builtin.
 }
 
 # Handle redirects

--- a/cookbooks/cdo-varnish/templates/default/default.vcl.erb
+++ b/cookbooks/cdo-varnish/templates/default/default.vcl.erb
@@ -31,7 +31,6 @@ backend <%=app%>_<%=id%> {
 <% end -%>
 
 sub vcl_init {
-  new dashboard = directors.round_robin();
 <% %w[pegasus dashboard].each do |app| -%>
   new <%=app%> = directors.round_robin();
 <%   backends.keys.each do |id| -%>

--- a/cookbooks/cdo-varnish/templates/default/default.vcl.erb
+++ b/cookbooks/cdo-varnish/templates/default/default.vcl.erb
@@ -1,15 +1,7 @@
 vcl 4.0;
-import cookie;
-import header;
 import directors;
 import std;
-import accept;
 
-<%
-  backends = node['cdo-varnish']['backends'].to_hash
-  redirects = node['cdo-varnish']['redirects'].dup
--%>
-<% backends.each_pair do |id, ip| -%>
 probe backend_healthcheck {
   .url = "/health_check";
   .window = 4;
@@ -18,24 +10,21 @@ probe backend_healthcheck {
   .interval = 15s;
   .timeout = 10s;
 }
-<%   %w[pegasus dashboard].each do |app| -%>
-backend <%=app%>_<%=id%> {
-  .host = "<%= ip %>";
+<% %w[pegasus dashboard].each do |app| -%>
+backend <%=app%>_localhost {
+  .host = "127.0.0.1";
   .port = "<%= node['cdo-apps'][app]['port'] %>";
   .connect_timeout = 600s;
   .first_byte_timeout = 600s;
   .between_bytes_timeout = 600s;
   .probe = backend_healthcheck;
 }
-<%   end -%>
 <% end -%>
 
 sub vcl_init {
 <% %w[pegasus dashboard].each do |app| -%>
   new <%=app%> = directors.round_robin();
-<%   backends.keys.each do |id| -%>
-  <%=app%>.add_backend(<%=app%>_<%= id %>);
-<%   end -%>
+  <%=app%>.add_backend(<%=app%>_localhost);
 <% end -%>
 }
 
@@ -52,7 +41,7 @@ sub vcl_recv
 
   # Use "/health_check" to keep this instance in the load balancer.
   if (req.method == "GET" && req.url ~ "^/health_check$") {
-    if (std.healthy(dashboard_<%=backends.keys.first%>) && std.healthy(pegasus_<%=backends.keys.first%>)) {
+    if (std.healthy(dashboard_localhost) && std.healthy(pegasus_localhost)) {
       return(synth(200, "Webapps are healthy."));
     } else {
       return(synth(503, "Webapps are not healthy."));
@@ -60,7 +49,7 @@ sub vcl_recv
   }
 <% %w[pegasus dashboard].each do |app| -%>
   if (req.method == "GET" && req.url ~ "^/health_check.<%=app%>$") {
-    if (std.healthy(<%=app%>_<%=backends.keys.first%>)) {
+    if (std.healthy(<%=app%>_localhost)) {
       return(synth(200, "<%=app%> is healthy."));
     } else {
       return(synth(503, "<%=app%> is not healthy."));
@@ -83,14 +72,14 @@ sub vcl_recv
     return(synth(751, "https://" + regsub(req.http.host, "^www\.","") + req.url));
   }
 <%
-  redirects.each_pair do |domain, site|
+  node['cdo-varnish']['redirects'].dup.each_pair do |domain, site|
     site = "https://#{site}" unless site =~ %r[^https?://]
-%>
+-%>
   else if(req.http.Host == "<%= domain %>")
   {
     return(synth(751, "<%= site %>" + req.url));
   }
-<% end %>
+<% end -%>
   # Redirect http to https
   if(req.http.X-Forwarded-Proto !~ "(?i)https") {
     return(synth(751, "https://" + req.http.host + req.url));

--- a/cookbooks/cdo-varnish/templates/default/default.vcl.erb
+++ b/cookbooks/cdo-varnish/templates/default/default.vcl.erb
@@ -1,7 +1,17 @@
 vcl 4.0;
+import cookie;
+import header;
 import directors;
 import std;
+import accept;
 
+<%
+  config = node['cdo-varnish']['config']
+  backends = node['cdo-varnish']['backends'].to_hash
+  redirects = node['cdo-varnish']['redirects'].dup
+%>
+
+<% backends.each_pair do |id, ip| %>
 probe backend_healthcheck {
   .url = "/health_check";
   .window = 4;
@@ -10,73 +20,229 @@ probe backend_healthcheck {
   .interval = 15s;
   .timeout = 10s;
 }
-<% %w[pegasus dashboard].each do |app| -%>
-backend <%=app%>_localhost {
-  .host = "127.0.0.1";
-  .port = "<%= node['cdo-apps'][app]['port'] %>";
+
+backend pegasus_<%= id %> {
+  .host = "<%= ip %>";
+  .port = "<%= node['cdo-apps']['pegasus']['port'] %>";
   .connect_timeout = 600s;
   .first_byte_timeout = 600s;
   .between_bytes_timeout = 600s;
   .probe = backend_healthcheck;
 }
-<% end -%>
+
+backend dashboard_<%= id %> {
+  .host = "<%= ip %>";
+  .port = "<%= node['cdo-apps']['dashboard']['port'] %>";
+  .connect_timeout = 600s;
+  .first_byte_timeout = 600s;
+  .between_bytes_timeout = 600s;
+  .probe = backend_healthcheck;
+}
+<% end %>
 
 sub vcl_init {
-<% %w[pegasus dashboard].each do |app| -%>
-  new <%=app%> = directors.round_robin();
-  <%=app%>.add_backend(<%=app%>_localhost);
-<% end -%>
+  new pegasus = directors.round_robin();
+  new dashboard = directors.round_robin();
+<% backends.keys.each do |id| %>
+  pegasus.add_backend(pegasus_<%= id %>);
+  dashboard.add_backend(dashboard_<%= id %>);
+<% end %>
+
+  # Default unsupported Accept-Language languages to en
+  new al_rule = accept.rule("en");
+  # Add supported Accept-Language languages
+<% node['cdo-apps']['i18n']['languages'].to_hash.keys.map {|k| k.to_s }.each do |lang| %>
+  al_rule.add("<%= lang %>");
+<% end %>
 }
 
 # Respond to incoming requests.
 sub vcl_recv
 {
-### HEALTH CHECKS
-# TODO: Move to ELBv2 Target Group health checks.
-
   # Use "/varnishcheck" to determine if you are hitting a Varnish instance.
   if (req.method == "GET" && req.url ~ "^/varnishcheck$") {
     return(synth(200, "Varnish is ready."));
   }
 
-  # Use "/health_check" to keep this instance in the load balancer.
-  if (req.method == "GET" && req.url ~ "^/health_check$") {
-    if (std.healthy(dashboard_localhost) && std.healthy(pegasus_localhost)) {
+  # Use "/health_check.php" to keep this instance in the load balancer.
+  if (req.method == "GET" && (req.url ~ "^/health_check.php$" || req.url ~ "^/health_check$")) {
+    if (std.healthy(dashboard_<%=backends.keys.first%>) && std.healthy(pegasus_<%=backends.keys.first%>)) {
       return(synth(200, "Webapps are healthy."));
     } else {
       return(synth(503, "Webapps are not healthy."));
     }
   }
-<% %w[pegasus dashboard].each do |app| -%>
-  if (req.method == "GET" && req.url ~ "^/health_check.<%=app%>$") {
-    if (std.healthy(<%=app%>_localhost)) {
-      return(synth(200, "<%=app%> is healthy."));
+
+  if (req.method == "GET" && req.url ~ "^/health_check.dashboard$") {
+    if (std.healthy(dashboard_<%=backends.keys.first%>)) {
+      return(synth(200, "Dashboard is healthy."));
     } else {
-      return(synth(503, "<%=app%> is not healthy."));
+      return(synth(503, "Dashboard is not healthy."));
     }
   }
-<% end -%>
-###
+
+  if (req.method == "GET" && req.url ~ "^/health_check.pegasus$") {
+    if (std.healthy(pegasus_<%=backends.keys.first%>)) {
+      return(synth(200, "Pegasus is healthy."));
+    } else {
+      return(synth(503, "Pegasus is not healthy."));
+    }
+  }
 
 ### REDIRECTS
-# Copy Accept-Language header to X-Varnish-Accept-Language.
-# TODO: Update application code to read Accept-Language instead of X-Varnish-Accept-Language.
 
+  if(req.http.host ~ "\.$")
+  {
+    /* Don't allow domain names that end in "." */
+    return(synth(751, "https://" + regsub(req.http.host, "\.$","") + req.url));
+  }
+  else if(req.http.host ~ "^www\.")
+  {
+    /* Normalize domain names to the short (non www.) form. */
+    return(synth(751, "https://" + regsub(req.http.host, "^www\.","") + req.url));
+  }
+<%
+  redirects.each_pair do |domain, site|
+    site = "https://#{site}" unless site =~ %r[^https?://]
+%>
+  else if(req.http.Host == "<%= domain %>")
+  {
+    return(synth(751, "<%= site %>" + req.url));
+  }
+<% end %>
+  # Redirect http to https
+  if(req.http.X-Forwarded-Proto !~ "(?i)https") {
+    return(synth(751, "https://" + req.http.host + req.url));
+  }
+###
+
+### REQUEST COOKIE+HEADER FILTER
+if(req.http.Cookie) {
+  cookie.parse(req.http.Cookie);
+}
+<%= setup_behavior(config, 'req', &method(:process_request)) %>
+if(req.http.Cookie) {
+  set req.http.Cookie = cookie.get_string();
+  if (req.http.Cookie == "") {
+    unset req.http.Cookie;
+  }
+}
+###
+
+# Normalize Accept-Language header into X-Varnish-Accept-Language for better cache hit rates.
 if (req.http.Accept-Language) {
-  set req.http.X-Varnish-Accept-Language = req.http.Accept-Language;
+  set req.http.X-Varnish-Accept-Language = al_rule.filter(req.http.Accept-Language);
+}
+
+# Collapse cookie-extracted language setting into X-Varnish-Accept-Language header if present.
+if (req.http.X-Cookie-language_) {
+  set req.http.X-Varnish-Accept-Language = req.http.X-Cookie-language_;
+  unset req.http.X-Cookie-language_;
 }
 
 ### PROXIES
-  # Host-based backend selection.
-  # TODO: Move to ELBv2 Listener Rules "forward" action, to select among multiple Target Groups.
-
-  if(req.http.host ~ "(dashboard|studio)") {
-    set req.backend_hint = dashboard.backend();
-  } else {
-    set req.backend_hint = pegasus.backend();
-  }
+<%= setup_behavior(config, 'req', &method(:process_proxy)) %>
 ###
 
-  # Disable caching, just proxy requests to backend.
+# Override builtin VCL with customizations:
+# 1. Allow caching whitelisted cookies.
+# 2. Return 403 instead of (pipe) on unsupported HTTP request methods.
+if (req.method != "GET" &&
+  req.method != "HEAD" &&
+  req.method != "PUT" &&
+  req.method != "POST" &&
+  req.method != "TRACE" &&
+  req.method != "OPTIONS" &&
+  req.method != "DELETE" &&
+  req.method != "PATCH") {
+  /* Non-RFC2616 or CONNECT which is weird. */
+  # return (pipe);
+  return(synth(403, "Unsupported HTTP request method."));
+}
+if (req.method != "GET" && req.method != "HEAD") {
+  /* We only deal with GET and HEAD by default */
   return (pass);
+}
+if (req.http.Authorization /* || req.http.Cookie */) {
+  /* Not cacheable by default */
+  return (pass);
+}
+
+return (hash);
+}
+
+# Handle the HTTP response coming from our backend
+# beresp == Back-end response from the web server.
+sub vcl_backend_response {
+
+### RESPONSE COOKIE FILTER
+# Only apply cookie filter to cached HTTP methods.
+if(bereq.method == "GET" || bereq.method == "HEAD") {
+<%= setup_behavior(config, 'bereq', &method(:process_response)) %>
+}
+###
+
+  if (beresp.http.Cache-Control) {
+    # Cache-Control: max-age directive overrides the Expires header.
+    # This line is not strictly necessary, but appropriate for a default http-cache config.
+    unset beresp.http.Expires;
+  }
+
+  # Keep all objects for 1h longer in the cache than their TTL specifies.
+  # So even if HTTP objects are expired (they've passed their TTL), we can still use them in case all backends go down.
+  # Old content to show is better than no content at all (or an error page).
+  # Ref: https://www.varnish-cache.org/docs/4.0/users-guide/vcl-grace.html
+  set beresp.grace = 1h;
+
+  # Workaround for https://www.varnish-cache.org/trac/ticket/1643
+  # Fixed in Varnish 4.1 (TODO: Remove workaround after upgrade)
+  if (bereq.http.range) {
+    set beresp.do_stream = false;
+  }
+
+### UPSTREAM VARY HEADER
+<%= setup_behavior(config, 'bereq', &method(:process_vary)) %>
+###
+
+  if (beresp.http.Vary) {
+    # Transform 'Accept-Language' Vary header field to 'X-Varnish-Accept-Language'.
+    set beresp.http.Vary = regsub(beresp.http.Vary, "(?<=\s|,|^)Accept-Language", "X-Varnish-Accept-Language");
+  }
+  # Pass-through to builtin.
+}
+
+sub vcl_deliver {
+  # Downstream Vary header.
+  if (resp.http.Vary) {
+    # Transform 'X-Varnish-Accept-Language' Vary header field back to 'Accept-Language'.
+    set resp.http.Vary = regsub(resp.http.Vary, "(?<=\s|,|^)X-Varnish-Accept-Language", "Accept-Language");
+
+    # Strip all "X-COOKIE-*" Vary header fields appearing anywhere in the comma-delimited header.
+    <% reg = '\s*X-COOKIE-[^,\s]+\s*' %>
+    if (resp.http.Vary ~ "<%= reg %>") {
+      set resp.http.Vary = regsuball(resp.http.Vary, "<%= "^#{reg},?\\s*|,#{reg}" %>", "");
+      <%= set_vary('Cookie', 'resp') %>
+    }
+  }
+  # Set a header to track a cache HIT/MISS.
+  if (obj.hits > 0) {
+    set resp.http.X-Varnish-Cache = "HIT";
+  }
+  else {
+    set resp.http.X-Varnish-Cache = "MISS";
+  }
+
+  set resp.http.X-Varnish-Node = server.hostname;
+  # Pass-through to builtin.
+}
+
+# Handle redirects
+sub vcl_synth {
+  if(resp.status == 751) {
+    # We use this special error status 751 to force redirects with 301 (permanent) redirects
+    # To use this, call the following from anywhere in vcl_recv: return (synth(751, "http://host/new.html"));
+    set resp.http.Location = resp.reason;
+    set resp.status = 301;
+    return(deliver);
+  }
 }

--- a/lib/cdo/aws/cloudfront.rb
+++ b/lib/cdo/aws/cloudfront.rb
@@ -245,6 +245,12 @@ module AWS
           Forward: behavior_config[:cookies]
         }
 
+      accept_language_fn =
+        {
+          EventType: 'viewer-request',
+           FunctionARN: {'Fn::Sub': 'arn:aws:cloudfront::${AWS::AccountId}:function/AcceptLanguage'}
+        }
+
       {
         AllowedMethods: ALLOWED_METHODS,
         CachedMethods: CACHED_METHODS,
@@ -256,6 +262,7 @@ module AWS
           Headers: headers,
           QueryString: behavior_config[:query] != false
         },
+        FunctionAssociations: headers.include?('Accept-Language') ? [accept_language_fn] : [],
         MaxTTL: 31_536_000, # =1 year,
         MinTTL: 0,
         SmoothStreaming: false,


### PR DESCRIPTION
WIP- add Accept-Language lookup CloudFront Function, and simplify Varnish configuration.

Still need to add CloudFront Function viewer-request associations to integrate the function into the cache behaviors.
(if time) It should be possible to push all of the remaining Varnish functionality into ~ELBv2 listener-rule logic~ nginx, and then bypass the Varnish port 80 entirely in favor of forwarding requests directly to 8080/8081 (dashboard/pegasus). This might end up being slightly more involved than the initial simplification in this PR, but I've left TODO comments in the remaining Varnish VCL to map out this direction.