### PR TITLE
Add dhivehi language in debug mode

### DIFF
--- a/dashboard/config/locales.yml
+++ b/dashboard/config/locales.yml
@@ -70,6 +70,13 @@
   english: "German"
   native: "Deutsch"
 
+"dv": "dv-MV"
+"dv-MV":
+  english: "Dhivehi"
+  native: "ދިވެހި"
+  debug: true
+  webfonts: false
+
 "el": "el-GR"
 "el-GR":
   english: "Greek"


### PR DESCRIPTION
An organization in the Maldives has been translating Dance Party and AI for Oceans into Dhivehi. As per the documentation on [how to add a new language for translation](https://docs.google.com/document/d/1AwBHOF1VJw7HlMdfmxpb-2d7kqbGWXjsLzUH6iUYAbI/edit), this change adds it to the dropdown language list in debug mode.

## Testing story
Tested locally
![image](https://user-images.githubusercontent.com/2933346/137074984-a6770a54-c5ec-4730-aa9a-b3f9a10c2c11.png)

## Follow-up work
After the Dhivehi translations have been synced, change debug to false in order to have Dhivehi show up on the language dropdown in production. Also change the value of supported_codeorg_b and supported_hoc_b in the [cdo-languages gsheet](https://docs.google.com/spreadsheets/d/10dS5PJKRt846ol9f9L3pKh03JfZkN7UIEcwMmiGS4i0/edit#gid=0) to true.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
