### PR TITLE
Allow students to view each other's work for peer review on bubble choice levels

### DIFF
--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -400,11 +400,18 @@ class ScriptLevelsController < ApplicationController
       return
     end
 
+    sublevel_to_view = nil
+    if @script_level.bubble_choice? && params[:sublevel_position]
+      sublevel_to_view = @script_level.level.sublevel_at(params[:sublevel_position].to_i - 1)
+    end
+
     user_to_view = User.find(params[:user_id])
-    if can?(:view_as_user, @script_level, user_to_view)
+    # Should we just separate these into two if statements
+    # so we don't have to do the view_as_user_for_code_review cancan check twice?
+    if can?(:view_as_user, @script_level, user_to_view, sublevel_to_view)
       @user = user_to_view
 
-      if can?(:view_as_user_for_code_review, @script_level, user_to_view)
+      if can?(:view_as_user_for_code_review, @script_level, user_to_view, sublevel_to_view)
         view_options(is_code_reviewing: true)
       end
     end
@@ -424,6 +431,7 @@ class ScriptLevelsController < ApplicationController
   end
 
   def select_level
+    # Should we put this into a helper?
     # If a BubbleChoice level's sublevel has been requested, return it.
     if @script_level.bubble_choice? && params[:sublevel_position]
       sublevel = @script_level.level.sublevel_at(params[:sublevel_position].to_i - 1)

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -400,14 +400,12 @@ class ScriptLevelsController < ApplicationController
       return
     end
 
-    sublevel_to_view = nil
-    if @script_level.bubble_choice? && params[:sublevel_position]
-      sublevel_to_view = @script_level.level.sublevel_at(params[:sublevel_position].to_i - 1)
-    end
+    # Grab bubble choice level that will be shown (if any),
+    # so we can check whether a student should be able to view
+    # another student's work for code review.
+    sublevel_to_view = select_bubble_choice_level
 
     user_to_view = User.find(params[:user_id])
-    # Should we just separate these into two if statements
-    # so we don't have to do the view_as_user_for_code_review cancan check twice?
     if can?(:view_as_user, @script_level, user_to_view, sublevel_to_view)
       @user = user_to_view
 
@@ -430,13 +428,15 @@ class ScriptLevelsController < ApplicationController
     end
   end
 
+  def select_bubble_choice_level
+    return unless @script_level.bubble_choice? && params[:sublevel_position]
+    @script_level.level.sublevel_at(params[:sublevel_position].to_i - 1)
+  end
+
   def select_level
-    # Should we put this into a helper?
     # If a BubbleChoice level's sublevel has been requested, return it.
-    if @script_level.bubble_choice? && params[:sublevel_position]
-      sublevel = @script_level.level.sublevel_at(params[:sublevel_position].to_i - 1)
-      return sublevel if sublevel
-    end
+    bubble_choice_level = select_bubble_choice_level
+    return bubble_choice_level if bubble_choice_level
 
     # If there's only one level in this scriptlevel, use that
     return @script_level.levels[0] if @script_level.levels.length == 1

--- a/dashboard/test/models/ability_test.rb
+++ b/dashboard/test/models/ability_test.rb
@@ -275,6 +275,26 @@ class AbilityTest < ActiveSupport::TestCase
     assert Ability.new(peer_reviewer).can? :view_as_user_for_code_review, javalab_script_level, project_owner
   end
 
+  test 'student in same CSA code review enabled section as student seeking code review can view as peer on bubble choice level' do
+    javalab_sublevel = create(:javalab)
+    bubble_choice_level = create :bubble_choice_level, sublevels: [javalab_sublevel]
+    bubble_choice_script_level = create :script_level,
+      levels: [bubble_choice_level]
+
+    project_owner = create :student
+    peer_reviewer = create :student
+    section = create :section, code_review_enabled: true
+    section.add_student project_owner
+    section.add_student peer_reviewer
+    create :reviewable_project,
+      user_id: project_owner.id,
+      script_id: bubble_choice_script_level.script_id,
+      level_id: javalab_sublevel.id
+
+    assert Ability.new(peer_reviewer).can? :view_as_user, bubble_choice_script_level, project_owner, javalab_sublevel
+    assert Ability.new(peer_reviewer).can? :view_as_user_for_code_review, bubble_choice_script_level, project_owner, javalab_sublevel
+  end
+
   test 'student in same CSA non code review enabled section as student seeking code review cannot view as peer' do
     # We enable read only access to other student work only on Javalab levels
     javalab_script_level = create :script_level,


### PR DESCRIPTION
This change enables students to view each other's work on "bubble choice" levels, such as the "Asphalt Art Project" in the first unit of CSA, when peer review is enabled:

http://studio.code.org/s/csa1-pilot/lessons/16/levels/1

## Testing story

I tested manually that, while logged in as a student, I was able to view another student's work in my section who had enabled peer review on a bubble choice level. I also confirmed I was able as a teacher leading that section to provide review on my student's work on bubble choice levels (I don't think this was ever an issue though).

I also added a unit test to cover this case.