### PR TITLE
Revert "Removing extra HoC certificates for Korean students"

### DIFF
--- a/apps/src/templates/Congrats.jsx
+++ b/apps/src/templates/Congrats.jsx
@@ -4,6 +4,7 @@ import Certificate from './Certificate';
 import StudentsBeyondHoc from './StudentsBeyondHoc';
 import TeachersBeyondHoc from './TeachersBeyondHoc';
 import styleConstants from '../styleConstants';
+import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
 import color from '../util/color';
 
 export default class Congrats extends Component {
@@ -42,8 +43,19 @@ export default class Congrats extends Component {
    */
   renderExtraCertificateLinks = (language, tutorial) => {
     let extraLinkUrl, extraLinkText;
-    // Add extra links here
-
+    // https://codedotorg.atlassian.net/browse/FND-1604
+    // these can be removed after July 25 2021
+    if (language === 'ko') {
+      if (/oceans/.test(tutorial)) {
+        extraLinkUrl = pegasus('/files/online-coding-party-2021-oceans.pdf');
+        extraLinkText =
+          '온라인 코딩 파티 인증서 받으러 가기! (과학기술정보통신부 인증)';
+      } else if (/dance/.test(tutorial)) {
+        extraLinkUrl = pegasus('/files/online-coding-party-2021-dance.pdf');
+        extraLinkText =
+          '온라인 코딩 파티 인증서 받으러 가기! (과학기술정보통신부 인증)';
+      }
+    }
     if (!extraLinkUrl || !extraLinkText) {
       // There are no extra links to render.
       return;

--- a/apps/src/templates/Congrats.jsx
+++ b/apps/src/templates/Congrats.jsx
@@ -43,8 +43,8 @@ export default class Congrats extends Component {
    */
   renderExtraCertificateLinks = (language, tutorial) => {
     let extraLinkUrl, extraLinkText;
-    // https://codedotorg.atlassian.net/browse/FND-1604
-    // these can be removed after July 25 2021
+    // https://codedotorg.atlassian.net/browse/FND-1749
+    // these can be removed after November 21 2021
     if (language === 'ko') {
       if (/oceans/.test(tutorial)) {
         extraLinkUrl = pegasus('/files/online-coding-party-2021-oceans.pdf');


### PR DESCRIPTION
**What**
The government agency in South Korea that runs their nationwide Online Coding Party campaign is starting season 2 of the campaign starting next Monday, October 11th, and running through Sunday, November 21st. We are just adding the special links back in this PR.

- Reverts code-dot-org/code-dot-org#41765
- Also updates the comments to reflect new situation

**Testing**
Tested and working locally
![Screen Shot 2021-10-07 at 2 48 01 PM](https://user-images.githubusercontent.com/48133820/136452603-445097b5-b72e-4ec6-88de-4394c59f5f98.png)