### PR TITLE
Update logging in `i18nStringTracker` and locale.js files

### DIFF
--- a/apps/src/ailab/locale-do-not-import.js
+++ b/apps/src/ailab/locale-do-not-import.js
@@ -12,5 +12,5 @@ import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
 import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
 
 let locale = safeLoadLocale('ailab_locale');
-locale = localeWithI18nStringTracker(locale, 'ailab_locale');
+locale = localeWithI18nStringTracker(locale, 'ailab');
 module.exports = locale;

--- a/apps/src/ailab/locale.js
+++ b/apps/src/ailab/locale.js
@@ -4,5 +4,5 @@ import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
 import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
 
 let locale = safeLoadLocale('ailab_locale');
-locale = localeWithI18nStringTracker(locale, 'ailab_locale');
+locale = localeWithI18nStringTracker(locale, 'ailab');
 module.exports = locale;

--- a/apps/src/applab/locale-do-not-import.js
+++ b/apps/src/applab/locale-do-not-import.js
@@ -12,5 +12,5 @@ import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
 import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
 
 let locale = safeLoadLocale('applab_locale');
-locale = localeWithI18nStringTracker(locale, 'applab_locale');
+locale = localeWithI18nStringTracker(locale, 'applab');
 module.exports = locale;

--- a/apps/src/bounce/locale.js
+++ b/apps/src/bounce/locale.js
@@ -4,5 +4,5 @@ import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
 import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
 
 let locale = safeLoadLocale('bounce_locale');
-locale = localeWithI18nStringTracker(locale, 'bounce_locale');
+locale = localeWithI18nStringTracker(locale, 'bounce');
 module.exports = locale;

--- a/apps/src/calc/locale.js
+++ b/apps/src/calc/locale.js
@@ -4,5 +4,5 @@ import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
 import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
 
 let locale = safeLoadLocale('calc_locale');
-locale = localeWithI18nStringTracker(locale, 'calc_locale');
+locale = localeWithI18nStringTracker(locale, 'calc');
 module.exports = locale;

--- a/apps/src/craft/locale.js
+++ b/apps/src/craft/locale.js
@@ -2,5 +2,5 @@ import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
 import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
 
 let locale = safeLoadLocale('craft_locale');
-locale = localeWithI18nStringTracker(locale, 'craft_locale');
+locale = localeWithI18nStringTracker(locale, 'craft');
 module.exports = locale;

--- a/apps/src/dance/locale.js
+++ b/apps/src/dance/locale.js
@@ -2,5 +2,5 @@ import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
 import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
 
 let locale = safeLoadLocale('dance_locale');
-locale = localeWithI18nStringTracker(locale, 'dance_locale');
+locale = localeWithI18nStringTracker(locale, 'dance');
 module.exports = locale;

--- a/apps/src/eval/locale.js
+++ b/apps/src/eval/locale.js
@@ -4,5 +4,5 @@ import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
 import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
 
 let locale = safeLoadLocale('eval_locale');
-locale = localeWithI18nStringTracker(locale, 'eval_locale');
+locale = localeWithI18nStringTracker(locale, 'eval');
 module.exports = locale;

--- a/apps/src/fish/locale-do-not-import.js
+++ b/apps/src/fish/locale-do-not-import.js
@@ -12,5 +12,5 @@ import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
 import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
 
 let locale = safeLoadLocale('fish_locale');
-locale = localeWithI18nStringTracker(locale, 'fish_locale');
+locale = localeWithI18nStringTracker(locale, 'fish');
 module.exports = locale;

--- a/apps/src/fish/locale.js
+++ b/apps/src/fish/locale.js
@@ -4,5 +4,5 @@ import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
 import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
 
 let locale = safeLoadLocale('fish_locale');
-locale = localeWithI18nStringTracker(locale, 'fish_locale');
+locale = localeWithI18nStringTracker(locale, 'fish');
 module.exports = locale;

--- a/apps/src/flappy/locale.js
+++ b/apps/src/flappy/locale.js
@@ -4,5 +4,5 @@ import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
 import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
 
 let locale = safeLoadLocale('flappy_locale');
-locale = localeWithI18nStringTracker(locale, 'flappy_locale');
+locale = localeWithI18nStringTracker(locale, 'flappy');
 module.exports = locale;

--- a/apps/src/javalab/locale-do-not-import.js
+++ b/apps/src/javalab/locale-do-not-import.js
@@ -12,5 +12,5 @@ import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
 import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
 
 let locale = safeLoadLocale('javalab_locale');
-locale = localeWithI18nStringTracker(locale, 'javalab_locale');
+locale = localeWithI18nStringTracker(locale, 'javalab');
 module.exports = locale;

--- a/apps/src/jigsaw/locale.js
+++ b/apps/src/jigsaw/locale.js
@@ -4,5 +4,5 @@ import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
 import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
 
 let locale = safeLoadLocale('jigsaw_locale');
-locale = localeWithI18nStringTracker(locale, 'jigsaw_locale');
+locale = localeWithI18nStringTracker(locale, 'jigsaw');
 module.exports = locale;

--- a/apps/src/maze/locale.js
+++ b/apps/src/maze/locale.js
@@ -3,5 +3,5 @@ import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
 import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
 
 let locale = safeLoadLocale('maze_locale');
-locale = localeWithI18nStringTracker(locale, 'maze_locale');
+locale = localeWithI18nStringTracker(locale, 'maze');
 module.exports = locale;

--- a/apps/src/netsim/locale-do-not-import.js
+++ b/apps/src/netsim/locale-do-not-import.js
@@ -12,5 +12,5 @@ import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
 import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
 
 let locale = safeLoadLocale('netsim_locale');
-locale = localeWithI18nStringTracker(locale, 'netsim_locale');
+locale = localeWithI18nStringTracker(locale, 'netsim');
 module.exports = locale;

--- a/apps/src/p5lab/gamelab/locale-do-not-import.js
+++ b/apps/src/p5lab/gamelab/locale-do-not-import.js
@@ -12,5 +12,5 @@ import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
 import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
 
 let locale = safeLoadLocale('gamelab_locale');
-locale = localeWithI18nStringTracker(locale, 'gamelab_locale');
+locale = localeWithI18nStringTracker(locale, 'gamelab');
 module.exports = locale;

--- a/apps/src/p5lab/spritelab/locale-do-not-import.js
+++ b/apps/src/p5lab/spritelab/locale-do-not-import.js
@@ -4,5 +4,5 @@ import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
 import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
 
 let locale = safeLoadLocale('spritelab_locale');
-locale = localeWithI18nStringTracker(locale, 'spritelab_locale');
+locale = localeWithI18nStringTracker(locale, 'spritelab');
 module.exports = locale;

--- a/apps/src/studio/locale.js
+++ b/apps/src/studio/locale.js
@@ -4,5 +4,5 @@ import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
 import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
 
 let locale = safeLoadLocale('studio_locale');
-locale = localeWithI18nStringTracker(locale, 'studio_locale');
+locale = localeWithI18nStringTracker(locale, 'studio');
 module.exports = locale;

--- a/apps/src/turtle/locale.js
+++ b/apps/src/turtle/locale.js
@@ -4,5 +4,5 @@ import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
 import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
 
 let locale = safeLoadLocale('turtle_locale');
-locale = localeWithI18nStringTracker(locale, 'turtle_locale');
+locale = localeWithI18nStringTracker(locale, 'turtle');
 module.exports = locale;

--- a/apps/src/tutorialExplorer/locale-do-not-import.js
+++ b/apps/src/tutorialExplorer/locale-do-not-import.js
@@ -11,5 +11,5 @@ import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
 import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
 
 let locale = safeLoadLocale('tutorialExplorer_locale');
-locale = localeWithI18nStringTracker(locale, 'tutorialExplorer_locale');
+locale = localeWithI18nStringTracker(locale, 'tutorialExplorer');
 module.exports = locale;

--- a/apps/src/util/i18nStringTrackerWorker.js
+++ b/apps/src/util/i18nStringTrackerWorker.js
@@ -46,7 +46,8 @@ class I18nStringTrackerWorker {
     }
 
     this.buffer[source] = this.buffer[source] || new Set();
-    this.buffer[source].add(stringKey);
+    this.buffer[source].add(`${source}.${stringKey}`);
+    console.log('this.buffer :', this.buffer);
 
     // schedule a buffer flush if there isn't already one.
     if (!this.pendingFlush) {

--- a/apps/src/util/i18nStringTrackerWorker.js
+++ b/apps/src/util/i18nStringTrackerWorker.js
@@ -47,7 +47,6 @@ class I18nStringTrackerWorker {
 
     this.buffer[source] = this.buffer[source] || new Set();
     this.buffer[source].add(`${source}.${stringKey}`);
-    console.log('this.buffer :', this.buffer);
 
     // schedule a buffer flush if there isn't already one.
     if (!this.pendingFlush) {

--- a/apps/src/util/locale-do-not-import.js
+++ b/apps/src/util/locale-do-not-import.js
@@ -12,5 +12,5 @@ import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
 import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
 
 let locale = safeLoadLocale('common_locale');
-locale = localeWithI18nStringTracker(locale, 'common_locale');
+locale = localeWithI18nStringTracker(locale, 'common');
 module.exports = locale;

--- a/apps/src/weblab/locale-do-not-import.js
+++ b/apps/src/weblab/locale-do-not-import.js
@@ -12,5 +12,5 @@ import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
 import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
 
 let locale = safeLoadLocale('weblab_locale');
-locale = localeWithI18nStringTracker(locale, 'weblab_locale');
+locale = localeWithI18nStringTracker(locale, 'weblab');
 module.exports = locale;

--- a/apps/src/weblab/locale.js
+++ b/apps/src/weblab/locale.js
@@ -4,5 +4,5 @@ import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
 import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
 
 let locale = safeLoadLocale('weblab_locale');
-locale = localeWithI18nStringTracker(locale, 'weblab_locale');
+locale = localeWithI18nStringTracker(locale, 'weblab');
 module.exports = locale;


### PR DESCRIPTION
**What**: This PR encapsulates two tasks. Updating `i18nStringTrackerWorker` to log the string keys with the source filename prepended, and updating the all of the individual `locale.js` files to log only the source name without the `_locale` appended to it.

**Why**: These updates will help to identify what JS source file the string key is from and avoid collisions (ex. two different "hello" keys)

## Links

- jira ticket: [FND-1714](https://codedotorg.atlassian.net/browse/FND-1714)
- jira ticket: [FND-1714](https://codedotorg.atlassian.net/browse/FND-1714)

## Testing story

Ran this branch locally and logged the contents of the buffer that will eventually be logged. The keys and values are in the correct format
![Screen Shot 2021-09-20 at 9 58 07 AM](https://user-images.githubusercontent.com/48133820/134026811-04d66180-b329-4eed-9ffe-bf8dcb3f6de0.png)


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
