### PR TITLE
Sections Controller: fix pilot course bug

### DIFF
--- a/dashboard/app/controllers/api/v1/sections_controller.rb
+++ b/dashboard/app/controllers/api/v1/sections_controller.rb
@@ -47,7 +47,7 @@ class Api::V1::SectionsController < Api::V1::JsonApiController
         login_type: params[:login_type],
         grade: Section.valid_grade?(params[:grade].to_s) ? params[:grade].to_s : nil,
         script_id: script_to_assign ? script_to_assign.id : params[:script_id],
-        course_id: params[:course_id] && UnitGroup.valid_course_id?(params[:course_id]) ?
+        course_id: params[:course_id] && UnitGroup.valid_course_id?(params[:course_id], current_user) ?
           params[:course_id].to_i : nil,
         lesson_extras: params['lesson_extras'] || false,
         pairing_allowed: params[:pairing_allowed].nil? ? true : params[:pairing_allowed],
@@ -220,7 +220,7 @@ class Api::V1::SectionsController < Api::V1::JsonApiController
   # Update course_id if user provided valid course_id
   # Set course_id to nil if invalid or no course_id provided
   def set_course_id(course_id)
-    return course_id if UnitGroup.valid_course_id?(course_id)
+    return course_id if UnitGroup.valid_course_id?(course_id, current_user)
     nil
   end
 end

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -320,8 +320,8 @@ class UnitGroup < ApplicationRecord
   # Returns whether the course id is valid, even if it is not "stable" yet.
   # @param course_id [String] id of the course we're checking the validity of
   # @return [Boolean] Whether this is a valid course ID
-  def self.valid_course_id?(course_id)
-    valid_courses.any? {|unit_group| unit_group.id == course_id.to_i}
+  def self.valid_course_id?(course_id, user = nil)
+    valid_courses(user: user).any? {|unit_group| unit_group.id == course_id.to_i}
   end
 
   # @param user [User]

--- a/dashboard/test/controllers/api/v1/sections_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/sections_controller_test.rb
@@ -480,6 +480,34 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
     assert_nil returned_section.unit_group
   end
 
+  test 'pilot teacher can assign the pilot course id' do
+    pilot_teacher = create :teacher, pilot_experiment: 'my-experiment'
+    pilot_unit_group = create :unit_group, pilot_experiment: 'my-experiment', published_state: SharedConstants::PUBLISHED_STATE.pilot
+    sign_in pilot_teacher
+    post :create, params: {
+      login_type: Section::LOGIN_TYPE_EMAIL,
+      course_id: pilot_unit_group.id
+    }
+    assert_response :success
+
+    assert_equal pilot_unit_group.id, returned_json['course_id']
+    assert_equal pilot_unit_group, returned_section.unit_group
+  end
+
+  test 'non pilot teacher cannot assign the pilot course id' do
+    pilot_unit_group = create :unit_group, pilot_experiment: 'my-experiment', published_state: SharedConstants::PUBLISHED_STATE.pilot
+    sign_in @teacher
+    post :create, params: {
+      login_type: Section::LOGIN_TYPE_EMAIL,
+      course_id: pilot_unit_group.id
+    }
+    assert_response :success
+    # TODO: Better to fail here?
+
+    assert_nil returned_json['course_id']
+    assert_nil returned_section.unit_group
+  end
+
   test 'can create with a script id but no course id' do
     sign_in @teacher
     post :create, params: {


### PR DESCRIPTION
We had a bug where if a pilot course section is created, the course id does not get saved to the section. This was because we check if the course is valid without passing in the user id of the user who created the section, and by default pilot courses are not valid. The fix is to pass the user id to the valid course check.

We need to fix this for CSA courses because we need to check if a section is a CSA section for code review.

## Links

- slack thread that discusses the issue: [slack](https://codedotorg.slack.com/archives/C0T10HG6N/p1631137547008900?thread_ts=1631134064.004900&cid=C0T10HG6N)

## Testing story
Tested locally. After this fix, creating or updating a CSA section persists the course id.

## Follow-up work
We need to write a script to update the existing CSA sections so they persist a course id.


## PR Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
