### PR TITLE
Only recalculate InstructionsCsfRightCol when height/collapsed props change

### DIFF
--- a/apps/src/templates/instructions/InstructionsCsfRightCol.jsx
+++ b/apps/src/templates/instructions/InstructionsCsfRightCol.jsx
@@ -46,8 +46,11 @@ class InstructionsCsfRightCol extends React.Component {
     this.updateDimensions();
   }
 
-  componentDidUpdate() {
-    this.updateDimensions();
+  componentDidUpdate(prevProps) {
+    const {height, collapsed} = this.props;
+    if (prevProps.height !== height || prevProps.collapsed !== collapsed) {
+      this.updateDimensions();
+    }
   }
 
   updateDimensions() {

--- a/apps/test/unit/templates/instructions/InstructionsCsfRightColTest.jsx
+++ b/apps/test/unit/templates/instructions/InstructionsCsfRightColTest.jsx
@@ -39,6 +39,37 @@ describe('InstructionsCsfRightCol', () => {
     expect(setColHeightSpy.calledOnce).to.be.true;
   });
 
+  it('only recalculates col width and height if height or collapsed props change', () => {
+    const setColWidthSpy = sinon.spy();
+    const setColHeightSpy = sinon.spy();
+    const wrapper = setUp({
+      setColHeight: setColHeightSpy,
+      setColWidth: setColWidthSpy,
+      height: 50,
+      collapsed: false,
+      isRtl: false
+    });
+
+    // Should be called after mount
+    expect(setColWidthSpy).to.have.been.calledOnce;
+    expect(setColHeightSpy).to.have.been.calledOnce;
+
+    // Should not be called when unrelated prop changes
+    wrapper.setProps({isRtl: true});
+    expect(setColWidthSpy).to.have.been.calledOnce;
+    expect(setColHeightSpy).to.have.been.calledOnce;
+
+    // Should be called when height changes
+    wrapper.setProps({height: 100});
+    expect(setColWidthSpy).to.have.been.calledTwice;
+    expect(setColHeightSpy).to.have.been.calledTwice;
+
+    // Should be called when collapsed changes
+    wrapper.setProps({collapsed: true});
+    expect(setColWidthSpy).to.have.been.calledThrice;
+    expect(setColHeightSpy).to.have.been.calledThrice;
+  });
+
   it('displays collapser button if there is feedback', () => {
     const wrapper = setUp({feedback: {message: 'feedback', isFailure: false}});
     expect(wrapper.find(CollapserButton)).to.have.length(1);


### PR DESCRIPTION
This fixes a bug that occurs when we upgrade redux/react-redux (implemented in #42184 and reverted in #42307). For users on Chromebooks at certain resolutions (device resolution, not browser resolution -- I repro'd on a Chromebook at 1301x731), CSF levels failed to load due to an infinite loop in the instructions panel, resulting in a white screen:
<img width="1150" alt="Screen Shot 2021-09-02 at 7 32 18 AM" src="https://user-images.githubusercontent.com/9812299/135938876-267b0c7f-851d-476a-b301-14afa8127a07.png">

I'm not sure why this only happens when we upgrade redux, but I think the fix is something we want anyways. `<InstructionsCSF/>` would get caught in an infinite loop where the `<CollapserButton/>` would shift and report a different width (always by +/- 1 pixel), causing it to report a new width to its parent, which would then re-render all of its children, and the loop would start again. (Links to relevant code below.) This change makes it so that we only recalculate the width of `<InstructionsCsfRightCol/>` (which renders the collapser button) if relevant props have changed, instead of every time `componentDidUpdate` is triggered.

Relevant code:
- [InstructionsCsfRightCol renders CollapserButton](https://github.com/code-dot-org/code-dot-org/blob/b4998e204a21a94fbd63b9eb47b82bc31f89225f/apps/src/templates/instructions/InstructionsCsfRightCol.jsx#L101-L113)
- The ref for CollapserButton is used to [calculate the width of InstructionsCsfRightCol](https://github.com/code-dot-org/code-dot-org/blob/b4998e204a21a94fbd63b9eb47b82bc31f89225f/apps/src/templates/instructions/InstructionsCsfRightCol.jsx#L72-L74)
- Previously, [`componentDidUpdate`](https://github.com/code-dot-org/code-dot-org/blob/b4998e204a21a94fbd63b9eb47b82bc31f89225f/apps/src/templates/instructions/InstructionsCsfRightCol.jsx#L49-L51), we always called [updateDimensions](https://github.com/code-dot-org/code-dot-org/blob/b4998e204a21a94fbd63b9eb47b82bc31f89225f/apps/src/templates/instructions/InstructionsCsfRightCol.jsx#L53-L56), which calls functions that report height and width to its parent, sets some state, and triggers a re-render if either have changed (e.g., [setRightColWidth](https://github.com/code-dot-org/code-dot-org/blob/b4998e204a21a94fbd63b9eb47b82bc31f89225f/apps/src/templates/instructions/InstructionsCSF.jsx#L271-L274))

This isn't ideal, but is necessary because the [`<ThreeColumns/>`](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/templates/instructions/ThreeColumns.jsx) requires us to use JS to calculate the widths of the 3 CSF instructions columns (see [this comment](https://github.com/code-dot-org/code-dot-org/blob/a97d86a49a993f703a467467043263e0c1be29af/apps/src/templates/instructions/InstructionsCSF.jsx#L36-L39)) when we should be using CSS, which would prevent this problem and simplify a lot of logic. That is a refactor we should do, but is slightly too large and shouldn't be tied to the redux upgrade.

I manually tested this on an adhoc with redux/react-redux upgraded and confirmed it fixes the issue. I've also tested this pretty thoroughly without the upgrade to ensure there is no change in existing behavior -- I'd like to ship this before the upgrade to keep the two changes decoupled and catch any regressions this may introduce before attempting to re-upgrade.

## Links

- [XTEAM-376](https://codedotorg.atlassian.net/browse/XTEAM-376)

## Testing story

Added a unit test to display new componentDidUpdate behavior.