### PR TITLE
Revert hoc caching

### DIFF
--- a/cookbooks/cdo-varnish/libraries/http_cache.rb
+++ b/cookbooks/cdo-varnish/libraries/http_cache.rb
@@ -27,8 +27,7 @@ class HttpCache
     '/s/hello-world-food/lessons/1/levels/11',
     '/s/hello-world-animals/lessons/1/levels/11',
     '/s/hello-world-retro/lessons/1/levels/11',
-    '/s/hello-world-emoji/lessons/1/levels/11',
-    '/s/outbreak/lessons/1/levels/10'
+    '/s/hello-world-emoji/lessons/1/levels/11'
   ]
 
   # A map from script name to script level URL pattern.
@@ -51,7 +50,6 @@ class HttpCache
     hello-world-animals
     hello-world-retro
     hello-world-emoji
-    outbreak
   ).map do |script_name|
     # Most scripts use the default route pattern.
     [script_name, "/s/#{script_name}/lessons/*"]

--- a/cookbooks/cdo-varnish/libraries/http_cache.rb
+++ b/cookbooks/cdo-varnish/libraries/http_cache.rb
@@ -18,16 +18,10 @@ class HttpCache
   ].freeze
 
   # A list of script levels that should not be cached, even though they are
-  # in a cacheable script, because teachers need to be able to review them.
-  # Currently, teachers are not able to review student work on cached levels.
+  # in a cacheable script, because they are project-backed.
   UNCACHED_UNIT_LEVEL_PATHS = [
     '/s/dance/lessons/1/levels/13',
-    '/s/dance-2019/lessons/1/levels/10',
-    '/s/poem-art/lessons/1/levels/9',
-    '/s/hello-world-food/lessons/1/levels/11',
-    '/s/hello-world-animals/lessons/1/levels/11',
-    '/s/hello-world-retro/lessons/1/levels/11',
-    '/s/hello-world-emoji/lessons/1/levels/11'
+    '/s/dance-2019/lessons/1/levels/10'
   ]
 
   # A map from script name to script level URL pattern.
@@ -45,11 +39,6 @@ class HttpCache
     dance
     dance-2019
     oceans
-    poem-art
-    hello-world-food
-    hello-world-animals
-    hello-world-retro
-    hello-world-emoji
   ).map do |script_name|
     # Most scripts use the default route pattern.
     [script_name, "/s/#{script_name}/lessons/*"]


### PR DESCRIPTION
Reverting these changes because it took us over the cache limit.
```
TestCloudFront
  test_cloudfront_limits                                          FAIL (0.02s)
Minitest::Assertion:         dashboard has 54 cache behaviors (max is 50)
        /home/ubuntu/test/shared/test/test_cloudfront.rb:17:in `block in test_cloudfront_limits'
        /home/ubuntu/test/shared/test/test_cloudfront.rb:9:in `each'
        /home/ubuntu/test/shared/test/test_cloudfront.rb:9:in `test_cloudfront_limits'
```

## Testing story
* Ran unit test

