### PR TITLE
Remove PDF button when published state is pilot

### DIFF
--- a/apps/src/code-studio/components/progress/UnitOverview.jsx
+++ b/apps/src/code-studio/components/progress/UnitOverview.jsx
@@ -30,6 +30,7 @@ import GoogleClassroomAttributionLabel from '@cdo/apps/templates/progress/Google
 import UnitCalendar from './UnitCalendar';
 import color from '@cdo/apps/util/color';
 import {shouldShowReviewStates} from '@cdo/apps/templates/progress/progressHelpers';
+import {PublishedState} from '@cdo/apps/util/sharedConstants';
 
 /**
  * Lesson progress component used in level header and script overview.
@@ -60,6 +61,7 @@ class UnitOverview extends React.Component {
     isMigrated: PropTypes.bool,
     scriptOverviewPdfUrl: PropTypes.string,
     scriptResourcesPdfUrl: PropTypes.string,
+    publishedState: PropTypes.oneOf(Object.values(PublishedState)).isRequired,
 
     // redux provided
     perLevelResults: PropTypes.object.isRequired,
@@ -129,7 +131,8 @@ class UnitOverview extends React.Component {
       unitCalendarLessons,
       isMigrated,
       scriptOverviewPdfUrl,
-      scriptResourcesPdfUrl
+      scriptResourcesPdfUrl,
+      publishedState
     } = this.props;
 
     const displayRedirectDialog =
@@ -207,6 +210,7 @@ class UnitOverview extends React.Component {
               isMigrated={isMigrated}
               scriptOverviewPdfUrl={scriptOverviewPdfUrl}
               scriptResourcesPdfUrl={scriptResourcesPdfUrl}
+              publishedState={publishedState}
             />
           </div>
         )}

--- a/apps/src/code-studio/components/progress/UnitOverviewTopRow.jsx
+++ b/apps/src/code-studio/components/progress/UnitOverviewTopRow.jsx
@@ -127,7 +127,9 @@ class UnitOverviewTopRow extends React.Component {
       ? styles.buttonMarginRTL
       : styles.buttonMarginLTR;
 
-    const showPDFButton = publishedState !== PublishedState.pilot;
+    const showPDFButton =
+      publishedState !== PublishedState.pilot &&
+      publishedState !== PublishedState.in_development;
 
     return (
       <div style={styles.buttonRow} className="unit-overview-top-row">

--- a/apps/src/code-studio/components/progress/UnitOverviewTopRow.jsx
+++ b/apps/src/code-studio/components/progress/UnitOverviewTopRow.jsx
@@ -16,6 +16,7 @@ import ResourcesDropdown from '@cdo/apps/code-studio/components/progress/Resourc
 import UnitCalendarButton from '@cdo/apps/code-studio/components/progress/UnitCalendarButton';
 import {unitCalendarLesson} from '../../../templates/progress/unitCalendarLessonShapes';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
+import {PublishedState} from '@cdo/apps/util/sharedConstants';
 
 export const NOT_STARTED = 'NOT_STARTED';
 export const IN_PROGRESS = 'IN_PROGRESS';
@@ -49,7 +50,8 @@ class UnitOverviewTopRow extends React.Component {
     showCalendar: PropTypes.bool,
     isMigrated: PropTypes.bool,
     scriptOverviewPdfUrl: PropTypes.string,
-    scriptResourcesPdfUrl: PropTypes.string
+    scriptResourcesPdfUrl: PropTypes.string,
+    publishedState: PropTypes.oneOf(Object.values(PublishedState)).isRequired
   };
 
   recordAndNavigateToPdf = (e, firehoseKey, url) => {
@@ -113,7 +115,8 @@ class UnitOverviewTopRow extends React.Component {
       showCalendar,
       unitCalendarLessons,
       weeklyInstructionalMinutes,
-      isMigrated
+      isMigrated,
+      publishedState
     } = this.props;
 
     const pdfDropdownOptions = this.compilePdfDropdownOptions();
@@ -123,6 +126,8 @@ class UnitOverviewTopRow extends React.Component {
     const buttonMarginStyle = isRtl
       ? styles.buttonMarginRTL
       : styles.buttonMarginLTR;
+
+    const showPDFButton = publishedState !== PublishedState.pilot;
 
     return (
       <div style={styles.buttonRow} className="unit-overview-top-row">
@@ -167,26 +172,28 @@ class UnitOverviewTopRow extends React.Component {
                 useMigratedResources={isMigrated}
               />
             )}
-          {pdfDropdownOptions.length > 0 && viewAs === ViewType.Teacher && (
-            <div style={{marginRight: 5}}>
-              <DropdownButton
-                text={i18n.printingOptions()}
-                color={Button.ButtonColor.blue}
-              >
-                {pdfDropdownOptions.map(option => (
-                  <a
-                    key={option.key}
-                    href={option.url}
-                    onClick={e =>
-                      this.recordAndNavigateToPdf(e, option.key, option.url)
-                    }
-                  >
-                    {option.name}
-                  </a>
-                ))}
-              </DropdownButton>
-            </div>
-          )}
+          {showPDFButton &&
+            pdfDropdownOptions.length > 0 &&
+            viewAs === ViewType.Teacher && (
+              <div style={{marginRight: 5}}>
+                <DropdownButton
+                  text={i18n.printingOptions()}
+                  color={Button.ButtonColor.blue}
+                >
+                  {pdfDropdownOptions.map(option => (
+                    <a
+                      key={option.key}
+                      href={option.url}
+                      onClick={e =>
+                        this.recordAndNavigateToPdf(e, option.key, option.url)
+                      }
+                    >
+                      {option.name}
+                    </a>
+                  ))}
+                </DropdownButton>
+              </div>
+            )}
           {showCalendar && viewAs === ViewType.Teacher && (
             <UnitCalendarButton
               lessons={unitCalendarLessons}

--- a/apps/src/code-studio/progress.js
+++ b/apps/src/code-studio/progress.js
@@ -301,6 +301,7 @@ progress.renderCourseProgress = function(scriptData) {
         isMigrated={scriptData.is_migrated}
         scriptOverviewPdfUrl={scriptData.scriptOverviewPdfUrl}
         scriptResourcesPdfUrl={scriptData.scriptResourcesPdfUrl}
+        publishedState={scriptData.published_state}
       />
     </Provider>,
     mountPoint

--- a/apps/src/templates/lessonOverview/LessonOverview.jsx
+++ b/apps/src/templates/lessonOverview/LessonOverview.jsx
@@ -97,7 +97,7 @@ class LessonOverview extends Component {
 
     const pdfDropdownOptions = this.compilePdfDropdownOptions();
 
-    const showPDFButton = lesson.publishedState !== PublishedState.pilot;
+    const showPDFButton = lesson.unit.publishedState !== PublishedState.pilot;
 
     return (
       <div className="lesson-overview">

--- a/apps/src/templates/lessonOverview/LessonOverview.jsx
+++ b/apps/src/templates/lessonOverview/LessonOverview.jsx
@@ -24,6 +24,7 @@ import Announcements from '../../code-studio/components/progress/Announcements';
 import LessonStandards from './LessonStandards';
 import StyledCodeBlock from './StyledCodeBlock';
 import VerifiedResourcesNotification from '@cdo/apps/templates/courseOverview/VerifiedResourcesNotification';
+import {PublishedState} from '@cdo/apps/util/sharedConstants';
 
 class LessonOverview extends Component {
   static propTypes = {
@@ -96,6 +97,8 @@ class LessonOverview extends Component {
 
     const pdfDropdownOptions = this.compilePdfDropdownOptions();
 
+    const showPDFButton = lesson.publishedState !== PublishedState.pilot;
+
     return (
       <div className="lesson-overview">
         <div className="lesson-overview-header">
@@ -107,7 +110,7 @@ class LessonOverview extends Component {
               {`< ${lesson.unit.displayName}`}
             </a>
             <div style={styles.dropdowns}>
-              {pdfDropdownOptions.length > 0 && (
+              {showPDFButton && pdfDropdownOptions.length > 0 && (
                 <div style={{marginRight: 5}}>
                   <DropdownButton
                     color={Button.ButtonColor.gray}

--- a/apps/src/templates/lessonOverview/LessonOverview.jsx
+++ b/apps/src/templates/lessonOverview/LessonOverview.jsx
@@ -97,7 +97,9 @@ class LessonOverview extends Component {
 
     const pdfDropdownOptions = this.compilePdfDropdownOptions();
 
-    const showPDFButton = lesson.unit.publishedState !== PublishedState.pilot;
+    const showPDFButton =
+      lesson.unit.publishedState !== PublishedState.pilot &&
+      lesson.unit.publishedState !== PublishedState.in_development;
 
     return (
       <div className="lesson-overview">

--- a/apps/test/unit/code-studio/components/progress/UnitOverviewTest.js
+++ b/apps/test/unit/code-studio/components/progress/UnitOverviewTest.js
@@ -25,6 +25,7 @@ const defaultProps = {
   sectionsForDropdown: [],
   unitHasLockableLessons: false,
   unitAllowsHiddenLessons: false,
+  publishedState: 'beta',
   versions: []
 };
 

--- a/apps/test/unit/code-studio/components/progress/UnitOverviewTopRowTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/UnitOverviewTopRowTest.jsx
@@ -17,6 +17,7 @@ import ProgressDetailToggle from '@cdo/apps/templates/progress/ProgressDetailTog
 import ResourcesDropdown from '@cdo/apps/code-studio/components/progress/ResourcesDropdown';
 import UnitCalendarButton from '@cdo/apps/code-studio/components/progress/UnitCalendarButton';
 import {testLessons} from './unitCalendarTestData';
+import {PublishedState} from '@cdo/apps/util/sharedConstants';
 
 const defaultProps = {
   sectionsForDropdown: [],
@@ -313,7 +314,20 @@ describe('UnitOverviewTopRow', () => {
         scriptOverviewPdfUrl="/link/to/script_overview.pdf"
         scriptResourcesPdfUrl="/link/to/script_resources.pdf"
         viewAs={ViewType.Teacher}
-        publishedState={'pilot'}
+        publishedState={PublishedState.pilot}
+      />
+    );
+    expect(wrapper.find(DropdownButton).length).to.equal(0);
+  });
+
+  it('does not render printing options dropdown when published state is in-development', () => {
+    const wrapper = shallow(
+      <UnitOverviewTopRow
+        {...defaultProps}
+        scriptOverviewPdfUrl="/link/to/script_overview.pdf"
+        scriptResourcesPdfUrl="/link/to/script_resources.pdf"
+        viewAs={ViewType.Teacher}
+        publishedState={PublishedState.in_development}
       />
     );
     expect(wrapper.find(DropdownButton).length).to.equal(0);

--- a/apps/test/unit/code-studio/components/progress/UnitOverviewTopRowTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/UnitOverviewTopRowTest.jsx
@@ -29,6 +29,7 @@ const defaultProps = {
   teacherResources: [],
   studentResources: [],
   showAssignButton: true,
+  publishedState: 'beta',
   isMigrated: false
 };
 
@@ -281,7 +282,7 @@ describe('UnitOverviewTopRow', () => {
     ).to.be.false;
   });
 
-  it('renders dropdown button with links to printing options', () => {
+  it('renders dropdown button with links to printing options when published state is not pilot', () => {
     const wrapper = shallow(
       <UnitOverviewTopRow
         {...defaultProps}
@@ -303,6 +304,19 @@ describe('UnitOverviewTopRow', () => {
       'Print Lesson Plans',
       'Print Handouts'
     ]);
+  });
+
+  it('does not render printing options dropdown when published state is pilot', () => {
+    const wrapper = shallow(
+      <UnitOverviewTopRow
+        {...defaultProps}
+        scriptOverviewPdfUrl="/link/to/script_overview.pdf"
+        scriptResourcesPdfUrl="/link/to/script_resources.pdf"
+        viewAs={ViewType.Teacher}
+        publishedState={'pilot'}
+      />
+    );
+    expect(wrapper.find(DropdownButton).length).to.equal(0);
   });
 
   it('does not render printing option dropdown for students', () => {

--- a/apps/test/unit/templates/lessonOverview/LessonOverviewTest.js
+++ b/apps/test/unit/templates/lessonOverview/LessonOverviewTest.js
@@ -21,6 +21,7 @@ describe('LessonOverview', () => {
         unit: {
           displayName: 'Unit 1',
           link: '/s/unit-1',
+          publishedState: 'beta',
           lessonGroups: [
             {
               key: 'lg-1',
@@ -290,7 +291,7 @@ describe('LessonOverview', () => {
     ).to.be.true;
   });
 
-  it('renders dropdown button with links to printing options', () => {
+  it('renders dropdown button with links to printing options if not pilot', () => {
     const lesson = {
       ...defaultProps.lesson,
       lessonPlanPdfUrl: '/link/to/lesson_plan.pdf',
@@ -312,5 +313,22 @@ describe('LessonOverview', () => {
       'Print Lesson Plan',
       'Print Handouts'
     ]);
+  });
+
+  it('does not render printing options dropdown for pilot course', () => {
+    const unit = {
+      ...defaultProps.lesson.unit,
+      publishedState: 'pilot'
+    };
+    const lesson = {
+      ...defaultProps.lesson,
+      unit: unit,
+      lessonPlanPdfUrl: '/link/to/lesson_plan.pdf',
+      scriptResourcesPdfUrl: '/link/to/script_resources.pdf'
+    };
+    const wrapper = shallow(
+      <LessonOverview {...defaultProps} lesson={lesson} />
+    );
+    expect(wrapper.find(DropdownButton).length).to.equal(0);
   });
 });

--- a/apps/test/unit/templates/lessonOverview/LessonOverviewTest.js
+++ b/apps/test/unit/templates/lessonOverview/LessonOverviewTest.js
@@ -12,6 +12,7 @@ import {
   fakeTeacherAnnouncement
 } from '../../code-studio/components/progress/FakeAnnouncementsTestData';
 import _ from 'lodash';
+import {PublishedState} from '@cdo/apps/util/sharedConstants';
 
 describe('LessonOverview', () => {
   let defaultProps;
@@ -318,7 +319,24 @@ describe('LessonOverview', () => {
   it('does not render printing options dropdown for pilot course', () => {
     const unit = {
       ...defaultProps.lesson.unit,
-      publishedState: 'pilot'
+      publishedState: PublishedState.pilot
+    };
+    const lesson = {
+      ...defaultProps.lesson,
+      unit: unit,
+      lessonPlanPdfUrl: '/link/to/lesson_plan.pdf',
+      scriptResourcesPdfUrl: '/link/to/script_resources.pdf'
+    };
+    const wrapper = shallow(
+      <LessonOverview {...defaultProps} lesson={lesson} />
+    );
+    expect(wrapper.find(DropdownButton).length).to.equal(0);
+  });
+
+  it('does not render printing options dropdown for in development course', () => {
+    const unit = {
+      ...defaultProps.lesson.unit,
+      publishedState: PublishedState.in_development
     };
     const lesson = {
       ...defaultProps.lesson,

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -446,8 +446,7 @@ class Lesson < ApplicationRecord
       courseVersionStandardsUrl: course_version_standards_url,
       isVerifiedTeacher: user&.authorized_teacher?,
       hasVerifiedResources: lockable || lesson_plan_has_verified_resources,
-      scriptResourcesPdfUrl: unit_resource_pdf_url,
-      publishedState: script.get_published_state
+      scriptResourcesPdfUrl: unit_resource_pdf_url
     }
   end
 

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -446,7 +446,8 @@ class Lesson < ApplicationRecord
       courseVersionStandardsUrl: course_version_standards_url,
       isVerifiedTeacher: user&.authorized_teacher?,
       hasVerifiedResources: lockable || lesson_plan_has_verified_resources,
-      scriptResourcesPdfUrl: unit_resource_pdf_url
+      scriptResourcesPdfUrl: unit_resource_pdf_url,
+      publishedState: script.get_published_state
     }
   end
 

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1612,7 +1612,8 @@ class Script < ApplicationRecord
     {
       displayName: title_for_display,
       link: link,
-      lessonGroups: lesson_groups.select {|lg| lg.lessons.any?(&:has_lesson_plan)}.map {|lg| lg.summarize_for_lesson_dropdown(is_student)}
+      lessonGroups: lesson_groups.select {|lg| lg.lessons.any?(&:has_lesson_plan)}.map {|lg| lg.summarize_for_lesson_dropdown(is_student)},
+      publishedState: get_published_state
     }
   end
 

--- a/dashboard/app/views/scripts/show.html.haml
+++ b/dashboard/app/views/scripts/show.html.haml
@@ -15,7 +15,8 @@
                             locale_code: request.locale,
                             course_link: @script.course_link(params[:section_id]),
                             course_title: @script.course_title || I18n.t('view_all_units'),
-                            sections: @sections_with_assigned_info}
+                            sections: @sections_with_assigned_info,
+                            published_state: @script.get_published_state}
 - scriptOverviewData = {scriptData: script_data.merge(additional_script_data)}
 - if @script.professional_learning_course? && @current_user && Plc::UserCourseEnrollment.exists?(user: @current_user, plc_course: @script.plc_course_unit.plc_course)
   -  scriptOverviewData[:plcBreadcrumb] = {unit_name: @script.plc_course_unit.unit_name, course_view_path: course_path(@script.plc_course_unit.plc_course.unit_group)}


### PR DESCRIPTION
Hides the print PDF button on the Unit Overview and Lesson Plan pages when a course is in pilot. This is because we can't generate the PDFs without a signed out user being able to get to those pages. 

<img width="1161" alt="Screen Shot 2021-09-09 at 4 22 03 PM" src="https://user-images.githubusercontent.com/208083/132757188-2788c898-f985-4228-867e-1e7d2e746620.png">


## Links

- jira ticket: https://codedotorg.atlassian.net/browse/PLAT-1182

## Testing story

- Added some unit tests to check that those buttons don't show when in pilot published state