### PR TITLE
Javalab: re-enable run tests button and connect to Javabuilder

### DIFF
--- a/apps/src/javalab/ControlButtons.jsx
+++ b/apps/src/javalab/ControlButtons.jsx
@@ -15,7 +15,8 @@ export default function ControlButtons({
   disableFinishButton,
   onContinue,
   renderSettings,
-  disableRunButtons,
+  disableRunButton,
+  disableTestButton,
   showTestButton,
   isSubmittable,
   isSubmitted
@@ -49,16 +50,17 @@ export default function ControlButtons({
           onClick={toggleRun}
           isHorizontal
           style={{...styles.button.all, ...styles.button.orange}}
-          isDisabled={disableRunButtons}
+          isDisabled={disableRunButton}
         />
         {showTestButton && (
           <JavalabButton
+            id="testButton"
             text={isTesting ? i18n.stopTests() : i18n.test()}
             icon={<FontAwesome icon="flask" className="fa" />}
             onClick={toggleTest}
             isHorizontal
             style={{...styles.button.all, ...styles.button.white}}
-            isDisabled={disableRunButtons}
+            isDisabled={disableTestButton}
           />
         )}
       </div>
@@ -87,7 +89,8 @@ ControlButtons.propTypes = {
   disableFinishButton: PropTypes.bool,
   onContinue: PropTypes.func.isRequired,
   renderSettings: PropTypes.func.isRequired,
-  disableRunButtons: PropTypes.bool,
+  disableRunButton: PropTypes.bool,
+  disableTestButton: PropTypes.bool,
   showTestButton: PropTypes.bool,
   isSubmittable: PropTypes.bool,
   isSubmitted: PropTypes.bool

--- a/apps/src/javalab/Javalab.js
+++ b/apps/src/javalab/Javalab.js
@@ -15,7 +15,8 @@ import javalab, {
   setLevelName,
   appendNewlineToConsoleLog,
   setIsRunning,
-  setDisableFinishButton
+  setDisableFinishButton,
+  setIsTesting
 } from './javalabRedux';
 import playground from './playgroundRedux';
 import {TestResults} from '@cdo/apps/constants';
@@ -103,6 +104,7 @@ Javalab.prototype.init = function(config) {
   config.afterClearPuzzle = this.afterClearPuzzle.bind(this);
   const onRun = this.onRun.bind(this);
   const onStop = this.onStop.bind(this);
+  const onTest = this.onTest.bind(this);
   const onContinue = this.onContinue.bind(this);
   const onCommitCode = this.onCommitCode.bind(this);
   const onInputMessage = this.onInputMessage.bind(this);
@@ -265,6 +267,7 @@ Javalab.prototype.init = function(config) {
         onMount={onMount}
         onRun={onRun}
         onStop={onStop}
+        onTest={onTest}
         onContinue={onContinue}
         onCommitCode={onCommitCode}
         onInputMessage={onInputMessage}
@@ -330,10 +333,12 @@ Javalab.prototype.executeJavabuilder = function(executionType) {
     getStore().getState().pageConstants.serverLevelId,
     options,
     this.onNewlineMessage,
-    this.setIsRunning
+    this.setIsRunning,
+    this.setIsTesting,
+    executionType
   );
   project.autosave(() => {
-    this.javabuilderConnection.connectJavabuilder(executionType);
+    this.javabuilderConnection.connectJavabuilder();
   });
   postContainedLevelAttempt(this.studioApp_);
 };
@@ -423,6 +428,10 @@ Javalab.prototype.onNewlineMessage = function() {
 
 Javalab.prototype.setIsRunning = function(isRunning) {
   getStore().dispatch(setIsRunning(isRunning));
+};
+
+Javalab.prototype.setIsTesting = function(isTesting) {
+  getStore().dispatch(setIsTesting(isTesting));
 };
 
 export default Javalab;

--- a/apps/src/javalab/JavalabView.jsx
+++ b/apps/src/javalab/JavalabView.jsx
@@ -5,7 +5,12 @@ import color from '@cdo/apps/util/color';
 import JavalabConsole from './JavalabConsole';
 import JavalabEditor from './JavalabEditor';
 import JavalabPanels from './JavalabPanels';
-import {appendOutputLog, setIsDarkMode, setIsRunning} from './javalabRedux';
+import {
+  appendOutputLog,
+  setIsDarkMode,
+  setIsRunning,
+  setIsTesting
+} from './javalabRedux';
 import StudioAppWrapper from '@cdo/apps/templates/StudioAppWrapper';
 import TopInstructions, {
   TabType
@@ -21,6 +26,7 @@ class JavalabView extends React.Component {
     onMount: PropTypes.func.isRequired,
     onRun: PropTypes.func.isRequired,
     onStop: PropTypes.func.isRequired,
+    onTest: PropTypes.func.isRequired,
     onContinue: PropTypes.func.isRequired,
     onCommitCode: PropTypes.func.isRequired,
     onInputMessage: PropTypes.func.isRequired,
@@ -40,15 +46,15 @@ class JavalabView extends React.Component {
     isEditingStartSources: PropTypes.bool,
     isRunning: PropTypes.bool,
     setIsRunning: PropTypes.func,
+    isTesting: PropTypes.bool,
+    setIsTesting: PropTypes.func,
+    canRun: PropTypes.bool,
+    canTest: PropTypes.bool,
     showProjectTemplateWorkspaceIcon: PropTypes.bool.isRequired,
     longInstructions: PropTypes.string,
     awaitingContainedResponse: PropTypes.bool,
     isSubmittable: PropTypes.bool,
     isSubmitted: PropTypes.bool
-  };
-
-  state = {
-    isTesting: false
   };
 
   componentDidMount() {
@@ -72,24 +78,32 @@ class JavalabView extends React.Component {
 
   // This controls the 'run' button state
   toggleRun = () => {
-    const toggledIsRunning = !this.props.isRunning;
-    this.props.setIsRunning(toggledIsRunning);
+    const {canRun, isRunning, setIsRunning, onRun, onStop} = this.props;
+    if (!canRun) {
+      return;
+    }
+    const toggledIsRunning = !isRunning;
+    setIsRunning(toggledIsRunning);
     if (toggledIsRunning) {
-      this.props.onRun();
+      onRun();
     } else {
-      this.props.onStop();
+      onStop();
     }
   };
 
-  // This controls the 'test' button state, but running/stopping tests
-  // is not yet implemented and will need to be added here.
+  // This controls the 'test' button state
   toggleTest = () => {
-    this.setState(
-      state => ({isTesting: !state.isTesting}),
-      () => {
-        // TODO: Run/stop tests.
-      }
-    );
+    const {canTest, isTesting, setIsTesting, onTest, onStop} = this.props;
+    if (!canTest) {
+      return;
+    }
+    const toggledIsTesting = !isTesting;
+    setIsTesting(toggledIsTesting);
+    if (toggledIsTesting) {
+      onTest();
+    } else {
+      onStop();
+    }
   };
 
   isLeftSideVisible = () => {
@@ -136,15 +150,17 @@ class JavalabView extends React.Component {
       onContinue,
       isEditingStartSources,
       isRunning,
+      isTesting,
       showProjectTemplateWorkspaceIcon,
       disableFinishButton,
       awaitingContainedResponse,
       isSubmittable,
       isSubmitted,
       isProjectTemplateLevel,
-      handleClearPuzzle
+      handleClearPuzzle,
+      canRun,
+      canTest
     } = this.props;
-    const {isTesting} = this.state;
 
     if (isDarkMode) {
       document.body.style.backgroundColor = '#1b1c17';
@@ -205,10 +221,11 @@ class JavalabView extends React.Component {
                     toggleTest={this.toggleTest}
                     isEditingStartSources={isEditingStartSources}
                     disableFinishButton={disableFinishButton}
-                    disableRunButtons={awaitingContainedResponse}
+                    disableRunButton={awaitingContainedResponse || !canRun}
+                    disableTestButton={awaitingContainedResponse || !canTest}
                     onContinue={() => onContinue(isSubmittable)}
                     renderSettings={this.renderSettings}
-                    showTestButton={false}
+                    showTestButton={true}
                     isSubmittable={isSubmittable}
                     isSubmitted={isSubmitted}
                   />
@@ -276,6 +293,9 @@ export default connect(
     isDarkMode: state.javalab.isDarkMode,
     isEditingStartSources: state.pageConstants.isEditingStartSources,
     isRunning: state.javalab.isRunning,
+    isTesting: state.javalab.isTesting,
+    canRun: !state.javalab.isTesting,
+    canTest: !state.javalab.isRunning,
     showProjectTemplateWorkspaceIcon: !!state.pageConstants
       .showProjectTemplateWorkspaceIcon,
     editorColumnHeight: state.javalab.editorColumnHeight,
@@ -288,6 +308,7 @@ export default connect(
   dispatch => ({
     appendOutputLog: log => dispatch(appendOutputLog(log)),
     setIsDarkMode: isDarkMode => dispatch(setIsDarkMode(isDarkMode)),
-    setIsRunning: isRunning => dispatch(setIsRunning(isRunning))
+    setIsRunning: isRunning => dispatch(setIsRunning(isRunning)),
+    setIsTesting: isTesting => dispatch(setIsTesting(isTesting))
   })
 )(UnconnectedJavalabView);

--- a/apps/src/javalab/JavalabView.jsx
+++ b/apps/src/javalab/JavalabView.jsx
@@ -20,6 +20,7 @@ import ControlButtons from './ControlButtons';
 import {CsaViewMode} from './constants';
 import styleConstants from '../styleConstants';
 import {queryParams} from '@cdo/apps/code-studio/utils';
+import experiments from '@cdo/apps/util/experiments';
 
 class JavalabView extends React.Component {
   static propTypes = {
@@ -225,7 +226,9 @@ class JavalabView extends React.Component {
                     disableTestButton={awaitingContainedResponse || !canTest}
                     onContinue={() => onContinue(isSubmittable)}
                     renderSettings={this.renderSettings}
-                    showTestButton={true}
+                    showTestButton={experiments.isEnabled(
+                      experiments.JAVALAB_UNIT_TESTS
+                    )}
                     isSubmittable={isSubmittable}
                     isSubmitted={isSubmitted}
                   />

--- a/apps/src/javalab/javalabRedux.js
+++ b/apps/src/javalab/javalabRedux.js
@@ -17,6 +17,7 @@ const SET_INSTRUCTIONS_HEIGHT = 'javalab/SET_INSTRUCTIONS_HEIGHT';
 const SET_INSTRUCTIONS_FULL_HEIGHT = 'javalab/SET_INSTRUCTIONS_FULL_HEIGHT';
 const REMOVE_FILE = 'javalab/REMOVE_FILE';
 const SET_IS_RUNNING = 'javalab/SET_IS_RUNNING';
+const SET_IS_TESTING = 'javalab/SET_IS_TESTING';
 const SET_CONSOLE_HEIGHT = 'javalab/SET_CONSOLE_HEIGHT';
 const EDITOR_COLUMN_HEIGHT = 'javalab/EDITOR_COLUMN_HEIGHT';
 const SET_BACKPACK_API = 'javalab/SET_BACKPACK_API';
@@ -36,6 +37,7 @@ const initialState = {
   instructionsHeight: 200,
   instructionsFullHeight: 200,
   isRunning: false,
+  isTesting: false,
   consoleHeight: 200,
   editorColumnHeight: 600,
   backpackApi: null,
@@ -125,6 +127,11 @@ export const removeFile = filename => ({
 export const setIsRunning = isRunning => ({
   type: SET_IS_RUNNING,
   isRunning
+});
+
+export const setIsTesting = isTesting => ({
+  type: SET_IS_TESTING,
+  isTesting
 });
 
 export const setBackpackApi = backpackApi => ({
@@ -335,6 +342,12 @@ export default function reducer(state = initialState, action) {
     return {
       ...state,
       isRunning: action.isRunning
+    };
+  }
+  if (action.type === SET_IS_TESTING) {
+    return {
+      ...state,
+      isTesting: action.isTesting
     };
   }
   if (action.type === SET_CONSOLE_HEIGHT) {

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -36,6 +36,7 @@ experiments.POEM_BOT = 'poemBot';
 experiments.CLEARER_SIGN_UP_USER_TYPE = 'clearerSignUpUserType';
 experiments.OPT_IN_EMAIL_REG_PARTNER = 'optInEmailRegPartner';
 experiments.MULTISELECT = 'multiselect';
+experiments.JAVALAB_UNIT_TESTS = 'javalabUnitTests';
 
 /**
  * This was a gamified version of the finish dialog, built in 2018,

--- a/apps/test/unit/javalab/ControlButtonsTest.js
+++ b/apps/test/unit/javalab/ControlButtonsTest.js
@@ -16,7 +16,9 @@ describe('Java Lab Control Buttons Test', () => {
       disableFinishButton: false,
       onContinue: () => {},
       renderSettings: () => {},
-      disableRunButtons: false,
+      disableRunButton: false,
+      disableTestButton: false,
+      showTestButton: true,
       isSubmittable: false,
       isSubmitted: false
     };
@@ -40,5 +42,29 @@ describe('Java Lab Control Buttons Test', () => {
     expect(finishButton).to.not.be.null;
     expect(finishButton.props().text).to.equal('Finish');
     expect(finishButton.props().onClick).to.not.be.null;
+  });
+
+  it('disables run button if disableRunButton is true', () => {
+    const wrapper = shallow(
+      <ControlButtons {...defaultProps} disableRunButton />
+    );
+    const runButton = wrapper.find('#runButton');
+    expect(runButton.props().isDisabled).to.be.true;
+  });
+
+  it('disables test button if disableTestButton is true', () => {
+    const wrapper = shallow(
+      <ControlButtons {...defaultProps} disableTestButton />
+    );
+    const testButton = wrapper.find('#testButton');
+    expect(testButton.props().isDisabled).to.be.true;
+  });
+
+  it('hides test button if showTestButton is false', () => {
+    const wrapper = shallow(
+      <ControlButtons {...defaultProps} showTestButton={false} />
+    );
+    const testButton = wrapper.find('#testButton');
+    expect(testButton).to.be.empty;
   });
 });


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Unhides and re-enables the test button in Javalab now that Javabuilder supports running tests (behind an experiment flag, `"javalabUnitTests"`). This turned out to be a little more involved than just hooking up the existing test function to the test button - there was some additional work required to ensure that Run and Test couldn't be called at the same time.

I also added a [tech debt task](https://codedotorg.atlassian.net/browse/CSA-1025) to the backlog to ensure that Javalab never has more than one Javabuilder execution at a time; in theory, this shouldn't happen as the logic here should prevent you from clicking Run while tests are in progress and vice versa, and even if it does, each lambda should provide an isolated environment per execution. Still though, it might be good to have an additional layer of security to prevent unintended consequences especially as we add new use cases for connecting to Javabuilder (e.g. compile only for backpack).

Test button present:
![Screen Shot 2021-10-26 at 11 46 17 AM](https://user-images.githubusercontent.com/85528507/138956127-ca7b696d-c19a-47da-a8fd-3271b48e2ff1.png)

Run button disabled during tests:
![Screen Shot 2021-10-26 at 11 47 04 AM](https://user-images.githubusercontent.com/85528507/138956155-b226b21d-c7e8-4b6f-b3cb-e71192ea3943.png)

Test button disabled during run:
![Screen Shot 2021-10-26 at 11 47 26 AM](https://user-images.githubusercontent.com/85528507/138956172-88a8b79c-2b4c-42fc-82f5-8861f57fb253.png)


## Links

JIRA: https://codedotorg.atlassian.net/browse/CSA-931

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Tested locally on All The Things + unit.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
