### PR TITLE
[Poetry][HOC] Add line numbers in preview mode

### DIFF
--- a/apps/src/p5lab/poetry/PoetryLibrary.js
+++ b/apps/src/p5lab/poetry/PoetryLibrary.js
@@ -42,7 +42,7 @@ export default class PoetryLibrary extends CoreLibrary {
     this.backgroundEffect = () => this.p5.background('white');
     this.foregroundEffects = [];
     this.lineEvents = {};
-    this.p5.textAlign(this.p5.LEFT);
+    this.p5.textAlign(this.p5.CENTER);
     this.p5.angleMode(this.p5.DEGREES);
     this.p5.noStroke();
 
@@ -440,7 +440,7 @@ export default class PoetryLibrary extends CoreLibrary {
     poemState.lines.forEach(line => {
       renderInfo.lines.push({
         text: line,
-        x: OUTER_MARGIN / 2,
+        x: PLAYSPACE_SIZE / 2,
         y: yCursor,
         size: lineSize,
         isPoemBodyLine: true
@@ -463,11 +463,6 @@ export default class PoetryLibrary extends CoreLibrary {
   drawFromRenderInfo(renderInfo) {
     this.p5.textFont(renderInfo.font.font);
     renderInfo.lines.forEach(item => {
-      if (item.isPoemBodyLine) {
-        this.p5.textAlign(this.p5.LEFT);
-      } else {
-        this.p5.textAlign(this.p5.CENTER);
-      }
       let fillColor = this.getP5Color(renderInfo.font.fill, item.alpha);
       this.p5.fill(fillColor);
       this.p5.textSize(item.size);
@@ -476,22 +471,27 @@ export default class PoetryLibrary extends CoreLibrary {
 
     if (this.isPreviewFrame()) {
       // Draw line numbers in preview frame only
-      this.p5.push();
-      this.p5.stroke('white');
-      this.p5.strokeWeight(2);
-      this.p5.fill('black');
-      this.p5.textFont('Arial');
-      this.p5.textSize(16);
-
-      let lineNum = 1;
-      renderInfo.lines.forEach(item => {
-        if (item.isPoemBodyLine) {
-          this.p5.text(lineNum, 5, item.y);
-          lineNum++;
-        }
-      });
-      this.p5.pop();
+      this.drawLineNumbers(renderInfo);
     }
+  }
+
+  drawLineNumbers(renderInfo) {
+    this.p5.push();
+    this.p5.textAlign(this.p5.LEFT);
+    this.p5.stroke('white');
+    this.p5.strokeWeight(2);
+    this.p5.fill('black');
+    this.p5.textFont('Arial');
+    this.p5.textSize(16);
+
+    let lineNum = 1;
+    renderInfo.lines.forEach(item => {
+      if (item.isPoemBodyLine) {
+        this.p5.text(lineNum, 5, item.y);
+        lineNum++;
+      }
+    });
+    this.p5.pop();
   }
 
   // polyfill for https://github.com/processing/p5.js/blob/main/src/color/p5.Color.js#L355

--- a/apps/src/p5lab/poetry/PoetryLibrary.js
+++ b/apps/src/p5lab/poetry/PoetryLibrary.js
@@ -42,7 +42,7 @@ export default class PoetryLibrary extends CoreLibrary {
     this.backgroundEffect = () => this.p5.background('white');
     this.foregroundEffects = [];
     this.lineEvents = {};
-    this.p5.textAlign(this.p5.CENTER);
+    this.p5.textAlign(this.p5.LEFT);
     this.p5.angleMode(this.p5.DEGREES);
     this.p5.noStroke();
 
@@ -440,7 +440,7 @@ export default class PoetryLibrary extends CoreLibrary {
     poemState.lines.forEach(line => {
       renderInfo.lines.push({
         text: line,
-        x: PLAYSPACE_SIZE / 2,
+        x: OUTER_MARGIN / 2,
         y: yCursor,
         size: lineSize,
         isPoemBodyLine: true
@@ -463,11 +463,35 @@ export default class PoetryLibrary extends CoreLibrary {
   drawFromRenderInfo(renderInfo) {
     this.p5.textFont(renderInfo.font.font);
     renderInfo.lines.forEach(item => {
+      if (item.isPoemBodyLine) {
+        this.p5.textAlign(this.p5.LEFT);
+      } else {
+        this.p5.textAlign(this.p5.CENTER);
+      }
       let fillColor = this.getP5Color(renderInfo.font.fill, item.alpha);
       this.p5.fill(fillColor);
       this.p5.textSize(item.size);
       this.p5.text(item.text, item.x, item.y);
     });
+
+    if (this.isPreviewFrame()) {
+      // Draw line numbers in preview frame only
+      this.p5.push();
+      this.p5.stroke('white');
+      this.p5.strokeWeight(2);
+      this.p5.fill('black');
+      this.p5.textFont('Arial');
+      this.p5.textSize(16);
+
+      let lineNum = 1;
+      renderInfo.lines.forEach(item => {
+        if (item.isPoemBodyLine) {
+          this.p5.text(lineNum, 5, item.y);
+          lineNum++;
+        }
+      });
+      this.p5.pop();
+    }
   }
 
   // polyfill for https://github.com/processing/p5.js/blob/main/src/color/p5.Color.js#L355


### PR DESCRIPTION
[jira](https://codedotorg.atlassian.net/browse/STAR-1805)

Adds line numbers only during preview
Line numbers are black with white outline to make them visible whether background is light or dark.
~Also makes the poem left-justified instead of centered.~

![image](https://user-images.githubusercontent.com/8787187/139118698-e1e21de7-4890-4d95-95ea-e343000e9564.png)
![image](https://user-images.githubusercontent.com/8787187/139118767-7ed12bed-9227-4522-8f09-5ebc752942f5.png)
![image](https://user-images.githubusercontent.com/8787187/139118869-d506b151-02de-47d6-b18b-635cc3a32aeb.png)
