### PR TITLE
Fix an invalid `I18n.t` call

### DIFF
--- a/dashboard/app/controllers/callouts_controller.rb
+++ b/dashboard/app/controllers/callouts_controller.rb
@@ -30,7 +30,7 @@ class CalloutsController < ApplicationController
 
     respond_to do |format|
       if @callout.save
-        format.html {redirect_to @callout, notice: I18n.t('crud.created', Callout.model_name.human)}
+        format.html {redirect_to @callout, notice: I18n.t('crud.created', model: Callout.model_name.human)}
         format.json {render action: 'show', status: :created, location: @callout}
       else
         format.html {render action: 'new'}


### PR DESCRIPTION
In Rails 5.2, it's incorrectly returning the string `"%{model} was successfully created."`; it Rails 6, it actually errors out. This change makes it work everywhere.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
