### PR TITLE
import csta2011 standards, exported from curriculum builder

### DIFF
--- a/dashboard/config/standards/csta2011_categories.csv
+++ b/dashboard/config/standards/csta2011_categories.csv
@@ -1,0 +1,6 @@
+framework,parent,category,type,description
+csta2011,,CD,Strand,Computers & Communication Devices
+csta2011,,CI,Strand,"Community, Global, and Ethical Impacts"
+csta2011,,CL,Strand,Collaboration
+csta2011,,CPP,Strand,Computing Practice & Programming
+csta2011,,CT,Strand,Computational Thinking

--- a/dashboard/config/standards/csta2011_standards.csv
+++ b/dashboard/config/standards/csta2011_standards.csv
@@ -1,0 +1,168 @@
+framework,category,standard,description
+csta2011,CD,CD.L1:3-01,Use standard input and output devices to successfully operate computers and related technologies.
+csta2011,CD,CD.L1:6-01,Demonstrate an appropriate level of proficiency with keyboards and other input and output devices.
+csta2011,CD,CD.L1:6-02,"Understand the pervasiveness of computers and computing in daily life (e.g., voicemail, downloading videos and audio files, microwave ovens, thermostats, wireless Internet, mobile computing devices, GPS systems)."
+csta2011,CD,CD.L1:6-03,Apply strategies for identifying simple hardware and software problems that may occur during use.
+csta2011,CD,CD.L1:6-04,Identify that information is coming to the computer from many sources over a network.
+csta2011,CD,CD.L1:6-05,Identify factors that distinguish humans from machines.
+csta2011,CD,CD.L1:6-06,"Recognize that computers model intelligent behavior (as found in robotics, speech and language recognition and computer animation)."
+csta2011,CD,CD.L2:1,Recognize that computers are devices that execute programs.
+csta2011,CD,CD.L2:2,Identify a variety of electronic devices that contain computational processors.
+csta2011,CD,CD.L2:3,Demonstrate an understanding of the relationship between hardware and software.
+csta2011,CD,CD.L2:4,"Use developmentally appropriate, accurate terminology when communicating about technology."
+csta2011,CD,CD.L2:5,Apply strategies for identifying and solving routine hardware problems that occur during everyday computer use.
+csta2011,CD,CD.L2:6,Describe the major components and functions of computer systems and networks.
+csta2011,CD,CD.L2:7,"Describe what distinguishes humans from machines, focusing on human intelligence versus machine intelligence and ways we can communicate."
+csta2011,CD,CD.L2:8,"Describe ways in which computers use models of intelligent behavior (e.g., robot motion, speech and language understanding, and computer vision)."
+csta2011,CD,CD.L3A:1,"Describe the unique features of computers embedded in mobile devices and vehicles (e.g., cell phones, automobiles, airplanes)."
+csta2011,CD,CD.L3A:10,Describe the major applications of artificial intelligence and robotics.
+csta2011,CD,CD.L3A:2,Develop criteria for purchasing or upgrading computer system hardware.
+csta2011,CD,CD.L3A:3,"Describe the principal components of computer organization (e.g., input, output, processing, and storage)."
+csta2011,CD,CD.L3A:4,Compare various forms of input and output.
+csta2011,CD,CD.L3A:5,"Explain the multiple levels of hardware and software that support program execution (e.g., compilers, interpreters, operating systems, networks)."
+csta2011,CD,CD.L3A:6,Apply strategies for identifying and solving routine hardware and software problems that occur in everyday life.
+csta2011,CD,CD.L3A:7,Compare and contrast client-server and peer-to-peer network strategies.
+csta2011,CD,CD.L3A:8,"Explain the basic components of computer networks (e.g., servers, file protection, routing, spoolers and queues, shared resources, and fault-tolerance)."
+csta2011,CD,CD.L3A:9,Describe how the Internet facilitates global communication.
+csta2011,CD,CD.L3B:1,Discuss the impact of modifications on the functionality of application programs.
+csta2011,CD,CD.L3B:2,"Identify and describe hardware (e.g., physical layers, logic gates, chips, components)."
+csta2011,CD,CD.L3B:3,"Identify and select the most appropriate file format based on trade-offs (e.g., accuracy, speed, ease of manipulation)."
+csta2011,CD,CD.L3B:4,"Describe the issues that impact network functionality (e.g., latency, bandwidth, firewalls, server capability)."
+csta2011,CD,CD.L3B:5,Explain the notion of intelligent behavior through computer modeling and robotics.
+csta2011,CI,CI.L1:3-01,Practice responsible digital citizenship (legal and ethical behaviors) in the use of technology systems and software.
+csta2011,CI,CI.L1:3-02,Identify positive and negative social and ethical behaviors for using technology.
+csta2011,CI,CI.L1:6-01,Discuss basic issues related to responsible use of technology and information and the consequences of inappropriate use.
+csta2011,CI,CI.L1:6-02,"Identify the impact of technology (e.g., social networking, cyber bullying, mobile computing and communication, web technologies, cyber security and virtualization) on personal life and society."
+csta2011,CI,CI.L1:6-03,"Evaluate the accuracy, relevance, appropriateness, comprehensiveness and biases that occur in electronic information sources."
+csta2011,CI,CI.L1:6-04,"Understand ethical issues that relate to computers and networks (e.g., equity of access, security, privacy, copyright and intellectual property)."
+csta2011,CI,CI.L2:1,Exhibit legal and ethical behaviors when using information and technology and discuss the consequences of misuse.
+csta2011,CI,CI.L2:2,"Demonstrate knowledge of changes in information technologies over time and the effects those changes have on education, the workplace and society."
+csta2011,CI,CI.L2:3,Analyze the positive and negative impacts of computing on human culture.
+csta2011,CI,CI.L2:4,"Evaluate the accuracy, relevance, appropriateness, comprehensiveness and bias of electronic information sources concerning real-world problems."
+csta2011,CI,CI.L2:5,"Describe ethical issues that relate to computers and networks (e.g., security, privacy, ownership and information sharing)."
+csta2011,CI,CI.L2:6,"Discuss how the unequal distribution of computing resources in a global economy raises issues of equity, access and power."
+csta2011,CI,CI.L3A:1,Compare appropriate and inappropriate social networking behaviors.
+csta2011,CI,CI.L3A:10,Describe security and privacy issues that relate to computer networks.
+csta2011,CI,CI.L3A:11,Explain the impact of the digital divide on access to critical information.
+csta2011,CI,CI.L3A:2,"Discuss the impact of computing technology on business and commerce (e.g., automated tracking of goods, automated financial transactions, e-commerce, cloud computing)."
+csta2011,CI,CI.L3A:3,Describe the role that adaptive technology can play in the lives of people with special needs.
+csta2011,CI,CI.L3A:4,"Compare the positive and negative impacts of technology on culture (e.g., social networking, delivery of news and other public media, and intercultural communication)."
+csta2011,CI,CI.L3A:5,Describe strategies for determining the reliability of information found on the Internet.
+csta2011,CI,CI.L3A:6,Differentiate between information access and information distribution rights.
+csta2011,CI,CI.L3A:7,Describe how different kinds of software licenses can be used to share and protect intellectual property.
+csta2011,CI,CI.L3A:8,Discuss the social and economic implications associated with hacking and software piracy.
+csta2011,CI,CI.L3A:9,"Describe different ways in which software is created and shared and their benefits and drawbacks (commercial software, public domain software, open source development)."
+csta2011,CI,CI.L3B:1,Demonstrate ethical use of modern communication media and devices.
+csta2011,CI,CI.L3B:2,Analyze the beneficial and harmful effects of computing innovations.
+csta2011,CI,CI.L3B:3,"Summarize how financial markets, transactions, and predictions have been transformed by automation."
+csta2011,CI,CI.L3B:4,Summarize how computation has revolutionized the way people build real and virtual organizations and infrastructures.
+csta2011,CI,CI.L3B:5,Identify laws and regulations that impact the development and use of software.
+csta2011,CI,CI.L3B:6,Analyze the impact of government regulation on privacy and security.
+csta2011,CI,CI.L3B:7,"Differentiate among open source, freeware, and proprietary software licenses and their applicability to different types of software."
+csta2011,CI,CI.L3B:8,"Relate issues of equity, access, and power to the distribution of computing resources in a global society."
+csta2011,CL,CL.L1:3-01,"Gather information and communicate electronically with others with support from teachers, family members or student partners."
+csta2011,CL,CL.L1:3-02,"Work cooperatively and collaboratively with peers, teachers and others using technology."
+csta2011,CL,CL.L1:6-01,"Use productivity technology tools (e.g., word processing, spreadsheet, presentation software) for individual and collaborative writing, communication and publishing activities."
+csta2011,CL,CL.L1:6-02,"Use online resources (e.g., email, online discussions, collaborative web environments) to participate in collaborative problem-solving activities for the purpose of developing solutions or products."
+csta2011,CL,CL.L1:6-03,Identify ways that teamwork and collaboration can support problem solving and innovation.
+csta2011,CL,CL.L2:1,Apply productivity/ multimedia tools and peripherals to group collaboration and support learning throughout the curriculum.
+csta2011,CL,CL.L2:2,"Collaboratively design, develop, publish and present products (e.g., videos, podcasts, websites) using technology resources that demonstrate and communicate curriculum. concepts."
+csta2011,CL,CL.L2:3,"Collaborate with peers, experts and others using collaborative practices such as pair programming, working in project teams and participating in-group active learning activities."
+csta2011,CL,CL.L2:4,"Exhibit dispositions necessary for collaboration: providing useful feedback, integrating feedback, understanding and accepting multiple perspectives, socialization."
+csta2011,CL,CL.L3A:1,Work in a team to design and develop a software artifact.
+csta2011,CL,CL.L3A:2,"Use collaborative tools to communicate with project team members (e.g., discussion threads, wikis, blogs, version control, etc.)."
+csta2011,CL,CL.L3A:3,"Describe how computing enhances traditional forms and enables new forms of experience, expression, communication, and collaboration."
+csta2011,CL,CL.L3A:4,Identify how collaboration influences the design and development of software products.
+csta2011,CL,CL.L3B:1,"Use project collaboration tools, version control systems, and Integrated Development Environments (IDEs) while working on a collaborative software project."
+csta2011,CL,CL.L3B:2,Demonstrate the software life cycle process by participating on a software project team.
+csta2011,CL,CL.L3B:3,Evaluate programs written by others for readability and usability.
+csta2011,CPP,CPP.L1:3-01,Use technology resources to conduct age-appropriate research.
+csta2011,CPP,CPP.L1:3-02,"Use developmentally appropriate multimedia resources (e.g., interactive books and educational software) to support learning across the curriculum."
+csta2011,CPP,CPP.L1:3-03,"Create developmentally appropriate multimedia products with support from teachers, family members or student partners."
+csta2011,CPP,CPP.L1:3-04,"Construct a set of statements to be acted out to accomplish a simple task (e.g., turtle instructions)."
+csta2011,CPP,CPP.L1:3-05,Identify jobs that use computing and technology.
+csta2011,CPP,CPP.L1:3-06,Gather and organize information using concept-mapping tools.
+csta2011,CPP,CPP.L1:6-01,"Use technology resources (e.g., calculators, data collection probes, mobile devices, videos, educational software and web tools) for problem-solving and self-directed learning."
+csta2011,CPP,CPP.L1:6-02,"Use general-purpose productivity tools and peripherals to support personal productivity, remediate skill deficits and facilitate learning."
+csta2011,CPP,CPP.L1:6-03,"Use technology tools (e.g., multimedia and text authoring, presentation, web tools, digital cameras and scanners) for individual and collaborative writing, communication and publishing activities."
+csta2011,CPP,CPP.L1:6-04,Gather and manipulate data using a variety of digital tools.
+csta2011,CPP,CPP.L1:6-05,"Construct a program as a set of step-by-step instructions to be acted out (e.g., make peanut butter and jelly sandwich activity)."
+csta2011,CPP,CPP.L1:6-06,Implement problem solutions using a block based visual programming language.
+csta2011,CPP,CPP.L1:6-07,"Use computing devices to access remote information, communicate with others in support of direct and independent learning and pursue personal interests."
+csta2011,CPP,CPP.L1:6-08,Navigate between webpages using hyperlinks and conduct simple searches using search engines.
+csta2011,CPP,CPP.L1:6-09,Identify a wide range of jobs that require knowledge or use of computing.
+csta2011,CPP,CPP.L1:6-10,Gather and manipulate data using a variety of digital tools.
+csta2011,CPP,CPP.L2:1,Select appropriate tools and technology resources to accomplish a variety of tasks and solve problems.
+csta2011,CPP,CPP.L2:2,Use a variety of multimedia tools and peripherals to support personal productivity and learning throughout the curriculum.
+csta2011,CPP,CPP.L2:3,"Design, develop, publish and present products (e.g., web pages, mobile applications, animations) using technology resources that demonstrate and communicate curriculum concepts."
+csta2011,CPP,CPP.L2:4,Demonstrate an understanding of algorithms and their practical application.
+csta2011,CPP,CPP.L2:5,"Implement problem solutions using a programming language, including: looping behavior, conditional statements, logic, expressions, variables and functions."
+csta2011,CPP,CPP.L2:6,"Demonstrate good practices in personal information security, using passwords, encryption and secure transactions."
+csta2011,CPP,CPP.L2:7,Identify interdisciplinary careers that are enhanced by computer science.
+csta2011,CPP,CPP.L2:8,"Demonstrate dispositions amenable to open-ended problem solving and programming (e.g., comfort with complexity, persistence, brainstorming, adaptability, patience, propensity to tinker, creativity, accepting challenge)."
+csta2011,CPP,CPP.L2:9,Collect and analyze data that is output from multiple runs of a computer program.
+csta2011,CPP,CPP.L3A:1,Create and organize web pages through the use of a variety of web programming design tools.
+csta2011,CPP,CPP.L3A:10,Explore a variety of careers to which computing is central.
+csta2011,CPP,CPP.L3A:11,Describe techniques for locating and collecting small and large-scale data sets.
+csta2011,CPP,CPP.L3A:12,"Describe how mathematical and statistical functions, sets, and logic are used in computation."
+csta2011,CPP,CPP.L3A:2,"Use mobile devices/ emulators to design, develop, and implement mobile computing applications."
+csta2011,CPP,CPP.L3A:3,"Use various debugging and testing methods to ensure program correctness (e.g., test cases, unit testing, white box, black box, integration testing)"
+csta2011,CPP,CPP.L3A:4,"Apply analysis, design, and implementation techniques to solve problems (e.g., use one or more software lifecycle models)."
+csta2011,CPP,CPP.L3A:5,Use Application Program Interfaces (APIs) and libraries to facilitate programming solutions.
+csta2011,CPP,CPP.L3A:6,Select appropriate file formats for various types and uses of data.
+csta2011,CPP,CPP.L3A:7,Describe a variety of programming languages available to solve problems and develop systems.
+csta2011,CPP,CPP.L3A:8,Explain the program execution process.
+csta2011,CPP,CPP.L3A:9,"Explain the principles of security by examining encryption, cryptography, and authentication techniques."
+csta2011,CPP,CPP.L3B:1,"Use advanced tools to create digital artifacts (e.g., web design, animation, video, multimedia)."
+csta2011,CPP,CPP.L3B:2,"Use tools of abstraction to decompose a large-scale computational problem (e.g., procedural abstraction, object-oriented design, functional design)."
+csta2011,CPP,CPP.L3B:3,Classify programming languages based on their level and application domain.
+csta2011,CPP,CPP.L3B:4,"Explore principles of system design in scaling, efficiency, and security."
+csta2011,CPP,CPP.L3B:5,Deploy principles of security by implementing encryption and authentication strategies.
+csta2011,CPP,CPP.L3B:6,Anticipate future careers and the technologies that will exist.
+csta2011,CPP,CPP.L3B:7,Use data analysis to enhance understanding of complex natural and human systems.
+csta2011,CPP,CPP.L3B:8,Deploy various data collection techniques for different types of problems.
+csta2011,CT,CT.L1:3-01,Recognize that software is created to control computer operations.
+csta2011,CT,CT.L1:3-02,Demonstrate how 0s and 1s can be used to represent information.
+csta2011,CT,CT.L1:6-01,"Understand and use the basic steps in algorithmic problem-solving (e.g., problem statement and exploration, examination of sample instances, design, implementation and testing)."
+csta2011,CT,CT.L1:6-02,"Develop a simple understanding of an algorithm (e.g., search, sequence of events or sorting) using computer-free exercises."
+csta2011,CT,CT.L1:6-03,Demonstrate how a string of bits can be used to represent alphanumeric information.
+csta2011,CT,CT.L1:6-04,Describe how a simulation can be used to solve a problem.
+csta2011,CT,CT.L1:6-05,Make a list of sub-problems to consider while addressing a larger problem.
+csta2011,CT,CT.L1:6-06,Understand the connections between computer science and other fields.
+csta2011,CT,CT.L2:1,"Use the basic steps in algorithmic problem-solving to design solutions (e.g., problem statement and exploration, examination of sample instances, design, implementing a solution, testing and evaluation)."
+csta2011,CT,CT.L2:10,Evaluate what kinds of problems can be solved using modeling and simulation.
+csta2011,CT,CT.L2:11,Analyze the degree to which a computer model accurately represents the real world.
+csta2011,CT,CT.L2:12,Use abstraction to decompose a problem into sub problems.
+csta2011,CT,CT.L2:13,"Understand the notion of hierarchy and abstraction in computing including high level languages, translation, instruction set and logic circuits."
+csta2011,CT,CT.L2:14,"Examine connections between elements of mathematics and computer science including binary numbers, logic, sets and functions."
+csta2011,CT,CT.L2:15,Provide examples of interdisciplinary applications of computational thinking.
+csta2011,CT,CT.L2:2,Describe the process of parallelization as it relates to problem solving.
+csta2011,CT,CT.L2:3,Define an algorithm as a sequence of instructions that can be processed by a computer.
+csta2011,CT,CT.L2:4,Evaluate ways that different algorithms may be used to solve the same problem.
+csta2011,CT,CT.L2:5,Act out searching and sorting algorithms.
+csta2011,CT,CT.L2:6,"Describe and analyze a sequence of instructions being followed (e.g., describe a characterâ€™s behavior in a video game as driven by rules and algorithms)."
+csta2011,CT,CT.L2:7,"Represent data in a variety of ways including text, sounds, pictures and numbers."
+csta2011,CT,CT.L2:8,"Use visual representations of problem states, structures and data (e.g., graphs, charts, network diagrams, flowcharts)."
+csta2011,CT,CT.L2:9,"Interact with content-specific models and simulations (e.g., ecosystems, epidemics, molecular dynamics) to support learning and research."
+csta2011,CT,CT.L3A:1,"Use predefined functions and parameters, classes and methods to divide a complex problem into simpler parts."
+csta2011,CT,CT.L3A:10,Describe the concept of parallel processing as a strategy to solve large problems.
+csta2011,CT,CT.L3A:11,Describe how computation shares features with art and music by translating human intention into an artifact.
+csta2011,CT,CT.L3A:2,"Describe a software development process used to solve software problems (e.g., design, coding, testing, verification)."
+csta2011,CT,CT.L3A:3,"Explain how sequence, selection, iteration, and recursion are building blocks of algorithms."
+csta2011,CT,CT.L3A:4,Compare techniques for analyzing massive data collections.
+csta2011,CT,CT.L3A:5,Describe the relationship between binary and hexadecimal representations.
+csta2011,CT,CT.L3A:6,Analyze the representation and trade-offs among various forms of digital information.
+csta2011,CT,CT.L3A:7,Describe how various types of data are stored in a computer system.
+csta2011,CT,CT.L3A:8,Use modeling and simulation to represent and understand natural phenomena.
+csta2011,CT,CT.L3A:9,Discuss the value of abstraction to manage problem complexity.
+csta2011,CT,CT.L3B:1,"Classify problems as tractable, intractable, or computationally unsolvable."
+csta2011,CT,CT.L3B:10,Decompose a problem by defining new functions and classes.
+csta2011,CT,CT.L3B:11,Demonstrate concurrency by separating processes into threads and dividing data into parallel streams.
+csta2011,CT,CT.L3B:2,Explain the value of heuristic algorithms to approximate solutions for intractable problems.
+csta2011,CT,CT.L3B:3,Critically examine classical algorithms and implement an original algorithm.
+csta2011,CT,CT.L3B:4,"Evaluate algorithms by their efficiency, correctness, and clarity."
+csta2011,CT,CT.L3B:5,Use data analysis to enhance understanding of complex natural and human systems.
+csta2011,CT,CT.L3B:6,"Compare and contrast simple data structures and their uses (e.g., arrays and lists)."
+csta2011,CT,CT.L3B:7,"Discuss the interpretation of binary sequences in a variety of forms (e.g., instructions, numbers, text, sound, image)."
+csta2011,CT,CT.L3B:8,"Use models and simulations to help formulate, refine, and test scientific hypotheses."
+csta2011,CT,CT.L3B:9,Analyze data and identify patterns through modeling and simulation.

--- a/dashboard/config/standards/frameworks.csv
+++ b/dashboard/config/standards/frameworks.csv
@@ -3,6 +3,7 @@ iste,ISTE Standards for Students
 ccela,Common Core English Language Arts Standards
 ccmath,Common Core Math Standards
 ngss,Next Generation Science Standards
+csta2011,CSTA K-12 Computer Science Standards (2011)
 csta,CSTA K-12 Computer Science Standards (2017)
 csp2021,CSP Conceptual Framework
 csa,CSA Conceptual Framework


### PR DESCRIPTION
Continues [PLAT-1265]. lesson import was failing for some of the HOC scripts that Mike needs imported, listed in https://docs.google.com/spreadsheets/d/1inzBUu4tlPh82JDiBIMCKVHacaMI-Hutex2e9inOJ4E/edit#gid=0. Using the import script being added in https://github.com/code-dot-org/code-dot-org/pull/42567, the errors looked like this:

```
Dave-MBP:~/src/cdo (import-hoc-lesson)$ bundle exec bin/curriculum/import_hoc_lesson_plan.rb -v -u playlab -p /hoc/plugged/4
Could not find Standard: {"shortcode"=>"CL.L1:6-02", "framework"=>"CSTA2011"}
Could not find Standard: {"shortcode"=>"CPP.L1:3-01", "framework"=>"CSTA2011"}
Could not find Standard: {"shortcode"=>"CPP.L1:6-01", "framework"=>"CSTA2011"}
Could not find Standard: {"shortcode"=>"CPP.L1:6-06", "framework"=>"CSTA2011"}
Could not find Standard: {"shortcode"=>"CPP.L2:3", "framework"=>"CSTA2011"}
Could not find Standard: {"shortcode"=>"CT.L2:12", "framework"=>"CSTA2011"}
Could not find Standard: {"shortcode"=>"CT.L2:7", "framework"=>"CSTA2011"}
ActiveRecord::AssociationTypeMismatch: Standard(#70143865308820) expected, got nil which is an instance of NilClass(#70144827473460)
  /Users/dsb/src/cdo/lib/cdo/lesson_import_helper.rb:68:in `update_lesson'
  ...
```

The solution is simply to import this standards framework from curriculum builder. Fortunately, previous work made it so that the following URLs produce the exact format needed for the _standards.csv and _categories.csv files added in this PR:
* https://www.codecurricula.com/standards/framework/CSTA2011_standards.csv
* https://www.codecurricula.com/standards/framework/CSTA2011_categories.csv

The line in frameworks.csv was added manually.

## Testing story

Manually verified that `rake seed:scripts` succeeds locally, and that rerunning the failing command above then succeeds.


[PLAT-1265]: https://codedotorg.atlassian.net/browse/PLAT-1265