### PR TITLE
Temporarily increasing the frequency of i18n logging so we can confirm it is working during business hours

### DIFF
--- a/lib/cdo/i18n_string_url_tracker.rb
+++ b/lib/cdo/i18n_string_url_tracker.rb
@@ -17,7 +17,8 @@ class I18nStringUrlTracker
 
   # The amount of time which will pass before the buffered i18n usage data is uploaded to Firehose.
   # Select a random interval time between the MIN and MAX so we can avoid all the servers flushing data at the same time.
-  FLUSH_INTERVAL_MIN = 8.hours
+  # TODO - Set MIN to 8 hours once we have proven this works.
+  FLUSH_INTERVAL_MIN = 1.hour
   FLUSH_INTERVAL_MAX = 16.hours
 
   MAX_BUFFER_SIZE = 250.megabytes


### PR DESCRIPTION
This is a new feature we are launching and we want to confirm it is working during business hours because we like to avoid pages/issues happening in the evening.

After we confirm there is data going to Redshift today, we will change the frequency from 1-16 hours to 8-16 hours.

# Deployment plan
- [x] After the DTP, log into the production-console, open the dashboard-console, and run `DCDO.set(I18nStringUrlTracker::I18N_STRING_TRACKING_DCDO_KEY, true)`
- [ ] Wait and hour and then monitor the `analysis.i18n_string_tracking_events` Redshift table for new data
- [ ] Also confirm CloudWatch dashboards don't show any spikes in unavailability, CPU, or memory usage.
- [ ] After data is confirmed to be flowing or an issue is found, run `DCDO.set(I18nStringUrlTracker::I18N_STRING_TRACKING_DCDO_KEY, false)`
- [ ] Open a new PR to set the `MIN` frequency to `8.hours`