### PR TITLE
Update sync down frequency

### DIFF
--- a/experimental/i18n-dev.crontab
+++ b/experimental/i18n-dev.crontab
@@ -33,7 +33,7 @@ HOME=/home/ubuntu
 30 8 * * MON (cd /home/ubuntu/code-dot-org && (bundle exec ./bin/i18n/sync-all.rb -yip | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error) >>/tmp/cronlog 2>&1
 
 # Run the sync down periodically throughout the week. Specifically:
-# - Run it every other hour. This is a somewhat arbitrarily-chosen frequency
+# - Run it every 4 hours. This is a somewhat arbitrarily-chosen frequency
 #   for a test period. We expect to refine this over time.
 # - Run it on the half-hour. Like for the full sync, this is done to reduce the
 #   chance of colliding with the CI Build.

--- a/experimental/i18n-dev.crontab
+++ b/experimental/i18n-dev.crontab
@@ -40,7 +40,7 @@ HOME=/home/ubuntu
 # - Run it every day except Monday. This is done so we don't conflict with the
 #   full sync, and also because we expect to spend Monday verifiying the
 #   results of the full sync.
-30 */2 * * SUN,TUE-SAT cd /home/ubuntu/code-dot-org && ((bundle exec ./bin/i18n/sync-all.rb -c down && bundle exec ./bin/i18n/sync-all.rb -c out) | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error
+30 */4 * * SUN,TUE-SAT cd /home/ubuntu/code-dot-org && ((bundle exec ./bin/i18n/sync-all.rb -c down && bundle exec ./bin/i18n/sync-all.rb -c out) | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error
 
 # Periodically check to see if the I18n Sync PRs have been merged and attempt
 # to return to staging.


### PR DESCRIPTION
**What**: Update `sync-down` frequency to once every 4 hours

**Why**: With half of the processors being used ([PR](https://github.com/code-dot-org/code-dot-org/pull/42413)) it now takes twice as long. This will hopefully prevent collisions with other cronjobs.

## Links

[PR reducing processors used](https://github.com/code-dot-org/code-dot-org/pull/42413)
