### PR TITLE
fix editing of units without user-facing lesson groups

### DIFF
--- a/dashboard/app/models/lesson_group.rb
+++ b/dashboard/app/models/lesson_group.rb
@@ -61,7 +61,6 @@ class LessonGroup < ApplicationRecord
 
     raw_lesson_groups&.map(&:deep_symbolize_keys)&.map do |raw_lesson_group|
       if !raw_lesson_group[:user_facing]
-        raise 'non-user-facing lesson group must have blank key' unless raw_lesson_group[:key].blank?
         lesson_group = LessonGroup.find_or_create_by!(
           key: '',
           script: script,


### PR DESCRIPTION
fixes a problem reported in [slack](https://codedotorg.slack.com/archives/C02EEGWLHR8/p1631894560048300) where a new script could not be saved: `Saving: {"base":["non-user-facing lesson group must have blank key"]}`. the problem was introduced in https://github.com/code-dot-org/code-dot-org/pull/42391. The problem is that the client actually does set 
a key for non-user-facing lesson groups: https://github.com/code-dot-org/code-dot-org/blob/b7194719675f32535f87f378712ef61c876d3ab0/apps/src/lib/levelbuilder/unit-editor/unitEditorRedux.js#L230-L231 and the server ignores it, so it was a mistake to add a check that the key was blank.

## Testing story

manually verified I could repro the problem without this change, and that the problem is resolved after.

## Follow-up work

we should have a UI test to make sure this scenario works end to end: https://codedotorg.atlassian.net/browse/PLAT-1317