### PR TITLE
skip generating curriculum pdfs if using legacy lesson plans

### DIFF
--- a/dashboard/lib/services/curriculum_pdfs.rb
+++ b/dashboard/lib/services/curriculum_pdfs.rb
@@ -100,6 +100,7 @@ module Services
 
       return false unless rack_env?(:staging)
       return false unless script_data['properties'].fetch('is_migrated', false)
+      return false if script_data['properties'].fetch('use_legacy_lesson_plans', false)
       return false if DCDO.get('disable_curriculum_pdf_generation', false)
 
       script = Script.find_by(name: script_data['name'])

--- a/dashboard/test/lib/services/curriculum_pdfs_test.rb
+++ b/dashboard/test/lib/services/curriculum_pdfs_test.rb
@@ -42,6 +42,24 @@ module Services
       refute Services::CurriculumPdfs.generate_pdfs?(script_data)
     end
 
+    test 'will not generate a PDF if using legacy lesson plans' do
+      CDO.stubs(:rack_env).returns(:staging)
+      script = create(:script)
+      script_data = {
+        'properties' => {
+          'is_migrated' => true,
+        },
+        'serialized_at' => Time.now.getutc,
+        'name' => script.name
+      }
+
+      script_data = JSON.parse(script_data.to_json)
+
+      assert Services::CurriculumPdfs.generate_pdfs?(script_data)
+      script_data['properties']['use_legacy_lesson_plans'] = true
+      refute Services::CurriculumPdfs.generate_pdfs?(script_data)
+    end
+
     test 'will not generate a overview PDF when unit does not have lesson plans' do
       CDO.stubs(:rack_env).returns(:staging)
       unit_with_lesson_plans = create(:script, is_migrated: true, published_state: SharedCourseConstants::PUBLISHED_STATE.beta)


### PR DESCRIPTION
Continues https://codedotorg.atlassian.net/browse/PLAT-830. The goal is to make sure we do not generate PDFs for any newly-migrated scripts, which are migrated without pulling in content from curriculum builder.

See https://github.com/code-dot-org/code-dot-org/pull/42499#issuecomment-921831977 for what `use_legacy_lesson_plans` does.

when migrating scripts without CB content, we set `use_legacy_lesson_plans` if the script does not have any lesson plans:  https://github.com/code-dot-org/code-dot-org/blob/5be3ab4d221dd898106749c2f31cd461076a3abe/bin/curriculum/migrate_unit.rb#L93-L100
existing PDF generation code skips most PDFs if the unit has no lessons:
* https://github.com/code-dot-org/code-dot-org/blob/426aa3ad6ad5886a967cbce5444e01779f26265d/dashboard/lib/services/curriculum_pdfs.rb#L120-L121
* https://github.com/code-dot-org/code-dot-org/blob/426aa3ad6ad5886a967cbce5444e01779f26265d/dashboard/lib/services/curriculum_pdfs.rb#L126-L127

This PR makes it so that we skip PDF generation entirely when `use_legacy_lesson_plans` is set.

together, this makes it so that any newly-migrated lesson plan (without content from CB) will not have PDFs generated for it.

## Testing story

* added new unit test
* manually verifyied that `script_data['properties']['use_legacy_lesson_plans']` gets set in this codepath when seeding a script that has `use_legacy_lesson_plans` set is seeded.

## Deployment strategy

This would be nice to get in before we migrate too many more scripts, to reduce the chances of PDF generation time increasing substantially.