### PR TITLE
Temporarily stop installing and running rbspy

### DIFF
--- a/aws/cloudformation/bootstrap_frontend.sh.erb
+++ b/aws/cloudformation/bootstrap_frontend.sh.erb
@@ -14,7 +14,11 @@ popd
 # Run rbspy for 2 minutes on 3 dashboard worker processes at startup.
 # We're doing this temporarily to help debug our deployment unavailability issue.
 # Find 3 dashboard worker process IDs and feed them to 3 rbspy invocations, in parallel using xargs.
-ps aux | grep "cluster worker" | grep dashboard | head -n 3 | tr --squeeze-repeats ' ' | cut -d ' ' -f 2 | xargs -P 3 -I {} sudo rbspy record --silent --duration 120 --pid {} &
+
+# Temporarily stop running rbspy on server startup because the current version of Chef client we use can't install rbyspy
+# because Chef client bundles a version of OpenSSL
+# that does not include the root certificate that the github.com site's SSL certificate is signed by.
+# ps aux | grep "cluster worker" | grep dashboard | head -n 3 | tr --squeeze-repeats ' ' | cut -d ' ' -f 2 | xargs -P 3 -I {} sudo rbspy record --silent --duration 120 --pid {} &
 
 # Increase EC2 instance metadata service retries/timeouts.
 export AWS_METADATA_SERVICE_TIMEOUT=30

--- a/cookbooks/cdo-apps/recipes/default.rb
+++ b/cookbooks/cdo-apps/recipes/default.rb
@@ -138,6 +138,8 @@ include_recipe 'cdo-tippecanoe' if node['cdo-apps']['daemon']
 # Patch to fix issue with systemd-resolved: https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1805183
 include_recipe 'cdo-apps::resolved'
 
-include_recipe 'cdo-apps::rbspy'
+# Temporarily stop installing rbspy because the current version of Chef client we use bundles a version of OpenSSL
+# that does not include the root certificate that the github.com site's SSL certificate is signed by.
+#include_recipe 'cdo-apps::rbspy'
 
 include_recipe 'cdo-apps::syslog_permissions'


### PR DESCRIPTION
Temporarily stop installing and running rbspy on front-end web application servers because Chef Client 15.2.20 doesn't trust the root certificate that signed the GitHub.com site's SSL certificate.

The version of Chef Infra Client that we utilize bundles a version of OpenSSL that includes a root certificate store that does not include several new root certificates issued recently. At least 2 web sites that our Chef cookbooks install software from (mirrors.kernel.org and GitHub.com) now use SSL certificates that are signed by root certificates that were issued after Chef Client 15.2.20 was released.

This Pull Request manually reverts #32846 which was merged to help investigate some stability issues during server startup on production, but hasn't been used in more than a year.

See also #42843

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
