### PR TITLE
Fix update_translation_status cronjob and logs

### DIFF
--- a/experimental/i18n-dev.crontab
+++ b/experimental/i18n-dev.crontab
@@ -47,4 +47,4 @@ HOME=/home/ubuntu
 0 */1 * * * cd /home/ubuntu/code-dot-org && git fetch && (bundle exec ./bin/i18n/sync-all.rb -y -c return-to-staging | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error
 
 # Update string translation status to Redshift
-0 0 * * * cd /home/ubuntu/code-dot-org && bundle exec .bin/i18n/translation_status/update_translation_status.rb
+0 0 * * * cd /home/ubuntu/code-dot-org && (bundle exec ./bin/i18n/translation_status/update_translation_status.rb | ./bin/i18n/slack_log) | ./bin/i18n/slack_error

--- a/experimental/i18n-dev.crontab
+++ b/experimental/i18n-dev.crontab
@@ -47,4 +47,4 @@ HOME=/home/ubuntu
 0 */1 * * * cd /home/ubuntu/code-dot-org && git fetch && (bundle exec ./bin/i18n/sync-all.rb -y -c return-to-staging | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error
 
 # Update string translation status to Redshift
-0 0 * * * cd /home/ubuntu/code-dot-org && (bundle exec ./bin/i18n/translation_status/update_translation_status.rb | ./bin/i18n/slack_log) | ./bin/i18n/slack_error
+0 0 * * * cd /home/ubuntu/code-dot-org && (bundle exec ./bin/i18n/translation_status/update_translation_status.rb | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error


### PR DESCRIPTION
**bug** - @dju90 noticed that there was no data in the `analysis.i18n_string_tracking_events` Redshift table.
**cause** - The cronjob which should regularly update that Redshift table had the wrong file path and was silently failing.
**fix** - Changed `.bin` to `./bin` and added logging to Slack so the team can quickly see if the job is failing.

## Links
- [JIRA](https://codedotorg.atlassian.net/browse/FND-1685)

## Testing story
* Manually ran on the `i18n-dev` server.

## Deployment strategy
* After it is merged I will copy/paste the config into the `i18n-dev` server using `crontab -e`.
## Follow-up work

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
