### PR TITLE
Load example solutions for cached levels async

### DIFF
--- a/apps/src/code-studio/components/progress/teacherPanel/TeacherPanel.jsx
+++ b/apps/src/code-studio/components/progress/teacherPanel/TeacherPanel.jsx
@@ -42,7 +42,8 @@ class TeacherPanel extends React.Component {
     unlockedLessonNames: PropTypes.arrayOf(PropTypes.string).isRequired,
     students: PropTypes.arrayOf(studentShape),
     levelsWithProgress: PropTypes.array,
-    loadLevelsWithProgress: PropTypes.func.isRequired
+    loadLevelsWithProgress: PropTypes.func.isRequired,
+    exampleSolutions: PropTypes.array
   };
 
   UNSAFE_componentWillReceiveProps(nextProps) {
@@ -85,7 +86,8 @@ class TeacherPanel extends React.Component {
       unitHasLockableLessons,
       unlockedLessonNames,
       students,
-      unitName
+      unitName,
+      exampleSolutions
     } = this.props;
 
     let currentStudent = null;
@@ -121,7 +123,7 @@ class TeacherPanel extends React.Component {
       viewAs === ViewType.Teacher && currentStudent;
 
     const displayLevelExamples =
-      viewAs === ViewType.Teacher && sectionData?.level_examples?.length > 0;
+      viewAs === ViewType.Teacher && exampleSolutions?.length > 0;
 
     const displayLockInfo =
       hasSections && unitHasLockableLessons && viewAs === ViewType.Teacher;
@@ -142,7 +144,7 @@ class TeacherPanel extends React.Component {
           )}
           {displayLevelExamples && (
             <div style={styles.exampleSolutions}>
-              {sectionData.level_examples.map((example, index) => (
+              {exampleSolutions.map((example, index) => (
                 <Button
                   __useDeprecatedTag
                   key={index}
@@ -299,7 +301,8 @@ export default connect(
       students: state.teacherSections.selectedStudents,
       levelsWithProgress: state.teacherPanel.levelsWithProgress,
       isLoadingLevelsWithProgress:
-        state.teacherPanel.isLoadingLevelsWithProgress
+        state.teacherPanel.isLoadingLevelsWithProgress,
+      exampleSolutions: state.pageConstants?.exampleSolutions
     };
   },
   dispatch => ({

--- a/apps/src/code-studio/initApp/loadApp.js
+++ b/apps/src/code-studio/initApp/loadApp.js
@@ -289,7 +289,7 @@ async function loadAppAsync(appOptions) {
   // that indicates that the level was cached and the channel id needs to be loaded client-side
   // through the user_progress request
   const shouldGetChannelId =
-    appOptions.levelRequiresChannel && !appOptions.channel;
+    !!appOptions.levelRequiresChannel && !appOptions.channel;
 
   if (appOptions.publicCaching) {
     // Disable social share by default on publicly-cached pages, because we don't know

--- a/apps/src/code-studio/initApp/loadApp.js
+++ b/apps/src/code-studio/initApp/loadApp.js
@@ -261,7 +261,7 @@ function loadProjectAndCheckAbuse(appOptions) {
  * @param {AppOptionsConfig} appOptions
  * @return {Promise.<AppOptionsConfig>}
  */
-function loadAppAsync(appOptions) {
+async function loadAppAsync(appOptions) {
   setupApp(appOptions);
 
   var isViewingSolution = clientState.queryParams('solution') === 'true';
@@ -278,7 +278,7 @@ function loadAppAsync(appOptions) {
   }
 
   if (isViewingSolution) {
-    return Promise.resolve(appOptions);
+    return appOptions;
   }
 
   if (appOptions.channel || isViewingStudentAnswer) {
@@ -291,62 +291,71 @@ function loadAppAsync(appOptions) {
   const shouldGetChannelId =
     appOptions.levelRequiresChannel && !appOptions.channel;
 
-  return new Promise((resolve, reject) => {
-    if (appOptions.publicCaching) {
-      // Disable social share by default on publicly-cached pages, because we don't know
-      // if the user is underage until we get data back from /api/user_progress/ and we
-      // should err on the side of not showing social links
-      appOptions.disableSocialShare = true;
+  if (appOptions.publicCaching) {
+    // Disable social share by default on publicly-cached pages, because we don't know
+    // if the user is underage until we get data back from /api/user_progress/ and we
+    // should err on the side of not showing social links
+    appOptions.disableSocialShare = true;
+  }
+
+  const userProgressRequest = $.ajax(
+    `/api/user_progress` +
+      `/${appOptions.scriptName}` +
+      `/${appOptions.lessonPosition}` +
+      `/${appOptions.levelPosition}` +
+      `/${appOptions.serverLevelId}` +
+      `?get_channel_id=${shouldGetChannelId}`
+  );
+
+  const sectionId = clientState.queryParams('section_id') || '';
+  const exampleSolutionsRequest = $.ajax(
+    `/api/example_solutions/${appOptions.serverScriptLevelId}/${
+      appOptions.serverLevelId
+    }?section_id=${sectionId}`
+  );
+
+  try {
+    const [data, exampleSolutions] = await Promise.all([
+      userProgressRequest,
+      exampleSolutionsRequest
+    ]);
+
+    appOptions.exampleSolutions = exampleSolutions;
+    appOptions.disableSocialShare = data.disableSocialShare;
+
+    // We do not need to process data.progress here because labs do not use
+    // the level progress data directly. (The progress bubbles in the header
+    // of the level pages are rendered by header.build in header.js.)
+
+    if (data.lastAttempt) {
+      appOptions.level.lastAttempt = data.lastAttempt.source;
+    } else if (!data.signedIn) {
+      // User is not signed in, load last attempt from session storage.
+      appOptions.level.lastAttempt = clientState.sourceForLevel(
+        appOptions.scriptName,
+        appOptions.serverProjectLevelId || appOptions.serverLevelId
+      );
     }
 
-    $.ajax(
-      `/api/user_progress` +
-        `/${appOptions.scriptName}` +
-        `/${appOptions.lessonPosition}` +
-        `/${appOptions.levelPosition}` +
-        `/${appOptions.serverLevelId}` +
-        `?get_channel_id=${shouldGetChannelId}`
-    )
-      .done(data => {
-        appOptions.disableSocialShare = data.disableSocialShare;
+    appOptions.level.isNavigator = data.isNavigator;
+    if (data.pairingDriver) {
+      appOptions.level.pairingDriver = data.pairingDriver;
+      appOptions.level.pairingAttempt = data.pairingAttempt;
+      appOptions.level.pairingChannelId = data.pairingChannelId;
+    }
 
-        // We do not need to process data.progress here because labs do not use
-        // the level progress data directly. (The progress bubbles in the header
-        // of the level pages are rendered by header.build in header.js.)
-
-        if (data.lastAttempt) {
-          appOptions.level.lastAttempt = data.lastAttempt.source;
-        } else if (!data.signedIn) {
-          // User is not signed in, load last attempt from session storage.
-          appOptions.level.lastAttempt = clientState.sourceForLevel(
-            appOptions.scriptName,
-            appOptions.serverProjectLevelId || appOptions.serverLevelId
-          );
-        }
-
-        appOptions.level.isNavigator = data.isNavigator;
-        if (data.pairingDriver) {
-          appOptions.level.pairingDriver = data.pairingDriver;
-          appOptions.level.pairingAttempt = data.pairingAttempt;
-          appOptions.level.pairingChannelId = data.pairingChannelId;
-        }
-
-        if (data.channel) {
-          appOptions.channel = data.channel;
-          appOptions.reduceChannelUpdates = data.reduceChannelUpdates;
-          loadProjectAndCheckAbuse(appOptions).then(appOptions => {
-            resolve(appOptions);
-          });
-        } else {
-          resolve(appOptions);
-        }
-      })
-      .fail(() => {
-        // TODO: Show an error to the user here? (LP-1815)
-        console.error('Could not load user progress.');
-        resolve(appOptions);
-      });
-  });
+    if (data.channel) {
+      appOptions.channel = data.channel;
+      appOptions.reduceChannelUpdates = data.reduceChannelUpdates;
+      return await loadProjectAndCheckAbuse(appOptions);
+    } else {
+      return appOptions;
+    }
+  } catch (err) {
+    // TODO: Show an error to the user here? (LP-1815)
+    console.error('Could not load user progress.');
+    return appOptions;
+  }
 }
 
 window.dashboard = window.dashboard || {};

--- a/apps/test/unit/code-studio/components/progress/teacherPanel/TeacherPanelTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/teacherPanel/TeacherPanelTest.jsx
@@ -29,7 +29,8 @@ const DEFAULT_PROPS = {
   unlockedLessonNames: [],
   students: null,
   levelsWithProgress: [],
-  loadLevelsWithProgress: () => {}
+  loadLevelsWithProgress: () => {},
+  exampleSolutions: []
 };
 
 const sectionScriptLevelData = [
@@ -188,47 +189,46 @@ describe('TeacherPanel', () => {
   });
 
   describe('Example Solutions', () => {
-    describe('on unit', () => {
-      it('does not display example solutions', () => {
-        const wrapper = setUp({
-          viewAs: ViewType.Teacher
-        });
-        expect(wrapper.find('Button')).to.have.length(0);
+    it('does not display example solutions if the viewType is student', () => {
+      const wrapper = setUp({
+        viewAs: ViewType.Student,
+        exampleSolutions: [
+          'https://studio.code.org/projects/applab/8cik_q8RCK57-Zv4Xeot_Q/view'
+        ]
       });
+      expect(wrapper.find('Button')).to.have.length(0);
     });
 
-    describe('on level', () => {
-      it('displays example solution for level with one example solution', () => {
-        const wrapper = setUp({
-          viewAs: ViewType.Teacher,
-          students: students,
-          sectionData: {
-            level_examples: [
-              'https://studio.code.org/projects/applab/8cik_q8RCK57-Zv4Xeot_Q/view'
-            ],
-            section: {
-              students: students
-            }
+    it('displays example solution for level with one example solution', () => {
+      const wrapper = setUp({
+        viewAs: ViewType.Teacher,
+        students: students,
+        exampleSolutions: [
+          'https://studio.code.org/projects/applab/8cik_q8RCK57-Zv4Xeot_Q/view'
+        ],
+        sectionData: {
+          section: {
+            students: students
           }
-        });
-
-        expect(wrapper.find('Button')).to.have.length(1);
+        }
       });
 
-      it('does not display example solution for level with no example solution', () => {
-        const wrapper = setUp({
-          viewAs: ViewType.Teacher,
-          students: students,
-          sectionData: {
-            level_examples: null,
-            section: {
-              students: students
-            }
-          }
-        });
+      expect(wrapper.find('Button')).to.have.length(1);
+    });
 
-        expect(wrapper.find('Button')).to.have.length(0);
+    it('does not display example solution for level with no example solution', () => {
+      const wrapper = setUp({
+        viewAs: ViewType.Teacher,
+        students: students,
+        exampleSolutions: null,
+        sectionData: {
+          section: {
+            students: students
+          }
+        }
       });
+
+      expect(wrapper.find('Button')).to.have.length(0);
     });
   });
 });

--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -478,6 +478,14 @@ class ApiController < ApplicationController
     render json: response
   end
 
+  # GET /api/example_solutions/:script_level_id/:level_id
+  def example_solutions
+    script_level = Script.cache_find_script_level params[:script_level_id].to_i
+    level = Script.cache_find_level params[:level_id].to_i
+    section_id = params[:section_id] ? params[:section_id].to_i : nil
+    render json: script_level.get_example_solutions(level, current_user, section_id)
+  end
+
   def section_text_responses
     section = load_section
     script = load_script(section)

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -216,6 +216,7 @@ module LevelsHelper
     view_options(user_id: current_user.id) if current_user
 
     view_options(server_level_id: @level.id)
+
     if @script_level
       view_options(
         lesson_position: @script_level.lesson.absolute_position,
@@ -296,10 +297,11 @@ module LevelsHelper
         view_options.camelize_keys
       end
 
+    @app_options[:serverScriptLevelId] = @script_level.id if @script_level
+    @app_options[:serverScriptId] = @script.id if @script
+    @app_options[:verifiedTeacher] = current_user && current_user.authorized_teacher?
+
     if @script_level && (@level.can_have_feedback? || @level.can_have_code_review?)
-      @app_options[:serverScriptId] = @script.id
-      @app_options[:serverScriptLevelId] = @script_level.id
-      @app_options[:verifiedTeacher] = current_user && current_user.authorized_teacher?
       @app_options[:canHaveFeedbackReviewState] = @level.can_have_feedback_review_state?
     end
 

--- a/dashboard/app/views/levels/_teacher_panel.html.haml
+++ b/dashboard/app/views/levels/_teacher_panel.html.haml
@@ -12,8 +12,5 @@
   - data[:teacher_level] = @script_level&.summarize_for_teacher_panel(@current_user)
   - data[:page_type] = 'level' if @level.present?
 
-- if @level && @script_level
-  - data[:level_examples] = @script_level.get_example_solutions(@level, @current_user, @section)
-
 - content_for(:head) do
   %script{src: webpack_asset_path('js/levels/_teacher_panel.js'), data: {teacherpanel: data.to_json }}

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -724,6 +724,7 @@ Dashboard::Application.routes.draw do
   get '/api/user_progress/:script', to: 'api#user_progress', as: 'user_progress'
   get '/api/user_progress/:script/:lesson_position/:level_position', to: 'api#user_progress_for_lesson', as: 'user_progress_for_lesson'
   get '/api/user_progress/:script/:lesson_position/:level_position/:level', to: 'api#user_progress_for_lesson', as: 'user_progress_for_lesson_and_level'
+  get '/api/example_solutions/:script_level_id/:level_id', to: 'api#example_solutions'
   put '/api/firehose_unreachable', to: 'api#firehose_unreachable'
   namespace :api do
     api_methods.each do |action|

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -532,7 +532,7 @@ ActiveRecord::Schema.define(version: 2021_10_26_211629) do
     t.index ["library_name", "library_version", "question_name"], name: "index_foorm_library_questions_on_multiple_fields", unique: true
   end
 
-  create_table "foorm_simple_survey_forms", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "foorm_simple_survey_forms", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "path", null: false
     t.string "kind"
     t.string "form_name", null: false
@@ -1813,7 +1813,7 @@ ActiveRecord::Schema.define(version: 2021_10_26_211629) do
     t.index ["published_state"], name: "index_unit_groups_on_published_state"
   end
 
-  create_table "unit_groups_resources", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "unit_groups_resources", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "unit_group_id"
     t.integer "resource_id"
     t.index ["resource_id", "unit_group_id"], name: "index_unit_groups_resources_on_resource_id_and_unit_group_id"

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -532,7 +532,7 @@ ActiveRecord::Schema.define(version: 2021_10_26_211629) do
     t.index ["library_name", "library_version", "question_name"], name: "index_foorm_library_questions_on_multiple_fields", unique: true
   end
 
-  create_table "foorm_simple_survey_forms", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "foorm_simple_survey_forms", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "path", null: false
     t.string "kind"
     t.string "form_name", null: false
@@ -1813,7 +1813,7 @@ ActiveRecord::Schema.define(version: 2021_10_26_211629) do
     t.index ["published_state"], name: "index_unit_groups_on_published_state"
   end
 
-  create_table "unit_groups_resources", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "unit_groups_resources", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "unit_group_id"
     t.integer "resource_id"
     t.index ["resource_id", "unit_group_id"], name: "index_unit_groups_resources_on_resource_id_and_unit_group_id"

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -80,6 +80,9 @@ class ApiControllerTest < ActionController::TestCase
   end
 
   test "example_solutions should call ScriptLevel get_example_solution" do
+    STUB_ENCRYPTION_KEY = SecureRandom.base64(Encryption::KEY_LENGTH / 8)
+    CDO.stubs(:properties_encryption_key).returns(STUB_ENCRYPTION_KEY)
+
     teacher = create :authorized_teacher
     sign_in teacher
 

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -79,6 +79,20 @@ class ApiControllerTest < ActionController::TestCase
     # UserLevel.create!(level_id: level.id, user_id: student.id, script_id: script.id, level_source: level_source)
   end
 
+  test "example_solutions should call ScriptLevel get_example_solution" do
+    teacher = create :authorized_teacher
+    sign_in teacher
+
+    section = create :section
+    level = create :dance, :with_example_solutions
+    script_level = create :script_level, levels: [level]
+
+    get :example_solutions, params: {script_level_id: script_level.id, level_id: level.id, section_id: section.id}
+
+    assert_response :success
+    assert_equal '["https://studio.code.org/projects/dance/example-1/view","https://studio.code.org/projects/dance/example-2/view"]', @response.body
+  end
+
   test "should get text_responses for section with default script" do
     get :section_text_responses, params: {section_id: @section.id}
     assert_response :success


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This is a portion of the full set of changes [here](https://github.com/code-dot-org/code-dot-org/pull/43126). I've split this out so that it's easier to review.

Changes here include:
- Updating load app to use await syntax instead of .then
- Load example solutions async in loadApp to ensure they're set to pageConstants redux for cached levels
- Teacher panel gets example solutions from redux instead of teacher_panel.html.haml

## Testing story
I tested that the example_solutions endpoint works and that example solutions are set to pageConstants.exampleSolutions for cached levels. Also added unit tests.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Follow-up work
Apply the rest of the changes in https://github.com/code-dot-org/code-dot-org/pull/43126
<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
