### PR TITLE
Upgrade Eyes a bit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,7 +96,7 @@ group :development, :test do
 
   # For UI testing.
   gem 'cucumber'
-  gem 'eyes_selenium', '3.17.19'
+  gem 'eyes_selenium', '3.18.4'
   gem 'minitest', '~> 5.5'
   gem 'minitest-around'
   gem 'minitest-reporters', '~> 1.2.0.beta3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -351,7 +351,7 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
-    css_parser (1.7.1)
+    css_parser (1.10.0)
       addressable
     cucumber (3.1.1)
       builder (>= 2.1.2)
@@ -401,17 +401,17 @@ GEM
     eventmachine (1.2.5)
     execjs (2.7.0)
     exifr (1.2.5)
-    eyes_core (3.17.19)
+    eyes_core (3.18.4)
       chunky_png (= 1.3.6)
       faraday
       faraday-cookie_jar
       faraday_middleware
       oily_png (~> 1.2)
       oj
-    eyes_selenium (3.17.19)
+    eyes_selenium (3.18.4)
       crass
       css_parser
-      eyes_core (= 3.17.19)
+      eyes_core (= 3.18.4)
       nokogiri
       selenium-webdriver
       state_machine
@@ -946,7 +946,7 @@ DEPENDENCIES
   devise_invitable (~> 1.6.0)
   dotiw
   execjs
-  eyes_selenium (= 3.17.19)
+  eyes_selenium (= 3.18.4)
   factory_girl_rails
   fakeredis
   firebase


### PR DESCRIPTION
Upgrade the Eyes gem from 3.17.19 to 3.18.4.

Followup to https://github.com/code-dot-org/code-dot-org/pull/37650.  The debug spew issue has apparently been resolved with this gem version.
