### PR TITLE
Fix searching for levels with name blockly

### DIFF
--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -112,7 +112,7 @@ class LevelsController < ApplicationController
   def filter_levels(params)
     # Gather filtered search results
     @levels = @levels.order(updated_at: :desc)
-    @levels = @levels.where('levels.name LIKE ?', "%#{params[:name]}%") if params[:name]
+    @levels = @levels.where('levels.name LIKE ?', "%#{params[:name]}%").or(@levels.where('levels.level_num LIKE ?', "%#{params[:name]}%")) if params[:name]
     @levels = @levels.where('levels.type = ?', params[:level_type]) if params[:level_type].present?
     @levels = @levels.joins(:script_levels).where('script_levels.script_id = ?', params[:script_id]) if params[:script_id].present?
     @levels = @levels.left_joins(:user).where('levels.user_id = ?', params[:owner_id]) if params[:owner_id].present?

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -594,7 +594,7 @@ class Level < ApplicationRecord
     {
       id: id.to_s,
       type: self.class.to_s,
-      name: name,
+      name: name == 'blockly' ? level_num : name,
       updated_at: updated_at.localtime.strftime("%D at %r"),
       owner: user&.name,
       url: "/levels/#{id}/edit",

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -78,6 +78,13 @@ class LevelsControllerTest < ActionController::TestCase
     assert_equal 22, JSON.parse(@response.body)['numPages']
   end
 
+  test "should get filtered levels with name matching level_num for blockly levels" do
+    create(:level, name: 'blockly', level_num: 'special_blockly_level')
+
+    get :get_filtered_levels, params: {name: 'special_blockly_level'}
+    assert_equal 'special_blockly_level', JSON.parse(@response.body)['levels'][0]["name"]
+  end
+
   test "should get filtered levels with level_type" do
     existing_levels_count = Odometer.all.count
     level = create(:level, type: 'Odometer')

--- a/dashboard/test/models/level_test.rb
+++ b/dashboard/test/models/level_test.rb
@@ -163,6 +163,14 @@ class LevelTest < ActiveSupport::TestCase
     assert_equal(summary[:url], "/levels/#{level.id}/edit")
   end
 
+  test "summarize_for_edit returns level_num for name on blockly level" do
+    blockly_level = create(:level, name: 'blockly', level_num: 'special_blockly_level')
+
+    summary = blockly_level.summarize_for_edit
+
+    assert_equal(summary[:name], 'special_blockly_level')
+  end
+
   test "get_question_text returns question text for free response level" do
     free_response_level = create :level, name: 'A question', long_instructions: 'Answer this question.',
       type: 'FreeResponse'


### PR DESCRIPTION
Dan and Mike pointed out that every old style blockly level was showing with blockly as its name in the AddLevelsDialog. The name we actually want to use for these levels is in the `level_num`. This updates the search and levels list to take level_num into account for these levels.

<img width="1048" alt="Screen Shot 2021-10-08 at 5 24 17 PM" src="https://user-images.githubusercontent.com/208083/136626316-959461a9-51fc-45cb-8453-bdfa435771f8.png">


## Links

Slack: https://codedotorg.slack.com/archives/C02EEGWLHR8/p1633726284200100

## Testing story

- Tested locally
- Existing Tests
- New unit tests