### PR TITLE
hoc2021: Serve smaller images

### DIFF
--- a/pegasus/sites.v3/code.org/public/learn/index.haml
+++ b/pegasus/sites.v3/code.org/public/learn/index.haml
@@ -106,7 +106,7 @@ style_min: false
 
   - if ["soon-hoc", "actual-hoc"].include?(hoc_mode)
     .banner.container_responsive{style: "display: flex"}
-      .col-33.tablet-feature{style: "align-items: stretch; background-image: url(/shared/images/hoc-cse-left-fade.png); background-position: 50% 50%; background-size: contain; background-repeat: no-repeat"}
+      .col-33.tablet-feature{style: "align-items: stretch; background-image: url(/shared/images/fit-1200/hoc-cse-left-fade.png); background-position: 50% 50%; background-size: contain; background-repeat: no-repeat"}
       .col-33
         .bannerHeading= hoc_s(:learn_banner_heading)
         = hoc_s(:learn_banner_blurb)
@@ -115,7 +115,7 @@ style_min: false
         .bannerTeachers
           %i{:class=>"fa fa-graduation-cap", :style=>"font-size: larger"}
           != hoc_s(:learn_banner_teachers_markdown, markdown: :inline, locals: {host_url: "https://hourofcode.com/#join", howto_url: "https://hourofcode.com/how-to"})
-      .col-33.tablet-feature{style: "align-items: stretch; background-image: url(/shared/images/hoc-cse-right-fade.png); background-position: 50% 50%; background-size: contain; background-repeat: no-repeat"}
+      .col-33.tablet-feature{style: "align-items: stretch; background-image: url(/shared/images/fit-1200/hoc-cse-right-fade.png); background-position: 50% 50%; background-size: contain; background-repeat: no-repeat"}
 
   - else
     .banner.container_responsive

--- a/pegasus/sites.v3/code.org/views/homepage_hero.haml
+++ b/pegasus/sites.v3/code.org/views/homepage_hero.haml
@@ -22,7 +22,7 @@
     %div{style: "padding-bottom: 20px; text-align: center"}
       %span.hero-message-line2.cse-hero-message-line2{style: "color: black; line-height: 1.2em; font-family: 'Gotham 5r', sans-serif", dir: "auto"}
         = hoc_s(:codeorg_homepage_celebrate_cse)
-    %img.phone-feature{src: "/shared/images/hoc-cse-arrows.png", style: "width: 100%; padding-bottom: 20px"}
+    %img.phone-feature{src: "/shared/images/fit-1200/hoc-cse-arrows.png", style: "width: 100%; padding-bottom: 20px"}
 
   - if show_single_hero == "changeworld"
     .hero-message-line1{style: "color: white; font-size: 28px; line-height: 28px; padding-top: 20px; padding-bottom: 20px; font-family: 'Gotham 5r', sans-serif", dir: "auto"}
@@ -80,10 +80,10 @@
   - if ["soon-hoc", "actual-hoc"].include?(hoc_mode)
     #actions
       %div{style: "display: flex"}
-        .col-33.tablet-feature{style: "align-items: stretch; background-image: url(/shared/images/hoc-cse-left-fade.png); background-position: 100% 50%; background-size: contain; background-repeat: no-repeat"}
+        .col-33.tablet-feature{style: "align-items: stretch; background-image: url(/shared/images/fit-1200/hoc-cse-left-fade.png); background-position: 100% 50%; background-size: contain; background-repeat: no-repeat"}
         .col-33
           = main_actions
-        .col-33.tablet-feature{style: "align-items: stretch; background-image: url(/shared/images/hoc-cse-right-fade.png); background-position: 0% 50%; background-size: contain; background-repeat: no-repeat"}
+        .col-33.tablet-feature{style: "align-items: stretch; background-image: url(/shared/images/fit-1200/hoc-cse-right-fade.png); background-position: 0% 50%; background-size: contain; background-repeat: no-repeat"}
 
   - else
     - if show_single_hero

--- a/pegasus/sites.v3/hourofcode.com/public/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/index.haml
@@ -93,7 +93,7 @@ social:
       .row
         - if ["soon-hoc", "actual-hoc"].include?(hoc_mode)
           %div{style: "color: black; display: flex"}
-            .col-md-4.hidden-sm.hidden-xs{style: "align-items: stretch; background-image: url(/shared/images/hoc-cse-left-fade.png); background-position: 100% 00%; background-size: contain; background-repeat: no-repeat"}
+            .col-md-4.hidden-sm.hidden-xs{style: "align-items: stretch; background-image: url(/shared/images/fit-1200/hoc-cse-left-fade.png); background-position: 100% 00%; background-size: contain; background-repeat: no-repeat"}
             .col-sm-12.col-md-4.no-padding-on-narrow
               #textbacking.no-padding-on-narrow
                 .front-header-banner.no-padding-on-narrow
@@ -101,13 +101,13 @@ social:
                     = hoc_s(:codeorg_homepage_celebrate_cse, markdown: true)
                   .front-header-description{style: "margin-bottom: 20px"}
                     = hoc_s(:hourofcode_homepage_hoc2018_header_line1)
-                %img.hidden-md.hidden-lg{src: "/shared/images/hoc-cse-arrows.png", style: "width: 100%; padding-bottom: 20px"}
+                %img.hidden-md.hidden-lg{src: "/shared/images/fit-1200/hoc-cse-arrows.png", style: "width: 100%; padding-bottom: 20px"}
                 .ctabuttongroup
                   #tryittext.ctatext
                     = view :hoc_action_buttons, hoc_mode: hoc_mode
               %br/
               %br/
-            .col-md-4.hidden-sm.hidden-xs{style: "align-items: stretch; background-image: url(/shared/images/hoc-cse-right-fade.png); background-position: 0% 0%; background-size: contain; background-repeat: no-repeat"}
+            .col-md-4.hidden-sm.hidden-xs{style: "align-items: stretch; background-image: url(/shared/images/fit-1200/hoc-cse-right-fade.png); background-position: 0% 0%; background-size: contain; background-repeat: no-repeat"}
 
         - else
           .col-12

--- a/pegasus/sites.v3/hourofcode.com/public/learn/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/learn/index.haml
@@ -89,7 +89,7 @@ social:
 
   - if ["soon-hoc", "actual-hoc"].include?(hoc_mode)
     .banner.container{style: "color: black; display: flex"}
-      .col-sm-4.hidden-xs{style: "align-items: stretch; background-image: url(/shared/images/hoc-cse-left-fade.png); background-position: 100% 50%; background-size: contain; background-repeat: no-repeat"}
+      .col-sm-4.hidden-xs{style: "align-items: stretch; background-image: url(/shared/images/fit-1200/hoc-cse-left-fade.png); background-position: 100% 50%; background-size: contain; background-repeat: no-repeat"}
       .col-sm-4.col-xs-12{style: "text-align: center"}
         .bannerHeading= hoc_s(:learn_banner_heading)
         = hoc_s(:learn_banner_blurb)
@@ -98,7 +98,7 @@ social:
         .bannerTeachers
           %i{:class=>"fa fa-graduation-cap", :style=>"font-size: larger"}
           != hoc_s(:learn_banner_teachers_markdown, markdown: :inline, locals: {host_url: "https://hourofcode.com/#join", howto_url: "https://hourofcode.com/how-to"})
-      .col-sm-4.hidden-xs{style: "align-items: stretch; background-image: url(/shared/images/hoc-cse-right-fade.png); background-position: 0% 50%; background-size: contain; background-repeat: no-repeat"}
+      .col-sm-4.hidden-xs{style: "align-items: stretch; background-image: url(/shared/images/fit-1200/hoc-cse-right-fade.png); background-position: 0% 50%; background-size: contain; background-repeat: no-repeat"}
 
   - else
     .banner.container{style: "color: black"}


### PR DESCRIPTION
The new source images are actually quite large in pixel dimensions, and we can happily serve them at significantly smaller dimensions while still looking fine, so the retrieval URLs have been adjusted to do this.

Follow-up to https://github.com/code-dot-org/code-dot-org/pull/42965.
