### PR TITLE
Show print button with only resource option for pilots and in-development

### DIFF
--- a/apps/src/code-studio/components/progress/UnitOverviewTopRow.jsx
+++ b/apps/src/code-studio/components/progress/UnitOverviewTopRow.jsx
@@ -76,9 +76,18 @@ class UnitOverviewTopRow extends React.Component {
   };
 
   compilePdfDropdownOptions = () => {
-    const {scriptOverviewPdfUrl, scriptResourcesPdfUrl} = this.props;
+    const {
+      scriptOverviewPdfUrl,
+      scriptResourcesPdfUrl,
+      publishedState
+    } = this.props;
+
+    const showOverviewPDFOption =
+      publishedState !== PublishedState.pilot &&
+      publishedState !== PublishedState.in_development;
+
     const options = [];
-    if (scriptOverviewPdfUrl) {
+    if (scriptOverviewPdfUrl && showOverviewPDFOption) {
       options.push({
         key: 'lessonPlans',
         name: i18n.printLessonPlans(),
@@ -115,8 +124,7 @@ class UnitOverviewTopRow extends React.Component {
       showCalendar,
       unitCalendarLessons,
       weeklyInstructionalMinutes,
-      isMigrated,
-      publishedState
+      isMigrated
     } = this.props;
 
     const pdfDropdownOptions = this.compilePdfDropdownOptions();
@@ -126,10 +134,6 @@ class UnitOverviewTopRow extends React.Component {
     const buttonMarginStyle = isRtl
       ? styles.buttonMarginRTL
       : styles.buttonMarginLTR;
-
-    const showPDFButton =
-      publishedState !== PublishedState.pilot &&
-      publishedState !== PublishedState.in_development;
 
     return (
       <div style={styles.buttonRow} className="unit-overview-top-row">
@@ -174,28 +178,26 @@ class UnitOverviewTopRow extends React.Component {
                 useMigratedResources={isMigrated}
               />
             )}
-          {showPDFButton &&
-            pdfDropdownOptions.length > 0 &&
-            viewAs === ViewType.Teacher && (
-              <div style={{marginRight: 5}}>
-                <DropdownButton
-                  text={i18n.printingOptions()}
-                  color={Button.ButtonColor.blue}
-                >
-                  {pdfDropdownOptions.map(option => (
-                    <a
-                      key={option.key}
-                      href={option.url}
-                      onClick={e =>
-                        this.recordAndNavigateToPdf(e, option.key, option.url)
-                      }
-                    >
-                      {option.name}
-                    </a>
-                  ))}
-                </DropdownButton>
-              </div>
-            )}
+          {pdfDropdownOptions.length > 0 && viewAs === ViewType.Teacher && (
+            <div style={{marginRight: 5}}>
+              <DropdownButton
+                text={i18n.printingOptions()}
+                color={Button.ButtonColor.blue}
+              >
+                {pdfDropdownOptions.map(option => (
+                  <a
+                    key={option.key}
+                    href={option.url}
+                    onClick={e =>
+                      this.recordAndNavigateToPdf(e, option.key, option.url)
+                    }
+                  >
+                    {option.name}
+                  </a>
+                ))}
+              </DropdownButton>
+            </div>
+          )}
           {showCalendar && viewAs === ViewType.Teacher && (
             <UnitCalendarButton
               lessons={unitCalendarLessons}

--- a/apps/src/templates/lessonOverview/LessonOverview.jsx
+++ b/apps/src/templates/lessonOverview/LessonOverview.jsx
@@ -63,9 +63,14 @@ class LessonOverview extends Component {
   };
 
   compilePdfDropdownOptions = () => {
-    const {lessonPlanPdfUrl, scriptResourcesPdfUrl} = this.props.lesson;
+    const {lessonPlanPdfUrl, scriptResourcesPdfUrl, unit} = this.props.lesson;
+
+    const showOverviewPDFOption =
+      unit.publishedState !== PublishedState.pilot &&
+      unit.publishedState !== PublishedState.in_development;
+
     const options = [];
-    if (lessonPlanPdfUrl) {
+    if (lessonPlanPdfUrl && showOverviewPDFOption) {
       options.push({
         key: 'singleLessonPlan',
         name: i18n.printLessonPlan(),
@@ -97,10 +102,6 @@ class LessonOverview extends Component {
 
     const pdfDropdownOptions = this.compilePdfDropdownOptions();
 
-    const showPDFButton =
-      lesson.unit.publishedState !== PublishedState.pilot &&
-      lesson.unit.publishedState !== PublishedState.in_development;
-
     return (
       <div className="lesson-overview">
         <div className="lesson-overview-header">
@@ -112,7 +113,7 @@ class LessonOverview extends Component {
               {`< ${lesson.unit.displayName}`}
             </a>
             <div style={styles.dropdowns}>
-              {showPDFButton && pdfDropdownOptions.length > 0 && (
+              {pdfDropdownOptions.length > 0 && (
                 <div style={{marginRight: 5}}>
                   <DropdownButton
                     color={Button.ButtonColor.gray}

--- a/apps/test/unit/code-studio/components/progress/UnitOverviewTopRowTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/UnitOverviewTopRowTest.jsx
@@ -283,7 +283,7 @@ describe('UnitOverviewTopRow', () => {
     ).to.be.false;
   });
 
-  it('renders dropdown button with links to printing options when published state is not pilot', () => {
+  it('renders dropdown button with links to printing options when published state is not pilot or indevelopment', () => {
     const wrapper = shallow(
       <UnitOverviewTopRow
         {...defaultProps}
@@ -307,7 +307,7 @@ describe('UnitOverviewTopRow', () => {
     ]);
   });
 
-  it('does not render printing options dropdown when published state is pilot', () => {
+  it('does not render overview printing option in dropdown for pilot course', () => {
     const wrapper = shallow(
       <UnitOverviewTopRow
         {...defaultProps}
@@ -317,10 +317,20 @@ describe('UnitOverviewTopRow', () => {
         publishedState={PublishedState.pilot}
       />
     );
-    expect(wrapper.find(DropdownButton).length).to.equal(0);
+    expect(wrapper.find(DropdownButton).length).to.equal(1);
+    const dropdownLinks = wrapper
+      .find(DropdownButton)
+      .first()
+      .props().children;
+    expect(dropdownLinks.map(link => link.props.href)).to.eql([
+      '/link/to/script_resources.pdf'
+    ]);
+    expect(dropdownLinks.map(link => link.props.children)).to.eql([
+      'Print Handouts'
+    ]);
   });
 
-  it('does not render printing options dropdown when published state is in-development', () => {
+  it('does not render overview printing option in dropdown for in development course', () => {
     const wrapper = shallow(
       <UnitOverviewTopRow
         {...defaultProps}
@@ -330,7 +340,17 @@ describe('UnitOverviewTopRow', () => {
         publishedState={PublishedState.in_development}
       />
     );
-    expect(wrapper.find(DropdownButton).length).to.equal(0);
+    expect(wrapper.find(DropdownButton).length).to.equal(1);
+    const dropdownLinks = wrapper
+      .find(DropdownButton)
+      .first()
+      .props().children;
+    expect(dropdownLinks.map(link => link.props.href)).to.eql([
+      '/link/to/script_resources.pdf'
+    ]);
+    expect(dropdownLinks.map(link => link.props.children)).to.eql([
+      'Print Handouts'
+    ]);
   });
 
   it('does not render printing option dropdown for students', () => {

--- a/apps/test/unit/templates/lessonOverview/LessonOverviewTest.js
+++ b/apps/test/unit/templates/lessonOverview/LessonOverviewTest.js
@@ -292,7 +292,7 @@ describe('LessonOverview', () => {
     ).to.be.true;
   });
 
-  it('renders dropdown button with links to printing options if not pilot', () => {
+  it('renders dropdown button with links to printing options if not pilot or in development', () => {
     const lesson = {
       ...defaultProps.lesson,
       lessonPlanPdfUrl: '/link/to/lesson_plan.pdf',
@@ -316,7 +316,7 @@ describe('LessonOverview', () => {
     ]);
   });
 
-  it('does not render printing options dropdown for pilot course', () => {
+  it('does not render overview printing option in dropdown for pilot course', () => {
     const unit = {
       ...defaultProps.lesson.unit,
       publishedState: PublishedState.pilot
@@ -330,10 +330,20 @@ describe('LessonOverview', () => {
     const wrapper = shallow(
       <LessonOverview {...defaultProps} lesson={lesson} />
     );
-    expect(wrapper.find(DropdownButton).length).to.equal(0);
+    expect(wrapper.find(DropdownButton).length).to.equal(1);
+    const dropdownLinks = wrapper
+      .find(DropdownButton)
+      .first()
+      .props().children;
+    expect(dropdownLinks.map(link => link.props.href)).to.eql([
+      '/link/to/script_resources.pdf'
+    ]);
+    expect(dropdownLinks.map(link => link.props.children)).to.eql([
+      'Print Handouts'
+    ]);
   });
 
-  it('does not render printing options dropdown for in development course', () => {
+  it('does not render overview printing option in dropdown for in development course', () => {
     const unit = {
       ...defaultProps.lesson.unit,
       publishedState: PublishedState.in_development
@@ -347,6 +357,16 @@ describe('LessonOverview', () => {
     const wrapper = shallow(
       <LessonOverview {...defaultProps} lesson={lesson} />
     );
-    expect(wrapper.find(DropdownButton).length).to.equal(0);
+    expect(wrapper.find(DropdownButton).length).to.equal(1);
+    const dropdownLinks = wrapper
+      .find(DropdownButton)
+      .first()
+      .props().children;
+    expect(dropdownLinks.map(link => link.props.href)).to.eql([
+      '/link/to/script_resources.pdf'
+    ]);
+    expect(dropdownLinks.map(link => link.props.children)).to.eql([
+      'Print Handouts'
+    ]);
   });
 });


### PR DESCRIPTION
We had [originally decided](https://github.com/code-dot-org/code-dot-org/pull/42363/files) to remove the entire print pdf button for pilots and in-development courses. However after a little more investigation we think the resources PDF works fine for pilot and in-development courses so we will keep that and just remove the overview pdf option.  This PR updates the work from the previous PR to make it so you can just see the resources option in the dropdown for pilot and in-development courses.

<img width="1161" alt="Screen Shot 2021-09-10 at 3 45 46 PM" src="https://user-images.githubusercontent.com/208083/132909095-bf4eb1e8-779d-4a52-9163-5a820f7838c4.png">


## Links

- jira ticket: https://codedotorg.atlassian.net/browse/PLAT-1182


## Testing story

- Updated the unit tests to reflect the updates to the way we are hiding just one option in the dropdown instead of the whole button