### PR TITLE
Update behavior_definition block ids

### DIFF
--- a/bin/oneoff/update_behavior_blocks_ids.rb
+++ b/bin/oneoff/update_behavior_blocks_ids.rb
@@ -6,6 +6,25 @@
 
 require_relative '../../dashboard/config/environment'
 
+BEHAVIORAL_DEFINITION_NAMES = %w(
+  driving with arrow keys
+  growing
+  jittering
+  moving east
+  moving north
+  moving south
+  moving west
+  moving with arrow keys
+  patrolling
+  shrinking
+  spinning left
+  spinning right
+  swimming left and right
+  wandering
+  chasing
+  acting goofy
+).freeze
+
 def for_each_level_file(&block)
   Dir.glob(Rails.root.join('config/scripts/**/*.level')).sort.map(&block)
 end
@@ -14,7 +33,7 @@ def level_name_from_path(path)
   File.basename(path, File.extname(path))
 end
 
-def update_wandering_behavior_blocks
+def update_behavior_blocks_ids
   updated_levels = 0
   skipped_levels = 0
 
@@ -27,15 +46,21 @@ def update_wandering_behavior_blocks
       next
     end
 
-    # Get all behavior_definition blocks that have "wandering" as their title text and id not set to "wandering"
-    titles = xml.xpath("//block[@type='behavior_definition']//title[text()='wandering'][not(@id = 'wandering')]")
-    if titles.empty?
-      skipped_levels += 1
-      next
+    # Get all behavior_definition blocks that have title texts and ids that are different
+    did_skip = true
+    BEHAVIORAL_DEFINITION_NAMES.each do |name|
+      titles = xml.xpath("//block[@type='behavior_definition']//title[text()='#{name}'][not(@id = '#{name}')]")
+      next if titles.empty?
+
+      titles.each do |title|
+        title['id'] = name
+      end
+      did_skip = false
     end
 
-    titles.each do |title|
-      title['id'] = 'wandering'
+    if did_skip
+      skipped_levels += 1
+      next
     end
 
     raw_level_data = xml.root.to_s
@@ -49,7 +74,7 @@ def update_wandering_behavior_blocks
   end
 
   puts "#{skipped_levels} level files didn't need updating"
-  puts "#{updated_levels} level files that had a wandering behavior_definition title updated"
+  puts "#{updated_levels} level files that had a behavior_definition title updated"
 end
 
-update_wandering_behavior_blocks
+update_behavior_blocks_ids

--- a/bin/oneoff/update_behavior_blocks_ids.rb
+++ b/bin/oneoff/update_behavior_blocks_ids.rb
@@ -1,8 +1,8 @@
 #!/usr/bin/env ruby
 
-# wandering behavioral blocks with no id set have their id
-# set on the frontend as their text value. This causes issues
-# when viewing the levels in different languages.
+# Behavioral blocks with no id set have their id
+# set on the frontend as their text value. This causes
+# issues when viewing the levels in different languages.
 
 require_relative '../../dashboard/config/environment'
 

--- a/bin/oneoff/update_wandering_behavior_blocks.rb
+++ b/bin/oneoff/update_wandering_behavior_blocks.rb
@@ -1,0 +1,55 @@
+#!/usr/bin/env ruby
+
+# wandering behavioral blocks with no id set have their id
+# set on the frontend as their text value. This causes issues
+# when viewing the levels in different languages.
+
+require_relative '../../dashboard/config/environment'
+
+def for_each_level_file(&block)
+  Dir.glob(Rails.root.join('config/scripts/**/*.level')).sort.map(&block)
+end
+
+def level_name_from_path(path)
+  File.basename(path, File.extname(path))
+end
+
+def update_wandering_behavior_blocks
+  updated_levels = 0
+  skipped_levels = 0
+
+  for_each_level_file do |path|
+    raw_level_data = File.read(path)
+
+    xml = Nokogiri::XML(raw_level_data, &:noblanks)
+    if xml.nil?
+      skipped_levels += 1
+      next
+    end
+
+    # Get all behavior_definition blocks that have "wandering" as their title text and id not set to "wandering"
+    titles = xml.xpath("//block[@type='behavior_definition']//title[text()='wandering'][not(@id = 'wandering')]")
+    if titles.empty?
+      skipped_levels += 1
+      next
+    end
+
+    titles.each do |title|
+      title['id'] = 'wandering'
+    end
+
+    raw_level_data = xml.root.to_s
+    File.write(path, raw_level_data)
+    updated_levels += 1
+  rescue Exception => e
+    # print filename for better debugging
+    new_e = Exception.new("in level: #{path}: #{e.message}")
+    new_e.set_backtrace(e.backtrace)
+    raise new_e
+  end
+
+  puts "#{skipped_levels} level files didn't need updating"
+  puts "#{updated_levels} level files that had a wandering behavior_definition title updated"
+end
+
+update_wandering_behavior_blocks

--- a/dashboard/config/scripts/levels/AllTheThings sprite lab with video.level
+++ b/dashboard/config/scripts/levels/AllTheThings sprite lab with video.level
@@ -313,7 +313,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/AllTheThings sprite lab with video.level
+++ b/dashboard/config/scripts/levels/AllTheThings sprite lab with video.level
@@ -234,7 +234,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -256,7 +256,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -431,7 +431,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -452,7 +452,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/AmandaSpriteLab.level
+++ b/dashboard/config/scripts/levels/AmandaSpriteLab.level
@@ -250,7 +250,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>change the size of a sprite</description>
             </mutation>
-            <title name="NAME">shrinking</title>
+            <title name="NAME" id="shrinking">shrinking</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -272,7 +272,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>change the size of a sprite</description>
             </mutation>
-            <title name="NAME">growing</title>
+            <title name="NAME" id="growing">growing</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -461,7 +461,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>randomly change the size of a sprite</description>
             </mutation>
-            <title name="NAME">jittering</title>
+            <title name="NAME" id="jittering">jittering</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -514,7 +514,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>move a sprite across the screen, reversing direction if it touches the edges</description>
             </mutation>
-            <title name="NAME">patrolling</title>
+            <title name="NAME" id="patrolling">patrolling</title>
             <statement name="STACK">
               <block type="gamelab_moveForward">
                 <value name="SPRITE">

--- a/dashboard/config/scripts/levels/AmandaSpriteLab.level
+++ b/dashboard/config/scripts/levels/AmandaSpriteLab.level
@@ -58,7 +58,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>move a sprite, changing its direction randomly</description>
             </mutation>
-            <title name="NAME">wandering</title>
+            <title name="NAME" id="wandering">wandering</title>
             <statement name="STACK">
               <block type="controls_if">
                 <value name="IF0">

--- a/dashboard/config/scripts/levels/Anjali Test Sprite Lab Project.level
+++ b/dashboard/config/scripts/levels/Anjali Test Sprite Lab Project.level
@@ -243,7 +243,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if" inline="false">
               <value name="IF0">
@@ -775,7 +775,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>move a sprite, changing its direction randomly</description>
             </mutation>
-            <title name="NAME">wandering</title>
+            <title name="NAME" id="wandering">wandering</title>
             <statement name="STACK">
               <block type="controls_if">
                 <value name="IF0">

--- a/dashboard/config/scripts/levels/Anjali Test Sprite Lab Project.level
+++ b/dashboard/config/scripts/levels/Anjali Test Sprite Lab Project.level
@@ -87,7 +87,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true">
               <title name="PROPERTY">"scale"</title>
@@ -108,7 +108,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true">
               <title name="PROPERTY">"scale"</title>
@@ -960,7 +960,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>change the size of a sprite</description>
             </mutation>
-            <title name="NAME">shrinking</title>
+            <title name="NAME" id="shrinking">shrinking</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -982,7 +982,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>change the size of a sprite</description>
             </mutation>
-            <title name="NAME">growing</title>
+            <title name="NAME" id="growing">growing</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -1171,7 +1171,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>randomly change the size of a sprite</description>
             </mutation>
-            <title name="NAME">jittering</title>
+            <title name="NAME" id="jittering">jittering</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -1224,7 +1224,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>move a sprite across the screen, reversing direction if it touches the edges</description>
             </mutation>
-            <title name="NAME">patrolling</title>
+            <title name="NAME" id="patrolling">patrolling</title>
             <statement name="STACK">
               <block type="gamelab_moveForward">
                 <value name="SPRITE">

--- a/dashboard/config/scripts/levels/CSTAdata1b.level
+++ b/dashboard/config/scripts/levels/CSTAdata1b.level
@@ -433,7 +433,7 @@
             <arg name="speed" type="Number"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">
@@ -982,7 +982,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>move a sprite, changing its direction randomly</description>
             </mutation>
-            <title name="NAME">wandering</title>
+            <title name="NAME" id="wandering">wandering</title>
             <statement name="STACK">
               <block type="controls_if">
                 <value name="IF0">

--- a/dashboard/config/scripts/levels/CSTAdata1b.level
+++ b/dashboard/config/scripts/levels/CSTAdata1b.level
@@ -1167,7 +1167,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>change the size of a sprite</description>
             </mutation>
-            <title name="NAME">shrinking</title>
+            <title name="NAME" id="shrinking">shrinking</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -1189,7 +1189,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>change the size of a sprite</description>
             </mutation>
-            <title name="NAME">growing</title>
+            <title name="NAME" id="growing">growing</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -1378,7 +1378,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>randomly change the size of a sprite</description>
             </mutation>
-            <title name="NAME">jittering</title>
+            <title name="NAME" id="jittering">jittering</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -1431,7 +1431,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>move a sprite across the screen, reversing direction if it touches the edges</description>
             </mutation>
-            <title name="NAME">patrolling</title>
+            <title name="NAME" id="patrolling">patrolling</title>
             <statement name="STACK">
               <block type="gamelab_moveForward">
                 <value name="SPRITE">

--- a/dashboard/config/scripts/levels/Code Break E12 Practice.level
+++ b/dashboard/config/scripts/levels/Code Break E12 Practice.level
@@ -1243,7 +1243,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Code Break E12 Practice.level
+++ b/dashboard/config/scripts/levels/Code Break E12 Practice.level
@@ -943,7 +943,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -1132,7 +1132,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -1212,7 +1212,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -1362,7 +1362,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/CodeBreak E02 Beg Challenge 1.level
+++ b/dashboard/config/scripts/levels/CodeBreak E02 Beg Challenge 1.level
@@ -76,7 +76,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/CodeBreak E02 Beg Challenge 1.level
+++ b/dashboard/config/scripts/levels/CodeBreak E02 Beg Challenge 1.level
@@ -261,7 +261,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -283,7 +283,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -472,7 +472,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -525,7 +525,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/CodeBreak E02 Beg Challenge 2.level
+++ b/dashboard/config/scripts/levels/CodeBreak E02 Beg Challenge 2.level
@@ -271,7 +271,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -293,7 +293,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -482,7 +482,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -535,7 +535,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/CodeBreak E02 Beg Challenge 2.level
+++ b/dashboard/config/scripts/levels/CodeBreak E02 Beg Challenge 2.level
@@ -86,7 +86,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/CodeBreak E05 Beg Challenge1.level
+++ b/dashboard/config/scripts/levels/CodeBreak E05 Beg Challenge1.level
@@ -264,7 +264,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -286,7 +286,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -475,7 +475,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -528,7 +528,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -961,7 +961,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -983,7 +983,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -1172,7 +1172,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -1225,7 +1225,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/CodeBreak E05 Beg Challenge1.level
+++ b/dashboard/config/scripts/levels/CodeBreak E05 Beg Challenge1.level
@@ -79,7 +79,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">
@@ -702,7 +702,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/CodeBreak E05 Beg Practice.level
+++ b/dashboard/config/scripts/levels/CodeBreak E05 Beg Practice.level
@@ -264,7 +264,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -286,7 +286,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -475,7 +475,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -528,7 +528,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -776,7 +776,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -798,7 +798,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -987,7 +987,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -1040,7 +1040,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/CodeBreak E05 Beg Practice.level
+++ b/dashboard/config/scripts/levels/CodeBreak E05 Beg Practice.level
@@ -79,7 +79,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">
@@ -591,7 +591,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/CodeBreak E05 Int Challenge1.level
+++ b/dashboard/config/scripts/levels/CodeBreak E05 Int Challenge1.level
@@ -82,7 +82,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">
@@ -705,7 +705,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/CodeBreak E05 Int Challenge1.level
+++ b/dashboard/config/scripts/levels/CodeBreak E05 Int Challenge1.level
@@ -267,7 +267,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -289,7 +289,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -478,7 +478,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -531,7 +531,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -964,7 +964,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -986,7 +986,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -1175,7 +1175,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -1228,7 +1228,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/CodeBreak E08 Beg Challenge 2.level
+++ b/dashboard/config/scripts/levels/CodeBreak E08 Beg Challenge 2.level
@@ -219,7 +219,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/CodeBreak E08 Beg Challenge1.level
+++ b/dashboard/config/scripts/levels/CodeBreak E08 Beg Challenge1.level
@@ -78,7 +78,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">
@@ -754,7 +754,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/CodeBreak E08 Beg Challenge1.level
+++ b/dashboard/config/scripts/levels/CodeBreak E08 Beg Challenge1.level
@@ -263,7 +263,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -285,7 +285,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -474,7 +474,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -527,7 +527,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -939,7 +939,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -961,7 +961,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -1150,7 +1150,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -1203,7 +1203,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/CodeBreak E12 Practice.level
+++ b/dashboard/config/scripts/levels/CodeBreak E12 Practice.level
@@ -973,7 +973,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -1162,7 +1162,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -1242,7 +1242,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -1392,7 +1392,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/CodeBreak E12 Practice.level
+++ b/dashboard/config/scripts/levels/CodeBreak E12 Practice.level
@@ -1273,7 +1273,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/CourseE_Project_SpriteLab.level
+++ b/dashboard/config/scripts/levels/CourseE_Project_SpriteLab.level
@@ -250,7 +250,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -272,7 +272,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -461,7 +461,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -514,7 +514,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -1115,7 +1115,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>change the size of a sprite</description>
             </mutation>
-            <title name="NAME">shrinking</title>
+            <title name="NAME" id="shrinking">shrinking</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -1137,7 +1137,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>change the size of a sprite</description>
             </mutation>
-            <title name="NAME">growing</title>
+            <title name="NAME" id="growing">growing</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -1326,7 +1326,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>randomly change the size of a sprite</description>
             </mutation>
-            <title name="NAME">jittering</title>
+            <title name="NAME" id="jittering">jittering</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -1379,7 +1379,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>move a sprite across the screen, reversing direction if it touches the edges</description>
             </mutation>
-            <title name="NAME">patrolling</title>
+            <title name="NAME" id="patrolling">patrolling</title>
             <statement name="STACK">
               <block type="gamelab_moveForward">
                 <value name="SPRITE">

--- a/dashboard/config/scripts/levels/CourseE_Project_SpriteLab.level
+++ b/dashboard/config/scripts/levels/CourseE_Project_SpriteLab.level
@@ -65,7 +65,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">
@@ -930,7 +930,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>move a sprite, changing its direction randomly</description>
             </mutation>
-            <title name="NAME">wandering</title>
+            <title name="NAME" id="wandering">wandering</title>
             <statement name="STACK">
               <block type="controls_if">
                 <value name="IF0">

--- a/dashboard/config/scripts/levels/CourseE_Project_SpriteLab_2019.level
+++ b/dashboard/config/scripts/levels/CourseE_Project_SpriteLab_2019.level
@@ -77,7 +77,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/CourseE_Project_SpriteLab_2019.level
+++ b/dashboard/config/scripts/levels/CourseE_Project_SpriteLab_2019.level
@@ -262,7 +262,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -284,7 +284,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -473,7 +473,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -526,7 +526,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/CourseE_Project_SpriteLab_2020.level
+++ b/dashboard/config/scripts/levels/CourseE_Project_SpriteLab_2020.level
@@ -77,7 +77,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/CourseE_Project_SpriteLab_2020.level
+++ b/dashboard/config/scripts/levels/CourseE_Project_SpriteLab_2020.level
@@ -262,7 +262,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -284,7 +284,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -473,7 +473,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -526,7 +526,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/CourseE_Project_SpriteLab_2021.level
+++ b/dashboard/config/scripts/levels/CourseE_Project_SpriteLab_2021.level
@@ -75,7 +75,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/CourseE_Project_SpriteLab_2021.level
+++ b/dashboard/config/scripts/levels/CourseE_Project_SpriteLab_2021.level
@@ -260,7 +260,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -282,7 +282,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -471,7 +471,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -524,7 +524,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/CourseE_hoops.level
+++ b/dashboard/config/scripts/levels/CourseE_hoops.level
@@ -505,7 +505,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -527,7 +527,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -653,7 +653,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -706,7 +706,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -1440,7 +1440,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>change the size of a sprite</description>
             </mutation>
-            <title name="NAME">shrinking</title>
+            <title name="NAME" id="shrinking">shrinking</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -1462,7 +1462,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>change the size of a sprite</description>
             </mutation>
-            <title name="NAME">growing</title>
+            <title name="NAME" id="growing">growing</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -1651,7 +1651,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>randomly change the size of a sprite</description>
             </mutation>
-            <title name="NAME">jittering</title>
+            <title name="NAME" id="jittering">jittering</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -1704,7 +1704,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>move a sprite across the screen, reversing direction if it touches the edges</description>
             </mutation>
-            <title name="NAME">patrolling</title>
+            <title name="NAME" id="patrolling">patrolling</title>
             <statement name="STACK">
               <block type="gamelab_moveForward">
                 <value name="SPRITE">

--- a/dashboard/config/scripts/levels/CourseE_hoops.level
+++ b/dashboard/config/scripts/levels/CourseE_hoops.level
@@ -248,7 +248,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">
@@ -1255,7 +1255,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>move a sprite, changing its direction randomly</description>
             </mutation>
-            <title name="NAME">wandering</title>
+            <title name="NAME" id="wandering">wandering</title>
             <statement name="STACK">
               <block type="controls_if">
                 <value name="IF0">

--- a/dashboard/config/scripts/levels/CourseE_hoops_2019.level
+++ b/dashboard/config/scripts/levels/CourseE_hoops_2019.level
@@ -255,7 +255,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">
@@ -1274,7 +1274,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>move a sprite, changing its direction randomly</description>
             </mutation>
-            <title name="NAME">wandering</title>
+            <title name="NAME" id="wandering">wandering</title>
             <statement name="STACK">
               <block type="controls_if">
                 <value name="IF0">

--- a/dashboard/config/scripts/levels/CourseE_hoops_2019.level
+++ b/dashboard/config/scripts/levels/CourseE_hoops_2019.level
@@ -512,7 +512,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -534,7 +534,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -660,7 +660,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -713,7 +713,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -1459,7 +1459,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>change the size of a sprite</description>
             </mutation>
-            <title name="NAME">shrinking</title>
+            <title name="NAME" id="shrinking">shrinking</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -1481,7 +1481,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>change the size of a sprite</description>
             </mutation>
-            <title name="NAME">growing</title>
+            <title name="NAME" id="growing">growing</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -1670,7 +1670,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>randomly change the size of a sprite</description>
             </mutation>
-            <title name="NAME">jittering</title>
+            <title name="NAME" id="jittering">jittering</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -1723,7 +1723,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>move a sprite across the screen, reversing direction if it touches the edges</description>
             </mutation>
-            <title name="NAME">patrolling</title>
+            <title name="NAME" id="patrolling">patrolling</title>
             <statement name="STACK">
               <block type="gamelab_moveForward">
                 <value name="SPRITE">

--- a/dashboard/config/scripts/levels/CourseF_Project_SpriteLab.level
+++ b/dashboard/config/scripts/levels/CourseF_Project_SpriteLab.level
@@ -257,7 +257,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -279,7 +279,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -468,7 +468,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -521,7 +521,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -1122,7 +1122,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>change the size of a sprite</description>
             </mutation>
-            <title name="NAME">shrinking</title>
+            <title name="NAME" id="shrinking">shrinking</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -1144,7 +1144,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>change the size of a sprite</description>
             </mutation>
-            <title name="NAME">growing</title>
+            <title name="NAME" id="growing">growing</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -1333,7 +1333,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>randomly change the size of a sprite</description>
             </mutation>
-            <title name="NAME">jittering</title>
+            <title name="NAME" id="jittering">jittering</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -1386,7 +1386,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>move a sprite across the screen, reversing direction if it touches the edges</description>
             </mutation>
-            <title name="NAME">patrolling</title>
+            <title name="NAME" id="patrolling">patrolling</title>
             <statement name="STACK">
               <block type="gamelab_moveForward">
                 <value name="SPRITE">

--- a/dashboard/config/scripts/levels/CourseF_Project_SpriteLab.level
+++ b/dashboard/config/scripts/levels/CourseF_Project_SpriteLab.level
@@ -72,7 +72,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">
@@ -937,7 +937,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>move a sprite, changing its direction randomly</description>
             </mutation>
-            <title name="NAME">wandering</title>
+            <title name="NAME" id="wandering">wandering</title>
             <statement name="STACK">
               <block type="controls_if">
                 <value name="IF0">

--- a/dashboard/config/scripts/levels/CourseF_Project_SpriteLab_2019.level
+++ b/dashboard/config/scripts/levels/CourseF_Project_SpriteLab_2019.level
@@ -159,7 +159,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -181,7 +181,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -370,7 +370,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -423,7 +423,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/CourseF_Project_SpriteLab_2019.level
+++ b/dashboard/config/scripts/levels/CourseF_Project_SpriteLab_2019.level
@@ -481,7 +481,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/CourseF_Project_SpriteLab_2020.level
+++ b/dashboard/config/scripts/levels/CourseF_Project_SpriteLab_2020.level
@@ -145,7 +145,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -167,7 +167,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -356,7 +356,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -409,7 +409,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/CourseF_Project_SpriteLab_2020.level
+++ b/dashboard/config/scripts/levels/CourseF_Project_SpriteLab_2020.level
@@ -467,7 +467,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/CourseF_outbreak1.level
+++ b/dashboard/config/scripts/levels/CourseF_outbreak1.level
@@ -168,7 +168,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/CourseF_outbreak2.level
+++ b/dashboard/config/scripts/levels/CourseF_outbreak2.level
@@ -234,7 +234,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/CourseF_outbreak3.level
+++ b/dashboard/config/scripts/levels/CourseF_outbreak3.level
@@ -252,7 +252,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/CourseF_outbreak4.level
+++ b/dashboard/config/scripts/levels/CourseF_outbreak4.level
@@ -269,7 +269,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/CourseF_outbreak4.level
+++ b/dashboard/config/scripts/levels/CourseF_outbreak4.level
@@ -454,7 +454,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -476,7 +476,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -665,7 +665,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -718,7 +718,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/CourseF_outbreak5.level
+++ b/dashboard/config/scripts/levels/CourseF_outbreak5.level
@@ -320,7 +320,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/CourseF_outbreak6.level
+++ b/dashboard/config/scripts/levels/CourseF_outbreak6.level
@@ -209,7 +209,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="gamelab_withPercentChance">
               <value name="NUM">

--- a/dashboard/config/scripts/levels/CourseF_outbreak7.level
+++ b/dashboard/config/scripts/levels/CourseF_outbreak7.level
@@ -652,7 +652,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -674,7 +674,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -863,7 +863,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -916,7 +916,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/CourseF_outbreak7.level
+++ b/dashboard/config/scripts/levels/CourseF_outbreak7.level
@@ -486,7 +486,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="gamelab_withPercentChance">
               <value name="NUM">

--- a/dashboard/config/scripts/levels/CourseF_outbreak8.level
+++ b/dashboard/config/scripts/levels/CourseF_outbreak8.level
@@ -485,7 +485,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="gamelab_withPercentChance">
               <value name="NUM">

--- a/dashboard/config/scripts/levels/CourseF_outbreak8.level
+++ b/dashboard/config/scripts/levels/CourseF_outbreak8.level
@@ -651,7 +651,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -673,7 +673,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -862,7 +862,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -915,7 +915,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/CourseF_outbreak_freeplay.level
+++ b/dashboard/config/scripts/levels/CourseF_outbreak_freeplay.level
@@ -483,7 +483,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="gamelab_withPercentChance">
               <value name="NUM">

--- a/dashboard/config/scripts/levels/CourseF_outbreak_freeplay.level
+++ b/dashboard/config/scripts/levels/CourseF_outbreak_freeplay.level
@@ -649,7 +649,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -671,7 +671,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -860,7 +860,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -913,7 +913,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/Dance Party 2 Validated.level
+++ b/dashboard/config/scripts/levels/Dance Party 2 Validated.level
@@ -190,7 +190,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if" inline="false">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Dance Party 2 Validated.level
+++ b/dashboard/config/scripts/levels/Dance Party 2 Validated.level
@@ -111,7 +111,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true">
               <title name="PROPERTY">"scale"</title>
@@ -133,7 +133,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward" inline="true">
               <value name="SPRITE">
@@ -308,7 +308,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true">
               <title name="PROPERTY">"scale"</title>
@@ -329,7 +329,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Dance Party 2.level
+++ b/dashboard/config/scripts/levels/Dance Party 2.level
@@ -202,7 +202,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Dance Party 2.level
+++ b/dashboard/config/scripts/levels/Dance Party 2.level
@@ -123,7 +123,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -145,7 +145,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -320,7 +320,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -341,7 +341,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Dance Party 2_2019.level
+++ b/dashboard/config/scripts/levels/Dance Party 2_2019.level
@@ -227,7 +227,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Dance Party 2_2019.level
+++ b/dashboard/config/scripts/levels/Dance Party 2_2019.level
@@ -148,7 +148,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -170,7 +170,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -345,7 +345,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -366,7 +366,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Dance Party 2_2020.level
+++ b/dashboard/config/scripts/levels/Dance Party 2_2020.level
@@ -227,7 +227,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Dance Party 2_2020.level
+++ b/dashboard/config/scripts/levels/Dance Party 2_2020.level
@@ -148,7 +148,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -170,7 +170,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -345,7 +345,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -366,7 +366,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Dance Party 2_2021.level
+++ b/dashboard/config/scripts/levels/Dance Party 2_2021.level
@@ -155,7 +155,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -177,7 +177,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -352,7 +352,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -373,7 +373,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Dance Party 2_2021.level
+++ b/dashboard/config/scripts/levels/Dance Party 2_2021.level
@@ -234,7 +234,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Dance Party 2_control.level
+++ b/dashboard/config/scripts/levels/Dance Party 2_control.level
@@ -143,7 +143,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -165,7 +165,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -340,7 +340,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -361,7 +361,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Dance Party 2_control.level
+++ b/dashboard/config/scripts/levels/Dance Party 2_control.level
@@ -222,7 +222,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Dance Party 2_experiment.level
+++ b/dashboard/config/scripts/levels/Dance Party 2_experiment.level
@@ -143,7 +143,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -165,7 +165,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -340,7 +340,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -361,7 +361,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Dance Party 2_experiment.level
+++ b/dashboard/config/scripts/levels/Dance Party 2_experiment.level
@@ -222,7 +222,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Dance Party 2_simple.level
+++ b/dashboard/config/scripts/levels/Dance Party 2_simple.level
@@ -191,7 +191,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if" inline="false">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Dance Party 2_simple.level
+++ b/dashboard/config/scripts/levels/Dance Party 2_simple.level
@@ -134,7 +134,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is moving, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">moving</title>
+          <title name="NAME" id="moving">moving</title>
           <statement name="STACK">
             <block type="gamelab_moveForward" inline="true">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/Dance Party 3_2019.level
+++ b/dashboard/config/scripts/levels/Dance Party 3_2019.level
@@ -181,7 +181,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -203,7 +203,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -378,7 +378,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -399,7 +399,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Dance Party 3_2019.level
+++ b/dashboard/config/scripts/levels/Dance Party 3_2019.level
@@ -260,7 +260,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Dance Party 3_2020.level
+++ b/dashboard/config/scripts/levels/Dance Party 3_2020.level
@@ -181,7 +181,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -203,7 +203,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -378,7 +378,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -399,7 +399,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Dance Party 3_2020.level
+++ b/dashboard/config/scripts/levels/Dance Party 3_2020.level
@@ -260,7 +260,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Dance Party 3_2021.level
+++ b/dashboard/config/scripts/levels/Dance Party 3_2021.level
@@ -265,7 +265,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Dance Party 3_2021.level
+++ b/dashboard/config/scripts/levels/Dance Party 3_2021.level
@@ -186,7 +186,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -208,7 +208,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -383,7 +383,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -404,7 +404,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Dance Party 3_control.level
+++ b/dashboard/config/scripts/levels/Dance Party 3_control.level
@@ -255,7 +255,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Dance Party 3_control.level
+++ b/dashboard/config/scripts/levels/Dance Party 3_control.level
@@ -176,7 +176,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -198,7 +198,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -373,7 +373,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -394,7 +394,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Dance Party 3_experiment.level
+++ b/dashboard/config/scripts/levels/Dance Party 3_experiment.level
@@ -255,7 +255,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Dance Party 3_experiment.level
+++ b/dashboard/config/scripts/levels/Dance Party 3_experiment.level
@@ -176,7 +176,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -198,7 +198,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -373,7 +373,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -394,7 +394,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Dance Party 4_2019.level
+++ b/dashboard/config/scripts/levels/Dance Party 4_2019.level
@@ -293,7 +293,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Dance Party 4_2019.level
+++ b/dashboard/config/scripts/levels/Dance Party 4_2019.level
@@ -214,7 +214,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -236,7 +236,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -411,7 +411,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -432,7 +432,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Dance Party 4_2020.level
+++ b/dashboard/config/scripts/levels/Dance Party 4_2020.level
@@ -293,7 +293,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Dance Party 4_2020.level
+++ b/dashboard/config/scripts/levels/Dance Party 4_2020.level
@@ -214,7 +214,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -236,7 +236,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -411,7 +411,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -432,7 +432,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Dance Party 4_2021.level
+++ b/dashboard/config/scripts/levels/Dance Party 4_2021.level
@@ -298,7 +298,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Dance Party 4_2021.level
+++ b/dashboard/config/scripts/levels/Dance Party 4_2021.level
@@ -219,7 +219,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -241,7 +241,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -416,7 +416,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -437,7 +437,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Dance Party 4_control.level
+++ b/dashboard/config/scripts/levels/Dance Party 4_control.level
@@ -288,7 +288,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Dance Party 4_control.level
+++ b/dashboard/config/scripts/levels/Dance Party 4_control.level
@@ -209,7 +209,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -231,7 +231,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -406,7 +406,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -427,7 +427,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Dance Party 4_experiment.level
+++ b/dashboard/config/scripts/levels/Dance Party 4_experiment.level
@@ -288,7 +288,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Dance Party 4_experiment.level
+++ b/dashboard/config/scripts/levels/Dance Party 4_experiment.level
@@ -209,7 +209,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -231,7 +231,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -406,7 +406,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -427,7 +427,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Dance Party 5_2019.level
+++ b/dashboard/config/scripts/levels/Dance Party 5_2019.level
@@ -259,7 +259,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -281,7 +281,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -456,7 +456,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -477,7 +477,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Dance Party 5_2019.level
+++ b/dashboard/config/scripts/levels/Dance Party 5_2019.level
@@ -338,7 +338,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Dance Party 5_2020.level
+++ b/dashboard/config/scripts/levels/Dance Party 5_2020.level
@@ -259,7 +259,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -281,7 +281,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -456,7 +456,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -477,7 +477,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Dance Party 5_2020.level
+++ b/dashboard/config/scripts/levels/Dance Party 5_2020.level
@@ -338,7 +338,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Dance Party 5_2021.level
+++ b/dashboard/config/scripts/levels/Dance Party 5_2021.level
@@ -264,7 +264,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -286,7 +286,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -461,7 +461,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -482,7 +482,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Dance Party 5_2021.level
+++ b/dashboard/config/scripts/levels/Dance Party 5_2021.level
@@ -343,7 +343,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Dance Party 5_control.level
+++ b/dashboard/config/scripts/levels/Dance Party 5_control.level
@@ -255,7 +255,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -277,7 +277,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -452,7 +452,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -473,7 +473,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Dance Party 5_control.level
+++ b/dashboard/config/scripts/levels/Dance Party 5_control.level
@@ -334,7 +334,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Dance Party 5_experiment.level
+++ b/dashboard/config/scripts/levels/Dance Party 5_experiment.level
@@ -255,7 +255,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -277,7 +277,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -452,7 +452,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -473,7 +473,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Dance Party 5_experiment.level
+++ b/dashboard/config/scripts/levels/Dance Party 5_experiment.level
@@ -334,7 +334,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Dance Party 6 - Validated.level
+++ b/dashboard/config/scripts/levels/Dance Party 6 - Validated.level
@@ -402,7 +402,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if" inline="false">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Dance Party 6 - Validated.level
+++ b/dashboard/config/scripts/levels/Dance Party 6 - Validated.level
@@ -69,7 +69,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true">
               <title name="PROPERTY">"scale"</title>
@@ -323,7 +323,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true">
               <title name="PROPERTY">"scale"</title>
@@ -345,7 +345,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward" inline="true">
               <value name="SPRITE">
@@ -520,7 +520,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Dance Party 6.level
+++ b/dashboard/config/scripts/levels/Dance Party 6.level
@@ -181,7 +181,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -333,7 +333,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -355,7 +355,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -530,7 +530,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Dance Party 6.level
+++ b/dashboard/config/scripts/levels/Dance Party 6.level
@@ -412,7 +412,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Dance Party 6_2019.level
+++ b/dashboard/config/scripts/levels/Dance Party 6_2019.level
@@ -213,7 +213,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -365,7 +365,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -387,7 +387,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -562,7 +562,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Dance Party 6_2019.level
+++ b/dashboard/config/scripts/levels/Dance Party 6_2019.level
@@ -444,7 +444,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Dance Party 6_2020.level
+++ b/dashboard/config/scripts/levels/Dance Party 6_2020.level
@@ -213,7 +213,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -365,7 +365,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -387,7 +387,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -562,7 +562,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Dance Party 6_2020.level
+++ b/dashboard/config/scripts/levels/Dance Party 6_2020.level
@@ -444,7 +444,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Dance Party 6_2021.level
+++ b/dashboard/config/scripts/levels/Dance Party 6_2021.level
@@ -450,7 +450,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Dance Party 6_2021.level
+++ b/dashboard/config/scripts/levels/Dance Party 6_2021.level
@@ -219,7 +219,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -371,7 +371,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -393,7 +393,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -568,7 +568,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Dance Party 6_control.level
+++ b/dashboard/config/scripts/levels/Dance Party 6_control.level
@@ -209,7 +209,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -361,7 +361,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -383,7 +383,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -558,7 +558,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Dance Party 6_control.level
+++ b/dashboard/config/scripts/levels/Dance Party 6_control.level
@@ -440,7 +440,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Dance Party 6_experiment.level
+++ b/dashboard/config/scripts/levels/Dance Party 6_experiment.level
@@ -209,7 +209,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -361,7 +361,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -383,7 +383,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -558,7 +558,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Dance Party 6_experiment.level
+++ b/dashboard/config/scripts/levels/Dance Party 6_experiment.level
@@ -440,7 +440,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Dance Party 6_simple.level
+++ b/dashboard/config/scripts/levels/Dance Party 6_simple.level
@@ -372,7 +372,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is moving, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">moving</title>
+          <title name="NAME" id="moving">moving</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/Dance Party 6_simple.level
+++ b/dashboard/config/scripts/levels/Dance Party 6_simple.level
@@ -429,7 +429,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Dance Party 7_2019.level
+++ b/dashboard/config/scripts/levels/Dance Party 7_2019.level
@@ -242,7 +242,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -394,7 +394,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -416,7 +416,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -591,7 +591,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Dance Party 7_2019.level
+++ b/dashboard/config/scripts/levels/Dance Party 7_2019.level
@@ -473,7 +473,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Dance Party 7_2020.level
+++ b/dashboard/config/scripts/levels/Dance Party 7_2020.level
@@ -242,7 +242,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -394,7 +394,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -416,7 +416,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -591,7 +591,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Dance Party 7_2020.level
+++ b/dashboard/config/scripts/levels/Dance Party 7_2020.level
@@ -473,7 +473,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Dance Party 7_2021.level
+++ b/dashboard/config/scripts/levels/Dance Party 7_2021.level
@@ -478,7 +478,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Dance Party 7_2021.level
+++ b/dashboard/config/scripts/levels/Dance Party 7_2021.level
@@ -247,7 +247,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -399,7 +399,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -421,7 +421,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -596,7 +596,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Dance Party 7_control.level
+++ b/dashboard/config/scripts/levels/Dance Party 7_control.level
@@ -468,7 +468,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Dance Party 7_control.level
+++ b/dashboard/config/scripts/levels/Dance Party 7_control.level
@@ -237,7 +237,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -389,7 +389,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -411,7 +411,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -586,7 +586,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Dance Party 7_experiment.level
+++ b/dashboard/config/scripts/levels/Dance Party 7_experiment.level
@@ -468,7 +468,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Dance Party 7_experiment.level
+++ b/dashboard/config/scripts/levels/Dance Party 7_experiment.level
@@ -237,7 +237,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -389,7 +389,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -411,7 +411,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -586,7 +586,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Dance Party 7_simple.level
+++ b/dashboard/config/scripts/levels/Dance Party 7_simple.level
@@ -381,7 +381,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Dance Party 7_simple.level
+++ b/dashboard/config/scripts/levels/Dance Party 7_simple.level
@@ -324,7 +324,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is moving, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">moving</title>
+          <title name="NAME" id="moving">moving</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/Dance Party Freeplay.level
+++ b/dashboard/config/scripts/levels/Dance Party Freeplay.level
@@ -358,7 +358,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if" inline="false">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Dance Party Freeplay.level
+++ b/dashboard/config/scripts/levels/Dance Party Freeplay.level
@@ -127,7 +127,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true">
               <title name="PROPERTY">"scale"</title>
@@ -279,7 +279,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true">
               <title name="PROPERTY">"scale"</title>
@@ -301,7 +301,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward" inline="true">
               <value name="SPRITE">
@@ -476,7 +476,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Dance Party Freeplay_simple.level
+++ b/dashboard/config/scripts/levels/Dance Party Freeplay_simple.level
@@ -346,7 +346,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if" inline="false">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Dance Party Freeplay_simple.level
+++ b/dashboard/config/scripts/levels/Dance Party Freeplay_simple.level
@@ -289,7 +289,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is moving, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">moving</title>
+          <title name="NAME" id="moving">moving</title>
           <statement name="STACK">
             <block type="gamelab_moveForward" inline="true">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/Dance Party Template 1_2019.level
+++ b/dashboard/config/scripts/levels/Dance Party Template 1_2019.level
@@ -202,7 +202,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Dance Party Template 1_2019.level
+++ b/dashboard/config/scripts/levels/Dance Party Template 1_2019.level
@@ -123,7 +123,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -145,7 +145,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -320,7 +320,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -341,7 +341,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Dance Party Template 1_2020.level
+++ b/dashboard/config/scripts/levels/Dance Party Template 1_2020.level
@@ -197,7 +197,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Dance Party Template 1_2020.level
+++ b/dashboard/config/scripts/levels/Dance Party Template 1_2020.level
@@ -118,7 +118,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -140,7 +140,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -315,7 +315,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -336,7 +336,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Dance Party Template 1_control.level
+++ b/dashboard/config/scripts/levels/Dance Party Template 1_control.level
@@ -119,7 +119,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -141,7 +141,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -316,7 +316,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -337,7 +337,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Dance Party Template 1_control.level
+++ b/dashboard/config/scripts/levels/Dance Party Template 1_control.level
@@ -198,7 +198,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Dance Party Template 1_experiment.level
+++ b/dashboard/config/scripts/levels/Dance Party Template 1_experiment.level
@@ -119,7 +119,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -141,7 +141,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -316,7 +316,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -337,7 +337,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Dance Party Template 1_experiment.level
+++ b/dashboard/config/scripts/levels/Dance Party Template 1_experiment.level
@@ -198,7 +198,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Dance Party Template 2_2019.level
+++ b/dashboard/config/scripts/levels/Dance Party Template 2_2019.level
@@ -163,7 +163,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -315,7 +315,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -337,7 +337,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -512,7 +512,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Dance Party Template 2_2019.level
+++ b/dashboard/config/scripts/levels/Dance Party Template 2_2019.level
@@ -394,7 +394,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Dance Party Template 2_2020.level
+++ b/dashboard/config/scripts/levels/Dance Party Template 2_2020.level
@@ -392,7 +392,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Dance Party Template 2_2020.level
+++ b/dashboard/config/scripts/levels/Dance Party Template 2_2020.level
@@ -161,7 +161,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -313,7 +313,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -335,7 +335,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -510,7 +510,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Dance Party Template 2_control.level
+++ b/dashboard/config/scripts/levels/Dance Party Template 2_control.level
@@ -162,7 +162,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -314,7 +314,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -336,7 +336,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -511,7 +511,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Dance Party Template 2_control.level
+++ b/dashboard/config/scripts/levels/Dance Party Template 2_control.level
@@ -393,7 +393,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Dance Party Template 2_experiment.level
+++ b/dashboard/config/scripts/levels/Dance Party Template 2_experiment.level
@@ -162,7 +162,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -314,7 +314,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -336,7 +336,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -511,7 +511,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Dance Party Template 2_experiment.level
+++ b/dashboard/config/scripts/levels/Dance Party Template 2_experiment.level
@@ -393,7 +393,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Fish Tank 2-validated_2019.level
+++ b/dashboard/config/scripts/levels/Fish Tank 2-validated_2019.level
@@ -233,7 +233,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -255,7 +255,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -430,7 +430,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -451,7 +451,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Fish Tank 2-validated_2019.level
+++ b/dashboard/config/scripts/levels/Fish Tank 2-validated_2019.level
@@ -312,7 +312,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Fish Tank 2-validated_2020.level
+++ b/dashboard/config/scripts/levels/Fish Tank 2-validated_2020.level
@@ -232,7 +232,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -254,7 +254,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -429,7 +429,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -450,7 +450,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Fish Tank 2-validated_2020.level
+++ b/dashboard/config/scripts/levels/Fish Tank 2-validated_2020.level
@@ -311,7 +311,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Fish Tank 2-validated_2021.level
+++ b/dashboard/config/scripts/levels/Fish Tank 2-validated_2021.level
@@ -238,7 +238,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -260,7 +260,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -435,7 +435,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -456,7 +456,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Fish Tank 2-validated_2021.level
+++ b/dashboard/config/scripts/levels/Fish Tank 2-validated_2021.level
@@ -317,7 +317,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Fish Tank 2-validated_control.level
+++ b/dashboard/config/scripts/levels/Fish Tank 2-validated_control.level
@@ -309,7 +309,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Fish Tank 2-validated_control.level
+++ b/dashboard/config/scripts/levels/Fish Tank 2-validated_control.level
@@ -230,7 +230,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -252,7 +252,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -427,7 +427,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -448,7 +448,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Fish Tank 2-validated_experiment.level
+++ b/dashboard/config/scripts/levels/Fish Tank 2-validated_experiment.level
@@ -309,7 +309,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Fish Tank 2-validated_experiment.level
+++ b/dashboard/config/scripts/levels/Fish Tank 2-validated_experiment.level
@@ -230,7 +230,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -252,7 +252,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -427,7 +427,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -448,7 +448,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Fish Tank 3-validated_2019.level
+++ b/dashboard/config/scripts/levels/Fish Tank 3-validated_2019.level
@@ -287,7 +287,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -309,7 +309,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -484,7 +484,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -505,7 +505,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Fish Tank 3-validated_2019.level
+++ b/dashboard/config/scripts/levels/Fish Tank 3-validated_2019.level
@@ -366,7 +366,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Fish Tank 3-validated_2020.level
+++ b/dashboard/config/scripts/levels/Fish Tank 3-validated_2020.level
@@ -291,7 +291,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -313,7 +313,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -488,7 +488,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -509,7 +509,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Fish Tank 3-validated_2020.level
+++ b/dashboard/config/scripts/levels/Fish Tank 3-validated_2020.level
@@ -370,7 +370,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Fish Tank 3-validated_2021.level
+++ b/dashboard/config/scripts/levels/Fish Tank 3-validated_2021.level
@@ -372,7 +372,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Fish Tank 3-validated_2021.level
+++ b/dashboard/config/scripts/levels/Fish Tank 3-validated_2021.level
@@ -293,7 +293,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -315,7 +315,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -490,7 +490,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -511,7 +511,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Fish Tank 3-validated_control.level
+++ b/dashboard/config/scripts/levels/Fish Tank 3-validated_control.level
@@ -284,7 +284,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -306,7 +306,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -481,7 +481,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -502,7 +502,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Fish Tank 3-validated_control.level
+++ b/dashboard/config/scripts/levels/Fish Tank 3-validated_control.level
@@ -363,7 +363,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Fish Tank 3-validated_experiment.level
+++ b/dashboard/config/scripts/levels/Fish Tank 3-validated_experiment.level
@@ -284,7 +284,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -306,7 +306,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -481,7 +481,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -502,7 +502,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Fish Tank 3-validated_experiment.level
+++ b/dashboard/config/scripts/levels/Fish Tank 3-validated_experiment.level
@@ -363,7 +363,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Fish Tank 4-validated_2019.level
+++ b/dashboard/config/scripts/levels/Fish Tank 4-validated_2019.level
@@ -377,7 +377,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Fish Tank 4-validated_2019.level
+++ b/dashboard/config/scripts/levels/Fish Tank 4-validated_2019.level
@@ -298,7 +298,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -320,7 +320,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -495,7 +495,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -516,7 +516,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Fish Tank 4-validated_2020.level
+++ b/dashboard/config/scripts/levels/Fish Tank 4-validated_2020.level
@@ -378,7 +378,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Fish Tank 4-validated_2020.level
+++ b/dashboard/config/scripts/levels/Fish Tank 4-validated_2020.level
@@ -299,7 +299,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -321,7 +321,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -496,7 +496,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -517,7 +517,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Fish Tank 4-validated_2021.level
+++ b/dashboard/config/scripts/levels/Fish Tank 4-validated_2021.level
@@ -380,7 +380,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Fish Tank 4-validated_2021.level
+++ b/dashboard/config/scripts/levels/Fish Tank 4-validated_2021.level
@@ -301,7 +301,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -323,7 +323,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -498,7 +498,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -519,7 +519,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Fish Tank 4-validated_control.level
+++ b/dashboard/config/scripts/levels/Fish Tank 4-validated_control.level
@@ -296,7 +296,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -318,7 +318,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -493,7 +493,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -514,7 +514,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Fish Tank 4-validated_control.level
+++ b/dashboard/config/scripts/levels/Fish Tank 4-validated_control.level
@@ -375,7 +375,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Fish Tank 4-validated_experiment.level
+++ b/dashboard/config/scripts/levels/Fish Tank 4-validated_experiment.level
@@ -296,7 +296,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -318,7 +318,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -493,7 +493,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -514,7 +514,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Fish Tank 4-validated_experiment.level
+++ b/dashboard/config/scripts/levels/Fish Tank 4-validated_experiment.level
@@ -375,7 +375,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Fish Tank 5-validated_2019.level
+++ b/dashboard/config/scripts/levels/Fish Tank 5-validated_2019.level
@@ -419,7 +419,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Fish Tank 5-validated_2019.level
+++ b/dashboard/config/scripts/levels/Fish Tank 5-validated_2019.level
@@ -340,7 +340,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -362,7 +362,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -537,7 +537,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -558,7 +558,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Fish Tank 5-validated_2019_implicitGroupTest.level
+++ b/dashboard/config/scripts/levels/Fish Tank 5-validated_2019_implicitGroupTest.level
@@ -197,7 +197,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Fish Tank 5-validated_2019_implicitGroupTest.level
+++ b/dashboard/config/scripts/levels/Fish Tank 5-validated_2019_implicitGroupTest.level
@@ -400,7 +400,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -422,7 +422,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -611,7 +611,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -664,7 +664,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/Fish Tank 5-validated_2020.level
+++ b/dashboard/config/scripts/levels/Fish Tank 5-validated_2020.level
@@ -419,7 +419,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Fish Tank 5-validated_2020.level
+++ b/dashboard/config/scripts/levels/Fish Tank 5-validated_2020.level
@@ -340,7 +340,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -362,7 +362,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -537,7 +537,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -558,7 +558,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Fish Tank 5-validated_2021.level
+++ b/dashboard/config/scripts/levels/Fish Tank 5-validated_2021.level
@@ -422,7 +422,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Fish Tank 5-validated_2021.level
+++ b/dashboard/config/scripts/levels/Fish Tank 5-validated_2021.level
@@ -343,7 +343,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -365,7 +365,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -540,7 +540,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -561,7 +561,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Fish Tank 5-validated_control.level
+++ b/dashboard/config/scripts/levels/Fish Tank 5-validated_control.level
@@ -416,7 +416,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Fish Tank 5-validated_control.level
+++ b/dashboard/config/scripts/levels/Fish Tank 5-validated_control.level
@@ -337,7 +337,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -359,7 +359,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -534,7 +534,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -555,7 +555,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Fish Tank 5-validated_experiment.level
+++ b/dashboard/config/scripts/levels/Fish Tank 5-validated_experiment.level
@@ -416,7 +416,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Fish Tank 5-validated_experiment.level
+++ b/dashboard/config/scripts/levels/Fish Tank 5-validated_experiment.level
@@ -337,7 +337,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -359,7 +359,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -534,7 +534,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -555,7 +555,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Fish Tank 6-validated_2019.level
+++ b/dashboard/config/scripts/levels/Fish Tank 6-validated_2019.level
@@ -369,7 +369,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -391,7 +391,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -566,7 +566,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -587,7 +587,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Fish Tank 6-validated_2019.level
+++ b/dashboard/config/scripts/levels/Fish Tank 6-validated_2019.level
@@ -448,7 +448,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Fish Tank 6-validated_2019_clone.level
+++ b/dashboard/config/scripts/levels/Fish Tank 6-validated_2019_clone.level
@@ -443,7 +443,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Fish Tank 6-validated_2019_clone.level
+++ b/dashboard/config/scripts/levels/Fish Tank 6-validated_2019_clone.level
@@ -364,7 +364,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -386,7 +386,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -561,7 +561,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -582,7 +582,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Fish Tank 6-validated_2020.level
+++ b/dashboard/config/scripts/levels/Fish Tank 6-validated_2020.level
@@ -368,7 +368,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -390,7 +390,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -565,7 +565,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -586,7 +586,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Fish Tank 6-validated_2020.level
+++ b/dashboard/config/scripts/levels/Fish Tank 6-validated_2020.level
@@ -447,7 +447,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Fish Tank 6-validated_2021.level
+++ b/dashboard/config/scripts/levels/Fish Tank 6-validated_2021.level
@@ -379,7 +379,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -401,7 +401,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -576,7 +576,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -597,7 +597,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Fish Tank 6-validated_2021.level
+++ b/dashboard/config/scripts/levels/Fish Tank 6-validated_2021.level
@@ -458,7 +458,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Fish Tank 6-validated_control.level
+++ b/dashboard/config/scripts/levels/Fish Tank 6-validated_control.level
@@ -443,7 +443,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Fish Tank 6-validated_control.level
+++ b/dashboard/config/scripts/levels/Fish Tank 6-validated_control.level
@@ -364,7 +364,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -386,7 +386,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -561,7 +561,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -582,7 +582,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Fish Tank 6-validated_experiment.level
+++ b/dashboard/config/scripts/levels/Fish Tank 6-validated_experiment.level
@@ -443,7 +443,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Fish Tank 6-validated_experiment.level
+++ b/dashboard/config/scripts/levels/Fish Tank 6-validated_experiment.level
@@ -364,7 +364,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -386,7 +386,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -561,7 +561,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -582,7 +582,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Fish Tank Template.level
+++ b/dashboard/config/scripts/levels/Fish Tank Template.level
@@ -297,7 +297,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if" inline="false">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Fish Tank Template.level
+++ b/dashboard/config/scripts/levels/Fish Tank Template.level
@@ -218,7 +218,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true">
               <title name="PROPERTY">"scale"</title>
@@ -240,7 +240,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward" inline="true">
               <value name="SPRITE">
@@ -415,7 +415,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true">
               <title name="PROPERTY">"scale"</title>
@@ -436,7 +436,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Fish Tank Template_2019.level
+++ b/dashboard/config/scripts/levels/Fish Tank Template_2019.level
@@ -220,7 +220,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -242,7 +242,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -417,7 +417,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -438,7 +438,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Fish Tank Template_2019.level
+++ b/dashboard/config/scripts/levels/Fish Tank Template_2019.level
@@ -299,7 +299,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Fish Tank Template_2019_clone.level
+++ b/dashboard/config/scripts/levels/Fish Tank Template_2019_clone.level
@@ -223,7 +223,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -245,7 +245,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -420,7 +420,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -441,7 +441,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Fish Tank Template_2019_clone.level
+++ b/dashboard/config/scripts/levels/Fish Tank Template_2019_clone.level
@@ -302,7 +302,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Fish Tank Template_2020.level
+++ b/dashboard/config/scripts/levels/Fish Tank Template_2020.level
@@ -297,7 +297,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Fish Tank Template_2020.level
+++ b/dashboard/config/scripts/levels/Fish Tank Template_2020.level
@@ -218,7 +218,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -240,7 +240,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -415,7 +415,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -436,7 +436,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Fish Tank Template_2021.level
+++ b/dashboard/config/scripts/levels/Fish Tank Template_2021.level
@@ -227,7 +227,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -249,7 +249,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -424,7 +424,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -445,7 +445,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Fish Tank Template_2021.level
+++ b/dashboard/config/scripts/levels/Fish Tank Template_2021.level
@@ -306,7 +306,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Fish Tank Template_control.level
+++ b/dashboard/config/scripts/levels/Fish Tank Template_control.level
@@ -298,7 +298,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Fish Tank Template_control.level
+++ b/dashboard/config/scripts/levels/Fish Tank Template_control.level
@@ -219,7 +219,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -241,7 +241,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -416,7 +416,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -437,7 +437,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Fish Tank Template_experiment.level
+++ b/dashboard/config/scripts/levels/Fish Tank Template_experiment.level
@@ -298,7 +298,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Fish Tank Template_experiment.level
+++ b/dashboard/config/scripts/levels/Fish Tank Template_experiment.level
@@ -219,7 +219,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -241,7 +241,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -416,7 +416,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -437,7 +437,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Fish Tank Template_simple.level
+++ b/dashboard/config/scripts/levels/Fish Tank Template_simple.level
@@ -293,7 +293,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if" inline="false">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Fish Tank Template_simple.level
+++ b/dashboard/config/scripts/levels/Fish Tank Template_simple.level
@@ -92,7 +92,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">swimming</title>
+          <title name="NAME" id="swimming">swimming</title>
           <statement name="STACK">
             <block type="controls_if" inline="false">
               <mutation elseif="1"/>
@@ -236,7 +236,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is moving, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">moving</title>
+          <title name="NAME" id="moving">moving</title>
           <statement name="STACK">
             <block type="gamelab_moveForward" inline="true">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/IPL_aboutme_3_2021.level
+++ b/dashboard/config/scripts/levels/IPL_aboutme_3_2021.level
@@ -287,7 +287,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -309,7 +309,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -498,7 +498,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -551,7 +551,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/IPL_aboutme_3_2021.level
+++ b/dashboard/config/scripts/levels/IPL_aboutme_3_2021.level
@@ -102,7 +102,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/IPL_aboutme_4_2021.level
+++ b/dashboard/config/scripts/levels/IPL_aboutme_4_2021.level
@@ -307,7 +307,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -329,7 +329,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -518,7 +518,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -571,7 +571,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/IPL_aboutme_4_2021.level
+++ b/dashboard/config/scripts/levels/IPL_aboutme_4_2021.level
@@ -122,7 +122,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/IPL_events_click.level
+++ b/dashboard/config/scripts/levels/IPL_events_click.level
@@ -182,7 +182,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -204,7 +204,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -379,7 +379,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -400,7 +400,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/IPL_events_click.level
+++ b/dashboard/config/scripts/levels/IPL_events_click.level
@@ -261,7 +261,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Josh Sprite Text.level
+++ b/dashboard/config/scripts/levels/Josh Sprite Text.level
@@ -158,7 +158,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Josh Sprite Text.level
+++ b/dashboard/config/scripts/levels/Josh Sprite Text.level
@@ -343,7 +343,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -365,7 +365,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -554,7 +554,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -607,7 +607,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/Mike Lab Block Demo.level
+++ b/dashboard/config/scripts/levels/Mike Lab Block Demo.level
@@ -115,7 +115,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="Mikelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Mike Lab Car Game.level
+++ b/dashboard/config/scripts/levels/Mike Lab Car Game.level
@@ -92,7 +92,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="Mikelab_changePropBy" inline="true">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Mike SL Proj Test.level
+++ b/dashboard/config/scripts/levels/Mike SL Proj Test.level
@@ -487,7 +487,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>move a sprite, changing its direction randomly</description>
             </mutation>
-            <title name="NAME">wandering</title>
+            <title name="NAME" id="wandering">wandering</title>
             <statement name="STACK">
               <block type="controls_if">
                 <value name="IF0">

--- a/dashboard/config/scripts/levels/Mike SL Proj Test.level
+++ b/dashboard/config/scripts/levels/Mike SL Proj Test.level
@@ -672,7 +672,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>change the size of a sprite</description>
             </mutation>
-            <title name="NAME">shrinking</title>
+            <title name="NAME" id="shrinking">shrinking</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -694,7 +694,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>change the size of a sprite</description>
             </mutation>
-            <title name="NAME">growing</title>
+            <title name="NAME" id="growing">growing</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -883,7 +883,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>randomly change the size of a sprite</description>
             </mutation>
-            <title name="NAME">jittering</title>
+            <title name="NAME" id="jittering">jittering</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -936,7 +936,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>move a sprite across the screen, reversing direction if it touches the edges</description>
             </mutation>
-            <title name="NAME">patrolling</title>
+            <title name="NAME" id="patrolling">patrolling</title>
             <statement name="STACK">
               <block type="gamelab_moveForward">
                 <value name="SPRITE">

--- a/dashboard/config/scripts/levels/MikeLab Key Events.level
+++ b/dashboard/config/scripts/levels/MikeLab Key Events.level
@@ -154,7 +154,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="Mikelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/MikeLab Text Events.level
+++ b/dashboard/config/scripts/levels/MikeLab Text Events.level
@@ -131,7 +131,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="Mikelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/New Mike Lab Project.level
+++ b/dashboard/config/scripts/levels/New Mike Lab Project.level
@@ -100,7 +100,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="Mikelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/New Sprite Lab Project - Ryan.level
+++ b/dashboard/config/scripts/levels/New Sprite Lab Project - Ryan.level
@@ -680,7 +680,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>change the size of a sprite</description>
             </mutation>
-            <title name="NAME">shrinking</title>
+            <title name="NAME" id="shrinking">shrinking</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -702,7 +702,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>change the size of a sprite</description>
             </mutation>
-            <title name="NAME">growing</title>
+            <title name="NAME" id="growing">growing</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -891,7 +891,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>randomly change the size of a sprite</description>
             </mutation>
-            <title name="NAME">jittering</title>
+            <title name="NAME" id="jittering">jittering</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -944,7 +944,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>move a sprite across the screen, reversing direction if it touches the edges</description>
             </mutation>
-            <title name="NAME">patrolling</title>
+            <title name="NAME" id="patrolling">patrolling</title>
             <statement name="STACK">
               <block type="gamelab_moveForward">
                 <value name="SPRITE">

--- a/dashboard/config/scripts/levels/New Sprite Lab Project - Ryan.level
+++ b/dashboard/config/scripts/levels/New Sprite Lab Project - Ryan.level
@@ -495,7 +495,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>move a sprite, changing its direction randomly</description>
             </mutation>
-            <title name="NAME">wandering</title>
+            <title name="NAME" id="wandering">wandering</title>
             <statement name="STACK">
               <block type="controls_if">
                 <value name="IF0">

--- a/dashboard/config/scripts/levels/OPD-K5-ESprites-2021.level
+++ b/dashboard/config/scripts/levels/OPD-K5-ESprites-2021.level
@@ -420,7 +420,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/OPD-K5-ESprites-2021.level
+++ b/dashboard/config/scripts/levels/OPD-K5-ESprites-2021.level
@@ -341,7 +341,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -363,7 +363,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -538,7 +538,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -559,7 +559,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/OPD-K5-EventsE-2021.level
+++ b/dashboard/config/scripts/levels/OPD-K5-EventsE-2021.level
@@ -230,7 +230,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/OPD-K5-EventsE-2021.level
+++ b/dashboard/config/scripts/levels/OPD-K5-EventsE-2021.level
@@ -151,7 +151,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -173,7 +173,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -348,7 +348,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -369,7 +369,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/OPD-K5-EventsF2-2021.level
+++ b/dashboard/config/scripts/levels/OPD-K5-EventsF2-2021.level
@@ -293,7 +293,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -315,7 +315,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -504,7 +504,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -557,7 +557,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/OPD-K5-EventsF2-2021.level
+++ b/dashboard/config/scripts/levels/OPD-K5-EventsF2-2021.level
@@ -108,7 +108,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/OPD-K5-IntroSprites-2021.level
+++ b/dashboard/config/scripts/levels/OPD-K5-IntroSprites-2021.level
@@ -315,7 +315,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/OPD-K5-IntroSprites-2021.level
+++ b/dashboard/config/scripts/levels/OPD-K5-IntroSprites-2021.level
@@ -236,7 +236,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -258,7 +258,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -433,7 +433,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -454,7 +454,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/OPD-K5-SpritesE-2021.level
+++ b/dashboard/config/scripts/levels/OPD-K5-SpritesE-2021.level
@@ -230,7 +230,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/OPD-K5-SpritesE-2021.level
+++ b/dashboard/config/scripts/levels/OPD-K5-SpritesE-2021.level
@@ -151,7 +151,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -173,7 +173,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -348,7 +348,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -369,7 +369,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/OPD-K5-spritelab-2.level
+++ b/dashboard/config/scripts/levels/OPD-K5-spritelab-2.level
@@ -231,7 +231,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -253,7 +253,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -428,7 +428,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -449,7 +449,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/OPD-K5-spritelab-2.level
+++ b/dashboard/config/scripts/levels/OPD-K5-spritelab-2.level
@@ -310,7 +310,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/OPD-K5-spritelab-2_2020.level
+++ b/dashboard/config/scripts/levels/OPD-K5-spritelab-2_2020.level
@@ -308,7 +308,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/OPD-K5-spritelab-2_2020.level
+++ b/dashboard/config/scripts/levels/OPD-K5-spritelab-2_2020.level
@@ -229,7 +229,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -251,7 +251,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -426,7 +426,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -447,7 +447,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/OPD-K5-spritelab-2_2021.level
+++ b/dashboard/config/scripts/levels/OPD-K5-spritelab-2_2021.level
@@ -308,7 +308,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/OPD-K5-spritelab-2_2021.level
+++ b/dashboard/config/scripts/levels/OPD-K5-spritelab-2_2021.level
@@ -229,7 +229,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -251,7 +251,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -426,7 +426,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -447,7 +447,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/OPD-K5-spritelab-3.level
+++ b/dashboard/config/scripts/levels/OPD-K5-spritelab-3.level
@@ -285,7 +285,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -307,7 +307,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -482,7 +482,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -503,7 +503,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/OPD-K5-spritelab-3.level
+++ b/dashboard/config/scripts/levels/OPD-K5-spritelab-3.level
@@ -364,7 +364,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/OPD-K5-spritelab-3_2020.level
+++ b/dashboard/config/scripts/levels/OPD-K5-spritelab-3_2020.level
@@ -362,7 +362,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/OPD-K5-spritelab-3_2020.level
+++ b/dashboard/config/scripts/levels/OPD-K5-spritelab-3_2020.level
@@ -283,7 +283,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -305,7 +305,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -480,7 +480,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -501,7 +501,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/OPD-K5-spritelab-3_2021.level
+++ b/dashboard/config/scripts/levels/OPD-K5-spritelab-3_2021.level
@@ -362,7 +362,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/OPD-K5-spritelab-3_2021.level
+++ b/dashboard/config/scripts/levels/OPD-K5-spritelab-3_2021.level
@@ -283,7 +283,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -305,7 +305,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -480,7 +480,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -501,7 +501,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/OPD-K5-spritelab-4.level
+++ b/dashboard/config/scripts/levels/OPD-K5-spritelab-4.level
@@ -376,7 +376,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/OPD-K5-spritelab-4.level
+++ b/dashboard/config/scripts/levels/OPD-K5-spritelab-4.level
@@ -297,7 +297,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -319,7 +319,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -494,7 +494,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -515,7 +515,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/OPD-K5-spritelab-4_2020.level
+++ b/dashboard/config/scripts/levels/OPD-K5-spritelab-4_2020.level
@@ -374,7 +374,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/OPD-K5-spritelab-4_2020.level
+++ b/dashboard/config/scripts/levels/OPD-K5-spritelab-4_2020.level
@@ -295,7 +295,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -317,7 +317,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -492,7 +492,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -513,7 +513,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/OPD-K5-spritelab-4_2021.level
+++ b/dashboard/config/scripts/levels/OPD-K5-spritelab-4_2021.level
@@ -374,7 +374,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/OPD-K5-spritelab-4_2021.level
+++ b/dashboard/config/scripts/levels/OPD-K5-spritelab-4_2021.level
@@ -295,7 +295,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -317,7 +317,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -492,7 +492,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -513,7 +513,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/OPD-K5-spritelab-6.level
+++ b/dashboard/config/scripts/levels/OPD-K5-spritelab-6.level
@@ -338,7 +338,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -360,7 +360,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -535,7 +535,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -556,7 +556,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/OPD-K5-spritelab-6.level
+++ b/dashboard/config/scripts/levels/OPD-K5-spritelab-6.level
@@ -417,7 +417,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/OPD-K5-spritelab-6_2020.level
+++ b/dashboard/config/scripts/levels/OPD-K5-spritelab-6_2020.level
@@ -336,7 +336,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -358,7 +358,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -533,7 +533,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -554,7 +554,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/OPD-K5-spritelab-6_2020.level
+++ b/dashboard/config/scripts/levels/OPD-K5-spritelab-6_2020.level
@@ -415,7 +415,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/OPD-K5-spritelab-6_2021.level
+++ b/dashboard/config/scripts/levels/OPD-K5-spritelab-6_2021.level
@@ -336,7 +336,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -358,7 +358,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -533,7 +533,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -554,7 +554,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/OPD-K5-spritelab-6_2021.level
+++ b/dashboard/config/scripts/levels/OPD-K5-spritelab-6_2021.level
@@ -415,7 +415,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/OPD-K5-spritelab-7.level
+++ b/dashboard/config/scripts/levels/OPD-K5-spritelab-7.level
@@ -444,7 +444,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/OPD-K5-spritelab-7.level
+++ b/dashboard/config/scripts/levels/OPD-K5-spritelab-7.level
@@ -365,7 +365,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -387,7 +387,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -562,7 +562,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -583,7 +583,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/OPD-K5-spritelab-7_2020.level
+++ b/dashboard/config/scripts/levels/OPD-K5-spritelab-7_2020.level
@@ -363,7 +363,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -385,7 +385,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -560,7 +560,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -581,7 +581,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/OPD-K5-spritelab-7_2020.level
+++ b/dashboard/config/scripts/levels/OPD-K5-spritelab-7_2020.level
@@ -442,7 +442,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/OPD-K5-spritelab-7_2021.level
+++ b/dashboard/config/scripts/levels/OPD-K5-spritelab-7_2021.level
@@ -363,7 +363,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -385,7 +385,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -560,7 +560,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -581,7 +581,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/OPD-K5-spritelab-7_2021.level
+++ b/dashboard/config/scripts/levels/OPD-K5-spritelab-7_2021.level
@@ -442,7 +442,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Ram and Kiki Loop Brainstorming.level
+++ b/dashboard/config/scripts/levels/Ram and Kiki Loop Brainstorming.level
@@ -434,7 +434,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if" inline="false">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Ram and Kiki Loop Brainstorming.level
+++ b/dashboard/config/scripts/levels/Ram and Kiki Loop Brainstorming.level
@@ -278,7 +278,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true">
               <title name="PROPERTY">"scale"</title>
@@ -299,7 +299,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Sprite Groups!.level
+++ b/dashboard/config/scripts/levels/Sprite Groups!.level
@@ -90,7 +90,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true">
               <title name="PROPERTY">"scale"</title>
@@ -111,7 +111,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true">
               <title name="PROPERTY">"scale"</title>
@@ -960,7 +960,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>change the size of a sprite</description>
             </mutation>
-            <title name="NAME">shrinking</title>
+            <title name="NAME" id="shrinking">shrinking</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -982,7 +982,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>change the size of a sprite</description>
             </mutation>
-            <title name="NAME">growing</title>
+            <title name="NAME" id="growing">growing</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -1171,7 +1171,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>randomly change the size of a sprite</description>
             </mutation>
-            <title name="NAME">jittering</title>
+            <title name="NAME" id="jittering">jittering</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -1224,7 +1224,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>move a sprite across the screen, reversing direction if it touches the edges</description>
             </mutation>
-            <title name="NAME">patrolling</title>
+            <title name="NAME" id="patrolling">patrolling</title>
             <statement name="STACK">
               <block type="gamelab_moveForward">
                 <value name="SPRITE">

--- a/dashboard/config/scripts/levels/Sprite Groups!.level
+++ b/dashboard/config/scripts/levels/Sprite Groups!.level
@@ -246,7 +246,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if" inline="false">
               <value name="IF0">
@@ -775,7 +775,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>move a sprite, changing its direction randomly</description>
             </mutation>
-            <title name="NAME">wandering</title>
+            <title name="NAME" id="wandering">wandering</title>
             <statement name="STACK">
               <block type="controls_if">
                 <value name="IF0">

--- a/dashboard/config/scripts/levels/Sprite Lab 2 Required Block.level
+++ b/dashboard/config/scripts/levels/Sprite Lab 2 Required Block.level
@@ -238,7 +238,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if" inline="false">
               <value name="IF0">
@@ -770,7 +770,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>move a sprite, changing its direction randomly</description>
             </mutation>
-            <title name="NAME">wandering</title>
+            <title name="NAME" id="wandering">wandering</title>
             <statement name="STACK">
               <block type="controls_if">
                 <value name="IF0">

--- a/dashboard/config/scripts/levels/Sprite Lab 2 Required Block.level
+++ b/dashboard/config/scripts/levels/Sprite Lab 2 Required Block.level
@@ -82,7 +82,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true">
               <title name="PROPERTY">"scale"</title>
@@ -103,7 +103,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true">
               <title name="PROPERTY">"scale"</title>
@@ -955,7 +955,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>change the size of a sprite</description>
             </mutation>
-            <title name="NAME">shrinking</title>
+            <title name="NAME" id="shrinking">shrinking</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -977,7 +977,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>change the size of a sprite</description>
             </mutation>
-            <title name="NAME">growing</title>
+            <title name="NAME" id="growing">growing</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -1166,7 +1166,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>randomly change the size of a sprite</description>
             </mutation>
-            <title name="NAME">jittering</title>
+            <title name="NAME" id="jittering">jittering</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -1219,7 +1219,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>move a sprite across the screen, reversing direction if it touches the edges</description>
             </mutation>
-            <title name="NAME">patrolling</title>
+            <title name="NAME" id="patrolling">patrolling</title>
             <statement name="STACK">
               <block type="gamelab_moveForward">
                 <value name="SPRITE">

--- a/dashboard/config/scripts/levels/Sprite Lab 2 Test.level
+++ b/dashboard/config/scripts/levels/Sprite Lab 2 Test.level
@@ -238,7 +238,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if" inline="false">
               <value name="IF0">
@@ -770,7 +770,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>move a sprite, changing its direction randomly</description>
             </mutation>
-            <title name="NAME">wandering</title>
+            <title name="NAME" id="wandering">wandering</title>
             <statement name="STACK">
               <block type="controls_if">
                 <value name="IF0">

--- a/dashboard/config/scripts/levels/Sprite Lab 2 Test.level
+++ b/dashboard/config/scripts/levels/Sprite Lab 2 Test.level
@@ -82,7 +82,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true">
               <title name="PROPERTY">"scale"</title>
@@ -103,7 +103,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true">
               <title name="PROPERTY">"scale"</title>
@@ -955,7 +955,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>change the size of a sprite</description>
             </mutation>
-            <title name="NAME">shrinking</title>
+            <title name="NAME" id="shrinking">shrinking</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -977,7 +977,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>change the size of a sprite</description>
             </mutation>
-            <title name="NAME">growing</title>
+            <title name="NAME" id="growing">growing</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -1166,7 +1166,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>randomly change the size of a sprite</description>
             </mutation>
-            <title name="NAME">jittering</title>
+            <title name="NAME" id="jittering">jittering</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -1219,7 +1219,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>move a sprite across the screen, reversing direction if it touches the edges</description>
             </mutation>
-            <title name="NAME">patrolling</title>
+            <title name="NAME" id="patrolling">patrolling</title>
             <statement name="STACK">
               <block type="gamelab_moveForward">
                 <value name="SPRITE">

--- a/dashboard/config/scripts/levels/Sprite Lab 2.0 Project.level
+++ b/dashboard/config/scripts/levels/Sprite Lab 2.0 Project.level
@@ -418,7 +418,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -439,7 +439,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -715,7 +715,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -737,7 +737,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -1409,7 +1409,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>change the size of a sprite</description>
             </mutation>
-            <title name="NAME">shrinking</title>
+            <title name="NAME" id="shrinking">shrinking</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -1431,7 +1431,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>change the size of a sprite</description>
             </mutation>
-            <title name="NAME">growing</title>
+            <title name="NAME" id="growing">growing</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -1620,7 +1620,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>randomly change the size of a sprite</description>
             </mutation>
-            <title name="NAME">jittering</title>
+            <title name="NAME" id="jittering">jittering</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -1673,7 +1673,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>move a sprite across the screen, reversing direction if it touches the edges</description>
             </mutation>
-            <title name="NAME">patrolling</title>
+            <title name="NAME" id="patrolling">patrolling</title>
             <statement name="STACK">
               <block type="gamelab_moveForward">
                 <value name="SPRITE">

--- a/dashboard/config/scripts/levels/Sprite Lab 2.0 Project.level
+++ b/dashboard/config/scripts/levels/Sprite Lab 2.0 Project.level
@@ -574,7 +574,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">
@@ -1224,7 +1224,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>move a sprite, changing its direction randomly</description>
             </mutation>
-            <title name="NAME">wandering</title>
+            <title name="NAME" id="wandering">wandering</title>
             <statement name="STACK">
               <block type="controls_if">
                 <value name="IF0">

--- a/dashboard/config/scripts/levels/Sprite Lab Block Pool Only.level
+++ b/dashboard/config/scripts/levels/Sprite Lab Block Pool Only.level
@@ -530,7 +530,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">spinning</title>
+          <title name="NAME" id="spinning">spinning</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true">
               <title name="PROPERTY">"rotation"</title>

--- a/dashboard/config/scripts/levels/Sprite Lab Blockly Behaviors.level
+++ b/dashboard/config/scripts/levels/Sprite Lab Blockly Behaviors.level
@@ -122,7 +122,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if" inline="false">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Sprite Lab Blockly Behaviors.level
+++ b/dashboard/config/scripts/levels/Sprite Lab Blockly Behaviors.level
@@ -101,7 +101,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changeProp" inline="true">
               <title name="PROPERTY">"scale"</title>
@@ -240,7 +240,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changeProp" inline="true">
               <title name="PROPERTY">"scale"</title>
@@ -261,7 +261,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changeProp" inline="true">
               <title name="PROPERTY">"scale"</title>
@@ -291,7 +291,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward" inline="true">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/Sprite Lab Parameterized Behaviors.level
+++ b/dashboard/config/scripts/levels/Sprite Lab Parameterized Behaviors.level
@@ -133,7 +133,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Sprite Lab Parameterized Behaviors.level
+++ b/dashboard/config/scripts/levels/Sprite Lab Parameterized Behaviors.level
@@ -446,7 +446,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -468,7 +468,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -657,7 +657,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -710,7 +710,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/SpriteLabDebugger.level
+++ b/dashboard/config/scripts/levels/SpriteLabDebugger.level
@@ -143,7 +143,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/SpriteLabDebugger.level
+++ b/dashboard/config/scripts/levels/SpriteLabDebugger.level
@@ -328,7 +328,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -350,7 +350,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -539,7 +539,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -592,7 +592,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/Story Lab Test.level
+++ b/dashboard/config/scripts/levels/Story Lab Test.level
@@ -167,7 +167,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="controls_if">
               <mutation else="1"/>
@@ -384,7 +384,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -573,7 +573,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -626,7 +626,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -1282,7 +1282,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>change the size of a sprite</description>
             </mutation>
-            <title name="NAME">shrinking</title>
+            <title name="NAME" id="shrinking">shrinking</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -1304,7 +1304,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>change the size of a sprite</description>
             </mutation>
-            <title name="NAME">growing</title>
+            <title name="NAME" id="growing">growing</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -1493,7 +1493,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>randomly change the size of a sprite</description>
             </mutation>
-            <title name="NAME">jittering</title>
+            <title name="NAME" id="jittering">jittering</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -1546,7 +1546,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>move a sprite across the screen, reversing direction if it touches the edges</description>
             </mutation>
-            <title name="NAME">patrolling</title>
+            <title name="NAME" id="patrolling">patrolling</title>
             <statement name="STACK">
               <block type="gamelab_moveForward">
                 <value name="SPRITE">

--- a/dashboard/config/scripts/levels/Story Lab Test.level
+++ b/dashboard/config/scripts/levels/Story Lab Test.level
@@ -199,7 +199,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">
@@ -1097,7 +1097,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>move a sprite, changing its direction randomly</description>
             </mutation>
-            <title name="NAME">wandering</title>
+            <title name="NAME" id="wandering">wandering</title>
             <statement name="STACK">
               <block type="controls_if">
                 <value name="IF0">

--- a/dashboard/config/scripts/levels/Swimming Fish Teacher Sandbox.level
+++ b/dashboard/config/scripts/levels/Swimming Fish Teacher Sandbox.level
@@ -270,7 +270,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -292,7 +292,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -481,7 +481,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -534,7 +534,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/Swimming Fish Teacher Sandbox.level
+++ b/dashboard/config/scripts/levels/Swimming Fish Teacher Sandbox.level
@@ -85,7 +85,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/TimeForCS Alligator.level
+++ b/dashboard/config/scripts/levels/TimeForCS Alligator.level
@@ -345,7 +345,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">
@@ -989,7 +989,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>move a sprite, changing its direction randomly</description>
             </mutation>
-            <title name="NAME">wandering</title>
+            <title name="NAME" id="wandering">wandering</title>
             <statement name="STACK">
               <block type="controls_if">
                 <value name="IF0">

--- a/dashboard/config/scripts/levels/TimeForCS Alligator.level
+++ b/dashboard/config/scripts/levels/TimeForCS Alligator.level
@@ -1174,7 +1174,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>change the size of a sprite</description>
             </mutation>
-            <title name="NAME">shrinking</title>
+            <title name="NAME" id="shrinking">shrinking</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -1196,7 +1196,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>change the size of a sprite</description>
             </mutation>
-            <title name="NAME">growing</title>
+            <title name="NAME" id="growing">growing</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -1385,7 +1385,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>randomly change the size of a sprite</description>
             </mutation>
-            <title name="NAME">jittering</title>
+            <title name="NAME" id="jittering">jittering</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -1438,7 +1438,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>move a sprite across the screen, reversing direction if it touches the edges</description>
             </mutation>
-            <title name="NAME">patrolling</title>
+            <title name="NAME" id="patrolling">patrolling</title>
             <statement name="STACK">
               <block type="gamelab_moveForward">
                 <value name="SPRITE">

--- a/dashboard/config/scripts/levels/TimeForCS Demo.level
+++ b/dashboard/config/scripts/levels/TimeForCS Demo.level
@@ -346,7 +346,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">
@@ -990,7 +990,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>move a sprite, changing its direction randomly</description>
             </mutation>
-            <title name="NAME">wandering</title>
+            <title name="NAME" id="wandering">wandering</title>
             <statement name="STACK">
               <block type="controls_if">
                 <value name="IF0">

--- a/dashboard/config/scripts/levels/TimeForCS Demo.level
+++ b/dashboard/config/scripts/levels/TimeForCS Demo.level
@@ -1175,7 +1175,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>change the size of a sprite</description>
             </mutation>
-            <title name="NAME">shrinking</title>
+            <title name="NAME" id="shrinking">shrinking</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -1197,7 +1197,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>change the size of a sprite</description>
             </mutation>
-            <title name="NAME">growing</title>
+            <title name="NAME" id="growing">growing</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -1386,7 +1386,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>randomly change the size of a sprite</description>
             </mutation>
-            <title name="NAME">jittering</title>
+            <title name="NAME" id="jittering">jittering</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -1439,7 +1439,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>move a sprite across the screen, reversing direction if it touches the edges</description>
             </mutation>
-            <title name="NAME">patrolling</title>
+            <title name="NAME" id="patrolling">patrolling</title>
             <statement name="STACK">
               <block type="gamelab_moveForward">
                 <value name="SPRITE">

--- a/dashboard/config/scripts/levels/Toolbox test.level
+++ b/dashboard/config/scripts/levels/Toolbox test.level
@@ -239,7 +239,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -261,7 +261,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -450,7 +450,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -503,7 +503,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/Toolbox test.level
+++ b/dashboard/config/scripts/levels/Toolbox test.level
@@ -54,7 +54,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Tortoise and Hare.level
+++ b/dashboard/config/scripts/levels/Tortoise and Hare.level
@@ -370,7 +370,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -392,7 +392,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -581,7 +581,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -634,7 +634,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/Tortoise and Hare.level
+++ b/dashboard/config/scripts/levels/Tortoise and Hare.level
@@ -207,7 +207,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Virtual Pet 1_2019.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 1_2019.level
@@ -344,7 +344,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Virtual Pet 1_2019.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 1_2019.level
@@ -558,7 +558,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -747,7 +747,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -800,7 +800,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -822,7 +822,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/Virtual Pet 1_2020.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 1_2020.level
@@ -344,7 +344,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Virtual Pet 1_2020.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 1_2020.level
@@ -558,7 +558,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -747,7 +747,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -800,7 +800,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -822,7 +822,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/Virtual Pet 2 - Validated (Ram).level
+++ b/dashboard/config/scripts/levels/Virtual Pet 2 - Validated (Ram).level
@@ -252,7 +252,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -305,7 +305,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -362,7 +362,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -383,7 +383,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Virtual Pet 2 - Validated (Ram).level
+++ b/dashboard/config/scripts/levels/Virtual Pet 2 - Validated (Ram).level
@@ -70,7 +70,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Virtual Pet 2 - Validated.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 2 - Validated.level
@@ -71,7 +71,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Virtual Pet 2 - Validated.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 2 - Validated.level
@@ -253,7 +253,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -306,7 +306,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -363,7 +363,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -384,7 +384,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Virtual Pet 2.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 2.level
@@ -138,7 +138,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -160,7 +160,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -335,7 +335,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -356,7 +356,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Virtual Pet 2.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 2.level
@@ -217,7 +217,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Virtual Pet 2_2019.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 2_2019.level
@@ -288,7 +288,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -310,7 +310,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -499,7 +499,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -552,7 +552,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/Virtual Pet 2_2019.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 2_2019.level
@@ -103,7 +103,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Virtual Pet 2_2020.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 2_2020.level
@@ -288,7 +288,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -310,7 +310,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -499,7 +499,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -552,7 +552,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/Virtual Pet 2_2020.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 2_2020.level
@@ -103,7 +103,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Virtual Pet 2_2021.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 2_2021.level
@@ -104,7 +104,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Virtual Pet 2_2021.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 2_2021.level
@@ -289,7 +289,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -311,7 +311,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -500,7 +500,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -553,7 +553,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/Virtual Pet 2_simple.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 2_simple.level
@@ -202,7 +202,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">moving</title>
+          <title name="NAME" id="moving">moving</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/Virtual Pet 2_simple.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 2_simple.level
@@ -259,7 +259,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Virtual Pet 3_2019.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 3_2019.level
@@ -507,7 +507,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -551,7 +551,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -951,7 +951,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -1026,7 +1026,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/Virtual Pet 3_2019.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 3_2019.level
@@ -181,7 +181,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Virtual Pet 3_2020.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 3_2020.level
@@ -507,7 +507,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -551,7 +551,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -951,7 +951,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -1026,7 +1026,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/Virtual Pet 3_2020.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 3_2020.level
@@ -181,7 +181,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Virtual Pet 3_2021.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 3_2021.level
@@ -507,7 +507,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -551,7 +551,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -951,7 +951,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -1026,7 +1026,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/Virtual Pet 3_2021.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 3_2021.level
@@ -181,7 +181,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Virtual Pet 4.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 4.level
@@ -129,7 +129,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true">
               <title name="PROPERTY">"scale"</title>
@@ -151,7 +151,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward" inline="true">
               <value name="SPRITE">
@@ -326,7 +326,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true">
               <title name="PROPERTY">"scale"</title>
@@ -347,7 +347,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Virtual Pet 4.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 4.level
@@ -208,7 +208,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if" inline="false">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Virtual Pet 4_2019.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 4_2019.level
@@ -226,7 +226,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Virtual Pet 4_2019.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 4_2019.level
@@ -411,7 +411,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -433,7 +433,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -622,7 +622,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -675,7 +675,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/Virtual Pet 4_2020.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 4_2020.level
@@ -226,7 +226,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Virtual Pet 4_2020.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 4_2020.level
@@ -411,7 +411,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -433,7 +433,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -622,7 +622,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -675,7 +675,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/Virtual Pet 4_2021.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 4_2021.level
@@ -405,7 +405,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -427,7 +427,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -616,7 +616,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -669,7 +669,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/Virtual Pet 4_2021.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 4_2021.level
@@ -220,7 +220,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Virtual Pet 4_simple.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 4_simple.level
@@ -124,7 +124,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true">
               <title name="PROPERTY">"scale"</title>
@@ -146,7 +146,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward" inline="true">
               <value name="SPRITE">
@@ -321,7 +321,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true">
               <title name="PROPERTY">"scale"</title>
@@ -342,7 +342,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Virtual Pet 4_simple.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 4_simple.level
@@ -203,7 +203,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if" inline="false">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Virtual Pet 5 - Validated.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 5 - Validated.level
@@ -300,7 +300,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -322,7 +322,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -379,7 +379,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -400,7 +400,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Virtual Pet 5 - Validated.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 5 - Validated.level
@@ -72,7 +72,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Virtual Pet 5.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 5.level
@@ -214,7 +214,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if" inline="false">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Virtual Pet 5.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 5.level
@@ -135,7 +135,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true">
               <title name="PROPERTY">"scale"</title>
@@ -157,7 +157,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward" inline="true">
               <value name="SPRITE">
@@ -332,7 +332,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true">
               <title name="PROPERTY">"scale"</title>
@@ -353,7 +353,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Virtual Pet 6.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 6.level
@@ -129,7 +129,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true">
               <title name="PROPERTY">"scale"</title>
@@ -151,7 +151,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward" inline="true">
               <value name="SPRITE">
@@ -326,7 +326,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true">
               <title name="PROPERTY">"scale"</title>
@@ -347,7 +347,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Virtual Pet 6.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 6.level
@@ -208,7 +208,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if" inline="false">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Virtual Pet Freeplay.level
+++ b/dashboard/config/scripts/levels/Virtual Pet Freeplay.level
@@ -211,7 +211,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if" inline="false">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Virtual Pet Freeplay.level
+++ b/dashboard/config/scripts/levels/Virtual Pet Freeplay.level
@@ -132,7 +132,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true">
               <title name="PROPERTY">"scale"</title>
@@ -154,7 +154,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward" inline="true">
               <value name="SPRITE">
@@ -329,7 +329,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true">
               <title name="PROPERTY">"scale"</title>
@@ -350,7 +350,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Virtual Pet Freeplay_2019.level
+++ b/dashboard/config/scripts/levels/Virtual Pet Freeplay_2019.level
@@ -130,7 +130,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true">
               <title name="PROPERTY">"scale"</title>
@@ -152,7 +152,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward" inline="true">
               <value name="SPRITE">
@@ -327,7 +327,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true">
               <title name="PROPERTY">"scale"</title>
@@ -348,7 +348,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/Virtual Pet Freeplay_2019.level
+++ b/dashboard/config/scripts/levels/Virtual Pet Freeplay_2019.level
@@ -209,7 +209,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if" inline="false">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Virtual Pet Template_2019.level
+++ b/dashboard/config/scripts/levels/Virtual Pet Template_2019.level
@@ -278,7 +278,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -300,7 +300,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -489,7 +489,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -542,7 +542,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/Virtual Pet Template_2019.level
+++ b/dashboard/config/scripts/levels/Virtual Pet Template_2019.level
@@ -81,7 +81,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Virtual Pet Template_2020.level
+++ b/dashboard/config/scripts/levels/Virtual Pet Template_2020.level
@@ -79,7 +79,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/Virtual Pet Template_2020.level
+++ b/dashboard/config/scripts/levels/Virtual Pet Template_2020.level
@@ -276,7 +276,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -298,7 +298,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -487,7 +487,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -540,7 +540,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/Virus Simulation for Code Bytes.level
+++ b/dashboard/config/scripts/levels/Virus Simulation for Code Bytes.level
@@ -86,7 +86,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">
@@ -407,7 +407,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/aatoolboxtest.level
+++ b/dashboard/config/scripts/levels/aatoolboxtest.level
@@ -250,7 +250,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>change the size of a sprite</description>
             </mutation>
-            <title name="NAME">shrinking</title>
+            <title name="NAME" id="shrinking">shrinking</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy" editable="false">
                 <title name="PROPERTY">"scale"</title>
@@ -272,7 +272,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>change the size of a sprite</description>
             </mutation>
-            <title name="NAME">growing</title>
+            <title name="NAME" id="growing">growing</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy" editable="false">
                 <title name="PROPERTY">"scale"</title>
@@ -461,7 +461,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>randomly change the size of a sprite</description>
             </mutation>
-            <title name="NAME">jittering</title>
+            <title name="NAME" id="jittering">jittering</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy" editable="false">
                 <title name="PROPERTY">"scale"</title>
@@ -514,7 +514,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>move a sprite across the screen, reversing direction if it touches the edges</description>
             </mutation>
-            <title name="NAME">patrolling</title>
+            <title name="NAME" id="patrolling">patrolling</title>
             <statement name="STACK">
               <block type="gamelab_moveForward" editable="false">
                 <value name="SPRITE">

--- a/dashboard/config/scripts/levels/aatoolboxtest.level
+++ b/dashboard/config/scripts/levels/aatoolboxtest.level
@@ -57,7 +57,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>move a sprite, changing its direction randomly</description>
             </mutation>
-            <title name="NAME">wandering</title>
+            <title name="NAME" id="wandering">wandering</title>
             <statement name="STACK">
               <block type="controls_if">
                 <value name="IF0">

--- a/dashboard/config/scripts/levels/alien fish example.level
+++ b/dashboard/config/scripts/levels/alien fish example.level
@@ -386,7 +386,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/alien fish example.level
+++ b/dashboard/config/scripts/levels/alien fish example.level
@@ -155,7 +155,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -307,7 +307,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -329,7 +329,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -504,7 +504,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/allthethings_fish_tank.level
+++ b/dashboard/config/scripts/levels/allthethings_fish_tank.level
@@ -214,7 +214,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true">
               <title name="PROPERTY">"scale"</title>
@@ -236,7 +236,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward" inline="true">
               <value name="SPRITE">
@@ -411,7 +411,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true">
               <title name="PROPERTY">"scale"</title>
@@ -432,7 +432,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/allthethings_fish_tank.level
+++ b/dashboard/config/scripts/levels/allthethings_fish_tank.level
@@ -293,7 +293,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if" inline="false">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/anjali_mini_toolbox_instructions.level
+++ b/dashboard/config/scripts/levels/anjali_mini_toolbox_instructions.level
@@ -54,7 +54,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">
@@ -358,7 +358,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/behaviors 1.level
+++ b/dashboard/config/scripts/levels/behaviors 1.level
@@ -326,7 +326,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -348,7 +348,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -537,7 +537,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -590,7 +590,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/behaviors 1.level
+++ b/dashboard/config/scripts/levels/behaviors 1.level
@@ -141,7 +141,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/behaviors 1_2020.level
+++ b/dashboard/config/scripts/levels/behaviors 1_2020.level
@@ -139,7 +139,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/behaviors 1_2020.level
+++ b/dashboard/config/scripts/levels/behaviors 1_2020.level
@@ -324,7 +324,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -346,7 +346,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -535,7 +535,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -588,7 +588,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/behaviors 1_2021.level
+++ b/dashboard/config/scripts/levels/behaviors 1_2021.level
@@ -322,7 +322,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -344,7 +344,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -533,7 +533,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -586,7 +586,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/behaviors 1_2021.level
+++ b/dashboard/config/scripts/levels/behaviors 1_2021.level
@@ -137,7 +137,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/behaviors 2.level
+++ b/dashboard/config/scripts/levels/behaviors 2.level
@@ -170,7 +170,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/behaviors 2.level
+++ b/dashboard/config/scripts/levels/behaviors 2.level
@@ -355,7 +355,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -377,7 +377,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -566,7 +566,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -619,7 +619,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/behaviors 2_2020.level
+++ b/dashboard/config/scripts/levels/behaviors 2_2020.level
@@ -172,7 +172,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/behaviors 2_2020.level
+++ b/dashboard/config/scripts/levels/behaviors 2_2020.level
@@ -357,7 +357,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -379,7 +379,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -568,7 +568,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -621,7 +621,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/behaviors 2_2021.level
+++ b/dashboard/config/scripts/levels/behaviors 2_2021.level
@@ -166,7 +166,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/behaviors 2_2021.level
+++ b/dashboard/config/scripts/levels/behaviors 2_2021.level
@@ -351,7 +351,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -373,7 +373,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -562,7 +562,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -615,7 +615,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/behaviors 3.level
+++ b/dashboard/config/scripts/levels/behaviors 3.level
@@ -379,7 +379,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -401,7 +401,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -590,7 +590,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -643,7 +643,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/behaviors 3.level
+++ b/dashboard/config/scripts/levels/behaviors 3.level
@@ -216,7 +216,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/behaviors 3_2020.level
+++ b/dashboard/config/scripts/levels/behaviors 3_2020.level
@@ -219,7 +219,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/behaviors 3_2020.level
+++ b/dashboard/config/scripts/levels/behaviors 3_2020.level
@@ -382,7 +382,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -404,7 +404,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -593,7 +593,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -646,7 +646,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/behaviors 3_2021.level
+++ b/dashboard/config/scripts/levels/behaviors 3_2021.level
@@ -213,7 +213,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/behaviors 3_2021.level
+++ b/dashboard/config/scripts/levels/behaviors 3_2021.level
@@ -376,7 +376,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -398,7 +398,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -587,7 +587,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -640,7 +640,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/behaviors 3a.level
+++ b/dashboard/config/scripts/levels/behaviors 3a.level
@@ -414,7 +414,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -436,7 +436,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -625,7 +625,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -678,7 +678,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/behaviors 3a.level
+++ b/dashboard/config/scripts/levels/behaviors 3a.level
@@ -273,7 +273,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/behaviors 3a_2020.level
+++ b/dashboard/config/scripts/levels/behaviors 3a_2020.level
@@ -413,7 +413,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -435,7 +435,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -624,7 +624,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -677,7 +677,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/behaviors 3a_2020.level
+++ b/dashboard/config/scripts/levels/behaviors 3a_2020.level
@@ -272,7 +272,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/behaviors 3a_2021.level
+++ b/dashboard/config/scripts/levels/behaviors 3a_2021.level
@@ -269,7 +269,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/behaviors 3a_2021.level
+++ b/dashboard/config/scripts/levels/behaviors 3a_2021.level
@@ -410,7 +410,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -432,7 +432,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -621,7 +621,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -674,7 +674,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/behaviors 4.level
+++ b/dashboard/config/scripts/levels/behaviors 4.level
@@ -366,7 +366,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -388,7 +388,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -577,7 +577,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -630,7 +630,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/behaviors 4.level
+++ b/dashboard/config/scripts/levels/behaviors 4.level
@@ -181,7 +181,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/behaviors 4_2020.level
+++ b/dashboard/config/scripts/levels/behaviors 4_2020.level
@@ -179,7 +179,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/behaviors 4_2020.level
+++ b/dashboard/config/scripts/levels/behaviors 4_2020.level
@@ -364,7 +364,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -386,7 +386,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -575,7 +575,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -628,7 +628,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/behaviors 4_2021.level
+++ b/dashboard/config/scripts/levels/behaviors 4_2021.level
@@ -362,7 +362,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -384,7 +384,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -573,7 +573,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -626,7 +626,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/behaviors 4_2021.level
+++ b/dashboard/config/scripts/levels/behaviors 4_2021.level
@@ -177,7 +177,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/behaviors 4a.level
+++ b/dashboard/config/scripts/levels/behaviors 4a.level
@@ -139,7 +139,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/behaviors 4a.level
+++ b/dashboard/config/scripts/levels/behaviors 4a.level
@@ -324,7 +324,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -346,7 +346,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -535,7 +535,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -588,7 +588,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/behaviors 5a.level
+++ b/dashboard/config/scripts/levels/behaviors 5a.level
@@ -147,7 +147,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">
@@ -834,7 +834,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/behaviors 5a.level
+++ b/dashboard/config/scripts/levels/behaviors 5a.level
@@ -310,7 +310,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -332,7 +332,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -521,7 +521,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -574,7 +574,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -997,7 +997,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -1019,7 +1019,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -1208,7 +1208,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -1261,7 +1261,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/behaviors 6.level
+++ b/dashboard/config/scripts/levels/behaviors 6.level
@@ -488,7 +488,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/behaviors 6.level
+++ b/dashboard/config/scripts/levels/behaviors 6.level
@@ -127,7 +127,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -149,7 +149,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -651,7 +651,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -673,7 +673,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -862,7 +862,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -915,7 +915,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/behaviors 6_2020.level
+++ b/dashboard/config/scripts/levels/behaviors 6_2020.level
@@ -489,7 +489,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/behaviors 6_2020.level
+++ b/dashboard/config/scripts/levels/behaviors 6_2020.level
@@ -128,7 +128,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -150,7 +150,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -652,7 +652,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -674,7 +674,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -863,7 +863,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -916,7 +916,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/behaviors 6_2021.level
+++ b/dashboard/config/scripts/levels/behaviors 6_2021.level
@@ -491,7 +491,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/behaviors 6_2021.level
+++ b/dashboard/config/scripts/levels/behaviors 6_2021.level
@@ -130,7 +130,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -152,7 +152,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -654,7 +654,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -676,7 +676,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -865,7 +865,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -918,7 +918,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/behaviors 7.level
+++ b/dashboard/config/scripts/levels/behaviors 7.level
@@ -499,7 +499,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/behaviors 7.level
+++ b/dashboard/config/scripts/levels/behaviors 7.level
@@ -178,7 +178,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -200,7 +200,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -662,7 +662,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -684,7 +684,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -873,7 +873,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -926,7 +926,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/behaviors 7_2020.level
+++ b/dashboard/config/scripts/levels/behaviors 7_2020.level
@@ -498,7 +498,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/behaviors 7_2020.level
+++ b/dashboard/config/scripts/levels/behaviors 7_2020.level
@@ -177,7 +177,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -199,7 +199,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -661,7 +661,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -683,7 +683,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -872,7 +872,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -925,7 +925,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/behaviors 7_2021.level
+++ b/dashboard/config/scripts/levels/behaviors 7_2021.level
@@ -497,7 +497,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/behaviors 7_2021.level
+++ b/dashboard/config/scripts/levels/behaviors 7_2021.level
@@ -176,7 +176,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -198,7 +198,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -660,7 +660,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -682,7 +682,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -871,7 +871,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -924,7 +924,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/contagion1.level
+++ b/dashboard/config/scripts/levels/contagion1.level
@@ -168,7 +168,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/courseE_Dogger_2.level
+++ b/dashboard/config/scripts/levels/courseE_Dogger_2.level
@@ -1166,7 +1166,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>change the size of a sprite</description>
             </mutation>
-            <title name="NAME">shrinking</title>
+            <title name="NAME" id="shrinking">shrinking</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -1188,7 +1188,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>change the size of a sprite</description>
             </mutation>
-            <title name="NAME">growing</title>
+            <title name="NAME" id="growing">growing</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -1377,7 +1377,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>randomly change the size of a sprite</description>
             </mutation>
-            <title name="NAME">jittering</title>
+            <title name="NAME" id="jittering">jittering</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -1430,7 +1430,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>move a sprite across the screen, reversing direction if it touches the edges</description>
             </mutation>
-            <title name="NAME">patrolling</title>
+            <title name="NAME" id="patrolling">patrolling</title>
             <statement name="STACK">
               <block type="gamelab_moveForward">
                 <value name="SPRITE">

--- a/dashboard/config/scripts/levels/courseE_Dogger_2.level
+++ b/dashboard/config/scripts/levels/courseE_Dogger_2.level
@@ -981,7 +981,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>move a sprite, changing its direction randomly</description>
             </mutation>
-            <title name="NAME">wandering</title>
+            <title name="NAME" id="wandering">wandering</title>
             <statement name="STACK">
               <block type="controls_if">
                 <value name="IF0">

--- a/dashboard/config/scripts/levels/courseE_Dogger_2_2019.level
+++ b/dashboard/config/scripts/levels/courseE_Dogger_2_2019.level
@@ -1184,7 +1184,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>change the size of a sprite</description>
             </mutation>
-            <title name="NAME">shrinking</title>
+            <title name="NAME" id="shrinking">shrinking</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -1206,7 +1206,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>change the size of a sprite</description>
             </mutation>
-            <title name="NAME">growing</title>
+            <title name="NAME" id="growing">growing</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -1395,7 +1395,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>randomly change the size of a sprite</description>
             </mutation>
-            <title name="NAME">jittering</title>
+            <title name="NAME" id="jittering">jittering</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -1448,7 +1448,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>move a sprite across the screen, reversing direction if it touches the edges</description>
             </mutation>
-            <title name="NAME">patrolling</title>
+            <title name="NAME" id="patrolling">patrolling</title>
             <statement name="STACK">
               <block type="gamelab_moveForward">
                 <value name="SPRITE">

--- a/dashboard/config/scripts/levels/courseE_Dogger_2_2019.level
+++ b/dashboard/config/scripts/levels/courseE_Dogger_2_2019.level
@@ -999,7 +999,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>move a sprite, changing its direction randomly</description>
             </mutation>
-            <title name="NAME">wandering</title>
+            <title name="NAME" id="wandering">wandering</title>
             <statement name="STACK">
               <block type="controls_if">
                 <value name="IF0">

--- a/dashboard/config/scripts/levels/courseE_aboutme_1.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_1.level
@@ -613,7 +613,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -635,7 +635,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -824,7 +824,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -877,7 +877,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/courseE_aboutme_1.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_1.level
@@ -428,7 +428,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/courseE_aboutme_1_2020.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_1_2020.level
@@ -614,7 +614,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -636,7 +636,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -825,7 +825,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -878,7 +878,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/courseE_aboutme_1_2020.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_1_2020.level
@@ -429,7 +429,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/courseE_aboutme_1_control.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_1_control.level
@@ -424,7 +424,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/courseE_aboutme_1_control.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_1_control.level
@@ -609,7 +609,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -631,7 +631,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -820,7 +820,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -873,7 +873,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/courseE_aboutme_1_experiment.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_1_experiment.level
@@ -424,7 +424,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/courseE_aboutme_1_experiment.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_1_experiment.level
@@ -609,7 +609,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -631,7 +631,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -820,7 +820,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -873,7 +873,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/courseE_aboutme_1_old.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_1_old.level
@@ -275,7 +275,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -297,7 +297,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -486,7 +486,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -539,7 +539,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/courseE_aboutme_1_old.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_1_old.level
@@ -61,7 +61,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/courseE_aboutme_2.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_2.level
@@ -82,7 +82,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/courseE_aboutme_2.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_2.level
@@ -267,7 +267,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -289,7 +289,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -478,7 +478,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -531,7 +531,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/courseE_aboutme_2_2020.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_2_2020.level
@@ -83,7 +83,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/courseE_aboutme_2_2020.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_2_2020.level
@@ -268,7 +268,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -290,7 +290,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -479,7 +479,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -532,7 +532,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/courseE_aboutme_2_2021.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_2_2021.level
@@ -83,7 +83,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/courseE_aboutme_2_2021.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_2_2021.level
@@ -268,7 +268,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -290,7 +290,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -479,7 +479,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -532,7 +532,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/courseE_aboutme_2_control.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_2_control.level
@@ -80,7 +80,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/courseE_aboutme_2_control.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_2_control.level
@@ -265,7 +265,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -287,7 +287,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -476,7 +476,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -529,7 +529,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/courseE_aboutme_2_experiment.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_2_experiment.level
@@ -80,7 +80,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/courseE_aboutme_2_experiment.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_2_experiment.level
@@ -265,7 +265,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -287,7 +287,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -476,7 +476,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -529,7 +529,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/courseE_aboutme_3.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_3.level
@@ -98,7 +98,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/courseE_aboutme_3.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_3.level
@@ -283,7 +283,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -305,7 +305,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -494,7 +494,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -547,7 +547,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/courseE_aboutme_3_2020.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_3_2020.level
@@ -285,7 +285,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -307,7 +307,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -496,7 +496,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -549,7 +549,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/courseE_aboutme_3_2020.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_3_2020.level
@@ -100,7 +100,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/courseE_aboutme_3_2021.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_3_2021.level
@@ -99,7 +99,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/courseE_aboutme_3_2021.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_3_2021.level
@@ -284,7 +284,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -306,7 +306,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -495,7 +495,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -548,7 +548,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/courseE_aboutme_3_control.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_3_control.level
@@ -95,7 +95,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/courseE_aboutme_3_control.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_3_control.level
@@ -280,7 +280,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -302,7 +302,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -491,7 +491,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -544,7 +544,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/courseE_aboutme_3_experiment.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_3_experiment.level
@@ -95,7 +95,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/courseE_aboutme_3_experiment.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_3_experiment.level
@@ -280,7 +280,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -302,7 +302,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -491,7 +491,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -544,7 +544,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/courseE_aboutme_4.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_4.level
@@ -304,7 +304,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -326,7 +326,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -515,7 +515,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -568,7 +568,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/courseE_aboutme_4.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_4.level
@@ -119,7 +119,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/courseE_aboutme_4_2020.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_4_2020.level
@@ -120,7 +120,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/courseE_aboutme_4_2020.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_4_2020.level
@@ -305,7 +305,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -327,7 +327,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -516,7 +516,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -569,7 +569,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/courseE_aboutme_4_2021.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_4_2021.level
@@ -120,7 +120,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/courseE_aboutme_4_2021.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_4_2021.level
@@ -305,7 +305,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -327,7 +327,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -516,7 +516,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -569,7 +569,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/courseE_aboutme_4_control.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_4_control.level
@@ -302,7 +302,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -324,7 +324,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -513,7 +513,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -566,7 +566,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/courseE_aboutme_4_control.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_4_control.level
@@ -117,7 +117,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/courseE_aboutme_4_experiment.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_4_experiment.level
@@ -302,7 +302,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -324,7 +324,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -513,7 +513,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -566,7 +566,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/courseE_aboutme_4_experiment.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_4_experiment.level
@@ -117,7 +117,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/courseE_aboutme_5.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_5.level
@@ -153,7 +153,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/courseE_aboutme_5.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_5.level
@@ -338,7 +338,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -360,7 +360,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -549,7 +549,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -602,7 +602,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/courseE_aboutme_5_2020.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_5_2020.level
@@ -339,7 +339,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -361,7 +361,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -550,7 +550,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -603,7 +603,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/courseE_aboutme_5_2020.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_5_2020.level
@@ -154,7 +154,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/courseE_aboutme_5_2021.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_5_2021.level
@@ -339,7 +339,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -361,7 +361,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -550,7 +550,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -603,7 +603,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/courseE_aboutme_5_2021.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_5_2021.level
@@ -154,7 +154,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/courseE_aboutme_5_control.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_5_control.level
@@ -150,7 +150,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/courseE_aboutme_5_control.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_5_control.level
@@ -335,7 +335,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -357,7 +357,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -546,7 +546,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -599,7 +599,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/courseE_aboutme_5_experiment.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_5_experiment.level
@@ -150,7 +150,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/courseE_aboutme_5_experiment.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_5_experiment.level
@@ -335,7 +335,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -357,7 +357,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -546,7 +546,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -599,7 +599,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/courseE_aboutme_again.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_again.level
@@ -56,7 +56,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/courseE_aboutme_again.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_again.level
@@ -512,7 +512,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -534,7 +534,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -723,7 +723,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -776,7 +776,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/courseE_aboutme_template.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_template.level
@@ -76,7 +76,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/courseE_aboutme_template.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_template.level
@@ -261,7 +261,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -283,7 +283,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -472,7 +472,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -525,7 +525,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/courseE_aboutme_template_2020.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_template_2020.level
@@ -75,7 +75,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/courseE_aboutme_template_2020.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_template_2020.level
@@ -260,7 +260,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -282,7 +282,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -471,7 +471,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -524,7 +524,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/courseE_aboutme_template_control.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_template_control.level
@@ -76,7 +76,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/courseE_aboutme_template_control.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_template_control.level
@@ -261,7 +261,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -283,7 +283,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -472,7 +472,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -525,7 +525,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/courseE_aboutme_template_experiment.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_template_experiment.level
@@ -76,7 +76,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/courseE_aboutme_template_experiment.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_template_experiment.level
@@ -261,7 +261,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -283,7 +283,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -472,7 +472,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -525,7 +525,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/courseE_aboutme_test.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_test.level
@@ -898,7 +898,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -920,7 +920,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -1109,7 +1109,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -1162,7 +1162,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/courseE_aboutme_test.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_test.level
@@ -713,7 +713,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/courseE_aboutme_test2.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_test2.level
@@ -515,7 +515,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -537,7 +537,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -726,7 +726,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -779,7 +779,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/courseE_aboutme_test2.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_test2.level
@@ -59,7 +59,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/courseF_DodgeBees.level
+++ b/dashboard/config/scripts/levels/courseF_DodgeBees.level
@@ -448,7 +448,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if" inline="false" uservisible="false">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/courseF_DodgeBees.level
+++ b/dashboard/config/scripts/levels/courseF_DodgeBees.level
@@ -292,7 +292,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true" uservisible="false">
               <title name="PROPERTY">"scale"</title>
@@ -313,7 +313,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true" uservisible="false">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/courseF_data_1.level
+++ b/dashboard/config/scripts/levels/courseF_data_1.level
@@ -259,7 +259,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">
@@ -966,7 +966,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>move a sprite, changing its direction randomly</description>
             </mutation>
-            <title name="NAME">wandering</title>
+            <title name="NAME" id="wandering">wandering</title>
             <statement name="STACK">
               <block type="controls_if">
                 <value name="IF0">

--- a/dashboard/config/scripts/levels/courseF_data_1.level
+++ b/dashboard/config/scripts/levels/courseF_data_1.level
@@ -473,7 +473,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -495,7 +495,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -684,7 +684,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -737,7 +737,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -1151,7 +1151,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>change the size of a sprite</description>
             </mutation>
-            <title name="NAME">shrinking</title>
+            <title name="NAME" id="shrinking">shrinking</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -1173,7 +1173,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>change the size of a sprite</description>
             </mutation>
-            <title name="NAME">growing</title>
+            <title name="NAME" id="growing">growing</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -1362,7 +1362,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>randomly change the size of a sprite</description>
             </mutation>
-            <title name="NAME">jittering</title>
+            <title name="NAME" id="jittering">jittering</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -1415,7 +1415,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>move a sprite across the screen, reversing direction if it touches the edges</description>
             </mutation>
-            <title name="NAME">patrolling</title>
+            <title name="NAME" id="patrolling">patrolling</title>
             <statement name="STACK">
               <block type="gamelab_moveForward">
                 <value name="SPRITE">

--- a/dashboard/config/scripts/levels/courseF_findMagicBear.level
+++ b/dashboard/config/scripts/levels/courseF_findMagicBear.level
@@ -449,7 +449,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if" inline="false" uservisible="false">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/courseF_findMagicBear.level
+++ b/dashboard/config/scripts/levels/courseF_findMagicBear.level
@@ -293,7 +293,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true" uservisible="false">
               <title name="PROPERTY">"scale"</title>
@@ -314,7 +314,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true" uservisible="false">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/courseF_findSize.level
+++ b/dashboard/config/scripts/levels/courseF_findSize.level
@@ -449,7 +449,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if" inline="false" uservisible="false">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/courseF_findSize.level
+++ b/dashboard/config/scripts/levels/courseF_findSize.level
@@ -293,7 +293,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true" uservisible="false">
               <title name="PROPERTY">"scale"</title>
@@ -314,7 +314,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true" uservisible="false">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/courseF_project_1.level
+++ b/dashboard/config/scripts/levels/courseF_project_1.level
@@ -909,7 +909,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -931,7 +931,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -1057,7 +1057,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -1110,7 +1110,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/courseF_project_1.level
+++ b/dashboard/config/scripts/levels/courseF_project_1.level
@@ -724,7 +724,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/courseF_project_1_2019.level
+++ b/dashboard/config/scripts/levels/courseF_project_1_2019.level
@@ -658,7 +658,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/courseF_project_1_2019.level
+++ b/dashboard/config/scripts/levels/courseF_project_1_2019.level
@@ -953,7 +953,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -975,7 +975,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -1101,7 +1101,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -1154,7 +1154,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/coursef_EOC_2 Ram.level
+++ b/dashboard/config/scripts/levels/coursef_EOC_2 Ram.level
@@ -83,7 +83,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Starts moving</description>
           </mutation>
-          <title name="NAME">moving</title>
+          <title name="NAME" id="moving">moving</title>
           <statement name="STACK">
             <block type="gamelab_moveInDirection" inline="true">
               <title name="DIRECTION">"South"</title>

--- a/dashboard/config/scripts/levels/coursef_EOC_2.level
+++ b/dashboard/config/scripts/levels/coursef_EOC_2.level
@@ -82,7 +82,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Starts moving</description>
           </mutation>
-          <title name="NAME">moving</title>
+          <title name="NAME" id="moving">moving</title>
           <statement name="STACK">
             <block type="gamelab_moveInDirection" inline="true">
               <title name="DIRECTION">"South"</title>

--- a/dashboard/config/scripts/levels/generic_storyboard_choices_backgrounds.level
+++ b/dashboard/config/scripts/levels/generic_storyboard_choices_backgrounds.level
@@ -309,7 +309,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -331,7 +331,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -506,7 +506,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -527,7 +527,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/generic_storyboard_choices_backgrounds.level
+++ b/dashboard/config/scripts/levels/generic_storyboard_choices_backgrounds.level
@@ -388,7 +388,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/generic_storyboard_choices_sounds.level
+++ b/dashboard/config/scripts/levels/generic_storyboard_choices_sounds.level
@@ -446,7 +446,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/generic_storyboard_choices_sounds.level
+++ b/dashboard/config/scripts/levels/generic_storyboard_choices_sounds.level
@@ -367,7 +367,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -389,7 +389,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -564,7 +564,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -585,7 +585,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/generic_storyboard_choices_sounds_no_categories.level
+++ b/dashboard/config/scripts/levels/generic_storyboard_choices_sounds_no_categories.level
@@ -391,7 +391,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -413,7 +413,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -588,7 +588,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -609,7 +609,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/generic_storyboard_choices_sounds_no_categories.level
+++ b/dashboard/config/scripts/levels/generic_storyboard_choices_sounds_no_categories.level
@@ -470,7 +470,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/generic_storyboard_choices_sprites.level
+++ b/dashboard/config/scripts/levels/generic_storyboard_choices_sprites.level
@@ -321,7 +321,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -343,7 +343,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -518,7 +518,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -539,7 +539,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/generic_storyboard_choices_sprites.level
+++ b/dashboard/config/scripts/levels/generic_storyboard_choices_sprites.level
@@ -400,7 +400,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/helloworld_animals_backgrounds.level
+++ b/dashboard/config/scripts/levels/helloworld_animals_backgrounds.level
@@ -309,7 +309,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -331,7 +331,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -506,7 +506,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -527,7 +527,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/helloworld_animals_backgrounds.level
+++ b/dashboard/config/scripts/levels/helloworld_animals_backgrounds.level
@@ -388,7 +388,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/helloworld_animals_sounds.level
+++ b/dashboard/config/scripts/levels/helloworld_animals_sounds.level
@@ -372,7 +372,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -394,7 +394,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -569,7 +569,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -590,7 +590,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/helloworld_animals_sounds.level
+++ b/dashboard/config/scripts/levels/helloworld_animals_sounds.level
@@ -451,7 +451,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/helloworld_batman_backgrounds.level
+++ b/dashboard/config/scripts/levels/helloworld_batman_backgrounds.level
@@ -309,7 +309,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -331,7 +331,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -506,7 +506,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -527,7 +527,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/helloworld_batman_backgrounds.level
+++ b/dashboard/config/scripts/levels/helloworld_batman_backgrounds.level
@@ -388,7 +388,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/helloworld_batman_sounds.level
+++ b/dashboard/config/scripts/levels/helloworld_batman_sounds.level
@@ -446,7 +446,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/helloworld_batman_sounds.level
+++ b/dashboard/config/scripts/levels/helloworld_batman_sounds.level
@@ -367,7 +367,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -389,7 +389,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -564,7 +564,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -585,7 +585,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/helloworld_emoji_backgrounds.level
+++ b/dashboard/config/scripts/levels/helloworld_emoji_backgrounds.level
@@ -385,7 +385,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/helloworld_emoji_backgrounds.level
+++ b/dashboard/config/scripts/levels/helloworld_emoji_backgrounds.level
@@ -306,7 +306,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -328,7 +328,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -503,7 +503,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -524,7 +524,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/helloworld_emoji_sounds.level
+++ b/dashboard/config/scripts/levels/helloworld_emoji_sounds.level
@@ -372,7 +372,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -394,7 +394,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -569,7 +569,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -590,7 +590,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/helloworld_emoji_sounds.level
+++ b/dashboard/config/scripts/levels/helloworld_emoji_sounds.level
@@ -451,7 +451,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/helloworld_food_backgrounds.level
+++ b/dashboard/config/scripts/levels/helloworld_food_backgrounds.level
@@ -387,7 +387,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/helloworld_food_backgrounds.level
+++ b/dashboard/config/scripts/levels/helloworld_food_backgrounds.level
@@ -308,7 +308,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -330,7 +330,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -505,7 +505,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -526,7 +526,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/helloworld_food_sounds.level
+++ b/dashboard/config/scripts/levels/helloworld_food_sounds.level
@@ -446,7 +446,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/helloworld_food_sounds.level
+++ b/dashboard/config/scripts/levels/helloworld_food_sounds.level
@@ -367,7 +367,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -389,7 +389,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -564,7 +564,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -585,7 +585,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/helloworld_retro_backgrounds.level
+++ b/dashboard/config/scripts/levels/helloworld_retro_backgrounds.level
@@ -385,7 +385,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/helloworld_retro_backgrounds.level
+++ b/dashboard/config/scripts/levels/helloworld_retro_backgrounds.level
@@ -306,7 +306,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -328,7 +328,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -503,7 +503,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -524,7 +524,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/helloworld_retro_sounds.level
+++ b/dashboard/config/scripts/levels/helloworld_retro_sounds.level
@@ -372,7 +372,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -394,7 +394,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -569,7 +569,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -590,7 +590,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/helloworld_retro_sounds.level
+++ b/dashboard/config/scripts/levels/helloworld_retro_sounds.level
@@ -451,7 +451,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/international_outbreak_freeplay.level
+++ b/dashboard/config/scripts/levels/international_outbreak_freeplay.level
@@ -482,7 +482,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="gamelab_withPercentChance">
               <value name="NUM">

--- a/dashboard/config/scripts/levels/international_outbreak_freeplay.level
+++ b/dashboard/config/scripts/levels/international_outbreak_freeplay.level
@@ -648,7 +648,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -670,7 +670,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -859,7 +859,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -912,7 +912,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/math_test.level
+++ b/dashboard/config/scripts/levels/math_test.level
@@ -33,7 +33,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>move a sprite, changing its direction randomly</description>
             </mutation>
-            <title name="NAME">wandering</title>
+            <title name="NAME" id="wandering">wandering</title>
             <statement name="STACK">
               <block type="controls_if">
                 <value name="IF0">

--- a/dashboard/config/scripts/levels/math_test.level
+++ b/dashboard/config/scripts/levels/math_test.level
@@ -218,7 +218,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>change the size of a sprite</description>
             </mutation>
-            <title name="NAME">shrinking</title>
+            <title name="NAME" id="shrinking">shrinking</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy" editable="false">
                 <title name="PROPERTY">"scale"</title>
@@ -240,7 +240,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>change the size of a sprite</description>
             </mutation>
-            <title name="NAME">growing</title>
+            <title name="NAME" id="growing">growing</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy" editable="false">
                 <title name="PROPERTY">"scale"</title>
@@ -429,7 +429,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>randomly change the size of a sprite</description>
             </mutation>
-            <title name="NAME">jittering</title>
+            <title name="NAME" id="jittering">jittering</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy" editable="false">
                 <title name="PROPERTY">"scale"</title>
@@ -482,7 +482,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>move a sprite across the screen, reversing direction if it touches the edges</description>
             </mutation>
-            <title name="NAME">patrolling</title>
+            <title name="NAME" id="patrolling">patrolling</title>
             <statement name="STACK">
               <block type="gamelab_moveForward" editable="false">
                 <value name="SPRITE">

--- a/dashboard/config/scripts/levels/mike-test.level
+++ b/dashboard/config/scripts/levels/mike-test.level
@@ -55,7 +55,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">
@@ -567,7 +567,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>move a sprite, changing its direction randomly</description>
             </mutation>
-            <title name="NAME">wandering</title>
+            <title name="NAME" id="wandering">wandering</title>
             <statement name="STACK">
               <block type="controls_if">
                 <value name="IF0">

--- a/dashboard/config/scripts/levels/mike-test.level
+++ b/dashboard/config/scripts/levels/mike-test.level
@@ -240,7 +240,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -262,7 +262,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -451,7 +451,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -504,7 +504,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -752,7 +752,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>change the size of a sprite</description>
             </mutation>
-            <title name="NAME">shrinking</title>
+            <title name="NAME" id="shrinking">shrinking</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -774,7 +774,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>change the size of a sprite</description>
             </mutation>
-            <title name="NAME">growing</title>
+            <title name="NAME" id="growing">growing</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -963,7 +963,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>randomly change the size of a sprite</description>
             </mutation>
-            <title name="NAME">jittering</title>
+            <title name="NAME" id="jittering">jittering</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -1016,7 +1016,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>move a sprite across the screen, reversing direction if it touches the edges</description>
             </mutation>
-            <title name="NAME">patrolling</title>
+            <title name="NAME" id="patrolling">patrolling</title>
             <statement name="STACK">
               <block type="gamelab_moveForward">
                 <value name="SPRITE">

--- a/dashboard/config/scripts/levels/outbreak1.level
+++ b/dashboard/config/scripts/levels/outbreak1.level
@@ -170,7 +170,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/outbreak2.level
+++ b/dashboard/config/scripts/levels/outbreak2.level
@@ -234,7 +234,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/outbreak3.level
+++ b/dashboard/config/scripts/levels/outbreak3.level
@@ -252,7 +252,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/outbreak4.level
+++ b/dashboard/config/scripts/levels/outbreak4.level
@@ -270,7 +270,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/outbreak4.level
+++ b/dashboard/config/scripts/levels/outbreak4.level
@@ -455,7 +455,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -477,7 +477,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -666,7 +666,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -719,7 +719,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/outbreak5.level
+++ b/dashboard/config/scripts/levels/outbreak5.level
@@ -320,7 +320,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/outbreak6.level
+++ b/dashboard/config/scripts/levels/outbreak6.level
@@ -208,7 +208,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="gamelab_withPercentChance">
               <value name="NUM">

--- a/dashboard/config/scripts/levels/outbreak7.level
+++ b/dashboard/config/scripts/levels/outbreak7.level
@@ -652,7 +652,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -674,7 +674,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -863,7 +863,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -916,7 +916,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/outbreak7.level
+++ b/dashboard/config/scripts/levels/outbreak7.level
@@ -486,7 +486,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="gamelab_withPercentChance">
               <value name="NUM">

--- a/dashboard/config/scripts/levels/outbreak8.level
+++ b/dashboard/config/scripts/levels/outbreak8.level
@@ -650,7 +650,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -672,7 +672,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -861,7 +861,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -914,7 +914,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/outbreak8.level
+++ b/dashboard/config/scripts/levels/outbreak8.level
@@ -484,7 +484,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="gamelab_withPercentChance">
               <value name="NUM">

--- a/dashboard/config/scripts/levels/outbreak_freeplay.level
+++ b/dashboard/config/scripts/levels/outbreak_freeplay.level
@@ -483,7 +483,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="gamelab_withPercentChance">
               <value name="NUM">

--- a/dashboard/config/scripts/levels/outbreak_freeplay.level
+++ b/dashboard/config/scripts/levels/outbreak_freeplay.level
@@ -649,7 +649,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -671,7 +671,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -860,7 +860,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -913,7 +913,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/outbreak_freeplay_basic.level
+++ b/dashboard/config/scripts/levels/outbreak_freeplay_basic.level
@@ -483,7 +483,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="gamelab_withPercentChance">
               <value name="NUM">

--- a/dashboard/config/scripts/levels/outbreak_freeplay_basic.level
+++ b/dashboard/config/scripts/levels/outbreak_freeplay_basic.level
@@ -649,7 +649,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -671,7 +671,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -860,7 +860,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -913,7 +913,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/outbreak_freeplay_data.level
+++ b/dashboard/config/scripts/levels/outbreak_freeplay_data.level
@@ -650,7 +650,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -672,7 +672,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -861,7 +861,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -914,7 +914,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/outbreak_freeplay_data.level
+++ b/dashboard/config/scripts/levels/outbreak_freeplay_data.level
@@ -484,7 +484,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="gamelab_withPercentChance">
               <value name="NUM">

--- a/dashboard/config/scripts/levels/sl-proj-temp.level
+++ b/dashboard/config/scripts/levels/sl-proj-temp.level
@@ -423,7 +423,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>move a sprite, changing its direction randomly</description>
             </mutation>
-            <title name="NAME">wandering</title>
+            <title name="NAME" id="wandering">wandering</title>
             <statement name="STACK">
               <block type="controls_if">
                 <value name="IF0">

--- a/dashboard/config/scripts/levels/sl-proj-temp.level
+++ b/dashboard/config/scripts/levels/sl-proj-temp.level
@@ -608,7 +608,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>change the size of a sprite</description>
             </mutation>
-            <title name="NAME">shrinking</title>
+            <title name="NAME" id="shrinking">shrinking</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -630,7 +630,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>change the size of a sprite</description>
             </mutation>
-            <title name="NAME">growing</title>
+            <title name="NAME" id="growing">growing</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -819,7 +819,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>randomly change the size of a sprite</description>
             </mutation>
-            <title name="NAME">jittering</title>
+            <title name="NAME" id="jittering">jittering</title>
             <statement name="STACK">
               <block type="gamelab_changePropBy">
                 <title name="PROPERTY">"scale"</title>
@@ -872,7 +872,7 @@
               <arg name="this sprite" type="Sprite"/>
               <description>move a sprite across the screen, reversing direction if it touches the edges</description>
             </mutation>
-            <title name="NAME">patrolling</title>
+            <title name="NAME" id="patrolling">patrolling</title>
             <statement name="STACK">
               <block type="gamelab_moveForward">
                 <value name="SPRITE">

--- a/dashboard/config/scripts/levels/sl-rock-paper-scissors.level
+++ b/dashboard/config/scripts/levels/sl-rock-paper-scissors.level
@@ -415,7 +415,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/sprite lab - ask and answer.level
+++ b/dashboard/config/scripts/levels/sprite lab - ask and answer.level
@@ -93,7 +93,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/sprite lab - ask and answer.level
+++ b/dashboard/config/scripts/levels/sprite lab - ask and answer.level
@@ -285,7 +285,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -307,7 +307,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -496,7 +496,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -549,7 +549,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/spritelab_hotcold_test.level
+++ b/dashboard/config/scripts/levels/spritelab_hotcold_test.level
@@ -449,7 +449,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if" inline="false" uservisible="false">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/spritelab_hotcold_test.level
+++ b/dashboard/config/scripts/levels/spritelab_hotcold_test.level
@@ -293,7 +293,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true" uservisible="false">
               <title name="PROPERTY">"scale"</title>
@@ -314,7 +314,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy" inline="true" uservisible="false">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/storyboard_choicesB_backgrounds.level
+++ b/dashboard/config/scripts/levels/storyboard_choicesB_backgrounds.level
@@ -423,7 +423,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/storyboard_choicesB_backgrounds.level
+++ b/dashboard/config/scripts/levels/storyboard_choicesB_backgrounds.level
@@ -344,7 +344,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -366,7 +366,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -541,7 +541,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -562,7 +562,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/storyboard_choicesB_sounds.level
+++ b/dashboard/config/scripts/levels/storyboard_choicesB_sounds.level
@@ -413,7 +413,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/storyboard_choicesB_sounds.level
+++ b/dashboard/config/scripts/levels/storyboard_choicesB_sounds.level
@@ -334,7 +334,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -356,7 +356,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -531,7 +531,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -552,7 +552,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/storyboard_choicesB_sprites.level
+++ b/dashboard/config/scripts/levels/storyboard_choicesB_sprites.level
@@ -302,7 +302,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -324,7 +324,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -499,7 +499,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -520,7 +520,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/storyboard_choicesB_sprites.level
+++ b/dashboard/config/scripts/levels/storyboard_choicesB_sprites.level
@@ -381,7 +381,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/storyboard_choices_backgrounds.level
+++ b/dashboard/config/scripts/levels/storyboard_choices_backgrounds.level
@@ -420,7 +420,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/storyboard_choices_backgrounds.level
+++ b/dashboard/config/scripts/levels/storyboard_choices_backgrounds.level
@@ -341,7 +341,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -363,7 +363,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -538,7 +538,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -559,7 +559,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/storyboard_choices_sounds.level
+++ b/dashboard/config/scripts/levels/storyboard_choices_sounds.level
@@ -407,7 +407,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/storyboard_choices_sounds.level
+++ b/dashboard/config/scripts/levels/storyboard_choices_sounds.level
@@ -328,7 +328,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -350,7 +350,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -525,7 +525,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -546,7 +546,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/storyboard_choices_sprites.level
+++ b/dashboard/config/scripts/levels/storyboard_choices_sprites.level
@@ -419,7 +419,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/storyboard_choices_sprites.level
+++ b/dashboard/config/scripts/levels/storyboard_choices_sprites.level
@@ -340,7 +340,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -362,7 +362,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -537,7 +537,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -558,7 +558,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/storyboard_project_costumes.level
+++ b/dashboard/config/scripts/levels/storyboard_project_costumes.level
@@ -269,7 +269,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -291,7 +291,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -480,7 +480,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -533,7 +533,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/storyboard_project_costumes.level
+++ b/dashboard/config/scripts/levels/storyboard_project_costumes.level
@@ -84,7 +84,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/storyboard_project_events.level
+++ b/dashboard/config/scripts/levels/storyboard_project_events.level
@@ -202,7 +202,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/storyboard_project_events.level
+++ b/dashboard/config/scripts/levels/storyboard_project_events.level
@@ -387,7 +387,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -409,7 +409,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -598,7 +598,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -651,7 +651,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/storyboard_project_print.level
+++ b/dashboard/config/scripts/levels/storyboard_project_print.level
@@ -333,7 +333,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -355,7 +355,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -544,7 +544,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -597,7 +597,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/storyboard_project_print.level
+++ b/dashboard/config/scripts/levels/storyboard_project_print.level
@@ -148,7 +148,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/storyboard_project_sprites.level
+++ b/dashboard/config/scripts/levels/storyboard_project_sprites.level
@@ -170,7 +170,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/storyboard_project_sprites.level
+++ b/dashboard/config/scripts/levels/storyboard_project_sprites.level
@@ -355,7 +355,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -377,7 +377,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -566,7 +566,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -619,7 +619,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/storyboard_project_start.level
+++ b/dashboard/config/scripts/levels/storyboard_project_start.level
@@ -133,7 +133,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/storyboard_project_start.level
+++ b/dashboard/config/scripts/levels/storyboard_project_start.level
@@ -318,7 +318,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -340,7 +340,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -529,7 +529,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -582,7 +582,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/teacherSandboxFish.level
+++ b/dashboard/config/scripts/levels/teacherSandboxFish.level
@@ -270,7 +270,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -292,7 +292,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -481,7 +481,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -534,7 +534,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/teacherSandboxFish.level
+++ b/dashboard/config/scripts/levels/teacherSandboxFish.level
@@ -85,7 +85,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/temp_startblocks.level
+++ b/dashboard/config/scripts/levels/temp_startblocks.level
@@ -504,7 +504,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -526,7 +526,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -715,7 +715,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -768,7 +768,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/temp_startblocks.level
+++ b/dashboard/config/scripts/levels/temp_startblocks.level
@@ -338,7 +338,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="gamelab_withPercentChance">
               <value name="NUM">

--- a/dashboard/config/scripts/levels/test shared behaviors.level
+++ b/dashboard/config/scripts/levels/test shared behaviors.level
@@ -251,7 +251,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -273,7 +273,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -462,7 +462,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -515,7 +515,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/test shared behaviors.level
+++ b/dashboard/config/scripts/levels/test shared behaviors.level
@@ -66,7 +66,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/timeforcs_demo_sl_2.level
+++ b/dashboard/config/scripts/levels/timeforcs_demo_sl_2.level
@@ -194,7 +194,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/timeforcs_demo_sl_2.level
+++ b/dashboard/config/scripts/levels/timeforcs_demo_sl_2.level
@@ -115,7 +115,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -137,7 +137,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -312,7 +312,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -333,7 +333,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/timeforcs_demo_sl_7.level
+++ b/dashboard/config/scripts/levels/timeforcs_demo_sl_7.level
@@ -407,7 +407,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/timeforcs_demo_sl_7.level
+++ b/dashboard/config/scripts/levels/timeforcs_demo_sl_7.level
@@ -176,7 +176,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -328,7 +328,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -350,7 +350,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -525,7 +525,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/timeforcs_demo_sl_9.level
+++ b/dashboard/config/scripts/levels/timeforcs_demo_sl_9.level
@@ -112,7 +112,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -264,7 +264,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -286,7 +286,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>Moves back and forth in one direction. To change the direction a sprite is patrolling, change its "movement direction"</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">
@@ -461,7 +461,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/scripts/levels/timeforcs_demo_sl_9.level
+++ b/dashboard/config/scripts/levels/timeforcs_demo_sl_9.level
@@ -343,7 +343,7 @@
           <mutation>
             <arg name="this sprite" type="Sprite"/>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/timeforcs_demo_spritelab_1.level
+++ b/dashboard/config/scripts/levels/timeforcs_demo_spritelab_1.level
@@ -952,7 +952,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -974,7 +974,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -1100,7 +1100,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -1153,7 +1153,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/timeforcs_demo_spritelab_1.level
+++ b/dashboard/config/scripts/levels/timeforcs_demo_spritelab_1.level
@@ -657,7 +657,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/timeforcs_demo_spritelab_2.level
+++ b/dashboard/config/scripts/levels/timeforcs_demo_spritelab_2.level
@@ -659,7 +659,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/timeforcs_demo_spritelab_2.level
+++ b/dashboard/config/scripts/levels/timeforcs_demo_spritelab_2.level
@@ -954,7 +954,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -976,7 +976,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -1102,7 +1102,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -1155,7 +1155,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/timeforcs_demo_spritelab_3.level
+++ b/dashboard/config/scripts/levels/timeforcs_demo_spritelab_3.level
@@ -659,7 +659,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/timeforcs_demo_spritelab_3.level
+++ b/dashboard/config/scripts/levels/timeforcs_demo_spritelab_3.level
@@ -954,7 +954,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -976,7 +976,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -1102,7 +1102,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -1155,7 +1155,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/timeforcs_demo_spritelab_4.level
+++ b/dashboard/config/scripts/levels/timeforcs_demo_spritelab_4.level
@@ -659,7 +659,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/timeforcs_demo_spritelab_4.level
+++ b/dashboard/config/scripts/levels/timeforcs_demo_spritelab_4.level
@@ -954,7 +954,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -976,7 +976,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -1102,7 +1102,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -1155,7 +1155,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/timeforcs_demo_spritelab_5.level
+++ b/dashboard/config/scripts/levels/timeforcs_demo_spritelab_5.level
@@ -659,7 +659,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/timeforcs_demo_spritelab_5.level
+++ b/dashboard/config/scripts/levels/timeforcs_demo_spritelab_5.level
@@ -954,7 +954,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -976,7 +976,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -1102,7 +1102,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -1155,7 +1155,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/virus_1_codebytes.level
+++ b/dashboard/config/scripts/levels/virus_1_codebytes.level
@@ -158,7 +158,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">
@@ -444,7 +444,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/virus_1_codebytes_elijah.level
+++ b/dashboard/config/scripts/levels/virus_1_codebytes_elijah.level
@@ -87,7 +87,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">
@@ -373,7 +373,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/virus_2_codebytes.level
+++ b/dashboard/config/scripts/levels/virus_2_codebytes.level
@@ -158,7 +158,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">
@@ -462,7 +462,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/virus_3_codebytes.level
+++ b/dashboard/config/scripts/levels/virus_3_codebytes.level
@@ -87,7 +87,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">
@@ -399,7 +399,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/virus_4_codebytes.level
+++ b/dashboard/config/scripts/levels/virus_4_codebytes.level
@@ -160,7 +160,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/virus_5_codebytes.level
+++ b/dashboard/config/scripts/levels/virus_5_codebytes.level
@@ -159,7 +159,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/virus_8_codebytes.level
+++ b/dashboard/config/scripts/levels/virus_8_codebytes.level
@@ -159,7 +159,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/virus_chance_codebytes.level
+++ b/dashboard/config/scripts/levels/virus_chance_codebytes.level
@@ -160,7 +160,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/virus_complete_codebytes.level
+++ b/dashboard/config/scripts/levels/virus_complete_codebytes.level
@@ -570,7 +570,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">
@@ -1385,7 +1385,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/virus_complete_codebytes.level
+++ b/dashboard/config/scripts/levels/virus_complete_codebytes.level
@@ -841,7 +841,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">shrinking</title>
+          <title name="NAME" id="shrinking">shrinking</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -863,7 +863,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>change the size of a sprite</description>
           </mutation>
-          <title name="NAME">growing</title>
+          <title name="NAME" id="growing">growing</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -1052,7 +1052,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>randomly change the size of a sprite</description>
           </mutation>
-          <title name="NAME">jittering</title>
+          <title name="NAME" id="jittering">jittering</title>
           <statement name="STACK">
             <block type="gamelab_changePropBy">
               <title name="PROPERTY">"scale"</title>
@@ -1105,7 +1105,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite across the screen, reversing direction if it touches the edges</description>
           </mutation>
-          <title name="NAME">patrolling</title>
+          <title name="NAME" id="patrolling">patrolling</title>
           <statement name="STACK">
             <block type="gamelab_moveForward">
               <value name="SPRITE">

--- a/dashboard/config/scripts/levels/virus_costumes_codebytes.level
+++ b/dashboard/config/scripts/levels/virus_costumes_codebytes.level
@@ -159,7 +159,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/virus_free_codebytes.level
+++ b/dashboard/config/scripts/levels/virus_free_codebytes.level
@@ -453,7 +453,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/virus_immunity_codebytes.level
+++ b/dashboard/config/scripts/levels/virus_immunity_codebytes.level
@@ -160,7 +160,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/virus_print_codebytes.level
+++ b/dashboard/config/scripts/levels/virus_print_codebytes.level
@@ -159,7 +159,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/virus_template_codebytes.level
+++ b/dashboard/config/scripts/levels/virus_template_codebytes.level
@@ -86,7 +86,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">
@@ -325,7 +325,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/virus_template_codebytes1.level
+++ b/dashboard/config/scripts/levels/virus_template_codebytes1.level
@@ -87,7 +87,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">
@@ -326,7 +326,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/virus_template_codebytes_fix.level
+++ b/dashboard/config/scripts/levels/virus_template_codebytes_fix.level
@@ -158,7 +158,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">
@@ -397,7 +397,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">

--- a/dashboard/config/scripts/levels/virus_tweaks_codebytes.level
+++ b/dashboard/config/scripts/levels/virus_tweaks_codebytes.level
@@ -159,7 +159,7 @@
             <arg name="this sprite" type="Sprite"/>
             <description>move a sprite, changing its direction randomly</description>
           </mutation>
-          <title name="NAME">wandering</title>
+          <title name="NAME" id="wandering">wandering</title>
           <statement name="STACK">
             <block type="controls_if">
               <value name="IF0">


### PR DESCRIPTION
**What**: Update all  `behavior_definition` block's `title` to contain an `id` equivalent to their text value using a oneoff script.  

**Why**: Function blocks are looked up by their `id`. [This PR goes more in depth as to why](https://github.com/code-dot-org/code-dot-org/pull/37983). If no `id` is set on the block's `title`, the `title`'s text value is used instead.  [This text value is translated](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/levels/blockly.rb#L579) and therefore causes the [initialization process](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/block_utils.js#L466) to not find the block and not add the function where necessary. This results in this specific level's(level in the Jira ticket) canvas breaking when the wandering block is used. This should also fix the other behavior definition types from breaking when translated as well.

## Links

[Slack bug bash](https://codedotorg.slack.com/archives/C0T0PNTM3/p1632760044435200)
- jira ticket: [FND-1727](https://codedotorg.atlassian.net/browse/FND-1727)


## Testing story

Ran oneoff locally and this fixed using the wandering block. The highlighted green block is the wandering function block that caused the level's canvas to crash.

![Screen Shot 2021-09-29 at 11 27 03 AM](https://user-images.githubusercontent.com/48133820/135310317-89bd0e63-d358-41ac-a5a6-31916512ff54.png)


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
