### PR TITLE
Javalab: allow levelbuilder teachers to delete comments

### DIFF
--- a/apps/src/templates/instructions/codeReview/Comment.jsx
+++ b/apps/src/templates/instructions/codeReview/Comment.jsx
@@ -17,7 +17,7 @@ class Comment extends Component {
     onDelete: PropTypes.func.isRequired,
     viewAsCodeReviewer: PropTypes.bool.isRequired,
     // Populated by Redux
-    viewAs: PropTypes.oneOf(Object.keys(ViewType))
+    viewAsTeacher: PropTypes.bool
   };
 
   state = {isShowingCommentOptions: false};
@@ -81,7 +81,7 @@ class Comment extends Component {
       isResolved,
       hasError
     } = this.props.comment;
-    const {viewAsCodeReviewer, viewAs} = this.props;
+    const {viewAsCodeReviewer, viewAsTeacher} = this.props;
 
     const {isShowingCommentOptions} = this.state;
 
@@ -100,7 +100,7 @@ class Comment extends Component {
               {this.renderFormattedTimestamp(timestampString)}
             </span>
             {isResolved && <i className="fa fa-check" style={styles.check} />}
-            {(viewAs === ViewType.Teacher || !viewAsCodeReviewer) && (
+            {(viewAsTeacher || !viewAsCodeReviewer) && (
               <i
                 className="fa fa-ellipsis-h"
                 style={styles.ellipsisMenu}
@@ -139,7 +139,9 @@ class Comment extends Component {
 }
 
 export const UnconnectedComment = Comment;
-export default connect(state => ({viewAs: state.viewAs}))(Comment);
+export default connect(state => ({
+  viewAsTeacher: state.viewAs === ViewType.Teacher
+}))(Comment);
 
 const sharedIconStyles = {
   fontSize: 18,

--- a/apps/src/templates/instructions/codeReview/Comment.jsx
+++ b/apps/src/templates/instructions/codeReview/Comment.jsx
@@ -1,4 +1,5 @@
 import React, {Component} from 'react';
+import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 import javalabMsg from '@cdo/javalab/locale';
@@ -7,13 +8,16 @@ import msg from '@cdo/locale';
 import {commentShape} from './commentShape';
 import CommentOptions from './CommentOptions';
 import Tooltip from '@cdo/apps/templates/Tooltip';
+import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 
-export default class Comment extends Component {
+class Comment extends Component {
   static propTypes = {
     comment: commentShape.isRequired,
     onResolveStateToggle: PropTypes.func.isRequired,
     onDelete: PropTypes.func.isRequired,
-    viewAsCodeReviewer: PropTypes.bool.isRequired
+    viewAsCodeReviewer: PropTypes.bool.isRequired,
+    // Populated by Redux
+    viewAs: PropTypes.oneOf(Object.keys(ViewType))
   };
 
   state = {isShowingCommentOptions: false};
@@ -77,7 +81,7 @@ export default class Comment extends Component {
       isResolved,
       hasError
     } = this.props.comment;
-    const {viewAsCodeReviewer} = this.props;
+    const {viewAsCodeReviewer, viewAs} = this.props;
 
     const {isShowingCommentOptions} = this.state;
 
@@ -96,7 +100,7 @@ export default class Comment extends Component {
               {this.renderFormattedTimestamp(timestampString)}
             </span>
             {isResolved && <i className="fa fa-check" style={styles.check} />}
-            {!viewAsCodeReviewer && (
+            {(viewAs === ViewType.Teacher || !viewAsCodeReviewer) && (
               <i
                 className="fa fa-ellipsis-h"
                 style={styles.ellipsisMenu}
@@ -133,6 +137,9 @@ export default class Comment extends Component {
     );
   }
 }
+
+export const UnconnectedComment = Comment;
+export default connect(state => ({viewAs: state.viewAs}))(Comment);
 
 const sharedIconStyles = {
   fontSize: 18,

--- a/apps/test/unit/templates/instructions/codeReview/CommentTest.jsx
+++ b/apps/test/unit/templates/instructions/codeReview/CommentTest.jsx
@@ -5,14 +5,16 @@ import {Factory} from 'rosie';
 import './CodeReviewTestHelper';
 import javalabMsg from '@cdo/javalab/locale';
 import color from '@cdo/apps/util/color';
-import Comment from '@cdo/apps/templates/instructions/codeReview/Comment';
+import {UnconnectedComment as Comment} from '@cdo/apps/templates/instructions/codeReview/Comment';
+import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 
 const DEFAULT_COMMENT = Factory.build('CodeReviewComment');
 const DEFAULT_PROPS = {
   comment: DEFAULT_COMMENT,
   onResolveStateToggle: () => {},
   onDelete: () => {},
-  viewAsCodeReviewer: false
+  viewAsCodeReviewer: false,
+  viewAs: ViewType.Student
 };
 
 describe('Code Review Comment', () => {
@@ -69,6 +71,14 @@ describe('Code Review Comment', () => {
 
   it('shows ellipsis and comment options when viewing not as code reviewer', () => {
     const wrapper = renderWrapper();
+    expect(wrapper.find('.fa.fa-ellipsis-h')).to.have.lengthOf(1);
+  });
+
+  it('shows ellipsis and comment options when viewing as teacher', () => {
+    const wrapper = renderWrapper(
+      {},
+      {viewAsCodeReviewer: true, viewAs: ViewType.Teacher}
+    );
     expect(wrapper.find('.fa.fa-ellipsis-h')).to.have.lengthOf(1);
   });
 

--- a/apps/test/unit/templates/instructions/codeReview/CommentTest.jsx
+++ b/apps/test/unit/templates/instructions/codeReview/CommentTest.jsx
@@ -6,7 +6,6 @@ import './CodeReviewTestHelper';
 import javalabMsg from '@cdo/javalab/locale';
 import color from '@cdo/apps/util/color';
 import {UnconnectedComment as Comment} from '@cdo/apps/templates/instructions/codeReview/Comment';
-import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 
 const DEFAULT_COMMENT = Factory.build('CodeReviewComment');
 const DEFAULT_PROPS = {
@@ -14,7 +13,7 @@ const DEFAULT_PROPS = {
   onResolveStateToggle: () => {},
   onDelete: () => {},
   viewAsCodeReviewer: false,
-  viewAs: ViewType.Student
+  viewAsTeacher: false
 };
 
 describe('Code Review Comment', () => {
@@ -77,7 +76,7 @@ describe('Code Review Comment', () => {
   it('shows ellipsis and comment options when viewing as teacher', () => {
     const wrapper = renderWrapper(
       {},
-      {viewAsCodeReviewer: true, viewAs: ViewType.Teacher}
+      {viewAsCodeReviewer: true, viewAsTeacher: true}
     );
     expect(wrapper.find('.fa.fa-ellipsis-h')).to.have.lengthOf(1);
   });


### PR DESCRIPTION
We had a bug where levelbuilder teachers could not delete comments. This is because levelbuilders get all permissions by default, and our check was that a specific permission was false. This PR updates that check to either be that the user is not viewing as a reviewer or that the user is viewing as a teacher.

## Links

- jira ticket: [CSA-697](https://codedotorg.atlassian.net/browse/CSA-697)


## Testing story
Tested locally--now both levelbuilder and non-levelbuilder teachers can delete comments.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
