### PR TITLE
[Google Blockly] Override color block color

### DIFF
--- a/apps/src/blockly/addons/cdoTheme.js
+++ b/apps/src/blockly/addons/cdoTheme.js
@@ -2,7 +2,11 @@ import GoogleBlockly from 'blockly/core';
 
 export default GoogleBlockly.Theme.defineTheme('modern', {
   base: GoogleBlockly.Themes.Classic,
-  blockStyles: {},
+  blockStyles: {
+    colour_blocks: {
+      colourPrimary: '#0093c9'
+    }
+  },
   categoryStyles: {},
   componentStyles: {
     toolboxBackgroundColour: '#DDDDDD'


### PR DESCRIPTION
The `colour_picker` block is a Blockly default, so it comes with its own styling. Thankfully, this is easy to customize using Blockly Themes.
Before
![image](https://user-images.githubusercontent.com/8787187/138955491-578b24bd-d7bd-48f0-91ba-75f9667d8264.png)

After
![image](https://user-images.githubusercontent.com/8787187/138955549-182d33ea-d68f-41d1-9b30-ef6bc2d34fe4.png)
