### PR TITLE
Translate non-jigsaw HOC lesson plans

### DIFF
--- a/dashboard/lib/services/i18n/curriculum_sync_utils/sync_in.rb
+++ b/dashboard/lib/services/i18n/curriculum_sync_utils/sync_in.rb
@@ -16,7 +16,7 @@ module Services
         # default.
         def self.serialize
           Script.all.each do |script|
-            next unless script.is_migrated? && !script.use_legacy_lesson_plans?
+            next unless script.is_migrated?
             next unless ScriptConstants.i18n? script.name
 
             # prepare data

--- a/dashboard/lib/services/i18n/curriculum_sync_utils/sync_in.rb
+++ b/dashboard/lib/services/i18n/curriculum_sync_utils/sync_in.rb
@@ -16,7 +16,7 @@ module Services
         # default.
         def self.serialize
           Script.all.each do |script|
-            next unless script.is_migrated?
+            next unless script.is_migrated? && !script.name == 'jigsaw'
             next unless ScriptConstants.i18n? script.name
 
             # prepare data

--- a/dashboard/lib/services/i18n/curriculum_sync_utils/sync_in.rb
+++ b/dashboard/lib/services/i18n/curriculum_sync_utils/sync_in.rb
@@ -16,7 +16,7 @@ module Services
         # default.
         def self.serialize
           Script.all.each do |script|
-            next unless script.is_migrated? && !script.name == 'jigsaw'
+            next unless script.is_migrated? && !(script.name == 'jigsaw')
             next unless ScriptConstants.i18n? script.name
 
             # prepare data


### PR DESCRIPTION
## Background

The curriculum team has finished editing all HOC lesson plans on code studio, with the exception of jigsaw. because time is short, this means we want to start translating all HOC lesson plans besides jigsaw starting with this Sunday's translation sync. Please see https://github.com/code-dot-org/code-dot-org/pull/42546 for more background.

## Description

1. permanently remove the `use_legacy_lesson_plan` flag from the sync_in logic. As far as we know, we are done migrating lesson plans from curriculum builder to code studio for live, translated scripts.
2. temporarily make an exception for jigsaw, since this is the one HOC lesson which is not yet ready to be translated.

if you don't like the special case for jigsaw in the sync-in code, I could instead temporarily modify `ScriptConstants.i18n?` to return false for jigsaw. however, I'd need someone familiar with i18n to assure me that this wouldn't mess up any other existing translations related to jigsaw.

## Testing story

not tested. please let me know if I can help with this

## Deployment strategy

This PR needs to be merged today to keep translations on track for Hour of Code. 

## Follow-up work

Next week, I'll merge https://github.com/code-dot-org/code-dot-org/pull/42904 to re-enable translations for jigsaw lesson plans.