### PR TITLE
Use spotify api

### DIFF
--- a/bin/cron/applab_datasets/spotify
+++ b/bin/cron/applab_datasets/spotify
@@ -27,24 +27,47 @@ CHART_TYPE = {
 def get_token
   client_id = CDO.spotify_api_client_id
   client_secret = CDO.spotify_api_client_secret
-  url = "https://accounts.spotify.com/api/token"
-  headers = {
-    'authorization' => 'Basic ' + Base64.strict_encode64(client_id + ':' + client_secret),
-    'content-type' => 'application/x-www-form-urlencoded',
-  }
-  form = {
-    'grant_type' => 'client_credentials'
-  }
-  auth_response = JSON.parse(RestClient.post(url, form, headers))
-  $token = auth_response['access_token']
+
+  begin
+    url = "https://accounts.spotify.com/api/token"
+    headers = {
+      'authorization' => 'Basic ' + Base64.strict_encode64(client_id + ':' + client_secret),
+      'content-type' => 'application/x-www-form-urlencoded',
+    }
+    form = {
+      'grant_type' => 'client_credentials'
+    }
+    auth_response = JSON.parse(RestClient.post(url, form, headers))
+    $token = auth_response['access_token']
+  rescue RestClient::Exception => e
+    Honeybadger.notify(
+      e,
+      error_message: "Failed to retrieve OAuth token from Spotify for use in App Lab Datasets.",
+      context: {
+        tenant_id: client_id,
+        url: url
+      }
+    )
+  end
 end
 
 def get_playlist_data(chart_type, playlist_id)
   # Filters for the query: a comma-separated list of the fields to return
   field_query = 'fields=tracks.items(track(name,href,artists,popularity))'
-  url = "#{BASE_URL}/playlists/#{playlist_id}?#{field_query}"
-  response = RestClient.get(url, {authorization: "Bearer #{$token}"})
-  return unless response.code == 200
+
+  begin
+    url = "#{BASE_URL}/playlists/#{playlist_id}?#{field_query}"
+    response = RestClient.get(url, {authorization: "Bearer #{$token}"})
+  rescue RestClient::Exception => e
+    Honeybadger.notify(
+      e,
+      error_message: "Failed to retrieve playlist data from Spotify for use in App Lab Datasets.",
+      context: {
+        playlist_id: playlist_id,
+      }
+    )
+    return
+  end
 
   items = JSON.parse(response)['tracks']['items']
   columns = ['id', 'Track Name', 'Artist', 'Position', 'URL']

--- a/bin/cron/applab_datasets/spotify
+++ b/bin/cron/applab_datasets/spotify
@@ -20,8 +20,8 @@ TOP_50_USA_ID = '37i9dQZEVXbLRQDuF5jeBp'
 PROFANITY_LOCALE = 'en-US'
 
 CHART_TYPE = {
-  TOP_50: 'TOP_50',
-  VIRAL_50: 'VIRAL_50',
+  TOP: 'TOP',
+  VIRAL: 'VIRAL',
 }
 
 def get_token
@@ -48,7 +48,9 @@ def get_playlist_data(chart_type, playlist_id)
 
   items = JSON.parse(response)['tracks']['items']
   columns = ['id', 'Track Name', 'Artist', 'Position', 'URL']
-  if chart_type === CHART_TYPE[:TOP_50] then columns << 'Popularity' end # Only include Popularity for Top Charts
+  if chart_type === CHART_TYPE[:TOP]
+    columns.insert(4, 'Popularity')   # Only include Popularity for Top Charts
+  end
 
   regex = generate_profanity_regex(items)
   records = {}
@@ -60,10 +62,10 @@ def get_playlist_data(chart_type, playlist_id)
 
     record = OpenStruct.new
     record.id = id
-    record.Position = id # list of track items returned in order of popularity
+    record.Position = id
     record['Track Name'] = track['name']
     record.Artist = track['artists'][0]['name'] # first will be main artist, featured artists included in record name
-    if chart_type === CHART_TYPE[:TOP_50] then record.Popularity = track['popularity'] end
+    if chart_type === CHART_TYPE[:TOP] then record.Popularity = track['popularity'] end
     record.URL = track['href']
 
     records[id] = record.to_h.to_json
@@ -78,7 +80,7 @@ def get_string_to_check(track)
   if track.nil?
     return ""
   else
-    return "#{track['name']} - #{track['artists'][0]['name']}"
+    return "#{track['name']} - #{track['artists'][0]['name']} "
   end
 end
 
@@ -92,23 +94,19 @@ end
 
 def main
   get_token
-  # fb = FirebaseHelper.new('shared')
+  fb = FirebaseHelper.new('shared')
 
-  records, columns = get_playlist_data(CHART_TYPE[:TOP_50], TOP_50_GLOBAL_ID)
-  puts 'TOP 50 GLOBAL', records, columns
+  records, columns = get_playlist_data(CHART_TYPE[:TOP], TOP_50_GLOBAL_ID)
+  fb.upload_live_table('Top 50 Worldwide', records, columns)
 
-  records, columns = get_playlist_data(CHART_TYPE[:TOP_50], TOP_50_USA_ID)
-  puts 'TOP 50 USA', records, columns
+  records, columns = get_playlist_data(CHART_TYPE[:TOP], TOP_50_USA_ID)
+  fb.upload_live_table('Top 50 USA', records, columns)
 
-  records, columns = get_playlist_data(CHART_TYPE[:VIRAL_50], VIRAL_50_GLOBAL_ID)
-  puts 'VIRAL 50 GLOBAL', records, columns
+  records, columns = get_playlist_data(CHART_TYPE[:VIRAL], VIRAL_50_GLOBAL_ID)
+  fb.upload_live_table('Viral 50 Worldwide', records, columns)
 
-  records, columns = get_playlist_data(CHART_TYPE[:VIRAL_50], VIRAL_50_USA_ID)
-  puts 'VIRAL 50 USA', records, columns
-
-  #TODO: create a test DB or check that the table will save as expected?
-
-  # fb.upload_live_table('Viral 50 Worldwide', records, columns)
+  records, columns = get_playlist_data(CHART_TYPE[:VIRAL], VIRAL_50_USA_ID)
+  fb.upload_live_table('Viral 50 USA', records, columns)
 end
 
 main

--- a/bin/cron/applab_datasets/spotify
+++ b/bin/cron/applab_datasets/spotify
@@ -4,100 +4,109 @@ abort 'Script already running' unless only_one_running?(__FILE__)
 
 # This script fetches spotify data from api.spotify and uploads to the shared firebase channel.
 require_relative '../../../deployment'
-require 'net/http'
-require 'csv'
 require 'ostruct'
 require_relative '../../../shared/middleware/helpers/firebase_helper'
 require 'cdo/profanity_filter'
+require 'rest-client'
 
-TOP_200_US_URL = 'https://spotifycharts.com/regional/us/daily/latest/download'
-TOP_200_WORLD_URL = 'https://spotifycharts.com/regional/global/daily/latest/download'
-VIRAL_50_US_URL = 'https://spotifycharts.com/viral/us/daily/latest/download'
-VIRAL_50_WORLD_URL = 'https://spotifycharts.com/viral/global/daily/latest/download'
+BASE_URL = 'https://api.spotify.com/v1'
+
+#PLAYLIST IDs
+VIRAL_50_GLOBAL_ID = '37i9dQZEVXbLiRSasKsNU9'
+VIRAL_50_USA_ID = '37i9dQZEVXbKuaTI1Z1Afx'
+TOP_50_GLOBAL_ID = '37i9dQZEVXbMDoHDwVN2tF'
+TOP_50_USA_ID = '37i9dQZEVXbLRQDuF5jeBp'
+
 PROFANITY_LOCALE = 'en-US'
 
-def get_top200_data(url)
-  records = {}
-  columns = ['id', 'Track Name', 'Artist', 'Position', 'Streams', 'URL']
-  response = Net::HTTP.get_response(URI(url))
-  return unless response.code == '200'
-  id = 1
-  response.body.force_encoding('utf-8')
-  csv = CSV.new(response.body)
-  lines = csv.read
-  lines.shift # first line just contains a note
-  lines.shift # second line is column names
-  regex = generate_profanity_regex(lines)
-  lines.each do |line|
-    next if regex&.match?(get_string_to_check(line)) # skip record if it contains profanity
+CHART_TYPE = {
+  TOP_50: 'TOP_50',
+  VIRAL_50: 'VIRAL_50',
+}
 
-    record = OpenStruct.new
-    record.id = id
-    record.Position = line[0].to_i
-    record['Track Name'] = line[1]
-    record.Artist = line[2]
-    record.Streams = line[3].to_i
-    record.URL = line[4]
-
-    records[id] = record.to_h.to_json
-    id += 1
-  end
-  return records, columns
+def get_token
+  url = "https://accounts.spotify.com/api/token"
+  headers = {
+    'authorization' => 'Basic ' + Base64.strict_encode64(CLIENT_ID + ':' + CLIENT_SECRET),
+    'content-type' => 'application/x-www-form-urlencoded',
+  }
+  form = {
+    'grant_type' => 'client_credentials'
+  }
+  auth_response = JSON.parse(RestClient.post(url, form, headers))
+  $token = auth_response['access_token']
 end
 
-def get_viral50_data(url)
-  records = {}
+def get_playlist_data(chart_type, playlist_id)
+  # Filters for the query: a comma-separated list of the fields to return
+  field_query = 'fields=tracks.items(track(name,href,artists,popularity))'
+  url = "#{BASE_URL}/playlists/#{playlist_id}?#{field_query}"
+  response = RestClient.get(url, {authorization: "Bearer #{$token}"})
+  return unless response.code == 200
+
+  items = JSON.parse(response)['tracks']['items']
   columns = ['id', 'Track Name', 'Artist', 'Position', 'URL']
-  response = Net::HTTP.get_response(URI(url))
-  return unless response.code == '200'
+  if chart_type === CHART_TYPE[:TOP_50] then columns << 'Popularity' end # Only include Popularity for Top Charts
+
+  regex = generate_profanity_regex(items)
+  records = {}
   id = 1
-  response.body.force_encoding('utf-8')
-  csv = CSV.new(response.body)
-  lines = csv.read
-  lines.shift # first line is column names
-  regex = generate_profanity_regex(lines)
-  lines.each do |line|
-    next if regex&.match?(get_string_to_check(line)) # skip record if it contains profanity
+
+  items.each do |item|
+    track = item['track']
+    next if track.nil? || regex&.match?(get_string_to_check(track)) # skip track if it is nil or contains profanity
 
     record = OpenStruct.new
     record.id = id
-    record.Position = line[0].to_i
-    record['Track Name'] = line[1]
-    record.Artist = line[2]
-    record.URL = line[3]
+    record.Position = id # list of track items returned in order of popularity
+    record['Track Name'] = track['name']
+    record.Artist = track['artists'][0]['name'] # first will be main artist, featured artists included in record name
+    if chart_type === CHART_TYPE[:TOP_50] then record.Popularity = track['popularity'] end
+    record.URL = track['href']
 
     records[id] = record.to_h.to_json
     id += 1
   end
+
   return records, columns
 end
 
-# Only check artist and song names for profanity
-def get_string_to_check(line)
-  "#{line[2]} - #{line[1]} "
+# Only check artist and track names for profanity
+def get_string_to_check(track)
+  if track.nil?
+    return ""
+  else
+    return "#{track['name']} - #{track['artists'][0]['name']}"
+  end
 end
 
 # Generates a case-insensitive regex of profanities in the entire dataset
-# to match each line against.
-def generate_profanity_regex(lines)
-  str = lines.reduce('') {|acc, line| acc + get_string_to_check(line)}
+# to match each item against.
+def generate_profanity_regex(items)
+  str = items.reduce('') {|acc, item| acc + get_string_to_check(item['track'])}
   profanities = ProfanityFilter.find_potential_profanities(str, PROFANITY_LOCALE) || []
   profanities.empty? ? nil : /(#{profanities.join("|")})/i
 end
 
 def main
-  fb = FirebaseHelper.new('shared')
-  records, columns = get_top200_data(TOP_200_US_URL)
-  fb.upload_live_table('Top 200 USA', records, columns)
+  get_token
+  # fb = FirebaseHelper.new('shared')
 
-  records, columns = get_top200_data(TOP_200_WORLD_URL)
-  fb.upload_live_table('Top 200 Worldwide', records, columns)
+  records, columns = get_playlist_data(CHART_TYPE[:TOP_50], TOP_50_GLOBAL_ID)
+  puts 'TOP 50 GLOBAL', records, columns
 
-  records, columns = get_viral50_data(VIRAL_50_US_URL)
-  fb.upload_live_table('Viral 50 USA', records, columns)
+  records, columns = get_playlist_data(CHART_TYPE[:TOP_50], TOP_50_USA_ID)
+  puts 'TOP 50 USA', records, columns
 
-  records, columns = get_viral50_data(VIRAL_50_WORLD_URL)
-  fb.upload_live_table('Viral 50 Worldwide', records, columns)
+  records, columns = get_playlist_data(CHART_TYPE[:VIRAL_50], VIRAL_50_GLOBAL_ID)
+  puts 'VIRAL 50 GLOBAL', records, columns
+
+  records, columns = get_playlist_data(CHART_TYPE[:VIRAL_50], VIRAL_50_USA_ID)
+  puts 'VIRAL 50 USA', records, columns
+
+  #TODO: create a test DB or check that the table will save as expected?
+
+  # fb.upload_live_table('Viral 50 Worldwide', records, columns)
 end
 
 main

--- a/bin/cron/applab_datasets/spotify
+++ b/bin/cron/applab_datasets/spotify
@@ -3,6 +3,12 @@ require_relative '../only_one'
 abort 'Script already running' unless only_one_running?(__FILE__)
 
 # This script fetches spotify data from api.spotify and uploads to the shared firebase channel.
+#
+# TESTING LOCALLY (Code.org engineers only)
+# In order to run this file locally, you'll need to temporarily configure your locals.yml file to include
+# development/cdo/spotify_api_client_id and development/cdo/spotify_api_client_secret values
+#
+
 require_relative '../../../deployment'
 require 'ostruct'
 require_relative '../../../shared/middleware/helpers/firebase_helper'

--- a/bin/cron/applab_datasets/spotify
+++ b/bin/cron/applab_datasets/spotify
@@ -25,9 +25,11 @@ CHART_TYPE = {
 }
 
 def get_token
+  client_id = CDO.spotify_api_client_id
+  client_secret = CDO.spotify_api_client_secret
   url = "https://accounts.spotify.com/api/token"
   headers = {
-    'authorization' => 'Basic ' + Base64.strict_encode64(CLIENT_ID + ':' + CLIENT_SECRET),
+    'authorization' => 'Basic ' + Base64.strict_encode64(client_id + ':' + client_secret),
     'content-type' => 'application/x-www-form-urlencoded',
   }
   form = {

--- a/bin/cron/applab_datasets/spotify
+++ b/bin/cron/applab_datasets/spotify
@@ -10,8 +10,9 @@ require 'cdo/profanity_filter'
 require 'rest-client'
 
 BASE_URL = 'https://api.spotify.com/v1'
+TOKEN_URL = 'https://accounts.spotify.com/api/token'
 
-#PLAYLIST IDs
+# PLAYLIST IDs
 VIRAL_50_GLOBAL_ID = '37i9dQZEVXbLiRSasKsNU9'
 VIRAL_50_USA_ID = '37i9dQZEVXbKuaTI1Z1Afx'
 TOP_50_GLOBAL_ID = '37i9dQZEVXbMDoHDwVN2tF'
@@ -29,7 +30,6 @@ def get_token
   client_secret = CDO.spotify_api_client_secret
 
   begin
-    url = "https://accounts.spotify.com/api/token"
     headers = {
       'authorization' => 'Basic ' + Base64.strict_encode64(client_id + ':' + client_secret),
       'content-type' => 'application/x-www-form-urlencoded',
@@ -37,7 +37,7 @@ def get_token
     form = {
       'grant_type' => 'client_credentials'
     }
-    auth_response = JSON.parse(RestClient.post(url, form, headers))
+    auth_response = JSON.parse(RestClient.post(TOKEN_URL, form, headers))
     $token = auth_response['access_token']
   rescue RestClient::Exception => e
     Honeybadger.notify(
@@ -64,6 +64,7 @@ def get_playlist_data(chart_type, playlist_id)
       error_message: "Failed to retrieve playlist data from Spotify for use in App Lab Datasets.",
       context: {
         playlist_id: playlist_id,
+        chart_type: chart_type
       }
     )
     return
@@ -71,9 +72,7 @@ def get_playlist_data(chart_type, playlist_id)
 
   items = JSON.parse(response)['tracks']['items']
   columns = ['id', 'Track Name', 'Artist', 'Position', 'URL']
-  if chart_type === CHART_TYPE[:TOP]
-    columns.insert(4, 'Popularity')   # Only include Popularity for Top Charts
-  end
+  columns.insert(4, 'Popularity') if chart_type === CHART_TYPE[:TOP] # Only include Popularity for Top Charts
 
   regex = generate_profanity_regex(items)
   records = {}
@@ -81,14 +80,14 @@ def get_playlist_data(chart_type, playlist_id)
 
   items.each do |item|
     track = item['track']
-    next if track.nil? || regex&.match?(get_string_to_check(track)) # skip track if it is nil or contains profanity
+    next if track.nil? || regex&.match?(get_track_info_string(track)) # Skip track if it is nil or contains profanity
 
     record = OpenStruct.new
     record.id = id
     record.Position = id
     record['Track Name'] = track['name']
-    record.Artist = track['artists'][0]['name'] # first will be main artist, featured artists included in record name
-    if chart_type === CHART_TYPE[:TOP] then record.Popularity = track['popularity'] end
+    record.Artist = track['artists'][0]['name'] # First will be main artist, featured artists included in record name
+    record.Popularity = track['popularity'] if chart_type === CHART_TYPE[:TOP]
     record.URL = track['href']
 
     records[id] = record.to_h.to_json
@@ -99,18 +98,15 @@ def get_playlist_data(chart_type, playlist_id)
 end
 
 # Only check artist and track names for profanity
-def get_string_to_check(track)
-  if track.nil?
-    return ""
-  else
-    return "#{track['name']} - #{track['artists'][0]['name']} "
-  end
+def get_track_info_string(track)
+  return '' if track.nil?
+  "#{track['name']} - #{track['artists'][0]['name']} "
 end
 
 # Generates a case-insensitive regex of profanities in the entire dataset
 # to match each item against.
 def generate_profanity_regex(items)
-  str = items.reduce('') {|acc, item| acc + get_string_to_check(item['track'])}
+  str = items.reduce('') {|acc, item| acc + get_track_info_string(item['track'])}
   profanities = ProfanityFilter.find_potential_profanities(str, PROFANITY_LOCALE) || []
   profanities.empty? ? nil : /(#{profanities.join("|")})/i
 end

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -547,3 +547,7 @@ imm_reader_subdomain:     cdo-immersive-reader-<%=env%>
 
 javabuilder_private_key: !Secret
 javabuilder_key_password: !Secret
+
+# Credentials for the Spotify API, used to provide playlist data in App Labs
+spotify_api_client_id: !Secret
+spotify_api_client_secret: !Secret

--- a/config/development.yml.erb
+++ b/config/development.yml.erb
@@ -46,3 +46,7 @@ pardot_private_key: !Secret
 redshift_host: !Secret
 redshift_password: !Secret
 redshift_username: !Secret
+
+# Credentials for the Spotify API, used to provide playlist data in App Labs
+spotify_api_client_id: !Secret
+spotify_api_client_secret: !Secret

--- a/config/development.yml.erb
+++ b/config/development.yml.erb
@@ -46,7 +46,3 @@ pardot_private_key: !Secret
 redshift_host: !Secret
 redshift_password: !Secret
 redshift_username: !Secret
-
-# Credentials for the Spotify API, used to provide playlist data in App Labs
-spotify_api_client_id: !Secret
-spotify_api_client_secret: !Secret

--- a/config/levelbuilder.yml.erb
+++ b/config/levelbuilder.yml.erb
@@ -20,7 +20,3 @@ custom_error_response: false
 
 # Configurations for making calls to the Immersive Reader API on Azure
 imm_reader_client_id:     '4fa6b522-6e6d-44c6-b023-98816b54566d'
-
-# Credentials for the Spotify API, used to provide playlist data in App Labs
-spotify_api_client_id: !Secret
-spotify_api_client_secret: !Secret

--- a/config/levelbuilder.yml.erb
+++ b/config/levelbuilder.yml.erb
@@ -20,3 +20,7 @@ custom_error_response: false
 
 # Configurations for making calls to the Immersive Reader API on Azure
 imm_reader_client_id:     '4fa6b522-6e6d-44c6-b023-98816b54566d'
+
+# Credentials for the Spotify API, used to provide playlist data in App Labs
+spotify_api_client_id: !Secret
+spotify_api_client_secret: !Secret

--- a/config/production.yml.erb
+++ b/config/production.yml.erb
@@ -35,3 +35,7 @@ afe_pardot_form_handler_url: !Secret
 # Configurations for making calls to the Immersive Reader API on Azure
 imm_reader_client_id:     '06d74083-9d25-43e4-acf6-0377f381a1e5'
 imm_reader_subdomain:     'cdo-immersive-reader-prod'
+
+# Credentials for the Spotify API, used to provide playlist data in App Labs
+spotify_api_client_id: !Secret
+spotify_api_client_secret: !Secret

--- a/config/production.yml.erb
+++ b/config/production.yml.erb
@@ -35,7 +35,3 @@ afe_pardot_form_handler_url: !Secret
 # Configurations for making calls to the Immersive Reader API on Azure
 imm_reader_client_id:     '06d74083-9d25-43e4-acf6-0377f381a1e5'
 imm_reader_subdomain:     'cdo-immersive-reader-prod'
-
-# Credentials for the Spotify API, used to provide playlist data in App Labs
-spotify_api_client_id: !Secret
-spotify_api_client_secret: !Secret

--- a/config/staging.yml.erb
+++ b/config/staging.yml.erb
@@ -13,7 +13,3 @@ custom_error_response: false
 
 # Configurations for making calls to the Immersive Reader API on Azure
 imm_reader_client_id:     '74937af0-55ee-411a-867a-57eefadec7d9'
-
-# Credentials for the Spotify API, used to provide playlist data in App Labs
-spotify_api_client_id: !Secret
-spotify_api_client_secret: !Secret

--- a/config/staging.yml.erb
+++ b/config/staging.yml.erb
@@ -13,3 +13,7 @@ custom_error_response: false
 
 # Configurations for making calls to the Immersive Reader API on Azure
 imm_reader_client_id:     '74937af0-55ee-411a-867a-57eefadec7d9'
+
+# Credentials for the Spotify API, used to provide playlist data in App Labs
+spotify_api_client_id: !Secret
+spotify_api_client_secret: !Secret

--- a/config/test.yml.erb
+++ b/config/test.yml.erb
@@ -47,7 +47,3 @@ disable_s3_image_uploads: true
 
 # provide a unique path for firebase channels data for ci, to avoid conflicts in channel ids.
 firebase_channel_id_suffix: '<%=ci ? "-#{circle_run_identifier}" : ''%>'
-
-# Credentials for the Spotify API, used to provide playlist data in App Labs
-spotify_api_client_id: !Secret
-spotify_api_client_secret: !Secret

--- a/config/test.yml.erb
+++ b/config/test.yml.erb
@@ -47,3 +47,7 @@ disable_s3_image_uploads: true
 
 # provide a unique path for firebase channels data for ci, to avoid conflicts in channel ids.
 firebase_channel_id_suffix: '<%=ci ? "-#{circle_run_identifier}" : ''%>'
+
+# Credentials for the Spotify API, used to provide playlist data in App Labs
+spotify_api_client_id: !Secret
+spotify_api_client_secret: !Secret

--- a/dashboard/app/controllers/datasets_controller.rb
+++ b/dashboard/app/controllers/datasets_controller.rb
@@ -8,7 +8,7 @@ class DatasetsController < ApplicationController
   authorize_resource class: false
 
   LIVE_DATASETS = ['Daily Weather', 'Top 200 USA', 'Top 200 Worldwide', 'Viral 50 USA', 'Viral 50 Worldwide',
-                   'COVID-19 Cases per US State', 'COVID-19 Cases per Country']
+                   'Top 50 USA', 'Top 50 Worldwide', 'COVID-19 Cases per US State', 'COVID-19 Cases per Country']
 
   # GET /datasets
   def index

--- a/lib/cdo/web_purify.rb
+++ b/lib/cdo/web_purify.rb
@@ -25,7 +25,7 @@ module WebPurify
     url = "http://api1.webpurify.com/services/rest/" \
       "?api_key=#{CDO.webpurify_key}" \
       "&method=webpurify.live.return" \
-      "&text=#{URI.encode(text)}" \
+      "&text=#{CGI.escape(text)}" \
       "&lang=#{language_codes}" \
       "&format=json"
     result = JSON.


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links
- jira ticket: https://codedotorg.atlassian.net/browse/STAR-1715

## Testing story
There were no existing tests for the spotify data logic, so no tests were updated as part of these changes. 

No tests were added either. The rationale for not testing this file is that the logic is primarily fetching and passing data between two different 3rd party APIs. The filtering also relies on a 3rd party api and those utility methods are already tested. 

## Follow-up work
- A bug was found during development where the dropdown in the datasets library includes unpublished datasets as part of the `# tables`. I looked into this to see if it would be an easy change to include as part of these changes, but determined that the fix should be separate. 

- I'll be connecting with curriculum to update the [Code.org Tool Documentation ](https://studio.code.org/docs/concepts/data-library/top-200-usa/)
- Ticket for follow up work to add UI notice about deprecating top 200 charts 
- We will need to publish the new top 50 charts once we're ready to expose them in the UI. 

## Security
New API credentials have been added to our AWS secrets manager, config files, and password manager. 

## PR Checklist:


- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
