### PR TITLE
Escape both quotes and backslashes for sql insert

### DIFF
--- a/bin/cron/create_rollup_tables
+++ b/bin/cron/create_rollup_tables
@@ -17,7 +17,7 @@ TIME_NOW = DateTime.now.strftime('%F %T').freeze
 #   quotations escaped. Returns nil on nil input.
 def sanitize_string_for_db(unsanitized)
   return nil if unsanitized.nil?
-  unsanitized.gsub(/[\r\n]+/, '').gsub(/\\|"/, '\\\\\\0')
+  unsanitized.gsub(/[\r\n]+/, '').dump
 end
 
 # @param contained_level [Level] The level to parse.
@@ -34,7 +34,7 @@ def get_contained_question(contained_level)
   end
 
   if contained_question_markdown.nil?
-    return contained_question_text
+    return contained_question_text || ""
   end
   if contained_question_text.nil?
     return contained_question_markdown
@@ -135,7 +135,8 @@ def main
         contained_level_id: sublevel.id,
         contained_level_type: sublevel.type,
         contained_level_page: 1,
-        contained_level_position: sublevel_index
+        contained_level_position: sublevel_index,
+        contained_level_text: sanitize_string_for_db("")
       }
     end
   end
@@ -230,7 +231,7 @@ def contained_levels_row(row_hash)
       "#{row_hash[:contained_level_type]}",
       #{row_hash[:contained_level_page]},
       #{row_hash[:contained_level_position]},
-      "#{row_hash[:contained_level_text]}"
+      #{row_hash[:contained_level_text]}
     )
   ROW
 end
@@ -242,7 +243,7 @@ def contained_level_answers_row(row_hash)
       "#{TIME_NOW}",
       #{row_hash[:contained_level_id]},
       #{row_hash[:answer_number]},
-      "#{row_hash[:answer_text]}",
+      #{row_hash[:answer_text]},
       #{row_hash[:correct]}
     )
   ROW

--- a/bin/cron/create_rollup_tables
+++ b/bin/cron/create_rollup_tables
@@ -8,6 +8,7 @@ require_relative 'only_one'
 abort 'Script already running' unless only_one_running?(__FILE__)
 
 require_relative '../../dashboard/config/environment'
+require 'honeybadger/ruby'
 
 TIME_NOW = DateTime.now.strftime('%F %T').freeze
 
@@ -16,7 +17,7 @@ TIME_NOW = DateTime.now.strftime('%F %T').freeze
 #   quotations escaped. Returns nil on nil input.
 def sanitize_string_for_db(unsanitized)
   return nil if unsanitized.nil?
-  unsanitized.gsub(/[\r\n]+/, '').gsub(/"/, '\"')
+  unsanitized.gsub(/[\r\n]+/, '').gsub(/\\|"/, '\\\\\\0')
 end
 
 # @param contained_level [Level] The level to parse.
@@ -148,53 +149,74 @@ def main
   batch_size = 2000
 
   # Write the data to the DB tables.
-  ActiveRecord::Base.connection.execute 'TRUNCATE contained_levels'
-  contained_levels.each_slice(batch_size) do |batch|
-    ActiveRecord::Base.connection.execute <<~SQL
-      INSERT INTO contained_levels (
-        created_at,
-        updated_at,
-        level_group_level_id,
-        contained_level_id,
-        contained_level_type,
-        contained_level_page,
-        contained_level_position,
-        contained_level_text
-      )
-      VALUES
-      #{batch.map {|row| contained_levels_row(row)}.join(",\n")}
-    SQL
+  begin
+    ActiveRecord::Base.connection.execute 'TRUNCATE contained_levels'
+    contained_levels.each_slice(batch_size) do |batch|
+      ActiveRecord::Base.connection.execute <<~SQL
+        INSERT INTO contained_levels (
+          created_at,
+          updated_at,
+          level_group_level_id,
+          contained_level_id,
+          contained_level_type,
+          contained_level_page,
+          contained_level_position,
+          contained_level_text
+        )
+        VALUES
+        #{batch.map {|row| contained_levels_row(row)}.join(",\n")}
+      SQL
+    end
+  rescue => e
+    Honeybadger.notify(
+      e,
+      error_message: "Error when writing contained_levels"
+    )
   end
 
-  ActiveRecord::Base.connection.execute 'TRUNCATE contained_level_answers'
-  contained_level_answers.each_slice(batch_size) do |batch|
-    ActiveRecord::Base.connection.execute <<~SQL
-      INSERT INTO contained_level_answers (
-        created_at,
-        updated_at,
-        level_id,
-        answer_number,
-        answer_text,
-        correct
-      )
-      VALUES
-      #{batch.map {|row| contained_level_answers_row(row)}.join(",\n")}
-    SQL
+  begin
+    ActiveRecord::Base.connection.execute 'TRUNCATE contained_level_answers'
+    contained_level_answers.each_slice(batch_size) do |batch|
+      ActiveRecord::Base.connection.execute <<~SQL
+        INSERT INTO contained_level_answers (
+          created_at,
+          updated_at,
+          level_id,
+          answer_number,
+          answer_text,
+          correct
+        )
+        VALUES
+        #{batch.map {|row| contained_level_answers_row(row)}.join(",\n")}
+      SQL
+    end
+  rescue => e
+    Honeybadger.notify(
+      e,
+      error_message: "Error when writing contained_level_answers"
+    )
   end
 
-  ActiveRecord::Base.connection.execute 'TRUNCATE level_sources_multi_types'
-  level_sources_multi_types.each_slice(batch_size) do |batch|
-    ActiveRecord::Base.connection.execute <<~SQL
-      INSERT INTO level_sources_multi_types (
-        level_source_id,
-        level_id,
-        data,
-        md5,
-        hidden
-      )
-      VALUES
-      #{batch.map {|row| level_sources_multi_types_row(row)}.join(",\n")}
-    SQL
+  begin
+    ActiveRecord::Base.connection.execute 'TRUNCATE level_sources_multi_types'
+    level_sources_multi_types.each_slice(batch_size) do |batch|
+      ActiveRecord::Base.connection.execute <<~SQL
+        INSERT INTO level_sources_multi_types (
+          level_source_id,
+          level_id,
+          data,
+          md5,
+          hidden
+        )
+        VALUES
+        #{batch.map {|row| level_sources_multi_types_row(row)}.join(",\n")}
+      SQL
+    end
+  rescue => e
+    Honeybadger.notify(
+      e,
+      error_message: "Error when writing level_sources_multi_type"
+    )
   end
 end
 


### PR DESCRIPTION
The rollup script was failing on levels with already escaped quotes, such as [this level](https://github.com/code-dot-org/code-dot-org/blob/4ec1e11deaa5f459bd6c4b482f68adc5ed1fca59/dashboard/config/scripts/csa_u2_assessment_q14.multi#L4). This PR also escapes backslashes.

I also added some rescues so that we attempt to generate all the tables even if one of them fails.

It may be easier to view this diff with [whitespace ignored](https://github.com/code-dot-org/code-dot-org/pull/42723/files?diff=split&w=1).

## Links

[Honeybadger error](https://app.honeybadger.io/projects/45435/faults/51801288)
[jira](https://codedotorg.atlassian.net/browse/PLAT-1332)

## Testing story

tested locally



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
