### PR TITLE
Prefactor: Change id on repeated element to class

### DIFF
--- a/apps/src/templates/instructions/codeReview/Comment.jsx
+++ b/apps/src/templates/instructions/codeReview/Comment.jsx
@@ -122,7 +122,7 @@ class Comment extends Component {
           </span>
         </div>
         <div
-          id={'code-review-comment-body'}
+          className={'code-review-comment-body'}
           style={{
             ...styles.comment,
             ...(isFromTeacher && styles.commentFromTeacher),

--- a/apps/test/unit/templates/instructions/codeReview/CommentTest.jsx
+++ b/apps/test/unit/templates/instructions/codeReview/CommentTest.jsx
@@ -37,7 +37,7 @@ describe('Code Review Comment', () => {
     const wrapper = renderWrapper(overrideProps);
 
     const commentBodyStyle = wrapper
-      .find('#code-review-comment-body')
+      .find('.code-review-comment-body')
       .first()
       .props().style;
 


### PR DESCRIPTION
Updated a repeated react component to use a class rather than an id. This doesn't change anything from a user perspective, but hardens the system against future bugs. 

The specific component is the comment in a code review:
<img src="https://user-images.githubusercontent.com/8324574/137553863-f76c14aa-bacb-4a4d-a831-9349bd385e86.png" width="300" />


A good article demonstrating the reasoning around avoiding id: https://www.javascriptstuff.com/use-refs-not-ids/

This is a prefactor for collapsing comments. We may end up using refs instead for the collapsing feature, but this seemed like a good first step to avoid bugs during development.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
