### PR TITLE
[Spritelab][Blockly] Add block text label for inline dummy inputs

### DIFF
--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -683,13 +683,15 @@ const STANDARD_INPUT_TYPES = {
   [INLINE_DUMMY_INPUT]: {
     addInput(blockly, block, inputConfig, currentInputRow) {
       if (inputConfig.customOptions && inputConfig.customOptions.assetUrl) {
-        currentInputRow.appendTitle(
-          new Blockly.FieldImage(
-            Blockly.assetUrl(inputConfig.customOptions.assetUrl),
-            inputConfig.customOptions.width,
-            inputConfig.customOptions.height
-          )
-        );
+        currentInputRow
+          .appendTitle(inputConfig.label)
+          .appendTitle(
+            new Blockly.FieldImage(
+              Blockly.assetUrl(inputConfig.customOptions.assetUrl),
+              inputConfig.customOptions.width,
+              inputConfig.customOptions.height
+            )
+          );
       }
     },
     generateCode(block, inputConfig) {


### PR DESCRIPTION
Support for image fields on LB-defined blocks was added here: https://github.com/code-dot-org/code-dot-org/pull/38321
However there's a bug/oversight that means that block text isn't getting added properly when it's adjacent to the inline dummy input. The reason for this is that the block text is technically just a label for the adjacent field, so we need to make sure we add the label for the inline dummy inputs

Before
![image](https://user-images.githubusercontent.com/8787187/133845888-86baecf6-ac2d-4ed0-8818-cd5b789ee76d.png)


After
![image](https://user-images.githubusercontent.com/8787187/133845834-456fe3a1-8e5d-498b-af0a-47ff1a1073ab.png)

fyi @ghemlick
