### PR TITLE
Javalab: Set tabs to be two columns

### DIFF
--- a/apps/src/javalab/editorSetup.js
+++ b/apps/src/javalab/editorSetup.js
@@ -44,7 +44,8 @@ const editorSetup = [
     ...commentKeymap,
     defaultTabBinding
   ]),
-  java()
+  java(),
+  EditorState.tabSize.of(2)
 ];
 
 export {editorSetup};


### PR DESCRIPTION
In code mirror, tabs are set by default to be 4 columns wide and whereas the auto indent is set at 2 spaces. This makes tabs two columns instead for consistency.

This should solve a couple errors reported on Zendesk: 
https://codeorg.zendesk.com/agent/tickets/348125
https://codeorg.zendesk.com/agent/tickets/352427 

Jira
https://codedotorg.atlassian.net/browse/CSA-712

Examples from code mirror: https://codemirror.net/6/examples/config/
Docs: https://codemirror.net/6/docs/ref/#state.EditorState.tabSize

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
