### PR TITLE
Subtract idle time from time spent

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -1738,8 +1738,6 @@ StudioApp.prototype.report = function(options) {
   const idleTimeSinceLastMilestone =
     totalIdleTime - this.milestoneStartTotalIdleTime;
 
-  console.log('idleTimeSinceLastMilestone', idleTimeSinceLastMilestone);
-
   // copy from options: app, level, result, testResult, program, onComplete
   var report = Object.assign({}, options, {
     pass: this.feedback_.canContinueToNextLevel(options.testResult),

--- a/apps/src/redux/commonReducers.js
+++ b/apps/src/redux/commonReducers.js
@@ -10,6 +10,7 @@ import instructions from './instructions';
 import instructionsDialog from './instructionsDialog';
 import watchedExpressions from './watchedExpressions';
 import feedback from './feedback';
+import studioAppActivity from './studioAppActivity';
 
 module.exports = {
   runState,
@@ -19,5 +20,6 @@ module.exports = {
   instructions,
   instructionsDialog,
   watchedExpressions,
-  feedback
+  feedback,
+  studioAppActivity
 };

--- a/apps/src/redux/studioAppActivity.js
+++ b/apps/src/redux/studioAppActivity.js
@@ -1,20 +1,68 @@
-const SET_IDLE_TIME = 'instructions/SET_IDLE_TIME';
+const SET_START_IDLE = 'studioAppActivity/SET_START_IDLE';
+const SET_END_IDLE = 'studioAppActivity/SET_END_IDLE';
+const RESET_IDLE_TIME = 'studioAppActivity/RESET_IDLE_TIME';
 
-const instructionsInitialState = {
-  idleTimeMs: 0
+const studioAppActivityInitialState = {
+  idleTimeSinceLastReport: 0,
+  idleStart: null,
+  isIdle: false
 };
 
-export default function reducer(state = instructionsInitialState, action) {
-  if (action.type === SET_IDLE_TIME) {
+export default function reducer(state = studioAppActivityInitialState, action) {
+  if (action.type === SET_START_IDLE) {
     return Object.assign({}, state, {
-      idleTimeMs: action.idleTimeMs
+      isIdle: true,
+      idleStart: new Date().getTime()
+    });
+  }
+
+  if (action.type === SET_END_IDLE) {
+    if (state.idleStart) {
+      const newIdleTime =
+        state.idleTimeSinceLastReport + timeSinceIdleStart(state);
+
+      return Object.assign({}, state, {
+        isIdle: false,
+        idleTimeSinceLastReport: newIdleTime
+      });
+    } else {
+      return state;
+    }
+  }
+
+  if (action.type === RESET_IDLE_TIME) {
+    const idleStart = state.isIdle ? new Date().getTime() : null;
+
+    return Object.assign({}, state, {
+      idleTimeSinceLastReport: 0,
+      idleStart
     });
   }
 
   return state;
 }
 
-export const setIdleTimeMs = idleTimeMs => ({
-  type: SET_IDLE_TIME,
-  idleTimeMs
+const timeSinceIdleStart = state => {
+  const now = new Date().getTime();
+  return now - state.idleStart;
+};
+
+export const setStartIdle = () => ({
+  type: SET_START_IDLE
 });
+
+export const setEndIdle = () => ({
+  type: SET_END_IDLE
+});
+
+export const resetIdleTime = () => ({
+  type: RESET_IDLE_TIME
+});
+
+export const getIdleTimeSinceLastReport = state => {
+  if (state.isIdle) {
+    return state.idleTimeSinceLastReport + timeSinceIdleStart(state);
+  } else {
+    return state.idleTimeSinceLastReport;
+  }
+};

--- a/apps/src/redux/studioAppActivity.js
+++ b/apps/src/redux/studioAppActivity.js
@@ -1,0 +1,20 @@
+const SET_IDLE_TIME = 'instructions/SET_IDLE_TIME';
+
+const instructionsInitialState = {
+  idleTimeMs: 0
+};
+
+export default function reducer(state = instructionsInitialState, action) {
+  if (action.type === SET_IDLE_TIME) {
+    return Object.assign({}, state, {
+      idleTimeMs: action.idleTimeMs
+    });
+  }
+
+  return state;
+}
+
+export const setIdleTimeMs = idleTimeMs => ({
+  type: SET_IDLE_TIME,
+  idleTimeMs
+});

--- a/apps/src/templates/StudioAppIdleTimer.jsx
+++ b/apps/src/templates/StudioAppIdleTimer.jsx
@@ -2,8 +2,9 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
 import IdleTimer from 'react-idle-timer';
-import {setIdleTimeMs} from '@cdo/apps/redux/studioAppActivity';
+import {setStartIdle, setEndIdle} from '@cdo/apps/redux/studioAppActivity';
 
+// Idle time doesn't start tracking until after IDLE_AFTER milliseconds of idling
 const IDLE_AFTER = 1000 * 60 * 2;
 
 /**
@@ -12,51 +13,29 @@ const IDLE_AFTER = 1000 * 60 * 2;
  */
 class StudioAppIdleTimer extends React.Component {
   static propTypes = {
-    totalIdleTime: PropTypes.number.isRequired,
-    setIdleTime: PropTypes.func.isRequired
-  };
-
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      idleStart: null
-    };
-  }
-
-  // This method isn't called until user has been idle for IDLE_AFTER ms,
-  // which is when we start actually tracking idle time
-  onIdle = () => {
-    this.setState({idleStart: new Date().getTime()});
-  };
-
-  onActive = () => {
-    if (this.state.idleStart) {
-      const now = new Date().getTime();
-      const timeSpentIdle = now - this.state.idleStart;
-      this.props.setIdleTime(this.props.totalIdleTime + timeSpentIdle);
-    }
+    setStartIdle: PropTypes.func.isRequired,
+    setEndIdle: PropTypes.func.isRequired
   };
 
   render() {
     return (
       <IdleTimer
         timeout={IDLE_AFTER}
-        onIdle={this.onIdle}
-        onActive={this.onActive}
-        debounce={250}
+        onIdle={this.props.setStartIdle}
+        onActive={this.props.setEndIdle}
       />
     );
   }
 }
 
 export default connect(
-  state => ({
-    totalIdleTime: state.studioAppActivity.idleTimeMs
-  }),
+  null,
   dispatch => ({
-    setIdleTime(ms) {
-      dispatch(setIdleTimeMs(ms));
+    setStartIdle(ms) {
+      dispatch(setStartIdle(ms));
+    },
+    setEndIdle(ms) {
+      dispatch(setEndIdle(ms));
     }
   })
 )(StudioAppIdleTimer);

--- a/apps/src/templates/StudioAppIdleTimer.jsx
+++ b/apps/src/templates/StudioAppIdleTimer.jsx
@@ -31,11 +31,11 @@ class StudioAppIdleTimer extends React.Component {
 export default connect(
   null,
   dispatch => ({
-    setStartIdle(ms) {
-      dispatch(setStartIdle(ms));
+    setStartIdle() {
+      dispatch(setStartIdle());
     },
-    setEndIdle(ms) {
-      dispatch(setEndIdle(ms));
+    setEndIdle() {
+      dispatch(setEndIdle());
     }
   })
 )(StudioAppIdleTimer);

--- a/apps/src/templates/StudioAppIdleTimer.jsx
+++ b/apps/src/templates/StudioAppIdleTimer.jsx
@@ -1,0 +1,66 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import {connect} from 'react-redux';
+import IdleTimer from 'react-idle-timer';
+import {setIdleTimeMs} from '@cdo/apps/redux/studioAppActivity';
+
+/**
+ * Wrapper component for all Code Studio app types, which provides rotate
+ * container and clear-div but otherwise just renders children.
+ */
+class StudioAppIdleTimer extends React.Component {
+  static propTypes = {
+    setIdleTime: PropTypes.func
+  };
+
+  constructor(props) {
+    super(props);
+    this.idleTimer = null;
+
+    this.state = {
+      lastIdleStart: null,
+      totalIdleTime: 0
+    };
+  }
+
+  onIdle = () => {
+    console.log('on Idle');
+    // Don't start calculating idle time until user has been idle for timeout seconds
+    this.setState({lastIdleStart: new Date().getTime()});
+  };
+
+  onActive = () => {
+    console.log('onAction');
+    if (this.state.lastIdleStart) {
+      const now = new Date().getTime();
+      const newIdleTime = now - this.state.lastIdleStart;
+      this.setState({
+        totalIdleTime: this.state.totalIdleTime + newIdleTime
+      });
+      this.props.setIdleTime(this.state.totalIdleTime + newIdleTime);
+    }
+  };
+
+  render() {
+    return (
+      <IdleTimer
+        ref={ref => {
+          this.idleTimer = ref;
+        }}
+        timeout={1000 * 15}
+        onIdle={this.onIdle}
+        onActive={this.onActive}
+        debounce={250}
+      />
+    );
+  }
+}
+
+export default connect(
+  null,
+  dispatch => ({
+    setIdleTime(ms) {
+      dispatch(setIdleTimeMs(ms));
+    }
+  })
+)(StudioAppIdleTimer);

--- a/apps/src/templates/StudioAppWrapper.jsx
+++ b/apps/src/templates/StudioAppWrapper.jsx
@@ -4,6 +4,7 @@ import FixZoomHelper from '../templates/FixZoomHelper';
 import HideToolbarHelper from '../templates/HideToolbarHelper';
 import RotateContainer from '../templates/RotateContainer';
 import {connect} from 'react-redux';
+import StudioAppIdleTimer from '@cdo/apps/templates/StudioAppIdleTimer';
 
 /**
  * Wrapper component for all Code Studio app types, which provides rotate
@@ -29,6 +30,7 @@ class StudioAppWrapper extends React.Component {
         {this.requiresLandscape() && (
           <RotateContainer assetUrl={this.props.assetUrl} />
         )}
+        <StudioAppIdleTimer />
         {this.props.children}
         <div className="clear" />
       </div>

--- a/apps/src/templates/StudioAppWrapper.jsx
+++ b/apps/src/templates/StudioAppWrapper.jsx
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import FixZoomHelper from '../templates/FixZoomHelper';
-import HideToolbarHelper from '../templates/HideToolbarHelper';
-import RotateContainer from '../templates/RotateContainer';
+import FixZoomHelper from '@cdo/apps/templates/FixZoomHelper';
+import HideToolbarHelper from '@cdo/apps/templates/HideToolbarHelper';
+import RotateContainer from '@cdo/apps/templates/RotateContainer';
 import {connect} from 'react-redux';
 import StudioAppIdleTimer from '@cdo/apps/templates/StudioAppIdleTimer';
 
@@ -37,6 +37,8 @@ class StudioAppWrapper extends React.Component {
     );
   }
 }
+
+export const UnconnectedStudioAppWrapper = StudioAppWrapper;
 
 export default connect(state => ({
   assetUrl: state.pageConstants.assetUrl,

--- a/apps/test/unit/templates/StudioAppWrapperTest.jsx
+++ b/apps/test/unit/templates/StudioAppWrapperTest.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import {expect} from '../../util/reconfiguredChai';
+import {UnconnectedStudioAppWrapper as StudioAppWrapper} from '@cdo/apps/templates/StudioAppWrapper';
+import FixZoomHelper from '@cdo/apps/templates/FixZoomHelper';
+import HideToolbarHelper from '@cdo/apps/templates/HideToolbarHelper';
+import RotateContainer from '@cdo/apps/templates/RotateContainer';
+import StudioAppIdleTimer from '@cdo/apps/templates/StudioAppIdleTimer';
+
+const DEFAULT_PROPS = {
+  assetUrl: () => '/',
+  isEmbedView: false,
+  isShareView: false,
+  children: <div />
+};
+
+const setUp = (overrideProps = {}) => {
+  const props = {...DEFAULT_PROPS, ...overrideProps};
+  return shallow(
+    <StudioAppWrapper {...props}>{props.children}</StudioAppWrapper>
+  );
+};
+
+describe('StudioAppWrapper', () => {
+  it('renders a FixZoomHelper', () => {
+    const wrapper = setUp();
+    expect(wrapper.find(FixZoomHelper)).to.have.length(1);
+  });
+
+  it('renders a HideToolbarHelper', () => {
+    const wrapper = setUp();
+    expect(wrapper.find(HideToolbarHelper)).to.have.length(1);
+  });
+
+  it('renders RotateContainer if not isEmbedView or isShareView', () => {
+    const wrapper = setUp({isEmbedView: false, isShareView: false});
+    expect(wrapper.find(RotateContainer)).to.have.length(1);
+  });
+
+  it('does not render RotateContainer if isEmbedView', () => {
+    const wrapper = setUp({isEmbedView: true, isShareView: false});
+    expect(wrapper.find(RotateContainer)).to.have.length(0);
+  });
+
+  it('does not render RotateContainer if isShareView', () => {
+    const wrapper = setUp({isEmbedView: false, isShareView: true});
+    expect(wrapper.find(RotateContainer)).to.have.length(0);
+  });
+
+  it('renders a StudioAppIdleTimer', () => {
+    const wrapper = setUp({isEmbedView: false, isShareView: true});
+    expect(wrapper.find(StudioAppIdleTimer)).to.have.length(1);
+  });
+
+  it('renders children', () => {
+    const child = <div className="child">some child</div>;
+    const wrapper = setUp({children: child});
+    expect(wrapper.find('.child')).to.have.length(1);
+  });
+});


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Added react-idle-timer component to `StudioAppWrapper` to be included on Studio Apps. The timer will track time spent idle, idle time will start tracking after 2 minutes of the user being idle. Idle time will then be set to `studioAppActivity` redux where it can be read by `StudioApp.js`. In `StudioApp.js` when time spent is recorded, we will subtract the idle time since the last milestone has posted. 

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
- jira ticket: [LP-1395](https://codedotorg.atlassian.net/browse/LP-1395)
<!--
- spec: []()

-->

## Testing story
I tested locally that the time spent idle is being recorded correctly and that the time_spent set on the user_level seemed right. I also added some unit tests. If anyone has ideas for additional tests, I'm open to ideas.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
