### PR TITLE
Reduce uncached HOC unit overview queries

### DIFF
--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -398,7 +398,7 @@ class ApiController < ApplicationController
     if current_user
       script = Script.get_from_cache(params[:script])
       user = params[:user_id].present? ? User.find(params[:user_id]) : current_user
-      teacher_viewing_student = current_user.students.include?(user)
+      teacher_viewing_student = !current_user.student? && current_user.students.include?(user)
       render json: summarize_user_progress(script, user).merge(
         {
           signedIn: true,

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -43,9 +43,11 @@ class ScriptsController < ApplicationController
     @redirect_unit_url = @script.redirect_to_unit_url(current_user, locale: request.locale)
 
     @show_redirect_warning = params[:redirect_warning] == 'true'
-    @section = current_user&.sections&.all&.find {|s| s.id == params[:section_id]}&.summarize
-    sections = current_user.try {|u| u.sections.all.reject(&:hidden).map {|s| s.slice(:id, :name, :script_id, :course_id)}}
-    @sections_with_assigned_info = sections&.map {|section| section.attributes.merge!({"isAssigned" => section[:script_id] == @script.id})}
+    unless current_user&.student?
+      @section = current_user&.sections&.all&.find {|s| s.id == params[:section_id]}&.summarize
+      sections = current_user.try {|u| u.sections.all.reject(&:hidden).map {|s| s.slice(:id, :name, :script_id, :course_id)}}
+      @sections_with_assigned_info = sections&.map {|section| section.attributes.merge!({"isAssigned" => section[:script_id] == @script.id})}
+    end
 
     @show_unversioned_redirect_warning = !!session[:show_unversioned_redirect_warning] && !@script.is_course
     session[:show_unversioned_redirect_warning] = false

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -43,8 +43,8 @@ class ScriptsController < ApplicationController
     @redirect_unit_url = @script.redirect_to_unit_url(current_user, locale: request.locale)
 
     @show_redirect_warning = params[:redirect_warning] == 'true'
-    @section = current_user&.sections&.find_by(id: params[:section_id])&.summarize
-    sections = current_user.try {|u| u.sections.where(hidden: false).select(:id, :name, :script_id, :course_id)}
+    @section = current_user&.sections&.all&.find {|s| s.id == params[:section_id]}&.summarize
+    sections = current_user.try {|u| u.sections.all.reject(&:hidden).map {|s| s.slice(:id, :name, :script_id, :course_id)}}
     @sections_with_assigned_info = sections&.map {|section| section.attributes.merge!({"isAssigned" => section[:script_id] == @script.id})}
 
     @show_unversioned_redirect_warning = !!session[:show_unversioned_redirect_warning] && !@script.is_course

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -44,7 +44,7 @@ class ScriptsController < ApplicationController
 
     @show_redirect_warning = params[:redirect_warning] == 'true'
     unless current_user&.student?
-      @section = current_user&.sections&.all&.find {|s| s.id == params[:section_id]}&.summarize
+      @section = current_user&.sections&.all&.find {|s| s.id.to_s == params[:section_id]}&.summarize
       sections = current_user.try {|u| u.sections.all.reject(&:hidden).map {|s| s.slice(:id, :name, :script_id, :course_id)}}
       @sections_with_assigned_info = sections&.map {|section| section.merge!({"isAssigned" => section[:script_id] == @script.id})}
     end

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -46,7 +46,7 @@ class ScriptsController < ApplicationController
     unless current_user&.student?
       @section = current_user&.sections&.all&.find {|s| s.id == params[:section_id]}&.summarize
       sections = current_user.try {|u| u.sections.all.reject(&:hidden).map {|s| s.slice(:id, :name, :script_id, :course_id)}}
-      @sections_with_assigned_info = sections&.map {|section| section.attributes.merge!({"isAssigned" => section[:script_id] == @script.id})}
+      @sections_with_assigned_info = sections&.map {|section| section.merge!({"isAssigned" => section[:script_id] == @script.id})}
     end
 
     @show_unversioned_redirect_warning = !!session[:show_unversioned_redirect_warning] && !@script.is_course

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -367,11 +367,10 @@ class Ability
     # Checks if user is directly enrolled in pilot or has a teacher enrolled
     if user.persisted?
       if user.has_pilot_experiment?(CSA_PILOT) ||
-        (!user.teachers.empty? &&
-          user.teachers.any? {|t| t.has_pilot_experiment?(CSA_PILOT)}) ||
+        user.teachers.any? {|t| t.has_pilot_experiment?(CSA_PILOT)} ||
           user.has_pilot_experiment?(CSA_PILOT_FACILITATORS) ||
-        (!user.teachers.empty? &&
-          user.teachers.any? {|t| t.has_pilot_experiment?(CSA_PILOT_FACILITATORS)})
+          user.teachers.any? {|t| t.has_pilot_experiment?(CSA_PILOT_FACILITATORS)}
+
         can :get_access_token, :javabuilder_session
       end
     end

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1668,7 +1668,7 @@ class User < ApplicationRecord
   end
 
   def all_sections
-    sections_as_teacher = student? ? [] : sections
+    sections_as_teacher = student? ? [] : sections.to_a
     sections_as_teacher.concat(sections_as_student).uniq
   end
 

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1667,12 +1667,15 @@ class User < ApplicationRecord
     user_course_data + user_script_data
   end
 
+  def all_sections
+    sections_as_teacher = student? ? [] : sections
+    sections_as_teacher.concat(sections_as_student).uniq
+  end
+
   # Figures out the unique set of courses assigned to sections that this user
   # is a part of.
   # @return [Array<Course>]
   def section_courses
-    all_sections = sections.to_a.concat(sections_as_student).uniq
-
     # In the future we may want to make it so that if assigned a script, but that
     # script has a default course, it shows up as a course here
     all_sections.map(&:unit_group).compact.uniq
@@ -1686,7 +1689,6 @@ class User < ApplicationRecord
   # is a part of. Includes default scripts for any assigned courses as well.
   # @return [Array<Script>]
   def section_scripts
-    all_sections = sections.to_a.concat(sections_as_student).uniq
     all_scripts = []
     all_sections.each do |section|
       if section.script.present?

--- a/dashboard/test/controllers/courses_controller_test.rb
+++ b/dashboard/test/controllers/courses_controller_test.rb
@@ -81,14 +81,14 @@ class CoursesControllerTest < ActionController::TestCase
 
     test 'student views course overview with caching enabled' do
       sign_in create(:student)
-      assert_cached_queries(6) do
+      assert_cached_queries(5) do
         get :show, params: {course_name: @unit_group.name}
       end
     end
 
     test 'teacher views course overview with caching enabled' do
       sign_in create(:teacher)
-      assert_cached_queries(9) do
+      assert_cached_queries(8) do
         get :show, params: {course_name: @unit_group.name}
       end
     end

--- a/dashboard/test/integration/db_query_test.rb
+++ b/dashboard/test/integration/db_query_test.rb
@@ -109,7 +109,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     student.assign_script(script)
     sign_in student
 
-    assert_cached_queries(7) do
+    assert_cached_queries(6) do
       get "/s/#{script.name}"
       assert_response :success
     end

--- a/dashboard/test/integration/db_query_test.rb
+++ b/dashboard/test/integration/db_query_test.rb
@@ -109,7 +109,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     student.assign_script(script)
     sign_in student
 
-    assert_cached_queries(10) do
+    assert_cached_queries(8) do
       get "/s/#{script.name}"
       assert_response :success
     end

--- a/dashboard/test/integration/db_query_test.rb
+++ b/dashboard/test/integration/db_query_test.rb
@@ -122,7 +122,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
       assert_response :success
     end
 
-    assert_cached_queries(4) do
+    assert_cached_queries(3) do
       get "/api/v1/teacher_feedbacks/count?student_id=#{student.id}"
       assert_response :success
     end

--- a/dashboard/test/integration/db_query_test.rb
+++ b/dashboard/test/integration/db_query_test.rb
@@ -117,7 +117,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     # Simulate all the ajax requests which the unit overview page sends to the
     # server on page load.
 
-    assert_cached_queries(10) do
+    assert_cached_queries(9) do
       get "/api/user_progress/#{script.name}"
       assert_response :success
     end

--- a/dashboard/test/integration/db_query_test.rb
+++ b/dashboard/test/integration/db_query_test.rb
@@ -109,7 +109,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     student.assign_script(script)
     sign_in student
 
-    assert_cached_queries(8) do
+    assert_cached_queries(7) do
       get "/s/#{script.name}"
       assert_response :success
     end

--- a/dashboard/test/testing/capture_queries.rb
+++ b/dashboard/test/testing/capture_queries.rb
@@ -30,7 +30,7 @@ module CaptureQueries
   end
 
   def assert_cached_queries(num, *args, &block)
-    Retryable.retryable(on: Minitest::Assertion, tries: 2, sleep: 0) do
+    Retryable.retryable(on: Minitest::Assertion, matching: /Wrong query count/, tries: 2, sleep: 0) do
       assert_queries(num, *args, &block)
     end
   end


### PR DESCRIPTION
Continues https://codedotorg.atlassian.net/browse/PLAT-1181. Follows https://github.com/code-dot-org/code-dot-org/pull/42737. This is my second and final pass at reducing query counts when loading the unit overview page for an uncached HOC unit.

## Testing story

I have reasonably high confidence in existing test coverage, given that it caught several bugs on lines I modified.