### PR TITLE
Migration to backfill storage apps value for backpack

### DIFF
--- a/dashboard/db/migrate/20210908195236_update_backpack_storage_apps_value.rb
+++ b/dashboard/db/migrate/20210908195236_update_backpack_storage_apps_value.rb
@@ -1,0 +1,11 @@
+class UpdateBackpackStorageAppsValue < ActiveRecord::Migration[5.2]
+  def change
+    Backpack.all.each do |backpack|
+      storage_app_row = PEGASUS_DB[:storage_apps].where(id: backpack.storage_app_id).first
+      if storage_app_row[:value] == "".to_json
+        new_value = {hidden: true}.to_json
+        PEGASUS_DB[:storage_apps].where(id: backpack.storage_app_id).update(value: new_value)
+      end
+    end
+  end
+end

--- a/dashboard/db/migrate/20210908195236_update_backpack_storage_apps_value.rb
+++ b/dashboard/db/migrate/20210908195236_update_backpack_storage_apps_value.rb
@@ -1,10 +1,9 @@
 class UpdateBackpackStorageAppsValue < ActiveRecord::Migration[5.2]
-  def change
-    Backpack.all.each do |backpack|
-      storage_app_row = PEGASUS_DB[:storage_apps].where(id: backpack.storage_app_id).first
-      if storage_app_row[:value] == "".to_json
+  def up
+    PEGASUS_DB[:storage_apps].where(project_type: 'backpack').each do |storage_app|
+      if storage_app[:value] == "".to_json
         new_value = {hidden: true}.to_json
-        PEGASUS_DB[:storage_apps].where(id: backpack.storage_app_id).update(value: new_value)
+        PEGASUS_DB[:storage_apps].where(id: storage_app[:id]).update(value: new_value)
       end
     end
   end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_20_182004) do
+ActiveRecord::Schema.define(version: 2021_09_08_195236) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Adds a migration which for all storage apps associated with backpack entries, replaces storage_app.value with {hidden: true} if it's an empty string. There are currently 538 rows in the backpacks table in production, so this migration will affect no more than 538 storage apps rows. I ran the migration locally against a clone of production which had 112 rows in the backpacks table, the migration took about 24 seconds to complete. I could use some feedback on if this seems like a safe migration to run in production.

## Links
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/42382.
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
Tested locally by running the migration against storage apps which have value = "" and verifying that the new value is correct.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
