### PR TITLE
update csd / csp survey lesson names to match their unit names

### DIFF
--- a/dashboard/config/locales/scripts.en.yml
+++ b/dashboard/config/locales/scripts.en.yml
@@ -5935,7 +5935,7 @@ en:
             CSP post survey 2018 staging:
               name: CSP post survey 2018 staging
             CSP post-course survey:
-              name: CSP post-course survey
+              name: CSP Student Post-Course Survey ('17-'18)
           student_description: Welcome to the Code.org CS Principles Post-Course Survey.  This survey takes about 15 minutes to complete.  Your responses are private and anonymous -- your teacher can see anonymous aggregate results for the whole class.  The results are vital for your teacher and for Code.org to sustain and improve the course.  Thanks for your time and consideration.
         public-key-cryptography:
           title: Public Key Cryptography Widgets
@@ -10483,7 +10483,7 @@ en:
               display_name: Post-Course Survey
           lessons:
             CSD post-course survey:
-              name: CSD post-course survey
+              name: CSD Student Post-Course Survey ('18-'19)
           student_description: Welcome to the Code.org CS Discoveries Post-Course Survey.  This survey takes about 15 minutes to complete.  Your responses are private and anonymous -- your teacher can see anonymous aggregate results for the whole class.  The results are vital for your teacher and for Code.org to sustain and improve the course.  Thanks for your time and consideration.
         csd-novice-18:
           title: CS Discoveries Novice Reflections 2018-2019
@@ -11912,7 +11912,7 @@ en:
               display_name: Survey
           lessons:
             CSP Mid-year survey:
-              name: CSP Mid-year survey
+              name: CSP Student Mid-year Survey
           student_description: Welcome to the Code.org CS Principles Mid-Year Survey.  This survey takes about 15 minutes to complete.  Your responses are private and anonymous -- your teacher can see anonymous aggregate results for the whole class.  The results are vital for your teacher and for Code.org to sustain and improve the course.  Thanks for your time and consideration.
         gamelab:
           title: Game Lab
@@ -14146,7 +14146,7 @@ en:
               display_name: Survey
           lessons:
             CSD post-course survey:
-              name: CSD post-course survey
+              name: CSD Student Post-Course Survey ('18-'19)
           student_description: "The CS Discoveries Post-Course Survey is an important tool we use to get feedback from you and make improvements to the course. \r\n The survey is private and anonymous -- your teacher can see anonymous aggregate results for the whole class.  The results are vital for your teacher and for Code.org to sustain and improve the course.  Thanks for your time and consideration."
         csp-post-survey-2018:
           title: CSP Student Post-Course Survey ('18-'19)
@@ -14158,7 +14158,7 @@ en:
               display_name: Survey
           lessons:
             CSP post-course survey:
-              name: CSP post-course survey
+              name: CSP Student Post-Course Survey ('18-'19)
           student_description: Welcome to the Code.org CS Principles Post-Course Survey.  This survey takes about 15 minutes to complete.  Your responses are private and anonymous -- your teacher can see anonymous aggregate results for the whole class.  The results are vital for your teacher and for Code.org to sustain and improve the course.  Thanks for your time and consideration.
         csp5-pilot:
           title: CSP Unit 5 Pilot - Lists, Loops, and Traversals

--- a/dashboard/config/scripts/csd-post-survey-2018.script
+++ b/dashboard/config/scripts/csd-post-survey-2018.script
@@ -4,6 +4,6 @@ has_verified_resources true
 published_state 'preview'
 
 lesson_group 'cspSurvey', display_name: 'Survey'
-lesson 'CSD post-course survey', display_name: 'CSD post-course survey', has_lesson_plan: true
+lesson 'CSD post-course survey', display_name: 'CSD Student Post-Course Survey (\'18-\'19)', has_lesson_plan: true
 level 'csd-post-survey-levelgroup-2018', progression: 'CS Discoveries Post-Course Survey', assessment: true
 

--- a/dashboard/config/scripts/csd-post-survey.script
+++ b/dashboard/config/scripts/csd-post-survey.script
@@ -6,6 +6,6 @@ published_state 'preview'
 is_course true
 
 lesson_group 'csd_survey', display_name: 'Post-Course Survey'
-lesson 'CSD post-course survey', display_name: 'CSD post-course survey', has_lesson_plan: false
+lesson 'CSD post-course survey', display_name: 'CSD Student Post-Course Survey (\'18-\'19)', has_lesson_plan: false
 level 'csd-post-survey-2017-levelgroup-2018-2nd-semester', progression: 'CS Discoveries Post-course Survey', assessment: true
 

--- a/dashboard/config/scripts/csp-mid-survey.script
+++ b/dashboard/config/scripts/csp-mid-survey.script
@@ -6,6 +6,6 @@ published_state 'preview'
 is_course true
 
 lesson_group 'cspSurvey', display_name: 'Survey'
-lesson 'CSP Mid-year survey', display_name: 'CSP Mid-year survey', has_lesson_plan: false
+lesson 'CSP Mid-year survey', display_name: 'CSP Student Mid-year Survey', has_lesson_plan: false
 level 'csp-post-survey-2017-levelgroup_2018', progression: 'CS Principles Mid-year Survey', assessment: true
 

--- a/dashboard/config/scripts/csp-post-survey-2018.script
+++ b/dashboard/config/scripts/csp-post-survey-2018.script
@@ -4,6 +4,6 @@ has_verified_resources true
 published_state 'preview'
 
 lesson_group 'cspSurvey', display_name: 'Survey'
-lesson 'CSP post-course survey', display_name: 'CSP post-course survey', has_lesson_plan: true
+lesson 'CSP post-course survey', display_name: 'CSP Student Post-Course Survey (\'18-\'19)', has_lesson_plan: true
 level 'csp-post-survey-levelgroup-2018', progression: 'CS Principles Post-course Survey', assessment: true
 

--- a/dashboard/config/scripts/csp-post-survey.script
+++ b/dashboard/config/scripts/csp-post-survey.script
@@ -3,6 +3,6 @@ has_verified_resources true
 published_state 'preview'
 
 lesson_group 'cspSurvey', display_name: 'Survey'
-lesson 'CSP post-course survey', display_name: 'CSP post-course survey', has_lesson_plan: false
+lesson 'CSP post-course survey', display_name: 'CSP Student Post-Course Survey (\'17-\'18)', has_lesson_plan: false
 level 'csp-post-survey-2018-levelgroup', progression: 'CS Principles Post-course Survey', assessment: true
 

--- a/dashboard/config/scripts_json/csd-post-survey-2018.script_json
+++ b/dashboard/config/scripts_json/csd-post-survey-2018.script_json
@@ -34,7 +34,7 @@
   "lessons": [
     {
       "key": "CSD post-course survey",
-      "name": "CSD post-course survey",
+      "name": "CSD Student Post-Course Survey ('18-'19)",
       "absolute_position": 1,
       "lockable": false,
       "has_lesson_plan": true,

--- a/dashboard/config/scripts_json/csd-post-survey.script_json
+++ b/dashboard/config/scripts_json/csd-post-survey.script_json
@@ -34,7 +34,7 @@
   "lessons": [
     {
       "key": "CSD post-course survey",
-      "name": "CSD post-course survey",
+      "name": "CSD Student Post-Course Survey ('18-'19)",
       "absolute_position": 1,
       "lockable": false,
       "has_lesson_plan": false,

--- a/dashboard/config/scripts_json/csp-mid-survey.script_json
+++ b/dashboard/config/scripts_json/csp-mid-survey.script_json
@@ -33,7 +33,7 @@
   "lessons": [
     {
       "key": "CSP Mid-year survey",
-      "name": "CSP Mid-year survey",
+      "name": "CSP Student Mid-year Survey",
       "absolute_position": 1,
       "lockable": false,
       "has_lesson_plan": false,

--- a/dashboard/config/scripts_json/csp-post-survey-2018.script_json
+++ b/dashboard/config/scripts_json/csp-post-survey-2018.script_json
@@ -34,7 +34,7 @@
   "lessons": [
     {
       "key": "CSP post-course survey",
-      "name": "CSP post-course survey",
+      "name": "CSP Student Post-Course Survey ('18-'19)",
       "absolute_position": 1,
       "lockable": false,
       "has_lesson_plan": true,

--- a/dashboard/config/scripts_json/csp-post-survey.script_json
+++ b/dashboard/config/scripts_json/csp-post-survey.script_json
@@ -31,7 +31,7 @@
   "lessons": [
     {
       "key": "CSP post-course survey",
-      "name": "CSP post-course survey",
+      "name": "CSP Student Post-Course Survey ('17-'18)",
       "absolute_position": 1,
       "lockable": false,
       "has_lesson_plan": false,


### PR DESCRIPTION
Starts https://codedotorg.atlassian.net/browse/PLAT-1027. 

https://github.com/code-dot-org/code-dot-org/pull/42604 outlines a process for fixing lesson names for hoc units. see that PR for more context.

This PR takes care of fixing lesson names for all single-lesson units which are not HOC units and are not currently having lesson plans imported into code studio. The goal of this PR is to make sure there is no user-visible change to `["csd-post-survey-2018", "csd-post-survey", "csp-mid-survey", "csp-post-survey-2018", "csp-post-survey"]` when we move from showing unit name to lesson name. Therefore, all I did was set the lesson name equal to the unit name:

```
unit_names = ["csd-post-survey-2018", "csd-post-survey", "csp-mid-survey", "csp-post-survey-2018", "csp-post-survey"]
Script.where(name: unit_names).each do |unit|
  unit.lessons.first.update!(name: unit.localized_title)
  unit.reload
  unit.write_script_dsl
  unit.write_script_json
  Script.merge_and_write_i18n(unit.lessons.first.i18n_hash, unit.name)
end
```

## Testing Story

Verified that `rake seed:all` still succeeds, and that there is no visible difference on script overview pages for the affected scripts:
![Screen Shot 2021-09-21 at 2 47 52 PM](https://user-images.githubusercontent.com/8001765/134252418-bd977f64-87f9-48f7-a847-8c02a8919180.png)
