### PR TITLE
Code Review Groups: Use better IDs in drag and drop

### DIFF
--- a/apps/src/templates/codeReviewGroups/CodeReviewGroup.jsx
+++ b/apps/src/templates/codeReviewGroups/CodeReviewGroup.jsx
@@ -9,18 +9,18 @@ import CodeReviewGroupMember from './CodeReviewGroupMember';
 // These are called "Droppables" in the package we're using (React Beautiful DnD).
 // More information on React Beautiful DnD can be found here:
 // https://github.com/atlassian/react-beautiful-dnd
-export default function CodeReviewGroup({members, index}) {
+export default function CodeReviewGroup({group}) {
   return (
-    <Droppable key={index} droppableId={`${index}`}>
+    <Droppable key={group.droppableId} droppableId={group.droppableId}>
       {(provided, snapshot) => (
         <div
           ref={provided.innerRef}
           style={getListStyle(snapshot.isDraggingOver)}
           {...provided.droppableProps}
         >
-          {members.map((member, index) => (
+          {group.members.map((member, index) => (
             <CodeReviewGroupMember
-              key={member.id}
+              key={member.followerId}
               member={member}
               index={index}
             />
@@ -34,8 +34,7 @@ export default function CodeReviewGroup({members, index}) {
 
 // TO DO: specify shape of members
 CodeReviewGroup.propTypes = {
-  members: PropTypes.array.isRequired,
-  index: PropTypes.number.isRequired
+  group: PropTypes.object.isRequired
 };
 
 const getListStyle = isDraggingOver => ({

--- a/apps/src/templates/codeReviewGroups/CodeReviewGroup.jsx
+++ b/apps/src/templates/codeReviewGroups/CodeReviewGroup.jsx
@@ -9,20 +9,21 @@ import CodeReviewGroupMember from './CodeReviewGroupMember';
 // These are called "Droppables" in the package we're using (React Beautiful DnD).
 // More information on React Beautiful DnD can be found here:
 // https://github.com/atlassian/react-beautiful-dnd
-export default function CodeReviewGroup({group}) {
+export default function CodeReviewGroup({droppableId, members}) {
   return (
-    <Droppable key={group.droppableId} droppableId={group.droppableId}>
+    <Droppable key={droppableId} droppableId={droppableId}>
       {(provided, snapshot) => (
         <div
           ref={provided.innerRef}
           style={getListStyle(snapshot.isDraggingOver)}
           {...provided.droppableProps}
         >
-          {group.members.map((member, index) => (
+          {members.map((member, index) => (
             <CodeReviewGroupMember
-              key={member.followerId}
-              member={member}
+              followerId={member.followerId}
+              name={member.name}
               index={index}
+              key={member.followerId}
             />
           ))}
           {provided.placeholder}
@@ -32,9 +33,11 @@ export default function CodeReviewGroup({group}) {
   );
 }
 
-// TO DO: specify shape of members
+// Each group needs a unique droppableId (rather than a database-provided group ID)
+// so that we can create new groups on the fly without any interaction with our backend.
 CodeReviewGroup.propTypes = {
-  group: PropTypes.object.isRequired
+  droppableId: PropTypes.string.isRequired,
+  members: PropTypes.array.isRequired
 };
 
 const getListStyle = isDraggingOver => ({

--- a/apps/src/templates/codeReviewGroups/CodeReviewGroupMember.jsx
+++ b/apps/src/templates/codeReviewGroups/CodeReviewGroupMember.jsx
@@ -9,11 +9,11 @@ import {grid} from './CodeReviewGroup';
 // These are called "Draggables" in the package we're using (React Beautiful DnD).
 // More information on React Beautiful DnD can be found here:
 // https://github.com/atlassian/react-beautiful-dnd
-export default function CodeReviewGroupMember({member, index}) {
+export default function CodeReviewGroupMember({followerId, name, index}) {
   return (
     <Draggable
-      key={member.followerId}
-      draggableId={member.followerId.toString()}
+      key={followerId}
+      draggableId={followerId.toString()}
       index={index}
       tab-index={index}
     >
@@ -33,7 +33,7 @@ export default function CodeReviewGroupMember({member, index}) {
               justifyContent: 'space-around'
             }}
           >
-            {member.name}
+            {name}
           </div>
         </div>
       )}
@@ -41,9 +41,9 @@ export default function CodeReviewGroupMember({member, index}) {
   );
 }
 
-// TO DO: should specify shape of member -- needs ID and content property that can be rendered.
 CodeReviewGroupMember.propTypes = {
-  member: PropTypes.object.isRequired,
+  followerId: PropTypes.number.isRequired,
+  name: PropTypes.string.isRequired,
   index: PropTypes.number.isRequired
 };
 

--- a/apps/src/templates/codeReviewGroups/CodeReviewGroupMember.jsx
+++ b/apps/src/templates/codeReviewGroups/CodeReviewGroupMember.jsx
@@ -12,8 +12,8 @@ import {grid} from './CodeReviewGroup';
 export default function CodeReviewGroupMember({member, index}) {
   return (
     <Draggable
-      key={member.id}
-      draggableId={member.id}
+      key={member.followerId}
+      draggableId={member.followerId.toString()}
       index={index}
       tab-index={index}
     >
@@ -22,7 +22,7 @@ export default function CodeReviewGroupMember({member, index}) {
           ref={provided.innerRef}
           {...provided.draggableProps}
           {...provided.dragHandleProps}
-          style={getItemStyle(
+          style={getMemberStyle(
             snapshot.isDragging,
             provided.draggableProps.style
           )}
@@ -47,8 +47,8 @@ CodeReviewGroupMember.propTypes = {
   index: PropTypes.number.isRequired
 };
 
-const getItemStyle = (isDragging, draggableStyle) => ({
-  // some basic styles to make the items look a bit nicer
+const getMemberStyle = (isDragging, draggableStyle) => ({
+  // some basic styles to make the group members look a bit nicer
   userSelect: 'none',
   padding: grid * 2,
   margin: grid,

--- a/apps/src/templates/codeReviewGroups/CodeReviewGroups.jsx
+++ b/apps/src/templates/codeReviewGroups/CodeReviewGroups.jsx
@@ -1,46 +1,61 @@
 import React, {useState} from 'react';
 import PropTypes from 'prop-types';
 import {DragDropContext} from 'react-beautiful-dnd';
+import _ from 'lodash';
 import CodeReviewGroup from './CodeReviewGroup';
+
+const DROPPABLE_ID_PREFIX = 'groupId';
 
 // Provides "drag and drop context" that allows us to drag
 // code review group members between groups as teachers arrange their students into code review groups.
 // More information on the package we're using here (React Beautiful DnD)
 // can be found here:
 // https://github.com/atlassian/react-beautiful-dnd
-export default function CodeReviewGroups({groups}) {
-  const [state, setState] = useState(groups);
+export default function CodeReviewGroups({initialGroups}) {
+  const [groups, setGroups] = useState(
+    initialGroups.map(group => addDroppableIdToGroup(group))
+  );
+
+  const getGroup = droppableId =>
+    _.find(groups, group => group.droppableId === droppableId);
 
   function onDragEnd(result) {
     const {source, destination} = result;
-    const sourceId = +source.droppableId;
+    const sourceId = source.droppableId;
 
     // dropped outside the group
     if (!destination) {
       return;
     }
 
-    const destinationId = +destination.droppableId;
+    const destinationId = destination.droppableId;
 
     if (sourceId === destinationId) {
-      // If an item was dropped in its current group.
-      const items = reorder(state[sourceId], source.index, destination.index);
-      const newState = [...state];
-      newState[sourceId] = items;
-      setState(newState);
-    } else {
-      // If an item was dropped in a different group.
-      const result = move(
-        state[sourceId],
-        state[destinationId],
-        source,
-        destination
+      // If a member was dropped in its current group.
+      const result = reorder(
+        getGroup(sourceId),
+        source.index,
+        destination.index
       );
-      const newState = [...state];
-      newState[sourceId] = result[sourceId];
-      newState[destinationId] = result[destinationId];
 
-      setState(newState.filter(group => group.length));
+      const newGroups = [...groups];
+      updateGroups(newGroups, result);
+      setGroups(newGroups);
+    } else {
+      // If a member was dropped in a different group.
+      const result = move(
+        getGroup(sourceId),
+        getGroup(destinationId),
+        source.index,
+        destination.index
+      );
+
+      const newGroups = [...groups];
+      updateGroups(newGroups, result.updatedSource);
+      updateGroups(newGroups, result.updatedDest);
+
+      // Remove any blank groups
+      setGroups(newGroups.filter(group => group.members.length));
     }
   }
 
@@ -49,50 +64,73 @@ export default function CodeReviewGroups({groups}) {
       <button
         type="button"
         onClick={() => {
-          setState([[], ...state]);
+          setGroups([generateNewGroup(), ...groups]);
         }}
       >
         Add new group
       </button>
       <div style={styles.groupsContainer}>
         <DragDropContext onDragEnd={onDragEnd}>
-          {state.map((groupMembers, groupIndex) => (
-            <CodeReviewGroup
-              key={groupIndex}
-              members={groupMembers}
-              index={groupIndex}
-            />
-          ))}
+          {groups.map((group, index) => {
+            return <CodeReviewGroup key={group.droppableId} group={group} />;
+          })}
         </DragDropContext>
       </div>
     </div>
   );
 }
 
-CodeReviewGroups.propTypes = {groups: PropTypes.array.isRequired};
+CodeReviewGroups.propTypes = {initialGroups: PropTypes.array.isRequired};
 
-// Reorders items in a group if item dragged elsewhere in the same group.
-const reorder = (list, startIndex, endIndex) => {
-  const result = Array.from(list);
-  const [removed] = result.splice(startIndex, 1);
-  result.splice(endIndex, 0, removed);
+// Reorders members in a group if member dragged elsewhere in the same group.
+// Returns a copied, updated group.
+const reorder = (group, startIndex, endIndex) => {
+  const result = {...group};
+  const [removed] = result.members.splice(startIndex, 1);
+  result.members.splice(endIndex, 0, removed);
 
   return result;
 };
 
-// Moves an item from one group to another group.
-const move = (source, destination, droppableSource, droppableDestination) => {
-  const sourceClone = Array.from(source);
-  const destClone = Array.from(destination);
-  const [removed] = sourceClone.splice(droppableSource.index, 1);
+// Moves an member from one group to another group.
+// Returns copies of both updated groups.
+const move = (
+  source,
+  destination,
+  droppableSourceIndex,
+  droppableDestinationIndex
+) => {
+  const updatedSource = {...source};
+  const updatedDest = {...destination};
+  const [removed] = updatedSource.members.splice(droppableSourceIndex, 1);
 
-  destClone.splice(droppableDestination.index, 0, removed);
+  updatedDest.members.splice(droppableDestinationIndex, 0, removed);
 
-  const result = {};
-  result[droppableSource.droppableId] = sourceClone;
-  result[droppableDestination.droppableId] = destClone;
+  return {updatedSource, updatedDest};
+};
 
-  return result;
+// Replaces one element in an existing list of groups
+// with an updated version of the group (ie, with more, less, or reordered members).
+const updateGroups = (existingGroups, newGroup) => {
+  const updatedGroupIndex = existingGroups.findIndex(
+    group => group.droppableId === newGroup.droppableId
+  );
+  existingGroups[updatedGroupIndex] = newGroup;
+};
+
+const addDroppableIdToGroup = group => {
+  group.droppableId = `${DROPPABLE_ID_PREFIX}${group.id}`;
+  return group;
+};
+
+// TO DO: present a modal that allows a user to select a group name before creating it.
+// We need to generate a unique identifier for each group that is generated on the client
+// before we save it -- use a timestamp for this unique identifier.
+const generateNewGroup = () => {
+  return {
+    droppableId: `${DROPPABLE_ID_PREFIX}${new Date().getTime()}`,
+    members: []
+  };
 };
 
 const styles = {

--- a/apps/src/templates/codeReviewGroups/CodeReviewGroups.jsx
+++ b/apps/src/templates/codeReviewGroups/CodeReviewGroups.jsx
@@ -71,8 +71,14 @@ export default function CodeReviewGroups({initialGroups}) {
       </button>
       <div style={styles.groupsContainer}>
         <DragDropContext onDragEnd={onDragEnd}>
-          {groups.map((group, index) => {
-            return <CodeReviewGroup key={group.droppableId} group={group} />;
+          {groups.map(group => {
+            return (
+              <CodeReviewGroup
+                droppableId={group.droppableId}
+                members={group.members}
+                key={group.droppableId}
+              />
+            );
           })}
         </DragDropContext>
       </div>

--- a/apps/src/templates/codeReviewGroups/CodeReviewGroups.jsx
+++ b/apps/src/templates/codeReviewGroups/CodeReviewGroups.jsx
@@ -38,9 +38,8 @@ export default function CodeReviewGroups({initialGroups}) {
         destination.index
       );
 
-      const newGroups = [...groups];
-      updateGroups(newGroups, result);
-      setGroups(newGroups);
+      const updatedGroups = updateGroups(groups, [result]);
+      setGroups(updatedGroups);
     } else {
       // If a member was dropped in a different group.
       const result = move(
@@ -50,12 +49,13 @@ export default function CodeReviewGroups({initialGroups}) {
         destination.index
       );
 
-      const newGroups = [...groups];
-      updateGroups(newGroups, result.updatedSource);
-      updateGroups(newGroups, result.updatedDest);
+      const updatedGroups = updateGroups(groups, [
+        result.updatedSource,
+        result.updatedDest
+      ]);
 
       // Remove any blank groups
-      setGroups(newGroups.filter(group => group.members.length));
+      setGroups(updatedGroups.filter(group => group.members.length));
     }
   }
 
@@ -115,13 +115,19 @@ const move = (
   return {updatedSource, updatedDest};
 };
 
-// Replaces one element in an existing list of groups
-// with an updated version of the group (ie, with more, less, or reordered members).
-const updateGroups = (existingGroups, newGroup) => {
-  const updatedGroupIndex = existingGroups.findIndex(
-    group => group.droppableId === newGroup.droppableId
-  );
-  existingGroups[updatedGroupIndex] = newGroup;
+// Returns a copied list of groups
+// with updated versions of the provided changedGroups (ie, with more, less, or reordered members).
+const updateGroups = (groups, changedGroups) => {
+  const updatedGroups = [...groups];
+
+  changedGroups.forEach(changedGroup => {
+    const updatedGroupIndex = updatedGroups.findIndex(
+      group => group.droppableId === changedGroup.droppableId
+    );
+    updatedGroups[updatedGroupIndex] = changedGroup;
+  });
+
+  return updatedGroups;
 };
 
 const addDroppableIdToGroup = group => {

--- a/apps/src/templates/codeReviewGroups/CodeReviewGroups.story.jsx
+++ b/apps/src/templates/codeReviewGroups/CodeReviewGroups.story.jsx
@@ -16,11 +16,18 @@ const names = [
 // Returns an array of objects that can be used to render a group.
 // Offset will creating objects starting at the offset indexed
 // element in the names array above, rather than the first element (default).
-const getItems = (count, offset = 0) =>
+const getMembers = (count, offset = 0) =>
   Array.from({length: count}, (v, k) => k).map(k => ({
-    id: names[k + offset],
+    followerId: k + offset,
     name: names[k + offset]
   }));
+
+// Create two groups of four people.
+// We'll also eventually pass in a group name as a top level property.
+const groups = [
+  {id: 1, members: getMembers(4)},
+  {id: 2, members: getMembers(4, 4)}
+];
 
 export default storybook => {
   storybook
@@ -28,7 +35,7 @@ export default storybook => {
     .addStoryTable([
       {
         name: 'Panel Showing Existing Code Review Groups',
-        story: () => <CodeReviewGroups groups={[getItems(4), getItems(4, 4)]} />
+        story: () => <CodeReviewGroups initialGroups={groups} />
       }
     ]);
 };


### PR DESCRIPTION
The prototype version of drag and drop code review groups relies on the [group index as it appears in the array of groups](https://github.com/code-dot-org/code-dot-org/blob/b86429f2c8cf38820abf191756d1a37fbbd5c6c1/apps/src/templates/codeReviewGroups/CodeReviewGroup.jsx#L14) as a unique identifier for each group. This PR moves to using a string identifier (`groupId#`) for each group, and is implemented in such a way that new groups can be created with unique IDs (based on a timestamp), which we'll need when creating groups as teachers are editing their code review group setup.

## Testing story

Still waiting on figuring out how to test this with Enzyme, so just hand tested for now that I could move members within groups, between groups, and create new groups.