### PR TITLE
[Poetry][Google Blockly] Fix code generation for events

### DIFF
--- a/apps/src/blockly/addons/cdoBlockDragger.js
+++ b/apps/src/blockly/addons/cdoBlockDragger.js
@@ -50,7 +50,9 @@ export default class BlockDragger extends GoogleBlockly.BlockDragger {
     // would be noticeable if this value were out of sync, even briefly.
     // This only matters if the block is not being deleted.
     if (!wouldDeleteBlock) {
-      this.draggingBlock_.setEnabled(!!this.draggingBlock_.parentBlock_);
+      const isTopBlock = this.draggingBlock_.previousConnection === null;
+      const hasParentBlock = !!this.draggingBlock_.parentBlock_;
+      this.draggingBlock_.setEnabled(isTopBlock || hasParentBlock);
     }
   }
 

--- a/apps/src/blockly/addons/cdoGenerator.js
+++ b/apps/src/blockly/addons/cdoGenerator.js
@@ -32,7 +32,11 @@ export default function initializeGenerator(blocklyWrapper) {
     if (block?.isUnused()) {
       return '';
     }
-    return originalBlockToCode.call(this, block, opt_thisOnly);
+    return originalBlockToCode.call(
+      this,
+      block,
+      block?.skipNextBlockGeneration || opt_thisOnly
+    );
   };
 
   blocklyWrapper.Generator.prefixLines = function(text, prefix) {


### PR DESCRIPTION
Code generation for:
![image](https://user-images.githubusercontent.com/8787187/138951467-aae42741-9040-4204-b103-2eae5fb0aca8.png)

Before
```
setBackground('#ffcc99');

whenLineShows(3, function (extraArgs) {
  makeNumSprites(3, "smiling_sun");
});
makeNumSprites(3, "smiling_sun");
```

After
```
setBackground('#ffcc99');

whenLineShows(3, function (extraArgs) {
  makeNumSprites(3, "smiling_sun");
});
```

Event blocks generate code for the rest of the stack as part of the event callback function. So we need to skip generating code for the rest of the blocks in the stack at the top level. 
`block.skipNextBlockGeneration` is set [here](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/block_utils.js#L1067) and is used by the Cdo Blockly code generator [here](https://github.com/code-dot-org/blockly/blob/main/generators/javascript.js#L225). For Google Blockly, we just need to pass the value through as `opt_thisOnly` in `blockToCode()` ([ref](https://github.com/google/blockly/blob/master/core/generator.js#L173))

This PR also contains a quick follow up to https://github.com/code-dot-org/code-dot-org/pull/43172. As a result of that change, we were inadvertently always setting event blocks to disabled since they never have a parent. The correct logic is that a block is disabled if it has a previous connection (ie. is not a top-level block) _and_ does not have a parent.