### PR TITLE
Javalab: don't wrap text and image item cleanup in Playground

### DIFF
--- a/apps/src/javalab/PlaygroundImage.jsx
+++ b/apps/src/javalab/PlaygroundImage.jsx
@@ -32,20 +32,7 @@ export default class PlaygroundImage extends React.Component {
     dynamicStyles.height = heightAdjusted;
     dynamicStyles.marginTop = yAdjusted;
     dynamicStyles.marginLeft = xAdjusted;
-    dynamicStyles.clipPath = `inset(0 ${this.getClipPath(
-      widthAdjusted,
-      xAdjusted
-    )} ${this.getClipPath(heightAdjusted, yAdjusted)} 0)`;
     return dynamicStyles;
-  }
-
-  // If the image would go outside of the 800x800 box we put playground
-  // into, cut it off at the appropriate dimension. This will crop any images
-  // that go outside of the box, which is our expected behavior.
-  getClipPath(dimension, coordinate) {
-    return dimension + coordinate > 800
-      ? `${dimension + coordinate - 800}px`
-      : 0;
   }
 
   render() {

--- a/apps/src/javalab/PlaygroundText.jsx
+++ b/apps/src/javalab/PlaygroundText.jsx
@@ -39,7 +39,6 @@ export default class PlaygroundText extends React.Component {
       left: x * 2,
       top: y * 2,
       zIndex: index,
-      lineHeight: 1,
       color: `rgb(${parseInt(colorRed)}, ${parseInt(colorGreen)}, ${parseInt(
         colorBlue
       )})`,
@@ -86,6 +85,7 @@ const styles = {
     display: 'flex',
     alignItems: 'center',
     transformOrigin: 'top left',
-    whiteSpace: 'nowrap'
+    whiteSpace: 'nowrap',
+    lineHeight: 1
   }
 };

--- a/apps/src/javalab/PlaygroundText.jsx
+++ b/apps/src/javalab/PlaygroundText.jsx
@@ -39,7 +39,7 @@ export default class PlaygroundText extends React.Component {
       left: x * 2,
       top: y * 2,
       zIndex: index,
-      height: height * 2,
+      lineHeight: 1,
       color: `rgb(${parseInt(colorRed)}, ${parseInt(colorGreen)}, ${parseInt(
         colorBlue
       )})`,
@@ -85,6 +85,7 @@ const styles = {
     position: 'absolute',
     display: 'flex',
     alignItems: 'center',
-    transformOrigin: 'top left'
+    transformOrigin: 'top left',
+    whiteSpace: 'nowrap'
   }
 };

--- a/apps/test/unit/javalab/PlaygroundImageTest.js
+++ b/apps/test/unit/javalab/PlaygroundImageTest.js
@@ -26,7 +26,6 @@ describe('PlaygroundImageTest', () => {
     // based on x * 2, we set the right clip path
     expect(imageStyles.width).to.equal(500);
     expect(imageStyles.marginLeft).to.equal(700);
-    expect(imageStyles.clipPath).to.equal('inset(0 400px 0 0)');
   });
 
   it('sets onClick correctly', () => {

--- a/apps/test/unit/javalab/PlaygroundTextTest.js
+++ b/apps/test/unit/javalab/PlaygroundTextTest.js
@@ -29,7 +29,6 @@ describe('PlaygroundImageTest', () => {
     // check dynamically generated styles
     expect(textStyles.top).to.equal(0);
     expect(textStyles.left).to.equal(700);
-    expect(textStyles.height).to.equal(200);
     expect(textStyles.fontSize).to.equal(200);
     expect(textStyles.fontFamily).to.equal(PlaygroundFontTypeFontFamilies.MONO);
     expect(textStyles.fontWeight).to.equal('bold');


### PR DESCRIPTION
One update, and one cleanup for how items are displayed in Playground:

1. Does not wrap text elements that are too long to fit in the Playground visualization area. Also makes line height tall enough that text on multiple lines would not overlap each other if we were to decide we wanted to wrap text at some point.
2. Removes unnecessary clip path code that became redundant when we started hiding elements overflowing the playground visualization [in this PR](https://github.com/code-dot-org/code-dot-org/pull/42764/files).

Behavior for images and text:

![image](https://user-images.githubusercontent.com/25372625/136628765-e8be6f3e-a65f-4209-8fc3-12b7d6997a32.png)

## Testing story

Tested manually that images and text overflowed the visualization area as expected (see screenshot above).