### PR TITLE
[PoemBot][HOC] Support background images for poembot

### DIFF
--- a/apps/src/p5lab/spritelab/poembot/commands/backgroundEffects.js
+++ b/apps/src/p5lab/spritelab/poembot/commands/backgroundEffects.js
@@ -8,6 +8,21 @@ export const commands = {
       this.p5.background(color);
     };
   },
+
+  setBackgroundImageAs(imageName) {
+    if (
+      this.p5._predefinedSpriteAnimations &&
+      this.p5._predefinedSpriteAnimations[imageName]
+    ) {
+      let backgroundImage = this.p5._predefinedSpriteAnimations[imageName];
+      backgroundImage.name = imageName;
+      backgroundImage.resize(400, 400);
+      this.backgroundEffect = () => {
+        this.p5.image(backgroundImage);
+      };
+    }
+  },
+
   // TODO: would it be possible to re-use the background/foreground effect code from dance party?
   setBackgroundEffect(effectName, palette) {
     this.validationInfo.backgroundEffect = effectName;

--- a/apps/src/p5lab/spritelab/poembot/commands/backgroundEffects.js
+++ b/apps/src/p5lab/spritelab/poembot/commands/backgroundEffects.js
@@ -1,5 +1,6 @@
 import * as utils from './utils';
 import {PALETTES} from '../constants';
+import {APP_WIDTH, APP_HEIGHT} from '../../../constants';
 
 export const commands = {
   setBackground(color) {
@@ -10,13 +11,10 @@ export const commands = {
   },
 
   setBackgroundImageAs(imageName) {
-    if (
-      this.p5._predefinedSpriteAnimations &&
-      this.p5._predefinedSpriteAnimations[imageName]
-    ) {
-      let backgroundImage = this.p5._predefinedSpriteAnimations[imageName];
+    const backgroundImage = this.p5._predefinedSpriteAnimations?.[imageName];
+    if (backgroundImage) {
       backgroundImage.name = imageName;
-      backgroundImage.resize(400, 400);
+      backgroundImage.resize(APP_WIDTH, APP_HEIGHT);
       this.backgroundEffect = () => {
         this.p5.image(backgroundImage);
       };


### PR DESCRIPTION
Add support for the spritelab `set background image` block. Very similar logic to https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/p5lab/spritelab/commands/worldCommands.js#L72 and https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/p5lab/spritelab/libraries/CoreLibrary.js#L51

Before:
![image](https://user-images.githubusercontent.com/8787187/133692046-115580ad-cbf6-41a4-9d59-7346e1e68637.png)

After:
![image](https://user-images.githubusercontent.com/8787187/133691992-a545598c-5d79-4dde-aafa-6c753e865118.png)
