### PR TITLE
Fix example solutions button

### DIFF
--- a/apps/src/templates/instructions/TopInstructions.jsx
+++ b/apps/src/templates/instructions/TopInstructions.jsx
@@ -737,6 +737,7 @@ class TopInstructions extends Component {
                 <div style={styles.exampleSolutions}>
                   {exampleSolutions.map((example, index) => (
                     <Button
+                      __useDeprecatedTag
                       key={index}
                       text={i18n.exampleSolution({number: index + 1})}
                       color={Button.ButtonColor.blue}
@@ -744,7 +745,6 @@ class TopInstructions extends Component {
                       target="_blank"
                       rel="noopener noreferrer"
                       ref={ref => (this.teacherOnlyTab = ref)}
-                      hidden={tabSelected !== TabType.TEACHER_ONLY}
                       style={styles.exampleSolutionButton}
                     />
                   ))}

--- a/apps/src/templates/instructions/TopInstructions.jsx
+++ b/apps/src/templates/instructions/TopInstructions.jsx
@@ -732,28 +732,27 @@ class TopInstructions extends Component {
                 onLoadComplete={this.forceTabResizeToMaxOrAvailableHeight}
               />
             )}
+            {tabSelected === TabType.TEACHER_ONLY &&
+              exampleSolutions.length > 0 && (
+                <div style={styles.exampleSolutions}>
+                  {exampleSolutions.map((example, index) => (
+                    <Button
+                      key={index}
+                      text={i18n.exampleSolution({number: index + 1})}
+                      color={Button.ButtonColor.blue}
+                      href={example}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      ref={ref => (this.teacherOnlyTab = ref)}
+                      hidden={tabSelected !== TabType.TEACHER_ONLY}
+                      style={styles.exampleSolutionButton}
+                    />
+                  ))}
+                </div>
+              )}
             {this.isViewingAsTeacher &&
-              (hasContainedLevels ||
-                teacherMarkdown ||
-                exampleSolutions.length > 0) && (
+              (hasContainedLevels || teacherMarkdown) && (
                 <div>
-                  {exampleSolutions.length > 0 && (
-                    <div style={styles.exampleSolutions}>
-                      {exampleSolutions.map((example, index) => (
-                        <Button
-                          key={index}
-                          text={i18n.exampleSolution({number: index + 1})}
-                          color={Button.ButtonColor.blue}
-                          href={example}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          ref={ref => (this.teacherOnlyTab = ref)}
-                          hidden={tabSelected !== TabType.TEACHER_ONLY}
-                          style={styles.exampleSolutionButton}
-                        />
-                      ))}
-                    </div>
-                  )}
                   {hasContainedLevels && (
                     <ContainedLevelAnswer
                       ref={ref => (this.teacherOnlyTab = ref)}

--- a/apps/test/unit/templates/instructions/TopInstructionsTest.jsx
+++ b/apps/test/unit/templates/instructions/TopInstructionsTest.jsx
@@ -106,6 +106,19 @@ describe('TopInstructions', () => {
     ).to.equal('Example Solution 1');
   });
 
+  it('does not display example solutions buttons in other tabs when available', () => {
+    const wrapper = shallow(
+      <TopInstructions
+        {...DEFAULT_PROPS}
+        initialSelectedTab={TabType.INSTRUCTIONS}
+        exampleSolutions={['link/1', 'link/2']}
+      />
+    );
+
+    expect(wrapper.state().tabSelected).to.equal(TabType.INSTRUCTIONS);
+    expect(wrapper.find('Button')).to.have.lengthOf(0);
+  });
+
   describe('viewing the Feedback Tab', () => {
     describe('as a teacher', () => {
       it('passes displayFeedback = false to TopInstructionsHeader on a level with no rubric where the teacher is not giving feedback', () => {


### PR DESCRIPTION
The example solutions button was showing up in all the tabs and the link was not working. The button was showing up in all the tabs because I did not put the code in the right spot in order to prevent it from showing up in other tabs. The button was not working because I had removed `__useDeprecatedTag` during the review process thinking I did not need it. Without this on the Button the links do not work.

https://user-images.githubusercontent.com/208083/136305172-e4c6cd84-1e8c-40b9-9abe-8dc26e6065b9.mov


## Links

Slack: https://codedotorg.slack.com/archives/C02EEGWLHR8/p1633560560175000

## Testing story

- Added a unit test for the button showing in the wrong tab
- Not sure of the best way to test that the button works. I could add an eyes test as follow up

