### PR TITLE
Execute can_see_finish.feature tests as student

### DIFF
--- a/dashboard/test/ui/features/star_labs/can_see_finish.feature
+++ b/dashboard/test/ui/features/star_labs/can_see_finish.feature
@@ -1,8 +1,7 @@
 Feature: Make sure we can see the finish button for all LEVEL TYPE levels on small screens
 
   Background:
-    Given I create an authorized teacher-associated student named "Sally"
-    And I sign in as "Teacher_Sally" and go home
+    Given I create a student named "Sally"
 
   @no_mobile
   Scenario: can see finish button on "Dance Party"

--- a/dashboard/test/ui/features/step_definitions/check_finish_button.rb
+++ b/dashboard/test/ui/features/step_definitions/check_finish_button.rb
@@ -1,22 +1,22 @@
 # Helper steps for dance party levels
 free_play_level_urls = {
   'blockly' => {
-    'Dance Party' => 'http://studio.code.org/s/dance/lessons/1/levels/13?noautoplay=true',
-    'Artist' => 'http://studio.code.org/s/20-hour/lessons/5/levels/10?noautoplay=true',
-    'Bounce' => 'http://studio.code.org/s/course3/lessons/15/levels/10?noautoplay=true',
-    'CS in Algebra' => 'http://studio.code.org/s/algebra/lessons/1/levels/2?noautoplay=true',
-    'Flappy' => 'http://studio.code.org/flappy/10?noautoplay=true',
-    'Sprite Lab' => 'http://studio.code.org/s/coursee-2019/lessons/9/levels/6?noautoplay=true'
+    'Dance Party' => 'http://studio.code.org/s/dance/lessons/1/levels/13?noautoplay=true&no_redirect=true',
+    'Artist' => 'http://studio.code.org/s/20-hour/lessons/5/levels/10?noautoplay=true&no_redirect=true',
+    'Bounce' => 'http://studio.code.org/s/course3/lessons/15/levels/10?noautoplay=true&no_redirect=true',
+    'CS in Algebra' => 'http://studio.code.org/s/algebra/lessons/1/levels/2?noautoplay=true&no_redirect=true',
+    'Flappy' => 'http://studio.code.org/flappy/10?noautoplay=true&no_redirect=true',
+    'Sprite Lab' => 'http://studio.code.org/s/coursee-2019/lessons/9/levels/6?noautoplay=true&no_redirect=true'
   },
   'droplet' => {
-    'App Lab' => 'http://studio.code.org/s/applab-intro/lessons/1/levels/15?noautoplay=true',
-    'Game Lab' => 'http://studio.code.org/s/csd3-2019/lessons/22/levels/12?noautoplay=true'
+    'App Lab' => 'http://studio.code.org/s/applab-intro/lessons/1/levels/15?noautoplay=true&no_redirect=true',
+    'Game Lab' => 'http://studio.code.org/s/csd3-2019/lessons/22/levels/12?noautoplay=true&no_redirect=true'
   },
   'minecraft' => {
-    'Minecraft Aquatic' => 'http://studio.code.org/s/aquatic/lessons/1/levels/12?noautoplay=true',
-    'Minecraft Heroes Journey' => 'http://studio.code.org/s/hero/lessons/1/levels/12?noautoplay=true',
-    'Minecraft Adventurer' => 'http://studio.code.org/s/mc/lessons/1/levels/14?noautoplay=true',
-    'Minecraft Designer' => 'http://studio.code.org/s/minecraft/lessons/1/levels/12?noautoplay=true'
+    'Minecraft Aquatic' => 'http://studio.code.org/s/aquatic/lessons/1/levels/12?noautoplay=true&no_redirect=true',
+    'Minecraft Heroes Journey' => 'http://studio.code.org/s/hero/lessons/1/levels/12?noautoplay=true&no_redirect=true',
+    'Minecraft Adventurer' => 'http://studio.code.org/s/mc/lessons/1/levels/14?noautoplay=true&no_redirect=true',
+    'Minecraft Designer' => 'http://studio.code.org/s/minecraft/lessons/1/levels/12?noautoplay=true&no_redirect=true'
   }
 }
 


### PR DESCRIPTION
This is a speculative fix for `can_see_finish.feature`, which fails occasionally but we haven't been able to reproduce the failing test behavior on a physical machine or through Saucelabs. There are more details in [this Jira comment](https://codedotorg.atlassian.net/browse/STAR-1390?focusedCommentId=19263) about how it fails.

Previously, we were running this test using a teacher account (I don't know why, but a teacher account doesn't seem necessary for this test), so my speculative fix here is to see if the teacher panel is somehow causing this flakiness by preventing the screen from resizing.

In the past 30 days, this test has failed on iPhone as follows (mostly for future reference since this info is only available for 30 days in Saucelabs):
| Lab/Tool | # Failures |
|---------|------------|
| CS in Algebra | 7 |
| Dance Party | 1 |
| Game Lab | 1 |
| Unrelated failure ("sad bee" where a page couldn't load and was unrelated to this test) | 3 |

## Links

- [STAR-1390](https://codedotorg.atlassian.net/browse/STAR-1390)