### PR TITLE
Add CloudFormation configuration for cdo-v3-files bucket

### DIFF
--- a/aws/cloudformation/s3_buckets.yml
+++ b/aws/cloudformation/s3_buckets.yml
@@ -57,6 +57,25 @@ Resources:
         BlockPublicPolicy: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
+  ## Create S3 bucket used to store weblab files and dance party thumbnails (possibly other use cases)
+  FilesBucket:
+    Type: "AWS::S3::Bucket"
+    DeletionPolicy: Retain
+    Properties:
+      BucketName: "cdo-v3-files"
+      VersioningConfiguration:
+        Status: "Enabled"
+      LifecycleConfiguration:
+        Rules:
+          -
+            Id: "60-day expiration of old versions"
+            NoncurrentVersionExpirationInDays: 60
+            Status: "Enabled"
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
   DroneLibraryBucketPolicy:
     Type: AWS::S3::BucketPolicy
     Properties:


### PR DESCRIPTION
Adds existing configuration for `cdo-v3-files` bucket. Similar to `cdo-v3-sources` configuration, but with no logging and no prefix specified to apply retention rules to specific paths.

## Testing story

~Hasn't been tested yet. Before merging, will import via AWS web console and look for drift in the bucket's configuration.~
We manually imported this configuration on 9/24/21 at ~2:15 PM PDT and noted no difference between the existing bucket's configuration and what we've specified in this PR (other than the inclusion of `PublicAccessBlockConfiguration`, which is known to cause drift when we import these configurations.