### PR TITLE
Frontend translation files in translation service

### DIFF
--- a/bin/i18n/test/translation_status/test_translation_service.rb
+++ b/bin/i18n/test/translation_status/test_translation_service.rb
@@ -40,4 +40,12 @@ class TranslationServiceTest < Minitest::Test
   def test_translated_given_pegasus_string_should_return_true
     assert @@translation_service.translated?('es-MX', :anybody_can_learn)
   end
+
+  def test_translated_given_frontend_string_should_return_true
+    assert @@translation_service.translated?('de-DE', 'turtle.loopVariable')
+  end
+
+  def test_translated_given_unknown_frontend_string_should_return_false
+    refute @@translation_service.translated?('de-DE', 'turtle.fill')
+  end
 end

--- a/bin/i18n/test/translation_status/test_translation_service.rb
+++ b/bin/i18n/test/translation_status/test_translation_service.rb
@@ -41,8 +41,12 @@ class TranslationServiceTest < Minitest::Test
     assert @@translation_service.translated?('es-MX', :anybody_can_learn)
   end
 
-  def test_translated_given_frontend_string_should_return_true
+  def test_translated_given_blockly_mooc_string_should_return_true
     assert @@translation_service.translated?('de-DE', 'turtle.loopVariable')
+  end
+
+  def test_translated_given_blockly_core_string_should_return_true
+    assert @@translation_service.translated?('de-DE', 'core.INLINE_INPUTS')
   end
 
   def test_translated_given_unknown_frontend_string_should_return_false

--- a/bin/i18n/translation_status/translation_service.rb
+++ b/bin/i18n/translation_status/translation_service.rb
@@ -5,6 +5,7 @@ require 'i18n'
 # Provides access to all the translations managed by the code-dot-org project.
 class TranslationService
   def initialize
+    store_frontend_translations
     # Normally we fallback to en-US, but we want to disable this so we detect missing strings.
     I18n.fallbacks.defaults = []
     I18n.backend.reload!
@@ -13,5 +14,27 @@ class TranslationService
   # Returns true if a translation exists for a given key, otherwise returns false.
   def translated?(locale, key)
     I18n.exists?(key, locale: locale)
+  end
+
+  # Aggregate all blockly-mooc translation JSON files to be loaded into i18n
+  def store_frontend_translations
+    locales_dir = Rails.root.join("../i18n/locales")
+    locales = Dir.glob(locales_dir.join("*")).map {|dir| File.basename(dir)}
+    locales.each do |locale|
+      translations = {}
+      Dir.glob(locales_dir.join("#{locale}/blockly-mooc/*.json")).each do |loc_file|
+        name = File.basename(loc_file, ".*")
+        puts name if locale.include? "de"
+        translations[name] = JSON.load(File.read(loc_file)).to_h
+      end
+      I18n.backend.store_translations(locale, translations)
+    end
+    puts I18n.exists?("turtle.loopVariable", locale: "de-DE")
+    puts I18n.exists?("tutorialExplorer.startButton", locale: "tr-TR")
+    puts I18n.exists?("turtle.loopVariable", locale: "tr-TR")
+
+    puts "***"
+    puts translated?('de-DE', 'turtle.loopVariable')
+    puts translated?('de-DE', 'turtle.fill')
   end
 end

--- a/bin/i18n/translation_status/translation_service.rb
+++ b/bin/i18n/translation_status/translation_service.rb
@@ -5,10 +5,10 @@ require 'i18n'
 # Provides access to all the translations managed by the code-dot-org project.
 class TranslationService
   def initialize
-    store_frontend_translations
     # Normally we fallback to en-US, but we want to disable this so we detect missing strings.
     I18n.fallbacks.defaults = []
     I18n.backend.reload!
+    store_frontend_translations
   end
 
   # Returns true if a translation exists for a given key, otherwise returns false.
@@ -24,17 +24,9 @@ class TranslationService
       translations = {}
       Dir.glob(locales_dir.join("#{locale}/blockly-mooc/*.json")).each do |loc_file|
         name = File.basename(loc_file, ".*")
-        puts name if locale.include? "de"
         translations[name] = JSON.load(File.read(loc_file)).to_h
       end
       I18n.backend.store_translations(locale, translations)
     end
-    puts I18n.exists?("turtle.loopVariable", locale: "de-DE")
-    puts I18n.exists?("tutorialExplorer.startButton", locale: "tr-TR")
-    puts I18n.exists?("turtle.loopVariable", locale: "tr-TR")
-
-    puts "***"
-    puts translated?('de-DE', 'turtle.loopVariable')
-    puts translated?('de-DE', 'turtle.fill')
   end
 end

--- a/bin/i18n/translation_status/translation_service.rb
+++ b/bin/i18n/translation_status/translation_service.rb
@@ -22,7 +22,7 @@ class TranslationService
     locales = Dir.glob(locales_dir.join("*")).map {|dir| File.basename(dir)}
     locales.each do |locale|
       translations = {}
-      Dir.glob(locales_dir.join("#{locale}/blockly-mooc/*.json")).each do |loc_file|
+      Dir.glob(locales_dir.join("#{locale}/blockly-*/*.json")).each do |loc_file|
         name = File.basename(loc_file, ".*")
         translations[name] = JSON.load(File.read(loc_file)).to_h
       end

--- a/bin/i18n/translation_status/translation_service.rb
+++ b/bin/i18n/translation_status/translation_service.rb
@@ -16,10 +16,10 @@ class TranslationService
     I18n.exists?(key, locale: locale)
   end
 
-  # Aggregate all blockly-mooc translation JSON files to be loaded into i18n
+  # Aggregate all blockly-mooc and blockly-core translation JSON files to be loaded into i18n
   def store_frontend_translations
     locales_dir = Rails.root.join("../i18n/locales")
-    locales = Dir.glob(locales_dir.join("*")).map {|dir| File.basename(dir)}
+    locales = Dir.glob(locales_dir.join("*-*")).map {|dir| File.basename(dir)}
     locales.each do |locale|
       translations = {}
       Dir.glob(locales_dir.join("#{locale}/blockly-*/*.json")).each do |loc_file|


### PR DESCRIPTION
**What**: The frontend translation files (specifically in the i18n `blockly-mooc` and `blockly-core` directories) are able to be looked up by the `translation_service` for existence.

**Why**: When logging the `translation_service` needs to have the ability to check for these translations that previously were only reference and accessible by the frontend.

- jira ticket: [FND-1690](https://codedotorg.atlassian.net/browse/FND-1690)

## Testing story

Tested in local console as well as added relevant unit tests

To run unit tests for `translation_service`:
1. `cd ./bin/i18n`
2. `RAILS_ENV=test RACK_ENV=test bundle exec rake test`

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
