### PR TITLE
hoc: allow sign-up even when map is hidden

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/public/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/index.haml
@@ -9,6 +9,11 @@ social:
 
 %link{href: "/css/highlights-homepage.css", rel: "stylesheet", id: "highlight-styles"}
 
+-# These are needed for the signup form, even if the map isn't currently showing.
+%script{src:'https://api.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js'}
+:javascript
+  mapboxgl.accessToken = "#{CDO.mapbox_access_token}";
+
 -facebook = {:u=>"http://#{request.host}/us"}
 
 -# We set the DCDO default to CDO.default_hoc_mode here because we can't change the DCDO flag on the test machine, but

--- a/pegasus/sites.v3/hourofcode.com/public/map.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/map.haml
@@ -5,6 +5,10 @@ layout: wide_index
 :ruby
   @header["title"] = hoc_s(:map_title)
 
+%script{src:'https://api.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js'}
+:javascript
+  mapboxgl.accessToken = "#{CDO.mapbox_access_token}";
+
 %script{type: "text/javascript", src: "/js/jquery.geocomplete.min.js"}
 
   = view :header

--- a/pegasus/sites.v3/hourofcode.com/views/hoc_events_map.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/hoc_events_map.haml
@@ -1,6 +1,5 @@
 %link{rel: "stylesheet", type: "text/css", href: "/css/map.css"}
 %link{href:'https://api.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css', rel:'stylesheet'}
-%script{src:'https://api.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js'}
 %script{src: webpack_asset_path("js/hourofcode.com/views/hoc_events_map.js"), defer:true}
 
 %div{id: 'mapbox-map'}
@@ -11,7 +10,3 @@
   %div= hoc_s(:map_legend_hoc_events)
   .color.red
   %div= hoc_s(:map_legend_cs_tech_jam)
-
-
-:javascript
-  mapboxgl.accessToken = "#{CDO.mapbox_access_token}";

--- a/pegasus/sites.v3/hourofcode.com/views/home_signup.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/home_signup.haml
@@ -4,7 +4,7 @@
 %a#hocsignupform{name: 'signup'}
 #join
   %h1#join-us-header=hoc_s(:front_join_us_button)
-  -if ["post-hoc", false].include?(hoc_mode)
+  -if ["actual-hoc", "post-hoc", false].include?(hoc_mode)
     #signup-closed
       !=hoc_s(:signup_registration_not_required_markdown, markdown: :inline, locals: {hoc_activities_url: resolve_url('/learn'), howto_guide_url: resolve_url('/how-to')})
       =hoc_s(:signup_registration_closed)

--- a/pegasus/sites.v3/hourofcode.com/views/home_signup.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/home_signup.haml
@@ -4,7 +4,7 @@
 %a#hocsignupform{name: 'signup'}
 #join
   %h1#join-us-header=hoc_s(:front_join_us_button)
-  -if ["actual-hoc", "post-hoc", false].include?(hoc_mode)
+  -if ["post-hoc", false].include?(hoc_mode)
     #signup-closed
       !=hoc_s(:signup_registration_not_required_markdown, markdown: :inline, locals: {hoc_activities_url: resolve_url('/learn'), howto_guide_url: resolve_url('/how-to')})
       =hoc_s(:signup_registration_closed)

--- a/pegasus/sites.v3/hourofcode.com/views/signup_form.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/signup_form.haml
@@ -159,4 +159,3 @@
   var signupErrorMessage = "#{signup_submit_error_message}";
   var censusErrorMessage = "#{signup_submit_census_error_message}";
   var hocYear = "#{hoc_year}"
-  if (typeof mapboxgl === 'object') {mapboxgl.accessToken = "#{CDO.mapbox_access_token}";}


### PR DESCRIPTION
This shuffles a bit of code so that event sign-up at https://hourofcode.com/ works, even when the map is replaced by a static image.

Followup to https://github.com/code-dot-org/code-dot-org/pull/38135.  That said, this should have no effect at the moment, because we [currently](https://github.com/code-dot-org/code-dot-org/pull/42581) disable the sign-up form at the same time the map is hidden, which is when `hoc_mode` is `"actual-hoc"`.  But it should mean the sign-up form works if we reenable it for `"actual-hoc"`.

