### PR TITLE
Randomize string tracking frequency

### DIFF
--- a/apps/src/util/i18nStringTrackerWorker.js
+++ b/apps/src/util/i18nStringTrackerWorker.js
@@ -66,6 +66,7 @@ class I18nStringTrackerWorker {
     this.buffer = {};
     this.pendingFlush = null;
 
+    // RNG to send only 1% of the time
     if (Math.floor(Math.random() * 100) === 0) {
       // Record the i18n string usage data.
       sendRecords(records);

--- a/apps/src/util/i18nStringTrackerWorker.js
+++ b/apps/src/util/i18nStringTrackerWorker.js
@@ -66,8 +66,10 @@ class I18nStringTrackerWorker {
     this.buffer = {};
     this.pendingFlush = null;
 
-    // Record the i18n string usage data.
-    sendRecords(records);
+    if (Math.floor(Math.random() * 100) === 0) {
+      // Record the i18n string usage data.
+      sendRecords(records);
+    }
   }
 }
 


### PR DESCRIPTION
**What**: When we show a translated string in React / JS, we send that data from the student's web browser back to our Rails server. We are now sending it 1% of the time.

**Why**: Too much data would be sent if the string tracking was recorded 100% of the time.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [FND-1686](https://codedotorg.atlassian.net/browse/FND-1686)

## Testing story

Tested locally with a higher frequency to make sure that it was randomized and still being called

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
