### PR TITLE
Update the PL Courses part of unit edit to deeper learning specific

### DIFF
--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -906,7 +906,16 @@ class UnitEditor extends React.Component {
         )}
 
         {this.props.isLevelbuilder && (
-          <CollapsibleEditorSection title="Professional Learning Settings">
+          <CollapsibleEditorSection
+            title="Deeper Learning Settings"
+            collapsed={true}
+          >
+            <p>
+              These settings are only used for deeper learning courses which use
+              the peer review system which is not part of the normal course
+              model. All other courses should be built in the normal course
+              model.
+            </p>
             <label>
               Deprecated
               <input

--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -910,12 +910,14 @@ class UnitEditor extends React.Component {
             title="Deeper Learning Settings"
             collapsed={true}
           >
-            <p>
-              These settings are only used for deeper learning courses which use
-              the peer review system which is not part of the normal course
-              model. All other courses should be built in the normal course
-              model.
-            </p>
+            <b>
+              <i>
+                These settings are only used for deeper learning courses which
+                use the peer review system which is not part of the normal
+                course model. All other courses should be built in the normal
+                course model.
+              </i>
+            </b>
             <label>
               Deprecated
               <input


### PR DESCRIPTION
Rename Professional Learning Settings to Deeper Learning Settings to clarify their use. Make the Deeper Learning Settings collapsed by default. 

#### Collapsed
<img width="1047" alt="Screen Shot 2021-09-22 at 11 31 03 PM" src="https://user-images.githubusercontent.com/208083/134451012-96114207-6410-45ff-9603-42324bdc3de8.png">

#### Warning Text
<img width="1028" alt="Screen Shot 2021-09-22 at 11 33 59 PM" src="https://user-images.githubusercontent.com/208083/134451118-77c8c7e3-b5c2-4f78-b186-76a30c7ea9d5.png">

## Links

Jira: https://codedotorg.atlassian.net/browse/PLAT-1330
Spec: https://docs.google.com/document/d/1qZpc90daxQiiqpcQUiUiGV2tQoaYEQUzOA72UZzBlVE

## Testing story

- Just tested manually