### PR TITLE
Disable the submit button during code review.

### DIFF
--- a/apps/src/javalab/Javalab.js
+++ b/apps/src/javalab/Javalab.js
@@ -246,7 +246,12 @@ Javalab.prototype.init = function(config) {
 
   getStore().dispatch(
     setDisableFinishButton(
-      !!config.readonlyWorkspace && !config.level.submittable
+      // The "submit" button overrides the finish button on a submittable level. A submittable level
+      // that has been submitted will be considered "readonly" but a student must still be able to
+      // unsubmit it. That is generally the only exception to a readonly workspace. However if a
+      // student is reviewing another student's code, we'd always want to disable the finish button.
+      (!!config.readonlyWorkspace && !config.level.submittable) ||
+        config.isCodeReviewing
     )
   );
 

--- a/apps/src/javalab/Javalab.js
+++ b/apps/src/javalab/Javalab.js
@@ -251,7 +251,7 @@ Javalab.prototype.init = function(config) {
       // unsubmit it. That is generally the only exception to a readonly workspace. However if a
       // student is reviewing another student's code, we'd always want to disable the finish button.
       (!!config.readonlyWorkspace && !config.level.submittable) ||
-        config.isCodeReviewing
+        !!config.isCodeReviewing
     )
   );
 

--- a/apps/test/unit/javalab/javalabTest.js
+++ b/apps/test/unit/javalab/javalabTest.js
@@ -15,7 +15,10 @@ import {
   restoreRedux
 } from '@cdo/apps/redux';
 import commonReducers from '@cdo/apps/redux/commonReducers';
-import {setAllSources} from '@cdo/apps/javalab/javalabRedux';
+import {
+  setAllSources,
+  setDisableFinishButton
+} from '@cdo/apps/javalab/javalabRedux';
 
 describe('Javalab', () => {
   let javalab;
@@ -62,6 +65,49 @@ describe('Javalab', () => {
       expect(eventStub.returnValue).to.equal('');
 
       project.hasOwnerChangedProject.restore();
+    });
+  });
+
+  describe('finish button', () => {
+    it('is disabled when reviewing code', () => {
+      config.isCodeReviewing = true;
+      javalab.init(config);
+      expect(getStore().dispatch).to.have.been.calledWith(
+        setDisableFinishButton(true)
+      );
+    });
+
+    it('is disabled on readonly workspaces', () => {
+      config.readonlyWorkspace = true;
+      javalab.init(config);
+      expect(getStore().dispatch).to.have.been.calledWith(
+        setDisableFinishButton(true)
+      );
+    });
+
+    it('is disabled when reviewing code on submittable levels', () => {
+      config.isCodeReviewing = true;
+      config.level.submittable = true;
+      javalab.init(config);
+      expect(getStore().dispatch).to.have.been.calledWith(
+        setDisableFinishButton(true)
+      );
+    });
+
+    it('is enabled on submitted levels', () => {
+      config.readonlyWorkspace = true;
+      config.level.submittable = true;
+      javalab.init(config);
+      expect(getStore().dispatch).to.have.been.calledWith(
+        setDisableFinishButton(false)
+      );
+    });
+
+    it('is enabled by default', () => {
+      javalab.init(config);
+      expect(getStore().dispatch).to.have.been.calledWith(
+        setDisableFinishButton(false)
+      );
     });
   });
 


### PR DESCRIPTION
This disables the finish/submit button when a student is reviewing another student's code. We normally rely on `isReadonlyWorkspace` to decide whether to disable the finish button during code reviews. However, submit levels need to keep the finish button enabled even in readonly workspaces to allow students to unsubmit a level. This adds another condition to check whether a student is specifically in the code review scenario.

![image](https://user-images.githubusercontent.com/8324574/136480352-c9741f61-807d-4f8b-b52f-f5ddb0b77187.png)


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [CSA-774](https://codedotorg.atlassian.net/browse/CSA-774)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
