### PR TITLE
Update DeleteAccountsHelper to handle UserLevel soft deletes

### DIFF
--- a/dashboard/test/helpers/delete_accounts_helper_test.rb
+++ b/dashboard/test/helpers/delete_accounts_helper_test.rb
@@ -497,6 +497,24 @@ class DeleteAccountsHelperTest < ActionView::TestCase
     assert_logged "Cleaned 1 UserLevel"
   end
 
+  test "Disconnects soft-deleted user_levels from level_sources" do
+    user_level = create :user_level, level_source: create(:level_source)
+
+    refute_nil user_level.level_source_id
+
+    # Same test as above except that we soft-delete the user_level before
+    # calling purge_user
+    user_level.destroy
+    assert user_level.deleted?
+
+    purge_user user_level.user
+    user_level.reload
+
+    assert_nil user_level.level_source_id
+
+    assert_logged "Cleaned 1 UserLevel"
+  end
+
   #
   # Table: dashboard.authentication_options
   # Note: acts_as_paranoid

--- a/lib/cdo/delete_accounts_helper.rb
+++ b/lib/cdo/delete_accounts_helper.rb
@@ -63,7 +63,7 @@ class DeleteAccountsHelper
   # @param [Integer] user_id The user to clean the LevelSource-backed progress of.
   def clean_level_source_backed_progress(user_id)
     @log.puts "Cleaning UserLevel"
-    updated_rows = UserLevel.where(user_id: user_id).update_all(level_source_id: nil)
+    updated_rows = UserLevel.with_deleted.where(user_id: user_id).update_all(level_source_id: nil)
     @log.puts "Cleaned #{updated_rows} UserLevel" if updated_rows > 0
 
     @log.puts "Cleaning Activity"


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Update DeleteAccountsHelper to include soft-deleted user_level rows.  This is a follow-up to #42235.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- original tech spec for "hard-delete": [doc](https://docs.google.com/document/d/1l2kB4COz8-NwZfNCGufj7RfdSm-B3waBmLenc6msWVs/edit#)
- jira ticket: [LP-1994](https://codedotorg.atlassian.net/browse/LP-1994)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
