### PR TITLE
Storage apps created through backpack have value hidden = true

### DIFF
--- a/dashboard/app/models/backpack.rb
+++ b/dashboard/app/models/backpack.rb
@@ -21,7 +21,7 @@ class Backpack < ApplicationRecord
     unless backpack
       # Create a storage app for this user's backpack
       storage_app = StorageApps.new(storage_id_for_user_id(user_id))
-      encrypted_id = storage_app.create('', ip: ip, type: 'backpack')
+      encrypted_id = storage_app.create({'hidden': true}, ip: ip, type: 'backpack')
       _, storage_app_id = storage_decrypt_channel_id(encrypted_id)
       backpack = create!(user_id: user_id, storage_app_id: storage_app_id)
     end

--- a/dashboard/test/models/backpack_test.rb
+++ b/dashboard/test/models/backpack_test.rb
@@ -16,6 +16,13 @@ class BackpackTest < ActiveSupport::TestCase
     assert_equal @user.id, backpack.user_id
   end
 
+  # storage apps with value hidden are hidden from a user's projects list
+  test 'storage_app that is created has value hidden = true' do
+    backpack = Backpack.find_or_create(@user.id, 'fake-ip')
+    storage_app = StorageApps.new(backpack.storage_app_id).get(backpack.channel)
+    assert storage_app["hidden"]
+  end
+
   test 'find_or_create returns existing backpack if it exists' do
     backpack = Backpack.find_or_create(@user.id, 'fake-ip')
     backpack2 = Backpack.find_or_create(@user.id, 'fake-ip')


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Background: for the new backpack feature for CSA, storage_app rows are created with the `value` column set to `""`. The personal projects API filters to storage apps based on the storage_app value. Having an empty string in this column breaks the API.

This PR updates storage_app rows created for backpack to have `value` set with hidden = true. Having hidden = true set on a storage_app means that it is not associated with a personal project and should be hidden from the projects view.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
- Zendesk ticket: [349821](https://codeorg.zendesk.com/agent/tickets/349821)
- Honeybader errors: [01FF34MPN0YKXBTKXQWBG7JS6V](https://app.honeybadger.io/projects/3240/faults/80837631/01FF34MPN0YKXBTKXQWBG7JS6V)
<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
I tested locally that having a storage_app row with the new value does not break the personal projects list. I added a basic unit test. I did not manually test creating a new backpack (not sure how this flow works).
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Follow-up work
I will write a migration to update storage_app rows where the value is set to `""`
<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
