### PR TITLE
Sprite Upload - Notify User if Upload Will Override Existing Image

### DIFF
--- a/apps/src/assetManagement/animationLibraryApi.js
+++ b/apps/src/assetManagement/animationLibraryApi.js
@@ -160,3 +160,9 @@ export function uploadMetadataToAnimationLibrary(destination, jsonData) {
       return Promise.reject(err);
     });
 }
+
+export function getLevelAnimationsFiles() {
+  return fetch(`/api/v1/animation-library/level-animations-filenames`).then(
+    response => response.json()
+  );
+}

--- a/apps/src/assetManagement/animationLibraryApi.js
+++ b/apps/src/assetManagement/animationLibraryApi.js
@@ -161,8 +161,8 @@ export function uploadMetadataToAnimationLibrary(destination, jsonData) {
     });
 }
 
-export function getLevelAnimationsFiles() {
-  return fetch(`/api/v1/animation-library/level-animations-filenames`).then(
+export function getLevelAnimationsFilenames() {
+  return fetch('/api/v1/animation-library/level-animations-filenames').then(
     response => response.json()
   );
 }

--- a/apps/src/code-studio/assets/SpriteUpload.jsx
+++ b/apps/src/code-studio/assets/SpriteUpload.jsx
@@ -18,8 +18,10 @@ export default class SpriteUpload extends React.Component {
     spriteAvailability: '',
     category: '',
     currentCategories: [],
+    currentManifest: [],
     aliases: [],
     metadata: '',
+    willOverride: false,
     uploadStatus: {
       success: null,
       message: ''
@@ -27,9 +29,12 @@ export default class SpriteUpload extends React.Component {
   };
 
   componentDidMount() {
-    getManifest('spritelab', 'en_us').then(data =>
-      this.setState({currentCategories: Object.keys(data.categories)})
-    );
+    getManifest('spritelab', 'en_us').then(data => {
+      this.setState({
+        currentCategories: Object.keys(data.categories),
+        currentManifest: Object.keys(data.metadata)
+      });
+    });
   }
 
   handleSubmit = event => {
@@ -81,11 +86,16 @@ export default class SpriteUpload extends React.Component {
 
   handleImageChange = event => {
     let file = event.target.files[0];
+    const name = file.name.split('.')[0];
+    const willOverride = this.state.currentManifest.includes(
+      `category_${this.state.category}/${name}`
+    );
     this.setState({
       fileData: file,
       filename: file.name,
       filePreviewURL: URL.createObjectURL(file),
-      uploadStatus: {success: null, message: ''}
+      uploadStatus: {success: null, message: ''},
+      willOverride: willOverride
     });
   };
 
@@ -127,7 +137,8 @@ export default class SpriteUpload extends React.Component {
       spriteAvailability,
       category,
       filename,
-      metadata
+      metadata,
+      willOverride
     } = this.state;
 
     // Only display the upload button when the user has uploaded an image and generated metadata
@@ -135,7 +146,8 @@ export default class SpriteUpload extends React.Component {
       spriteAvailability === '' ||
       (spriteAvailability === SpriteLocation.library && category === '') ||
       filename === '' ||
-      metadata === '';
+      metadata === '' ||
+      willOverride;
 
     return (
       <div>

--- a/apps/src/code-studio/assets/SpriteUpload.jsx
+++ b/apps/src/code-studio/assets/SpriteUpload.jsx
@@ -9,12 +9,7 @@ import {
 } from '@cdo/apps/assetManagement/animationLibraryApi';
 
 const SpriteLocation = makeEnum('library', 'level');
-const UploadStatus = makeEnum(
-  'uploadFail',
-  'uploadSuccess',
-  'filenameOverride',
-  'none'
-);
+const UploadStatus = makeEnum('fail', 'success', 'filenameOverride', 'none');
 
 // Levelbuilder tool for adding sprites to the Spritelab animation library.
 export default class SpriteUpload extends React.Component {
@@ -79,7 +74,7 @@ export default class SpriteUpload extends React.Component {
       .then(() => {
         this.setState({
           uploadStatus: {
-            success: UploadStatus.uploadSuccess,
+            status: UploadStatus.success,
             message: 'Successfully Uploaded Sprite and Metadata'
           }
         });
@@ -90,7 +85,7 @@ export default class SpriteUpload extends React.Component {
         }
         this.setState({
           uploadStatus: {
-            success: UploadStatus.uploadFailure,
+            status: UploadStatus.failure,
             message: `${error.toString()}: Error Uploading Sprite or Metadata. Please try again. If this occurs again, please reach out to an engineer.`
           }
         });
@@ -153,7 +148,7 @@ export default class SpriteUpload extends React.Component {
     this.setState({aliases: processedAliases});
   };
 
-  // Returns an upload status object - noting "filenameOverride" or "null"
+  // Set the upload status to indicate whether this file would override another
   determineIfSpriteAlreadyExists = (spriteAvailability, filename, category) => {
     let {currentLibrarySprites, currentLevelSprites} = this.state;
     let willOverride;
@@ -214,7 +209,7 @@ export default class SpriteUpload extends React.Component {
       metadata === '' ||
       uploadStatus.status === UploadStatus.filenameOverride;
 
-    const uploadSuccessful = uploadStatus.status === UploadStatus.uploadSuccess;
+    const uploadSuccessful = uploadStatus.status === UploadStatus.success;
 
     return (
       <div>

--- a/apps/src/code-studio/assets/SpriteUpload.jsx
+++ b/apps/src/code-studio/assets/SpriteUpload.jsx
@@ -215,6 +215,17 @@ export default class SpriteUpload extends React.Component {
             <h3>Image Preview:</h3>
             <img ref="spritePreview" src={filePreviewURL} />
           </label>
+          {willOverride && (
+            <p
+              style={{
+                ...styles.uploadStatusMessage,
+                ...styles.uploadFailure
+              }}
+            >
+              A sprite already exists with this name. Please rename the sprite
+              and re-upload.
+            </p>
+          )}
           <br />
 
           <h2 style={styles.spriteUploadStep}>

--- a/apps/src/code-studio/assets/SpriteUpload.jsx
+++ b/apps/src/code-studio/assets/SpriteUpload.jsx
@@ -93,18 +93,13 @@ export default class SpriteUpload extends React.Component {
   };
 
   handleImageChange = event => {
-    let {
-      currentLibrarySprites,
-      currentLevelSprites,
-      spriteAvailability,
-      category
-    } = this.state;
+    let {spriteAvailability, category} = this.state;
     let file = event.target.files[0];
-    const name = file.name.split('.')[0];
-    const willOverride =
-      spriteAvailability === SpriteLocation.library
-        ? currentLibrarySprites.includes(`category_${category}/${name}`)
-        : currentLevelSprites.includes(`level_animations/${name}`);
+    const willOverride = this.determineIfSpriteAlreadyExists(
+      spriteAvailability,
+      file.name.split('.')[0],
+      category
+    );
     this.setState({
       fileData: file,
       filename: file.name,
@@ -115,19 +110,45 @@ export default class SpriteUpload extends React.Component {
   };
 
   handleCategoryChange = event => {
+    let {filename, spriteAvailability} = this.state;
+    const willOverride = this.determineIfSpriteAlreadyExists(
+      spriteAvailability,
+      filename.split('.')[0],
+      event.target.value
+    );
     this.setState({
-      category: event.target.value
+      category: event.target.value,
+      willOverride: willOverride
     });
   };
 
   handleAvailabilityChange = event => {
-    this.setState({spriteAvailability: event.target.value, category: ''});
+    let {filename, category} = this.state;
+    const willOverride = this.determineIfSpriteAlreadyExists(
+      event.target.value,
+      filename.split('.')[0],
+      category
+    );
+    this.setState({
+      spriteAvailability: event.target.value,
+      category: '',
+      willOverride: willOverride
+    });
   };
 
   handleAliasChange = event => {
     const aliases = event.target.value?.split(',') || [];
     let processedAliases = aliases.map(alias => alias.trim());
     this.setState({aliases: processedAliases});
+  };
+
+  determineIfSpriteAlreadyExists = (spriteAvailability, filename, category) => {
+    let {currentLibrarySprites, currentLevelSprites, fileData} = this.state;
+    const willOverride =
+      spriteAvailability === SpriteLocation.library
+        ? currentLibrarySprites.includes(`category_${category}/${filename}`)
+        : currentLevelSprites.includes(`level_animations/${filename}`);
+    return fileData && willOverride;
   };
 
   generateMetadata = () => {

--- a/apps/src/code-studio/assets/SpriteUpload.jsx
+++ b/apps/src/code-studio/assets/SpriteUpload.jsx
@@ -3,6 +3,7 @@ import color from '@cdo/apps/util/color';
 import {makeEnum} from '@cdo/apps/utils';
 import {
   getManifest,
+  getLevelAnimationsFiles,
   uploadSpriteToAnimationLibrary,
   uploadMetadataToAnimationLibrary
 } from '@cdo/apps/assetManagement/animationLibraryApi';
@@ -18,7 +19,8 @@ export default class SpriteUpload extends React.Component {
     spriteAvailability: '',
     category: '',
     currentCategories: [],
-    currentManifest: [],
+    currentLibrarySprites: [],
+    currentLevelSprites: [],
     aliases: [],
     metadata: '',
     willOverride: false,
@@ -29,10 +31,16 @@ export default class SpriteUpload extends React.Component {
   };
 
   componentDidMount() {
+    // Get list of sprites from level-specific folder
+    getLevelAnimationsFiles().then(files => {
+      this.setState({currentLevelSprites: files.filenames});
+    });
+
+    // Get data from the spritelab library manifest
     getManifest('spritelab', 'en_us').then(data => {
       this.setState({
         currentCategories: Object.keys(data.categories),
-        currentManifest: Object.keys(data.metadata)
+        currentLibrarySprites: Object.keys(data.metadata)
       });
     });
   }
@@ -85,11 +93,18 @@ export default class SpriteUpload extends React.Component {
   };
 
   handleImageChange = event => {
+    let {
+      currentLibrarySprites,
+      currentLevelSprites,
+      spriteAvailability,
+      category
+    } = this.state;
     let file = event.target.files[0];
     const name = file.name.split('.')[0];
-    const willOverride = this.state.currentManifest.includes(
-      `category_${this.state.category}/${name}`
-    );
+    const willOverride =
+      spriteAvailability === SpriteLocation.library
+        ? currentLibrarySprites.includes(`category_${category}/${name}`)
+        : currentLevelSprites.includes(`level_animations/${name}`);
     this.setState({
       fileData: file,
       filename: file.name,

--- a/shared/middleware/animation_library_api.rb
+++ b/shared/middleware/animation_library_api.rb
@@ -129,6 +129,22 @@ class AnimationLibraryApi < Sinatra::Base
   end
 
   #
+  # GET /api/v1/animation-library/level-animations-filenames/
+  #
+  # Retrieve filenames from the level-animations bucket
+  get %r{/api/v1/animation-library/level-animations-filenames} do
+    animations_by_name = []
+    prefix = 'level_animations'
+    bucket = Aws::S3::Bucket.new(ANIMATION_LIBRARY_BUCKET)
+    bucket.objects({prefix: prefix}).each do |object_summary|
+      animation_name = object_summary.key[/level_animations[^.]+/]
+      # Push into animations collection if unique
+      animations_by_name.push(animation_name)
+    end
+    {filenames: animations_by_name}.to_json
+  end
+
+  #
   # POST /api/v1/animation-library/default-spritelab/
   #
   # Update default sprite list in S3


### PR DESCRIPTION
This PR makes it so that users cannot upload a sprite to S3 if it will override a pre-existing sprite. This PR makes it so the final step - a button which will upload the metadata and image, cannot be triggered until a new image or path is selected. Additionally, a red error message is displayed to the user. A file's path can be changed by uploading a new file (with a different file name, selecting a different library category, or choosing to move the sprite to/from "LevelSpecific" to "Library" animation, so this check is re-done when any of those inputs change.

This does mean that legitimate sprite overrides (for example, replacing the 'category_animals/cat.png' with a picture of a tuxedo cat (the best kind of cat)) will need an engineer or someone with S3 access to manually edit the metadata and img. I'm hopeful that is a small enough edge case that we won't need to deal with it too much, but if we start getting many such cases, we can consider alternatives.

Screenshot showing error message when image would override.
![Screenshot from 2021-10-08 12-13-48](https://user-images.githubusercontent.com/2959170/136637085-4f877341-3cf0-4147-b7ef-dfd7695e2f29.png)


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
