### PR TITLE
Playground: Set background image

### DIFF
--- a/apps/i18n/javalab/en_us.json
+++ b/apps/i18n/javalab/en_us.json
@@ -52,6 +52,7 @@
   "fileImportError": "One or more file names are reserved by Java Lab and cannot be imported into this project. Files unable to be imported:",
   "fileImportWarning": "You have one or more duplicate file names between this project and your selected backpack files. Duplicate file names are:",
   "fileImportWarningConfirm": "Do you want to replace these files with the files from your backpack?",
+  "fileLoadError": "There was an error loading the file {filename}.",
   "genericSaveErrorTitle": "Save error",
   "genericErrorMessage": "Please try again",
   "import": "Import",

--- a/apps/src/javalab/Javalab.js
+++ b/apps/src/javalab/Javalab.js
@@ -131,7 +131,8 @@ Javalab.prototype.init = function(config) {
       this.miniApp = new Playground(
         this.onOutputMessage,
         this.onNewlineMessage,
-        onJavabuilderMessage
+        onJavabuilderMessage,
+        this.level.name
       );
       this.visualization = <PlaygroundVisualizationColumn />;
       break;

--- a/apps/src/javalab/Playground.js
+++ b/apps/src/javalab/Playground.js
@@ -1,5 +1,6 @@
 import {PlaygroundSignalType} from './constants';
 import {assets, starterAssets} from '@cdo/apps/clientApi';
+import javalabMsg from '@cdo/javalab/locale';
 
 export default class Playground {
   constructor(
@@ -7,6 +8,7 @@ export default class Playground {
     onNewlineMessage,
     onJavabuilderMessage,
     levelName,
+    // Only used for testing
     starterAssetsApi,
     assetsApi
   ) {
@@ -17,6 +19,8 @@ export default class Playground {
     this.isGameOver = false;
     this.levelName = levelName;
     this.starterAssetFilenames = [];
+
+    // Assigned only for testing; should use imports from clientApi normally
     this.starterAssetsApi = starterAssetsApi || starterAssets;
     this.assetsApi = assetsApi || assets;
 
@@ -32,6 +36,11 @@ export default class Playground {
     response.starter_assets.forEach(asset => {
       this.starterAssetFilenames.push(asset.filename);
     });
+  };
+
+  onFileLoadError = filename => {
+    this.onOutputMessage(javalabMsg.fileLoadError({filename}));
+    this.onNewlineMessage();
   };
 
   handleSignal(data) {
@@ -115,14 +124,20 @@ export default class Playground {
       return;
     }
 
+    const filename = backgroundData.filename;
+
     const backgroundElement = this.getBackgroundElement();
-    backgroundElement.src = this.getUrl(backgroundData.filename);
+    backgroundElement.onerror = () => {
+      this.onFileLoadError(filename);
+    };
+    backgroundElement.src = this.getUrl(filename);
     backgroundElement.style.opacity = 1.0;
   }
 
   reset() {
     this.isGameOver = false;
     this.isGameRunning = false;
+    this.resetBackgroundElement();
   }
 
   // TODO: Call this from click handler on new clickable items
@@ -145,5 +160,12 @@ export default class Playground {
 
   getBackgroundElement() {
     return document.getElementById('playground-background');
+  }
+
+  resetBackgroundElement() {
+    const backgroundElement = this.getBackgroundElement();
+    backgroundElement.onerror = undefined;
+    backgroundElement.src = undefined;
+    backgroundElement.style.opacity = 0.0;
   }
 }

--- a/apps/src/javalab/PlaygroundVisualizationColumn.jsx
+++ b/apps/src/javalab/PlaygroundVisualizationColumn.jsx
@@ -40,6 +40,10 @@ class PlaygroundVisualizationColumn extends React.Component {
         <div style={{opacity}}>
           <ProtectedVisualizationDiv>
             <div id="playground-container" style={styles.playground}>
+              <img
+                id="playground-background"
+                style={styles.playgroundBackground}
+              />
               <div id="playground" style={styles.playgroundDiv} />
               <audio id="playground-audio" autoPlay={true} />
             </div>
@@ -60,6 +64,15 @@ const styles = {
     width: 800,
     height: 800,
     overflow: 'hidden'
+  },
+  playgroundBackground: {
+    position: 'absolute',
+    width: 800,
+    height: 800,
+    top: 0,
+    left: 0,
+    opacity: 0,
+    zIndex: -1
   }
 };
 

--- a/apps/test/unit/javalab/PlaygroundTest.js
+++ b/apps/test/unit/javalab/PlaygroundTest.js
@@ -1,0 +1,116 @@
+import sinon from 'sinon';
+import {expect} from '../../util/reconfiguredChai';
+import Playground from '@cdo/apps/javalab/Playground';
+import {PlaygroundSignalType} from '@cdo/apps/javalab/constants';
+
+describe('Playground', () => {
+  const levelName = 'level';
+  const starterAsset1 = 'starterAsset1';
+
+  const starterAssetsResponse = {
+    starter_assets: [{filename: starterAsset1}]
+  };
+
+  let backgroundElement,
+    onOutputMessage,
+    onNewlineMessage,
+    onJavabuilderMessage,
+    starterAssetsApi,
+    assetsApi,
+    playground;
+
+  beforeEach(() => {
+    onOutputMessage = sinon.stub();
+    onNewlineMessage = sinon.stub();
+    onJavabuilderMessage = sinon.stub();
+    starterAssetsApi = {
+      getStarterAssets: (levelName, onSuccess, onFailure) => {
+        onSuccess({
+          response: JSON.stringify(starterAssetsResponse)
+        });
+      },
+      withLevelName: levelName => ({
+        basePath: filename => `${levelName}/${filename}`
+      })
+    };
+    assetsApi = {
+      basePath: filename => `assets/${filename}`
+    };
+
+    backgroundElement = {
+      style: {
+        opacity: 0
+      }
+    };
+
+    playground = new Playground(
+      onOutputMessage,
+      onNewlineMessage,
+      onJavabuilderMessage,
+      levelName,
+      starterAssetsApi,
+      assetsApi
+    );
+
+    playground.getBackgroundElement = () => backgroundElement;
+  });
+
+  it('sets background image when receiving a SET_BACKGROUND_IMAGE message for a starter asset', () => {
+    const data = {
+      value: PlaygroundSignalType.SET_BACKGROUND_IMAGE,
+      detail: {
+        filename: starterAsset1
+      }
+    };
+
+    expect(backgroundElement.src).to.be.undefined;
+    expect(backgroundElement.style.opacity).to.equal(0);
+
+    playground.handleSignal(data);
+
+    expect(backgroundElement.src).to.equal(`${levelName}/${starterAsset1}`);
+    expect(backgroundElement.style.opacity).to.equal(1.0);
+  });
+
+  it('sets background image when receiving a SET_BACKGROUND_IMAGE message for an uploaded asset', () => {
+    const assetFile = 'assetFile';
+    const data = {
+      value: PlaygroundSignalType.SET_BACKGROUND_IMAGE,
+      detail: {
+        filename: assetFile
+      }
+    };
+
+    expect(backgroundElement.src).to.be.undefined;
+    expect(backgroundElement.style.opacity).to.equal(0);
+
+    playground.handleSignal(data);
+
+    expect(backgroundElement.src).to.equal(`assets/${assetFile}`);
+    expect(backgroundElement.style.opacity).to.equal(1.0);
+  });
+
+  it("doesn't set background image if game is over", () => {
+    const exitMessage = {
+      value: PlaygroundSignalType.EXIT
+    };
+
+    const data = {
+      value: PlaygroundSignalType.SET_BACKGROUND_IMAGE,
+      detail: {
+        filename: 'filename'
+      }
+    };
+
+    playground.handleSignal(exitMessage);
+
+    expect(backgroundElement.src).to.be.undefined;
+    expect(backgroundElement.style.opacity).to.equal(0);
+
+    playground.handleSignal(data);
+
+    // Background should not update
+    expect(backgroundElement.src).to.be.undefined;
+    expect(backgroundElement.style.opacity).to.equal(0);
+  });
+});

--- a/apps/test/unit/javalab/PlaygroundTest.js
+++ b/apps/test/unit/javalab/PlaygroundTest.js
@@ -2,6 +2,7 @@ import sinon from 'sinon';
 import {expect} from '../../util/reconfiguredChai';
 import Playground from '@cdo/apps/javalab/Playground';
 import {PlaygroundSignalType} from '@cdo/apps/javalab/constants';
+import javalabMsg from '@cdo/javalab/locale';
 
 describe('Playground', () => {
   const levelName = 'level';
@@ -65,11 +66,17 @@ describe('Playground', () => {
 
     expect(backgroundElement.src).to.be.undefined;
     expect(backgroundElement.style.opacity).to.equal(0);
+    expect(backgroundElement.onerror).to.be.undefined;
 
     playground.handleSignal(data);
 
     expect(backgroundElement.src).to.equal(`${levelName}/${starterAsset1}`);
     expect(backgroundElement.style.opacity).to.equal(1.0);
+    expect(backgroundElement.onerror).to.exist;
+
+    // Verify onerror callback
+    backgroundElement.onerror();
+    verifyOnFileLoadError(starterAsset1);
   });
 
   it('sets background image when receiving a SET_BACKGROUND_IMAGE message for an uploaded asset', () => {
@@ -83,11 +90,17 @@ describe('Playground', () => {
 
     expect(backgroundElement.src).to.be.undefined;
     expect(backgroundElement.style.opacity).to.equal(0);
+    expect(backgroundElement.onerror).to.be.undefined;
 
     playground.handleSignal(data);
 
     expect(backgroundElement.src).to.equal(`assets/${assetFile}`);
     expect(backgroundElement.style.opacity).to.equal(1.0);
+    expect(backgroundElement.onerror).to.exist;
+
+    // Verify onerror callback
+    backgroundElement.onerror();
+    verifyOnFileLoadError(assetFile);
   });
 
   it("doesn't set background image if game is over", () => {
@@ -106,11 +119,43 @@ describe('Playground', () => {
 
     expect(backgroundElement.src).to.be.undefined;
     expect(backgroundElement.style.opacity).to.equal(0);
+    expect(backgroundElement.onerror).to.be.undefined;
 
     playground.handleSignal(data);
 
     // Background should not update
     expect(backgroundElement.src).to.be.undefined;
     expect(backgroundElement.style.opacity).to.equal(0);
+    expect(backgroundElement.onerror).to.be.undefined;
   });
+
+  it('resets the background image on reset()', () => {
+    const data = {
+      value: PlaygroundSignalType.SET_BACKGROUND_IMAGE,
+      detail: {
+        filename: 'filename'
+      }
+    };
+
+    playground.handleSignal(data);
+
+    expect(backgroundElement.src).to.exist;
+    expect(backgroundElement.style.opacity).to.equal(1.0);
+    expect(backgroundElement.onerror).to.exist;
+
+    playground.reset();
+
+    expect(backgroundElement.src).to.be.undefined;
+    expect(backgroundElement.style.opacity).to.equal(0);
+    expect(backgroundElement.onerror).to.be.undefined;
+  });
+
+  function verifyOnFileLoadError(filename) {
+    sinon.assert.calledOnce(onOutputMessage);
+    sinon.assert.calledWith(
+      onOutputMessage,
+      javalabMsg.fileLoadError({filename})
+    );
+    sinon.assert.calledOnce(onNewlineMessage);
+  }
 });


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Handles the SET_BACKGROUND_IMAGE message and sets the background image of the playground based on the file name.

I also added a generic file load error callback that can be used if there is an error loading an asset file. Javabuilder will also be verifying that the file exists in the student's project, but this provides some fallback validation. The error displays like:

![Screen Shot 2021-09-22 at 12 23 32 PM](https://user-images.githubusercontent.com/85528507/134411709-4a03ee1a-303e-45e7-9a5e-1417096674a0.png)
## Links
JIRA: https://codedotorg.atlassian.net/browse/CSA-843
Spec: https://docs.google.com/document/d/1Moo2s5EXZRp5rMg1VW9jlOqs_GeMN5yjU8FJgoqOEMk/edit#heading=h.yth48qvin8gl
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
Testing: local (all the things level) & unit
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
