### PR TITLE
Change paletteParams to be a list of objects and persist them

### DIFF
--- a/bin/oneoff/pullOutBlocks.js
+++ b/bin/oneoff/pullOutBlocks.js
@@ -16,6 +16,10 @@ var gamelabBlocksToImport = [
 ];
 
 applabBlocksToImport.forEach(block => {
+  const paletteParams = block["paletteParams"].map(param => {
+    return { name: param };
+  });
+  block["paletteParams"] = paletteParams;
   fs.writeFile(
     `dashboard/config/programming_expressions/applab/${block.func}.json`,
     JSON.stringify(block, null, 2),
@@ -33,6 +37,10 @@ applabBlocksToImport.forEach(block => {
 });
 
 gamelabBlocksToImport.forEach(block => {
+  const paletteParams = block["paletteParams"].map(param => {
+    return { name: param };
+  });
+  block["paletteParams"] = paletteParams;
   fs.writeFile(
     `dashboard/config/programming_expressions/gamelab/${block.func}.json`,
     JSON.stringify(block, null, 2),

--- a/dashboard/app/models/programming_expression.rb
+++ b/dashboard/app/models/programming_expression.rb
@@ -35,7 +35,7 @@ class ProgrammingExpression < ApplicationRecord
     content
     return_value
     tips
-    paletteParams
+    palette_params
   )
 
   def key_format
@@ -74,7 +74,7 @@ class ProgrammingExpression < ApplicationRecord
         category: expression_config['category'],
         color: expression_config['config']['color'],
         syntax: expression_config['config']['func'] || expression_config['config']['name'],
-        paletteParams: expression_config['paletteParams']
+        palette_params: expression_config['paletteParams']
       }
     else
       {
@@ -84,7 +84,7 @@ class ProgrammingExpression < ApplicationRecord
         category: expression_config['category'],
         color: ProgrammingExpression.get_category_color(expression_config['category']),
         syntax: syntax,
-        paletteParams: expression_config['paletteParams']
+        palette_params: expression_config['paletteParams']
       }
     end
   end

--- a/dashboard/app/models/programming_expression.rb
+++ b/dashboard/app/models/programming_expression.rb
@@ -35,6 +35,7 @@ class ProgrammingExpression < ApplicationRecord
     content
     return_value
     tips
+    paletteParams
   )
 
   def key_format
@@ -72,7 +73,8 @@ class ProgrammingExpression < ApplicationRecord
         programming_environment_id: programming_environment.id,
         category: expression_config['category'],
         color: expression_config['config']['color'],
-        syntax: expression_config['config']['func'] || expression_config['config']['name']
+        syntax: expression_config['config']['func'] || expression_config['config']['name'],
+        paletteParams: expression_config['paletteParams']
       }
     else
       {
@@ -81,7 +83,8 @@ class ProgrammingExpression < ApplicationRecord
         programming_environment_id: programming_environment.id,
         category: expression_config['category'],
         color: ProgrammingExpression.get_category_color(expression_config['category']),
-        syntax: syntax
+        syntax: syntax,
+        paletteParams: expression_config['paletteParams']
       }
     end
   end
@@ -91,7 +94,7 @@ class ProgrammingExpression < ApplicationRecord
     if config['syntax']
       syntax = config['syntax']
     elsif config['paletteParams']
-      syntax = config['func'] + "(" + config['paletteParams'].join(', ') + ")"
+      syntax = config['func'] + "(" + config['paletteParams'].map {|p| p['name']} .join(', ') + ")"
     elsif config['block']
       syntax = config['block']
     end

--- a/dashboard/config/programming_expressions/applab/accelerometer.getAcceleration.json
+++ b/dashboard/config/programming_expressions/applab/accelerometer.getAcceleration.json
@@ -3,7 +3,9 @@
   "category": "Circuit",
   "type": "value",
   "paletteParams": [
-    "orientationType"
+    {
+      "name": "orientationType"
+    }
   ],
   "params": [
     "\"x\""

--- a/dashboard/config/programming_expressions/applab/accelerometer.getOrientation.json
+++ b/dashboard/config/programming_expressions/applab/accelerometer.getOrientation.json
@@ -3,7 +3,9 @@
   "category": "Circuit",
   "type": "value",
   "paletteParams": [
-    "orientationType"
+    {
+      "name": "orientationType"
+    }
   ],
   "params": [
     "\"inclination\""

--- a/dashboard/config/programming_expressions/applab/addPair.json
+++ b/dashboard/config/programming_expressions/applab/addPair.json
@@ -2,9 +2,15 @@
   "func": "addPair",
   "category": "Variables",
   "paletteParams": [
-    "object",
-    "\"key\"",
-    "\"value\""
+    {
+      "name": "object"
+    },
+    {
+      "name": "\"key\""
+    },
+    {
+      "name": "\"value\""
+    }
   ],
   "params": [
     "object",

--- a/dashboard/config/programming_expressions/applab/analogRead.json
+++ b/dashboard/config/programming_expressions/applab/analogRead.json
@@ -4,7 +4,9 @@
   "type": "value",
   "nativeIsAsync": true,
   "paletteParams": [
-    "pin"
+    {
+      "name": "pin"
+    }
   ],
   "params": [
     "5"

--- a/dashboard/config/programming_expressions/applab/analogWrite.json
+++ b/dashboard/config/programming_expressions/applab/analogWrite.json
@@ -2,8 +2,12 @@
   "func": "analogWrite",
   "category": "Maker",
   "paletteParams": [
-    "pin",
-    "value"
+    {
+      "name": "pin"
+    },
+    {
+      "name": "value"
+    }
   ],
   "params": [
     "5",

--- a/dashboard/config/programming_expressions/applab/appendItem.json
+++ b/dashboard/config/programming_expressions/applab/appendItem.json
@@ -2,8 +2,12 @@
   "func": "appendItem",
   "category": "Variables",
   "paletteParams": [
-    "list",
-    "item"
+    {
+      "name": "list"
+    },
+    {
+      "name": "item"
+    }
   ],
   "params": [
     "list",

--- a/dashboard/config/programming_expressions/applab/arcLeft.json
+++ b/dashboard/config/programming_expressions/applab/arcLeft.json
@@ -2,8 +2,12 @@
   "func": "arcLeft",
   "category": "Turtle",
   "paletteParams": [
-    "angle",
-    "radius"
+    {
+      "name": "angle"
+    },
+    {
+      "name": "radius"
+    }
   ],
   "params": [
     "90",

--- a/dashboard/config/programming_expressions/applab/arcRight.json
+++ b/dashboard/config/programming_expressions/applab/arcRight.json
@@ -2,8 +2,12 @@
   "func": "arcRight",
   "category": "Turtle",
   "paletteParams": [
-    "angle",
-    "radius"
+    {
+      "name": "angle"
+    },
+    {
+      "name": "radius"
+    }
   ],
   "params": [
     "90",

--- a/dashboard/config/programming_expressions/applab/blink.json
+++ b/dashboard/config/programming_expressions/applab/blink.json
@@ -2,7 +2,9 @@
   "func": "blink",
   "category": "Circuit",
   "paletteParams": [
-    "interval"
+    {
+      "name": "interval"
+    }
   ],
   "params": [
     "100"

--- a/dashboard/config/programming_expressions/applab/button.json
+++ b/dashboard/config/programming_expressions/applab/button.json
@@ -2,8 +2,12 @@
   "func": "button",
   "category": "UI controls",
   "paletteParams": [
-    "id",
-    "text"
+    {
+      "name": "id"
+    },
+    {
+      "name": "text"
+    }
   ],
   "params": [
     "\"id\"",

--- a/dashboard/config/programming_expressions/applab/buzzer.frequency.json
+++ b/dashboard/config/programming_expressions/applab/buzzer.frequency.json
@@ -2,8 +2,12 @@
   "func": "buzzer.frequency",
   "category": "Circuit",
   "paletteParams": [
-    "frequency",
-    "duration"
+    {
+      "name": "frequency"
+    },
+    {
+      "name": "duration"
+    }
   ],
   "params": [
     "500",

--- a/dashboard/config/programming_expressions/applab/buzzer.note.json
+++ b/dashboard/config/programming_expressions/applab/buzzer.note.json
@@ -2,8 +2,12 @@
   "func": "buzzer.note",
   "category": "Circuit",
   "paletteParams": [
-    "note",
-    "duration"
+    {
+      "name": "note"
+    },
+    {
+      "name": "duration"
+    }
   ],
   "params": [
     "\"A4\"",

--- a/dashboard/config/programming_expressions/applab/buzzer.play.json
+++ b/dashboard/config/programming_expressions/applab/buzzer.play.json
@@ -2,8 +2,12 @@
   "func": "buzzer.play",
   "category": "Circuit",
   "paletteParams": [
-    "notes",
-    "tempo"
+    {
+      "name": "notes"
+    },
+    {
+      "name": "tempo"
+    }
   ],
   "paramButtons": {
     "minArgs": 1,

--- a/dashboard/config/programming_expressions/applab/buzzer.playNotes.json
+++ b/dashboard/config/programming_expressions/applab/buzzer.playNotes.json
@@ -2,8 +2,12 @@
   "func": "buzzer.playNotes",
   "category": "Circuit",
   "paletteParams": [
-    "notes",
-    "tempo"
+    {
+      "name": "notes"
+    },
+    {
+      "name": "tempo"
+    }
   ],
   "paramButtons": {
     "minArgs": 1,

--- a/dashboard/config/programming_expressions/applab/buzzer.playSong.json
+++ b/dashboard/config/programming_expressions/applab/buzzer.playSong.json
@@ -2,8 +2,12 @@
   "func": "buzzer.playSong",
   "category": "Circuit",
   "paletteParams": [
-    "notes",
-    "tempo"
+    {
+      "name": "notes"
+    },
+    {
+      "name": "tempo"
+    }
   ],
   "paramButtons": {
     "minArgs": 1,

--- a/dashboard/config/programming_expressions/applab/checkbox.json
+++ b/dashboard/config/programming_expressions/applab/checkbox.json
@@ -2,8 +2,12 @@
   "func": "checkbox",
   "category": "UI controls",
   "paletteParams": [
-    "id",
-    "checked"
+    {
+      "name": "id"
+    },
+    {
+      "name": "checked"
+    }
   ],
   "params": [
     "\"id\"",

--- a/dashboard/config/programming_expressions/applab/circle.json
+++ b/dashboard/config/programming_expressions/applab/circle.json
@@ -2,8 +2,14 @@
   "func": "circle",
   "category": "Canvas",
   "paletteParams": [
-    "x",
-    "y",
-    "radius"
+    {
+      "name": "x"
+    },
+    {
+      "name": "y"
+    },
+    {
+      "name": "radius"
+    }
   ]
 }

--- a/dashboard/config/programming_expressions/applab/clearInterval.json
+++ b/dashboard/config/programming_expressions/applab/clearInterval.json
@@ -2,7 +2,9 @@
   "func": "clearInterval",
   "category": "Control",
   "paletteParams": [
-    "__"
+    {
+      "name": "__"
+    }
   ],
   "params": [
     "__"

--- a/dashboard/config/programming_expressions/applab/clearTimeout.json
+++ b/dashboard/config/programming_expressions/applab/clearTimeout.json
@@ -2,7 +2,9 @@
   "func": "clearTimeout",
   "category": "Control",
   "paletteParams": [
-    "__"
+    {
+      "name": "__"
+    }
   ],
   "params": [
     "__"

--- a/dashboard/config/programming_expressions/applab/color.json
+++ b/dashboard/config/programming_expressions/applab/color.json
@@ -2,7 +2,9 @@
   "func": "color",
   "category": "Circuit",
   "paletteParams": [
-    "color"
+    {
+      "name": "color"
+    }
   ],
   "params": [
     "\"#FF00FF\""

--- a/dashboard/config/programming_expressions/applab/console.log.json
+++ b/dashboard/config/programming_expressions/applab/console.log.json
@@ -2,7 +2,9 @@
   "func": "console.log",
   "category": "Variables",
   "paletteParams": [
-    "message"
+    {
+      "name": "message"
+    }
   ],
   "params": [
     "\"message\""

--- a/dashboard/config/programming_expressions/applab/createButton.json
+++ b/dashboard/config/programming_expressions/applab/createButton.json
@@ -2,7 +2,9 @@
   "func": "createButton",
   "category": "Maker",
   "paletteParams": [
-    "pin"
+    {
+      "name": "pin"
+    }
   ],
   "params": [
     "0"

--- a/dashboard/config/programming_expressions/applab/createCanvas.json
+++ b/dashboard/config/programming_expressions/applab/createCanvas.json
@@ -6,8 +6,14 @@
     "maxArgs": 3
   },
   "paletteParams": [
-    "id",
-    "width",
-    "height"
+    {
+      "name": "id"
+    },
+    {
+      "name": "width"
+    },
+    {
+      "name": "height"
+    }
   ]
 }

--- a/dashboard/config/programming_expressions/applab/createCapacitiveTouchSensor.json
+++ b/dashboard/config/programming_expressions/applab/createCapacitiveTouchSensor.json
@@ -2,7 +2,9 @@
   "func": "createCapacitiveTouchSensor",
   "category": "Maker",
   "paletteParams": [
-    "pin"
+    {
+      "name": "pin"
+    }
   ],
   "params": [
     "0"

--- a/dashboard/config/programming_expressions/applab/createLed.json
+++ b/dashboard/config/programming_expressions/applab/createLed.json
@@ -2,7 +2,9 @@
   "func": "createLed",
   "category": "Maker",
   "paletteParams": [
-    "pin"
+    {
+      "name": "pin"
+    }
   ],
   "params": [
     "0"

--- a/dashboard/config/programming_expressions/applab/createRecord.json
+++ b/dashboard/config/programming_expressions/applab/createRecord.json
@@ -2,9 +2,15 @@
   "func": "createRecord",
   "category": "Data",
   "paletteParams": [
-    "table",
-    "record",
-    "callback"
+    {
+      "name": "table"
+    },
+    {
+      "name": "record"
+    },
+    {
+      "name": "callback"
+    }
   ],
   "params": [
     "\"mytable\"",

--- a/dashboard/config/programming_expressions/applab/deleteElement.json
+++ b/dashboard/config/programming_expressions/applab/deleteElement.json
@@ -2,7 +2,9 @@
   "func": "deleteElement",
   "category": "UI controls",
   "paletteParams": [
-    "id"
+    {
+      "name": "id"
+    }
   ],
   "params": [
     "\"id\""

--- a/dashboard/config/programming_expressions/applab/deleteRecord.json
+++ b/dashboard/config/programming_expressions/applab/deleteRecord.json
@@ -2,9 +2,15 @@
   "func": "deleteRecord",
   "category": "Data",
   "paletteParams": [
-    "table",
-    "record",
-    "callback"
+    {
+      "name": "table"
+    },
+    {
+      "name": "record"
+    },
+    {
+      "name": "callback"
+    }
   ],
   "params": [
     "\"mytable\"",

--- a/dashboard/config/programming_expressions/applab/digitalRead.json
+++ b/dashboard/config/programming_expressions/applab/digitalRead.json
@@ -4,7 +4,9 @@
   "type": "value",
   "nativeIsAsync": true,
   "paletteParams": [
-    "pin"
+    {
+      "name": "pin"
+    }
   ],
   "params": [
     "\"D4\""

--- a/dashboard/config/programming_expressions/applab/digitalWrite.json
+++ b/dashboard/config/programming_expressions/applab/digitalWrite.json
@@ -2,8 +2,12 @@
   "func": "digitalWrite",
   "category": "Maker",
   "paletteParams": [
-    "pin",
-    "value"
+    {
+      "name": "pin"
+    },
+    {
+      "name": "value"
+    }
   ],
   "params": [
     "13",

--- a/dashboard/config/programming_expressions/applab/dot.json
+++ b/dashboard/config/programming_expressions/applab/dot.json
@@ -2,7 +2,9 @@
   "func": "dot",
   "category": "Turtle",
   "paletteParams": [
-    "radius"
+    {
+      "name": "radius"
+    }
   ],
   "params": [
     "5"

--- a/dashboard/config/programming_expressions/applab/drawChart.json
+++ b/dashboard/config/programming_expressions/applab/drawChart.json
@@ -6,9 +6,15 @@
     "maxArgs": 5
   },
   "paletteParams": [
-    "chartId",
-    "chartType",
-    "chartData"
+    {
+      "name": "chartId"
+    },
+    {
+      "name": "chartType"
+    },
+    {
+      "name": "chartData"
+    }
   ],
   "params": [
     "\"chartId\"",

--- a/dashboard/config/programming_expressions/applab/drawChartFromRecords.json
+++ b/dashboard/config/programming_expressions/applab/drawChartFromRecords.json
@@ -6,10 +6,18 @@
     "maxArgs": 6
   },
   "paletteParams": [
-    "chartId",
-    "chartType",
-    "tableName",
-    "columns"
+    {
+      "name": "chartId"
+    },
+    {
+      "name": "chartType"
+    },
+    {
+      "name": "tableName"
+    },
+    {
+      "name": "columns"
+    }
   ],
   "params": [
     "\"chartId\"",

--- a/dashboard/config/programming_expressions/applab/drawImage.json
+++ b/dashboard/config/programming_expressions/applab/drawImage.json
@@ -2,9 +2,15 @@
   "func": "drawImage",
   "category": "Canvas",
   "paletteParams": [
-    "id",
-    "x",
-    "y"
+    {
+      "name": "id"
+    },
+    {
+      "name": "x"
+    },
+    {
+      "name": "y"
+    }
   ],
   "params": [
     "\"id\"",

--- a/dashboard/config/programming_expressions/applab/drawImageURL.json
+++ b/dashboard/config/programming_expressions/applab/drawImageURL.json
@@ -6,7 +6,9 @@
     "maxArgs": 6
   },
   "paletteParams": [
-    "url"
+    {
+      "name": "url"
+    }
   ],
   "params": [
     "\"https://code.org/images/logo.png\""

--- a/dashboard/config/programming_expressions/applab/dropdown.json
+++ b/dashboard/config/programming_expressions/applab/dropdown.json
@@ -5,9 +5,15 @@
     "minArgs": 1
   },
   "paletteParams": [
-    "id",
-    "option1",
-    "etc"
+    {
+      "name": "id"
+    },
+    {
+      "name": "option1"
+    },
+    {
+      "name": "etc"
+    }
   ],
   "params": [
     "\"id\"",

--- a/dashboard/config/programming_expressions/applab/getAlpha.json
+++ b/dashboard/config/programming_expressions/applab/getAlpha.json
@@ -2,9 +2,15 @@
   "func": "getAlpha",
   "category": "Canvas",
   "paletteParams": [
-    "imgData",
-    "x",
-    "y"
+    {
+      "name": "imgData"
+    },
+    {
+      "name": "x"
+    },
+    {
+      "name": "y"
+    }
   ],
   "params": [
     "imgData",

--- a/dashboard/config/programming_expressions/applab/getBlue.json
+++ b/dashboard/config/programming_expressions/applab/getBlue.json
@@ -2,9 +2,15 @@
   "func": "getBlue",
   "category": "Canvas",
   "paletteParams": [
-    "imgData",
-    "x",
-    "y"
+    {
+      "name": "imgData"
+    },
+    {
+      "name": "x"
+    },
+    {
+      "name": "y"
+    }
   ],
   "params": [
     "imgData",

--- a/dashboard/config/programming_expressions/applab/getChecked.json
+++ b/dashboard/config/programming_expressions/applab/getChecked.json
@@ -2,7 +2,9 @@
   "func": "getChecked",
   "category": "UI controls",
   "paletteParams": [
-    "id"
+    {
+      "name": "id"
+    }
   ],
   "params": [
     "\"id\""

--- a/dashboard/config/programming_expressions/applab/getColumn.json
+++ b/dashboard/config/programming_expressions/applab/getColumn.json
@@ -2,8 +2,12 @@
   "func": "getColumn",
   "category": "Data",
   "paletteParams": [
-    "table",
-    "column"
+    {
+      "name": "table"
+    },
+    {
+      "name": "column"
+    }
   ],
   "params": [
     "\"mytable\"",

--- a/dashboard/config/programming_expressions/applab/getGreen.json
+++ b/dashboard/config/programming_expressions/applab/getGreen.json
@@ -2,9 +2,15 @@
   "func": "getGreen",
   "category": "Canvas",
   "paletteParams": [
-    "imgData",
-    "x",
-    "y"
+    {
+      "name": "imgData"
+    },
+    {
+      "name": "x"
+    },
+    {
+      "name": "y"
+    }
   ],
   "params": [
     "imgData",

--- a/dashboard/config/programming_expressions/applab/getImageData.json
+++ b/dashboard/config/programming_expressions/applab/getImageData.json
@@ -2,10 +2,18 @@
   "func": "getImageData",
   "category": "Canvas",
   "paletteParams": [
-    "x",
-    "y",
-    "width",
-    "height"
+    {
+      "name": "x"
+    },
+    {
+      "name": "y"
+    },
+    {
+      "name": "width"
+    },
+    {
+      "name": "height"
+    }
   ],
   "type": "value"
 }

--- a/dashboard/config/programming_expressions/applab/getImageURL.json
+++ b/dashboard/config/programming_expressions/applab/getImageURL.json
@@ -2,7 +2,9 @@
   "func": "getImageURL",
   "category": "UI controls",
   "paletteParams": [
-    "id"
+    {
+      "name": "id"
+    }
   ],
   "params": [
     "\"id\""

--- a/dashboard/config/programming_expressions/applab/getKeyValue.json
+++ b/dashboard/config/programming_expressions/applab/getKeyValue.json
@@ -2,8 +2,12 @@
   "func": "getKeyValue",
   "category": "Data",
   "paletteParams": [
-    "key",
-    "callback"
+    {
+      "name": "key"
+    },
+    {
+      "name": "callback"
+    }
   ],
   "params": [
     "\"key\"",

--- a/dashboard/config/programming_expressions/applab/getKeyValueSync.json
+++ b/dashboard/config/programming_expressions/applab/getKeyValueSync.json
@@ -2,7 +2,9 @@
   "func": "getKeyValueSync",
   "category": "Data",
   "paletteParams": [
-    "key"
+    {
+      "name": "key"
+    }
   ],
   "params": [
     "\"key\""

--- a/dashboard/config/programming_expressions/applab/getNumber.json
+++ b/dashboard/config/programming_expressions/applab/getNumber.json
@@ -2,7 +2,9 @@
   "func": "getNumber",
   "category": "UI controls",
   "paletteParams": [
-    "id"
+    {
+      "name": "id"
+    }
   ],
   "params": [
     "\"id\""

--- a/dashboard/config/programming_expressions/applab/getPrediction.json
+++ b/dashboard/config/programming_expressions/applab/getPrediction.json
@@ -2,10 +2,18 @@
   "func": "getPrediction",
   "category": "Data",
   "paletteParams": [
-    "name",
-    "id",
-    "data",
-    "callback"
+    {
+      "name": "name"
+    },
+    {
+      "name": "id"
+    },
+    {
+      "name": "data"
+    },
+    {
+      "name": "callback"
+    }
   ],
   "params": [
     "\"name\"",

--- a/dashboard/config/programming_expressions/applab/getProperty.json
+++ b/dashboard/config/programming_expressions/applab/getProperty.json
@@ -2,8 +2,12 @@
   "func": "getProperty",
   "category": "UI controls",
   "paletteParams": [
-    "id",
-    "property"
+    {
+      "name": "id"
+    },
+    {
+      "name": "property"
+    }
   ],
   "params": [
     "\"id\"",

--- a/dashboard/config/programming_expressions/applab/getRed.json
+++ b/dashboard/config/programming_expressions/applab/getRed.json
@@ -2,9 +2,15 @@
   "func": "getRed",
   "category": "Canvas",
   "paletteParams": [
-    "imgData",
-    "x",
-    "y"
+    {
+      "name": "imgData"
+    },
+    {
+      "name": "x"
+    },
+    {
+      "name": "y"
+    }
   ],
   "params": [
     "imgData",

--- a/dashboard/config/programming_expressions/applab/getText.json
+++ b/dashboard/config/programming_expressions/applab/getText.json
@@ -2,7 +2,9 @@
   "func": "getText",
   "category": "UI controls",
   "paletteParams": [
-    "id"
+    {
+      "name": "id"
+    }
   ],
   "params": [
     "\"id\""

--- a/dashboard/config/programming_expressions/applab/getValue.json
+++ b/dashboard/config/programming_expressions/applab/getValue.json
@@ -2,8 +2,12 @@
   "func": "getValue",
   "category": "Variables",
   "paletteParams": [
-    "object",
-    "\"key\""
+    {
+      "name": "object"
+    },
+    {
+      "name": "\"key\""
+    }
   ],
   "params": [
     "{\"key\": \"value\"}",

--- a/dashboard/config/programming_expressions/applab/getXPosition.json
+++ b/dashboard/config/programming_expressions/applab/getXPosition.json
@@ -2,7 +2,9 @@
   "func": "getXPosition",
   "category": "UI controls",
   "paletteParams": [
-    "id"
+    {
+      "name": "id"
+    }
   ],
   "params": [
     "\"id\""

--- a/dashboard/config/programming_expressions/applab/getYPosition.json
+++ b/dashboard/config/programming_expressions/applab/getYPosition.json
@@ -2,7 +2,9 @@
   "func": "getYPosition",
   "category": "UI controls",
   "paletteParams": [
-    "id"
+    {
+      "name": "id"
+    }
   ],
   "params": [
     "\"id\""

--- a/dashboard/config/programming_expressions/applab/hideElement.json
+++ b/dashboard/config/programming_expressions/applab/hideElement.json
@@ -2,7 +2,9 @@
   "func": "hideElement",
   "category": "UI controls",
   "paletteParams": [
-    "id"
+    {
+      "name": "id"
+    }
   ],
   "params": [
     "\"id\""

--- a/dashboard/config/programming_expressions/applab/image.json
+++ b/dashboard/config/programming_expressions/applab/image.json
@@ -2,12 +2,17 @@
   "func": "image",
   "category": "UI controls",
   "paletteParams": [
-    "id",
-    "url"
+    {
+      "name": "id"
+    },
+    {
+      "name": "url"
+    }
   ],
   "params": [
     "\"id\"",
     "\"https://code.org/images/logo.png\""
   ],
-  "dropdown": {}
+  "dropdown": {
+  }
 }

--- a/dashboard/config/programming_expressions/applab/includes.json
+++ b/dashboard/config/programming_expressions/applab/includes.json
@@ -2,7 +2,9 @@
   "func": "includes",
   "category": "Variables",
   "paletteParams": [
-    "searchValue"
+    {
+      "name": "searchValue"
+    }
   ],
   "params": [
     "\"World\""

--- a/dashboard/config/programming_expressions/applab/indexOf.json
+++ b/dashboard/config/programming_expressions/applab/indexOf.json
@@ -2,7 +2,9 @@
   "func": "indexOf",
   "category": "Variables",
   "paletteParams": [
-    "searchValue"
+    {
+      "name": "searchValue"
+    }
   ],
   "params": [
     "\"World\""

--- a/dashboard/config/programming_expressions/applab/insertItem.json
+++ b/dashboard/config/programming_expressions/applab/insertItem.json
@@ -2,9 +2,15 @@
   "func": "insertItem",
   "category": "Variables",
   "paletteParams": [
-    "list",
-    "index",
-    "item"
+    {
+      "name": "list"
+    },
+    {
+      "name": "index"
+    },
+    {
+      "name": "item"
+    }
   ],
   "params": [
     "list",

--- a/dashboard/config/programming_expressions/applab/join.json
+++ b/dashboard/config/programming_expressions/applab/join.json
@@ -3,7 +3,9 @@
   "category": "Variables",
   "modeOptionName": "*.join",
   "paletteParams": [
-    "separator"
+    {
+      "name": "separator"
+    }
   ],
   "params": [
     "\"-\""

--- a/dashboard/config/programming_expressions/applab/led.blink.json
+++ b/dashboard/config/programming_expressions/applab/led.blink.json
@@ -2,7 +2,9 @@
   "func": "led.blink",
   "category": "Circuit",
   "paletteParams": [
-    "interval"
+    {
+      "name": "interval"
+    }
   ],
   "params": [
     "200"

--- a/dashboard/config/programming_expressions/applab/led.pulse.json
+++ b/dashboard/config/programming_expressions/applab/led.pulse.json
@@ -2,7 +2,9 @@
   "func": "led.pulse",
   "category": "Circuit",
   "paletteParams": [
-    "interval"
+    {
+      "name": "interval"
+    }
   ],
   "params": [
     "200"

--- a/dashboard/config/programming_expressions/applab/ledScreen.scrollString.json
+++ b/dashboard/config/programming_expressions/applab/ledScreen.scrollString.json
@@ -5,6 +5,8 @@
     "\"Hello World!\""
   ],
   "paletteParams": [
-    "string"
+    {
+      "name": "string"
+    }
   ]
 }

--- a/dashboard/config/programming_expressions/applab/lightSensor.getAveragedValue.json
+++ b/dashboard/config/programming_expressions/applab/lightSensor.getAveragedValue.json
@@ -5,7 +5,9 @@
     "500"
   ],
   "paletteParams": [
-    "ms"
+    {
+      "name": "ms"
+    }
   ],
   "type": "value"
 }

--- a/dashboard/config/programming_expressions/applab/lightSensor.setScale.json
+++ b/dashboard/config/programming_expressions/applab/lightSensor.setScale.json
@@ -6,7 +6,11 @@
     "100"
   ],
   "paletteParams": [
-    "low",
-    "high"
+    {
+      "name": "low"
+    },
+    {
+      "name": "high"
+    }
   ]
 }

--- a/dashboard/config/programming_expressions/applab/line.json
+++ b/dashboard/config/programming_expressions/applab/line.json
@@ -2,9 +2,17 @@
   "func": "line",
   "category": "Canvas",
   "paletteParams": [
-    "x1",
-    "y1",
-    "x2",
-    "y2"
+    {
+      "name": "x1"
+    },
+    {
+      "name": "y1"
+    },
+    {
+      "name": "x2"
+    },
+    {
+      "name": "y2"
+    }
   ]
 }

--- a/dashboard/config/programming_expressions/applab/move.json
+++ b/dashboard/config/programming_expressions/applab/move.json
@@ -2,8 +2,12 @@
   "func": "move",
   "category": "Turtle",
   "paletteParams": [
-    "x",
-    "y"
+    {
+      "name": "x"
+    },
+    {
+      "name": "y"
+    }
   ],
   "params": [
     "25",

--- a/dashboard/config/programming_expressions/applab/moveBackward.json
+++ b/dashboard/config/programming_expressions/applab/moveBackward.json
@@ -2,7 +2,9 @@
   "func": "moveBackward",
   "category": "Turtle",
   "paletteParams": [
-    "pixels"
+    {
+      "name": "pixels"
+    }
   ],
   "params": [
     "25"

--- a/dashboard/config/programming_expressions/applab/moveForward.json
+++ b/dashboard/config/programming_expressions/applab/moveForward.json
@@ -2,7 +2,9 @@
   "func": "moveForward",
   "category": "Turtle",
   "paletteParams": [
-    "pixels"
+    {
+      "name": "pixels"
+    }
   ],
   "params": [
     "25"

--- a/dashboard/config/programming_expressions/applab/moveTo.json
+++ b/dashboard/config/programming_expressions/applab/moveTo.json
@@ -2,8 +2,12 @@
   "func": "moveTo",
   "category": "Turtle",
   "paletteParams": [
-    "x",
-    "y"
+    {
+      "name": "x"
+    },
+    {
+      "name": "y"
+    }
   ],
   "params": [
     "0",

--- a/dashboard/config/programming_expressions/applab/onBoardEvent.json
+++ b/dashboard/config/programming_expressions/applab/onBoardEvent.json
@@ -2,9 +2,15 @@
   "func": "onBoardEvent",
   "category": "Circuit",
   "paletteParams": [
-    "component",
-    "event",
-    "callback"
+    {
+      "name": "component"
+    },
+    {
+      "name": "event"
+    },
+    {
+      "name": "callback"
+    }
   ],
   "params": [
     "buttonA",

--- a/dashboard/config/programming_expressions/applab/onEvent.json
+++ b/dashboard/config/programming_expressions/applab/onEvent.json
@@ -2,9 +2,15 @@
   "func": "onEvent",
   "category": "UI controls",
   "paletteParams": [
-    "id",
-    "type",
-    "callback"
+    {
+      "name": "id"
+    },
+    {
+      "name": "type"
+    },
+    {
+      "name": "callback"
+    }
   ],
   "params": [
     "\"id\"",

--- a/dashboard/config/programming_expressions/applab/onRecordEvent.json
+++ b/dashboard/config/programming_expressions/applab/onRecordEvent.json
@@ -2,8 +2,12 @@
   "func": "onRecordEvent",
   "category": "Data",
   "paletteParams": [
-    "table",
-    "callback"
+    {
+      "name": "table"
+    },
+    {
+      "name": "callback"
+    }
   ],
   "params": [
     "\"mytable\"",

--- a/dashboard/config/programming_expressions/applab/open.json
+++ b/dashboard/config/programming_expressions/applab/open.json
@@ -2,7 +2,9 @@
   "func": "open",
   "category": "UI controls",
   "paletteParams": [
-    "url"
+    {
+      "name": "url"
+    }
   ],
   "params": [
     "\"https://code.org\""

--- a/dashboard/config/programming_expressions/applab/penColor.json
+++ b/dashboard/config/programming_expressions/applab/penColor.json
@@ -2,7 +2,9 @@
   "func": "penColor",
   "category": "Turtle",
   "paletteParams": [
-    "color"
+    {
+      "name": "color"
+    }
   ],
   "params": [
     "\"red\""

--- a/dashboard/config/programming_expressions/applab/penRGB.json
+++ b/dashboard/config/programming_expressions/applab/penRGB.json
@@ -6,9 +6,15 @@
     "maxArgs": 4
   },
   "paletteParams": [
-    "r",
-    "g",
-    "b"
+    {
+      "name": "r"
+    },
+    {
+      "name": "g"
+    },
+    {
+      "name": "b"
+    }
   ],
   "params": [
     "120",

--- a/dashboard/config/programming_expressions/applab/penWidth.json
+++ b/dashboard/config/programming_expressions/applab/penWidth.json
@@ -2,7 +2,9 @@
   "func": "penWidth",
   "category": "Turtle",
   "paletteParams": [
-    "width"
+    {
+      "name": "width"
+    }
   ],
   "params": [
     "3"

--- a/dashboard/config/programming_expressions/applab/pinMode.json
+++ b/dashboard/config/programming_expressions/applab/pinMode.json
@@ -2,8 +2,12 @@
   "func": "pinMode",
   "category": "Maker",
   "paletteParams": [
-    "pin",
-    "mode"
+    {
+      "name": "pin"
+    },
+    {
+      "name": "mode"
+    }
   ],
   "params": [
     "13",

--- a/dashboard/config/programming_expressions/applab/playSound.json
+++ b/dashboard/config/programming_expressions/applab/playSound.json
@@ -6,8 +6,12 @@
     "maxArgs": 2
   },
   "paletteParams": [
-    "url",
-    "loop"
+    {
+      "name": "url"
+    },
+    {
+      "name": "loop"
+    }
   ],
   "params": [
     "\"sound://default.mp3\"",

--- a/dashboard/config/programming_expressions/applab/playSpeech.json
+++ b/dashboard/config/programming_expressions/applab/playSpeech.json
@@ -6,9 +6,15 @@
     "maxArgs": 3
   },
   "paletteParams": [
-    "text",
-    "gender",
-    "language"
+    {
+      "name": "text"
+    },
+    {
+      "name": "gender"
+    },
+    {
+      "name": "language"
+    }
   ],
   "params": [
     "\"Hello World!\"",

--- a/dashboard/config/programming_expressions/applab/pulse.json
+++ b/dashboard/config/programming_expressions/applab/pulse.json
@@ -2,7 +2,9 @@
   "func": "pulse",
   "category": "Circuit",
   "paletteParams": [
-    "interval"
+    {
+      "name": "interval"
+    }
   ],
   "params": [
     "300"

--- a/dashboard/config/programming_expressions/applab/putImageData.json
+++ b/dashboard/config/programming_expressions/applab/putImageData.json
@@ -2,9 +2,15 @@
   "func": "putImageData",
   "category": "Canvas",
   "paletteParams": [
-    "imgData",
-    "x",
-    "y"
+    {
+      "name": "imgData"
+    },
+    {
+      "name": "x"
+    },
+    {
+      "name": "y"
+    }
   ],
   "params": [
     "imgData",

--- a/dashboard/config/programming_expressions/applab/radioButton.json
+++ b/dashboard/config/programming_expressions/applab/radioButton.json
@@ -6,8 +6,12 @@
     "maxArgs": 3
   },
   "paletteParams": [
-    "id",
-    "checked"
+    {
+      "name": "id"
+    },
+    {
+      "name": "checked"
+    }
   ],
   "params": [
     "\"id\"",

--- a/dashboard/config/programming_expressions/applab/readRecords.json
+++ b/dashboard/config/programming_expressions/applab/readRecords.json
@@ -2,9 +2,15 @@
   "func": "readRecords",
   "category": "Data",
   "paletteParams": [
-    "table",
-    "terms",
-    "callback"
+    {
+      "name": "table"
+    },
+    {
+      "name": "terms"
+    },
+    {
+      "name": "callback"
+    }
   ],
   "params": [
     "\"mytable\"",

--- a/dashboard/config/programming_expressions/applab/rect.json
+++ b/dashboard/config/programming_expressions/applab/rect.json
@@ -2,9 +2,17 @@
   "func": "rect",
   "category": "Canvas",
   "paletteParams": [
-    "x",
-    "y",
-    "width",
-    "height"
+    {
+      "name": "x"
+    },
+    {
+      "name": "y"
+    },
+    {
+      "name": "width"
+    },
+    {
+      "name": "height"
+    }
   ]
 }

--- a/dashboard/config/programming_expressions/applab/removeItem.json
+++ b/dashboard/config/programming_expressions/applab/removeItem.json
@@ -2,8 +2,12 @@
   "func": "removeItem",
   "category": "Variables",
   "paletteParams": [
-    "list",
-    "index"
+    {
+      "name": "list"
+    },
+    {
+      "name": "index"
+    }
   ],
   "params": [
     "list",

--- a/dashboard/config/programming_expressions/applab/rgb.json
+++ b/dashboard/config/programming_expressions/applab/rgb.json
@@ -6,10 +6,18 @@
     "maxArgs": 4
   },
   "paletteParams": [
-    "r",
-    "g",
-    "b",
-    "a"
+    {
+      "name": "r"
+    },
+    {
+      "name": "g"
+    },
+    {
+      "name": "b"
+    },
+    {
+      "name": "a"
+    }
   ],
   "params": [
     "250",

--- a/dashboard/config/programming_expressions/applab/setActiveCanvas.json
+++ b/dashboard/config/programming_expressions/applab/setActiveCanvas.json
@@ -2,7 +2,9 @@
   "func": "setActiveCanvas",
   "category": "Canvas",
   "paletteParams": [
-    "id"
+    {
+      "name": "id"
+    }
   ],
   "params": [
     "\"id\""

--- a/dashboard/config/programming_expressions/applab/setAlpha.json
+++ b/dashboard/config/programming_expressions/applab/setAlpha.json
@@ -2,10 +2,18 @@
   "func": "setAlpha",
   "category": "Canvas",
   "paletteParams": [
-    "imgData",
-    "x",
-    "y",
-    "a"
+    {
+      "name": "imgData"
+    },
+    {
+      "name": "x"
+    },
+    {
+      "name": "y"
+    },
+    {
+      "name": "a"
+    }
   ],
   "params": [
     "imgData",

--- a/dashboard/config/programming_expressions/applab/setBlue.json
+++ b/dashboard/config/programming_expressions/applab/setBlue.json
@@ -2,10 +2,18 @@
   "func": "setBlue",
   "category": "Canvas",
   "paletteParams": [
-    "imgData",
-    "x",
-    "y",
-    "b"
+    {
+      "name": "imgData"
+    },
+    {
+      "name": "x"
+    },
+    {
+      "name": "y"
+    },
+    {
+      "name": "b"
+    }
   ],
   "params": [
     "imgData",

--- a/dashboard/config/programming_expressions/applab/setChecked.json
+++ b/dashboard/config/programming_expressions/applab/setChecked.json
@@ -2,8 +2,12 @@
   "func": "setChecked",
   "category": "UI controls",
   "paletteParams": [
-    "id",
-    "checked"
+    {
+      "name": "id"
+    },
+    {
+      "name": "checked"
+    }
   ],
   "params": [
     "\"id\"",

--- a/dashboard/config/programming_expressions/applab/setFillColor.json
+++ b/dashboard/config/programming_expressions/applab/setFillColor.json
@@ -2,7 +2,9 @@
   "func": "setFillColor",
   "category": "Canvas",
   "paletteParams": [
-    "color"
+    {
+      "name": "color"
+    }
   ],
   "params": [
     "\"yellow\""

--- a/dashboard/config/programming_expressions/applab/setGreen.json
+++ b/dashboard/config/programming_expressions/applab/setGreen.json
@@ -2,10 +2,18 @@
   "func": "setGreen",
   "category": "Canvas",
   "paletteParams": [
-    "imgData",
-    "x",
-    "y",
-    "g"
+    {
+      "name": "imgData"
+    },
+    {
+      "name": "x"
+    },
+    {
+      "name": "y"
+    },
+    {
+      "name": "g"
+    }
   ],
   "params": [
     "imgData",

--- a/dashboard/config/programming_expressions/applab/setImageURL.json
+++ b/dashboard/config/programming_expressions/applab/setImageURL.json
@@ -2,8 +2,12 @@
   "func": "setImageURL",
   "category": "UI controls",
   "paletteParams": [
-    "id",
-    "url"
+    {
+      "name": "id"
+    },
+    {
+      "name": "url"
+    }
   ],
   "params": [
     "\"id\"",

--- a/dashboard/config/programming_expressions/applab/setInterval.json
+++ b/dashboard/config/programming_expressions/applab/setInterval.json
@@ -3,8 +3,12 @@
   "category": "Control",
   "type": "either",
   "paletteParams": [
-    "callback",
-    "ms"
+    {
+      "name": "callback"
+    },
+    {
+      "name": "ms"
+    }
   ],
   "params": [
     "function() {\n  \n}",

--- a/dashboard/config/programming_expressions/applab/setKeyValue.json
+++ b/dashboard/config/programming_expressions/applab/setKeyValue.json
@@ -2,9 +2,15 @@
   "func": "setKeyValue",
   "category": "Data",
   "paletteParams": [
-    "key",
-    "value",
-    "callback"
+    {
+      "name": "key"
+    },
+    {
+      "name": "value"
+    },
+    {
+      "name": "callback"
+    }
   ],
   "params": [
     "\"key\"",

--- a/dashboard/config/programming_expressions/applab/setKeyValueSync.json
+++ b/dashboard/config/programming_expressions/applab/setKeyValueSync.json
@@ -2,8 +2,12 @@
   "func": "setKeyValueSync",
   "category": "Data",
   "paletteParams": [
-    "key",
-    "value"
+    {
+      "name": "key"
+    },
+    {
+      "name": "value"
+    }
   ],
   "params": [
     "\"key\"",

--- a/dashboard/config/programming_expressions/applab/setNumber.json
+++ b/dashboard/config/programming_expressions/applab/setNumber.json
@@ -2,8 +2,12 @@
   "func": "setNumber",
   "category": "UI controls",
   "paletteParams": [
-    "id",
-    "number"
+    {
+      "name": "id"
+    },
+    {
+      "name": "number"
+    }
   ],
   "params": [
     "\"id\"",

--- a/dashboard/config/programming_expressions/applab/setPosition.json
+++ b/dashboard/config/programming_expressions/applab/setPosition.json
@@ -6,11 +6,21 @@
     "maxArgs": 5
   },
   "paletteParams": [
-    "id",
-    "x",
-    "y",
-    "width",
-    "height"
+    {
+      "name": "id"
+    },
+    {
+      "name": "x"
+    },
+    {
+      "name": "y"
+    },
+    {
+      "name": "width"
+    },
+    {
+      "name": "height"
+    }
   ],
   "params": [
     "\"id\"",

--- a/dashboard/config/programming_expressions/applab/setProperty.json
+++ b/dashboard/config/programming_expressions/applab/setProperty.json
@@ -2,9 +2,15 @@
   "func": "setProperty",
   "category": "UI controls",
   "paletteParams": [
-    "id",
-    "property",
-    "value"
+    {
+      "name": "id"
+    },
+    {
+      "name": "property"
+    },
+    {
+      "name": "value"
+    }
   ],
   "params": [
     "\"id\"",

--- a/dashboard/config/programming_expressions/applab/setRGB.json
+++ b/dashboard/config/programming_expressions/applab/setRGB.json
@@ -6,12 +6,24 @@
     "maxArgs": 7
   },
   "paletteParams": [
-    "imgData",
-    "x",
-    "y",
-    "r",
-    "g",
-    "b"
+    {
+      "name": "imgData"
+    },
+    {
+      "name": "x"
+    },
+    {
+      "name": "y"
+    },
+    {
+      "name": "r"
+    },
+    {
+      "name": "g"
+    },
+    {
+      "name": "b"
+    }
   ],
   "params": [
     "imgData",

--- a/dashboard/config/programming_expressions/applab/setRed.json
+++ b/dashboard/config/programming_expressions/applab/setRed.json
@@ -2,10 +2,18 @@
   "func": "setRed",
   "category": "Canvas",
   "paletteParams": [
-    "imgData",
-    "x",
-    "y",
-    "r"
+    {
+      "name": "imgData"
+    },
+    {
+      "name": "x"
+    },
+    {
+      "name": "y"
+    },
+    {
+      "name": "r"
+    }
   ],
   "params": [
     "imgData",

--- a/dashboard/config/programming_expressions/applab/setScreen.json
+++ b/dashboard/config/programming_expressions/applab/setScreen.json
@@ -2,7 +2,9 @@
   "func": "setScreen",
   "category": "UI controls",
   "paletteParams": [
-    "screenId"
+    {
+      "name": "screenId"
+    }
   ],
   "params": [
     "\"screen1\""

--- a/dashboard/config/programming_expressions/applab/setSelectionRange.json
+++ b/dashboard/config/programming_expressions/applab/setSelectionRange.json
@@ -2,9 +2,15 @@
   "func": "setSelectionRange",
   "category": "Advanced",
   "paletteParams": [
-    "id",
-    "start",
-    "end"
+    {
+      "name": "id"
+    },
+    {
+      "name": "start"
+    },
+    {
+      "name": "end"
+    }
   ],
   "params": [
     "\"id\"",

--- a/dashboard/config/programming_expressions/applab/setSize.json
+++ b/dashboard/config/programming_expressions/applab/setSize.json
@@ -2,9 +2,15 @@
   "func": "setSize",
   "category": "UI controls",
   "paletteParams": [
-    "id",
-    "width",
-    "height"
+    {
+      "name": "id"
+    },
+    {
+      "name": "width"
+    },
+    {
+      "name": "height"
+    }
   ],
   "params": [
     "\"id\"",

--- a/dashboard/config/programming_expressions/applab/setStrokeColor.json
+++ b/dashboard/config/programming_expressions/applab/setStrokeColor.json
@@ -2,7 +2,9 @@
   "func": "setStrokeColor",
   "category": "Canvas",
   "paletteParams": [
-    "color"
+    {
+      "name": "color"
+    }
   ],
   "params": [
     "\"red\""

--- a/dashboard/config/programming_expressions/applab/setStrokeWidth.json
+++ b/dashboard/config/programming_expressions/applab/setStrokeWidth.json
@@ -2,7 +2,9 @@
   "func": "setStrokeWidth",
   "category": "Canvas",
   "paletteParams": [
-    "width"
+    {
+      "name": "width"
+    }
   ],
   "params": [
     "3"

--- a/dashboard/config/programming_expressions/applab/setText.json
+++ b/dashboard/config/programming_expressions/applab/setText.json
@@ -2,8 +2,12 @@
   "func": "setText",
   "category": "UI controls",
   "paletteParams": [
-    "id",
-    "text"
+    {
+      "name": "id"
+    },
+    {
+      "name": "text"
+    }
   ],
   "params": [
     "\"id\"",

--- a/dashboard/config/programming_expressions/applab/setTimeout.json
+++ b/dashboard/config/programming_expressions/applab/setTimeout.json
@@ -3,8 +3,12 @@
   "category": "Control",
   "type": "either",
   "paletteParams": [
-    "callback",
-    "ms"
+    {
+      "name": "callback"
+    },
+    {
+      "name": "ms"
+    }
   ],
   "params": [
     "function() {\n  \n}",

--- a/dashboard/config/programming_expressions/applab/showElement.json
+++ b/dashboard/config/programming_expressions/applab/showElement.json
@@ -2,7 +2,9 @@
   "func": "showElement",
   "category": "UI controls",
   "paletteParams": [
-    "id"
+    {
+      "name": "id"
+    }
   ],
   "params": [
     "\"id\""

--- a/dashboard/config/programming_expressions/applab/soundSensor.getAveragedValue.json
+++ b/dashboard/config/programming_expressions/applab/soundSensor.getAveragedValue.json
@@ -5,7 +5,9 @@
     "500"
   ],
   "paletteParams": [
-    "ms"
+    {
+      "name": "ms"
+    }
   ],
   "type": "value"
 }

--- a/dashboard/config/programming_expressions/applab/soundSensor.setScale.json
+++ b/dashboard/config/programming_expressions/applab/soundSensor.setScale.json
@@ -6,7 +6,11 @@
     "100"
   ],
   "paletteParams": [
-    "low",
-    "high"
+    {
+      "name": "low"
+    },
+    {
+      "name": "high"
+    }
   ]
 }

--- a/dashboard/config/programming_expressions/applab/speed.json
+++ b/dashboard/config/programming_expressions/applab/speed.json
@@ -2,7 +2,9 @@
   "func": "speed",
   "category": "Turtle",
   "paletteParams": [
-    "value"
+    {
+      "name": "value"
+    }
   ],
   "params": [
     "50"

--- a/dashboard/config/programming_expressions/applab/startWebRequest.json
+++ b/dashboard/config/programming_expressions/applab/startWebRequest.json
@@ -2,8 +2,12 @@
   "func": "startWebRequest",
   "category": "Data",
   "paletteParams": [
-    "url",
-    "callback"
+    {
+      "name": "url"
+    },
+    {
+      "name": "callback"
+    }
   ],
   "params": [
     "\"https://en.wikipedia.org/w/api.php?origin=*&action=parse&format=json&prop=text&page=computer&section=1&disablelimitreport=true\"",

--- a/dashboard/config/programming_expressions/applab/startWebRequestSync.json
+++ b/dashboard/config/programming_expressions/applab/startWebRequestSync.json
@@ -2,7 +2,9 @@
   "func": "startWebRequestSync",
   "category": "Data",
   "paletteParams": [
-    "url"
+    {
+      "name": "url"
+    }
   ],
   "nativeIsAsync": true,
   "noAutocomplete": true

--- a/dashboard/config/programming_expressions/applab/stopSound.json
+++ b/dashboard/config/programming_expressions/applab/stopSound.json
@@ -6,10 +6,13 @@
     "maxArgs": 1
   },
   "paletteParams": [
-    "url"
+    {
+      "name": "url"
+    }
   ],
   "params": [
     "\"sound://default.mp3\""
   ],
-  "dropdown": {}
+  "dropdown": {
+  }
 }

--- a/dashboard/config/programming_expressions/applab/substring.json
+++ b/dashboard/config/programming_expressions/applab/substring.json
@@ -2,8 +2,12 @@
   "func": "substring",
   "category": "Variables",
   "paletteParams": [
-    "start",
-    "end"
+    {
+      "name": "start"
+    },
+    {
+      "name": "end"
+    }
   ],
   "params": [
     "6",

--- a/dashboard/config/programming_expressions/applab/textInput.json
+++ b/dashboard/config/programming_expressions/applab/textInput.json
@@ -2,8 +2,12 @@
   "func": "textInput",
   "category": "UI controls",
   "paletteParams": [
-    "id",
-    "text"
+    {
+      "name": "id"
+    },
+    {
+      "name": "text"
+    }
   ],
   "params": [
     "\"id\"",

--- a/dashboard/config/programming_expressions/applab/textLabel.json
+++ b/dashboard/config/programming_expressions/applab/textLabel.json
@@ -2,8 +2,12 @@
   "func": "textLabel",
   "category": "UI controls",
   "paletteParams": [
-    "id",
-    "text"
+    {
+      "name": "id"
+    },
+    {
+      "name": "text"
+    }
   ],
   "params": [
     "\"id\"",

--- a/dashboard/config/programming_expressions/applab/timedLoop.json
+++ b/dashboard/config/programming_expressions/applab/timedLoop.json
@@ -2,8 +2,12 @@
   "func": "timedLoop",
   "category": "Control",
   "paletteParams": [
-    "ms",
-    "callback"
+    {
+      "name": "ms"
+    },
+    {
+      "name": "callback"
+    }
   ],
   "params": [
     "1000",

--- a/dashboard/config/programming_expressions/applab/turnLeft.json
+++ b/dashboard/config/programming_expressions/applab/turnLeft.json
@@ -6,7 +6,9 @@
     "maxArgs": 1
   },
   "paletteParams": [
-    "angle"
+    {
+      "name": "angle"
+    }
   ],
   "params": [
     "90"

--- a/dashboard/config/programming_expressions/applab/turnRight.json
+++ b/dashboard/config/programming_expressions/applab/turnRight.json
@@ -6,7 +6,9 @@
     "maxArgs": 1
   },
   "paletteParams": [
-    "angle"
+    {
+      "name": "angle"
+    }
   ],
   "params": [
     "90"

--- a/dashboard/config/programming_expressions/applab/turnTo.json
+++ b/dashboard/config/programming_expressions/applab/turnTo.json
@@ -2,7 +2,9 @@
   "func": "turnTo",
   "category": "Turtle",
   "paletteParams": [
-    "angle"
+    {
+      "name": "angle"
+    }
   ],
   "params": [
     "0"

--- a/dashboard/config/programming_expressions/applab/updateRecord.json
+++ b/dashboard/config/programming_expressions/applab/updateRecord.json
@@ -2,9 +2,15 @@
   "func": "updateRecord",
   "category": "Data",
   "paletteParams": [
-    "table",
-    "record",
-    "callback"
+    {
+      "name": "table"
+    },
+    {
+      "name": "record"
+    },
+    {
+      "name": "callback"
+    }
   ],
   "params": [
     "\"mytable\"",

--- a/dashboard/config/programming_expressions/applab/write.json
+++ b/dashboard/config/programming_expressions/applab/write.json
@@ -2,7 +2,9 @@
   "func": "write",
   "category": "UI controls",
   "paletteParams": [
-    "text"
+    {
+      "name": "text"
+    }
   ],
   "params": [
     "\"text\""

--- a/dashboard/config/programming_expressions/gamelab/abs.json
+++ b/dashboard/config/programming_expressions/gamelab/abs.json
@@ -2,7 +2,9 @@
   "func": "abs",
   "category": "Math",
   "paletteParams": [
-    "num"
+    {
+      "name": "num"
+    }
   ],
   "params": [
     "-1"

--- a/dashboard/config/programming_expressions/gamelab/acos.json
+++ b/dashboard/config/programming_expressions/gamelab/acos.json
@@ -2,7 +2,9 @@
   "func": "acos",
   "category": "Math",
   "paletteParams": [
-    "value"
+    {
+      "name": "value"
+    }
   ],
   "params": [
     "0"

--- a/dashboard/config/programming_expressions/gamelab/add.json
+++ b/dashboard/config/programming_expressions/gamelab/add.json
@@ -2,7 +2,9 @@
   "func": "add",
   "category": "Groups",
   "paletteParams": [
-    "sprite"
+    {
+      "name": "sprite"
+    }
   ],
   "params": [
     "sprite"

--- a/dashboard/config/programming_expressions/gamelab/addAnimation.json
+++ b/dashboard/config/programming_expressions/gamelab/addAnimation.json
@@ -2,8 +2,12 @@
   "func": "addAnimation",
   "category": "Sprites",
   "paletteParams": [
-    "label",
-    "animation"
+    {
+      "name": "label"
+    },
+    {
+      "name": "animation"
+    }
   ],
   "params": [
     "\"animation_1\"",

--- a/dashboard/config/programming_expressions/gamelab/addImage.json
+++ b/dashboard/config/programming_expressions/gamelab/addImage.json
@@ -2,8 +2,12 @@
   "func": "addImage",
   "category": "Sprites",
   "paletteParams": [
-    "label",
-    "image"
+    {
+      "name": "label"
+    },
+    {
+      "name": "image"
+    }
   ],
   "params": [
     "\"img1\"",

--- a/dashboard/config/programming_expressions/gamelab/addSpeed.json
+++ b/dashboard/config/programming_expressions/gamelab/addSpeed.json
@@ -2,8 +2,12 @@
   "func": "addSpeed",
   "category": "Sprites",
   "paletteParams": [
-    "speed",
-    "angle"
+    {
+      "name": "speed"
+    },
+    {
+      "name": "angle"
+    }
   ],
   "params": [
     "1",

--- a/dashboard/config/programming_expressions/gamelab/addToGroup.json
+++ b/dashboard/config/programming_expressions/gamelab/addToGroup.json
@@ -2,7 +2,9 @@
   "func": "addToGroup",
   "category": "Sprites",
   "paletteParams": [
-    "group"
+    {
+      "name": "group"
+    }
   ],
   "params": [
     "group"

--- a/dashboard/config/programming_expressions/gamelab/angleMode.json
+++ b/dashboard/config/programming_expressions/gamelab/angleMode.json
@@ -2,7 +2,9 @@
   "func": "angleMode",
   "category": "Math",
   "paletteParams": [
-    "mode"
+    {
+      "name": "mode"
+    }
   ],
   "params": [
     "DEGREES"

--- a/dashboard/config/programming_expressions/gamelab/animation.json
+++ b/dashboard/config/programming_expressions/gamelab/animation.json
@@ -2,9 +2,15 @@
   "func": "animation",
   "category": "Animations",
   "paletteParams": [
-    "animation",
-    "x",
-    "y"
+    {
+      "name": "animation"
+    },
+    {
+      "name": "x"
+    },
+    {
+      "name": "y"
+    }
   ],
   "params": [
     "anim",

--- a/dashboard/config/programming_expressions/gamelab/arc.json
+++ b/dashboard/config/programming_expressions/gamelab/arc.json
@@ -2,12 +2,24 @@
   "func": "arc",
   "category": "Drawing",
   "paletteParams": [
-    "x",
-    "y",
-    "w",
-    "h",
-    "start",
-    "stop"
+    {
+      "name": "x"
+    },
+    {
+      "name": "y"
+    },
+    {
+      "name": "w"
+    },
+    {
+      "name": "h"
+    },
+    {
+      "name": "start"
+    },
+    {
+      "name": "stop"
+    }
   ],
   "params": [
     "0",

--- a/dashboard/config/programming_expressions/gamelab/asin.json
+++ b/dashboard/config/programming_expressions/gamelab/asin.json
@@ -2,7 +2,9 @@
   "func": "asin",
   "category": "Math",
   "paletteParams": [
-    "value"
+    {
+      "name": "value"
+    }
   ],
   "params": [
     "0"

--- a/dashboard/config/programming_expressions/gamelab/atan.json
+++ b/dashboard/config/programming_expressions/gamelab/atan.json
@@ -2,7 +2,9 @@
   "func": "atan",
   "category": "Math",
   "paletteParams": [
-    "value"
+    {
+      "name": "value"
+    }
   ],
   "params": [
     "0"

--- a/dashboard/config/programming_expressions/gamelab/atan2.json
+++ b/dashboard/config/programming_expressions/gamelab/atan2.json
@@ -2,8 +2,12 @@
   "func": "atan2",
   "category": "Math",
   "paletteParams": [
-    "y",
-    "x"
+    {
+      "name": "y"
+    },
+    {
+      "name": "x"
+    }
   ],
   "params": [
     "10",

--- a/dashboard/config/programming_expressions/gamelab/attractionPoint.json
+++ b/dashboard/config/programming_expressions/gamelab/attractionPoint.json
@@ -2,9 +2,15 @@
   "func": "attractionPoint",
   "category": "Sprites",
   "paletteParams": [
-    "speed",
-    "x",
-    "y"
+    {
+      "name": "speed"
+    },
+    {
+      "name": "x"
+    },
+    {
+      "name": "y"
+    }
   ],
   "params": [
     "1",

--- a/dashboard/config/programming_expressions/gamelab/background.json
+++ b/dashboard/config/programming_expressions/gamelab/background.json
@@ -2,7 +2,9 @@
   "func": "background",
   "category": "Drawing",
   "paletteParams": [
-    "color"
+    {
+      "name": "color"
+    }
   ],
   "params": [
     "\"white\""

--- a/dashboard/config/programming_expressions/gamelab/bounce.json
+++ b/dashboard/config/programming_expressions/gamelab/bounce.json
@@ -2,7 +2,9 @@
   "func": "bounce",
   "category": "Sprites",
   "paletteParams": [
-    "target"
+    {
+      "name": "target"
+    }
   ],
   "params": [
     "target"

--- a/dashboard/config/programming_expressions/gamelab/bounceOff.json
+++ b/dashboard/config/programming_expressions/gamelab/bounceOff.json
@@ -2,7 +2,9 @@
   "func": "bounceOff",
   "category": "Sprites",
   "paletteParams": [
-    "target"
+    {
+      "name": "target"
+    }
   ],
   "params": [
     "target"

--- a/dashboard/config/programming_expressions/gamelab/ceil.json
+++ b/dashboard/config/programming_expressions/gamelab/ceil.json
@@ -2,7 +2,9 @@
   "func": "ceil",
   "category": "Math",
   "paletteParams": [
-    "num"
+    {
+      "name": "num"
+    }
   ],
   "params": [
     "0.1"

--- a/dashboard/config/programming_expressions/gamelab/changeAnimation.json
+++ b/dashboard/config/programming_expressions/gamelab/changeAnimation.json
@@ -2,7 +2,9 @@
   "func": "changeAnimation",
   "category": "Sprites",
   "paletteParams": [
-    "label"
+    {
+      "name": "label"
+    }
   ],
   "params": [
     "\"animation_1\""

--- a/dashboard/config/programming_expressions/gamelab/changeFrame.json
+++ b/dashboard/config/programming_expressions/gamelab/changeFrame.json
@@ -2,7 +2,9 @@
   "func": "changeFrame",
   "category": "Animations",
   "paletteParams": [
-    "frame"
+    {
+      "name": "frame"
+    }
   ],
   "params": [
     "0"

--- a/dashboard/config/programming_expressions/gamelab/changeImage.json
+++ b/dashboard/config/programming_expressions/gamelab/changeImage.json
@@ -2,7 +2,9 @@
   "func": "changeImage",
   "category": "Sprites",
   "paletteParams": [
-    "label"
+    {
+      "name": "label"
+    }
   ],
   "params": [
     "\"img1\""

--- a/dashboard/config/programming_expressions/gamelab/clearInterval.json
+++ b/dashboard/config/programming_expressions/gamelab/clearInterval.json
@@ -2,7 +2,9 @@
   "func": "clearInterval",
   "category": "Control",
   "paletteParams": [
-    "__"
+    {
+      "name": "__"
+    }
   ],
   "params": [
     "__"

--- a/dashboard/config/programming_expressions/gamelab/clearTimeout.json
+++ b/dashboard/config/programming_expressions/gamelab/clearTimeout.json
@@ -2,7 +2,9 @@
   "func": "clearTimeout",
   "category": "Control",
   "paletteParams": [
-    "__"
+    {
+      "name": "__"
+    }
   ],
   "params": [
     "__"

--- a/dashboard/config/programming_expressions/gamelab/collide.json
+++ b/dashboard/config/programming_expressions/gamelab/collide.json
@@ -2,7 +2,9 @@
   "func": "collide",
   "category": "Sprites",
   "paletteParams": [
-    "target"
+    {
+      "name": "target"
+    }
   ],
   "params": [
     "target"

--- a/dashboard/config/programming_expressions/gamelab/consoleLog.json
+++ b/dashboard/config/programming_expressions/gamelab/consoleLog.json
@@ -2,7 +2,9 @@
   "func": "console.log",
   "category": "Variables",
   "paletteParams": [
-    "message"
+    {
+      "name": "message"
+    }
   ],
   "params": [
     "\"message\""

--- a/dashboard/config/programming_expressions/gamelab/constrain.json
+++ b/dashboard/config/programming_expressions/gamelab/constrain.json
@@ -2,9 +2,15 @@
   "func": "constrain",
   "category": "Math",
   "paletteParams": [
-    "num",
-    "low",
-    "high"
+    {
+      "name": "num"
+    },
+    {
+      "name": "low"
+    },
+    {
+      "name": "high"
+    }
   ],
   "params": [
     "1.1",

--- a/dashboard/config/programming_expressions/gamelab/contains.json
+++ b/dashboard/config/programming_expressions/gamelab/contains.json
@@ -2,7 +2,9 @@
   "func": "contains",
   "category": "Groups",
   "paletteParams": [
-    "sprite"
+    {
+      "name": "sprite"
+    }
   ],
   "params": [
     "sprite"

--- a/dashboard/config/programming_expressions/gamelab/cos.json
+++ b/dashboard/config/programming_expressions/gamelab/cos.json
@@ -2,7 +2,9 @@
   "func": "cos",
   "category": "Math",
   "paletteParams": [
-    "angle"
+    {
+      "name": "angle"
+    }
   ],
   "params": [
     "0"

--- a/dashboard/config/programming_expressions/gamelab/createSprite.json
+++ b/dashboard/config/programming_expressions/gamelab/createSprite.json
@@ -2,8 +2,12 @@
   "func": "var sprite = createSprite",
   "category": "Sprites",
   "paletteParams": [
-    "x",
-    "y"
+    {
+      "name": "x"
+    },
+    {
+      "name": "y"
+    }
   ],
   "params": [
     "200",

--- a/dashboard/config/programming_expressions/gamelab/degrees.json
+++ b/dashboard/config/programming_expressions/gamelab/degrees.json
@@ -2,7 +2,9 @@
   "func": "degrees",
   "category": "Math",
   "paletteParams": [
-    "radians"
+    {
+      "name": "radians"
+    }
   ],
   "params": [
     "0"

--- a/dashboard/config/programming_expressions/gamelab/displace.json
+++ b/dashboard/config/programming_expressions/gamelab/displace.json
@@ -2,7 +2,9 @@
   "func": "displace",
   "category": "Sprites",
   "paletteParams": [
-    "target"
+    {
+      "name": "target"
+    }
   ],
   "params": [
     "target"

--- a/dashboard/config/programming_expressions/gamelab/dist.json
+++ b/dashboard/config/programming_expressions/gamelab/dist.json
@@ -2,10 +2,18 @@
   "func": "dist",
   "category": "Math",
   "paletteParams": [
-    "x1",
-    "y1",
-    "x2",
-    "y2"
+    {
+      "name": "x1"
+    },
+    {
+      "name": "y1"
+    },
+    {
+      "name": "x2"
+    },
+    {
+      "name": "y2"
+    }
   ],
   "params": [
     "0",

--- a/dashboard/config/programming_expressions/gamelab/ellipse.json
+++ b/dashboard/config/programming_expressions/gamelab/ellipse.json
@@ -6,10 +6,18 @@
     "maxArgs": 4
   },
   "paletteParams": [
-    "x",
-    "y",
-    "w",
-    "h"
+    {
+      "name": "x"
+    },
+    {
+      "name": "y"
+    },
+    {
+      "name": "w"
+    },
+    {
+      "name": "h"
+    }
   ],
   "params": [
     "200",

--- a/dashboard/config/programming_expressions/gamelab/exp.json
+++ b/dashboard/config/programming_expressions/gamelab/exp.json
@@ -2,7 +2,9 @@
   "func": "exp",
   "category": "Math",
   "paletteParams": [
-    "num"
+    {
+      "name": "num"
+    }
   ],
   "params": [
     "1"

--- a/dashboard/config/programming_expressions/gamelab/fill.json
+++ b/dashboard/config/programming_expressions/gamelab/fill.json
@@ -2,7 +2,9 @@
   "func": "fill",
   "category": "Drawing",
   "paletteParams": [
-    "color"
+    {
+      "name": "color"
+    }
   ],
   "params": [
     "\"yellow\""

--- a/dashboard/config/programming_expressions/gamelab/floor.json
+++ b/dashboard/config/programming_expressions/gamelab/floor.json
@@ -2,7 +2,9 @@
   "func": "floor",
   "category": "Math",
   "paletteParams": [
-    "num"
+    {
+      "name": "num"
+    }
   ],
   "params": [
     "0.9"

--- a/dashboard/config/programming_expressions/gamelab/get.json
+++ b/dashboard/config/programming_expressions/gamelab/get.json
@@ -2,7 +2,9 @@
   "func": "get",
   "category": "Groups",
   "paletteParams": [
-    "i"
+    {
+      "name": "i"
+    }
   ],
   "params": [
     "0"

--- a/dashboard/config/programming_expressions/gamelab/goToFrame.json
+++ b/dashboard/config/programming_expressions/gamelab/goToFrame.json
@@ -2,7 +2,9 @@
   "func": "goToFrame",
   "category": "Animations",
   "paletteParams": [
-    "frame"
+    {
+      "name": "frame"
+    }
   ],
   "params": [
     "1"

--- a/dashboard/config/programming_expressions/gamelab/groupBounce.json
+++ b/dashboard/config/programming_expressions/gamelab/groupBounce.json
@@ -2,7 +2,9 @@
   "func": "group.bounce",
   "category": "Groups",
   "paletteParams": [
-    "target"
+    {
+      "name": "target"
+    }
   ],
   "params": [
     "target"

--- a/dashboard/config/programming_expressions/gamelab/groupBounceOff.json
+++ b/dashboard/config/programming_expressions/gamelab/groupBounceOff.json
@@ -2,7 +2,9 @@
   "func": "group.bounceOff",
   "category": "Groups",
   "paletteParams": [
-    "target"
+    {
+      "name": "target"
+    }
   ],
   "params": [
     "target"

--- a/dashboard/config/programming_expressions/gamelab/groupCollide.json
+++ b/dashboard/config/programming_expressions/gamelab/groupCollide.json
@@ -2,7 +2,9 @@
   "func": "group.collide",
   "category": "Groups",
   "paletteParams": [
-    "target"
+    {
+      "name": "target"
+    }
   ],
   "params": [
     "target"

--- a/dashboard/config/programming_expressions/gamelab/groupDisplace.json
+++ b/dashboard/config/programming_expressions/gamelab/groupDisplace.json
@@ -2,7 +2,9 @@
   "func": "group.displace",
   "category": "Groups",
   "paletteParams": [
-    "target"
+    {
+      "name": "target"
+    }
   ],
   "params": [
     "target"

--- a/dashboard/config/programming_expressions/gamelab/groupIsTouching.json
+++ b/dashboard/config/programming_expressions/gamelab/groupIsTouching.json
@@ -2,7 +2,9 @@
   "func": "group.isTouching",
   "category": "Groups",
   "paletteParams": [
-    "target"
+    {
+      "name": "target"
+    }
   ],
   "params": [
     "target"

--- a/dashboard/config/programming_expressions/gamelab/groupOverlap.json
+++ b/dashboard/config/programming_expressions/gamelab/groupOverlap.json
@@ -2,7 +2,9 @@
   "func": "group.overlap",
   "category": "Groups",
   "paletteParams": [
-    "target"
+    {
+      "name": "target"
+    }
   ],
   "params": [
     "target"

--- a/dashboard/config/programming_expressions/gamelab/image.json
+++ b/dashboard/config/programming_expressions/gamelab/image.json
@@ -2,15 +2,33 @@
   "func": "image",
   "category": "Drawing",
   "paletteParams": [
-    "image",
-    "srcX",
-    "srcY",
-    "srcW",
-    "srcH",
-    "x",
-    "y",
-    "w",
-    "h"
+    {
+      "name": "image"
+    },
+    {
+      "name": "srcX"
+    },
+    {
+      "name": "srcY"
+    },
+    {
+      "name": "srcW"
+    },
+    {
+      "name": "srcH"
+    },
+    {
+      "name": "x"
+    },
+    {
+      "name": "y"
+    },
+    {
+      "name": "w"
+    },
+    {
+      "name": "h"
+    }
   ],
   "params": [
     "img",

--- a/dashboard/config/programming_expressions/gamelab/includes.json
+++ b/dashboard/config/programming_expressions/gamelab/includes.json
@@ -2,7 +2,9 @@
   "func": "includes",
   "category": "Variables",
   "paletteParams": [
-    "searchValue"
+    {
+      "name": "searchValue"
+    }
   ],
   "params": [
     "\"World\""

--- a/dashboard/config/programming_expressions/gamelab/indexOf.json
+++ b/dashboard/config/programming_expressions/gamelab/indexOf.json
@@ -2,7 +2,9 @@
   "func": "indexOf",
   "category": "Variables",
   "paletteParams": [
-    "searchValue"
+    {
+      "name": "searchValue"
+    }
   ],
   "params": [
     "\"World\""

--- a/dashboard/config/programming_expressions/gamelab/isTouching.json
+++ b/dashboard/config/programming_expressions/gamelab/isTouching.json
@@ -2,7 +2,9 @@
   "func": "isTouching",
   "category": "Sprites",
   "paletteParams": [
-    "target"
+    {
+      "name": "target"
+    }
   ],
   "params": [
     "target"

--- a/dashboard/config/programming_expressions/gamelab/keyDown.json
+++ b/dashboard/config/programming_expressions/gamelab/keyDown.json
@@ -1,7 +1,9 @@
 {
   "func": "keyDown",
   "paletteParams": [
-    "code"
+    {
+      "name": "code"
+    }
   ],
   "params": [
     "\"up\""

--- a/dashboard/config/programming_expressions/gamelab/keyWentDown.json
+++ b/dashboard/config/programming_expressions/gamelab/keyWentDown.json
@@ -1,7 +1,9 @@
 {
   "func": "keyWentDown",
   "paletteParams": [
-    "code"
+    {
+      "name": "code"
+    }
   ],
   "params": [
     "\"up\""

--- a/dashboard/config/programming_expressions/gamelab/keyWentUp.json
+++ b/dashboard/config/programming_expressions/gamelab/keyWentUp.json
@@ -1,7 +1,9 @@
 {
   "func": "keyWentUp",
   "paletteParams": [
-    "code"
+    {
+      "name": "code"
+    }
   ],
   "params": [
     "\"up\""

--- a/dashboard/config/programming_expressions/gamelab/lerp.json
+++ b/dashboard/config/programming_expressions/gamelab/lerp.json
@@ -2,9 +2,15 @@
   "func": "lerp",
   "category": "Math",
   "paletteParams": [
-    "start",
-    "stop",
-    "amt"
+    {
+      "name": "start"
+    },
+    {
+      "name": "stop"
+    },
+    {
+      "name": "amt"
+    }
   ],
   "params": [
     "0",

--- a/dashboard/config/programming_expressions/gamelab/limitSpeed.json
+++ b/dashboard/config/programming_expressions/gamelab/limitSpeed.json
@@ -2,7 +2,9 @@
   "func": "limitSpeed",
   "category": "Sprites",
   "paletteParams": [
-    "max"
+    {
+      "name": "max"
+    }
   ],
   "params": [
     "3"

--- a/dashboard/config/programming_expressions/gamelab/line.json
+++ b/dashboard/config/programming_expressions/gamelab/line.json
@@ -2,10 +2,18 @@
   "func": "line",
   "category": "Drawing",
   "paletteParams": [
-    "x1",
-    "y1",
-    "x2",
-    "y2"
+    {
+      "name": "x1"
+    },
+    {
+      "name": "y1"
+    },
+    {
+      "name": "x2"
+    },
+    {
+      "name": "y2"
+    }
   ],
   "params": [
     "0",

--- a/dashboard/config/programming_expressions/gamelab/loadImage.json
+++ b/dashboard/config/programming_expressions/gamelab/loadImage.json
@@ -2,7 +2,9 @@
   "func": "loadImage",
   "category": "Drawing",
   "paletteParams": [
-    "url"
+    {
+      "name": "url"
+    }
   ],
   "params": [
     "\"https://code.org/images/logo.png\""

--- a/dashboard/config/programming_expressions/gamelab/log.json
+++ b/dashboard/config/programming_expressions/gamelab/log.json
@@ -2,7 +2,9 @@
   "func": "log",
   "category": "Math",
   "paletteParams": [
-    "num"
+    {
+      "name": "num"
+    }
   ],
   "params": [
     "1"

--- a/dashboard/config/programming_expressions/gamelab/mag.json
+++ b/dashboard/config/programming_expressions/gamelab/mag.json
@@ -2,8 +2,12 @@
   "func": "mag",
   "category": "Math",
   "paletteParams": [
-    "a",
-    "b"
+    {
+      "name": "a"
+    },
+    {
+      "name": "b"
+    }
   ],
   "params": [
     "100",

--- a/dashboard/config/programming_expressions/gamelab/map.json
+++ b/dashboard/config/programming_expressions/gamelab/map.json
@@ -2,11 +2,21 @@
   "func": "map",
   "category": "Math",
   "paletteParams": [
-    "value",
-    "start1",
-    "stop1",
-    "start2",
-    "stop"
+    {
+      "name": "value"
+    },
+    {
+      "name": "start1"
+    },
+    {
+      "name": "stop1"
+    },
+    {
+      "name": "start2"
+    },
+    {
+      "name": "stop"
+    }
   ],
   "params": [
     "0.9",

--- a/dashboard/config/programming_expressions/gamelab/max.json
+++ b/dashboard/config/programming_expressions/gamelab/max.json
@@ -2,8 +2,12 @@
   "func": "max",
   "category": "Math",
   "paletteParams": [
-    "n1",
-    "n2"
+    {
+      "name": "n1"
+    },
+    {
+      "name": "n2"
+    }
   ],
   "params": [
     "1",

--- a/dashboard/config/programming_expressions/gamelab/min.json
+++ b/dashboard/config/programming_expressions/gamelab/min.json
@@ -2,8 +2,12 @@
   "func": "min",
   "category": "Math",
   "paletteParams": [
-    "n1",
-    "n2"
+    {
+      "name": "n1"
+    },
+    {
+      "name": "n2"
+    }
   ],
   "params": [
     "1",

--- a/dashboard/config/programming_expressions/gamelab/mirrorX.json
+++ b/dashboard/config/programming_expressions/gamelab/mirrorX.json
@@ -2,7 +2,9 @@
   "func": "mirrorX",
   "category": "Sprites",
   "paletteParams": [
-    "dir"
+    {
+      "name": "dir"
+    }
   ],
   "params": [
     "-1"

--- a/dashboard/config/programming_expressions/gamelab/mirrorY.json
+++ b/dashboard/config/programming_expressions/gamelab/mirrorY.json
@@ -2,7 +2,9 @@
   "func": "mirrorY",
   "category": "Sprites",
   "paletteParams": [
-    "dir"
+    {
+      "name": "dir"
+    }
   ],
   "params": [
     "-1"

--- a/dashboard/config/programming_expressions/gamelab/mouseDown.json
+++ b/dashboard/config/programming_expressions/gamelab/mouseDown.json
@@ -1,7 +1,9 @@
 {
   "func": "mouseDown",
   "paletteParams": [
-    "button"
+    {
+      "name": "button"
+    }
   ],
   "params": [
     "\"leftButton\""

--- a/dashboard/config/programming_expressions/gamelab/mouseIsOver.json
+++ b/dashboard/config/programming_expressions/gamelab/mouseIsOver.json
@@ -1,7 +1,9 @@
 {
   "func": "mouseIsOver",
   "paletteParams": [
-    "sprite"
+    {
+      "name": "sprite"
+    }
   ],
   "params": [
     "sprite"

--- a/dashboard/config/programming_expressions/gamelab/mousePressedOver.json
+++ b/dashboard/config/programming_expressions/gamelab/mousePressedOver.json
@@ -1,7 +1,9 @@
 {
   "func": "mousePressedOver",
   "paletteParams": [
-    "sprite"
+    {
+      "name": "sprite"
+    }
   ],
   "params": [
     "sprite"

--- a/dashboard/config/programming_expressions/gamelab/mouseWentDown.json
+++ b/dashboard/config/programming_expressions/gamelab/mouseWentDown.json
@@ -1,7 +1,9 @@
 {
   "func": "mouseWentDown",
   "paletteParams": [
-    "button"
+    {
+      "name": "button"
+    }
   ],
   "params": [
     "\"leftButton\""

--- a/dashboard/config/programming_expressions/gamelab/mouseWentUp.json
+++ b/dashboard/config/programming_expressions/gamelab/mouseWentUp.json
@@ -1,7 +1,9 @@
 {
   "func": "mouseWentUp",
   "paletteParams": [
-    "button"
+    {
+      "name": "button"
+    }
   ],
   "params": [
     "\"leftButton\""

--- a/dashboard/config/programming_expressions/gamelab/norm.json
+++ b/dashboard/config/programming_expressions/gamelab/norm.json
@@ -2,9 +2,15 @@
   "func": "norm",
   "category": "Math",
   "paletteParams": [
-    "value",
-    "start",
-    "stop"
+    {
+      "name": "value"
+    },
+    {
+      "name": "start"
+    },
+    {
+      "name": "stop"
+    }
   ],
   "params": [
     "90",

--- a/dashboard/config/programming_expressions/gamelab/overlap.json
+++ b/dashboard/config/programming_expressions/gamelab/overlap.json
@@ -2,7 +2,9 @@
   "func": "overlap",
   "category": "Sprites",
   "paletteParams": [
-    "target"
+    {
+      "name": "target"
+    }
   ],
   "params": [
     "target"

--- a/dashboard/config/programming_expressions/gamelab/playSound.json
+++ b/dashboard/config/programming_expressions/gamelab/playSound.json
@@ -6,8 +6,12 @@
     "maxArgs": 2
   },
   "paletteParams": [
-    "url",
-    "loop"
+    {
+      "name": "url"
+    },
+    {
+      "name": "loop"
+    }
   ],
   "params": [
     "\"sound://default.mp3\"",

--- a/dashboard/config/programming_expressions/gamelab/playSpeech.json
+++ b/dashboard/config/programming_expressions/gamelab/playSpeech.json
@@ -6,9 +6,15 @@
     "maxArgs": 3
   },
   "paletteParams": [
-    "text",
-    "gender",
-    "language"
+    {
+      "name": "text"
+    },
+    {
+      "name": "gender"
+    },
+    {
+      "name": "language"
+    }
   ],
   "params": [
     "\"Hello World!\"",

--- a/dashboard/config/programming_expressions/gamelab/point.json
+++ b/dashboard/config/programming_expressions/gamelab/point.json
@@ -2,8 +2,12 @@
   "func": "point",
   "category": "Drawing",
   "paletteParams": [
-    "x",
-    "y"
+    {
+      "name": "x"
+    },
+    {
+      "name": "y"
+    }
   ],
   "params": [
     "200",

--- a/dashboard/config/programming_expressions/gamelab/pointTo.json
+++ b/dashboard/config/programming_expressions/gamelab/pointTo.json
@@ -2,8 +2,12 @@
   "func": "pointTo",
   "category": "Sprites",
   "paletteParams": [
-    "x",
-    "y"
+    {
+      "name": "x"
+    },
+    {
+      "name": "y"
+    }
   ],
   "params": [
     "200",

--- a/dashboard/config/programming_expressions/gamelab/pointToEach.json
+++ b/dashboard/config/programming_expressions/gamelab/pointToEach.json
@@ -2,8 +2,12 @@
   "func": "pointToEach",
   "category": "Groups",
   "paletteParams": [
-    "x",
-    "y"
+    {
+      "name": "x"
+    },
+    {
+      "name": "y"
+    }
   ],
   "params": [
     "200",

--- a/dashboard/config/programming_expressions/gamelab/pow.json
+++ b/dashboard/config/programming_expressions/gamelab/pow.json
@@ -2,8 +2,12 @@
   "func": "pow",
   "category": "Math",
   "paletteParams": [
-    "n",
-    "e"
+    {
+      "name": "n"
+    },
+    {
+      "name": "e"
+    }
   ],
   "params": [
     "10",

--- a/dashboard/config/programming_expressions/gamelab/radians.json
+++ b/dashboard/config/programming_expressions/gamelab/radians.json
@@ -2,7 +2,9 @@
   "func": "radians",
   "category": "Math",
   "paletteParams": [
-    "degrees"
+    {
+      "name": "degrees"
+    }
   ],
   "params": [
     "0"

--- a/dashboard/config/programming_expressions/gamelab/random.json
+++ b/dashboard/config/programming_expressions/gamelab/random.json
@@ -2,8 +2,12 @@
   "func": "random",
   "category": "Math",
   "paletteParams": [
-    "min",
-    "max"
+    {
+      "name": "min"
+    },
+    {
+      "name": "max"
+    }
   ],
   "params": [
     "1",

--- a/dashboard/config/programming_expressions/gamelab/randomGaussian.json
+++ b/dashboard/config/programming_expressions/gamelab/randomGaussian.json
@@ -2,8 +2,12 @@
   "func": "randomGaussian",
   "category": "Math",
   "paletteParams": [
-    "mean",
-    "sd"
+    {
+      "name": "mean"
+    },
+    {
+      "name": "sd"
+    }
   ],
   "params": [
     "0",

--- a/dashboard/config/programming_expressions/gamelab/randomSeed.json
+++ b/dashboard/config/programming_expressions/gamelab/randomSeed.json
@@ -2,7 +2,9 @@
   "func": "randomSeed",
   "category": "Math",
   "paletteParams": [
-    "seed"
+    {
+      "name": "seed"
+    }
   ],
   "params": [
     "99"

--- a/dashboard/config/programming_expressions/gamelab/rect.json
+++ b/dashboard/config/programming_expressions/gamelab/rect.json
@@ -6,10 +6,18 @@
     "maxArgs": 4
   },
   "paletteParams": [
-    "x",
-    "y",
-    "w",
-    "h"
+    {
+      "name": "x"
+    },
+    {
+      "name": "y"
+    },
+    {
+      "name": "w"
+    },
+    {
+      "name": "h"
+    }
   ],
   "params": [
     "100",

--- a/dashboard/config/programming_expressions/gamelab/regularPolygon.json
+++ b/dashboard/config/programming_expressions/gamelab/regularPolygon.json
@@ -2,10 +2,18 @@
   "func": "regularPolygon",
   "category": "Drawing",
   "paletteParams": [
-    "x",
-    "y",
-    "sides",
-    "size"
+    {
+      "name": "x"
+    },
+    {
+      "name": "y"
+    },
+    {
+      "name": "sides"
+    },
+    {
+      "name": "size"
+    }
   ],
   "params": [
     "200",

--- a/dashboard/config/programming_expressions/gamelab/remove.json
+++ b/dashboard/config/programming_expressions/gamelab/remove.json
@@ -2,7 +2,9 @@
   "func": "remove",
   "category": "Groups",
   "paletteParams": [
-    "sprite"
+    {
+      "name": "sprite"
+    }
   ],
   "params": [
     "sprite"

--- a/dashboard/config/programming_expressions/gamelab/rgb.json
+++ b/dashboard/config/programming_expressions/gamelab/rgb.json
@@ -6,9 +6,15 @@
     "maxArgs": 4
   },
   "paletteParams": [
-    "r",
-    "g",
-    "b"
+    {
+      "name": "r"
+    },
+    {
+      "name": "g"
+    },
+    {
+      "name": "b"
+    }
   ],
   "params": [
     "255",

--- a/dashboard/config/programming_expressions/gamelab/round.json
+++ b/dashboard/config/programming_expressions/gamelab/round.json
@@ -2,7 +2,9 @@
   "func": "round",
   "category": "Math",
   "paletteParams": [
-    "num"
+    {
+      "name": "num"
+    }
   ],
   "params": [
     "0.9"

--- a/dashboard/config/programming_expressions/gamelab/setAnimation.json
+++ b/dashboard/config/programming_expressions/gamelab/setAnimation.json
@@ -2,11 +2,14 @@
   "func": "setAnimation",
   "category": "Sprites",
   "paletteParams": [
-    "label"
+    {
+      "name": "label"
+    }
   ],
   "params": [
     "\"animation_1\""
   ],
-  "dropdown": {},
+  "dropdown": {
+  },
   "modeOptionName": "*.setAnimation"
 }

--- a/dashboard/config/programming_expressions/gamelab/setAnimationEach.json
+++ b/dashboard/config/programming_expressions/gamelab/setAnimationEach.json
@@ -2,11 +2,14 @@
   "func": "setAnimationEach",
   "category": "Groups",
   "paletteParams": [
-    "label"
+    {
+      "name": "label"
+    }
   ],
   "params": [
     "\"animation_1\""
   ],
-  "dropdown": {},
+  "dropdown": {
+  },
   "modeOptionName": "*.setAnimationEach"
 }

--- a/dashboard/config/programming_expressions/gamelab/setCollider.json
+++ b/dashboard/config/programming_expressions/gamelab/setCollider.json
@@ -6,7 +6,9 @@
     "maxArgs": 6
   },
   "paletteParams": [
-    "type"
+    {
+      "name": "type"
+    }
   ],
   "params": [
     "\"rectangle\""

--- a/dashboard/config/programming_expressions/gamelab/setColliderEach.json
+++ b/dashboard/config/programming_expressions/gamelab/setColliderEach.json
@@ -6,7 +6,9 @@
     "maxArgs": 6
   },
   "paletteParams": [
-    "type"
+    {
+      "name": "type"
+    }
   ],
   "params": [
     "\"rectangle\""

--- a/dashboard/config/programming_expressions/gamelab/setColorEach.json
+++ b/dashboard/config/programming_expressions/gamelab/setColorEach.json
@@ -2,7 +2,9 @@
   "func": "setColorEach",
   "category": "Groups",
   "paletteParams": [
-    "color"
+    {
+      "name": "color"
+    }
   ],
   "params": [
     "\"blue\""

--- a/dashboard/config/programming_expressions/gamelab/setDepthEach.json
+++ b/dashboard/config/programming_expressions/gamelab/setDepthEach.json
@@ -2,7 +2,9 @@
   "func": "setDepthEach",
   "category": "Groups",
   "paletteParams": [
-    "depth"
+    {
+      "name": "depth"
+    }
   ],
   "params": [
     "1"

--- a/dashboard/config/programming_expressions/gamelab/setFrame.json
+++ b/dashboard/config/programming_expressions/gamelab/setFrame.json
@@ -2,7 +2,9 @@
   "func": "setFrame",
   "category": "Sprites",
   "paletteParams": [
-    "frame"
+    {
+      "name": "frame"
+    }
   ],
   "params": [
     "0"

--- a/dashboard/config/programming_expressions/gamelab/setHeightEach.json
+++ b/dashboard/config/programming_expressions/gamelab/setHeightEach.json
@@ -2,7 +2,9 @@
   "func": "setHeightEach",
   "category": "Groups",
   "paletteParams": [
-    "height"
+    {
+      "name": "height"
+    }
   ],
   "params": [
     "50"

--- a/dashboard/config/programming_expressions/gamelab/setInterval.json
+++ b/dashboard/config/programming_expressions/gamelab/setInterval.json
@@ -3,8 +3,12 @@
   "category": "Control",
   "type": "either",
   "paletteParams": [
-    "callback",
-    "ms"
+    {
+      "name": "callback"
+    },
+    {
+      "name": "ms"
+    }
   ],
   "params": [
     "function() {\n  \n}",

--- a/dashboard/config/programming_expressions/gamelab/setLifetimeEach.json
+++ b/dashboard/config/programming_expressions/gamelab/setLifetimeEach.json
@@ -2,7 +2,9 @@
   "func": "setLifetimeEach",
   "category": "Groups",
   "paletteParams": [
-    "lifetime"
+    {
+      "name": "lifetime"
+    }
   ],
   "params": [
     "5"

--- a/dashboard/config/programming_expressions/gamelab/setMirrorXEach.json
+++ b/dashboard/config/programming_expressions/gamelab/setMirrorXEach.json
@@ -2,7 +2,9 @@
   "func": "setMirrorXEach",
   "category": "Groups",
   "paletteParams": [
-    "dir"
+    {
+      "name": "dir"
+    }
   ],
   "params": [
     "-1"

--- a/dashboard/config/programming_expressions/gamelab/setMirrorYEach.json
+++ b/dashboard/config/programming_expressions/gamelab/setMirrorYEach.json
@@ -2,7 +2,9 @@
   "func": "setMirrorYEach",
   "category": "Groups",
   "paletteParams": [
-    "dir"
+    {
+      "name": "dir"
+    }
   ],
   "params": [
     "-1"

--- a/dashboard/config/programming_expressions/gamelab/setRotateToDirectionEach.json
+++ b/dashboard/config/programming_expressions/gamelab/setRotateToDirectionEach.json
@@ -2,7 +2,9 @@
   "func": "setRotateToDirectionEach",
   "category": "Groups",
   "paletteParams": [
-    "bool"
+    {
+      "name": "bool"
+    }
   ],
   "params": [
     "true"

--- a/dashboard/config/programming_expressions/gamelab/setRotationEach.json
+++ b/dashboard/config/programming_expressions/gamelab/setRotationEach.json
@@ -2,7 +2,9 @@
   "func": "setRotationEach",
   "category": "Groups",
   "paletteParams": [
-    "angle"
+    {
+      "name": "angle"
+    }
   ],
   "params": [
     "90"

--- a/dashboard/config/programming_expressions/gamelab/setRotationSpeedEach.json
+++ b/dashboard/config/programming_expressions/gamelab/setRotationSpeedEach.json
@@ -2,7 +2,9 @@
   "func": "setRotationSpeedEach",
   "category": "Groups",
   "paletteParams": [
-    "speed"
+    {
+      "name": "speed"
+    }
   ],
   "params": [
     "5"

--- a/dashboard/config/programming_expressions/gamelab/setScaleEach.json
+++ b/dashboard/config/programming_expressions/gamelab/setScaleEach.json
@@ -2,7 +2,9 @@
   "func": "setScaleEach",
   "category": "Groups",
   "paletteParams": [
-    "scale"
+    {
+      "name": "scale"
+    }
   ],
   "params": [
     "5"

--- a/dashboard/config/programming_expressions/gamelab/setSpeedAndDirection.json
+++ b/dashboard/config/programming_expressions/gamelab/setSpeedAndDirection.json
@@ -2,8 +2,12 @@
   "func": "setSpeedAndDirection",
   "category": "Sprites",
   "paletteParams": [
-    "speed",
-    "angle"
+    {
+      "name": "speed"
+    },
+    {
+      "name": "angle"
+    }
   ],
   "params": [
     "1",

--- a/dashboard/config/programming_expressions/gamelab/setSpeedAndDirectionEach.json
+++ b/dashboard/config/programming_expressions/gamelab/setSpeedAndDirectionEach.json
@@ -2,8 +2,12 @@
   "func": "setSpeedAndDirectionEach",
   "category": "Groups",
   "paletteParams": [
-    "speed",
-    "angle"
+    {
+      "name": "speed"
+    },
+    {
+      "name": "angle"
+    }
   ],
   "params": [
     "1",

--- a/dashboard/config/programming_expressions/gamelab/setTimeout.json
+++ b/dashboard/config/programming_expressions/gamelab/setTimeout.json
@@ -3,8 +3,12 @@
   "category": "Control",
   "type": "either",
   "paletteParams": [
-    "callback",
-    "ms"
+    {
+      "name": "callback"
+    },
+    {
+      "name": "ms"
+    }
   ],
   "params": [
     "function() {\n  \n}",

--- a/dashboard/config/programming_expressions/gamelab/setTintEach.json
+++ b/dashboard/config/programming_expressions/gamelab/setTintEach.json
@@ -2,7 +2,9 @@
   "func": "setTintEach",
   "category": "Groups",
   "paletteParams": [
-    "color"
+    {
+      "name": "color"
+    }
   ],
   "params": [
     "\"blue\""

--- a/dashboard/config/programming_expressions/gamelab/setVelocity.json
+++ b/dashboard/config/programming_expressions/gamelab/setVelocity.json
@@ -2,8 +2,12 @@
   "func": "setVelocity",
   "category": "Sprites",
   "paletteParams": [
-    "x",
-    "y"
+    {
+      "name": "x"
+    },
+    {
+      "name": "y"
+    }
   ],
   "params": [
     "1",

--- a/dashboard/config/programming_expressions/gamelab/setVelocityEach.json
+++ b/dashboard/config/programming_expressions/gamelab/setVelocityEach.json
@@ -2,8 +2,12 @@
   "func": "setVelocityEach",
   "category": "Groups",
   "paletteParams": [
-    "x",
-    "y"
+    {
+      "name": "x"
+    },
+    {
+      "name": "y"
+    }
   ],
   "params": [
     "1",

--- a/dashboard/config/programming_expressions/gamelab/setVelocityXEach.json
+++ b/dashboard/config/programming_expressions/gamelab/setVelocityXEach.json
@@ -2,7 +2,9 @@
   "func": "setVelocityXEach",
   "category": "Groups",
   "paletteParams": [
-    "velocityX"
+    {
+      "name": "velocityX"
+    }
   ],
   "params": [
     "3"

--- a/dashboard/config/programming_expressions/gamelab/setVelocityYEach.json
+++ b/dashboard/config/programming_expressions/gamelab/setVelocityYEach.json
@@ -2,7 +2,9 @@
   "func": "setVelocityYEach",
   "category": "Groups",
   "paletteParams": [
-    "velocityY"
+    {
+      "name": "velocityY"
+    }
   ],
   "params": [
     "3"

--- a/dashboard/config/programming_expressions/gamelab/setVisibleEach.json
+++ b/dashboard/config/programming_expressions/gamelab/setVisibleEach.json
@@ -2,7 +2,9 @@
   "func": "setVisibleEach",
   "category": "Groups",
   "paletteParams": [
-    "bool"
+    {
+      "name": "bool"
+    }
   ],
   "params": [
     "false"

--- a/dashboard/config/programming_expressions/gamelab/setWidthEach.json
+++ b/dashboard/config/programming_expressions/gamelab/setWidthEach.json
@@ -2,7 +2,9 @@
   "func": "setWidthEach",
   "category": "Groups",
   "paletteParams": [
-    "width"
+    {
+      "name": "width"
+    }
   ],
   "params": [
     "50"

--- a/dashboard/config/programming_expressions/gamelab/shape.json
+++ b/dashboard/config/programming_expressions/gamelab/shape.json
@@ -5,12 +5,24 @@
     "minArgs": 6
   },
   "paletteParams": [
-    "x1",
-    "y1",
-    "x2",
-    "y2",
-    "x3",
-    "y3"
+    {
+      "name": "x1"
+    },
+    {
+      "name": "y1"
+    },
+    {
+      "name": "x2"
+    },
+    {
+      "name": "y2"
+    },
+    {
+      "name": "x3"
+    },
+    {
+      "name": "y3"
+    }
   ],
   "params": [
     "200",

--- a/dashboard/config/programming_expressions/gamelab/showMobileControls.json
+++ b/dashboard/config/programming_expressions/gamelab/showMobileControls.json
@@ -1,10 +1,18 @@
 {
   "func": "showMobileControls",
   "paletteParams": [
-    "spaceButtonVisible",
-    "dpadVisible",
-    "dpadFourWay",
-    "mobileOnly"
+    {
+      "name": "spaceButtonVisible"
+    },
+    {
+      "name": "dpadVisible"
+    },
+    {
+      "name": "dpadFourWay"
+    },
+    {
+      "name": "mobileOnly"
+    }
   ],
   "params": [
     "true",

--- a/dashboard/config/programming_expressions/gamelab/sin.json
+++ b/dashboard/config/programming_expressions/gamelab/sin.json
@@ -2,7 +2,9 @@
   "func": "sin",
   "category": "Math",
   "paletteParams": [
-    "angle"
+    {
+      "name": "angle"
+    }
   ],
   "params": [
     "0"

--- a/dashboard/config/programming_expressions/gamelab/sq.json
+++ b/dashboard/config/programming_expressions/gamelab/sq.json
@@ -2,7 +2,9 @@
   "func": "sq",
   "category": "Math",
   "paletteParams": [
-    "num"
+    {
+      "name": "num"
+    }
   ],
   "params": [
     "2"

--- a/dashboard/config/programming_expressions/gamelab/sqrt.json
+++ b/dashboard/config/programming_expressions/gamelab/sqrt.json
@@ -2,7 +2,9 @@
   "func": "sqrt",
   "category": "Math",
   "paletteParams": [
-    "num"
+    {
+      "name": "num"
+    }
   ],
   "params": [
     "9"

--- a/dashboard/config/programming_expressions/gamelab/stopSound.json
+++ b/dashboard/config/programming_expressions/gamelab/stopSound.json
@@ -6,10 +6,13 @@
     "maxArgs": 1
   },
   "paletteParams": [
-    "url"
+    {
+      "name": "url"
+    }
   ],
   "params": [
     "\"sound://default.mp3\""
   ],
-  "dropdown": {}
+  "dropdown": {
+  }
 }

--- a/dashboard/config/programming_expressions/gamelab/stroke.json
+++ b/dashboard/config/programming_expressions/gamelab/stroke.json
@@ -2,7 +2,9 @@
   "func": "stroke",
   "category": "Drawing",
   "paletteParams": [
-    "color"
+    {
+      "name": "color"
+    }
   ],
   "params": [
     "\"blue\""

--- a/dashboard/config/programming_expressions/gamelab/strokeWeight.json
+++ b/dashboard/config/programming_expressions/gamelab/strokeWeight.json
@@ -2,7 +2,9 @@
   "func": "strokeWeight",
   "category": "Drawing",
   "paletteParams": [
-    "size"
+    {
+      "name": "size"
+    }
   ],
   "params": [
     "3"

--- a/dashboard/config/programming_expressions/gamelab/substring.json
+++ b/dashboard/config/programming_expressions/gamelab/substring.json
@@ -2,8 +2,12 @@
   "func": "substring",
   "category": "Variables",
   "paletteParams": [
-    "start",
-    "end"
+    {
+      "name": "start"
+    },
+    {
+      "name": "end"
+    }
   ],
   "params": [
     "6",

--- a/dashboard/config/programming_expressions/gamelab/tan.json
+++ b/dashboard/config/programming_expressions/gamelab/tan.json
@@ -2,7 +2,9 @@
   "func": "tan",
   "category": "Math",
   "paletteParams": [
-    "angle"
+    {
+      "name": "angle"
+    }
   ],
   "params": [
     "0"

--- a/dashboard/config/programming_expressions/gamelab/text.json
+++ b/dashboard/config/programming_expressions/gamelab/text.json
@@ -2,9 +2,15 @@
   "func": "text",
   "category": "Drawing",
   "paletteParams": [
-    "str",
-    "x",
-    "y"
+    {
+      "name": "str"
+    },
+    {
+      "name": "x"
+    },
+    {
+      "name": "y"
+    }
   ],
   "params": [
     "\"text\"",

--- a/dashboard/config/programming_expressions/gamelab/textAlign.json
+++ b/dashboard/config/programming_expressions/gamelab/textAlign.json
@@ -2,8 +2,12 @@
   "func": "textAlign",
   "category": "Drawing",
   "paletteParams": [
-    "horiz",
-    "vert"
+    {
+      "name": "horiz"
+    },
+    {
+      "name": "vert"
+    }
   ],
   "params": [
     "CENTER",

--- a/dashboard/config/programming_expressions/gamelab/textFont.json
+++ b/dashboard/config/programming_expressions/gamelab/textFont.json
@@ -2,7 +2,9 @@
   "func": "textFont",
   "category": "Drawing",
   "paletteParams": [
-    "font"
+    {
+      "name": "font"
+    }
   ],
   "params": [
     "\"Arial\""

--- a/dashboard/config/programming_expressions/gamelab/textSize.json
+++ b/dashboard/config/programming_expressions/gamelab/textSize.json
@@ -2,7 +2,9 @@
   "func": "textSize",
   "category": "Drawing",
   "paletteParams": [
-    "pixels"
+    {
+      "name": "pixels"
+    }
   ],
   "params": [
     "12"

--- a/dashboard/config/programming_expressions/gamelab/timedLoop.json
+++ b/dashboard/config/programming_expressions/gamelab/timedLoop.json
@@ -2,8 +2,12 @@
   "func": "timedLoop",
   "category": "Control",
   "paletteParams": [
-    "ms",
-    "callback"
+    {
+      "name": "ms"
+    },
+    {
+      "name": "callback"
+    }
   ],
   "params": [
     "1000",

--- a/dashboard/config/programming_expressions/gamelab/triangle.json
+++ b/dashboard/config/programming_expressions/gamelab/triangle.json
@@ -2,12 +2,24 @@
   "func": "triangle",
   "category": "Drawing",
   "paletteParams": [
-    "x1",
-    "y1",
-    "x2",
-    "y2",
-    "x3",
-    "y3"
+    {
+      "name": "x1"
+    },
+    {
+      "name": "y1"
+    },
+    {
+      "name": "x2"
+    },
+    {
+      "name": "y2"
+    },
+    {
+      "name": "x3"
+    },
+    {
+      "name": "y3"
+    }
   ],
   "params": [
     "200",


### PR DESCRIPTION
This PR persists `palette_params` to the db on seed and changes the type of `paletteParams` to be a list of objects instead of a list of strings. This is in preparation for allowing the editing of parameters in code docs.

Parameters in code docs will have a bit more information than just name, including a type, a description, and whether or not they are required. See [this spec](https://docs.google.com/document/d/1CuMG8vlECM0xLs8kq5hocUS5ToyPWipjTGU841W2wvs/edit#) for more context. I propose saving this extra data along with the name in `palette_params`. (Note that this data is not serialized as part of this PR.)

There is also a `params` field, however that is often more of an example of the value of the parameter, see [color](https://github.com/code-dot-org/code-dot-org/blob/27582e52436cb578afe4eaf70e2907cb2ffb1cee/dashboard/config/programming_expressions/applab/color.json#L8). I don't see an obvious use for the `params` field and was planning on removing it in the future.

I would recommend viewing the [Ruby diff](https://github.com/code-dot-org/code-dot-org/pull/43165/files?authenticity_token=JwPOUZ8%2BbcUqTTLTdW0tmTBZ7fH5yrTwq7%2Fe7Qj8WTedAVwK1m7Qg0PUmaEFOhrrzunRAqqOMtPkIGfI7KTiDA%3D%3D&file-filters%5B%5D=.rb) on its own first as github takes a minute to load all the json diffs.

I modified the json files using the following script:
```
Dir.glob(Rails.root.join("config/programming_expressions/{applab,gamelab,weblab,spritelab}/*.json")).each do |path|
  serialization = JSON.parse(File.read(path))
  next unless serialization['paletteParams']
  palleteParams = serialization['paletteParams'].map do |param|
    {name: param}
  end
  serialization['paletteParams'] = palleteParams
  File.write(path, JSON.pretty_generate(serialization))
end
```

## Testing story

seeded locally and manually verified the syntax of a couple expressions

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
