### PR TITLE
[HOC] costume experiment for tab button too

### DIFF
--- a/apps/src/p5lab/P5LabVisualizationHeader.jsx
+++ b/apps/src/p5lab/P5LabVisualizationHeader.jsx
@@ -1,7 +1,9 @@
 /** @file Row of controls above the visualization. */
 import PropTypes from 'prop-types';
 import React from 'react';
+import experiments from '@cdo/apps/util/experiments';
 import {changeInterfaceMode} from './actions';
+import {Goal, show} from './redux/animationPicker';
 import {connect} from 'react-redux';
 import {P5LabInterfaceMode, P5LabType} from './constants';
 import msg from '@cdo/locale';
@@ -28,7 +30,8 @@ class P5LabVisualizationHeader extends React.Component {
     isBlockly: PropTypes.bool.isRequired,
     numAllowedModes: PropTypes.number.isRequired,
     isShareView: PropTypes.bool.isRequired,
-    isReadOnlyWorkspace: PropTypes.bool.isRequired
+    isReadOnlyWorkspace: PropTypes.bool.isRequired,
+    openAnimationPicker: PropTypes.func.isRequired
   };
 
   changeInterfaceMode = mode => {
@@ -55,6 +58,21 @@ class P5LabVisualizationHeader extends React.Component {
     }
 
     this.props.onInterfaceModeChange(mode);
+
+    /*
+     * User Experiment for costume tab:
+     * Treatment B: Clicking button switches to the Costume Tab and opens the animation picker modal
+     * Original (No treatment): Clicking button switches to the Costume Tab (and does not open the modal)
+     *
+     * This user experiment will be conducted in November 2021. This code should be removed
+     * and the behavior should revert to the original behavior by November 11, 2021.
+     */
+    if (
+      experiments.isEnabled(experiments.COSTUME_TAB_B) &&
+      mode === P5LabInterfaceMode.ANIMATION
+    ) {
+      this.props.openAnimationPicker();
+    }
   };
 
   shouldShowPoemSelector() {
@@ -126,6 +144,7 @@ export default connect(
     isReadOnlyWorkspace: state.pageConstants.isReadOnlyWorkspace
   }),
   dispatch => ({
-    onInterfaceModeChange: mode => dispatch(changeInterfaceMode(mode))
+    onInterfaceModeChange: mode => dispatch(changeInterfaceMode(mode)),
+    openAnimationPicker: () => dispatch(show(Goal.NEW_ANIMATION, true))
   })
 )(P5LabVisualizationHeader);


### PR DESCRIPTION
follow up to https://github.com/code-dot-org/code-dot-org/pull/43220
for experiment option B- clicking the costume tab button should have the same behavior: switch to the costume tab *and* open the animation picker modal