### PR TITLE
Remove newlines from "get produce" German translations

### DIFF
--- a/dashboard/config/locales/function_definitions.de-DE.json
+++ b/dashboard/config/locales/function_definitions.de-DE.json
@@ -2883,7 +2883,7 @@
             "name": "untersuche Quadrat nach Mais"
           },
           "get produce": {
-            "name": "Landwirtschaftliche Erzeugnisse holen\n"
+            "name": "Landwirtschaftliche Erzeugnisse holen"
           },
           "get all pumpkins": {
             "name": "hole alle Kürbisse"
@@ -2900,7 +2900,7 @@
             "name": "untersuche Quadrat nach Mais"
           },
           "get produce": {
-            "name": "Landwirtschaftliche Erzeugnisse holen\n"
+            "name": "Landwirtschaftliche Erzeugnisse holen"
           },
           "get all pumpkins": {
             "name": "hole alle Kürbisse"
@@ -2917,7 +2917,7 @@
             "name": "untersuche Quadrat nach Mais"
           },
           "get produce": {
-            "name": "Landwirtschaftliche Erzeugnisse holen\n"
+            "name": "Landwirtschaftliche Erzeugnisse holen"
           },
           "get all pumpkins": {
             "name": "hole alle Kürbisse"
@@ -4281,7 +4281,7 @@
             "name": "untersuche Quadrat nach Mais"
           },
           "get produce": {
-            "name": "Landwirtschaftliche Erzeugnisse holen\n"
+            "name": "Landwirtschaftliche Erzeugnisse holen"
           },
           "get all pumpkins": {
             "name": "hole alle Kürbisse"


### PR DESCRIPTION
**What**: Removed the newlines in German "get produce" translations. Also [removed them from crowdin so they aren't reintroduced](https://crowdin.com/translate/codeorg/all/enus-de?filter=basic&value=0#q=Landwirtschaftliche) with future i18n syncs.

**Why**: The newlines were being used in the function name as the hex equivalent `0A` causing the call to be undefined. Breaking the run button.
![image](https://user-images.githubusercontent.com/48133820/135326548-09fc2b11-bfe1-4c37-ad44-38aca605f6e5.png)


## Links

- jira ticket: [FND-1703](https://codedotorg.atlassian.net/browse/FND-1703)

## Testing story

Tested locally and was able to successfully run the broken levels

## Follow-up work

Notify user the issue is fixed on zendesk

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
