### PR TITLE
[Poetry][HOC] Filter out title+author for line events

### DIFF
--- a/apps/src/p5lab/poetry/PoetryLibrary.js
+++ b/apps/src/p5lab/poetry/PoetryLibrary.js
@@ -62,7 +62,11 @@ export default class PoetryLibrary extends CoreLibrary {
         );
         // Don't fire line events in preview
         if (!this.isPreviewFrame()) {
-          for (let i = 0; i < renderInfo.lines.length; i++) {
+          // filter non-poem-body lines (title and author) for line events
+          const poemLines = renderInfo.lines.filter(
+            line => line.isPoemBodyLine
+          );
+          for (let i = 0; i < poemLines.length; i++) {
             const lineNum = i + 1; // students will 1-index the lines
             if (this.lineEvents[lineNum] && !this.lineEvents[lineNum].fired) {
               // Fire line events
@@ -404,7 +408,8 @@ export default class PoetryLibrary extends CoreLibrary {
           poemState.title,
           poemState.font.font,
           FONT_SIZE * 2
-        )
+        ),
+        isPoemBodyLine: false
       });
       yCursor += LINE_HEIGHT;
     }
@@ -414,7 +419,8 @@ export default class PoetryLibrary extends CoreLibrary {
         text: poemState.author,
         x: PLAYSPACE_SIZE / 2,
         y: yCursor,
-        size: this.getScaledFontSize(poemState.author, poemState.font.font, 16)
+        size: this.getScaledFontSize(poemState.author, poemState.font.font, 16),
+        isPoemBodyLine: false
       });
       yCursor += LINE_HEIGHT;
     }
@@ -434,7 +440,8 @@ export default class PoetryLibrary extends CoreLibrary {
         text: line,
         x: PLAYSPACE_SIZE / 2,
         y: yCursor,
-        size: lineSize
+        size: lineSize,
+        isPoemBodyLine: true
       });
       yCursor += lineHeight;
     });


### PR DESCRIPTION
Fixes a regression introduced by https://github.com/code-dot-org/code-dot-org/pull/43159/

Even though we have the author and title text in the `renderInfo.lines` array now, they shouldn't count as lines for the `whenLineEvent` block.

Before:
![Oct-25-2021 20-07-12](https://user-images.githubusercontent.com/8787187/138802287-a15fa5b5-3b4d-4e38-b1b8-15c5bf2ce354.gif)

After:
![Oct-25-2021 20-05-16](https://user-images.githubusercontent.com/8787187/138802296-11388e3f-f068-4cce-89cf-c5f974af9d26.gif)
