### PR TITLE
preflight minor changes related to new script update api

### DIFF
--- a/dashboard/app/dsl/script_dsl.rb
+++ b/dashboard/app/dsl/script_dsl.rb
@@ -86,7 +86,8 @@ class ScriptDSL < BaseDSL
         key: key,
         display_name: properties[:display_name],
         big_questions: [],
-        lessons: []
+        lessons: [],
+        user_facing: true
       }.compact
     end
   end

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -100,7 +100,7 @@ class Lesson < ApplicationRecord
           key: raw_lesson[:key],
           script: unit
         ) do |l|
-          l.name = "" # will be updated below, but cant be null
+          l.name = raw_lesson[:name]
           l.relative_position = 0 # will be updated below, but cant be null
           l.has_lesson_plan = true # will be reset below if specified
         end

--- a/dashboard/app/models/lesson_group.rb
+++ b/dashboard/app/models/lesson_group.rb
@@ -59,7 +59,7 @@ class LessonGroup < ApplicationRecord
 
     counters = Counters.new(0, 0, 0, 0)
 
-    raw_lesson_groups&.map do |raw_lesson_group|
+    raw_lesson_groups&.map(&:deep_symbolize_keys)&.map do |raw_lesson_group|
       if !raw_lesson_group[:user_facing]
         raise 'non-user-facing lesson group must have blank key' unless raw_lesson_group[:key].blank?
         lesson_group = LessonGroup.find_or_create_by!(

--- a/dashboard/app/models/lesson_group.rb
+++ b/dashboard/app/models/lesson_group.rb
@@ -60,8 +60,9 @@ class LessonGroup < ApplicationRecord
     counters = Counters.new(0, 0, 0, 0)
 
     raw_lesson_groups&.map do |raw_lesson_group|
-      if raw_lesson_group[:key].nil?
-        lesson_group = LessonGroup.find_or_create_by(
+      if !raw_lesson_group[:user_facing]
+        raise 'non-user-facing lesson group must have blank key' unless raw_lesson_group[:key].blank?
+        lesson_group = LessonGroup.find_or_create_by!(
           key: '',
           script: script,
           user_facing: false,
@@ -72,11 +73,13 @@ class LessonGroup < ApplicationRecord
         LessonGroup.prevent_blank_display_name(raw_lesson_group)
         LessonGroup.prevent_changing_stable_i18n_key(script, raw_lesson_group)
 
-        lesson_group = LessonGroup.find_or_create_by(
+        lesson_group = LessonGroup.find_or_create_by!(
           key: raw_lesson_group[:key],
           script: script,
-          user_facing: true
-        )
+          user_facing: true,
+        ) do |lg|
+          lg.position = 1 # will be updated below, but can't be nil
+        end
 
         lesson_group.assign_attributes(
           position: lesson_group_position += 1,

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -146,7 +146,7 @@ class ScriptLevel < ApplicationRecord
 
   def self.remove_variants(raw_script_level)
     first_active_level = raw_script_level[:levels].find do |raw_level|
-      variant = raw_script_level[:properties][:variants].try(:[], raw_level[:name])
+      variant = raw_script_level[:properties][:variants].try(:[], raw_level[:name].to_sym)
       !(variant && variant[:active] == false)
     end
     raw_script_level[:levels] = [first_active_level]

--- a/dashboard/test/dsl/script_dsl_test.rb
+++ b/dashboard/test/dsl/script_dsl_test.rb
@@ -711,7 +711,8 @@ level 'Level 3'
                 {levels: [{name: "Level 2"}]},
               ]
             }
-          ]
+          ],
+          user_facing: true,
         ]
       }
     )
@@ -753,6 +754,7 @@ level 'Level 3'
                 ]
               }
             ],
+            user_facing: true,
             description: 'This is a description',
           },
           {
@@ -760,6 +762,7 @@ level 'Level 3'
             display_name: "empty lesson group",
             big_questions: "empty lesson group questions",
             lessons: [],
+            user_facing: true,
             description: "empty lesson group description"
           },
           {
@@ -774,7 +777,8 @@ level 'Level 3'
                   {levels: [{name: "Level 2"}]},
                 ]
               }
-            ]
+            ],
+            user_facing: true,
           }
         ]
       }
@@ -1143,7 +1147,8 @@ level 'Level 3'
                 {levels: [{name: 'Level 2'}]},
               ]
             }
-          ]
+          ],
+          user_facing: true,
         ]
       }
     )

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -423,6 +423,7 @@ class ScriptTest < ActiveSupport::TestCase
       {name: 'test script', published_state: SharedConstants::PUBLISHED_STATE.beta},
       [{
         key: "my_key",
+        user_facing: true,
         display_name: "Content",
         lessons: [{name: "Lesson1", key: 'lesson1', script_levels: [{levels: [{name: create(:applab).name}]}]}]
       }]
@@ -431,6 +432,7 @@ class ScriptTest < ActiveSupport::TestCase
       {name: 'test script', published_state: SharedConstants::PUBLISHED_STATE.beta},
       [{
         key: "my_key",
+        user_facing: true,
         display_name: "Content",
         lessons: [{name: "Lesson1", key: 'lesson1', script_levels: [{levels: [{name: create(:gamelab).name}]}]}]
       }]
@@ -442,6 +444,7 @@ class ScriptTest < ActiveSupport::TestCase
       {name: 'test script', published_state: SharedConstants::PUBLISHED_STATE.preview, login_required: true},
       [{
         key: "my_key",
+        user_facing: true,
         display_name: "Content",
         lessons: [{name: "Lesson1", key: 'lesson1', script_levels: [{levels: [{name: create(:applab).name}]}]}]
       }]
@@ -450,6 +453,7 @@ class ScriptTest < ActiveSupport::TestCase
       {name: 'test script', published_state: SharedConstants::PUBLISHED_STATE.preview, login_required: true},
       [{
         key: "my_key",
+        user_facing: true,
         display_name: "Content",
         lessons: [{name: "Lesson1", key: 'lesson1', script_levels: [{levels: [{name: create(:gamelab).name}]}]}]
       }]


### PR DESCRIPTION
As part of creating the new script update API for migrated scripts, I had to make some changes which will affect the non-migrated script update path. I've pulled as many of those changes out into this PR as I can, in hopes of catching any problems they might cause ahead of time. The remaining work to get migrated scripts working on the new script update API can be seen here (draft): https://github.com/code-dot-org/code-dot-org/pull/42282 . 

The changes in this PR are as follows (see the first 3 individual commits for details):
1. set the lesson name immediately when creating a new lesson
2. use `user_facing` rather than checking whether the key is nil to determine if a lesson group is user-facing
3. use `deep_symbolize_keys`, to standardize the data being passed in from ScriptDSL (for unmigrated scripts) and the data from the new script update api (for migrated scripts) in the next PR

## Testing story

* updated existing test coverage
* manually verified that saving the script edit page still works for migrated and unmigrated scripts, with and without user-facing lesson groups
