### PR TITLE
add user data for cookies for marketing

### DIFF
--- a/dashboard/app/controllers/home_controller.rb
+++ b/dashboard/app/controllers/home_controller.rb
@@ -145,6 +145,12 @@ class HomeController < ApplicationController
       donor_banner_name ||= params[:forceDonorTeacherBanner]
       show_census_banner = !!(!donor_banner_name && current_user.show_census_teacher_banner?)
 
+      # The following cookies are used by marketing to create personalized experiences for teachers, such as displaying
+      # specific banner content.
+      current_user.marketing_segment_data&.compact&.each do |segment_name, value|
+        cookies[environment_specific_cookie_name("_teacher_#{segment_name}")] = {value: value, domain: :all}
+      end
+
       @homepage_data[:isTeacher] = true
       @homepage_data[:hocLaunch] = DCDO.get('hoc_launch', CDO.default_hoc_launch)
       @homepage_data[:joined_sections] = student_sections

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -2071,8 +2071,10 @@ class User < ApplicationRecord
     TERMS_OF_SERVICE_VERSIONS.last
   end
 
-  def school
-    @school ||= Queries::SchoolInfo.last_complete(self)&.school
+  # Ideally this would just be called school, but school is already a column
+  # on the user table representing the school name
+  def school_info_school
+    Queries::SchoolInfo.last_complete(self)&.school
   end
 
   def show_census_teacher_banner?
@@ -2084,7 +2086,7 @@ class User < ApplicationRecord
   # Returns the name of the donor for the donor teacher banner and donor footer, or nil if none.
   # Donors are associated with certain schools, captured in DonorSchool and populated from a Pegasus gsheet
   def school_donor_name
-    school_id = school&.id
+    school_id = school_info_school&.id
     donor_name = DonorSchool.find_by(nces_id: school_id)&.name if school_id
 
     donor_name
@@ -2392,7 +2394,7 @@ class User < ApplicationRecord
   end
 
   def school_stats
-    @school_stats ||= school&.most_recent_school_stats
+    @school_stats ||= school_info_school&.most_recent_school_stats
   end
 
   def hidden_lesson_ids(sections)

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -2353,10 +2353,10 @@ class User < ApplicationRecord
   # The data returned by this method is set to cookies for the marketing team to
   # use in Optimizely for segmenting teacher user experience.
   def marketing_segment_data
-    return unless user.teacher?
+    return unless teacher?
 
     {
-      locale: locale,
+      locale: read_attribute(:locale),
       account_age_in_years: account_age_in_years,
       grades: grades_being_taught.any? ? grades_being_taught.to_json : nil,
       courses: courses_being_taught.any? ? courses_being_taught.to_json : nil,
@@ -2380,7 +2380,7 @@ class User < ApplicationRecord
 
   # Returns a list of all courses that the teacher currently has sections for
   def courses_being_taught
-    sections.map {|section| section.script.curriculum_umbrella}
+    sections.map {|section| section.script&.curriculum_umbrella}.compact.uniq
   end
 
   def has_attended_pd?

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -2361,32 +2361,33 @@ class User < ApplicationRecord
       locale: read_attribute(:locale),
       account_age_in_years: account_age_in_years,
       grades: grades_being_taught.any? ? grades_being_taught.to_json : nil,
-      courses: courses_being_taught.any? ? courses_being_taught.to_json : nil,
+      curriculums: curriculums_being_taught.any? ? curriculums_being_taught.to_json : nil,
       has_attended_pd: has_attended_pd?,
       within_us: within_united_states?,
       school_percent_frl: school_stats&.frl_eligible_total,
       school_title_i: school_stats&.title_i_status
-    }.compact
+    }
   end
 
   def self.marketing_segment_data_keys
-    %w(locale account_age_in_years grades courses has_attended_pd within_usschool_percent_frl school_title_i)
+    %w(locale account_age_in_years grades curriculums has_attended_pd within_us school_percent_frl school_title_i)
   end
 
   private
 
   def account_age_in_years
-    ((Time.now - created_at.to_time) / 1.year).floor
+    ((Time.now - created_at.to_time) / 1.year).round
   end
 
   # Returns a list of all grades that the teacher currently has sections for
   def grades_being_taught
-    sections.map(&:grade).uniq
+    @grades_being_taught ||= sections.map(&:grade).uniq
   end
 
-  # Returns a list of all courses that the teacher currently has sections for
-  def courses_being_taught
-    sections.map {|section| section.script&.curriculum_umbrella}.compact.uniq
+  # Returns a list of all curriculums that the teacher currently has sections for
+  # ex: ["csf", "csd"]
+  def curriculums_being_taught
+    @curriculums_being_taught ||= sections.map {|section| section.script&.curriculum_umbrella}.compact.uniq
   end
 
   def has_attended_pd?

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -2367,6 +2367,10 @@ class User < ApplicationRecord
     }.compact
   end
 
+  def self.marketing_segment_data_keys
+    %w(locale account_age_in_years grades courses has_attended_pd within_usschool_percent_frl school_title_i)
+  end
+
   private
 
   def account_age_in_years

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -207,6 +207,8 @@ class User < ApplicationRecord
     class_name: 'Pd::Application::ApplicationBase',
     dependent: :destroy
 
+  has_many :pd_attendances, class_name: 'Pd::Attendance', foreign_key: :teacher_id
+
   has_many :sign_ins
   has_many :user_geos, -> {order 'updated_at desc'}
 
@@ -515,6 +517,10 @@ class User < ApplicationRecord
   def make_teachers_21
     return unless teacher?
     self.age = 21
+  end
+
+  def account_age_in_years
+    ((Time.now - created_at.to_time) / 1.year).floor
   end
 
   def normalize_email
@@ -1570,6 +1576,15 @@ class User < ApplicationRecord
   # Returns the set of courses the user has been assigned to or has progress in.
   def courses_as_student
     visible_scripts.map(&:unit_group).compact.concat(section_courses).uniq
+  end
+
+  # Returns a list of all grades that the teacher currently has sections for
+  def grades_being_taught
+    sections.map(&:grade).uniq
+  end
+
+  def has_attended_pd?
+    pd_attendances.any?
   end
 
   # Checks if there are any launched scripts assigned to the user.

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1583,6 +1583,11 @@ class User < ApplicationRecord
     sections.map(&:grade).uniq
   end
 
+  # Returns a list of all courses that the teacher currently has sections for
+  def courses_being_taught
+    sections.map {|section| section.script.curriculum_umbrella}
+  end
+
   def has_attended_pd?
     pd_attendances.any?
   end

--- a/dashboard/config/initializers/devise.rb
+++ b/dashboard/config/initializers/devise.rb
@@ -362,7 +362,7 @@ Devise.setup do |config|
 
     # The following cookies are used by marketing to create personalized experiences for teachers, such as displaying
     # specific banner content.
-    user.marketing_segment_data&.each do |segment_name, value|
+    user.marketing_segment_data&.compact&.each do |segment_name, value|
       auth.cookies[environment_specific_cookie_name("_teacher_#{segment_name}")] = {value: value, domain: :all}
     end
   end

--- a/dashboard/config/initializers/devise.rb
+++ b/dashboard/config/initializers/devise.rb
@@ -374,8 +374,8 @@ Devise.setup do |config|
     auth.cookies[environment_specific_cookie_name("_experiments")] = {value: "", expires: Time.at(0), domain: :all}
     auth.cookies[environment_specific_cookie_name("_assumed_identity")] = {value: "", expires: Time.at(0), domain: :all, httponly: true}
 
-    user.marketing_segment_data&.each do |segment_name, _|
-      auth.cookies[environment_specific_cookie_name("_teacher_#{segment_name}")] = {value: "", expires: Time.at(0), domain: :all}
+    User.marketing_segment_data_keys.each do |key|
+      auth.cookies[environment_specific_cookie_name("_teacher_#{key}")] = {value: "", expires: Time.at(0), domain: :all}
     end
   end
 

--- a/dashboard/config/initializers/devise.rb
+++ b/dashboard/config/initializers/devise.rb
@@ -365,8 +365,10 @@ Devise.setup do |config|
     if user.teacher?
       auth.cookies[environment_specific_cookie_name("_teacher_locale")] = {value: user.locale, domain: :all}
       auth.cookies[environment_specific_cookie_name("_teacher_account_age_in_years")] = {value: user.account_age_in_years, domain: :all}
-      auth.cookies[environment_specific_cookie_name("_teacher_grades_taught")] = {value: user.grades_being_taught.to_json, domain: :all}
+      auth.cookies[environment_specific_cookie_name("_teacher_grades")] = {value: user.grades_being_taught.to_json, domain: :all}
+      auth.cookies[environment_specific_cookie_name("_teacher_courses")] = {value: user.courses_being_taught.to_json, domain: :all}
       auth.cookies[environment_specific_cookie_name("_teacher_has_attended_pd")] = {value: user.has_attended_pd?, domain: :all}
+      auth.cookies[environment_specific_cookie_name("_teacher_within_us")] = {value: user.within_united_states?, domain: :all}
     end
   end
 

--- a/dashboard/config/initializers/devise.rb
+++ b/dashboard/config/initializers/devise.rb
@@ -359,12 +359,6 @@ Devise.setup do |config|
     auth.cookies[environment_specific_cookie_name("_user_type")] = {value: user_type, domain: :all, httponly: true}
     auth.cookies[environment_specific_cookie_name("_shortName")] = {value: user.short_name, domain: :all}
     auth.cookies[environment_specific_cookie_name("_experiments")] = {value: user.get_active_experiment_names.to_json, domain: :all}
-
-    # The following cookies are used by marketing to create personalized experiences for teachers, such as displaying
-    # specific banner content.
-    user.marketing_segment_data&.compact&.each do |segment_name, value|
-      auth.cookies[environment_specific_cookie_name("_teacher_#{segment_name}")] = {value: value, domain: :all}
-    end
   end
 
   Warden::Manager.before_logout do |_, auth|
@@ -374,6 +368,9 @@ Devise.setup do |config|
     auth.cookies[environment_specific_cookie_name("_experiments")] = {value: "", expires: Time.at(0), domain: :all}
     auth.cookies[environment_specific_cookie_name("_assumed_identity")] = {value: "", expires: Time.at(0), domain: :all, httponly: true}
 
+    # These marketing cookies are set in the home_controller in init_homepage. When the user logs out, we
+    # remove these cookies because they are user-specific. The cookies are set in init_homepage instead of after_set_user
+    # to minimize the number of times we perfom the queries for the cookie values.
     User.marketing_segment_data_keys.each do |key|
       auth.cookies[environment_specific_cookie_name("_teacher_#{key}")] = {value: "", expires: Time.at(0), domain: :all}
     end

--- a/dashboard/config/initializers/devise.rb
+++ b/dashboard/config/initializers/devise.rb
@@ -362,13 +362,8 @@ Devise.setup do |config|
 
     # The following cookies are used by marketing to create personalized experiences for teachers, such as displaying
     # specific banner content.
-    if user.teacher?
-      auth.cookies[environment_specific_cookie_name("_teacher_locale")] = {value: user.locale, domain: :all}
-      auth.cookies[environment_specific_cookie_name("_teacher_account_age_in_years")] = {value: user.account_age_in_years, domain: :all}
-      auth.cookies[environment_specific_cookie_name("_teacher_grades")] = {value: user.grades_being_taught.to_json, domain: :all}
-      auth.cookies[environment_specific_cookie_name("_teacher_courses")] = {value: user.courses_being_taught.to_json, domain: :all}
-      auth.cookies[environment_specific_cookie_name("_teacher_has_attended_pd")] = {value: user.has_attended_pd?, domain: :all}
-      auth.cookies[environment_specific_cookie_name("_teacher_within_us")] = {value: user.within_united_states?, domain: :all}
+    user.marketing_segment_data&.each do |segment_name, value|
+      auth.cookies[environment_specific_cookie_name("_teacher_#{segment_name}")] = {value: value, domain: :all}
     end
   end
 
@@ -378,6 +373,10 @@ Devise.setup do |config|
     auth.cookies[environment_specific_cookie_name("_shortName")] = {value: "", expires: Time.at(0), domain: :all}
     auth.cookies[environment_specific_cookie_name("_experiments")] = {value: "", expires: Time.at(0), domain: :all}
     auth.cookies[environment_specific_cookie_name("_assumed_identity")] = {value: "", expires: Time.at(0), domain: :all, httponly: true}
+
+    user.marketing_segment_data&.each do |segment_name, _|
+      auth.cookies[environment_specific_cookie_name("_teacher_#{segment_name}")] = {value: "", expires: Time.at(0), domain: :all}
+    end
   end
 
   # ==> Mountable engine configurations

--- a/dashboard/config/initializers/devise.rb
+++ b/dashboard/config/initializers/devise.rb
@@ -359,6 +359,15 @@ Devise.setup do |config|
     auth.cookies[environment_specific_cookie_name("_user_type")] = {value: user_type, domain: :all, httponly: true}
     auth.cookies[environment_specific_cookie_name("_shortName")] = {value: user.short_name, domain: :all}
     auth.cookies[environment_specific_cookie_name("_experiments")] = {value: user.get_active_experiment_names.to_json, domain: :all}
+
+    # The following cookies are used by marketing to create personalized experiences for teachers, such as displaying
+    # specific banner content.
+    if user.teacher?
+      auth.cookies[environment_specific_cookie_name("_teacher_locale")] = {value: user.locale, domain: :all}
+      auth.cookies[environment_specific_cookie_name("_teacher_account_age_in_years")] = {value: user.account_age_in_years, domain: :all}
+      auth.cookies[environment_specific_cookie_name("_teacher_grades_taught")] = {value: user.grades_being_taught.to_json, domain: :all}
+      auth.cookies[environment_specific_cookie_name("_teacher_has_attended_pd")] = {value: user.has_attended_pd?, domain: :all}
+    end
   end
 
   Warden::Manager.before_logout do |_, auth|

--- a/dashboard/test/controllers/api/v1/assessments_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/assessments_controller_test.rb
@@ -702,7 +702,7 @@ class Api::V1::AssessmentsControllerTest < ActionController::TestCase
       create :teacher_feedback, script: script, level: weblab_level, student: student, teacher: @teacher
     end
 
-    assert_queries 13 do
+    assert_queries 17 do
       get :section_feedback, params: {section_id: @section.id, script_id: script.id}
     end
 

--- a/dashboard/test/controllers/api/v1/assessments_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/assessments_controller_test.rb
@@ -702,7 +702,7 @@ class Api::V1::AssessmentsControllerTest < ActionController::TestCase
       create :teacher_feedback, script: script, level: weblab_level, student: student, teacher: @teacher
     end
 
-    assert_queries 17 do
+    assert_queries 13 do
       get :section_feedback, params: {section_id: @section.id, script_id: script.id}
     end
 

--- a/dashboard/test/controllers/api/v1/teacher_scores_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/teacher_scores_controller_test.rb
@@ -147,7 +147,7 @@ class Api::V1::TeacherScoresControllerTest < ActionDispatch::IntegrationTest
 
     post '/dashboardapi/v1/teacher_scores', params: {section_id: section.id, lesson_scores: [{lesson_id: lesson.id, score: score}]}
 
-    assert_queries 11 do
+    assert_queries 7 do
       get "/dashboardapi/v1/teacher_scores/#{section.id}/#{script.id}"
     end
 
@@ -159,7 +159,7 @@ class Api::V1::TeacherScoresControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal section.students.count, 11
 
-    assert_queries 11 do
+    assert_queries 7 do
       get "/dashboardapi/v1/teacher_scores/#{section.id}/#{script.id}"
     end
   end

--- a/dashboard/test/controllers/api/v1/teacher_scores_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/teacher_scores_controller_test.rb
@@ -147,7 +147,7 @@ class Api::V1::TeacherScoresControllerTest < ActionDispatch::IntegrationTest
 
     post '/dashboardapi/v1/teacher_scores', params: {section_id: section.id, lesson_scores: [{lesson_id: lesson.id, score: score}]}
 
-    assert_queries 7 do
+    assert_queries 11 do
       get "/dashboardapi/v1/teacher_scores/#{section.id}/#{script.id}"
     end
 
@@ -159,7 +159,7 @@ class Api::V1::TeacherScoresControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal section.students.count, 11
 
-    assert_queries 7 do
+    assert_queries 11 do
       get "/dashboardapi/v1/teacher_scores/#{section.id}/#{script.id}"
     end
   end

--- a/dashboard/test/controllers/api_controller_queries_test.rb
+++ b/dashboard/test/controllers/api_controller_queries_test.rb
@@ -23,7 +23,7 @@ class ApiControllerQueriesTest < ActionDispatch::IntegrationTest
 
     sign_in_as section.teacher
 
-    assert_queries 11 do
+    assert_queries 15 do
       get '/dashboardapi/section_level_progress', params: {
         section_id: section.id,
         script_id: script.id

--- a/dashboard/test/controllers/api_controller_queries_test.rb
+++ b/dashboard/test/controllers/api_controller_queries_test.rb
@@ -23,7 +23,7 @@ class ApiControllerQueriesTest < ActionDispatch::IntegrationTest
 
     sign_in_as section.teacher
 
-    assert_queries 15 do
+    assert_queries 11 do
       get '/dashboardapi/section_level_progress', params: {
         section_id: section.id,
         script_id: script.id

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -938,7 +938,7 @@ class ApiControllerTest < ActionController::TestCase
   test "should get progress for section with section script" do
     Script.stubs(:should_cache?).returns true
 
-    assert_queries 8 do
+    assert_queries 12 do
       get :section_progress, params: {section_id: @flappy_section.id}
     end
     assert_response :success
@@ -1216,10 +1216,6 @@ class ApiControllerTest < ActionController::TestCase
 
     assert_response :forbidden
   end
-
-  # test "" do
-
-  # end
 
   test "script_structure returns summarized script" do
     overview_path = 'http://script.overview/path'

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -938,7 +938,7 @@ class ApiControllerTest < ActionController::TestCase
   test "should get progress for section with section script" do
     Script.stubs(:should_cache?).returns true
 
-    assert_queries 12 do
+    assert_queries 8 do
       get :section_progress, params: {section_id: @flappy_section.id}
     end
     assert_response :success

--- a/dashboard/test/controllers/courses_controller_test.rb
+++ b/dashboard/test/controllers/courses_controller_test.rb
@@ -39,15 +39,15 @@ class CoursesControllerTest < ActionController::TestCase
       @unit_group_regular = create :unit_group, name: 'non-plc-course', published_state: SharedConstants::PUBLISHED_STATE.beta
     end
 
-    test_user_gets_response_for :index, response: :success, user: :teacher, queries: 8
+    test_user_gets_response_for :index, response: :success, user: :teacher, queries: 4
 
-    test_user_gets_response_for :index, response: :success, user: :admin, queries: 8
+    test_user_gets_response_for :index, response: :success, user: :admin, queries: 4
 
     test_user_gets_response_for :index, response: :success, user: :user, queries: 4
 
-    test_user_gets_response_for :show, response: :success, user: :teacher, params: -> {{course_name: @unit_group_regular.name}}, queries: 13
+    test_user_gets_response_for :show, response: :success, user: :teacher, params: -> {{course_name: @unit_group_regular.name}}, queries: 10
 
-    test_user_gets_response_for :show, response: :forbidden, user: :admin, params: -> {{course_name: @unit_group_regular.name}}, queries: 7
+    test_user_gets_response_for :show, response: :forbidden, user: :admin, params: -> {{course_name: @unit_group_regular.name}}, queries: 3
   end
 
   class CachedQueryCounts < ActionController::TestCase

--- a/dashboard/test/controllers/courses_controller_test.rb
+++ b/dashboard/test/controllers/courses_controller_test.rb
@@ -39,15 +39,15 @@ class CoursesControllerTest < ActionController::TestCase
       @unit_group_regular = create :unit_group, name: 'non-plc-course', published_state: SharedConstants::PUBLISHED_STATE.beta
     end
 
-    test_user_gets_response_for :index, response: :success, user: :teacher, queries: 4
+    test_user_gets_response_for :index, response: :success, user: :teacher, queries: 8
 
-    test_user_gets_response_for :index, response: :success, user: :admin, queries: 4
+    test_user_gets_response_for :index, response: :success, user: :admin, queries: 8
 
     test_user_gets_response_for :index, response: :success, user: :user, queries: 4
 
-    test_user_gets_response_for :show, response: :success, user: :teacher, params: -> {{course_name: @unit_group_regular.name}}, queries: 10
+    test_user_gets_response_for :show, response: :success, user: :teacher, params: -> {{course_name: @unit_group_regular.name}}, queries: 13
 
-    test_user_gets_response_for :show, response: :forbidden, user: :admin, params: -> {{course_name: @unit_group_regular.name}}, queries: 3
+    test_user_gets_response_for :show, response: :forbidden, user: :admin, params: -> {{course_name: @unit_group_regular.name}}, queries: 7
   end
 
   class CachedQueryCounts < ActionController::TestCase

--- a/dashboard/test/controllers/home_controller_test.rb
+++ b/dashboard/test/controllers/home_controller_test.rb
@@ -19,6 +19,17 @@ class HomeControllerTest < ActionController::TestCase
     assert_redirected_to '/home'
   end
 
+  test "teacher logging in gets expected cookies set" do
+    teacher = create :teacher
+    sign_in teacher
+    get :index
+
+    cookie_header = @response.header['Set-Cookie']
+    assert cookie_header.include?("teacher_account_age_in_years")
+    assert cookie_header.include?("teacher_within_us")
+    assert cookie_header.include?("teacher_has_attended_pd")
+  end
+
   test "teacher with assigned course/script redirected to index" do
     teacher = create :teacher
     script = create :script
@@ -362,7 +373,7 @@ class HomeControllerTest < ActionController::TestCase
   # TODO: remove this test when workshop_organizer is deprecated
   test 'workshop organizers see dashboard links' do
     sign_in create(:workshop_organizer, :with_terms_of_service)
-    query_count = 13
+    query_count = 15
     assert_queries query_count do
       get :home
     end
@@ -371,7 +382,7 @@ class HomeControllerTest < ActionController::TestCase
 
   test 'program managers see dashboard links' do
     sign_in create(:program_manager, :with_terms_of_service)
-    query_count = 15
+    query_count = 17
     assert_queries query_count do
       get :home
     end
@@ -380,7 +391,7 @@ class HomeControllerTest < ActionController::TestCase
 
   test 'workshop admins see dashboard links' do
     sign_in create(:workshop_admin, :with_terms_of_service)
-    query_count = 12
+    query_count = 14
     assert_queries query_count do
       get :home
     end
@@ -390,7 +401,7 @@ class HomeControllerTest < ActionController::TestCase
   test 'facilitators see dashboard links' do
     facilitator = create(:facilitator, :with_terms_of_service)
     sign_in facilitator
-    query_count = 13
+    query_count = 15
     assert_queries query_count do
       get :home
     end
@@ -399,7 +410,7 @@ class HomeControllerTest < ActionController::TestCase
 
   test 'teachers cannot see dashboard links' do
     sign_in create(:terms_of_service_teacher)
-    query_count = 11
+    query_count = 13
     assert_queries query_count do
       get :home
     end
@@ -408,7 +419,7 @@ class HomeControllerTest < ActionController::TestCase
 
   test 'workshop admins see application dashboard links' do
     sign_in create(:workshop_admin, :with_terms_of_service)
-    query_count = 12
+    query_count = 14
     assert_queries query_count do
       get :home
     end
@@ -419,7 +430,7 @@ class HomeControllerTest < ActionController::TestCase
   # TODO: remove this test when workshop_organizer is deprecated
   test 'workshop organizers who are regional partner program managers see application dashboard links' do
     sign_in create(:workshop_organizer, :as_regional_partner_program_manager, :with_terms_of_service)
-    query_count = 15
+    query_count = 17
     assert_queries query_count do
       get :home
     end
@@ -429,7 +440,7 @@ class HomeControllerTest < ActionController::TestCase
 
   test 'program managers see application dashboard links' do
     sign_in create(:program_manager, :with_terms_of_service)
-    query_count = 15
+    query_count = 17
     assert_queries query_count do
       get :home
     end
@@ -440,7 +451,7 @@ class HomeControllerTest < ActionController::TestCase
   # TODO: remove this test when workshop_organizer is deprecated
   test 'workshop organizers who are not regional partner program managers do not see application dashboard links' do
     sign_in create(:workshop_organizer, :with_terms_of_service)
-    query_count = 13
+    query_count = 15
     assert_queries query_count do
       get :home
     end

--- a/dashboard/test/controllers/home_controller_test.rb
+++ b/dashboard/test/controllers/home_controller_test.rb
@@ -19,17 +19,6 @@ class HomeControllerTest < ActionController::TestCase
     assert_redirected_to '/home'
   end
 
-  test "teacher logging in gets expected cookies set" do
-    teacher = create :teacher
-    sign_in teacher
-    get :index
-
-    cookie_header = @response.header['Set-Cookie']
-    assert cookie_header.include?("teacher_account_age_in_years")
-    assert cookie_header.include?("teacher_within_us")
-    assert cookie_header.include?("teacher_has_attended_pd")
-  end
-
   test "teacher with assigned course/script redirected to index" do
     teacher = create :teacher
     script = create :script
@@ -322,6 +311,17 @@ class HomeControllerTest < ActionController::TestCase
     get :home
 
     assert_select '#thank-donors-modal', true
+  end
+
+  test "teacher visiting homepage gets expected cookies set" do
+    teacher = create :teacher
+    sign_in teacher
+    get :home
+
+    cookie_header = @response.header['Set-Cookie']
+    assert cookie_header.include?("teacher_account_age_in_years")
+    assert cookie_header.include?("teacher_within_us")
+    assert cookie_header.include?("teacher_has_attended_pd")
   end
 
   test 'student on second login does not get thank donors dialog' do

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -4536,8 +4536,8 @@ class UserTest < ActiveSupport::TestCase
 
   test 'marketing_segment_data returns expected account age for teacher' do
     teacher = create :teacher, created_at: 20.months.ago
-    # 20 months = 1.66 years -> 1 full year
-    assert_equal 1, teacher.marketing_segment_data[:account_age_in_years]
+    # 20 months = 1.66 years rounds to 2 years
+    assert_equal 2, teacher.marketing_segment_data[:account_age_in_years]
   end
 
   test 'marketing_segment_data returns expected locale' do
@@ -4562,21 +4562,21 @@ class UserTest < ActiveSupport::TestCase
     assert_nil teacher.marketing_segment_data[:grades]
   end
 
-  test 'marketing_segment_data returns expected courses for teacher with sections' do
+  test 'marketing_segment_data returns expected curriculums for teacher with sections' do
     teacher = create :teacher
     csf_script = create :csf_script
     csd_script = create :csd_script
     create :section, user: teacher, script: csf_script
     create :section, user: teacher, script: csd_script
 
-    expected_courses = ["CSF", "CSD"]
-    marketing_segment_courses = JSON.parse(teacher.marketing_segment_data[:courses])
-    assert_equal expected_courses.sort, marketing_segment_courses.sort
+    expected_curriculums = ["CSF", "CSD"]
+    marketing_segment_curriculums = JSON.parse(teacher.marketing_segment_data[:curriculums])
+    assert_equal expected_curriculums.sort, marketing_segment_curriculums.sort
   end
 
-  test 'marketing_segment_data does not return courses for teacher with no sections' do
+  test 'marketing_segment_data does not return curriculums for teacher with no sections' do
     teacher = create :teacher
-    assert_nil teacher.marketing_segment_data[:courses]
+    assert_nil teacher.marketing_segment_data[:curriculums]
   end
 
   test 'marketing_segment_data returns expected value for has_attended_pd' do
@@ -4607,5 +4607,10 @@ class UserTest < ActiveSupport::TestCase
     school_info = create :school_info, school: school
     teacher = create :teacher, school_info: school_info
     assert_equal title_i_status, teacher.marketing_segment_data[:school_title_i]
+  end
+
+  test "marketing_segment_data returns the same keys as marketing_segment_data_keys" do
+    teacher = create :teacher
+    assert_equal User.marketing_segment_data_keys.sort, teacher.marketing_segment_data.keys.map(&:to_s).sort
   end
 end

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -4515,4 +4515,97 @@ class UserTest < ActiveSupport::TestCase
     user.increment_section_attempts
     assert_equal 1, user.properties['section_attempts']
   end
+
+  test 'school returns the school associated with the user' do
+    school = create :school
+    school_info = create :school_info, school: school
+    user = create :teacher, school_info: school_info
+
+    assert_equal school.id, user.school.id
+  end
+
+  test 'school returns nil if user has no school association' do
+    user = create :teacher
+    assert_nil user.school
+  end
+
+  test 'marketing_segment_data returns nil if user is not a teacher' do
+    student = create :student
+    assert_nil student.marketing_segment_data
+  end
+
+  test 'marketing_segment_data returns expected account age for teacher' do
+    teacher = create :teacher, created_at: 20.months.ago
+    # 20 months = 1.66 years -> 1 full year
+    assert_equal 1, teacher.marketing_segment_data[:account_age_in_years]
+  end
+
+  test 'marketing_segment_data returns expected locale' do
+    locale = "en-US"
+    teacher = create :teacher, locale: locale
+    assert_equal locale, teacher.marketing_segment_data[:locale]
+  end
+
+  test 'marketing_segment_data returns expected grades for teacher with sections' do
+    teacher = create :teacher
+    create :section, user: teacher, grade: "6"
+    create :section, user: teacher, grade: "6"
+    create :section, user: teacher, grade: "7"
+
+    expected_grades = ["6", "7"]
+    marketing_segment_grades = JSON.parse(teacher.marketing_segment_data[:grades])
+    assert_equal expected_grades.sort, marketing_segment_grades.sort
+  end
+
+  test 'marketing_segment_data does not return grades for teacher with no sections' do
+    teacher = create :teacher
+    assert_nil teacher.marketing_segment_data[:grades]
+  end
+
+  test 'marketing_segment_data returns expected courses for teacher with sections' do
+    teacher = create :teacher
+    csf_script = create :csf_script
+    csd_script = create :csd_script
+    create :section, user: teacher, script: csf_script
+    create :section, user: teacher, script: csd_script
+
+    expected_courses = ["CSF", "CSD"]
+    marketing_segment_courses = JSON.parse(teacher.marketing_segment_data[:courses])
+    assert_equal expected_courses.sort, marketing_segment_courses.sort
+  end
+
+  test 'marketing_segment_data does not return courses for teacher with no sections' do
+    teacher = create :teacher
+    assert_nil teacher.marketing_segment_data[:courses]
+  end
+
+  test 'marketing_segment_data returns expected value for has_attended_pd' do
+    teacher = create :teacher
+    create :pd_attendance, teacher: teacher
+    assert teacher.marketing_segment_data[:has_attended_pd]
+  end
+
+  test 'marketing_segment_data returns expected value for within_us' do
+    teacher = create :teacher
+    create :user_geo, country: "United States", user: teacher
+    assert teacher.marketing_segment_data[:within_us]
+  end
+
+  test 'marketing_segment_data returns expected value for school_percent_frl' do
+    frl_eligible_total = 35
+    school = create :school
+    create :school_stats_by_year, school: school, frl_eligible_total: frl_eligible_total
+    school_info = create :school_info, school: school
+    teacher = create :teacher, school_info: school_info
+    assert_equal frl_eligible_total, teacher.marketing_segment_data[:school_percent_frl]
+  end
+
+  test 'marketing_segment_data returns expected value for school_title_i' do
+    title_i_status = '5'
+    school = create :school
+    create :school_stats_by_year, school: school, title_i_status: title_i_status
+    school_info = create :school_info, school: school
+    teacher = create :teacher, school_info: school_info
+    assert_equal title_i_status, teacher.marketing_segment_data[:school_title_i]
+  end
 end

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -4516,17 +4516,17 @@ class UserTest < ActiveSupport::TestCase
     assert_equal 1, user.properties['section_attempts']
   end
 
-  test 'school returns the school associated with the user' do
+  test 'school_info_school returns the school associated with the user' do
     school = create :school
     school_info = create :school_info, school: school
     user = create :teacher, school_info: school_info
 
-    assert_equal school.id, user.school.id
+    assert_equal school.id, user.school_info_school.id
   end
 
-  test 'school returns nil if user has no school association' do
+  test 'school_info_school returns nil if user has no school association' do
     user = create :teacher
-    assert_nil user.school
+    assert_nil user.school_info_school
   end
 
   test 'marketing_segment_data returns nil if user is not a teacher' do


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
The changes here add cookies which can be used by marketing to segment the user experience on Optimizely. The cookies will be added when the teacher visits the homepage and will be removed on log-out. I was able to verify that the cookies were being set through tests and by running locally.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
- jira ticket: [LP-2039](https://codedotorg.atlassian.net/browse/LP-2039)
<!--
- spec: []()
-->

## Testing story
Tested through unit tests that set-cookies header had expected values
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
