### PR TITLE
specify lesson_groups param when creating unit

### DIFF
--- a/apps/src/lib/levelbuilder/unit-editor/NewUnitForm.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/NewUnitForm.jsx
@@ -25,6 +25,7 @@ export default function NewUnitForm() {
       </label>
       <input name="script[name]" />
       <input name="is_migrated" value={true} type="hidden" />
+      <input name="lesson_groups" value={'[]'} type="hidden" />
       <br />
       <button className="btn btn-primary" type="submit" style={buttonStyle}>
         Save Changes


### PR DESCRIPTION
Fixes a regression reported in [slack](https://codedotorg.slack.com/archives/C02EEGWLHR8/p1631814290041700), introduced in https://github.com/code-dot-org/code-dot-org/pull/42282.

## Testing story

manually verified that script creation is working again, and that the user sees the new/migrated script edit page after.

## Follow-up work

add a ui test to make sure we do not break this scenario: https://codedotorg.atlassian.net/browse/PLAT-1311