### PR TITLE
Add Accept-Language lookup CloudFront Function

### DIFF
--- a/aws/cloudformation/accept-language.js.erb
+++ b/aws/cloudformation/accept-language.js.erb
@@ -1,0 +1,74 @@
+// CloudFront Functions handler to normalize Accept-Language header for optimized caching.
+<% require 'cdo/languages' -%>
+var tags = <%= Languages.table.select(:locale_s, :code_s).map {|x| x.values.values}.flatten.uniq.map(&:downcase).to_json %>;
+var defaultTag = 'en';
+
+function handler(event) {
+    var headers = event.request.headers;
+    var languageCookie = event.request.cookies.language_;
+    var languageHeader = headers['accept-language'] ? headers['accept-language'].value : '';
+    headers['accept-language'] = {value: languageCookie && languageCookie.value || lookup(languageHeader, tags, defaultTag)};
+    return event.request;
+}
+
+/*
+  Parse an Accept-Language request header field,
+  performing a "lookup" of a matching language tag for the given request.
+
+  References:
+
+  HTTP/1.1 Semantics and Content, RFC 7231
+  Section 5.3, Request Header Fields: Content Negotiation
+  Quality Values, Section 5.3.1 (https://datatracker.ietf.org/doc/html/rfc7231#section-5.3.1)
+  Accept-Language, Section 5.3.5 (https://datatracker.ietf.org/doc/html/rfc7231#section-5.3.5)
+  
+  Matching of Language Tags, RFC 4647
+  Types of Matching: Lookup, Section 3.4 (https://datatracker.ietf.org/doc/html/rfc4647#section-3.4)
+ */
+function lookup(acceptLanguage, tags, defaultTag) {
+    // 'Language tags and thus language ranges are to be treated as case-insensitive' (RFC4647 Section 2)
+    // Normalize header and tags to lowercase.
+    acceptLanguage = acceptLanguage.toLowerCase();
+
+    /*
+      JavaScript regex translation of Accept-Language ABNF syntax:
+
+      Accept-Language = 1#( language-range [ weight ] )
+      1#element       => element *( OWS "," OWS element )
+      language-range  = (1*8ALPHA *("-" 1*8alphanum)) / "*"
+      alphanum        = ALPHA / DIGIT
+      weight          = OWS ";" OWS "q=" qvalue
+      qvalue          = ( "0" [ "." 0*3DIGIT ] )
+                      / ( "1" [ "." 0*3("0") ] )
+     */
+    var regex = /(?<range>([a-z]{1,8})(-([a-z0-9]{1,8}))*|\*)(\s*;\s*q=(?<qvalue>0(\.[0-9]{0,3})?|1(\.0{0,3})?))?(\s*,\s*)?/g
+
+    var match,
+      /* 'Each application, protocol, or specification that uses lookup MUST
+      define the defaulting behavior when no tag matches the language
+      priority list.' (RFC4647 Section 3.4.1) */
+      bestTag = defaultTag,
+      // 'a value of 0 means "not acceptable".' (RFC7231 Section 5.3.1)
+      bestWeight = 0;
+
+      while ((match = regex.exec(acceptLanguage)) !== null) {
+        // 'If no "q" parameter is present, the default weight is 1.' (RFC7231 Section 5.3.1)
+        var weight = match.groups.qvalue ? parseFloat(match.groups.qvalue) : 1.0
+        if (weight > bestWeight) {
+            /* 'In the lookup scheme, the language range is progressively truncated
+            from the end until a matching language tag is located.' (RFC4647 Section 3.4) */
+            var range = match.groups.range;
+            var oldRange = null;
+            while(range !== oldRange) {
+                if (tags.includes(range)) {
+                    bestWeight = weight;
+                    bestTag = range;
+                    break;
+                }
+                oldRange = range;
+                range = oldRange.replace(/-([a-z0-9]{1,8})$/, '');
+            }
+        }
+    }
+    return bestTag;
+}

--- a/aws/cloudformation/lambda.yml.erb
+++ b/aws/cloudformation/lambda.yml.erb
@@ -333,6 +333,14 @@ Resources:
       Action: 'lambda:InvokeFunction'
       Principal: events.amazonaws.com
       SourceArn: !GetAtt SessionEvent.Arn
+  AcceptLanguageFunction:
+    Type: AWS::CloudFront::Function
+    Properties:
+      Name: AcceptLanguage
+      FunctionCode: <%=js_erb 'accept-language.js.erb', max: FUNCTION_MAX %>
+      FunctionConfig:
+        Comment: "Normalizes Accept-Language header from viewer requests"
+        Runtime: cloudfront-js-1.0
 Outputs:
   AMIManager:
     Value: !GetAtt AMIManager.Arn


### PR DESCRIPTION
Adds a [CloudFront Function](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cloudfront-functions.html) that normalizes the `Accept-Language` header by parsing the provided language-range priority list, performing a Lookup against the set of language tags supported by the application.

We also incorporate a `language_` cookie into the normalized header in order to allow users to override their user agent's language settings through a language-selection combo box in our footer.

This normalization improves cache efficiency across localized pages when varying content based on the value of the `Accept-Language` HTTP request header.

This is a CloudFront Function replacement for the [`libvmod-accept`](https://github.com/gquintard/libvmod-accept/tree/5.2) behavior in Varnish.

The PR also associates this function for relevant behaviors: this normalization function will only apply to behaviors that include the `Accept-Language` header in their cache key, and that _do not_ also include session cookies in their cache key (because behaviors including session cookies are uncacheable).

### Migration plan

- Merge this PR, associating the new CloudFront Function with all relevant distribution behaviors. The Varnish language-header normalization will remain in place, and will effectively become a no-op (because the header will be normalized in CloudFront first).
- Monitor the rollout to ensure behavior remains the same, no new errors or issues arise, etc.
- Remove the header normalization from Varnish in a future PR