### PR TITLE
hoc: hide event sign-up during actual-hoc

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/views/home_signup.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/home_signup.haml
@@ -4,7 +4,7 @@
 %a#hocsignupform{name: 'signup'}
 #join
   %h1#join-us-header=hoc_s(:front_join_us_button)
-  -if ["post-hoc", false].include?(hoc_mode)
+  -if ["actual-hoc", "post-hoc", false].include?(hoc_mode)
     #signup-closed
       !=hoc_s(:signup_registration_not_required_markdown, markdown: :inline, locals: {hoc_activities_url: resolve_url('/learn'), howto_guide_url: resolve_url('/how-to')})
       =hoc_s(:signup_registration_closed)


### PR DESCRIPTION
During the 2020 Hour of Code, there was an issue with the event sign-up form when the map on https://hourofcode.com/ was replaced by a static image, which we do each year.

It's possible that we can fix this (with some work in https://github.com/code-dot-org/code-dot-org/pull/38135 but additional work expected).  But last year, we opted to simply hide the form with a temporary hack in https://github.com/code-dot-org/code-dot-org/pull/38138 (which was undone in https://github.com/code-dot-org/code-dot-org/pull/38343).

For now, this just puts that change back in place more formally, so that the event sign-up for is hidden when `hoc_mode` is `"actual_hoc"`.
