### PR TITLE
[Poetry][HOC] Make default poem optional

### DIFF
--- a/apps/src/p5lab/poetry/PoemSelector.jsx
+++ b/apps/src/p5lab/poetry/PoemSelector.jsx
@@ -72,6 +72,10 @@ PoemEditor.propTypes = {
 };
 
 function PoemSelector(props) {
+  if (!appOptions.level.showPoemDropdown) {
+    return null;
+  }
+
   const [isOpen, setIsOpen] = useState(false);
   const [selectedPoem, setSelectedPoem] = useState(undefined);
 
@@ -96,8 +100,10 @@ function PoemSelector(props) {
 
   if (!selectedPoem) {
     const defaultPoem = POEMS[appOptions.level.defaultPoem];
-    setSelectedPoem(defaultPoem.title);
-    props.onChangePoem(defaultPoem);
+    if (defaultPoem) {
+      setSelectedPoem(defaultPoem.title);
+      props.onChangePoem(defaultPoem);
+    }
   }
 
   return (

--- a/dashboard/app/models/levels/poetry.rb
+++ b/dashboard/app/models/levels/poetry.rb
@@ -26,6 +26,7 @@
 
 class Poetry < GamelabJr
   serialized_attrs %w(
+    show_poem_dropdown
     default_poem
   )
 
@@ -62,6 +63,7 @@ class Poetry < GamelabJr
   # Used by levelbuilders to set a default poem on a Poetry level.
   def self.hoc_poems
     [
+      ['', ''],
       ['My Brilliant Image', 'hafez'],
       ['Twinkle, Twinkle Little Star', 'carroll_1'],
       ['Crocodile', 'carroll_2'],

--- a/dashboard/app/views/levels/editors/fields/_default_poem.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_default_poem.html.haml
@@ -2,5 +2,8 @@
   Default Poem
 
 #defaultPoem.in.collapse
-  = f.label :default_poem, 'Default Poem'
+  = render partial: 'levels/editors/fields/checkboxes',
+    locals: {f: f, field_name: :show_poem_dropdown,
+    description: "Show poem selector dropdown"}
+  = f.label :default_poem, 'Default Poem (Only applies if poem selector dropdown is shown)'
   = f.select :default_poem, options_for_select(@level.class.hoc_poems, @level.default_poem)


### PR DESCRIPTION
Follow up to https://github.com/code-dot-org/code-dot-org/pull/42744 because I had missed a requirement that the poem dropdown be optional. The poem dropdown is only for the HOC levels. The CSC module will have students write their own poems programatically, so the dropdown should not be shown.

With default poem set and show dropdown checked:
![image](https://user-images.githubusercontent.com/8787187/135509357-e22a18d6-68bc-4b24-bcc2-a3600bcfef3c.png)
![image](https://user-images.githubusercontent.com/8787187/135509249-0c043bdc-c8e2-49f2-b57d-42b8112fd500.png)

With show dropdown unchecked:
![image](https://user-images.githubusercontent.com/8787187/135509422-9c249476-495c-4581-837c-36061bdb9ce5.png)
![image](https://user-images.githubusercontent.com/8787187/135509641-497c4702-1100-4b9c-9d48-4e996e1c3a40.png)



## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
