### PR TITLE
conditionally show lesson name instead of unit name in single-lesson units

### DIFF
--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -263,11 +263,21 @@ class Lesson < ApplicationRecord
   end
 
   def localized_name
-    if script.lessons.many?
+    # The behavior to show the script title instead of the lesson name in
+    # single-lesson scripts is deprecated.
+    #
+    # TODO(dave): once all scripts are migrated and no longer
+    # using legacy lesson plans, remove this condition and consolidate with
+    # localized_name_for_lesson_show.
+    if script.lessons.many? || (script.is_migrated && !script.use_legacy_lesson_plans)
       I18n.t "data.script.name.#{script.name}.lessons.#{key}.name"
     else
       I18n.t "data.script.name.#{script.name}.title"
     end
+  end
+
+  def localized_name_for_lesson_show
+    I18n.t "data.script.name.#{script.name}.lessons.#{key}.name"
   end
 
   def localized_lesson_plan
@@ -485,7 +495,7 @@ class Lesson < ApplicationRecord
       position: relative_position,
       lockable: lockable,
       key: key,
-      displayName: localized_name,
+      displayName: localized_name_for_lesson_show,
       overview: render_property(:overview),
       announcements: announcements,
       purpose: render_property(:purpose),

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -266,7 +266,7 @@ class Lesson < ApplicationRecord
     # The behavior to show the script title instead of the lesson name in
     # single-lesson scripts is deprecated.
     #
-    # TODO(dave): once all scripts are migrated and no longer
+    # TODO(dave): once all scripts with exactly one lesson are migrated and no longer
     # using legacy lesson plans, remove this condition and consolidate with
     # localized_name_for_lesson_show.
     if script.lessons.many? || (script.is_migrated && !script.use_legacy_lesson_plans)

--- a/dashboard/test/controllers/lessons_controller_test.rb
+++ b/dashboard/test/controllers/lessons_controller_test.rb
@@ -262,9 +262,9 @@ class LessonsControllerTest < ActionController::TestCase
   test 'show lesson when lesson is the only lesson in script' do
     script = create :script, name: 'one-lesson-script', is_migrated: true
     lesson_group = create :lesson_group, script: script
-    @solo_lesson_in_script = create(
+    solo_lesson_in_script = create(
       :lesson,
-      name: 'lesson display name',
+      name: @lesson_name,
       script_id: script.id,
       lesson_group_id: lesson_group.id,
       has_lesson_plan: true,
@@ -278,10 +278,10 @@ class LessonsControllerTest < ActionController::TestCase
       'data' => {
         'script' => {
           'name' => {
-            @solo_lesson_in_script.script.name => {
+            script.name => {
               'title' => @script_title,
               'lessons' => {
-                @lesson.name => {
+                solo_lesson_in_script.key => {
                   'name' => @lesson_name
                 }
               }
@@ -292,19 +292,17 @@ class LessonsControllerTest < ActionController::TestCase
     }
 
     I18n.backend.store_translations 'en-US', custom_i18n
-    assert_equal @script_title, @solo_lesson_in_script.script.localized_title
-
-    # a bit weird, but this is what happens when there is only one lesson.
-    assert_equal @script_title, @solo_lesson_in_script.localized_name
+    assert_equal @lesson_name, solo_lesson_in_script.localized_name
 
     get :show, params: {
       script_id: script.name,
-      position: @solo_lesson_in_script.relative_position
+      position: solo_lesson_in_script.relative_position
     }
     assert_response :ok
     assert(@response.body.include?(@script_title))
-    assert(@response.body.include?(@solo_lesson_in_script.overview))
-    assert(@response.body.include?(script_lesson_path(@solo_lesson_in_script.script, @solo_lesson_in_script)))
+    assert(@response.body.include?(@lesson_name))
+    assert(@response.body.include?(solo_lesson_in_script.overview))
+    assert(@response.body.include?(script_lesson_path(solo_lesson_in_script.script, solo_lesson_in_script)))
   end
 
   test 'show lesson when script has multiple lessons' do


### PR DESCRIPTION
## Background

Finishes https://codedotorg.atlassian.net/browse/PLAT-1027. Here is a list of all the launched, single-lesson units in our system:
```
[levelbuilder] dashboard > Script.where(published_state: ['preview', 'stable']).all.select{|script| !script.lessons.many?}.map(&:name)
=> ["flappy", "jigsaw", "artist", "playlab", "frozen", "hourofcode", "infinity", "text-compression", "iceage", "starwars", "gumball", "mc", "starwarsblocks", "basketball", "hoc-encryption", "minecraft", "sports", "csp-post-survey", "applab-intro", "hero", "csd-post-survey", "dance", "aquatic", "dance-extras", "csp-mid-survey", "csd-post-survey-2018", "csp-post-survey-2018", "dance-2019", "dance-extras-2019", "oceans", "outbreak"]
```

Most of these are HOC scripts, which are currently having their lesson plans imported from curriculum builder. For more context on that, see https://github.com/code-dot-org/code-dot-org/pull/42567.

The following scripts from the list above are not HOC scripts: `["jigsaw", "csd-post-survey-2018", "csd-post-survey", "csp-mid-survey", "csp-post-survey-2018", "csp-post-survey"]` . 

## Description

Here is the plan for display names of lessons in single-lesson units:

1. #42602: for all non-HOC lessons, set lesson name equal to unit name.
2. (this PR) while newly imported HOC units are in a partially migrated state (`is_migrated && use_legacy_lesson_plans`), show curriculum writers the actual lesson name on the teacher lesson plan page, but keep showing the unit name to all users on the unit overview page.
3. when editing new HOC lesson plans, Mike will work with Debbie to make sure the title on the new lesson plan page is updated to something that is suitable to show on the unit overview page (probably this will just get set to the unit display name).
4. once all HOC lesson plans have been signed off on by curriculum, we'll set `use_legacy_lesson_plans: false` on them. at this time, the code introduced in this PR will start showing the lesson name on the unit overview page to all users.
5. clean up the TODO introduced in this PR. This is tracked by [PLAT-858] 

## Screenshots

The following unit has `is_migrated` and `use_legacy_lesson_plans` both set in my local DB, after having imported its lesson plan from curriculum builder.

### unit overview page

![Screen Shot 2021-09-21 at 7 19 07 AM](https://user-images.githubusercontent.com/8001765/134188135-cd39caa4-e7d4-4800-a204-d1a7cb035601.png)

### code studio lesson plan

![Screen Shot 2021-09-21 at 7 22 31 AM](https://user-images.githubusercontent.com/8001765/134188792-d81064e7-917e-4010-b8c0-bd0147a4b12c.png)

### Curriculum Builder lesson plan

![Screen Shot 2021-09-21 at 7 22 42 AM](https://user-images.githubusercontent.com/8001765/134188817-78b7a511-714f-494e-a4fd-0963777ac74e.png)

## Testing story

manual verification shown in screenshots. also verified that there are no launched units which should be affected by the change to the logic in `localized_name`:
```
[levelbuilder] dashboard > Script.where(published_state: ['preview', 'stable']).all.select{|script| !script.lessons.many? && script.is_migrated}.count
=> 0
```

## Deployment strategy

[PLAT-858]: https://codedotorg.atlassian.net/browse/PLAT-858