### PR TITLE
fix lesson edit links for lessons without lesson plans

### DIFF
--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -398,7 +398,9 @@ class Lesson < ApplicationRecord
     # a user trying to edit a lesson plan via /s/[script-name]/lessons/1/edit
     # has sufficient permissions or not. therefore, use a different path
     # when editing lesson plans in hoc scripts.
-    ScriptConfig.hoc_scripts.include?(script.name) ? edit_lesson_path(id: id) : script_lesson_edit_path(script, self)
+    has_lesson_plan && !ScriptConfig.hoc_scripts.include?(script.name) ?
+      script_lesson_edit_path(script, self) :
+      edit_lesson_path(id: id)
   end
 
   def get_uncached_show_path

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -1003,10 +1003,13 @@ class LessonTest < ActiveSupport::TestCase
 
     other_unit = create :script
     other_lesson_group = create :lesson_group, script: other_unit
-    other_lesson = create :lesson, script: other_unit, lesson_group: other_lesson_group
+    lesson_without_plan = create :lesson, script: other_unit, lesson_group: other_lesson_group, relative_position: 1, absolute_position: 1, has_lesson_plan: false
+    lesson_with_plan = create :lesson, script: other_unit, lesson_group: other_lesson_group, relative_position: 1, absolute_position: 2, has_lesson_plan: true
 
-    assert_equal "/s/#{other_unit.name}/lessons/1", other_lesson.get_uncached_show_path
-    assert_equal "/s/#{other_unit.name}/lessons/1/edit", other_lesson.get_uncached_edit_path
+    assert_equal "/s/#{other_unit.name}/lessons/1", lesson_with_plan.get_uncached_show_path
+    assert_equal "/s/#{other_unit.name}/lessons/1/edit", lesson_with_plan.get_uncached_edit_path
+
+    assert_equal "/lessons/#{lesson_without_plan.id}/edit", lesson_without_plan.get_uncached_edit_path
   end
 
   class LessonCopyTests < ActiveSupport::TestCase


### PR DESCRIPTION
https://github.com/code-dot-org/code-dot-org/pull/42503 overstepped a bit in that it changed a few lesson edit urls from the `/lessons/12345/edit` format to the `/s/script-name/lessons/1/edit` format. This doesn't work because the latter format looks only for scripts with lesson plans. the solution is to go back to using the less-ambiguous `/lessons/12345/edit` format for lessons without lesson plans.

### before

going to levelbuilder-studio.code.org/s/csp1-2021/edit and clicking the ✏️  icon for the first unit, which has no lesson plan:
![Screen Shot 2021-09-24 at 1 10 20 PM](https://user-images.githubusercontent.com/8001765/134734173-279cbf42-a8ac-4cc3-b532-cdcf0dc61801.png)
opens the edit page for the second lesson, which is the first unit with a lesson plan.

### after

clicking the ✏️  icon takes you to the lesson edit page for the first lesson, which has no lesson plan.

## Testing story

* manual verification described above
* updated existing unit tests