### PR TITLE
Code Review Groups: Create CodeReviewGroup model/table

### DIFF
--- a/dashboard/app/models/code_review_group.rb
+++ b/dashboard/app/models/code_review_group.rb
@@ -1,0 +1,16 @@
+# == Schema Information
+#
+# Table name: code_review_groups
+#
+#  id         :bigint           not null, primary key
+#  section_id :bigint           not null
+#  name       :string(255)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_code_review_groups_on_section_id  (section_id)
+#
+class CodeReviewGroup < ApplicationRecord
+end

--- a/dashboard/db/migrate/20211026204516_create_code_review_groups.rb
+++ b/dashboard/db/migrate/20211026204516_create_code_review_groups.rb
@@ -1,0 +1,11 @@
+class CreateCodeReviewGroups < ActiveRecord::Migration[5.2]
+  def change
+    # This statement creates an index on section_id (which is desired),
+    # although I cannot find documentation on why that is the case.
+    create_table :code_review_groups do |t|
+      t.belongs_to :section, null: false
+      t.string :name
+      t.timestamps
+    end
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_22_020848) do
+ActiveRecord::Schema.define(version: 2021_10_26_204516) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -290,6 +290,14 @@ ActiveRecord::Schema.define(version: 2021_10_22_020848) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["storage_app_id", "project_version"], name: "index_code_review_comments_on_storage_app_id_and_version"
+  end
+
+  create_table "code_review_groups", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+    t.bigint "section_id", null: false
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["section_id"], name: "index_code_review_groups_on_section_id"
   end
 
   create_table "concepts", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|


### PR DESCRIPTION
Adds a new model/table (CodeReviewGroup/code_review_groups) to store metadata about groups of students assigned to work together for code review (ie, a name for the group, and what section the group belongs to).

## Testing story

Tested manually. I tried to add the desired index (section_id) manually, but found that this command generated an index by default. I wasn't sure why (and can't find anything in the docs), so added a comment in case anyone is ever looking for where we generated the section_id index on this table.