### PR TITLE
Add Dream Variations and Dream Deferred to Poembot

### DIFF
--- a/apps/src/p5lab/spritelab/poembot/constants.js
+++ b/apps/src/p5lab/spritelab/poembot/constants.js
@@ -164,5 +164,35 @@ export const POEMS = {
       'You may not come out',
       'The same person who went in.'
     ]
+  },
+  hughes_1: {
+    author: 'Langston Hughes',
+    title: 'Dream Variations',
+    lines: [
+      'To fling my arms wide',
+      'In the face of the sun,',
+      'Dance! Whirl! Whirl!',
+      'Till the quick day is done.',
+      'Rest at pale evening...',
+      'A tall, slim tree...',
+      'Night coming tenderly',
+      '  Black like me.'
+    ]
+  },
+  hughes_2: {
+    author: 'Langston Hughes',
+    title: 'Dream Deferred',
+    lines: [
+      'What happens to a dream deferred?',
+      'Does it dry up,',
+      'Like a raisin in the sun?',
+      'Or fester like a sore --',
+      'And then run?',
+      'Does it stink like rotten meat?',
+      'Or crust and sugar over --',
+      'Like a syrupy sweet?',
+      'Maybe it just sags',
+      'Like a heavy load.'
+    ]
   }
 };


### PR DESCRIPTION
This pull request should make two new poems available in Poembot Sprite Lab levels: "Dream Variations" and "Dream Deferred" by Langston Hughes. 

These poems can then be added to the "set poem" block by a curriculum writer on levelbuilder:
![image](https://user-images.githubusercontent.com/43474485/132529763-65842213-86df-4356-89cb-027d6aec76e4.png)
![image](https://user-images.githubusercontent.com/43474485/132530061-2cdaa762-fa37-41a3-ba5d-d8ee3d82d796.png)

