### PR TITLE
Force production domain for Crowdin URL keys

### DIFF
--- a/dashboard/lib/services/i18n/curriculum_sync_utils/serializers.rb
+++ b/dashboard/lib/services/i18n/curriculum_sync_utils/serializers.rb
@@ -100,7 +100,8 @@ module Services
 
         # override
         def crowdin_key
-          Rails.application.routes.url_helpers.script_lesson_url(object.script, object)
+          path = Rails.application.routes.url_helpers.script_lesson_path(object.script, object)
+          URI.join("https://studio.code.org", path)
         end
       end
 
@@ -111,7 +112,8 @@ module Services
 
         # override
         def crowdin_key
-          Rails.application.routes.url_helpers.script_url(object)
+          path = Rails.application.routes.url_helpers.script_path(object)
+          URI.join("https://studio.code.org", path)
         end
       end
     end


### PR DESCRIPTION
Using the default as we were means that we end up with `localhost-studio.code.org:3000` in the Crowdin keys, which is less than useful for translators. Updating the logic to match what we already do for level URL keys:

https://github.com/code-dot-org/code-dot-org/blob/f02aba129c00f369e318f866baffa7daddb99f96/bin/i18n/i18n_script_utils.rb#L141-L145

Note that this change will require us to manually re-apply translations.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
