### PR TITLE
Add early return if text is nil

### DIFF
--- a/lib/cdo/web_purify.rb
+++ b/lib/cdo/web_purify.rb
@@ -16,6 +16,7 @@ module WebPurify
   # @return [Array<String>, nil] The profanities (if any) or nil (if none).
   def self.find_potential_profanities(text, language_codes = ['en'])
     return nil unless CDO.webpurify_key && Gatekeeper.allows('webpurify', default: true)
+    return nil if text.nil?
     # Convert language codes to a list of two character codes, comma separated.
     language_codes = language_codes.
       map {|language_code| language_code[0..1]}.


### PR DESCRIPTION
Small fix related to change in `webpurify.rb` as part of https://github.com/code-dot-org/code-dot-org/pull/42775. `CGI.escape` doesn't gracefully handle `nil`, so we're adding in an early return since we don't need to make the API call if `text.isNil` 
