### PR TITLE
Fix callout styling

### DIFF
--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -1471,7 +1471,7 @@ html[dir=rtl] .qtip-content {
 }
 
 .cdo-qtips {
-  z-index: 2000 !important;
+  z-index: 1030 !important;
 }
 
 .tooltip-x-close.qtip-icon {

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -1471,7 +1471,7 @@ html[dir=rtl] .qtip-content {
 }
 
 .cdo-qtips {
-  z-index: 1;
+  z-index: 2000 !important;
 }
 
 .tooltip-x-close.qtip-icon {

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -1371,7 +1371,7 @@ body.iframe_embed_app_and_code {
 
   position: absolute;
   cursor: pointer;
-  z-index: 1;
+  z-index: 10;
   background: image-url("x_button.png") no-repeat center center;
   background-size: 100% auto;
 


### PR DESCRIPTION
- When a callout's close button is in the same corner as its triangle, the triangle overlaps the close button. This will adjust the z-index of the close button to be on top of the triangle.
- When a callout happens in the instructions, the instruction box overlaps the callout. This will adjust the z-index of the callout so it is always on top of the instructions.

Before instruction box overlap fix: 
![callout-overlap](https://user-images.githubusercontent.com/86268316/138159154-3d149543-3fbf-49ce-9466-e978566b014b.png)

Before triangle overlap fix:
![triangle-overlap](https://user-images.githubusercontent.com/86268316/138159342-f7c4b125-6925-4de2-82fa-eb89a3d7f3d8.png)

Fixed:
![rtl-callout](https://user-images.githubusercontent.com/86268316/138155835-3bc8e62a-f781-4bf6-8af8-6832a3c910db.png)

## Links

- jira ticket: [FND-1773](https://codedotorg.atlassian.net/browse/FND-1773)
