### PR TITLE
Render valid React for Blockly XML in <SafeMarkdown/>

### DIFF
--- a/apps/src/templates/SafeMarkdown.jsx
+++ b/apps/src/templates/SafeMarkdown.jsx
@@ -53,6 +53,13 @@ blocklyTags.forEach(tag => {
   schema.attributes[tag] = ['block_text', 'id', 'inline', 'name', 'type'];
 });
 
+function BlocklyXml(props) {
+  return <xml is="xml" {...props} />;
+}
+function BlocklyBlock(props) {
+  return <block is="block" {...props} />;
+}
+
 const markdownToReact = Parser.create()
   .getParser()
   // include custom plugins
@@ -68,7 +75,11 @@ const markdownToReact = Parser.create()
   .use(rehypeSanitize, schema)
   // convert the HAST to React
   .use(rehypeReact, {
-    createElement: React.createElement
+    createElement: React.createElement,
+    components: {
+      xml: BlocklyXml,
+      block: BlocklyBlock
+    }
   });
 
 const markdownToReactExternalLinks = markdownToReact().use(externalLinks, {

--- a/apps/test/unit/templates/SafeMarkdownTest.js
+++ b/apps/test/unit/templates/SafeMarkdownTest.js
@@ -141,19 +141,11 @@ describe('SafeMarkdown', () => {
     );
 
     expect(
-      inlineXml.equals(
-        <div>
-          <p>
-            Text with{' '}
-            <xml>
-              <block type="xml" />
-            </xml>{' '}
-            inline
-          </p>
-        </div>
-      ),
+      inlineXml.html(),
       'inline xml blocks render within their containing paragraph'
-    ).to.equal(true);
+    ).to.equal(
+      '<div><p>Text with <xml is="xml"><block is="block" type="xml"></block></xml> inline</p></div>'
+    );
 
     // Need to use markdown={} rather than markdown="" here so React doesn't
     // escape the newlines
@@ -171,7 +163,7 @@ describe('SafeMarkdown', () => {
       blockXml.html(),
       'block xml blocks render as top-level elements (siblings to paragraphs)'
     ).to.equal(
-      '<div><p>Text with</p>\n<xml><block type="xml"></block></xml>\n<p>in its own block</p></div>'
+      '<div><p>Text with</p>\n<xml is="xml"><block is="block" type="xml"></block></xml>\n<p>in its own block</p></div>'
     );
   });
 
@@ -280,15 +272,9 @@ describe('SafeMarkdown', () => {
     const xmlJSInjection = shallow(
       <SafeMarkdown markdown='<xml onload="alert(&#x22;foxtrot&#x22;)"><block/></xml>' />
     );
-    expect(
-      xmlJSInjection.equals(
-        <div>
-          <xml>
-            <block />
-          </xml>
-        </div>
-      ),
-      'JS events in XML are ignored'
-    ).to.equal(true);
+
+    expect(xmlJSInjection.html(), 'JS events in XML are ignored').to.equal(
+      '<div><xml is="xml"><block is="block"></block></xml></div>'
+    );
   });
 });

--- a/apps/test/unit/templates/instructions/InstructionsCSFTest.jsx
+++ b/apps/test/unit/templates/instructions/InstructionsCSFTest.jsx
@@ -19,7 +19,7 @@ import isRtl from '@cdo/apps/code-studio/isRtlRedux';
 
 // TODO: Fix/unskip this test (only 1 test in this describe block).
 // Tracked by https://codedotorg.atlassian.net/browse/STAR-1680
-describe.skip('InstructionsCSF', () => {
+describe('InstructionsCSF', () => {
   beforeEach(() => {
     stubRedux();
     registerReducers({authoredHints, instructions, isRtl, pageConstants});

--- a/apps/test/unit/templates/instructions/InstructionsCSFTest.jsx
+++ b/apps/test/unit/templates/instructions/InstructionsCSFTest.jsx
@@ -17,8 +17,6 @@ import authoredHints from '@cdo/apps/redux/authoredHints';
 import pageConstants, {setPageConstants} from '@cdo/apps/redux/pageConstants';
 import isRtl from '@cdo/apps/code-studio/isRtlRedux';
 
-// TODO: Fix/unskip this test (only 1 test in this describe block).
-// Tracked by https://codedotorg.atlassian.net/browse/STAR-1680
 describe('InstructionsCSF', () => {
   beforeEach(() => {
     stubRedux();


### PR DESCRIPTION
This change updates our `<SafeMarkdown/>` component to render Blockly XML in a way that is valid React. We do this by wrapping each Blockly element in a custom component and using the [`components` option in rehype-react](https://github.com/rehypejs/rehype-react#optionscomponents).

Since Blockly elements aren't valid React (e.g., `<xml>` isn't a valid React component), we were previously seeing warnings any time Blockly blocks were rendered by our instructions panel:
![image (3) (1)](https://user-images.githubusercontent.com/9812299/132912327-c957fab4-a7db-4eb3-a4fa-b2fd0f545d84.png)

This would also cause unit tests to fail for the same reason (we fail unit tests when console.warn is called), so we no longer have to skip or allow warnings in InstructionsCSFTest.js.

## Links

- [STAR-1680](https://codedotorg.atlassian.net/browse/STAR-1680) - Unskip InstructionsCSFTest
- [STAR-1708](https://codedotorg.atlassian.net/browse/STAR-1708) - `<InstructionsCSF/>` logs warnings for instructions with embedded Blockly blocks

## Testing story

Updates unit tests.