### PR TITLE
Javalab: add refresh button to code review

### DIFF
--- a/apps/i18n/javalab/en_us.json
+++ b/apps/i18n/javalab/en_us.json
@@ -78,6 +78,7 @@
   "noOtherReviews": "No other projects are ready for review yet.",
   "onlyVisibleToYou": "teacher comments are only visible to you",
   "programCompleted": "Program completed.",
+  "refresh": "Refresh",
   "reOpen": "Re-open",
   "replace": "Replace",
   "reviewClassmateProject": "Review a classmate’s project...",

--- a/apps/src/templates/instructions/ReviewTab.jsx
+++ b/apps/src/templates/instructions/ReviewTab.jsx
@@ -491,7 +491,6 @@ const styles = {
   },
   refreshButtonStyle: {
     margin: '10px 0',
-    fontSize: 13,
-    padding: '0 15px'
+    fontSize: 13
   }
 };

--- a/apps/src/templates/instructions/ReviewTab.jsx
+++ b/apps/src/templates/instructions/ReviewTab.jsx
@@ -382,12 +382,14 @@ class ReviewTab extends Component {
 
     return (
       <div style={styles.reviewsContainer}>
-        <div>
+        <div style={styles.refreshButtonContainer}>
           <Button
             key="refresh"
-            text="refresh"
+            icon="refresh"
+            text={javalabMsg.refresh()}
             onClick={this.onClickRefresh}
-            color="gray"
+            color={Button.ButtonColor.blue}
+            style={styles.refreshButtonStyle}
           />
         </div>
         <div style={styles.reviewHeader}>
@@ -443,7 +445,7 @@ const styles = {
     justifyContent: 'center'
   },
   reviewsContainer: {
-    margin: '25px 5%'
+    margin: '0px 5% 25px 5%'
   },
   reviewCheckboxRow: {
     margin: 0,
@@ -482,5 +484,14 @@ const styles = {
   },
   reviewDisabledText: {
     fontStyle: 'italic'
+  },
+  refreshButtonContainer: {
+    display: 'flex',
+    justifyContent: 'end'
+  },
+  refreshButtonStyle: {
+    margin: '10px 0',
+    fontSize: 13,
+    padding: '0 15px'
   }
 };

--- a/apps/test/unit/templates/instructions/ReviewTabTest.jsx
+++ b/apps/test/unit/templates/instructions/ReviewTabTest.jsx
@@ -9,6 +9,7 @@ import Comment from '@cdo/apps/templates/instructions/codeReview/Comment';
 import CommentEditor from '@cdo/apps/templates/instructions/codeReview/CommentEditor';
 import ReviewNavigator from '@cdo/apps/templates/instructions/codeReview/ReviewNavigator';
 import Spinner from '@cdo/apps/code-studio/pd/components/spinner';
+import Button from '@cdo/apps/templates/Button';
 
 describe('Code Review Tab', () => {
   const token = 'token';
@@ -69,21 +70,21 @@ describe('Code Review Tab', () => {
       );
     });
 
-    it('renders loading spinner before initial load is completed', () => {
+    it('renders loading spinner before load is completed', () => {
       expect(wrapper.find(Spinner).length).to.equal(1);
     });
 
-    it('calls onLoadComplete callback after initial load is completed', () => {
+    it('calls onLoadComplete callback after load is completed', () => {
       onLoadComplete.resetHistory();
       sinon.assert.notCalled(onLoadComplete);
 
-      wrapper.setState({initialLoadCompleted: true});
+      wrapper.setState({loadingReviewData: false});
       sinon.assert.calledOnce(onLoadComplete);
     });
 
     describe('after load', () => {
       beforeEach(() => {
-        wrapper.setState({initialLoadCompleted: true});
+        wrapper.setState({loadingReviewData: false});
       });
 
       it('renders without error if project has no comments', () => {
@@ -277,6 +278,17 @@ describe('Code Review Tab', () => {
       it('shows the ReviewNavigator if viewing own project', () => {
         expect(wrapper.find(ReviewNavigator).length).to.equal(1);
       });
+
+      it('reloads data on clicking refresh button', () => {
+        expect(wrapper.state().loadingReviewData).to.be.false;
+        expect(wrapper.find(Button).length).to.equal(1);
+        wrapper
+          .find(Button)
+          .first()
+          .simulate('click');
+
+        expect(wrapper.state().loadingReviewData).to.be.true;
+      });
     });
   });
 
@@ -301,7 +313,7 @@ describe('Code Review Tab', () => {
         reviewEnabled: false
       });
 
-      wrapper.setState({initialLoadCompleted: true});
+      wrapper.setState({loadingReviewData: false});
       expect(wrapper.find(CommentEditor).length).to.equal(1);
     });
 

--- a/apps/test/unit/templates/instructions/ReviewTabTest.jsx
+++ b/apps/test/unit/templates/instructions/ReviewTabTest.jsx
@@ -285,7 +285,7 @@ describe('Code Review Tab', () => {
         wrapper
           .find(Button)
           .first()
-          .simulate('click');
+          .invoke('onClick')();
 
         expect(wrapper.state().loadingReviewData).to.be.true;
       });


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Adds a refresh button to the code review tab. This refreshes all data in the tab that is initially loaded when switching over to the tab.

![Screen Shot 2021-10-22 at 4 05 35 PM](https://user-images.githubusercontent.com/85528507/138523179-841a8dca-cb38-4169-a2ae-141cb113f419.png)


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

JIRA: https://codedotorg.atlassian.net/browse/CSA-962

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

Tested locally - checked that new comments and/or updates to comment state appear after clicking refresh.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
