### PR TITLE
Add caching for HOC 2021 scripts

### DIFF
--- a/cookbooks/cdo-varnish/libraries/http_cache.rb
+++ b/cookbooks/cdo-varnish/libraries/http_cache.rb
@@ -18,10 +18,16 @@ class HttpCache
   ].freeze
 
   # A list of script levels that should not be cached, even though they are
-  # in a cacheable script, because they are project-backed.
+  # in a cacheable script, because teachers need to be able to review them.
+  # Currently, teachers are not able to review student work on cached levels.
   UNCACHED_UNIT_LEVEL_PATHS = [
     '/s/dance/lessons/1/levels/13',
-    '/s/dance-2019/lessons/1/levels/10'
+    '/s/dance-2019/lessons/1/levels/10',
+    '/s/poem-art/lessons/1/levels/9',
+    '/s/hello-world-food/lessons/1/levels/11',
+    '/s/hello-world-animals/lessons/1/levels/11',
+    '/s/hello-world-retro/lessons/1/levels/11',
+    '/s/hello-world-emoji/lessons/1/levels/11'
   ]
 
   # A map from script name to script level URL pattern.
@@ -39,6 +45,11 @@ class HttpCache
     dance
     dance-2019
     oceans
+    poem-art
+    hello-world-food
+    hello-world-animals
+    hello-world-retro
+    hello-world-emoji
   ).map do |script_name|
     # Most scripts use the default route pattern.
     [script_name, "/s/#{script_name}/lessons/*"]

--- a/cookbooks/cdo-varnish/libraries/http_cache.rb
+++ b/cookbooks/cdo-varnish/libraries/http_cache.rb
@@ -27,7 +27,8 @@ class HttpCache
     '/s/hello-world-food/lessons/1/levels/11',
     '/s/hello-world-animals/lessons/1/levels/11',
     '/s/hello-world-retro/lessons/1/levels/11',
-    '/s/hello-world-emoji/lessons/1/levels/11'
+    '/s/hello-world-emoji/lessons/1/levels/11',
+    '/s/outbreak/lessons/1/levels/10'
   ]
 
   # A map from script name to script level URL pattern.
@@ -50,6 +51,7 @@ class HttpCache
     hello-world-animals
     hello-world-retro
     hello-world-emoji
+    outbreak
   ).map do |script_name|
     # Most scripts use the default route pattern.
     [script_name, "/s/#{script_name}/lessons/*"]


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Add caching to HOC 2021 scripts except for the last level of each script which is a "free play" level. We're leaving this last level uncached to allow teachers to view student work.


## Testing story
Tested locally that scripts added to caching list were being cached
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
