### PR TITLE
Fix bug of inconsistent Code logo left-spacing

### DIFF
--- a/shared/css/header.scss
+++ b/shared/css/header.scss
@@ -41,7 +41,7 @@
 
     #logo-wrapper {
       display: inline-block;
-      padding: 4px 0 4px 16px;
+      padding: 4px 0 4px 1px;
       float: left;
 
       #logo {


### PR DESCRIPTION
Made Code logo padding consistent so that switching between a signed-in and non-signed-in state doesn't cause the logo to visually shift. The inconsistent spacing is shown below, as well as screenshots of the fixed output with varying username lengths (to show that the size of the dropdown with the username doesn't affect the spacing).

### Issue with spacing
![Original sign in logo issue](https://user-images.githubusercontent.com/56283563/137036173-0386d66b-ebb9-4199-a1f3-1fa568a5d70a.png)

### Fixed spacing
![Fixed overall code logo spacing](https://user-images.githubusercontent.com/56283563/137036570-5db771ba-ca5e-43ef-8958-eb6ba06b5bfa.jpg)

## Links
Issue linked [here](https://codedotorg.atlassian.net/browse/FND-582).

## Testing story
Manual testing on multiple browsers to ensure consistent spacing across signed-in states and browsers.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
