### PR TITLE
Hide dpad for Shared Sprite Lab projects in mobile [test all browsers]

### DIFF
--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -220,6 +220,9 @@ P5Lab.prototype.init = function(config) {
     this.skin.winAvatar = mediaUrl;
     this.skin.failureAvatar = mediaUrl;
 
+    // SpriteLab projects don't allow users to include dpad controls
+    defaultMobileControlsConfig.dpadVisible = false;
+
     injectErrorHandler(
       new BlocklyModeErrorHandler(() => this.JSInterpreter, null)
     );

--- a/dashboard/test/ui/features/star_labs/share_buttons.feature
+++ b/dashboard/test/ui/features/star_labs/share_buttons.feature
@@ -27,7 +27,7 @@ Feature: Share Buttons
     And I wait until element "#gameButtons" is visible
     And element "#studio-dpad-rim" is not displayed
   
-  Scenario: Dpad appears for Sprite Lab Share
+  Scenario: Dpad appears for Game Lab Share
     Given I am on "http://studio.code.org/projects/gamelab/"
     And I wait for the page to fully load
     When I navigate to the shared version of my project

--- a/dashboard/test/ui/features/star_labs/share_buttons.feature
+++ b/dashboard/test/ui/features/star_labs/share_buttons.feature
@@ -17,3 +17,19 @@ Feature: Share Buttons
     When I navigate to the shared version of my project
     And I wait until element "#gameButtons" is visible
     And element "#open-workspace" does not exist
+
+  # Making DPad button show up in Game Lab and not in Sprite Lab
+
+  Scenario: Dpad does not appear for Sprite Lab Share
+    Given I am on "http://studio.code.org/projects/spritelab/"
+    And I wait for the page to fully load
+    When I navigate to the shared version of my project
+    And I wait until element "#gameButtons" is visible
+    And element "#studio-dpad-rim" is not displayed
+  
+  Scenario: Dpad appears for Sprite Lab Share
+    Given I am on "http://studio.code.org/projects/gamelab/"
+    And I wait for the page to fully load
+    When I navigate to the shared version of my project
+    And I wait until element "#gameButtons" is visible
+    And element "#studio-dpad-rim" is displayed

--- a/dashboard/test/ui/features/star_labs/share_buttons.feature
+++ b/dashboard/test/ui/features/star_labs/share_buttons.feature
@@ -18,15 +18,17 @@ Feature: Share Buttons
     And I wait until element "#gameButtons" is visible
     And element "#open-workspace" does not exist
 
-  # Making DPad button show up in Game Lab and not in Sprite Lab
+  # Making DPad button show up in Game Lab and not in Sprite Lab for mobile
 
+  @no_ie @no_safari @no_firefox @no_chrome
   Scenario: Dpad does not appear for Sprite Lab Share
     Given I am on "http://studio.code.org/projects/spritelab/"
     And I wait for the page to fully load
     When I navigate to the shared version of my project
     And I wait until element "#gameButtons" is visible
     And element "#studio-dpad-rim" is not displayed
-  
+
+  @no_ie @no_safari @no_firefox @no_chrome
   Scenario: Dpad appears for Game Lab Share
     Given I am on "http://studio.code.org/projects/gamelab/"
     And I wait for the page to fully load


### PR DESCRIPTION
SpriteLab projects in share mode were showing a dpad (inherited from GameLabs). Since SpriteLabs don't utilize dpads (arrow keys only) this change is to hide it by default. 

## Links
- jira ticket: [STAR-1574](https://codedotorg.atlassian.net/browse/STAR-1574)

## Testing story
UI test added

## PR Checklist:


- [x] Tests provide adequate coverage
- [x] Code is well-commented
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
