### PR TITLE
General old dialog cleanup

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -1302,15 +1302,13 @@ StudioApp.prototype.showInstructionsDialog_ = function(level, autoClose) {
 
   var headerElement;
 
-  var puzzleTitle = msg.puzzleTitle({
-    stage_total: level.lesson_total,
-    puzzle_number: level.puzzle_number
-  });
-
   if (isMarkdownMode) {
     headerElement = document.createElement('h1');
     headerElement.className = 'markdown-level-header-text dialog-title';
-    headerElement.innerHTML = puzzleTitle;
+    headerElement.innerHTML = msg.puzzleTitle({
+      stage_total: level.lesson_total,
+      puzzle_number: level.puzzle_number
+    });
     if (!this.icon) {
       headerElement.className += ' no-modal-icon';
     }

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -1295,13 +1295,7 @@ StudioApp.prototype.showInstructionsDialog_ = function(level, autoClose) {
     !!reduxState.instructions.longInstructions &&
     !reduxState.instructionsDialog.imgOnly;
 
-  var instructionsDiv = document.createElement('div');
-  instructionsDiv.className = isMarkdownMode
-    ? 'markdown-instructions-container'
-    : 'instructions-container';
-
   var headerElement;
-
   if (isMarkdownMode) {
     headerElement = document.createElement('h1');
     headerElement.className = 'markdown-level-header-text dialog-title';
@@ -1320,6 +1314,10 @@ StudioApp.prototype.showInstructionsDialog_ = function(level, autoClose) {
   // elements that don't want to be rendered until they are in the DOM
   var instructionsReactContainer = document.createElement('div');
   instructionsReactContainer.className = 'instructions-content';
+  var instructionsDiv = document.createElement('div');
+  instructionsDiv.className = isMarkdownMode
+    ? 'markdown-instructions-container'
+    : 'instructions-container';
   instructionsDiv.appendChild(instructionsReactContainer);
 
   var buttons = document.createElement('div');

--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -1505,10 +1505,10 @@ Applab.showConfirmationDialog = function(config) {
 
   var buttons = document.createElement('div');
   ReactDOM.render(
-    React.createElement(DialogButtons, {
-      confirmText: commonMsg.dialogOK(),
-      cancelText: commonMsg.dialogCancel()
-    }),
+    <DialogButtons
+      confirmText={commonMsg.dialogOK()}
+      cancelText={commonMsg.dialogCancel()}
+    />,
     buttons
   );
   contentDiv.appendChild(buttons);

--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -1,10 +1,21 @@
+// Globals used in this file:
+//   Blockly
+
 import $ from 'jquery';
 import {getStore} from './redux';
 import React from 'react';
 import {Provider} from 'react-redux';
 import ReactDOM from 'react-dom';
+import msg from '@cdo/locale';
+import dom from './dom';
 import LegacyDialog from './code-studio/LegacyDialog';
+import ChallengeDialog from './templates/ChallengeDialog';
 import project from './code-studio/initApp/project';
+import FeedbackBlocks from './feedbackBlocks';
+import puzzleRatingUtils from './puzzleRatingUtils';
+import DialogButtons from './templates/DialogButtons';
+import CodeWritten from './templates/feedback/CodeWritten';
+import GeneratedCode from './templates/feedback/GeneratedCode';
 import {dataURIToBlob} from './imageUtils';
 import trackEvent from './util/trackEvent';
 import {getValidatedResult} from './containedLevels';
@@ -26,7 +37,10 @@ import clientState from '@cdo/apps/code-studio/clientState';
 
 // Types of blocks that do not count toward displayed block count. Used
 // by FeedbackUtils.blockShouldBeCounted_
-var UNCOUNTED_BLOCK_TYPES = ['draw_colour', 'alpha', 'comment'];
+const UNCOUNTED_BLOCK_TYPES = ['draw_colour', 'alpha', 'comment'];
+
+const FIREHOSE_STUDY = 'feedback_dialog';
+let dialog_type = 'default';
 
 /**
  * Bag of utility functions related to building and displaying feedback
@@ -39,23 +53,6 @@ var FeedbackUtils = function(studioApp) {
   this.studioApp_ = studioApp;
 };
 module.exports = FeedbackUtils;
-
-// Globals used in this file:
-//   Blockly
-
-/** @type {Object<string, function>} */
-var msg = require('@cdo/locale');
-var dom = require('./dom');
-var FeedbackBlocks = require('./feedbackBlocks');
-var puzzleRatingUtils = require('./puzzleRatingUtils');
-var DialogButtons = require('./templates/DialogButtons');
-var CodeWritten = require('./templates/feedback/CodeWritten');
-var GeneratedCode = require('./templates/feedback/GeneratedCode');
-
-import ChallengeDialog from './templates/ChallengeDialog';
-
-const FIREHOSE_STUDY = 'feedback_dialog';
-let dialog_type = 'default';
 
 /**
  * @typedef {Object} FeedbackOptions

--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -692,18 +692,19 @@ FeedbackUtils.prototype.getFeedbackButtons_ = function(options) {
   }
 
   ReactDOM.render(
-    React.createElement(DialogButtons, {
-      tryAgain: tryAgainText,
-      continueText:
+    <DialogButtons
+      tryAgain={tryAgainText}
+      continueText={
         options.continueText ||
-        (options.finalLevel ? msg.finish() : msg.continue()),
-      nextLevel: this.canContinueToNextLevel(options.feedbackType),
-      shouldPromptForHint: this.shouldPromptForHint(options.feedbackType),
-      userId: options.userId,
-      isK1: options.isK1,
-      assetUrl: this.studioApp_.assetUrl,
-      freePlay: options.freePlay
-    }),
+        (options.finalLevel ? msg.finish() : msg.continue())
+      }
+      nextLevel={this.canContinueToNextLevel(options.feedbackType)}
+      shouldPromptForHint={this.shouldPromptForHint(options.feedbackType)}
+      userId={options.userId}
+      isK1={options.isK1}
+      assetUrl={this.studioApp_.assetUrl}
+      freePlay={options.freePlay}
+    />,
     buttons
   );
 
@@ -1410,12 +1411,7 @@ FeedbackUtils.prototype.showToggleBlocksError = function() {
   contentDiv.innerHTML = msg.toggleBlocksErrorMsg();
 
   var buttons = document.createElement('div');
-  ReactDOM.render(
-    React.createElement(DialogButtons, {
-      ok: true
-    }),
-    buttons
-  );
+  ReactDOM.render(<DialogButtons ok={true} />, buttons);
   contentDiv.appendChild(buttons);
 
   var dialog = this.createModalDialog({

--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -700,7 +700,6 @@ FeedbackUtils.prototype.getFeedbackButtons_ = function(options) {
       }
       nextLevel={this.canContinueToNextLevel(options.feedbackType)}
       shouldPromptForHint={this.shouldPromptForHint(options.feedbackType)}
-      userId={options.userId}
       isK1={options.isK1}
       assetUrl={this.studioApp_.assetUrl}
       freePlay={options.freePlay}


### PR DESCRIPTION
I was doing a deep dive into how/where we use [StudioApp.showInstructionsDialog_](https://github.com/code-dot-org/code-dot-org/blob/fcb5e6fd2f7ee12bf8b45cb4b4e7842beb289d64/apps/src/StudioApp.js#L1292) (and subsequently [FeedbackUtils.createModalDialog](https://github.com/code-dot-org/code-dot-org/blob/fcb5e6fd2f7ee12bf8b45cb4b4e7842beb289d64/apps/src/feedback.js#L1838), which the StudioApp function uses), and this is some cleanup I did along the way that is unrelated to the actual work I'm doing 😄 