### PR TITLE
Pegasus: Template partials get parameters

### DIFF
--- a/pegasus/router.rb
+++ b/pegasus/router.rb
@@ -391,11 +391,15 @@ class Documents < Sinatra::Base
       # translator accidentally translates the path to the template, we simply
       # render nothing rather than throwing an error
       template_content.
-        gsub(/{{([^,]*),([^}]*)}}/) do
-          uri = $1.strip
+        # Extract anything between {{ and }}.
+        gsub(/{{([^}]*)}}/) do
+          # Extract the partial name, and possibly a string with all the parameters.
+          split = $1.scan(/\s*([^ ,]*)[, ]*(.*)/)[0]
 
-          # Adapted from https://stackoverflow.com/a/23612782.
-          locals = $2.scan(/("(?:\\.|[^"])*"|[^\s]*):\s*("(?:\\.|[^"])*"|[^\s]*)/).
+          uri = split[0]
+
+          # Parse the parameters.  Adapted from https://stackoverflow.com/a/23612782.
+          locals = split[1].scan(/("(?:\\.|[^"])*"|[^\s]*):\s*("(?:\\.|[^"])*"|[^\s]*)/).
             map(&:compact).
             to_h.
             transform_values(&:undump)

--- a/pegasus/sites.v3/code.org/public/educate/csc.md.partial
+++ b/pegasus/sites.v3/code.org/public/educate/csc.md.partial
@@ -9,15 +9,26 @@ style_min: true
 
 First part of content.
 
+## Section 0
+
+<div style="width: 100px">{{ codebreak_promoreel }}</div>
+
 ## Section 1
 
 {{ csc_module, title: "Title 1", grades: "3-5", description: "Some kind of \"description goes\" here." }}
 
 {{ csc_module, title: "Title 2", description: "Another description here.", action: "Do action" }}
 
-
 ## Section 2
+
+<div style="width: 100px">{{codebreak_promoreel}}</div>
+
+## Section 3
 
 {{ csc_module, title: "Title 3", grades: "3-5", description: "Some kind of \"description goes\" here." }}
 
 {{ csc_module, title: "Title 4", description: "Another description here, isn't it!", action: "Do action" }}
+
+## Section 4
+
+<div style="width: 100px">{{ codebreak_promoreel }}</div>

--- a/pegasus/sites.v3/code.org/public/educate/csc.md.partial
+++ b/pegasus/sites.v3/code.org/public/educate/csc.md.partial
@@ -1,0 +1,23 @@
+---
+title: CS Connections
+video_player: true
+theme: responsive
+style_min: true
+---
+
+# Heading
+
+First part of content.
+
+## Section 1
+
+{{ csc_module, title: "Title 1", grades: "3-5", description: "Some kind of \"description goes\" here." }}
+
+{{ csc_module, title: "Title 2", description: "Another description here.", action: "Do action" }}
+
+
+## Section 2
+
+{{ csc_module, title: "Title 3", grades: "3-5", description: "Some kind of \"description goes\" here." }}
+
+{{ csc_module, title: "Title 4", description: "Another description here, isn't it!", action: "Do action" }}

--- a/pegasus/sites.v3/code.org/views/csc_module.haml
+++ b/pegasus/sites.v3/code.org/views/csc_module.haml
@@ -1,0 +1,13 @@
+.col-50{style: "padding: 10px"}
+  .div{style: "background-color: #02516b; padding: 20px; border-radius: 10px; color: white"}
+    .div{style: "font-size: 24px; line-height: 1.5;"}
+      = title
+    - if defined?(grades)
+      .div
+        Grades
+        = grades
+    .div
+      = description
+    - if defined?(action)
+      %button
+        = action


### PR DESCRIPTION
Template types that use the `{{ }}` syntax for rendering a partial can now pass parameters to those partials.  The syntax is like this:

```
{{ path/to/partial, param1: "value1", param2: "value2" }}
```

The motivation for this work is that somebody can author a single file (say an `.md.partial`) which includes partials that take user-facing strings as parameters, and the file (including these strings) can be localised.  No external string table modifications will be required.

This aligns with a larger goal of allowing content editors to edit simple markdown files, while still having access to a rich component library of partials that can be driven by parameters, and allowing such content to be localised without additional effort.

### Sample .md.partial file rendering:

![localhost code org_3000_educate_csc](https://user-images.githubusercontent.com/2205926/134284955-bc901bc0-c269-4b8d-87e1-750768de09fa.png)

Keywords: `hoc2021`