### PR TITLE
Adding 'login required' back to send to students link

### DIFF
--- a/apps/src/templates/progress/ProgressLessonTeacherInfo.jsx
+++ b/apps/src/templates/progress/ProgressLessonTeacherInfo.jsx
@@ -84,10 +84,12 @@ class ProgressLessonTeacherInfo extends React.Component {
       isLessonHiddenForSection(hiddenLessonState, sectionId, lesson.id);
     const courseId =
       (section && section.code && parseInt(section.code.substring(2))) || null;
+    const loginRequiredLessonStartUrl =
+      lesson.lessonStartUrl + '?login_required=true';
     const shouldRender =
       lesson.lesson_plan_html_url ||
       (lesson.lockable && !hasNoSections) ||
-      lesson.lessonStartUrl ||
+      loginRequiredLessonStartUrl ||
       showHiddenForSectionToggle;
     if (!shouldRender) {
       return null;
@@ -128,7 +130,7 @@ class ProgressLessonTeacherInfo extends React.Component {
         {lesson.lessonStartUrl && !(lesson.lockable && !lockableAuthorized) && (
           <div style={styles.buttonContainer}>
             <SendLesson
-              lessonUrl={lesson.lessonStartUrl}
+              lessonUrl={loginRequiredLessonStartUrl}
               lessonTitle={lesson.name}
               courseid={courseId}
               analyticsData={JSON.stringify(this.firehoseData())}

--- a/apps/test/unit/templates/progress/ProgressLessonTeacherInfoTest.js
+++ b/apps/test/unit/templates/progress/ProgressLessonTeacherInfoTest.js
@@ -48,6 +48,30 @@ describe('ProgressLessonTeacherInfo', () => {
     assert.equal(wrapperWithPlan.find('Button').props().color, 'blue');
   });
 
+  it('updates the lesson url to require login', () => {
+    const lessonWithoutPlan = {
+      ...fakeLesson('Maze', 1)
+    };
+    const wrapper = shallow(
+      <ProgressLessonTeacherInfo
+        lesson={lessonWithoutPlan}
+        section={MOCK_SECTION}
+        unitAllowsHiddenLessons={false}
+        hiddenLessonState={Immutable.fromJS({
+          lessonsBySection: {11: {}}
+        })}
+        unitName="My Unit"
+        hasNoSections={false}
+        toggleHiddenLesson={() => {}}
+        lockableAuthorized={false}
+      />
+    );
+    assert.equal(
+      wrapper.find('SendLesson').props().lessonUrl,
+      'code.org?login_required=true'
+    );
+  });
+
   it('renders a purple Button if and only if we have a student lesson plan', () => {
     const lessonWithoutPlan = {
       ...fakeLesson('Maze', 1)


### PR DESCRIPTION
This PR is related to https://github.com/code-dot-org/code-dot-org/pull/42606, fixing an update to the sendLesson button that mistakenly removed the "loginRequired" parameter. 

This should address the incorrect redirecting found in this ticket: https://codedotorg.atlassian.net/browse/LP-2079. 

## Testing story

Added a unit test in ProgressLessonTeacherInfoTest that double checks the url sent to the SendLesson component is updated with the loginrequired url.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
