### PR TITLE
Fix valid_courses to give the right information based on user

### DIFF
--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -312,7 +312,7 @@ class UnitGroup < ApplicationRecord
   # Returns whether the course id is valid, even if it is not "stable" yet.
   # @param course_id [String] id of the course we're checking the validity of
   # @return [Boolean] Whether this is a valid course ID
-  def self.valid_course_id?(course_id, user = nil)
+  def self.valid_course_id?(course_id, user)
     UnitGroup.valid_courses(user: user).any? {|unit_group| unit_group.id == course_id.to_i}
   end
 

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -285,9 +285,6 @@ class UnitGroup < ApplicationRecord
   # @return [Array<UnitGroup>]
   def self.valid_courses(user: nil)
     courses = all_courses.select(&:launched?)
-    if user && has_any_course_experiments?(user)
-      return courses
-    end
 
     if user && has_any_pilot_access?(user)
       pilot_courses = all_courses.select {|c| c.has_pilot_access?(user)}
@@ -312,16 +309,11 @@ class UnitGroup < ApplicationRecord
     Experiment.any_enabled?(user: user, experiment_names: UnitGroupUnit.experiments)
   end
 
-  # Get the set of valid courses for the dropdown in our sections table.
-  def self.valid_courses_without_cache
-    UnitGroup.all.select(&:launched?)
-  end
-
   # Returns whether the course id is valid, even if it is not "stable" yet.
   # @param course_id [String] id of the course we're checking the validity of
   # @return [Boolean] Whether this is a valid course ID
   def self.valid_course_id?(course_id, user = nil)
-    valid_courses(user: user).any? {|unit_group| unit_group.id == course_id.to_i}
+    UnitGroup.valid_courses(user: user).any? {|unit_group| unit_group.id == course_id.to_i}
   end
 
   # @param user [User]
@@ -329,7 +321,7 @@ class UnitGroup < ApplicationRecord
   # Users should only be able to assign one of their valid courses.
   def assignable_for_user?(user)
     if user&.teacher?
-      UnitGroup.valid_course_id?(id)
+      UnitGroup.valid_course_id?(id, user)
     end
   end
 

--- a/dashboard/test/models/unit_group_test.rb
+++ b/dashboard/test/models/unit_group_test.rb
@@ -866,6 +866,31 @@ class UnitGroupTest < ActiveSupport::TestCase
     assert_equal UnitGroup.valid_courses(user: teacher), [csp_2019]
   end
 
+  test "assignable_for_user?: normal courses" do
+    student = create :student
+    teacher = create :teacher
+    levelbuilder = create :levelbuilder
+    course = create :unit_group, published_state: SharedConstants::PUBLISHED_STATE.stable
+
+    refute course.assignable_for_user?(student)
+    assert course.assignable_for_user?(teacher)
+    assert course.assignable_for_user?(levelbuilder)
+  end
+
+  test "assignable_for_user?: works for pilot courses" do
+    student = create :student
+    teacher = create :teacher
+    levelbuilder = create :levelbuilder
+    pilot_teacher = create :teacher, pilot_experiment: 'my-experiment'
+    pilot_course = create :unit_group, pilot_experiment: 'my-experiment'
+    assert UnitGroup.any?(&:pilot?)
+
+    refute pilot_course.assignable_for_user?(student)
+    refute pilot_course.assignable_for_user?(teacher)
+    assert pilot_course.assignable_for_user?(pilot_teacher)
+    assert pilot_course.assignable_for_user?(levelbuilder)
+  end
+
   test "update_teacher_resources" do
     unit_group = create :unit_group
     unit_group.update_teacher_resources(['professionalLearning'], ['/link/to/plc'])


### PR DESCRIPTION
The curriculum team reported that the assign to section button was not working on the Course Overview page for pilot courses. I traced it back to issues with the `assignable_for_user?` path. The user was not getting passed through.

Adding it and updating a couple things in the valid_courses method led to the button showing for pilot courses for pilot teachers and levelbuilders:

<img width="1780" alt="Screen Shot 2021-09-16 at 9 27 32 PM" src="https://user-images.githubusercontent.com/208083/133709113-ff74b79a-3f26-40b1-a43a-7d054121cfbe.png">


## Links

Jira: https://codedotorg.atlassian.net/browse/PLAT-1309

## Testing story

Added unit tests to prevent issue from happening again

