### PR TITLE
hoc2021: Set hoc_mode on test to 'soon-hoc'

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -416,8 +416,8 @@ proxy: false # If true, generated URLs will not include explicit port numbers in
 # Run dashboard-server with the level editing interface enabled (for admins)
 levelbuilder_mode:
 
-default_hoc_mode:   pre-hoc # overridden by 'hoc_mode' DCDO param, except in :test
-default_hoc_launch: ''       # overridden by 'hoc_launch' DCDO param, except in :test
+default_hoc_mode: soon-hoc  # overridden by 'hoc_mode' DCDO param, except in :test
+default_hoc_launch: ''      # overridden by 'hoc_launch' DCDO param, except in :test
 
 # teacher_application_mode values: 'open', 'closing-soon', 'closed'
 default_teacher_application_mode: 'closed' # overridden by 'teacher_application_mode' DCDO param, except in :test


### PR DESCRIPTION
Other environments (including `staging` & `production`) have now moved to `hoc_mode` being `"soon-hoc"` for 2021.  The test environment was left out, but that was helful because it helped make sure that the changes to enable `"soon-hoc"` didn't regress any of the pages while still running as `"pre-hoc"`.  Now, though, we can move the test environment over.
