### PR TITLE
Log failures for daily_weather dataset

### DIFF
--- a/bin/cron/applab_datasets/daily_weather
+++ b/bin/cron/applab_datasets/daily_weather
@@ -9,10 +9,11 @@ require 'json'
 require 'ostruct'
 require 'date'
 require_relative '../../../shared/middleware/helpers/firebase_helper'
+require 'honeybadger/ruby'
 
 WeatherForecastOffice = Struct.new(:city, :state, :zip)
 
-API_KEY = '6e86f0c363cd54b5645603030b2f0f76'
+API_KEY = CDO.open_weather_api_key
 NUM_DAYS = 5
 
 def cardinal_dir_from_degrees(degrees)
@@ -157,7 +158,13 @@ def get_weather_data
 
     url = "http://api.openweathermap.org/data/2.5/forecast/daily?zip=#{office.zip},us&cnt=#{NUM_DAYS}&units=imperial&appid=#{API_KEY}"
     response = Net::HTTP.get_response(URI(url))
-    next unless response.code == '200'
+    if response.code != '200'
+      Honeybadger.notify(
+        error: response.message,
+        error_message: "Failed to retrieve data from Open Weather API for use with App Labs datasets.",
+      )
+      next
+    end
 
     parsed_response = JSON.parse(response.body)
     measurements = parsed_response['list']
@@ -202,6 +209,12 @@ end
 def main
   fb = FirebaseHelper.new('shared')
   records, columns = get_weather_data
+  if records.empty?
+    Honeybadger.notify(
+      error_message: "No data returned from OpenWeather API. No records will be written to firebase."
+      )
+    return
+  end
   fb.upload_live_table('Daily Weather', records, columns)
 end
 

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -551,3 +551,6 @@ javabuilder_key_password: !Secret
 # Credentials for the Spotify API, used to provide playlist data in App Labs
 spotify_api_client_id: !Secret
 spotify_api_client_secret: !Secret
+
+# Credentials for the Open Weather API, used to provide weather data in App Labs
+open_weather_api_key: !Secret


### PR DESCRIPTION
Adding logging through `HoneyBadger` in case calls to the `OpenWeather API` fail or return an empty dataset. 

Also moves API Key to pull from AWS Secrets (value already added to `base` set of environments in AWS) 
## Links
- jira ticket: https://codedotorg.atlassian.net/browse/STAR-1707

## PR Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
