### PR TITLE
Convert SeamlessDatabasePool's database configuration to new Rails 6 DatabaseConfiguration object

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,13 +29,7 @@ gem 'sinatra', '2.0.2', require: 'sinatra/base'
 
 gem 'mysql2', '>= 0.4.1'
 
-# Rails 6 introduced some chages to the way database configurations are
-# implemented that seamless_database_pool does not support. We provide our own
-# version that knows how to interact with Rails 6, to give us a transiton path
-# from "Rails 5 with seamless_database_pool" to "Rails 6 with Rails Multiple
-# Databases". Once we are fully transitioned to the latter, this dependency can
-# be entirely removed.
-gem 'seamless_database_pool', github: 'code-dot-org/seamless_database_pool', ref: 'rails-6-compatibility'
+gem 'seamless_database_pool', '>= 1.0.20'
 
 gem 'dalli' # memcached
 gem 'dalli-elasticache' # ElastiCache Auto Discovery memcached nodes

--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,13 @@ gem 'sinatra', '2.0.2', require: 'sinatra/base'
 
 gem 'mysql2', '>= 0.4.1'
 
-gem 'seamless_database_pool', '>= 1.0.20'
+# Rails 6 introduced some chages to the way database configurations are
+# implemented that seamless_database_pool does not support. We provide our own
+# version that knows how to interact with Rails 6, to give us a transiton path
+# from "Rails 5 with seamless_database_pool" to "Rails 6 with Rails Multiple
+# Databases". Once we are fully transitioned to the latter, this dependency can
+# be entirely removed.
+gem 'seamless_database_pool', github: 'code-dot-org/seamless_database_pool', ref: 'rails-6-compatibility'
 
 gem 'dalli' # memcached
 gem 'dalli-elasticache' # ElastiCache Auto Discovery memcached nodes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,14 +47,6 @@ GIT
       tilt
 
 GIT
-  remote: https://github.com/code-dot-org/seamless_database_pool.git
-  revision: ce3cfc0b56cbca1cb3c468a2263767fd0b6197fb
-  ref: rails-6-compatibility
-  specs:
-    seamless_database_pool (1.0.20)
-      activerecord (>= 3.2.0)
-
-GIT
   remote: https://github.com/dooly-ai/omniauth-microsoft_v2_auth.git
   revision: db19d64c2ddb017dddb9a0ff2cee1d84d2fad287
   specs:
@@ -794,6 +786,8 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
+    seamless_database_pool (1.0.20)
+      activerecord (>= 3.2.0)
     selenium-webdriver (3.141.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2, >= 1.2.2)
@@ -1052,7 +1046,7 @@ DEPENDENCIES
   scenic-mysql_adapter
   scss_lint
   sdoc
-  seamless_database_pool!
+  seamless_database_pool (>= 1.0.20)
   selenium-webdriver (= 3.141.0)
   sequel
   shotgun

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,14 @@ GIT
       tilt
 
 GIT
+  remote: https://github.com/code-dot-org/seamless_database_pool.git
+  revision: ce3cfc0b56cbca1cb3c468a2263767fd0b6197fb
+  ref: rails-6-compatibility
+  specs:
+    seamless_database_pool (1.0.20)
+      activerecord (>= 3.2.0)
+
+GIT
   remote: https://github.com/dooly-ai/omniauth-microsoft_v2_auth.git
   revision: db19d64c2ddb017dddb9a0ff2cee1d84d2fad287
   specs:
@@ -786,8 +794,6 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
-    seamless_database_pool (1.0.20)
-      activerecord (>= 3.2.0)
     selenium-webdriver (3.141.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2, >= 1.2.2)
@@ -1046,7 +1052,7 @@ DEPENDENCIES
   scenic-mysql_adapter
   scss_lint
   sdoc
-  seamless_database_pool (>= 1.0.20)
+  seamless_database_pool!
   selenium-webdriver (= 3.141.0)
   sequel
   shotgun

--- a/dashboard/config/initializers/rails_6_compatible_seamless_database_pool.rb
+++ b/dashboard/config/initializers/rails_6_compatible_seamless_database_pool.rb
@@ -1,0 +1,25 @@
+# The SeamlessDatabasePool gem was written for an old version of Rails which
+# used raw hashes for database configurations, rather than the dedicated
+# DatabaseConfiguration object introduced in Rails 6.
+#
+# We eventually want to deprecate this gem in favor of the native Rails
+# Multiple Databases configuration support introduced in 6, but until then we
+# want this to continue working, so add some logic here to wrap the old stuff
+# in the new stuff when appropriate.
+module Rails6CompatibleSeamlessDatabasePool
+  def self.prepended(base)
+    class << base
+      prepend ClassMethods
+    end
+  end
+
+  module ClassMethods
+    def master_database_configuration(database_configs)
+      configs = super(database_configs)
+      configs = ActiveRecord::DatabaseConfigurations.new(configs) if ActiveRecord.const_defined?(:DatabaseConfigurations)
+      configs
+    end
+  end
+end
+
+SeamlessDatabasePool.prepend Rails6CompatibleSeamlessDatabasePool


### PR DESCRIPTION
Rather than the simple hash it used to be. Necessary to allow the gem to continue to work while we transition on to Rails 6, until we deprecate it in favor of Rails 6's native support for configuring multiple databases.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
