### PR TITLE
Allow signed in users to access /projects/javalab/new

### DIFF
--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -142,7 +142,7 @@ class ProjectsController < ApplicationController
     },
     javalab: {
       name: 'New Java Lab Project',
-      levelbuilder_required: true
+      login_required: true
     }
   }.with_indifferent_access.freeze
 


### PR DESCRIPTION
Previously, only levelbuilders could create a new Javalab project when visiting studio.code.org/projects/javalab/new. This change allows any signed in user to access this URL.

The behavior for a signed in user visiting this page is that they can access it, but cannot access Javabuilder (similar to when visiting an /allthethings level as a user who is not in the pilot).

## Testing story

Tested manually with a student and teacher account in the pilot (both could access/run Javabuilder code), and a student who was not in the pilot (could access page, could not access Javabuilder).