### PR TITLE
Adding i18n string tracking for core.json Blockly strings

### DIFF
--- a/apps/src/sites/studio/pages/blockly.js
+++ b/apps/src/sites/studio/pages/blockly.js
@@ -12,5 +12,9 @@ import 'pepjs';
 
 import CDOBlockly from '@code-dot-org/blockly';
 import initializeCdoBlocklyWrapper from '@cdo/apps/blockly/cdoBlocklyWrapper';
+import trackBlocklyStrings from '@cdo/apps/util/i18nBlockyStringTracker';
 
 window.Blockly = initializeCdoBlocklyWrapper(CDOBlockly);
+
+// Track the strings used by the Blockly code.
+trackBlocklyStrings();

--- a/apps/src/util/i18nBlockyStringTracker.js
+++ b/apps/src/util/i18nBlockyStringTracker.js
@@ -1,0 +1,38 @@
+import experiments from '@cdo/apps/util/experiments';
+import {getI18nStringTrackerWorker} from '@cdo/apps/util/i18nStringTrackerWorker';
+
+export default function trackBlocklyStrings() {
+  if (!experiments.isEnabled(experiments.I18N_TRACKING)) {
+    return;
+  }
+
+  // Blockly strings are used on most levels, therefore we can reduce how often we actually log
+  // the string usage.
+  // Track usage 1% of the time.
+  if (Math.floor(Math.random() * 100) !== 0) {
+    return;
+  }
+
+  // The strings used by Blockly blocks are defined in the Blockly.Msg object. We will wait a few
+  // seconds for all the i18n strings to be loaded into the Blockly.Msg object and then scan it.
+  setTimeout(() => {
+    if (window.Blockly && window.Blockly.Msg) {
+      Object.keys(window.Blockly.Msg).forEach(stringKey => {
+        // The blockly strings are in core.json
+        log(stringKey, 'core');
+      });
+    }
+  }, 5000);
+}
+
+// Records the usage of the given i18n string key from the given source file.
+// @param {string} stringKey  The string key used to look up the i18n value e.g. 'home.banner_text'
+// @param {string} source Context for where the given string key came from e.g. 'maze', 'dance', etc.
+function log(stringKey, source) {
+  if (!stringKey || !source) {
+    return;
+  }
+
+  // Send the usage data to a background worker thread to be buffered and sent.
+  getI18nStringTrackerWorker().log(stringKey, source);
+}


### PR DESCRIPTION
The translatable strings used by Blockly are stored as values in the `Blockly.Msg` object. The strings come from a file called `core.json`.  In order to log what strings a student's computer loaded, we will scan all the string keys in `Blockly.Msg` and pass them to the i18n string tracking API. 

*Example core.js*
```
Blockly.Msg.ACTUAL = "llamar";
Blockly.Msg.ADD = "Añadir";
```

Work done:
- Create a stand alone file containing the logic for scanning and logging the i18n strings in `core.json`
- Log this information infrequently since it doesn't change very often and we want to reduce the network traffic being sent back to our servers.
- Logging is triggered by use of `blockly.js` since this file should be used whenever blockly blocks are involved.

## Links
- [JIRA](https://codedotorg.atlassian.net/browse/FND-1694)

## Testing story
* Used the browser's network monitor to confirm the REST requests were sent to log the `Blockly.Msg` string keys.
  * Since there is a 1/10,000 chance the string keys are actually logged (1% chance of logging core.json strings * 1% chance of logging any string tracking data), I modified the code to always log the strings.

## Deployment strategy
- It is behind an experiment flag, so there shouldn't be an issue.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
