### PR TITLE
Load basic user data to redux async, initialized in header

### DIFF
--- a/apps/src/code-studio/header.js
+++ b/apps/src/code-studio/header.js
@@ -19,6 +19,7 @@ import ReactDOM from 'react-dom';
 import {Provider} from 'react-redux';
 import progress from './progress';
 import {getStore} from '../redux';
+import {asyncLoadUserData} from '@cdo/apps/templates/currentUserRedux';
 
 import {PUZZLE_PAGE_NONE} from '@cdo/apps/templates/progress/progressTypes';
 import HeaderMiddle from '@cdo/apps/code-studio/components/header/HeaderMiddle';
@@ -165,6 +166,11 @@ function setupReduxSubscribers(store) {
   });
 }
 setupReduxSubscribers(getStore());
+
+function setUpGlobalData(store) {
+  store.dispatch(asyncLoadUserData());
+}
+setUpGlobalData(getStore());
 
 header.showMinimalProjectHeader = function() {
   getStore().dispatch(refreshProjectName());

--- a/apps/src/sites/studio/pages/home/_homepage.js
+++ b/apps/src/sites/studio/pages/home/_homepage.js
@@ -18,9 +18,7 @@ import {
   setValidGrades,
   setShowLockSectionField // DCDO Flag - show/hide Lock Section field
 } from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
-import currentUser, {
-  setCurrentUserId
-} from '@cdo/apps/templates/currentUserRedux';
+import currentUser from '@cdo/apps/templates/currentUserRedux';
 import {initializeHiddenScripts} from '@cdo/apps/code-studio/hiddenLessonRedux';
 import {updateQueryParam} from '@cdo/apps/code-studio/utils';
 import locales, {setLocaleCode} from '@cdo/apps/redux/localesRedux';
@@ -46,7 +44,6 @@ function showHomepage() {
   store.dispatch(initializeHiddenScripts(homepageData.hiddenScripts));
   store.dispatch(setPageType(pageTypes.homepage));
   store.dispatch(setLocaleCode(homepageData.localeCode));
-  store.dispatch(setCurrentUserId(homepageData.currentUserId));
 
   // DCDO Flag - show/hide Lock Section field
   store.dispatch(setShowLockSectionField(homepageData.showLockSectionField));

--- a/apps/src/sites/studio/pages/scripts/show.js
+++ b/apps/src/sites/studio/pages/scripts/show.js
@@ -9,7 +9,6 @@ import plcHeaderReducer, {
 import {getStore} from '@cdo/apps/code-studio/redux';
 import {registerReducers} from '@cdo/apps/redux';
 import {renderCourseProgress} from '@cdo/apps/code-studio/progress';
-import {setCurrentUserId} from '@cdo/apps/templates/currentUserRedux';
 import {
   setVerified,
   setVerifiedResources
@@ -36,10 +35,6 @@ function initPage() {
     store.dispatch(
       setPlcHeader(plcBreadcrumb.unit_name, plcBreadcrumb.course_view_path)
     );
-  }
-
-  if (scriptData.user_id) {
-    store.dispatch(setCurrentUserId(scriptData.user_id));
   }
 
   if (scriptData.has_verified_resources) {

--- a/apps/src/sites/studio/pages/teacher_dashboard/show.js
+++ b/apps/src/sites/studio/pages/teacher_dashboard/show.js
@@ -30,8 +30,6 @@ import sectionStandardsProgress from '@cdo/apps/templates/sectionProgress/standa
 import unitSelection from '@cdo/apps/redux/unitSelectionRedux';
 import TeacherDashboard from '@cdo/apps/templates/teacherDashboard/TeacherDashboard';
 import currentUser, {
-  setCurrentUserId,
-  setCurrentUserName,
   setCurrentUserHasSeenStandardsReportInfo
 } from '@cdo/apps/templates/currentUserRedux';
 import {setValidScripts} from '../../../../redux/unitSelectionRedux';
@@ -46,7 +44,6 @@ const {
   validScripts,
   studentScriptIds,
   validCourses,
-  currentUserId,
   hasSeenStandardsReportInfo,
   localeCode,
   textToSpeechUnitIds,
@@ -72,8 +69,6 @@ $(document).ready(function() {
   });
   const store = getStore();
   // TODO: (madelynkasula) remove duplication in sectionData.setSection and teacherSections.setSections
-  store.dispatch(setCurrentUserId(currentUserId));
-  store.dispatch(setCurrentUserName(scriptData.userName));
   store.dispatch(
     setCurrentUserHasSeenStandardsReportInfo(hasSeenStandardsReportInfo)
   );

--- a/apps/src/templates/currentUserRedux.js
+++ b/apps/src/templates/currentUserRedux.js
@@ -23,6 +23,7 @@ export const setUserSignedIn = isSignedIn => ({
   isSignedIn
 });
 export const setUserType = userType => ({type: SET_USER_TYPE, userType});
+const setInitialData = serverUser => ({type: SET_INITIAL_DATA, serverUser});
 
 const initialState = {
   userId: null,
@@ -74,19 +75,26 @@ export default function currentUser(state = initialState, action) {
 }
 
 export const asyncLoadUserData = () => dispatch => {
-  $.ajax('/api/v1/users/current_user')
-    .done(data => {
-      if (!data.is_signed_in) {
-        dispatch(setUserSignedIn(false));
-      } else {
-        dispatch(setUserSignedIn(true));
-        dispatch({
-          type: SET_INITIAL_DATA,
-          serverUser: data
-        });
+  currentUserFromServer(dispatch);
+};
+
+const currentUserFromServer = dispatch => {
+  return fetch('/api/v1/users/current')
+    .then(response => response.json())
+    .then(data => {
+      dispatch(setUserSignedIn(data.is_signed_in));
+      if (data.is_signed_in) {
+        dispatch(setInitialData(data));
       }
     })
-    .fail(err => {
+    .catch(err => {
       console.log(err);
     });
 };
+
+// export private function(s) to expose to unit testing
+export const __testonly__ = IN_UNIT_TEST
+  ? {
+      currentUserFromServer
+    }
+  : {};

--- a/apps/src/templates/currentUserRedux.js
+++ b/apps/src/templates/currentUserRedux.js
@@ -1,16 +1,15 @@
 import {makeEnum} from '../utils';
 
-const SET_CURRENT_USER_ID = 'currentUser/SET_CURRENT_USER_ID';
 const SET_CURRENT_USER_NAME = 'currentUser/SET_CURRENT_USER_NAME';
 const SET_USER_SIGNED_IN = 'currentUser/SET_USER_SIGNED_IN';
 const SET_USER_TYPE = 'currentUser/SET_USER_TYPE';
 const SET_HAS_SEEN_STANDARDS_REPORT =
   'currentUser/SET_HAS_SEEN_STANDARDS_REPORT';
+const SET_INITIAL_DATA = 'currentUser/SET_INITIAL_DATA';
 
 export const SignInState = makeEnum('Unknown', 'SignedIn', 'SignedOut');
 
 // Action creators
-export const setCurrentUserId = userId => ({type: SET_CURRENT_USER_ID, userId});
 export const setCurrentUserName = userName => ({
   type: SET_CURRENT_USER_NAME,
   userName
@@ -34,12 +33,6 @@ const initialState = {
 };
 
 export default function currentUser(state = initialState, action) {
-  if (action.type === SET_CURRENT_USER_ID) {
-    return {
-      ...state,
-      userId: action.userId
-    };
-  }
   if (action.type === SET_CURRENT_USER_NAME) {
     return {
       ...state,
@@ -60,12 +53,40 @@ export default function currentUser(state = initialState, action) {
         : SignInState.SignedOut
     };
   }
-
   if (action.type === SET_USER_TYPE) {
     return {
       ...state,
       userType: action.userType
     };
   }
+
+  if (action.type === SET_INITIAL_DATA) {
+    const {id, username, user_type} = action.serverUser;
+    return {
+      ...state,
+      userId: id,
+      userName: username,
+      userType: user_type
+    };
+  }
+
   return state;
 }
+
+export const asyncLoadUserData = () => dispatch => {
+  $.ajax('/api/v1/users/current_user')
+    .done(data => {
+      if (!data.is_signed_in) {
+        dispatch(setUserSignedIn(false));
+      } else {
+        dispatch(setUserSignedIn(true));
+        dispatch({
+          type: SET_INITIAL_DATA,
+          serverUser: data
+        });
+      }
+    })
+    .fail(err => {
+      console.log(err);
+    });
+};

--- a/apps/test/unit/code-studio/currentUserReduxTest.js
+++ b/apps/test/unit/code-studio/currentUserReduxTest.js
@@ -1,10 +1,12 @@
 import {assert} from '../../util/reconfiguredChai';
+import sinon from 'sinon';
 import currentUser, {
   SignInState,
   setUserSignedIn,
   setUserType,
   setCurrentUserHasSeenStandardsReportInfo,
-  setCurrentUserName
+  setCurrentUserName,
+  __testonly__
 } from '@cdo/apps/templates/currentUserRedux';
 
 describe('currentUserRedux', () => {
@@ -18,6 +20,7 @@ describe('currentUserRedux', () => {
       assert.deepEqual(nextState.userName, 'Test Person');
     });
   });
+
   describe('setUserSignedIn', () => {
     it('can update signInState', () => {
       const signedIn = currentUser(initialState, setUserSignedIn(true));
@@ -30,6 +33,7 @@ describe('currentUserRedux', () => {
       assert.equal(initialState.signInState, SignInState.Unknown);
     });
   });
+
   describe('setUserType', () => {
     it('can set the current user type', () => {
       const action = setUserType('teacher');
@@ -38,12 +42,50 @@ describe('currentUserRedux', () => {
       assert.deepEqual(nextState.userType, 'teacher');
     });
   });
+
   describe('setCurrentUserHasSeenStandardsReportInfo', () => {
     it('can set the standards info dialog to seen', () => {
       const action = setCurrentUserHasSeenStandardsReportInfo(true);
       const nextState = currentUser(initialState, action);
 
       assert.deepEqual(nextState.hasSeenStandardsReportInfo, true);
+    });
+  });
+
+  describe('asyncLoadUserData', () => {
+    const {currentUserFromServer} = __testonly__;
+
+    it('calls /users/current and sets user data to state', async () => {
+      const dispatchSpy = sinon.spy();
+      const serverUser = {
+        id: 1,
+        username: 'test_user',
+        user_type: 'teacher',
+        is_signed_in: true
+      };
+
+      function mockApiResponse() {
+        return new window.Response(JSON.stringify(serverUser), {
+          status: 200,
+          headers: {'Content-type': 'application/json'}
+        });
+      }
+
+      const fetchStub = sinon.stub(window, 'fetch');
+      fetchStub
+        .withArgs('/api/v1/users/current')
+        .returns(Promise.resolve(mockApiResponse()));
+
+      await currentUserFromServer(dispatchSpy);
+
+      const dispatchCalls = dispatchSpy.getCalls();
+      const action1 = dispatchCalls[0].args[0];
+      assert.equal('currentUser/SET_USER_SIGNED_IN', action1.type);
+      assert.equal(true, action1.isSignedIn);
+
+      const action2 = dispatchCalls[1].args[0];
+      assert.equal('currentUser/SET_INITIAL_DATA', action2.type);
+      assert.deepEqual(serverUser, action2.serverUser);
     });
   });
 });

--- a/apps/test/unit/code-studio/currentUserReduxTest.js
+++ b/apps/test/unit/code-studio/currentUserReduxTest.js
@@ -1,6 +1,5 @@
 import {assert} from '../../util/reconfiguredChai';
 import currentUser, {
-  setCurrentUserId,
   SignInState,
   setUserSignedIn,
   setUserType,
@@ -11,14 +10,6 @@ import currentUser, {
 describe('currentUserRedux', () => {
   const initialState = currentUser(undefined, {});
 
-  describe('setCurrentUserId', () => {
-    it('can set the current user id', () => {
-      const action = setCurrentUserId(1);
-      const nextState = currentUser(initialState, action);
-
-      assert.deepEqual(nextState.userId, 1);
-    });
-  });
   describe('setCurrentUserName', () => {
     it('can set the current user name', () => {
       const action = setCurrentUserName('Test Person');

--- a/dashboard/app/controllers/api/v1/users_controller.rb
+++ b/dashboard/app/controllers/api/v1/users_controller.rb
@@ -3,7 +3,7 @@ require 'cdo/firehose'
 class Api::V1::UsersController < Api::V1::JsonApiController
   before_action :load_user
   skip_before_action :verify_authenticity_token
-  skip_before_action :load_user, only: [:get_current_user]
+  skip_before_action :load_user, only: [:current]
 
   def load_user
     user_id = params[:user_id]
@@ -13,8 +13,8 @@ class Api::V1::UsersController < Api::V1::JsonApiController
     @user = current_user
   end
 
-  # GET /api/v1/users/current_user
-  def get_current_user
+  # GET /api/v1/users/current
+  def current
     if current_user
       render json: {
         id: current_user.id,

--- a/dashboard/app/controllers/api/v1/users_controller.rb
+++ b/dashboard/app/controllers/api/v1/users_controller.rb
@@ -3,6 +3,7 @@ require 'cdo/firehose'
 class Api::V1::UsersController < Api::V1::JsonApiController
   before_action :load_user
   skip_before_action :verify_authenticity_token
+  skip_before_action :load_user, only: [:get_current_user]
 
   def load_user
     user_id = params[:user_id]
@@ -10,6 +11,22 @@ class Api::V1::UsersController < Api::V1::JsonApiController
       raise CanCan::AccessDenied
     end
     @user = current_user
+  end
+
+  # GET /api/v1/users/current_user
+  def get_current_user
+    if current_user
+      render json: {
+        id: current_user.id,
+        username: current_user.username,
+        user_type: current_user.user_type,
+        is_signed_in: true
+      }
+    else
+      render json: {
+        is_signed_in: false
+      }
+    end
   end
 
   # GET /api/v1/users/<user_id>/school_name

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -751,6 +751,7 @@ Dashboard::Application.routes.draw do
       get 'users/:user_id/using_text_mode', to: 'users#get_using_text_mode'
       get 'users/:user_id/display_theme', to: 'users#get_display_theme'
       get 'users/:user_id/contact_details', to: 'users#get_contact_details'
+      get 'users/current_user', to: 'users#get_current_user'
       get 'users/:user_id/school_name', to: 'users#get_school_name'
       get 'users/:user_id/school_donor_name', to: 'users#get_school_donor_name'
 

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -751,7 +751,7 @@ Dashboard::Application.routes.draw do
       get 'users/:user_id/using_text_mode', to: 'users#get_using_text_mode'
       get 'users/:user_id/display_theme', to: 'users#get_display_theme'
       get 'users/:user_id/contact_details', to: 'users#get_contact_details'
-      get 'users/current_user', to: 'users#get_current_user'
+      get 'users/current', to: 'users#current'
       get 'users/:user_id/school_name', to: 'users#get_school_name'
       get 'users/:user_id/school_donor_name', to: 'users#get_school_donor_name'
 

--- a/dashboard/test/controllers/api/v1/users_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/users_controller_test.rb
@@ -165,6 +165,25 @@ class Api::V1::UsersControllerTest < ActionController::TestCase
     assert_equal true, test_user.has_seen_standards_report_info_dialog
   end
 
+  test "a get request to get current returns signed out user info" do
+    get :current
+    assert_response :success
+    response = JSON.parse(@response.body)
+    assert_equal false, response["is_signed_in"]
+  end
+
+  test "a get request to get current returns signed in user info" do
+    teacher = create :teacher
+    sign_in(teacher)
+    get :current
+    assert_response :success
+    response = JSON.parse(@response.body)
+    assert_equal true, response["is_signed_in"]
+    assert_equal teacher.id, response["id"]
+    assert_equal teacher.username, response["username"]
+    assert_equal "teacher", response["user_type"]
+  end
+
   test "a get request to get school_name returns school object" do
     sign_in(@user)
     get :get_school_name, params: {user_id: @user.id}


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This is a portion of the work required to make the teacher panel load on cached pages (https://github.com/code-dot-org/code-dot-org/pull/43126).

Changes include:
- Creating a new endpoint to query data about the current user
- The header dispatches the query to get the current user and set the result to `currentUserRedux`, this request is made in the header to ensure that this data is available across all pages that include the header
- Removes a variety of actions to dispatch setting current user information for different pages since it's now happening in the header

## Testing story
Added unit tests and verified that current user data is being set on various pages.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
