### PR TITLE
Stop generating TTS URLs for unsupported locales

### DIFF
--- a/dashboard/app/models/concerns/text_to_speech.rb
+++ b/dashboard/app/models/concerns/text_to_speech.rb
@@ -123,7 +123,13 @@ module TextToSpeech
     TextToSpeech.tts_upload_to_s3(text, filename, context)
   end
 
-  def tts_url(text)
+  # Returns the URL where the TTS audio file can be downloaded for the given text and locale
+  # @param text [String] The text which is being read aloud in the TTS file.
+  # @param locale [Symbol] The locale of the language being spoken e.g. :'en-US', :'es-MX'
+  # @return [String] URL where the TTS audio file can be downloaded from. `nil` is returned if any of
+  # the params are blank or if TTS is not supported for the given locale.
+  def tts_url(text, locale = I18n.locale)
+    return nil unless TextToSpeech.locale_supported?(locale) && !text.blank?
     "https://tts.code.org/#{tts_path(text)}"
   end
 

--- a/dashboard/test/models/blockly_test.rb
+++ b/dashboard/test/models/blockly_test.rb
@@ -472,7 +472,7 @@ XML
   end
 
   test 'localizes authored hints' do
-    test_locale = :"te-ST"
+    test_locale = :"es-MX"
     level_name = 'test_localize_authored_hints'
 
     I18n.locale = test_locale
@@ -504,10 +504,10 @@ XML
     localized_hints = JSON.parse(level.localized_authored_hints)
 
     assert_equal localized_hints[0]["hint_markdown"], "first test markdown"
-    assert_equal localized_hints[0]["tts_url"], "https://tts.code.org/sharon22k/180/100/1889ea7b2140fc1aef28a2145df32fbb/test_localize_authored_hints.mp3"
+    assert_equal localized_hints[0]["tts_url"], "https://tts.code.org/rosa22k/180/100/1889ea7b2140fc1aef28a2145df32fbb/test_localize_authored_hints.mp3"
 
     assert_equal localized_hints[1]["hint_markdown"], "second test markdown"
-    assert_equal localized_hints[1]["tts_url"], "https://tts.code.org/sharon22k/180/100/62885e459602efbd236f324c4796acc9/test_localize_authored_hints.mp3"
+    assert_equal localized_hints[1]["tts_url"], "https://tts.code.org/rosa22k/180/100/62885e459602efbd236f324c4796acc9/test_localize_authored_hints.mp3"
   end
 
   test 'localized_blocks_with_placeholder_texts' do

--- a/dashboard/test/models/concerns/text_to_speech_test.rb
+++ b/dashboard/test/models/concerns/text_to_speech_test.rb
@@ -223,4 +223,13 @@ class TextToSpeechTest < ActiveSupport::TestCase
     outer_level.contained_level_names = [contained_level_two.name]
     assert outer_level.tts_should_update_long_instructions?
   end
+
+  test 'tts_url should return nil given locale not supported for TTS' do
+    assert_nil(@level_without_instructions.tts_url(@level_without_instructions.tts_short_instructions_text, :'te-ST'))
+  end
+
+  test 'tts_url should return a url to a tts file' do
+    expected_tts_url = 'https://tts.code.org/sharon22k/180/100/71c7e35e3633b5dfce472bcbed146e9f/.mp3'
+    assert_equal(expected_tts_url, @level_with_instructions.tts_url(@level_with_instructions.tts_short_instructions_text, :'en-US'))
+  end
 end


### PR DESCRIPTION
**bug** - The javascript console showed a 403 error when loading the TextToSpeech(TTS) file for a level and there was a whitespace gap in the UI next to the immersive reader button.
**cause** - The React TTS button was being given URLs to file which don't exist. The files don't exist because we do not support TTS for those languages.
**fix** - Don't generate TTS URL's for languages/locales we don't have TTS support for.

## Links
- [JIRA](https://codedotorg.atlassian.net/browse/FND-1704)

## Testing story
* Unit tests
* Checked German versions of levels and confirmed there was no reserved space for the TTS button and the javascript console didn't show a `403` error.
  * http://localhost-studio.code.org:3000/s/coursea-2019/lessons/5/levels/10/lang/de-DE

## Screenshots
### Before
Note the empty space highlighted by the red box

![Screen Shot 2021-10-19 at 4 23 52 PM](https://user-images.githubusercontent.com/1372238/138003921-5c9cefa9-80dd-4f07-9c70-d0cc2cfdd581.png)
----

### After
Note there is no empty space anymore
![Screen Shot 2021-10-19 at 4 24 57 PM](https://user-images.githubusercontent.com/1372238/138003926-898976c3-369a-4bc4-886d-59aac8b06a03.png)

----

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
