### PR TITLE
Make sure to check length of example solutions instead of existence

### DIFF
--- a/apps/src/code-studio/components/progress/teacherPanel/TeacherPanel.jsx
+++ b/apps/src/code-studio/components/progress/teacherPanel/TeacherPanel.jsx
@@ -121,7 +121,9 @@ class TeacherPanel extends React.Component {
       viewAs === ViewType.Teacher && currentStudent;
 
     const displayLevelExamples =
-      viewAs === ViewType.Teacher && sectionData && sectionData.level_examples;
+      viewAs === ViewType.Teacher &&
+      sectionData &&
+      sectionData.level_examples.length > 0;
 
     const displayLockInfo =
       hasSections && unitHasLockableLessons && viewAs === ViewType.Teacher;


### PR DESCRIPTION
https://github.com/code-dot-org/code-dot-org/pull/42743 added some extra pixels above 'Viewing section:' in the teacher panel. This is because we return an empty array from get_example_solutions if none are available. However in the Teacher Panel we were checking if we should display example solutions based on the existence of the array and not its length like we had set up in the Teacher Only Tab.  This makes it so we check length instead.

I double checked a bunch of levels to make sure examples solutions still show up in the teacher panel correctly. 
