### PR TITLE
Revert "Fix bug of inconsistent Code logo left-spacing"

### DIFF
--- a/shared/css/header.scss
+++ b/shared/css/header.scss
@@ -41,7 +41,7 @@
 
     #logo-wrapper {
       display: inline-block;
-      padding: 4px 0 4px 1px;
+      padding: 4px 0 4px 16px;
       float: left;
 
       #logo {


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#42953

It fixed the logo spacing bug listed in that PR but failed to do so in certain languages such as Arabic and Hebrew.

Future work:
- Instead of having the previous setup of 2 separate styles for the signed in/out logos in the header, make the styling identical