### PR TITLE
Add data to NoMethodError for progress

### DIFF
--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -261,7 +261,13 @@ module UsersHelper
             sum_time_spent = bubble_choice_progress.values.reduce(0) do |sum, sublevel_progress|
               sublevel_progress[:time_spent] ? sum + sublevel_progress[:time_spent] : sum
             end
-            level_progress[:time_spent] = sum_time_spent if sum_time_spent > 0
+
+            begin
+              level_progress[:time_spent] = sum_time_spent if sum_time_spent > 0
+            # re-raising the error with more information to debug
+            rescue NoMethodError => error
+              raise error, "Level: #{level.id}, User: #{user.id}, Level_for_progress: #{level_for_progress.id}", error.backtrace
+            end
           end
         end
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
We've had an error on `/dashboardapi/section_level_progress/<section>` which has been increasing in frequency over the last few months:
![Screen Shot 2021-10-13 at 2 30 58 PM](https://user-images.githubusercontent.com/24235215/137215395-df1b7257-5392-4210-af4d-d498ffdf4cf4.png)

The error is `NoMethodError: undefined method []=' for nil:NilClass`, which I determined would be caused for a bubble choice level if a student does not have overall progress for the level but has progress on a sublevel. It's hard for me to imagine how this could happen. I reloaded the endpoint with the same parameters that it failed with and got 200s. I logged in as various teachers looking for a pattern that could be causing this among their student progress with no luck.

I need more data. So I've rescued the error and re-raised it with more information about the specific student and level. 

## Links
Error: https://app.honeybadger.io/projects/3240/faults/80852799/01FHX8JY4SPJER77W141CNQ155
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
I've tested locally that raising the error results in the expected message:
![Screen Shot 2021-10-13 at 2 37 13 PM](https://user-images.githubusercontent.com/24235215/137216056-e19f04f0-a660-4761-b533-b00b40359bd3.png)


<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

## Follow-up work
Once I have more data, I'll look into the specific levels and students that this is happening for.
<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
