### PR TITLE
Weblab remove beta tag

### DIFF
--- a/apps/src/code-studio/components/header/ProjectHeader.jsx
+++ b/apps/src/code-studio/components/header/ProjectHeader.jsx
@@ -3,8 +3,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
-import i18n from '@cdo/locale';
-
 import EditableProjectName from './EditableProjectName';
 import ProjectImport from './ProjectImport';
 import ProjectRemix from './ProjectRemix';
@@ -29,12 +27,6 @@ class ProjectHeader extends React.Component {
         {/* For Minecraft Code Connection (aka CodeBuilder) projects, add the
             option to import code from an Hour of Code share link */}
         {appOptions.level.isConnectionLevel && <ProjectImport />}
-
-        {/* TODO: Remove this (and the related style) when Web Lab is no longer
-            in beta.*/}
-        {appOptions.app === 'weblab' && (
-          <div className="beta-notice">{i18n.beta()}</div>
-        )}
       </div>
     );
   }

--- a/apps/src/templates/studioHomepages/CourseBlocksTools.jsx
+++ b/apps/src/templates/studioHomepages/CourseBlocksTools.jsx
@@ -28,7 +28,6 @@ class CourseBlocksTools extends Component {
       },
       {
         heading: i18n.courseBlocksToolsWebLab(),
-        callout: `(${i18n.beta()})`,
         description: i18n.courseBlocksToolsWebLabDescription(),
         link: pegasus('/weblab')
       },

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -205,17 +205,6 @@ img.video_thumbnail {
       float: left;
       clear: left;
     }
-    // TODO: Remove when Game Lab is no longer in beta
-    .beta-notice {
-      float: left;
-      margin-left: 10px;
-      display: inline-block;
-      padding: 7px 0;
-      font-family: $gotham-extra-bold;
-      font-size: 20px;
-      line-height: 20px;
-      color: $droplet_yellow;
-    }
   }
 
   .header_text {
@@ -1021,17 +1010,6 @@ $default-modal-width: 640px;
   .project_name_wrapper .header_text {
     float: left;
     clear: left;
-  }
-  // TODO: Remove when Game Lab is no longer in beta
-  .beta-notice {
-    float: left;
-    margin-left: 10px;
-    display: inline-block;
-    padding: 7px 0;
-    font-family: $gotham-extra-bold;
-    font-size: 20px;
-    line-height: 20px;
-    color: $droplet_yellow;
   }
 }
 

--- a/pegasus/sites.v3/code.org/public/educate/weblab.haml
+++ b/pegasus/sites.v3/code.org/public/educate/weblab.haml
@@ -7,7 +7,7 @@ video_player: true
 %link{href: "/css/jumbotron-banner.css", rel: "stylesheet"}
 %link{href: "/shared/css/course-blocks.css", rel: "stylesheet"}
 
-= view :jumbotron_banner, img: CDO.code_org_url("/images/app-lab/girl-cropped.jpg"), title: "Web Lab (beta)", desc: "Web Lab is a programming environment where you can make simple web pages using HTML and CSS. Design your web pages and share your site in seconds.", specs: "Ages 13+, all modern browsers, English only", url: CDO.studio_url('/p/weblab'), cta: "Make a web page", photo_cred: "Photo courtesy of Fundación Sadosky", nav_bar: [{text: 'Resources', url: '#resources'}]
+= view :jumbotron_banner, img: CDO.code_org_url("/images/app-lab/girl-cropped.jpg"), title: "Web Lab", desc: "Web Lab is a programming environment where you can make simple web pages using HTML and CSS. Design your web pages and share your site in seconds.", specs: "Ages 13+, all modern browsers, English only", url: CDO.studio_url('/p/weblab'), cta: "Make a web page", photo_cred: "Photo courtesy of Fundación Sadosky", nav_bar: [{text: 'Resources', url: '#resources'}]
 
 #resources
   %h1 Resources


### PR DESCRIPTION
Removing the beta tag from Weblab 🎉 I'm pretty sure I caught all the spots where we specified Weblab was in beta, but it was sprinkled in various places across dashboard, apps, and pegasus, so hopefully I didn't miss any.

1. In the project header on any Weblab level/project
<img width="555" alt="Screen Shot 2021-09-30 at 5 48 50 PM" src="https://user-images.githubusercontent.com/9812299/135549437-b639f335-10e8-4580-a1c2-1121f95fcae2.png">

2. On the course card (used in various places)
<img width="272" alt="Screen Shot 2021-09-30 at 5 48 24 PM" src="https://user-images.githubusercontent.com/9812299/135549440-67feea14-690d-49c8-abd3-ecee05ba4ebe.png">

3. On https://code.org/educate/weblab
<img width="984" alt="Screen Shot 2021-09-30 at 5 51 54 PM" src="https://user-images.githubusercontent.com/9812299/135549474-d68a5bb2-db45-416a-86aa-d104b431ef95.png">

## Links

- [STAR-809](https://codedotorg.atlassian.net/browse/STAR-809)