### PR TITLE
Javalab: Fix Teacher review tab bug

### DIFF
--- a/apps/src/templates/instructions/TopInstructions.jsx
+++ b/apps/src/templates/instructions/TopInstructions.jsx
@@ -133,12 +133,16 @@ class TopInstructions extends Component {
       this.props.readOnlyWorkspace &&
       window.location.search.includes('user_id');
 
+    const defaultTeacherTab = this.props.displayReviewTab
+      ? TabType.REVIEW
+      : TabType.COMMENTS;
+
     this.state = {
       // We don't want to start in the comments tab for CSF since its hidden
       tabSelected:
         this.props.initialSelectedTab ||
         (teacherViewingStudentWork && this.props.noInstructionsWhenCollapsed
-          ? TabType.COMMENTS
+          ? defaultTeacherTab
           : TabType.INSTRUCTIONS),
       feedbacks: [],
       rubric: null,

--- a/apps/src/templates/instructions/TopInstructions.jsx
+++ b/apps/src/templates/instructions/TopInstructions.jsx
@@ -133,7 +133,7 @@ class TopInstructions extends Component {
       this.props.readOnlyWorkspace &&
       window.location.search.includes('user_id');
 
-    const defaultTeacherTab = this.props.displayReviewTab
+    const teacherViewingStudentTab = this.props.displayReviewTab
       ? TabType.REVIEW
       : TabType.COMMENTS;
 
@@ -142,7 +142,7 @@ class TopInstructions extends Component {
       tabSelected:
         this.props.initialSelectedTab ||
         (teacherViewingStudentWork && this.props.noInstructionsWhenCollapsed
-          ? defaultTeacherTab
+          ? teacherViewingStudentTab
           : TabType.INSTRUCTIONS),
       feedbacks: [],
       rubric: null,


### PR DESCRIPTION
We had a bug where if a teacher was reviewing student code, on initial load the review tab looked empty:

![Screen Shot 2021-10-07 at 11 36 27 AM](https://user-images.githubusercontent.com/33666587/136476097-016f7d03-eaab-41b1-923c-9a5f009ee6c8.png)

This was because it was trying to set the default tab to `comments` instead of review. Now if the teacher is viewing student code and we are showing the review tab, default to `review`.
## Links

- jira ticket: [CSA-713](https://codedotorg.atlassian.net/browse/CSA-713)


## Testing story
Tested locally for both a CSA and non-CSA level, and both types work (CSA loads the review tab and non-CSA loads feedback).

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
