### PR TITLE
Add retries to Resource PDF Generation

### DIFF
--- a/dashboard/test/lib/services/curriculum_pdfs/resources_test.rb
+++ b/dashboard/test/lib/services/curriculum_pdfs/resources_test.rb
@@ -17,6 +17,12 @@ class Services::CurriculumPdfs::ResourcesTest < ActiveSupport::TestCase
     @fake_google_drive_file.stubs(:id).returns("google-drive-file-id")
     Services::CurriculumPdfs.stubs(:google_drive_file_by_url).returns(@fake_google_drive_file)
 
+    # We have some custom logic in the title page generation which aggressively
+    # checks for the actual existence of the file on the filesystem and raises
+    # an exception if it doesn't find it; we don't actually want to create any
+    # files on the filesystem as part of our test, so we stub that method
+    Services::CurriculumPdfs.stubs(:generate_lesson_resources_title_page)
+
     # mock some file operations for the 'download PDF from url' case
     IO.stubs(:copy_stream)
     URI.stubs(:open).returns(StringIO.new)


### PR DESCRIPTION
For background, we've had an intermittent issue with the Curriculum PDF generation process in which when it comes time to collate all our individual PDFs together in the rollup, GhostScript complains that it can't find all the files that we're telling it to roll up, and the PDF generation fails.

I've been able to track down the failure to specifically the title pages that we generate in the Resource rollup to differentiate the lessons within a script. Unfortunately, I have been unable to get any kind of reliable repro, much less to figure out *why* this is happening in the first place.

Because I know where the problem is but not why it is, and because it happens so rarely as to make further investigation difficult, I'm resorting to a retry. It's not a good solution, but it's the best I got at this point.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
