### PR TITLE
Use code studio lesson plans

### DIFF
--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -78,6 +78,7 @@ class UnitEditor extends React.Component {
     isMigrated: PropTypes.bool,
     initialIncludeStudentLessonPlans: PropTypes.bool,
     initialCourseVersionId: PropTypes.number,
+    initialUseCodeStudioLessonPlans: PropTypes.bool,
     preventCourseVersionChange: PropTypes.bool,
     scriptPath: PropTypes.string.isRequired,
 
@@ -147,6 +148,7 @@ class UnitEditor extends React.Component {
       hasImportedLessonDescriptions: false,
       oldScriptText: this.props.initialLessonLevelData,
       includeStudentLessonPlans: this.props.initialIncludeStudentLessonPlans,
+      useCodeStudioLessonPlans: this.props.initialUseCodeStudioLessonPlans,
       deprecated: this.props.initialDeprecated,
       publishedState: this.props.initialPublishedState
     };
@@ -301,6 +303,7 @@ class UnitEditor extends React.Component {
       ),
       is_migrated: this.props.isMigrated,
       include_student_lesson_plans: this.state.includeStudentLessonPlans,
+      use_code_studio_lesson_plans: this.state.useCodeStudioLessonPlans,
       is_maker_unit: this.state.isMakerUnit
     };
 
@@ -678,9 +681,51 @@ class UnitEditor extends React.Component {
         </CollapsibleEditorSection>
 
         <CollapsibleEditorSection title="Lesson Settings">
-          {!this.props.isMigrated && (
+          <label>
+            Use Code Studio Lesson Plans
+            <input
+              type="checkbox"
+              checked={
+                this.props.isMigrated && this.state.useCodeStudioLessonPlans
+              }
+              style={styles.checkbox}
+              onChange={() =>
+                this.setState({
+                  useCodeStudioLessonPlans: !this.state.useCodeStudioLessonPlans
+                })
+              }
+              disabled={!this.props.isMigrated}
+            />
+            <HelpTip>
+              {!this.props.isMigrated && (
+                <p>this option is only available for migrated scripts.</p>
+              )}
+              {this.props.isMigrated && (
+                <p>
+                  Whether to show our users the code-studio-based lesson plans
+                  for this unit, as opposed to showing them the lesson plans on
+                  curriculum builder. When a script is first migrated, this box
+                  is left unchecked. Once you're satisfied with the contents of
+                  the new lesson plans on levelbuilder, check this box to make
+                  the code studio lesson plans visible to our teachers and
+                  students.
+                </p>
+              )}
+            </HelpTip>
+          </label>
+          {!(this.props.isMigrated && this.state.useCodeStudioLessonPlans) && (
             <label>
               Curriculum Path
+              <HelpTip>
+                <p>
+                  When "Use Code Studio Lesson Plans" is unchecked, this field
+                  determines the location of the lesson plan. If left blank, it
+                  will look for special file under
+                  code.org/curriculum/[unit]/[lesson]. If you want to disable
+                  lesson plans entirely, you must go to each lesson edit page
+                  and uncheck "Has Lesson Plan".
+                </p>
+              </HelpTip>
               <input
                 value={this.state.curriculumPath}
                 style={styles.input}

--- a/apps/src/sites/studio/pages/scripts/edit.js
+++ b/apps/src/sites/studio/pages/scripts/edit.js
@@ -104,6 +104,9 @@ export default function initPage(unitEditorData) {
         initialIncludeStudentLessonPlans={
           scriptData.includeStudentLessonPlans || false
         }
+        initialUseCodeStudioLessonPlans={
+          scriptData.useCodeStudioLessonPlans || false
+        }
         scriptPath={scriptData.scriptPath}
       />
     </Provider>,

--- a/apps/test/unit/lib/levelbuilder/script-editor/UnitEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/UnitEditorTest.jsx
@@ -111,8 +111,8 @@ describe('UnitEditor', () => {
     it('uses old unit editor for non migrated unit', () => {
       const wrapper = createWrapper({});
 
-      expect(wrapper.find('input').length).to.equal(22);
-      expect(wrapper.find('input[type="checkbox"]').length).to.equal(11);
+      expect(wrapper.find('input').length).to.equal(23);
+      expect(wrapper.find('input[type="checkbox"]').length).to.equal(12);
       expect(wrapper.find('textarea').length).to.equal(3);
       expect(wrapper.find('select').length).to.equal(4);
       expect(wrapper.find('CollapsibleEditorSection').length).to.equal(8);
@@ -128,8 +128,8 @@ describe('UnitEditor', () => {
         initialCourseVersionId: 1
       });
 
-      expect(wrapper.find('input').length).to.equal(26);
-      expect(wrapper.find('input[type="checkbox"]').length).to.equal(13);
+      expect(wrapper.find('input').length).to.equal(28);
+      expect(wrapper.find('input[type="checkbox"]').length).to.equal(14);
       expect(wrapper.find('textarea').length).to.equal(4);
       expect(wrapper.find('select').length).to.equal(3);
       expect(wrapper.find('CollapsibleEditorSection').length).to.equal(9);

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -276,6 +276,7 @@ class ScriptsController < ApplicationController
       :pilot_experiment,
       :editor_experiment,
       :include_student_lesson_plans,
+      :use_code_studio_lesson_plans,
       :lesson_groups,
       resourceTypes: [],
       resourceLinks: [],

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1578,6 +1578,7 @@ class Script < ApplicationRecord
       showCalendar: is_migrated ? show_calendar : false, #prevent calendar from showing for non-migrated units for now
       weeklyInstructionalMinutes: weekly_instructional_minutes,
       includeStudentLessonPlans: is_migrated ? include_student_lesson_plans : false,
+      useCodeStudioLessonPlans: is_migrated && use_code_studio_lesson_plans,
       courseVersionId: get_course_version&.id,
       scriptOverviewPdfUrl: get_unit_overview_pdf_url,
       scriptResourcesPdfUrl: get_unit_resources_pdf_url,
@@ -1809,6 +1810,7 @@ class Script < ApplicationRecord
       :show_calendar,
       :is_migrated,
       :include_student_lesson_plans,
+      :use_code_studio_lesson_plans,
       :is_maker_unit
     ]
     not_defaulted_keys = [

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -241,6 +241,7 @@ class Script < ApplicationRecord
     is_migrated
     seeded_from
     is_maker_unit
+    use_code_studio_lesson_plans
   )
 
   def self.twenty_hour_unit


### PR DESCRIPTION
starts https://codedotorg.atlassian.net/browse/PLAT-856 . the first step is to add a flag which when unchecked indicates that, although the unit is migrated, it should still use lesson plans on CB. The HelpTip text in the PR diff also adds a bit of detail about what's going on.

## screenshots

### unmigrated unit, checkbox disabled
![Screen Shot 2021-09-15 at 3 33 54 PM](https://user-images.githubusercontent.com/8001765/133520797-d2d34c44-8d63-46b1-9c07-4812cf3f371b.png)

### migrated unit, unchecked

![Screen Shot 2021-09-15 at 3 34 21 PM](https://user-images.githubusercontent.com/8001765/133521104-6e90b768-ffe7-48d8-ba02-37ce48ce2852.png)

### migrated unit, checked

![Screen Shot 2021-09-15 at 3 34 40 PM](https://user-images.githubusercontent.com/8001765/133521175-888313e7-b563-48d9-a48d-e32b9f0f8ec1.png)

## Testing story

manually verified that the setting persists after checking/unchecking, saving, and reloading the unit edit page. also verified the setting appears in the script_json.

## Deployment strategy

once this change reaches levelbuilder, I'll use the rails console on the levelbuilder machine to set this flag for all units which are currently migrated: 
```
Script.all.select(&:is_migrated).each do |u| 
  u.update!(use_code_studio_lesson_plans: true)
  u.write_script_json
end
```
that'll get us into a state where we can safely start to show code studio lesson plans only when use_code_studio_lesson_plans is true.