### PR TITLE
Only show save and return to buttons on level edit when level is in a script

### DIFF
--- a/dashboard/app/views/levels/edit.html.haml
+++ b/dashboard/app/views/levels/edit.html.haml
@@ -64,16 +64,17 @@
   .actions{style: "position: fixed; bottom: 0px; width: 100%; background-color: rgb(231, 232, 234); left: 0px; z-index: 900; display: flex; justify-content: flex-end; margin: 0px; align-items: center"}
     = f.submit 'Save and publish your completed work', {:class => 'publishLevel', :style => "background-color: #f0c14b; margin-bottom: 10px; height: 35px"}
     %div{style: "display: flex; flex-direction: column; padding: 10px 10px 0px 10px"}
-      %p Or, save, publish, and return to:
-      %ul
-        - @level.script_levels.each do |script_level|
-          %li
-            = f.submit build_script_level_path(script_level), {:class=> 'publishLevel', :name => "redirect", :style => "font-family: monospace; margin-bottom: 10px"}
-        - BubbleChoice.parent_levels(@level.name).each do |parent_level|
-          - parent_level.script_levels.each do |script_level|
+      - if @in_script
+        %p Or, save, publish, and return to:
+        %ul
+          - @level.script_levels.each do |script_level|
             %li
-              - position = parent_level.sublevel_position(@level)
-              = f.submit build_script_level_path(script_level, sublevel_position: position), {:class=> 'publishLevel', :name => "redirect", :style => "font-family: monospace; margin-bottom: 10px"}
+              = f.submit build_script_level_path(script_level), {:class=> 'publishLevel', :name => "redirect", :style => "font-family: monospace; margin-bottom: 10px"}
+          - BubbleChoice.parent_levels(@level.name).each do |parent_level|
+            - parent_level.script_levels.each do |script_level|
+              %li
+                - position = parent_level.sublevel_position(@level)
+                = f.submit build_script_level_path(script_level, sublevel_position: position), {:class=> 'publishLevel', :name => "redirect", :style => "font-family: monospace; margin-bottom: 10px"}
 
 %pre#validation-error.validation-error{style: 'background-color: yellow; display: none'}
 :javascript


### PR DESCRIPTION
There was an issue where the save and return to buttons on the level edit page were showing levels that were not associated with the new level being created. This PR makes sure we only show save and return to buttons if a level is in a unit. This should also prevent those buttons from showing up when creating a new level because it won't yet be in a unit. I could not use  `new_record?` to check that it was a new record because there are two pages to create a new level and once you get to the second one `new_record?` no longer returns true.

<img width="1785" alt="Screen Shot 2021-09-10 at 4 01 55 PM" src="https://user-images.githubusercontent.com/208083/132911457-9796b427-c7e7-4f7c-8452-ec7b618d1a50.png">

## Links

- jira ticket:https://codedotorg.atlassian.net/browse/PLAT-1268

## Testing story

- Tested locally to check that it worked for a new level and didn't impact an existing level