### PR TITLE
Use legacy lesson plans

### DIFF
--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -684,6 +684,8 @@ class UnitEditor extends React.Component {
         <CollapsibleEditorSection title="Lesson Settings">
           {this.props.isMigrated && this.props.initialUseLegacyLessonPlans && (
             <label>
+              {/* TODO(dave): enable or remove this button, once we figure out
+              what controls we want to make available to curriculum writers. */}
               <Button
                 text={'Use Code Studio Lesson Plans'}
                 size={Button.ButtonSize.narrow}
@@ -696,7 +698,7 @@ class UnitEditor extends React.Component {
                     this.setState({useLegacyLessonPlans: false});
                   }
                 }}
-                disabled={!this.state.useLegacyLessonPlans}
+                disabled
               />
               <HelpTip>
                 <p>

--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -78,7 +78,7 @@ class UnitEditor extends React.Component {
     isMigrated: PropTypes.bool,
     initialIncludeStudentLessonPlans: PropTypes.bool,
     initialCourseVersionId: PropTypes.number,
-    initialUseCodeStudioLessonPlans: PropTypes.bool,
+    initialUseLegacyLessonPlans: PropTypes.bool,
     preventCourseVersionChange: PropTypes.bool,
     scriptPath: PropTypes.string.isRequired,
 
@@ -148,7 +148,7 @@ class UnitEditor extends React.Component {
       hasImportedLessonDescriptions: false,
       oldScriptText: this.props.initialLessonLevelData,
       includeStudentLessonPlans: this.props.initialIncludeStudentLessonPlans,
-      useCodeStudioLessonPlans: this.props.initialUseCodeStudioLessonPlans,
+      useLegacyLessonPlans: this.props.initialUseLegacyLessonPlans,
       deprecated: this.props.initialDeprecated,
       publishedState: this.props.initialPublishedState
     };
@@ -303,7 +303,7 @@ class UnitEditor extends React.Component {
       ),
       is_migrated: this.props.isMigrated,
       include_student_lesson_plans: this.state.includeStudentLessonPlans,
-      use_code_studio_lesson_plans: this.state.useCodeStudioLessonPlans,
+      use_legacy_lesson_plans: this.state.useLegacyLessonPlans,
       is_maker_unit: this.state.isMakerUnit
     };
 
@@ -685,13 +685,11 @@ class UnitEditor extends React.Component {
             Use Code Studio Lesson Plans
             <input
               type="checkbox"
-              checked={
-                this.props.isMigrated && this.state.useCodeStudioLessonPlans
-              }
+              checked={this.props.isMigrated && this.state.useLegacyLessonPlans}
               style={styles.checkbox}
               onChange={() =>
                 this.setState({
-                  useCodeStudioLessonPlans: !this.state.useCodeStudioLessonPlans
+                  useLegacyLessonPlans: !this.state.useLegacyLessonPlans
                 })
               }
               disabled={!this.props.isMigrated}
@@ -713,7 +711,7 @@ class UnitEditor extends React.Component {
               )}
             </HelpTip>
           </label>
-          {!(this.props.isMigrated && this.state.useCodeStudioLessonPlans) && (
+          {!(this.props.isMigrated && this.state.useLegacyLessonPlans) && (
             <label>
               Curriculum Path
               <HelpTip>

--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -682,10 +682,12 @@ class UnitEditor extends React.Component {
 
         <CollapsibleEditorSection title="Lesson Settings">
           <label>
-            Use Code Studio Lesson Plans
+            Use Legacy Lesson Plans
             <input
               type="checkbox"
-              checked={this.props.isMigrated && this.state.useLegacyLessonPlans}
+              checked={
+                !this.props.isMigrated || this.state.useLegacyLessonPlans
+              }
               style={styles.checkbox}
               onChange={() =>
                 this.setState({
@@ -696,7 +698,7 @@ class UnitEditor extends React.Component {
             />
             <HelpTip>
               {!this.props.isMigrated && (
-                <p>this option is only available for migrated scripts.</p>
+                <p>unmigrated scripts must use legacy lesson plans.</p>
               )}
               {this.props.isMigrated && (
                 <p>
@@ -711,7 +713,7 @@ class UnitEditor extends React.Component {
               )}
             </HelpTip>
           </label>
-          {!(this.props.isMigrated && this.state.useLegacyLessonPlans) && (
+          {(!this.props.isMigrated || this.state.useLegacyLessonPlans) && (
             <label>
               Curriculum Path
               <HelpTip>

--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -698,9 +698,12 @@ class UnitEditor extends React.Component {
               />
               <HelpTip>
                 <p>
-                  Click to stop using legacy lesson plans on curriculum.code.org
-                  or google docs, and start using lesson plans on
-                  studio.code.org, for all lessons in this unit.
+                  This unit contains lesson plans which have been imported from
+                  curriculum.code.org to studio.code.org, however we are still
+                  pointing our users to lesson plans on curriculum.code.org.
+                  Once you have reviewed the new content, click this button to
+                  start using the lesson plans on studio.code.org, for all
+                  lessons in this unit.
                 </p>
               </HelpTip>
             </label>

--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -25,6 +25,7 @@ import {lessonGroupShape} from './shapes';
 import SaveBar from '@cdo/apps/lib/levelbuilder/SaveBar';
 import CourseVersionPublishingEditor from '@cdo/apps/lib/levelbuilder/CourseVersionPublishingEditor';
 import {PublishedState} from '@cdo/apps/util/sharedConstants';
+import Button from '@cdo/apps/templates/Button';
 
 const VIDEO_KEY_REGEX = /video_key_for_next_level/g;
 
@@ -683,27 +684,23 @@ class UnitEditor extends React.Component {
         <CollapsibleEditorSection title="Lesson Settings">
           {this.props.isMigrated && this.props.initialUseLegacyLessonPlans && (
             <label>
-              Use Legacy Lesson Plans
-              <input
-                type="checkbox"
-                checked={this.state.useLegacyLessonPlans}
-                style={styles.checkbox}
-                onChange={() =>
+              <Button
+                text={'Use Code Studio Lesson Plans'}
+                size={Button.ButtonSize.narrow}
+                color={Button.ButtonColor.white}
+                style={{margin: 0, height: 30, lineHeight: '8px'}}
+                onClick={() =>
                   this.setState({
-                    useLegacyLessonPlans: !this.state.useLegacyLessonPlans
+                    useLegacyLessonPlans: false
                   })
                 }
+                disabled={!this.state.useLegacyLessonPlans}
               />
               <HelpTip>
                 <p>
-                  Whether to show legacy lesson plans for this unit. legacy
-                  lesson plans live either on curriculum builder or google docs,
-                  as opposed to on code studio. When lesson plans are first
-                  imported from curriculum builder, this box is initially
-                  checked so that you can review the new code studio lesson plan
-                  content before it goes live. Once you're satisfied with the
-                  content, uncheck this box to make the code studio lesson plans
-                  visible to teachers and students.
+                  Click to stop using legacy lesson plans on curriculum.code.org
+                  or google docs, and start using lesson plans on
+                  studio.code.org, for all lessons in this unit.
                 </p>
               </HelpTip>
             </label>
@@ -715,7 +712,8 @@ class UnitEditor extends React.Component {
                 <p>
                   This field determines the location of the legacy lesson plan.
                   If left blank, it will look for special file under
-                  code.org/curriculum/[unit]/[lesson]. If you want to disable
+                  code.org/curriculum/[unit]/[lesson] which redirects to
+                  curriculum.code.org or google docs. If you want to disable
                   lesson plans entirely, you must go to each lesson edit page
                   and uncheck "Has Lesson Plan".
                 </p>

--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -689,11 +689,13 @@ class UnitEditor extends React.Component {
                 size={Button.ButtonSize.narrow}
                 color={Button.ButtonColor.white}
                 style={{margin: 0, height: 30, lineHeight: '8px'}}
-                onClick={() =>
-                  this.setState({
-                    useLegacyLessonPlans: false
-                  })
-                }
+                onClick={e => {
+                  e.preventDefault();
+                  const msg = 'Are you sure? This action cannot be undone.';
+                  if (window.confirm(msg)) {
+                    this.setState({useLegacyLessonPlans: false});
+                  }
+                }}
                 disabled={!this.state.useLegacyLessonPlans}
               />
               <HelpTip>

--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -681,46 +681,40 @@ class UnitEditor extends React.Component {
         </CollapsibleEditorSection>
 
         <CollapsibleEditorSection title="Lesson Settings">
-          <label>
-            Use Legacy Lesson Plans
-            <input
-              type="checkbox"
-              checked={
-                !this.props.isMigrated || this.state.useLegacyLessonPlans
-              }
-              style={styles.checkbox}
-              onChange={() =>
-                this.setState({
-                  useLegacyLessonPlans: !this.state.useLegacyLessonPlans
-                })
-              }
-              disabled={!this.props.isMigrated}
-            />
-            <HelpTip>
-              {!this.props.isMigrated && (
-                <p>unmigrated scripts must use legacy lesson plans.</p>
-              )}
-              {this.props.isMigrated && (
-                <p>
-                  Whether to show our users the code-studio-based lesson plans
-                  for this unit, as opposed to showing them the lesson plans on
-                  curriculum builder. When a script is first migrated, this box
-                  is left unchecked. Once you're satisfied with the contents of
-                  the new lesson plans on levelbuilder, check this box to make
-                  the code studio lesson plans visible to our teachers and
-                  students.
-                </p>
-              )}
-            </HelpTip>
-          </label>
-          {(!this.props.isMigrated || this.state.useLegacyLessonPlans) && (
+          {this.props.isMigrated && this.props.initialUseLegacyLessonPlans && (
             <label>
-              Curriculum Path
+              Use Legacy Lesson Plans
+              <input
+                type="checkbox"
+                checked={this.state.useLegacyLessonPlans}
+                style={styles.checkbox}
+                onChange={() =>
+                  this.setState({
+                    useLegacyLessonPlans: !this.state.useLegacyLessonPlans
+                  })
+                }
+              />
               <HelpTip>
                 <p>
-                  When "Use Code Studio Lesson Plans" is unchecked, this field
-                  determines the location of the lesson plan. If left blank, it
-                  will look for special file under
+                  Whether to show legacy lesson plans for this unit. legacy
+                  lesson plans live either on curriculum builder or google docs,
+                  as opposed to on code studio. When lesson plans are first
+                  imported from curriculum builder, this box is initially
+                  checked so that you can review the new code studio lesson plan
+                  content before it goes live. Once you're satisfied with the
+                  content, uncheck this box to make the code studio lesson plans
+                  visible to teachers and students.
+                </p>
+              </HelpTip>
+            </label>
+          )}
+          {(!this.props.isMigrated || this.state.useLegacyLessonPlans) && (
+            <label>
+              Legacy Lesson Plan Path
+              <HelpTip>
+                <p>
+                  This field determines the location of the legacy lesson plan.
+                  If left blank, it will look for special file under
                   code.org/curriculum/[unit]/[lesson]. If you want to disable
                   lesson plans entirely, you must go to each lesson edit page
                   and uncheck "Has Lesson Plan".

--- a/apps/src/sites/studio/pages/scripts/edit.js
+++ b/apps/src/sites/studio/pages/scripts/edit.js
@@ -104,9 +104,7 @@ export default function initPage(unitEditorData) {
         initialIncludeStudentLessonPlans={
           scriptData.includeStudentLessonPlans || false
         }
-        initialUseCodeStudioLessonPlans={
-          scriptData.useCodeStudioLessonPlans || false
-        }
+        initialUseLegacyLessonPlans={scriptData.useLegacyLessonPlans || false}
         scriptPath={scriptData.scriptPath}
       />
     </Provider>,

--- a/apps/test/unit/lib/levelbuilder/script-editor/UnitEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/UnitEditorTest.jsx
@@ -111,8 +111,8 @@ describe('UnitEditor', () => {
     it('uses old unit editor for non migrated unit', () => {
       const wrapper = createWrapper({});
 
-      expect(wrapper.find('input').length).to.equal(23);
-      expect(wrapper.find('input[type="checkbox"]').length).to.equal(12);
+      expect(wrapper.find('input').length).to.equal(22);
+      expect(wrapper.find('input[type="checkbox"]').length).to.equal(11);
       expect(wrapper.find('textarea').length).to.equal(3);
       expect(wrapper.find('select').length).to.equal(4);
       expect(wrapper.find('CollapsibleEditorSection').length).to.equal(8);
@@ -128,8 +128,8 @@ describe('UnitEditor', () => {
         initialCourseVersionId: 1
       });
 
-      expect(wrapper.find('input').length).to.equal(28);
-      expect(wrapper.find('input[type="checkbox"]').length).to.equal(14);
+      expect(wrapper.find('input').length).to.equal(26);
+      expect(wrapper.find('input[type="checkbox"]').length).to.equal(13);
       expect(wrapper.find('textarea').length).to.equal(4);
       expect(wrapper.find('select').length).to.equal(3);
       expect(wrapper.find('CollapsibleEditorSection').length).to.equal(9);

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -276,7 +276,7 @@ class ScriptsController < ApplicationController
       :pilot_experiment,
       :editor_experiment,
       :include_student_lesson_plans,
-      :use_code_studio_lesson_plans,
+      :use_legacy_lesson_plans,
       :lesson_groups,
       resourceTypes: [],
       resourceLinks: [],

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -241,7 +241,7 @@ class Script < ApplicationRecord
     is_migrated
     seeded_from
     is_maker_unit
-    use_code_studio_lesson_plans
+    use_legacy_lesson_plans
   )
 
   def self.twenty_hour_unit
@@ -1578,7 +1578,7 @@ class Script < ApplicationRecord
       showCalendar: is_migrated ? show_calendar : false, #prevent calendar from showing for non-migrated units for now
       weeklyInstructionalMinutes: weekly_instructional_minutes,
       includeStudentLessonPlans: is_migrated ? include_student_lesson_plans : false,
-      useCodeStudioLessonPlans: is_migrated && use_code_studio_lesson_plans,
+      useLegacyLessonPlans: is_migrated && use_legacy_lesson_plans,
       courseVersionId: get_course_version&.id,
       scriptOverviewPdfUrl: get_unit_overview_pdf_url,
       scriptResourcesPdfUrl: get_unit_resources_pdf_url,
@@ -1810,7 +1810,7 @@ class Script < ApplicationRecord
       :show_calendar,
       :is_migrated,
       :include_student_lesson_plans,
-      :use_code_studio_lesson_plans,
+      :use_legacy_lesson_plans,
       :is_maker_unit
     ]
     not_defaulted_keys = [


### PR DESCRIPTION
Follow-up from https://github.com/code-dot-org/code-dot-org/pull/42496.

1. switch from `use_code_studio_lesson_plans` to `use_legacy_lesson_plans`, inverting the logic
2. change edit UI to use a button so that the setting can only be used in one direction, and disappears entirely once moved onto code studio lesson plans

### migrated script

https://user-images.githubusercontent.com/8001765/133786820-49b9357f-0d81-4b98-8e68-ce9f0d438ad7.mov

### unmigrated script

![Screen Shot 2021-09-17 at 5 58 37 AM](https://user-images.githubusercontent.com/8001765/133786790-f322060f-5be8-459f-8f06-85227b9a606b.png)

## Testing story

manual verification shown in screenshots. also confirmed that the right data gets written to the database and script json upon pressing the button.