### PR TITLE
Make teacher banner dismiss-able

### DIFF
--- a/apps/src/templates/studioHomepages/MarketingAnnouncementBanner.jsx
+++ b/apps/src/templates/studioHomepages/MarketingAnnouncementBanner.jsx
@@ -10,7 +10,7 @@ import shapes from './shapes';
 // a button to dismiss the banner. It also listens for modifications to the banner through
 // optimizely and checks if the new version of the banner has been dismissed.
 const MarketingAnnouncementBanner = ({announcement, marginBottom}) => {
-  const id = 'special-annoucement-action-block';
+  const id = 'special-announcement-action-block';
   const [displayBanner, setDisplayBanner] = useState(true);
 
   useEffect(() => {
@@ -32,10 +32,33 @@ const MarketingAnnouncementBanner = ({announcement, marginBottom}) => {
   };
 
   const getLocalStorageBannerKey = () => {
-    // The banner ID will be modified by marketing when they create a variation of the banner
-    // in optimizely, so we query it from the DOM instead of storing it in the component
-    const bannerId = document.getElementById(id).dataset.bannerId;
+    let bannerId = announcement.id;
+
+    const optimizelyId = getOptimizelyModifiedElementId();
+    if (optimizelyId) {
+      bannerId = optimizelyId;
+    }
+
     return `display-announcement-${bannerId}`;
+  };
+
+  const getOptimizelyModifiedElementId = () => {
+    const allBannerElements = document.getElementById(id).querySelectorAll('*');
+
+    const getOptlyDataAttrKey = element => {
+      return Object.keys(element.dataset).find(key => key.includes('optly'));
+    };
+
+    // Finds an element that was modified by optimizely if one exists
+    const optlyModifiedElement = [...allBannerElements].find(el =>
+      getOptlyDataAttrKey(el)
+    );
+
+    if (optlyModifiedElement) {
+      // Returns the optimizely data attribute key for the changed element
+      // will be something like optly-0ef57bf5F12b-4290A4dbA1de95a9b5cd
+      return getOptlyDataAttrKey(optlyModifiedElement);
+    }
   };
 
   const onDismiss = () => {
@@ -52,20 +75,18 @@ const MarketingAnnouncementBanner = ({announcement, marginBottom}) => {
 
   return (
     <div
-      id={id}
-      // When marketing makes a variation of the banner they will
-      // update the data-banner-id, we will track variations of the banner
-      // through this data attribute
-      data-banner-id={announcement.id}
+      id="homepage-banner"
       style={{
         ...styles.container,
         display: bannerDisplayStyle
       }}
     >
-      <SpecialAnnouncementActionBlock
-        announcement={announcement}
-        marginBottom={marginBottom}
-      />
+      <div id={id}>
+        <SpecialAnnouncementActionBlock
+          announcement={announcement}
+          marginBottom={marginBottom}
+        />
+      </div>
       <Button
         text="×"
         onClick={onDismiss}

--- a/apps/src/templates/studioHomepages/MarketingAnnouncementBanner.jsx
+++ b/apps/src/templates/studioHomepages/MarketingAnnouncementBanner.jsx
@@ -1,0 +1,97 @@
+import PropTypes from 'prop-types';
+import React, {useState, useEffect} from 'react';
+import {SpecialAnnouncementActionBlock} from './TwoColumnActionBlock';
+import {tryGetLocalStorage, trySetLocalStorage} from '@cdo/apps/utils';
+import Button from '@cdo/apps/templates/Button';
+import color from '../../util/color';
+import shapes from './shapes';
+
+// MarketingAnnouncementBanner is a wrapper around SpecialAnnouncementActionBlock which adds
+// a button to dismiss the banner. It also listens for modifications to the banner through
+// optimizely and checks if the new version of the banner has been dismissed.
+const MarketingAnnouncementBanner = ({announcement, marginBottom}) => {
+  const id = 'special-annoucement-action-block';
+  const [displayBanner, setDisplayBanner] = useState(true);
+
+  useEffect(() => {
+    if (window['optimizely']) {
+      const optimizelyUtils = window['optimizely'].get('utils');
+      // When modifications are made to the banner through optimizely, check whether
+      // this version of the banner has been dismissed by the teacher
+      optimizelyUtils.observeSelector(`#${id}`, checkShouldDisplayBanner);
+    }
+    checkShouldDisplayBanner();
+  }, []);
+
+  const checkShouldDisplayBanner = () => {
+    const bannerKey = getLocalStorageBannerKey();
+    const displayBanner = tryGetLocalStorage(bannerKey, true);
+    if (displayBanner === 'false') {
+      setDisplayBanner(false);
+    }
+  };
+
+  const getLocalStorageBannerKey = () => {
+    // The banner ID will be modified by marketing when they create a variation of the banner
+    // in optimizely, so we query it from the DOM instead of storing it in the component
+    const bannerId = document.getElementById(id).dataset.bannerId;
+    return `display-announcement-${bannerId}`;
+  };
+
+  const onDismiss = () => {
+    const bannerKey = getLocalStorageBannerKey();
+    trySetLocalStorage(bannerKey, false);
+    setDisplayBanner(false);
+  };
+
+  // This banner is hidden through css because it still needs to be accessible
+  // in the DOM so that it can be manipulated by Optimizely by marketing.
+  // Once it has been modified through optimizely, checkShouldDisplayBanner is called
+  // and the value of displayBanner may change.
+  const bannerDisplayStyle = displayBanner ? 'block' : 'none';
+
+  return (
+    <div
+      id={id}
+      // When marketing makes a variation of the banner they will
+      // update the data-banner-id, we will track variations of the banner
+      // through this data attribute
+      data-banner-id={announcement.id}
+      style={{
+        ...styles.container,
+        display: bannerDisplayStyle
+      }}
+    >
+      <SpecialAnnouncementActionBlock
+        announcement={announcement}
+        marginBottom={marginBottom}
+      />
+      <Button
+        text="×"
+        onClick={onDismiss}
+        style={styles.dismissButtonStyle}
+        styleAsText={true}
+      />
+    </div>
+  );
+};
+
+const styles = {
+  container: {
+    position: 'relative'
+  },
+  dismissButtonStyle: {
+    position: 'absolute',
+    top: '6px',
+    right: '10px',
+    color: color.charcoal,
+    fontSize: '22px'
+  }
+};
+
+MarketingAnnouncementBanner.propTypes = {
+  announcement: shapes.specialAnnouncement,
+  marginBottom: PropTypes.string
+};
+
+export default MarketingAnnouncementBanner;

--- a/apps/src/templates/studioHomepages/TeacherHomepage.jsx
+++ b/apps/src/templates/studioHomepages/TeacherHomepage.jsx
@@ -3,7 +3,6 @@ import React, {useState, useEffect, useRef} from 'react';
 import {connect} from 'react-redux';
 import $ from 'jquery';
 import HeaderBanner from '../HeaderBanner';
-import SpecialAnnouncement from './SpecialAnnouncement';
 import Notification from '../Notification';
 import MarketingAnnouncementBanner from './MarketingAnnouncementBanner';
 import RecentCourses from './RecentCourses';
@@ -134,11 +133,6 @@ export const UnconnectedTeacherHomepage = ({
   // Whether we show the regular announcement/notification
   const showAnnouncement = false;
 
-  // Whether we show the fallback (translatable) SpecialAnnouncement if there is no
-  // specialAnnouncement passed in as a prop. Currently we only show the fallback for
-  // English-speaking teachers.
-  const showFallbackSpecialAnnouncement = true;
-
   // Verify background image works for both LTR and RTL languages.
   const backgroundUrl = '/shared/images/banners/teacher-homepage-hero.jpg';
 
@@ -177,14 +171,6 @@ export const UnconnectedTeacherHomepage = ({
           </div>
         )}
         {!showAnnouncement && <br />}
-        {/* The current fallback announcement is for English-speaking teachers only. This announcement type
-        is designed to be translatable and in the future can be used for non-English teachers as a fallback
-        to the marketing-configured announcement. */}
-        {showFallbackSpecialAnnouncement &&
-          isEnglish &&
-          !specialAnnouncement && (
-            <SpecialAnnouncement isEnglish={isEnglish} isTeacher={true} />
-          )}
         {displayCensusBanner && (
           <div>
             <CensusTeacherBanner

--- a/apps/src/templates/studioHomepages/TeacherHomepage.jsx
+++ b/apps/src/templates/studioHomepages/TeacherHomepage.jsx
@@ -5,7 +5,7 @@ import $ from 'jquery';
 import HeaderBanner from '../HeaderBanner';
 import SpecialAnnouncement from './SpecialAnnouncement';
 import Notification from '../Notification';
-import {SpecialAnnouncementActionBlock} from './TwoColumnActionBlock';
+import MarketingAnnouncementBanner from './MarketingAnnouncementBanner';
 import RecentCourses from './RecentCourses';
 import TeacherSections from './TeacherSections';
 import StudentSections from './StudentSections';
@@ -156,7 +156,7 @@ export const UnconnectedTeacherHomepage = ({
         <ProtectedStatefulDiv ref={teacherReminders} />
         {showNpsSurvey && <NpsSurveyBlock />}
         {isEnglish && specialAnnouncement && (
-          <SpecialAnnouncementActionBlock
+          <MarketingAnnouncementBanner
             announcement={specialAnnouncement}
             marginBottom="30px"
           />

--- a/apps/src/templates/studioHomepages/shapes.jsx
+++ b/apps/src/templates/studioHomepages/shapes.jsx
@@ -42,6 +42,7 @@ const shapes = {
     id: PropTypes.string.isRequired
   }),
   specialAnnouncement: PropTypes.shape({
+    id: PropTypes.string,
     image: PropTypes.string.isRequired,
     title: PropTypes.string.isRequired,
     body: PropTypes.string.isRequired,

--- a/apps/test/unit/templates/studioHomepages/MarketingAnnouncementBannerTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/MarketingAnnouncementBannerTest.jsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import {Provider} from 'react-redux';
+import {expect} from '../../../util/reconfiguredChai';
+import {shallow, mount} from 'enzyme';
+import MarketingAnnouncementBanner from '@cdo/apps/templates/studioHomepages/MarketingAnnouncementBanner';
+import * as utils from '@cdo/apps/utils';
+import sinon from 'sinon';
+import {createStore, combineReducers} from 'redux';
+import isRtl from '@cdo/apps/code-studio/isRtlRedux';
+import responsive from '@cdo/apps/code-studio/responsiveRedux';
+
+const DEFAULT_PROPS = {
+  announcement: {
+    id: 'announcement-id',
+    image: '/image',
+    title: 'Announcement Title',
+    body: 'Descriptive information..',
+    buttonUrl: '/takemehere',
+    buttonText: 'Click me'
+  },
+  marginBottom: '20px'
+};
+
+const setUpShallow = (overrideProps = {}) => {
+  const props = {...DEFAULT_PROPS, ...overrideProps};
+  return shallow(<MarketingAnnouncementBanner {...props} />);
+};
+
+const store = createStore(combineReducers({isRtl, responsive}));
+
+before(() => {
+  // Avoid `attachTo: document.body` Warning
+  const div = document.createElement('div');
+  div.setAttribute('id', 'container');
+  document.body.appendChild(div);
+});
+
+after(() => {
+  const div = document.getElementById('container');
+  if (div) {
+    document.body.removeChild(div);
+  }
+});
+
+const setUpMount = (overrideProps = {}) => {
+  const props = {...DEFAULT_PROPS, ...overrideProps};
+
+  // A child of MarketingAnnouncementBanner requires the redux store
+  // and we need to mount to be able to test changes based on click interations
+  return mount(
+    <Provider store={store}>
+      <MarketingAnnouncementBanner {...props} />
+    </Provider>,
+    {attachTo: document.getElementById('container')}
+  );
+};
+
+const isBannerDisplayed = wrapper => {
+  return wrapper.find('#homepage-banner').props().style.display === 'block';
+};
+
+describe('MarketingAnnouncementBanner', () => {
+  it('if banner has not been dismissed, banner is displayed', () => {
+    sinon.stub(utils, 'tryGetLocalStorage').returns(null);
+
+    const wrapper = setUpShallow();
+    expect(isBannerDisplayed(wrapper)).to.be.true;
+    utils.tryGetLocalStorage.restore();
+  });
+
+  it('if banner has been dismissed, banner is not displayed', () => {
+    sinon.stub(utils, 'tryGetLocalStorage').returns('false');
+
+    const wrapper = setUpMount();
+    expect(isBannerDisplayed(wrapper)).to.be.false;
+
+    utils.tryGetLocalStorage.restore();
+  });
+
+  it('when banner is being displayed, clicking button hides banner', () => {
+    sinon.stub(utils, 'tryGetLocalStorage').returns(null);
+
+    const wrapper = setUpShallow();
+    wrapper.find('Button').simulate('click');
+    expect(isBannerDisplayed(wrapper)).to.be.false;
+
+    utils.tryGetLocalStorage.restore();
+  });
+
+  it('when banner is being displayed, clicking sets local storage', () => {
+    sinon.stub(utils, 'tryGetLocalStorage').returns(null);
+
+    const setLocalStorageSpy = sinon.spy(utils, 'trySetLocalStorage');
+    const wrapper = setUpShallow();
+    wrapper.find('Button').simulate('click');
+    expect(setLocalStorageSpy.calledOnce);
+
+    utils.tryGetLocalStorage.restore();
+  });
+});

--- a/apps/test/unit/templates/studioHomepages/TeacherHomepageTest.js
+++ b/apps/test/unit/templates/studioHomepages/TeacherHomepageTest.js
@@ -91,11 +91,6 @@ describe('TeacherHomepage', () => {
     assert(!wrapper.find('Notification').exists());
   });
 
-  it('renders a SpecialAnnouncement if isEnglish and there is no specialAnnouncement', () => {
-    const wrapper = setUp({specialAnnouncement: null, isEnglish: true});
-    assert(wrapper.find('SpecialAnnouncement').exists());
-  });
-
   it('renders a CensusTeacherBanner if showCensusBanner is true', () => {
     const wrapper = setUp({showCensusBanner: true});
     assert(wrapper.find('CensusTeacherBanner').exists());

--- a/dashboard/lib/announcements.rb
+++ b/dashboard/lib/announcements.rb
@@ -17,10 +17,11 @@ class Announcements
     return nil if @@load_error || !@@announcements_data
     pages = @@announcements_data[:pages]
     banners = @@announcements_data[:banners]
-    return nil unless pages[page]
+    banner_id_for_page = pages[page]
+    return nil unless banner_id_for_page
 
-    banner = banners[pages[page]]
-    banner ? banner : nil
+    banner = banners[banner_id_for_page]
+    banner ? banner.merge({"id": banner_id_for_page}) : nil
   end
 
   def self.load_announcements

--- a/dashboard/test/lib/announcements_test.rb
+++ b/dashboard/test/lib/announcements_test.rb
@@ -14,6 +14,7 @@ class AnnouncementsTest < ActiveSupport::TestCase
     assert_equal("Join us", announcement[:buttonText])
     assert_equal("https://code.org/educate/professional-learning/middle-high", announcement[:buttonUrl])
     assert_equal("teacher-apps-open-2021-sign-up", announcement[:buttonId])
+    assert_equal("teacher-apps-open-2021", announcement[:id])
   end
 
   test 'gets home announcement' do
@@ -28,6 +29,7 @@ class AnnouncementsTest < ActiveSupport::TestCase
     assert_equal("Join us 2!", announcement[:buttonText2])
     assert_equal("https://code.org/educate/professional-learning", announcement[:buttonUrl2])
     assert_equal("teacher-apps-closing-2020-sign-up-2", announcement[:buttonId2])
+    assert_equal("teacher-apps-closing-2020", announcement[:id])
   end
 
   test 'returns nil for invalid banner id' do


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Adds a new button on the top right of the teacher banner which will dismiss the banner.
![Screen Shot 2021-10-08 at 12 23 48 PM](https://user-images.githubusercontent.com/24235215/136614489-ebb2242a-a8cb-4add-b1b1-6491df69abae.png)

The dismiss action will store whether the banner has been dismissed in local browser storage. If the banner has been modified by Optimizely, we will find the Optimizely HTML data attribute which corresponds to the modification and set the local storage value based on the attribute so that we can properly track which variation of the banner has been dismissed.

Video of Optimizely-changed banner loading, being dismissed and page reloading with dismissed optimizely banner:

https://user-images.githubusercontent.com/24235215/137013120-d789618d-cbb8-4ebb-92c7-6c4cc6c7ab12.mov

## Links
- jira ticket: [LP-2039](https://codedotorg.atlassian.net/browse/LP-2039)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()

-->

## Testing story
Tested locally and added unit tests. I also set up an Optimizely experiment targeting localhost to test with an active Optimizely experiment.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
