### PR TITLE
[Poetry][HOC] Add Poem Selector Dropdown

### DIFF
--- a/apps/i18n/poetry/en_us.json
+++ b/apps/i18n/poetry/en_us.json
@@ -9,6 +9,7 @@
   "noTextEffects": "You need to add a text effect to your project.",
   "oneTextEffect": "Great work! You added one text effect. Try adding another.",
   "removedSprite": "It looks like you removed a sprite. You can add it back from the **Sprites** toolbox.",
+  "selectPoem": "Select Poem",
   "setSize": "Use a `set size` block to change the size of your sprite. Use a number other than 100.",
   "spriteEvent": "Try adding or removing a sprite under your `when line shows` event block.",
   "successAddedSprite": "Great work adding a new sprite with an event! Click “Keep Playing” to try removing a sprite with an event.",

--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -209,10 +209,10 @@ export default class P5Lab {
       throw new Error('P5Lab requires a StudioApp');
     }
 
-    this.isSpritelab = this.studioApp_.isUsingBlockly();
+    this.isBlockly = this.studioApp_.isUsingBlockly();
 
     this.skin = config.skin;
-    if (this.isSpritelab) {
+    if (this.isBlockly) {
       const mediaUrl = `/blockly/media/spritelab/${config.level
         .instructionsIcon || 'avatar'}.png`;
       this.skin.smallStaticAvatar = mediaUrl;
@@ -271,7 +271,7 @@ export default class P5Lab {
       onPreload: this.onP5Preload.bind(this),
       onSetup: this.onP5Setup.bind(this),
       onDraw: this.onP5Draw.bind(this),
-      spritelab: this.isSpritelab
+      spritelab: this.isBlockly
     });
 
     config.afterClearPuzzle = function() {
@@ -284,14 +284,14 @@ export default class P5Lab {
         setInitialAnimationList(
           this.startAnimations,
           false /* shouldRunV3Migration */,
-          this.isSpritelab
+          this.isBlockly
         )
       );
       this.studioApp_.resetButtonClick();
     }.bind(this);
 
     config.dropletConfig = dropletConfig;
-    config.appMsg = this.isSpritelab ? spritelabMsg : gamelabMsg;
+    config.appMsg = this.isBlockly ? spritelabMsg : gamelabMsg;
     this.studioApp_.loadLibraryBlocks(config);
 
     // hide makeYourOwn on the share page
@@ -317,8 +317,8 @@ export default class P5Lab {
     // instructions to display). Otherwise provide a way for us to have top pane
     // instructions disabled by default, but able to turn them on.
     config.noInstructionsWhenCollapsed =
-      !this.isSpritelab ||
-      (this.isSpritelab &&
+      !this.isBlockly ||
+      (this.isBlockly &&
         !hasInstructions(
           this.level.shortInstructions,
           this.level.longInstructions,
@@ -397,7 +397,7 @@ export default class P5Lab {
 
       this.setCrosshairCursorForPlaySpace();
 
-      if (this.isSpritelab) {
+      if (this.isBlockly) {
         this.currentCode = Blockly.getWorkspaceCode();
         this.studioApp_.addChangeHandler(() => {
           const newCode = Blockly.getWorkspaceCode();
@@ -421,7 +421,7 @@ export default class P5Lab {
       (!config.hideSource &&
         !config.level.debuggerDisabled &&
         !config.level.iframeEmbedAppAndCode);
-    var showPauseButton = this.isSpritelab && !config.level.hidePauseButton;
+    var showPauseButton = this.isBlockly && !config.level.hidePauseButton;
     var showDebugConsole = config.level.editCode && !config.hideSource;
     this.debuggerEnabled =
       showDebugButtons || showPauseButton || showDebugConsole;
@@ -467,7 +467,7 @@ export default class P5Lab {
       showAnimationMode: !config.level.hideAnimationMode,
       startInAnimationTab: config.level.startInAnimationTab,
       allAnimationsSingleFrame:
-        config.level.allAnimationsSingleFrame || this.isSpritelab,
+        config.level.allAnimationsSingleFrame || this.isBlockly,
       isIframeEmbed: !!config.level.iframeEmbed,
       isProjectLevel: !!config.level.isProjectLevel,
       isSubmittable: !!config.level.submittable,
@@ -493,8 +493,8 @@ export default class P5Lab {
     getStore().dispatch(
       setInitialAnimationList(
         initialAnimationList,
-        this.isSpritelab /* shouldRunV3Migration */,
-        this.isSpritelab
+        this.isBlockly /* shouldRunV3Migration */,
+        this.isBlockly
       )
     );
 
@@ -525,6 +525,7 @@ export default class P5Lab {
               pauseHandler={this.onPause?.bind(this)}
               hidePauseButton={!!this.level.hidePauseButton}
               onPromptAnswer={this.onPromptAnswer?.bind(this)}
+              labType={this.getLabType()}
             />
           </Provider>,
           document.getElementById(config.containerId)
@@ -544,7 +545,7 @@ export default class P5Lab {
    * @param {Object} initialAnimationList
    */
   loadAnyMissingDefaultAnimations(initialAnimationList) {
-    if (!this.isSpritelab) {
+    if (!this.isBlockly) {
       return initialAnimationList;
     }
     let configDictionary = {};
@@ -745,7 +746,7 @@ export default class P5Lab {
       getStore().getState().pageConstants.isShareView
     );
 
-    if (this.isSpritelab) {
+    if (this.isBlockly) {
       // Add to reserved word list: API, local variables in execution evironment
       // (execute) and the infinite loop detection function.
       Blockly.JavaScript.addReservedWords(
@@ -890,7 +891,7 @@ export default class P5Lab {
   }
 
   onPuzzleComplete(submit, testResult, message) {
-    let msg = this.isSpritelab ? spritelabMsg : gamelabMsg;
+    let msg = this.isBlockly ? spritelabMsg : gamelabMsg;
     if (message && msg[message]) {
       this.message = msg[message]();
     }
@@ -1048,7 +1049,7 @@ export default class P5Lab {
     this.studioApp_.clearAndAttachRuntimeAnnotations();
 
     if (
-      this.isSpritelab &&
+      this.isBlockly &&
       (this.studioApp_.hasUnwantedExtraTopBlocks() ||
         this.studioApp_.hasDuplicateVariablesInForLoops())
     ) {
@@ -1088,7 +1089,7 @@ export default class P5Lab {
         );
       }
 
-      if (this.isSpritelab) {
+      if (this.isBlockly) {
         this.spritelabLibrary = this.createLibrary({p5: this.p5Wrapper.p5});
 
         const spritelabCommands = this.spritelabLibrary.commands;
@@ -1237,7 +1238,7 @@ export default class P5Lab {
    */
   onP5Preload() {
     Promise.all([
-      this.isSpritelab
+      this.isBlockly
         ? this.preloadSpriteImages_()
         : this.preloadAnimations_(this.level.pauseAnimationsByDefault),
       this.maybePreloadBackgrounds_(),
@@ -1259,7 +1260,7 @@ export default class P5Lab {
 
   // Preloads background images if this is Sprite Lab
   maybePreloadBackgrounds_() {
-    if (!this.isSpritelab) {
+    if (!this.isBlockly) {
       return Promise.resolve();
     }
     return this.p5Wrapper.preloadBackgrounds();
@@ -1509,7 +1510,7 @@ export default class P5Lab {
           this.eventHandlers.draw.apply(null);
           this.runValidationCode();
         });
-      } else if (this.isSpritelab) {
+      } else if (this.isBlockly) {
         this.eventHandlers.draw.apply(null);
       }
     }
@@ -1590,7 +1591,7 @@ export default class P5Lab {
    */
   displayFeedback_() {
     var level = this.level;
-    let msg = this.isSpritelab ? spritelabMsg : gamelabMsg;
+    let msg = this.isBlockly ? spritelabMsg : gamelabMsg;
 
     this.studioApp_.displayFeedback({
       feedbackType: this.testResults,

--- a/apps/src/p5lab/P5LabView.jsx
+++ b/apps/src/p5lab/P5LabView.jsx
@@ -8,13 +8,18 @@ import AnimationTab from './AnimationTab/AnimationTab';
 import StudioAppWrapper from '@cdo/apps/templates/StudioAppWrapper';
 import ErrorDialogStack from './ErrorDialogStack';
 import AnimationJsonViewer from './AnimationJsonViewer';
-import {P5LabInterfaceMode, APP_WIDTH, APP_HEIGHT} from './constants';
+import {
+  P5LabInterfaceMode,
+  P5LabType,
+  APP_WIDTH,
+  APP_HEIGHT
+} from './constants';
 import P5LabVisualizationHeader from './P5LabVisualizationHeader';
 import P5LabVisualizationColumn from './P5LabVisualizationColumn';
 import InstructionsWithWorkspace from '@cdo/apps/templates/instructions/InstructionsWithWorkspace';
 import {isResponsiveFromState} from '@cdo/apps/templates/ProtectedVisualizationDiv';
 import CodeWorkspace from '@cdo/apps/templates/CodeWorkspace';
-import {allowAnimationMode, showVisualizationHeader} from './stateQueries';
+import {allowAnimationMode} from './stateQueries';
 import IFrameEmbedOverlay from '@cdo/apps/templates/IFrameEmbedOverlay';
 import VisualizationResizeBar from '@cdo/apps/lib/ui/VisualizationResizeBar';
 import AnimationPicker from './AnimationPicker/AnimationPicker';
@@ -31,6 +36,7 @@ class P5LabView extends React.Component {
     pauseHandler: PropTypes.func.isRequired,
     hidePauseButton: PropTypes.bool.isRequired,
     onPromptAnswer: PropTypes.func,
+    labType: PropTypes.oneOf(Object.keys(P5LabType)).isRequired,
     // Provided by Redux
     interfaceMode: PropTypes.oneOf([
       P5LabInterfaceMode.CODE,
@@ -40,10 +46,9 @@ class P5LabView extends React.Component {
     hideSource: PropTypes.bool.isRequired,
     pinWorkspaceToBottom: PropTypes.bool.isRequired,
     allowAnimationMode: PropTypes.bool.isRequired,
-    showVisualizationHeader: PropTypes.bool.isRequired,
     isIframeEmbed: PropTypes.bool.isRequired,
     isRunning: PropTypes.bool.isRequired,
-    spriteLab: PropTypes.bool.isRequired,
+    isBlockly: PropTypes.bool.isRequired,
     isBackground: PropTypes.bool
   };
 
@@ -61,7 +66,7 @@ class P5LabView extends React.Component {
   componentDidMount() {
     this.props.onMount();
     const locale = window.appOptions.locale;
-    const app = this.props.spriteLab ? 'spritelab' : 'gamelab';
+    const app = this.props.isBlockly ? 'spritelab' : 'gamelab';
     getManifest(app, locale).then(libraryManifest => {
       this.setState({libraryManifest});
     });
@@ -100,7 +105,7 @@ class P5LabView extends React.Component {
     // we don't want them to be able to navigate to all categories if we're only showing backgrounds
     const navigable = !this.props.isBackground;
     // we don't want to show backgrounds if we're looking for sprites in spritelab
-    const hideBackgrounds = !this.props.isBackground && this.props.spriteLab;
+    const hideBackgrounds = !this.props.isBackground && this.props.isBlockly;
     // we don't want students to be able to draw their own backgrounds in spritelab so if we're showing
     // backgrounds alone, we must be in spritelab and we should get rid of the draw your own option
     const canDraw = !this.props.isBackground;
@@ -111,7 +116,7 @@ class P5LabView extends React.Component {
           className={visualizationColumnClassNames}
           style={visualizationColumnStyle}
         >
-          {this.props.showVisualizationHeader && <P5LabVisualizationHeader />}
+          <P5LabVisualizationHeader labType={this.props.labType} />
           <P5LabVisualizationColumn
             finishButton={showFinishButton}
             pauseHandler={this.props.pauseHandler}
@@ -123,8 +128,8 @@ class P5LabView extends React.Component {
               channelId={this.getChannelId()}
               allowedExtensions=".png,.jpg,.jpeg"
               libraryManifest={this.state.libraryManifest}
-              hideUploadOption={this.props.spriteLab}
-              hideAnimationNames={this.props.spriteLab}
+              hideUploadOption={this.props.isBlockly}
+              hideAnimationNames={this.props.isBlockly}
               navigable={navigable}
               defaultQuery={this.props.isBackground ? defaultQuery : undefined}
               hideBackgrounds={hideBackgrounds}
@@ -142,7 +147,7 @@ class P5LabView extends React.Component {
         )}
         <VisualizationResizeBar />
         <InstructionsWithWorkspace>
-          <CodeWorkspace withSettingsCog={!this.props.spriteLab} />
+          <CodeWorkspace withSettingsCog={!this.props.isBlockly} />
         </InstructionsWithWorkspace>
       </div>
     );
@@ -155,9 +160,9 @@ class P5LabView extends React.Component {
       <AnimationTab
         channelId={this.getChannelId()}
         libraryManifest={this.state.libraryManifest}
-        hideUploadOption={this.props.spriteLab}
-        hideAnimationNames={this.props.spriteLab}
-        hideBackgrounds={this.props.spriteLab}
+        hideUploadOption={this.props.isBlockly}
+        hideAnimationNames={this.props.isBlockly}
+        hideBackgrounds={this.props.isBlockly}
       />
     ) : (
       undefined
@@ -181,9 +186,8 @@ export default connect(state => ({
   isResponsive: isResponsiveFromState(state),
   pinWorkspaceToBottom: state.pageConstants.pinWorkspaceToBottom,
   allowAnimationMode: allowAnimationMode(state),
-  showVisualizationHeader: showVisualizationHeader(state),
   isRunning: state.runState.isRunning,
   isIframeEmbed: state.pageConstants.isIframeEmbed,
-  spriteLab: state.pageConstants.isBlockly,
+  isBlockly: state.pageConstants.isBlockly,
   isBackground: state.animationPicker.isBackground
 }))(P5LabView);

--- a/apps/src/p5lab/P5LabVisualizationHeader.jsx
+++ b/apps/src/p5lab/P5LabVisualizationHeader.jsx
@@ -3,12 +3,12 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {changeInterfaceMode} from './actions';
 import {connect} from 'react-redux';
-import {P5LabInterfaceMode} from './constants';
+import {P5LabInterfaceMode, P5LabType} from './constants';
 import msg from '@cdo/locale';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
 import ToggleGroup from '@cdo/apps/templates/ToggleGroup';
 import styleConstants from '@cdo/apps/styleConstants';
-import {allowAnimationMode} from './stateQueries';
+import {allowAnimationMode, countAllowedModes} from './stateQueries';
 import * as utils from '../utils';
 
 /**
@@ -16,19 +16,21 @@ import * as utils from '../utils';
  */
 class P5LabVisualizationHeader extends React.Component {
   static propTypes = {
+    labType: PropTypes.oneOf(Object.keys(P5LabType)).isRequired,
     interfaceMode: PropTypes.oneOf([
       P5LabInterfaceMode.CODE,
       P5LabInterfaceMode.ANIMATION
     ]).isRequired,
     allowAnimationMode: PropTypes.bool.isRequired,
     onInterfaceModeChange: PropTypes.func.isRequired,
-    spriteLab: PropTypes.bool.isRequired
+    isBlockly: PropTypes.bool.isRequired,
+    numAllowedModes: PropTypes.number.isRequired
   };
 
   changeInterfaceMode = mode => {
     // Make sure code workspace is rendered properly after switching from the Animation Tab.
     if (mode === P5LabInterfaceMode.CODE) {
-      if (this.props.spriteLab) {
+      if (this.props.isBlockly) {
         // Sprite Lab (Blockly) doesn't need a window resize event, but it does need to rerender.
         setTimeout(() => Blockly.mainBlockSpace.render(), 0);
       } else {
@@ -36,7 +38,7 @@ class P5LabVisualizationHeader extends React.Component {
         setTimeout(() => utils.fireResizeEvent(), 0);
       }
     } else if (mode === P5LabInterfaceMode.ANIMATION) {
-      if (this.props.spriteLab) {
+      if (this.props.isBlockly) {
         Blockly.WidgetDiv.hide();
       }
 
@@ -44,7 +46,7 @@ class P5LabVisualizationHeader extends React.Component {
         study: 'animation-library',
         study_group: 'control-2020',
         event: 'tab-click',
-        data_string: this.props.spriteLab ? 'spritelab' : 'gamelab'
+        data_string: this.props.isBlockly ? 'spritelab' : 'gamelab'
       });
     }
 
@@ -54,24 +56,34 @@ class P5LabVisualizationHeader extends React.Component {
   render() {
     const {interfaceMode, allowAnimationMode} = this.props;
     return (
-      <div style={styles.main} id="playSpaceHeader">
-        <ToggleGroup
-          selected={interfaceMode}
-          onChange={this.changeInterfaceMode}
-        >
-          <button type="button" value={P5LabInterfaceMode.CODE} id="codeMode">
-            {msg.codeMode()}
-          </button>
-          {allowAnimationMode && (
-            <button
-              type="button"
-              value={P5LabInterfaceMode.ANIMATION}
-              id="animationMode"
+      <div>
+        {this.props.numAllowedModes > 1 && (
+          <div style={styles.main} id="playSpaceHeader">
+            <ToggleGroup
+              selected={interfaceMode}
+              onChange={this.changeInterfaceMode}
             >
-              {this.props.spriteLab ? msg.costumeMode() : msg.animationMode()}
-            </button>
-          )}
-        </ToggleGroup>
+              <button
+                type="button"
+                value={P5LabInterfaceMode.CODE}
+                id="codeMode"
+              >
+                {msg.codeMode()}
+              </button>
+              {allowAnimationMode && (
+                <button
+                  type="button"
+                  value={P5LabInterfaceMode.ANIMATION}
+                  id="animationMode"
+                >
+                  {this.props.isBlockly
+                    ? msg.costumeMode()
+                    : msg.animationMode()}
+                </button>
+              )}
+            </ToggleGroup>
+          </div>
+        )}
       </div>
     );
   }
@@ -86,7 +98,8 @@ export default connect(
   state => ({
     interfaceMode: state.interfaceMode,
     allowAnimationMode: allowAnimationMode(state),
-    spriteLab: state.pageConstants.isBlockly
+    isBlockly: state.pageConstants.isBlockly,
+    numAllowedModes: countAllowedModes(state)
   }),
   dispatch => ({
     onInterfaceModeChange: mode => dispatch(changeInterfaceMode(mode))

--- a/apps/src/p5lab/P5LabVisualizationHeader.jsx
+++ b/apps/src/p5lab/P5LabVisualizationHeader.jsx
@@ -9,6 +9,7 @@ import firehoseClient from '@cdo/apps/lib/util/firehose';
 import ToggleGroup from '@cdo/apps/templates/ToggleGroup';
 import styleConstants from '@cdo/apps/styleConstants';
 import {allowAnimationMode, countAllowedModes} from './stateQueries';
+import PoemSelector from './poetry/PoemSelector';
 import * as utils from '../utils';
 
 /**
@@ -57,6 +58,7 @@ class P5LabVisualizationHeader extends React.Component {
     const {interfaceMode, allowAnimationMode} = this.props;
     return (
       <div>
+        {this.props.labType === P5LabType.POETRY && <PoemSelector />}
         {this.props.numAllowedModes > 1 && (
           <div style={styles.main} id="playSpaceHeader">
             <ToggleGroup

--- a/apps/src/p5lab/constants.js
+++ b/apps/src/p5lab/constants.js
@@ -4,6 +4,9 @@ var utils = require('@cdo/apps/utils');
 /** @enum {string} */
 export const P5LabInterfaceMode = utils.makeEnum('CODE', 'ANIMATION');
 
+/** @enum {string} */
+export const P5LabType = utils.makeEnum('GAMELAB', 'SPRITELAB', 'POETRY');
+
 /** @const {number} */
 export const APP_WIDTH = 400;
 

--- a/apps/src/p5lab/gamelab/GameLab.js
+++ b/apps/src/p5lab/gamelab/GameLab.js
@@ -1,9 +1,14 @@
 import P5Lab from '../P5Lab';
+import {P5LabType} from '../constants';
 import project from '@cdo/apps/code-studio/initApp/project';
 import {showLevelBuilderSaveButton} from '../../code-studio/header';
 import color from '@cdo/apps/util/color';
 
 export default class GameLab extends P5Lab {
+  getLabType() {
+    return P5LabType.GAMELAB;
+  }
+
   init(config) {
     if (!this.studioApp_) {
       throw new Error('GameLab requires a StudioApp');

--- a/apps/src/p5lab/poetry/PoemSelector.jsx
+++ b/apps/src/p5lab/poetry/PoemSelector.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import msg from '@cdo/poetry/locale';
+import {APP_WIDTH} from '../constants';
+import {POEMS} from './constants';
+
+export default function PoemSelector(props) {
+  const onChange = e => {
+    const poemTitle = e.target.value;
+    const poem = Object.values(POEMS).find(poem => poem.title === poemTitle);
+    if (poem) {
+      console.log(poem);
+    }
+  };
+  return (
+    <div style={styles.container}>
+      <label>
+        <b>{msg.selectPoem()}</b>
+      </label>
+      <select style={styles.selector} onChange={onChange}>
+        {Object.values(POEMS).map(poem => (
+          <option key={poem.title} value={poem.title}>
+            {poem.title}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+const styles = {
+  container: {
+    maxWidth: APP_WIDTH
+  },
+  selector: {
+    width: '100%'
+  }
+};

--- a/apps/src/p5lab/poetry/PoemSelector.jsx
+++ b/apps/src/p5lab/poetry/PoemSelector.jsx
@@ -1,14 +1,17 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+import {connect} from 'react-redux';
+import {setPoem} from '../redux/poetry';
 import msg from '@cdo/poetry/locale';
 import {APP_WIDTH} from '../constants';
 import {POEMS} from './constants';
 
-export default function PoemSelector(props) {
+function PoemSelector(props) {
   const onChange = e => {
     const poemTitle = e.target.value;
     const poem = Object.values(POEMS).find(poem => poem.title === poemTitle);
     if (poem) {
-      console.log(poem);
+      props.onChangePoem(poem);
     }
   };
   return (
@@ -27,6 +30,11 @@ export default function PoemSelector(props) {
   );
 }
 
+PoemSelector.propTypes = {
+  // from Redux
+  onChangePoem: PropTypes.func.isRequired
+};
+
 const styles = {
   container: {
     maxWidth: APP_WIDTH
@@ -35,3 +43,12 @@ const styles = {
     width: '100%'
   }
 };
+
+export default connect(
+  state => ({}),
+  dispatch => ({
+    onChangePoem(poem) {
+      dispatch(setPoem(poem));
+    }
+  })
+)(PoemSelector);

--- a/apps/src/p5lab/poetry/Poetry.js
+++ b/apps/src/p5lab/poetry/Poetry.js
@@ -14,4 +14,20 @@ export default class Poetry extends SpriteLab {
     }
     return new PoetryLibrary(args.p5);
   }
+
+  setupReduxSubscribers(store) {
+    super.setupReduxSubscribers(store);
+    let state = {};
+    store.subscribe(() => {
+      const lastState = state;
+      state = store.getState();
+
+      if (
+        lastState.poetry &&
+        lastState.poetry.selectedPoem.title !== state.poetry.selectedPoem.title
+      ) {
+        this.reset();
+      }
+    });
+  }
 }

--- a/apps/src/p5lab/poetry/Poetry.js
+++ b/apps/src/p5lab/poetry/Poetry.js
@@ -1,7 +1,12 @@
+import {P5LabType} from '../constants';
 import SpriteLab from '../spritelab/SpriteLab';
 import PoetryLibrary from './PoetryLibrary';
 
 export default class Poetry extends SpriteLab {
+  getLabType() {
+    return P5LabType.POETRY;
+  }
+
   createLibrary(args) {
     if (!args.p5) {
       console.warn('cannot create poetry library without p5 instance');

--- a/apps/src/p5lab/poetry/PoetryLibrary.js
+++ b/apps/src/p5lab/poetry/PoetryLibrary.js
@@ -1,3 +1,4 @@
+import {getStore} from '@cdo/apps/redux';
 import CoreLibrary from '../spritelab/CoreLibrary';
 import {POEMS} from './constants';
 import * as utils from './commands/utils';
@@ -18,9 +19,7 @@ export default class PoetryLibrary extends CoreLibrary {
       endTime: POEM_DURATION
     };
     this.poemState = {
-      title: '',
-      author: '',
-      lines: [],
+      ...getStore().getState().poetry.selectedPoem,
       font: {
         fill: 'black',
         stroke: 'rgba(0,0,0,0)',

--- a/apps/src/p5lab/reducers.js
+++ b/apps/src/p5lab/reducers.js
@@ -13,6 +13,7 @@ import animationTab from './redux/animationTab';
 import locationPicker from './redux/locationPicker';
 import textConsole from './redux/textConsole';
 import spritelabInputList from './redux/spritelabInput';
+import poetry from './redux/poetry';
 import locales from '@cdo/apps/redux/localesRedux';
 var errorDialogStack = require('./redux/errorDialogStack').default;
 var P5LabInterfaceMode = require('./constants').P5LabInterfaceMode;
@@ -64,5 +65,6 @@ module.exports = {
   locationPicker,
   textConsole,
   spritelabInputList,
+  poetry,
   locales
 };

--- a/apps/src/p5lab/redux/poetry.js
+++ b/apps/src/p5lab/redux/poetry.js
@@ -1,0 +1,24 @@
+const SET_POEM = 'poetry/SET_POEM';
+
+export default function poetry(state, action) {
+  state = state || {selectedPoem: {title: '', author: '', lines: []}};
+  switch (action.type) {
+    case SET_POEM:
+      return {
+        selectedPoem: {
+          title: action.title || '',
+          author: action.author || '',
+          lines: [...(action.lines || [])]
+        }
+      };
+    default:
+      return state;
+  }
+}
+
+export function setPoem(poem) {
+  return {
+    type: SET_POEM,
+    ...poem
+  };
+}

--- a/apps/src/p5lab/spritelab/SpriteLab.js
+++ b/apps/src/p5lab/spritelab/SpriteLab.js
@@ -1,5 +1,6 @@
 import * as utils from '@cdo/apps/utils';
 import P5Lab from '../P5Lab';
+import {P5LabType} from '../constants';
 import Sounds from '@cdo/apps/Sounds';
 import {getStore} from '@cdo/apps/redux';
 import {clearConsole} from '../redux/textConsole';
@@ -7,6 +8,10 @@ import {clearPrompts, popPrompt} from '../redux/spritelabInput';
 import CoreLibrary from './CoreLibrary';
 
 export default class SpriteLab extends P5Lab {
+  getLabType() {
+    return P5LabType.SPRITELAB;
+  }
+
   createLibrary(args) {
     if (!args.p5) {
       console.warn('cannot create SpriteLab library without p5 instance');

--- a/apps/src/p5lab/stateQueries.js
+++ b/apps/src/p5lab/stateQueries.js
@@ -34,20 +34,10 @@ function allowCodeMode() {
  * @param {Object} state - Game Lab redux state.
  * @returns {number}
  */
-function countAllowedModes(state) {
+export function countAllowedModes(state) {
   return [allowCodeMode(state), allowAnimationMode(state)].reduce(
     (m, n) => m + (n ? 1 : 0)
   );
-}
-
-/**
- * Decide whether we should show the visualization header (which, in Game Lab,
- * only contains the mode toggle).
- * @param {Object} state - Game Lab redux state.
- * @returns {boolean}
- */
-export function showVisualizationHeader(state) {
-  return countAllowedModes(state) > 1;
 }
 
 /**

--- a/apps/test/unit/p5lab/spritelab/SpritelabTest.js
+++ b/apps/test/unit/p5lab/spritelab/SpritelabTest.js
@@ -96,7 +96,7 @@ describe('SpriteLab', () => {
       });
 
       it('includes backgrounds if there are none', () => {
-        instance.isSpritelab = true;
+        instance.isBlockly = true;
         const initialAnimationList = {
           orderedKeys: ['2223bab1-0b27-4ad1-ad2e-7eb3dd0997c2'],
           propsByKey: {
@@ -113,7 +113,7 @@ describe('SpriteLab', () => {
       });
 
       it('does not modify the list if there is an animation in the backgrounds category', () => {
-        instance.isSpritelab = true;
+        instance.isBlockly = true;
         const initialAnimationList = {
           orderedKeys: ['2223bab1-0b27-4ad1-ad2e-7eb3dd0997c2'],
           propsByKey: {
@@ -130,7 +130,7 @@ describe('SpriteLab', () => {
       });
 
       it('does not modify the list if there is an animation that matches a background', () => {
-        instance.isSpritelab = true;
+        instance.isBlockly = true;
         const initialAnimationList = {
           orderedKeys: ['2223bab1-0b27-4ad1-ad2e-7eb3dd0997c2'],
           propsByKey: {

--- a/apps/test/unit/p5lab/stateQueriesTest.js
+++ b/apps/test/unit/p5lab/stateQueriesTest.js
@@ -3,7 +3,7 @@ import {expect} from '../../util/reconfiguredChai';
 import {forEveryBooleanPermutation} from '../../util/testUtils';
 import {
   allowAnimationMode,
-  showVisualizationHeader
+  countAllowedModes
 } from '@cdo/apps/p5lab/stateQueries';
 
 describe('stateQueries', function() {
@@ -73,18 +73,11 @@ describe('stateQueries', function() {
     });
   });
 
-  describe('showVisualizationHeader', function() {
-    it('is shown whenever animation mode is allowed, and hidden when it is not allowed', function() {
-      forEveryBooleanPermutation((a, b, c, d) => {
-        const state = stateFromPageConstants({
-          showAnimationMode: a,
-          isEmbedView: b,
-          isShareView: c,
-          isReadOnlyWorkspace: d
-        });
-        expect(allowAnimationMode(state)).to.equal(
-          showVisualizationHeader(state)
-        );
+  describe('countAllowedModes', function() {
+    it('is either 1 or 2, depending on whether animation mode is allowed', function() {
+      forEveryBooleanPermutation(a => {
+        const state = stateFromPageConstants({showAnimationMode: a});
+        expect(countAllowedModes(state)).to.equal(a ? 2 : 1);
       });
     });
   });


### PR DESCRIPTION
Similar to https://github.com/code-dot-org/code-dot-org/pull/42023, but updated to reflect Poetry now being its own level type

![image](https://user-images.githubusercontent.com/8787187/135012965-645fe36a-f6f5-42d9-9ff6-54daf2f692f7.png)
![image](https://user-images.githubusercontent.com/8787187/135012991-2fafbae0-7968-4e1b-91e0-140c0fb27471.png)
![image](https://user-images.githubusercontent.com/8787187/135013005-bd0ea972-c057-47b9-bc13-b7134cac3b46.png)


No changes in Sprite Lab or Game Lab:
![image](https://user-images.githubusercontent.com/8787187/135012872-4c6dc668-cfc3-4bec-8741-708a218b804d.png)
![image](https://user-images.githubusercontent.com/8787187/135012885-71fc7d99-e045-4fbc-a27c-7daf0dcbe9f8.png)

Up next:
- "Create your own" option for students to enter their own poem text
- Set default poem as level configuration
- Save selected poem in student progress