### PR TITLE
Delay hoc lesson plan sync

### DIFF
--- a/dashboard/lib/services/i18n/curriculum_sync_utils/sync_in.rb
+++ b/dashboard/lib/services/i18n/curriculum_sync_utils/sync_in.rb
@@ -16,7 +16,7 @@ module Services
         # default.
         def self.serialize
           Script.all.each do |script|
-            next unless script.is_migrated?
+            next unless script.is_migrated? && !script.use_legacy_lesson_plans?
             next unless ScriptConstants.i18n? script.name
 
             # prepare data


### PR DESCRIPTION
We are moving HOC lesson plans for curriculum builder to code studio. there will be a period of time where the HOC scripts are marked as `is_migrated`, but the lesson plan content is not ready for translation or public viewing. during this time, those scripts will have the flag `use_legacy_lesson_plans` set, which tells us to keep using lesson plans on curriculum builder for those scripts.

There is still an open question of whether we need two separate flags, one for when the lesson plan is ready to be translated and another for when it is ready to be served. For now, there is only one flag, and this PR will make it so that when we start importing HOC lesson plans next week, they do not immediately get translated.

See https://github.com/code-dot-org/code-dot-org/pull/42499 and [slack](https://codedotorg.slack.com/archives/C02EEGWLHR8/p1631898684058300) for more context. 

## Testing story

please let me know if I can help with testing this.

## Follow-up work

https://codedotorg.atlassian.net/browse/PLAT-1318
