### PR TITLE
I18n tracking data will be flushed every 8-16 hours.

### DIFF
--- a/lib/cdo/i18n_string_url_tracker.rb
+++ b/lib/cdo/i18n_string_url_tracker.rb
@@ -17,8 +17,7 @@ class I18nStringUrlTracker
 
   # The amount of time which will pass before the buffered i18n usage data is uploaded to Firehose.
   # Select a random interval time between the MIN and MAX so we can avoid all the servers flushing data at the same time.
-  # TODO - Set MIN to 8 hours once we have proven this works.
-  FLUSH_INTERVAL_MIN = 1.hour
+  FLUSH_INTERVAL_MIN = 8.hours
   FLUSH_INTERVAL_MAX = 16.hours
 
   MAX_BUFFER_SIZE = 250.megabytes


### PR DESCRIPTION
The minimum was originally set to 1 hour so we could quickly verify the tracking system was working during business hours. This change will restore it to be every 8-16 hours so we only sync the data 1-2 times a day.