### PR TITLE
Updating Piskel to the latest version which supports i18n

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -60,7 +60,7 @@
     "@code-dot-org/ml-activities": "0.0.26",
     "@code-dot-org/ml-playground": "0.0.39",
     "@code-dot-org/p5.play": "^1.3.20-cdo",
-    "@code-dot-org/piskel": "0.13.0-cdo.6",
+    "@code-dot-org/piskel": "0.13.0-cdo.7",
     "@code-dot-org/redactable-markdown": "0.4.0",
     "@react-bootstrap/pagination": "^1.0.0",
     "@storybook/addon-actions": "^4.1.16",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1672,9 +1672,12 @@
     opentype.js "^0.4.9"
     reqwest "^1.1.5"
 
-"@code-dot-org/piskel@0.13.0-cdo.6":
-  version "0.13.0-cdo.6"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/piskel/-/piskel-0.13.0-cdo.6.tgz#0e919b94e76f9d33dce673e980ac18f3395a62fc"
+"@code-dot-org/piskel@0.13.0-cdo.7":
+  version "0.13.0-cdo.7"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/piskel/-/piskel-0.13.0-cdo.7.tgz#b7793889485ac953af0b268fa5545dad7c6078db"
+  integrity sha512-sdPuYTksDB2oLG/SFmCOpGf2IudUuHI30SwMyyHb6AxOUkrx+CwT6vIzqvy20Ejt6f0rK4J15HSLuojfelGqkw==
+  dependencies:
+    messageformat "^2.3.0"
 
 "@code-dot-org/redactable-markdown@0.4.0":
   version "0.4.0"
@@ -10274,7 +10277,7 @@ messageformat-parser@^4.1.2:
   resolved "https://registry.yarnpkg.com/messageformat-parser/-/messageformat-parser-4.1.3.tgz#b824787f57fcda7d50769f5b63e8d4fda68f5b9e"
   integrity sha512-2fU3XDCanRqeOCkn7R5zW5VQHWf+T3hH65SzuqRvjatBK7r4uyFa5mEX+k6F9Bd04LVM5G4/BHBTUJsOdW7uyg==
 
-messageformat@2.3.0:
+messageformat@2.3.0, messageformat@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/messageformat/-/messageformat-2.3.0.tgz#de263c49029d5eae65d7ee25e0754f57f425ad91"
   integrity sha512-uTzvsv0lTeQxYI2y1NPa1lItL5VRI8Gb93Y2K2ue5gBPyrbJxfDi/EYWxh2PKv5yO42AJeeqblS9MJSh/IEk4w==


### PR DESCRIPTION
The [@code-dot-org/piskel ](https://www.npmjs.com/package/@code-dot-org/piskel) NPM package has a new version `0.13.0-cdo.7` which includes i18n support. Now tooltips and UI elements for Piskel will be translatable to other languages. The dashboard app has already been updated to send Piskel the current locale code, all we need to do is update the package version we depend on.

## Links
- [JIRA](https://codedotorg.atlassian.net/browse/FND-1564)

## Testing story
- Ran local dashboard server
  - `cd apps`
  - `yarn install`
  - `yarn start`
  - start your dashboard server
  - start a new Sprite Lab
  - use the language selector in the lower left to select Spanish
  - In the upper left, click "Costumes"
  - Hover your mouse over some of the drawing tools and observe that the tooltips are translated

## Screenshot
![Screen Shot 2021-09-16 at 5 00 17 PM](https://user-images.githubusercontent.com/1372238/133703925-6b427f8e-7f54-4031-8d7d-ed91481cf9f0.png)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
