### PR TITLE
edit outbreak lesson plan on adhoc

### DIFF
--- a/dashboard/config/locales/scripts.en.yml
+++ b/dashboard/config/locales/scripts.en.yml
@@ -18946,6 +18946,10 @@ en:
           lessons:
             Virus Simulation for Code Bytes:
               name: Coding a Simulation
+            Outbreak:
+              name: Coding a Simulation
+              description_student: A virus has come to Monster Town! Learn to create a virus simulator and help the monsters get back to being healthy.
+              description_teacher: 'This lesson combines **skill-building** around events with a **mini-project** where students get to build their own computer simulation in Sprite Lab. Students will study the simulation to understand how quickly a virus can spread and what can be done to slow it down. '
           lesson_groups:
             outbreak:
               display_name: Outbreak Simulation

--- a/dashboard/config/scripts_json/outbreak.script_json
+++ b/dashboard/config/scripts_json/outbreak.script_json
@@ -10,7 +10,7 @@
     },
     "new_name": null,
     "family_name": "outbreak",
-    "serialized_at": "2021-09-24 18:57:50 UTC",
+    "serialized_at": "2021-09-24 22:14:22 UTC",
     "published_state": "preview",
     "seeding_key": {
       "script.name": "outbreak"
@@ -32,16 +32,20 @@
   ],
   "lessons": [
     {
-      "key": "Virus Simulation for Code Bytes",
+      "key": "Outbreak",
       "name": "Coding a Simulation",
       "absolute_position": 1,
       "lockable": false,
-      "has_lesson_plan": false,
+      "has_lesson_plan": true,
       "relative_position": 1,
       "properties": {
+        "overview": "This lesson combines **skill-building** around events with a **mini-project** where students get to build their own computer simulation in Sprite Lab. Students will study the simulation to understand how quickly a virus can spread and what can be done to slow it down. ",
+        "preparation": "- Play through the puzzles to find any potential problem areas for your class.\n- Make sure every student has a reflection journal.\n",
+        "purpose": "In the previous lesson, students collected and interpreted data from a simple simulation.  In this lesson, students will follow instructions to code their own simulation model. Students’ prior knowledge about virus outbreaks in the real world will be applied to a fictitious scenario. \n",
+        "student_overview": "A virus has come to Monster Town! Learn to create a virus simulator and help the monsters get back to being healthy."
       },
       "seeding_key": {
-        "lesson.key": "Virus Simulation for Code Bytes",
+        "lesson.key": "Outbreak",
         "lesson_group.key": "outbreak",
         "script.name": "outbreak"
       }
@@ -49,14 +53,41 @@
   ],
   "lesson_activities": [
     {
-      "key": "06dfaf3b-e495-4577-baa6-883a782e198f",
+      "key": "2f9ea489-720e-4dab-ae4b-4036a6385f4d",
       "position": 1,
       "properties": {
-        "name": "Levels"
+        "duration": 10,
+        "name": "Warm Up"
       },
       "seeding_key": {
-        "lesson_activity.key": "06dfaf3b-e495-4577-baa6-883a782e198f",
-        "lesson.key": "Virus Simulation for Code Bytes",
+        "lesson_activity.key": "2f9ea489-720e-4dab-ae4b-4036a6385f4d",
+        "lesson.key": "Outbreak",
+        "lesson_group.key": "outbreak",
+        "script.name": "outbreak"
+      }
+    },
+    {
+      "key": "a4b68e1c-d78c-455c-922f-2fd57f697f58",
+      "position": 2,
+      "properties": {
+        "name": "Main Activity"
+      },
+      "seeding_key": {
+        "lesson_activity.key": "a4b68e1c-d78c-455c-922f-2fd57f697f58",
+        "lesson.key": "Outbreak",
+        "lesson_group.key": "outbreak",
+        "script.name": "outbreak"
+      }
+    },
+    {
+      "key": "fdab57b2-566f-4f6f-a42d-967cf95bc73a",
+      "position": 3,
+      "properties": {
+        "name": "Wrap Up"
+      },
+      "seeding_key": {
+        "lesson_activity.key": "fdab57b2-566f-4f6f-a42d-967cf95bc73a",
+        "lesson.key": "Outbreak",
         "lesson_group.key": "outbreak",
         "script.name": "outbreak"
       }
@@ -64,48 +95,174 @@
   ],
   "activity_sections": [
     {
-      "key": "f86ae28c-7f78-4f08-a649-8abf70a55601",
+      "key": "8581ae5d-4d2a-4221-b820-5920dd449b6c",
       "position": 1,
       "properties": {
+        "description": "**Discuss:**\n- *What do we know about how a virus spreads?*\n- *What can cause a virus to spread through a town more quickly?*\n- *What can help slow the spread of a virus down?*\n\nThe goal of this discussion is for students to have an opportunity to activate prior knowledge and see their ideas on the board. This is also an opportunity to investigate some misconceptions about how viruses spread.\n",
+        "name": "Introduction"
+      },
+      "seeding_key": {
+        "activity_section.key": "8581ae5d-4d2a-4221-b820-5920dd449b6c",
+        "lesson_activity.key": "2f9ea489-720e-4dab-ae4b-4036a6385f4d"
+      }
+    },
+    {
+      "key": "cd8941e5-023c-486f-84a2-eeaf126c394c",
+      "position": 2,
+      "properties": {
+      },
+      "seeding_key": {
+        "activity_section.key": "cd8941e5-023c-486f-84a2-eeaf126c394c",
+        "lesson_activity.key": "2f9ea489-720e-4dab-ae4b-4036a6385f4d"
+      }
+    },
+    {
+      "key": "d63c77c1-4167-4360-ab98-25610934beda",
+      "position": 1,
+      "properties": {
+        "description": "*In today’s lesson, you’re going to “Monster Town” where a virus outbreak is about to happen. Dr. Monster needs your help to slow the spread of the virus.*\n\n*You will create an outbreak simulator in Sprite Lab, and then use it to understand how a virus can spread. You’ll also help all of the monsters get healthy again!*",
+        "name": "Outbreak",
+        "progression_name": "Outbreak",
+        "remarks": true
+      },
+      "seeding_key": {
+        "activity_section.key": "d63c77c1-4167-4360-ab98-25610934beda",
+        "lesson_activity.key": "a4b68e1c-d78c-455c-922f-2fd57f697f58"
+      }
+    },
+    {
+      "key": "385c2c6a-f7e4-4c90-b081-7030d22193ed",
+      "position": 2,
+      "properties": {
+        "description": "**Do This:** Read *Welcome to Monster Town* as a class.\n",
         "progression_name": "Welcome to Monster Town"
       },
       "seeding_key": {
-        "activity_section.key": "f86ae28c-7f78-4f08-a649-8abf70a55601",
-        "lesson_activity.key": "06dfaf3b-e495-4577-baa6-883a782e198f"
+        "activity_section.key": "385c2c6a-f7e4-4c90-b081-7030d22193ed",
+        "lesson_activity.key": "a4b68e1c-d78c-455c-922f-2fd57f697f58"
       }
     },
     {
-      "key": "469f328e-f384-4319-9bd0-e0b4e603d3a6",
-      "position": 2,
+      "key": "60837b14-7f66-4848-9c51-1c6aa9a21ad9",
+      "position": 3,
       "properties": {
+        "description": "**Do This:** Review the vocabulary, **models and simulations** with students, by building off of the previous lesson. A simulation is a computer model of a process or system.\n\n"
+      },
+      "seeding_key": {
+        "activity_section.key": "60837b14-7f66-4848-9c51-1c6aa9a21ad9",
+        "lesson_activity.key": "a4b68e1c-d78c-455c-922f-2fd57f697f58"
+      }
+    },
+    {
+      "key": "13a06294-2f2a-4661-9947-46ed5843913f",
+      "position": 4,
+      "properties": {
+        "description": "*Today, we will make a place like Monster Town come alive by writing some code. In this simulation, you’re going to use sprites to represent the different monsters. The sprites will have different costumes to tell us things like whether they are sick or healthy. You’ll also use behaviors to get the monsters moving. Finally, you’ll use events to change the costume of a sprite when two sprites touch on this screen. This will represent one monster passing the virus to another. You will make predictions about what will happen to the neighbors of Monster Town, and help them get healthy again!* ",
+        "remarks": true
+      },
+      "seeding_key": {
+        "activity_section.key": "13a06294-2f2a-4661-9947-46ed5843913f",
+        "lesson_activity.key": "a4b68e1c-d78c-455c-922f-2fd57f697f58"
+      }
+    },
+    {
+      "key": "c3a7e014-dfaf-4b99-baac-540d1462a6db",
+      "position": 5,
+      "properties": {
+        "description": "**Do This:** Show the “Lots of Sprites” video and discuss how the special blocks inside the event blocks work.",
+        "progression_name": "Video: Lots of Sprites",
+        "tips": [
+          {
+            "type": "teachingTip",
+            "markdown": "The event blocks in this lesson are more advanced than what students have used so far in the course. Make sure students know that they can expand the green event blocks by pressing the + button. Students are working with lots of sprites today. Normally, commands in Sprite Lab affect all of the sprites with the same costume. The blocks inside the event block will make it so each attached action only affects the sprites that were involved in that event."
+          }
+        ]
+      },
+      "seeding_key": {
+        "activity_section.key": "c3a7e014-dfaf-4b99-baac-540d1462a6db",
+        "lesson_activity.key": "a4b68e1c-d78c-455c-922f-2fd57f697f58"
+      }
+    },
+    {
+      "key": "df13fa93-37df-4188-837d-462c48179625",
+      "position": 6,
+      "properties": {
+        "description": "**Do This:** Transition students to their computers, and have them begin following the instructions for each level in the skill building section. If students finish this section early, they can continue experimenting with their code in Level 6 until the class is ready to move on.",
         "progression_name": "Skill Building"
       },
       "seeding_key": {
-        "activity_section.key": "469f328e-f384-4319-9bd0-e0b4e603d3a6",
-        "lesson_activity.key": "06dfaf3b-e495-4577-baa6-883a782e198f"
+        "activity_section.key": "df13fa93-37df-4188-837d-462c48179625",
+        "lesson_activity.key": "a4b68e1c-d78c-455c-922f-2fd57f697f58"
       }
     },
     {
-      "key": "7ae620e6-5b98-405a-86a0-ac4fa8f13dce",
-      "position": 3,
+      "key": "05b36f45-0f29-4ad3-8669-6c4d4ff65bf5",
+      "position": 7,
       "properties": {
+        "description": "**Do This:** Bring the class back together to read *Outbreak: Thinking Like a Scientist.*",
+        "progression_name": "Learning from Simulations"
+      },
+      "seeding_key": {
+        "activity_section.key": "05b36f45-0f29-4ad3-8669-6c4d4ff65bf5",
+        "lesson_activity.key": "a4b68e1c-d78c-455c-922f-2fd57f697f58"
+      }
+    },
+    {
+      "key": "ae9fb00b-5b7e-4ecb-94c9-c778a2eba24e",
+      "position": 8,
+      "properties": {
+        "description": "**Do this:** Transition students back to their computers, and have them work through the remaining levels. Some of these levels offer optional challenges. Encourage students to read the instructions carefully and to experiment with their simulations.",
         "progression_name": "Mini-Project: Outbreak Simulator"
       },
       "seeding_key": {
-        "activity_section.key": "7ae620e6-5b98-405a-86a0-ac4fa8f13dce",
-        "lesson_activity.key": "06dfaf3b-e495-4577-baa6-883a782e198f"
+        "activity_section.key": "ae9fb00b-5b7e-4ecb-94c9-c778a2eba24e",
+        "lesson_activity.key": "a4b68e1c-d78c-455c-922f-2fd57f697f58"
       }
     },
     {
-      "key": "cc3be08b-bfb2-4e05-9b83-29d4a81f2b7d",
-      "position": 4,
+      "key": "0620e645-f84e-47ca-809b-3dcbe803d83e",
+      "position": 9,
       "properties": {
-        "name": "Free Play",
         "progression_name": "Free Play"
       },
       "seeding_key": {
-        "activity_section.key": "cc3be08b-bfb2-4e05-9b83-29d4a81f2b7d",
-        "lesson_activity.key": "06dfaf3b-e495-4577-baa6-883a782e198f"
+        "activity_section.key": "0620e645-f84e-47ca-809b-3dcbe803d83e",
+        "lesson_activity.key": "a4b68e1c-d78c-455c-922f-2fd57f697f58"
+      }
+    },
+    {
+      "key": "3a53855f-2fc4-48f1-a05e-1bd8e2c265e0",
+      "position": 1,
+      "properties": {
+        "description": "*Simulations are a great way to learn things that can be hard to observe in the real world. They help scientists solve problems, predict how to solve the problem, and test new ideas safely and efficiently. Your simulation is a way to show how a virus outbreak in Monster Town might look.*",
+        "remarks": true
+      },
+      "seeding_key": {
+        "activity_section.key": "3a53855f-2fc4-48f1-a05e-1bd8e2c265e0",
+        "lesson_activity.key": "fdab57b2-566f-4f6f-a42d-967cf95bc73a"
+      }
+    },
+    {
+      "key": "b3189fd8-5272-4de4-953a-f4848b2ddb5c",
+      "position": 2,
+      "properties": {
+        "description": "**Discuss:**\n- How can simulations be helpful in the real world? \n- How can simulations help us understand the world around us? \n- How can simulations improve the way we test out ideas? \n\nThe goal of the discussion is for students to understand that simulations are a way to model complex systems in an interactive way. They should also see how simulations let people test out ideas quickly, cheaply and safely. "
+      },
+      "seeding_key": {
+        "activity_section.key": "b3189fd8-5272-4de4-953a-f4848b2ddb5c",
+        "lesson_activity.key": "fdab57b2-566f-4f6f-a42d-967cf95bc73a"
+      }
+    },
+    {
+      "key": "b8e884f1-eae0-4138-8778-0972f90e34d9",
+      "position": 3,
+      "properties": {
+        "description": "\n\n\n**Prompts:**\n- How is this simulation like the real world? How is it different?\n- What would you want to change/add to your simulation?\n",
+        "name": "Reflection"
+      },
+      "seeding_key": {
+        "activity_section.key": "b8e884f1-eae0-4138-8778-0972f90e34d9",
+        "lesson_activity.key": "fdab57b2-566f-4f6f-a42d-967cf95bc73a"
       }
     }
   ],
@@ -123,10 +280,10 @@
         "script_level.level_keys": [
           "CourseF_outbreak_story"
         ],
-        "lesson.key": "Virus Simulation for Code Bytes",
+        "lesson.key": "Outbreak",
         "lesson_group.key": "outbreak",
         "script.name": "outbreak",
-        "activity_section.key": "f86ae28c-7f78-4f08-a649-8abf70a55601"
+        "activity_section.key": "385c2c6a-f7e4-4c90-b081-7030d22193ed"
       },
       "level_keys": [
         "CourseF_outbreak_story"
@@ -138,6 +295,28 @@
       "activity_section_position": 1,
       "assessment": false,
       "properties": {
+        "progression": "Video: Lots of Sprites"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseF_lotsofsprites_video"
+        ],
+        "lesson.key": "Outbreak",
+        "lesson_group.key": "outbreak",
+        "script.name": "outbreak",
+        "activity_section.key": "c3a7e014-dfaf-4b99-baac-540d1462a6db"
+      },
+      "level_keys": [
+        "courseF_lotsofsprites_video"
+      ]
+    },
+    {
+      "chapter": 3,
+      "position": 3,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
         "progression": "Skill Building"
       },
       "bonus": false,
@@ -145,18 +324,18 @@
         "script_level.level_keys": [
           "CourseF_outbreak1"
         ],
-        "lesson.key": "Virus Simulation for Code Bytes",
+        "lesson.key": "Outbreak",
         "lesson_group.key": "outbreak",
         "script.name": "outbreak",
-        "activity_section.key": "469f328e-f384-4319-9bd0-e0b4e603d3a6"
+        "activity_section.key": "df13fa93-37df-4188-837d-462c48179625"
       },
       "level_keys": [
         "CourseF_outbreak1"
       ]
     },
     {
-      "chapter": 3,
-      "position": 3,
+      "chapter": 4,
+      "position": 4,
       "activity_section_position": 2,
       "assessment": false,
       "properties": {
@@ -167,18 +346,18 @@
         "script_level.level_keys": [
           "CourseF_outbreak2"
         ],
-        "lesson.key": "Virus Simulation for Code Bytes",
+        "lesson.key": "Outbreak",
         "lesson_group.key": "outbreak",
         "script.name": "outbreak",
-        "activity_section.key": "469f328e-f384-4319-9bd0-e0b4e603d3a6"
+        "activity_section.key": "df13fa93-37df-4188-837d-462c48179625"
       },
       "level_keys": [
         "CourseF_outbreak2"
       ]
     },
     {
-      "chapter": 4,
-      "position": 4,
+      "chapter": 5,
+      "position": 5,
       "activity_section_position": 3,
       "assessment": false,
       "properties": {
@@ -189,18 +368,18 @@
         "script_level.level_keys": [
           "CourseF_outbreak3"
         ],
-        "lesson.key": "Virus Simulation for Code Bytes",
+        "lesson.key": "Outbreak",
         "lesson_group.key": "outbreak",
         "script.name": "outbreak",
-        "activity_section.key": "469f328e-f384-4319-9bd0-e0b4e603d3a6"
+        "activity_section.key": "df13fa93-37df-4188-837d-462c48179625"
       },
       "level_keys": [
         "CourseF_outbreak3"
       ]
     },
     {
-      "chapter": 5,
-      "position": 5,
+      "chapter": 6,
+      "position": 6,
       "activity_section_position": 4,
       "assessment": false,
       "properties": {
@@ -211,18 +390,40 @@
         "script_level.level_keys": [
           "CourseF_outbreak4"
         ],
-        "lesson.key": "Virus Simulation for Code Bytes",
+        "lesson.key": "Outbreak",
         "lesson_group.key": "outbreak",
         "script.name": "outbreak",
-        "activity_section.key": "469f328e-f384-4319-9bd0-e0b4e603d3a6"
+        "activity_section.key": "df13fa93-37df-4188-837d-462c48179625"
       },
       "level_keys": [
         "CourseF_outbreak4"
       ]
     },
     {
-      "chapter": 6,
-      "position": 6,
+      "chapter": 7,
+      "position": 7,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+        "progression": "Learning from Simulations"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "CourseF_outbreak_story2"
+        ],
+        "lesson.key": "Outbreak",
+        "lesson_group.key": "outbreak",
+        "script.name": "outbreak",
+        "activity_section.key": "05b36f45-0f29-4ad3-8669-6c4d4ff65bf5"
+      },
+      "level_keys": [
+        "CourseF_outbreak_story2"
+      ]
+    },
+    {
+      "chapter": 8,
+      "position": 8,
       "activity_section_position": 1,
       "assessment": false,
       "properties": {
@@ -233,18 +434,18 @@
         "script_level.level_keys": [
           "CourseF_outbreak5"
         ],
-        "lesson.key": "Virus Simulation for Code Bytes",
+        "lesson.key": "Outbreak",
         "lesson_group.key": "outbreak",
         "script.name": "outbreak",
-        "activity_section.key": "7ae620e6-5b98-405a-86a0-ac4fa8f13dce"
+        "activity_section.key": "ae9fb00b-5b7e-4ecb-94c9-c778a2eba24e"
       },
       "level_keys": [
         "CourseF_outbreak5"
       ]
     },
     {
-      "chapter": 7,
-      "position": 7,
+      "chapter": 9,
+      "position": 9,
       "activity_section_position": 2,
       "assessment": false,
       "properties": {
@@ -255,18 +456,18 @@
         "script_level.level_keys": [
           "CourseF_outbreak6"
         ],
-        "lesson.key": "Virus Simulation for Code Bytes",
+        "lesson.key": "Outbreak",
         "lesson_group.key": "outbreak",
         "script.name": "outbreak",
-        "activity_section.key": "7ae620e6-5b98-405a-86a0-ac4fa8f13dce"
+        "activity_section.key": "ae9fb00b-5b7e-4ecb-94c9-c778a2eba24e"
       },
       "level_keys": [
         "CourseF_outbreak6"
       ]
     },
     {
-      "chapter": 8,
-      "position": 8,
+      "chapter": 10,
+      "position": 10,
       "activity_section_position": 3,
       "assessment": false,
       "properties": {
@@ -277,18 +478,18 @@
         "script_level.level_keys": [
           "CourseF_outbreak7"
         ],
-        "lesson.key": "Virus Simulation for Code Bytes",
+        "lesson.key": "Outbreak",
         "lesson_group.key": "outbreak",
         "script.name": "outbreak",
-        "activity_section.key": "7ae620e6-5b98-405a-86a0-ac4fa8f13dce"
+        "activity_section.key": "ae9fb00b-5b7e-4ecb-94c9-c778a2eba24e"
       },
       "level_keys": [
         "CourseF_outbreak7"
       ]
     },
     {
-      "chapter": 9,
-      "position": 9,
+      "chapter": 11,
+      "position": 11,
       "activity_section_position": 4,
       "assessment": false,
       "properties": {
@@ -299,18 +500,18 @@
         "script_level.level_keys": [
           "CourseF_outbreak8"
         ],
-        "lesson.key": "Virus Simulation for Code Bytes",
+        "lesson.key": "Outbreak",
         "lesson_group.key": "outbreak",
         "script.name": "outbreak",
-        "activity_section.key": "7ae620e6-5b98-405a-86a0-ac4fa8f13dce"
+        "activity_section.key": "ae9fb00b-5b7e-4ecb-94c9-c778a2eba24e"
       },
       "level_keys": [
         "CourseF_outbreak8"
       ]
     },
     {
-      "chapter": 10,
-      "position": 10,
+      "chapter": 12,
+      "position": 12,
       "activity_section_position": 1,
       "assessment": false,
       "properties": {
@@ -321,10 +522,10 @@
         "script_level.level_keys": [
           "international_outbreak_freeplay"
         ],
-        "lesson.key": "Virus Simulation for Code Bytes",
+        "lesson.key": "Outbreak",
         "lesson_group.key": "outbreak",
         "script.name": "outbreak",
-        "activity_section.key": "cc3be08b-bfb2-4e05-9b83-29d4a81f2b7d"
+        "activity_section.key": "0620e645-f84e-47ca-809b-3dcbe803d83e"
       },
       "level_keys": [
         "international_outbreak_freeplay"
@@ -338,10 +539,22 @@
         "script_level.level_keys": [
           "CourseF_outbreak_story"
         ],
-        "lesson.key": "Virus Simulation for Code Bytes",
+        "lesson.key": "Outbreak",
         "lesson_group.key": "outbreak",
         "script.name": "outbreak",
-        "activity_section.key": "f86ae28c-7f78-4f08-a649-8abf70a55601"
+        "activity_section.key": "385c2c6a-f7e4-4c90-b081-7030d22193ed"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "courseF_lotsofsprites_video",
+        "script_level.level_keys": [
+          "courseF_lotsofsprites_video"
+        ],
+        "lesson.key": "Outbreak",
+        "lesson_group.key": "outbreak",
+        "script.name": "outbreak",
+        "activity_section.key": "c3a7e014-dfaf-4b99-baac-540d1462a6db"
       }
     },
     {
@@ -350,10 +563,10 @@
         "script_level.level_keys": [
           "CourseF_outbreak1"
         ],
-        "lesson.key": "Virus Simulation for Code Bytes",
+        "lesson.key": "Outbreak",
         "lesson_group.key": "outbreak",
         "script.name": "outbreak",
-        "activity_section.key": "469f328e-f384-4319-9bd0-e0b4e603d3a6"
+        "activity_section.key": "df13fa93-37df-4188-837d-462c48179625"
       }
     },
     {
@@ -362,10 +575,10 @@
         "script_level.level_keys": [
           "CourseF_outbreak2"
         ],
-        "lesson.key": "Virus Simulation for Code Bytes",
+        "lesson.key": "Outbreak",
         "lesson_group.key": "outbreak",
         "script.name": "outbreak",
-        "activity_section.key": "469f328e-f384-4319-9bd0-e0b4e603d3a6"
+        "activity_section.key": "df13fa93-37df-4188-837d-462c48179625"
       }
     },
     {
@@ -374,10 +587,10 @@
         "script_level.level_keys": [
           "CourseF_outbreak3"
         ],
-        "lesson.key": "Virus Simulation for Code Bytes",
+        "lesson.key": "Outbreak",
         "lesson_group.key": "outbreak",
         "script.name": "outbreak",
-        "activity_section.key": "469f328e-f384-4319-9bd0-e0b4e603d3a6"
+        "activity_section.key": "df13fa93-37df-4188-837d-462c48179625"
       }
     },
     {
@@ -386,10 +599,22 @@
         "script_level.level_keys": [
           "CourseF_outbreak4"
         ],
-        "lesson.key": "Virus Simulation for Code Bytes",
+        "lesson.key": "Outbreak",
         "lesson_group.key": "outbreak",
         "script.name": "outbreak",
-        "activity_section.key": "469f328e-f384-4319-9bd0-e0b4e603d3a6"
+        "activity_section.key": "df13fa93-37df-4188-837d-462c48179625"
+      }
+    },
+    {
+      "seeding_key": {
+        "level.key": "CourseF_outbreak_story2",
+        "script_level.level_keys": [
+          "CourseF_outbreak_story2"
+        ],
+        "lesson.key": "Outbreak",
+        "lesson_group.key": "outbreak",
+        "script.name": "outbreak",
+        "activity_section.key": "05b36f45-0f29-4ad3-8669-6c4d4ff65bf5"
       }
     },
     {
@@ -398,10 +623,10 @@
         "script_level.level_keys": [
           "CourseF_outbreak5"
         ],
-        "lesson.key": "Virus Simulation for Code Bytes",
+        "lesson.key": "Outbreak",
         "lesson_group.key": "outbreak",
         "script.name": "outbreak",
-        "activity_section.key": "7ae620e6-5b98-405a-86a0-ac4fa8f13dce"
+        "activity_section.key": "ae9fb00b-5b7e-4ecb-94c9-c778a2eba24e"
       }
     },
     {
@@ -410,10 +635,10 @@
         "script_level.level_keys": [
           "CourseF_outbreak6"
         ],
-        "lesson.key": "Virus Simulation for Code Bytes",
+        "lesson.key": "Outbreak",
         "lesson_group.key": "outbreak",
         "script.name": "outbreak",
-        "activity_section.key": "7ae620e6-5b98-405a-86a0-ac4fa8f13dce"
+        "activity_section.key": "ae9fb00b-5b7e-4ecb-94c9-c778a2eba24e"
       }
     },
     {
@@ -422,10 +647,10 @@
         "script_level.level_keys": [
           "CourseF_outbreak7"
         ],
-        "lesson.key": "Virus Simulation for Code Bytes",
+        "lesson.key": "Outbreak",
         "lesson_group.key": "outbreak",
         "script.name": "outbreak",
-        "activity_section.key": "7ae620e6-5b98-405a-86a0-ac4fa8f13dce"
+        "activity_section.key": "ae9fb00b-5b7e-4ecb-94c9-c778a2eba24e"
       }
     },
     {
@@ -434,10 +659,10 @@
         "script_level.level_keys": [
           "CourseF_outbreak8"
         ],
-        "lesson.key": "Virus Simulation for Code Bytes",
+        "lesson.key": "Outbreak",
         "lesson_group.key": "outbreak",
         "script.name": "outbreak",
-        "activity_section.key": "7ae620e6-5b98-405a-86a0-ac4fa8f13dce"
+        "activity_section.key": "ae9fb00b-5b7e-4ecb-94c9-c778a2eba24e"
       }
     },
     {
@@ -446,10 +671,10 @@
         "script_level.level_keys": [
           "international_outbreak_freeplay"
         ],
-        "lesson.key": "Virus Simulation for Code Bytes",
+        "lesson.key": "Outbreak",
         "lesson_group.key": "outbreak",
         "script.name": "outbreak",
-        "activity_section.key": "cc3be08b-bfb2-4e05-9b83-29d4a81f2b7d"
+        "activity_section.key": "0620e645-f84e-47ca-809b-3dcbe803d83e"
       }
     }
   ],
@@ -466,10 +691,40 @@
 
   ],
   "vocabularies": [
-
+    {
+      "key": "event",
+      "word": "Event",
+      "definition": "An action that causes something to happen.",
+      "properties": {
+      },
+      "seeding_key": {
+        "vocabulary.key": "event"
+      }
+    },
+    {
+      "key": "models_and_simulations",
+      "word": "Models and Simulations",
+      "definition": "a program which replicates or mimics key features of a real world event in order to investigate its behavior without the cost, time, or danger of running an experiment in real life.",
+      "properties": {
+      },
+      "seeding_key": {
+        "vocabulary.key": "models_and_simulations"
+      }
+    }
   ],
   "lessons_vocabularies": [
-
+    {
+      "seeding_key": {
+        "lesson.key": "Outbreak",
+        "vocabulary.key": "event"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Outbreak",
+        "vocabulary.key": "models_and_simulations"
+      }
+    }
   ],
   "lessons_programming_expressions": [
 
@@ -478,7 +733,20 @@
 
   ],
   "lessons_standards": [
-
+    {
+      "seeding_key": {
+        "lesson.key": "Outbreak",
+        "framework.shortcode": "csta",
+        "standard.shortcode": "1B-DA-07"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Outbreak",
+        "framework.shortcode": "csta",
+        "standard.shortcode": "1B-IC-18"
+      }
+    }
   ],
   "lessons_opportunity_standards": [
 


### PR DESCRIPTION
Continues https://codedotorg.atlassian.net/browse/PLAT-1334.

## The Plan
1. #42661: migrate the outbreak unit, without adding lesson plans.
2. (this PR) copy the lesson plans locally, push them to a branch, spin up an adhoc in levelbuilder mode, and let the curriculum writers edit the lesson plans there.
3. once edits are complete, capture the local edits, and merge them into staging. (those edits will also be pushed into this PR, after which point this PR will be sent for review to be merged into staging).

## Description

This PR currently contains an initial copy of the outbreak lesson plan, copied from https://levelbuilder-studio.code.org/s/coursef-2021/lessons/17. The lesson plan and the existing outbreak script each contained some levels which the other did not. I included all the levels which appeared in either place, and will let the curriculum writers decide what to remove.

You can see the outbreak unit here: 
* https://adhoc-outbreak-lesson-plan-studio.cdn-code.org/s/outbreak
* https://adhoc-outbreak-lesson-plan-studio.cdn-code.org/s/outbreak/lessons/1

## Testing story

## Deployment strategy

## Follow-up work
