### PR TITLE
Peer review: refresh peer list on dropdown click

### DIFF
--- a/apps/i18n/javalab/en_us.json
+++ b/apps/i18n/javalab/en_us.json
@@ -32,7 +32,7 @@
   "enablePeerReview": "Enable Peer Review",
   "errorJavabuilderConnectionGeneral": "We hit an error connecting to our server. Try again.",
   "errorJavabuilderConnectionNotAuthorized": "You are not authorized to access Javalab. Do you need to log in or join a section?",
-  "errorLoadingClassmates": "There was an error loading the list of your classmates. Switch to 'Instructions' and back to 'Review' to reload the list.",
+  "errorLoadingClassmates": "There was an error loading the list of your classmates. Please try again.",
   "errorMediaImageLoadError": "There was an error loading the image.",
   "errorNeighborhoodInvalidGrid": "There was an error loading the neighborhood level. Please contact us at support@code.org, and be sure to include the URL to this page in your message.",
   "errorNeighborhoodInvalidDirection": "The direction provided is not a recognized. Supported directions are \"north\", \"south\", \"east\", and \"west\".",

--- a/apps/src/templates/instructions/ReviewTab.jsx
+++ b/apps/src/templates/instructions/ReviewTab.jsx
@@ -35,10 +35,8 @@ class ReviewTab extends Component {
     reviewableProjectId: '',
     loadingReviewableState: false,
     errorSavingReviewableProject: false,
-    errorLoadingReviewablePeers: false,
     comments: [],
     forceRecreateEditorKey: 0,
-    reviewablePeers: [],
     projectOwnerName: '',
     authorizationError: false,
     commentSaveError: false,
@@ -66,13 +64,7 @@ class ReviewTab extends Component {
     `?${VIEWING_CODE_REVIEW_URL_PARAM}=true`;
 
   componentDidMount() {
-    const {
-      channelId,
-      serverLevelId,
-      serverScriptId,
-      viewAsCodeReviewer,
-      viewAsTeacher
-    } = this.props;
+    const {channelId, serverLevelId, serverScriptId} = this.props;
 
     // If there's no channelId (happens when a teacher is viewing as a student who has not done any work on a level),
     // do not make API calls that require a channelId
@@ -114,19 +106,6 @@ class ReviewTab extends Component {
         })
     );
 
-    if (!(viewAsCodeReviewer || viewAsTeacher)) {
-      initialLoadPromises.push(
-        this.dataApi
-          .getReviewablePeers()
-          .done(data => this.setState({reviewablePeers: data}))
-          .fail(() => {
-            this.setState({
-              errorLoadingReviewablePeers: true
-            });
-          })
-      );
-    }
-
     Promise.all(initialLoadPromises).finally(() => {
       this.setState({initialLoadCompleted: true});
     });
@@ -137,6 +116,13 @@ class ReviewTab extends Component {
       this.props.onLoadComplete();
     }
   }
+
+  loadPeers = (onSuccess, onFailure) => {
+    this.dataApi
+      .getReviewablePeers()
+      .done(onSuccess)
+      .fail(onFailure);
+  };
 
   onNewCommentCancel = () => {
     this.setState({
@@ -363,9 +349,7 @@ class ReviewTab extends Component {
       isReadyForReview,
       errorSavingReviewableProject,
       projectOwnerName,
-      reviewCheckboxEnabled,
-      reviewablePeers,
-      errorLoadingReviewablePeers
+      reviewCheckboxEnabled
     } = this.state;
 
     // channelId is not available on projects where the student has not edited the starter code.
@@ -392,11 +376,10 @@ class ReviewTab extends Component {
           {codeReviewEnabled && !viewAsTeacher && (
             <>
               <ReviewNavigator
-                peers={reviewablePeers}
                 onSelectPeer={this.onSelectPeer}
                 onReturnToProject={this.onClickBackToProject}
                 viewPeerList={!viewAsCodeReviewer}
-                loadError={errorLoadingReviewablePeers}
+                loadPeers={this.loadPeers}
               />
               {reviewCheckboxEnabled &&
                 !viewAsCodeReviewer &&

--- a/apps/src/templates/instructions/codeReview/ReviewNavigator.jsx
+++ b/apps/src/templates/instructions/codeReview/ReviewNavigator.jsx
@@ -3,18 +3,46 @@ import PropTypes from 'prop-types';
 import DropdownButton from '@cdo/apps/templates/DropdownButton';
 import Button from '@cdo/apps/templates/Button';
 import javalabMsg from '@cdo/javalab/locale';
+import Spinner from '@cdo/apps/code-studio/pd/components/spinner';
 
 class ReviewNavigator extends Component {
   static propTypes = {
-    peers: PropTypes.array,
     onSelectPeer: PropTypes.func,
     onReturnToProject: PropTypes.func,
     viewPeerList: PropTypes.bool,
-    loadError: PropTypes.bool
+    loadPeers: PropTypes.func
+  };
+
+  state = {
+    peers: [],
+    loadError: false,
+    loadInProgress: false
+  };
+
+  onDropdownClick = () => {
+    this.setState({loadInProgress: true, loadError: false, peers: []});
+    this.props.loadPeers(this.onPeerLoadSuccess, this.onPeerLoadFailure);
+  };
+
+  onPeerLoadSuccess = peerList => {
+    this.setState({peers: peerList, loadInProgress: false});
+  };
+
+  onPeerLoadFailure = () => {
+    console.log('in peer load failure');
+    this.setState({loadError: true, loadInProgress: false});
   };
 
   getPeerList() {
-    const {loadError, peers, onSelectPeer} = this.props;
+    const {onSelectPeer} = this.props;
+    const {loadError, peers, loadInProgress} = this.state;
+    if (loadInProgress) {
+      return [
+        <a key="loading" onClick={() => {}}>
+          <Spinner size="medium" />
+        </a>
+      ];
+    }
     if (loadError || !Array.isArray(peers)) {
       return [
         <a key="error" onClick={() => {}}>
@@ -48,6 +76,7 @@ class ReviewNavigator extends Component {
         <DropdownButton
           text={javalabMsg.reviewClassmateProject()}
           color={Button.ButtonColor.white}
+          onClick={this.onDropdownClick}
         >
           {this.getPeerList()}
         </DropdownButton>

--- a/apps/src/templates/instructions/codeReview/ReviewNavigator.jsx
+++ b/apps/src/templates/instructions/codeReview/ReviewNavigator.jsx
@@ -29,7 +29,6 @@ class ReviewNavigator extends Component {
   };
 
   onPeerLoadFailure = () => {
-    console.log('in peer load failure');
     this.setState({loadError: true, loadInProgress: false});
   };
 

--- a/apps/test/unit/templates/instructions/ReviewNavigatorTest.js
+++ b/apps/test/unit/templates/instructions/ReviewNavigatorTest.js
@@ -15,25 +15,27 @@ describe('Review Navigator', () => {
     expect(wrapper.find('Button').length).to.equal(1);
   });
 
-  it('renders an error when passed a load error', () => {
-    let wrapper = shallow(<ReviewNavigator viewPeerList loadError />);
-
+  it('renders an error if there is a load error', () => {
+    let wrapper = shallow(<ReviewNavigator viewPeerList />);
+    wrapper.instance().setState({loadError: true});
     let link = wrapper.find('a');
     expect(link.length).to.equal(1);
     expect(link.key()).to.equal('error');
   });
 
   it('renders an error when peers is undefined', () => {
-    let wrapper = shallow(<ReviewNavigator viewPeerList peers={undefined} />);
+    let wrapper = shallow(<ReviewNavigator viewPeerList />);
 
+    wrapper.instance().setState({peers: undefined});
     let link = wrapper.find('a');
     expect(link.length).to.equal(1);
     expect(link.key()).to.equal('error');
   });
 
   it('renders a default message when peers is empty', () => {
-    let wrapper = shallow(<ReviewNavigator viewPeerList peers={[]} />);
+    let wrapper = shallow(<ReviewNavigator viewPeerList />);
 
+    wrapper.instance().setState({peers: []});
     let link = wrapper.find('a');
     expect(link.length).to.equal(1);
     expect(link.key()).to.equal('no-reviews');
@@ -52,7 +54,8 @@ describe('Review Navigator', () => {
         id: 2
       }
     ];
-    let wrapper = shallow(<ReviewNavigator viewPeerList peers={peerList} />);
+    let wrapper = shallow(<ReviewNavigator viewPeerList />);
+    wrapper.instance().setState({peers: peerList});
 
     let link = wrapper.find('a');
     expect(link.length).to.equal(2);
@@ -60,5 +63,14 @@ describe('Review Navigator', () => {
     expect(link.first().text()).to.equal(firstStudent);
     expect(link.last().key()).to.equal('2');
     expect(link.last().text()).to.equal(secondStudent);
+  });
+
+  it('renders a spinner when loading peers', () => {
+    let wrapper = shallow(<ReviewNavigator viewPeerList />);
+
+    wrapper.instance().setState({loadInProgress: true});
+    let link = wrapper.find('a');
+    expect(link.length).to.equal(1);
+    expect(link.key()).to.equal('loading');
   });
 });


### PR DESCRIPTION
Refresh a students list of peers every time the "review a classmate's project" dropdown is clicked.
Now while the list is loading the user sees a spinner:
![Screen Shot 2021-09-30 at 2 24 50 PM](https://user-images.githubusercontent.com/33666587/135533153-62a11525-8753-4038-82ad-97b41df99f29.png)


If there is an error loading peers the message no longer mentions the need to switch tabs (previously it said to go back to the instructions tab):

![Screen Shot 2021-09-30 at 2 24 45 PM](https://user-images.githubusercontent.com/33666587/135533102-9def23d3-8f7a-450d-9215-5d8bba904e3f.png)

## Links

- jira ticket: [CSA-794](https://codedotorg.atlassian.net/browse/CSA-794)


## Testing story
Tested locally and added unit tests.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
