### PR TITLE
Sprite Upload - Small fixes - Category, content-type, and filename

### DIFF
--- a/apps/src/code-studio/assets/SpriteUpload.jsx
+++ b/apps/src/code-studio/assets/SpriteUpload.jsx
@@ -108,8 +108,9 @@ export default class SpriteUpload extends React.Component {
   generateMetadata = () => {
     const {filename, aliases, category} = this.state;
     let image = this.refs.spritePreview;
+    let name = filename.split('.')[0];
     let metadata = {
-      name: filename,
+      name: name,
       aliases: aliases,
       frameCount: 1,
       frameSize: {x: image.clientWidth, y: image.clientHeight},

--- a/apps/src/code-studio/assets/SpriteUpload.jsx
+++ b/apps/src/code-studio/assets/SpriteUpload.jsx
@@ -108,9 +108,8 @@ export default class SpriteUpload extends React.Component {
   generateMetadata = () => {
     const {filename, aliases, category} = this.state;
     let image = this.refs.spritePreview;
-    let name = filename.split('.')[0];
     let metadata = {
-      name: name,
+      name: filename.split('.')[0],
       aliases: aliases,
       frameCount: 1,
       frameSize: {x: image.clientWidth, y: image.clientHeight},

--- a/apps/src/code-studio/assets/SpriteUpload.jsx
+++ b/apps/src/code-studio/assets/SpriteUpload.jsx
@@ -106,7 +106,7 @@ export default class SpriteUpload extends React.Component {
   };
 
   generateMetadata = () => {
-    const {filename, aliases} = this.state;
+    const {filename, aliases, category} = this.state;
     let image = this.refs.spritePreview;
     let metadata = {
       name: filename,
@@ -114,7 +114,8 @@ export default class SpriteUpload extends React.Component {
       frameCount: 1,
       frameSize: {x: image.clientWidth, y: image.clientHeight},
       looping: true,
-      frameDelay: 2
+      frameDelay: 2,
+      categories: [category]
     };
     this.setState({metadata: JSON.stringify(metadata)});
   };

--- a/shared/middleware/animation_library_api.rb
+++ b/shared/middleware/animation_library_api.rb
@@ -51,7 +51,7 @@ class AnimationLibraryApi < Sinatra::Base
       body = request.body
       key = "level_animations/#{animation_name}"
 
-      Aws::S3::Bucket.new(ANIMATION_LIBRARY_BUCKET).put_object(key: key, body: body)
+      Aws::S3::Bucket.new(ANIMATION_LIBRARY_BUCKET).put_object(key: key, body: body, content_type: request.content_type)
     else
       bad_request
     end
@@ -67,7 +67,7 @@ class AnimationLibraryApi < Sinatra::Base
       body = request.body
       key = "spritelab/#{category}/#{animation_name}"
 
-      Aws::S3::Bucket.new(ANIMATION_LIBRARY_BUCKET).put_object(key: key, body: body)
+      Aws::S3::Bucket.new(ANIMATION_LIBRARY_BUCKET).put_object(key: key, body: body, content_type: request.content_type)
     else
       bad_request
     end
@@ -138,7 +138,7 @@ class AnimationLibraryApi < Sinatra::Base
       body = request.body.string
       key = ANIMATION_DEFAULT_MANIFEST_LEVELBUILDER
 
-      Aws::S3::Bucket.new(ANIMATION_LIBRARY_BUCKET).put_object(key: key, body: body)
+      Aws::S3::Bucket.new(ANIMATION_LIBRARY_BUCKET).put_object(key: key, body: body, content_type: request.content_type)
     else
       bad_request
     end
@@ -154,7 +154,7 @@ class AnimationLibraryApi < Sinatra::Base
       body = request.body.string
       key = ANIMATION_DEFAULT_MANIFEST_JSON_LEVELBUILDER
 
-      Aws::S3::Bucket.new(ANIMATION_LIBRARY_BUCKET).put_object(key: key, body: body)
+      Aws::S3::Bucket.new(ANIMATION_LIBRARY_BUCKET).put_object(key: key, body: body, content_type: request.content_type)
     else
       bad_request
     end


### PR DESCRIPTION
After using the Sprite Upload system to get new sprites up, I found some issues that need fixing. This PR covers three of them.

* The sprite name in the metadata should not include the filetype.
* The Sprite files and metadata files that are added to S3 need to have the content-type enforced.
* The metadata should include the categories to which the sprite gets added.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
