### PR TITLE
[Poetry] Don't autoplay poems in non-hoc levels

### DIFF
--- a/apps/src/p5lab/poetry/PoetryLibrary.js
+++ b/apps/src/p5lab/poetry/PoetryLibrary.js
@@ -1,3 +1,4 @@
+/* global appOptions */
 import _ from 'lodash';
 import {getStore} from '@cdo/apps/redux';
 import CoreLibrary from '../spritelab/CoreLibrary';
@@ -32,7 +33,8 @@ export default class PoetryLibrary extends CoreLibrary {
       // The animation can be restarted with the animatePoem() block, which
       // updates this value.
       // This value is used as an offset when calculating which lines to show.
-      animationStartFrame: 1
+      animationStartFrame:
+        appOptions.level.standaloneAppName === 'poetry_hoc' ? 1 : null
     };
     this.backgroundEffect = () => this.p5.background('white');
     this.foregroundEffects = [];
@@ -297,6 +299,10 @@ export default class PoetryLibrary extends CoreLibrary {
   }
 
   applyGlobalLineAnimation(renderInfo, frameCount) {
+    if (this.poemState.animationStartFrame === null) {
+      return renderInfo;
+    }
+
     // Add 2 so there's time before the first line and after the last line
     const framesPerLine = POEM_DURATION / (renderInfo.lines.length + 2);
 


### PR DESCRIPTION
Show the poem all at once:
![image](https://user-images.githubusercontent.com/8787187/138032118-34e8578c-8d94-417f-8a0f-3a54863b0c5f.png)

Unless the student uses the animate poem block:
![image](https://user-images.githubusercontent.com/8787187/138032171-72eb1270-ab78-4805-a046-63d1bf0825d8.png)

Only applies to non-hoc levels