### PR TITLE
Admins can remove teacher from pilot in admin pages

### DIFF
--- a/dashboard/app/controllers/admin_search_controller.rb
+++ b/dashboard/app/controllers/admin_search_controller.rb
@@ -121,4 +121,18 @@ class AdminSearchController < ApplicationController
     end
     redirect_to action: 'show_pilot', pilot_name: pilot_name
   end
+
+  def remove_from_pilot
+    email = params[:email]
+    pilot_name = params[:pilot_name]
+    return head :bad_request unless Pilot.exists?(name: pilot_name)
+
+    user = User.find_by_email_or_hashed_email(email)
+    e = Experiment.where(name: pilot_name, min_user_id: user.id).first
+    Experiment.delete(e.id)
+
+    flash[:notice] = "Successfully removed #{email} from #{pilot_name}"
+
+    redirect_to action: 'show_pilot', pilot_name: pilot_name
+  end
 end

--- a/dashboard/app/controllers/admin_search_controller.rb
+++ b/dashboard/app/controllers/admin_search_controller.rb
@@ -123,6 +123,8 @@ class AdminSearchController < ApplicationController
   end
 
   def remove_from_pilot
+    puts "REMOVING"
+
     email = params[:email]
     pilot_name = params[:pilot_name]
     return head :bad_request unless Pilot.exists?(name: pilot_name)

--- a/dashboard/app/controllers/admin_search_controller.rb
+++ b/dashboard/app/controllers/admin_search_controller.rb
@@ -123,8 +123,6 @@ class AdminSearchController < ApplicationController
   end
 
   def remove_from_pilot
-    puts "REMOVING"
-
     email = params[:email]
     pilot_name = params[:pilot_name]
     return head :bad_request unless Pilot.exists?(name: pilot_name)

--- a/dashboard/app/views/admin_search/show_pilot.html.haml
+++ b/dashboard/app/views/admin_search/show_pilot.html.haml
@@ -19,18 +19,7 @@
       %td
         %span= email
       %td
-        .btn.btn-link{"href" => "#remove_pilot_user", "role" => "button", "data-toggle" => "modal"} Remove
-
-.modal.hide.fade#remove_pilot_user{"role"=>"dialog", "aria-labelledby" => "remove_pilot_userLabel", "aria-hidden" => "true"}
-  .modal-header
-    %button.close{"data-dismiss" => "modal", "aria-hidden" => "true"}
-      x
-    %h3#remove_pilot_userLabel
-      Remove Pilot User
-  .modal-body
-    You are about to remove this participant from this pilot.  Once you do this all progress this participant has made will be lost.  Are you sure?
-  .modal-footer
-    = form_tag controller: 'admin_search', action: 'remove_from_pilot', class: 'form-inline', method: "post" do
-      = hidden_field_tag 'email', 'levelbuilder@dev.com'
-      = hidden_field_tag 'pilot_name', @pilot_name
-      = submit_tag "Remove", class: 'btn-primary'
+        = form_tag controller: 'admin_search', action: 'remove_from_pilot', class: 'form-inline', method: "post" do
+          = hidden_field_tag 'email', email
+          = hidden_field_tag 'pilot_name', @pilot_name
+          = submit_tag "Remove", class: 'btn-primary', data:{confirm: "You are about to remove " + email + " from this pilot.  Once you do this all progress this participant has made will be lost.  Are you sure?"}

--- a/dashboard/app/views/admin_search/show_pilot.html.haml
+++ b/dashboard/app/views/admin_search/show_pilot.html.haml
@@ -12,7 +12,14 @@
   %tr
     %th
       %span Current Pilot Participants
+    %th
+      %span Actions
   - @emails.each do |email|
     %tr
       %td
         %span= email
+      %td
+        = form_tag controller: 'admin_search', action: 'remove_from_pilot', method: "post" do
+          = hidden_field_tag 'email', email
+          = hidden_field_tag 'pilot_name', @pilot_name
+          = submit_tag "Remove", class: 'btn'

--- a/dashboard/app/views/admin_search/show_pilot.html.haml
+++ b/dashboard/app/views/admin_search/show_pilot.html.haml
@@ -19,7 +19,18 @@
       %td
         %span= email
       %td
-        = form_tag controller: 'admin_search', action: 'remove_from_pilot', method: "post" do
-          = hidden_field_tag 'email', email
-          = hidden_field_tag 'pilot_name', @pilot_name
-          = submit_tag "Remove", class: 'btn'
+        .btn.btn-link{"href" => "#remove_pilot_user", "role" => "button", "data-toggle" => "modal"} Remove
+
+.modal.hide.fade#remove_pilot_user{"role"=>"dialog", "aria-labelledby" => "remove_pilot_userLabel", "aria-hidden" => "true"}
+  .modal-header
+    %button.close{"data-dismiss" => "modal", "aria-hidden" => "true"}
+      x
+    %h3#remove_pilot_userLabel
+      Remove Pilot User
+  .modal-body
+    You are about to remove this participant from this pilot.  Once you do this all progress this participant has made will be lost.  Are you sure?
+  .modal-footer
+    = form_tag controller: 'admin_search', action: 'remove_from_pilot', class: 'form-inline', method: "post" do
+      = hidden_field_tag 'email', 'levelbuilder@dev.com'
+      = hidden_field_tag 'pilot_name', @pilot_name
+      = submit_tag "Remove", class: 'btn-primary'

--- a/dashboard/app/views/admin_search/show_pilot.html.haml
+++ b/dashboard/app/views/admin_search/show_pilot.html.haml
@@ -15,11 +15,11 @@
     %th
       %span Actions
   - @emails.each do |email|
-    %tr
+    %tr{style: 'border-bottom: 2px solid #5b6770;'}
       %td.email
         %span= email
       %td.actions
-        = form_tag controller: 'admin_search', action: 'remove_from_pilot', class: 'form-inline', method: "post" do
+        = form_tag({controller: 'admin_search', action: 'remove_from_pilot', method: "post"}, style: 'margin: 5px;')do
           = hidden_field_tag 'email', email
           = hidden_field_tag 'pilot_name', @pilot_name
           = submit_tag "Remove", class: 'btn-primary', data:{confirm: "You are about to remove " + email + " from this pilot.  Once you do this all progress this participant has made will be lost.  Are you sure?"}

--- a/dashboard/app/views/admin_search/show_pilot.html.haml
+++ b/dashboard/app/views/admin_search/show_pilot.html.haml
@@ -16,9 +16,9 @@
       %span Actions
   - @emails.each do |email|
     %tr
-      %td
+      %td.email
         %span= email
-      %td
+      %td.actions
         = form_tag controller: 'admin_search', action: 'remove_from_pilot', class: 'form-inline', method: "post" do
           = hidden_field_tag 'email', email
           = hidden_field_tag 'pilot_name', @pilot_name

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -430,6 +430,7 @@ Dashboard::Application.routes.draw do
   post '/admin/pilots/', to: 'admin_search#create_pilot', as: 'create_pilot'
   get '/admin/pilots/:pilot_name', to: 'admin_search#show_pilot', as: 'show_pilot'
   post '/admin/add_to_pilot', to: 'admin_search#add_to_pilot', as: 'add_to_pilot'
+  post '/admin/remove_from_pilot', to: 'admin_search#remove_from_pilot', as: 'remove_from_pilot'
 
   # internal engineering dashboards
   get '/admin/dynamic_config', to: 'dynamic_config#show', as: 'dynamic_config_state'

--- a/dashboard/test/controllers/admin_search_controller_test.rb
+++ b/dashboard/test/controllers/admin_search_controller_test.rb
@@ -192,20 +192,24 @@ class AdminSearchControllerTest < ActionController::TestCase
     create :teacher, pilot_experiment: pilot2.name, email: 'cspnot@example.com'
     get :show_pilot, params: {pilot_name: pilot1.name}
     assert_response :success
-    assert_select 'table tr td', 1
-    assert_select 'table tr td', 'csp@example.com'
+    assert_select 'table tr td.email', {count: 1, text: "csp@example.com"}
+    assert_select 'table tr td.actions form input.btn-primary', 1
   end
 
   #
   # add_to_pilot tests
   #
 
-  test 'can add teacher to pilot' do
+  test 'can add and remove teacher from pilot' do
     teacher = create :teacher
     pilot_name = create(:pilot).name
     post :add_to_pilot, params: {email: teacher.email, pilot_name: pilot_name}
 
     assert SingleUserExperiment.find_by(min_user_id: teacher.id, name: pilot_name).present?
+
+    post :remove_from_pilot, params: {email: teacher.email, pilot_name: pilot_name}
+
+    refute SingleUserExperiment.find_by(min_user_id: teacher.id, name: pilot_name).present?
   end
 
   test 'can add multiple teachers to pilot' do
@@ -303,18 +307,6 @@ class AdminSearchControllerTest < ActionController::TestCase
 
     sign_in @not_admin
     post :add_to_pilot, params: {email: teacher.email, pilot_name: pilot_name}
-
-    refute SingleUserExperiment.find_by(min_user_id: teacher.id, name: pilot_name).present?
-  end
-
-  test 'can remove teacher from pilot' do
-    teacher = create :teacher
-    pilot_name = create(:pilot).name
-    post :add_to_pilot, params: {email: teacher.email, pilot_name: pilot_name}
-
-    assert SingleUserExperiment.find_by(min_user_id: teacher.id, name: pilot_name).present?
-
-    post :remove_from_pilot, params: {email: teacher.email, pilot_name: pilot_name}
 
     refute SingleUserExperiment.find_by(min_user_id: teacher.id, name: pilot_name).present?
   end

--- a/dashboard/test/controllers/admin_search_controller_test.rb
+++ b/dashboard/test/controllers/admin_search_controller_test.rb
@@ -306,4 +306,16 @@ class AdminSearchControllerTest < ActionController::TestCase
 
     refute SingleUserExperiment.find_by(min_user_id: teacher.id, name: pilot_name).present?
   end
+
+  test 'can remove teacher from pilot' do
+    teacher = create :teacher
+    pilot_name = create(:pilot).name
+    post :add_to_pilot, params: {email: teacher.email, pilot_name: pilot_name}
+
+    assert SingleUserExperiment.find_by(min_user_id: teacher.id, name: pilot_name).present?
+
+    post :remove_from_pilot, params: {email: teacher.email, pilot_name: pilot_name}
+
+    refute SingleUserExperiment.find_by(min_user_id: teacher.id, name: pilot_name).present?
+  end
 end


### PR DESCRIPTION
Allows admins to remove piloters using the pilot admin page. 

### Add button to piloters table for removing
<img width="688" alt="Screen Shot 2021-09-09 at 4 08 31 PM" src="https://user-images.githubusercontent.com/208083/132755459-e644052f-7ef9-482d-8451-16c13c8f0d69.png">

### Make sure to confirm the delete
<img width="1113" alt="Screen Shot 2021-09-09 at 4 07 59 PM" src="https://user-images.githubusercontent.com/208083/132755487-1f65053c-158d-4eef-85d9-262e5b0b1c63.png">

### Give a flash when person has been removed
<img width="1061" alt="Screen Shot 2021-09-09 at 4 08 15 PM" src="https://user-images.githubusercontent.com/208083/132755498-cffbfd34-78cb-4e4d-a773-09d0b8a784fc.png">


## Links

- jira ticket: https://codedotorg.atlassian.net/browse/PLAT-1184

## Testing story

- Tests to check removing piloter and the table that is displayed with the remove button