### PR TITLE
Update application email error message

### DIFF
--- a/dashboard/app/models/pd/application/email.rb
+++ b/dashboard/app/models/pd/application/email.rb
@@ -43,8 +43,8 @@ module Pd::Application
 
       if errors.any?
         msg = "Error sending emails for applications. Errors:\n"
-        errors.each do |application_id, error|
-          msg << "    Application #{application_id}: #{error}\n"
+        errors.each do |email_id, error|
+          msg << "    Email #{email_id}: #{error}\n"
         end
         raise msg
       end


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Might as well fix this while its on my mind.

see stderr in context:
honeybadger: [error](https://app.honeybadger.io/projects/45435/faults/48199539/01FH60MV1ESHKZ13P2DFARK9FJ#notice-context)

"Application 73249: invalid email address for application 35729"
should read
"Email 73249: invalid email address for application 35729"