### PR TITLE
Removing progress bars from i18n sync

### DIFF
--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -330,7 +330,7 @@ def localize_animation_library
   spritelab_animation_source_file = "#{I18N_SOURCE_DIR}/animations/spritelab_animation_library.json"
   FileUtils.mkdir_p(File.dirname(spritelab_animation_source_file))
   File.open(spritelab_animation_source_file, "w") do |file|
-    animation_strings = ManifestBuilder.new({spritelab: true, silent: true}).get_animation_strings
+    animation_strings = ManifestBuilder.new({spritelab: true, quiet: true}).get_animation_strings
     file.write(JSON.pretty_generate(animation_strings))
   end
 end

--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -358,7 +358,7 @@ def distribute_translations(upload_manifests)
     ### Animation library
     spritelab_animation_translation_path = "/animations/spritelab_animation_library.json"
     if file_changed?(locale, spritelab_animation_translation_path)
-      @manifest_builder ||= ManifestBuilder.new({spritelab: true, upload_to_s3: true})
+      @manifest_builder ||= ManifestBuilder.new({spritelab: true, upload_to_s3: true, quiet: true})
       spritelab_animation_translation_file = File.join(locale_dir, spritelab_animation_translation_path)
       translations = JSON.load(File.open(spritelab_animation_translation_file))
       # Use js_locale here as the animation library is used by apps


### PR DESCRIPTION
When building manifests, by default there is a progress bar printed to the terminal as the script runs. This ends up spamming our slack channel, so instead we should use the `quiet` option to suppress the progress bar.

Work done:
* Fixed the sync-in which was already trying to quiet the progress bar but used the wrong option `silent`.
* Added `quiet: true` to the sync-out script.
* 
## Testing story
* Didn't test, but did check against the options detailed in https://github.com/code-dot-org/code-dot-org/blob/staging/bin/animation_assets/manifest_builder.rb#L35

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->
