### PR TITLE
Javalab: Update webpack to transpile @lezer packages

### DIFF
--- a/apps/webpack.js
+++ b/apps/webpack.js
@@ -26,9 +26,7 @@ var toTranspileWithinNodeModules = [
   path.resolve(__dirname, 'node_modules', 'ml-distance-euclidean'),
   path.resolve(__dirname, 'node_modules', '@codemirror'),
   path.resolve(__dirname, 'node_modules', 'style-mod'),
-  path.resolve(__dirname, 'node_modules', 'lezer-tree'),
-  path.resolve(__dirname, 'node_modules', 'lezer-java'),
-  path.resolve(__dirname, 'node_modules', 'lezer'),
+  path.resolve(__dirname, 'node_modules', '@lezer'),
   path.resolve(
     __dirname,
     'node_modules',


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Missed this change while upgrading to the newest version of CodeMirror. The `lezer` set of packages updated to `@lezer`, so the webpack config also had to be updated accordingly.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

`build:dist` succeeded locally after change.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
