### PR TITLE
Update DOTD Slack Integration

### DIFF
--- a/aws/ci_build
+++ b/aws/ci_build
@@ -162,11 +162,9 @@ def main
         ChatClient.message 'server operations', commit_url, color: 'gray', message_format: 'text'
         DevelopersTopic.set_dtp 'yes'
         InfraProductionTopic.set_dtp_commit GitHub.sha('production')
-        ChatClient.set_reminder(
-          'developers',
-          "@#{DevelopersTopic.dotd}",
-          "to check Zendesk in 2 hours"
-         )
+
+        # Schedule a reminder for the dotd to check Zendesk in 2 hours
+        Slack.remind(Slack.user_id(DevelopersTopic.dotd), Time.now.to_i + 7200, 'check Zendesk')
 
         # Check hoc_mode and hoc_launch only on successful DTPs, so that we get about 1 reminder per
         # day to bring staging, test and production to the same hoc_mode and hoc_launch after a

--- a/aws/ci_build
+++ b/aws/ci_build
@@ -164,7 +164,7 @@ def main
         InfraProductionTopic.set_dtp_commit GitHub.sha('production')
 
         # Schedule a reminder for the dotd to check Zendesk in 2 hours
-        Slack.remind(Slack.user_id(DevelopersTopic.dotd), Time.now.to_i + 7200, 'check Zendesk')
+        Slack.remind(Slack.user_id(DevelopersTopic.dotd), Time.now.to_i + 7200, 'check <https://codeorg.zendesk.com/agent/filters/46080486|Zendesk>')
 
         # Check hoc_mode and hoc_launch only on successful DTPs, so that we get about 1 reminder per
         # day to bring staging, test and production to the same hoc_mode and hoc_launch after a

--- a/aws/ci_build
+++ b/aws/ci_build
@@ -164,7 +164,7 @@ def main
         InfraProductionTopic.set_dtp_commit GitHub.sha('production')
 
         # Schedule a reminder for the dotd to check Zendesk in 2 hours
-        Slack.remind(Slack.user_id(DevelopersTopic.dotd), Time.now.to_i + 7200, 'check <https://codeorg.zendesk.com/agent/filters/46080486|Zendesk>')
+        Slack.remind(Slack.user_id(DevelopersTopic.dotd), Time.now.to_i + 7200, 'Reminder: check <https://codeorg.zendesk.com/agent/filters/44863373|Zendesk>')
 
         # Check hoc_mode and hoc_launch only on successful DTPs, so that we get about 1 reminder per
         # day to bring staging, test and production to the same hoc_mode and hoc_launch after a

--- a/bin/dotd
+++ b/bin/dotd
@@ -38,8 +38,9 @@ def check_for_cdo_keys
     Create your API tokens from these pages:
 
       https://github.com/settings/tokens ('public_repo' permission)
-      https://api.slack.com/custom-integrations/legacy-tokens
       https://app.honeybadger.io/users/edit#authentication
+
+    The slack_token can be found in the Shared-Engineering folder in LastPass, under DOTD Slack Token.
 
     Please add them to your locals.yml and rerun the script.
     CDO.devinternal_db_writer should be pulled automatically from AWS Secrets Manager.

--- a/bin/dotd
+++ b/bin/dotd
@@ -476,16 +476,6 @@ end
 def main
   check_for_cdo_keys
 
-  # auto-join Slack rooms where the DOTD might be @mentioned
-  # or need to affect the room topic.
-  Slack.join_room('developers')
-  Slack.join_room('deploy-status')
-  Slack.join_room('infra-staging')
-  Slack.join_room('infra-test')
-  Slack.join_room('infra-production')
-  Slack.join_room('infra-honeybadger')
-  Slack.join_room('levelbuilder')
-
   dotd_name = ENV['CDODEV_DOTD_NAME'] || ENV['USER']
   @logger.info("#{Time.new.strftime('%A, %B %d %Y')}: #{dotd_name} is DOTD")
 

--- a/bin/dotd
+++ b/bin/dotd
@@ -33,14 +33,14 @@ def check_for_cdo_keys
 
   puts <<-EOS.unindent
 
-    This script requires CDO.github_access_token, CDO.slack_token, and CDO.honeybadger_api_token and CDO.devinternal_db_writer.
+    This script requires CDO.github_access_token, CDO.slack_bot_token, and CDO.honeybadger_api_token and CDO.devinternal_db_writer.
 
     Create your API tokens from these pages:
 
       https://github.com/settings/tokens ('public_repo' permission)
       https://app.honeybadger.io/users/edit#authentication
 
-    The slack_token can be found in the Shared-Engineering folder in LastPass, under DOTD Slack Token.
+    The slack_bot_token can be found in the Shared-Engineering folder in LastPass, under DOTD Slack Bot Token.
 
     Please add them to your locals.yml and rerun the script.
     CDO.devinternal_db_writer should be pulled automatically from AWS Secrets Manager.

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -197,6 +197,7 @@ slack_set_last_dtt_green_token:
 slack_start_build_token:
 slack_endpoint:                 !Secret
 slack_token:                    !Secret
+slack_bot_token:                !Secret
 slack_log_room:                 <%=env%>
 hip_chat_logging:               false
 # Logging endpoint used by broken link checker.

--- a/lib/cdo/chat_client.rb
+++ b/lib/cdo/chat_client.rb
@@ -44,14 +44,6 @@ class ChatClient
     )
   end
 
-  # @param room [String] Name of the Slack channel to post  /remind to.
-  # @param recipient [String] Slack user to remind, include @ in the argument
-  # @param reminder [String] Message for the /remind commmand
-  def self.set_reminder(room, recipient, reminder)
-    message = recipient + " " + reminder
-    Slack.command(room, "remind", message)
-  end
-
   def self.snippet(message)
     Slack.snippet(CDO.slack_log_room, message)
   end

--- a/lib/cdo/slack.rb
+++ b/lib/cdo/slack.rb
@@ -1,6 +1,7 @@
+require 'uri'
 require 'net/http'
-require 'open-uri'
 require 'retryable'
+require 'json'
 
 class Slack
   COLOR_MAP = {
@@ -225,5 +226,21 @@ class Slack
       gsub(/<a href=['"]([^'"]+)['"]>/, '<\1|').
       gsub(/<\/a>/, '>').
       gsub(/<br\/?>/, "\n")
+  end
+
+  private_class_method def self.post_to_slack(url, payload = nil)
+    headers = {
+      "Content-type" => "application/json; charset=utf-8",
+      "Authorization" => "Bearer #{SLACK_TOKEN}"
+    }
+
+    uri = URI(url)
+    https = Net::HTTP.new(uri.host, uri.port)
+    https.use_ssl = true
+    req = Net::HTTP::Post.new(url, headers)
+    req.body = payload.to_json if payload
+
+    res = https.request(req)
+    JSON.parse(res.body)
   end
 end

--- a/lib/cdo/slack.rb
+++ b/lib/cdo/slack.rb
@@ -86,9 +86,7 @@ class Slack
     url = "https://slack.com/api/conversations.setTopic"
     payload = {"channel" => channel_id, "topic" => new_topic}
     result = post_to_slack(url, payload)
-
-    raise "Failed to update topic in #{channel_name}" unless result
-    return true
+    return !!result
   end
 
   def self.replace_user_links(message)

--- a/lib/test/cdo/test_slack.rb
+++ b/lib/test/cdo/test_slack.rb
@@ -14,39 +14,37 @@ class SlackTest < Minitest::Test
   end
 
   def test_get_topic
-    Slack.expects(:open).returns(
-      stub(
-        read: {
-          'ok' => true,
-          'channel' => {
-            'topic' => {
-              'value' => FAKE_TOPIC
-            }
+    Slack.expects(:post_to_slack).returns(
+      {
+        'ok' => true,
+        'channel' => {
+          'topic' => {
+            'value' => FAKE_TOPIC
           }
-        }.to_json
-      )
+        }
+      }
     )
     actual_topic = Slack.get_topic FAKE_CHANNEL
     assert_equal FAKE_TOPIC, actual_topic
   end
 
   def test_get_topic_with_error_response
-    Slack.expects(:open).returns(stub(read: {'ok' => false}.to_json))
+    Slack.stubs(:post_to_slack).returns(false)
     assert_nil Slack.get_topic FAKE_CHANNEL
   end
 
   def test_update_topic
-    Slack.expects(:open).returns(stub(read: {'ok' => true}.to_json))
+    Slack.stubs(:post_to_slack).returns({'ok' => true})
     assert Slack.update_topic(FAKE_CHANNEL, FAKE_TOPIC)
   end
 
   def test_join_room
-    Slack.expects(:open).returns(stub(read: {'ok' => true}.to_json))
+    Slack.stubs(:post_to_slack).returns({'ok' => true})
     assert Slack.join_room(FAKE_CHANNEL)
   end
 
   def test_update_topic_with_error_response
-    Slack.expects(:open).returns(stub(read: {'ok' => false}.to_json))
+    Slack.stubs(:post_to_slack).returns(false)
     refute Slack.update_topic(FAKE_CHANNEL, FAKE_TOPIC)
   end
 


### PR DESCRIPTION
Our Slack API integration currently relies on [legacy tokens](https://api.slack.com/legacy/custom-integrations/legacy-tokens), which have been deprecated in favor of Slack App (or Bot) tokens. While existing legacy tokens continue to work for now, new tokens are no longer being issued, which has resulted in engineers having to share personal tokens around with new hires. Legacy tokens will likely be removed entirely in a future Slack update, so let's get ahead of that and switch our Slack API calls to use a new Bot token that can be properly shared!

A few notes:
- Legacy tokens could be passed as a query param to the Slack API. This is not the case with Bot tokens, which must be passed in the request's authorization header, so every function that makes Slack calls had to be updated to do so.
- We were using the hidden `chat.command` endpoint, which was not updated to accept Bot tokens. Since this was only being used in the `ci_build` script to set a `/remind`er for the DOTD, I replaced the `command` function with a `remind` function that utilizes the `chat.scheduleMessage` endpoint to send a DM from the bot to a given user at a given time.
- We also have a `message` function that is widely used across the codebase. This function utilizes an incoming webhook to send messages to various channels in Slack, and never used the legacy token to do so. I opted to leave this function untouched.

## Links

Context: [Slack thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1598036308026100)
Jira ticket: [FND-1699](https://codedotorg.atlassian.net/browse/FND-1699)
More info: [doc](https://www.google.com/url?q=https://docs.google.com/document/d/1yvMKrHNVmKHCC_tu2m6C6AjZfsN-ZYlDEGl211pLDdo/edit?usp%3Dsharing&sa=D&source=calendar&ust=1634080126705762&usg=AOvVaw23By2izUQ44wS_qCdBpvPf)

## Testing story

Existing Slack tests have been updated accordingly

## Deployment strategy & follow-up

Once deployed, automated processes that post to Slack (using anything other than Slack.message) will need to do so using the new Bot token. The `locals.yml` of all servers currently using a legacy token will need to be updated to use the new token.

Once individual engineers pull this change locally, they should update their own `locals.yml` to use the new bot token before running the DOTD script.
