### PR TITLE
[Poetry] no shared functions checkbox for poetry

### DIFF
--- a/dashboard/app/views/levels/editors/fields/_blockly.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_blockly.html.haml
@@ -47,7 +47,7 @@
       %p Number is a multiplier for how long each step takes (so higher numbers are slower). Default is 5 for Maze, 2 for Bee.
       = f.number_field :step_speed
 
-  - if @level.is_a? GamelabJr
+  - if @level.instance_of?(GamelabJr)
     .field
       = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :include_shared_functions, description: "Make shared functions and behaviors available"}
 


### PR DESCRIPTION
quick follow up to https://github.com/code-dot-org/code-dot-org/pull/43157

Since we don't want or need these levels to have the shared functions enabled, this PR removes the checkbox from the level edit page so that it doesn't get checked by accident.

Before
![image](https://user-images.githubusercontent.com/8787187/139166493-6b6c1a41-06cc-4c4d-b1d5-aedb3c266d87.png)

After
![image](https://user-images.githubusercontent.com/8787187/139166436-a1f05ad9-cb12-4c38-bbb8-b0bf8ed6af60.png)
