### PR TITLE
[Poetry][HOC] Progress bar should last until validation end time

### DIFF
--- a/apps/src/p5lab/poetry/PoetryLibrary.js
+++ b/apps/src/p5lab/poetry/PoetryLibrary.js
@@ -234,7 +234,7 @@ export default class PoetryLibrary extends CoreLibrary {
         this.p5.rect(
           0,
           390,
-          (this.p5.frameCount / POEM_DURATION) * PLAYSPACE_SIZE,
+          (this.p5.frameCount / this.validationInfo.endTime) * PLAYSPACE_SIZE,
           10
         );
         this.p5.pop();


### PR DESCRIPTION
quick follow up to https://github.com/code-dot-org/code-dot-org/pull/43183
Now that we have some buffer time between the end of the poem and when the validation code ends the level, we should make sure the progress bar lasts until the validation code endTime.