### PR TITLE
[Spritelab] Rename spritelabLibrary -> library

### DIFF
--- a/apps/src/p5lab/spritelab/SpriteLab.js
+++ b/apps/src/p5lab/spritelab/SpriteLab.js
@@ -67,15 +67,15 @@ export default class SpriteLab extends P5Lab {
   onPause(isPaused) {
     const current = new Date().getTime();
     if (isPaused) {
-      this.spritelabLibrary.endPause(current);
+      this.library.endPause(current);
     } else {
-      this.spritelabLibrary.startPause(current);
+      this.library.startPause(current);
     }
   }
 
   onPromptAnswer(variableName, value) {
     getStore().dispatch(popPrompt());
-    this.spritelabLibrary.onPromptAnswer(variableName, value);
+    this.library.onPromptAnswer(variableName, value);
   }
 
   setupReduxSubscribers(store) {


### PR DESCRIPTION
Quick follow up to https://github.com/code-dot-org/code-dot-org/pull/42787
Just missed a few places that we need to update the name to `library`
This resulted in prompts + pause not working in spritelab

[slack thread](https://codedotorg.slack.com/archives/C1B3PNDL7/p1633456231113500)