### PR TITLE
Hide non-verified teacher warning on course overview until data loads

### DIFF
--- a/apps/src/code-studio/components/progress/teacherPanel/TeacherPanel.jsx
+++ b/apps/src/code-studio/components/progress/teacherPanel/TeacherPanel.jsx
@@ -38,7 +38,7 @@ class TeacherPanel extends React.Component {
       id: PropTypes.number.isRequired,
       name: PropTypes.string.isRequired
     }),
-    unitHasLockableLessons: PropTypes.bool.isRequired,
+    unitHasLockableLessons: PropTypes.bool,
     unlockedLessonNames: PropTypes.arrayOf(PropTypes.string).isRequired,
     students: PropTypes.arrayOf(studentShape),
     levelsWithProgress: PropTypes.array,

--- a/apps/src/code-studio/components/progress/teacherPanel/TeacherPanel.jsx
+++ b/apps/src/code-studio/components/progress/teacherPanel/TeacherPanel.jsx
@@ -38,7 +38,7 @@ class TeacherPanel extends React.Component {
       id: PropTypes.number.isRequired,
       name: PropTypes.string.isRequired
     }),
-    unitHasLockableLessons: PropTypes.bool,
+    unitHasLockableLessons: PropTypes.bool.isRequired,
     unlockedLessonNames: PropTypes.arrayOf(PropTypes.string).isRequired,
     students: PropTypes.arrayOf(studentShape),
     levelsWithProgress: PropTypes.array,

--- a/apps/src/code-studio/lessonLockRedux.js
+++ b/apps/src/code-studio/lessonLockRedux.js
@@ -29,7 +29,8 @@ const initialState = {
   lockStatus: [],
   saving: false,
   // whether user is allowed to see lockable lessons
-  lockableAuthorized: false
+  lockableAuthorized: null,
+  lockableAuthorizedLoaded: false
 };
 
 /**
@@ -38,7 +39,8 @@ const initialState = {
 export default function reducer(state = initialState, action) {
   if (action.type === AUTHORIZE_LOCKABLE) {
     return Object.assign({}, state, {
-      lockableAuthorized: true
+      lockableAuthorized: action.isAuthorized,
+      lockableAuthorizedLoaded: true
     });
   }
 
@@ -142,7 +144,10 @@ export default function reducer(state = initialState, action) {
 /**
  * Authorizes the user to be able to see lockable lessons
  */
-export const authorizeLockable = () => ({type: AUTHORIZE_LOCKABLE});
+export const authorizeLockable = isAuthorized => ({
+  type: AUTHORIZE_LOCKABLE,
+  isAuthorized
+});
 
 export const openLockDialog = (sectionId, lessonId) => ({
   type: OPEN_LOCK_DIALOG,

--- a/apps/src/code-studio/progressRedux.js
+++ b/apps/src/code-studio/progressRedux.js
@@ -340,7 +340,9 @@ const userProgressFromServer = (state, dispatch, userId = null) => {
     method: 'GET',
     data: {user_id: userId}
   }).done(data => {
-    data = data || {};
+    if (!data || _.isEmpty(data)) {
+      return;
+    }
 
     if (data.isVerifiedTeacher) {
       dispatch(setVerified());

--- a/apps/src/code-studio/progressRedux.js
+++ b/apps/src/code-studio/progressRedux.js
@@ -365,9 +365,7 @@ const userProgressFromServer = (state, dispatch, userId = null) => {
       );
     }
 
-    if (data.lockableAuthorized) {
-      dispatch(authorizeLockable());
-    }
+    dispatch(authorizeLockable(data.lockableAuthorized));
 
     if (data.completed) {
       dispatch(setScriptCompleted());

--- a/apps/src/templates/progress/ProgressLesson.jsx
+++ b/apps/src/templates/progress/ProgressLesson.jsx
@@ -127,8 +127,13 @@ class ProgressLesson extends React.Component {
     // don't need to pass it separately from lesson here and in ProgressLessonTeacherInfo.
     const lessonUrl = levels[0] && levels[0].url;
 
-    const lockableUnauthorized =
-      this.props.lockableAuthorizedLoaded && !this.props.lockableAuthorized;
+    // If a teacher is not verified they will not be lockableAuthorized (meaning they can't
+    // lock or unlock lessons). For lockableUnauthorizedTeacher we will display a warning explaining
+    // that they need to be verified to unlock lessons.
+    const lockableUnauthorizedTeacher =
+      viewAs === ViewType.Teacher &&
+      this.props.lockableAuthorizedLoaded &&
+      !this.props.lockableAuthorized;
 
     return (
       <div
@@ -191,19 +196,17 @@ class ProgressLesson extends React.Component {
                 </span>
               )}
           </div>
-          {lesson.lockable &&
-            lockableUnauthorized &&
-            viewAs === ViewType.Teacher && (
-              <div style={styles.notAuthorizedWarning}>
-                {i18n.unverifiedTeacherLockWarning()}
-                <a
-                  style={styles.learnMoreLink}
-                  href="https://support.code.org/hc/en-us/articles/115001550131-Becoming-a-verified-teacher-CS-Principles-and-CS-Discoveries-only-"
-                >
-                  {i18n.learnMoreWithPeriod()}
-                </a>
-              </div>
-            )}
+          {lesson.lockable && lockableUnauthorizedTeacher && (
+            <div style={styles.notAuthorizedWarning}>
+              {i18n.unverifiedTeacherLockWarning()}
+              <a
+                style={styles.learnMoreLink}
+                href="https://support.code.org/hc/en-us/articles/115001550131-Becoming-a-verified-teacher-CS-Principles-and-CS-Discoveries-only-"
+              >
+                {i18n.learnMoreWithPeriod()}
+              </a>
+            </div>
+          )}
           {!this.state.collapsed && (
             <ProgressLessonContent
               description={description}

--- a/apps/src/templates/progress/ProgressLesson.jsx
+++ b/apps/src/templates/progress/ProgressLesson.jsx
@@ -32,7 +32,8 @@ class ProgressLesson extends React.Component {
     lessonIsVisible: PropTypes.func.isRequired,
     lessonIsLockedForUser: PropTypes.func.isRequired,
     selectedSectionId: PropTypes.string,
-    lockableAuthorized: PropTypes.bool.isRequired,
+    lockableAuthorized: PropTypes.bool,
+    lockableAuthorizedLoaded: PropTypes.bool.isRequired,
     lessonIsLockedForAllStudents: PropTypes.func.isRequired,
     isRtl: PropTypes.bool
   };
@@ -125,6 +126,10 @@ class ProgressLesson extends React.Component {
     // TODO: Make the back-end return a lesson url as part of the lesson metadata so we
     // don't need to pass it separately from lesson here and in ProgressLessonTeacherInfo.
     const lessonUrl = levels[0] && levels[0].url;
+
+    const lockableUnauthorized =
+      this.props.lockableAuthorizedLoaded && !this.props.lockableAuthorized;
+
     return (
       <div
         className="uitest-progress-lesson"
@@ -187,7 +192,7 @@ class ProgressLesson extends React.Component {
               )}
           </div>
           {lesson.lockable &&
-            !this.props.lockableAuthorized &&
+            lockableUnauthorized &&
             viewAs === ViewType.Teacher && (
               <div style={styles.notAuthorizedWarning}>
                 {i18n.unverifiedTeacherLockWarning()}
@@ -299,6 +304,7 @@ export default connect(state => ({
   showTeacherInfo: state.progress.showTeacherInfo,
   viewAs: state.viewAs,
   lockableAuthorized: state.lessonLock.lockableAuthorized,
+  lockableAuthorizedLoaded: state.lessonLock.lockableAuthorizedLoaded,
   lessonIsVisible: (lesson, viewAs) => lessonIsVisible(lesson, state, viewAs),
   lessonIsLockedForUser: (lesson, levels, viewAs) =>
     lessonIsLockedForUser(lesson, levels, state, viewAs),

--- a/apps/src/templates/progress/ProgressLesson.jsx
+++ b/apps/src/templates/progress/ProgressLesson.jsx
@@ -33,7 +33,7 @@ class ProgressLesson extends React.Component {
     lessonIsLockedForUser: PropTypes.func.isRequired,
     selectedSectionId: PropTypes.string,
     lockableAuthorized: PropTypes.bool,
-    lockableAuthorizedLoaded: PropTypes.bool.isRequired,
+    lockableAuthorizedLoaded: PropTypes.bool,
     lessonIsLockedForAllStudents: PropTypes.func.isRequired,
     isRtl: PropTypes.bool
   };

--- a/apps/src/templates/progress/ProgressLesson.jsx
+++ b/apps/src/templates/progress/ProgressLesson.jsx
@@ -33,7 +33,7 @@ class ProgressLesson extends React.Component {
     lessonIsLockedForUser: PropTypes.func.isRequired,
     selectedSectionId: PropTypes.string,
     lockableAuthorized: PropTypes.bool,
-    lockableAuthorizedLoaded: PropTypes.bool,
+    lockableAuthorizedLoaded: PropTypes.bool.isRequired,
     lessonIsLockedForAllStudents: PropTypes.func.isRequired,
     isRtl: PropTypes.bool
   };
@@ -128,9 +128,10 @@ class ProgressLesson extends React.Component {
     const lessonUrl = levels[0] && levels[0].url;
 
     // If a teacher is not verified they will not be lockableAuthorized (meaning they can't
-    // lock or unlock lessons). For lockableUnauthorizedTeacher we will display a warning explaining
-    // that they need to be verified to unlock lessons.
-    const lockableUnauthorizedTeacher =
+    // lock or unlock lessons). For a lockable lesson where teacher is not authorized, we will
+    // display a warning explaining that they need to be verified to unlock lessons.
+    const showNotAuthorizedWarning =
+      lesson.lockable &&
       viewAs === ViewType.Teacher &&
       this.props.lockableAuthorizedLoaded &&
       !this.props.lockableAuthorized;
@@ -196,7 +197,7 @@ class ProgressLesson extends React.Component {
                 </span>
               )}
           </div>
-          {lesson.lockable && lockableUnauthorizedTeacher && (
+          {showNotAuthorizedWarning && (
             <div style={styles.notAuthorizedWarning}>
               {i18n.unverifiedTeacherLockWarning()}
               <a

--- a/apps/src/templates/progress/ProgressLesson.story.jsx
+++ b/apps/src/templates/progress/ProgressLesson.story.jsx
@@ -25,7 +25,8 @@ const defaultProps = {
   lessonIsVisible: () => true,
   lessonIsLockedForUser: () => false,
   lessonIsLockedForAllStudents: () => false,
-  lockableAuthorized: true
+  lockableAuthorized: true,
+  lockableAuthorizedLoaded: true
 };
 
 export default storybook => {

--- a/apps/src/templates/progress/ProgressLessonTeacherInfo.jsx
+++ b/apps/src/templates/progress/ProgressLessonTeacherInfo.jsx
@@ -33,7 +33,7 @@ class ProgressLessonTeacherInfo extends React.Component {
     unitName: PropTypes.string.isRequired,
     hasNoSections: PropTypes.bool.isRequired,
     toggleHiddenLesson: PropTypes.func.isRequired,
-    lockableAuthorized: PropTypes.bool.isRequired
+    lockableAuthorized: PropTypes.bool
   };
 
   constructor(props) {

--- a/apps/src/templates/progress/progressTestHelpers.js
+++ b/apps/src/templates/progress/progressTestHelpers.js
@@ -82,7 +82,8 @@ export const createStoreWithHiddenLesson = (viewAs, lessonId) => {
       lessonsBySectionId: {
         '11': {}
       },
-      lockableAuthorized: false
+      lockableAuthorized: false,
+      lockableAuthorizedLoaded: true
     },
     viewAs: viewAs,
     teacherSections: {
@@ -116,7 +117,8 @@ export const createStoreWithLockedLesson = (
       lessonsBySectionId: {
         '11': {}
       },
-      lockableAuthorized: lockableAuthorized
+      lockableAuthorized: lockableAuthorized,
+      lockableAuthorizedLoaded: true
     },
     viewAs: viewAs,
     teacherSections: {

--- a/apps/test/unit/templates/progress/ProgressLessonTest.js
+++ b/apps/test/unit/templates/progress/ProgressLessonTest.js
@@ -24,6 +24,7 @@ describe('ProgressLesson', () => {
     lessonIsVisible: () => true,
     lessonIsLockedForUser: () => false,
     lessonIsLockedForAllStudents: () => false,
+    lockableAuthorizedLoaded: true,
     lockableAuthorized: true
   };
 
@@ -289,12 +290,13 @@ describe('ProgressLesson', () => {
     );
   });
 
-  it('shows not verified warning on lockable lesson when viewing as unverified teacher', () => {
+  it('shows not verified warning on lockable lesson when lockableAuthorizedLoaded and lockableAuthorized is false', () => {
     const wrapper = shallow(
       <ProgressLesson
         {...defaultProps}
         viewAs={ViewType.Teacher}
         lesson={fakeLesson('lesson1', 1, true)}
+        lockableAuthorizedLoaded={true}
         lockableAuthorized={false}
         lessonIsLockedForUser={() => true}
       />
@@ -304,13 +306,29 @@ describe('ProgressLesson', () => {
     );
   });
 
-  it('does not show not verified warning on lockable lesson when viewing as verified teacher', () => {
+  it('does not show not verified warning on lockable lesson when lockableAuthorizedLoaded and lockableAuthorized is true', () => {
     const wrapper = shallow(
       <ProgressLesson
         {...defaultProps}
         viewAs={ViewType.Teacher}
         lesson={fakeLesson('lesson1', 1, true)}
+        lockableAuthorizedLoaded={true}
         lockableAuthorized={true}
+      />
+    );
+    expect(wrapper.text()).to.not.include(
+      'This lesson is locked - you need to become a verified teacher to unlock it.'
+    );
+  });
+
+  it('does not show not verified warning on lockable lesson when lockableAuthorizedLoaded is false', () => {
+    const wrapper = shallow(
+      <ProgressLesson
+        {...defaultProps}
+        viewAs={ViewType.Teacher}
+        lesson={fakeLesson('lesson1', 1, true)}
+        lockableAuthorizedLoaded={false}
+        lockableAuthorized={false}
       />
     );
     expect(wrapper.text()).to.not.include(

--- a/apps/test/unit/templates/progress/ProgressLessonTest.js
+++ b/apps/test/unit/templates/progress/ProgressLessonTest.js
@@ -328,7 +328,7 @@ describe('ProgressLesson', () => {
         viewAs={ViewType.Teacher}
         lesson={fakeLesson('lesson1', 1, true)}
         lockableAuthorizedLoaded={false}
-        lockableAuthorized={false}
+        lockableAuthorized={null}
       />
     );
     expect(wrapper.text()).to.not.include(


### PR DESCRIPTION
Hides the unverified teacher message while data is loading instead of showing it by default until data has loaded.

Before:

https://user-images.githubusercontent.com/24235215/133688819-2dafca25-dd1f-402a-af84-11f297db21c8.mov


After:

https://user-images.githubusercontent.com/24235215/133688835-ff60b953-199f-4b1e-b20c-04862a56ec29.mov

In Slack we discussed showing the progress bubbles as unlocked for the teacher, I implemented this, but then realized that if we showed bubbles as unlocked for the teacher if the lesson is unlocked for only one student, it may confuse the teacher into thinking they've unlocked it for every student. There is also some strange behavior with the lock icon that I think we should revisit. I left a note in the [LP questions for Amanda google doc](https://docs.google.com/document/d/1VEz2wXD6PRDydbBzMeGUxfELaF6a-RVEZqq_Zxnke_s/edit), so we can determine the expected behavior.

<!--




  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
- jira ticket: [LP-2008](https://codedotorg.atlassian.net/browse/LP-2008)
<!--
- spec: []()

-->

## Testing story
Tested locally and added unit test
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Follow-up work
Determine how/when the lock icon should show and when the bubbles should show as unlocked for the teacher.
<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
