### PR TITLE
[Poetry] Add Poem Selector to height calculation

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -1342,7 +1342,8 @@ function resizePinnedBelowVisualizationArea() {
     'spelling-table-wrapper',
     'gameButtons',
     'gameButtonExtras',
-    'song-selector-wrapper'
+    'song-selector-wrapper',
+    'poemSelector'
   ];
   possibleElementsAbove.forEach(id => {
     let element = document.getElementById(id);

--- a/apps/src/p5lab/poetry/PoemSelector.jsx
+++ b/apps/src/p5lab/poetry/PoemSelector.jsx
@@ -113,7 +113,7 @@ function PoemSelector(props) {
   };
 
   return (
-    <div style={styles.container}>
+    <div id="poemSelector" style={styles.container}>
       <PoemEditor isOpen={isOpen} handleClose={handleClose} />
       <label>
         <b>{msg.selectPoem()}</b>


### PR DESCRIPTION
Added the Poem Selector to the list of elements used to calculate the position of #belowVisualization`.

## Links
https://studio.code.org/s/poem-art/lessons/1/levels/1
![image](https://user-images.githubusercontent.com/73763104/137548270-6ab57eef-49ec-4586-af50-a2550b45bfd5.png)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
I need some assistance from a *Labs dev to test this locally. I could not get the video and links to show up on my local environment.
http://localhost-studio.code.org:3000/s/poem-art/lessons/1/levels/1

