### PR TITLE
Use static-asset cache behavior for media-proxy path

### DIFF
--- a/cookbooks/cdo-varnish/libraries/http_cache.rb
+++ b/cookbooks/cdo-varnish/libraries/http_cache.rb
@@ -238,7 +238,7 @@ class HttpCache
           },
           {
             # For static-asset paths, don't forward any cookies or additional headers.
-            path: STATIC_ASSET_EXTENSION_PATHS + %w(/blockly/media/*),
+            path: STATIC_ASSET_EXTENSION_PATHS + %w(/blockly/media/* /media),
             headers: [],
             cookies: 'none'
           },


### PR DESCRIPTION
Adds `/media` path pattern for a static-asset cache behavior, to properly cache media-proxy requests in CloudFront.
Since media requests to this path only include the asset extension in the query string (e.g., `/media?u=http://[...].jpg`), CloudFront does not include the query in its path pattern matching (only the path), so it does not match.

The Varnish regex implementation of path-pattern matching _did_ match against the query string, which allowed these requests to be cached at the Varnish layer, but that was actually an unintended bug.

In order to support our application with Varnish disabled (#42441), this behavior needs to be added for the `/media` path directly, so CloudFront can properly cache these static assets.