### PR TITLE
[Spritelab|Poetry] add id to pause button for callout

### DIFF
--- a/apps/src/templates/PauseButton.jsx
+++ b/apps/src/templates/PauseButton.jsx
@@ -42,6 +42,7 @@ class PauseButton extends React.Component {
         style={buttonStyle}
         disabled={!this.props.isRunning}
         className="no-focus-outline"
+        id="pauseButton"
       >
         <div style={styles.container}>
           <i


### PR DESCRIPTION
This element needs to have an id so that curriculum writers can attach a callout to it.