### PR TITLE
[Poetry][HOC] Small cleanups

### DIFF
--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -1109,13 +1109,13 @@ export default class P5Lab {
       }
 
       if (this.isBlockly) {
-        this.spritelabLibrary = this.createLibrary({p5: this.p5Wrapper.p5});
+        this.library = this.createLibrary({p5: this.p5Wrapper.p5});
 
-        const spritelabCommands = this.spritelabLibrary.commands;
-        for (const command in spritelabCommands) {
+        const libraryCommands = this.library.commands;
+        for (const command in libraryCommands) {
           this.JSInterpreter.createGlobalProperty(
             command,
-            spritelabCommands[command].bind(this.spritelabLibrary),
+            libraryCommands[command].bind(this.library),
             null
           );
         }

--- a/apps/src/p5lab/poetry/PoemSelector.jsx
+++ b/apps/src/p5lab/poetry/PoemSelector.jsx
@@ -50,7 +50,6 @@ function PoemEditor(props) {
       onClick={() =>
         props.handleClose({title, author, lines: poem.split('\n')})
       }
-      key="confirm"
       type="confirm"
     />
   );

--- a/apps/src/p5lab/poetry/PoetryLibrary.js
+++ b/apps/src/p5lab/poetry/PoetryLibrary.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import {getStore} from '@cdo/apps/redux';
 import CoreLibrary from '../spritelab/CoreLibrary';
 import {POEMS} from './constants';
@@ -19,7 +20,7 @@ export default class PoetryLibrary extends CoreLibrary {
       endTime: POEM_DURATION
     };
     this.poemState = {
-      ...getStore().getState().poetry.selectedPoem,
+      ..._.cloneDeep(getStore().getState().poetry.selectedPoem),
       font: {
         fill: 'black',
         stroke: 'rgba(0,0,0,0)',


### PR DESCRIPTION
3 quick fixes, grouped under 1 PR just for convenience.

- renames `spritelabLibrary` -> `library` and `spritelabCommands` -> `commands` in P5Lab since this code also applies to Poetry
- removes unnecessary `key` attribute from the `<FooterButton>` in the create your own poem modal
- Deep clones the poem state. This fixes a problem where `addLine` was modifying the actual object in redux unintentionally.