### PR TITLE
Peer Review: Clean up checkbox UI

### DIFF
--- a/apps/src/templates/instructions/ReviewTab.jsx
+++ b/apps/src/templates/instructions/ReviewTab.jsx
@@ -252,21 +252,23 @@ class ReviewTab extends Component {
 
     return (
       <div style={styles.checkboxContainer}>
-        <label style={styles.label}>
-          {loadingReviewableState ? (
-            <Spinner size="small" style={styles.checkbox} />
-          ) : (
-            <input
-              type="checkbox"
-              checked={isReadyForReview}
-              onChange={() => {
-                this.setReadyForReview(!isReadyForReview);
-              }}
-              style={styles.checkbox}
-            />
-          )}
-          {javalabMsg.enablePeerReview()}
-        </label>
+        <div style={styles.reviewCheckboxRow}>
+          <label>
+            {loadingReviewableState ? (
+              <Spinner size="small" style={styles.checkbox} />
+            ) : (
+              <input
+                type="checkbox"
+                checked={isReadyForReview}
+                onChange={() => {
+                  this.setReadyForReview(!isReadyForReview);
+                }}
+                style={styles.checkbox}
+              />
+            )}
+            {javalabMsg.enablePeerReview()}
+          </label>
+        </div>
       </div>
     );
   }
@@ -495,7 +497,7 @@ const styles = {
   reviewsContainer: {
     margin: '25px 5%'
   },
-  label: {
+  reviewCheckboxRow: {
     margin: 0,
     display: 'flex',
     justifyContent: 'flex-end',


### PR DESCRIPTION
Previously the "Enable Peer Review" checkbox could be checked from anywhere in the row containing the checkbox. We suspect this caused students to accidentally uncheck the box. This changes the checkbox to only be checked via the actual box or the "Enable Peer Review" text.

I recommend viewing this with whitespace changes hidden.
## Testing story
Tested locally. No visible changes beyond where you can check the box.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
