### PR TITLE
Playground: fast-click prevention

### DIFF
--- a/apps/src/javalab/Playground.js
+++ b/apps/src/javalab/Playground.js
@@ -17,6 +17,9 @@ import {
 import color from '@cdo/apps/util/color';
 
 const DEFAULT_BACKGROUND_COLOR = color.white;
+// Amount of time in ms after a click to re-enable click events
+// (in case an UPDATE_COMPLETE message is never received)
+export const REENABLE_CLICK_EVENTS_TIMEOUT_MS = 1500;
 
 export default class Playground {
   constructor(
@@ -32,9 +35,11 @@ export default class Playground {
     this.onOutputMessage = onOutputMessage;
     this.onNewlineMessage = onNewlineMessage;
     this.onJavabuilderMessage = onJavabuilderMessage;
+    this.levelName = levelName;
     this.setIsProgramRunning = setIsProgramRunning;
     this.isGameRunning = false;
-    this.levelName = levelName;
+    this.updateInProgress = false;
+    this.reenableClickEventsTimeoutId = null;
     this.starterAssetFilenames = [];
 
     // Assigned only for testing; should use imports from clientApi normally
@@ -74,12 +79,18 @@ export default class Playground {
     this.onNewlineMessage();
   };
 
+  reenableClickEvents = () => {
+    this.updateInProgress = false;
+    this.reenableClickEventsTimeoutId = null;
+  };
+
   handleSignal(data) {
     switch (data.value) {
       case PlaygroundSignalType.RUN:
         this.isGameRunning = true;
         break;
       case PlaygroundSignalType.EXIT:
+        this.handleUpdateComplete();
         this.endGame();
         break;
       case PlaygroundSignalType.ADD_CLICKABLE_ITEM:
@@ -103,6 +114,8 @@ export default class Playground {
       case PlaygroundSignalType.SET_BACKGROUND_IMAGE:
         this.setBackgroundImage(data.detail);
         break;
+      case PlaygroundSignalType.UPDATE_COMPLETE:
+        this.handleUpdateComplete();
     }
   }
 
@@ -219,11 +232,23 @@ export default class Playground {
   }
 
   handleImageClick(imageId) {
-    if (!this.isGameRunning) {
-      // can only handle click events if game is running
+    if (!this.isGameRunning || this.updateInProgress) {
+      // can only handle click events if game is running and update is not in progress
       return;
     }
+    this.updateInProgress = true;
+    this.reenableClickEventsTimeoutId = setTimeout(
+      this.reenableClickEvents,
+      REENABLE_CLICK_EVENTS_TIMEOUT_MS
+    );
     this.onJavabuilderMessage(WebSocketMessageType.PLAYGROUND, imageId);
+  }
+
+  handleUpdateComplete() {
+    this.updateInProgress = false;
+    if (this.reenableClickEventsTimeoutId) {
+      clearTimeout(this.reenableClickEventsTimeoutId);
+    }
   }
 
   getUrl(filename) {

--- a/apps/src/javalab/constants.js
+++ b/apps/src/javalab/constants.js
@@ -127,7 +127,9 @@ export const PlaygroundSignalType = {
   // Play a sound
   PLAY_SOUND: 'PLAY_SOUND',
   // Set the background image of the Playground
-  SET_BACKGROUND_IMAGE: 'SET_BACKGROUND_IMAGE'
+  SET_BACKGROUND_IMAGE: 'SET_BACKGROUND_IMAGE',
+  // Indicate that the current update cycle has completed
+  UPDATE_COMPLETE: 'UPDATE_COMPLETE'
 };
 
 export const PlaygroundFontTypeFontFamilies = {

--- a/apps/test/unit/javalab/PlaygroundTest.js
+++ b/apps/test/unit/javalab/PlaygroundTest.js
@@ -34,11 +34,13 @@ describe('Playground', () => {
     starterAssetsApi,
     assetsApi,
     playground,
-    setIsProgramRunning;
+    setIsProgramRunning,
+    clock;
 
   beforeEach(() => {
     stubRedux();
     registerReducers({playground: playgroundRedux});
+    clock = sinon.useFakeTimers();
     onOutputMessage = sinon.stub();
     onNewlineMessage = sinon.stub();
     onJavabuilderMessage = sinon.stub();
@@ -85,6 +87,7 @@ describe('Playground', () => {
   afterEach(() => {
     sinon.restore();
     restoreRedux();
+    clock.restore();
   });
 
   it('sets background image when receiving a SET_BACKGROUND_IMAGE message for a starter asset', () => {
@@ -465,7 +468,7 @@ describe('Playground', () => {
     expect(onJavabuilderMessage).to.have.been.calledOnce;
   });
 
-  it('re-enables click events after timeout', done => {
+  it('re-enables click events after timeout', () => {
     playground.handleSignal({value: PlaygroundSignalType.RUN});
 
     const imageId = 'id';
@@ -477,12 +480,11 @@ describe('Playground', () => {
     // Should not be called again
     expect(onJavabuilderMessage).to.have.not.been.called;
 
-    setTimeout(() => {
-      playground.handleImageClick(imageId);
-      // Should be able to send message after timeout
-      expect(onJavabuilderMessage).to.have.been.calledOnce;
-      done();
-    }, REENABLE_CLICK_EVENTS_TIMEOUT_MS + 1);
+    clock.tick(REENABLE_CLICK_EVENTS_TIMEOUT_MS + 1);
+
+    // Should be able to send message after timeout
+    playground.handleImageClick(imageId);
+    expect(onJavabuilderMessage).to.have.been.calledOnce;
   });
 
   function verifyOnFileLoadError(filename) {

--- a/apps/test/unit/javalab/PlaygroundTest.js
+++ b/apps/test/unit/javalab/PlaygroundTest.js
@@ -1,6 +1,8 @@
 import sinon from 'sinon';
 import {expect} from '../../util/reconfiguredChai';
-import Playground from '@cdo/apps/javalab/Playground';
+import Playground, {
+  REENABLE_CLICK_EVENTS_TIMEOUT_MS
+} from '@cdo/apps/javalab/Playground';
 import {
   PlaygroundSignalType,
   WebSocketMessageType
@@ -443,6 +445,44 @@ describe('Playground', () => {
     expect(setIsProgramRunning).to.have.been.calledWith(false);
     expect(onOutputMessage).to.have.been.calledOnce;
     expect(onNewlineMessage).to.have.been.calledOnce;
+  });
+
+  it('does not send click event if update is in progress', () => {
+    playground.handleSignal({value: PlaygroundSignalType.RUN});
+
+    const imageId = 'id';
+    playground.handleImageClick(imageId);
+    expect(onJavabuilderMessage).to.have.been.calledOnce;
+
+    onJavabuilderMessage.reset();
+    playground.handleImageClick(imageId);
+    // Should not be called again
+    expect(onJavabuilderMessage).to.have.not.been.called;
+
+    playground.handleSignal({value: PlaygroundSignalType.UPDATE_COMPLETE});
+    playground.handleImageClick(imageId);
+    // Should be able to send message after receiving UPDATE_COMPLETE
+    expect(onJavabuilderMessage).to.have.been.calledOnce;
+  });
+
+  it('re-enables click events after timeout', done => {
+    playground.handleSignal({value: PlaygroundSignalType.RUN});
+
+    const imageId = 'id';
+    playground.handleImageClick(imageId);
+    expect(onJavabuilderMessage).to.have.been.calledOnce;
+
+    onJavabuilderMessage.reset();
+    playground.handleImageClick(imageId);
+    // Should not be called again
+    expect(onJavabuilderMessage).to.have.not.been.called;
+
+    setTimeout(() => {
+      playground.handleImageClick(imageId);
+      // Should be able to send message after timeout
+      expect(onJavabuilderMessage).to.have.been.calledOnce;
+      done();
+    }, REENABLE_CLICK_EVENTS_TIMEOUT_MS + 1);
   });
 
   function verifyOnFileLoadError(filename) {


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

This adds fast-click prevention to Playground so that only one click event is sent per update cycle. This prevents inconsistent behavior, such as sending multiple click events for an image that should be removed by the first click. After sending a click event, Javalab listens for an UPDATE_COMPLETE message from Javabuilder to re-enable click events. If no message is received (which ideally should not happen), Javalab automatically re-enables click events after a timeout. This timeout is currently set to 1.5s - I estimated this based off of our prototype performance testing and adding a buffer in case of slower messages, but we can definitely bump this up as necessary.

Note: the corresponding Javabuilder change to send the UPDATE_COMPLETE message should be merged and deployed before this change is merged (PR: https://github.com/code-dot-org/javabuilder/pull/128)

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

JIRA: https://codedotorg.atlassian.net/browse/CSA-841
Spec: https://docs.google.com/document/d/1Moo2s5EXZRp5rMg1VW9jlOqs_GeMN5yjU8FJgoqOEMk/edit#heading=h.ebgh0nv0kqtx
Related Javabuilder PR: https://github.com/code-dot-org/javabuilder/pull/128

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Tested locally on All The Things level & unit

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
