### PR TITLE
[PoemBot][HOC] Fix addLine bug

### DIFF
--- a/apps/src/p5lab/spritelab/libraries/PoemBotLibrary.js
+++ b/apps/src/p5lab/spritelab/libraries/PoemBotLibrary.js
@@ -124,10 +124,13 @@ export default class PoemBotLibrary extends CoreLibrary {
       },
 
       setPoem(key) {
-        if (POEMS[key]) {
+        const poem = POEMS[key];
+        if (poem) {
           this.poemState = {
             ...this.poemState,
-            ...POEMS[key]
+            author: poem.author,
+            title: poem.title,
+            lines: [...poem.lines]
           };
         }
       },


### PR DESCRIPTION
Fixes a small bug where the poem state was accidentally mutating the poem constant. This was resulting in duplicate lines being added (most noticeable in preview mode where the code updates every keystroke)

Before:
![image](https://user-images.githubusercontent.com/8787187/133683442-1ffc96f5-b0d5-4bc2-ac2e-caf315be8ec1.png)

After:
![image](https://user-images.githubusercontent.com/8787187/133684365-d3d75768-088d-45cb-a6a6-d7e9a0b69898.png)
