### PR TITLE
Fix skinny cs journeys banner on wide screen

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/csjourneys.css
+++ b/pegasus/sites.v3/code.org/public/css/csjourneys.css
@@ -86,6 +86,14 @@ h1.csjourneys-banner-header {
   overflow: hidden;
 }
 
+.csjourneys-skinny-banner-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: relative;
+  padding: 0 10px;
+}
+
 .csjourneys-skinny-banner-content {
   display: flex;
   flex-direction: column;

--- a/pegasus/sites.v3/code.org/views/csjourneys_skinny_banner.haml
+++ b/pegasus/sites.v3/code.org/views/csjourneys_skinny_banner.haml
@@ -1,7 +1,7 @@
 - if Homepage.show_csjourneys_banner(request)
   %link{:href=>"/css/csjourneys.css", :rel=>"stylesheet"}
   .csjourneys-skinny-banner
-    .csjourneys-banner-container
+    .csjourneys-skinny-banner-container
       %img.desktop-feature.csjourneys-skinny-banner-footprint-right{:src=>"/images/csjourneys/csjourneys-footsteps-right.png"}
       .csjourneys-skinny-banner-content
         %img.csjourneys-skinny-banner-logo{:src=>"/images/csjourneys/csjourneys-banner-new.png", :alt=>"CS Journeys"}


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Footprints were positioned incorrectly on large screens.
Before:
![Screen Shot 2021-09-09 at 1 36 39 PM](https://user-images.githubusercontent.com/24235215/132759204-354d0db9-c1ff-4ad6-a1d4-d846bde59d2f.png)
After:
![Screen Shot 2021-09-09 at 1 35 58 PM](https://user-images.githubusercontent.com/24235215/132759214-7143be96-7fd7-4940-adee-9fdbd1f415e2.png)

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
Reported in slack: https://codedotorg.slack.com/archives/C0SUN2SSF/p1631215669002300
<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
Tested locally
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
