### PR TITLE
remove height from resource cards

### DIFF
--- a/apps/src/templates/studioHomepages/ResourceCard.jsx
+++ b/apps/src/templates/studioHomepages/ResourceCard.jsx
@@ -90,7 +90,6 @@ class ResourceCard extends Component {
 
 const styles = {
   card: {
-    height: 250,
     width: 310,
     background: color.teal
   },
@@ -139,7 +138,6 @@ const styles = {
     fontFamily: '"Gotham 4r", sans-serif',
     fontSize: 14,
     lineHeight: '21px',
-    height: 140,
     marginBottom: 5,
     overflowY: 'auto'
   },


### PR DESCRIPTION
Removes height from resource cards in order to avoid a scrollbar as described in #39410. Duplicate of #42388 to use a different branch.

## PR Checklist:

- [X] Tests provide adequate coverage
- [X] Privacy and Security impacts have been assessed
- [X] Code is well-commented
- [X] New features are translatable or updates will not break translations
- [X] User impact is well-understood and desirable
- [X] Pull Request is labeled appropriately

Before:
![Before](https://user-images.githubusercontent.com/89611911/132767001-26e72579-d6b9-45bb-9f2d-b12225e765c5.PNG)

After:
![After](https://user-images.githubusercontent.com/89611911/132766995-3eae88ef-e7e3-4746-b41f-275592124036.PNG)
