### PR TITLE
[Poetry] Hide poem dropdown in view mode

### DIFF
--- a/apps/src/p5lab/P5LabVisualizationHeader.jsx
+++ b/apps/src/p5lab/P5LabVisualizationHeader.jsx
@@ -27,7 +27,8 @@ class P5LabVisualizationHeader extends React.Component {
     onInterfaceModeChange: PropTypes.func.isRequired,
     isBlockly: PropTypes.bool.isRequired,
     numAllowedModes: PropTypes.number.isRequired,
-    isShareView: PropTypes.bool.isRequired
+    isShareView: PropTypes.bool.isRequired,
+    isReadOnlyWorkspace: PropTypes.bool.isRequired
   };
 
   changeInterfaceMode = mode => {
@@ -58,11 +59,13 @@ class P5LabVisualizationHeader extends React.Component {
 
   render() {
     const {interfaceMode, allowAnimationMode} = this.props;
+    const shouldShowPoemSelector =
+      this.props.labType === P5LabType.POETRY &&
+      !this.props.isShareView &&
+      !this.props.isReadOnlyWorkspace;
     return (
       <div>
-        {!this.props.isShareView && this.props.labType === P5LabType.POETRY && (
-          <PoemSelector />
-        )}
+        {shouldShowPoemSelector && <PoemSelector />}
         {this.props.numAllowedModes > 1 && (
           <div style={styles.main} id="playSpaceHeader">
             <ToggleGroup
@@ -114,7 +117,8 @@ export default connect(
     allowAnimationMode: allowAnimationMode(state),
     isBlockly: state.pageConstants.isBlockly,
     numAllowedModes: countAllowedModes(state),
-    isShareView: state.pageConstants.isShareView
+    isShareView: state.pageConstants.isShareView,
+    isReadOnlyWorkspace: state.pageConstants.isReadOnlyWorkspace
   }),
   dispatch => ({
     onInterfaceModeChange: mode => dispatch(changeInterfaceMode(mode))

--- a/apps/src/p5lab/P5LabVisualizationHeader.jsx
+++ b/apps/src/p5lab/P5LabVisualizationHeader.jsx
@@ -57,15 +57,20 @@ class P5LabVisualizationHeader extends React.Component {
     this.props.onInterfaceModeChange(mode);
   };
 
+  shouldShowPoemSelector() {
+    return (
+      this.props.labType === P5LabType.POETRY &&
+      this.props.interfaceMode === P5LabInterfaceMode.CODE &&
+      !this.props.isShareView &&
+      !this.props.isReadOnlyWorkspace
+    );
+  }
+
   render() {
     const {interfaceMode, allowAnimationMode} = this.props;
-    const shouldShowPoemSelector =
-      this.props.labType === P5LabType.POETRY &&
-      !this.props.isShareView &&
-      !this.props.isReadOnlyWorkspace;
     return (
       <div>
-        {shouldShowPoemSelector && <PoemSelector />}
+        {this.shouldShowPoemSelector() && <PoemSelector />}
         {this.props.numAllowedModes > 1 && (
           <div style={styles.main} id="playSpaceHeader">
             <ToggleGroup


### PR DESCRIPTION
We don't want to allow other users to change the selected poem in the dropdown when they're viewing someone else's project
Also hide the poem dropdown in the costume tab.

Before
![image](https://user-images.githubusercontent.com/8787187/138336560-83ebc664-c505-4dae-a1dc-b8b2772754e7.png)
![image](https://user-images.githubusercontent.com/8787187/138341542-2b3bcc97-858d-41a4-b34c-60787e035379.png)

After
![image](https://user-images.githubusercontent.com/8787187/138336535-2c0012e7-ffd1-4607-ab8e-439a306ccee3.png)
![image](https://user-images.githubusercontent.com/8787187/138341463-08ce30ed-061f-46b6-9906-0f5b4a029fe5.png)


Side note- we might want to also do this for dance party? right now you *can* change the song in view mode.