### PR TITLE
Ensure after multiple script switches we're showing up-to-date progress

### DIFF
--- a/apps/src/templates/sectionProgress/ProgressViewHeader.jsx
+++ b/apps/src/templates/sectionProgress/ProgressViewHeader.jsx
@@ -10,14 +10,12 @@ import firehoseClient from '../../lib/util/firehose';
 import color from '../../util/color';
 import {h3Style} from '../../lib/ui/Headings';
 import StandardsViewHeaderButtons from './standards/StandardsViewHeaderButtons';
-import FontAwesome from '@cdo/apps/templates/FontAwesome';
 
 class ProgressViewHeader extends Component {
   static propTypes = {
     scriptId: PropTypes.number,
     //redux
     currentView: PropTypes.oneOf(Object.values(ViewType)),
-    refreshing: PropTypes.bool,
     section: sectionDataPropType.isRequired,
     scriptFriendlyName: PropTypes.string.isRequired,
     scriptData: scriptDataPropType
@@ -44,7 +42,7 @@ class ProgressViewHeader extends Component {
   };
 
   render() {
-    const {currentView, scriptFriendlyName, refreshing} = this.props;
+    const {currentView, scriptFriendlyName} = this.props;
     const linkToOverview = this.getLinkToOverview();
     const headingText = {
       [ViewType.SUMMARY]: i18n.lessonsAttempted() + ' ',
@@ -63,17 +61,6 @@ class ProgressViewHeader extends Component {
             {scriptFriendlyName}
           </a>
         </span>
-        {refreshing && (
-          <span style={styles.refreshing}>
-            <FontAwesome
-              id="uitest-spinner"
-              icon="spinner"
-              className="fa-pulse"
-              style={styles.refreshSpinner}
-            />
-            {i18n.updating()}
-          </span>
-        )}
         {currentView === ViewType.STANDARDS && (
           <StandardsViewHeaderButtons sectionId={this.props.section.id} />
         )}
@@ -95,12 +82,6 @@ const styles = {
   },
   scriptLink: {
     color: color.teal
-  },
-  refreshing: {
-    color: color.orange
-  },
-  refreshSpinner: {
-    marginRight: 5
   }
 };
 
@@ -109,7 +90,6 @@ export const UnconnectedProgressViewHeader = ProgressViewHeader;
 export default connect(state => ({
   section: state.sectionData.section,
   currentView: state.sectionProgress.currentView,
-  refreshing: state.sectionProgress.isRefreshingProgress,
   scriptData: getCurrentUnitData(state),
   scriptFriendlyName: getSelectedScriptFriendlyName(state)
 }))(ProgressViewHeader);

--- a/apps/src/templates/sectionProgress/SectionProgress.jsx
+++ b/apps/src/templates/sectionProgress/SectionProgress.jsx
@@ -42,6 +42,7 @@ class SectionProgress extends Component {
     setScriptId: PropTypes.func.isRequired,
     setLessonOfInterest: PropTypes.func.isRequired,
     isLoadingProgress: PropTypes.bool.isRequired,
+    isRefreshingProgress: PropTypes.bool,
     showStandardsIntroDialog: PropTypes.bool
   };
 
@@ -115,9 +116,11 @@ class SectionProgress extends Component {
       scriptId,
       scriptData,
       isLoadingProgress,
+      isRefreshingProgress,
       showStandardsIntroDialog
     } = this.props;
-    const levelDataInitialized = scriptData && !isLoadingProgress;
+    const levelDataInitialized =
+      scriptData && !isLoadingProgress && !isRefreshingProgress;
     const lessons = scriptData ? scriptData.lessons : [];
     const scriptWithStandardsSelected =
       levelDataInitialized && scriptData.hasStandards;
@@ -219,6 +222,7 @@ export default connect(
     currentView: state.sectionProgress.currentView,
     scriptData: getCurrentUnitData(state),
     isLoadingProgress: state.sectionProgress.isLoadingProgress,
+    isRefreshingProgress: state.sectionProgress.isRefreshingProgress,
     showStandardsIntroDialog: !state.currentUser.hasSeenStandardsReportInfo
   }),
   dispatch => ({

--- a/apps/test/unit/templates/sectionProgress/ProgressViewHeaderTest.jsx
+++ b/apps/test/unit/templates/sectionProgress/ProgressViewHeaderTest.jsx
@@ -43,10 +43,4 @@ describe('ProgressViewHeader', () => {
       wrapper.find('Connect(StandardsViewHeaderButtons)')
     ).to.have.lengthOf(0);
   });
-
-  it('displays a spinner when refreshing', () => {
-    let headerProps = {...DEFAULT_PROPS, ...{refreshing: true}};
-    const wrapper = shallow(<ProgressViewHeader {...headerProps} />);
-    expect(wrapper.find('FontAwesome')).to.have.lengthOf(1);
-  });
 });


### PR DESCRIPTION
[LP-2047](https://codedotorg.atlassian.net/browse/LP-2047)

In the Progress Table of the Teacher Dashboard when switching from one script to another and back to the original, progress was not loading for the original script. In the case where we already have level progress for a given script, we dispatch an action to refresh progress rather than load progress. However, when displaying progress we were only checking state to see if the load was complete and needed to additionally check if the refresh is complete. My best guess is this bug has been around since #35567 when the concept of refreshing was introduced to handle updating the last progress timestamp tooltip. 

BEFORE 

https://user-images.githubusercontent.com/12300669/135549238-b01cc0bf-536a-4293-b015-50efb2744e44.mov

AFTER 

https://user-images.githubusercontent.com/12300669/135548867-c2823c49-411c-41c9-921b-95e1b9e451ce.mov

I also deleted this orange updating spinner and message. It's positioned strangely and confusing because there is already a differently styled loading spinner when the tab contents update. 

<img width="1098" alt="Screen Shot 2021-09-30 at 8 17 00 PM" src="https://user-images.githubusercontent.com/12300669/135547178-88a4315a-93db-4197-ae6b-7bf9f91fe4b3.png">
