### PR TITLE
[Google Blockly][Poetry] Don't use sharedFunctions in Poetry

### DIFF
--- a/apps/src/p5lab/poetry/PoetryLibrary.js
+++ b/apps/src/p5lab/poetry/PoetryLibrary.js
@@ -6,6 +6,7 @@ import {POEMS} from './constants';
 import * as utils from './commands/utils';
 import {commands as backgroundEffects} from './commands/backgroundEffects';
 import {commands as foregroundEffects} from './commands/foregroundEffects';
+import {commands as behaviors} from './commands/behaviors';
 import spritelabCommands from '../spritelab/commands/index';
 
 const OUTER_MARGIN = 50;
@@ -229,7 +230,8 @@ export default class PoetryLibrary extends CoreLibrary {
       },
 
       ...backgroundEffects,
-      ...foregroundEffects
+      ...foregroundEffects,
+      ...behaviors
     };
   }
 

--- a/apps/src/p5lab/poetry/commands/behaviors.js
+++ b/apps/src/p5lab/poetry/commands/behaviors.js
@@ -1,0 +1,110 @@
+import * as utils from './utils';
+
+export const commands = {
+  fluttering(spriteArg) {
+    const sprite = this.getSpriteArray(spriteArg)[0];
+    sprite.y += utils.randomInt(-1, 1);
+  },
+  growing(spriteArg) {
+    const sprite = this.getSpriteArray(spriteArg)[0];
+    sprite.setScale(sprite.getScale() + 1 / 100);
+  },
+  jittering(spriteArg) {
+    const sprite = this.getSpriteArray(spriteArg)[0];
+    sprite.setScale(sprite.getScale() + utils.randomInt(-1, 1) / 100);
+  },
+  moving_north_and_looping(spriteArg) {
+    const sprite = this.getSpriteArray(spriteArg)[0];
+    sprite.y -= sprite.speed;
+    if (sprite.y < -50) {
+      sprite.y = 450;
+    }
+  },
+  moving_south_and_looping(spriteArg) {
+    const sprite = this.getSpriteArray(spriteArg)[0];
+    sprite.y += sprite.speed;
+    if (sprite.y > 450) {
+      sprite.y = -50;
+    }
+  },
+  moving_east_and_looping(spriteArg) {
+    const sprite = this.getSpriteArray(spriteArg)[0];
+    sprite.mirrorX(1);
+
+    sprite.x += sprite.speed;
+    if (sprite.x > 450) {
+      sprite.x = -50;
+    }
+  },
+  moving_west_and_looping(spriteArg) {
+    const sprite = this.getSpriteArray(spriteArg)[0];
+    sprite.mirrorX(-1);
+
+    sprite.x -= sprite.speed;
+    if (sprite.x < -50) {
+      sprite.x = 450;
+    }
+  },
+  shrinking(spriteArg) {
+    const sprite = this.getSpriteArray(spriteArg)[0];
+    sprite.setScale(sprite.getScale() - 1 / 100);
+  },
+  spinning_left(spriteArg) {
+    const sprite = this.getSpriteArray(spriteArg)[0];
+    sprite.rotation -= 6;
+  },
+  spinning_right(spriteArg) {
+    const sprite = this.getSpriteArray(spriteArg)[0];
+    sprite.rotation += 6;
+  },
+  swimming_left_and_right(spriteArg) {
+    if (!this.p5.edges) {
+      this.p5.createEdgeSprites();
+    }
+
+    const sprite = this.getSpriteArray(spriteArg)[0];
+    if (sprite.direction === 0) {
+      sprite.mirrorX(1);
+    } else if (sprite.direction === 180) {
+      sprite.mirrorX(-1);
+    }
+    let direction = sprite.direction % 360;
+    sprite.x += sprite.speed * Math.cos((direction * Math.PI) / 180);
+    sprite.y += sprite.speed * Math.sin((direction * Math.PI) / 180);
+
+    if (sprite.isTouching(this.p5.edges)) {
+      this.p5.edges.displace(sprite);
+      sprite.direction = (sprite.direction + 180) % 360;
+    }
+  },
+  wandering(spriteArg) {
+    if (!this.p5.edges) {
+      this.p5.createEdgeSprites();
+    }
+
+    const sprite = this.getSpriteArray(spriteArg)[0];
+    if (utils.randomInt(0, 100) < 20) {
+      sprite.direction = (sprite.direction + utils.randomInt(-25, 25)) % 360;
+    }
+
+    let direction = sprite.direction % 360;
+    sprite.x += sprite.speed * Math.cos((direction * Math.PI) / 180);
+    sprite.y += sprite.speed * Math.sin((direction * Math.PI) / 180);
+
+    if (sprite.isTouching(this.p5.edges)) {
+      this.p5.edges.displace(sprite);
+      sprite.direction = (sprite.direction + utils.randomInt(135, 225)) % 360;
+    }
+    if (sprite.direction > 270 || sprite.direction < 90) {
+      sprite.mirrorX(1);
+    } else {
+      sprite.mirrorX(-1);
+    }
+  },
+  wobbling(spriteArg) {
+    const sprite = this.getSpriteArray(spriteArg)[0];
+    if (utils.randomInt(0, 100) < 50) {
+      sprite.rotation = utils.randomInt(-1, 1);
+    }
+  }
+};

--- a/apps/src/p5lab/poetry/commands/behaviors.js
+++ b/apps/src/p5lab/poetry/commands/behaviors.js
@@ -1,18 +1,25 @@
 import * as utils from './utils';
 
+// These functions are duplicated from https://levelbuilder-studio.code.org/functions
+// In Sprite Lab, behaviors are defined using blockly so that students can edit
+// the behavior functions. In Poetry, we just need the function definitions, we don't
+// need them to be editable by students.
 export const commands = {
   fluttering(spriteArg) {
     const sprite = this.getSpriteArray(spriteArg)[0];
     sprite.y += utils.randomInt(-1, 1);
   },
+
   growing(spriteArg) {
     const sprite = this.getSpriteArray(spriteArg)[0];
     sprite.setScale(sprite.getScale() + 1 / 100);
   },
+
   jittering(spriteArg) {
     const sprite = this.getSpriteArray(spriteArg)[0];
     sprite.setScale(sprite.getScale() + utils.randomInt(-1, 1) / 100);
   },
+
   moving_north_and_looping(spriteArg) {
     const sprite = this.getSpriteArray(spriteArg)[0];
     sprite.y -= sprite.speed;
@@ -20,6 +27,7 @@ export const commands = {
       sprite.y = 450;
     }
   },
+
   moving_south_and_looping(spriteArg) {
     const sprite = this.getSpriteArray(spriteArg)[0];
     sprite.y += sprite.speed;
@@ -27,6 +35,7 @@ export const commands = {
       sprite.y = -50;
     }
   },
+
   moving_east_and_looping(spriteArg) {
     const sprite = this.getSpriteArray(spriteArg)[0];
     sprite.mirrorX(1);
@@ -36,6 +45,7 @@ export const commands = {
       sprite.x = -50;
     }
   },
+
   moving_west_and_looping(spriteArg) {
     const sprite = this.getSpriteArray(spriteArg)[0];
     sprite.mirrorX(-1);
@@ -45,18 +55,22 @@ export const commands = {
       sprite.x = 450;
     }
   },
+
   shrinking(spriteArg) {
     const sprite = this.getSpriteArray(spriteArg)[0];
     sprite.setScale(sprite.getScale() - 1 / 100);
   },
+
   spinning_left(spriteArg) {
     const sprite = this.getSpriteArray(spriteArg)[0];
     sprite.rotation -= 6;
   },
+
   spinning_right(spriteArg) {
     const sprite = this.getSpriteArray(spriteArg)[0];
     sprite.rotation += 6;
   },
+
   swimming_left_and_right(spriteArg) {
     if (!this.p5.edges) {
       this.p5.createEdgeSprites();
@@ -77,6 +91,7 @@ export const commands = {
       sprite.direction = (sprite.direction + 180) % 360;
     }
   },
+
   wandering(spriteArg) {
     if (!this.p5.edges) {
       this.p5.createEdgeSprites();
@@ -101,6 +116,7 @@ export const commands = {
       sprite.mirrorX(-1);
     }
   },
+
   wobbling(spriteArg) {
     const sprite = this.getSpriteArray(spriteArg)[0];
     if (utils.randomInt(0, 100) < 50) {

--- a/dashboard/config/scripts/levels/New Poetry Project.level
+++ b/dashboard/config/scripts/levels/New Poetry Project.level
@@ -21,7 +21,7 @@
     "disable_param_editing": "true",
     "hide_share_and_remix": "false",
     "disable_if_else_editing": "false",
-    "include_shared_functions": "true",
+    "include_shared_functions": "false",
     "free_play": "true",
     "validation_enabled": "false",
     "show_debug_watch": "false",

--- a/dashboard/config/scripts/levels/poetry_hoc_addSprites.level
+++ b/dashboard/config/scripts/levels/poetry_hoc_addSprites.level
@@ -25,7 +25,7 @@
     "disable_param_editing": "true",
     "hide_share_and_remix": "true",
     "disable_if_else_editing": "false",
-    "include_shared_functions": "true",
+    "include_shared_functions": "false",
     "free_play": "false",
     "start_in_animation_tab": "false",
     "all_animations_single_frame": "true",

--- a/dashboard/config/scripts/levels/poetry_hoc_backgroundEffects.level
+++ b/dashboard/config/scripts/levels/poetry_hoc_backgroundEffects.level
@@ -25,7 +25,7 @@
     "never_autoplay_video": "false",
     "disable_param_editing": "true",
     "disable_if_else_editing": "false",
-    "include_shared_functions": "true",
+    "include_shared_functions": "false",
     "free_play": "false",
     "show_debug_watch": "true",
     "expand_debugger": "false",

--- a/dashboard/config/scripts/levels/poetry_hoc_events1.level
+++ b/dashboard/config/scripts/levels/poetry_hoc_events1.level
@@ -25,7 +25,7 @@
     "never_autoplay_video": "false",
     "disable_param_editing": "true",
     "disable_if_else_editing": "false",
-    "include_shared_functions": "true",
+    "include_shared_functions": "false",
     "free_play": "false",
     "show_debug_watch": "true",
     "expand_debugger": "false",

--- a/dashboard/config/scripts/levels/poetry_hoc_exemplar1.level
+++ b/dashboard/config/scripts/levels/poetry_hoc_exemplar1.level
@@ -22,7 +22,7 @@
     "never_autoplay_video": "false",
     "disable_param_editing": "true",
     "disable_if_else_editing": "false",
-    "include_shared_functions": "true",
+    "include_shared_functions": "false",
     "free_play": "false",
     "show_debug_watch": "true",
     "expand_debugger": "false",

--- a/dashboard/config/scripts/levels/poetry_hoc_exemplar2.level
+++ b/dashboard/config/scripts/levels/poetry_hoc_exemplar2.level
@@ -22,7 +22,7 @@
     "disable_param_editing": "true",
     "hide_share_and_remix": "true",
     "disable_if_else_editing": "false",
-    "include_shared_functions": "true",
+    "include_shared_functions": "false",
     "free_play": "false",
     "start_in_animation_tab": "false",
     "all_animations_single_frame": "true",

--- a/dashboard/config/scripts/levels/poetry_hoc_freeplay.level
+++ b/dashboard/config/scripts/levels/poetry_hoc_freeplay.level
@@ -23,7 +23,7 @@
     "never_autoplay_video": "false",
     "disable_param_editing": "true",
     "disable_if_else_editing": "false",
-    "include_shared_functions": "true",
+    "include_shared_functions": "false",
     "free_play": "true",
     "start_in_animation_tab": "false",
     "all_animations_single_frame": "true",

--- a/dashboard/config/scripts/levels/poetry_hoc_modal_delay.level
+++ b/dashboard/config/scripts/levels/poetry_hoc_modal_delay.level
@@ -26,7 +26,7 @@
     "never_autoplay_video": "false",
     "disable_param_editing": "true",
     "disable_if_else_editing": "false",
-    "include_shared_functions": "true",
+    "include_shared_functions": "false",
     "free_play": "false",
     "show_debug_watch": "true",
     "expand_debugger": "false",

--- a/dashboard/config/scripts/levels/poetry_hoc_sounds.level
+++ b/dashboard/config/scripts/levels/poetry_hoc_sounds.level
@@ -25,7 +25,7 @@
     "never_autoplay_video": "false",
     "disable_param_editing": "true",
     "disable_if_else_editing": "false",
-    "include_shared_functions": "true",
+    "include_shared_functions": "false",
     "free_play": "false",
     "show_debug_watch": "true",
     "expand_debugger": "false",

--- a/dashboard/config/scripts/levels/poetry_hoc_spriteBehaviors.level
+++ b/dashboard/config/scripts/levels/poetry_hoc_spriteBehaviors.level
@@ -24,7 +24,7 @@
     "never_autoplay_video": "false",
     "disable_param_editing": "true",
     "disable_if_else_editing": "false",
-    "include_shared_functions": "true",
+    "include_shared_functions": "false",
     "free_play": "false",
     "show_debug_watch": "true",
     "expand_debugger": "false",

--- a/dashboard/config/scripts/levels/poetry_hoc_spriteSizes.level
+++ b/dashboard/config/scripts/levels/poetry_hoc_spriteSizes.level
@@ -25,7 +25,7 @@
     "never_autoplay_video": "false",
     "disable_param_editing": "true",
     "disable_if_else_editing": "false",
-    "include_shared_functions": "true",
+    "include_shared_functions": "false",
     "free_play": "false",
     "show_debug_watch": "true",
     "expand_debugger": "false",

--- a/dashboard/config/scripts/levels/poetry_module_animate_freeplay.level
+++ b/dashboard/config/scripts/levels/poetry_module_animate_freeplay.level
@@ -23,7 +23,7 @@
     "never_autoplay_video": "false",
     "disable_param_editing": "true",
     "disable_if_else_editing": "false",
-    "include_shared_functions": "true",
+    "include_shared_functions": "false",
     "free_play": "false",
     "start_in_animation_tab": "false",
     "all_animations_single_frame": "true",

--- a/dashboard/config/scripts/levels/poetry_module_animate_poem.level
+++ b/dashboard/config/scripts/levels/poetry_module_animate_poem.level
@@ -23,7 +23,7 @@
     "never_autoplay_video": "false",
     "disable_param_editing": "true",
     "disable_if_else_editing": "false",
-    "include_shared_functions": "true",
+    "include_shared_functions": "false",
     "free_play": "false",
     "start_in_animation_tab": "false",
     "all_animations_single_frame": "true",

--- a/dashboard/config/scripts/levels/poetry_module_choice_conditionals.level
+++ b/dashboard/config/scripts/levels/poetry_module_choice_conditionals.level
@@ -23,7 +23,7 @@
     "never_autoplay_video": "false",
     "disable_param_editing": "true",
     "disable_if_else_editing": "false",
-    "include_shared_functions": "true",
+    "include_shared_functions": "false",
     "free_play": "false",
     "start_in_animation_tab": "false",
     "all_animations_single_frame": "true",

--- a/dashboard/config/scripts/levels/poetry_module_choice_prompts.level
+++ b/dashboard/config/scripts/levels/poetry_module_choice_prompts.level
@@ -23,7 +23,7 @@
     "never_autoplay_video": "false",
     "disable_param_editing": "true",
     "disable_if_else_editing": "false",
-    "include_shared_functions": "true",
+    "include_shared_functions": "false",
     "free_play": "false",
     "start_in_animation_tab": "false",
     "all_animations_single_frame": "true",

--- a/dashboard/config/scripts/levels/poetry_module_choices_exemplar.level
+++ b/dashboard/config/scripts/levels/poetry_module_choices_exemplar.level
@@ -23,7 +23,7 @@
     "never_autoplay_video": "false",
     "disable_param_editing": "true",
     "disable_if_else_editing": "false",
-    "include_shared_functions": "true",
+    "include_shared_functions": "false",
     "free_play": "false",
     "start_in_animation_tab": "false",
     "all_animations_single_frame": "true",

--- a/dashboard/config/scripts/levels/poetry_module_conditionals_freeplay.level
+++ b/dashboard/config/scripts/levels/poetry_module_conditionals_freeplay.level
@@ -23,7 +23,7 @@
     "never_autoplay_video": "false",
     "disable_param_editing": "true",
     "disable_if_else_editing": "false",
-    "include_shared_functions": "true",
+    "include_shared_functions": "false",
     "free_play": "false",
     "start_in_animation_tab": "false",
     "all_animations_single_frame": "true",

--- a/dashboard/config/scripts/levels/poetry_module_freeplay.level
+++ b/dashboard/config/scripts/levels/poetry_module_freeplay.level
@@ -23,7 +23,7 @@
     "never_autoplay_video": "false",
     "disable_param_editing": "true",
     "disable_if_else_editing": "false",
-    "include_shared_functions": "true",
+    "include_shared_functions": "false",
     "free_play": "false",
     "start_in_animation_tab": "false",
     "all_animations_single_frame": "true",

--- a/dashboard/config/scripts/levels/poetry_module_generator_concatenation.level
+++ b/dashboard/config/scripts/levels/poetry_module_generator_concatenation.level
@@ -23,7 +23,7 @@
     "never_autoplay_video": "false",
     "disable_param_editing": "true",
     "disable_if_else_editing": "false",
-    "include_shared_functions": "true",
+    "include_shared_functions": "false",
     "free_play": "false",
     "start_in_animation_tab": "false",
     "all_animations_single_frame": "true",

--- a/dashboard/config/scripts/levels/poetry_module_generator_freeplay.level
+++ b/dashboard/config/scripts/levels/poetry_module_generator_freeplay.level
@@ -23,7 +23,7 @@
     "never_autoplay_video": "false",
     "disable_param_editing": "true",
     "disable_if_else_editing": "false",
-    "include_shared_functions": "true",
+    "include_shared_functions": "false",
     "free_play": "false",
     "start_in_animation_tab": "false",
     "all_animations_single_frame": "true",

--- a/dashboard/config/scripts/levels/poetry_module_generator_prompt.level
+++ b/dashboard/config/scripts/levels/poetry_module_generator_prompt.level
@@ -23,7 +23,7 @@
     "never_autoplay_video": "false",
     "disable_param_editing": "true",
     "disable_if_else_editing": "false",
-    "include_shared_functions": "true",
+    "include_shared_functions": "false",
     "free_play": "false",
     "start_in_animation_tab": "false",
     "all_animations_single_frame": "true",

--- a/dashboard/config/scripts/levels/poetry_module_generator_repeat.level
+++ b/dashboard/config/scripts/levels/poetry_module_generator_repeat.level
@@ -23,7 +23,7 @@
     "never_autoplay_video": "false",
     "disable_param_editing": "true",
     "disable_if_else_editing": "false",
-    "include_shared_functions": "true",
+    "include_shared_functions": "false",
     "free_play": "false",
     "start_in_animation_tab": "false",
     "all_animations_single_frame": "true",

--- a/dashboard/config/scripts/levels/poetry_module_template.level
+++ b/dashboard/config/scripts/levels/poetry_module_template.level
@@ -23,7 +23,7 @@
     "never_autoplay_video": "false",
     "disable_param_editing": "true",
     "disable_if_else_editing": "false",
-    "include_shared_functions": "true",
+    "include_shared_functions": "false",
     "free_play": "false",
     "start_in_animation_tab": "false",
     "all_animations_single_frame": "true",

--- a/dashboard/config/scripts/levels/poetry_module_template_initial.level
+++ b/dashboard/config/scripts/levels/poetry_module_template_initial.level
@@ -23,7 +23,7 @@
     "never_autoplay_video": "false",
     "disable_param_editing": "true",
     "disable_if_else_editing": "false",
-    "include_shared_functions": "true",
+    "include_shared_functions": "false",
     "free_play": "false",
     "start_in_animation_tab": "false",
     "all_animations_single_frame": "true",

--- a/dashboard/config/scripts/levels/poetry_module_variables_exemplar2.level
+++ b/dashboard/config/scripts/levels/poetry_module_variables_exemplar2.level
@@ -23,7 +23,7 @@
     "never_autoplay_video": "false",
     "disable_param_editing": "true",
     "disable_if_else_editing": "false",
-    "include_shared_functions": "true",
+    "include_shared_functions": "false",
     "free_play": "false",
     "start_in_animation_tab": "false",
     "all_animations_single_frame": "true",

--- a/dashboard/config/scripts/levels/poetry_module_variables_freeplay.level
+++ b/dashboard/config/scripts/levels/poetry_module_variables_freeplay.level
@@ -23,7 +23,7 @@
     "never_autoplay_video": "false",
     "disable_param_editing": "true",
     "disable_if_else_editing": "false",
-    "include_shared_functions": "true",
+    "include_shared_functions": "false",
     "free_play": "false",
     "start_in_animation_tab": "false",
     "all_animations_single_frame": "true",


### PR DESCRIPTION
Blockly shared functions (https://levelbuilder-studio.code.org/functions) aka behaviors are defined in Blockly and typically allow users to edit the behavior definitions:
![image](https://user-images.githubusercontent.com/8787187/138536508-e40a00db-92cb-41c0-b684-a47a9d6e3dfd.png)

Poetry has a simplified version of behaviors that looks like this and *does not allow students to edit the behaviors*:
![image](https://user-images.githubusercontent.com/8787187/138536532-a461f1e7-30d8-412c-983d-ec94c7d8f2c4.png)

When we eventually migrate spritelab to use google blockly, we'll need to do a bunch of work to make behavior definitons and the behavior modal work. However, for Poetry HOC, we don't really need to blockly features to work, we just need the behavior functions to be defined.

The solution here is to implement the behavior functions as commands in the PoetryLibrary, that way we don't need `includeSharedFunctions` to be set for Poetry levels, and the behavior block will still work. It's a little less than ideal to duplicate these definitions, but I think it's okay to facilitate shipping Poetry using google blockly.

Google Blockly:
![Oct-22-2021 18-12-03](https://user-images.githubusercontent.com/8787187/138536722-39252df9-ee2e-4840-bb8e-48c184d740f4.gif)

Note for reviewer- not sure if I'm explaining any of this well, so please lmk if there are things I should add to this description!