### PR TITLE
Update CollapsibleEditorSection to use hooks

### DIFF
--- a/apps/src/lib/levelbuilder/CollapsibleEditorSection.jsx
+++ b/apps/src/lib/levelbuilder/CollapsibleEditorSection.jsx
@@ -3,7 +3,7 @@ import React, {useState} from 'react';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import styleConstants from '@cdo/apps/styleConstants';
 
-export function CollapsibleEditorSection(props) {
+export default function CollapsibleEditorSection(props) {
   const [collapsed, setCollapsed] = useState(props.collapsed || false);
 
   const {title, fullWidth} = props;

--- a/apps/src/lib/levelbuilder/CollapsibleEditorSection.jsx
+++ b/apps/src/lib/levelbuilder/CollapsibleEditorSection.jsx
@@ -1,53 +1,41 @@
 import PropTypes from 'prop-types';
-import React, {Component} from 'react';
+import React, {useState} from 'react';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import styleConstants from '@cdo/apps/styleConstants';
 
-export default class CollapsibleEditorSection extends Component {
-  static propTypes = {
-    title: PropTypes.string,
-    fullWidth: PropTypes.bool,
-    collapsed: PropTypes.bool,
-    children: PropTypes.any
+export function CollapsibleEditorSection(props) {
+  const [collapsed, setCollapsed] = useState(props.collapsed || false);
+
+  const {title, fullWidth} = props;
+  const editorsStyle = {
+    ...styles.editors,
+    width: fullWidth ? null : styleConstants['content-width']
   };
 
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      collapsed: this.props.collapsed || false // Default to open if nothing provided
-    };
-  }
-
-  render() {
-    const {title, fullWidth} = this.props;
-    const editorsStyle = {
-      ...styles.editors,
-      width: fullWidth ? null : styleConstants['content-width']
-    };
-    return (
-      <div>
-        <div style={styles.header}>
-          <h2
-            onClick={() => {
-              this.setState({collapsed: !this.state.collapsed});
-            }}
-            style={styles.title}
-          >
-            <FontAwesome
-              icon={this.state.collapsed ? 'expand' : 'compress'}
-              style={styles.icon}
-            />
-            {title}
-          </h2>
-        </div>
-        <div style={editorsStyle} hidden={this.state.collapsed}>
-          {this.props.children}
-        </div>
+  return (
+    <div>
+      <div style={styles.header}>
+        <h2 onClick={() => setCollapsed(!collapsed)} style={styles.title}>
+          <FontAwesome
+            icon={collapsed ? 'expand' : 'compress'}
+            style={styles.icon}
+          />
+          {title}
+        </h2>
       </div>
-    );
-  }
+      <div style={editorsStyle} hidden={collapsed}>
+        {props.children}
+      </div>
+    </div>
+  );
 }
+
+CollapsibleEditorSection.propTypes = {
+  title: PropTypes.string,
+  fullWidth: PropTypes.bool,
+  collapsed: PropTypes.bool,
+  children: PropTypes.any
+};
 
 const styles = {
   header: {

--- a/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingExpressionEditor.jsx
+++ b/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingExpressionEditor.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 import TextareaWithMarkdownPreview from '@cdo/apps/lib/levelbuilder/TextareaWithMarkdownPreview';
-import CollapsibleEditorSection from '@cdo/apps/lib/levelbuilder/CollapsibleEditorSection';
+import {CollapsibleEditorSection} from '@cdo/apps/lib/levelbuilder/CollapsibleEditorSection';
 import HelpTip from '@cdo/apps/lib/ui/HelpTip';
 import SaveBar from '@cdo/apps/lib/levelbuilder/SaveBar';
 import {navigateToHref} from '@cdo/apps/utils';

--- a/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingExpressionEditor.jsx
+++ b/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingExpressionEditor.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 import TextareaWithMarkdownPreview from '@cdo/apps/lib/levelbuilder/TextareaWithMarkdownPreview';
-import {CollapsibleEditorSection} from '@cdo/apps/lib/levelbuilder/CollapsibleEditorSection';
+import CollapsibleEditorSection from '@cdo/apps/lib/levelbuilder/CollapsibleEditorSection';
 import HelpTip from '@cdo/apps/lib/ui/HelpTip';
 import SaveBar from '@cdo/apps/lib/levelbuilder/SaveBar';
 import {navigateToHref} from '@cdo/apps/utils';

--- a/apps/src/lib/levelbuilder/course-editor/CourseTypeEditor.jsx
+++ b/apps/src/lib/levelbuilder/course-editor/CourseTypeEditor.jsx
@@ -7,7 +7,7 @@ import {
   ParticipantAudience,
   InstructionType
 } from '@cdo/apps/generated/curriculum/sharedCourseConstants';
-import {CollapsibleEditorSection} from '@cdo/apps/lib/levelbuilder/CollapsibleEditorSection';
+import CollapsibleEditorSection from '@cdo/apps/lib/levelbuilder/CollapsibleEditorSection';
 
 const INSTRUCTOR_AUDIENCE_DISPLAY_NAMES = {
   [InstructorAudience.teacher]: 'Teacher',

--- a/apps/src/lib/levelbuilder/course-editor/CourseTypeEditor.jsx
+++ b/apps/src/lib/levelbuilder/course-editor/CourseTypeEditor.jsx
@@ -7,7 +7,7 @@ import {
   ParticipantAudience,
   InstructionType
 } from '@cdo/apps/generated/curriculum/sharedCourseConstants';
-import CollapsibleEditorSection from '@cdo/apps/lib/levelbuilder/CollapsibleEditorSection';
+import {CollapsibleEditorSection} from '@cdo/apps/lib/levelbuilder/CollapsibleEditorSection';
 
 const INSTRUCTOR_AUDIENCE_DISPLAY_NAMES = {
   [InstructorAudience.teacher]: 'Teacher',

--- a/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
@@ -9,7 +9,7 @@ import StandardsEditor from '@cdo/apps/lib/levelbuilder/lesson-editor/StandardsE
 import TextareaWithMarkdownPreview from '@cdo/apps/lib/levelbuilder/TextareaWithMarkdownPreview';
 import HelpTip from '@cdo/apps/lib/ui/HelpTip';
 import AnnouncementsEditor from '@cdo/apps/lib/levelbuilder/announcementsEditor/AnnouncementsEditor';
-import CollapsibleEditorSection from '@cdo/apps/lib/levelbuilder/CollapsibleEditorSection';
+import {CollapsibleEditorSection} from '@cdo/apps/lib/levelbuilder/CollapsibleEditorSection';
 import RelatedLessons from './RelatedLessons';
 import {
   relatedLessonShape,

--- a/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
@@ -9,7 +9,7 @@ import StandardsEditor from '@cdo/apps/lib/levelbuilder/lesson-editor/StandardsE
 import TextareaWithMarkdownPreview from '@cdo/apps/lib/levelbuilder/TextareaWithMarkdownPreview';
 import HelpTip from '@cdo/apps/lib/ui/HelpTip';
 import AnnouncementsEditor from '@cdo/apps/lib/levelbuilder/announcementsEditor/AnnouncementsEditor';
-import {CollapsibleEditorSection} from '@cdo/apps/lib/levelbuilder/CollapsibleEditorSection';
+import CollapsibleEditorSection from '@cdo/apps/lib/levelbuilder/CollapsibleEditorSection';
 import RelatedLessons from './RelatedLessons';
 import {
   relatedLessonShape,

--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -9,7 +9,7 @@ import HelpTip from '@cdo/apps/lib/ui/HelpTip';
 import LessonExtrasEditor from '@cdo/apps/lib/levelbuilder/unit-editor/LessonExtrasEditor';
 import color from '@cdo/apps/util/color';
 import TextareaWithMarkdownPreview from '@cdo/apps/lib/levelbuilder/TextareaWithMarkdownPreview';
-import CollapsibleEditorSection from '@cdo/apps/lib/levelbuilder/CollapsibleEditorSection';
+import {CollapsibleEditorSection} from '@cdo/apps/lib/levelbuilder/CollapsibleEditorSection';
 import ResourceType, {
   resourceShape
 } from '@cdo/apps/templates/courseOverview/resourceType';

--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -9,7 +9,7 @@ import HelpTip from '@cdo/apps/lib/ui/HelpTip';
 import LessonExtrasEditor from '@cdo/apps/lib/levelbuilder/unit-editor/LessonExtrasEditor';
 import color from '@cdo/apps/util/color';
 import TextareaWithMarkdownPreview from '@cdo/apps/lib/levelbuilder/TextareaWithMarkdownPreview';
-import {CollapsibleEditorSection} from '@cdo/apps/lib/levelbuilder/CollapsibleEditorSection';
+import CollapsibleEditorSection from '@cdo/apps/lib/levelbuilder/CollapsibleEditorSection';
 import ResourceType, {
   resourceShape
 } from '@cdo/apps/templates/courseOverview/resourceType';

--- a/apps/test/unit/lib/levelbuilder/CollapsibleEditorSectionTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/CollapsibleEditorSectionTest.jsx
@@ -20,8 +20,9 @@ describe('CollapsibleEditorSection', () => {
     expect(wrapper.contains('Section Title')).to.be.true;
     expect(wrapper.contains('Child')).to.be.true;
     expect(wrapper.find('span').length).to.equal(1);
-    expect(wrapper.find('FontAwesome').length).to.equal(1);
-    expect(wrapper.state().collapsed).to.equal(false);
+    let icon = wrapper.find('FontAwesome');
+    expect(icon.length).to.equal(1);
+    expect(icon.props().icon).to.include('compress');
 
     const editorsWrapper = wrapper.children().last();
     expect(editorsWrapper.props().style.width).to.equal(970);
@@ -45,12 +46,10 @@ describe('CollapsibleEditorSection', () => {
     );
 
     let icon = wrapper.find('FontAwesome');
-    expect(wrapper.state().collapsed).to.equal(false);
     expect(icon.props().icon).to.include('compress');
 
     wrapper.find('h2').simulate('click');
 
-    expect(wrapper.state().collapsed).to.equal(true);
     expect(wrapper.find('FontAwesome').props().icon).to.include('expand');
   });
 });

--- a/apps/test/unit/lib/levelbuilder/CollapsibleEditorSectionTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/CollapsibleEditorSectionTest.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {shallow, mount} from 'enzyme';
 import {expect} from '../../../util/reconfiguredChai';
-import CollapsibleEditorSection from '@cdo/apps/lib/levelbuilder/CollapsibleEditorSection';
+import {CollapsibleEditorSection} from '@cdo/apps/lib/levelbuilder/CollapsibleEditorSection';
 
 describe('CollapsibleEditorSection', () => {
   let defaultProps;

--- a/apps/test/unit/lib/levelbuilder/CollapsibleEditorSectionTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/CollapsibleEditorSectionTest.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {shallow, mount} from 'enzyme';
 import {expect} from '../../../util/reconfiguredChai';
-import {CollapsibleEditorSection} from '@cdo/apps/lib/levelbuilder/CollapsibleEditorSection';
+import CollapsibleEditorSection from '@cdo/apps/lib/levelbuilder/CollapsibleEditorSection';
 
 describe('CollapsibleEditorSection', () => {
   let defaultProps;


### PR DESCRIPTION
Updates the CollapsibleEditorSection (the way we group settings on edit pages) to use hooks!  Moved this.state to useState. Updated the tests because they were checking state and we don't have access to that anymore. Instead just check the result of changing the state is correct. 

## Links

- [Jira](https://codedotorg.atlassian.net/browse/PLAT-1393)

## Testing story

- Updated existing tests
- Checked that the LessonEditor loaded