### PR TITLE
Fix adding programming expression to lesson plan

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/ProgrammingExpressionsEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ProgrammingExpressionsEditor.jsx
@@ -146,8 +146,7 @@ class ProgrammingExpressionsEditor extends Component {
   };
 
   handleCloseAddProgrammingExpression = programmingExpression => {
-    this.setState(
-      {addProgrammingExpressionOpen: false},
+    this.setState({addProgrammingExpressionOpen: false}, () =>
       this.props.addProgrammingExpression(programmingExpression)
     );
   };


### PR DESCRIPTION
A callback was an object instead of a function, causing the page to crash when it tried to call it. Console errors after attempting to add a programming expression to a lesson plan (before this PR):
![Screen Shot 2021-09-30 at 12 21 49 PM](https://user-images.githubusercontent.com/46464143/135640803-52764dfd-462e-4159-91fd-f571cb3925ca.png)

I believe this broke after the React upgrade. When I went back to before the upgrade, there were console errors but the page didn't crash like it does now.

I couldn't figure out a good way to add a test for this. I could add a UI test if folks think that's useful but I couldn't get a unit test to fail on staging and pass with this PR.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
