### PR TITLE
Fix the Latam HOC event count

### DIFF
--- a/pegasus/helpers/hourofcode_helpers.rb
+++ b/pegasus/helpers/hourofcode_helpers.rb
@@ -193,6 +193,8 @@ def country_count
   code = HOC_COUNTRIES[@country]['country_code'] || @country
   totals = fetch_hoc_metrics['hoc_country_totals']
 
+  # If the country is Latam, return the sum of all events in Latam.
+  #  Otherwise return the total for the given country.
   return @country == 'la' ? latam_count(totals) : totals[code.upcase]
 end
 

--- a/pegasus/helpers/hourofcode_helpers.rb
+++ b/pegasus/helpers/hourofcode_helpers.rb
@@ -182,9 +182,18 @@ def company_count
   return fetch_hoc_metrics['hoc_company_totals'][@company]
 end
 
+# We get counts for the individual countries in Latin America,
+#  so let's sum those up to get the total for all of Latam
+def latam_count(totals)
+  latam_totals = totals.slice(*LATAM_COUNTRY_CODES)
+  return latam_totals.inject(0) {|sum, tuple| sum + tuple[1]}
+end
+
 def country_count
   code = HOC_COUNTRIES[@country]['country_code'] || @country
-  return fetch_hoc_metrics['hoc_country_totals'][code.upcase]
+  totals = fetch_hoc_metrics['hoc_country_totals']
+
+  return @country == 'la' ? latam_count(totals) : totals[code.upcase]
 end
 
 def country_full_name


### PR DESCRIPTION
We don't store a count of HOC events in Latin America, we store a count of the individual countries in Latin America. When we query the `country_count` of `la`, let's instead sum the counts of all Latam countries, so the hourofcode.com index page displays the correct number of events.

![latam_events](https://user-images.githubusercontent.com/86268316/134751798-372012bc-17ce-47bf-b1a2-d0522063c3e0.png)

The pre-prod databases don't store these counts, so for the sake of testing I queried the current `hoc_country_totals` on production and hardcoded them locally. hourofcode.com/la now correctly displays 112 events instead of 0 🎉 
(Ignore the "0 events registered in 2020", I didn't hardcode that total locally. That value works in production today and is unaffected by this change.)

## Links

- jira ticket: ["Zero events" in Latin America on hourofcode.com/la](https://codedotorg.atlassian.net/browse/FND-1723)