### PR TITLE
[Google Blockly] Bump to 6.20210701.0

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -238,7 +238,7 @@
     "@codemirror/view": "^0.18.0",
     "@microsoft/immersive-reader-sdk": "^1.1.0",
     "ace-builds": "^1.4.12",
-    "blockly": "5.20210325.1",
+    "blockly": "6.20210701.0",
     "crypto-js": "^3.1.9-1",
     "details-element-polyfill": "https://github.com/javan/details-element-polyfill",
     "filesaver.js": "0.2.0",

--- a/apps/src/blockly/addons/cdoBlockDragger.js
+++ b/apps/src/blockly/addons/cdoBlockDragger.js
@@ -4,8 +4,8 @@ export default class BlockDragger extends GoogleBlockly.BlockDragger {
   /** Show trashcan over toolbox while dragging
    * @override
    */
-  dragBlock(e, currentDragDeltaXY) {
-    super.dragBlock(e, currentDragDeltaXY);
+  drag(e, currentDragDeltaXY) {
+    super.drag(e, currentDragDeltaXY);
     const isDraggingFromFlyout_ = !!Blockly.mainBlockSpace.currentGesture_
       .flyout_;
 
@@ -26,7 +26,7 @@ export default class BlockDragger extends GoogleBlockly.BlockDragger {
    * so negative block coordinates are valid, but we want to keep everything flowing down and to the right from (0,0).
    * @override
    */
-  endBlockDrag(e, currentDragDeltaXY) {
+  endDrag(e, currentDragDeltaXY) {
     // Don't let the block end with a negative position, unless it's getting deleted.
     if (!this.draggedConnectionManager_.wouldDeleteBlock()) {
       const endPosition = this.draggingBlock_.getRelativeToSurfaceXY();
@@ -38,8 +38,9 @@ export default class BlockDragger extends GoogleBlockly.BlockDragger {
       }
     }
 
-    super.endBlockDrag(e, currentDragDeltaXY);
+    super.endDrag(e, currentDragDeltaXY);
     this.workspace_.trashcan.setDisabled(false);
+    this.workspace_.trashcan.setLidOpen(false);
     this.workspace_.hideTrashcan();
   }
 
@@ -50,6 +51,8 @@ export default class BlockDragger extends GoogleBlockly.BlockDragger {
     super.updateCursorDuringBlockDrag_();
     if (this.draggedConnectionManager_.wouldDeleteBlock()) {
       this.workspace_.trashcan.setLidOpen(true);
+    } else {
+      this.workspace_.trashcan.setLidOpen(false);
     }
   }
 }

--- a/apps/src/blockly/addons/cdoBlockDragger.js
+++ b/apps/src/blockly/addons/cdoBlockDragger.js
@@ -49,10 +49,7 @@ export default class BlockDragger extends GoogleBlockly.BlockDragger {
    */
   updateCursorDuringBlockDrag_() {
     super.updateCursorDuringBlockDrag_();
-    if (this.draggedConnectionManager_.wouldDeleteBlock()) {
-      this.workspace_.trashcan.setLidOpen(true);
-    } else {
-      this.workspace_.trashcan.setLidOpen(false);
-    }
+    const wouldDeleteBlock = this.draggedConnectionManager_.wouldDeleteBlock();
+    this.workspace_.trashcan.setLidOpen(wouldDeleteBlock);
   }
 }

--- a/apps/src/blockly/addons/cdoTrashcan.js
+++ b/apps/src/blockly/addons/cdoTrashcan.js
@@ -54,7 +54,7 @@ export default class CdoTrashcan extends GoogleBlockly.Trashcan {
    */
   position() {
     // Not yet initialized.
-    if (!this.verticalSpacing_) {
+    if (!this.initialized_) {
       return;
     }
     var metrics = this.workspace_.getMetrics();
@@ -64,7 +64,7 @@ export default class CdoTrashcan extends GoogleBlockly.Trashcan {
     }
 
     this.left_ = Math.round(metrics.flyoutWidth / 2 - this.WIDTH_ / 2);
-    this.top_ = this.verticalSpacing_;
+    this.top_ = this.MARGIN_VERTICAL_ * 2;
 
     this.svgGroup_.setAttribute(
       'transform',

--- a/apps/src/blockly/addons/cdoWorkspaceSvg.js
+++ b/apps/src/blockly/addons/cdoWorkspaceSvg.js
@@ -27,13 +27,6 @@ export default class WorkspaceSvg extends GoogleBlockly.WorkspaceSvg {
     this.trashcan = new Blockly.Trashcan(this);
     var svgTrashcan = this.trashcan.createDom();
     this.flyout_.svgGroup_.appendChild(svgTrashcan);
-    this.pluginManager_.addPlugin({
-      id: 'trashcan',
-      plugin: this.trashcan,
-      weight: 1,
-      types: [Blockly.PluginManager.Type.POSITIONABLE]
-    });
-
     this.hideTrashcan();
   }
   addUnusedBlocksHelpListener(helpClickFunc) {

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -123,7 +123,6 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.wrapReadOnlyProperty('Msg');
   blocklyWrapper.wrapReadOnlyProperty('Names');
   blocklyWrapper.wrapReadOnlyProperty('netsim_locale');
-  blocklyWrapper.wrapReadOnlyProperty('PluginManager');
   blocklyWrapper.wrapReadOnlyProperty('Procedures');
   blocklyWrapper.wrapReadOnlyProperty('registry');
   blocklyWrapper.wrapReadOnlyProperty('removeChangeListener');
@@ -161,6 +160,13 @@ function initializeBlocklyWrapper(blocklyInstance) {
     blocklyWrapper.blockly_.registry.Type.METRICS_MANAGER,
     blocklyWrapper.blockly_.registry.DEFAULT,
     CdoMetricsManager,
+    true /* opt_allowOverrides */
+  );
+
+  blocklyWrapper.blockly_.registry.register(
+    blocklyWrapper.blockly_.registry.Type.BLOCK_DRAGGER,
+    blocklyWrapper.blockly_.registry.DEFAULT,
+    CdoBlockDragger,
     true /* opt_allowOverrides */
   );
 

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -3701,10 +3701,10 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
-blockly@5.20210325.1:
-  version "5.20210325.1"
-  resolved "https://registry.yarnpkg.com/blockly/-/blockly-5.20210325.1.tgz#c0a73174318dc61f4de116548ace2b2970dd4a58"
-  integrity sha512-qrilYPovJeDfxKDWm1YBUCPVNElh/iyC1szaHTIPZHj9C9YPpSzZOeFyyrPBbYRudzbo8kjBOWMtHnN1bLjkoQ==
+blockly@6.20210701.0:
+  version "6.20210701.0"
+  resolved "https://registry.yarnpkg.com/blockly/-/blockly-6.20210701.0.tgz#578dbdc59a61339a6ba29a69d0dc7bebeb8a19d1"
+  integrity sha512-cNrwFOAxXE5Pbs1FJAyLTlSRzpNW/C+0gPT2rGQDOJVVKcyF3vhFC1StgnxvQNsv//ueuksKWIXxDuSWh1VI4w==
   dependencies:
     jsdom "15.2.1"
 


### PR DESCRIPTION
Release: https://github.com/google/blockly/releases/tag/6.20210701.0

This bump went pretty smoothly, there were just a couple tweaks needed for the trashcan:
- some methods got renamed in `BlockDragger`
- Use `registry.register` for our `BlockDragger` override
- `verticalSpacing_` instance variable was removed from `Trashcan`, so we need to use `initialized_` instead

I tested several Flappy levels on Mac / Chrome + Safari + Firefox, but it'd be great if people could test other OS/Browser combos if possible