### PR TITLE
Playground: add/update/remove text items

### DIFF
--- a/apps/src/javalab/Playground.js
+++ b/apps/src/javalab/Playground.js
@@ -132,12 +132,17 @@ export default class Playground {
       // can't add new items if the game is over or if the item already exists
       return;
     }
+    console.log(itemData);
 
     const textData = {
       text: itemData.text,
       x: itemData.x,
       y: itemData.y,
       height: itemData.height,
+      rotation: itemData.rotation,
+      red: itemData.colorRed,
+      blue: itemData.colorBlue,
+      green: itemData.colorGreen,
       type: PlaygroundItemType.TEXT
     };
     this.addPlaygroundItem(itemData.id, textData);

--- a/apps/src/javalab/Playground.js
+++ b/apps/src/javalab/Playground.js
@@ -172,7 +172,6 @@ export default class Playground {
         // we don't need to pass filename as imageData
         delete changedItemData.filename;
       }
-      return changedItemData;
     }
 
     // No changes to itemData required for text items other than removing ID property.

--- a/apps/src/javalab/Playground.js
+++ b/apps/src/javalab/Playground.js
@@ -139,6 +139,7 @@ export default class Playground {
       x: itemData.x,
       y: itemData.y,
       height: itemData.height,
+      index: itemData.index,
       rotation: itemData.rotation,
       red: itemData.colorRed,
       blue: itemData.colorBlue,

--- a/apps/src/javalab/Playground.js
+++ b/apps/src/javalab/Playground.js
@@ -156,27 +156,27 @@ export default class Playground {
       return;
     }
 
-    const newItemData = this.getNewItemData(itemData);
-    this.changePlaygroundItem(itemData.id, newItemData);
+    const changedItemData = this.getChangedItemData(itemData);
+    this.changePlaygroundItem(itemData.id, changedItemData);
   }
 
-  getNewItemData(itemData) {
+  getChangedItemData(itemData) {
     // We do not include the ID as part of each item's data.
     // The ID serves as the key referencing an object that contains the item's contents.
-    const newItemData = {...itemData};
-    delete newItemData.id;
+    const changedItemData = {...itemData};
+    delete changedItemData.id;
 
     if (this.getItem(itemData.id).type === PlaygroundItemType.IMAGE) {
       if (itemData.filename) {
-        newItemData.fileUrl = this.getUrl(itemData.filename);
+        changedItemData.fileUrl = this.getUrl(itemData.filename);
         // we don't need to pass filename as imageData
-        delete newItemData.filename;
+        delete changedItemData.filename;
       }
-      return newItemData;
+      return changedItemData;
     }
 
     // No changes to itemData required for text items other than removing ID property.
-    return newItemData;
+    return changedItemData;
   }
 
   playSound(soundData) {

--- a/apps/src/javalab/Playground.js
+++ b/apps/src/javalab/Playground.js
@@ -133,20 +133,12 @@ export default class Playground {
       return;
     }
 
-    const textData = {
-      text: itemData.text,
-      x: itemData.x,
-      y: itemData.y,
-      height: itemData.height,
-      index: itemData.index,
-      rotation: itemData.rotation,
-      red: itemData.colorRed,
-      blue: itemData.colorBlue,
-      green: itemData.colorGreen,
-      font: itemData.font,
-      fontStyle: itemData.fontStyle,
-      type: PlaygroundItemType.TEXT
-    };
+    const textData = {...itemData};
+    delete textData.id;
+    textData.type = PlaygroundItemType.TEXT;
+
+    console.log(textData);
+
     this.addPlaygroundItem(itemData.id, textData);
   }
 
@@ -174,8 +166,8 @@ export default class Playground {
         delete newImageData.filename;
       }
       this.changePlaygroundItem(itemData.id, newImageData);
+    } else if (this.getItem(itemData.id).type === PlaygroundItemType.TEXT) {
     }
-    // TODO: handle text changes
   }
 
   playSound(soundData) {

--- a/apps/src/javalab/Playground.js
+++ b/apps/src/javalab/Playground.js
@@ -143,6 +143,8 @@ export default class Playground {
       red: itemData.colorRed,
       blue: itemData.colorBlue,
       green: itemData.colorGreen,
+      fontFamily: itemData.font,
+      fontStyle: itemData.fontStyle,
       type: PlaygroundItemType.TEXT
     };
     this.addPlaygroundItem(itemData.id, textData);

--- a/apps/src/javalab/Playground.js
+++ b/apps/src/javalab/Playground.js
@@ -107,7 +107,7 @@ export default class Playground {
 
   addImageHelper(itemData, isClickable) {
     // ignore request if the game is over or if the item already exists
-    if (this.isGameOver || this.imageItemExists(itemData)) {
+    if (this.isGameOver || this.itemExists(itemData)) {
       return;
     }
     let onClick = isClickable
@@ -128,7 +128,7 @@ export default class Playground {
   }
 
   addTextItem(itemData) {
-    if (this.isGameOver || this.imageItemExists(itemData)) {
+    if (this.isGameOver || this.itemExists(itemData)) {
       // can't add new items if the game is over or if the item already exists
       return;
     }
@@ -155,7 +155,7 @@ export default class Playground {
       // can't remove items if game is over
       return;
     }
-    if (this.imageItemExists(itemData)) {
+    if (this.itemExists(itemData)) {
       this.removePlaygroundItem(itemData.id);
     }
     // TODO: handle text deletion
@@ -166,7 +166,7 @@ export default class Playground {
       // can't change items if game is over
       return;
     }
-    if (this.imageItemExists(itemData)) {
+    if (this.getItem(itemData.id).type === PlaygroundItemType.IMAGE) {
       const newImageData = {...itemData};
       if (itemData.filename) {
         newImageData.fileUrl = this.getUrl(itemData.filename);
@@ -263,7 +263,11 @@ export default class Playground {
     this.isGameOver = true;
   }
 
-  imageItemExists(itemData) {
+  itemExists(itemData) {
     return getItemIds(getStore().getState().playground).includes(itemData.id);
+  }
+
+  getItem(itemId) {
+    return getStore().getState().playground.itemData[itemId];
   }
 }

--- a/apps/src/javalab/Playground.js
+++ b/apps/src/javalab/Playground.js
@@ -151,8 +151,8 @@ export default class Playground {
   }
 
   changeItem(itemData) {
-    if (this.isGameOver) {
-      // can't change items if game is over
+    if (this.isGameOver || !this.itemExists(itemData)) {
+      // can't change items if game is over or if the item does not exist
       return;
     }
 
@@ -175,12 +175,8 @@ export default class Playground {
       return newItemData;
     }
 
-    if (this.getItem(itemData.id).type === PlaygroundItemType.IMAGE) {
-      this.changePlaygroundItem(itemData.id, newItemData);
-      return newItemData;
-    }
-
-    return itemData;
+    // No changes to itemData required for text items other than removing ID property.
+    return newItemData;
   }
 
   playSound(soundData) {

--- a/apps/src/javalab/Playground.js
+++ b/apps/src/javalab/Playground.js
@@ -132,7 +132,6 @@ export default class Playground {
       // can't add new items if the game is over or if the item already exists
       return;
     }
-    console.log(itemData);
 
     const textData = {
       text: itemData.text,
@@ -144,7 +143,7 @@ export default class Playground {
       red: itemData.colorRed,
       blue: itemData.colorBlue,
       green: itemData.colorGreen,
-      fontFamily: itemData.font,
+      font: itemData.font,
       fontStyle: itemData.fontStyle,
       type: PlaygroundItemType.TEXT
     };

--- a/apps/src/javalab/Playground.js
+++ b/apps/src/javalab/Playground.js
@@ -107,7 +107,7 @@ export default class Playground {
 
   addImageHelper(itemData, isClickable) {
     // ignore request if the game is over or if the item already exists
-    if (this.isGameOver || this.itemExists(itemData)) {
+    if (this.isGameOver || this.imageItemExists(itemData)) {
       return;
     }
     let onClick = isClickable
@@ -128,7 +128,7 @@ export default class Playground {
   }
 
   addTextItem(itemData) {
-    if (this.isGameOver || this.itemExists(itemData)) {
+    if (this.isGameOver || this.imageItemExists(itemData)) {
       // can't add new items if the game is over or if the item already exists
       return;
     }
@@ -155,7 +155,7 @@ export default class Playground {
       // can't remove items if game is over
       return;
     }
-    if (this.itemExists(itemData)) {
+    if (this.imageItemExists(itemData)) {
       this.removePlaygroundItem(itemData.id);
     }
     // TODO: handle text deletion
@@ -166,7 +166,7 @@ export default class Playground {
       // can't change items if game is over
       return;
     }
-    if (this.itemExists(itemData)) {
+    if (this.imageItemExists(itemData)) {
       const newImageData = {...itemData};
       if (itemData.filename) {
         newImageData.fileUrl = this.getUrl(itemData.filename);
@@ -263,7 +263,7 @@ export default class Playground {
     this.isGameOver = true;
   }
 
-  itemExists(itemData) {
+  imageItemExists(itemData) {
     return getItemIds(getStore().getState().playground).includes(itemData.id);
   }
 }

--- a/apps/src/javalab/Playground.js
+++ b/apps/src/javalab/Playground.js
@@ -148,7 +148,6 @@ export default class Playground {
     if (this.itemExists(itemData)) {
       this.removePlaygroundItem(itemData.id);
     }
-    // TODO: handle text deletion
   }
 
   changeItem(itemData) {

--- a/apps/src/javalab/Playground.js
+++ b/apps/src/javalab/Playground.js
@@ -107,7 +107,7 @@ export default class Playground {
 
   addImageHelper(itemData, isClickable) {
     // ignore request if the game is over or if the item already exists
-    if (this.isGameOver || this.imageItemExists(itemData)) {
+    if (this.isGameOver || this.itemExists(itemData)) {
       return;
     }
     let onClick = isClickable
@@ -128,10 +128,19 @@ export default class Playground {
   }
 
   addTextItem(itemData) {
-    if (this.isGameOver) {
-      // can't add new items if the game is over
+    if (this.isGameOver || this.itemExists(itemData)) {
+      // can't add new items if the game is over or if the item already exists
       return;
     }
+
+    const textData = {
+      text: itemData.text,
+      x: itemData.x,
+      y: itemData.y,
+      height: itemData.height,
+      type: PlaygroundItemType.TEXT
+    };
+    this.addPlaygroundItem(itemData.id, textData);
   }
 
   removeItem(itemData) {
@@ -139,7 +148,7 @@ export default class Playground {
       // can't remove items if game is over
       return;
     }
-    if (this.imageItemExists(itemData)) {
+    if (this.itemExists(itemData)) {
       this.removePlaygroundItem(itemData.id);
     }
     // TODO: handle text deletion
@@ -150,7 +159,7 @@ export default class Playground {
       // can't change items if game is over
       return;
     }
-    if (this.imageItemExists(itemData)) {
+    if (this.itemExists(itemData)) {
       const newImageData = {...itemData};
       if (itemData.filename) {
         newImageData.fileUrl = this.getUrl(itemData.filename);
@@ -247,7 +256,7 @@ export default class Playground {
     this.isGameOver = true;
   }
 
-  imageItemExists(itemData) {
+  itemExists(itemData) {
     return getItemIds(getStore().getState().playground).includes(itemData.id);
   }
 }

--- a/apps/src/javalab/Playground.js
+++ b/apps/src/javalab/Playground.js
@@ -137,8 +137,6 @@ export default class Playground {
     delete textData.id;
     textData.type = PlaygroundItemType.TEXT;
 
-    console.log(textData);
-
     this.addPlaygroundItem(itemData.id, textData);
   }
 
@@ -158,16 +156,32 @@ export default class Playground {
       // can't change items if game is over
       return;
     }
+
+    const newItemData = this.getNewItemData(itemData);
+    this.changePlaygroundItem(itemData.id, newItemData);
+  }
+
+  getNewItemData(itemData) {
+    // We do not include the ID as part of each item's data.
+    // The ID serves as the key referencing an object that contains the item's contents.
+    const newItemData = {...itemData};
+    delete newItemData.id;
+
     if (this.getItem(itemData.id).type === PlaygroundItemType.IMAGE) {
-      const newImageData = {...itemData};
       if (itemData.filename) {
-        newImageData.fileUrl = this.getUrl(itemData.filename);
+        newItemData.fileUrl = this.getUrl(itemData.filename);
         // we don't need to pass filename as imageData
-        delete newImageData.filename;
+        delete newItemData.filename;
       }
-      this.changePlaygroundItem(itemData.id, newImageData);
-    } else if (this.getItem(itemData.id).type === PlaygroundItemType.TEXT) {
+      return newItemData;
     }
+
+    if (this.getItem(itemData.id).type === PlaygroundItemType.IMAGE) {
+      this.changePlaygroundItem(itemData.id, newItemData);
+      return newItemData;
+    }
+
+    return itemData;
   }
 
   playSound(soundData) {

--- a/apps/src/javalab/PlaygroundText.jsx
+++ b/apps/src/javalab/PlaygroundText.jsx
@@ -12,10 +12,18 @@ export default class PlaygroundText extends React.Component {
     rotation: PropTypes.string.isRequired,
     red: PropTypes.string.isRequired,
     blue: PropTypes.string.isRequired,
-    green: PropTypes.string.isRequired
+    green: PropTypes.string.isRequired,
+    fontFamily: PropTypes.string.isRequired,
+    fontStyle: PropTypes.string.isRequired
   };
 
   render() {
+    const fontFamilyMap = {
+      SANS: 'sans-serif',
+      SERIF: 'serif',
+      MONO: 'monospace'
+    };
+
     const {
       id,
       text,
@@ -26,7 +34,9 @@ export default class PlaygroundText extends React.Component {
       rotation,
       red,
       blue,
-      green
+      green,
+      fontFamily,
+      fontStyle
     } = this.props;
     console.log(rotation);
     // what to do with overflow text?
@@ -35,12 +45,17 @@ export default class PlaygroundText extends React.Component {
       marginTop: parseInt(y),
       zIndex: index,
       fontSize: parseInt(height),
-      fontFamily: 'Courier',
-      fontStyle: 'italic',
-      fontWeight: 'bold',
+      fontFamily: fontFamilyMap[fontFamily],
       color: `rgb(${parseInt(red)}, ${parseInt(green)}, ${parseInt(blue)})`,
       transform: `rotate(${parseFloat(rotation)}deg)`
     };
+
+    if (fontStyle === 'BOLD' || fontStyle === 'BOLD_ITALIC') {
+      dynamicStyle.fontWeight = 'bold';
+    }
+    if (fontStyle === 'ITALIC' || fontStyle === 'BOLD_ITALIC') {
+      dynamicStyle.fontStyle = 'italic';
+    }
 
     return (
       <span style={{...dynamicStyle, ...styles.textStyle}} id={id}>

--- a/apps/src/javalab/PlaygroundText.jsx
+++ b/apps/src/javalab/PlaygroundText.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {PlaygroundFontStyleType, PlaygroundFontType} from './constants';
 
 export default class PlaygroundText extends React.Component {
   static propTypes = {
@@ -13,20 +14,12 @@ export default class PlaygroundText extends React.Component {
     red: PropTypes.string.isRequired,
     blue: PropTypes.string.isRequired,
     green: PropTypes.string.isRequired,
-    fontFamily: PropTypes.string.isRequired,
+    font: PropTypes.string.isRequired,
     fontStyle: PropTypes.string.isRequired
   };
 
-  render() {
-    const fontFamilyMap = {
-      SANS: 'sans-serif',
-      SERIF: 'serif',
-      MONO: 'monospace'
-    };
-
+  getDynamicStyles() {
     const {
-      id,
-      text,
       x,
       y,
       height,
@@ -35,32 +28,49 @@ export default class PlaygroundText extends React.Component {
       red,
       blue,
       green,
-      fontFamily,
+      font,
       fontStyle
     } = this.props;
-    console.log(rotation);
-    // what to do with overflow text?
-    const dynamicStyle = {
+
+    console.log(PlaygroundFontType);
+
+    const dynamicStyles = {
       left: x * 2,
       top: y * 2,
       zIndex: index,
-      height: parseInt(height) * 2,
-      fontSize: parseInt(height) * 2,
-      fontFamily: fontFamilyMap[fontFamily],
+      height: height * 2,
+      fontSize: height * 2,
+      fontFamily: PlaygroundFontType[font],
       color: `rgb(${parseInt(red)}, ${parseInt(green)}, ${parseInt(blue)})`,
-      transformOrigin: 'top left',
       transform: `rotate(${parseFloat(rotation)}deg)`
     };
 
-    if (fontStyle === 'BOLD' || fontStyle === 'BOLD_ITALIC') {
-      dynamicStyle.fontWeight = 'bold';
+    if (
+      [
+        PlaygroundFontStyleType.BOLD,
+        PlaygroundFontStyleType.BOLD_ITALIC
+      ].includes(fontStyle)
+    ) {
+      dynamicStyles.fontWeight = 'bold';
     }
-    if (fontStyle === 'ITALIC' || fontStyle === 'BOLD_ITALIC') {
-      dynamicStyle.fontStyle = 'italic';
+    if (
+      [
+        PlaygroundFontStyleType.ITALIC,
+        PlaygroundFontStyleType.BOLD_ITALIC
+      ].includes(fontStyle)
+    ) {
+      dynamicStyles.fontStyle = 'italic';
     }
 
+    return dynamicStyles;
+  }
+
+  render() {
+    const {id, text} = this.props;
+    const dynamicStyles = this.getDynamicStyles();
+
     return (
-      <span style={{...dynamicStyle, ...styles.textStyle}} id={id}>
+      <span style={{...dynamicStyles, ...styles.textStyle}} id={id}>
         {text}
       </span>
     );
@@ -71,6 +81,7 @@ const styles = {
   textStyle: {
     position: 'absolute',
     display: 'flex',
-    alignItems: 'center'
+    alignItems: 'center',
+    transformOrigin: 'top left'
   }
 };

--- a/apps/src/javalab/PlaygroundText.jsx
+++ b/apps/src/javalab/PlaygroundText.jsx
@@ -11,9 +11,9 @@ export default class PlaygroundText extends React.Component {
     height: PropTypes.string.isRequired,
     index: PropTypes.string.isRequired,
     rotation: PropTypes.string.isRequired,
-    red: PropTypes.string.isRequired,
-    blue: PropTypes.string.isRequired,
-    green: PropTypes.string.isRequired,
+    colorRed: PropTypes.string.isRequired,
+    colorGreen: PropTypes.string.isRequired,
+    colorBlue: PropTypes.string.isRequired,
     font: PropTypes.string.isRequired,
     fontStyle: PropTypes.string.isRequired
   };
@@ -25,9 +25,9 @@ export default class PlaygroundText extends React.Component {
       height,
       index,
       rotation,
-      red,
-      blue,
-      green,
+      colorRed,
+      colorGreen,
+      colorBlue,
       font,
       fontStyle
     } = this.props;
@@ -37,7 +37,9 @@ export default class PlaygroundText extends React.Component {
       top: y * 2,
       zIndex: index,
       height: height * 2,
-      color: `rgb(${parseInt(red)}, ${parseInt(green)}, ${parseInt(blue)})`,
+      color: `rgb(${parseInt(colorRed)}, ${parseInt(colorGreen)}, ${parseInt(
+        colorBlue
+      )})`,
       transform: `rotate(${parseFloat(rotation)}deg)`,
       fontSize: height * 2,
       fontFamily: PlaygroundFontType[font]

--- a/apps/src/javalab/PlaygroundText.jsx
+++ b/apps/src/javalab/PlaygroundText.jsx
@@ -1,33 +1,54 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export default function PlaygroundText({id, text, x, y, height}) {
-  // what to do with overflow text?
-  const dynamicStyle = {
-    marginLeft: parseInt(x),
-    marginTop: parseInt(y),
-    zIndex: 100,
-    fontSize: parseInt(height),
-    fontFamily: 'Courier',
-    fontStyle: 'italic',
-    fontWeight: 'bold',
-    color: 'red'
+export default class PlaygroundText extends React.Component {
+  static propTypes = {
+    id: PropTypes.string.isRequired,
+    text: PropTypes.string.isRequired,
+    x: PropTypes.string.isRequired,
+    y: PropTypes.string.isRequired,
+    height: PropTypes.string.isRequired,
+    index: PropTypes.string.isRequired,
+    rotation: PropTypes.string.isRequired,
+    red: PropTypes.string.isRequired,
+    blue: PropTypes.string.isRequired,
+    green: PropTypes.string.isRequired
   };
 
-  return (
-    <span style={{...dynamicStyle, ...styles.textStyle}} id={id}>
-      {text}
-    </span>
-  );
-}
+  render() {
+    const {
+      id,
+      text,
+      x,
+      y,
+      height,
+      index,
+      rotation,
+      red,
+      blue,
+      green
+    } = this.props;
+    console.log(rotation);
+    // what to do with overflow text?
+    const dynamicStyle = {
+      marginLeft: parseInt(x),
+      marginTop: parseInt(y),
+      zIndex: index,
+      fontSize: parseInt(height),
+      fontFamily: 'Courier',
+      fontStyle: 'italic',
+      fontWeight: 'bold',
+      color: `rgb(${parseInt(red)}, ${parseInt(green)}, ${parseInt(blue)})`,
+      transform: `rotate(${parseFloat(rotation)}deg)`
+    };
 
-PlaygroundText.propTypes = {
-  id: PropTypes.string.isRequired,
-  text: PropTypes.string.isRequired,
-  x: PropTypes.string.isRequired,
-  y: PropTypes.string.isRequired,
-  height: PropTypes.string.isRequired
-};
+    return (
+      <span style={{...dynamicStyle, ...styles.textStyle}} id={id}>
+        {text}
+      </span>
+    );
+  }
+}
 
 const styles = {
   textStyle: {

--- a/apps/src/javalab/PlaygroundText.jsx
+++ b/apps/src/javalab/PlaygroundText.jsx
@@ -41,12 +41,14 @@ export default class PlaygroundText extends React.Component {
     console.log(rotation);
     // what to do with overflow text?
     const dynamicStyle = {
-      marginLeft: parseInt(x),
-      marginTop: parseInt(y),
+      left: x * 2,
+      top: y * 2,
       zIndex: index,
-      fontSize: parseInt(height),
+      height: parseInt(height) * 2,
+      fontSize: parseInt(height) * 2,
       fontFamily: fontFamilyMap[fontFamily],
       color: `rgb(${parseInt(red)}, ${parseInt(green)}, ${parseInt(blue)})`,
+      transformOrigin: 'top left',
       transform: `rotate(${parseFloat(rotation)}deg)`
     };
 
@@ -67,6 +69,8 @@ export default class PlaygroundText extends React.Component {
 
 const styles = {
   textStyle: {
-    position: 'absolute'
+    position: 'absolute',
+    display: 'flex',
+    alignItems: 'center'
   }
 };

--- a/apps/src/javalab/PlaygroundText.jsx
+++ b/apps/src/javalab/PlaygroundText.jsx
@@ -2,11 +2,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 export default function PlaygroundText({id, text, x, y, height}) {
+  // what to do with overflow text?
   const dynamicStyle = {
     marginLeft: parseInt(x),
     marginTop: parseInt(y),
     zIndex: 100,
-    fontSize: parseInt(height)
+    fontSize: parseInt(height),
+    fontFamily: 'Courier',
+    fontStyle: 'italic',
+    fontWeight: 'bold',
+    color: 'red'
   };
 
   return (

--- a/apps/src/javalab/PlaygroundText.jsx
+++ b/apps/src/javalab/PlaygroundText.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default function PlaygroundText({id, text, x, y, height}) {
+  const dynamicStyle = {
+    marginLeft: parseInt(x),
+    marginTop: parseInt(y),
+    zIndex: 100,
+    fontSize: parseInt(height)
+  };
+
+  return (
+    <span style={{...dynamicStyle, ...styles.textStyle}} id={id}>
+      {text}
+    </span>
+  );
+}
+
+PlaygroundText.propTypes = {
+  id: PropTypes.string.isRequired,
+  text: PropTypes.string.isRequired,
+  x: PropTypes.string.isRequired,
+  y: PropTypes.string.isRequired,
+  height: PropTypes.string.isRequired
+};
+
+const styles = {
+  textStyle: {
+    position: 'absolute'
+  }
+};

--- a/apps/src/javalab/PlaygroundText.jsx
+++ b/apps/src/javalab/PlaygroundText.jsx
@@ -32,17 +32,15 @@ export default class PlaygroundText extends React.Component {
       fontStyle
     } = this.props;
 
-    console.log(PlaygroundFontType);
-
     const dynamicStyles = {
       left: x * 2,
       top: y * 2,
       zIndex: index,
       height: height * 2,
-      fontSize: height * 2,
-      fontFamily: PlaygroundFontType[font],
       color: `rgb(${parseInt(red)}, ${parseInt(green)}, ${parseInt(blue)})`,
-      transform: `rotate(${parseFloat(rotation)}deg)`
+      transform: `rotate(${parseFloat(rotation)}deg)`,
+      fontSize: height * 2,
+      fontFamily: PlaygroundFontType[font]
     };
 
     if (

--- a/apps/src/javalab/PlaygroundText.jsx
+++ b/apps/src/javalab/PlaygroundText.jsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {PlaygroundFontStyleType, PlaygroundFontType} from './constants';
+import {
+  PlaygroundFontStyleType,
+  PlaygroundFontTypeFontFamilies
+} from './constants';
 
 export default class PlaygroundText extends React.Component {
   static propTypes = {
@@ -42,7 +45,7 @@ export default class PlaygroundText extends React.Component {
       )})`,
       transform: `rotate(${parseFloat(rotation)}deg)`,
       fontSize: height * 2,
-      fontFamily: PlaygroundFontType[font]
+      fontFamily: PlaygroundFontTypeFontFamilies[font]
     };
 
     if (

--- a/apps/src/javalab/PlaygroundVisualizationColumn.jsx
+++ b/apps/src/javalab/PlaygroundVisualizationColumn.jsx
@@ -82,7 +82,8 @@ const styles = {
   playground: {
     backgroundColor: 'white',
     width: 800,
-    height: 800
+    height: 800,
+    overflow: 'hidden'
   },
   playgroundDiv: {
     width: 800,

--- a/apps/src/javalab/PlaygroundVisualizationColumn.jsx
+++ b/apps/src/javalab/PlaygroundVisualizationColumn.jsx
@@ -5,6 +5,7 @@ import PreviewPaneHeader from './PreviewPaneHeader';
 import classNames from 'classnames';
 import {toggleVisualizationCollapsed} from './javalabRedux';
 import PlaygroundImage from './PlaygroundImage';
+import PlaygroundText from './PlaygroundText';
 import {PlaygroundItemType} from './constants';
 
 class PlaygroundVisualizationColumn extends React.Component {
@@ -27,6 +28,8 @@ class PlaygroundVisualizationColumn extends React.Component {
       const itemData = playgroundItemData[itemId];
       if (itemData.type === PlaygroundItemType.IMAGE) {
         return <PlaygroundImage key={itemId} id={itemId} {...itemData} />;
+      } else if (itemData.type === PlaygroundItemType.TEXT) {
+        return <PlaygroundText key={itemId} id={itemId} {...itemData} />;
       }
     });
     return items;

--- a/apps/src/javalab/constants.js
+++ b/apps/src/javalab/constants.js
@@ -129,10 +129,10 @@ export const PlaygroundSignalType = {
   SET_BACKGROUND_IMAGE: 'SET_BACKGROUND_IMAGE'
 };
 
-export const PlaygroundFontType = {
-  SANS: 'sans-serif',
-  SERIF: 'serif',
-  MONO: 'monospace'
+export const PlaygroundFontTypeFontFamilies = {
+  SANS: 'Arial, Helvetica, sans-serif',
+  SERIF: '"Times New Roman", Times, serif',
+  MONO: '"Courier New", Courier, monospace'
 };
 
 export const PlaygroundFontStyleType = makeEnum(

--- a/apps/src/javalab/constants.js
+++ b/apps/src/javalab/constants.js
@@ -129,6 +129,19 @@ export const PlaygroundSignalType = {
   SET_BACKGROUND_IMAGE: 'SET_BACKGROUND_IMAGE'
 };
 
+export const PlaygroundFontType = {
+  SANS: 'sans-serif',
+  SERIF: 'serif',
+  MONO: 'monospace'
+};
+
+export const PlaygroundFontStyleType = makeEnum(
+  'NORMAL',
+  'BOLD',
+  'ITALIC',
+  'BOLD_ITALIC'
+);
+
 export const PlaygroundItemType = {
   IMAGE: 'image',
   TEXT: 'text'

--- a/apps/test/unit/javalab/PlaygroundTest.js
+++ b/apps/test/unit/javalab/PlaygroundTest.js
@@ -231,39 +231,36 @@ describe('Playground', () => {
     const id = 'test_id';
     const data = {
       value: PlaygroundSignalType.ADD_CLICKABLE_ITEM,
-      detail: {
-        filename: starterAsset1,
-        x: 0,
-        y: 0,
-        width: 100,
-        height: 50,
-        id: id
-      }
+      detail: createSampleImageDetails('assetFile', id)
     };
 
     playground.handleSignal(data);
     const itemData = getStore().getState().playground.itemData;
-    expect(itemData[id].width).to.equal(100);
+    expect(itemData[id].width).to.equal('100');
   });
 
   it('adds clickable image when receiving a ADD_CLICKABLE_ITEM message for an uploaded asset', () => {
-    const assetFile = 'assetFile';
     const id = 'test_id';
     const data = {
       value: PlaygroundSignalType.ADD_CLICKABLE_ITEM,
-      detail: {
-        filename: assetFile,
-        x: 0,
-        y: 0,
-        width: 100,
-        height: 50,
-        id: id
-      }
+      detail: createSampleImageDetails('assetFile', id)
     };
 
     playground.handleSignal(data);
     const itemData = getStore().getState().playground.itemData;
-    expect(itemData[id].height).to.equal(50);
+    expect(itemData[id].height).to.equal('50');
+  });
+
+  it('adds text item when receiving a ADD_TEXT_ITEM message', () => {
+    const id = 'test_id';
+    const data = {
+      value: PlaygroundSignalType.ADD_TEXT_ITEM,
+      detail: createSampleTextDetails(id)
+    };
+
+    playground.handleSignal(data);
+    const itemData = getStore().getState().playground.itemData;
+    expect(itemData[id].height).to.equal('50');
   });
 
   it('resets sound element on reset()', () => {
@@ -324,6 +321,25 @@ describe('Playground', () => {
     expect(Object.keys(itemData).length).to.equal(2);
   });
 
+  it('can add multiple text items via ADD_TEXT_ITEM', () => {
+    const firstId = 'first_id';
+    const secondId = 'second_id';
+    const firstData = {
+      value: PlaygroundSignalType.ADD_TEXT_ITEM,
+      detail: createSampleTextDetails(firstId)
+    };
+    const secondData = {
+      value: PlaygroundSignalType.ADD_TEXT_ITEM,
+      detail: createSampleTextDetails(secondId)
+    };
+
+    playground.handleSignal(firstData);
+    playground.handleSignal(secondData);
+
+    const itemData = getStore().getState().playground.itemData;
+    expect(Object.keys(itemData).length).to.equal(2);
+  });
+
   it('does not add duplicate images from ADD_IMAGE_ITEM', () => {
     const assetFile = 'assetFile';
     const id = 'first_id';
@@ -339,7 +355,21 @@ describe('Playground', () => {
     expect(Object.keys(itemData).length).to.equal(1);
   });
 
-  it('call changeItem after CHANGE_ITEM', () => {
+  it('does not add duplicate text items from ADD_TEXT_ITEM', () => {
+    const id = 'first_id';
+    const data = {
+      value: PlaygroundSignalType.ADD_TEXT_ITEM,
+      detail: createSampleTextDetails(id)
+    };
+
+    playground.handleSignal(data);
+    playground.handleSignal(data);
+
+    const itemData = getStore().getState().playground.itemData;
+    expect(Object.keys(itemData).length).to.equal(1);
+  });
+
+  it('updates an image item via CHANGE_ITEM after adding it', () => {
     const assetFile = 'assetFile';
     const id = 'first_id';
     const addData = {
@@ -350,7 +380,7 @@ describe('Playground', () => {
       value: PlaygroundSignalType.CHANGE_ITEM,
       detail: {
         id: id,
-        height: 200
+        height: '200'
       }
     };
 
@@ -358,7 +388,30 @@ describe('Playground', () => {
     playground.handleSignal(changeData);
 
     const itemData = getStore().getState().playground.itemData;
-    expect(itemData[id].height).to.equal(200);
+    expect(itemData[id].height).to.equal('200');
+  });
+
+  it('updates a text item via CHANGE_ITEM after adding it', () => {
+    const id = 'first_id';
+    const addData = {
+      value: PlaygroundSignalType.ADD_TEXT_ITEM,
+      detail: createSampleTextDetails(id)
+    };
+    const changeData = {
+      value: PlaygroundSignalType.CHANGE_ITEM,
+      detail: {
+        id: id,
+        height: '200',
+        fontStyle: 'NORMAL'
+      }
+    };
+
+    playground.handleSignal(addData);
+    playground.handleSignal(changeData);
+
+    const itemData = getStore().getState().playground.itemData;
+    expect(itemData[id].height).to.equal('200');
+    expect(itemData[id].fontStyle).to.equal('NORMAL');
   });
 
   it('can remove an item with REMOVE_ITEM', () => {
@@ -394,11 +447,28 @@ describe('Playground', () => {
   function createSampleImageDetails(filename, id) {
     return {
       filename: filename,
-      x: 0,
-      y: 0,
-      width: 100,
-      height: 50,
+      x: '0',
+      y: '0',
+      width: '100',
+      height: '50',
       id: id
+    };
+  }
+
+  function createSampleTextDetails(id) {
+    return {
+      id: id,
+      text: 'some text',
+      x: '200',
+      y: '200',
+      height: '50',
+      index: '1',
+      rotation: '45',
+      colorRed: '0',
+      colorGreen: '0',
+      colorBlue: '255',
+      font: 'SANS',
+      fontStyle: 'BOLD'
     };
   }
 

--- a/apps/test/unit/javalab/PlaygroundTextTest.js
+++ b/apps/test/unit/javalab/PlaygroundTextTest.js
@@ -7,14 +7,15 @@ describe('PlaygroundImageTest', () => {
   it('sets styles correctly', () => {
     const props = {
       id: '1',
+      text: 'some text',
       x: '350',
       y: '0',
       height: '100',
       index: '0',
       rotation: '90.5',
-      red: '0',
-      blue: '0',
-      green: '255',
+      colorRed: '0',
+      colorGreen: '255',
+      colorBlue: '0',
       font: 'MONO',
       fontStyle: 'BOLD_ITALIC'
     };
@@ -32,7 +33,7 @@ describe('PlaygroundImageTest', () => {
     expect(textStyles.fontFamily).to.equal('monospace');
     expect(textStyles.fontWeight).to.equal('bold');
     expect(textStyles.fontStyle).to.equal('italic');
-    expect(textStyles.color).to.equal('rgb(0,255,0)');
+    expect(textStyles.color).to.equal('rgb(0, 255, 0)');
     expect(textStyles.transform).to.equal('rotate(90.5deg)');
   });
 });

--- a/apps/test/unit/javalab/PlaygroundTextTest.js
+++ b/apps/test/unit/javalab/PlaygroundTextTest.js
@@ -2,6 +2,7 @@ import React from 'react';
 import {expect} from '../../util/reconfiguredChai';
 import {shallow} from 'enzyme';
 import PlaygroundText from '@cdo/apps/javalab/PlaygroundText';
+import {PlaygroundFontTypeFontFamilies} from '@cdo/apps/javalab/constants';
 
 describe('PlaygroundImageTest', () => {
   it('sets styles correctly', () => {
@@ -30,7 +31,7 @@ describe('PlaygroundImageTest', () => {
     expect(textStyles.left).to.equal(700);
     expect(textStyles.height).to.equal(200);
     expect(textStyles.fontSize).to.equal(200);
-    expect(textStyles.fontFamily).to.equal('monospace');
+    expect(textStyles.fontFamily).to.equal(PlaygroundFontTypeFontFamilies.MONO);
     expect(textStyles.fontWeight).to.equal('bold');
     expect(textStyles.fontStyle).to.equal('italic');
     expect(textStyles.color).to.equal('rgb(0, 255, 0)');

--- a/apps/test/unit/javalab/PlaygroundTextTest.js
+++ b/apps/test/unit/javalab/PlaygroundTextTest.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import {expect} from '../../util/reconfiguredChai';
+import {shallow} from 'enzyme';
+import PlaygroundText from '@cdo/apps/javalab/PlaygroundText';
+
+describe('PlaygroundImageTest', () => {
+  it('sets styles correctly', () => {
+    const props = {
+      id: '1',
+      x: '350',
+      y: '0',
+      height: '100',
+      index: '0',
+      rotation: '90.5',
+      red: '0',
+      blue: '0',
+      green: '255',
+      font: 'MONO',
+      fontStyle: 'BOLD_ITALIC'
+    };
+
+    const wrapper = shallow(<PlaygroundText {...props} />);
+    const textStyles = wrapper
+      .find('span')
+      .first()
+      .props().style;
+    // check dynamically generated styles
+    expect(textStyles.top).to.equal(0);
+    expect(textStyles.left).to.equal(700);
+    expect(textStyles.height).to.equal(200);
+    expect(textStyles.fontSize).to.equal(200);
+    expect(textStyles.fontFamily).to.equal('monospace');
+    expect(textStyles.fontWeight).to.equal('bold');
+    expect(textStyles.fontStyle).to.equal('italic');
+    expect(textStyles.color).to.equal('rgb(0,255,0)');
+    expect(textStyles.transform).to.equal('rotate(90.5deg)');
+  });
+});


### PR DESCRIPTION
Allows adding text items to Playground when signal received from Javabuilder, in addition to allowing updates of existing text items. Adds no additional logic to remove text items from Playground (code was already in place to do this).

## Testing story

Tested adding, updating, and removing text manually in Javalab. Also added unit tests to cover adding new items, checking that we do not allow adding the same item twice, updating items, and removing an item.