### PR TITLE
Playground: set background image to empty string instead of undefined on reset

### DIFF
--- a/apps/src/javalab/Playground.js
+++ b/apps/src/javalab/Playground.js
@@ -165,7 +165,7 @@ export default class Playground {
   resetBackgroundElement() {
     const backgroundElement = this.getBackgroundElement();
     backgroundElement.onerror = undefined;
-    backgroundElement.src = undefined;
+    backgroundElement.src = '';
     backgroundElement.style.opacity = 0.0;
   }
 }

--- a/apps/test/unit/javalab/PlaygroundTest.js
+++ b/apps/test/unit/javalab/PlaygroundTest.js
@@ -145,7 +145,7 @@ describe('Playground', () => {
 
     playground.reset();
 
-    expect(backgroundElement.src).to.be.undefined;
+    expect(backgroundElement.src).to.equal('');
     expect(backgroundElement.style.opacity).to.equal(0);
     expect(backgroundElement.onerror).to.be.undefined;
   });


### PR DESCRIPTION
Minor followup from https://github.com/code-dot-org/code-dot-org/pull/42607 - setting the background image src to undefined was causing 404 errors on reset, so this sets it to an empty string instead.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

Tested locally - confirmed that on reset there are no network errors.

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
