### PR TITLE
Remove unused instructionsDialog redux state

### DIFF
--- a/apps/src/netsim/netsim.js
+++ b/apps/src/netsim/netsim.js
@@ -1407,8 +1407,7 @@ NetSim.prototype.showInstructionsDialog = function() {
   getStore().dispatch(
     openInstructionsDialog({
       autoClose: false,
-      imgOnly: false,
-      hintsOnly: false
+      imgOnly: false
     })
   );
 };

--- a/apps/src/netsim/netsim.js
+++ b/apps/src/netsim/netsim.js
@@ -1404,10 +1404,5 @@ NetSim.prototype.resetShard = function() {
  * Show the instrutions modal dialog on top of the NetSim interface.
  */
 NetSim.prototype.showInstructionsDialog = function() {
-  getStore().dispatch(
-    openInstructionsDialog({
-      autoClose: false,
-      imgOnly: false
-    })
-  );
+  getStore().dispatch(openInstructionsDialog({imgOnly: false}));
 };

--- a/apps/src/redux/instructionsDialog.js
+++ b/apps/src/redux/instructionsDialog.js
@@ -3,7 +3,6 @@ const CLOSE_DIALOG = 'instructionsDialog/CLOSE_DIALOG';
 
 const initialState = {
   open: false,
-  autoClose: false,
   imgOnly: false
 };
 
@@ -14,7 +13,6 @@ export default function reducer(state = initialState, action) {
     }
     return {
       open: true,
-      autoClose: action.autoClose,
       imgOnly: action.imgOnly,
       imgUrl: action.imgUrl
     };
@@ -31,9 +29,8 @@ export default function reducer(state = initialState, action) {
   return state;
 }
 
-export const openDialog = ({autoClose, imgOnly, imgUrl}) => ({
+export const openDialog = ({imgOnly, imgUrl}) => ({
   type: OPEN_DIALOG,
-  autoClose,
   imgOnly,
   imgUrl
 });

--- a/apps/src/redux/instructionsDialog.js
+++ b/apps/src/redux/instructionsDialog.js
@@ -4,8 +4,7 @@ const CLOSE_DIALOG = 'instructionsDialog/CLOSE_DIALOG';
 const initialState = {
   open: false,
   autoClose: false,
-  imgOnly: false,
-  hintsOnly: false
+  imgOnly: false
 };
 
 export default function reducer(state = initialState, action) {
@@ -13,14 +12,10 @@ export default function reducer(state = initialState, action) {
     if (state.open === true) {
       throw new Error('dialog is already open');
     }
-    if (action.imgOnly && action.hintsOnly) {
-      throw new Error('cant have imgOnly and hintsOnly');
-    }
     return {
       open: true,
       autoClose: action.autoClose,
       imgOnly: action.imgOnly,
-      hintsOnly: action.hintsOnly,
       imgUrl: action.imgUrl
     };
   }
@@ -36,11 +31,10 @@ export default function reducer(state = initialState, action) {
   return state;
 }
 
-export const openDialog = ({autoClose, imgOnly, hintsOnly, imgUrl}) => ({
+export const openDialog = ({autoClose, imgOnly, imgUrl}) => ({
   type: OPEN_DIALOG,
   autoClose,
   imgOnly,
-  hintsOnly,
   imgUrl
 });
 

--- a/apps/src/templates/EnhancedSafeMarkdown.jsx
+++ b/apps/src/templates/EnhancedSafeMarkdown.jsx
@@ -43,7 +43,6 @@ export const ExpandableImagesWrapper = connect(
     showImageDialog(imgUrl) {
       dispatch(
         openDialog({
-          autoClose: false,
           imgOnly: true,
           imgUrl
         })

--- a/apps/src/templates/EnhancedSafeMarkdown.jsx
+++ b/apps/src/templates/EnhancedSafeMarkdown.jsx
@@ -45,7 +45,6 @@ export const ExpandableImagesWrapper = connect(
         openDialog({
           autoClose: false,
           imgOnly: true,
-          hintsOnly: false,
           imgUrl
         })
       );

--- a/apps/src/templates/instructions/AniGifPreview.jsx
+++ b/apps/src/templates/instructions/AniGifPreview.jsx
@@ -55,8 +55,7 @@ export default connect(
       dispatch(
         openDialog({
           autoClose: false,
-          imgOnly: true,
-          hintsOnly: false
+          imgOnly: true
         })
       );
     }

--- a/apps/src/templates/instructions/AniGifPreview.jsx
+++ b/apps/src/templates/instructions/AniGifPreview.jsx
@@ -52,12 +52,7 @@ export default connect(
   }),
   dispatch => ({
     showInstructionsDialog() {
-      dispatch(
-        openDialog({
-          autoClose: false,
-          imgOnly: true
-        })
-      );
+      dispatch(openDialog({imgOnly: true}));
     }
   })
 )(ImagePreview);


### PR DESCRIPTION
Clean up after #42875.

Removes 2 pieces of unused redux state from instructionsDialog: `hintsOnly` and `autoClose`. Both pieces of state were always set to false, so this code was dead. It used to be used when the instructions dialog was shown on most (maybe all?) levels, but now this dialog is only used on NetSim levels and for expanding images/GIFs embedded in the instructions panel, so neither feature is relevant.