### PR TITLE
Make channel backed levels cacheable

### DIFF
--- a/apps/src/code-studio/appOptions.js
+++ b/apps/src/code-studio/appOptions.js
@@ -64,6 +64,7 @@
  * @property {string} locale
  * @property {?Object} azureSpeechServiceVoices
  * @property {?string} authenticityToken
+ * @property {boolean} levelRequiresChannel
  */
 
 /**

--- a/apps/src/code-studio/initApp/loadApp.js
+++ b/apps/src/code-studio/initApp/loadApp.js
@@ -285,11 +285,12 @@ function loadAppAsync(appOptions) {
     return Promise.resolve(appOptions);
   }
 
-  // maureen come back and figure out what to do about isViewingStudentAnswer here..
   if (appOptions.channel || isViewingStudentAnswer) {
     return loadProjectAndCheckAbuse(appOptions);
   }
 
+  // shouldLoadChannel will be true for channel backed levels on publicly-cached pages
+  // We will need to load the channel client-side from api/user_progress
   const shouldLoadChannel = appOptions.shouldLoadChannel && !appOptions.channel;
 
   return new Promise((resolve, reject) => {
@@ -331,7 +332,6 @@ function loadAppAsync(appOptions) {
           appOptions.level.pairingAttempt = data.pairingAttempt;
           appOptions.level.pairingChannelId = data.pairingChannelId;
         }
-        console.log(data);
 
         if (data.channel) {
           appOptions.channel = data.channel;
@@ -489,8 +489,6 @@ export default function loadAppOptions() {
     } else {
       getStore().dispatch(setAppLoadStarted());
       loadAppAsync(appOptions).then(appOptions => {
-        console.log('maureen loaded');
-        console.log(appOptions);
         project.init(sourceHandler);
         getStore().dispatch(setAppLoaded());
         resolve(appOptions);

--- a/apps/src/code-studio/initApp/loadApp.js
+++ b/apps/src/code-studio/initApp/loadApp.js
@@ -289,9 +289,11 @@ function loadAppAsync(appOptions) {
     return loadProjectAndCheckAbuse(appOptions);
   }
 
-  // shouldLoadChannel will be true for channel backed levels on publicly-cached pages
-  // We will need to load the channel client-side from api/user_progress
-  const shouldLoadChannel = appOptions.shouldLoadChannel && !appOptions.channel;
+  // If the level requires a channel but no channel was passed from the server through app_options,
+  // that indicates that the level was cached and the channel id needs to be loaded client-side
+  // through the user_progress request
+  const shouldGetChannelId =
+    appOptions.levelRequiresChannel && !appOptions.channel;
 
   return new Promise((resolve, reject) => {
     if (appOptions.publicCaching) {
@@ -307,7 +309,7 @@ function loadAppAsync(appOptions) {
         `/${appOptions.lessonPosition}` +
         `/${appOptions.levelPosition}` +
         `/${appOptions.serverLevelId}` +
-        `?load_channel=${shouldLoadChannel}`
+        `?get_channel_id=${shouldGetChannelId}`
     )
       .done(data => {
         appOptions.disableSocialShare = data.disableSocialShare;

--- a/apps/test/unit/code-studio/initApp/loadAppTest.js
+++ b/apps/test/unit/code-studio/initApp/loadAppTest.js
@@ -144,14 +144,14 @@ describe('loadApp.js', () => {
     });
   });
 
-  it('passes get_channel_id true to load user progress if appOptions has shouldLoadChannel true and no channel', done => {
+  it('passes get_channel_id true to load user progress if appOptions has levelRequiresChannel true and no channel', done => {
     appOptions = {
       ...appOptions,
       scriptName: 'test-script',
       lessonPosition: '1',
       levelPosition: '2',
       serverLevelId: '123',
-      shouldLoadChannel: true
+      levelRequiresChannel: true
     };
 
     $.ajax.restore();

--- a/apps/test/unit/code-studio/initApp/loadAppTest.js
+++ b/apps/test/unit/code-studio/initApp/loadAppTest.js
@@ -8,6 +8,7 @@ import loadAppOptions, {
 } from '@cdo/apps/code-studio/initApp/loadApp';
 import {files} from '@cdo/apps/clientApi';
 import * as imageUtils from '@cdo/apps/imageUtils';
+import project from '@cdo/apps/code-studio/initApp/project';
 
 const SERVER_LEVEL_ID = 5;
 const SERVER_PROJECT_LEVEL_ID = 10;
@@ -29,6 +30,14 @@ describe('loadApp.js', () => {
         readLevelId = levelId;
         return OLD_CODE;
       });
+    sinon.stub(project, 'load').callsFake(() => ({
+      then: successCallback => successCallback()
+    }));
+    sinon.stub(project, 'hideBecauseAbusive').returns(false);
+    sinon.stub(project, 'hideBecausePrivacyViolationOrProfane').returns(false);
+    sinon.stub(project, 'getSharingDisabled').returns(false);
+  });
+  beforeEach(() => {
     sinon.stub($, 'ajax').callsFake(() => ({
       done: successCallback => ({
         fail: failureCallback => {
@@ -36,8 +45,6 @@ describe('loadApp.js', () => {
         }
       })
     }));
-  });
-  beforeEach(() => {
     writtenLevelId = undefined;
     readLevelId = undefined;
     appOptions = {
@@ -52,8 +59,14 @@ describe('loadApp.js', () => {
   after(() => {
     clientState.writeSourceForLevel.restore();
     clientState.sourceForLevel.restore();
-    $.ajax.restore();
+    project.load.restore();
+    project.hideBecauseAbusive.restore();
+    project.hideBecausePrivacyViolationOrProfane.restore();
+    project.getSharingDisabled.restore();
     window.appOptions = oldAppOptions;
+  });
+  afterEach(() => {
+    $.ajax.restore();
   });
 
   it('loads attempt stored under server level id', done => {
@@ -127,6 +140,40 @@ describe('loadApp.js', () => {
 
       document.body.removeChild(appOptionsData);
       queryParamsStub.restore();
+      done();
+    });
+  });
+
+  it('passes load_channel true to load user progress if appOptions has shouldLoadChannel true and no channel', done => {
+    appOptions = {
+      ...appOptions,
+      scriptName: 'test-script',
+      lessonPosition: '1',
+      levelPosition: '2',
+      serverLevelId: '123',
+      shouldLoadChannel: true
+    };
+
+    $.ajax.restore();
+    const ajaxStub = sinon.stub($, 'ajax');
+    const responseChannel = 'fakeChannelId';
+    ajaxStub
+      .withArgs(`/api/user_progress/test-script/1/2/123?load_channel=true`)
+      .callsFake(() => ({
+        done: successCallback => ({
+          fail: failureCallback => {
+            successCallback({signedIn: false, channel: responseChannel});
+          }
+        })
+      }));
+
+    const appOptionsData = document.createElement('script');
+    appOptionsData.setAttribute('data-appoptions', JSON.stringify(appOptions));
+    document.body.appendChild(appOptionsData);
+
+    loadAppOptions().then(() => {
+      expect(window.appOptions.channel).to.equal(responseChannel);
+      document.body.removeChild(appOptionsData);
       done();
     });
   });

--- a/apps/test/unit/code-studio/initApp/loadAppTest.js
+++ b/apps/test/unit/code-studio/initApp/loadAppTest.js
@@ -144,7 +144,7 @@ describe('loadApp.js', () => {
     });
   });
 
-  it('passes load_channel true to load user progress if appOptions has shouldLoadChannel true and no channel', done => {
+  it('passes get_channel_id true to load user progress if appOptions has shouldLoadChannel true and no channel', done => {
     appOptions = {
       ...appOptions,
       scriptName: 'test-script',
@@ -158,7 +158,7 @@ describe('loadApp.js', () => {
     const ajaxStub = sinon.stub($, 'ajax');
     const responseChannel = 'fakeChannelId';
     ajaxStub
-      .withArgs(`/api/user_progress/test-script/1/2/123?load_channel=true`)
+      .withArgs(`/api/user_progress/test-script/1/2/123?get_channel_id=true`)
       .callsFake(() => ({
         done: successCallback => ({
           fail: failureCallback => {

--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -469,7 +469,7 @@ class ApiController < ApplicationController
       )
     end
 
-    if params[:load_channel] == "true"
+    if params[:get_channel_id] == "true"
       response[:channel] = get_channel_for(level, script.id, current_user)
     end
 

--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -469,6 +469,10 @@ class ApiController < ApplicationController
       )
     end
 
+    if params[:load_channel] == "true"
+      response[:channel] = get_channel_for(level, script.id, current_user)
+    end
+
     render json: response
   end
 

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -179,14 +179,20 @@ module LevelsHelper
     # Unsafe to generate these twice, so use the cached version if it exists.
     return @app_options unless @app_options.nil?
 
-    if (@level.channel_backed? && params[:action] != 'edit_blocks') || @level.is_a?(Javalab)
+    should_load_channel = (@level.channel_backed? && params[:action] != 'edit_blocks') || @level.is_a?(Javalab)
+    level_not_cached = current_user.present?
+    if should_load_channel && level_not_cached
       view_options(
         channel: get_channel_for(@level, @script&.id, @user),
-        server_project_level_id: @level.project_template_level.try(:id),
       )
       # readonly if viewing another user's channel
       readonly_view_options if @user
     end
+
+    view_options(
+      should_load_channel: should_load_channel,
+      server_project_level_id: @level.project_template_level.try(:id)
+    )
 
     # For levels with a backpack option (currently all Javalab), get the backpack channel token if it exists
     if @level.is_a?(Javalab) && (@user || current_user)

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -186,6 +186,7 @@ module LevelsHelper
     is_cached_level = @public_caching && !is_caching_exception
 
     level_requires_channel = (@level.channel_backed? && params[:action] != 'edit_blocks') || @level.is_a?(Javalab)
+    # If the level is cached, the channel is loaded client-side in loadApp.js
     if level_requires_channel && !is_cached_level
       view_options(
         channel: get_channel_for(@level, @script&.id, @user),

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -180,7 +180,8 @@ module LevelsHelper
     return @app_options unless @app_options.nil?
 
     should_load_channel = (@level.channel_backed? && params[:action] != 'edit_blocks') || @level.is_a?(Javalab)
-    level_not_cached = current_user.present?
+    # If we have loaded a user, the page must not be publicly cached
+    level_not_cached = current_user || @user
     if should_load_channel && level_not_cached
       view_options(
         channel: get_channel_for(@level, @script&.id, @user),

--- a/dashboard/app/helpers/view_options_helper.rb
+++ b/dashboard/app/helpers/view_options_helper.rb
@@ -41,7 +41,7 @@ module ViewOptionsHelper
     :useGoogleBlockly,
     :disallowed_html_tags,
     :backpack_channel,
-    :should_load_channel
+    :level_requires_channel
   )
   # Sets custom options to be used by the view layer. The option hash is frozen once read.
   def view_options(opts = nil)

--- a/dashboard/app/helpers/view_options_helper.rb
+++ b/dashboard/app/helpers/view_options_helper.rb
@@ -40,7 +40,8 @@ module ViewOptionsHelper
     :authenticity_token,
     :useGoogleBlockly,
     :disallowed_html_tags,
-    :backpack_channel
+    :backpack_channel,
+    :should_load_channel
   )
   # Sets custom options to be used by the view layer. The option hash is frozen once read.
   def view_options(opts = nil)

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -828,7 +828,7 @@ class ApiControllerTest < ActionController::TestCase
     )
   end
 
-  test "user_progress_for_lesson should return channel when param load_channel is true" do
+  test "user_progress_for_lesson should return channel when param get_channel_id is true" do
     script = create(:script, :with_levels, levels_count: 1)
     level = script.script_levels.first.level
 
@@ -842,14 +842,14 @@ class ApiControllerTest < ActionController::TestCase
       script: script.name,
       lesson_position: 1,
       level_position: 1,
-      load_channel: true
+      get_channel_id: true
     }
 
     body = JSON.parse(response.body)
     assert_equal expected_channel, body['channel']
   end
 
-  test "user_progress_for_lesson should not return channel when param load_channel is false" do
+  test "user_progress_for_lesson should not return channel when param get_channel_id is false" do
     script = create(:script, :with_levels, levels_count: 1)
     level = script.script_levels.first.level
 
@@ -862,7 +862,7 @@ class ApiControllerTest < ActionController::TestCase
       script: script.name,
       lesson_position: 1,
       level_position: 1,
-      load_channel: false
+      get_channel_id: false
     }
 
     body = JSON.parse(response.body)

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -828,6 +828,47 @@ class ApiControllerTest < ActionController::TestCase
     )
   end
 
+  test "user_progress_for_lesson should return channel when param load_channel is true" do
+    script = create(:script, :with_levels, levels_count: 1)
+    level = script.script_levels.first.level
+
+    user = create :user, total_lines: 2
+    sign_in user
+
+    channel_token = create :channel_token, level: level, script_id: script.id, storage_id: storage_id_for_user_id(user.id)
+    expected_channel = channel_token.channel
+
+    get :user_progress_for_lesson, params: {
+      script: script.name,
+      lesson_position: 1,
+      level_position: 1,
+      load_channel: true
+    }
+
+    body = JSON.parse(response.body)
+    assert_equal expected_channel, body['channel']
+  end
+
+  test "user_progress_for_lesson should not return channel when param load_channel is false" do
+    script = create(:script, :with_levels, levels_count: 1)
+    level = script.script_levels.first.level
+
+    user = create :user, total_lines: 2
+    sign_in user
+
+    create :channel_token, level: level, script_id: script.id, storage_id: storage_id_for_user_id(user.id)
+
+    get :user_progress_for_lesson, params: {
+      script: script.name,
+      lesson_position: 1,
+      level_position: 1,
+      load_channel: false
+    }
+
+    body = JSON.parse(response.body)
+    assert_nil body['channel']
+  end
+
   test "should slog the contained level id when present" do
     slogger = FakeSlogger.new
     CDO.set_slogger_for_test(slogger)

--- a/dashboard/test/helpers/levels_helper_test.rb
+++ b/dashboard/test/helpers/levels_helper_test.rb
@@ -202,19 +202,26 @@ class LevelsHelperTest < ActionView::TestCase
     assert_equal blockly_level_options, level.blockly_level_options
   end
 
-  test 'app_options sets a channel if a user is present for a channel-backed level' do
+  test 'app_options sets a channel if the level is not cached for a channel-backed level' do
     user = create :user
     sign_in user
 
+    ScriptConfig.stubs(:allows_public_caching_for_script).returns(false)
+
+    @script = create(:script)
     @level = create :applab
+    create(:script_level, script: @script, levels: [@level])
+
     assert_not_nil app_options['channel']
   end
 
-  # The reason we do not set a channel if a user is not present, is that this may
-  # indicate that the level is cached and therefore we will not load user-related data
-  # server-side (but rather load it in loadApp.js, client-side)
-  test 'app_options does not set a channel if a user is not present' do
+  test 'app_options does not set a channel if the level is cached' do
+    ScriptConfig.stubs(:allows_public_caching_for_script).returns(true)
+
+    @script = create(:script)
     @level = create :applab
+    create(:script_level, script: @script, levels: [@level])
+
     assert_nil app_options['channel']
   end
 

--- a/dashboard/test/helpers/levels_helper_test.rb
+++ b/dashboard/test/helpers/levels_helper_test.rb
@@ -202,7 +202,28 @@ class LevelsHelperTest < ActionView::TestCase
     assert_equal blockly_level_options, level.blockly_level_options
   end
 
-  test 'app_options sets a channel' do
+  test 'app_options sets a channel if a user is present for a channel-backed level' do
+    user = create :user
+    sign_in user
+
+    @level = create :applab
+    assert_not_nil app_options['channel']
+  end
+
+  # The reason we do not set a channel if a user is not present, is that this may
+  # indicate that the level is cached and therefore we will not load user-related data
+  # server-side (but rather load it in loadApp.js, client-side)
+  test 'app_options does not set a channel if a user is not present' do
+    @level = create :applab
+    assert_nil app_options['channel']
+  end
+
+  test "app_options sets should_load_channel to true if level is channel backed" do
+    @level = create :applab
+    assert_equal true, app_options['shouldLoadChannel']
+  end
+
+  test 'get_channel_for sets a channel' do
     user = create :user
     sign_in user
 
@@ -217,14 +238,6 @@ class LevelsHelperTest < ActionView::TestCase
     # Request it for a different level, should get a different channel
     level = create(:level, :blockly)
     assert_not_equal channel, get_channel_for(level, script.id)
-  end
-
-  test 'applab levels should have channels' do
-    user = create :user
-    sign_in user
-
-    @level = create :applab
-    assert_not_nil app_options['channel']
   end
 
   test 'applab levels should not load channel when viewing student solution of a student without a channel' do

--- a/dashboard/test/helpers/levels_helper_test.rb
+++ b/dashboard/test/helpers/levels_helper_test.rb
@@ -218,9 +218,9 @@ class LevelsHelperTest < ActionView::TestCase
     assert_nil app_options['channel']
   end
 
-  test "app_options sets should_load_channel to true if level is channel backed" do
+  test "app_options sets level_requires_channel to true if level is channel backed" do
     @level = create :applab
-    assert_equal true, app_options['shouldLoadChannel']
+    assert_equal true, app_options['levelRequiresChannel']
   end
 
   test 'get_channel_for sets a channel' do


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
The changes made here allow channel-backed levels to be cacheable. The channel for the user and level will only be retrieved server-side in `app_options` if a user is present, which signifies that the level is not cached. For levels that require a channel, a new `app_option` called `should_load_channel` will be set to let the client know that the channel will need to be retrieved client-side on load if it was not retrieved server-side. I updated the `user_progress` request made on the client to retrieve progress for cached levels to also return the channel if necessary.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
- jira ticket: [LP-2051](https://codedotorg.atlassian.net/browse/LP-2051)
<!--
- spec: []()
-->

## Testing story
Tested locally by allowing the channel-backed level `/s/dance-2019/lessons/1/levels/10` to be cached, tested that progress was saved and loaded properly for a logged-in and logged-out user. I also tested what would happen if a teacher visited the page with a `user_id` param, it renders the 'cannot view student work on this level' message, as we would expect for cached levels.

I also added several unit tests.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
