### PR TITLE
Add a comment explaining channel token query fallback

### DIFF
--- a/dashboard/app/models/channel_token.rb
+++ b/dashboard/app/models/channel_token.rb
@@ -60,6 +60,14 @@ class ChannelToken < ApplicationRecord
 
   # Finds the channel token. If a channel token exists for the user and level with and without a script ID,
   # the channel token with the script_id takes precedence.
+  #
+  # Background: The Channel Tokens table did not always have a script_id column. Originally, a channel token for a level
+  # was identified by the level_id. Since we use the same level in different scripts, we needed to include
+  # script_id to identify the correct channel token for a level (https://codedotorg.atlassian.net/browse/LP-1395). As part of
+  # this work, we had to backfill the channel tokens table with the proper script_id. For some channel tokens it was not
+  # possible to identify which script they were associated with. For these channel tokens the script_id was left empty, which
+  # is why we need to query for a channel token with script_id and fallback on one without script_id.
+  #
   # @param [Level] level The level associated with the channel token request.
   # @param [String] user_storage_id The ID of the storage app associated with the channel token request.
   # @param [Integer] script_id The ID of the script associated with the channel token.


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
When we query for channel tokens, we query by script_id and missing script_id because our backfill for script_id will not be able to identify a script_id for every channel token. In this PR I leave a comment explaining the intent and background for this logic.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
- jira ticket: [LP-1843](https://codedotorg.atlassian.net/browse/LP-1843)
<!--
- spec: []()

-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
