### PR TITLE
Add Firehose Event for Tracking Archiving/Restoring Sections

### DIFF
--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
@@ -179,8 +179,15 @@ export const toggleSectionHidden = sectionId => (dispatch, getState) => {
   const currentlyHidden = getRoot(state).sections[sectionId].hidden;
   dispatch(editSectionProperties({hidden: !currentlyHidden}));
 
-  // ADD FIREHOSE EVENT HERE
-
+  // Track archive/restore section action
+  firehoseClient.putRecord({
+    study: 'teacher_dashboard_actions',
+    study_group: 'toggleSectionHidden',
+    event: currentlyHidden ? 'restoreSection' : 'archiveSection',
+    data_json: JSON.stringify({
+      section_id: sectionId
+    })
+  });
   return dispatch(finishEditingSection());
 };
 

--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
@@ -178,6 +178,9 @@ export const toggleSectionHidden = sectionId => (dispatch, getState) => {
   const state = getState();
   const currentlyHidden = getRoot(state).sections[sectionId].hidden;
   dispatch(editSectionProperties({hidden: !currentlyHidden}));
+
+  // ADD FIREHOSE EVENT HERE
+
   return dispatch(finishEditingSection());
 };
 


### PR DESCRIPTION
Add a Firehose event that tracks when teachers archive or restore (a.k.a. un-archive) their sections. This is part of a multi-step process to rebrand archiving and removing sections so that those two actions do what teachers expect them to do (since there is confusion on what actually happens behind the scenes when sections are archived vs. removed). This Firehose event will help track what teachers do in regards to their sections relating to archiving/restoring sections.

The Firehose event tracks:
- Whether the teacher is archiving the section or restoring it
- The id of the section being modified
- Time stamp of the action

## Links
Small component at the end of [this spec](https://docs.google.com/document/d/1bSG8FV6OpBZBQPLA63tTN9oJ9gCk7vkC_S-neQ7Dnws/edit#) on archiving/removing sections doing what teachers expect them to do.

## Testing story
Manually tested in multiple browsers to ensure a firehose event with the correct information is logged.

Archiving section Firehose log in Chrome example:
![Archive example](https://user-images.githubusercontent.com/56283563/136599402-da82ee5b-e0f7-48cf-a89f-2d13bb764a29.JPG)

Restoring section Firehose log in Chrome example:
![Restore example](https://user-images.githubusercontent.com/56283563/136599416-5d194f4c-03de-49ab-ae47-0b6b5a1f92be.JPG)

## Follow-up work
In general, continue to work on the components of the spec above but nothing specific to this firehose event at the moment.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
