### PR TITLE
Fix lesson overview page bug

### DIFF
--- a/apps/src/templates/instructions/TopInstructions.jsx
+++ b/apps/src/templates/instructions/TopInstructions.jsx
@@ -620,8 +620,8 @@ class TopInstructions extends Component {
 
     const studentHasFeedback = this.isViewingAsStudent && feedbacks.length > 0;
 
-    // If we're displaying the review tab the teacher can leave feedback in that tab
-    // so we hide the teacher feedback tab if there's no rubric to avoid confusion about
+    // If we're displaying the review tab (for CSA peer review) the teacher can leave feedback in that tab,
+    // in that case we hide the feedback tab (unless there's a rubric) to avoid confusion about
     // where the teacher should leave feedback
     const displayFeedback =
       !!rubric ||

--- a/apps/src/templates/instructions/teacherFeedback/TeacherFeedback.jsx
+++ b/apps/src/templates/instructions/teacherFeedback/TeacherFeedback.jsx
@@ -357,7 +357,8 @@ export default connect(
     verifiedTeacher: state.pageConstants && state.pageConstants.verifiedTeacher,
     selectedSectionId:
       state.teacherSections && state.teacherSections.selectedSectionId,
-    canHaveFeedbackReviewState: state.pageConstants.canHaveFeedbackReviewState
+    canHaveFeedbackReviewState:
+      state.pageConstants && state.pageConstants.canHaveFeedbackReviewState
   }),
   dispatch => ({
     updateUserProgress(userId) {


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
We have a bug where TopInstructions is rendered without redux, so the child - TeacherFeedback component could not get `canHaveFeedbackReviewState` from the redux state.pageConstants because `pageConstants` did not exist in this context. 

What I've done here is a quick patch to fix the bug. Testing this is a little bit difficult and would require more of an integration test since several components and redux are involved. In the past I've considered whether TeacherFeedback should be a connected component or not, after this bug I'm leaning towards no. However, I'd like a bit more time to think about what the right pattern is for this, so I've created myself a ticket to revisit this when I have more time https://codedotorg.atlassian.net/browse/LP-2060.

Dialog now opens:
<img width="1171" alt="Screen Shot 2021-09-28 at 4 11 42 PM" src="https://user-images.githubusercontent.com/24235215/135179294-8aff86ea-0ab8-40e9-96cd-bf6aedfa27fb.png">

## Links
Slack thread: https://codedotorg.slack.com/archives/CA3KCSGTD/p1632859982104300
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
I just tested this manually, setting up the full integration test needed is a bit of a pain and I want to revisit this area anyway so I'm postponing writing tests for now.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
