### PR TITLE
Add instructor_audience and participant_audience

### DIFF
--- a/apps/script/generateSharedConstants.rb
+++ b/apps/script/generateSharedConstants.rb
@@ -91,6 +91,8 @@ def main
         %w(
       PUBLISHED_STATE
       INSTRUCTION_TYPE
+      PARTICIPANT_AUDIENCE
+      INSTRUCTOR_AUDIENCE
     ),
       source_module: SharedCourseConstants, transform_keys: false
     ),

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -2,27 +2,31 @@
 #
 # Table name: scripts
 #
-#  id               :integer          not null, primary key
-#  name             :string(255)      not null
-#  created_at       :datetime
-#  updated_at       :datetime
-#  wrapup_video_id  :integer
-#  user_id          :integer
-#  login_required   :boolean          default(FALSE), not null
-#  properties       :text(65535)
-#  new_name         :string(255)
-#  family_name      :string(255)
-#  published_state  :string(255)      default("in_development")
-#  instruction_type :string(255)
+#  id                   :integer          not null, primary key
+#  name                 :string(255)      not null
+#  created_at           :datetime
+#  updated_at           :datetime
+#  wrapup_video_id      :integer
+#  user_id              :integer
+#  login_required       :boolean          default(FALSE), not null
+#  properties           :text(65535)
+#  new_name             :string(255)
+#  family_name          :string(255)
+#  published_state      :string(255)      default("in_development")
+#  instruction_type     :string(255)
+#  instructor_audience  :string(255)
+#  participant_audience :string(255)
 #
 # Indexes
 #
-#  index_scripts_on_family_name       (family_name)
-#  index_scripts_on_instruction_type  (instruction_type)
-#  index_scripts_on_name              (name) UNIQUE
-#  index_scripts_on_new_name          (new_name) UNIQUE
-#  index_scripts_on_published_state   (published_state)
-#  index_scripts_on_wrapup_video_id   (wrapup_video_id)
+#  index_scripts_on_family_name           (family_name)
+#  index_scripts_on_instruction_type      (instruction_type)
+#  index_scripts_on_instructor_audience   (instructor_audience)
+#  index_scripts_on_name                  (name) UNIQUE
+#  index_scripts_on_new_name              (new_name) UNIQUE
+#  index_scripts_on_participant_audience  (participant_audience)
+#  index_scripts_on_published_state       (published_state)
+#  index_scripts_on_wrapup_video_id       (wrapup_video_id)
 #
 
 require 'cdo/script_constants'
@@ -150,6 +154,8 @@ class Script < ApplicationRecord
 
   validates :published_state, acceptance: {accept: SharedCourseConstants::PUBLISHED_STATE.to_h.values.push(nil), message: 'must be nil, in_development, pilot, beta, preview or stable'}
   validates :instruction_type, acceptance: {accept: SharedCourseConstants::INSTRUCTION_TYPE.to_h.values.push(nil), message: 'must be nil, teacher_led or self_paced'}
+  validates :instructor_audience, acceptance: {accept: SharedCourseConstants::INSTRUCTOR_AUDIENCE.to_h.values.push(nil), message: 'must be nil, code.org admin, plc reviewer, facilitator, or teacher'}
+  validates :participant_audience, acceptance: {accept: SharedCourseConstants::PARTICIPANT_AUDIENCE.to_h.values.push(nil), message: 'must be nil, facilitator, teacher, or student'}
 
   def prevent_duplicate_levels
     reload

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -2,19 +2,23 @@
 #
 # Table name: unit_groups
 #
-#  id               :integer          not null, primary key
-#  name             :string(255)
-#  properties       :text(65535)
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
-#  published_state  :string(255)      default("in_development"), not null
-#  instruction_type :string(255)      default("teacher_led"), not null
+#  id                   :integer          not null, primary key
+#  name                 :string(255)
+#  properties           :text(65535)
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  published_state      :string(255)      default("in_development"), not null
+#  instruction_type     :string(255)      default("teacher_led"), not null
+#  instructor_audience  :string(255)      default("teacher"), not null
+#  participant_audience :string(255)      default("student"), not null
 #
 # Indexes
 #
-#  index_unit_groups_on_instruction_type  (instruction_type)
-#  index_unit_groups_on_name              (name)
-#  index_unit_groups_on_published_state   (published_state)
+#  index_unit_groups_on_instruction_type      (instruction_type)
+#  index_unit_groups_on_instructor_audience   (instructor_audience)
+#  index_unit_groups_on_name                  (name)
+#  index_unit_groups_on_participant_audience  (participant_audience)
+#  index_unit_groups_on_published_state       (published_state)
 #
 
 require 'cdo/script_constants'
@@ -54,7 +58,9 @@ class UnitGroup < ApplicationRecord
   end
 
   validates :published_state, acceptance: {accept: SharedCourseConstants::PUBLISHED_STATE.to_h.values, message: 'must be in_development, pilot, beta, preview or stable'}
-  validates :instruction_type, acceptance: {accept: SharedCourseConstants::INSTRUCTION_TYPE.to_h.values.push(nil), message: 'must be teacher_led or self_paced'}
+  validates :instruction_type, acceptance: {accept: SharedCourseConstants::INSTRUCTION_TYPE.to_h.values, message: 'must be teacher_led or self_paced'}
+  validates :instructor_audience, acceptance: {accept: SharedCourseConstants::INSTRUCTOR_AUDIENCE.to_h.values, message: 'must be code.org admin, plc reviewer, facilitator, or teacher'}
+  validates :participant_audience, acceptance: {accept: SharedCourseConstants::PARTICIPANT_AUDIENCE.to_h.values, message: 'must be facilitator, teacher, or student'}
 
   def skip_name_format_validation
     !!plc_course

--- a/dashboard/db/migrate/20211022020848_add_audiences_to_script_and_unit_group.rb
+++ b/dashboard/db/migrate/20211022020848_add_audiences_to_script_and_unit_group.rb
@@ -1,0 +1,21 @@
+class AddAudiencesToScriptAndUnitGroup < ActiveRecord::Migration[5.2]
+  def up
+    add_column :scripts, :instructor_audience, :string
+    add_column :scripts, :participant_audience, :string
+    add_index :scripts, :instructor_audience
+    add_index :scripts, :participant_audience
+
+    add_column :unit_groups, :instructor_audience, :string, null: false, default: 'teacher'
+    add_column :unit_groups, :participant_audience, :string, null: false, default: 'student'
+    add_index :unit_groups, :instructor_audience
+    add_index :unit_groups, :participant_audience
+  end
+
+  def down
+    remove_column :unit_groups, :instructor_audience
+    remove_column :unit_groups, :participant_audience
+
+    remove_column :scripts, :instructor_audience
+    remove_column :scripts, :participant_audience
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_16_020346) do
+ActiveRecord::Schema.define(version: 2021_10_22_020848) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -1557,10 +1557,14 @@ ActiveRecord::Schema.define(version: 2021_10_16_020346) do
     t.string "family_name"
     t.string "published_state", default: "in_development"
     t.string "instruction_type"
+    t.string "instructor_audience"
+    t.string "participant_audience"
     t.index ["family_name"], name: "index_scripts_on_family_name"
     t.index ["instruction_type"], name: "index_scripts_on_instruction_type"
+    t.index ["instructor_audience"], name: "index_scripts_on_instructor_audience"
     t.index ["name"], name: "index_scripts_on_name", unique: true
     t.index ["new_name"], name: "index_scripts_on_new_name", unique: true
+    t.index ["participant_audience"], name: "index_scripts_on_participant_audience"
     t.index ["published_state"], name: "index_scripts_on_published_state"
     t.index ["wrapup_video_id"], name: "index_scripts_on_wrapup_video_id"
   end
@@ -1783,8 +1787,12 @@ ActiveRecord::Schema.define(version: 2021_10_16_020346) do
     t.datetime "updated_at", null: false
     t.string "published_state", default: "in_development", null: false
     t.string "instruction_type", default: "teacher_led", null: false
+    t.string "instructor_audience", default: "teacher", null: false
+    t.string "participant_audience", default: "student", null: false
     t.index ["instruction_type"], name: "index_unit_groups_on_instruction_type"
+    t.index ["instructor_audience"], name: "index_unit_groups_on_instructor_audience"
     t.index ["name"], name: "index_unit_groups_on_name"
+    t.index ["participant_audience"], name: "index_unit_groups_on_participant_audience"
     t.index ["published_state"], name: "index_unit_groups_on_published_state"
   end
 

--- a/lib/cdo/shared_constants/curriculum/shared_course_constants.rb
+++ b/lib/cdo/shared_constants/curriculum/shared_course_constants.rb
@@ -17,4 +17,23 @@ module SharedCourseConstants
       self_paced: "self_paced"
     }
   ).freeze
+
+  # Used to determine who can teach a course
+  INSTRUCTOR_AUDIENCE = OpenStruct.new(
+    {
+      code_admin: "code_admin",
+      plc_reviewer: "plc_reviewer",
+      facilitator: "facilitator",
+      teacher: "teacher"
+    }
+  ).freeze
+
+  # Used to determine who the learners are in a course
+  PARTICIPANT_AUDIENCE = OpenStruct.new(
+    {
+      facilitator: "facilitator",
+      teacher: "teacher",
+      student: "student"
+    }
+  ).freeze
 end


### PR DESCRIPTION
Creates the instructor_audience and participant_audience fields on Script and UnitGroup. These will be used to determine who is teaching a course and who is learning in a course. See the product spec and eng plan for more details.

## Links

- [First step of Part 2 of Eng Plan](https://docs.google.com/document/d/1V61xONU0-mleMEEdHWNxhvZtYIPRCB31mT_hbUXusCQ/edit#)
- [Product Spec](https://docs.google.com/document/d/1qZpc90daxQiiqpcQUiUiGV2tQoaYEQUzOA72UZzBlVE/edit#)
- [Jira](https://codedotorg.atlassian.net/browse/PLAT-1342)

## Testing story

- Ran migration
