### PR TITLE
Log changes to 'instructional minutes' dropdown on unit calendar 

### DIFF
--- a/apps/src/code-studio/components/progress/UnitCalendarButton.jsx
+++ b/apps/src/code-studio/components/progress/UnitCalendarButton.jsx
@@ -57,6 +57,7 @@ export default class UnitCalendarButton extends React.Component {
             weeklyInstructionalMinutes={
               this.props.weeklyInstructionalMinutes || 225
             }
+            scriptId={this.props.scriptId}
           />
         )}
       </div>

--- a/apps/src/code-studio/components/progress/UnitCalendarDialog.jsx
+++ b/apps/src/code-studio/components/progress/UnitCalendarDialog.jsx
@@ -5,6 +5,7 @@ import BaseDialog from '@cdo/apps/templates/BaseDialog';
 import Button from '@cdo/apps/templates/Button';
 import UnitCalendar from './UnitCalendar';
 import {unitCalendarLesson} from '@cdo/apps/templates/progress/unitCalendarLessonShapes';
+import firehoseClient from '@cdo/apps/lib/util/firehose';
 
 const WEEKLY_INSTRUCTIONAL_MINUTES_OPTIONS = [45, 90, 135, 180, 225, 450];
 export const WEEK_WIDTH = 585;
@@ -14,7 +15,8 @@ export default class UnitCalendarDialog extends Component {
     isOpen: PropTypes.bool.isRequired,
     handleClose: PropTypes.func.isRequired,
     lessons: PropTypes.arrayOf(unitCalendarLesson).isRequired,
-    weeklyInstructionalMinutes: PropTypes.number.isRequired
+    weeklyInstructionalMinutes: PropTypes.number.isRequired,
+    scriptId: PropTypes.number.isRequired
   };
 
   constructor(props) {
@@ -37,6 +39,26 @@ export default class UnitCalendarDialog extends Component {
     ));
   };
 
+  logMinutesChange = (originalTime, newTime) => {
+    const record = {
+      study: 'script_overview_actions',
+      study_group: 'unit_calendar',
+      event: 'update_instructional_minutes',
+      data_json: JSON.stringify({
+        original_time: originalTime,
+        new_time: newTime,
+        script_id: this.props.scriptId
+      })
+    };
+    firehoseClient.putRecord(record, {includeUserId: true});
+  };
+
+  changeMinutes = e => {
+    const newTime = e.target.value;
+    this.logMinutesChange(this.state.instructionalMinutes, newTime);
+    this.setState({instructionalMinutes: newTime});
+  };
+
   render() {
     const {isOpen, handleClose, lessons} = this.props;
     return (
@@ -53,9 +75,7 @@ export default class UnitCalendarDialog extends Component {
             {i18n.instructionalMinutesPerWeek()}
           </div>
           <select
-            onChange={e =>
-              this.setState({instructionalMinutes: e.target.value})
-            }
+            onChange={e => this.changeMinutes(e)}
             value={this.state.instructionalMinutes}
             style={styles.dropdown}
           >

--- a/apps/src/code-studio/components/progress/UnitCalendarDialog.jsx
+++ b/apps/src/code-studio/components/progress/UnitCalendarDialog.jsx
@@ -84,7 +84,7 @@ export default class UnitCalendarDialog extends Component {
         </div>
         <UnitCalendar
           lessons={lessons}
-          weeklyInstructionalMinutes={this.state.instructionalMinutes}
+          weeklyInstructionalMinutes={Number(this.state.instructionalMinutes)}
           weekWidth={WEEK_WIDTH}
         />
         <Button

--- a/apps/src/code-studio/components/progress/UnitCalendarDialog.jsx
+++ b/apps/src/code-studio/components/progress/UnitCalendarDialog.jsx
@@ -56,7 +56,7 @@ export default class UnitCalendarDialog extends Component {
   changeMinutes = e => {
     const newTime = e.target.value;
     this.logMinutesChange(this.state.instructionalMinutes, newTime);
-    this.setState({instructionalMinutes: newTime});
+    this.setState({instructionalMinutes: Number(newTime)});
   };
 
   render() {
@@ -84,7 +84,7 @@ export default class UnitCalendarDialog extends Component {
         </div>
         <UnitCalendar
           lessons={lessons}
-          weeklyInstructionalMinutes={Number(this.state.instructionalMinutes)}
+          weeklyInstructionalMinutes={this.state.instructionalMinutes}
           weekWidth={WEEK_WIDTH}
         />
         <Button

--- a/apps/src/code-studio/components/progress/UnitCalendarDialog.story.jsx
+++ b/apps/src/code-studio/components/progress/UnitCalendarDialog.story.jsx
@@ -47,6 +47,7 @@ export default storybook =>
             handleClose={() => console.log('Unit Calendar Dialog Closed')}
             lessons={sampleLessonList}
             weeklyInstructionalMinutes={90}
+            scriptId={123}
           />
         </div>
       )

--- a/apps/test/unit/code-studio/components/progress/UnitCalendarButtonTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/UnitCalendarButtonTest.jsx
@@ -24,6 +24,7 @@ describe('UnitCalendarButton', () => {
           lessons={testLessons}
           weeklyInstructionalMinutes={90}
           handleClose={wrapper.instance().closeDialog}
+          scriptId={1}
         />
       )
     ).to.be.true;

--- a/apps/test/unit/code-studio/components/progress/UnitCalendarDialogTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/UnitCalendarDialogTest.jsx
@@ -15,6 +15,7 @@ describe('UnitCalendarDialog', () => {
         handleClose={() => console.log('hello')}
         lessons={testLessons}
         weeklyInstructionalMinutes={90}
+        scriptId={123}
       />
     );
     expect(
@@ -35,6 +36,7 @@ describe('UnitCalendarDialog', () => {
         handleClose={() => console.log('hello')}
         lessons={testLessons}
         weeklyInstructionalMinutes={45}
+        scriptId={123}
       />
     );
     expect(wrapper.find('option').length).to.equal(6);
@@ -63,6 +65,7 @@ describe('UnitCalendarDialog', () => {
         handleClose={() => console.log('hello')}
         lessons={testLessons}
         weeklyInstructionalMinutes={20}
+        scriptId={123}
       />
     );
     expect(wrapper.find('option').length).to.equal(7);
@@ -91,6 +94,7 @@ describe('UnitCalendarDialog', () => {
         handleClose={() => console.log('hello')}
         lessons={testLessons}
         weeklyInstructionalMinutes={45}
+        scriptId={123}
       />
     );
     expect(wrapper.state('instructionalMinutes')).to.equal(45);


### PR DESCRIPTION
[LP-2037](https://codedotorg.atlassian.net/browse/LP-2037)

The new '21/'22 units have calendars that map how long each lesson is expected to take. For example: 
![Screen Shot 2021-09-27 at 3 55 33 PM](https://user-images.githubusercontent.com/12300669/134976300-fe691d26-c757-4b08-a364-c97504911dd6.png)
 
This PR adds the requested instrumentation such that each time the instructional minutes dropdown is changed we log the interaction including the initial time and the new time. 
![Screen Shot 2021-09-27 at 3 53 41 PM](https://user-images.githubusercontent.com/12300669/134976448-b50bf91a-f3d0-42d8-b6a8-0ff679164a4f.png)

