### PR TITLE
Reduce Parallel processors used in i18n `sync-out`

### DIFF
--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -126,9 +126,9 @@ def restore_redacted_files
     ERR
   end
 
-  puts "Restoring redacted files in #{locales.count} locales, parallelized between #{Parallel.processor_count} processes"
+  puts "Restoring redacted files in #{locales.count} locales, parallelized between #{Parallel.processor_count / 2} processes"
 
-  Parallel.each(locales) do |prop|
+  Parallel.each(locales, in_processes: (Parallel.processor_count / 2)) do |prop|
     locale = prop[:locale_s]
     next if locale == 'en-US'
     next unless File.directory?("i18n/locales/#{locale}/")
@@ -317,9 +317,9 @@ end
 # back to blockly, apps, pegasus, and dashboard.
 def distribute_translations(upload_manifests)
   locales = Languages.get_locale
-  puts "Distributing translations in #{locales.count} locales, parallelized between #{Parallel.processor_count} processes"
+  puts "Distributing translations in #{locales.count} locales, parallelized between #{Parallel.processor_count / 2} processes"
 
-  Parallel.each(locales) do |prop|
+  Parallel.each(locales, in_processes: (Parallel.processor_count / 2)) do |prop|
     locale = prop[:locale_s]
     locale_dir = File.join("i18n/locales", locale)
     next if locale == 'en-US'


### PR DESCRIPTION
**What**: Use half of the machine's processors when using `Parallel` loops within `bin/i18n/sync-out.rb`

**Why**: The sync out process would often fail with a `Sequel::DatabaseDisconnectError` when using all of a machine's processors (that is the default)

Error:
```Sync out failed from the error: Sequel::DatabaseDisconnectError: Mysql2::Error::ConnectionError: Lost connection to MySQL server during query```

## Links

[Link to example](https://codedotorg.slack.com/archives/C99KAHFK9/p1631154984382600)

## Testing story

Ran `sync-out` locally with these changes and no longer received this error.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
