### PR TITLE
[Spritelab][Validation] Set name property on background images

### DIFF
--- a/apps/src/p5lab/spritelab/commands/worldCommands.js
+++ b/apps/src/p5lab/spritelab/commands/worldCommands.js
@@ -65,12 +65,13 @@ export const commands = {
     }
   },
 
-  setBackgroundImageAs(img) {
+  setBackgroundImageAs(imageName) {
     if (
       this.p5._predefinedSpriteAnimations &&
-      this.p5._predefinedSpriteAnimations[img]
+      this.p5._predefinedSpriteAnimations[imageName]
     ) {
-      let backgroundImage = this.p5._predefinedSpriteAnimations[img];
+      let backgroundImage = this.p5._predefinedSpriteAnimations[imageName];
+      backgroundImage.name = imageName;
       this.setBackground(backgroundImage);
     }
   },

--- a/apps/src/p5lab/spritelab/commands/worldCommands.js
+++ b/apps/src/p5lab/spritelab/commands/worldCommands.js
@@ -58,9 +58,13 @@ export const commands = {
   },
 
   // Deprecated. The new background block is setBackgroundImageAs
-  setBackgroundImage(img) {
-    if (this.p5._preloadedBackgrounds && this.p5._preloadedBackgrounds[img]) {
-      let backgroundImage = this.p5._preloadedBackgrounds[img];
+  setBackgroundImage(imageName) {
+    if (
+      this.p5._preloadedBackgrounds &&
+      this.p5._preloadedBackgrounds[imageName]
+    ) {
+      let backgroundImage = this.p5._preloadedBackgrounds[imageName];
+      backgroundImage.name = imageName;
       this.setBackground(backgroundImage);
     }
   },


### PR DESCRIPTION
The validation command for checking whether a student had a background image was always returning `undefined`, and it turned out it was because the background object did not have a name property.  https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/p5lab/spritelab/commands/validationCommands.js#L6

The solution is just to add a `name` property to the `p5.Image` object, so that `validationCommands.getBackground` works as expected.