### PR TITLE
Revert "Revert "Add script to backfill Parent-Child level relationships""

### DIFF
--- a/bin/oneoff/backfill_parent-child_relationships.rb
+++ b/bin/oneoff/backfill_parent-child_relationships.rb
@@ -1,0 +1,27 @@
+#!/usr/bin/env ruby
+require_relative '../../lib/cdo/only_one'
+abort 'Script already running' unless only_one_running?(__FILE__)
+
+require_relative '../../dashboard/config/environment'
+
+def main
+  Level.includes(:child_levels).all.each do |level|
+    if level.contained_level_names.present?
+      begin
+        level.setup_contained_levels
+      rescue => e
+        puts e
+      end
+    end
+
+    if level.project_template_level_name.present?
+      begin
+        level.setup_project_template_level
+      rescue => e
+        puts e
+      end
+    end
+  end
+end
+
+main

--- a/bin/oneoff/backfill_parent-child_relationships.rb
+++ b/bin/oneoff/backfill_parent-child_relationships.rb
@@ -14,6 +14,9 @@ def main
       end
     end
 
+    # Our linter wants us to use `next` here rather than `if`, but doing so
+    # breaks parallelism with the other block
+    # rubocop:disable Style/Next
     if level.project_template_level_name.present?
       begin
         level.setup_project_template_level
@@ -21,6 +24,7 @@ def main
         puts e
       end
     end
+    # rubocop:enable Style/Next
   end
 end
 


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#42351, restoring https://github.com/code-dot-org/code-dot-org/pull/42320

The original PR failed because our linter wanted the second `if` block replaced with `next`, but doing so would break parallelism with the first `if` block so I decided to keep the code as-is and add a linter ignore directive.