### PR TITLE
Add more validation for programming expression keys

### DIFF
--- a/dashboard/app/models/programming_expression.rb
+++ b/dashboard/app/models/programming_expression.rb
@@ -24,19 +24,33 @@ class ProgrammingExpression < ApplicationRecord
   has_and_belongs_to_many :lessons, join_table: :lessons_programming_expressions
   has_many :lessons_programming_expressions
 
-  validates_uniqueness_of :key, scope: :programming_environment_id
+  validates_uniqueness_of :key, scope: :programming_environment_id, case_sensitive: false
+  validate :key_format
 
   serialized_attrs %w(
     color
     syntax
   )
 
-  KEY_CHAR_RE = /[A-Za-z0-9\-\_\.]/
-  KEY_RE = /\A#{KEY_CHAR_RE}+\Z/
-  validates_format_of :key,
-    presence: true,
-    with: KEY_RE,
-    message: "must only be letters, numbers, dashes, underscores, and periods. Got \"%{value}\""
+  def key_format
+    if key.blank?
+      errors.add(:base, 'Key must not be blank')
+      return false
+    end
+
+    if key[0] == '.' || key[-1] == '.'
+      errors.add(:base, 'Key cannot start or end with period')
+      return false
+    end
+
+    key_char_re = /[A-Za-z0-9\-\_\.]/
+    key_re = /\A#{key_char_re}+\Z/
+    unless key_re.match?(key)
+      errors.add(:base, "must only be letters, numbers, dashes, underscores, and periods. Got ${key}")
+      return false
+    end
+    return true
+  end
 
   def self.properties_from_file(path, content)
     expression_config = JSON.parse(content)

--- a/dashboard/test/models/programming_expression_test.rb
+++ b/dashboard/test/models/programming_expression_test.rb
@@ -14,9 +14,40 @@ class ProgrammingExpressionTest < ActiveSupport::TestCase
     assert_equal 1, lesson.programming_expressions.length
   end
 
-  test "programming expression cannot have invalid key" do
-    assert_raises ActiveRecord::RecordInvalid do
-      ProgrammingExpression.create!(key: 'an invalid key', name: 'invalid block')
+  class KeyConstraintTests < ActiveSupport::TestCase
+    setup do
+      @programming_environment = create :programming_environment
+    end
+
+    test "programming expression key cannot be blank" do
+      assert_raises ActiveRecord::RecordInvalid do
+        ProgrammingExpression.create!(key: '', name: 'invalid block', programming_environment_id: @programming_environment.id)
+      end
+    end
+
+    test "programming expression cannot key with invalid characters" do
+      assert_raises ActiveRecord::RecordInvalid do
+        ProgrammingExpression.create!(key: 'an invalid key', name: 'invalid block', programming_environment_id: @programming_environment.id)
+      end
+    end
+
+    test "programming expression key cannot start with a period" do
+      assert_raises ActiveRecord::RecordInvalid do
+        ProgrammingExpression.create!(key: '.key', name: 'invalid block', programming_environment_id: @programming_environment.id)
+      end
+    end
+
+    test "programming expression key cannot end with a period" do
+      assert_raises ActiveRecord::RecordInvalid do
+        ProgrammingExpression.create!(key: 'key.', name: 'invalid block', programming_environment_id: @programming_environment.id)
+      end
+    end
+
+    test "programming expression key uniqueness ignores casing" do
+      create :programming_expression, key: 'myBlock', programming_environment: @programming_environment
+      assert_raises ActiveRecord::RecordInvalid do
+        ProgrammingExpression.create!(key: 'myblock', name: 'invalid block', programming_environment_id: @programming_environment.id)
+      end
     end
   end
 end


### PR DESCRIPTION
Follow up to #42689.

Adds more robust validation for programming expression key format:
- keys must be case-insensitive unique within a programming environment
- keys must not start or end with a period
- key must not be blank (unchanged in this PR)
- keys must only contain letters, numbers, period, underscores, or dashes (unchanged in this PR)

These keys will be used in both files and URLs. I may need to add more constraints in the future, but I figured this was a start.

## Testing story

added unit tests


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
