### PR TITLE
Add 'noopener,noreferrer' to window.open calls that open in a new tab

### DIFF
--- a/apps/src/applab/ExternalRedirectDialog.jsx
+++ b/apps/src/applab/ExternalRedirectDialog.jsx
@@ -16,7 +16,7 @@ class ExternalRedirectDialog extends React.Component {
   };
 
   handleRedirect(url) {
-    window.open(url, '_blank');
+    window.open(url, '_blank', 'noopener,noreferrer');
     this.props.handleClose();
   }
 

--- a/apps/src/blockTooltips/DropletTooltipManager.js
+++ b/apps/src/blockTooltips/DropletTooltipManager.js
@@ -148,7 +148,11 @@ DropletTooltipManager.prototype.showDocFor = function(functionName) {
 
   var tooltip = this.getDropletTooltip(functionName);
   if (tooltip.customDocURL) {
-    var win = window.open(tooltip.customDocURL, '_blank');
+    var win = window.open(
+      tooltip.customDocURL,
+      '_blank',
+      'noopener,noreferrer'
+    );
     win.focus();
     return;
   }

--- a/apps/src/code-studio/components/ExportDialog/Dialog.jsx
+++ b/apps/src/code-studio/components/ExportDialog/Dialog.jsx
@@ -312,7 +312,11 @@ class ExportDialog extends React.Component {
     }
     // TODO: use new URL format once snack-web has been updated for this flow
     // TODO: pass iconUri and splashImageUri to expo.io
-    window.open(`https://snack.expo.io/${expoSnackId}`, '_blank');
+    window.open(
+      `https://snack.expo.io/${expoSnackId}`,
+      '_blank',
+      'noopener,noreferrer'
+    );
   }
 
   checkForApkBuild(apkBuildId, expoSnackId) {

--- a/apps/src/code-studio/components/progress/LessonLockDialog.jsx
+++ b/apps/src/code-studio/components/progress/LessonLockDialog.jsx
@@ -63,7 +63,7 @@ class LessonLockDialog extends React.Component {
       this.props.selectedSectionId,
       '/assessments'
     );
-    window.open(assessmentsUrl, '_blank');
+    window.open(assessmentsUrl, '_blank', 'noopener,noreferrer');
   };
 
   handleRadioChange = event => {

--- a/apps/src/lib/kits/maker/ui/MakerStatusOverlay.jsx
+++ b/apps/src/lib/kits/maker/ui/MakerStatusOverlay.jsx
@@ -81,7 +81,7 @@ export default connect(
       getConnectionError(state) instanceof UnsupportedBrowserError,
     hasConnectionError: hasConnectionError(state),
     handleOpenSetupPage: () => {
-      window.open('/maker/setup', '_blank');
+      window.open('/maker/setup', '_blank', 'noopener,noreferrer');
     }
   }),
   {

--- a/apps/src/templates/instructions/TopInstructions.jsx
+++ b/apps/src/templates/instructions/TopInstructions.jsx
@@ -405,7 +405,11 @@ class TopInstructions extends Component {
    * Handle a click on the Documentation PaneButton.
    */
   handleDocumentationClick = () => {
-    const win = window.open(this.props.documentationUrl, '_blank');
+    const win = window.open(
+      this.props.documentationUrl,
+      '_blank',
+      'noopener,noreferrer'
+    );
     win.focus();
   };
 

--- a/apps/src/templates/manageStudents/DownloadParentLetter.jsx
+++ b/apps/src/templates/manageStudents/DownloadParentLetter.jsx
@@ -16,7 +16,7 @@ export default class DownloadParentLetter extends Component {
 
   onDownloadParentLetter = () => {
     const url = teacherDashboardUrl(this.props.sectionId, '/parent_letter');
-    window.open(url, '_blank');
+    window.open(url, '_blank', 'noopener,noreferrer');
     firehoseClient.putRecord(
       {
         study: 'teacher-dashboard',

--- a/apps/src/templates/manageStudents/ManageStudentsActionsCell.jsx
+++ b/apps/src/templates/manageStudents/ManageStudentsActionsCell.jsx
@@ -192,7 +192,7 @@ class ManageStudentsActionsCell extends Component {
     const {id, sectionId} = this.props;
     const url =
       teacherDashboardUrl(sectionId, '/parent_letter') + `?studentId=${id}`;
-    window.open(url, '_blank');
+    window.open(url, '_blank', 'noopener,noreferrer');
     firehoseClient.putRecord(
       {
         study: 'teacher-dashboard',

--- a/apps/src/templates/manageStudents/ManageStudentsTable.jsx
+++ b/apps/src/templates/manageStudents/ManageStudentsTable.jsx
@@ -674,7 +674,7 @@ class ManageStudentsTable extends Component {
     const {sectionId} = this.props;
     const url =
       teacherDashboardUrl(sectionId, '/login_info') + `?autoPrint=true`;
-    window.open(url, '_blank');
+    window.open(url, '_blank', 'noopener,noreferrer');
   }
 
   showSectionCodeDialog() {


### PR DESCRIPTION
I noticed an instance where we used window.open to open a link in a new tab without adding `noopener` and `noreferrer`. I used the command `git grep -l 'window\.open(.*, ._blank.)'` to identify similar instances and updated them all here. I didn't audit these and instead just figured this would be a quick win.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
