### PR TITLE
Fix NoMethodError in api # section_level_progress

### DIFF
--- a/dashboard/app/controllers/api/v1/teacher_feedbacks_controller.rb
+++ b/dashboard/app/controllers/api/v1/teacher_feedbacks_controller.rb
@@ -53,7 +53,7 @@ class Api::V1::TeacherFeedbacksController < Api::V1::JsonApiController
     @teacher_feedback.teacher_id = current_user.id
 
     if @teacher_feedback.save
-      if @teacher_feedback.review_state == TeacherFeedback::REVIEW_STATES.keepWorking
+      if @teacher_feedback.keep_working?
         reset_progress_for_keep_working(@teacher_feedback)
       end
 

--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -243,7 +243,7 @@ module UsersHelper
     script.script_levels.each do |sl|
       sl.level_ids.each do |level_id|
         level = Level.cache_find(level_id)
-        level_for_progress = level.get_level_for_progress(user, script)
+        level_for_progress = level.get_level_for_progress(user, script, user_levels_by_level, teacher_feedback_by_level)
         ul = user_levels_by_level.try(:[], level_for_progress.id)
 
         feedback = teacher_feedback_by_level.try(:[], level_for_progress.id)

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -755,9 +755,14 @@ class Level < ApplicationRecord
     }
   end
 
-  def get_level_for_progress(student, script)
+  def get_level_for_progress(student, script, user_levels_by_level = nil, teacher_feedback_by_level = nil)
     if is_a?(BubbleChoice)
-      sublevel_for_progress = try(:get_sublevel_for_progress, student, script)
+      sublevel_for_progress = if user_levels_by_level.nil? && teacher_feedback_by_level.nil?
+                                try(:get_sublevel_for_progress, student, script)
+                              else
+                                try(:get_sublevel_for_progress_from_data, user_levels_by_level, teacher_feedback_by_level)
+                              end
+
       return sublevel_for_progress || self
     elsif contained_levels.any?
       # https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/views/levels/_contained_levels.html.haml#L1

--- a/dashboard/app/models/teacher_feedback.rb
+++ b/dashboard/app/models/teacher_feedback.rb
@@ -228,7 +228,11 @@ class TeacherFeedback < ApplicationRecord
   def awaiting_teacher_review?(is_latest = false)
     return false unless is_latest
 
-    return review_state == REVIEW_STATES.keepWorking && student_updated_since_feedback?
+    return keep_working? && student_updated_since_feedback?
+  end
+
+  def keep_working?
+    return review_state == REVIEW_STATES.keepWorking
   end
 
   private

--- a/dashboard/test/models/teacher_feedback_test.rb
+++ b/dashboard/test/models/teacher_feedback_test.rb
@@ -215,6 +215,18 @@ class TeacherFeedbackTest < ActiveSupport::TestCase
     assert_equal(feedback.awaiting_teacher_review?(true), true)
   end
 
+  test 'keep_working? returns true if review_state is keep working' do
+    feedback = create :teacher_feedback, review_state: TeacherFeedback::REVIEW_STATES.keepWorking
+
+    assert_equal(feedback.keep_working?, true)
+  end
+
+  test 'keep_working? returns false if review_state is not keep working' do
+    feedback = create :teacher_feedback, review_state: TeacherFeedback::REVIEW_STATES.completed
+
+    assert_equal(feedback.keep_working?, false)
+  end
+
   test 'destroys when teacher is destroyed' do
     teacher = create :teacher
     first_feedback = create :teacher_feedback, teacher: teacher


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Error: https://app.honeybadger.io/projects/3240/faults/82008202

In `users_helper` `merge_user_progress_by_level` takes a hash of user levels (`user_levels_by_level`) and feedback (`teacher_feedback_by_level`) for a user and outputs a summary of their progress on a script. The thing that was causing the error is `get_level_for_progress` which performs a new query for Bubble Choice levels to get the sublevel that will represent the progress for the level. If the user updates a sublevel between when `user_levels_by_level` is queried and `get_level_for_progress` is executed, `get_level_for_progress` will return a level where the user level does not exist in `user_levels_by_level`, causing `level_progress` to be `nil` and resulting in an error when attempting to set `time_spent` on `level_progress`.

The solution is to use `user_levels_by_level` and `teacher_feedback_by_level` to determine the sublevel to represent the level's progress, rather than performing a new query.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
- jira ticket: [LP-2048](https://codedotorg.atlassian.net/browse/LP-2048)
<!--
- spec: []()

-->

## Testing story
Tested locally that the same level for progress was retrieved from old method vs new method. Also added unit tests
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
