### PR TITLE
Delete unused options.builder path in StudioApp.prototype.report

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -5,7 +5,6 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import {EventEmitter} from 'events';
 import _ from 'lodash';
-import url from 'url';
 import {Provider} from 'react-redux';
 import trackEvent from './util/trackEvent';
 
@@ -1688,36 +1687,6 @@ StudioApp.prototype.getTestResults = function(levelComplete, options) {
   );
 };
 
-// Builds the dom to get more info from the user. After user enters info
-// and click "create level" onAttemptCallback is called to deliver the info
-// to the server.
-StudioApp.prototype.builderForm_ = function(onAttemptCallback) {
-  var builderDetails = document.createElement('div');
-  builderDetails.innerHTML = require('./templates/builder.html.ejs')();
-  var dialog = this.createModalDialog({
-    contentDiv: builderDetails,
-    icon: this.icon
-  });
-  var createLevelButton = document.getElementById('create-level-button');
-  dom.addClickTouchEvent(createLevelButton, function() {
-    var instructions = builderDetails.querySelector('[name="instructions"]')
-      .value;
-    var name = builderDetails.querySelector('[name="level_name"]').value;
-    var query = url.parse(window.location.href, true).query;
-    onAttemptCallback(
-      utils.extend(
-        {
-          instructions: instructions,
-          name: name
-        },
-        query
-      )
-    );
-  });
-
-  dialog.show({backdrop: 'static'});
-};
-
 /**
  * Report back to the server, if available.
  * @param {MilestoneReport} options
@@ -1747,24 +1716,8 @@ StudioApp.prototype.report = function(options) {
   // they cannot have modified. In that case, don't report it to the service
   // or call the onComplete() callback expected. The app will just sit
   // there with the Reset button as the only option.
-  var self = this;
   if (!(this.hideSource && this.share) && !readOnly) {
-    var onAttemptCallback = (function() {
-      return function(builderDetails) {
-        for (var option in builderDetails) {
-          report[option] = builderDetails[option];
-        }
-        self.onAttempt(report);
-      };
-    })();
-
-    // If this is the level builder, go to builderForm to get more info from
-    // the level builder.
-    if (options.builder) {
-      this.builderForm_(onAttemptCallback);
-    } else {
-      onAttemptCallback();
-    }
+    this.onAttempt(report);
   }
 };
 

--- a/apps/src/templates/builder.html.ejs
+++ b/apps/src/templates/builder.html.ejs
@@ -1,6 +1,0 @@
-<div><span>Instructions: </span><textarea type="text" name="instructions"></textarea></div>
-<div><span>Level Name: </span><textarea type="text" name="level_name"></textarea></div>
-<button id="create-level-button" class="launch">
-  Create Level
-</button>
-<div id="builder-error"></div>


### PR DESCRIPTION
Removing some dead code. `StudioApp.prototype.report` accepts an options object with a `builder` key that is never used. I'm pretty sure this is just leftover from an old way of building levels -- if `options.builder` is truthy, we open a dialog to get more information from the levelbuilder.

None of the consumers of this function use the `builder` option, and I tested building some levels and couldn't get the dialog to trigger, so I'm fairly confident this is just dead code. Here are all the places we call `StudioApp.prototype.report`:
- [StudioApp.prototype.silentlyReport](https://github.com/code-dot-org/code-dot-org/blob/d1455dc0eea44d599dd8ac5fd3c486d0e819e2d4/apps/src/StudioApp.js#L1805)
- [StudioApp.prototype.skipLevel](https://github.com/code-dot-org/code-dot-org/blob/d1455dc0eea44d599dd8ac5fd3c486d0e819e2d4/apps/src/StudioApp.js#L2041)
- [Ailab.prototype.onContinue](https://github.com/code-dot-org/code-dot-org/blob/d1455dc0eea44d599dd8ac5fd3c486d0e819e2d4/apps/src/ailab/Ailab.js#L145)
- [Applab.onPuzzleComplete](https://github.com/code-dot-org/code-dot-org/blob/d1455dc0eea44d599dd8ac5fd3c486d0e819e2d4/apps/src/applab/applab.js#L1655)
- [Bounce.onPuzzleComplete](https://github.com/code-dot-org/code-dot-org/blob/d1455dc0eea44d599dd8ac5fd3c486d0e819e2d4/apps/src/bounce/bounce.js#L1195)
- [Calc.execute](https://github.com/code-dot-org/code-dot-org/blob/d1455dc0eea44d599dd8ac5fd3c486d0e819e2d4/apps/src/calc/calc.js#L728)
- Craft.reportResult: [agent](https://github.com/code-dot-org/code-dot-org/blob/295e6b73c8a4f1af7da69a16034a1c9d3347a1a9/apps/src/craft/agent/craft.js#L829), [simple](https://github.com/code-dot-org/code-dot-org/blob/295e6b73c8a4f1af7da69a16034a1c9d3347a1a9/apps/src/craft/simple/craft.js#L910), [aquatic](https://github.com/code-dot-org/code-dot-org/blob/295e6b73c8a4f1af7da69a16034a1c9d3347a1a9/apps/src/craft/aquatic/craft.js#L639), [designer](https://github.com/code-dot-org/code-dot-org/blob/295e6b73c8a4f1af7da69a16034a1c9d3347a1a9/apps/src/craft/designer/craft.js#L967)
- [Dance.prototype.onPuzzleComplete](https://github.com/code-dot-org/code-dot-org/blob/295e6b73c8a4f1af7da69a16034a1c9d3347a1a9/apps/src/dance/Dance.js#L488)
- [Eval.execute](https://github.com/code-dot-org/code-dot-org/blob/295e6b73c8a4f1af7da69a16034a1c9d3347a1a9/apps/src/eval/eval.js#L509-L522)
- [Fish.prototype.onContinue](https://github.com/code-dot-org/code-dot-org/blob/295e6b73c8a4f1af7da69a16034a1c9d3347a1a9/apps/src/fish/Fish.js#L103)
- [Flappy.sendReport](https://github.com/code-dot-org/code-dot-org/blob/295e6b73c8a4f1af7da69a16034a1c9d3347a1a9/apps/src/flappy/flappy.js#L897)
- [Javalab.prototype.onContinue](https://github.com/code-dot-org/code-dot-org/blob/295e6b73c8a4f1af7da69a16034a1c9d3347a1a9/apps/src/javalab/Javalab.js#L375)
- [Jigsaw.onPuzzleComplete](https://github.com/code-dot-org/code-dot-org/blob/295e6b73c8a4f1af7da69a16034a1c9d3347a1a9/apps/src/jigsaw/jigsaw.js#L273)
- [Maze.prototype.execute_](https://github.com/code-dot-org/code-dot-org/blob/295e6b73c8a4f1af7da69a16034a1c9d3347a1a9/apps/src/maze/maze.js#L490)
- [P5Lab.prototype.onPuzzleComplete](https://github.com/code-dot-org/code-dot-org/blob/295e6b73c8a4f1af7da69a16034a1c9d3347a1a9/apps/src/p5lab/P5Lab.js#L977)
- [Studio.onPuzzleComplete](https://github.com/code-dot-org/code-dot-org/blob/295e6b73c8a4f1af7da69a16034a1c9d3347a1a9/apps/src/studio/studio.js#L3785)
- [Artist.prototype.report](https://github.com/code-dot-org/code-dot-org/blob/295e6b73c8a4f1af7da69a16034a1c9d3347a1a9/apps/src/turtle/artist.js#L1525)
- [WebLab.prototype.reportResult](https://github.com/code-dot-org/code-dot-org/blob/295e6b73c8a4f1af7da69a16034a1c9d3347a1a9/apps/src/weblab/WebLab.js#L343)

Thankfully, each consumer hardcodes the `options` object passed to `report`, so that gives a fair amount of confidence that the `builder` option is never used.