### PR TITLE
Add slack_bot_token to development.yml.erb

### DIFF
--- a/bin/dotd
+++ b/bin/dotd
@@ -26,10 +26,10 @@ LOG_FILE = "#{Dir.tmpdir}/dotd.log".freeze
   "[#{time.strftime('%I:%M %p')}]: #{msg}\n"
 end
 
-# Checks that CDO.github_access_token, CDO.slack_token, CDO.honeybadger_api_token, and CDO.devinternal_db_writer
+# Checks that CDO.github_access_token, CDO.slack_bot_token, CDO.honeybadger_api_token, and CDO.devinternal_db_writer
 # are defined. If not, exits the program.
 def check_for_cdo_keys
-  return if CDO.github_access_token && CDO.slack_token && CDO.honeybadger_api_token && CDO.devinternal_db_writer
+  return if CDO.github_access_token && CDO.slack_bot_token && CDO.honeybadger_api_token && CDO.devinternal_db_writer
 
   puts <<-EOS.unindent
 
@@ -40,10 +40,8 @@ def check_for_cdo_keys
       https://github.com/settings/tokens ('public_repo' permission)
       https://app.honeybadger.io/users/edit#authentication
 
-    The slack_bot_token can be found in the Shared-Engineering folder in LastPass, under DOTD Slack Bot Token.
-
     Please add them to your locals.yml and rerun the script.
-    CDO.devinternal_db_writer should be pulled automatically from AWS Secrets Manager.
+    CDO.devinternal_db_writer and CDO.slack_bot_token should be pulled automatically from AWS Secrets Manager.
 
   EOS
   exit

--- a/config/development.yml.erb
+++ b/config/development.yml.erb
@@ -46,3 +46,5 @@ pardot_private_key: !Secret
 redshift_host: !Secret
 redshift_password: !Secret
 redshift_username: !Secret
+
+slack_bot_token: !Secret


### PR DESCRIPTION
- Give development environments access to the slack_bot_token for running the dotd script.
- Update dotd script to require slack_bot_token instead of the deprecated slack_token.
