### PR TITLE
Update CSA Sections one off script

### DIFF
--- a/bin/oneoff/backfill_data/backfill_csa_section_course_id
+++ b/bin/oneoff/backfill_data/backfill_csa_section_course_id
@@ -1,0 +1,44 @@
+#!/usr/bin/env ruby
+
+require_relative '../../../dashboard/config/environment'
+
+CDO.log = Logger.new(STDOUT)
+ActiveRecord::Base.record_timestamps = false
+
+options = {actually_update: false}
+OptionParser.new do |opts|
+  opts.banner = "Usage: #{File.basename(__FILE__)} [options]"
+  opts.on('-u', '--actually-update', 'Actually perform the update.') do
+    options[:actually_update] = true
+  end
+  opts.on('-h', '--help', 'Add -u to perform the update.') do
+    puts opts
+    exit
+  end
+end.parse!
+CDO.log.info "Called with options: #{options}"
+
+pilot_names = %w(csa-pilot csa-pilot-facilitator)
+updated = []
+
+pilot_names.each do |pilot_name|
+  CDO.log.info "fixing pilot #{pilot_name}."
+  pilot = UnitGroup.find_by_name(pilot_name)
+  script_ids = UnitGroupUnit.where(course_id: pilot.id).pluck(:script_id)
+  sections = Section.where(course_id: nil, script_id: script_ids)
+  CDO.log.info "found #{sections.length} sections to update."
+  sections.each do |section|
+    if options[:actually_update]
+      section.course_id = pilot.id
+      section.save!
+    end
+    updated << section.id
+  end
+end
+
+if options[:actually_update]
+  CDO.log.info "Update complete. Updated #{updated.length} sections."
+else
+  CDO.log.info "Dry run complete. Would have updated #{updated.length} sections."
+end
+CDO.log.info "Sections updated: #{updated}"

--- a/bin/oneoff/backfill_data/backfill_pilot_section_course_id
+++ b/bin/oneoff/backfill_data/backfill_pilot_section_course_id
@@ -36,11 +36,17 @@ pilot_names.each do |pilot_name|
   sections = Section.where(course_id: nil, script_id: script_ids)
   CDO.log.info "found #{sections.length} sections to update."
   sections.each do |section|
+    add_to_updated = true
     if options[:actually_update]
       section.course_id = pilot.id
-      section.save!
+      begin
+        section.save!
+      rescue ActiveRecord::RecordInvalid
+        CDO.log.info "could not update section #{section.id}"
+        add_to_updated = false
+      end
     end
-    updated << section.id
+    updated << section.id if add_to_updated
   end
 end
 

--- a/bin/oneoff/backfill_data/backfill_pilot_section_course_id
+++ b/bin/oneoff/backfill_data/backfill_pilot_section_course_id
@@ -24,7 +24,15 @@ updated = []
 pilot_names.each do |pilot_name|
   CDO.log.info "fixing pilot #{pilot_name}."
   pilot = UnitGroup.find_by_name(pilot_name)
+  unless pilot
+    CDO.log.info "could not find pilot #{pilot_name}"
+    next
+  end
   script_ids = UnitGroupUnit.where(course_id: pilot.id).pluck(:script_id)
+  if script_ids.empty?
+    CDO.log.info "pilot #{pilot_name} had no script ids"
+    next
+  end
   sections = Section.where(course_id: nil, script_id: script_ids)
   CDO.log.info "found #{sections.length} sections to update."
   sections.each do |section|


### PR DESCRIPTION
We had a bug where pilot sections have a null course id, fixed in this [PR](https://github.com/code-dot-org/code-dot-org/pull/42401). We need to fix the CSA pilot sections to have a course_id in order to improve our code review feature. This one off script will update sections with a null course_id and a script id that is part of csa-pilot or csa-pilot-facilitator to have the correct course id. 

If other pilots need to be updated to have course_ids this script is easily adaptable to sub out a different pilot name.

## Testing story
Tested the script locally in dry run and update mode and it fixed the correct sections. There are (as of today) 125 csa-pilot and csa-pilot-facilitator sections so the update should not impact production at all.

## Deployment strategy
We should run this after the bug fix PR has been deployed, but it can be merged before that.


## PR Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
