### PR TITLE
Playground: add basic files

### DIFF
--- a/apps/src/javalab/Javalab.js
+++ b/apps/src/javalab/Javalab.js
@@ -35,6 +35,8 @@ import {
 } from '../containedLevels';
 import {lockContainedLevelAnswers} from '@cdo/apps/code-studio/levels/codeStudioLevels';
 import {initializeSubmitHelper, onSubmitComplete} from '../submitHelper';
+import Playground from './Playground';
+import PlaygroundVisualizationColumn from './PlaygroundVisualizationColumn';
 
 /**
  * On small mobile devices, when in portrait orientation, we show an overlay
@@ -121,9 +123,12 @@ Javalab.prototype.init = function(config) {
       this.visualization = <NeighborhoodVisualizationColumn />;
       break;
     case CsaViewMode.THEATER:
-    case CsaViewMode.PLAYGROUND:
       this.miniApp = new Theater(this.onOutputMessage, this.onNewlineMessage);
       this.visualization = <TheaterVisualizationColumn />;
+      break;
+    case CsaViewMode.PLAYGROUND:
+      this.miniApp = new Playground();
+      this.visualization = <PlaygroundVisualizationColumn />;
       break;
   }
 

--- a/apps/src/javalab/JavalabPanels.jsx
+++ b/apps/src/javalab/JavalabPanels.jsx
@@ -189,8 +189,10 @@ class JavalabPanels extends React.Component {
         $('#svgMaze').css('transform', scaleCss);
         break;
       case CsaViewMode.THEATER:
-      case CsaViewMode.PLAYGROUND:
         $('#theater-container').css('transform', scaleCss);
+        break;
+      case CsaViewMode.PLAYGROUND:
+        $('#playground-container').css('transform', scaleCss);
         break;
     }
 

--- a/apps/src/javalab/Playground.js
+++ b/apps/src/javalab/Playground.js
@@ -1,0 +1,1 @@
+export default class Playground {}

--- a/apps/src/javalab/PlaygroundVisualizationColumn.jsx
+++ b/apps/src/javalab/PlaygroundVisualizationColumn.jsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {connect} from 'react-redux';
+import PreviewPaneHeader from './PreviewPaneHeader';
+import ProtectedVisualizationDiv from '@cdo/apps/templates/ProtectedVisualizationDiv';
+import {toggleVisualizationCollapsed} from './javalabRedux';
+
+class PlaygroundVisualizationColumn extends React.Component {
+  static propTypes = {
+    // populated by redux
+    isReadOnlyWorkspace: PropTypes.bool,
+    isCollapsed: PropTypes.bool,
+    toggleVisualizationCollapsed: PropTypes.func
+  };
+
+  state = {
+    isFullscreen: false
+  };
+
+  render() {
+    const {
+      isReadOnlyWorkspace,
+      isCollapsed,
+      toggleVisualizationCollapsed
+    } = this.props;
+    const {isFullscreen} = this.state;
+
+    const opacity = isCollapsed ? 0 : 1;
+
+    return (
+      <div>
+        <PreviewPaneHeader
+          isCollapsed={isCollapsed}
+          isFullscreen={isFullscreen}
+          showAssetManagerButton
+          disableAssetManagerButton={isReadOnlyWorkspace}
+          showPreviewTitle={false}
+          toggleVisualizationCollapsed={toggleVisualizationCollapsed}
+        />
+        <div style={{opacity}}>
+          <ProtectedVisualizationDiv>
+            <div id="playground-container" style={styles.playground}>
+              <div id="playground" style={styles.playgroundDiv} />
+              <audio id="playground-audio" autoPlay={true} />
+            </div>
+          </ProtectedVisualizationDiv>
+        </div>
+      </div>
+    );
+  }
+}
+
+const styles = {
+  playground: {
+    backgroundColor: 'white',
+    width: 800,
+    height: 800
+  },
+  playgroundDiv: {
+    width: 800,
+    height: 800,
+    overflow: 'hidden'
+  }
+};
+
+export default connect(
+  state => ({
+    isReadOnlyWorkspace: state.pageConstants.isReadOnlyWorkspace,
+    isCollapsed: state.javalab.isVisualizationCollapsed
+  }),
+  dispatch => ({
+    toggleVisualizationCollapsed() {
+      dispatch(toggleVisualizationCollapsed());
+    }
+  })
+)(PlaygroundVisualizationColumn);


### PR DESCRIPTION
Add the boilerplate code for setting up the playground in Javalab. Right now the playground is just a blank white square.

## Links

- spec: [Playground](https://docs.google.com/document/d/1Moo2s5EXZRp5rMg1VW9jlOqs_GeMN5yjU8FJgoqOEMk/edit#heading=h.eydnjtq99gsk)

## Testing story
Tested locally, allthethings Javalab 9 still loads correctly.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
