### PR TITLE
[HOC] a/b/c options for costumes button for testing

### DIFF
--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -8,8 +8,9 @@ import {APP_HEIGHT, P5LabInterfaceMode} from '../constants';
 import {TOOLBOX_EDIT_MODE} from '../../constants';
 import {animationSourceUrl} from '../redux/animationList';
 import {changeInterfaceMode} from '../actions';
-import {Goal, showBackground} from '../redux/animationPicker';
+import {Goal, show, showBackground} from '../redux/animationPicker';
 import i18n from '@cdo/locale';
+import experiments from '@cdo/apps/util/experiments';
 import spritelabMsg from '@cdo/spritelab/locale';
 function animations(areBackgrounds) {
   const animationList = getStore().getState().animationList;
@@ -177,6 +178,17 @@ const customInputTypes = {
   costumePicker: {
     addInput(blockly, block, inputConfig, currentInputRow) {
       let buttons;
+      /*
+       * A/B/C experiment for costume tab:
+       * Treatment A: Clicking button opens the animation picker modal over the codespace
+       * Treatment B: Clicking button switches to the Costume Tab and opens the animation picker modal
+       * Original (No treatment): Clicking button switches to the Costume Tab (and does not open the modal)
+       *
+       * This user experiment will be conducted in November 2021. This code should be removed
+       * and the behavior should revert to the original behavior by November 11, 2021.
+       */
+      const isAEnabled = experiments.isEnabled(experiments.COSTUME_TAB_A);
+      const isBEnabled = experiments.isEnabled(experiments.COSTUME_TAB_B);
       if (
         getStore().getState().pageConstants &&
         getStore().getState().pageConstants.showAnimationMode
@@ -185,9 +197,18 @@ const customInputTypes = {
           {
             text: i18n.costumeMode(),
             action: () => {
-              getStore().dispatch(
-                changeInterfaceMode(P5LabInterfaceMode.ANIMATION)
-              );
+              if (isAEnabled) {
+                getStore().dispatch(show(Goal.NEW_ANIMATION, true));
+              } else if (isBEnabled) {
+                getStore().dispatch(
+                  changeInterfaceMode(P5LabInterfaceMode.ANIMATION)
+                );
+                getStore().dispatch(show(Goal.NEW_ANIMATION, true));
+              } else {
+                getStore().dispatch(
+                  changeInterfaceMode(P5LabInterfaceMode.ANIMATION)
+                );
+              }
             }
           }
         ];

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -32,11 +32,12 @@ experiments.I18N_TRACKING = 'i18n-tracking';
 experiments.TIME_SPENT = 'time-spent';
 experiments.BYPASS_DIALOG_POPUP = 'bypass-dialog-popup';
 experiments.SPECIAL_TOPIC = 'special-topic';
-experiments.POEM_BOT = 'poemBot';
 experiments.CLEARER_SIGN_UP_USER_TYPE = 'clearerSignUpUserType';
 experiments.OPT_IN_EMAIL_REG_PARTNER = 'optInEmailRegPartner';
 experiments.MULTISELECT = 'multiselect';
 experiments.JAVALAB_UNIT_TESTS = 'javalabUnitTests';
+experiments.COSTUME_TAB_A = 'costumeTabA';
+experiments.COSTUME_TAB_B = 'costumeTabB';
 
 /**
  * This was a gamified version of the finish dialog, built in 2018,


### PR DESCRIPTION
cc @KylieModen 

We want to test out a few different options for the behavior of the button in the sprite dropdown. This code will be reverted after we do some classroom testing next week.

Option A: Clicking button opens the animation picker modal over the codespace

![A-selectFromModal](https://user-images.githubusercontent.com/8787187/139125567-23a4e69c-bfe2-40e0-92a5-7e8c8bdc9a8f.gif)
![A-costumeTab](https://user-images.githubusercontent.com/8787187/139125588-0906fd4d-e212-4bb6-bb9c-d5460ae4ee01.gif)

Option B: Clicking button goes to the costume tab and opens the animation picker modal
![B-selectFromModal](https://user-images.githubusercontent.com/8787187/139125631-a3482702-5f4a-4e2a-8d83-f7bed70ff74e.gif)
![B-draw](https://user-images.githubusercontent.com/8787187/139125618-4825b859-6952-4909-867c-a19b36bacaca.gif)


Default: Clicking button goes to the costume tab
![default](https://user-images.githubusercontent.com/8787187/139125671-d38e137a-1ada-484d-b208-92cc6cda4dec.gif)

