### PR TITLE
Script perf improvements / UI test cleanup

### DIFF
--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1697,6 +1697,7 @@ class Script < ApplicationRecord
     @@level_cache = nil
     @@all_scripts = nil
     @@visible_units = nil
+    @@maker_units = nil
     Rails.cache.delete UNIT_CACHE_KEY
   end
 

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -272,19 +272,19 @@ class Script < ApplicationRecord
   end
 
   def self.lesson_extras_script_ids
-    @@lesson_extras_scripts ||= all_scripts.select(&:lesson_extras_available?).pluck(:id)
+    @@lesson_extras_script_ids ||= all_scripts.select(&:lesson_extras_available?).pluck(:id)
   end
 
   def self.maker_units
-    visible_units.select(&:is_maker_unit?)
+    @@maker_units ||= visible_units.select(&:is_maker_unit?)
   end
 
   def self.text_to_speech_unit_ids
-    all_scripts.select(&:text_to_speech_enabled?).pluck(:id)
+    @@text_to_speech_unit_ids ||= all_scripts.select(&:text_to_speech_enabled?).pluck(:id)
   end
 
   def self.pre_reader_unit_ids
-    all_scripts.select(&:pre_reader_tts_level?).pluck(:id)
+    @@pre_reader_unit_ids ||= all_scripts.select(&:pre_reader_tts_level?).pluck(:id)
   end
 
   # Get the set of units that are valid for the current user, ignoring those
@@ -329,7 +329,7 @@ class Script < ApplicationRecord
     private
 
     def visible_units
-      all_scripts.select(&:launched?).to_a.freeze
+      @@visible_units ||= all_scripts.select(&:launched?).to_a.freeze
     end
   end
 
@@ -1696,6 +1696,7 @@ class Script < ApplicationRecord
     @@unit_family_cache = nil
     @@level_cache = nil
     @@all_scripts = nil
+    @@visible_units = nil
     Rails.cache.delete UNIT_CACHE_KEY
   end
 

--- a/dashboard/test/controllers/api/v1/sections_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/sections_controller_test.rb
@@ -28,6 +28,8 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
     @csp_script = create(:script, name: 'csp1', published_state: SharedConstants::PUBLISHED_STATE.stable)
     create(:unit_group_unit, unit_group: @csp_unit_group, script: @csp_script, position: 1)
     @csp_script.reload
+
+    Script.clear_cache
   end
 
   test 'logged out cannot list sections' do

--- a/dashboard/test/controllers/maker_controller_test.rb
+++ b/dashboard/test/controllers/maker_controller_test.rb
@@ -20,6 +20,8 @@ class MakerControllerTest < ActionController::TestCase
     @csd6_2018 = ensure_script Script::CSD6_2018_NAME, '2018'
     @csd6_2019 = ensure_script Script::CSD6_2019_NAME, '2019'
     @csd6_2020_unstable = ensure_script 'csd6-2020-unstable', '2020', false
+
+    Script.clear_cache
   end
 
   test_redirect_to_sign_in_for :home

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -32,8 +32,9 @@ class ScriptTest < ActiveSupport::TestCase
     # We also want to test level_concept_difficulties, so make sure to give it
     # one.
     @cacheable_level = create(:level, :with_script, level_concept_difficulty: create(:level_concept_difficulty))
+  end
 
-    # ensure that we have freshly generated caches with this unit_group/unit
+  setup do
     UnitGroup.clear_cache
     Script.clear_cache
   end

--- a/dashboard/test/ui/features/curriculum_platform/levelbuilder/lesson_edit_page.feature
+++ b/dashboard/test/ui/features/curriculum_platform/levelbuilder/lesson_edit_page.feature
@@ -90,6 +90,8 @@ Feature: Using the Lesson Edit Page
     And I wait until element ".progress-bubble" contains text "1"
     Then element ".progress-bubble" contains text "2"
 
+    And I delete the temp unit with lessons
+
   @no_firefox
   Scenario: Update script level properties
     Given I create a levelbuilder named "Levi"
@@ -112,3 +114,5 @@ Feature: Using the Lesson Edit Page
     And I press ".uitest-level-token-name" using jQuery
     And I wait until element ".level-token-checkboxes" is visible
     Then element ".level-token-checkboxes input[type=checkbox]:nth(1)" is checked
+
+    And I delete the temp unit with lessons


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

With a tip from Bethany, I investigated the UI test flakiness as a performance issue.  Rendering the home page after signing in was taking a long time which was appears to be causing some tests to time out.  An immediate cause of the slowness is the large number of scripts in the test db which caused some methods that iterate through `Script.all_scripts` to take several seconds.  All such calls are now cached.  This should also provide a small perf improvement in production.

The large number of scripts in the test db was due to two tests not cleaning up temporary scripts.  This has also been fixed.

Finally, I will manually delete unused scripts and associated data on the test db.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- [slack thread](https://codedotorg.slack.com/archives/C03CK49G9/p1631119093031100)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
