### PR TITLE
Display warning if project uses Top 200 datasets

### DIFF
--- a/apps/i18n/applab/en_us.json
+++ b/apps/i18n/applab/en_us.json
@@ -19,6 +19,7 @@
   "designWorkspaceHeader": "Workspace",
   "designElementPhotoSelectClickName": "Change",
   "designElementPhotoSelectClickDescription": "Triggered when a photo is selected.",
+  "deprecatedDataset": "The {name} dataset is deprecated. Use {alternative} instead!",
   "dropletBlock_appendItem_description": "Append the item to the end of the array.",
   "dropletBlock_appendItem_param0_description": "The array to be modified.",
   "dropletBlock_appendItem_param1_description": "The item to add to the end of the array.",
@@ -392,8 +393,6 @@
   "shareApplabTwitterDonor": "Check out the app I made. (Thanks {donor} for supporting @codeorg)",
   "shareGame": "Share your app:",
   "tableDoesNotExistError": "You tried to read records from a table called \"{tableName}\" but that table doesn't exist in this app",
-  "top200UsaWarning": "The Top 200 USA dataset used in this project is being removed on Dec. 1. Consider using the supported Top 50 USA dataset instead.",
-  "top200WorldwideWarning": "The Top 200 Worldwide dataset used in this project is being removed on Dec. 1. Consider using the supported Top 50 Worldwide dataset instead.",
   "tryAgainText": "Keep working",
   "viewData": "View Data",
   "yes": "Yes"

--- a/apps/i18n/applab/en_us.json
+++ b/apps/i18n/applab/en_us.json
@@ -19,7 +19,7 @@
   "designWorkspaceHeader": "Workspace",
   "designElementPhotoSelectClickName": "Change",
   "designElementPhotoSelectClickDescription": "Triggered when a photo is selected.",
-  "deprecatedDataset": "The {name} dataset is deprecated. Use {alternative} instead!",
+  "deprecatedDataset": "The {name} dataset used in this project is being removed on Dec. 1. Consider using the supported {alternative} dataset instead.",
   "dropletBlock_appendItem_description": "Append the item to the end of the array.",
   "dropletBlock_appendItem_param0_description": "The array to be modified.",
   "dropletBlock_appendItem_param1_description": "The item to add to the end of the array.",

--- a/apps/i18n/applab/en_us.json
+++ b/apps/i18n/applab/en_us.json
@@ -392,6 +392,8 @@
   "shareApplabTwitterDonor": "Check out the app I made. (Thanks {donor} for supporting @codeorg)",
   "shareGame": "Share your app:",
   "tableDoesNotExistError": "You tried to read records from a table called \"{tableName}\" but that table doesn't exist in this app",
+  "top200UsaWarning": "The Top 200 USA dataset used in this project is being removed on Dec. 1. Consider using the supported Top 50 USA dataset instead.",
+  "top200WorldwideWarning": "The Top 200 Worldwide dataset used in this project is being removed on Dec. 1. Consider using the supported Top 50 Worldwide dataset instead.",
   "tryAgainText": "Keep working",
   "viewData": "View Data",
   "yes": "Yes"

--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -947,6 +947,7 @@ function setupReduxSubscribers(store) {
       let tableName =
         typeof snapshot.key === 'function' ? snapshot.key() : snapshot.key;
       tableName = unescapeFirebaseKey(tableName);
+      checkDataSetForWarning(tableName);
       store.dispatch(addTableName(tableName, tableType.SHARED));
     });
     currentTableRef.on('child_removed', snapshot => {
@@ -956,6 +957,27 @@ function setupReduxSubscribers(store) {
       store.dispatch(deleteTableName(tableName));
     });
   }
+}
+
+/**
+ * Show warning if project is using spotify datasets that will be deprecated.
+ * To be removed once old datasets are removed (https://codedotorg.atlassian.net/browse/STAR-1797)
+ */
+function checkDataSetForWarning(tableName) {
+  if (tableName !== 'Top 200 USA' && tableName !== 'Top 200 Worldwide') {
+    return;
+  }
+
+  const msg =
+    tableName === 'Top 200 USA'
+      ? applabMsg.top200UsaWarning()
+      : applabMsg.top200WorldwideWarning();
+
+  studioApp().displayWorkspaceAlert(
+    'warning',
+    <div>{msg}</div>,
+    true /* bottom */
+  );
 }
 
 Applab.onIsRunningChange = function() {

--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -90,6 +90,14 @@ import {MB_API} from '../lib/kits/maker/boards/microBit/MicroBitConstants';
 import autogenerateML from '@cdo/apps/applab/ai';
 
 /**
+ * Constants for Spotify dataset alert
+ */
+const TOP_200_USA = 'Top 200 USA';
+const TOP_200_Worldwide = 'Top 200 Worldwide';
+const TOP_50_USA = 'Top 200 USA';
+const TOP_50_Worldwide = 'Top 200 Worldwide';
+
+/**
  * Create a namespace for the application.
  * @implements LogTarget
  */
@@ -964,14 +972,15 @@ function setupReduxSubscribers(store) {
  * To be removed once old datasets are removed (https://codedotorg.atlassian.net/browse/STAR-1797)
  */
 function checkDataSetForWarning(tableName) {
-  if (tableName !== 'Top 200 USA' && tableName !== 'Top 200 Worldwide') {
+  // Only two datasets will need to be handled: TOP_200_USA and TOP_200_WORLDWIDE
+  if (tableName !== TOP_200_USA && tableName !== TOP_200_Worldwide) {
     return;
   }
 
-  const msg =
-    tableName === 'Top 200 USA'
-      ? applabMsg.top200UsaWarning()
-      : applabMsg.top200WorldwideWarning();
+  const msg = applabMsg.deprecatedDataset({
+    name: tableName === TOP_200_USA ? TOP_200_USA : TOP_200_Worldwide,
+    alternative: tableName === TOP_200_USA ? TOP_50_USA : TOP_50_Worldwide
+  });
 
   studioApp().displayWorkspaceAlert(
     'warning',


### PR DESCRIPTION
Adding a workspace alert notification to warn users who have imported any of the `Top 200` spotify datasets that are going to be removed on / after Dec. 1st. 

https://user-images.githubusercontent.com/35442460/137405540-f59ea59e-913c-41e0-8e6a-e66a2042725f.mov


## Links
- jira ticket: https://codedotorg.atlassian.net/browse/STAR-1761

## Testing story
Not sure if this needs to be tested as this code will be deleted in the next 2 months, but happy to add them if we think that's best! 

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work
- Future ticket to actually remove the old datasets: https://codedotorg.atlassian.net/browse/STAR-1797


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
