### PR TITLE
[Levelbuilder] Fix import path for Blockly edit pages

### DIFF
--- a/apps/src/sites/studio/pages/blocks/edit.js
+++ b/apps/src/sites/studio/pages/blocks/edit.js
@@ -6,7 +6,7 @@ import {parseElement} from '@cdo/apps/xml';
 import {installCustomBlocks} from '@cdo/apps/block_utils';
 import {customInputTypes as spritelabCustomInputTypes} from '@cdo/apps/p5lab/spritelab/blocks';
 import {customInputTypes as dancelabCustomInputTypes} from '@cdo/apps/dance/blocks';
-import {valueTypeTabShapeMap} from '@cdo/apps/p5lab/constants';
+import {valueTypeTabShapeMap} from '@cdo/apps/p5lab/spritelab/constants';
 import animationList, {
   setInitialAnimationList
 } from '@cdo/apps/p5lab/redux/animationList';

--- a/apps/src/sites/studio/pages/blocks/index.js
+++ b/apps/src/sites/studio/pages/blocks/index.js
@@ -4,7 +4,7 @@ import jsonic from 'jsonic';
 import {parseElement} from '@cdo/apps/xml';
 import {installCustomBlocks} from '@cdo/apps/block_utils';
 import {customInputTypes} from '@cdo/apps/p5lab/spritelab/blocks';
-import {valueTypeTabShapeMap} from '@cdo/apps/p5lab/constants';
+import {valueTypeTabShapeMap} from '@cdo/apps/p5lab/spritelab/constants';
 import {shrinkBlockSpaceContainer} from '@cdo/apps/templates/instructions/utils';
 import animationList, {
   setInitialAnimationList

--- a/apps/src/sites/studio/pages/shared_blockly_functions/edit.js
+++ b/apps/src/sites/studio/pages/shared_blockly_functions/edit.js
@@ -3,7 +3,7 @@ import unzip from 'lodash/unzip';
 import assetUrl from '@cdo/apps/code-studio/assetUrl';
 
 import {install, customInputTypes} from '@cdo/apps/p5lab/spritelab/blocks';
-import {valueTypeTabShapeMap} from '@cdo/apps/p5lab/constants';
+import {valueTypeTabShapeMap} from '@cdo/apps/p5lab/spritelab/constants';
 import {installCustomBlocks} from '@cdo/apps/block_utils';
 
 const customSimpleDialog = function({


### PR DESCRIPTION
Quick follow up to https://github.com/code-dot-org/code-dot-org/pull/42592 just to fix a couple wrong import paths.
The block edit pages on levelbuilder are currently broken because of these imports.
![image](https://user-images.githubusercontent.com/8787187/135299818-e78dc1fe-c86f-4c3a-8bb1-bf30941a37cd.png)

No user-facing issues since these pages are accessible to levelbuilders only.