### PR TITLE
Extract admin redirect into shared controller action

### DIFF
--- a/dashboard/app/controllers/application_controller.rb
+++ b/dashboard/app/controllers/application_controller.rb
@@ -260,6 +260,10 @@ class ApplicationController < ActionController::Base
     authorize! :read, :reports
   end
 
+  def redirect_admin_from_labs
+    redirect_to root_path, flash: {alert: 'Labs not allowed for admins.'} if current_user&.admin?
+  end
+
   # Pairings are stored as an array of user ids in the session
   # (storing full objects is not a good idea because the session is
   # saved as a cookie)

--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -3,7 +3,7 @@ require 'cdo/firehose'
 
 class ProjectsController < ApplicationController
   before_action :authenticate_user!, except: [:load, :create_new, :show, :edit, :readonly, :redirect_legacy, :public, :index, :export_config]
-  before_action :redirect_admin_from_labs, only: [:index, :load, :create_new, :show, :edit, :remix]
+  before_action :redirect_admin_from_labs, only: [:load, :create_new, :show, :edit, :remix]
   before_action :authorize_load_project!, only: [:load, :create_new, :edit, :remix]
   before_action :set_level, only: [:load, :create_new, :show, :edit, :readonly, :remix, :export_config, :export_create_channel]
   protect_from_forgery except: :export_config
@@ -151,8 +151,9 @@ class ProjectsController < ApplicationController
   # GET /projects/:tab_name
   # Where a valid :tab_name is (nil|public|libraries)
   def index
-    if !current_user && params[:tab_name] != 'public'
-      return redirect_to '/projects/public'
+    unless params[:tab_name] == 'public'
+      return redirect_to '/projects/public' unless current_user
+      redirect_admin_from_labs
     end
 
     view_options(full_width: true, responsive_content: false, no_padding_container: true, has_i18n: true)

--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -3,6 +3,7 @@ require 'cdo/firehose'
 
 class ProjectsController < ApplicationController
   before_action :authenticate_user!, except: [:load, :create_new, :show, :edit, :readonly, :redirect_legacy, :public, :index, :export_config]
+  before_action :redirect_admin_from_labs, only: [:index, :load, :create_new, :show, :edit, :remix]
   before_action :authorize_load_project!, only: [:load, :create_new, :edit, :remix]
   before_action :set_level, only: [:load, :create_new, :show, :edit, :readonly, :remix, :export_config, :export_create_channel]
   protect_from_forgery except: :export_config
@@ -150,9 +151,8 @@ class ProjectsController < ApplicationController
   # GET /projects/:tab_name
   # Where a valid :tab_name is (nil|public|libraries)
   def index
-    unless params[:tab_name] == 'public'
-      return redirect_to '/projects/public' unless current_user
-      return redirect_to '/', flash: {alert: 'Labs not allowed for admins.'} if current_user.admin
+    if !current_user && params[:tab_name] != 'public'
+      return redirect_to '/projects/public'
     end
 
     view_options(full_width: true, responsive_content: false, no_padding_container: true, has_i18n: true)
@@ -230,10 +230,6 @@ class ProjectsController < ApplicationController
   end
 
   def load
-    if current_user.try(:admin)
-      redirect_to '/', flash: {alert: 'Labs not allowed for admins.'}
-      return
-    end
     return if redirect_under_13_without_tos_teacher(@level)
     if current_user
       channel = StorageApps.new(storage_id_for_current_user).most_recent(params[:key])
@@ -247,10 +243,6 @@ class ProjectsController < ApplicationController
   end
 
   def create_new
-    if current_user.try(:admin)
-      redirect_to '/', flash: {alert: 'Labs not allowed for admins.'}
-      return
-    end
     return if redirect_under_13_without_tos_teacher(@level)
     channel = ChannelToken.create_channel(
       request.ip,
@@ -276,10 +268,6 @@ class ProjectsController < ApplicationController
   end
 
   def show
-    if current_user.try(:admin)
-      redirect_to '/', flash: {alert: 'Labs not allowed for admins.'}
-      return
-    end
     if params.key?(:nosource)
       # projects can optionally be embedded without making their source
       # available. to keep people from just twiddling the url to get to the
@@ -365,19 +353,11 @@ class ProjectsController < ApplicationController
   end
 
   def edit
-    if current_user.try(:admin)
-      redirect_to '/', flash: {alert: 'Labs not allowed for admins.'}
-      return
-    end
     return if redirect_under_13_without_tos_teacher(@level)
     show
   end
 
   def remix
-    if current_user.try(:admin)
-      redirect_to '/', flash: {alert: 'Labs not allowed for admins.'}
-      return
-    end
     return if redirect_under_13_without_tos_teacher(@level)
     src_channel_id = params[:channel_id]
     begin

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -19,6 +19,7 @@ class ScriptLevelsController < ApplicationController
   DEFAULT_PUBLIC_CLIENT_MAX_AGE = DEFAULT_PUBLIC_PROXY_MAX_AGE * 2
 
   before_action :disable_session_for_cached_pages
+  before_action :redirect_admin_from_labs, only: [:reset, :next, :show, :lesson_extras]
   before_action :set_redirect_override, only: [:show]
 
   def disable_session_for_cached_pages

--- a/dashboard/test/controllers/projects_controller_test.rb
+++ b/dashboard/test/controllers/projects_controller_test.rb
@@ -59,14 +59,14 @@ class ProjectsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
-  test "index: redirect to '/' if user is admin" do
+  test "index: redirect admins to root" do
     sign_in create(:admin)
 
     get :index
-    assert_redirected_to '/'
+    assert_redirected_to root_path
 
     get :index, params: {tab_name: 'libraries'}
-    assert_redirected_to '/'
+    assert_redirected_to root_path
 
     # Don't redirect if we're already on /projects/public
     get :index, params: {tab_name: 'public'}
@@ -257,16 +257,16 @@ class ProjectsControllerTest < ActionController::TestCase
     sign_in_with_request create(:admin)
 
     get :index
-    assert_redirected_to '/'
+    assert_redirected_to root_path
 
     %w(applab gamelab).each do |lab|
       get :load, params: {key: lab}
-      assert_redirected_to '/'
+      assert_redirected_to root_path
     end
 
     %w(applab gamelab).each do |lab|
       get :show, params: {key: lab, share: true, channel_id: 'fake_channel_id'}
-      assert_redirected_to '/'
+      assert_redirected_to root_path
     end
   end
 

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -855,6 +855,12 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     assert_redirected_to_sign_in
   end
 
+  test "reset redirects admins to root" do
+    sign_in create(:admin)
+    get :reset, params: {script_id: Script::HOC_NAME}
+    assert_redirected_to root_path
+  end
+
   test "show with the reset param should reset session when not logged in" do
     client_state.set_level_progress(create(:script_level), 10)
     refute client_state.level_progress_is_empty_for_test
@@ -987,6 +993,12 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     assert_equal('//test.code.org/api/hour/finish/starwars', script_completion_redirect(Script.find_by_name(Script::STARWARS_NAME)))
   end
 
+  test "show redirects admins to root" do
+    sign_in create(:admin)
+    get :show, params: {script_id: Script::HOC_NAME, chapter: '20'}
+    assert_redirected_to root_path
+  end
+
   test 'end of HoC for logged in user works' do
     sign_in(create(:user))
     get :show, params: {script_id: Script::HOC_NAME, chapter: '20'}
@@ -1008,6 +1020,12 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   #   assert(!@response.body.include?('hoc_wrapup'))
   #   assert(@response.body.include?('/s/1/level/show?chapter=next'))
   # end
+
+  test "next redirects admins to root" do
+    sign_in create(:admin)
+    get :next, params: {script_id: Script::HOC_NAME}
+    assert_redirected_to root_path
+  end
 
   test 'next for non signed in user' do
     get :next, params: {script_id: Script::HOC_NAME}
@@ -1844,6 +1862,22 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     }
     assert_response :success
     assert_nil assigns(:view_options)[:is_challenge_level]
+  end
+
+  test "lesson_extras redirects admins to root" do
+    script = create :script
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
+    script_level = create :script_level, lesson: lesson, script: script, bonus: true
+
+    sign_in create(:admin)
+    get :lesson_extras, params: {
+      script_id: script,
+      lesson_position: 1,
+      level_name: script_level.level.name
+    }
+
+    assert_redirected_to root_path
   end
 
   test "specifying a bonus level name will direct to that level" do


### PR DESCRIPTION
Redirects admins to /home (root route of our Rails app) when they visit certain ScriptLevelsController actions (basically all of them -- reset, next, show, and lesson_extras). Previously, these methods used CanCan authorization that would return a 403, resulting in admins seeing a blank white page:
https://github.com/code-dot-org/code-dot-org/blob/1e52e39bba7424512ac22530ebb143249a09e88b/dashboard/app/controllers/script_levels_controller.rb#L38

This would cause confusion and admins would think there was something broken on that page. Now, we redirect admins in the same way we do for ProjectsController routes. This functionality has been pulled into a common ApplicationController method so we can use it as a before_action throughout our controllers.

## Links

- [STAR-1696](https://codedotorg.atlassian.net/browse/STAR-1696)

## Testing story

Adds/updates unit tests.