### PR TITLE
Remove Optimizely code from 'Clearer Sign-up User Type Selection' experiment

### DIFF
--- a/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
+++ b/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
@@ -49,7 +49,8 @@ let userInOptimizelyVariant = experiments.isEnabled(
 $(document).ready(() => {
   const schoolInfoMountPoint = document.getElementById('school-info-inputs');
 
-  // Keep track of user type
+  // Keep track of user type. Uses '$('#user_user_type')[0].value' here in case page is refreshed
+  // (e.g. if the user does not input all required fields and tries to submit the sign-up form).
   let userType = $('#user_user_type')[0].value;
   init();
 

--- a/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
+++ b/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
@@ -51,20 +51,8 @@ $(document).ready(() => {
   init();
 
   function init() {
-    // TO-DELETE ONCE CLEARER USER TYPE BUTTONS OPTIMIZELY-EXPERIMENT IS COMPLETE (start)
-    if (experiments.isEnabled(experiments.CLEARER_SIGN_UP_USER_TYPE)) {
-      // If in variant, toggle large buttons
-      document.getElementById('select-user-type-original').style.cssText =
-        'display:none;';
-    } else {
-      // Otherwise (also the default), keep original dropdown
-      document.getElementById('select-user-type-variant').style.cssText =
-        'display:none;';
-      document.getElementById('signup-select-user-type-label').style.cssText =
-        'width:220px;';
-    }
-    // TO-DELETE ONCE CLEARER USER TYPE BUTTONS OPTIMIZELY-EXPERIMENT IS COMPLETE (end)
     setUserType(getUserType());
+    styleSelectedUserTypeButton(getUserType());
     renderSchoolInfo();
     renderParentSignUpSection();
   }
@@ -79,9 +67,8 @@ $(document).ready(() => {
       return false;
     }
 
-    // Optimizely-related code for new sign-up user-type buttons (start)
+    // Trigger Optimizely counter for user type selection
     optimizelyCountUserTypeSelection(getUserType());
-    // Optimizely-related code for new sign-up user-type buttons (end)
 
     // Optimizely-related code for teacher opting to share email with regional partner (start)
     optimizelyCountSuccessSignupWithRegPartnerOpt();
@@ -134,7 +121,6 @@ $(document).ready(() => {
     }
   }
 
-  // Keep if sign-up user type experiment favors variant (start)
   // Event listeners for changing the user type
   document.addEventListener('selectUserTypeTeacher', e => {
     $('#user_user_type').val('teacher');
@@ -156,9 +142,8 @@ $(document).ready(() => {
       teacherButton.classList.remove('select-user-type-button-selected');
     }
   }
-  // Keep if sign-up user type experiment favors variant (end)
 
-  // Optimizely-related code for new sign-up user-type buttons
+  // Optimizely metric for seeing which user type new users select
   function optimizelyCountUserTypeSelection(userType) {
     window['optimizely'] = window['optimizely'] || [];
     window['optimizely'].push({type: 'event', eventName: userType});
@@ -170,16 +155,8 @@ $(document).ready(() => {
     window['optimizely'].push({type: 'event', eventName: 'successSignUp'});
   }
 
-  // Keep if sign-up user type experiment favors original (just func. below)
-  $('#user_user_type').change(function() {
-    var value = $(this).val();
-    setUserType(value);
-  });
-
   function getUserType() {
-    var value = $('#user_user_type')[0].value;
-    styleSelectedUserTypeButton(value);
-    return value;
+    return $('#user_user_type')[0].value;
   }
 
   function setUserType(userType) {

--- a/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
+++ b/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
@@ -49,8 +49,7 @@ let userInOptimizelyVariant = experiments.isEnabled(
 $(document).ready(() => {
   const schoolInfoMountPoint = document.getElementById('school-info-inputs');
 
-  // Keep track of user type. Uses '$('#user_user_type')[0].value' here in case page is refreshed
-  // (e.g. if the user does not input all required fields and tries to submit the sign-up form).
+  // Keep track of user type
   let userType = $('#user_user_type')[0].value;
   init();
 

--- a/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
+++ b/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
@@ -52,7 +52,6 @@ $(document).ready(() => {
 
   function init() {
     setUserType(getUserType());
-    styleSelectedUserTypeButton(getUserType());
     renderSchoolInfo();
     renderParentSignUpSection();
   }
@@ -124,12 +123,10 @@ $(document).ready(() => {
   // Event listeners for changing the user type
   document.addEventListener('selectUserTypeTeacher', e => {
     $('#user_user_type').val('teacher');
-    styleSelectedUserTypeButton('teacher');
     setUserType('teacher');
   });
   document.addEventListener('selectUserTypeStudent', e => {
     $('#user_user_type').val('student');
-    styleSelectedUserTypeButton('student');
     setUserType('student');
   });
 
@@ -170,6 +167,7 @@ $(document).ready(() => {
       // Show student fields by default.
       switchToStudent();
     }
+    styleSelectedUserTypeButton(userType);
   }
 
   function switchToTeacher() {

--- a/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
+++ b/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
@@ -48,10 +48,13 @@ let userInOptimizelyVariant = experiments.isEnabled(
 
 $(document).ready(() => {
   const schoolInfoMountPoint = document.getElementById('school-info-inputs');
+
+  // Keep track of user type
+  let userType = $('#user_user_type')[0].value;
   init();
 
   function init() {
-    setUserType(getUserType());
+    setUserType(userType);
     renderSchoolInfo();
     renderParentSignUpSection();
   }
@@ -67,7 +70,7 @@ $(document).ready(() => {
     }
 
     // Trigger Optimizely counter for user type selection
-    optimizelyCountUserTypeSelection(getUserType());
+    optimizelyCountUserTypeSelection(userType);
 
     // Optimizely-related code for teacher opting to share email with regional partner (start)
     optimizelyCountSuccessSignupWithRegPartnerOpt();
@@ -75,7 +78,7 @@ $(document).ready(() => {
 
     alreadySubmitted = true;
     // Clean up school data and set age for teachers.
-    if (getUserType() === 'teacher') {
+    if (userType === 'teacher') {
       cleanSchoolInfo();
       $('#user_age').val('21+');
     }
@@ -101,7 +104,7 @@ $(document).ready(() => {
   $('#user_parent_email_preference_opt_in_required').change(function() {
     // If the user_type is currently blank, switch the user_type to 'student' because that is the only user_type which
     // allows the parent sign up section of the form.
-    if (getUserType() === '') {
+    if (userType === '') {
       $('#user_user_type')
         .val('student')
         .change();
@@ -152,22 +155,19 @@ $(document).ready(() => {
     window['optimizely'].push({type: 'event', eventName: 'successSignUp'});
   }
 
-  function getUserType() {
-    return $('#user_user_type')[0].value;
-  }
-
-  function setUserType(userType) {
-    if (userType) {
-      trackUserType(userType);
+  function setUserType(newUserType) {
+    if (newUserType) {
+      trackUserType(newUserType);
     }
 
-    if (userType === 'teacher') {
+    if (newUserType === 'teacher') {
       switchToTeacher();
     } else {
       // Show student fields by default.
       switchToStudent();
     }
-    styleSelectedUserTypeButton(userType);
+    styleSelectedUserTypeButton(newUserType);
+    userType = newUserType;
   }
 
   function switchToTeacher() {

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -33,7 +33,6 @@ experiments.TIME_SPENT = 'time-spent';
 experiments.BYPASS_DIALOG_POPUP = 'bypass-dialog-popup';
 experiments.SPECIAL_TOPIC = 'special-topic';
 experiments.POEM_BOT = 'poemBot';
-experiments.CLEARER_SIGN_UP_USER_TYPE = 'clearerSignUpUserType';
 experiments.OPT_IN_EMAIL_REG_PARTNER = 'optInEmailRegPartner';
 experiments.MULTISELECT = 'multiselect';
 

--- a/dashboard/app/views/devise/registrations/_finish_sign_up.html.haml
+++ b/dashboard/app/views/devise/registrations/_finish_sign_up.html.haml
@@ -30,7 +30,6 @@
         = f.label :user_type, t('signup_form.user_type_label')
         - if @user.errors[:user_type].present?
           %p.error= t('activerecord.errors.messages.blank')
-      -# Sign-up user type variant
       .span5{:id => 'select-user-type-variant'}
         %button.select-user-type-student-button{id: 'select-user-type-student', type: 'button', onClick: 'selectUserTypeStudent()'}
           %b.user-type-name= t('signup_form.user_type_student')
@@ -46,8 +45,7 @@
             %li= t('signup_form.user_type_teacher_ability_2')
             %li= t('signup_form.user_type_teacher_ability_3')
             %li= t('signup_form.user_type_teacher_ability_4')
-      -# Sign-up user type original
-      .span5{:id => 'select-user-type-original'}
+      .span5{:id => 'select-user-type-original', :style => 'display:none;'}
         = f.select :user_type, user_type_options, {include_blank: true}, {disabled: @user.should_disable_user_type?}
       .span2
     .row#parent-email-container


### PR DESCRIPTION
Removed unnecessary code now that the 'Clearer Sign-up User Type Selection' Optimizely experiment has concluded. [The results](https://app.optimizely.com/v2/projects/12977480133/results/20603050402/experiments/20592950647?previousView=VARIATIONS) showed that there was no statistically significant decrease in user sign-ups due to the user type button changes.

This includes both removing code added only for the duration of the experiment (i.e. toggling between the original and the variant) and replacing the original design with the variant design. For tracking user type selection before the sign-up form is submitted, I switched to using a local variable since the previously-used dropdown is no longer being used so user type can easily be tracked in the `_finish_sign_up.js` file. The variable `$('#user_type')` is referenced upon declaring the user type variable so that any previous user type selections in this session will persist in case the page refreshes (e.g. the user doesn't fill in all required fields and tries to submit the sign-up form).

This PR will reflect the changes in [this PR](https://github.com/code-dot-org/code-dot-org/pull/41608) but will no longer contain code kept for the Optimizely experiment.

## Links
- [Original PR this relates to](https://github.com/code-dot-org/code-dot-org/pull/41608)
- [Optimizely experiment results](https://app.optimizely.com/v2/projects/12977480133/results/20603050402/experiments/20592950647?previousView=VARIATIONS)

## Testing story
I ensured the behavior was identical to the results of the original and manually tested by switching between Student and Teacher account types and made an account with both successfully. Also checked that the user cannot create an account without explicitly clicking either 'Student' or 'Teacher.'

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
