### PR TITLE
retry on OpenTimeout errors as well

### DIFF
--- a/lib/cdo/contact_rollups/v2/pardot_helpers.rb
+++ b/lib/cdo/contact_rollups/v2/pardot_helpers.rb
@@ -17,7 +17,7 @@ module PardotHelpers
   # @param retriable_errors [Array<Exception>]
   # @raise [ArgumentError] if no block given
   # @raise One of the retriable errors if they occurs more than max_tries times
-  def try_with_exponential_backoff(max_tries, retriable_errors = [Net::ReadTimeout])
+  def try_with_exponential_backoff(max_tries, retriable_errors = [Net::OpenTimeout, Net::ReadTimeout])
     raise ArgumentError.new('No block given') unless block_given?
 
     max_sleep_seconds = 10


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

This will add Net::OpenTimeout to the list of errors that get retried for pardot requests (previously only ReadTimeout was retried)

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- honeybadger: [error](https://app.honeybadger.io/projects/3240/faults/81407269/01FFP641DC3CJD8CD4KBS5RC96?page=0)
- jira ticket: [PLAT-1310](https://codedotorg.atlassian.net/browse/PLAT-1310)
