### PR TITLE
Print sections login info card without new windows

### DIFF
--- a/apps/src/templates/teacherDashboard/SectionLoginInfo.jsx
+++ b/apps/src/templates/teacherDashboard/SectionLoginInfo.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import _ from 'lodash';
 import {connect} from 'react-redux';
 import i18n from '@cdo/locale';
 import color from '@cdo/apps/util/color';
@@ -189,27 +188,32 @@ class WordOrPictureLogins extends React.Component {
   }
 
   printLoginCards = () => {
-    const printArea = document.getElementById('printArea').outerHTML;
-    // Adding a unique ID to the window name allows for multiple instances of this window
-    // to be open at once without affecting each other.
-    const windowName = `printWindow-${_.uniqueId()}`;
-    let printWindow = window.open('', windowName, '');
     const {section} = this.props;
+    const printArea = document.getElementById('printArea').outerHTML;
+    // Popup blockers cause issues with creating a new window for printing.
+    // Creating a hidden iframe temporarily on the page as a workaround.
+    const printIframe = document.createElement('iframe');
+    printIframe.style.display = 'none';
 
-    printWindow.document.open();
-    printWindow.addEventListener('load', event => {
-      printWindow.print();
+    // Wrapping `write` calls in an onload event listener
+    // to allow contentDocument/contentWindow initialization.
+    printIframe.addEventListener('load', event => {
+      printIframe.contentDocument.write(
+        `<html><head><title>${i18n.printLoginCards_windowTitle({
+          sectionName: section.name
+        })}</title></head>`
+      );
+      printIframe.contentDocument.write(`<body>${printArea}</body></html>`);
+      printIframe.contentWindow.print();
     });
+    document.body.appendChild(printIframe);
 
-    printWindow.document.write(
-      `<html><head><title>${i18n.printLoginCards_windowTitle({
-        sectionName: section.name
-      })}</title></head>`
-    );
-    printWindow.document.write('<body onafterprint="self.close()">');
-    printWindow.document.write(printArea);
-    printWindow.document.write('</body></html>');
-    printWindow.document.close();
+    // `onafterprint` event handling isn't consistent across browsers.
+    // Using a timeout allows the iframe `print()` to block before
+    // deleting the iframe.
+    setTimeout(function() {
+      printIframe.remove();
+    }, 1000);
   };
 
   render() {

--- a/apps/src/templates/teacherDashboard/SectionLoginInfo.jsx
+++ b/apps/src/templates/teacherDashboard/SectionLoginInfo.jsx
@@ -198,12 +198,14 @@ class WordOrPictureLogins extends React.Component {
     // Wrapping `write` calls in an onload event listener
     // to allow contentDocument/contentWindow initialization.
     printIframe.addEventListener('load', event => {
+      printIframe.contentDocument.open();
       printIframe.contentDocument.write(
         `<html><head><title>${i18n.printLoginCards_windowTitle({
           sectionName: section.name
-        })}</title></head>`
+        })}</title></head>
+        <body>${printArea}</body></html>`
       );
-      printIframe.contentDocument.write(`<body>${printArea}</body></html>`);
+      printIframe.contentDocument.close();
       printIframe.contentWindow.print();
     });
     document.body.appendChild(printIframe);


### PR DESCRIPTION
**What**: Create a hidden iframe on the existing teach dashboard > section > login info page to use for printing the login cards.

**Why**: The existing implementation opens a new window in the browser to print from. These are often blocked by pop up blockers.  This doesn't allow the user to print and breaks the page.

## Links

- jira ticket: [FND-1726](https://codedotorg.atlassian.net/browse/FND-1726)

## Testing story

Tested locally on latest version of Chrome, Firefox, and Safari(15.0)

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Follow-up work

Safari has a confirmation for when a page attempts to print more than once.  Printing the first time either with the `autoPrint` flag in the URL or with the button works. Following attempts after don't print correctly.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
