### PR TITLE
JavaLab: small layout fix

### DIFF
--- a/apps/src/javalab/JavalabPanels.jsx
+++ b/apps/src/javalab/JavalabPanels.jsx
@@ -65,7 +65,9 @@ class JavalabPanels extends React.Component {
 
   componentDidUpdate(prevProps, prevState) {
     if (
-      prevProps.isInstructionsCollapsed !== this.props.isInstructionsCollapsed
+      prevProps.isInstructionsCollapsed !==
+        this.props.isInstructionsCollapsed ||
+      prevProps.isVisualizationCollapsed !== this.props.isVisualizationCollapsed
     ) {
       this.updateLayoutThrottled(this.props.leftWidth);
     }


### PR DESCRIPTION
There was a small bug: collapsing instructions and the visualization, then uncollapsing instructions, then uncollapsing the visualization, would result in no visualization being visible.  With this fix, a change in visualization collapse state now updates the layout.

Followup to https://github.com/code-dot-org/code-dot-org/pull/41688
