### PR TITLE
Add labType for AnimationTab

### DIFF
--- a/apps/src/p5lab/AnimationTab/AnimationTab.jsx
+++ b/apps/src/p5lab/AnimationTab/AnimationTab.jsx
@@ -11,6 +11,7 @@ import AnimationList from './AnimationList';
 import ResizablePanes from '@cdo/apps/templates/ResizablePanes';
 import PiskelEditor from './PiskelEditor';
 import * as shapes from '../shapes';
+import {P5LabType} from '@cdo/apps/p5lab/constants';
 
 /**
  * Root of the animation editor interface mode for GameLab
@@ -23,6 +24,7 @@ class AnimationTab extends React.Component {
     hideUploadOption: PropTypes.bool.isRequired,
     hideAnimationNames: PropTypes.bool.isRequired,
     hideBackgrounds: PropTypes.bool.isRequired,
+    labType: PropTypes.oneOf(Object.keys(P5LabType)).isRequired,
 
     // Provided by Redux
     columnSizes: PropTypes.arrayOf(PropTypes.number).isRequired,
@@ -42,7 +44,7 @@ class AnimationTab extends React.Component {
           onChange={this.props.onColumnWidthsChange}
         >
           <div style={styles.animationsColumn}>
-            <P5LabVisualizationHeader />
+            <P5LabVisualizationHeader labType={this.props.labType} />
             <AnimationList hideBackgrounds={this.props.hideBackgrounds} />
           </div>
           <div style={styles.editorColumn}>

--- a/apps/src/p5lab/P5LabView.jsx
+++ b/apps/src/p5lab/P5LabView.jsx
@@ -163,6 +163,7 @@ class P5LabView extends React.Component {
         hideUploadOption={this.props.isBlockly}
         hideAnimationNames={this.props.isBlockly}
         hideBackgrounds={this.props.isBlockly}
+        labType={this.props.labType}
       />
     ) : (
       undefined


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/42718/

Adding the required labType to AnimationTab so it can be piped through to the P5LabVisualizationHeader.

cc: @ajpal 

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
