### PR TITLE
Update NetSim instructions dialog

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -28,7 +28,8 @@ import DialogButtons from './templates/DialogButtons';
 import DialogInstructions from './templates/instructions/DialogInstructions';
 import DropletTooltipManager from './blockTooltips/DropletTooltipManager';
 import FeedbackUtils from './feedback';
-import InstructionsDialogWrapper from './templates/instructions/InstructionsDialogWrapper';
+import InstructionsDialog from '@cdo/apps/templates/instructions/InstructionsDialog';
+import InstructionsDialogWrapperDEPRECATED from './templates/instructions/InstructionsDialogWrapperDEPRECATED';
 import SmallFooter from './code-studio/components/SmallFooter';
 import Sounds from './Sounds';
 import VersionHistory from './templates/VersionHistory';
@@ -319,15 +320,27 @@ StudioApp.prototype.init = function(config) {
   this.configureDom(config);
 
   if (!config.level.iframeEmbedAppAndCode) {
+    // We are migrating usages of InstructionsDialogWrapperDEPRECATED to use
+    // InstructionsDialog instead. NetSim is the first consumer to be migrated.
+    const useNewDialog = config.app === 'netsim';
     ReactDOM.render(
       <Provider store={getStore()}>
-        <div>
-          <InstructionsDialogWrapper
-            showInstructionsDialog={autoClose => {
-              this.showInstructionsDialog_(config.level, autoClose);
-            }}
+        {useNewDialog ? (
+          <InstructionsDialog
+            title={msg.puzzleTitle({
+              stage_total: config.level.lesson_total,
+              puzzle_number: config.level.puzzle_number
+            })}
           />
-        </div>
+        ) : (
+          <div>
+            <InstructionsDialogWrapperDEPRECATED
+              showInstructionsDialog={autoClose => {
+                this.showInstructionsDialog_(config.level, autoClose);
+              }}
+            />
+          </div>
+        )}
       </Provider>,
       document.body.appendChild(document.createElement('div'))
     );

--- a/apps/src/componentLibrary/StylizedBaseDialog.jsx
+++ b/apps/src/componentLibrary/StylizedBaseDialog.jsx
@@ -54,12 +54,15 @@ export default function StylizedBaseDialog(props) {
     return passThrough;
   }
 
-  const title =
-    typeof props.title === 'string' ? (
-      <h1 style={styles.title}>{props.title}</h1>
-    ) : (
-      props.title
-    );
+  function renderTitle() {
+    const {title} = props;
+    if (typeof title === 'string') {
+      return <h1 style={styles.title}>{title}</h1>;
+    } else {
+      return title;
+    }
+  }
+
   const horizontalRule =
     props.type === 'simple' ? null : <hr style={styles.hr} />;
   const defaultButtons = [
@@ -79,9 +82,9 @@ export default function StylizedBaseDialog(props) {
 
   return (
     <BaseDialog {...passThroughProps()} useUpdatedStyles>
-      {title && (
+      {props.title && (
         <>
-          <div style={styles.container}>{title}</div>
+          <div style={styles.container}>{renderTitle()}</div>
           {horizontalRule}
         </>
       )}

--- a/apps/src/componentLibrary/StylizedBaseDialog.jsx
+++ b/apps/src/componentLibrary/StylizedBaseDialog.jsx
@@ -43,6 +43,7 @@ FooterButton.propTypes = {
 FooterButton.defaultProps = {
   type: 'default'
 };
+
 export default function StylizedBaseDialog(props) {
   // Remove any props that should *not* be passed through to <BaseDialog/>.
   function passThroughProps() {
@@ -53,6 +54,14 @@ export default function StylizedBaseDialog(props) {
     return passThrough;
   }
 
+  const title =
+    typeof props.title === 'string' ? (
+      <h1 style={styles.title}>{props.title}</h1>
+    ) : (
+      props.title
+    );
+  const horizontalRule =
+    props.type === 'simple' ? null : <hr style={styles.hr} />;
   const defaultButtons = [
     <FooterButton
       key="cancel"
@@ -70,14 +79,23 @@ export default function StylizedBaseDialog(props) {
 
   return (
     <BaseDialog {...passThroughProps()} useUpdatedStyles>
-      <div style={styles.container}>
-        <h1 style={styles.title}>{props.title}</h1>
+      {title && (
+        <>
+          <div style={styles.container}>{title}</div>
+          {horizontalRule}
+        </>
+      )}
+      <div
+        style={{
+          ...styles.container,
+          ...(props.type === 'simple' ? {} : {padding: GUTTER})
+        }}
+      >
+        {props.body}
       </div>
-      <hr style={styles.hr} />
-      <div style={{...styles.container, ...styles.body}}>{props.body}</div>
       {!props.hideFooter && (
         <div>
-          <hr style={styles.hr} />
+          {horizontalRule}
           <div
             style={{
               ...styles.container,
@@ -94,7 +112,7 @@ export default function StylizedBaseDialog(props) {
 }
 
 StylizedBaseDialog.propTypes = {
-  title: PropTypes.string.isRequired,
+  title: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
   body: PropTypes.oneOfType([PropTypes.element, PropTypes.string]).isRequired,
   footerJustification: PropTypes.oneOf([
     'flex-start',
@@ -107,7 +125,8 @@ StylizedBaseDialog.propTypes = {
   cancellationButtonText: PropTypes.string.isRequired,
   handleConfirmation: PropTypes.func,
   handleClose: PropTypes.func.isRequired,
-  handleCancellation: PropTypes.func
+  handleCancellation: PropTypes.func,
+  type: PropTypes.oneOf(['default', 'simple'])
 };
 
 StylizedBaseDialog.defaultProps = {
@@ -115,7 +134,8 @@ StylizedBaseDialog.defaultProps = {
   renderFooter: buttons => buttons,
   hideFooter: false,
   confirmationButtonText: i18n.dialogOK(),
-  cancellationButtonText: i18n.dialogCancel()
+  cancellationButtonText: i18n.dialogCancel(),
+  type: 'default'
 };
 
 const GUTTER = 20;
@@ -129,9 +149,6 @@ const styles = {
   hr: {
     margin: 0,
     borderColor: color.lighter_gray
-  },
-  body: {
-    padding: GUTTER
   },
   footer: {
     display: 'flex',

--- a/apps/src/componentLibrary/StylizedBaseDialog.story.jsx
+++ b/apps/src/componentLibrary/StylizedBaseDialog.story.jsx
@@ -15,8 +15,17 @@ export default storybook => {
     .storiesOf('Dialogs/StylizedBaseDialog', module)
     .addStoryTable([
       {
-        name: 'Default',
+        name: 'Default dialog',
         story: () => <StylizedBaseDialog {...DEFAULT_PROPS} />
+      },
+      {
+        name: "'Simple' dialog",
+        description: 'Does not display <hr>',
+        story: () => <StylizedBaseDialog {...DEFAULT_PROPS} type="simple" />
+      },
+      {
+        name: 'Dialog without a title',
+        story: () => <StylizedBaseDialog {...DEFAULT_PROPS} title={null} />
       },
       {
         name: 'Left-justified footer buttons',

--- a/apps/src/templates/instructions/InstructionsDialog.jsx
+++ b/apps/src/templates/instructions/InstructionsDialog.jsx
@@ -16,7 +16,6 @@ export function InstructionsDialog(props) {
         props.title &&
         props.showTitle && <h1 style={styles.title}>{props.title}</h1>
       }
-      // TODO: make this scrollable instead of entire dialog scrolling?
       body={<DialogInstructions />}
       renderFooter={() => (
         <FooterButton
@@ -45,7 +44,7 @@ export default connect(
     isOpen: state.instructionsDialog.open,
     // The presence of longInstructions determines showTitle because
     // the grandchild of this component, <Instructions/>, uses this same calculation
-    // in its renderMainBody method. This avoids rendering the title twice.
+    // in its renderMainBody method. This prevents rendering the title twice.
     showTitle: !!state.instructions.longInstructions
   }),
   dispatch => ({

--- a/apps/src/templates/instructions/InstructionsDialog.jsx
+++ b/apps/src/templates/instructions/InstructionsDialog.jsx
@@ -14,7 +14,7 @@ export function InstructionsDialog(props) {
       isOpen={props.isOpen}
       title={
         props.title &&
-        props.showTitle && <h1 style={{fontSize: 24}}>{props.title}</h1>
+        props.showTitle && <h1 style={styles.title}>{props.title}</h1>
       }
       // TODO: make this scrollable instead of entire dialog scrolling?
       body={<DialogInstructions />}
@@ -40,10 +40,6 @@ InstructionsDialog.propTypes = {
   showTitle: PropTypes.bool
 };
 
-InstructionsDialog.defaultProps = {
-  showTitle: true
-};
-
 export default connect(
   state => ({
     isOpen: state.instructionsDialog.open,
@@ -56,3 +52,9 @@ export default connect(
     handleClose: () => dispatch(closeDialog())
   })
 )(InstructionsDialog);
+
+const styles = {
+  title: {
+    fontSize: 24
+  }
+};

--- a/apps/src/templates/instructions/InstructionsDialog.jsx
+++ b/apps/src/templates/instructions/InstructionsDialog.jsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {connect} from 'react-redux';
+import i18n from '@cdo/locale';
+import StylizedBaseDialog, {
+  FooterButton
+} from '@cdo/apps/componentLibrary/StylizedBaseDialog';
+import DialogInstructions from '@cdo/apps/templates/instructions/DialogInstructions';
+import {closeDialog} from '@cdo/apps/redux/instructionsDialog';
+
+export function InstructionsDialog(props) {
+  return (
+    <StylizedBaseDialog
+      isOpen={props.isOpen}
+      title={
+        props.title &&
+        props.showTitle && <h1 style={{fontSize: 24}}>{props.title}</h1>
+      }
+      // TODO: make this scrollable instead of entire dialog scrolling?
+      body={<DialogInstructions />}
+      renderFooter={() => (
+        <FooterButton
+          type="confirm"
+          text={i18n.dialogOK()}
+          onClick={props.handleClose}
+        />
+      )}
+      handleClose={props.handleClose}
+      type="simple"
+    />
+  );
+}
+
+InstructionsDialog.propTypes = {
+  title: PropTypes.string,
+
+  // Provided by Redux.
+  isOpen: PropTypes.bool,
+  handleClose: PropTypes.func.isRequired,
+  showTitle: PropTypes.bool
+};
+
+InstructionsDialog.defaultProps = {
+  showTitle: true
+};
+
+export default connect(
+  state => ({
+    isOpen: state.instructionsDialog.open,
+    // The presence of longInstructions determines showTitle because
+    // the grandchild of this component, <Instructions/>, uses this same calculation
+    // in its renderMainBody method. This avoids rendering the title twice.
+    showTitle: !!state.instructions.longInstructions
+  }),
+  dispatch => ({
+    handleClose: () => dispatch(closeDialog())
+  })
+)(InstructionsDialog);

--- a/apps/src/templates/instructions/InstructionsDialogWrapperDEPRECATED.jsx
+++ b/apps/src/templates/instructions/InstructionsDialogWrapperDEPRECATED.jsx
@@ -3,6 +3,10 @@ import React from 'react';
 import {connect} from 'react-redux';
 
 /**
+ * This component is deprecated and should not be used. Its only current usage is in StudioApp.js,
+ * but multiple apps/scenarios need to be migrated before we can remove this component.
+ * Any new consumers should use apps/src/templates/instructions/InstructionsDialog.jsx instead.
+ *
  * A component for managing our instructions dialog. Right now the entirety of
  * the actual content is managed by showInstructionsDialog rather than this
  * component, with this component just determining when we should show the

--- a/apps/test/unit/templates/instructions/InstructionsDialogWrapperDEPRECATEDTest.jsx
+++ b/apps/test/unit/templates/instructions/InstructionsDialogWrapperDEPRECATEDTest.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {mount} from 'enzyme';
 import sinon from 'sinon';
 import {expect} from '../../../util/reconfiguredChai';
-import {UnwrappedInstructionsDialogWrapper as InstructionsDialogWrapper} from '@cdo/apps/templates/instructions/InstructionsDialogWrapper';
+import {UnwrappedInstructionsDialogWrapper as InstructionsDialogWrapper} from '@cdo/apps/templates/instructions/InstructionsDialogWrapperDEPRECATED';
 
 describe('InstructionsDialogWrapper', () => {
   let spy, wrapper;


### PR DESCRIPTION
Adds `<InstructionsDialog/>` and migrates NetSim as its first consumer. Also updates `<StylizedBaseDialog/>` to support this new component.

**Old dialog** (essentially LegacyDialog; rendering logic is explained below):
<img width="1277" alt="Screen Shot 2021-09-22 at 9 02 38 AM" src="https://user-images.githubusercontent.com/9812299/134387589-8391b29b-89e1-468a-b356-ef84d6d80b1e.png">

**New dialog**
_With scrolling content:_

https://user-images.githubusercontent.com/9812299/134387751-e863cf5d-17e2-42ea-812f-fa2b3cd3b0a9.mov

_With shorter/non-scrolling content:_
<img width="1277" alt="Screen Shot 2021-09-22 at 9 03 50 AM" src="https://user-images.githubusercontent.com/9812299/134387705-4dee2d59-a67f-479a-bb08-be1072cac2c4.png">

#### `<InstructionsDialog/>`

Replaces [InstructionsDialogWrapper](https://github.com/code-dot-org/code-dot-org/blob/0106a9d42a5b342cffabfeee0514f1005580b8cb/apps/src/templates/instructions/InstructionsDialogWrapperDEPRECATED.jsx), which is now deprecated. That component is deprecated because it was using a lot of non-React logic and components -- it will be safer and easier to migrate to a new component than to try to refactor this one. A description of how `<InstructionsDialogWrapperDEPRECATED/>` works:
- `StudioApp.init` renders it [here](https://github.com/code-dot-org/code-dot-org/blob/2ad79623a06faf24cccf577795f4e4a6ce7a1eb3/apps/src/StudioApp.js#L336-L342)
- Somewhere else in our code, we use redux to set state that tells that dialog to open ([netsim.js example](https://github.com/code-dot-org/code-dot-org/blob/be1954cfdae5f3c61a3cbd3cd387fc8eacb57ef6/apps/src/netsim/netsim.js#L1408))
- InstructionsDialogWrapperDEPRECATED listens for this state change and calls its `showInstructionsDialog` prop. That prop is always set to [StudioApp.showInstructionsDialog_](https://github.com/code-dot-org/code-dot-org/blob/be1954cfdae5f3c61a3cbd3cd387fc8eacb57ef6/apps/src/StudioApp.js#L1292) (the only consumer of this component), so that method is triggered
- StudioApp.showInstructionsDialog_ then uses a combination of the DOM API, jQuery, and React to create a dialog body and render it into [LegacyDialog](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/code-studio/LegacyDialog.js) (which is all jQuery)

This was not only difficult to understand, but causing bugs. StudioApp.showInstructionsDialog_ would render the dialog buttons using `<DialogButtons/>` [here](https://github.com/code-dot-org/code-dot-org/blob/be1954cfdae5f3c61a3cbd3cd387fc8eacb57ef6/apps/src/StudioApp.js#L1329), and while that's a React component, it renders [LegacyButton](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/templates/LegacyButton.jsx) and does not accept an onClick handler. Instead, StudioApp would assume the rendered DialogButton element had a particular ID and used [jQuery to then add a click handler](https://github.com/code-dot-org/code-dot-org/blob/be1954cfdae5f3c61a3cbd3cd387fc8eacb57ef6/apps/src/StudioApp.js#L1384-L1394) to it. This caused a race condition because that element had not yet rendered, so the click handler was never attached to the button.

#### `<StylizedBaseDialog/>`

I made two changes to this component to support this new dialog (and prepare for future consumers, although more changes will likely be needed): add a `type` prop for simplified styling (and whatever other types we may add later, with 'simple' being the first type), and allow the dialog title to be optional.

<img width="1489" alt="Screen Shot 2021-09-22 at 8 42 11 AM" src="https://user-images.githubusercontent.com/9812299/134388156-be9abc63-6154-4b8a-9cdc-7c30e33c6e75.png">


## Links

- Fixes [STAR-1705](https://codedotorg.atlassian.net/browse/STAR-1705)

## Testing story

Adds storybook coverage for new `<StylizedBaseDialog/>` functionality.

## Follow-up work

- [STAR-1737](https://codedotorg.atlassian.net/browse/STAR-1737) - Remove remaining usages of `<InstructionsDialogWrapperDEPRECATED/>` (only used in StudioApp.js, but used in various different scenarios)