### PR TITLE
Javalab theater: stop sound and video on stop click

### DIFF
--- a/apps/src/javalab/MediaUtils.js
+++ b/apps/src/javalab/MediaUtils.js
@@ -1,9 +1,0 @@
-export function resetAudioElement(audioElement) {
-  audioElement.pause();
-  resetMediaElement(audioElement);
-}
-
-export function resetMediaElement(element) {
-  element.onerror = undefined;
-  element.src = '';
-}

--- a/apps/src/javalab/MediaUtils.js
+++ b/apps/src/javalab/MediaUtils.js
@@ -1,0 +1,9 @@
+export function resetAudioElement(audioElement) {
+  audioElement.pause();
+  resetMediaElement(audioElement);
+}
+
+export function resetMediaElement(element) {
+  element.onerror = undefined;
+  element.src = '';
+}

--- a/apps/src/javalab/Playground.js
+++ b/apps/src/javalab/Playground.js
@@ -15,6 +15,7 @@ import {
   getItemIds
 } from './playgroundRedux';
 import color from '@cdo/apps/util/color';
+import {resetMediaElement, resetAudioElement} from './MediaUtils';
 
 const DEFAULT_BACKGROUND_COLOR = color.white;
 // Amount of time in ms after a click to re-enable click events
@@ -64,7 +65,7 @@ export default class Playground {
 
   onStop() {
     this.endGame();
-    this.resetAudioElement();
+    resetAudioElement(this.getAudioElement());
   }
 
   onStarterAssetsReceived = result => {
@@ -237,7 +238,7 @@ export default class Playground {
     // reset playground items to be empty
     this.setPlaygroundItems({});
     this.resetBackgroundElement();
-    this.resetAudioElement();
+    resetAudioElement(this.getAudioElement());
     this.resetContainer();
   }
 
@@ -283,21 +284,10 @@ export default class Playground {
     return document.getElementById('playground-container');
   }
 
-  resetAudioElement() {
-    const audioElement = this.getAudioElement();
-    audioElement.pause();
-    this.resetMediaElement(audioElement);
-  }
-
   resetBackgroundElement() {
     const backgroundElement = this.getBackgroundElement();
     backgroundElement.style.opacity = 0.0;
-    this.resetMediaElement(backgroundElement);
-  }
-
-  resetMediaElement(element) {
-    element.onerror = undefined;
-    element.src = '';
+    resetMediaElement(backgroundElement);
   }
 
   resetContainer() {

--- a/apps/src/javalab/Playground.js
+++ b/apps/src/javalab/Playground.js
@@ -15,7 +15,6 @@ import {
   getItemIds
 } from './playgroundRedux';
 import color from '@cdo/apps/util/color';
-import {resetMediaElement, resetAudioElement} from './MediaUtils';
 
 const DEFAULT_BACKGROUND_COLOR = color.white;
 // Amount of time in ms after a click to re-enable click events
@@ -65,7 +64,7 @@ export default class Playground {
 
   onStop() {
     this.endGame();
-    resetAudioElement(this.getAudioElement());
+    this.resetAudioElement();
   }
 
   onStarterAssetsReceived = result => {
@@ -238,7 +237,7 @@ export default class Playground {
     // reset playground items to be empty
     this.setPlaygroundItems({});
     this.resetBackgroundElement();
-    resetAudioElement(this.getAudioElement());
+    this.resetAudioElement();
     this.resetContainer();
   }
 
@@ -284,10 +283,21 @@ export default class Playground {
     return document.getElementById('playground-container');
   }
 
+  resetAudioElement() {
+    const audioElement = this.getAudioElement();
+    audioElement.pause();
+    this.resetMediaElement(audioElement);
+  }
+
   resetBackgroundElement() {
     const backgroundElement = this.getBackgroundElement();
     backgroundElement.style.opacity = 0.0;
-    resetMediaElement(backgroundElement);
+    this.resetMediaElement(backgroundElement);
+  }
+
+  resetMediaElement(element) {
+    element.onerror = undefined;
+    element.src = '';
   }
 
   resetContainer() {

--- a/apps/src/javalab/Theater.js
+++ b/apps/src/javalab/Theater.js
@@ -1,6 +1,5 @@
 import {TheaterSignalType, STATUS_MESSAGE_PREFIX} from './constants';
 import javalabMsg from '@cdo/javalab/locale';
-import {resetAudioElement, resetMediaElement} from './MediaUtils';
 
 export default class Theater {
   constructor(onOutputMessage, onNewlineMessage) {
@@ -52,8 +51,10 @@ export default class Theater {
   }
 
   resetAudioAndVideo() {
-    resetAudioElement(this.getAudioElement());
-    resetMediaElement(this.getImgElement());
+    const audioElement = this.getAudioElement();
+    audioElement.pause();
+    audioElement.src = '';
+    this.getImgElement().src = '';
   }
 
   getImgElement() {

--- a/apps/src/javalab/Theater.js
+++ b/apps/src/javalab/Theater.js
@@ -1,5 +1,6 @@
 import {TheaterSignalType, STATUS_MESSAGE_PREFIX} from './constants';
 import javalabMsg from '@cdo/javalab/locale';
+import {resetAudioElement, resetMediaElement} from './MediaUtils';
 
 export default class Theater {
   constructor(onOutputMessage, onNewlineMessage) {
@@ -43,7 +44,16 @@ export default class Theater {
   reset() {
     this.loadEventsFinished = 0;
     this.getImgElement().style.visibility = 'hidden';
-    this.getAudioElement().src = '';
+    this.resetAudioAndVideo();
+  }
+
+  onStop() {
+    this.resetAudioAndVideo();
+  }
+
+  resetAudioAndVideo() {
+    resetAudioElement(this.getAudioElement());
+    resetMediaElement(this.getImgElement());
   }
 
   getImgElement() {


### PR DESCRIPTION
In the theater, stop any playing audio and reset the video to the original background image if the stop button is clicked. Previously pressing stop would not stop playback.

## Links

- jira ticket: [CSA-941](https://codedotorg.atlassian.net/browse/CSA-941)

## Testing story
Tested locally

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
