### PR TITLE
[Google Blockly][Poetry] Don't generate code for dragging blocks

### DIFF
--- a/apps/src/blockly/addons/cdoBlockDragger.js
+++ b/apps/src/blockly/addons/cdoBlockDragger.js
@@ -27,8 +27,9 @@ export default class BlockDragger extends GoogleBlockly.BlockDragger {
    * @override
    */
   endDrag(e, currentDragDeltaXY) {
+    const wouldDeleteBlock = this.draggedConnectionManager_.wouldDeleteBlock();
     // Don't let the block end with a negative position, unless it's getting deleted.
-    if (!this.draggedConnectionManager_.wouldDeleteBlock()) {
+    if (!wouldDeleteBlock) {
       const endPosition = this.draggingBlock_.getRelativeToSurfaceXY();
       if (endPosition.x < 0) {
         currentDragDeltaXY.x -= endPosition.x;
@@ -42,6 +43,10 @@ export default class BlockDragger extends GoogleBlockly.BlockDragger {
     this.workspace_.trashcan.setDisabled(false);
     this.workspace_.trashcan.setLidOpen(false);
     this.workspace_.hideTrashcan();
+
+    if (!wouldDeleteBlock) {
+      this.draggingBlock_.setEnabled(!!this.draggingBlock_.parentBlock_);
+    }
   }
 
   /** Open trashcan lid whenever the block is over the toolbox, not only if it's over the trashcan itself.

--- a/apps/src/blockly/addons/cdoBlockDragger.js
+++ b/apps/src/blockly/addons/cdoBlockDragger.js
@@ -44,6 +44,11 @@ export default class BlockDragger extends GoogleBlockly.BlockDragger {
     this.workspace_.trashcan.setLidOpen(false);
     this.workspace_.hideTrashcan();
 
+    // Core Blockly logic will eventually update the block's disabled state, but
+    // we want to update it immediately. We rely on this value to skip
+    // code generation for disabled blocks, and since we have live-preview, it
+    // would be noticeable if this value were out of sync, even briefly.
+    // This only matters if the block is not being deleted.
     if (!wouldDeleteBlock) {
       this.draggingBlock_.setEnabled(!!this.draggingBlock_.parentBlock_);
     }

--- a/apps/src/blockly/addons/cdoBlockSvg.js
+++ b/apps/src/blockly/addons/cdoBlockSvg.js
@@ -23,6 +23,13 @@ export default class BlockSvg extends GoogleBlockly.BlockSvg {
     super.mixin(mixinObj, true);
   }
 
+  isUnused() {
+    return (
+      this.disabled ||
+      this.workspace?.currentGesture_?.blockDragger_?.draggingBlock_ === this
+    );
+  }
+
   isVisible() {
     // TODO (eventually), but all Flappy blocks are visible, so this won't be a problem
     // until we convert other labs

--- a/apps/src/blockly/addons/cdoGenerator.js
+++ b/apps/src/blockly/addons/cdoGenerator.js
@@ -24,6 +24,17 @@ export default function initializeGenerator(blocklyWrapper) {
     return code;
   };
 
+  const originalBlockToCode = blocklyWrapper.Generator.prototype.blockToCode;
+  blocklyWrapper.Generator.prototype.blockToCode = function(
+    block,
+    opt_thisOnly
+  ) {
+    if (block?.isUnused()) {
+      return '';
+    }
+    return originalBlockToCode.call(this, block, opt_thisOnly);
+  };
+
   blocklyWrapper.Generator.prefixLines = function(text, prefix) {
     return blocklyWrapper.JavaScript.prefixLines(text, prefix);
   };


### PR DESCRIPTION
Sort of similar to https://github.com/code-dot-org/blockly/pull/122
Basically, the issue was that Blockly was generating code for blocks while they were dragged, which resulted in incorrect preview code during the drag.

[jira](https://codedotorg.atlassian.net/browse/STAR-1866)

Before
![Oct-25-2021 13-58-06](https://user-images.githubusercontent.com/8787187/138772219-265c0d2d-7dfb-49ff-a79c-18d1dc7b8ab8.gif)

After
![Oct-25-2021 14-17-54](https://user-images.githubusercontent.com/8787187/138772421-55800cf7-21aa-428e-8582-d90d47c09eac.gif)
