### PR TITLE
Enable button to launch code studio lesson plans on HOC units

### DIFF
--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -691,7 +691,9 @@ class UnitEditor extends React.Component {
                 style={{margin: 0, height: 30, lineHeight: '8px'}}
                 onClick={e => {
                   e.preventDefault();
-                  const msg = 'Are you sure? This action cannot be undone.';
+                  const msg =
+                    'Are you sure? This action cannot be undone. Please ' +
+                    'confirm that translations are complete before proceeding.';
                   if (window.confirm(msg)) {
                     this.setState({useLegacyLessonPlans: false});
                   }

--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -684,8 +684,6 @@ class UnitEditor extends React.Component {
         <CollapsibleEditorSection title="Lesson Settings">
           {this.props.isMigrated && this.props.initialUseLegacyLessonPlans && (
             <label>
-              {/* TODO(dave): enable or remove this button, once we figure out
-              what controls we want to make available to curriculum writers. */}
               <Button
                 text={'Use Code Studio Lesson Plans'}
                 size={Button.ButtonSize.narrow}
@@ -698,7 +696,7 @@ class UnitEditor extends React.Component {
                     this.setState({useLegacyLessonPlans: false});
                   }
                 }}
-                disabled
+                disabled={!this.state.useLegacyLessonPlans}
               />
               <HelpTip>
                 <p>


### PR DESCRIPTION
Follow-on to #42534. This PR just enables the button that was already implemented.

## Screenshots

### enabling code studio lesson plans

this video shows the logic for when the button is disabled or hidden after it is clicked.

https://user-images.githubusercontent.com/8001765/137198009-e61910ab-1974-4444-af9f-942a09b74106.mov

### unit overview page 

before / after enabling code studio lesson plans

![Screen Shot 2021-10-13 at 11 58 58 AM](https://user-images.githubusercontent.com/8001765/137197045-d6ee1cfb-93cb-4385-b3e0-8c5fa2782efa.png)

## Testing story

manual verification as shown in screenshots. also verified that `use_legacy_lesson_plans` gets updated in the .script_json file.