### PR TITLE
Default Varnish to Disabled

### DIFF
--- a/cookbooks/cdo-varnish/attributes/default.rb
+++ b/cookbooks/cdo-varnish/attributes/default.rb
@@ -1,5 +1,5 @@
 default['cdo-varnish'] = {
-  enabled: true,
+  enabled: false,
   'backends' => {
     'localhost' => '127.0.0.1',
   },


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/42441; updates the `node['cdo-varnish']['enabled']` default

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
