### PR TITLE
[Poetry][HOC] Only set poem state for poetry_hoc levels

### DIFF
--- a/apps/src/p5lab/poetry/Poetry.js
+++ b/apps/src/p5lab/poetry/Poetry.js
@@ -9,11 +9,10 @@ import {POEMS} from './constants';
 export default class Poetry extends SpriteLab {
   init(config) {
     super.init(config);
-    if (config.level.standaloneAppName === 'poetry_hoc') {
-      const poem = config.level.selectedPoem || POEMS[this.level.defaultPoem];
-      if (poem) {
-        getStore().dispatch(setPoem(poem));
-      }
+
+    const poem = config.level.selectedPoem || POEMS[this.level.defaultPoem];
+    if (poem) {
+      getStore().dispatch(setPoem(poem));
     }
   }
 

--- a/apps/src/p5lab/poetry/Poetry.js
+++ b/apps/src/p5lab/poetry/Poetry.js
@@ -9,7 +9,6 @@ import {POEMS} from './constants';
 export default class Poetry extends SpriteLab {
   init(config) {
     super.init(config);
-
     const poem = config.level.selectedPoem || POEMS[this.level.defaultPoem];
     if (poem) {
       getStore().dispatch(setPoem(poem));

--- a/apps/src/p5lab/poetry/Poetry.js
+++ b/apps/src/p5lab/poetry/Poetry.js
@@ -9,9 +9,11 @@ import {POEMS} from './constants';
 export default class Poetry extends SpriteLab {
   init(config) {
     super.init(config);
-    const poem = config.level.selectedPoem || POEMS[this.level.defaultPoem];
-    if (poem) {
-      getStore().dispatch(setPoem(poem));
+    if (config.level.standaloneAppName === 'poetry_hoc') {
+      const poem = config.level.selectedPoem || POEMS[this.level.defaultPoem];
+      if (poem) {
+        getStore().dispatch(setPoem(poem));
+      }
     }
   }
 

--- a/dashboard/app/models/levels/poetry.rb
+++ b/dashboard/app/models/levels/poetry.rb
@@ -25,10 +25,16 @@
 #
 
 class Poetry < GamelabJr
+  before_save :check_default_poem
+
   serialized_attrs %w(
     default_poem
     standalone_app_name
   )
+
+  def check_default_poem
+    self.default_poem = nil unless standalone_app_name == 'poetry_hoc'
+  end
 
   # Poetry levels use the same shared_functions as GamelabJr
   def shared_function_type

--- a/dashboard/app/views/levels/editors/fields/_poetry_fields.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_poetry_fields.html.haml
@@ -7,7 +7,7 @@
     %p Poetry HOC levels have a poem dropdown above the playspace and auto-animate the poem.
     = f.select :standalone_app_name, options_for_select(@level.class.standalone_app_names, @level.standalone_app_name), {}, onchange: 'toggleFields(this.value);'
 
-  #defaultPoem{class: ('collapse' if @level.standalone_app_name != 'Poetry HOC')}
+  #defaultPoem{class: ('collapse' if @level.standalone_app_name != 'poetry_hoc')}
     = f.label :default_poem, 'Default Poem'
     = f.select :default_poem, options_for_select(@level.class.hoc_poems, @level.default_poem)
 


### PR DESCRIPTION
reported via [slack thread](https://codedotorg.slack.com/archives/C01GFDRTBCP/p1634152919002900)

If there's no poem dropdown, we don't want to set the poem state even if the user somehow has a poem set in their progress or the level has a default poem. When there's no poem dropdown, the poem must be set using blocks.