### PR TITLE
Increase test coverage for pilot assignments 

### DIFF
--- a/dashboard/test/controllers/api/v1/sections_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/sections_controller_test.rb
@@ -510,6 +510,20 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
     assert_nil returned_section.unit_group
   end
 
+  test 'pilot teacher can assign pilot script' do
+    pilot_teacher = create :teacher, pilot_experiment: 'my-experiment'
+    pilot_script = create :script, pilot_experiment: 'my-experiment', published_state: SharedConstants::PUBLISHED_STATE.pilot
+    sign_in pilot_teacher
+    post :create, params: {
+      login_type: Section::LOGIN_TYPE_EMAIL,
+      script: {id: pilot_script.id}
+    }
+    assert_response :success
+
+    assert_equal pilot_script.id, returned_json['script']['id']
+    assert_equal pilot_script, returned_section.script
+  end
+
   test 'non pilot teacher cannot assign a pilot script' do
     pilot_script = create :script, pilot_experiment: 'my-experiment', published_state: SharedConstants::PUBLISHED_STATE.pilot
     sign_in @teacher

--- a/dashboard/test/controllers/api/v1/sections_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/sections_controller_test.rb
@@ -510,6 +510,20 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
     assert_nil returned_section.unit_group
   end
 
+  test 'non pilot teacher cannot assign a pilot script' do
+    pilot_script = create :script, pilot_experiment: 'my-experiment', published_state: SharedConstants::PUBLISHED_STATE.pilot
+    sign_in @teacher
+    post :create, params: {
+      login_type: Section::LOGIN_TYPE_EMAIL,
+      script: {id: pilot_script.id}
+    }
+    assert_response :success
+    # TODO: Better to fail here?
+
+    assert_nil returned_json['script']['id']
+    assert_nil returned_section.script
+  end
+
   test 'can create with a script id but no course id' do
     sign_in @teacher
     post :create, params: {


### PR DESCRIPTION
[LP-2044](https://codedotorg.atlassian.net/browse/LP-2044)

In #42401 a bug was fixed wherein pilot courses could not be assigned to pilot teachers because we weren't passing the `current_user` into the check for course validity. It was suspected that there was a similar issue with script assignment.

I added two test cases 1.) non pilot teachers can not assign pilot scripts and 2.) pilot teachers can assign pilot scripts to verify that pilot script assignment _is_ working as expected. When a script is assigned we already do pass in the current_user: 

        script_id: script_to_assign ? script_to_assign.id : params[:script_id],

and `script_to_assign` is set like this: 

    script_to_assign = valid_script && Script.get_from_cache(params[:script][:id])

where `valid_script` checks if the script is assignable to the current user

    valid_script = params[:script] && Script.valid_unit_id?(current_user, params[:script][:id])