### PR TITLE
[Poetry][HOC] Level config for default poem

### DIFF
--- a/apps/src/p5lab/poetry/PoemSelector.jsx
+++ b/apps/src/p5lab/poetry/PoemSelector.jsx
@@ -1,4 +1,5 @@
-import React from 'react';
+/* global appOptions */
+import React, {useState} from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import {setPoem} from '../redux/poetry';
@@ -7,19 +8,29 @@ import {APP_WIDTH} from '../constants';
 import {POEMS} from './constants';
 
 function PoemSelector(props) {
+  const [selectedPoem, setSelectedPoem] = useState(undefined);
+
   const onChange = e => {
     const poemTitle = e.target.value;
+    setSelectedPoem(poemTitle);
     const poem = Object.values(POEMS).find(poem => poem.title === poemTitle);
     if (poem) {
       props.onChangePoem(poem);
     }
   };
+
+  if (!selectedPoem) {
+    const defaultPoem = POEMS[appOptions.level.defaultPoem];
+    setSelectedPoem(defaultPoem.title);
+    props.onChangePoem(defaultPoem);
+  }
+
   return (
     <div style={styles.container}>
       <label>
         <b>{msg.selectPoem()}</b>
       </label>
-      <select style={styles.selector} onChange={onChange}>
+      <select value={selectedPoem} style={styles.selector} onChange={onChange}>
         {Object.values(POEMS).map(poem => (
           <option key={poem.title} value={poem.title}>
             {poem.title}

--- a/dashboard/app/models/levels/poetry.rb
+++ b/dashboard/app/models/levels/poetry.rb
@@ -25,6 +25,10 @@
 #
 
 class Poetry < GamelabJr
+  serialized_attrs %w(
+    default_poem
+  )
+
   def self.skins
     ['gamelab']
   end
@@ -53,5 +57,26 @@ class Poetry < GamelabJr
   end
 
   def common_blocks(type)
+  end
+
+  # Used by levelbuilders to set a default poem on a Poetry level.
+  def self.hoc_poems
+    [
+      ['My Brilliant Image', 'hafez'],
+      ['Twinkle, Twinkle Little Star', 'carroll_1'],
+      ['Crocodile', 'carroll_2'],
+      ['Jabberwocky', 'carroll_3'],
+      ['Sing', 'rumi_1'],
+      ['Ocean', 'rumi_2'],
+      ['Wynken, Blynken, and Nod', 'field'],
+      ['Warm Summer Sun', 'twain'],
+      ['I Wandered Lonely as a Cloud', 'wordsworth'],
+      ['Harlem', 'hughes'],
+      ['Don\'t Go Into the Library', 'rios'],
+      ['Dream Variations', 'hughes_1'],
+      ['In the Garden', 'hopler'],
+      ['Return', 'lomeli'],
+      ['Toasting Marshmallows', 'singer']
+    ]
   end
 end

--- a/dashboard/app/views/levels/editors/_poetry.html.haml
+++ b/dashboard/app/views/levels/editors/_poetry.html.haml
@@ -5,6 +5,8 @@
 = render partial: 'levels/editors/fields/bubble_choice_sublevel', locals: {f: f}
 = render partial: 'levels/editors/fields/special_level_types', locals: {f: f}
 
+= render partial: 'levels/editors/fields/default_poem', locals: {f: f}
+
 = render partial: 'levels/editors/fields/debugger', locals: {f: f}
 = render partial: 'levels/editors/fields/control_buttons', locals: {f: f}
 = render partial: 'levels/editors/fields/animation', locals: {f: f}

--- a/dashboard/app/views/levels/editors/fields/_default_poem.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_default_poem.html.haml
@@ -1,0 +1,6 @@
+%h1.control-legend{data: {toggle: "collapse", target: "#defaultPoem"}}
+  Default Poem
+
+#defaultPoem.in.collapse
+  = f.label :default_poem, 'Default Poem'
+  = f.select :default_poem, options_for_select(@level.class.hoc_poems, @level.default_poem)


### PR DESCRIPTION
Enables levelbuilders to set the default poem for each level. Modeled closely after how default songs work in dance party.

Levelbuilder edit field:
![image](https://user-images.githubusercontent.com/8787187/135201924-1cb04492-7c8c-4e9a-ac7d-7634f7dec255.png)
![image](https://user-images.githubusercontent.com/8787187/135201952-4e663499-bedc-4972-a336-db33377d1a2e.png)

On first page load:
![image](https://user-images.githubusercontent.com/8787187/135201970-3eecf96e-dd15-4a2c-a9ec-4e13641b9628.png)

After manually selecting a different poem from the dropdown:
![image](https://user-images.githubusercontent.com/8787187/135201986-eed9c654-9918-402b-bf5c-0e93139d831e.png)
