### PR TITLE
Javalab: don't call exit on exception

### DIFF
--- a/apps/src/javalab/JavabuilderConnection.js
+++ b/apps/src/javalab/JavabuilderConnection.js
@@ -132,7 +132,6 @@ export default class JavabuilderConnection {
       case WebSocketMessageType.EXCEPTION:
         handleException(data, this.onOutputMessage);
         this.onNewlineMessage();
-        this.onExit();
         break;
       case WebSocketMessageType.DEBUG:
         if (window.location.hostname.includes('localhost')) {


### PR DESCRIPTION
[This PR](https://github.com/code-dot-org/javabuilder/pull/132) ensures we always send an exit message after any exception is thrown in Javabuilder. We no longer need to manually call exit in Javalab after an exception. 

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
