### PR TITLE
Fix Host header in Nginx backend override

### DIFF
--- a/cookbooks/cdo-nginx/templates/default/nginx.conf.erb
+++ b/cookbooks/cdo-nginx/templates/default/nginx.conf.erb
@@ -42,12 +42,21 @@ http {
     default "pegasus";
   }
 
+  map $http_x_cdo_backend $upstream_host {
+    # Override host using X-Cdo-Backend header.
+    dashboard "<%=CDO.dashboard_hostname%>";
+    pegasus "<%=CDO.pegasus_hostname%>";
+
+    # Default to original host variable.
+    default $http_host;
+  }
+
   server {
     listen 80 default_server deferred;
     server_name _;
     location / {
       proxy_pass http://unix:<%= @run_dir %>/$upstream.sock;
-      proxy_set_header Host $http_host;
+      proxy_set_header Host $upstream_host;
     }
   }
 <%   redirects = node['cdo-varnish']['redirects'].group_by(&:last).transform_values {|v| v.to_h.keys}


### PR DESCRIPTION
Followup to #42441.
Update nginx configuration to override the `Host` header to the backend hostname when overriding backend via `X-Cdo-Backend` header.
This behavior already exists in Varnish, and seems to be necessary in order for some of the `studio.code.org/v2` routes to resolve correctly, since some Pegasus logic expects the Host to be 'code.org' in order to resolve page paths correctly.
