### PR TITLE
Create a fresh level for this PeerReview test

### DIFF
--- a/dashboard/test/models/peer_review_test.rb
+++ b/dashboard/test/models/peer_review_test.rb
@@ -47,14 +47,20 @@ class PeerReviewTest < ActiveSupport::TestCase
   end
 
   test 'submitting a peer reviewed level in instructor review only script should create one escalated PeerReview object' do
+    level = create(:free_response)
+    level.update!(
+      submittable: true,
+      peer_reviewable: 'true'
+    )
     script_only_instructor_review = create :script, only_instructor_review_required: true
-    script_level_only_instructor_review = create :script_level, levels: [@level], script: script_only_instructor_review
+    script_level_only_instructor_review = create :script_level, levels: [level], script: script_only_instructor_review
+    level_source = create :level_source, level: level
 
     assert_difference('PeerReview.count', 1) do
-      track_progress @level_source.id, @user, script_level_only_instructor_review
+      track_progress level_source.id, @user, script_level_only_instructor_review
     end
 
-    assert_equal ['escalated'], PeerReview.where(submitter: @user, level: @level).map(&:status)
+    assert_equal ['escalated'], PeerReview.where(submitter: @user, level: level).map(&:status)
   end
 
   test 'submitting a non peer reviewable level should not create Peer Review objects' do


### PR DESCRIPTION
Rather than reusing the existing one.

It's not entirely clear to me why, but as-is, this fails in Rails 6:

```
FAIL["test_submitting_a_peer_reviewed_level_in_instructor_review_only_script_should_create_one_escalated_PeerReview_object", "PeerReviewTest", 16.74003479105886]
test_submitting_a_peer_reviewed_level_in_instructor_review_only_script_should_create_one_escalated_PeerReview_object#PeerReviewTest (16.74s)
"PeerReview.count" didn't change by 1.
Expected: 1
Actual: 0
test/models/peer_review_test.rb:53:in `block in <class:PeerReviewTest>'
test/testing/setup_all_and_teardown_all.rb:36:in `run'
```
But *only* when the while test file is run at once; when the test runs in isolation, it works just fine. This implies to me that we're dealing with some leaky state, hence this change makes sense even if it isn't fully understood.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
