### PR TITLE
Javalab: fix save pop up behavior

### DIFF
--- a/apps/src/javalab/Javalab.js
+++ b/apps/src/javalab/Javalab.js
@@ -227,10 +227,6 @@ Javalab.prototype.init = function(config) {
   // Dispatches a redux update of isDarkMode
   getStore().dispatch(setIsDarkMode(this.isDarkMode));
 
-  // ensure autosave is executed on first run by manually setting
-  // projectChanged to true.
-  project.projectChanged();
-
   getStore().dispatch(
     setBackpackApi(new BackpackClientApi(config.backpackChannel))
   );
@@ -283,6 +279,12 @@ Javalab.prototype.beforeUnload = function(event) {
 
 // Called by the Javalab app when it wants execute student code.
 Javalab.prototype.onRun = function() {
+  if (this.studioApp_.attempts === 0) {
+    // ensure we save to S3 on the first run.
+    // Javabuilder requires code to be saved to S3.
+    project.projectChanged();
+  }
+
   this.studioApp_.attempts++;
   if (this.studioApp_.hasContainedLevels) {
     lockContainedLevelAnswers();


### PR DESCRIPTION
Previously if you loaded a javalab page, did not change anything, then navigated away within 30 seconds you would get an error that you had unsaved changes. The reason for this is we had `projectChanged` set to true on load so that the first time you ran the code it would save to S3 whether or not you made changes, since Javabuilder needs the code to be on S3. Moved this `projectChanged` call to `onRun` if this is the first attempt for the session.

## Links

- jira ticket: [CSA-708](https://codedotorg.atlassian.net/browse/CSA-708)

## Testing story
Tested locally--we still save on first run but don't get a popup if the user navigates away.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
