### PR TITLE
Streamline adhoc startup

### DIFF
--- a/config/adhoc.yml.erb
+++ b/config/adhoc.yml.erb
@@ -15,3 +15,7 @@ custom_error_response: false
 
 javabuilder_private_key: !Secret
 javabuilder_key_password: !Secret
+properties_encryption_key: !Secret
+firebase_name: cdo-v3-adhoc
+firebase_secret: !Secret
+firebase_shared_secret: !Secret

--- a/dashboard/app/controllers/application_controller.rb
+++ b/dashboard/app/controllers/application_controller.rb
@@ -63,7 +63,7 @@ class ApplicationController < ActionController::Base
     if !current_user && request.format == :html
       # we don't know who you are, you can try to sign in
       authenticate_user!
-    elsif [:development, :adhoc].include? rack_env
+    elsif rack_env?(:development, :adhoc)
       raise
     else
       # we know who you are, you shouldn't be here

--- a/dashboard/app/controllers/application_controller.rb
+++ b/dashboard/app/controllers/application_controller.rb
@@ -63,7 +63,7 @@ class ApplicationController < ActionController::Base
     if !current_user && request.format == :html
       # we don't know who you are, you can try to sign in
       authenticate_user!
-    elsif rack_env? :development
+    elsif [:development, :adhoc].include? rack_env
       raise
     else
       # we know who you are, you shouldn't be here

--- a/dashboard/config/environments/adhoc.rb
+++ b/dashboard/config/environments/adhoc.rb
@@ -13,9 +13,9 @@ Dashboard::Application.configure do
   # Rake tasks automatically ignore this option for performance.
   config.eager_load = true
 
-  # Disable full error reports for profiling/load-testing, due to memory leak:
-  # https://github.com/rails/rails/issues/27273
-  config.consider_all_requests_local = false
+  # Consider disabling full error reports for profiling/load-testing by setting
+  # this flag to false, due to memory leak: https://github.com/rails/rails/issues/27273
+  config.consider_all_requests_local = true
 
   config.action_controller.perform_caching = true
   config.public_file_server.enabled = true
@@ -31,7 +31,7 @@ Dashboard::Application.configure do
   config.log_formatter = ::Logger::Formatter.new
 
   # Log condensed lines to syslog for centralized logging.
-  config.lograge.enabled = true
+  config.lograge.enabled = false
   config.lograge.formatter = Lograge::Formatters::Cee.new
   require 'syslog/logger'
   config.logger = Syslog::Logger.new 'dashboard', Syslog::LOG_LOCAL0


### PR DESCRIPTION
This PR contains changes I generally have to make on the adhoc environment each time I start one up. They fall into 2 categories:
1. make seeding and loading of levels work (f91aa72)
2. make it easier to see errors (befe650)

SSHServerName: adhoc-streamline-adhoc-startup
DashboardURL: https://adhoc-streamline-adhoc-startup-studio.cdn-code.org

## Testing story

* `rake seed:all` can now seed all scripts and levels
* urls to any project-backed level now work: https://adhoc-streamline-adhoc-startup-studio.cdn-code.org/s/allthethings/lessons/18/levels/1 
* various error cases now show full error details, including CanCan authorization errors:
![Screen Shot 2021-09-24 at 5 14 16 PM](https://user-images.githubusercontent.com/8001765/134751148-ff604b76-92ae-499b-b2dc-fc893df6dc53.png)
  