### PR TITLE
Update gamelab_behavior_get block ids

### DIFF
--- a/bin/oneoff/update_behavior_blocks_ids2.rb
+++ b/bin/oneoff/update_behavior_blocks_ids2.rb
@@ -1,0 +1,80 @@
+#!/usr/bin/env ruby
+
+# Behavioral blocks with no id set have their id
+# set on the frontend as their text value. This causes
+# issues when viewing the levels in different languages.
+
+require_relative '../../dashboard/config/environment'
+
+BEHAVIORAL_DEFINITION_NAMES = %w(
+  driving with arrow keys
+  growing
+  jittering
+  moving east
+  moving north
+  moving south
+  moving west
+  moving with arrow keys
+  patrolling
+  shrinking
+  spinning left
+  spinning right
+  swimming left and right
+  wandering
+  chasing
+  acting goofy
+).freeze
+
+def for_each_level_file(&block)
+  Dir.glob(Rails.root.join('config/scripts/**/*.level')).sort.map(&block)
+end
+
+def level_name_from_path(path)
+  File.basename(path, File.extname(path))
+end
+
+def update_behavior_blocks_ids
+  updated_levels = 0
+  skipped_levels = 0
+
+  for_each_level_file do |path|
+    raw_level_data = File.read(path)
+
+    xml = Nokogiri::XML(raw_level_data, &:noblanks)
+    if xml.nil?
+      skipped_levels += 1
+      next
+    end
+
+    # Get all gamelab_behavior_get blocks that have title texts and ids that are different
+    did_skip = true
+    BEHAVIORAL_DEFINITION_NAMES.each do |name|
+      titles = xml.xpath("//block[@type='gamelab_behavior_get']//title[text()='#{name}'][not(@id = '#{name}')]")
+      next if titles.empty?
+
+      titles.each do |title|
+        title['id'] = name
+      end
+      did_skip = false
+    end
+
+    if did_skip
+      skipped_levels += 1
+      next
+    end
+
+    raw_level_data = xml.root.to_s
+    File.write(path, raw_level_data)
+    updated_levels += 1
+  rescue Exception => e
+    # print filename for better debugging
+    new_e = Exception.new("in level: #{path}: #{e.message}")
+    new_e.set_backtrace(e.backtrace)
+    raise new_e
+  end
+
+  puts "#{skipped_levels} level files didn't need updating"
+  puts "#{updated_levels} level files that had a behavior_definition title updated"
+end
+
+update_behavior_blocks_ids

--- a/dashboard/config/scripts/levels/CSTAdata1b.level
+++ b/dashboard/config/scripts/levels/CSTAdata1b.level
@@ -248,7 +248,7 @@
                                               <mutation>
                                                 <arg name="speed" type="Number"/>
                                               </mutation>
-                                              <title name="VAR">wandering</title>
+                                              <title name="VAR" id="wandering">wandering</title>
                                               <value name="ARG0">
                                                 <block type="math_number">
                                                   <title name="NUM">1</title>
@@ -268,7 +268,7 @@
                                                   <mutation>
                                                     <arg name="speed" type="Number"/>
                                                   </mutation>
-                                                  <title name="VAR">wandering</title>
+                                                  <title name="VAR" id="wandering">wandering</title>
                                                   <value name="ARG0">
                                                     <block type="math_number">
                                                       <title name="NUM">3</title>
@@ -288,7 +288,7 @@
                                                       <mutation>
                                                         <arg name="speed" type="Number"/>
                                                       </mutation>
-                                                      <title name="VAR">wandering</title>
+                                                      <title name="VAR" id="wandering">wandering</title>
                                                       <value name="ARG0">
                                                         <block type="math_number">
                                                           <title name="NUM">2</title>

--- a/dashboard/config/scripts/levels/CodeBreak E05 Beg Challenge1.level
+++ b/dashboard/config/scripts/levels/CodeBreak E05 Beg Challenge1.level
@@ -648,7 +648,7 @@
                                   <value name="BEHAVIOR">
                                     <block type="gamelab_behavior_get">
                                       <mutation/>
-                                      <title name="VAR">wandering</title>
+                                      <title name="VAR" id="wandering">wandering</title>
                                     </block>
                                   </value>
                                   <next>
@@ -661,7 +661,7 @@
                                       <value name="BEHAVIOR">
                                         <block type="gamelab_behavior_get">
                                           <mutation/>
-                                          <title name="VAR">wandering</title>
+                                          <title name="VAR" id="wandering">wandering</title>
                                         </block>
                                       </value>
                                     </block>
@@ -1362,7 +1362,7 @@
             <value name="BEHAVIOR">
               <block type="gamelab_behavior_get">
                 <mutation/>
-                <title name="VAR">wandering</title>
+                <title name="VAR" id="wandering">wandering</title>
               </block>
             </value>
           </block>

--- a/dashboard/config/scripts/levels/CodeBreak E05 Beg Practice.level
+++ b/dashboard/config/scripts/levels/CodeBreak E05 Beg Practice.level
@@ -1189,7 +1189,7 @@
             <value name="BEHAVIOR">
               <block type="gamelab_behavior_get">
                 <mutation/>
-                <title name="VAR">wandering</title>
+                <title name="VAR" id="wandering">wandering</title>
               </block>
             </value>
           </block>

--- a/dashboard/config/scripts/levels/CodeBreak E05 Int Challenge1.level
+++ b/dashboard/config/scripts/levels/CodeBreak E05 Int Challenge1.level
@@ -651,7 +651,7 @@
                                   <value name="BEHAVIOR">
                                     <block type="gamelab_behavior_get">
                                       <mutation/>
-                                      <title name="VAR">wandering</title>
+                                      <title name="VAR" id="wandering">wandering</title>
                                     </block>
                                   </value>
                                   <next>
@@ -664,7 +664,7 @@
                                       <value name="BEHAVIOR">
                                         <block type="gamelab_behavior_get">
                                           <mutation/>
-                                          <title name="VAR">wandering</title>
+                                          <title name="VAR" id="wandering">wandering</title>
                                         </block>
                                       </value>
                                     </block>
@@ -1476,7 +1476,7 @@
           <block type="gamelab_removeBehaviorSimple"/>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">wandering</title>
+            <title name="VAR" id="wandering">wandering</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
@@ -1484,15 +1484,15 @@
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">shrinking</title>
+            <title name="VAR" id="shrinking">shrinking</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">jittering</title>
+            <title name="VAR" id="jittering">jittering</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">growing</title>
+            <title name="VAR" id="growing">growing</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>

--- a/dashboard/config/scripts/levels/CodeBreak E08 Beg Challenge 2.level
+++ b/dashboard/config/scripts/levels/CodeBreak E08 Beg Challenge 2.level
@@ -149,7 +149,7 @@
                                       <value name="BEHAVIOR">
                                         <block type="gamelab_behavior_get">
                                           <mutation/>
-                                          <title name="VAR">wandering</title>
+                                          <title name="VAR" id="wandering">wandering</title>
                                         </block>
                                       </value>
                                       <next>
@@ -190,7 +190,7 @@
                                                   <value name="BEHAVIOR">
                                                     <block type="gamelab_behavior_get">
                                                       <mutation/>
-                                                      <title name="VAR">wandering</title>
+                                                      <title name="VAR" id="wandering">wandering</title>
                                                     </block>
                                                   </value>
                                                 </block>

--- a/dashboard/config/scripts/levels/CodeBreak E08 Beg Challenge1.level
+++ b/dashboard/config/scripts/levels/CodeBreak E08 Beg Challenge1.level
@@ -670,7 +670,7 @@
                                               <value name="BEHAVIOR">
                                                 <block type="gamelab_behavior_get">
                                                   <mutation/>
-                                                  <title name="VAR">wandering</title>
+                                                  <title name="VAR" id="wandering">wandering</title>
                                                 </block>
                                               </value>
                                               <next>
@@ -711,7 +711,7 @@
                                                           <value name="BEHAVIOR">
                                                             <block type="gamelab_behavior_get">
                                                             <mutation/>
-                                                            <title name="VAR">wandering</title>
+                                                            <title name="VAR" id="wandering">wandering</title>
                                                             </block>
                                                           </value>
                                                           <next>
@@ -1451,7 +1451,7 @@
           <block type="gamelab_removeBehaviorSimple"/>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">wandering</title>
+            <title name="VAR" id="wandering">wandering</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
@@ -1459,15 +1459,15 @@
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">shrinking</title>
+            <title name="VAR" id="shrinking">shrinking</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">jittering</title>
+            <title name="VAR" id="jittering">jittering</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">growing</title>
+            <title name="VAR" id="growing">growing</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>

--- a/dashboard/config/scripts/levels/CourseE_hoops.level
+++ b/dashboard/config/scripts/levels/CourseE_hoops.level
@@ -96,7 +96,7 @@
                           <value name="BEHAVIOR">
                             <block type="gamelab_behavior_get">
                               <mutation/>
-                              <title name="VAR">patrolling</title>
+                              <title name="VAR" id="patrolling">patrolling</title>
                             </block>
                           </value>
                           <next>

--- a/dashboard/config/scripts/levels/CourseE_hoops_2019.level
+++ b/dashboard/config/scripts/levels/CourseE_hoops_2019.level
@@ -103,7 +103,7 @@
                           <value name="BEHAVIOR">
                             <block type="gamelab_behavior_get">
                               <mutation/>
-                              <title name="VAR">patrolling</title>
+                              <title name="VAR" id="patrolling">patrolling</title>
                             </block>
                           </value>
                           <next>

--- a/dashboard/config/scripts/levels/CourseF_outbreak2.level
+++ b/dashboard/config/scripts/levels/CourseF_outbreak2.level
@@ -126,7 +126,7 @@
                               <value name="BEHAVIOR">
                                 <block type="gamelab_behavior_get">
                                   <mutation/>
-                                  <title name="VAR">wandering</title>
+                                  <title name="VAR" id="wandering">wandering</title>
                                 </block>
                               </value>
                             </block>

--- a/dashboard/config/scripts/levels/CourseF_outbreak3.level
+++ b/dashboard/config/scripts/levels/CourseF_outbreak3.level
@@ -125,7 +125,7 @@
                               <value name="BEHAVIOR">
                                 <block type="gamelab_behavior_get">
                                   <mutation/>
-                                  <title name="VAR">wandering</title>
+                                  <title name="VAR" id="wandering">wandering</title>
                                 </block>
                               </value>
                             </block>

--- a/dashboard/config/scripts/levels/CourseF_outbreak4.level
+++ b/dashboard/config/scripts/levels/CourseF_outbreak4.level
@@ -126,7 +126,7 @@
                               <value name="BEHAVIOR">
                                 <block type="gamelab_behavior_get">
                                   <mutation/>
-                                  <title name="VAR">wandering</title>
+                                  <title name="VAR" id="wandering">wandering</title>
                                 </block>
                               </value>
                             </block>

--- a/dashboard/config/scripts/levels/CourseF_outbreak5.level
+++ b/dashboard/config/scripts/levels/CourseF_outbreak5.level
@@ -129,7 +129,7 @@
                               <value name="BEHAVIOR">
                                 <block type="gamelab_behavior_get">
                                   <mutation/>
-                                  <title name="VAR">wandering</title>
+                                  <title name="VAR" id="wandering">wandering</title>
                                 </block>
                               </value>
                             </block>

--- a/dashboard/config/scripts/levels/CourseF_outbreak6.level
+++ b/dashboard/config/scripts/levels/CourseF_outbreak6.level
@@ -347,7 +347,7 @@
                               <value name="BEHAVIOR">
                                 <block type="gamelab_behavior_get">
                                   <mutation/>
-                                  <title name="VAR">wandering</title>
+                                  <title name="VAR" id="wandering">wandering</title>
                                 </block>
                               </value>
                               <next>

--- a/dashboard/config/scripts/levels/CourseF_outbreak7.level
+++ b/dashboard/config/scripts/levels/CourseF_outbreak7.level
@@ -129,7 +129,7 @@
                               <value name="BEHAVIOR">
                                 <block type="gamelab_behavior_get">
                                   <mutation/>
-                                  <title name="VAR">wandering</title>
+                                  <title name="VAR" id="wandering">wandering</title>
                                 </block>
                               </value>
                               <next>

--- a/dashboard/config/scripts/levels/CourseF_outbreak8.level
+++ b/dashboard/config/scripts/levels/CourseF_outbreak8.level
@@ -128,7 +128,7 @@
                               <value name="BEHAVIOR">
                                 <block type="gamelab_behavior_get">
                                   <mutation/>
-                                  <title name="VAR">wandering</title>
+                                  <title name="VAR" id="wandering">wandering</title>
                                 </block>
                               </value>
                               <next>

--- a/dashboard/config/scripts/levels/CourseF_outbreak_freeplay.level
+++ b/dashboard/config/scripts/levels/CourseF_outbreak_freeplay.level
@@ -126,7 +126,7 @@
                               <value name="BEHAVIOR">
                                 <block type="gamelab_behavior_get">
                                   <mutation/>
-                                  <title name="VAR">wandering</title>
+                                  <title name="VAR" id="wandering">wandering</title>
                                 </block>
                               </value>
                               <next>

--- a/dashboard/config/scripts/levels/Dance Party 2 Validated.level
+++ b/dashboard/config/scripts/levels/Dance Party 2 Validated.level
@@ -101,7 +101,7 @@
               </value>
               <value name="BEHAVIOR">
                 <block type="gamelab_behavior_get">
-                  <title name="VAR">patrolling</title>
+                  <title name="VAR" id="patrolling">patrolling</title>
                 </block>
               </value>
             </block>
@@ -523,16 +523,16 @@
             <title name="VAR">spinning right</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">growing</title>
+            <title name="VAR" id="growing">growing</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">jittering</title>
+            <title name="VAR" id="jittering">jittering</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">shrinking</title>
+            <title name="VAR" id="shrinking">shrinking</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">patrolling</title>
+            <title name="VAR" id="patrolling">patrolling</title>
           </block>
           <block type="gamelab_behavior_get">
             <title name="VAR">moving north</title>
@@ -547,7 +547,7 @@
             <title name="VAR">moving west</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">wandering</title>
+            <title name="VAR" id="wandering">wandering</title>
           </block>
         </category>
         <category name="Events">

--- a/dashboard/config/scripts/levels/Dance Party 2.level
+++ b/dashboard/config/scripts/levels/Dance Party 2.level
@@ -113,7 +113,7 @@
               <value name="BEHAVIOR">
                 <block type="gamelab_behavior_get">
                   <mutation/>
-                  <title name="VAR">patrolling</title>
+                  <title name="VAR" id="patrolling">patrolling</title>
                 </block>
               </value>
             </block>
@@ -680,16 +680,16 @@
             <title name="VAR">spinning right</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">growing</title>
+            <title name="VAR" id="growing">growing</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">jittering</title>
+            <title name="VAR" id="jittering">jittering</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">shrinking</title>
+            <title name="VAR" id="shrinking">shrinking</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">patrolling</title>
+            <title name="VAR" id="patrolling">patrolling</title>
           </block>
           <block type="gamelab_behavior_get">
             <title name="VAR">moving north</title>
@@ -704,7 +704,7 @@
             <title name="VAR">moving west</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">wandering</title>
+            <title name="VAR" id="wandering">wandering</title>
           </block>
         </category>
         <category name="Events">

--- a/dashboard/config/scripts/levels/Dance Party 2_simple.level
+++ b/dashboard/config/scripts/levels/Dance Party 2_simple.level
@@ -102,7 +102,7 @@
               </value>
               <value name="BEHAVIOR">
                 <block type="gamelab_behavior_get">
-                  <title name="VAR">moving</title>
+                  <title name="VAR" id="moving">moving</title>
                 </block>
               </value>
             </block>
@@ -533,7 +533,7 @@
             <title name="VAR">getting smaller</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">moving</title>
+            <title name="VAR" id="moving">moving</title>
           </block>
           <block type="gamelab_behavior_get">
             <title name="VAR">moving north</title>
@@ -548,7 +548,7 @@
             <title name="VAR">moving west</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">wandering</title>
+            <title name="VAR" id="wandering">wandering</title>
           </block>
         </category>
         <category name="Events">

--- a/dashboard/config/scripts/levels/Dance Party 3_2019.level
+++ b/dashboard/config/scripts/levels/Dance Party 3_2019.level
@@ -171,7 +171,7 @@
               <value name="BEHAVIOR">
                 <block type="gamelab_behavior_get">
                   <mutation/>
-                  <title name="VAR">wandering</title>
+                  <title name="VAR" id="wandering">wandering</title>
                 </block>
               </value>
             </block>

--- a/dashboard/config/scripts/levels/Dance Party 3_2020.level
+++ b/dashboard/config/scripts/levels/Dance Party 3_2020.level
@@ -171,7 +171,7 @@
               <value name="BEHAVIOR">
                 <block type="gamelab_behavior_get">
                   <mutation/>
-                  <title name="VAR">wandering</title>
+                  <title name="VAR" id="wandering">wandering</title>
                 </block>
               </value>
             </block>

--- a/dashboard/config/scripts/levels/Dance Party 3_2021.level
+++ b/dashboard/config/scripts/levels/Dance Party 3_2021.level
@@ -176,7 +176,7 @@
               <value name="BEHAVIOR">
                 <block type="gamelab_behavior_get">
                   <mutation/>
-                  <title name="VAR">wandering</title>
+                  <title name="VAR" id="wandering">wandering</title>
                 </block>
               </value>
             </block>

--- a/dashboard/config/scripts/levels/Dance Party 3_control.level
+++ b/dashboard/config/scripts/levels/Dance Party 3_control.level
@@ -166,7 +166,7 @@
               <value name="BEHAVIOR">
                 <block type="gamelab_behavior_get">
                   <mutation/>
-                  <title name="VAR">wandering</title>
+                  <title name="VAR" id="wandering">wandering</title>
                 </block>
               </value>
             </block>

--- a/dashboard/config/scripts/levels/Dance Party 3_experiment.level
+++ b/dashboard/config/scripts/levels/Dance Party 3_experiment.level
@@ -166,7 +166,7 @@
               <value name="BEHAVIOR">
                 <block type="gamelab_behavior_get">
                   <mutation/>
-                  <title name="VAR">wandering</title>
+                  <title name="VAR" id="wandering">wandering</title>
                 </block>
               </value>
             </block>

--- a/dashboard/config/scripts/levels/Dance Party 4_2019.level
+++ b/dashboard/config/scripts/levels/Dance Party 4_2019.level
@@ -159,7 +159,7 @@
               <value name="BEHAVIOR">
                 <block type="gamelab_behavior_get">
                   <mutation/>
-                  <title name="VAR">wandering</title>
+                  <title name="VAR" id="wandering">wandering</title>
                 </block>
               </value>
             </block>
@@ -182,7 +182,7 @@
               <value name="BEHAVIOR">
                 <block type="gamelab_behavior_get">
                   <mutation/>
-                  <title name="VAR">jittering</title>
+                  <title name="VAR" id="jittering">jittering</title>
                 </block>
               </value>
             </block>

--- a/dashboard/config/scripts/levels/Dance Party 4_2020.level
+++ b/dashboard/config/scripts/levels/Dance Party 4_2020.level
@@ -159,7 +159,7 @@
               <value name="BEHAVIOR">
                 <block type="gamelab_behavior_get">
                   <mutation/>
-                  <title name="VAR">wandering</title>
+                  <title name="VAR" id="wandering">wandering</title>
                 </block>
               </value>
             </block>
@@ -182,7 +182,7 @@
               <value name="BEHAVIOR">
                 <block type="gamelab_behavior_get">
                   <mutation/>
-                  <title name="VAR">jittering</title>
+                  <title name="VAR" id="jittering">jittering</title>
                 </block>
               </value>
             </block>

--- a/dashboard/config/scripts/levels/Dance Party 4_2021.level
+++ b/dashboard/config/scripts/levels/Dance Party 4_2021.level
@@ -164,7 +164,7 @@
               <value name="BEHAVIOR">
                 <block type="gamelab_behavior_get">
                   <mutation/>
-                  <title name="VAR">wandering</title>
+                  <title name="VAR" id="wandering">wandering</title>
                 </block>
               </value>
             </block>
@@ -187,7 +187,7 @@
               <value name="BEHAVIOR">
                 <block type="gamelab_behavior_get">
                   <mutation/>
-                  <title name="VAR">jittering</title>
+                  <title name="VAR" id="jittering">jittering</title>
                 </block>
               </value>
             </block>

--- a/dashboard/config/scripts/levels/Dance Party 4_control.level
+++ b/dashboard/config/scripts/levels/Dance Party 4_control.level
@@ -154,7 +154,7 @@
               <value name="BEHAVIOR">
                 <block type="gamelab_behavior_get">
                   <mutation/>
-                  <title name="VAR">wandering</title>
+                  <title name="VAR" id="wandering">wandering</title>
                 </block>
               </value>
             </block>
@@ -177,7 +177,7 @@
               <value name="BEHAVIOR">
                 <block type="gamelab_behavior_get">
                   <mutation/>
-                  <title name="VAR">jittering</title>
+                  <title name="VAR" id="jittering">jittering</title>
                 </block>
               </value>
             </block>

--- a/dashboard/config/scripts/levels/Dance Party 4_experiment.level
+++ b/dashboard/config/scripts/levels/Dance Party 4_experiment.level
@@ -154,7 +154,7 @@
               <value name="BEHAVIOR">
                 <block type="gamelab_behavior_get">
                   <mutation/>
-                  <title name="VAR">wandering</title>
+                  <title name="VAR" id="wandering">wandering</title>
                 </block>
               </value>
             </block>
@@ -177,7 +177,7 @@
               <value name="BEHAVIOR">
                 <block type="gamelab_behavior_get">
                   <mutation/>
-                  <title name="VAR">jittering</title>
+                  <title name="VAR" id="jittering">jittering</title>
                 </block>
               </value>
             </block>

--- a/dashboard/config/scripts/levels/Dance Party 5_2019.level
+++ b/dashboard/config/scripts/levels/Dance Party 5_2019.level
@@ -158,7 +158,7 @@
               <value name="BEHAVIOR">
                 <block type="gamelab_behavior_get">
                   <mutation/>
-                  <title name="VAR">wandering</title>
+                  <title name="VAR" id="wandering">wandering</title>
                 </block>
               </value>
             </block>
@@ -181,7 +181,7 @@
               <value name="BEHAVIOR">
                 <block type="gamelab_behavior_get">
                   <mutation/>
-                  <title name="VAR">jittering</title>
+                  <title name="VAR" id="jittering">jittering</title>
                 </block>
               </value>
             </block>

--- a/dashboard/config/scripts/levels/Dance Party 5_2020.level
+++ b/dashboard/config/scripts/levels/Dance Party 5_2020.level
@@ -158,7 +158,7 @@
               <value name="BEHAVIOR">
                 <block type="gamelab_behavior_get">
                   <mutation/>
-                  <title name="VAR">wandering</title>
+                  <title name="VAR" id="wandering">wandering</title>
                 </block>
               </value>
             </block>
@@ -181,7 +181,7 @@
               <value name="BEHAVIOR">
                 <block type="gamelab_behavior_get">
                   <mutation/>
-                  <title name="VAR">jittering</title>
+                  <title name="VAR" id="jittering">jittering</title>
                 </block>
               </value>
             </block>

--- a/dashboard/config/scripts/levels/Dance Party 5_2021.level
+++ b/dashboard/config/scripts/levels/Dance Party 5_2021.level
@@ -163,7 +163,7 @@
               <value name="BEHAVIOR">
                 <block type="gamelab_behavior_get">
                   <mutation/>
-                  <title name="VAR">wandering</title>
+                  <title name="VAR" id="wandering">wandering</title>
                 </block>
               </value>
             </block>
@@ -186,7 +186,7 @@
               <value name="BEHAVIOR">
                 <block type="gamelab_behavior_get">
                   <mutation/>
-                  <title name="VAR">jittering</title>
+                  <title name="VAR" id="jittering">jittering</title>
                 </block>
               </value>
             </block>

--- a/dashboard/config/scripts/levels/Dance Party 5_control.level
+++ b/dashboard/config/scripts/levels/Dance Party 5_control.level
@@ -154,7 +154,7 @@
               <value name="BEHAVIOR">
                 <block type="gamelab_behavior_get">
                   <mutation/>
-                  <title name="VAR">wandering</title>
+                  <title name="VAR" id="wandering">wandering</title>
                 </block>
               </value>
             </block>
@@ -177,7 +177,7 @@
               <value name="BEHAVIOR">
                 <block type="gamelab_behavior_get">
                   <mutation/>
-                  <title name="VAR">jittering</title>
+                  <title name="VAR" id="jittering">jittering</title>
                 </block>
               </value>
             </block>

--- a/dashboard/config/scripts/levels/Dance Party 5_experiment.level
+++ b/dashboard/config/scripts/levels/Dance Party 5_experiment.level
@@ -154,7 +154,7 @@
               <value name="BEHAVIOR">
                 <block type="gamelab_behavior_get">
                   <mutation/>
-                  <title name="VAR">wandering</title>
+                  <title name="VAR" id="wandering">wandering</title>
                 </block>
               </value>
             </block>
@@ -177,7 +177,7 @@
               <value name="BEHAVIOR">
                 <block type="gamelab_behavior_get">
                   <mutation/>
-                  <title name="VAR">jittering</title>
+                  <title name="VAR" id="jittering">jittering</title>
                 </block>
               </value>
             </block>

--- a/dashboard/config/scripts/levels/Dance Party 6 - Validated.level
+++ b/dashboard/config/scripts/levels/Dance Party 6 - Validated.level
@@ -139,7 +139,7 @@
                               </value>
                               <value name="BEHAVIOR">
                                 <block type="gamelab_behavior_get">
-                                  <title name="VAR">jittering</title>
+                                  <title name="VAR" id="jittering">jittering</title>
                                 </block>
                               </value>
                               <next>
@@ -151,7 +151,7 @@
                                   </value>
                                   <value name="BEHAVIOR">
                                     <block type="gamelab_behavior_get">
-                                      <title name="VAR">patrolling</title>
+                                      <title name="VAR" id="patrolling">patrolling</title>
                                     </block>
                                   </value>
                                   <next>
@@ -163,7 +163,7 @@
                                       </value>
                                       <value name="BEHAVIOR">
                                         <block type="gamelab_behavior_get">
-                                          <title name="VAR">wandering</title>
+                                          <title name="VAR" id="wandering">wandering</title>
                                         </block>
                                       </value>
                                     </block>
@@ -705,16 +705,16 @@
             <title name="VAR">spinning right</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">growing</title>
+            <title name="VAR" id="growing">growing</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">jittering</title>
+            <title name="VAR" id="jittering">jittering</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">shrinking</title>
+            <title name="VAR" id="shrinking">shrinking</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">patrolling</title>
+            <title name="VAR" id="patrolling">patrolling</title>
           </block>
           <block type="gamelab_behavior_get">
             <title name="VAR">moving north</title>
@@ -729,7 +729,7 @@
             <title name="VAR">moving west</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">wandering</title>
+            <title name="VAR" id="wandering">wandering</title>
           </block>
         </category>
         <category name="Events">

--- a/dashboard/config/scripts/levels/Dance Party 6.level
+++ b/dashboard/config/scripts/levels/Dance Party 6.level
@@ -117,7 +117,7 @@
                               <value name="BEHAVIOR">
                                 <block type="gamelab_behavior_get">
                                   <mutation/>
-                                  <title name="VAR">jittering</title>
+                                  <title name="VAR" id="jittering">jittering</title>
                                 </block>
                               </value>
                               <next>
@@ -130,7 +130,7 @@
                                   <value name="BEHAVIOR">
                                     <block type="gamelab_behavior_get">
                                       <mutation/>
-                                      <title name="VAR">patrolling</title>
+                                      <title name="VAR" id="patrolling">patrolling</title>
                                     </block>
                                   </value>
                                   <next>
@@ -143,7 +143,7 @@
                                       <value name="BEHAVIOR">
                                         <block type="gamelab_behavior_get">
                                           <mutation/>
-                                          <title name="VAR">wandering</title>
+                                          <title name="VAR" id="wandering">wandering</title>
                                         </block>
                                       </value>
                                     </block>
@@ -715,16 +715,16 @@
             <title name="VAR">spinning right</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">growing</title>
+            <title name="VAR" id="growing">growing</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">jittering</title>
+            <title name="VAR" id="jittering">jittering</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">shrinking</title>
+            <title name="VAR" id="shrinking">shrinking</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">patrolling</title>
+            <title name="VAR" id="patrolling">patrolling</title>
           </block>
           <block type="gamelab_behavior_get">
             <title name="VAR">moving north</title>
@@ -739,7 +739,7 @@
             <title name="VAR">moving west</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">wandering</title>
+            <title name="VAR" id="wandering">wandering</title>
           </block>
         </category>
         <category name="Events">

--- a/dashboard/config/scripts/levels/Dance Party 6_2019.level
+++ b/dashboard/config/scripts/levels/Dance Party 6_2019.level
@@ -128,7 +128,7 @@
                                   <value name="BEHAVIOR">
                                     <block type="gamelab_behavior_get">
                                       <mutation/>
-                                      <title name="VAR">jittering</title>
+                                      <title name="VAR" id="jittering">jittering</title>
                                     </block>
                                   </value>
                                   <next>
@@ -141,7 +141,7 @@
                                       <value name="BEHAVIOR">
                                         <block type="gamelab_behavior_get">
                                           <mutation/>
-                                          <title name="VAR">patrolling</title>
+                                          <title name="VAR" id="patrolling">patrolling</title>
                                         </block>
                                       </value>
                                       <next>
@@ -154,7 +154,7 @@
                                           <value name="BEHAVIOR">
                                             <block type="gamelab_behavior_get">
                                               <mutation/>
-                                              <title name="VAR">wandering</title>
+                                              <title name="VAR" id="wandering">wandering</title>
                                             </block>
                                           </value>
                                         </block>

--- a/dashboard/config/scripts/levels/Dance Party 6_2020.level
+++ b/dashboard/config/scripts/levels/Dance Party 6_2020.level
@@ -128,7 +128,7 @@
                                   <value name="BEHAVIOR">
                                     <block type="gamelab_behavior_get">
                                       <mutation/>
-                                      <title name="VAR">jittering</title>
+                                      <title name="VAR" id="jittering">jittering</title>
                                     </block>
                                   </value>
                                   <next>
@@ -141,7 +141,7 @@
                                       <value name="BEHAVIOR">
                                         <block type="gamelab_behavior_get">
                                           <mutation/>
-                                          <title name="VAR">patrolling</title>
+                                          <title name="VAR" id="patrolling">patrolling</title>
                                         </block>
                                       </value>
                                       <next>
@@ -154,7 +154,7 @@
                                           <value name="BEHAVIOR">
                                             <block type="gamelab_behavior_get">
                                               <mutation/>
-                                              <title name="VAR">wandering</title>
+                                              <title name="VAR" id="wandering">wandering</title>
                                             </block>
                                           </value>
                                         </block>

--- a/dashboard/config/scripts/levels/Dance Party 6_2021.level
+++ b/dashboard/config/scripts/levels/Dance Party 6_2021.level
@@ -134,7 +134,7 @@
                                   <value name="BEHAVIOR">
                                     <block type="gamelab_behavior_get">
                                       <mutation/>
-                                      <title name="VAR">jittering</title>
+                                      <title name="VAR" id="jittering">jittering</title>
                                     </block>
                                   </value>
                                   <next>
@@ -147,7 +147,7 @@
                                       <value name="BEHAVIOR">
                                         <block type="gamelab_behavior_get">
                                           <mutation/>
-                                          <title name="VAR">patrolling</title>
+                                          <title name="VAR" id="patrolling">patrolling</title>
                                         </block>
                                       </value>
                                       <next>
@@ -160,7 +160,7 @@
                                           <value name="BEHAVIOR">
                                             <block type="gamelab_behavior_get">
                                               <mutation/>
-                                              <title name="VAR">wandering</title>
+                                              <title name="VAR" id="wandering">wandering</title>
                                             </block>
                                           </value>
                                         </block>

--- a/dashboard/config/scripts/levels/Dance Party 6_control.level
+++ b/dashboard/config/scripts/levels/Dance Party 6_control.level
@@ -124,7 +124,7 @@
                                   <value name="BEHAVIOR">
                                     <block type="gamelab_behavior_get">
                                       <mutation/>
-                                      <title name="VAR">jittering</title>
+                                      <title name="VAR" id="jittering">jittering</title>
                                     </block>
                                   </value>
                                   <next>
@@ -137,7 +137,7 @@
                                       <value name="BEHAVIOR">
                                         <block type="gamelab_behavior_get">
                                           <mutation/>
-                                          <title name="VAR">patrolling</title>
+                                          <title name="VAR" id="patrolling">patrolling</title>
                                         </block>
                                       </value>
                                       <next>
@@ -150,7 +150,7 @@
                                           <value name="BEHAVIOR">
                                             <block type="gamelab_behavior_get">
                                               <mutation/>
-                                              <title name="VAR">wandering</title>
+                                              <title name="VAR" id="wandering">wandering</title>
                                             </block>
                                           </value>
                                         </block>

--- a/dashboard/config/scripts/levels/Dance Party 6_experiment.level
+++ b/dashboard/config/scripts/levels/Dance Party 6_experiment.level
@@ -124,7 +124,7 @@
                                   <value name="BEHAVIOR">
                                     <block type="gamelab_behavior_get">
                                       <mutation/>
-                                      <title name="VAR">jittering</title>
+                                      <title name="VAR" id="jittering">jittering</title>
                                     </block>
                                   </value>
                                   <next>
@@ -137,7 +137,7 @@
                                       <value name="BEHAVIOR">
                                         <block type="gamelab_behavior_get">
                                           <mutation/>
-                                          <title name="VAR">patrolling</title>
+                                          <title name="VAR" id="patrolling">patrolling</title>
                                         </block>
                                       </value>
                                       <next>
@@ -150,7 +150,7 @@
                                           <value name="BEHAVIOR">
                                             <block type="gamelab_behavior_get">
                                               <mutation/>
-                                              <title name="VAR">wandering</title>
+                                              <title name="VAR" id="wandering">wandering</title>
                                             </block>
                                           </value>
                                         </block>

--- a/dashboard/config/scripts/levels/Dance Party 6_simple.level
+++ b/dashboard/config/scripts/levels/Dance Party 6_simple.level
@@ -177,7 +177,7 @@
                                   <value name="BEHAVIOR">
                                     <block type="gamelab_behavior_get">
                                       <mutation/>
-                                      <title name="VAR">moving</title>
+                                      <title name="VAR" id="moving">moving</title>
                                     </block>
                                   </value>
                                   <next>
@@ -190,7 +190,7 @@
                                       <value name="BEHAVIOR">
                                         <block type="gamelab_behavior_get">
                                           <mutation/>
-                                          <title name="VAR">wandering</title>
+                                          <title name="VAR" id="wandering">wandering</title>
                                         </block>
                                       </value>
                                     </block>
@@ -741,7 +741,7 @@
             <title name="VAR">getting smaller</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">moving</title>
+            <title name="VAR" id="moving">moving</title>
           </block>
           <block type="gamelab_behavior_get">
             <title name="VAR">moving north</title>
@@ -756,7 +756,7 @@
             <title name="VAR">moving west</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">wandering</title>
+            <title name="VAR" id="wandering">wandering</title>
           </block>
         </category>
         <category name="Events">

--- a/dashboard/config/scripts/levels/Dance Party 7_2019.level
+++ b/dashboard/config/scripts/levels/Dance Party 7_2019.level
@@ -129,7 +129,7 @@
                                   <value name="BEHAVIOR">
                                     <block type="gamelab_behavior_get">
                                       <mutation/>
-                                      <title name="VAR">jittering</title>
+                                      <title name="VAR" id="jittering">jittering</title>
                                     </block>
                                   </value>
                                   <next>
@@ -142,7 +142,7 @@
                                       <value name="BEHAVIOR">
                                         <block type="gamelab_behavior_get">
                                           <mutation/>
-                                          <title name="VAR">patrolling</title>
+                                          <title name="VAR" id="patrolling">patrolling</title>
                                         </block>
                                       </value>
                                       <next>
@@ -155,7 +155,7 @@
                                           <value name="BEHAVIOR">
                                             <block type="gamelab_behavior_get">
                                               <mutation/>
-                                              <title name="VAR">wandering</title>
+                                              <title name="VAR" id="wandering">wandering</title>
                                             </block>
                                           </value>
                                         </block>

--- a/dashboard/config/scripts/levels/Dance Party 7_2020.level
+++ b/dashboard/config/scripts/levels/Dance Party 7_2020.level
@@ -129,7 +129,7 @@
                                   <value name="BEHAVIOR">
                                     <block type="gamelab_behavior_get">
                                       <mutation/>
-                                      <title name="VAR">jittering</title>
+                                      <title name="VAR" id="jittering">jittering</title>
                                     </block>
                                   </value>
                                   <next>
@@ -142,7 +142,7 @@
                                       <value name="BEHAVIOR">
                                         <block type="gamelab_behavior_get">
                                           <mutation/>
-                                          <title name="VAR">patrolling</title>
+                                          <title name="VAR" id="patrolling">patrolling</title>
                                         </block>
                                       </value>
                                       <next>
@@ -155,7 +155,7 @@
                                           <value name="BEHAVIOR">
                                             <block type="gamelab_behavior_get">
                                               <mutation/>
-                                              <title name="VAR">wandering</title>
+                                              <title name="VAR" id="wandering">wandering</title>
                                             </block>
                                           </value>
                                         </block>

--- a/dashboard/config/scripts/levels/Dance Party 7_2021.level
+++ b/dashboard/config/scripts/levels/Dance Party 7_2021.level
@@ -134,7 +134,7 @@
                                   <value name="BEHAVIOR">
                                     <block type="gamelab_behavior_get">
                                       <mutation/>
-                                      <title name="VAR">jittering</title>
+                                      <title name="VAR" id="jittering">jittering</title>
                                     </block>
                                   </value>
                                   <next>
@@ -147,7 +147,7 @@
                                       <value name="BEHAVIOR">
                                         <block type="gamelab_behavior_get">
                                           <mutation/>
-                                          <title name="VAR">patrolling</title>
+                                          <title name="VAR" id="patrolling">patrolling</title>
                                         </block>
                                       </value>
                                       <next>
@@ -160,7 +160,7 @@
                                           <value name="BEHAVIOR">
                                             <block type="gamelab_behavior_get">
                                               <mutation/>
-                                              <title name="VAR">wandering</title>
+                                              <title name="VAR" id="wandering">wandering</title>
                                             </block>
                                           </value>
                                         </block>

--- a/dashboard/config/scripts/levels/Dance Party 7_control.level
+++ b/dashboard/config/scripts/levels/Dance Party 7_control.level
@@ -124,7 +124,7 @@
                                   <value name="BEHAVIOR">
                                     <block type="gamelab_behavior_get">
                                       <mutation/>
-                                      <title name="VAR">jittering</title>
+                                      <title name="VAR" id="jittering">jittering</title>
                                     </block>
                                   </value>
                                   <next>
@@ -137,7 +137,7 @@
                                       <value name="BEHAVIOR">
                                         <block type="gamelab_behavior_get">
                                           <mutation/>
-                                          <title name="VAR">patrolling</title>
+                                          <title name="VAR" id="patrolling">patrolling</title>
                                         </block>
                                       </value>
                                       <next>
@@ -150,7 +150,7 @@
                                           <value name="BEHAVIOR">
                                             <block type="gamelab_behavior_get">
                                               <mutation/>
-                                              <title name="VAR">wandering</title>
+                                              <title name="VAR" id="wandering">wandering</title>
                                             </block>
                                           </value>
                                         </block>

--- a/dashboard/config/scripts/levels/Dance Party 7_experiment.level
+++ b/dashboard/config/scripts/levels/Dance Party 7_experiment.level
@@ -124,7 +124,7 @@
                                   <value name="BEHAVIOR">
                                     <block type="gamelab_behavior_get">
                                       <mutation/>
-                                      <title name="VAR">jittering</title>
+                                      <title name="VAR" id="jittering">jittering</title>
                                     </block>
                                   </value>
                                   <next>
@@ -137,7 +137,7 @@
                                       <value name="BEHAVIOR">
                                         <block type="gamelab_behavior_get">
                                           <mutation/>
-                                          <title name="VAR">patrolling</title>
+                                          <title name="VAR" id="patrolling">patrolling</title>
                                         </block>
                                       </value>
                                       <next>
@@ -150,7 +150,7 @@
                                           <value name="BEHAVIOR">
                                             <block type="gamelab_behavior_get">
                                               <mutation/>
-                                              <title name="VAR">wandering</title>
+                                              <title name="VAR" id="wandering">wandering</title>
                                             </block>
                                           </value>
                                         </block>

--- a/dashboard/config/scripts/levels/Dance Party Freeplay.level
+++ b/dashboard/config/scripts/levels/Dance Party Freeplay.level
@@ -820,16 +820,16 @@
             <title name="VAR">spinning right</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">growing</title>
+            <title name="VAR" id="growing">growing</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">jittering</title>
+            <title name="VAR" id="jittering">jittering</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">shrinking</title>
+            <title name="VAR" id="shrinking">shrinking</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">patrolling</title>
+            <title name="VAR" id="patrolling">patrolling</title>
           </block>
           <block type="gamelab_behavior_get">
             <title name="VAR">moving north</title>
@@ -844,7 +844,7 @@
             <title name="VAR">moving west</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">wandering</title>
+            <title name="VAR" id="wandering">wandering</title>
           </block>
         </category>
         <category name="Variables" custom="VARIABLE"/>

--- a/dashboard/config/scripts/levels/Dance Party Freeplay_simple.level
+++ b/dashboard/config/scripts/levels/Dance Party Freeplay_simple.level
@@ -836,7 +836,7 @@
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">moving</title>
+            <title name="VAR" id="moving">moving</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
@@ -856,7 +856,7 @@
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">wandering</title>
+            <title name="VAR" id="wandering">wandering</title>
           </block>
           <block type="gamelab_followingSprite">
             <value name="TARGET">

--- a/dashboard/config/scripts/levels/Dance Party Template 1_2019.level
+++ b/dashboard/config/scripts/levels/Dance Party Template 1_2019.level
@@ -113,7 +113,7 @@
               <value name="BEHAVIOR">
                 <block type="gamelab_behavior_get">
                   <mutation/>
-                  <title name="VAR">patrolling</title>
+                  <title name="VAR" id="patrolling">patrolling</title>
                 </block>
               </value>
             </block>

--- a/dashboard/config/scripts/levels/Dance Party Template 1_2020.level
+++ b/dashboard/config/scripts/levels/Dance Party Template 1_2020.level
@@ -108,7 +108,7 @@
               <value name="BEHAVIOR">
                 <block type="gamelab_behavior_get">
                   <mutation/>
-                  <title name="VAR">patrolling</title>
+                  <title name="VAR" id="patrolling">patrolling</title>
                 </block>
               </value>
             </block>

--- a/dashboard/config/scripts/levels/Dance Party Template 1_control.level
+++ b/dashboard/config/scripts/levels/Dance Party Template 1_control.level
@@ -109,7 +109,7 @@
               <value name="BEHAVIOR">
                 <block type="gamelab_behavior_get">
                   <mutation/>
-                  <title name="VAR">patrolling</title>
+                  <title name="VAR" id="patrolling">patrolling</title>
                 </block>
               </value>
             </block>

--- a/dashboard/config/scripts/levels/Dance Party Template 1_experiment.level
+++ b/dashboard/config/scripts/levels/Dance Party Template 1_experiment.level
@@ -109,7 +109,7 @@
               <value name="BEHAVIOR">
                 <block type="gamelab_behavior_get">
                   <mutation/>
-                  <title name="VAR">patrolling</title>
+                  <title name="VAR" id="patrolling">patrolling</title>
                 </block>
               </value>
             </block>

--- a/dashboard/config/scripts/levels/Dance Party Template 2_2019.level
+++ b/dashboard/config/scripts/levels/Dance Party Template 2_2019.level
@@ -115,7 +115,7 @@
                               <value name="BEHAVIOR">
                                 <block type="gamelab_behavior_get">
                                   <mutation/>
-                                  <title name="VAR">jittering</title>
+                                  <title name="VAR" id="jittering">jittering</title>
                                 </block>
                               </value>
                               <next>
@@ -128,7 +128,7 @@
                                   <value name="BEHAVIOR">
                                     <block type="gamelab_behavior_get">
                                       <mutation/>
-                                      <title name="VAR">patrolling</title>
+                                      <title name="VAR" id="patrolling">patrolling</title>
                                     </block>
                                   </value>
                                   <next>
@@ -141,7 +141,7 @@
                                       <value name="BEHAVIOR">
                                         <block type="gamelab_behavior_get">
                                           <mutation/>
-                                          <title name="VAR">wandering</title>
+                                          <title name="VAR" id="wandering">wandering</title>
                                         </block>
                                       </value>
                                     </block>

--- a/dashboard/config/scripts/levels/Dance Party Template 2_2020.level
+++ b/dashboard/config/scripts/levels/Dance Party Template 2_2020.level
@@ -113,7 +113,7 @@
                               <value name="BEHAVIOR">
                                 <block type="gamelab_behavior_get">
                                   <mutation/>
-                                  <title name="VAR">jittering</title>
+                                  <title name="VAR" id="jittering">jittering</title>
                                 </block>
                               </value>
                               <next>
@@ -126,7 +126,7 @@
                                   <value name="BEHAVIOR">
                                     <block type="gamelab_behavior_get">
                                       <mutation/>
-                                      <title name="VAR">patrolling</title>
+                                      <title name="VAR" id="patrolling">patrolling</title>
                                     </block>
                                   </value>
                                   <next>
@@ -139,7 +139,7 @@
                                       <value name="BEHAVIOR">
                                         <block type="gamelab_behavior_get">
                                           <mutation/>
-                                          <title name="VAR">wandering</title>
+                                          <title name="VAR" id="wandering">wandering</title>
                                         </block>
                                       </value>
                                     </block>

--- a/dashboard/config/scripts/levels/Dance Party Template 2_control.level
+++ b/dashboard/config/scripts/levels/Dance Party Template 2_control.level
@@ -114,7 +114,7 @@
                               <value name="BEHAVIOR">
                                 <block type="gamelab_behavior_get">
                                   <mutation/>
-                                  <title name="VAR">jittering</title>
+                                  <title name="VAR" id="jittering">jittering</title>
                                 </block>
                               </value>
                               <next>
@@ -127,7 +127,7 @@
                                   <value name="BEHAVIOR">
                                     <block type="gamelab_behavior_get">
                                       <mutation/>
-                                      <title name="VAR">patrolling</title>
+                                      <title name="VAR" id="patrolling">patrolling</title>
                                     </block>
                                   </value>
                                   <next>
@@ -140,7 +140,7 @@
                                       <value name="BEHAVIOR">
                                         <block type="gamelab_behavior_get">
                                           <mutation/>
-                                          <title name="VAR">wandering</title>
+                                          <title name="VAR" id="wandering">wandering</title>
                                         </block>
                                       </value>
                                     </block>

--- a/dashboard/config/scripts/levels/Dance Party Template 2_experiment.level
+++ b/dashboard/config/scripts/levels/Dance Party Template 2_experiment.level
@@ -114,7 +114,7 @@
                               <value name="BEHAVIOR">
                                 <block type="gamelab_behavior_get">
                                   <mutation/>
-                                  <title name="VAR">jittering</title>
+                                  <title name="VAR" id="jittering">jittering</title>
                                 </block>
                               </value>
                               <next>
@@ -127,7 +127,7 @@
                                   <value name="BEHAVIOR">
                                     <block type="gamelab_behavior_get">
                                       <mutation/>
-                                      <title name="VAR">patrolling</title>
+                                      <title name="VAR" id="patrolling">patrolling</title>
                                     </block>
                                   </value>
                                   <next>
@@ -140,7 +140,7 @@
                                       <value name="BEHAVIOR">
                                         <block type="gamelab_behavior_get">
                                           <mutation/>
-                                          <title name="VAR">wandering</title>
+                                          <title name="VAR" id="wandering">wandering</title>
                                         </block>
                                       </value>
                                     </block>

--- a/dashboard/config/scripts/levels/Fish Tank 3-validated_simple.level
+++ b/dashboard/config/scripts/levels/Fish Tank 3-validated_simple.level
@@ -100,7 +100,7 @@
           <title name="VAR">turning</title>
         </block>
         <block type="gamelab_behavior_get">
-          <title name="VAR">swimming</title>
+          <title name="VAR" id="swimming">swimming</title>
         </block>
         <block type="gamelab_comment">
           <title name="COMMENT"/>

--- a/dashboard/config/scripts/levels/Fish Tank 5-validated_2019_implicitGroupTest.level
+++ b/dashboard/config/scripts/levels/Fish Tank 5-validated_2019_implicitGroupTest.level
@@ -124,7 +124,7 @@
                               <value name="BEHAVIOR">
                                 <block type="gamelab_behavior_get">
                                   <mutation/>
-                                  <title name="VAR">wandering</title>
+                                  <title name="VAR" id="wandering">wandering</title>
                                 </block>
                               </value>
                             </block>

--- a/dashboard/config/scripts/levels/Fish Tank 6-validated_simple.level
+++ b/dashboard/config/scripts/levels/Fish Tank 6-validated_simple.level
@@ -107,7 +107,7 @@
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">swimming</title>
+            <title name="VAR" id="swimming">swimming</title>
           </block>
         </category>
         <category name="Comments">

--- a/dashboard/config/scripts/levels/Fish Tank 7-validated.level
+++ b/dashboard/config/scripts/levels/Fish Tank 7-validated.level
@@ -223,19 +223,19 @@
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">growing</title>
+            <title name="VAR" id="growing">growing</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">jittering</title>
+            <title name="VAR" id="jittering">jittering</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">shrinking</title>
+            <title name="VAR" id="shrinking">shrinking</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">patrolling</title>
+            <title name="VAR" id="patrolling">patrolling</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
@@ -255,7 +255,7 @@
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">wandering</title>
+            <title name="VAR" id="wandering">wandering</title>
           </block>
         </category>
         <category name="Events">

--- a/dashboard/config/scripts/levels/Fish Tank 7-validated_simple.level
+++ b/dashboard/config/scripts/levels/Fish Tank 7-validated_simple.level
@@ -200,7 +200,7 @@
             <title name="VAR">turning</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">swimming</title>
+            <title name="VAR" id="swimming">swimming</title>
           </block>
           <block type="gamelab_behavior_get">
             <title name="VAR">getting bigger</title>
@@ -212,7 +212,7 @@
             <title name="VAR">getting smaller</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">moving</title>
+            <title name="VAR" id="moving">moving</title>
           </block>
           <block type="gamelab_behavior_get">
             <title name="VAR">moving north</title>
@@ -227,7 +227,7 @@
             <title name="VAR">moving west</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">wandering</title>
+            <title name="VAR" id="wandering">wandering</title>
           </block>
         </category>
         <category name="Events">

--- a/dashboard/config/scripts/levels/IPL_events_click.level
+++ b/dashboard/config/scripts/levels/IPL_events_click.level
@@ -172,7 +172,7 @@
               <value name="BEHAVIOR">
                 <block type="gamelab_behavior_get">
                   <mutation/>
-                  <title name="VAR">wandering</title>
+                  <title name="VAR" id="wandering">wandering</title>
                 </block>
               </value>
             </block>

--- a/dashboard/config/scripts/levels/Mike Lab Car Game.level
+++ b/dashboard/config/scripts/levels/Mike Lab Car Game.level
@@ -80,7 +80,7 @@
                   <value name="BEHAVIOR">
                     <block type="gamelab_behavior_get">
                       <mutation/>
-                      <title name="VAR">jittering</title>
+                      <title name="VAR" id="jittering">jittering</title>
                     </block>
                   </value>
                 </block>

--- a/dashboard/config/scripts/levels/Outbreak_contagion_teachers.level
+++ b/dashboard/config/scripts/levels/Outbreak_contagion_teachers.level
@@ -588,7 +588,7 @@
             <value name="BEHAVIOR">
               <block type="gamelab_behavior_get">
                 <mutation/>
-                <title name="VAR">wandering</title>
+                <title name="VAR" id="wandering">wandering</title>
               </block>
             </value>
           </block>

--- a/dashboard/config/scripts/levels/Sprite Lab 2.0 Project.level
+++ b/dashboard/config/scripts/levels/Sprite Lab 2.0 Project.level
@@ -205,7 +205,7 @@
               <value name="BEHAVIOR">
                 <block type="gamelab_behavior_get">
                   <mutation/>
-                  <title name="VAR">wandering</title>
+                  <title name="VAR" id="wandering">wandering</title>
                 </block>
               </value>
             </block>
@@ -224,7 +224,7 @@
               <value name="BEHAVIOR">
                 <block type="gamelab_behavior_get">
                   <mutation/>
-                  <title name="VAR">wandering</title>
+                  <title name="VAR" id="wandering">wandering</title>
                 </block>
               </value>
             </block>
@@ -243,7 +243,7 @@
               <value name="BEHAVIOR">
                 <block type="gamelab_behavior_get">
                   <mutation/>
-                  <title name="VAR">wandering</title>
+                  <title name="VAR" id="wandering">wandering</title>
                 </block>
               </value>
             </block>
@@ -262,7 +262,7 @@
               <value name="BEHAVIOR">
                 <block type="gamelab_behavior_get">
                   <mutation/>
-                  <title name="VAR">wandering</title>
+                  <title name="VAR" id="wandering">wandering</title>
                 </block>
               </value>
               <next>
@@ -275,7 +275,7 @@
                   <value name="BEHAVIOR">
                     <block type="gamelab_behavior_get">
                       <mutation/>
-                      <title name="VAR">wandering</title>
+                      <title name="VAR" id="wandering">wandering</title>
                     </block>
                   </value>
                   <next>
@@ -288,7 +288,7 @@
                       <value name="BEHAVIOR">
                         <block type="gamelab_behavior_get">
                           <mutation/>
-                          <title name="VAR">wandering</title>
+                          <title name="VAR" id="wandering">wandering</title>
                         </block>
                       </value>
                     </block>

--- a/dashboard/config/scripts/levels/SpriteLabDebugger.level
+++ b/dashboard/config/scripts/levels/SpriteLabDebugger.level
@@ -84,7 +84,7 @@
               <value name="BEHAVIOR">
                 <block type="gamelab_behavior_get">
                   <mutation/>
-                  <title name="VAR">growing</title>
+                  <title name="VAR" id="growing">growing</title>
                 </block>
               </value>
               <next>
@@ -97,7 +97,7 @@
                   <value name="BEHAVIOR">
                     <block type="gamelab_behavior_get">
                       <mutation/>
-                      <title name="VAR">shrinking</title>
+                      <title name="VAR" id="shrinking">shrinking</title>
                     </block>
                   </value>
                 </block>
@@ -117,7 +117,7 @@
               <value name="BEHAVIOR">
                 <block type="gamelab_behavior_get">
                   <mutation/>
-                  <title name="VAR">shrinking</title>
+                  <title name="VAR" id="shrinking">shrinking</title>
                 </block>
               </value>
               <next>
@@ -130,7 +130,7 @@
                   <value name="BEHAVIOR">
                     <block type="gamelab_behavior_get">
                       <mutation/>
-                      <title name="VAR">growing</title>
+                      <title name="VAR" id="growing">growing</title>
                     </block>
                   </value>
                 </block>

--- a/dashboard/config/scripts/levels/TimeForCS Alligator.level
+++ b/dashboard/config/scripts/levels/TimeForCS Alligator.level
@@ -148,7 +148,7 @@
                                           <value name="BEHAVIOR">
                                             <block type="gamelab_behavior_get">
                                               <mutation/>
-                                              <title name="VAR">wandering</title>
+                                              <title name="VAR" id="wandering">wandering</title>
                                             </block>
                                           </value>
                                         </block>

--- a/dashboard/config/scripts/levels/TimeForCS Demo.level
+++ b/dashboard/config/scripts/levels/TimeForCS Demo.level
@@ -149,7 +149,7 @@
                                           <value name="BEHAVIOR">
                                             <block type="gamelab_behavior_get">
                                               <mutation/>
-                                              <title name="VAR">wandering</title>
+                                              <title name="VAR" id="wandering">wandering</title>
                                             </block>
                                           </value>
                                         </block>

--- a/dashboard/config/scripts/levels/Virtual Pet 1.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 1.level
@@ -108,7 +108,7 @@
               <value name="BEHAVIOR">
                 <block type="gamelab_behavior_get">
                   <mutation/>
-                  <title name="VAR">wandering</title>
+                  <title name="VAR" id="wandering">wandering</title>
                 </block>
               </value>
             </block>

--- a/dashboard/config/scripts/levels/Virtual Pet 1_2019.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 1_2019.level
@@ -127,7 +127,7 @@
                                   <value name="BEHAVIOR">
                                     <block type="gamelab_behavior_get">
                                       <mutation/>
-                                      <title name="VAR">wandering</title>
+                                      <title name="VAR" id="wandering">wandering</title>
                                     </block>
                                   </value>
                                   <next>
@@ -140,7 +140,7 @@
                                       <value name="BEHAVIOR">
                                         <block type="gamelab_behavior_get">
                                           <mutation/>
-                                          <title name="VAR">wandering</title>
+                                          <title name="VAR" id="wandering">wandering</title>
                                         </block>
                                       </value>
                                     </block>

--- a/dashboard/config/scripts/levels/Virtual Pet 1_2020.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 1_2020.level
@@ -127,7 +127,7 @@
                                   <value name="BEHAVIOR">
                                     <block type="gamelab_behavior_get">
                                       <mutation/>
-                                      <title name="VAR">wandering</title>
+                                      <title name="VAR" id="wandering">wandering</title>
                                     </block>
                                   </value>
                                   <next>
@@ -140,7 +140,7 @@
                                       <value name="BEHAVIOR">
                                         <block type="gamelab_behavior_get">
                                           <mutation/>
-                                          <title name="VAR">wandering</title>
+                                          <title name="VAR" id="wandering">wandering</title>
                                         </block>
                                       </value>
                                     </block>

--- a/dashboard/config/scripts/levels/Virtual Pet 2 - Validated (Ram).level
+++ b/dashboard/config/scripts/levels/Virtual Pet 2 - Validated (Ram).level
@@ -242,7 +242,7 @@
               </value>
               <value name="BEHAVIOR">
                 <block type="gamelab_behavior_get">
-                  <title name="VAR">wandering</title>
+                  <title name="VAR" id="wandering">wandering</title>
                 </block>
               </value>
             </block>
@@ -709,16 +709,16 @@
             <title name="VAR">spinning right</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">growing</title>
+            <title name="VAR" id="growing">growing</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">jittering</title>
+            <title name="VAR" id="jittering">jittering</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">shrinking</title>
+            <title name="VAR" id="shrinking">shrinking</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">patrolling</title>
+            <title name="VAR" id="patrolling">patrolling</title>
           </block>
           <block type="gamelab_behavior_get">
             <title name="VAR">moving north</title>
@@ -733,7 +733,7 @@
             <title name="VAR">moving west</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">wandering</title>
+            <title name="VAR" id="wandering">wandering</title>
           </block>
         </category>
         <category name="Variables" custom="VARIABLE"/>

--- a/dashboard/config/scripts/levels/Virtual Pet 2 - Validated.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 2 - Validated.level
@@ -243,7 +243,7 @@
               </value>
               <value name="BEHAVIOR">
                 <block type="gamelab_behavior_get">
-                  <title name="VAR">wandering</title>
+                  <title name="VAR" id="wandering">wandering</title>
                 </block>
               </value>
             </block>
@@ -710,16 +710,16 @@
             <title name="VAR">spinning right</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">growing</title>
+            <title name="VAR" id="growing">growing</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">jittering</title>
+            <title name="VAR" id="jittering">jittering</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">shrinking</title>
+            <title name="VAR" id="shrinking">shrinking</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">patrolling</title>
+            <title name="VAR" id="patrolling">patrolling</title>
           </block>
           <block type="gamelab_behavior_get">
             <title name="VAR">moving north</title>
@@ -734,7 +734,7 @@
             <title name="VAR">moving west</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">wandering</title>
+            <title name="VAR" id="wandering">wandering</title>
           </block>
         </category>
         <category name="Variables" custom="VARIABLE"/>

--- a/dashboard/config/scripts/levels/Virtual Pet 2.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 2.level
@@ -128,7 +128,7 @@
               <value name="BEHAVIOR">
                 <block type="gamelab_behavior_get">
                   <mutation/>
-                  <title name="VAR">wandering</title>
+                  <title name="VAR" id="wandering">wandering</title>
                 </block>
               </value>
             </block>
@@ -828,16 +828,16 @@
             <title name="VAR">spinning right</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">growing</title>
+            <title name="VAR" id="growing">growing</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">jittering</title>
+            <title name="VAR" id="jittering">jittering</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">shrinking</title>
+            <title name="VAR" id="shrinking">shrinking</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">patrolling</title>
+            <title name="VAR" id="patrolling">patrolling</title>
           </block>
           <block type="gamelab_behavior_get">
             <title name="VAR">moving north</title>
@@ -852,7 +852,7 @@
             <title name="VAR">moving west</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">wandering</title>
+            <title name="VAR" id="wandering">wandering</title>
           </block>
         </category>
         <category name="Variables" custom="VARIABLE"/>

--- a/dashboard/config/scripts/levels/Virtual Pet 2_simple.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 2_simple.level
@@ -170,7 +170,7 @@
               <value name="BEHAVIOR">
                 <block type="gamelab_behavior_get">
                   <mutation/>
-                  <title name="VAR">wandering</title>
+                  <title name="VAR" id="wandering">wandering</title>
                 </block>
               </value>
             </block>
@@ -708,7 +708,7 @@
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">moving</title>
+            <title name="VAR" id="moving">moving</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
@@ -728,7 +728,7 @@
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">wandering</title>
+            <title name="VAR" id="wandering">wandering</title>
           </block>
         </category>
         <category name="Variables" custom="VARIABLE"/>

--- a/dashboard/config/scripts/levels/Virtual Pet 2_simple_clone.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 2_simple_clone.level
@@ -272,7 +272,7 @@
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">moving</title>
+            <title name="VAR" id="moving">moving</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
@@ -292,7 +292,7 @@
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">wandering</title>
+            <title name="VAR" id="wandering">wandering</title>
           </block>
         </category>
         <category name="Variables" custom="VARIABLE"/>

--- a/dashboard/config/scripts/levels/Virtual Pet 3.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 3.level
@@ -131,7 +131,7 @@
               </value>
               <value name="BEHAVIOR">
                 <block type="gamelab_behavior_get">
-                  <title name="VAR">wandering</title>
+                  <title name="VAR" id="wandering">wandering</title>
                 </block>
               </value>
             </block>
@@ -342,19 +342,19 @@
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">growing</title>
+            <title name="VAR" id="growing">growing</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">jittering</title>
+            <title name="VAR" id="jittering">jittering</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">shrinking</title>
+            <title name="VAR" id="shrinking">shrinking</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">patrolling</title>
+            <title name="VAR" id="patrolling">patrolling</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
@@ -374,7 +374,7 @@
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">wandering</title>
+            <title name="VAR" id="wandering">wandering</title>
           </block>
         </category>
         <category name="Variables" custom="VARIABLE"/>

--- a/dashboard/config/scripts/levels/Virtual Pet 3_simple.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 3_simple.level
@@ -300,19 +300,19 @@
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">growing</title>
+            <title name="VAR" id="growing">growing</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">jittering</title>
+            <title name="VAR" id="jittering">jittering</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">shrinking</title>
+            <title name="VAR" id="shrinking">shrinking</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">patrolling</title>
+            <title name="VAR" id="patrolling">patrolling</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
@@ -332,7 +332,7 @@
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">wandering</title>
+            <title name="VAR" id="wandering">wandering</title>
           </block>
         </category>
         <category name="Variables" custom="VARIABLE"/>

--- a/dashboard/config/scripts/levels/Virtual Pet 4.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 4.level
@@ -673,16 +673,16 @@
             <title name="VAR">spinning right</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">growing</title>
+            <title name="VAR" id="growing">growing</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">jittering</title>
+            <title name="VAR" id="jittering">jittering</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">shrinking</title>
+            <title name="VAR" id="shrinking">shrinking</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">patrolling</title>
+            <title name="VAR" id="patrolling">patrolling</title>
           </block>
           <block type="gamelab_behavior_get">
             <title name="VAR">moving north</title>
@@ -697,7 +697,7 @@
             <title name="VAR">moving west</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">wandering</title>
+            <title name="VAR" id="wandering">wandering</title>
           </block>
         </category>
         <category name="Variables" custom="VARIABLE"/>

--- a/dashboard/config/scripts/levels/Virtual Pet 4_2019.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 4_2019.level
@@ -116,7 +116,7 @@
                               <value name="BEHAVIOR">
                                 <block type="gamelab_behavior_get">
                                   <mutation/>
-                                  <title name="VAR">wandering</title>
+                                  <title name="VAR" id="wandering">wandering</title>
                                 </block>
                               </value>
                               <next>
@@ -129,7 +129,7 @@
                                   <value name="BEHAVIOR">
                                     <block type="gamelab_behavior_get">
                                       <mutation/>
-                                      <title name="VAR">wandering</title>
+                                      <title name="VAR" id="wandering">wandering</title>
                                     </block>
                                   </value>
                                 </block>

--- a/dashboard/config/scripts/levels/Virtual Pet 4_2020.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 4_2020.level
@@ -116,7 +116,7 @@
                               <value name="BEHAVIOR">
                                 <block type="gamelab_behavior_get">
                                   <mutation/>
-                                  <title name="VAR">wandering</title>
+                                  <title name="VAR" id="wandering">wandering</title>
                                 </block>
                               </value>
                               <next>
@@ -129,7 +129,7 @@
                                   <value name="BEHAVIOR">
                                     <block type="gamelab_behavior_get">
                                       <mutation/>
-                                      <title name="VAR">wandering</title>
+                                      <title name="VAR" id="wandering">wandering</title>
                                     </block>
                                   </value>
                                 </block>

--- a/dashboard/config/scripts/levels/Virtual Pet 4_2021.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 4_2021.level
@@ -110,7 +110,7 @@
                               <value name="BEHAVIOR">
                                 <block type="gamelab_behavior_get">
                                   <mutation/>
-                                  <title name="VAR">wandering</title>
+                                  <title name="VAR" id="wandering">wandering</title>
                                 </block>
                               </value>
                               <next>
@@ -123,7 +123,7 @@
                                   <value name="BEHAVIOR">
                                     <block type="gamelab_behavior_get">
                                       <mutation/>
-                                      <title name="VAR">wandering</title>
+                                      <title name="VAR" id="wandering">wandering</title>
                                     </block>
                                   </value>
                                 </block>

--- a/dashboard/config/scripts/levels/Virtual Pet 4_simple.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 4_simple.level
@@ -668,16 +668,16 @@
             <title name="VAR">spinning right</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">growing</title>
+            <title name="VAR" id="growing">growing</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">jittering</title>
+            <title name="VAR" id="jittering">jittering</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">shrinking</title>
+            <title name="VAR" id="shrinking">shrinking</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">patrolling</title>
+            <title name="VAR" id="patrolling">patrolling</title>
           </block>
           <block type="gamelab_behavior_get">
             <title name="VAR">moving north</title>
@@ -692,7 +692,7 @@
             <title name="VAR">moving west</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">wandering</title>
+            <title name="VAR" id="wandering">wandering</title>
           </block>
         </category>
         <category name="Variables" custom="VARIABLE"/>

--- a/dashboard/config/scripts/levels/Virtual Pet 5 - Validated.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 5 - Validated.level
@@ -234,7 +234,7 @@
               </value>
               <value name="BEHAVIOR">
                 <block type="gamelab_behavior_get">
-                  <title name="VAR">wandering</title>
+                  <title name="VAR" id="wandering">wandering</title>
                 </block>
               </value>
             </block>
@@ -726,16 +726,16 @@
             <title name="VAR">spinning right</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">growing</title>
+            <title name="VAR" id="growing">growing</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">jittering</title>
+            <title name="VAR" id="jittering">jittering</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">shrinking</title>
+            <title name="VAR" id="shrinking">shrinking</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">patrolling</title>
+            <title name="VAR" id="patrolling">patrolling</title>
           </block>
           <block type="gamelab_behavior_get">
             <title name="VAR">moving north</title>
@@ -750,7 +750,7 @@
             <title name="VAR">moving west</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">wandering</title>
+            <title name="VAR" id="wandering">wandering</title>
           </block>
         </category>
         <category name="Variables" custom="VARIABLE"/>

--- a/dashboard/config/scripts/levels/Virtual Pet 5.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 5.level
@@ -692,16 +692,16 @@
             <title name="VAR">spinning right</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">growing</title>
+            <title name="VAR" id="growing">growing</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">jittering</title>
+            <title name="VAR" id="jittering">jittering</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">shrinking</title>
+            <title name="VAR" id="shrinking">shrinking</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">patrolling</title>
+            <title name="VAR" id="patrolling">patrolling</title>
           </block>
           <block type="gamelab_behavior_get">
             <title name="VAR">moving north</title>
@@ -716,7 +716,7 @@
             <title name="VAR">moving west</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">wandering</title>
+            <title name="VAR" id="wandering">wandering</title>
           </block>
         </category>
         <category name="Variables" custom="VARIABLE"/>

--- a/dashboard/config/scripts/levels/Virtual Pet 5_simple.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 5_simple.level
@@ -271,16 +271,16 @@
             <title name="VAR">spinning right</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">growing</title>
+            <title name="VAR" id="growing">growing</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">jittering</title>
+            <title name="VAR" id="jittering">jittering</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">shrinking</title>
+            <title name="VAR" id="shrinking">shrinking</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">patrolling</title>
+            <title name="VAR" id="patrolling">patrolling</title>
           </block>
           <block type="gamelab_behavior_get">
             <title name="VAR">moving north</title>
@@ -295,7 +295,7 @@
             <title name="VAR">moving west</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">wandering</title>
+            <title name="VAR" id="wandering">wandering</title>
           </block>
         </category>
         <category name="Variables" custom="VARIABLE"/>

--- a/dashboard/config/scripts/levels/Virtual Pet 6.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 6.level
@@ -673,16 +673,16 @@
             <title name="VAR">spinning right</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">growing</title>
+            <title name="VAR" id="growing">growing</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">jittering</title>
+            <title name="VAR" id="jittering">jittering</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">shrinking</title>
+            <title name="VAR" id="shrinking">shrinking</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">patrolling</title>
+            <title name="VAR" id="patrolling">patrolling</title>
           </block>
           <block type="gamelab_behavior_get">
             <title name="VAR">moving north</title>
@@ -697,7 +697,7 @@
             <title name="VAR">moving west</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">wandering</title>
+            <title name="VAR" id="wandering">wandering</title>
           </block>
         </category>
         <category name="Variables" custom="VARIABLE"/>

--- a/dashboard/config/scripts/levels/Virtual Pet 6_simple.level
+++ b/dashboard/config/scripts/levels/Virtual Pet 6_simple.level
@@ -249,19 +249,19 @@
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">growing</title>
+            <title name="VAR" id="growing">growing</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">jittering</title>
+            <title name="VAR" id="jittering">jittering</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">shrinking</title>
+            <title name="VAR" id="shrinking">shrinking</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">patrolling</title>
+            <title name="VAR" id="patrolling">patrolling</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
@@ -281,7 +281,7 @@
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">wandering</title>
+            <title name="VAR" id="wandering">wandering</title>
           </block>
         </category>
         <category name="Variables" custom="VARIABLE"/>

--- a/dashboard/config/scripts/levels/Virtual Pet Freeplay.level
+++ b/dashboard/config/scripts/levels/Virtual Pet Freeplay.level
@@ -676,16 +676,16 @@
             <title name="VAR">spinning right</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">growing</title>
+            <title name="VAR" id="growing">growing</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">jittering</title>
+            <title name="VAR" id="jittering">jittering</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">shrinking</title>
+            <title name="VAR" id="shrinking">shrinking</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">patrolling</title>
+            <title name="VAR" id="patrolling">patrolling</title>
           </block>
           <block type="gamelab_behavior_get">
             <title name="VAR">moving north</title>
@@ -700,7 +700,7 @@
             <title name="VAR">moving west</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">wandering</title>
+            <title name="VAR" id="wandering">wandering</title>
           </block>
         </category>
         <category name="Variables" custom="VARIABLE"/>

--- a/dashboard/config/scripts/levels/Virtual Pet Freeplay_2019.level
+++ b/dashboard/config/scripts/levels/Virtual Pet Freeplay_2019.level
@@ -674,16 +674,16 @@
             <title name="VAR">spinning right</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">growing</title>
+            <title name="VAR" id="growing">growing</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">jittering</title>
+            <title name="VAR" id="jittering">jittering</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">shrinking</title>
+            <title name="VAR" id="shrinking">shrinking</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">patrolling</title>
+            <title name="VAR" id="patrolling">patrolling</title>
           </block>
           <block type="gamelab_behavior_get">
             <title name="VAR">moving north</title>
@@ -698,7 +698,7 @@
             <title name="VAR">moving west</title>
           </block>
           <block type="gamelab_behavior_get">
-            <title name="VAR">wandering</title>
+            <title name="VAR" id="wandering">wandering</title>
           </block>
         </category>
         <category name="Variables" custom="VARIABLE"/>

--- a/dashboard/config/scripts/levels/Virtual Pet Freeplay_simple.level
+++ b/dashboard/config/scripts/levels/Virtual Pet Freeplay_simple.level
@@ -249,19 +249,19 @@
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">growing</title>
+            <title name="VAR" id="growing">growing</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">jittering</title>
+            <title name="VAR" id="jittering">jittering</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">shrinking</title>
+            <title name="VAR" id="shrinking">shrinking</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">patrolling</title>
+            <title name="VAR" id="patrolling">patrolling</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
@@ -281,7 +281,7 @@
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">wandering</title>
+            <title name="VAR" id="wandering">wandering</title>
           </block>
         </category>
         <category name="Variables" custom="VARIABLE"/>

--- a/dashboard/config/scripts/levels/Virus Simulation for Code Bytes.level
+++ b/dashboard/config/scripts/levels/Virus Simulation for Code Bytes.level
@@ -242,7 +242,7 @@
             <value name="BEHAVIOR">
               <block type="gamelab_behavior_get">
                 <mutation/>
-                <title name="VAR">wandering</title>
+                <title name="VAR" id="wandering">wandering</title>
               </block>
             </value>
           </block>
@@ -325,7 +325,7 @@
                               <value name="BEHAVIOR">
                                 <block type="gamelab_behavior_get">
                                   <mutation/>
-                                  <title name="VAR">wandering</title>
+                                  <title name="VAR" id="wandering">wandering</title>
                                 </block>
                               </value>
                             </block>

--- a/dashboard/config/scripts/levels/aatoolboxtest.level
+++ b/dashboard/config/scripts/levels/aatoolboxtest.level
@@ -173,11 +173,11 @@
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">growing</title>
+            <title name="VAR" id="growing">growing</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">jittering</title>
+            <title name="VAR" id="jittering">jittering</title>
           </block>
           <block type="behavior_definition" deletable="false" movable="false" editable="false">
             <mutation>

--- a/dashboard/config/scripts/levels/alien fish example.level
+++ b/dashboard/config/scripts/levels/alien fish example.level
@@ -107,7 +107,7 @@
                               <value name="BEHAVIOR">
                                 <block type="gamelab_behavior_get">
                                   <mutation/>
-                                  <title name="VAR">jittering</title>
+                                  <title name="VAR" id="jittering">jittering</title>
                                 </block>
                               </value>
                               <next>
@@ -120,7 +120,7 @@
                                   <value name="BEHAVIOR">
                                     <block type="gamelab_behavior_get">
                                       <mutation/>
-                                      <title name="VAR">patrolling</title>
+                                      <title name="VAR" id="patrolling">patrolling</title>
                                     </block>
                                   </value>
                                   <next>
@@ -133,7 +133,7 @@
                                       <value name="BEHAVIOR">
                                         <block type="gamelab_behavior_get">
                                           <mutation/>
-                                          <title name="VAR">wandering</title>
+                                          <title name="VAR" id="wandering">wandering</title>
                                         </block>
                                       </value>
                                     </block>

--- a/dashboard/config/scripts/levels/anjali_mini_toolbox_instructions.level
+++ b/dashboard/config/scripts/levels/anjali_mini_toolbox_instructions.level
@@ -210,7 +210,7 @@
             <value name="BEHAVIOR">
               <block type="gamelab_behavior_get">
                 <mutation/>
-                <title name="VAR">wandering</title>
+                <title name="VAR" id="wandering">wandering</title>
               </block>
             </value>
           </block>
@@ -276,7 +276,7 @@
                               <value name="BEHAVIOR">
                                 <block type="gamelab_behavior_get">
                                   <mutation/>
-                                  <title name="VAR">wandering</title>
+                                  <title name="VAR" id="wandering">wandering</title>
                                 </block>
                               </value>
                             </block>

--- a/dashboard/config/scripts/levels/contagion1.level
+++ b/dashboard/config/scripts/levels/contagion1.level
@@ -332,7 +332,7 @@
             <value name="BEHAVIOR">
               <block type="gamelab_behavior_get">
                 <mutation/>
-                <title name="VAR">wandering</title>
+                <title name="VAR" id="wandering">wandering</title>
               </block>
             </value>
           </block>

--- a/dashboard/config/scripts/levels/contagion_recovery.level
+++ b/dashboard/config/scripts/levels/contagion_recovery.level
@@ -123,7 +123,7 @@
             <value name="BEHAVIOR">
               <block type="gamelab_behavior_get">
                 <mutation/>
-                <title name="VAR">wandering</title>
+                <title name="VAR" id="wandering">wandering</title>
               </block>
             </value>
           </block>

--- a/dashboard/config/scripts/levels/contagion_teachers.level
+++ b/dashboard/config/scripts/levels/contagion_teachers.level
@@ -587,7 +587,7 @@
             <value name="BEHAVIOR">
               <block type="gamelab_behavior_get">
                 <mutation/>
-                <title name="VAR">wandering</title>
+                <title name="VAR" id="wandering">wandering</title>
               </block>
             </value>
           </block>

--- a/dashboard/config/scripts/levels/contagion_teachers2.level
+++ b/dashboard/config/scripts/levels/contagion_teachers2.level
@@ -605,7 +605,7 @@
             <value name="BEHAVIOR">
               <block type="gamelab_behavior_get">
                 <mutation/>
-                <title name="VAR">wandering</title>
+                <title name="VAR" id="wandering">wandering</title>
               </block>
             </value>
           </block>

--- a/dashboard/config/scripts/levels/courseE_aboutme_1.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_1.level
@@ -235,7 +235,7 @@
                   <value name="BEHAVIOR">
                     <block type="gamelab_behavior_get">
                       <mutation/>
-                      <title name="VAR">jittering</title>
+                      <title name="VAR" id="jittering">jittering</title>
                     </block>
                   </value>
                 </block>

--- a/dashboard/config/scripts/levels/courseE_aboutme_1_2020.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_1_2020.level
@@ -236,7 +236,7 @@
                   <value name="BEHAVIOR">
                     <block type="gamelab_behavior_get">
                       <mutation/>
-                      <title name="VAR">jittering</title>
+                      <title name="VAR" id="jittering">jittering</title>
                     </block>
                   </value>
                 </block>

--- a/dashboard/config/scripts/levels/courseE_aboutme_1_control.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_1_control.level
@@ -231,7 +231,7 @@
                   <value name="BEHAVIOR">
                     <block type="gamelab_behavior_get">
                       <mutation/>
-                      <title name="VAR">jittering</title>
+                      <title name="VAR" id="jittering">jittering</title>
                     </block>
                   </value>
                 </block>

--- a/dashboard/config/scripts/levels/courseE_aboutme_1_experiment.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_1_experiment.level
@@ -231,7 +231,7 @@
                   <value name="BEHAVIOR">
                     <block type="gamelab_behavior_get">
                       <mutation/>
-                      <title name="VAR">jittering</title>
+                      <title name="VAR" id="jittering">jittering</title>
                     </block>
                   </value>
                 </block>

--- a/dashboard/config/scripts/levels/courseE_aboutme_again.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_again.level
@@ -291,7 +291,7 @@
                                   <value name="BEHAVIOR">
                                     <block type="gamelab_behavior_get">
                                       <mutation/>
-                                      <title name="VAR">jittering</title>
+                                      <title name="VAR" id="jittering">jittering</title>
                                     </block>
                                   </value>
                                   <next>
@@ -304,7 +304,7 @@
                                       <value name="BEHAVIOR">
                                         <block type="gamelab_behavior_get">
                                           <mutation/>
-                                          <title name="VAR">wandering</title>
+                                          <title name="VAR" id="wandering">wandering</title>
                                         </block>
                                       </value>
                                     </block>
@@ -920,19 +920,19 @@
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">growing</title>
+            <title name="VAR" id="growing">growing</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">jittering</title>
+            <title name="VAR" id="jittering">jittering</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">shrinking</title>
+            <title name="VAR" id="shrinking">shrinking</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">patrolling</title>
+            <title name="VAR" id="patrolling">patrolling</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
@@ -952,7 +952,7 @@
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">wandering</title>
+            <title name="VAR" id="wandering">wandering</title>
           </block>
         </category>
         <category name="Variables" custom="VARIABLE"/>

--- a/dashboard/config/scripts/levels/courseE_aboutme_test.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_test.level
@@ -261,7 +261,7 @@
                                       <value name="BEHAVIOR">
                                         <block type="gamelab_behavior_get">
                                           <mutation/>
-                                          <title name="VAR">jittering</title>
+                                          <title name="VAR" id="jittering">jittering</title>
                                         </block>
                                       </value>
                                       <next>
@@ -274,7 +274,7 @@
                                           <value name="BEHAVIOR">
                                             <block type="gamelab_behavior_get">
                                               <mutation/>
-                                              <title name="VAR">wandering</title>
+                                              <title name="VAR" id="wandering">wandering</title>
                                             </block>
                                           </value>
                                           <next>
@@ -1813,19 +1813,19 @@
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">growing</title>
+            <title name="VAR" id="growing">growing</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">jittering</title>
+            <title name="VAR" id="jittering">jittering</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">shrinking</title>
+            <title name="VAR" id="shrinking">shrinking</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">patrolling</title>
+            <title name="VAR" id="patrolling">patrolling</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
@@ -1845,7 +1845,7 @@
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">wandering</title>
+            <title name="VAR" id="wandering">wandering</title>
           </block>
         </category>
         <category name="Variables" custom="VARIABLE"/>

--- a/dashboard/config/scripts/levels/courseE_aboutme_test2.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_test2.level
@@ -294,7 +294,7 @@
                                   <value name="BEHAVIOR">
                                     <block type="gamelab_behavior_get">
                                       <mutation/>
-                                      <title name="VAR">jittering</title>
+                                      <title name="VAR" id="jittering">jittering</title>
                                     </block>
                                   </value>
                                   <next>
@@ -307,7 +307,7 @@
                                       <value name="BEHAVIOR">
                                         <block type="gamelab_behavior_get">
                                           <mutation/>
-                                          <title name="VAR">wandering</title>
+                                          <title name="VAR" id="wandering">wandering</title>
                                         </block>
                                       </value>
                                     </block>
@@ -923,19 +923,19 @@
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">growing</title>
+            <title name="VAR" id="growing">growing</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">jittering</title>
+            <title name="VAR" id="jittering">jittering</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">shrinking</title>
+            <title name="VAR" id="shrinking">shrinking</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">patrolling</title>
+            <title name="VAR" id="patrolling">patrolling</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
@@ -955,7 +955,7 @@
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">wandering</title>
+            <title name="VAR" id="wandering">wandering</title>
           </block>
         </category>
         <category name="Variables" custom="VARIABLE"/>

--- a/dashboard/config/scripts/levels/coursef_EOC_2 Ram.level
+++ b/dashboard/config/scripts/levels/coursef_EOC_2 Ram.level
@@ -203,7 +203,7 @@
                                               </value>
                                               <value name="BEHAVIOR">
                                                 <block type="gamelab_behavior_get">
-                                                  <title name="VAR">moving</title>
+                                                  <title name="VAR" id="moving">moving</title>
                                                 </block>
                                               </value>
                                             </block>

--- a/dashboard/config/scripts/levels/coursef_EOC_2.level
+++ b/dashboard/config/scripts/levels/coursef_EOC_2.level
@@ -202,7 +202,7 @@
                                               </value>
                                               <value name="BEHAVIOR">
                                                 <block type="gamelab_behavior_get">
-                                                  <title name="VAR">moving</title>
+                                                  <title name="VAR" id="moving">moving</title>
                                                 </block>
                                               </value>
                                             </block>

--- a/dashboard/config/scripts/levels/international_outbreak_freeplay.level
+++ b/dashboard/config/scripts/levels/international_outbreak_freeplay.level
@@ -125,7 +125,7 @@
                               <value name="BEHAVIOR">
                                 <block type="gamelab_behavior_get">
                                   <mutation/>
-                                  <title name="VAR">wandering</title>
+                                  <title name="VAR" id="wandering">wandering</title>
                                 </block>
                               </value>
                               <next>

--- a/dashboard/config/scripts/levels/outbreak1.level
+++ b/dashboard/config/scripts/levels/outbreak1.level
@@ -334,7 +334,7 @@
             <value name="BEHAVIOR">
               <block type="gamelab_behavior_get">
                 <mutation/>
-                <title name="VAR">wandering</title>
+                <title name="VAR" id="wandering">wandering</title>
               </block>
             </value>
           </block>

--- a/dashboard/config/scripts/levels/outbreak2.level
+++ b/dashboard/config/scripts/levels/outbreak2.level
@@ -126,7 +126,7 @@
                               <value name="BEHAVIOR">
                                 <block type="gamelab_behavior_get">
                                   <mutation/>
-                                  <title name="VAR">wandering</title>
+                                  <title name="VAR" id="wandering">wandering</title>
                                 </block>
                               </value>
                             </block>

--- a/dashboard/config/scripts/levels/outbreak3.level
+++ b/dashboard/config/scripts/levels/outbreak3.level
@@ -125,7 +125,7 @@
                               <value name="BEHAVIOR">
                                 <block type="gamelab_behavior_get">
                                   <mutation/>
-                                  <title name="VAR">wandering</title>
+                                  <title name="VAR" id="wandering">wandering</title>
                                 </block>
                               </value>
                             </block>
@@ -408,7 +408,7 @@
             <value name="BEHAVIOR">
               <block type="gamelab_behavior_get">
                 <mutation/>
-                <title name="VAR">wandering</title>
+                <title name="VAR" id="wandering">wandering</title>
               </block>
             </value>
           </block>

--- a/dashboard/config/scripts/levels/outbreak4.level
+++ b/dashboard/config/scripts/levels/outbreak4.level
@@ -127,7 +127,7 @@
                               <value name="BEHAVIOR">
                                 <block type="gamelab_behavior_get">
                                   <mutation/>
-                                  <title name="VAR">wandering</title>
+                                  <title name="VAR" id="wandering">wandering</title>
                                 </block>
                               </value>
                             </block>
@@ -916,7 +916,7 @@
             <value name="BEHAVIOR">
               <block type="gamelab_behavior_get">
                 <mutation/>
-                <title name="VAR">wandering</title>
+                <title name="VAR" id="wandering">wandering</title>
               </block>
             </value>
           </block>

--- a/dashboard/config/scripts/levels/outbreak5.level
+++ b/dashboard/config/scripts/levels/outbreak5.level
@@ -129,7 +129,7 @@
                               <value name="BEHAVIOR">
                                 <block type="gamelab_behavior_get">
                                   <mutation/>
-                                  <title name="VAR">wandering</title>
+                                  <title name="VAR" id="wandering">wandering</title>
                                 </block>
                               </value>
                             </block>
@@ -476,7 +476,7 @@
             <value name="BEHAVIOR">
               <block type="gamelab_behavior_get">
                 <mutation/>
-                <title name="VAR">wandering</title>
+                <title name="VAR" id="wandering">wandering</title>
               </block>
             </value>
           </block>

--- a/dashboard/config/scripts/levels/outbreak6.level
+++ b/dashboard/config/scripts/levels/outbreak6.level
@@ -346,7 +346,7 @@
                               <value name="BEHAVIOR">
                                 <block type="gamelab_behavior_get">
                                   <mutation/>
-                                  <title name="VAR">wandering</title>
+                                  <title name="VAR" id="wandering">wandering</title>
                                 </block>
                               </value>
                               <next>

--- a/dashboard/config/scripts/levels/outbreak7.level
+++ b/dashboard/config/scripts/levels/outbreak7.level
@@ -129,7 +129,7 @@
                               <value name="BEHAVIOR">
                                 <block type="gamelab_behavior_get">
                                   <mutation/>
-                                  <title name="VAR">wandering</title>
+                                  <title name="VAR" id="wandering">wandering</title>
                                 </block>
                               </value>
                               <next>

--- a/dashboard/config/scripts/levels/outbreak8.level
+++ b/dashboard/config/scripts/levels/outbreak8.level
@@ -127,7 +127,7 @@
                               <value name="BEHAVIOR">
                                 <block type="gamelab_behavior_get">
                                   <mutation/>
-                                  <title name="VAR">wandering</title>
+                                  <title name="VAR" id="wandering">wandering</title>
                                 </block>
                               </value>
                               <next>

--- a/dashboard/config/scripts/levels/outbreak_freeplay.level
+++ b/dashboard/config/scripts/levels/outbreak_freeplay.level
@@ -126,7 +126,7 @@
                               <value name="BEHAVIOR">
                                 <block type="gamelab_behavior_get">
                                   <mutation/>
-                                  <title name="VAR">wandering</title>
+                                  <title name="VAR" id="wandering">wandering</title>
                                 </block>
                               </value>
                               <next>

--- a/dashboard/config/scripts/levels/outbreak_freeplay_basic.level
+++ b/dashboard/config/scripts/levels/outbreak_freeplay_basic.level
@@ -126,7 +126,7 @@
                               <value name="BEHAVIOR">
                                 <block type="gamelab_behavior_get">
                                   <mutation/>
-                                  <title name="VAR">wandering</title>
+                                  <title name="VAR" id="wandering">wandering</title>
                                 </block>
                               </value>
                               <next>

--- a/dashboard/config/scripts/levels/outbreak_freeplay_data.level
+++ b/dashboard/config/scripts/levels/outbreak_freeplay_data.level
@@ -127,7 +127,7 @@
                               <value name="BEHAVIOR">
                                 <block type="gamelab_behavior_get">
                                   <mutation/>
-                                  <title name="VAR">wandering</title>
+                                  <title name="VAR" id="wandering">wandering</title>
                                 </block>
                               </value>
                               <next>

--- a/dashboard/config/scripts/levels/sl-rock-paper-scissors.level
+++ b/dashboard/config/scripts/levels/sl-rock-paper-scissors.level
@@ -354,7 +354,7 @@
                                                       <value name="BEHAVIOR">
                                                         <block type="gamelab_behavior_get">
                                                           <mutation/>
-                                                          <title name="VAR">wandering</title>
+                                                          <title name="VAR" id="wandering">wandering</title>
                                                         </block>
                                                       </value>
                                                       <next>
@@ -367,7 +367,7 @@
                                                           <value name="BEHAVIOR">
                                                             <block type="gamelab_behavior_get">
                                                             <mutation/>
-                                                            <title name="VAR">wandering</title>
+                                                            <title name="VAR" id="wandering">wandering</title>
                                                             </block>
                                                           </value>
                                                           <next>
@@ -380,7 +380,7 @@
                                                             <value name="BEHAVIOR">
                                                             <block type="gamelab_behavior_get">
                                                             <mutation/>
-                                                            <title name="VAR">wandering</title>
+                                                            <title name="VAR" id="wandering">wandering</title>
                                                             </block>
                                                             </value>
                                                             </block>

--- a/dashboard/config/scripts/levels/temp_startblocks.level
+++ b/dashboard/config/scripts/levels/temp_startblocks.level
@@ -119,7 +119,7 @@
                               <value name="BEHAVIOR">
                                 <block type="gamelab_behavior_get">
                                   <mutation/>
-                                  <title name="VAR">wandering</title>
+                                  <title name="VAR" id="wandering">wandering</title>
                                 </block>
                               </value>
                               <next>

--- a/dashboard/config/scripts/levels/test shared behaviors.level
+++ b/dashboard/config/scripts/levels/test shared behaviors.level
@@ -57,7 +57,7 @@
           <value name="BEHAVIOR">
             <block type="gamelab_behavior_get">
               <mutation/>
-              <title name="VAR">wandering</title>
+              <title name="VAR" id="wandering">wandering</title>
             </block>
           </value>
         </block>

--- a/dashboard/config/scripts/levels/timeforcs_demo_sl_2.level
+++ b/dashboard/config/scripts/levels/timeforcs_demo_sl_2.level
@@ -105,7 +105,7 @@
               <value name="BEHAVIOR">
                 <block type="gamelab_behavior_get">
                   <mutation/>
-                  <title name="VAR">patrolling</title>
+                  <title name="VAR" id="patrolling">patrolling</title>
                 </block>
               </value>
             </block>
@@ -696,19 +696,19 @@
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">growing</title>
+            <title name="VAR" id="growing">growing</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">jittering</title>
+            <title name="VAR" id="jittering">jittering</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">shrinking</title>
+            <title name="VAR" id="shrinking">shrinking</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">patrolling</title>
+            <title name="VAR" id="patrolling">patrolling</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
@@ -728,7 +728,7 @@
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">wandering</title>
+            <title name="VAR" id="wandering">wandering</title>
           </block>
         </category>
         <category name="Events">

--- a/dashboard/config/scripts/levels/timeforcs_demo_sl_7.level
+++ b/dashboard/config/scripts/levels/timeforcs_demo_sl_7.level
@@ -111,7 +111,7 @@
                               <value name="BEHAVIOR">
                                 <block type="gamelab_behavior_get">
                                   <mutation/>
-                                  <title name="VAR">jittering</title>
+                                  <title name="VAR" id="jittering">jittering</title>
                                 </block>
                               </value>
                               <next>
@@ -124,7 +124,7 @@
                                   <value name="BEHAVIOR">
                                     <block type="gamelab_behavior_get">
                                       <mutation/>
-                                      <title name="VAR">patrolling</title>
+                                      <title name="VAR" id="patrolling">patrolling</title>
                                     </block>
                                   </value>
                                   <next>
@@ -137,7 +137,7 @@
                                       <value name="BEHAVIOR">
                                         <block type="gamelab_behavior_get">
                                           <mutation/>
-                                          <title name="VAR">wandering</title>
+                                          <title name="VAR" id="wandering">wandering</title>
                                         </block>
                                       </value>
                                     </block>
@@ -711,19 +711,19 @@
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">growing</title>
+            <title name="VAR" id="growing">growing</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">jittering</title>
+            <title name="VAR" id="jittering">jittering</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">shrinking</title>
+            <title name="VAR" id="shrinking">shrinking</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">patrolling</title>
+            <title name="VAR" id="patrolling">patrolling</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
@@ -743,7 +743,7 @@
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">wandering</title>
+            <title name="VAR" id="wandering">wandering</title>
           </block>
         </category>
         <category name="Events">

--- a/dashboard/config/scripts/levels/timeforcs_demo_sl_9.level
+++ b/dashboard/config/scripts/levels/timeforcs_demo_sl_9.level
@@ -661,19 +661,19 @@
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">growing</title>
+            <title name="VAR" id="growing">growing</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">jittering</title>
+            <title name="VAR" id="jittering">jittering</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">shrinking</title>
+            <title name="VAR" id="shrinking">shrinking</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">patrolling</title>
+            <title name="VAR" id="patrolling">patrolling</title>
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
@@ -693,7 +693,7 @@
           </block>
           <block type="gamelab_behavior_get">
             <mutation/>
-            <title name="VAR">wandering</title>
+            <title name="VAR" id="wandering">wandering</title>
           </block>
         </category>
         <category name="Events">

--- a/dashboard/config/scripts/levels/virus_1_codebytes.level
+++ b/dashboard/config/scripts/levels/virus_1_codebytes.level
@@ -314,7 +314,7 @@
             <value name="BEHAVIOR">
               <block type="gamelab_behavior_get">
                 <mutation/>
-                <title name="VAR">wandering</title>
+                <title name="VAR" id="wandering">wandering</title>
               </block>
             </value>
           </block>
@@ -362,7 +362,7 @@
                               <value name="BEHAVIOR">
                                 <block type="gamelab_behavior_get">
                                   <mutation/>
-                                  <title name="VAR">wandering</title>
+                                  <title name="VAR" id="wandering">wandering</title>
                                 </block>
                               </value>
                             </block>

--- a/dashboard/config/scripts/levels/virus_1_codebytes_elijah.level
+++ b/dashboard/config/scripts/levels/virus_1_codebytes_elijah.level
@@ -243,7 +243,7 @@
             <value name="BEHAVIOR">
               <block type="gamelab_behavior_get">
                 <mutation/>
-                <title name="VAR">wandering</title>
+                <title name="VAR" id="wandering">wandering</title>
               </block>
             </value>
           </block>
@@ -291,7 +291,7 @@
                               <value name="BEHAVIOR">
                                 <block type="gamelab_behavior_get">
                                   <mutation/>
-                                  <title name="VAR">wandering</title>
+                                  <title name="VAR" id="wandering">wandering</title>
                                 </block>
                               </value>
                             </block>

--- a/dashboard/config/scripts/levels/virus_2_codebytes.level
+++ b/dashboard/config/scripts/levels/virus_2_codebytes.level
@@ -314,7 +314,7 @@
             <value name="BEHAVIOR">
               <block type="gamelab_behavior_get">
                 <mutation/>
-                <title name="VAR">wandering</title>
+                <title name="VAR" id="wandering">wandering</title>
               </block>
             </value>
           </block>
@@ -380,7 +380,7 @@
                               <value name="BEHAVIOR">
                                 <block type="gamelab_behavior_get">
                                   <mutation/>
-                                  <title name="VAR">wandering</title>
+                                  <title name="VAR" id="wandering">wandering</title>
                                 </block>
                               </value>
                             </block>

--- a/dashboard/config/scripts/levels/virus_3_codebytes.level
+++ b/dashboard/config/scripts/levels/virus_3_codebytes.level
@@ -243,7 +243,7 @@
             <value name="BEHAVIOR">
               <block type="gamelab_behavior_get">
                 <mutation/>
-                <title name="VAR">wandering</title>
+                <title name="VAR" id="wandering">wandering</title>
               </block>
             </value>
           </block>
@@ -317,7 +317,7 @@
                               <value name="BEHAVIOR">
                                 <block type="gamelab_behavior_get">
                                   <mutation/>
-                                  <title name="VAR">wandering</title>
+                                  <title name="VAR" id="wandering">wandering</title>
                                 </block>
                               </value>
                             </block>

--- a/dashboard/config/scripts/levels/virus_complete_codebytes.level
+++ b/dashboard/config/scripts/levels/virus_complete_codebytes.level
@@ -123,7 +123,7 @@
                               <value name="BEHAVIOR">
                                 <block type="gamelab_behavior_get">
                                   <mutation/>
-                                  <title name="VAR">wandering</title>
+                                  <title name="VAR" id="wandering">wandering</title>
                                 </block>
                               </value>
                               <next>
@@ -1303,7 +1303,7 @@
                               <value name="BEHAVIOR">
                                 <block type="gamelab_behavior_get">
                                   <mutation/>
-                                  <title name="VAR">wandering</title>
+                                  <title name="VAR" id="wandering">wandering</title>
                                 </block>
                               </value>
                             </block>

--- a/dashboard/config/scripts/levels/virus_template_codebytes.level
+++ b/dashboard/config/scripts/levels/virus_template_codebytes.level
@@ -243,7 +243,7 @@
                               <value name="BEHAVIOR">
                                 <block type="gamelab_behavior_get">
                                   <mutation/>
-                                  <title name="VAR">wandering</title>
+                                  <title name="VAR" id="wandering">wandering</title>
                                 </block>
                               </value>
                             </block>

--- a/dashboard/config/scripts/levels/virus_template_codebytes1.level
+++ b/dashboard/config/scripts/levels/virus_template_codebytes1.level
@@ -244,7 +244,7 @@
                               <value name="BEHAVIOR">
                                 <block type="gamelab_behavior_get">
                                   <mutation/>
-                                  <title name="VAR">wandering</title>
+                                  <title name="VAR" id="wandering">wandering</title>
                                 </block>
                               </value>
                             </block>

--- a/dashboard/config/scripts/levels/virus_template_codebytes_fix.level
+++ b/dashboard/config/scripts/levels/virus_template_codebytes_fix.level
@@ -315,7 +315,7 @@
                               <value name="BEHAVIOR">
                                 <block type="gamelab_behavior_get">
                                   <mutation/>
-                                  <title name="VAR">wandering</title>
+                                  <title name="VAR" id="wandering">wandering</title>
                                 </block>
                               </value>
                             </block>


### PR DESCRIPTION
Very similar PR to https://github.com/code-dot-org/code-dot-org/pull/42749, explicitly setting the id on `gamelab_behavior_get` blocks this time. This will make sure that the `start_blocks` will have the proper english id even when the block text is translated.

## Links

- jira ticket: [FND-1772](https://codedotorg.atlassian.net/browse/FND-1772)
