### PR TITLE
[Poetry] Fix remove block

### DIFF
--- a/apps/src/p5lab/poetry/PoetryLibrary.js
+++ b/apps/src/p5lab/poetry/PoetryLibrary.js
@@ -5,6 +5,7 @@ import {POEMS} from './constants';
 import * as utils from './commands/utils';
 import {commands as backgroundEffects} from './commands/backgroundEffects';
 import {commands as foregroundEffects} from './commands/foregroundEffects';
+import spritelabCommands from '../spritelab/commands/index';
 
 const OUTER_MARGIN = 50;
 const LINE_HEIGHT = 50;
@@ -74,6 +75,10 @@ export default class PoetryLibrary extends CoreLibrary {
         if (!this.isPreviewFrame()) {
           this.foregroundEffects.forEach(effect => effect.func());
         }
+      },
+
+      destroy(costume) {
+        spritelabCommands.destroy.call(this, {costume});
       },
 
       // And add custom Poem Bot commands


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/8787187/138186441-d32c088d-ebbe-4712-9170-43e4565d72b9.png)

After
![image](https://user-images.githubusercontent.com/8787187/138186470-e86ee2f0-2d60-4271-aeae-f93be6ca58e5.png)

The issue is that we were generating the code `destroy("sun")` but the spritelab command expects the argument to be `{costume: "sun"}` not just `"sun"`. The solution here is to just make an intermediate function in PoetryLibrary that calls through to the right spritelab command but changes the argument.