### PR TITLE
Javalab: only show serialized maze field for neighborhood levels

### DIFF
--- a/dashboard/app/views/levels/editors/fields/_csa_fields.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_csa_fields.html.haml
@@ -11,10 +11,10 @@
       = f.label :start_direction
       = f.select :start_direction, options_for_select(@level.class.start_directions, @level.start_direction)
 
-  .field
-    = f.label :serialized_maze
-    - maze_value = @level.serialized_maze ? JSON.pretty_generate(@level.serialized_maze) : ''
-    = f.text_area :serialized_maze, value: maze_value, rows: 20, class: 'input-block-level'
+    .field
+      = f.label :serialized_maze
+      - maze_value = @level.serialized_maze ? JSON.pretty_generate(@level.serialized_maze) : ''
+      = f.text_area :serialized_maze, value: maze_value, rows: 20, class: 'input-block-level'
 
 -# This element exists instead of the _encrypted_examples element as a temporary workaround in order
 -# to facilitate level urls instead of project urls in the example solutions. This is needed because


### PR DESCRIPTION
We had a bug in our haml for javalab level building that showed the serialized maze field for all Javalab level types. The fix was to indent that field so it fell under the neighborhood check. Now the field only shows up for neighborhood levels

## Links
- jira ticket: [CSA-441](https://codedotorg.atlassian.net/browse/CSA-441)


## Testing story
Tested locally

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
