### PR TITLE
Update information in CourseOverview to use redux

### DIFF
--- a/apps/src/sites/studio/pages/courses/show.js
+++ b/apps/src/sites/studio/pages/courses/show.js
@@ -101,11 +101,7 @@ function showCourseOverview() {
         teacherResources={teacherResources}
         migratedTeacherResources={courseSummary.migrated_teacher_resources}
         studentResources={courseSummary.student_resources}
-        isTeacher={isTeacher}
-        viewAs={ViewType.Teacher}
         scripts={courseSummary.scripts}
-        isVerifiedTeacher={!!scriptData.is_verified_teacher}
-        hasVerifiedResources={!!courseSummary.has_verified_resources}
         versions={convertAssignmentVersionShapeFromServer(versions)}
         showVersionWarning={
           !!scriptData.show_version_warning && versions.length > 1

--- a/apps/src/templates/courseOverview/CourseOverview.js
+++ b/apps/src/templates/courseOverview/CourseOverview.js
@@ -52,7 +52,6 @@ class CourseOverview extends Component {
     teacherResources: PropTypes.arrayOf(resourceShape),
     migratedTeacherResources: PropTypes.arrayOf(migratedResourceShape),
     studentResources: PropTypes.arrayOf(migratedResourceShape),
-    isTeacher: PropTypes.bool.isRequired,
     viewAs: PropTypes.oneOf(Object.values(ViewType)).isRequired,
     scripts: PropTypes.array.isRequired,
     isVerifiedTeacher: PropTypes.bool.isRequired,
@@ -126,7 +125,6 @@ class CourseOverview extends Component {
       teacherResources,
       migratedTeacherResources,
       studentResources,
-      isTeacher,
       viewAs,
       scripts,
       isVerifiedTeacher,
@@ -142,10 +140,7 @@ class CourseOverview extends Component {
     } = this.props;
 
     const showNotification =
-      viewAs === ViewType.Teacher &&
-      isTeacher &&
-      !isVerifiedTeacher &&
-      hasVerifiedResources;
+      viewAs === ViewType.Teacher && !isVerifiedTeacher && hasVerifiedResources;
 
     // Only display viewable versions in course version dropdown.
     const filteredVersions = versions.filter(version => version.canViewVersion);
@@ -230,7 +225,7 @@ class CourseOverview extends Component {
             studentResources={studentResources}
             showAssignButton={showAssignButton}
             useMigratedResources={useMigratedResources}
-            isTeacher={isTeacher}
+            isTeacher={viewAs === ViewType.Teacher}
           />
         </div>
         {scripts.map((script, index) => (
@@ -288,5 +283,8 @@ export default connect((state, ownProps) => ({
     true
   ),
   isSignedIn: state.currentUser.signInState === SignInState.SignedIn,
+  viewAs: state.viewAs,
+  isVerifiedTeacher: state.verifiedTeacher.isVerified,
+  hasVerifiedResources: state.verifiedTeacher.hasVerifiedResources,
   announcements: state.announcements || []
 }))(CourseOverview);

--- a/apps/test/unit/templates/courseOverview/CourseOverviewTest.js
+++ b/apps/test/unit/templates/courseOverview/CourseOverviewTest.js
@@ -19,7 +19,6 @@ const defaultProps = {
     '# Teacher description \n This is the course description with [link](https://studio.code.org/home) **Bold** *italics* ',
   sectionsInfo: [],
   teacherResources: [],
-  isTeacher: true,
   viewAs: ViewType.Teacher,
   scripts: [
     {


### PR DESCRIPTION
Dan pointed out that the descriptions we show on the CourseOverview did not work like the descriptions we show on the UnitOverview. When looking into this I noticed that we were not actually using the redux information we were setting for the CourseOverview and were always defaulting to view as teacher. I have update a bunch of things to use the redux information we were already setting up.

This makes it so when signed out you see the student description on the CourseOverview page as Dan suggested.

## Links

- [Slack Convo](https://codedotorg.slack.com/archives/CNZP84FJ5/p1631039657074100)

## Testing story

- Existing tests
