### PR TITLE
Postflight script update api

### DIFF
--- a/apps/src/lib/levelbuilder/unit-editor/LessonToken.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/LessonToken.jsx
@@ -73,7 +73,6 @@ export class LessonTokenContents extends Component {
   };
 
   handleEditLesson = () => {
-    window.lessonEditorOpened = true;
     const url = this.props.lesson.lessonEditPath;
     const win = window.open(url, 'noopener', 'noreferrer');
     win.focus();

--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -219,19 +219,6 @@ class UnitEditor extends React.Component {
         shouldCloseAfterSave = false;
       }
     }
-    // HACK: until the unit edit page no longer overwrites changes to the
-    // arrangement of levels within lessons, give the user a warning
-    if (
-      window.lessonEditorOpened &&
-      !confirm(
-        'WARNING: It looks like you opened a lesson edit page from this unit edit page. ' +
-          'If you made any changes on the lesson edit page which you do not ' +
-          'wish to lose, please click cancel now and reload this page before ' +
-          'saving any changes to this unit edit page.'
-      )
-    ) {
-      shouldCloseAfterSave = false;
-    }
 
     if (this.state.showCalendar && !this.state.weeklyInstructionalMinutes) {
       this.setState({

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -124,10 +124,7 @@ class ScriptsController < ApplicationController
       raise msg
     end
 
-    # TODO: disable this check for migrated scripts once they are using the new,
-    # non-dsl script update api. at that time, the above check on script.updated_at
-    # will provide sufficient protection against write conflicts on migrated scripts.
-    if params[:old_unit_text]
+    if !@script.is_migrated && params[:old_unit_text]
       current_unit_text = ScriptDSL.serialize_lesson_groups(@script).strip
       old_unit_text = params[:old_unit_text].strip
       if old_unit_text != current_unit_text

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -140,21 +140,6 @@ class ScriptsController < ApplicationController
 
     unit_text = params[:script_text]
     if @script.update_text(unit_params, unit_text, i18n_params, general_params)
-
-      # For migrated scripts, we use the updated_at field to detect potential
-      # write conflicts when a curriculum editor tries to save an out-of-date
-      # script edit page. therefore, touch the `updated_at` column whenever we
-      # we save, even if it did not result an a change to the actual script
-      # object. that way, we'll prevent write conflicts on changes to lesson
-      # groups, as well as on fields which live only in scripts.en.yml.
-      # TODO(dave): consolidate this into the new update api codepath for
-      # migrated scripts, once that codepath exists.
-      @script.reload
-      if @script.is_migrated
-        @script.touch(:updated_at)
-        @script.save!
-      end
-
       @script.reload
       render json: @script.summarize_for_unit_edit
     else

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1071,6 +1071,15 @@ class Script < ApplicationRecord
       temp_lgs = LessonGroup.add_lesson_groups(raw_lesson_groups, unit, new_suffix, editor_experiment)
       unit.reload
       unit.lesson_groups = temp_lgs
+
+      # For migrated scripts, we use the updated_at field to detect potential
+      # write conflicts when a curriculum editor tries to save an out-of-date
+      # script edit page. therefore, touch the `updated_at` column whenever we
+      # we save, even if it did not result an a change to the actual script
+      # object. that way, we'll prevent write conflicts on changes to lesson
+      # groups, as well as on fields which live only in scripts.en.yml.
+      unit.touch(:updated_at) if unit.is_migrated
+
       unit.save!
       unit.prevent_legacy_script_levels_in_migrated_units
 


### PR DESCRIPTION
Cleanup PR following #42282.

* 224f452 - address TODO regarding when we touch updated_at, to reduce number of `reload` calls
* ab15415 - address TODO removing integrity check based on script dsl contents, which we no longer need for migrated scripts
* 00d6629 - remove integrity check we no longer need for preventing write conflicts between lesson edit and unit edit pages

## Testing story

existing test coverage, also manually verified that edit page still works for migrated units