### PR TITLE
Redirect to unit overview at lesson end 

### DIFF
--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -2106,4 +2106,8 @@ class Script < ApplicationRecord
       Services::CurriculumPdfs.get_unit_resources_url(self)
     end
   end
+
+  def teacher_led?
+    instruction_type == SharedCourseConstants::INSTRUCTION_TYPE.teacher_led
+  end
 end

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -2109,7 +2109,7 @@ class Script < ApplicationRecord
 
   # To help teachers have more control over the pacing of certain scripts, we
   # send students on the last level of a lesson to the unit overview page.
-  def should_show_unit_overview_between_lessons
+  def show_unit_overview_between_lessons?
     csd? || csp? || csa?
   end
 end

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -2107,7 +2107,9 @@ class Script < ApplicationRecord
     end
   end
 
-  def teacher_led?
-    instruction_type == SharedCourseConstants::INSTRUCTION_TYPE.teacher_led
+  # To help teachers have more control over the pacing of certain scripts, we
+  # send students on the last level of a lesson to the unit overview page.
+  def should_show_unit_overview_between_lessons
+    csd? || csp? || csa?
   end
 end

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -258,10 +258,12 @@ class ScriptLevel < ApplicationRecord
       # to that lesson
       script_lesson_extras_path(script.name, (extras_lesson || lesson).relative_position)
     else
-      # To help teachers have more control over the pacing of teacher-led
-      # scripts, we send students on the last level of a lesson to lesson
-      # extras (if available) or the unit overview page.
-      if end_of_lesson? && script.teacher_led?
+      # To help teachers have more control over the pacing of certain
+      # scripts, we send students on the last level of a lesson to the unit
+      # overview page.
+      if end_of_lesson? &&
+        script.should_show_unit_overview_between_lessons &&
+        user.has_pilot_experiment?('end-of-lesson-redirects')
         if script.lesson_extras_available
           script_lesson_extras_path(script.name, (extras_lesson || lesson).relative_position)
         else

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -262,7 +262,7 @@ class ScriptLevel < ApplicationRecord
       # scripts, we send students on the last level of a lesson to the unit
       # overview page.
       if end_of_lesson? &&
-        script.should_show_unit_overview_between_lessons &&
+        script.show_unit_overview_between_lessons &&
         user.has_pilot_experiment?('end-of-lesson-redirects')
         if script.lesson_extras_available
           script_lesson_extras_path(script.name, (extras_lesson || lesson).relative_position)

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -258,7 +258,18 @@ class ScriptLevel < ApplicationRecord
       # to that lesson
       script_lesson_extras_path(script.name, (extras_lesson || lesson).relative_position)
     else
-      level_to_follow ? build_script_level_path(level_to_follow) : script_completion_redirect(script)
+      # To help teachers have more control over the pacing of teacher-led
+      # scripts, we send students on the last level of a lesson to lesson
+      # extras (if available) or the unit overview page.
+      if end_of_lesson? && script.teacher_led?
+        if script.lesson_extras_available
+          script_lesson_extras_path(script.name, (extras_lesson || lesson).relative_position)
+        else
+          script_path(script)
+        end
+      else
+        level_to_follow ? build_script_level_path(level_to_follow) : script_completion_redirect(script)
+      end
     end
   end
 

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -262,7 +262,7 @@ class ScriptLevel < ApplicationRecord
       # scripts, we send students on the last level of a lesson to the unit
       # overview page.
       if end_of_lesson? &&
-        script.show_unit_overview_between_lessons &&
+        script.show_unit_overview_between_lessons? &&
         user.has_pilot_experiment?('end-of-lesson-redirects')
         if script.lesson_extras_available
           script_lesson_extras_path(script.name, (extras_lesson || lesson).relative_position)


### PR DESCRIPTION
[LP-2072](https://codedotorg.atlassian.net/browse/LP-2072)
[Spec](https://docs.google.com/document/d/1STMLxX2UphYMXLKIvgnctH7vuacCQPNHOB1KgS2VygA/edit#bookmark=id.h64pzxt4r0wo)

Redirect students in courses from the last level of a lesson to lesson extras (if available) or to the unit overview page.  We've been getting Zendesk reports from 6-12 teachers that they're having a hard time keeping their students in the right place and working together. Adding in some "speed bumps" that take students back to the unit overview page at the end of a lesson. 