### PR TITLE
Add Search to TutorialExplorer

### DIFF
--- a/apps/src/templates/SearchBar.jsx
+++ b/apps/src/templates/SearchBar.jsx
@@ -60,14 +60,14 @@ const styles = {
   },
   icon: {
     position: 'absolute',
-    top: 5,
+    top: 6,
     left: 5,
     fontSize: 16,
     color: color.light_gray
   },
   clearIcon: {
     position: 'absolute',
-    top: 5,
+    top: 6,
     right: 5,
     fontSize: 16,
     color: color.light_gray

--- a/apps/src/templates/SearchBar.jsx
+++ b/apps/src/templates/SearchBar.jsx
@@ -70,7 +70,8 @@ const styles = {
     top: 6,
     right: 5,
     fontSize: 16,
-    color: color.light_gray
+    color: color.light_gray,
+    cursor: 'pointer'
   },
   searchArea: {
     position: 'relative',

--- a/apps/src/tutorialExplorer/search.jsx
+++ b/apps/src/tutorialExplorer/search.jsx
@@ -10,7 +10,7 @@ export default class Search extends React.Component {
 
   handleChange = e => {
     const value = e ? e.target.value : '';
-    this.props.onChange(value.toLowerCase());
+    this.props.onChange(value);
   };
 
   render() {

--- a/apps/src/tutorialExplorer/search.jsx
+++ b/apps/src/tutorialExplorer/search.jsx
@@ -5,7 +5,8 @@ import SearchBar from '../templates/SearchBar';
 
 export default class Search extends React.Component {
   static propTypes = {
-    onChange: PropTypes.func.isRequired
+    onChange: PropTypes.func.isRequired,
+    showClearIcon: PropTypes.bool
   };
 
   handleChange = e => {
@@ -17,7 +18,7 @@ export default class Search extends React.Component {
     return (
       <FilterGroupContainer text="Search">
         <SearchBar
-          clearButton
+          clearButton={this.props.showClearIcon}
           onChange={this.handleChange}
           placeholderText=""
         />

--- a/apps/src/tutorialExplorer/search.jsx
+++ b/apps/src/tutorialExplorer/search.jsx
@@ -1,0 +1,27 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import FilterGroupContainer from './filterGroupContainer';
+import SearchBar from '../templates/SearchBar';
+
+export default class Search extends React.Component {
+  static propTypes = {
+    onChange: PropTypes.func.isRequired
+  };
+
+  handleChange = e => {
+    const value = e ? e.target.value : '';
+    this.props.onChange(value.toLowerCase());
+  };
+
+  render() {
+    return (
+      <FilterGroupContainer text="Search">
+        <SearchBar
+          clearButton
+          onChange={this.handleChange}
+          placeholderText=""
+        />
+      </FilterGroupContainer>
+    );
+  }
+}

--- a/apps/src/tutorialExplorer/search.jsx
+++ b/apps/src/tutorialExplorer/search.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import FilterGroupContainer from './filterGroupContainer';
 import SearchBar from '../templates/SearchBar';
+import debounce from 'lodash/debounce';
 
 export default class Search extends React.Component {
   static propTypes = {
@@ -9,9 +10,11 @@ export default class Search extends React.Component {
     showClearIcon: PropTypes.bool
   };
 
+  debouncedOnChange = debounce(this.props.onChange, 300);
+
   handleChange = e => {
     const value = e ? e.target.value : '';
-    this.props.onChange(value);
+    this.debouncedOnChange(value);
   };
 
   render() {

--- a/apps/src/tutorialExplorer/tutorialExplorer.js
+++ b/apps/src/tutorialExplorer/tutorialExplorer.js
@@ -10,6 +10,7 @@ import FilterHeader from './filterHeader';
 import FilterSet from './filterSet';
 import TutorialSet from './tutorialSet';
 import ToggleAllTutorialsButton from './toggleAllTutorialsButton';
+import Search from './Search';
 import {
   isTutorialSortByFieldNamePopularity,
   TutorialsSortByOptions,
@@ -63,7 +64,13 @@ export default class TutorialExplorer extends React.Component {
 
     const sortBy = props.defaultSortBy;
     const orgName = TutorialsOrgName.all;
-    const filteredTutorials = this.filterTutorialSet(filters, sortBy, orgName);
+    const defaultSearchTerm = '';
+    const filteredTutorials = this.filterTutorialSet(
+      filters,
+      sortBy,
+      orgName,
+      defaultSearchTerm
+    );
     const filteredTutorialsForLocale = this.filterTutorialSetForLocale();
     const showingAllTutorials = this.isLocaleEnglish();
 
@@ -78,9 +85,27 @@ export default class TutorialExplorer extends React.Component {
       showingModalFilters: false,
       sortBy: sortBy,
       orgName: orgName,
-      showingAllTutorials: showingAllTutorials
+      showingAllTutorials: showingAllTutorials,
+      searchTerm: defaultSearchTerm
     };
   }
+
+  handleSearchTerm = searchTerm => {
+    const filteredTutorials = this.filterTutorialSet(
+      this.state.filters,
+      this.state.sortBy,
+      this.state.orgName,
+      searchTerm
+    );
+
+    this.setState({
+      searchTerm,
+      filteredTutorials,
+      filteredTutorialsCount: filteredTutorials.length
+    });
+
+    this.scrollToTop();
+  };
 
   /**
    * Called when a filter in a filter group has its checkbox
@@ -118,7 +143,8 @@ export default class TutorialExplorer extends React.Component {
     const filteredTutorials = this.filterTutorialSet(
       newState.filters,
       this.state.sortBy,
-      this.state.orgName
+      this.state.orgName,
+      this.state.searchTerm
     );
 
     this.setState({
@@ -137,7 +163,8 @@ export default class TutorialExplorer extends React.Component {
     const filteredTutorials = this.filterTutorialSet(
       this.state.filters,
       value,
-      this.state.orgName
+      this.state.orgName,
+      this.state.searchTerm
     );
     this.setState({
       filteredTutorials,
@@ -155,7 +182,8 @@ export default class TutorialExplorer extends React.Component {
     const filteredTutorials = this.filterTutorialSet(
       this.state.filters,
       this.state.sortBy,
-      value
+      value,
+      this.state.searchTerm
     );
     this.setState({
       filteredTutorials,
@@ -227,15 +255,15 @@ export default class TutorialExplorer extends React.Component {
    *
    * Whether en or non-en user, this filters as though the user is of "en-US" locale.
    */
-  filterTutorialSet(filters, sortBy, orgName) {
+  filterTutorialSet(filters, sortBy, orgName, searchTerm) {
     const grade = filters.grade[0];
-
     const filterProps = {
       filters: filters,
       hideFilters: this.props.hideFilters,
       locale: 'en-US',
       orgName: orgName,
-      sortByFieldName: this.getSortByFieldName(sortBy, grade)
+      sortByFieldName: this.getSortByFieldName(sortBy, grade),
+      searchTerm: searchTerm
     };
 
     return TutorialExplorer.filterTutorials(this.props.tutorials, filterProps);
@@ -382,7 +410,8 @@ export default class TutorialExplorer extends React.Component {
       orgName,
       filters,
       hideFilters,
-      sortByFieldName
+      sortByFieldName,
+      searchTerm
     } = filterProps;
 
     const filteredTutorials = tutorials
@@ -420,6 +449,14 @@ export default class TutorialExplorer extends React.Component {
           orgName !== TutorialsOrgName.all &&
           tutorial.orgname !== orgName &&
           !(orgName === orgNameCodeOrg && tutorial.orgname === orgNameMinecraft)
+        ) {
+          return false;
+        }
+
+        if (
+          searchTerm !== '' &&
+          (!tutorial.name.toLowerCase().includes(searchTerm) ||
+            !tutorial.longdescription.toLowerCase().includes(searchTerm))
         ) {
           return false;
         }
@@ -587,6 +624,7 @@ export default class TutorialExplorer extends React.Component {
                     width: getResponsiveValue({xs: 100, md: 20})
                   }}
                 >
+                  <Search onChange={this.handleSearchTerm} />
                   <FilterSet
                     mobileLayout={this.state.mobileLayout}
                     uniqueOrgNames={this.getUniqueOrgNames()}

--- a/apps/src/tutorialExplorer/tutorialExplorer.js
+++ b/apps/src/tutorialExplorer/tutorialExplorer.js
@@ -10,7 +10,7 @@ import FilterHeader from './filterHeader';
 import FilterSet from './filterSet';
 import TutorialSet from './tutorialSet';
 import ToggleAllTutorialsButton from './toggleAllTutorialsButton';
-import Search from './Search';
+import Search from './search';
 import {
   isTutorialSortByFieldNamePopularity,
   TutorialsSortByOptions,
@@ -414,6 +414,8 @@ export default class TutorialExplorer extends React.Component {
       searchTerm
     } = filterProps;
 
+    const cleanSearchTerm = searchTerm?.toLowerCase()?.trim();
+
     const filteredTutorials = tutorials
       .filter(tutorial => {
         // Check that the tutorial isn't marked as DoNotShow.  If it does,
@@ -454,9 +456,11 @@ export default class TutorialExplorer extends React.Component {
         }
 
         if (
-          searchTerm !== '' &&
-          (!tutorial.name.toLowerCase().includes(searchTerm) ||
-            !tutorial.longdescription.toLowerCase().includes(searchTerm))
+          searchTerm &&
+          !(
+            tutorial.name.toLowerCase().includes(cleanSearchTerm) ||
+            tutorial.longdescription.toLowerCase().includes(cleanSearchTerm)
+          )
         ) {
           return false;
         }

--- a/apps/src/tutorialExplorer/tutorialExplorer.js
+++ b/apps/src/tutorialExplorer/tutorialExplorer.js
@@ -459,7 +459,7 @@ export default class TutorialExplorer extends React.Component {
           searchTerm &&
           !(
             tutorial.name.toLowerCase().includes(cleanSearchTerm) ||
-            tutorial.longdescription.toLowerCase().includes(cleanSearchTerm)
+            tutorial.longdescription?.toLowerCase().includes(cleanSearchTerm)
           )
         ) {
           return false;

--- a/apps/src/tutorialExplorer/tutorialExplorer.js
+++ b/apps/src/tutorialExplorer/tutorialExplorer.js
@@ -628,7 +628,10 @@ export default class TutorialExplorer extends React.Component {
                     width: getResponsiveValue({xs: 100, md: 20})
                   }}
                 >
-                  <Search onChange={this.handleSearchTerm} />
+                  <Search
+                    onChange={this.handleSearchTerm}
+                    showClearIcon={this.state.searchTerm !== ''}
+                  />
                   <FilterSet
                     mobileLayout={this.state.mobileLayout}
                     uniqueOrgNames={this.getUniqueOrgNames()}

--- a/apps/src/tutorialExplorer/tutorialExplorer.js
+++ b/apps/src/tutorialExplorer/tutorialExplorer.js
@@ -103,8 +103,6 @@ export default class TutorialExplorer extends React.Component {
       filteredTutorials,
       filteredTutorialsCount: filteredTutorials.length
     });
-
-    this.scrollToTop();
   };
 
   /**

--- a/apps/test/unit/tutorialExplorer/TutorialExplorerTest.js
+++ b/apps/test/unit/tutorialExplorer/TutorialExplorerTest.js
@@ -311,4 +311,56 @@ describe('TutorialExplorer filterTutorials tests', function() {
     assert.equal(uniqueOrgNames[1], 'tech');
     assert.equal(uniqueOrgNames[2], longOrgName);
   });
+
+  it('get tutorials by search term', function() {
+    const specTutorials = [
+      {
+        name: 'specific',
+        orgname: 'tech',
+        tags: '',
+        languages_supported: 'en',
+        tags_platform: 'browser,ipad',
+        tags_subject: 'math',
+        tags_activity_type: '',
+        displayweight: 5,
+        popularityrank: 9
+      },
+      {
+        name: 'special',
+        orgname: 'tech',
+        tags: '',
+        languages_supported: 'en',
+        tags_platform: 'browser,ipad',
+        tags_subject: 'math',
+        tags_activity_type: '',
+        displayweight: 5,
+        popularityrank: 10
+      }
+    ];
+
+    const tutorialsWithSpec = tutorials.concat(specTutorials);
+
+    const props = {
+      filters: {},
+      locale: 'en-us',
+      sortBy: 'displayweight',
+      orgname: 'all',
+      sortByFieldName: 'displayweight',
+      searchTerm: 'spec'
+    };
+
+    const filtered = TutorialExplorer.filterTutorials(tutorialsWithSpec, props);
+    assert.equal(filtered.length, 2);
+    assert.equal(filtered[0].name, 'specific');
+    assert.equal(filtered[1].name, 'special');
+
+    props.searchTerm = 'specific';
+
+    const filtered2 = TutorialExplorer.filterTutorials(
+      tutorialsWithSpec,
+      props
+    );
+    assert.equal(filtered2.length, 1);
+    assert.equal(filtered2[0].name, 'specific');
+  });
 });

--- a/apps/test/unit/tutorialExplorer/TutorialExplorerTest.js
+++ b/apps/test/unit/tutorialExplorer/TutorialExplorerTest.js
@@ -362,5 +362,13 @@ describe('TutorialExplorer filterTutorials tests', function() {
     );
     assert.equal(filtered2.length, 1);
     assert.equal(filtered2[0].name, 'specific');
+
+    props.searchTerm = 'dinosaur';
+
+    const filtered3 = TutorialExplorer.filterTutorials(
+      tutorialsWithSpec,
+      props
+    );
+    assert.equal(filtered3.length, 0);
   });
 });

--- a/apps/test/unit/tutorialExplorer/TutorialExplorerTest.js
+++ b/apps/test/unit/tutorialExplorer/TutorialExplorerTest.js
@@ -110,6 +110,31 @@ describe('TutorialExplorer filterTutorials tests', function() {
       popularityrank: 9
     }
   ];
+  const specTutorials = [
+    {
+      name: 'specific',
+      orgname: 'tech',
+      tags: '',
+      languages_supported: 'en',
+      tags_platform: 'browser,ipad',
+      tags_subject: 'art',
+      tags_activity_type: '',
+      displayweight: 5,
+      popularityrank: 9
+    },
+    {
+      name: 'special',
+      orgname: 'code',
+      tags: '',
+      languages_supported: 'en',
+      tags_platform: 'browser,ipad',
+      tags_subject: 'math',
+      tags_activity_type: '',
+      displayweight: 5,
+      popularityrank: 10
+    }
+  ];
+  const tutorialsWithSpec = tutorials.concat(specTutorials);
 
   it('no filter, but do-not-show works', function() {
     const props = {
@@ -313,33 +338,6 @@ describe('TutorialExplorer filterTutorials tests', function() {
   });
 
   it('get tutorials by search term', function() {
-    const specTutorials = [
-      {
-        name: 'specific',
-        orgname: 'tech',
-        tags: '',
-        languages_supported: 'en',
-        tags_platform: 'browser,ipad',
-        tags_subject: 'math',
-        tags_activity_type: '',
-        displayweight: 5,
-        popularityrank: 9
-      },
-      {
-        name: 'special',
-        orgname: 'tech',
-        tags: '',
-        languages_supported: 'en',
-        tags_platform: 'browser,ipad',
-        tags_subject: 'math',
-        tags_activity_type: '',
-        displayweight: 5,
-        popularityrank: 10
-      }
-    ];
-
-    const tutorialsWithSpec = tutorials.concat(specTutorials);
-
     const props = {
       filters: {},
       locale: 'en-us',
@@ -370,5 +368,30 @@ describe('TutorialExplorer filterTutorials tests', function() {
       props
     );
     assert.equal(filtered3.length, 0);
+  });
+
+  it('get tutorials by search term and subject filter', function() {
+    const props = {
+      filters: {
+        subject: ['math']
+      },
+      locale: 'en-us',
+      sortBy: 'displayweight',
+      orgname: 'code',
+      sortByFieldName: 'displayweight',
+      searchTerm: 'spec'
+    };
+
+    const filtered = TutorialExplorer.filterTutorials(tutorialsWithSpec, props);
+    assert.equal(filtered.length, 1);
+    assert.equal(filtered[0].name, 'special');
+
+    props.searchTerm = 'specific';
+
+    const filtered2 = TutorialExplorer.filterTutorials(
+      tutorialsWithSpec,
+      props
+    );
+    assert.equal(filtered2.length, 0);
   });
 });


### PR DESCRIPTION
[LP-2043](https://codedotorg.atlassian.net/browse/LP-2043)

hourofcode.org/learn and code.org/learn display a "Tutorial Explorer" that shows the available Hour of Code tutorials. The data for the Tutorial Explorer is backed by a Google sheet. Users can currently filter by a variety of criteria such as curricular topics, creator, length and grade level. The displayed tutorials can be sorted by popularity and recommendation, and we prioritize tutorials translated in the user's language if known. 

However, it remains tricky to find a particular tutorial if, for example, you're looking for a tutorial featuring a specific character.  This PR includes a potential lightweight implementation of search for HOC tutorials by adding a search input box to the filter options and using the entered search term to match against tutorial names and long descriptions on the client. 
 
https://user-images.githubusercontent.com/12300669/133290618-c5e64c95-e004-4113-ac62-143517084831.mov

 Considerations: 

- Terms need to be exact text matches (i.e. “Christmas” as a search term would not return the Grinch tutorial because “Christmas” is not in the name or descriptive text of the tutorial). We could mitigate this with an additional metadata or key term column in the Gsheet; however that could be cumbersome to maintain and would be impossible to anticipate every user's potential search terms. 

- The loosest filters return ~660 tutorials. Searching for keywords could become prohibitively non-performant over time with more tutorials and more data to search for each. Additionally, we're searching on each keystroke in this implementation rather than when a full word is entered which could be excessive. 

- Search is hard to test.  I spot checked a handful of terms and the tutorials I'd expect them to return but finding and fixing bugs (times when a search term should definitely match a tutorial, but doesn't, for example) will be tricky. 

- I haven't tested how this fares in non-English yet. If it seems like a viable option to meet product requirements in review, I'll give that a try. 