### PR TITLE
Fixed audio playback in Firefox/Theater

### DIFF
--- a/apps/src/javalab/TheaterVisualizationColumn.jsx
+++ b/apps/src/javalab/TheaterVisualizationColumn.jsx
@@ -41,7 +41,7 @@ class TheaterVisualizationColumn extends React.Component {
           <ProtectedVisualizationDiv>
             <div id="theater-container" style={styles.theater}>
               <img id="theater" style={styles.theaterImage} />
-              <audio id="theater-audio" />
+              <audio id="theater-audio" preload="auto" />
             </div>
           </ProtectedVisualizationDiv>
         </div>


### PR DESCRIPTION
We were seeing an issue where Firefox would not start the playback of audio files in Theater when the URL was from S3. We hypothesize that this was caused by S3 only providing the metadata by default and/or Firefox only downloading the Metadata until asked to do more. We suspect this because the S3 urls were returning with a 206 response. Additionally, on Firefox, a ~900kb file only downloaded ~30kb. 

Because of this, `canplaythrough` was never triggered on Firefox. Setting the preload value to "auto" enforces a full download of the file.

Full details in the MDN docs: https://developer.mozilla.org/en-US/docs/Web/Guide/Audio_and_video_delivery/Cross-browser_audio_basics

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
