### PR TITLE
Retry on both ReadTimeout and OpenTimeout errors

### DIFF
--- a/lib/cdo/crowdin/project.rb
+++ b/lib/cdo/crowdin/project.rb
@@ -53,7 +53,9 @@ module Crowdin
       end
 
       only_head ? self.class.head("/export-file", options) : self.class.get("/export-file", options)
-    rescue Net::ReadTimeout => error
+
+      timeouts = [Net::ReadTimeout, Net::OpenTimeout]
+    rescue *timeouts => error
       # Handle a timeout by simply retrying. We default to three attempts before
       # giving up; if this doesn't work out, other things we could consider:
       #

--- a/lib/cdo/crowdin/project.rb
+++ b/lib/cdo/crowdin/project.rb
@@ -54,8 +54,7 @@ module Crowdin
 
       only_head ? self.class.head("/export-file", options) : self.class.get("/export-file", options)
 
-      timeouts = [Net::ReadTimeout, Net::OpenTimeout]
-    rescue *timeouts => error
+    rescue Net::ReadTimeout, Net::OpenTimeout => error
       # Handle a timeout by simply retrying. We default to three attempts before
       # giving up; if this doesn't work out, other things we could consider:
       #


### PR DESCRIPTION
The syncdown has been failing frequently on a `Net::OpenTimeout` exception at random points of completion. We already catch and retry on `Net::ReadTimeout` exceptions, so let's catch and retry on both
