### PR TITLE
Patch for Honeybadger error

### DIFF
--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -262,7 +262,7 @@ module UsersHelper
               sublevel_progress[:time_spent] ? sum + sublevel_progress[:time_spent] : sum
             end
 
-            # We need to check that level_progress exists due to a race condition where the user makes sublevel
+            # The existence of level_progress needs to be checked due to a race condition where the user makes sublevel
             # progress between when user_levels_by_level is fetched and when level_for_progress is fetched. In this
             # case, user_levels_by_level may not include the user level for the new level_for_progress, resulting in nil
             # level_progress. This may manifest for the user as a bubble choice bubble looking as though it hasn't been tried


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This is an alternative solution to https://github.com/code-dot-org/code-dot-org/pull/43023.

In the solution presented in #43023, I added additional logic to determine the primary sublevel given the hashes of data. This complicates the overall logic and decreases maintainability for an error that doesn't occur very often. The new solution presented here does not add much additional logic, the downside is that users may be able to see the bug manifested in unexpected state of a bubble choice parent bubble.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
- jira ticket: [LP-2048](https://codedotorg.atlassian.net/browse/LP-2048)
<!--
- spec: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
