### PR TITLE
hoc2021: Optional SVG animation for code.org/ homepage

### DIFF
--- a/pegasus/sites.v3/code.org/public/hourofcode/overview.haml
+++ b/pegasus/sites.v3/code.org/public/hourofcode/overview.haml
@@ -56,12 +56,18 @@ social:
   - hoc_cse_enable_svg = DCDO.get("hoc_cse_enable_svg", false)
   - hoc_image = ["soon-hoc", "actual-hoc"].include?(hoc_mode) ? "/images/hoc-cse-banner.png" : "/images/hoc2020-banner.png"
 
-  .full-resource-block
+  .full-resource-block{style: "position: relative"}
     - if ["soon-hoc", "actual-hoc"].include?(hoc_mode) && hoc_cse_enable_svg
       :css
         .bars path { mix-blend-mode: multiply; }
-      %svg.bars{viewBox: "0 0 485 260", style: "border: 1px solid #949ca2;"}
-        %image{href:"/images/hour-of-code-logo-halo.png", height:"144", width:"144", x: "50%", y: "50%", transform: "translate(-72,-72)"}
+      #bars{style: "display: flex; padding-bottom: 10px"}
+        #left-bars-img{style: "/* opacity: 0.2; */ width: 33%; align-items: stretch; background-image: url(/shared/images/fit-1200/hoc-cse-left-fade.png); background-position: 100% 50%; background-size: contain; background-repeat: no-repeat"}
+        %div{style: "width: 33%; box-shadow: 5px 0px 4px 3px rgb(255 255 255), -5px 0px 4px 3px rgb(255 255 255); z-index: 1; position: relative; min-height: 200px"}
+          %img{src:"/shared/images/hour-of-code-logo.png", style: "top: 50%; left: 50%; transform: translate(-50%,-50%); width: 80%; position: absolute;"}
+        #right-bars-img{style: "/* opacity: 0.2; */ width: 33%; align-items: stretch; background-image: url(/shared/images/fit-1200/hoc-cse-right-fade.png); background-position: 0% 50%; background-size: contain; background-repeat: no-repeat"}
+      %svg#left-bars-svg{viewBox: "0 0 210 250", style: "opacity: 0; position: absolute; /*border: 1px solid #949ca2;*/ width: 0; height: 0"}
+      %svg#right-bars-svg{viewBox: "0 0 210 250", style: "opacity: 0; position: absolute; /*border: 1px solid #949ca2;*/ width: 0; height: 0"}
+
     - else
       %img.full-resource-image{src: hoc_image, style: "border: 1px solid #949ca2;"}
     .activities-info

--- a/pegasus/sites.v3/code.org/public/hourofcode/overview.haml
+++ b/pegasus/sites.v3/code.org/public/hourofcode/overview.haml
@@ -62,12 +62,12 @@ social:
         .bars path { mix-blend-mode: multiply; }
       %a{href: CDO.hourofcode_url('/learn')}
         #bars{style: "display: flex; padding-bottom: 10px; padding-top: 10px; border: 1px solid #949ca2"}
-          #left-bars-img{style: "/* opacity: 0.2; */ width: 33%; align-items: stretch; background-image: url(/shared/images/fit-1200/hoc-cse-left-fade.png); background-position: 100% 50%; background-size: contain; background-repeat: no-repeat"}
+          #left-bars-img{style: "width: 33%; align-items: stretch; background-image: url(/shared/images/fit-1200/hoc-cse-left-fade.png); background-position: 100% 50%; background-size: contain; background-repeat: no-repeat"}
           %div{style: "width: 33%; box-shadow: 5px 0px 4px 3px rgb(255 255 255), -5px 0px 4px 3px rgb(255 255 255); z-index: 1; position: relative; min-height: 200px"}
             %img{src:"/shared/images/hour-of-code-logo.png", style: "top: 50%; left: 50%; transform: translate(-50%,-50%); width: 80%; position: absolute;"}
-          #right-bars-img{style: "/* opacity: 0.2; */ width: 33%; align-items: stretch; background-image: url(/shared/images/fit-1200/hoc-cse-right-fade.png); background-position: 0% 50%; background-size: contain; background-repeat: no-repeat"}
-        %svg#left-bars-svg{viewBox: "0 0 210 250", style: "opacity: 0; position: absolute; /*border: 1px solid #949ca2;*/ width: 0; height: 0"}
-        %svg#right-bars-svg{viewBox: "0 0 210 250", style: "opacity: 0; position: absolute; /*border: 1px solid #949ca2;*/ width: 0; height: 0"}
+          #right-bars-img{style: "width: 33%; align-items: stretch; background-image: url(/shared/images/fit-1200/hoc-cse-right-fade.png); background-position: 0% 50%; background-size: contain; background-repeat: no-repeat"}
+        %svg#left-bars-svg{viewBox: "0 0 210 250", style: "opacity: 0; position: absolute; width: 0; height: 0"}
+        %svg#right-bars-svg{viewBox: "0 0 210 250", style: "opacity: 0; position: absolute; width: 0; height: 0"}
 
     - else
       %a{href: CDO.hourofcode_url('/learn')}

--- a/pegasus/sites.v3/code.org/public/hourofcode/overview.haml
+++ b/pegasus/sites.v3/code.org/public/hourofcode/overview.haml
@@ -63,7 +63,7 @@ social:
       %a{href: CDO.hourofcode_url('/learn')}
         #bars{style: "display: flex; padding-bottom: 10px; padding-top: 10px; border: 1px solid #949ca2"}
           #left-bars-img{style: "width: 33%; align-items: stretch; background-image: url(/shared/images/fit-1200/hoc-cse-left-fade.png); background-position: 100% 50%; background-size: contain; background-repeat: no-repeat"}
-          %div{style: "width: 33%; box-shadow: 5px 0px 4px 3px rgb(255 255 255), -5px 0px 4px 3px rgb(255 255 255); z-index: 1; position: relative; min-height: 200px"}
+          %div{style: "width: 33%; box-shadow: 15px 0px 4px 3px rgb(255 255 255), -5px 0px 4px 3px rgb(255 255 255); z-index: 1; position: relative; min-height: 200px"}
             %img{src:"/shared/images/hour-of-code-logo.png", style: "top: 50%; left: 50%; transform: translate(-50%,-50%); width: 80%; position: absolute;"}
           #right-bars-img{style: "width: 33%; align-items: stretch; background-image: url(/shared/images/fit-1200/hoc-cse-right-fade.png); background-position: 0% 50%; background-size: contain; background-repeat: no-repeat"}
         %svg#left-bars-svg{viewBox: "0 0 210 250", style: "opacity: 0; position: absolute; width: 0; height: 0"}

--- a/pegasus/sites.v3/code.org/public/hourofcode/overview.haml
+++ b/pegasus/sites.v3/code.org/public/hourofcode/overview.haml
@@ -60,22 +60,24 @@ social:
     - if ["soon-hoc", "actual-hoc"].include?(hoc_mode) && hoc_cse_enable_svg
       :css
         .bars path { mix-blend-mode: multiply; }
-      #bars{style: "display: flex; padding-bottom: 10px"}
-        #left-bars-img{style: "/* opacity: 0.2; */ width: 33%; align-items: stretch; background-image: url(/shared/images/fit-1200/hoc-cse-left-fade.png); background-position: 100% 50%; background-size: contain; background-repeat: no-repeat"}
-        %div{style: "width: 33%; box-shadow: 5px 0px 4px 3px rgb(255 255 255), -5px 0px 4px 3px rgb(255 255 255); z-index: 1; position: relative; min-height: 200px"}
-          %img{src:"/shared/images/hour-of-code-logo.png", style: "top: 50%; left: 50%; transform: translate(-50%,-50%); width: 80%; position: absolute;"}
-        #right-bars-img{style: "/* opacity: 0.2; */ width: 33%; align-items: stretch; background-image: url(/shared/images/fit-1200/hoc-cse-right-fade.png); background-position: 0% 50%; background-size: contain; background-repeat: no-repeat"}
-      %svg#left-bars-svg{viewBox: "0 0 210 250", style: "opacity: 0; position: absolute; /*border: 1px solid #949ca2;*/ width: 0; height: 0"}
-      %svg#right-bars-svg{viewBox: "0 0 210 250", style: "opacity: 0; position: absolute; /*border: 1px solid #949ca2;*/ width: 0; height: 0"}
+      %a{href: CDO.hourofcode_url('/learn')}
+        #bars{style: "display: flex; padding-bottom: 10px; padding-top: 10px; border: 1px solid #949ca2"}
+          #left-bars-img{style: "/* opacity: 0.2; */ width: 33%; align-items: stretch; background-image: url(/shared/images/fit-1200/hoc-cse-left-fade.png); background-position: 100% 50%; background-size: contain; background-repeat: no-repeat"}
+          %div{style: "width: 33%; box-shadow: 5px 0px 4px 3px rgb(255 255 255), -5px 0px 4px 3px rgb(255 255 255); z-index: 1; position: relative; min-height: 200px"}
+            %img{src:"/shared/images/hour-of-code-logo.png", style: "top: 50%; left: 50%; transform: translate(-50%,-50%); width: 80%; position: absolute;"}
+          #right-bars-img{style: "/* opacity: 0.2; */ width: 33%; align-items: stretch; background-image: url(/shared/images/fit-1200/hoc-cse-right-fade.png); background-position: 0% 50%; background-size: contain; background-repeat: no-repeat"}
+        %svg#left-bars-svg{viewBox: "0 0 210 250", style: "opacity: 0; position: absolute; /*border: 1px solid #949ca2;*/ width: 0; height: 0"}
+        %svg#right-bars-svg{viewBox: "0 0 210 250", style: "opacity: 0; position: absolute; /*border: 1px solid #949ca2;*/ width: 0; height: 0"}
 
     - else
-      %img.full-resource-image{src: hoc_image, style: "border: 1px solid #949ca2;"}
+      %a{href: CDO.hourofcode_url('/learn')}
+        %img.full-resource-image{src: hoc_image, style: "border: 1px solid #949ca2"}
     .activities-info
       %span
         %h2.resource-title.white= I18n.t(:hoc_overview_partner_activities_title)
         = I18n.t(:hoc_overview_partner_activities_body)
       %span
-        %a{href: "https://hourofcode.com/learn"}
+        %a{href: CDO.hourofcode_url('/learn')}
           %button.tutorial-info-start.tutorial-gray= I18n.t(:hoc_overview_partner_activities_link)
 
   .hoc-tiles-container

--- a/pegasus/sites.v3/code.org/public/js/cse-bars.js
+++ b/pegasus/sites.v3/code.org/public/js/cse-bars.js
@@ -1,3 +1,6 @@
+/* Curious about this temporary code?  There's more detail at
+ * https://github.com/code-dot-org/code-dot-org/pull/43037 */
+
 var gridSize = 18;
 var strokeWidth = 11;
 
@@ -47,7 +50,7 @@ $(document).ready(function() {
     [
       {
         type: "line",
-        start: [12, 7],
+        start: [13, 7],
         end: [8, 7],
         color: rgbString(204, 244, 134)
       },
@@ -55,8 +58,13 @@ $(document).ready(function() {
     ],
     [
       {
+        type: "line",
+        start: [13, 8],
+        end: [12, 8],
+        color: rgbString(138, 80, 163)
+      },
+      {
         type: "arc",
-        start: [12, 8],
         end: [11, 9],
         color: rgbString(138, 80, 163),
         direction: "left-down"
@@ -115,7 +123,7 @@ $(document).ready(function() {
     [
       {
         type: "line",
-        start: [12, 5],
+        start: [13, 5],
         end: [11, 5],
         color: rgbString(144, 140, 203)
       },
@@ -149,26 +157,31 @@ $(document).ready(function() {
   barDefinitions[1] = [
     [
       {
-        type: "arc",
+        type: "line",
         start: [0, 6],
-        end: [1, 5],
+        end: [1, 6],
+        color: rgbString(144, 140, 203)
+      },
+      {
+        type: "arc",
+        end: [2, 5],
         color: rgbString(144, 140, 203),
         direction: "right-up"
       },
       {
         type: "line",
-        end: [1, 2],
+        end: [2, 2],
         color: rgbString(138, 80, 163)
       },
       {
         type: "arc",
-        end: [2, 1],
+        end: [3, 1],
         color: rgbString(138, 80, 163),
         direction: "up-right"
       },
       {
         type: "line",
-        end: [5, 1],
+        end: [6, 1],
         color: rgbString(138, 80, 163)
       },
 
@@ -327,7 +340,7 @@ function handleResizePanel(panelIdImg, panelIdSvg, constrainToRight) {
   var targetHeight = $(panelIdImg).outerHeight();
 
   // This is the width/height of our SVGs.
-  var aspectRatio = 0.9;
+  var aspectRatio = 1;
 
   // This is the width/height of the divs which show the regular images.
   var targetAspectRatio = targetWidth / targetHeight;

--- a/pegasus/sites.v3/code.org/public/js/cse-bars.js
+++ b/pegasus/sites.v3/code.org/public/js/cse-bars.js
@@ -590,11 +590,11 @@ function drawBar(panelRef, barDefinition, startX, startY) {
 function rgbString(r, g, b) {
   return (
     "rgba(" +
-    (r - 255 + 255 * 0.8) / 0.8 +
+    Math.round((r - 255 + 255 * 0.8) / 0.8) +
     ", " +
-    (g - 255 + 255 * 0.8) / 0.8 +
+    Math.round((g - 255 + 255 * 0.8) / 0.8) +
     ", " +
-    (b - 255 + 255 * 0.8) / 0.8 +
+    Math.round((b - 255 + 255 * 0.8) / 0.8) +
     ", " +
     "0.8)"
   );

--- a/pegasus/sites.v3/code.org/public/js/cse-bars.js
+++ b/pegasus/sites.v3/code.org/public/js/cse-bars.js
@@ -16,8 +16,8 @@ function shuffleArray(array) {
 $(document).ready(function() {
   var barDefinitions = [];
 
+  // Left panel.
   barDefinitions[0] = [
-    // Originally left side, index 6.
     [
       {
         type: "line",
@@ -44,7 +44,6 @@ $(document).ready(function() {
       },
       { type: "arrow", color: rgbString(92, 180, 228), direction: "left" }
     ],
-    // Originally left side, index 7.
     [
       {
         type: "line",
@@ -54,7 +53,6 @@ $(document).ready(function() {
       },
       { type: "arrow", color: rgbString(188, 212, 95), direction: "left" }
     ],
-    // Originally left side, index 8.
     [
       {
         type: "arc",
@@ -99,7 +97,6 @@ $(document).ready(function() {
       },
       { type: "arrow", color: rgbString(0, 173, 160), direction: "left" }
     ],
-    // Originally left side, index 9.
     [
       {
         type: "arc",
@@ -115,7 +112,6 @@ $(document).ready(function() {
       },
       { type: "arrow", color: rgbString(234, 76, 155), direction: "left" }
     ],
-    // Originally left side.
     [
       {
         type: "line",
@@ -149,8 +145,8 @@ $(document).ready(function() {
     ]
   ];
 
+  // Right panel.
   barDefinitions[1] = [
-    // Originallly right side, index 0.
     [
       {
         type: "arc",
@@ -178,7 +174,6 @@ $(document).ready(function() {
 
       { type: "arrow", color: rgbString(234, 76, 155), direction: "right" }
     ],
-    // Originally right side, index 1.
     [
       {
         type: "line",
@@ -206,7 +201,6 @@ $(document).ready(function() {
 
       { type: "arrow", color: rgbString(88, 108, 179), direction: "right" }
     ],
-    // Originally right side, index 2.
     [
       {
         type: "line",
@@ -233,7 +227,6 @@ $(document).ready(function() {
       },
       { type: "arrow", color: rgbString(234, 76, 155), direction: "right" }
     ],
-    // Originally right side, index 3.
     [
       {
         type: "line",
@@ -254,7 +247,6 @@ $(document).ready(function() {
       },
       { type: "arrow", color: rgbString(176, 214, 109), direction: "right" }
     ],
-    // Originally right side, index 4.
     [
       {
         type: "arc",
@@ -287,6 +279,7 @@ $(document).ready(function() {
 
   var panelIds = ["#left-bars-svg", "#right-bars-svg"];
 
+  // For each panel, shuffle the bars, then draw the initial content.
   var bars = [];
   for (var panel = 0; panel < barDefinitions.length; panel++) {
     bars[panel] = [];
@@ -297,16 +290,20 @@ $(document).ready(function() {
     }
   }
 
+  // Adjust the SVGs to have the correct locations & size now, and make
+  // sure to do it again if the window is resized.
   handleResize();
   $(window).resize(function() {
     handleResize();
   });
 
+  // Hide the regular images and show the SVGs.
   $("#left-bars-img").animate({ opacity: 0 }, 1000);
   $("#right-bars-img").animate({ opacity: 0 }, 1000);
   $("#left-bars-svg").animate({ opacity: 1 }, 1000);
   $("#right-bars-svg").animate({ opacity: 1 }, 1000);
 
+  // Start animating smoothly.
   setInterval(function() {
     for (var panel = 0; panel < barDefinitions.length; panel++) {
       for (var bar = 0; bar < barDefinitions[panel].length; bar++) {
@@ -323,47 +320,44 @@ function handleResize() {
 }
 
 function handleResizePanel(panelIdImg, panelIdSvg, constrainToRight) {
-  // .position() uses position relative to the offset parent,
+  // We want the SVGs to match the divs (which show the regular images using
+  // background-image) in location & size.
   var pos = $(panelIdImg).position();
-
-  // .outerWidth() takes into account border and padding.
   var targetWidth = $(panelIdImg).outerWidth();
   var targetHeight = $(panelIdImg).outerHeight();
 
-  // what is our width / height?
+  // This is the width/height of our SVGs.
   var aspectRatio = 0.9;
+
+  // This is the width/height of the divs which show the regular images.
+  var targetAspectRatio = targetWidth / targetHeight;
 
   var top, left, width, height;
 
-  var targetAspectRatio = targetWidth / targetHeight;
+  // Now, we essentially simulate `background-size: contain`, by determining
+  // the maximum size and correct position of our SVG that will fit in the div which shows
+  // the regular image.
   if (targetAspectRatio > aspectRatio) {
-    // constrain by height
+    // Constrain by height...
     height = targetHeight;
     width = targetHeight * aspectRatio;
     top = pos.top;
   } else {
-    // constrain by width
+    // Constrain by width, and vertically center...
     width = targetWidth;
     height = targetWidth / aspectRatio;
     top = pos.top + (targetHeight - height) / 2;
   }
 
+  // As for horiontal positioning, we push the left panel to the right, and the right
+  // panel to the left.
   if (constrainToRight) {
     left = targetWidth - width + pos.left;
-    //left = (targetWidth - width) / 2;
   } else {
     left = pos.left;
   }
-  //show the menu directly over the placeholder
-  /*
-  $(".bars").first().css({
-      position: "absolute",
-      top: (pos.top + width*2) + "px",
-      left: pos.left + "px",
-      width: width
-  }).show();
-  */
 
+  // And now our SVG will sit directly on top of the div which shows the regular image.
   $(panelIdSvg)
     .css({
       position: "absolute",
@@ -394,6 +388,7 @@ function updateBar(barDefinition, bar, barIndex, step) {
     if (bar[segment].element.head1 && bar[segment].element.head2) {
       scaledOffset = offset * bar[segment].element.head1.totalLength;
 
+      // Improve performance by not adjsting the SVG if the value hasn't changed.
       if (scaledOffset !== bar[segment].offset) {
         bar[segment].element.head1.setAttributeNS(
           null,
@@ -411,6 +406,7 @@ function updateBar(barDefinition, bar, barIndex, step) {
     } else {
       scaledOffset = offset * bar[segment].element.totalLength;
 
+      // Improve performance by not adjsting the SVG if the value hasn't changed.
       if (scaledOffset !== bar[segment].offset) {
         bar[segment].element.setAttributeNS(
           null,
@@ -576,23 +572,21 @@ function drawBar(panelRef, barDefinition, startX, startY) {
       currentY = barDef.end[1];
     }
 
+    // We save the offset here to cache the current value, and improve
+    // performance by not changing the SVG if that value hasn't changed
+    // since last time.
     result[segment] = { element: obj, offset: len };
   }
-
-  /*
-  obj = document.createElementNS("http://www.w3.org/2000/svg", "image");
-  obj.setAttributeNS(null, "height", "144");
-  obj.setAttributeNS(null, "width", "144");
-  obj.setAttributeNS(null, "href", "/images/hour-of-code-logo-halo.png");
-  obj.setAttributeNS(null, "transform", "translate(-72,-72)");
-  obj.setAttributeNS(null, "x", "50%");
-  obj.setAttributeNS(null, "y", "50%");
-  panelRef.appendChild(obj);
-  */
 
   return result;
 }
 
+// The definitions at the top of this file use RGB values for opacity 1.
+// For SVG rendering, we draw the bars with opacity 0.8 so that we get the
+// nice colour-mixing at the intersection points.  As well as generating
+// the appropriate RGB string, this function maps the specified RGB to an
+// RGB value which will render as the specified RGB would have with opacity
+// 11, but with opacity 0.8.
 function rgbString(r, g, b) {
   return (
     "rgba(" +

--- a/pegasus/sites.v3/code.org/public/js/cse-bars.js
+++ b/pegasus/sites.v3/code.org/public/js/cse-bars.js
@@ -302,10 +302,10 @@ $(document).ready(function() {
     handleResize();
   });
 
-  $("#left-bars-img").fadeTo(1000, 0);
-  $("#right-bars-img").fadeTo(1000, 0);
-  $("#left-bars-svg").fadeTo(1000, 1);
-  $("#right-bars-svg").fadeTo(1000, 1);
+  $("#left-bars-img").animate({ opacity: 0 }, 1000);
+  $("#right-bars-img").animate({ opacity: 0 }, 1000);
+  $("#left-bars-svg").animate({ opacity: 1 }, 1000);
+  $("#right-bars-svg").animate({ opacity: 1 }, 1000);
 
   setInterval(function() {
     for (var panel = 0; panel < barDefinitions.length; panel++) {

--- a/pegasus/sites.v3/code.org/public/js/cse-bars.js
+++ b/pegasus/sites.v3/code.org/public/js/cse-bars.js
@@ -17,279 +17,295 @@ $(document).ready(function() {
   var barDefinitions = [];
 
   barDefinitions[0] = [
-    // Originallly right side, index 0.
-    [
-      {
-        type: "arc",
-        start: [17, 6],
-        end: [18, 5],
-        color: "rgba(144, 140, 203, 0.8)",
-        direction: "right-up"
-      },
-      {
-        type: "line",
-        end: [18, 2],
-        color: "rgba(138, 80, 163, 0.8)"
-      },
-      {
-        type: "arc",
-        end: [19, 1],
-        color: "rgba(138, 80, 163, 0.8)",
-        direction: "up-right"
-      },
-      {
-        type: "line",
-        end: [22, 1],
-        color: "rgba(138, 80, 163, 0.8)"
-      },
-
-      { type: "arrow", color: "rgba(234, 76, 155, 0.8)", direction: "right" }
-    ],
-    // Originally right side, index 1.
-    [
-      {
-        type: "line",
-        start: [17, 4],
-        end: [20, 4],
-        color: "rgba(87, 106, 181, 0.8)"
-      },
-      {
-        type: "arc",
-        end: [21, 5],
-        color: "rgba(87, 106, 181, 0.8)",
-        direction: "right-down"
-      },
-      {
-        type: "arc",
-        end: [22, 6],
-        color: "rgba(56, 133, 201, 0.8)",
-        direction: "down-right"
-      },
-      {
-        type: "line",
-        end: [27, 6],
-        color: "rgba(56, 133, 201, 0.8)"
-      }
-    ],
-    // Originally right side, index 2.
-    [
-      {
-        type: "line",
-        start: [17, 7],
-        end: [19, 7],
-        color: "rgba(251, 164, 65, 0.8)"
-      },
-      {
-        type: "arc",
-        end: [20, 8],
-        color: "rgba(251, 164, 65, 0.8)",
-        direction: "right-down"
-      },
-      {
-        type: "arc",
-        end: [21, 9],
-        color: "rgba(251, 164, 65, 0.8)",
-        direction: "down-right"
-      },
-      {
-        type: "line",
-        end: [24, 9],
-        color: "rgba(251, 164, 65, 0.8)"
-      },
-      { type: "arrow", color: "rgba(234, 76, 155, 0.8)", direction: "right" }
-    ],
-    // Originally right side, index 3.
-    [
-      {
-        type: "line",
-        start: [22, 9],
-        end: [22, 11],
-        color: "rgba(92, 187, 216, 0.8)"
-      },
-      {
-        type: "arc",
-        end: [23, 12],
-        color: "rgba(96, 197, 169, 0.8)",
-        direction: "down-right"
-      },
-      {
-        type: "line",
-        end: [25, 12],
-        color: "rgba(135, 201, 115, 0.8)"
-      },
-      { type: "arrow", color: "rgba(176, 214, 109, 0.8)", direction: "right" }
-    ],
-    // Originally right side, index 4.
-    [
-      {
-        type: "arc",
-        start: [17, 9],
-        end: [18, 10],
-        color: "rgba(144, 140, 203, 0.8)",
-        direction: "right-down"
-      },
-      {
-        type: "line",
-        start: [18, 10],
-        end: [18, 12],
-        color: "rgba(144, 140, 203, 0.8)",
-        direction: "right-down"
-      },
-      {
-        type: "arc",
-        end: [19, 13],
-        color: "rgba(144, 140, 203, 0.8)",
-        direction: "down-right"
-      },
-      {
-        type: "line",
-        end: [22, 13],
-        color: "rgba(144, 140, 203, 0.8)"
-      },
-      { type: "arrow", color: "rgba(0, 173, 160, 0.8)", direction: "right" }
-    ],
-    // Originally right side, index 5.
-    [
-      {
-        type: "line",
-        start: [10, 5],
-        end: [9, 5],
-        color: "rgba(144, 140, 203, 0.8)"
-      },
-      {
-        type: "arc",
-        end: [8, 4],
-        color: "rgba(234, 76, 155, 0.8)",
-        direction: 'left-up"'
-      },
-      {
-        type: "line",
-        start: [8, 4],
-        end: [8, 2],
-        color: "rgba(234, 76, 155, 0.8)"
-      },
-      {
-        type: "arc",
-        end: [7, 1],
-        color: "rgba(251, 164, 65, 0.8)",
-        direction: "up-left"
-      },
-      {
-        type: "line",
-        end: [4, 1],
-        color: "rgba(251, 164, 65, 0.8)"
-      },
-
-      { type: "arrow", color: "rgba(244, 137, 221, 0.8)", direction: "left" }
-    ],
     // Originally left side, index 6.
     [
       {
         type: "line",
-        start: [8, 3],
-        end: [3, 3],
-        color: "rgba(135, 201, 115, 0.8)"
+        start: [10, 3],
+        end: [5, 3],
+        color: rgbString(135, 201, 115)
       },
       {
         type: "arc",
-        end: [2, 4],
-        color: "rgba(96, 197, 169, 0.8)",
+        end: [4, 4],
+        color: rgbString(96, 197, 169),
         direction: "left-down"
       },
       {
         type: "arc",
-        end: [1, 5],
-        color: "rgba(136, 210, 245, 0.8)",
+        end: [3, 5],
+        color: rgbString(136, 210, 245),
         direction: "down-left"
       },
       {
         type: "line",
         end: [0, 5],
-        color: "rgba(136, 210, 245, 0.8)"
-      }
+        color: rgbString(136, 210, 245)
+      },
+      { type: "arrow", color: rgbString(92, 180, 228), direction: "left" }
     ],
     // Originally left side, index 7.
     [
       {
         type: "line",
-        start: [10, 7],
-        end: [6, 7],
-        color: "rgba(204, 244, 134, 0.8)"
+        start: [12, 7],
+        end: [8, 7],
+        color: rgbString(204, 244, 134)
       },
-      { type: "arrow", color: "rgba(188, 212, 95, 0.8)", direction: "left" }
+      { type: "arrow", color: rgbString(188, 212, 95), direction: "left" }
     ],
     // Originally left side, index 8.
     [
       {
         type: "arc",
-        start: [10, 8],
-        end: [9, 9],
-        color: "rgba(138, 80, 163, 0.8)",
+        start: [12, 8],
+        end: [11, 9],
+        color: rgbString(138, 80, 163),
         direction: "left-down"
       },
       {
         type: "line",
-        end: [9, 11],
-        color: "rgba(140, 124, 189, 0.8)"
+        end: [11, 11],
+        color: rgbString(140, 124, 189)
       },
       {
         type: "arc",
-        end: [8, 12],
-        color: "rgba(138, 80, 163, 0.8)",
+        end: [10, 12],
+        color: rgbString(138, 80, 163),
         direction: "down-left"
       },
       {
         type: "line",
-        end: [6, 12],
-        color: "rgba(211, 136, 189, 0.8)"
+        end: [8, 12],
+        color: rgbString(211, 136, 189)
       },
       {
         type: "arc",
-        end: [5, 11],
-        color: "rgba(211, 136, 189, 0.8)",
+        end: [7, 11],
+        color: rgbString(211, 136, 189),
         direction: "left-up"
       },
       {
         type: "arc",
-        end: [4, 10],
-        color: "rgba(211, 136, 189, 0.8)",
+        end: [6, 10],
+        color: rgbString(211, 136, 189),
         direction: "up-left"
       },
       {
         type: "line",
-        end: [1, 10],
-        color: "rgba(211, 136, 189, 0.8)",
+        end: [3, 10],
+        color: rgbString(211, 136, 189),
         direction: "up-left"
       },
-      { type: "arrow", color: "rgba(0, 173, 160, 0.8)", direction: "left" }
+      { type: "arrow", color: rgbString(0, 173, 160), direction: "left" }
     ],
     // Originally left side, index 9.
     [
       {
         type: "arc",
-        start: [7, 12],
-        end: [6, 13],
-        color: "rgba(138, 80, 163, 0.8)",
+        start: [9, 12],
+        end: [8, 13],
+        color: rgbString(138, 80, 163),
         direction: "down-left"
       },
       {
         type: "line",
-        end: [3, 13],
-        color: "rgba(138, 80, 163, 0.8)"
+        end: [5, 13],
+        color: rgbString(138, 80, 163)
       },
-      { type: "arrow", color: "rgba(234, 76, 155, 0.8)", direction: "left" }
+      { type: "arrow", color: rgbString(234, 76, 155), direction: "left" }
+    ],
+    // Originally left side.
+    [
+      {
+        type: "line",
+        start: [12, 5],
+        end: [11, 5],
+        color: rgbString(144, 140, 203)
+      },
+      {
+        type: "arc",
+        end: [10, 4],
+        color: rgbString(234, 76, 155),
+        direction: 'left-up"'
+      },
+      {
+        type: "line",
+        end: [10, 2],
+        color: rgbString(234, 76, 155)
+      },
+      {
+        type: "arc",
+        end: [9, 1],
+        color: rgbString(251, 164, 65),
+        direction: "up-left"
+      },
+      {
+        type: "line",
+        end: [6, 1],
+        color: rgbString(251, 164, 65)
+      },
+      { type: "arrow", color: rgbString(244, 137, 221), direction: "left" }
     ]
   ];
+
+  barDefinitions[1] = [
+    // Originallly right side, index 0.
+    [
+      {
+        type: "arc",
+        start: [0, 6],
+        end: [1, 5],
+        color: rgbString(144, 140, 203),
+        direction: "right-up"
+      },
+      {
+        type: "line",
+        end: [1, 2],
+        color: rgbString(138, 80, 163)
+      },
+      {
+        type: "arc",
+        end: [2, 1],
+        color: rgbString(138, 80, 163),
+        direction: "up-right"
+      },
+      {
+        type: "line",
+        end: [5, 1],
+        color: rgbString(138, 80, 163)
+      },
+
+      { type: "arrow", color: rgbString(234, 76, 155), direction: "right" }
+    ],
+    // Originally right side, index 1.
+    [
+      {
+        type: "line",
+        start: [0, 4],
+        end: [3, 4],
+        color: rgbString(87, 106, 181)
+      },
+      {
+        type: "arc",
+        end: [4, 5],
+        color: rgbString(87, 106, 181),
+        direction: "right-down"
+      },
+      {
+        type: "arc",
+        end: [5, 6],
+        color: rgbString(56, 133, 201),
+        direction: "down-right"
+      },
+      {
+        type: "line",
+        end: [11, 6],
+        color: rgbString(56, 133, 201)
+      },
+
+      { type: "arrow", color: rgbString(88, 108, 179), direction: "right" }
+    ],
+    // Originally right side, index 2.
+    [
+      {
+        type: "line",
+        start: [0, 7],
+        end: [2, 7],
+        color: rgbString(251, 164, 65)
+      },
+      {
+        type: "arc",
+        end: [3, 8],
+        color: rgbString(251, 164, 65),
+        direction: "right-down"
+      },
+      {
+        type: "arc",
+        end: [4, 9],
+        color: rgbString(251, 164, 65),
+        direction: "down-right"
+      },
+      {
+        type: "line",
+        end: [7, 9],
+        color: rgbString(251, 164, 65)
+      },
+      { type: "arrow", color: rgbString(234, 76, 155), direction: "right" }
+    ],
+    // Originally right side, index 3.
+    [
+      {
+        type: "line",
+        start: [5, 9],
+        end: [5, 11],
+        color: rgbString(92, 187, 216)
+      },
+      {
+        type: "arc",
+        end: [6, 12],
+        color: rgbString(96, 197, 169),
+        direction: "down-right"
+      },
+      {
+        type: "line",
+        end: [8, 12],
+        color: rgbString(135, 201, 115)
+      },
+      { type: "arrow", color: rgbString(176, 214, 109), direction: "right" }
+    ],
+    // Originally right side, index 4.
+    [
+      {
+        type: "arc",
+        start: [0, 9],
+        end: [1, 10],
+        color: rgbString(144, 140, 203),
+        direction: "right-down"
+      },
+      {
+        type: "line",
+        start: [1, 10],
+        end: [1, 12],
+        color: rgbString(144, 140, 203),
+        direction: "right-down"
+      },
+      {
+        type: "arc",
+        end: [2, 13],
+        color: rgbString(144, 140, 203),
+        direction: "down-right"
+      },
+      {
+        type: "line",
+        end: [5, 13],
+        color: rgbString(144, 140, 203)
+      },
+      { type: "arrow", color: rgbString(0, 173, 160), direction: "right" }
+    ]
+  ];
+
+  var panelIds = ["#left-bars-svg", "#right-bars-svg"];
 
   var bars = [];
   for (var panel = 0; panel < barDefinitions.length; panel++) {
     bars[panel] = [];
-    var panelRef = $(".bars")[panel];
+    var panelRef = $(panelIds[panel])[0];
     shuffleArray(barDefinitions[panel]);
     for (var bar = 0; bar < barDefinitions[panel].length; bar++) {
       bars[panel][bar] = drawBar(panelRef, barDefinitions[panel][bar]);
     }
   }
+
+  handleResize();
+  $(window).resize(function() {
+    handleResize();
+  });
+
+  $("#left-bars-img").fadeTo(1000, 0);
+  $("#right-bars-img").fadeTo(1000, 0);
+  $("#left-bars-svg").fadeTo(1000, 1);
+  $("#right-bars-svg").fadeTo(1000, 1);
 
   setInterval(function() {
     for (var panel = 0; panel < barDefinitions.length; panel++) {
@@ -300,6 +316,64 @@ $(document).ready(function() {
     step += 0.02;
   }, 1000 / 60);
 });
+
+function handleResize() {
+  handleResizePanel("#left-bars-img", "#left-bars-svg", true);
+  handleResizePanel("#right-bars-img", "#right-bars-svg", false);
+}
+
+function handleResizePanel(panelIdImg, panelIdSvg, constrainToRight) {
+  // .position() uses position relative to the offset parent,
+  var pos = $(panelIdImg).position();
+
+  // .outerWidth() takes into account border and padding.
+  var targetWidth = $(panelIdImg).outerWidth();
+  var targetHeight = $(panelIdImg).outerHeight();
+
+  // what is our width / height?
+  var aspectRatio = 0.9;
+
+  var top, left, width, height;
+
+  var targetAspectRatio = targetWidth / targetHeight;
+  if (targetAspectRatio > aspectRatio) {
+    // constrain by height
+    height = targetHeight;
+    width = targetHeight * aspectRatio;
+    top = pos.top;
+  } else {
+    // constrain by width
+    width = targetWidth;
+    height = targetWidth / aspectRatio;
+    top = pos.top + (targetHeight - height) / 2;
+  }
+
+  if (constrainToRight) {
+    left = targetWidth - width + pos.left;
+    //left = (targetWidth - width) / 2;
+  } else {
+    left = pos.left;
+  }
+  //show the menu directly over the placeholder
+  /*
+  $(".bars").first().css({
+      position: "absolute",
+      top: (pos.top + width*2) + "px",
+      left: pos.left + "px",
+      width: width
+  }).show();
+  */
+
+  $(panelIdSvg)
+    .css({
+      position: "absolute",
+      top: top + "px",
+      left: left + "px",
+      width: width,
+      height: height
+    })
+    .show();
+}
 
 function updateBar(barDefinition, bar, barIndex, step) {
   for (var segment = 0; segment < barDefinition.length; segment++) {
@@ -492,6 +566,7 @@ function drawBar(panelRef, barDefinition, startX, startY) {
     result[segment] = obj;
   }
 
+  /*
   obj = document.createElementNS("http://www.w3.org/2000/svg", "image");
   obj.setAttributeNS(null, "height", "144");
   obj.setAttributeNS(null, "width", "144");
@@ -500,6 +575,20 @@ function drawBar(panelRef, barDefinition, startX, startY) {
   obj.setAttributeNS(null, "x", "50%");
   obj.setAttributeNS(null, "y", "50%");
   panelRef.appendChild(obj);
+  */
 
   return result;
+}
+
+function rgbString(r, g, b) {
+  return (
+    "rgba(" +
+    (r - 255 + 255 * 0.8) / 0.8 +
+    ", " +
+    (g - 255 + 255 * 0.8) / 0.8 +
+    ", " +
+    (b - 255 + 255 * 0.8) / 0.8 +
+    ", " +
+    "0.8)"
+  );
 }

--- a/pegasus/sites.v3/code.org/public/js/cse-bars.js
+++ b/pegasus/sites.v3/code.org/public/js/cse-bars.js
@@ -391,21 +391,34 @@ function updateBar(barDefinition, bar, barIndex, step) {
 
     var scaledOffset;
 
-    if (bar[segment].head1 && bar[segment].head2) {
-      scaledOffset = offset * bar[segment].head1.totalLength;
-      bar[segment].head1.setAttributeNS(
-        null,
-        "stroke-dashoffset",
-        scaledOffset
-      );
-      bar[segment].head2.setAttributeNS(
-        null,
-        "stroke-dashoffset",
-        scaledOffset
-      );
+    if (bar[segment].element.head1 && bar[segment].element.head2) {
+      scaledOffset = offset * bar[segment].element.head1.totalLength;
+
+      if (scaledOffset !== bar[segment].offset) {
+        bar[segment].element.head1.setAttributeNS(
+          null,
+          "stroke-dashoffset",
+          scaledOffset
+        );
+        bar[segment].element.head2.setAttributeNS(
+          null,
+          "stroke-dashoffset",
+          scaledOffset
+        );
+
+        bar[segment].offset = scaledOffset;
+      }
     } else {
-      scaledOffset = offset * bar[segment].totalLength;
-      bar[segment].setAttributeNS(null, "stroke-dashoffset", scaledOffset);
+      scaledOffset = offset * bar[segment].element.totalLength;
+
+      if (scaledOffset !== bar[segment].offset) {
+        bar[segment].element.setAttributeNS(
+          null,
+          "stroke-dashoffset",
+          scaledOffset
+        );
+        bar[segment].offset = scaledOffset;
+      }
     }
   }
 }
@@ -563,7 +576,7 @@ function drawBar(panelRef, barDefinition, startX, startY) {
       currentY = barDef.end[1];
     }
 
-    result[segment] = obj;
+    result[segment] = { element: obj, offset: len };
   }
 
   /*

--- a/pegasus/sites.v3/code.org/views/homepage_hero.haml
+++ b/pegasus/sites.v3/code.org/views/homepage_hero.haml
@@ -81,12 +81,12 @@
   - if ["soon-hoc", "actual-hoc"].include?(hoc_mode)
     #actions
       #bars{style: "display: flex"}
-        #left-bars-img.col-33.tablet-feature{style: "/* opacity: 0.2; */ align-items: stretch; background-image: url(/shared/images/fit-1200/hoc-cse-left-fade.png); background-position: 100% 50%; background-size: contain; background-repeat: no-repeat"}
+        #left-bars-img.col-33.tablet-feature{style: "align-items: stretch; background-image: url(/shared/images/fit-1200/hoc-cse-left-fade.png); background-position: 100% 50%; background-size: contain; background-repeat: no-repeat"}
         .col-33{style: "box-shadow: 10px 0px 4px 3px rgb(255 255 255), -10px 0px 4px 3px rgb(255 255 255); z-index: 1; background-color: white"}
           = main_actions
-        #right-bars-img.col-33.tablet-feature{style: "/* opacity: 0.2; */ align-items: stretch; background-image: url(/shared/images/fit-1200/hoc-cse-right-fade.png); background-position: 0% 50%; background-size: contain; background-repeat: no-repeat"}
-      %svg#left-bars-svg.tablet-feature{viewBox: "0 0 210 250", style: "opacity: 0; position: absolute; /*border: 1px solid #949ca2;*/ width: 0; height: 0"}
-      %svg#right-bars-svg.tablet-feature{viewBox: "0 0 210 250", style: "opacity: 0; position: absolute; /*border: 1px solid #949ca2;*/ width: 0; height: 0"}
+        #right-bars-img.col-33.tablet-feature{style: "align-items: stretch; background-image: url(/shared/images/fit-1200/hoc-cse-right-fade.png); background-position: 0% 50%; background-size: contain; background-repeat: no-repeat"}
+      %svg#left-bars-svg.tablet-feature{viewBox: "0 0 210 250", style: "opacity: 0; position: absolute; width: 0; height: 0"}
+      %svg#right-bars-svg.tablet-feature{viewBox: "0 0 210 250", style: "opacity: 0; position: absolute; width: 0; height: 0"}
 
   - else
     - if show_single_hero

--- a/pegasus/sites.v3/code.org/views/homepage_hero.haml
+++ b/pegasus/sites.v3/code.org/views/homepage_hero.haml
@@ -17,7 +17,7 @@
 
 - main_actions = capture_haml do
   - if show_single_hero == "cse"
-    .hero-message-line1{style: "color: black; font-size: 28px; line-height: 28px; padding-top: 20px; padding-bottom: 20px; font-family: 'Gotham 4r', sans-serif", dir: "auto"}
+    .hero-message-line1{style: "color: black; font-size: 28px; line-height: 28px; padding-bottom: 20px; font-family: 'Gotham 4r', sans-serif", dir: "auto"}
       = hoc_s(:codeorg_homepage_hoc_is_coming)
     %div{style: "padding-bottom: 20px; text-align: center"}
       %span.hero-message-line2.cse-hero-message-line2{style: "color: black; line-height: 1.2em; font-family: 'Gotham 5r', sans-serif", dir: "auto"}
@@ -79,11 +79,13 @@
 
   - if ["soon-hoc", "actual-hoc"].include?(hoc_mode)
     #actions
-      %div{style: "display: flex"}
-        .col-33.tablet-feature{style: "align-items: stretch; background-image: url(/shared/images/fit-1200/hoc-cse-left-fade.png); background-position: 100% 50%; background-size: contain; background-repeat: no-repeat"}
-        .col-33
+      #bars{style: "display: flex"}
+        #left-bars-img.col-33.tablet-feature{style: "/* opacity: 0.2; */ align-items: stretch; background-image: url(/shared/images/fit-1200/hoc-cse-left-fade.png); background-position: 100% 50%; background-size: contain; background-repeat: no-repeat"}
+        .col-33{style: "box-shadow: 10px 0px 4px 3px rgb(255 255 255), -10px 0px 4px 3px rgb(255 255 255); z-index: 1"}
           = main_actions
-        .col-33.tablet-feature{style: "align-items: stretch; background-image: url(/shared/images/fit-1200/hoc-cse-right-fade.png); background-position: 0% 50%; background-size: contain; background-repeat: no-repeat"}
+        #right-bars-img.col-33.tablet-feature{style: "/* opacity: 0.2; */ align-items: stretch; background-image: url(/shared/images/fit-1200/hoc-cse-right-fade.png); background-position: 0% 50%; background-size: contain; background-repeat: no-repeat"}
+      %svg#left-bars-svg{viewBox: "0 0 210 250", style: "opacity: 0; position: absolute; /*border: 1px solid #949ca2;*/ width: 0; height: 0"}
+      %svg#right-bars-svg{viewBox: "0 0 210 250", style: "opacity: 0; position: absolute; /*border: 1px solid #949ca2;*/ width: 0; height: 0"}
 
   - else
     - if show_single_hero
@@ -204,3 +206,6 @@
 
     showQuote(lastImage, currentImage);
   }
+
+- if ["soon-hoc", "actual-hoc"].include?(hoc_mode)
+  %script{src: "/js/cse-bars.js"}

--- a/pegasus/sites.v3/code.org/views/homepage_hero.haml
+++ b/pegasus/sites.v3/code.org/views/homepage_hero.haml
@@ -16,6 +16,16 @@
     }
   }
 
+  #cse-main-actions {
+    box-shadow: 0px 0px 20px 20px rgb(255 255 255), 0px 0px 20px 20px rgb(255 255 255);
+  }
+
+  @media screen and (max-width: 970px) {
+    #cse-main-actions {
+      box-shadow: 0px 0px 20px 10px rgb(255 255 255), 0px 0px 20px 10px rgb(255 255 255);
+    }
+  }
+
 - main_actions = capture_haml do
   - if show_single_hero == "cse"
     .hero-message-line1{style: "color: black; font-size: 28px; line-height: 28px; padding-bottom: 20px; font-family: 'Gotham 4r', sans-serif", dir: "auto"}
@@ -82,11 +92,11 @@
     #actions
       #bars{style: "display: flex"}
         #left-bars-img.col-33.tablet-feature{style: "align-items: stretch; background-image: url(/shared/images/fit-1200/hoc-cse-left-fade.png); background-position: 100% 50%; background-size: contain; background-repeat: no-repeat"}
-        .col-33{style: "box-shadow: 10px 0px 4px 3px rgb(255 255 255), -10px 0px 4px 3px rgb(255 255 255); z-index: 1; background-color: white"}
+        #cse-main-actions.col-33{style: "z-index: 1; background-color: white"}
           = main_actions
         #right-bars-img.col-33.tablet-feature{style: "align-items: stretch; background-image: url(/shared/images/fit-1200/hoc-cse-right-fade.png); background-position: 0% 50%; background-size: contain; background-repeat: no-repeat"}
-      %svg#left-bars-svg.tablet-feature{viewBox: "0 0 210 250", style: "opacity: 0; position: absolute; width: 0; height: 0"}
-      %svg#right-bars-svg.tablet-feature{viewBox: "0 0 210 250", style: "opacity: 0; position: absolute; width: 0; height: 0"}
+      %svg#left-bars-svg.tablet-feature{viewBox: "0 0 235 250", style: "opacity: 0; position: absolute; width: 0; height: 0"}
+      %svg#right-bars-svg.tablet-feature{viewBox: "0 0 235 250", style: "opacity: 0; position: absolute; width: 0; height: 0"}
 
   - else
     - if show_single_hero

--- a/pegasus/sites.v3/code.org/views/homepage_hero.haml
+++ b/pegasus/sites.v3/code.org/views/homepage_hero.haml
@@ -1,5 +1,6 @@
 :ruby
   hoc_mode = DCDO.get("hoc_mode", CDO.default_hoc_mode)
+  hoc_cse_enable_svg = DCDO.get("hoc_cse_enable_svg", false)
   show_single_hero = Homepage.show_single_hero(request)
   heroes_arranged, hero_display_time = Homepage.get_heroes_arranged(request)
   actions = Homepage.get_actions(request)
@@ -81,7 +82,7 @@
     #actions
       #bars{style: "display: flex"}
         #left-bars-img.col-33.tablet-feature{style: "/* opacity: 0.2; */ align-items: stretch; background-image: url(/shared/images/fit-1200/hoc-cse-left-fade.png); background-position: 100% 50%; background-size: contain; background-repeat: no-repeat"}
-        .col-33{style: "box-shadow: 10px 0px 4px 3px rgb(255 255 255), -10px 0px 4px 3px rgb(255 255 255); z-index: 1"}
+        .col-33{style: "box-shadow: 10px 0px 4px 3px rgb(255 255 255), -10px 0px 4px 3px rgb(255 255 255); z-index: 1; background-color: white"}
           = main_actions
         #right-bars-img.col-33.tablet-feature{style: "/* opacity: 0.2; */ align-items: stretch; background-image: url(/shared/images/fit-1200/hoc-cse-right-fade.png); background-position: 0% 50%; background-size: contain; background-repeat: no-repeat"}
       %svg#left-bars-svg.tablet-feature{viewBox: "0 0 210 250", style: "opacity: 0; position: absolute; /*border: 1px solid #949ca2;*/ width: 0; height: 0"}
@@ -207,5 +208,5 @@
     showQuote(lastImage, currentImage);
   }
 
-- if ["soon-hoc", "actual-hoc"].include?(hoc_mode)
+- if ["soon-hoc", "actual-hoc"].include?(hoc_mode) && hoc_cse_enable_svg
   %script{src: "/js/cse-bars.js"}

--- a/pegasus/sites.v3/code.org/views/homepage_hero.haml
+++ b/pegasus/sites.v3/code.org/views/homepage_hero.haml
@@ -84,8 +84,8 @@
         .col-33{style: "box-shadow: 10px 0px 4px 3px rgb(255 255 255), -10px 0px 4px 3px rgb(255 255 255); z-index: 1"}
           = main_actions
         #right-bars-img.col-33.tablet-feature{style: "/* opacity: 0.2; */ align-items: stretch; background-image: url(/shared/images/fit-1200/hoc-cse-right-fade.png); background-position: 0% 50%; background-size: contain; background-repeat: no-repeat"}
-      %svg#left-bars-svg{viewBox: "0 0 210 250", style: "opacity: 0; position: absolute; /*border: 1px solid #949ca2;*/ width: 0; height: 0"}
-      %svg#right-bars-svg{viewBox: "0 0 210 250", style: "opacity: 0; position: absolute; /*border: 1px solid #949ca2;*/ width: 0; height: 0"}
+      %svg#left-bars-svg.tablet-feature{viewBox: "0 0 210 250", style: "opacity: 0; position: absolute; /*border: 1px solid #949ca2;*/ width: 0; height: 0"}
+      %svg#right-bars-svg.tablet-feature{viewBox: "0 0 210 250", style: "opacity: 0; position: absolute; /*border: 1px solid #949ca2;*/ width: 0; height: 0"}
 
   - else
     - if show_single_hero


### PR DESCRIPTION
This updates the animated SVG code added for https://code.org/hourofcode/overview in https://github.com/code-dot-org/code-dot-org/pull/42963 and gets it running on the https://code.org/ homepage as well.

By default, both pages use regular, static images, but if the `hoc_cse_enable_svg` DCDO flag is set to `true` those are replaced by a pair of SVGs which are animated by JavaScript.

The animated SVG on https://code.org/hourofcode/overview has been updated to use a pair of animated SVGS, left & right, which was necessary to share the code with the https://code.org/ homepage.

The code is still temporary and will be thrown away once we change theme again, but it has gotten a little more powerful.  Notably:

- It drives a pair of panels, left & right.
- It assumes regular images (rendered using `background-image` in `div`s laid out by the browser) are to be shown at first.  If the SVG is disabled, or the JavaScript fails to execute, then that's all that happens.  But otherwise the code fades these out and fades in the SVGs once they have been rendered.
- It essentially replicates the browser's implementation of `background-size: contain` to position & fit each SVG panel to match the `div`s with the regular images, maximizing the size of the SVG within its "container" while maintaining its aspect ratio.
- It improves performance by caching the `stroke-dashoffset` and not updating the SVG attribute if it hasn't changed since last time.  Without this, Chrome was occasionally warning that a `setInterval` handler was taking a bit long.

Again, tested and looks to work correctly in all the regular browsers: Chrome, Safari, Firefox, Edge, and IE11.

# default

### code.org/

<img width="1280" alt="Screen Shot 2021-10-17 at 2 06 38 PM" src="https://user-images.githubusercontent.com/2205926/137609288-a8185a28-5de6-48e4-a5ab-065979e9d61d.png">

### code.org/hourofcode/overview

<img width="1280" alt="Screen Shot 2021-10-17 at 2 06 52 PM" src="https://user-images.githubusercontent.com/2205926/137609294-a440a3ac-eb6d-4e36-bf52-c1e0598d6bee.png">

# SVG animation

### code.org/

https://user-images.githubusercontent.com/2205926/137617030-23c8193c-7505-4f75-b391-b6e2595952bc.mov

### code.org/hourofcode/overview

https://user-images.githubusercontent.com/2205926/137609440-dcc41518-8f7d-4515-91bb-4ec0ba38b491.mov

