### PR TITLE
[Poetry][HOC] Allow Poetry levels to use GamelabJr shared functions

### DIFF
--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -709,9 +709,15 @@ class Blockly < Level
     Block.for(type)
   end
 
+  # Default to getting shared_functions of same level type, but allows subclasses to override
+  # this value if needed. See poetry.rb
+  def shared_function_type
+    type
+  end
+
   def shared_functions
-    Rails.cache.fetch("shared_functions/#{type}", force: !Script.should_cache?) do
-      SharedBlocklyFunction.where(level_type: type).map(&:to_xml_fragment)
+    Rails.cache.fetch("shared_functions/#{shared_function_type}", force: !Script.should_cache?) do
+      SharedBlocklyFunction.where(level_type: shared_function_type).map(&:to_xml_fragment)
     end.join
   end
 

--- a/dashboard/app/models/levels/poetry.rb
+++ b/dashboard/app/models/levels/poetry.rb
@@ -30,6 +30,11 @@ class Poetry < GamelabJr
     default_poem
   )
 
+  # Poetry levels use the same shared_functions as GamelabJr
+  def shared_function_type
+    GamelabJr
+  end
+
   def self.skins
     ['gamelab']
   end


### PR DESCRIPTION
Allows poetry levels to use the same shared_functions as GamelabJr (Spritelab)
Once this change goes out, we'll need to update all the relevant Poetry levels on levelbuilder to include the GamelabJr block pool and make sure the checkbox is checked to include shared functions. The only reason I'm not doing that in this PR is to avoid merge conflicts with the levelbuilder scoop since these levels are under active development.

Before
![image](https://user-images.githubusercontent.com/8787187/136099617-a9f22894-7440-4f2f-aa36-5611ced49946.png)


After
![image](https://user-images.githubusercontent.com/8787187/136099656-15f5c4ab-b6b0-4a58-b5c1-80f6d6b2cba4.png)
