### PR TITLE
Code Review: format peers available for review in controller

### DIFF
--- a/apps/src/templates/instructions/ReviewTab.jsx
+++ b/apps/src/templates/instructions/ReviewTab.jsx
@@ -127,12 +127,7 @@ class ReviewTab extends Component {
           codeReviewDataApi
             .getReviewablePeers(channelId, serverLevelId, serverScriptId)
             .done(data => {
-              this.setState({
-                reviewablePeers: _.chain(data)
-                  .filter(peerEntry => peerEntry && peerEntry.length === 2)
-                  .map(peerEntry => ({id: peerEntry[0], name: peerEntry[1]}))
-                  .value()
-              });
+              this.setState({reviewablePeers: data});
               resolve();
             })
             .fail(() => {

--- a/apps/test/unit/templates/instructions/ReviewTabTest.jsx
+++ b/apps/test/unit/templates/instructions/ReviewTabTest.jsx
@@ -349,10 +349,7 @@ describe('Code Review Tab', () => {
       id: 2
     };
 
-    stubGetReviewablePeersServerCall([
-      [peer1.id, peer1.name],
-      [peer2.id, peer2.name]
-    ]);
+    stubGetReviewablePeersServerCall([peer1, peer2]);
 
     server.respond();
 

--- a/dashboard/app/controllers/reviewable_projects_controller.rb
+++ b/dashboard/app/controllers/reviewable_projects_controller.rb
@@ -75,7 +75,7 @@ class ReviewableProjectsController < ApplicationController
       script_id: params[:script_id]
     ).map(&:user)
 
-    return render json: peers_ready_for_review.pluck(:id, :name)
+    return render json: peers_ready_for_review.map {|user| {id: user.id, name: user.name}}
   end
 
   def decrypt_channel_id

--- a/dashboard/test/controllers/reviewable_projects_controller_test.rb
+++ b/dashboard/test/controllers/reviewable_projects_controller_test.rb
@@ -191,7 +191,7 @@ class ReviewableProjectsControllerTest < ActionController::TestCase
     sign_in @another_student
     get :for_level, params: {level_id: @project_level_id, script_id: @project_script_id}
 
-    assert_equal [[@project_owner.id, @project_owner.name]], JSON.parse(response.body)
+    assert_equal [{'id' => @project_owner.id, 'name' => @project_owner.name}], JSON.parse(response.body)
   end
 
   test 'student does not get projects available for review if project available but not in same section' do


### PR DESCRIPTION
Provide data on peers available for review from controller in appropriate shape, instead of having to reshape in JS.

## Testing story

Tested manually in case where we have reviewable peers. Also tested case where we have no reviewable peers, where Ruby returns a blank array when you try to map through a blank array.