### PR TITLE
Fix background top offset for small bubbles

### DIFF
--- a/apps/src/templates/progress/ProgressBubbleSet.jsx
+++ b/apps/src/templates/progress/ProgressBubbleSet.jsx
@@ -70,7 +70,8 @@ class ProgressBubbleSet extends React.Component {
     const containerStyleProp = {
       ...styles.container,
       ...(level.isUnplugged && styles.pillContainer),
-      ...(level.isConceptLevel && styles.diamondContainer)
+      ...(level.isConceptLevel && styles.diamondContainer),
+      ...(isSublevel && styles.containerSublevel)
     };
 
     return (
@@ -142,7 +143,7 @@ const styles = {
     top: (18 + 4 + 12 + 6 - 10) / 2
   },
   backgroundSublevel: {
-    top: 4
+    top: 9
   },
   backgroundFirst: {
     left: 15
@@ -152,6 +153,9 @@ const styles = {
   },
   container: {
     position: 'relative'
+  },
+  containerSublevel: {
+    top: 5
   },
   diamondContainer: {
     // Height needed only by IE to get diamonds to line up properly


### PR DESCRIPTION
There's an alignment issue on the bubbles in the level details dialog for bubble choice levels.

Before:
<img width="1353" alt="Screen Shot 2021-09-07 at 2 48 48 PM" src="https://user-images.githubusercontent.com/46464143/132415316-1a80dbcc-1688-4659-8a82-e84473ad3808.png">


Now:
<img width="1370" alt="Screen Shot 2021-09-07 at 2 41 17 PM" src="https://user-images.githubusercontent.com/46464143/132415263-60fa0636-8785-4e69-bf14-d814f12063a1.png">



It looks like this is the only pathway that shows the small bubbles using this component. I did check the progress table, which I believe uses a different component, but definitely shows individual bubble choice bubbles:
<img width="646" alt="Screen Shot 2021-09-07 at 2 41 39 PM" src="https://user-images.githubusercontent.com/46464143/132415243-fb1e8a2a-95f0-46c2-bf9c-9f088519d533.png">

Let me know if I should look at anything else! This PR will create some eyes diffs which will need to be accepted.


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
