### PR TITLE
migrate outbreak unit

### DIFF
--- a/dashboard/config/scripts/outbreak.script
+++ b/dashboard/config/scripts/outbreak.script
@@ -1,18 +1,1 @@
-family_name 'outbreak'
-version_year 'unversioned'
-published_state 'preview'
-is_course true
-
-lesson_group 'outbreak', display_name: 'Outbreak Simulation'
-lesson 'Virus Simulation for Code Bytes', display_name: 'Coding a Simulation', has_lesson_plan: false
-level 'CourseF_outbreak_story', progression: 'Welcome to Monster Town'
-level 'CourseF_outbreak1', progression: 'Skill Building'
-level 'CourseF_outbreak2', progression: 'Skill Building'
-level 'CourseF_outbreak3', progression: 'Skill Building'
-level 'CourseF_outbreak4', progression: 'Skill Building'
-level 'CourseF_outbreak5', progression: 'Mini-Project: Outbreak Simulator'
-level 'CourseF_outbreak6', progression: 'Mini-Project: Outbreak Simulator'
-level 'CourseF_outbreak7', progression: 'Mini-Project: Outbreak Simulator'
-level 'CourseF_outbreak8', progression: 'Mini-Project: Outbreak Simulator'
-level 'international_outbreak_freeplay', progression: 'Free Play'
-
+is_migrated true

--- a/dashboard/config/scripts_json/outbreak.script_json
+++ b/dashboard/config/scripts_json/outbreak.script_json
@@ -5,11 +5,12 @@
     "login_required": false,
     "properties": {
       "version_year": "unversioned",
-      "is_course": true
+      "is_course": true,
+      "is_migrated": true
     },
     "new_name": null,
     "family_name": "outbreak",
-    "serialized_at": "2021-08-26 19:35:28 UTC",
+    "serialized_at": "2021-09-24 18:57:50 UTC",
     "published_state": "preview",
     "seeding_key": {
       "script.name": "outbreak"
@@ -47,21 +48,74 @@
     }
   ],
   "lesson_activities": [
-
+    {
+      "key": "06dfaf3b-e495-4577-baa6-883a782e198f",
+      "position": 1,
+      "properties": {
+        "name": "Levels"
+      },
+      "seeding_key": {
+        "lesson_activity.key": "06dfaf3b-e495-4577-baa6-883a782e198f",
+        "lesson.key": "Virus Simulation for Code Bytes",
+        "lesson_group.key": "outbreak",
+        "script.name": "outbreak"
+      }
+    }
   ],
   "activity_sections": [
-
+    {
+      "key": "f86ae28c-7f78-4f08-a649-8abf70a55601",
+      "position": 1,
+      "properties": {
+        "progression_name": "Welcome to Monster Town"
+      },
+      "seeding_key": {
+        "activity_section.key": "f86ae28c-7f78-4f08-a649-8abf70a55601",
+        "lesson_activity.key": "06dfaf3b-e495-4577-baa6-883a782e198f"
+      }
+    },
+    {
+      "key": "469f328e-f384-4319-9bd0-e0b4e603d3a6",
+      "position": 2,
+      "properties": {
+        "progression_name": "Skill Building"
+      },
+      "seeding_key": {
+        "activity_section.key": "469f328e-f384-4319-9bd0-e0b4e603d3a6",
+        "lesson_activity.key": "06dfaf3b-e495-4577-baa6-883a782e198f"
+      }
+    },
+    {
+      "key": "7ae620e6-5b98-405a-86a0-ac4fa8f13dce",
+      "position": 3,
+      "properties": {
+        "progression_name": "Mini-Project: Outbreak Simulator"
+      },
+      "seeding_key": {
+        "activity_section.key": "7ae620e6-5b98-405a-86a0-ac4fa8f13dce",
+        "lesson_activity.key": "06dfaf3b-e495-4577-baa6-883a782e198f"
+      }
+    },
+    {
+      "key": "cc3be08b-bfb2-4e05-9b83-29d4a81f2b7d",
+      "position": 4,
+      "properties": {
+        "name": "Free Play",
+        "progression_name": "Free Play"
+      },
+      "seeding_key": {
+        "activity_section.key": "cc3be08b-bfb2-4e05-9b83-29d4a81f2b7d",
+        "lesson_activity.key": "06dfaf3b-e495-4577-baa6-883a782e198f"
+      }
+    }
   ],
   "script_levels": [
     {
       "chapter": 1,
       "position": 1,
-      "activity_section_position": null,
+      "activity_section_position": 1,
       "assessment": false,
       "properties": {
-        "level_keys": [
-          "CourseF_outbreak_story"
-        ],
         "progression": "Welcome to Monster Town"
       },
       "bonus": false,
@@ -71,7 +125,8 @@
         ],
         "lesson.key": "Virus Simulation for Code Bytes",
         "lesson_group.key": "outbreak",
-        "script.name": "outbreak"
+        "script.name": "outbreak",
+        "activity_section.key": "f86ae28c-7f78-4f08-a649-8abf70a55601"
       },
       "level_keys": [
         "CourseF_outbreak_story"
@@ -80,12 +135,9 @@
     {
       "chapter": 2,
       "position": 2,
-      "activity_section_position": null,
+      "activity_section_position": 1,
       "assessment": false,
       "properties": {
-        "level_keys": [
-          "CourseF_outbreak1"
-        ],
         "progression": "Skill Building"
       },
       "bonus": false,
@@ -95,7 +147,8 @@
         ],
         "lesson.key": "Virus Simulation for Code Bytes",
         "lesson_group.key": "outbreak",
-        "script.name": "outbreak"
+        "script.name": "outbreak",
+        "activity_section.key": "469f328e-f384-4319-9bd0-e0b4e603d3a6"
       },
       "level_keys": [
         "CourseF_outbreak1"
@@ -104,12 +157,9 @@
     {
       "chapter": 3,
       "position": 3,
-      "activity_section_position": null,
+      "activity_section_position": 2,
       "assessment": false,
       "properties": {
-        "level_keys": [
-          "CourseF_outbreak2"
-        ],
         "progression": "Skill Building"
       },
       "bonus": false,
@@ -119,7 +169,8 @@
         ],
         "lesson.key": "Virus Simulation for Code Bytes",
         "lesson_group.key": "outbreak",
-        "script.name": "outbreak"
+        "script.name": "outbreak",
+        "activity_section.key": "469f328e-f384-4319-9bd0-e0b4e603d3a6"
       },
       "level_keys": [
         "CourseF_outbreak2"
@@ -128,12 +179,9 @@
     {
       "chapter": 4,
       "position": 4,
-      "activity_section_position": null,
+      "activity_section_position": 3,
       "assessment": false,
       "properties": {
-        "level_keys": [
-          "CourseF_outbreak3"
-        ],
         "progression": "Skill Building"
       },
       "bonus": false,
@@ -143,7 +191,8 @@
         ],
         "lesson.key": "Virus Simulation for Code Bytes",
         "lesson_group.key": "outbreak",
-        "script.name": "outbreak"
+        "script.name": "outbreak",
+        "activity_section.key": "469f328e-f384-4319-9bd0-e0b4e603d3a6"
       },
       "level_keys": [
         "CourseF_outbreak3"
@@ -152,12 +201,9 @@
     {
       "chapter": 5,
       "position": 5,
-      "activity_section_position": null,
+      "activity_section_position": 4,
       "assessment": false,
       "properties": {
-        "level_keys": [
-          "CourseF_outbreak4"
-        ],
         "progression": "Skill Building"
       },
       "bonus": false,
@@ -167,7 +213,8 @@
         ],
         "lesson.key": "Virus Simulation for Code Bytes",
         "lesson_group.key": "outbreak",
-        "script.name": "outbreak"
+        "script.name": "outbreak",
+        "activity_section.key": "469f328e-f384-4319-9bd0-e0b4e603d3a6"
       },
       "level_keys": [
         "CourseF_outbreak4"
@@ -176,12 +223,9 @@
     {
       "chapter": 6,
       "position": 6,
-      "activity_section_position": null,
+      "activity_section_position": 1,
       "assessment": false,
       "properties": {
-        "level_keys": [
-          "CourseF_outbreak5"
-        ],
         "progression": "Mini-Project: Outbreak Simulator"
       },
       "bonus": false,
@@ -191,7 +235,8 @@
         ],
         "lesson.key": "Virus Simulation for Code Bytes",
         "lesson_group.key": "outbreak",
-        "script.name": "outbreak"
+        "script.name": "outbreak",
+        "activity_section.key": "7ae620e6-5b98-405a-86a0-ac4fa8f13dce"
       },
       "level_keys": [
         "CourseF_outbreak5"
@@ -200,12 +245,9 @@
     {
       "chapter": 7,
       "position": 7,
-      "activity_section_position": null,
+      "activity_section_position": 2,
       "assessment": false,
       "properties": {
-        "level_keys": [
-          "CourseF_outbreak6"
-        ],
         "progression": "Mini-Project: Outbreak Simulator"
       },
       "bonus": false,
@@ -215,7 +257,8 @@
         ],
         "lesson.key": "Virus Simulation for Code Bytes",
         "lesson_group.key": "outbreak",
-        "script.name": "outbreak"
+        "script.name": "outbreak",
+        "activity_section.key": "7ae620e6-5b98-405a-86a0-ac4fa8f13dce"
       },
       "level_keys": [
         "CourseF_outbreak6"
@@ -224,12 +267,9 @@
     {
       "chapter": 8,
       "position": 8,
-      "activity_section_position": null,
+      "activity_section_position": 3,
       "assessment": false,
       "properties": {
-        "level_keys": [
-          "CourseF_outbreak7"
-        ],
         "progression": "Mini-Project: Outbreak Simulator"
       },
       "bonus": false,
@@ -239,7 +279,8 @@
         ],
         "lesson.key": "Virus Simulation for Code Bytes",
         "lesson_group.key": "outbreak",
-        "script.name": "outbreak"
+        "script.name": "outbreak",
+        "activity_section.key": "7ae620e6-5b98-405a-86a0-ac4fa8f13dce"
       },
       "level_keys": [
         "CourseF_outbreak7"
@@ -248,12 +289,9 @@
     {
       "chapter": 9,
       "position": 9,
-      "activity_section_position": null,
+      "activity_section_position": 4,
       "assessment": false,
       "properties": {
-        "level_keys": [
-          "CourseF_outbreak8"
-        ],
         "progression": "Mini-Project: Outbreak Simulator"
       },
       "bonus": false,
@@ -263,7 +301,8 @@
         ],
         "lesson.key": "Virus Simulation for Code Bytes",
         "lesson_group.key": "outbreak",
-        "script.name": "outbreak"
+        "script.name": "outbreak",
+        "activity_section.key": "7ae620e6-5b98-405a-86a0-ac4fa8f13dce"
       },
       "level_keys": [
         "CourseF_outbreak8"
@@ -272,12 +311,9 @@
     {
       "chapter": 10,
       "position": 10,
-      "activity_section_position": null,
+      "activity_section_position": 1,
       "assessment": false,
       "properties": {
-        "level_keys": [
-          "international_outbreak_freeplay"
-        ],
         "progression": "Free Play"
       },
       "bonus": false,
@@ -287,7 +323,8 @@
         ],
         "lesson.key": "Virus Simulation for Code Bytes",
         "lesson_group.key": "outbreak",
-        "script.name": "outbreak"
+        "script.name": "outbreak",
+        "activity_section.key": "cc3be08b-bfb2-4e05-9b83-29d4a81f2b7d"
       },
       "level_keys": [
         "international_outbreak_freeplay"
@@ -303,7 +340,8 @@
         ],
         "lesson.key": "Virus Simulation for Code Bytes",
         "lesson_group.key": "outbreak",
-        "script.name": "outbreak"
+        "script.name": "outbreak",
+        "activity_section.key": "f86ae28c-7f78-4f08-a649-8abf70a55601"
       }
     },
     {
@@ -314,7 +352,8 @@
         ],
         "lesson.key": "Virus Simulation for Code Bytes",
         "lesson_group.key": "outbreak",
-        "script.name": "outbreak"
+        "script.name": "outbreak",
+        "activity_section.key": "469f328e-f384-4319-9bd0-e0b4e603d3a6"
       }
     },
     {
@@ -325,7 +364,8 @@
         ],
         "lesson.key": "Virus Simulation for Code Bytes",
         "lesson_group.key": "outbreak",
-        "script.name": "outbreak"
+        "script.name": "outbreak",
+        "activity_section.key": "469f328e-f384-4319-9bd0-e0b4e603d3a6"
       }
     },
     {
@@ -336,7 +376,8 @@
         ],
         "lesson.key": "Virus Simulation for Code Bytes",
         "lesson_group.key": "outbreak",
-        "script.name": "outbreak"
+        "script.name": "outbreak",
+        "activity_section.key": "469f328e-f384-4319-9bd0-e0b4e603d3a6"
       }
     },
     {
@@ -347,7 +388,8 @@
         ],
         "lesson.key": "Virus Simulation for Code Bytes",
         "lesson_group.key": "outbreak",
-        "script.name": "outbreak"
+        "script.name": "outbreak",
+        "activity_section.key": "469f328e-f384-4319-9bd0-e0b4e603d3a6"
       }
     },
     {
@@ -358,7 +400,8 @@
         ],
         "lesson.key": "Virus Simulation for Code Bytes",
         "lesson_group.key": "outbreak",
-        "script.name": "outbreak"
+        "script.name": "outbreak",
+        "activity_section.key": "7ae620e6-5b98-405a-86a0-ac4fa8f13dce"
       }
     },
     {
@@ -369,7 +412,8 @@
         ],
         "lesson.key": "Virus Simulation for Code Bytes",
         "lesson_group.key": "outbreak",
-        "script.name": "outbreak"
+        "script.name": "outbreak",
+        "activity_section.key": "7ae620e6-5b98-405a-86a0-ac4fa8f13dce"
       }
     },
     {
@@ -380,7 +424,8 @@
         ],
         "lesson.key": "Virus Simulation for Code Bytes",
         "lesson_group.key": "outbreak",
-        "script.name": "outbreak"
+        "script.name": "outbreak",
+        "activity_section.key": "7ae620e6-5b98-405a-86a0-ac4fa8f13dce"
       }
     },
     {
@@ -391,7 +436,8 @@
         ],
         "lesson.key": "Virus Simulation for Code Bytes",
         "lesson_group.key": "outbreak",
-        "script.name": "outbreak"
+        "script.name": "outbreak",
+        "activity_section.key": "7ae620e6-5b98-405a-86a0-ac4fa8f13dce"
       }
     },
     {
@@ -402,7 +448,8 @@
         ],
         "lesson.key": "Virus Simulation for Code Bytes",
         "lesson_group.key": "outbreak",
-        "script.name": "outbreak"
+        "script.name": "outbreak",
+        "activity_section.key": "cc3be08b-bfb2-4e05-9b83-29d4a81f2b7d"
       }
     }
   ],


### PR DESCRIPTION
## Background

Starts https://codedotorg.atlassian.net/browse/PLAT-1334. 

### short version

Outbreak is different from previously imported HOC units, which requires us to handle it differently. See the "long version" here for what's different about outbreak and why the previously way of importing HOC lesson plans won't work. Or, just skip to the Plan section below and look for any holes in what's proposed there.

### long version (optional read)

Other HOC scripts had lesson plans imported from CB in https://github.com/code-dot-org/code-dot-org/pull/42567 and https://github.com/code-dot-org/code-dot-org/pull/42608. That strategy relied on two assumptions:
1. during import, we could set `has_lesson_plan: true` (which makes the View Lesson Plan button appear), because we had an existing CB lesson plan to point to
2. when curriculum is done editing and we go to enable translations, it will be acceptable to either:
  (a) wait for all lesson plans to be ready for translations, then remove the `use_legacy_lesson_plans` condition from https://github.com/code-dot-org/code-dot-org/blob/3bfeddde4689a55666c29ce26d178b90c12a322d/dashboard/lib/services/i18n/curriculum_sync_utils/sync_in.rb#L19 to send them all to translators in one batch; or
  (b) once some lesson plans are ready for translations, remove the  `use_legacy_lesson_plans` condition, and temporarily remove any scripts which are NOT ready from the `i18n` list in `script_constants.rb` to temporarily pause translations on them, until those lesson plans are also ready to be translated.

Unfortunately, these assumptions do not hold for the outbreak script:
1. there is no lesson plan on CB
2. because outbreak is a new/flagship HOC unit:
  (a) we cannot afford to wait until all other lesson plans are translated before beginning translations on outbreak
  (b)  we do not have the option to temporarily pause translations, because non-lesson-plan content needs to keep getting translated

therefore, a different approach is needed.

## Plan

The plan for outbreak lesson plans is as follows:
1. (this PR) migrate the outbreak script, without adding lesson plans. this step has no classroom-facing changes, but does change the editor experience to start using the new script edit UI. 
2. ~#42684: copy the lesson plans locally, push them to a branch, spin up an adhoc in levelbuilder mode, and let the curriculum writers edit the lesson plans there.~
3. ~once edits are complete, capture the local edits there, and merge them into staging.~ 

~After step 3, translations will begin and the lesson plans will also be publicly visible. unlike other HOC scripts, it is ok that the new lesson plans visible before they have been translated, because this does not remove access to any already-translated content on any existing Curriculum Builder lesson plan.~

UPDATE: the plan has changed a bit. please see #42705 for details.

## Description

In this PR we are migrating the outbreak script. To do this, I ran the following commands via rails console:
```
script = Script.find_by_name('outbreak')
script.update!(is_migrated: true)
require 'cdo/lesson_import_helper'
LessonImportHelper.update_lesson(script.lessons.first, ['Lesson'])
script.fix_script_level_positions
script.write_script_dsl
script.write_script_json
```

I borrowed these commands from here: 
* https://github.com/code-dot-org/code-dot-org/blob/463c5c603b2de5ed33587c6b6238825b129b87d2/bin/curriculum/import_unit_details.rb#L116-L118
* https://github.com/code-dot-org/code-dot-org/blob/463c5c603b2de5ed33587c6b6238825b129b87d2/bin/curriculum/import_unit_details.rb#L130-L133

It's possible I could have updated `import_unit_details.rb` instead of borrowing from it, but we are under some time pressure to get outbreak lesson plans edited and translated, so I went with the shortest path. I will most likely need to update `import_unit_details.rb` soon, when I go to migrate the hundreds of remaining unmigrated units.

## Testing story

manually verified the following on the changes in this PR:
* Removed and re-seeded the outbreak script locally
* Verified that there are no user-visible changes, including that no View Lesson Plan button appears
* verified that the script edit page loads and saves
