### PR TITLE
Refactor of props and enable/disable review logic

### DIFF
--- a/apps/test/unit/templates/instructions/ReviewTabTest.jsx
+++ b/apps/test/unit/templates/instructions/ReviewTabTest.jsx
@@ -7,22 +7,14 @@ import './codeReview/CodeReviewTestHelper';
 import {UnconnectedReviewTab as ReviewTab} from '@cdo/apps/templates/instructions/ReviewTab';
 import Comment from '@cdo/apps/templates/instructions/codeReview/Comment';
 import CommentEditor from '@cdo/apps/templates/instructions/codeReview/CommentEditor';
-import {
-  getStore,
-  registerReducers,
-  restoreRedux,
-  stubRedux
-} from '@cdo/apps/redux';
-import commonReducers from '@cdo/apps/redux/commonReducers';
-import {setPageConstants} from '@cdo/apps/redux/pageConstants';
 import ReviewNavigator from '@cdo/apps/templates/instructions/codeReview/ReviewNavigator';
 import Spinner from '@cdo/apps/code-studio/pd/components/spinner';
 
 describe('Code Review Tab', () => {
   const token = 'token';
   const channelId = 'test123';
-  const serverLevelId = 'serverLevelId123';
-  const serverScriptId = 'serverScriptId123';
+  const serverLevelId = 123;
+  const serverScriptId = 123;
   const reviewableProjectId = 'reviewableProjectId123';
   const existingComment = Factory.build('CodeReviewComment');
   let wrapper, server, clock, onLoadComplete;
@@ -53,25 +45,6 @@ describe('Code Review Tab', () => {
     );
 
     onLoadComplete = sinon.spy();
-
-    stubRedux();
-    registerReducers(commonReducers);
-    getStore().dispatch(
-      setPageConstants({
-        channelId,
-        serverLevelId,
-        serverScriptId
-      })
-    );
-
-    wrapper = shallow(
-      <ReviewTab
-        onLoadComplete={onLoadComplete}
-        codeReviewEnabled
-        viewAsCodeReviewer={false}
-      />
-    );
-    wrapper.setState({initialLoadCompleted: true});
   });
 
   afterEach(() => {
@@ -80,269 +53,263 @@ describe('Code Review Tab', () => {
     }
 
     server.restore();
-    restoreRedux();
   });
 
-  it('renders loading spinner before initial load is completed', () => {
-    wrapper = shallow(
-      <ReviewTab
-        onLoadComplete={onLoadComplete}
-        codeReviewEnabled
-        viewAsCodeReviewer={false}
-      />
-    );
-
-    expect(wrapper.find(Spinner).length).to.equal(1);
-  });
-
-  it('calls onLoadComplete callback after initial load is completed', () => {
-    onLoadComplete.resetHistory();
-
-    wrapper = shallow(
-      <ReviewTab
-        onLoadComplete={onLoadComplete}
-        codeReviewEnabled
-        viewAsCodeReviewer={false}
-      />
-    );
-    sinon.assert.notCalled(onLoadComplete);
-
-    wrapper.setState({initialLoadCompleted: true});
-    sinon.assert.calledOnce(onLoadComplete);
-  });
-
-  it('renders without error if project has no comments', () => {
-    server.respondWith(
-      'GET',
-      `/code_review_comments/project_comments?channel_id=${channelId}`,
-      [200, {'Content-Type': 'application/json'}, JSON.stringify([])]
-    );
-    server.respond();
-
-    expect(wrapper.find(Comment).length).to.equal(0);
-  });
-
-  it('renders a comment fetched on mount if one exists', () => {
-    expect(wrapper.find(Comment).length).to.equal(0);
-    server.respond();
-    expect(wrapper.find(Comment).length).to.equal(1);
-  });
-
-  it('submits request and shows new comment after one is created', () => {
-    const testCommentText = 'test comment text';
-    const newlyCreatedComment = Factory.build('CodeReviewComment', {
-      commentText: testCommentText
+  describe('viewing as code owner with review enabled', () => {
+    beforeEach(() => {
+      wrapper = shallow(
+        <ReviewTab
+          onLoadComplete={onLoadComplete}
+          codeReviewEnabled
+          viewAsCodeReviewer={false}
+          channelId={channelId}
+          serverLevelId={serverLevelId}
+          serverScriptId={serverScriptId}
+        />
+      );
     });
 
-    server.respondWith('POST', '/code_review_comments', [
-      200,
-      {'Content-Type': 'application/json'},
-      JSON.stringify(newlyCreatedComment)
-    ]);
-
-    server.respond();
-    expect(wrapper.find(Comment).length).to.equal(1);
-
-    wrapper.instance().onNewCommentSubmit(testCommentText);
-    server.respond();
-    expect(wrapper.find(Comment).length).to.equal(2);
-    expect(
-      wrapper
-        .find(Comment)
-        .at(1)
-        .props().comment.commentText
-    ).to.equal(testCommentText);
-  });
-
-  it('hides comment box if there is an authorization error on comment', () => {
-    // first, enable peer review
-    stubReviewableStatusProjectServerCall({
-      canMarkReviewable: false,
-      reviewEnabled: true
+    it('renders loading spinner before initial load is completed', () => {
+      expect(wrapper.find(Spinner).length).to.equal(1);
     });
 
-    const testCommentText = 'test comment text';
-    server.respond();
+    it('calls onLoadComplete callback after initial load is completed', () => {
+      onLoadComplete.resetHistory();
+      sinon.assert.notCalled(onLoadComplete);
 
-    // initial server response loads a comment
-    expect(wrapper.find(CommentEditor).length).to.equal(1);
-    expect(wrapper.find(Comment).length).to.equal(1);
-
-    // fake a 404 for saving a comment
-    server.respondWith('POST', '/code_review_comments', [
-      404,
-      {'Content-Type': 'application/json'},
-      'error'
-    ]);
-
-    wrapper.instance().onNewCommentSubmit(testCommentText);
-    server.respond();
-    // should still only have 1 comment, not 2
-    expect(wrapper.find(Comment).length).to.equal(1);
-    expect(wrapper.find(CommentEditor).length).to.equal(0);
-    expect(wrapper.state().authorizationError).to.be.true;
-  });
-
-  it('removes a comment when one is deleted', () => {
-    server.respond();
-
-    expect(wrapper.find(Comment).length).to.equal(1);
-    wrapper.instance().onCommentDelete(existingComment.id);
-    server.respond();
-    expect(wrapper.find(Comment).length).to.equal(0);
-  });
-
-  it('resolves a comment when one is resolved', () => {
-    server.respond();
-
-    expect(
-      wrapper
-        .find(Comment)
-        .at(0)
-        .props().comment.isResolved
-    ).to.be.false;
-    wrapper.instance().onCommentResolveStateToggle(existingComment.id, true);
-    server.respond();
-    expect(
-      wrapper
-        .find(Comment)
-        .at(0)
-        .props().comment.isResolved
-    ).to.be.true;
-  });
-
-  it('sets hasError to true when comment update request fails and does not update comment', () => {
-    clock = sinon.useFakeTimers();
-
-    server.respondWith(
-      'PATCH',
-      `/code_review_comments/${existingComment.id}/toggle_resolved`,
-      [400, {}, '']
-    );
-
-    server.respond();
-
-    expect(
-      wrapper
-        .find(Comment)
-        .at(0)
-        .props().comment.hasError
-    ).to.be.undefined;
-    expect(
-      wrapper
-        .find(Comment)
-        .at(0)
-        .props().comment.isResolved
-    ).to.be.false;
-    wrapper.instance().onCommentResolveStateToggle(existingComment.id, true);
-    server.respond();
-    expect(
-      wrapper
-        .find(Comment)
-        .at(0)
-        .props().comment.hasError
-    ).to.be.true;
-    expect(
-      wrapper
-        .find(Comment)
-        .at(0)
-        .props().comment.isResolved
-    ).to.be.false;
-  });
-
-  it('sets hasError to true when comment delete request fails and does not remove comment from UI', () => {
-    clock = sinon.useFakeTimers();
-
-    server.respondWith(
-      'DELETE',
-      `/code_review_comments/${existingComment.id}`,
-      [400, {}, '']
-    );
-
-    server.respond();
-
-    expect(
-      wrapper
-        .find(Comment)
-        .at(0)
-        .props().comment.hasError
-    ).to.be.undefined;
-    wrapper.instance().onCommentDelete(existingComment.id, true);
-    server.respond();
-    expect(
-      wrapper
-        .find(Comment)
-        .at(0)
-        .props().comment.hasError
-    ).to.be.true;
-  });
-
-  it('shows the review checkbox if enabled', () => {
-    stubReviewableStatusProjectServerCall({
-      canMarkReviewable: true,
-      reviewEnabled: true,
-      id: reviewableProjectId
+      wrapper.setState({initialLoadCompleted: true});
+      sinon.assert.calledOnce(onLoadComplete);
     });
 
-    const input = wrapper.find('input');
-    expect(input).to.exist;
-    expect(input.props().checked).to.be.true;
+    describe('after load', () => {
+      beforeEach(() => {
+        wrapper.setState({initialLoadCompleted: true});
+      });
+
+      it('renders without error if project has no comments', () => {
+        server.respondWith(
+          'GET',
+          `/code_review_comments/project_comments?channel_id=${channelId}`,
+          [200, {'Content-Type': 'application/json'}, JSON.stringify([])]
+        );
+        server.respond();
+
+        expect(wrapper.find(Comment).length).to.equal(0);
+      });
+
+      it('renders a comment fetched on mount if one exists', () => {
+        expect(wrapper.find(Comment).length).to.equal(0);
+        server.respond();
+        expect(wrapper.find(Comment).length).to.equal(1);
+      });
+
+      it('submits request and shows new comment after one is created', () => {
+        const testCommentText = 'test comment text';
+        const newlyCreatedComment = Factory.build('CodeReviewComment', {
+          commentText: testCommentText
+        });
+
+        server.respondWith('POST', '/code_review_comments', [
+          200,
+          {'Content-Type': 'application/json'},
+          JSON.stringify(newlyCreatedComment)
+        ]);
+
+        server.respond();
+        expect(wrapper.find(Comment).length).to.equal(1);
+
+        wrapper.instance().onNewCommentSubmit(testCommentText);
+        server.respond();
+        const comment = wrapper.find(Comment);
+        expect(comment.length).to.equal(2);
+        expect(comment.at(1).props().comment.commentText).to.equal(
+          testCommentText
+        );
+      });
+
+      it('hides comment box if there is an authorization error on comment', () => {
+        // first, enable peer review
+        stubReviewableStatusProjectServerCall({
+          canMarkReviewable: false,
+          reviewEnabled: true
+        });
+
+        const testCommentText = 'test comment text';
+        server.respond();
+
+        // initial server response loads a comment
+        expect(wrapper.find(CommentEditor).length).to.equal(1);
+        expect(wrapper.find(Comment).length).to.equal(1);
+
+        // fake a 404 for saving a comment
+        server.respondWith('POST', '/code_review_comments', [
+          404,
+          {'Content-Type': 'application/json'},
+          'error'
+        ]);
+
+        wrapper.instance().onNewCommentSubmit(testCommentText);
+        server.respond();
+        // should still only have 1 comment, not 2
+        expect(wrapper.find(Comment).length).to.equal(1);
+        expect(wrapper.find(CommentEditor).length).to.equal(0);
+        expect(wrapper.state().authorizationError).to.be.true;
+      });
+
+      it('removes a comment when one is deleted', () => {
+        server.respond();
+
+        expect(wrapper.find(Comment).length).to.equal(1);
+        wrapper.instance().onCommentDelete(existingComment.id);
+        server.respond();
+        expect(wrapper.find(Comment).length).to.equal(0);
+      });
+
+      it('resolves a comment when one is resolved', () => {
+        server.respond();
+
+        expect(
+          wrapper
+            .find(Comment)
+            .at(0)
+            .props().comment.isResolved
+        ).to.be.false;
+        wrapper
+          .instance()
+          .onCommentResolveStateToggle(existingComment.id, true);
+        server.respond();
+        expect(
+          wrapper
+            .find(Comment)
+            .at(0)
+            .props().comment.isResolved
+        ).to.be.true;
+      });
+
+      it('sets hasError to true when comment update request fails and does not update comment', () => {
+        clock = sinon.useFakeTimers();
+        server.respondWith(
+          'PATCH',
+          `/code_review_comments/${existingComment.id}/toggle_resolved`,
+          [400, {}, '']
+        );
+
+        server.respond();
+        let firstComment = wrapper.find(Comment).at(0);
+        expect(firstComment.props().comment.hasError).to.be.undefined;
+        expect(firstComment.props().comment.isResolved).to.be.false;
+
+        wrapper
+          .instance()
+          .onCommentResolveStateToggle(existingComment.id, true);
+        server.respond();
+        firstComment = wrapper.find(Comment).at(0);
+        expect(firstComment.props().comment.hasError).to.be.true;
+        expect(firstComment.props().comment.isResolved).to.be.false;
+      });
+
+      it('sets hasError to true when comment delete request fails and does not remove comment from UI', () => {
+        clock = sinon.useFakeTimers();
+
+        server.respondWith(
+          'DELETE',
+          `/code_review_comments/${existingComment.id}`,
+          [400, {}, '']
+        );
+
+        server.respond();
+
+        expect(
+          wrapper
+            .find(Comment)
+            .at(0)
+            .props().comment.hasError
+        ).to.be.undefined;
+        wrapper.instance().onCommentDelete(existingComment.id, true);
+        server.respond();
+        expect(
+          wrapper
+            .find(Comment)
+            .at(0)
+            .props().comment.hasError
+        ).to.be.true;
+      });
+
+      it('shows the review checkbox if enabled', () => {
+        stubReviewableStatusProjectServerCall({
+          canMarkReviewable: true,
+          reviewEnabled: true,
+          id: reviewableProjectId
+        });
+
+        const input = wrapper.find('input');
+        expect(input).to.exist;
+        expect(input.props().checked).to.be.true;
+      });
+
+      it('hides the review checkbox if disabled', () => {
+        stubReviewableStatusProjectServerCall({
+          canMarkReviewable: false,
+          reviewEnabled: false
+        });
+
+        const input = wrapper.find('input');
+        expect(input).to.be.empty;
+      });
+
+      it('shows comment input if peer review enabled', () => {
+        stubReviewableStatusProjectServerCall({
+          canMarkReviewable: false,
+          reviewEnabled: true
+        });
+
+        expect(wrapper.find(CommentEditor).length).to.equal(1);
+      });
+
+      it('hides comment input if peer review disabled', () => {
+        stubReviewableStatusProjectServerCall({
+          canMarkReviewable: false,
+          reviewEnabled: false
+        });
+
+        expect(wrapper.find(CommentEditor).length).to.equal(0);
+      });
+
+      it('shows the ReviewNavigator if viewing own project', () => {
+        expect(wrapper.find(ReviewNavigator).length).to.equal(1);
+      });
+    });
   });
 
-  it('hides the review checkbox if disabled', () => {
-    stubReviewableStatusProjectServerCall({
-      canMarkReviewable: false,
-      reviewEnabled: false
+  describe('viewing as teacher with review enabled', () => {
+    beforeEach(() => {
+      wrapper = shallow(
+        <ReviewTab
+          onLoadComplete={onLoadComplete}
+          codeReviewEnabled={false}
+          viewAsCodeReviewer={false}
+          viewAsTeacher={true}
+          channelId={channelId}
+          serverLevelId={serverLevelId}
+          serverScriptId={serverScriptId}
+        />
+      );
     });
 
-    const input = wrapper.find('input');
-    expect(input).to.be.empty;
-  });
+    it('always shows comment input', () => {
+      stubReviewableStatusProjectServerCall({
+        canMarkReviewable: false,
+        reviewEnabled: false
+      });
 
-  it('shows comment input if peer review enabled', () => {
-    stubReviewableStatusProjectServerCall({
-      canMarkReviewable: false,
-      reviewEnabled: true
+      wrapper.setState({initialLoadCompleted: true});
+
+      expect(wrapper.find(CommentEditor).length).to.equal(1);
     });
 
-    expect(wrapper.find(CommentEditor).length).to.equal(1);
-  });
-
-  it('hides comment input if peer review disabled', () => {
-    stubReviewableStatusProjectServerCall({
-      canMarkReviewable: false,
-      reviewEnabled: false
+    it('does not show the ReviewNavigator', () => {
+      expect(wrapper.find(ReviewNavigator).length).to.equal(0);
     });
-
-    expect(wrapper.find(CommentEditor).length).to.equal(0);
-  });
-
-  it('always shows comment input for teachers', () => {
-    stubReviewableStatusProjectServerCall({
-      canMarkReviewable: false,
-      reviewEnabled: false
-    });
-
-    wrapper = shallow(
-      <ReviewTab
-        onLoadComplete={onLoadComplete}
-        codeReviewEnabled={false}
-        viewAsCodeReviewer={false}
-        viewAsTeacher={true}
-      />
-    );
-    wrapper.setState({initialLoadCompleted: true});
-
-    expect(wrapper.find(CommentEditor).length).to.equal(1);
-  });
-
-  it('shows the ReviewNavigator if viewing own project', () => {
-    expect(wrapper.find(ReviewNavigator).length).to.equal(1);
-  });
-
-  it('does not show the ReviewNavigator if a teacher is viewing the project', () => {
-    wrapper.setProps({viewAsTeacher: true});
-    expect(wrapper.find(ReviewNavigator).length).to.equal(0);
   });
 
   it('does not render enable code review checkbox when codeReviewEnabled is false', () => {

--- a/apps/test/unit/templates/instructions/ReviewTabTest.jsx
+++ b/apps/test/unit/templates/instructions/ReviewTabTest.jsx
@@ -253,8 +253,7 @@ describe('Code Review Tab', () => {
           reviewEnabled: false
         });
 
-        const input = wrapper.find('input');
-        expect(input).to.be.empty;
+        expect(wrapper.find('input')).to.be.empty;
       });
 
       it('shows comment input if peer review enabled', () => {
@@ -303,7 +302,6 @@ describe('Code Review Tab', () => {
       });
 
       wrapper.setState({initialLoadCompleted: true});
-
       expect(wrapper.find(CommentEditor).length).to.equal(1);
     });
 


### PR DESCRIPTION
Quick refactor to move away from the `getStore().getState()` calls as well as to consolidate the logic around the enable/disable Code Review toggle.

Note to the reviewer: The test file changes are best viewed with the whitespace diff off.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
