### PR TITLE
Convert TeacherHomepage to functional component

### DIFF
--- a/apps/src/templates/studioHomepages/TeacherHomepage.jsx
+++ b/apps/src/templates/studioHomepages/TeacherHomepage.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
-import React, {Component} from 'react';
+import React, {useState, useEffect, useRef} from 'react';
 import {connect} from 'react-redux';
-import ReactDOM from 'react-dom';
 import $ from 'jquery';
 import HeaderBanner from '../HeaderBanner';
 import SpecialAnnouncement from './SpecialAnnouncement';
@@ -20,267 +19,247 @@ import CensusTeacherBanner from '../census2017/CensusTeacherBanner';
 import DonorTeacherBanner from '@cdo/apps/templates/DonorTeacherBanner';
 import {beginGoogleImportRosterFlow} from '../teacherDashboard/teacherSectionsRedux';
 
-export class UnconnectedTeacherHomepage extends Component {
-  static propTypes = {
-    joinedSections: shapes.sections,
-    hocLaunch: PropTypes.string,
-    courses: shapes.courses,
-    topCourse: shapes.topCourse,
-    announcement: shapes.teacherAnnouncement,
-    queryStringOpen: PropTypes.string,
-    canViewAdvancedTools: PropTypes.bool,
-    isEnglish: PropTypes.bool.isRequired,
-    ncesSchoolId: PropTypes.string,
-    showCensusBanner: PropTypes.bool.isRequired,
-    showNpsSurvey: PropTypes.bool,
-    donorBannerName: PropTypes.string,
-    censusQuestion: PropTypes.oneOf(['how_many_10_hours', 'how_many_20_hours']),
-    teacherName: PropTypes.string,
-    teacherId: PropTypes.number,
-    teacherEmail: PropTypes.string,
-    schoolYear: PropTypes.number,
-    specialAnnouncement: shapes.specialAnnouncement,
-    beginGoogleImportRosterFlow: PropTypes.func
-  };
+export const UnconnectedTeacherHomepage = ({
+  announcement,
+  canViewAdvancedTools,
+  censusQuestion,
+  courses,
+  donorBannerName,
+  isEnglish,
+  joinedSections,
+  ncesSchoolId,
+  queryStringOpen,
+  schoolYear,
+  showCensusBanner,
+  showNpsSurvey,
+  specialAnnouncement,
+  teacherEmail,
+  teacherId,
+  teacherName,
+  topCourse,
+  beginGoogleImportRosterFlow
+}) => {
+  const censusBanner = useRef(null);
+  const teacherReminders = useRef(null);
+  const flashes = useRef(null);
 
-  state = {
-    showCensusBanner: this.props.showCensusBanner
-  };
+  const [displayCensusBanner, setDisplayCensusBanner] = useState(
+    showCensusBanner
+  );
+  const [
+    censusSubmittedSuccessfully,
+    setCensusSubmittedSuccessfully
+  ] = useState(null);
+  const [
+    censusBannerTeachesSelection,
+    setCensusBannerTeachesSelection
+  ] = useState(null);
+  const [
+    censusBannerInClassSelection,
+    setCensusBannerInClassSelection
+  ] = useState(null);
+  const [showCensusUnknownError, setShowCensusUnknownError] = useState(false);
+  const [showCensusInvalidError, setShowCensusInvalidError] = useState(false);
 
-  bindCensusBanner = banner => {
-    this.censusBanner = banner;
-  };
-
-  handleCensusBannerTeachesChange(event) {
-    this.setState({
-      censusBannerTeachesSelection: event.target.id === 'teachesYes'
-    });
-  }
-
-  handleCensusBannerInClassChange(event) {
-    this.setState({
-      censusBannerInClassSelection: event.target.id === 'inClass'
-    });
-  }
-
-  handleCensusBannerSubmit() {
-    if (this.censusBanner.isValid()) {
-      $.ajax({
-        url: '/dashboardapi/v1/census/CensusTeacherBannerV1',
-        type: 'post',
-        dataType: 'json',
-        data: this.censusBanner.getData()
-      })
-        .done(this.handleCensusSubmitSuccess)
-        .fail(this.handleCensusSubmitError);
-    } else {
-      this.setState({showCensusInvalidError: true});
-    }
-  }
-
-  handleCensusSubmitSuccess = () => {
-    this.setState({censusSubmittedSuccessfully: true});
-    this.dismissCensusBanner(null, this.logDismissCensusBannerError);
-  };
-
-  handleCensusSubmitError = () => {
-    this.setState({
-      showCensusUnknownError: true
-    });
-  };
-
-  dismissCensusBanner(onSuccess, onFailure) {
-    $.ajax({
-      url: `/api/v1/users/${this.props.teacherId}/dismiss_census_banner`,
-      type: 'post'
-    })
-      .done(onSuccess)
-      .fail(onFailure);
-  }
-
-  logDismissCensusBannerError = xhr => {
-    console.error(
-      `Failed to dismiss future census banner! ${xhr.responseText}`
-    );
-  };
-
-  hideCensusBanner = () => {
-    this.setState({
-      showCensusBanner: false
-    });
-  };
-
-  dismissAndHideCensusBanner() {
-    this.dismissCensusBanner(
-      this.hideCensusBanner,
-      this.handleDismissAndHideCensusBannerError
-    );
-  }
-
-  handleDismissAndHideCensusBannerError = xhr => {
-    this.logDismissCensusBannerError(xhr);
-    this.hideCensusBanner();
-  };
-
-  postponeCensusBanner() {
-    $.ajax({
-      url: `/api/v1/users/${this.props.teacherId}/postpone_census_banner`,
-      type: 'post'
-    })
-      .done(this.hideCensusBanner)
-      .fail(this.handlePostponeCensusBannerError);
-  }
-
-  handlePostponeCensusBannerError = xhr => {
-    console.error(`Failed to postpone census banner! ${xhr.responseText}`);
-    this.hideCensusBanner();
-  };
-
-  componentDidMount() {
+  useEffect(() => {
     // The component used here is implemented in legacy HAML/CSS rather than React.
     $('#teacher_reminders')
-      .appendTo(ReactDOM.findDOMNode(this.refs.teacherReminders))
+      .appendTo(teacherReminders.current.refs.root)
       .show();
     $('#flashes')
-      .appendTo(ReactDOM.findDOMNode(this.refs.flashes))
+      .appendTo(flashes.current.refs.root)
       .show();
 
     // A special on-load behavior: If requested by queryparam, automatically
     // launch the Google Classroom rostering flow.
-    const {queryStringOpen, beginGoogleImportRosterFlow} = this.props;
     if (queryStringOpen === 'rosterDialog') {
       beginGoogleImportRosterFlow();
     }
-  }
+  }, []);
 
-  render() {
-    const {
-      courses,
-      topCourse,
-      announcement,
-      joinedSections,
-      ncesSchoolId,
-      censusQuestion,
-      schoolYear,
-      showNpsSurvey,
-      teacherId,
-      teacherName,
-      teacherEmail,
-      canViewAdvancedTools,
-      isEnglish,
-      specialAnnouncement,
-      donorBannerName
-    } = this.props;
+  const handleCensusBannerSubmit = () => {
+    if (censusBanner.current.isValid()) {
+      $.ajax({
+        url: '/dashboardapi/v1/census/CensusTeacherBannerV1',
+        type: 'post',
+        dataType: 'json',
+        data: censusBanner.current.getData()
+      })
+        .done(() => {
+          setCensusSubmittedSuccessfully(true);
+          dismissCensusBanner(null, null);
+        })
+        .fail(() => {
+          setShowCensusUnknownError(true);
+        });
+    } else {
+      setShowCensusInvalidError(true);
+    }
+  };
 
-    // Whether we show the regular announcement/notification
-    const showAnnouncement = false;
+  const dismissCensusBanner = (onSuccess, onFailure) => {
+    $.ajax({
+      url: `/api/v1/users/${teacherId}/dismiss_census_banner`,
+      type: 'post'
+    })
+      .done(onSuccess)
+      .fail(xhr => {
+        console.error(
+          `Failed to dismiss future census banner! ${xhr.responseText}`
+        );
+        onFailure();
+      });
+  };
 
-    // Whether we show the fallback (translatable) SpecialAnnouncement if there is no
-    // specialAnnouncement passed in as a prop. Currently we only show the fallback for
-    // English-speaking teachers.
-    const showFallbackSpecialAnnouncement = true;
+  const hideCensusBanner = () => {
+    setDisplayCensusBanner(false);
+  };
 
-    // Verify background image works for both LTR and RTL languages.
-    const backgroundUrl = '/shared/images/banners/teacher-homepage-hero.jpg';
+  const dismissAndHideCensusBanner = () => {
+    dismissCensusBanner(hideCensusBanner, hideCensusBanner);
+  };
 
-    const showDonorBanner = isEnglish && donorBannerName;
+  const postponeCensusBanner = () => {
+    $.ajax({
+      url: `/api/v1/users/${teacherId}/postpone_census_banner`,
+      type: 'post'
+    })
+      .done(hideCensusBanner)
+      .fail(xhr => {
+        console.error(`Failed to postpone census banner! ${xhr.responseText}`);
+        hideCensusBanner();
+      });
+  };
 
-    return (
-      <div>
-        <HeaderBanner
-          headingText={i18n.homepageHeading()}
-          short={true}
-          backgroundUrl={backgroundUrl}
-        />
-        <div className={'container main'}>
-          <ProtectedStatefulDiv ref="flashes" />
-          <ProtectedStatefulDiv ref="teacherReminders" />
-          {showNpsSurvey && <NpsSurveyBlock />}
-          {isEnglish && specialAnnouncement && (
-            <SpecialAnnouncementActionBlock
-              announcement={specialAnnouncement}
-              marginBottom="30px"
+  // Whether we show the regular announcement/notification
+  const showAnnouncement = false;
+
+  // Whether we show the fallback (translatable) SpecialAnnouncement if there is no
+  // specialAnnouncement passed in as a prop. Currently we only show the fallback for
+  // English-speaking teachers.
+  const showFallbackSpecialAnnouncement = true;
+
+  // Verify background image works for both LTR and RTL languages.
+  const backgroundUrl = '/shared/images/banners/teacher-homepage-hero.jpg';
+
+  const showDonorBanner = isEnglish && donorBannerName;
+
+  return (
+    <div>
+      <HeaderBanner
+        headingText={i18n.homepageHeading()}
+        short={true}
+        backgroundUrl={backgroundUrl}
+      />
+      <div className={'container main'}>
+        <ProtectedStatefulDiv ref={flashes} />
+        <ProtectedStatefulDiv ref={teacherReminders} />
+        {showNpsSurvey && <NpsSurveyBlock />}
+        {isEnglish && specialAnnouncement && (
+          <SpecialAnnouncementActionBlock
+            announcement={specialAnnouncement}
+            marginBottom="30px"
+          />
+        )}
+        {announcement && showAnnouncement && (
+          <div>
+            <Notification
+              type={announcement.type || 'bullhorn'}
+              notice={announcement.heading}
+              details={announcement.description}
+              dismissible={true}
+              buttonText={announcement.buttonText}
+              buttonLink={announcement.link}
+              newWindow={true}
+              googleAnalyticsId={announcement.id}
             />
+            <div style={styles.clear} />
+          </div>
+        )}
+        {!showAnnouncement && <br />}
+        {/* The current fallback announcement is for English-speaking teachers only. This announcement type
+        is designed to be translatable and in the future can be used for non-English teachers as a fallback
+        to the marketing-configured announcement. */}
+        {showFallbackSpecialAnnouncement &&
+          isEnglish &&
+          !specialAnnouncement && (
+            <SpecialAnnouncement isEnglish={isEnglish} isTeacher={true} />
           )}
-          {announcement && showAnnouncement && (
-            <div>
-              <Notification
-                type={announcement.type || 'bullhorn'}
-                notice={announcement.heading}
-                details={announcement.description}
-                dismissible={true}
-                buttonText={announcement.buttonText}
-                buttonLink={announcement.link}
-                newWindow={true}
-                googleAnalyticsId={announcement.id}
-              />
-              <div style={styles.clear} />
-            </div>
-          )}
-          {!showAnnouncement && <br />}
-          {/* The current fallback announcement is for English-speaking teachers only. This announcement type
-          is designed to be translatable and in the future can be used for non-English teachers as a fallback
-          to the marketing-configured announcement. */}
-          {showFallbackSpecialAnnouncement &&
-            isEnglish &&
-            !specialAnnouncement && (
-              <SpecialAnnouncement isEnglish={isEnglish} isTeacher={true} />
-            )}
-          {this.state.showCensusBanner && (
-            <div>
-              <CensusTeacherBanner
-                ref={this.bindCensusBanner}
-                schoolYear={schoolYear}
-                ncesSchoolId={ncesSchoolId}
-                question={censusQuestion}
-                teaches={this.state.censusBannerTeachesSelection}
-                inClass={this.state.censusBannerInClassSelection}
-                teacherId={teacherId}
-                teacherName={teacherName}
-                teacherEmail={teacherEmail}
-                showInvalidError={this.state.showCensusInvalidError}
-                showUnknownError={this.state.showCensusUnknownError}
-                submittedSuccessfully={this.state.censusSubmittedSuccessfully}
-                onSubmit={() => this.handleCensusBannerSubmit()}
-                onDismiss={() => this.dismissAndHideCensusBanner()}
-                onPostpone={() => this.postponeCensusBanner()}
-                onTeachesChange={event =>
-                  this.handleCensusBannerTeachesChange(event)
-                }
-                onInClassChange={event =>
-                  this.handleCensusBannerInClassChange(event)
-                }
-              />
-              <br />
-            </div>
-          )}
-          {showDonorBanner && (
-            <div>
-              <DonorTeacherBanner
-                showPegasusLink={true}
-                source="teacher_home"
-              />
-              <div style={styles.clear} />
-            </div>
-          )}
-          <TeacherSections />
-          <RecentCourses
-            courses={courses}
-            topCourse={topCourse}
-            showAllCoursesLink={true}
-            isTeacher={true}
-          />
-          <TeacherResources />
-          <ProjectWidgetWithData
-            canViewFullList={true}
-            canViewAdvancedTools={canViewAdvancedTools}
-          />
-          <StudentSections initialSections={joinedSections} isTeacher={true} />
-        </div>
+        {displayCensusBanner && (
+          <div>
+            <CensusTeacherBanner
+              ref={censusBanner}
+              schoolYear={schoolYear}
+              ncesSchoolId={ncesSchoolId}
+              question={censusQuestion}
+              teaches={censusBannerTeachesSelection}
+              inClass={censusBannerInClassSelection}
+              teacherId={teacherId}
+              teacherName={teacherName}
+              teacherEmail={teacherEmail}
+              showInvalidError={showCensusInvalidError}
+              showUnknownError={showCensusUnknownError}
+              submittedSuccessfully={censusSubmittedSuccessfully}
+              onSubmit={() => handleCensusBannerSubmit()}
+              onDismiss={() => dismissAndHideCensusBanner()}
+              onPostpone={() => postponeCensusBanner()}
+              onTeachesChange={event =>
+                setCensusBannerTeachesSelection(
+                  event.target.id === 'teachesYes'
+                )
+              }
+              onInClassChange={event =>
+                setCensusBannerInClassSelection(event.target.id === 'inClass')
+              }
+            />
+            <br />
+          </div>
+        )}
+        {showDonorBanner && (
+          <div>
+            <DonorTeacherBanner showPegasusLink={true} source="teacher_home" />
+            <div style={styles.clear} />
+          </div>
+        )}
+        <TeacherSections />
+        <RecentCourses
+          courses={courses}
+          topCourse={topCourse}
+          showAllCoursesLink={true}
+          isTeacher={true}
+        />
+        <TeacherResources />
+        <ProjectWidgetWithData
+          canViewFullList={true}
+          canViewAdvancedTools={canViewAdvancedTools}
+        />
+        <StudentSections initialSections={joinedSections} isTeacher={true} />
       </div>
-    );
-  }
-}
+    </div>
+  );
+};
+
+UnconnectedTeacherHomepage.propTypes = {
+  announcement: shapes.teacherAnnouncement,
+  canViewAdvancedTools: PropTypes.bool,
+  censusQuestion: PropTypes.oneOf(['how_many_10_hours', 'how_many_20_hours']),
+  courses: shapes.courses,
+  donorBannerName: PropTypes.string,
+  hocLaunch: PropTypes.string,
+  isEnglish: PropTypes.bool.isRequired,
+  joinedSections: shapes.sections,
+  ncesSchoolId: PropTypes.string,
+  queryStringOpen: PropTypes.string,
+  schoolYear: PropTypes.number,
+  showCensusBanner: PropTypes.bool.isRequired,
+  showNpsSurvey: PropTypes.bool,
+  specialAnnouncement: shapes.specialAnnouncement,
+  teacherEmail: PropTypes.string,
+  teacherId: PropTypes.number,
+  teacherName: PropTypes.string,
+  topCourse: shapes.topCourse,
+  beginGoogleImportRosterFlow: PropTypes.func
+};
 
 const styles = {
   clear: {

--- a/apps/test/unit/templates/studioHomepages/TeacherHomepageTest.js
+++ b/apps/test/unit/templates/studioHomepages/TeacherHomepageTest.js
@@ -6,17 +6,27 @@ import {UnconnectedTeacherHomepage as TeacherHomepage} from '@cdo/apps/templates
 import TeacherSections from '@cdo/apps/templates/studioHomepages/TeacherSections';
 import {courses, topCourse} from './homepagesTestData';
 
-describe('TeacherHomepage', () => {
-  const TEST_PROPS = {
-    announcements: [],
-    courses,
-    topCourse,
-    codeOrgUrlPrefix: 'http://localhost:3000',
-    joinedSections: [],
-    isEnglish: true,
-    showCensusBanner: false
-  };
+const DEFAULT_PROPS = {
+  announcements: [],
+  censusQuestion: 'how_many_10_hours',
+  courses,
+  topCourse,
+  isEnglish: true,
+  joinedSections: [],
+  ncesSchoolId: 'school-id',
+  schoolYear: 2021,
+  showCensusBanner: false,
+  teacherId: 1,
+  teacherEmail: 'teacher@code.org',
+  teacherName: 'Teacher'
+};
 
+const setUp = (overrideProps = {}) => {
+  const props = {...DEFAULT_PROPS, ...overrideProps};
+  return shallow(<TeacherHomepage {...props} />);
+};
+
+describe('TeacherHomepage', () => {
   let server;
   const successResponse = () => [
     200,
@@ -31,7 +41,7 @@ describe('TeacherHomepage', () => {
   afterEach(() => server.restore());
 
   it('shows a non-extended Header Banner that says My Dashboard', () => {
-    const wrapper = shallow(<TeacherHomepage {...TEST_PROPS} />);
+    const wrapper = setUp();
     const headerBanner = wrapper.find('Connect(HeaderBanner)');
     assert.deepEqual(headerBanner.props(), {
       headingText: 'My Dashboard',
@@ -40,23 +50,69 @@ describe('TeacherHomepage', () => {
     });
   });
 
-  it('references 2 ProtectedStatefulDivs', () => {
-    const wrapper = shallow(<TeacherHomepage {...TEST_PROPS} />);
+  it('renders 2 ProtectedStatefulDivs', () => {
+    const wrapper = setUp();
     assert.lengthOf(wrapper.find('ProtectedStatefulDiv'), 2);
   });
 
+  it('renders a NpsSurveyBlock if showNpsSurvey is true', () => {
+    const wrapper = setUp({showNpsSurvey: true});
+    assert(wrapper.find('NpsSurveyBlock').exists());
+  });
+
+  it('renders a SpecialAnnouncementActionBlock if isEnglish and specialAnnouncement exists', () => {
+    const specialAnnouncement = {
+      title: 'An announcement',
+      image: '/image',
+      body: 'body',
+      buttonUrl: '/button',
+      buttonText: 'press me'
+    };
+    const wrapper = setUp({
+      isEnglish: true,
+      specialAnnouncement
+    });
+    assert(wrapper.find('SpecialAnnouncementActionBlock').exists());
+  });
+
+  // Notifications are configured not to be rendered right now with showAnnouncement = false
+  it('does not render a Notification', () => {
+    const announcement = {
+      heading: 'heading',
+      buttonText: 'press me',
+      description: 'description',
+      link: '/link',
+      image: '/image',
+      id: 'id'
+    };
+    const wrapper = setUp({
+      announcement
+    });
+    assert(!wrapper.find('Notification').exists());
+  });
+
+  it('renders a SpecialAnnouncement if isEnglish and there is no specialAnnouncement', () => {
+    const wrapper = setUp({specialAnnouncement: null, isEnglish: true});
+    assert(wrapper.find('SpecialAnnouncement').exists());
+  });
+
+  it('renders a CensusTeacherBanner if showCensusBanner is true', () => {
+    const wrapper = setUp({showCensusBanner: true});
+    assert(wrapper.find('CensusTeacherBanner').exists());
+  });
+
+  it('renders a DonorTeacherBanner if isEnglish and donorBannerName exists', () => {
+    const wrapper = setUp({isEnglish: true, donorBannerName: 'Donor Name'});
+    assert(wrapper.find('DonorTeacherBanner').exists());
+  });
+
   it('renders a TeacherSections component', () => {
-    const wrapper = shallow(<TeacherHomepage {...TEST_PROPS} />);
+    const wrapper = setUp();
     assert(wrapper.containsMatchingElement(<TeacherSections />));
   });
 
-  it('renders a StudentSections component', () => {
-    const wrapper = shallow(<TeacherHomepage {...TEST_PROPS} />);
-    assert(wrapper.find('StudentSections').exists());
-  });
-
   it('renders a RecentCourses component', () => {
-    const wrapper = shallow(<TeacherHomepage {...TEST_PROPS} />);
+    const wrapper = setUp();
     const recentCourses = wrapper.find('RecentCourses');
     assert.deepEqual(recentCourses.props(), {
       showAllCoursesLink: true,
@@ -67,8 +123,18 @@ describe('TeacherHomepage', () => {
     });
   });
 
-  it('shows ProjectWidgetWithData component', () => {
-    const wrapper = shallow(<TeacherHomepage {...TEST_PROPS} />);
+  it('renders a TeacherResources component', () => {
+    const wrapper = setUp();
+    assert(wrapper.find('TeacherResources').exists());
+  });
+
+  it('renders a StudentSections component', () => {
+    const wrapper = setUp();
+    assert(wrapper.find('StudentSections').exists());
+  });
+
+  it('renders ProjectWidgetWithData component', () => {
+    const wrapper = setUp();
     assert(wrapper.find('ProjectWidgetWithData').exists());
   });
 });


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
I wanted to make the teacher homepage banner dismiss-able but decided I'd convert the component to a functional component first. In the process, I discovered the unit tests were seriously lacking so I added a couple of basic unit tests.

## Testing story
Tested locally that census banner and teacher announcements were still working as expected and the page rendered without errors. Also added to the unit tests.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Follow-up work
There is a lot of census banner logic that could be extracted to a different component, but there were enough changes here that I didn't want to add that. It's potential follow-up work that we could do later to further clean up this component.
<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->
<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
