### PR TITLE
[Spritelab] Fix avatar/ChallengeDialog overlap

### DIFF
--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -290,37 +290,26 @@ FeedbackUtils.prototype.displayFeedback = function(
         onContinue();
       };
     }
-    if (isPerfect) {
-      ReactDOM.render(
-        <ChallengeDialog
-          title={msg.challengeLevelPerfectTitle()}
-          avatar={icon}
-          complete
-          handlePrimary={onChallengeContinue}
-          primaryButtonLabel={msg.continue()}
-          cancelButtonLabel={msg.tryAgain()}
-          showPuzzleRatingButtons={showPuzzleRatingButtons}
-        >
-          {displayShowCode && this.getShowCodeComponent_(options, true)}
-        </ChallengeDialog>,
-        container
-      );
-    } else {
-      ReactDOM.render(
-        <ChallengeDialog
-          title={msg.challengeLevelPassTitle()}
-          avatar={icon}
-          handlePrimary={onChallengeContinue}
-          primaryButtonLabel={msg.continue()}
-          cancelButtonLabel={msg.tryAgain()}
-          showPuzzleRatingButtons={showPuzzleRatingButtons}
-          text={msg.challengeLevelPassText({idealBlocks})}
-        >
-          {displayShowCode && this.getShowCodeComponent_(options, true)}
-        </ChallengeDialog>,
-        container
-      );
-    }
+
+    ReactDOM.render(
+      <ChallengeDialog
+        title={
+          isPerfect
+            ? msg.challengeLevelPerfectTitle()
+            : msg.challengeLevelPassTitle()
+        }
+        avatar={icon}
+        text={isPerfect ? null : msg.challengeLevelPassText({idealBlocks})}
+        complete={isPerfect}
+        handlePrimary={onChallengeContinue}
+        primaryButtonLabel={msg.continue()}
+        cancelButtonLabel={msg.tryAgain()}
+        showPuzzleRatingButtons={showPuzzleRatingButtons}
+      >
+        {displayShowCode && this.getShowCodeComponent_(options, true)}
+      </ChallengeDialog>,
+      container
+    );
     return;
   }
 

--- a/apps/src/templates/ChallengeDialog.jsx
+++ b/apps/src/templates/ChallengeDialog.jsx
@@ -82,7 +82,7 @@ class ChallengeDialog extends React.Component {
           />
         </div>
         <div style={styles.content}>
-          <div style={styles.text}>{this.props.text}</div>
+          {this.props.text && <div style={styles.text}>{this.props.text}</div>}
           {this.props.children}
         </div>
         <LegacyButton

--- a/apps/src/templates/ChallengeDialog.story.jsx
+++ b/apps/src/templates/ChallengeDialog.story.jsx
@@ -4,7 +4,7 @@ import GeneratedCode from './feedback/GeneratedCode';
 import React from 'react';
 
 const wrapperStyle = {
-  marginTop: 200
+  marginTop: 100
 };
 
 export default storybook => {

--- a/apps/src/templates/ChallengeDialog.story.jsx
+++ b/apps/src/templates/ChallengeDialog.story.jsx
@@ -27,6 +27,23 @@ export default storybook => {
       )
     },
     {
+      name: 'Starting dialog with large avatar',
+      description: 'Shrinks the avatar to prevent overlap with dialog content.',
+      story: () => (
+        <div style={wrapperStyle}>
+          <ChallengeDialog
+            hideBackdrop
+            avatar="/blockly/media/spritelab/avatar.png"
+            cancelButtonLabel="Skip for now"
+            primaryButtonLabel="I'm Ready!"
+            text="Challenge Puzzles are lessons designed to stretch your brain! Just do the best that you can!"
+            title="Challenge Puzzle!"
+            isIntro
+          />
+        </div>
+      )
+    },
+    {
       name: 'Starting Dialog if previously completed',
       description: 'Shows up as soon as you load the puzzle.',
       story: () => (

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -2902,7 +2902,8 @@ $modal-no-icon-gap: 22px;
 }
 
 .modal-image {
-  width: $modal-image-width;
+  max-width: $modal-image-width;
+  max-height: 100px;
   height: auto;
   margin-top: -75px;
   position: absolute;


### PR DESCRIPTION
This is only relevant to Spritelab because the Spritelab avatar is larger than others and we noticed this in Outbreak testing.

When rendering a large avatar in `<ChallengeDialog/>` on Spritelab levels, the text would overlap with the avatar. This fixes that and includes some small clean-up.

**Before:**
![image-20210826-164351](https://user-images.githubusercontent.com/9812299/134428685-3d875561-3f9e-4813-a698-81fed685e2b7.png)

**After:**
<img width="583" alt="Screen Shot 2021-09-22 at 2 59 06 PM" src="https://user-images.githubusercontent.com/9812299/134428694-97966043-4e9f-401b-b4f2-564d03e41ef1.png">

## Links

- [STAR-1701](https://codedotorg.atlassian.net/browse/STAR-1701)

## Testing story

Adds a storybook entry for this case.