### PR TITLE
[Poetry][HOC] Add Google Analytics for poem choice

### DIFF
--- a/apps/src/p5lab/poetry/Poetry.js
+++ b/apps/src/p5lab/poetry/Poetry.js
@@ -1,5 +1,6 @@
 import msg from '@cdo/poetry/locale';
 import {getStore} from '@cdo/apps/redux';
+import trackEvent from '@cdo/apps/util/trackEvent';
 import {setPoem} from '../redux/poetry';
 import {P5LabType} from '../constants';
 import SpriteLab from '../spritelab/SpriteLab';
@@ -34,6 +35,13 @@ export default class Poetry extends SpriteLab {
       return;
     }
     return new PoetryLibrary(args.p5);
+  }
+
+  runButtonClick() {
+    super.runButtonClick();
+    const poem = getPoem(getStore().getState().poetry?.selectedPoem?.key);
+    const poemTitle = poem ? poem.title : 'Custom';
+    trackEvent('HoC_Poem', 'Play-2021', poemTitle);
   }
 
   preloadInstructorImage() {


### PR DESCRIPTION
Modeled after https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/dance/Dance.js#L542

If students enter their own poem, the logged event will have the value `"Custom"`. I think this will make it easier to track usage than if we had separate events for every student's poem title, but @KylieModen lmk if that's not what you had in mind.

[jira](https://codedotorg.atlassian.net/browse/STAR-1794)