### PR TITLE
Fix Rubocop linting errors that were missed

### DIFF
--- a/dashboard/app/controllers/teacher_feedbacks_controller.rb
+++ b/dashboard/app/controllers/teacher_feedbacks_controller.rb
@@ -23,13 +23,13 @@ class TeacherFeedbacksController < ApplicationController
     @feedbacks_by_level = []
 
     feedbacks_grouped_by_level = @feedbacks_as_student.group_by {|feedback| "#{feedback.script_id}_#{feedback.level_id}"}
-    
+
     feedbacks_grouped_by_level.each do |_, feedbacks|
       level_details = feedbacks[0].get_script_level&.summary_for_feedback
 
       summarized_feedbacks = feedbacks.each_with_index.map do |feedback, i|
-        isLatest = i == 0
-        feedback.summarize(isLatest)
+        is_latest = i == 0
+        feedback.summarize(is_latest)
       end
 
       level_feedbacks = level_details.merge({feedbacks: summarized_feedbacks})


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
I accidentally committed changes to staging in feedbacks_controller that violated Rubocop linting, this fixes the issue.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
