### PR TITLE
Add Blockly option to the level types dropdown for filtering

### DIFF
--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -112,7 +112,14 @@ class LevelsController < ApplicationController
   def filter_levels(params)
     # Gather filtered search results
     @levels = @levels.order(updated_at: :desc)
-    @levels = @levels.where('levels.name LIKE ?', "%#{params[:name]}%").or(@levels.where('levels.level_num LIKE ?', "%#{params[:name]}%")) if params[:name]
+    if params[:name]
+      if params[:name].include? 'blockly:'
+        level_num = params[:name].split(":")[2]
+        @levels = @levels.where('levels.level_num LIKE ?', "%#{level_num}%")
+      else
+        @levels = @levels.where('levels.name LIKE ?', "%#{params[:name]}%").or(@levels.where('levels.level_num LIKE ?', "%#{params[:name]}%"))
+      end
+    end
     @levels = @levels.where('levels.type = ?', params[:level_type]) if params[:level_type].present?
     @levels = @levels.joins(:script_levels).where('script_levels.script_id = ?', params[:script_id]) if params[:script_id].present?
     @levels = @levels.left_joins(:user).where('levels.user_id = ?', params[:owner_id]) if params[:owner_id].present?

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -98,6 +98,10 @@ class LevelsController < ApplicationController
   # GET /levels/get_filtered_levels/
   # Get all the information for levels after filtering
   def get_filtered_levels
+    if params[:name]&.start_with?('blockly:')
+      @levels = [Level.find_by_key(params[:name]).summarize_for_edit]
+      return render json: {numPages: 1, levels: @levels}
+    end
     filter_levels(params)
 
     @levels = @levels.limit(150)
@@ -112,14 +116,7 @@ class LevelsController < ApplicationController
   def filter_levels(params)
     # Gather filtered search results
     @levels = @levels.order(updated_at: :desc)
-    if params[:name]
-      if params[:name].include? 'blockly:'
-        level_num = params[:name].split(":")[2]
-        @levels = @levels.where('levels.level_num LIKE ?', "%#{level_num}%")
-      else
-        @levels = @levels.where('levels.name LIKE ?', "%#{params[:name]}%").or(@levels.where('levels.level_num LIKE ?', "%#{params[:name]}%"))
-      end
-    end
+    @levels = @levels.where('levels.name LIKE ?', "%#{params[:name]}%").or(@levels.where('levels.level_num LIKE ?', "%#{params[:name]}%")) if params[:name]
     @levels = @levels.where('levels.type = ?', params[:level_type]) if params[:level_type].present?
     @levels = @levels.joins(:script_levels).where('script_levels.script_id = ?', params[:script_id]) if params[:script_id].present?
     @levels = @levels.left_joins(:user).where('levels.user_id = ?', params[:owner_id]) if params[:owner_id].present?

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -742,7 +742,7 @@ class Level < ApplicationRecord
     {
       levelOptions: [
         ['All types', ''],
-        *LevelsController::LEVEL_CLASSES.map {|x| [x.name, x.name]}.sort_by {|a| a[0]}
+        *LevelsController::LEVEL_CLASSES.map {|x| [x.name, x.name]}.push(['Blockly', 'Blockly']).sort_by {|a| a[0]}
       ],
       scriptOptions: [
         ['All scripts', ''],

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -594,7 +594,7 @@ class Level < ApplicationRecord
     {
       id: id.to_s,
       type: self.class.to_s,
-      name: name == 'blockly' ? level_num : name,
+      name: name == 'blockly' ? key : name,
       updated_at: updated_at.localtime.strftime("%D at %r"),
       owner: user&.name,
       url: "/levels/#{id}/edit",

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -594,7 +594,7 @@ class Level < ApplicationRecord
     {
       id: id.to_s,
       type: self.class.to_s,
-      name: name == 'blockly' ? key : name,
+      name: key,
       updated_at: updated_at.localtime.strftime("%D at %r"),
       owner: user&.name,
       url: "/levels/#{id}/edit",

--- a/dashboard/app/views/levels/_admin.html.haml
+++ b/dashboard/app/views/levels/_admin.html.haml
@@ -1,9 +1,6 @@
 - if current_user && (current_user.levelbuilder? || current_user.project_validator? || Experiment.get_editor_experiment(current_user))
   = render layout: 'shared/extra_links' do
-    - if @level.name == 'blockly'
-      %strong= @level.key
-    - else
-      %strong= @level.name
+    %strong= @level.key
     %ul
       %li= link_to level_path(@level), level_path(@level)
       -if @level.level_concept_difficulty && !@level.level_concept_difficulty.concept_difficulties_as_string.empty?

--- a/dashboard/app/views/levels/_admin.html.haml
+++ b/dashboard/app/views/levels/_admin.html.haml
@@ -1,6 +1,9 @@
 - if current_user && (current_user.levelbuilder? || current_user.project_validator? || Experiment.get_editor_experiment(current_user))
   = render layout: 'shared/extra_links' do
-    %strong= @level.name
+    - if @level.name == 'blockly'
+      %strong= @level.key
+    - else
+      %strong= @level.name
     %ul
       %li= link_to level_path(@level), level_path(@level)
       -if @level.level_concept_difficulty && !@level.level_concept_difficulty.concept_difficulties_as_string.empty?

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -88,7 +88,7 @@ class LevelsControllerTest < ActionController::TestCase
 
   test "should get filtered levels with level_type" do
     existing_levels_count = Odometer.all.count
-    level = create(:level, type: 'Odometer')
+    level = create(:odometer)
     get :get_filtered_levels, params: {page: 1, level_type: 'Odometer'}
     assert_equal existing_levels_count + 1, JSON.parse(@response.body)['levels'].length
     assert_equal level.name, JSON.parse(@response.body)['levels'][0]["name"]
@@ -104,9 +104,9 @@ class LevelsControllerTest < ActionController::TestCase
 
   test "should get filtered levels with owner_id" do
     Level.where(user_id: @levelbuilder.id).destroy_all
-    level = create :level, user: @levelbuilder
+    level = create :applab, user: @levelbuilder
     get :get_filtered_levels, params: {page: 1, owner_id: @levelbuilder.id}
-    assert_equal level[:name], JSON.parse(@response.body)['levels'][0]["name"]
+    assert_equal level.name, JSON.parse(@response.body)['levels'][0]["name"]
     assert_equal 1, JSON.parse(@response.body)['numPages']
   end
 

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -78,11 +78,11 @@ class LevelsControllerTest < ActionController::TestCase
     assert_equal 22, JSON.parse(@response.body)['numPages']
   end
 
-  test "should get filtered levels with name matching level_num for blockly levels" do
+  test "should get filtered levels with name matching level key for blockly levels" do
     create(:level, name: 'blockly', level_num: 'special_blockly_level')
 
-    get :get_filtered_levels, params: {name: 'special_blockly_level'}
-    assert_equal 'special_blockly_level', JSON.parse(@response.body)['levels'][0]["name"]
+    get :get_filtered_levels, params: {name: 'blockly:Studio:special_blockly_level'}
+    assert_equal 'blockly:Studio:special_blockly_level', JSON.parse(@response.body)['levels'][0]["name"]
   end
 
   test "should get filtered levels with level_type" do

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -79,10 +79,11 @@ class LevelsControllerTest < ActionController::TestCase
   end
 
   test "should get filtered levels with name matching level key for blockly levels" do
-    create(:level, name: 'blockly', level_num: 'special_blockly_level')
+    game = Game.find_by_name("CustomMaze")
+    create(:level, name: 'blockly', level_num: 'special_blockly_level', game_id: game.id, type: "Maze")
 
-    get :get_filtered_levels, params: {name: 'blockly:Studio:special_blockly_level'}
-    assert_equal 'blockly:Studio:special_blockly_level', JSON.parse(@response.body)['levels'][0]["name"]
+    get :get_filtered_levels, params: {name: 'blockly:CustomMaze:special_blockly_level'}
+    assert_equal 'blockly:CustomMaze:special_blockly_level', JSON.parse(@response.body)['levels'][0]["name"]
   end
 
   test "should get filtered levels with level_type" do

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -573,6 +573,11 @@ FactoryGirl.define do
     game {Game.bounce}
   end
 
+  factory :odometer, parent: :level, class: Odometer do
+    game {Game.odometer}
+    level_num 'custom'
+  end
+
   factory :artist, parent: :level, class: Artist do
     game {Game.custom_artist}
   end
@@ -583,6 +588,7 @@ FactoryGirl.define do
 
   factory :applab, parent: :level, class: Applab do
     game {Game.applab}
+    level_num 'custom'
 
     trait :with_autoplay_video do
       video_key {create(:video).key}
@@ -599,18 +605,22 @@ FactoryGirl.define do
 
   factory :free_response, parent: :level, class: FreeResponse do
     game {Game.free_response}
+    level_num 'custom'
   end
 
   factory :playlab, parent: :level, class: Studio do
     game {create(:game, app: Game::PLAYLAB)}
+    level_num 'custom'
   end
 
   factory :gamelab, parent: :level, class: Gamelab do
     game {Game.gamelab}
+    level_num 'custom'
   end
 
   factory :weblab, parent: :level, class: Weblab do
     game {Game.weblab}
+    level_num 'custom'
   end
 
   factory :multi, parent: :level, class: Multi do
@@ -657,6 +667,7 @@ FactoryGirl.define do
 
   factory :javalab, parent: :level, class: Javalab do
     game {Game.javalab}
+    level_num 'custom'
 
     trait :with_example_solutions do
       after(:create) do |level|
@@ -668,10 +679,12 @@ FactoryGirl.define do
 
   factory :spritelab, parent: :level, class: GamelabJr do
     game {Game.spritelab}
+    level_num 'custom'
   end
 
   factory :dance, parent: :level, class: Dancelab do
     game {Game.dance}
+    level_num 'custom'
   end
 
   factory :block do

--- a/dashboard/test/models/level_test.rb
+++ b/dashboard/test/models/level_test.rb
@@ -164,11 +164,12 @@ class LevelTest < ActiveSupport::TestCase
   end
 
   test "summarize_for_edit returns level_num for name on blockly level" do
-    blockly_level = create(:level, name: 'blockly', level_num: 'special_blockly_level')
+    game = Game.find_by_name("CustomMaze")
+    blockly_level = create(:level, name: 'blockly', level_num: 'special_blockly_level', game_id: game.id, type: "Maze")
 
     summary = blockly_level.summarize_for_edit
 
-    assert_equal(summary[:name], 'blockly:Studio:special_blockly_level')
+    assert_equal(summary[:name], 'blockly:CustomMaze:special_blockly_level')
   end
 
   test "get_question_text returns question text for free response level" do

--- a/dashboard/test/models/level_test.rb
+++ b/dashboard/test/models/level_test.rb
@@ -168,7 +168,7 @@ class LevelTest < ActiveSupport::TestCase
 
     summary = blockly_level.summarize_for_edit
 
-    assert_equal(summary[:name], 'special_blockly_level')
+    assert_equal(summary[:name], 'blockly:Studio:special_blockly_level')
   end
 
   test "get_question_text returns question text for free response level" do

--- a/dashboard/test/models/level_test.rb
+++ b/dashboard/test/models/level_test.rb
@@ -1100,7 +1100,7 @@ class LevelTest < ActiveSupport::TestCase
   test "get search options" do
     search_options = Level.search_options
     assert_equal search_options[:levelOptions].map {|option| option[0]}, [
-      "All types", "Ailab", "Applab", "Artist", "Bounce", "BubbleChoice", "Calc", "ContractMatch",
+      "All types", "Ailab", "Applab", "Artist", "Blockly", "Bounce", "BubbleChoice", "Calc", "ContractMatch",
       "Craft", "CurriculumReference", "Dancelab", "Eval", "EvaluationMulti", "External",
       "ExternalLink", "Fish", "Flappy", "FreeResponse", "FrequencyAnalysis", "Gamelab",
       "GamelabJr", "Javalab", "Karel", "LevelGroup", "Map", "Match", "Maze", "Multi", "NetSim",


### PR DESCRIPTION
Follow up to https://github.com/code-dot-org/code-dot-org/pull/42916. Added Blockly as an option to the level types dropdown to allow editors to filter for Blockly specific levels. 



https://user-images.githubusercontent.com/208083/137204705-e85e9d98-7b0d-4268-aca9-e896ca58c4a2.mov


## Links

Previous PR: https://github.com/code-dot-org/code-dot-org/pull/42916
Jira: https://codedotorg.atlassian.net/browse/PLAT-1375

## Testing story

- Manual testing shown in the video