### PR TITLE
count all queries when loading a hoc level page

### DIFF
--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -464,7 +464,7 @@ class ApiController < ApplicationController
         tag: 'activity_start',
         script_level_id: script_level.try(:id),
         level_id: level.contained_levels.empty? ? level.id : level.contained_levels.first.id,
-        user_agent: request.user_agent.valid_encoding? ? request.user_agent : 'invalid_encoding',
+        user_agent: request.user_agent&.valid_encoding? ? request.user_agent : 'invalid_encoding',
         locale: locale
       )
     end

--- a/dashboard/test/integration/db_query_test.rb
+++ b/dashboard/test/integration/db_query_test.rb
@@ -158,7 +158,6 @@ class DBQueryTest < ActionDispatch::IntegrationTest
 
     assert_cached_queries(10) do
       get "/api/user_progress/#{script.name}/1/1/#{level.id}"
-      puts @response.body
       assert_response :success
     end
 

--- a/dashboard/test/integration/db_query_test.rb
+++ b/dashboard/test/integration/db_query_test.rb
@@ -129,7 +129,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
   end
 
   test "student in section views uncached hoc level" do
-    script = create(
+    unit = create(
       :script,
       :with_levels,
       levels_count: 10,
@@ -138,18 +138,18 @@ class DBQueryTest < ActionDispatch::IntegrationTest
       version_year: 'unversioned',
       published_state: SharedConstants::PUBLISHED_STATE.stable
     )
-    CourseOffering.add_course_offering(script)
-    level = script.levels.first
+    CourseOffering.add_course_offering(unit)
+    level = unit.levels.first
 
     teacher = create :teacher
-    section = create :section, user: teacher, script: script
+    section = create :section, user: teacher, script: unit
     student = create :student
     section.students = [student]
-    student.assign_script(script)
+    student.assign_script(unit)
     sign_in student
 
     assert_cached_queries(19) do
-      get "/s/#{script.name}/lessons/1/levels/1"
+      get "/s/#{unit.name}/lessons/1/levels/1"
       assert_response :success
     end
 
@@ -157,7 +157,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     # server on page load.
 
     assert_cached_queries(10) do
-      get "/api/user_progress/#{script.name}/1/1/#{level.id}"
+      get "/api/user_progress/#{unit.name}/1/1/#{level.id}"
       assert_response :success
     end
 

--- a/dashboard/test/integration/db_query_test.rb
+++ b/dashboard/test/integration/db_query_test.rb
@@ -142,7 +142,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     level = script.levels.first
 
     teacher = create :teacher
-    section = create :section, user: teacher
+    section = create :section, user: teacher, script: script
     student = create :student
     section.students = [student]
     student.assign_script(script)

--- a/dashboard/test/integration/db_query_test.rb
+++ b/dashboard/test/integration/db_query_test.rb
@@ -127,4 +127,44 @@ class DBQueryTest < ActionDispatch::IntegrationTest
       assert_response :success
     end
   end
+
+  test "student in section views uncached hoc level" do
+    script = create(
+      :script,
+      :with_levels,
+      levels_count: 10,
+      is_course: true,
+      family_name: 'hoc-family',
+      version_year: 'unversioned',
+      published_state: SharedConstants::PUBLISHED_STATE.stable
+    )
+    CourseOffering.add_course_offering(script)
+    level = script.levels.first
+
+    teacher = create :teacher
+    section = create :section, user: teacher
+    student = create :student
+    section.students = [student]
+    student.assign_script(script)
+    sign_in student
+
+    assert_cached_queries(19) do
+      get "/s/#{script.name}/lessons/1/levels/1"
+      assert_response :success
+    end
+
+    # Simulate all the ajax requests which the level page sends to the
+    # server on page load.
+
+    assert_cached_queries(10) do
+      get "/api/user_progress/#{script.name}/1/1/#{level.id}"
+      puts @response.body
+      assert_response :success
+    end
+
+    assert_cached_queries(3) do
+      get "/levels/#{level.id}/get_rubric"
+      assert_response :success
+    end
+  end
 end


### PR DESCRIPTION
Finishes https://codedotorg.atlassian.net/browse/PLAT-1181. Mostly copies https://github.com/code-dot-org/code-dot-org/pull/42737. 

This PR just adds a new unit test covering all the requests I could capture when loading a script level page. The first thing to note is that there are no cacheable curriculum-related objects being queried from the database, which was the explicit goal of PLAT-1181. I also poked around a bit to see if I could shave off any other queries, but didn't see any low hanging fruit. So, my proposal is to add this query count test, in hopes of (1) documenting some of the existing queries on the uncached HOC script level page, and (2) protecting against regressions to this query count.

## Testing story

* new unit test to count queries
* relying on existing tests to cover the small non-test code change

## Future work

If we were going to try to shave off more queries here in the future, I would think about doing it by disabling certain features for certain high profile scripts, including:
* teacher feedback
* `section_hidden_scripts` (does this even make sense for scripts which are standalone courses?)
* `section_hidden_stages` (does this even make sense for scripts with one lesson?)
* rubrics

of course, adding any HOC scripts to the [CACHED_UNITS_MAP](https://github.com/code-dot-org/code-dot-org/blob/8f6785bb50e7b8994bec321271b3f9d82d8b80fa/cookbooks/cdo-varnish/libraries/http_cache.rb#L28) would strip the user session cookies from the requests and result in avoiding many (most? almost all?) of these queries.