### PR TITLE
Use enums for propTypes in StylizedBaseDialog & FooterButton

### DIFF
--- a/apps/src/componentLibrary/StylizedBaseDialog.jsx
+++ b/apps/src/componentLibrary/StylizedBaseDialog.jsx
@@ -14,27 +14,30 @@ import Button from '@cdo/apps/templates/Button';
  */
 
 const FooterButtonType = makeEnum('cancel', 'confirm', 'default');
+const FooterButtonColor = {
+  [FooterButtonType.cancel]: Button.ButtonColor.gray,
+  [FooterButtonType.confirm]: Button.ButtonColor.orange
+};
+
 const DialogStyle = makeEnum('default', 'simple');
 
 export function FooterButton(props) {
-  const isConfirm = props.type === FooterButtonType.confirm;
-  const isCancel = props.type === FooterButtonType.cancel;
-  const color = props.color || (isConfirm && 'orange') || (isCancel && 'gray');
+  function color() {
+    if (props.color) {
+      return props.color;
+    }
+
+    return FooterButtonColor[props.type];
+  }
 
   // TODO: We shouldn't need to override <Button/> styles -- they should likely be default.
   // Tracked by https://codedotorg.atlassian.net/browse/STAR-1616.
   const style = {
     ...styles.buttons.all,
-    ...(isConfirm && styles.buttons.confirmation)
+    ...(styles.buttons[props.type] || {})
   };
 
-  return (
-    <Button
-      style={style}
-      color={typeof color === 'string' ? color : undefined}
-      {...props}
-    />
-  );
+  return <Button style={style} color={color()} {...props} />;
 }
 
 // This component renders a <Button/>, so it will also accept/require any propTypes
@@ -164,6 +167,6 @@ const styles = {
   },
   buttons: {
     all: {boxShadow: 'none'},
-    confirmation: {borderColor: color.orange}
+    [FooterButtonType.confirm]: {borderColor: color.orange}
   }
 };

--- a/apps/src/componentLibrary/StylizedBaseDialog.jsx
+++ b/apps/src/componentLibrary/StylizedBaseDialog.jsx
@@ -75,13 +75,13 @@ export default function StylizedBaseDialog(props) {
   const defaultButtons = [
     <FooterButton
       key="cancel"
-      type="cancel"
+      type={FooterButtonType.cancel}
       text={props.cancellationButtonText}
       onClick={props.handleCancellation || props.handleClose}
     />,
     <FooterButton
       key="confirm"
-      type="confirm"
+      type={FooterButtonType.confirm}
       text={props.confirmationButtonText}
       onClick={props.handleConfirmation || props.handleClose}
     />

--- a/apps/src/componentLibrary/StylizedBaseDialog.jsx
+++ b/apps/src/componentLibrary/StylizedBaseDialog.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import i18n from '@cdo/locale';
 import color from '@cdo/apps/util/color';
+import {makeEnum} from '@cdo/apps/utils';
 import BaseDialog from '@cdo/apps/templates/BaseDialog';
 import Button from '@cdo/apps/templates/Button';
 
@@ -12,9 +13,12 @@ import Button from '@cdo/apps/templates/Button';
  * Includes a FooterButton component that appropriately styles buttons for the dialog.
  */
 
+const FooterButtonType = makeEnum('cancel', 'confirm', 'default');
+const DialogStyle = makeEnum('default', 'simple');
+
 export function FooterButton(props) {
-  const isConfirm = props.type === 'confirm';
-  const isCancel = props.type === 'cancel';
+  const isConfirm = props.type === FooterButtonType.confirm;
+  const isCancel = props.type === FooterButtonType.cancel;
   const color = props.color || (isConfirm && 'orange') || (isCancel && 'gray');
 
   // TODO: We shouldn't need to override <Button/> styles -- they should likely be default.
@@ -36,12 +40,12 @@ export function FooterButton(props) {
 // This component renders a <Button/>, so it will also accept/require any propTypes
 // from that component.
 FooterButton.propTypes = {
-  type: PropTypes.oneOf(['confirm', 'cancel', 'default']).isRequired,
+  type: PropTypes.oneOf(Object.keys(FooterButtonType)).isRequired,
   color: PropTypes.string
 };
 
 FooterButton.defaultProps = {
-  type: 'default'
+  type: FooterButtonType.default
 };
 
 export default function StylizedBaseDialog(props) {
@@ -64,7 +68,7 @@ export default function StylizedBaseDialog(props) {
   }
 
   const horizontalRule =
-    props.type === 'simple' ? null : <hr style={styles.hr} />;
+    props.type === DialogStyle.simple ? null : <hr style={styles.hr} />;
   const defaultButtons = [
     <FooterButton
       key="cancel"
@@ -91,7 +95,7 @@ export default function StylizedBaseDialog(props) {
       <div
         style={{
           ...styles.container,
-          ...(props.type === 'simple' ? {} : {padding: GUTTER})
+          ...(props.type === DialogStyle.simple ? {} : {padding: GUTTER})
         }}
       >
         {props.body}
@@ -129,7 +133,7 @@ StylizedBaseDialog.propTypes = {
   handleConfirmation: PropTypes.func,
   handleClose: PropTypes.func.isRequired,
   handleCancellation: PropTypes.func,
-  type: PropTypes.oneOf(['default', 'simple'])
+  type: PropTypes.oneOf(Object.keys(DialogStyle))
 };
 
 StylizedBaseDialog.defaultProps = {
@@ -138,7 +142,7 @@ StylizedBaseDialog.defaultProps = {
   hideFooter: false,
   confirmationButtonText: i18n.dialogOK(),
   cancellationButtonText: i18n.dialogCancel(),
-  type: 'default'
+  type: DialogStyle.default
 };
 
 const GUTTER = 20;

--- a/apps/src/componentLibrary/StylizedBaseDialog.jsx
+++ b/apps/src/componentLibrary/StylizedBaseDialog.jsx
@@ -98,7 +98,7 @@ export default function StylizedBaseDialog(props) {
       <div
         style={{
           ...styles.container,
-          ...(props.type === DialogStyle.simple ? {} : {padding: GUTTER})
+          ...(styles.body[props.type] || {})
         }}
       >
         {props.body}
@@ -159,6 +159,9 @@ const styles = {
   hr: {
     margin: 0,
     borderColor: color.lighter_gray
+  },
+  body: {
+    [DialogStyle.default]: {padding: GUTTER}
   },
   footer: {
     display: 'flex',


### PR DESCRIPTION
Clean up from some feedback from @ajpal on #42622. This is a pure refactor, so there is no visible change here.