### PR TITLE
Javalab: Add UI component that lets a user add a custom image

### DIFF
--- a/apps/src/javalab/Javalab.js
+++ b/apps/src/javalab/Javalab.js
@@ -16,7 +16,9 @@ import javalab, {
   appendNewlineToConsoleLog,
   setIsRunning,
   setDisableFinishButton,
-  setIsTesting
+  setIsTesting,
+  openPhotoPrompter,
+  closePhotoPrompter
 } from './javalabRedux';
 import playground from './playgroundRedux';
 import {TestResults} from '@cdo/apps/constants';
@@ -109,6 +111,9 @@ Javalab.prototype.init = function(config) {
   const onCommitCode = this.onCommitCode.bind(this);
   const onInputMessage = this.onInputMessage.bind(this);
   const onJavabuilderMessage = this.onJavabuilderMessage.bind(this);
+  const onPhotoPrompterFileSelected = this.onPhotoPrompterFileSelected.bind(
+    this
+  );
 
   switch (this.level.csaViewMode) {
     case CsaViewMode.NEIGHBORHOOD:
@@ -127,7 +132,12 @@ Javalab.prototype.init = function(config) {
       this.visualization = <NeighborhoodVisualizationColumn />;
       break;
     case CsaViewMode.THEATER:
-      this.miniApp = new Theater(this.onOutputMessage, this.onNewlineMessage);
+      this.miniApp = new Theater(
+        this.onOutputMessage,
+        this.onNewlineMessage,
+        this.openPhotoPrompter,
+        this.closePhotoPrompter
+      );
       this.visualization = <TheaterVisualizationColumn />;
       break;
     case CsaViewMode.PLAYGROUND:
@@ -277,6 +287,7 @@ Javalab.prototype.init = function(config) {
         handleClearPuzzle={() => {
           return this.studioApp_.handleClearPuzzle(config);
         }}
+        onPhotoPrompterFileSelected={onPhotoPrompterFileSelected}
       />
     </Provider>,
     document.getElementById(config.containerId)
@@ -432,6 +443,19 @@ Javalab.prototype.setIsRunning = function(isRunning) {
 
 Javalab.prototype.setIsTesting = function(isTesting) {
   getStore().dispatch(setIsTesting(isTesting));
+};
+
+Javalab.prototype.openPhotoPrompter = function(promptText) {
+  getStore().dispatch(openPhotoPrompter(promptText));
+};
+
+Javalab.prototype.closePhotoPrompter = function() {
+  getStore().dispatch(closePhotoPrompter());
+};
+
+Javalab.prototype.onPhotoPrompterFileSelected = function(photo) {
+  // Only pass the selected photo the mini-app if it supports the photo prompter
+  this.miniApp?.onPhotoPrompterFileSelected?.(photo);
 };
 
 export default Javalab;

--- a/apps/src/javalab/Javalab.js
+++ b/apps/src/javalab/Javalab.js
@@ -454,7 +454,7 @@ Javalab.prototype.closePhotoPrompter = function() {
 };
 
 Javalab.prototype.onPhotoPrompterFileSelected = function(photo) {
-  // Only pass the selected photo the mini-app if it supports the photo prompter
+  // Only pass the selected photo to the mini-app if it supports the photo prompter
   this.miniApp?.onPhotoPrompterFileSelected?.(photo);
 };
 

--- a/apps/src/javalab/JavalabConsole.jsx
+++ b/apps/src/javalab/JavalabConsole.jsx
@@ -4,12 +4,17 @@ import PropTypes from 'prop-types';
 import javalabMsg from '@cdo/javalab/locale';
 import color from '@cdo/apps/util/color';
 import {KeyCodes} from '@cdo/apps/constants';
-import {appendInputLog, clearConsoleLogs} from './javalabRedux';
+import {
+  appendInputLog,
+  clearConsoleLogs,
+  closePhotoPrompter
+} from './javalabRedux';
 import CommandHistory from '@cdo/apps/lib/tools/jsdebugger/CommandHistory';
 import PaneHeader, {
   PaneSection,
   PaneButton
 } from '@cdo/apps/templates/PaneHeader';
+import PhotoSelectionView from './components/PhotoSelectionView';
 
 /**
  * Set the cursor position to the end of the text content in a div element.
@@ -34,6 +39,7 @@ function moveCaretToEndOfDiv(element) {
 class JavalabConsole extends React.Component {
   static propTypes = {
     onInputMessage: PropTypes.func.isRequired,
+    onPhotoPrompterFileSelected: PropTypes.func.isRequired,
     bottomRow: PropTypes.element,
     style: PropTypes.object,
 
@@ -41,7 +47,10 @@ class JavalabConsole extends React.Component {
     consoleLogs: PropTypes.array,
     appendInputLog: PropTypes.func,
     clearConsoleLogs: PropTypes.func,
-    isDarkMode: PropTypes.bool
+    isDarkMode: PropTypes.bool,
+    isPhotoPrompterOpen: PropTypes.bool,
+    closePhotoPrompter: PropTypes.func,
+    photoPrompterPromptText: PropTypes.string
   };
 
   state = {
@@ -146,7 +155,16 @@ class JavalabConsole extends React.Component {
   };
 
   render() {
-    const {isDarkMode, style, bottomRow, clearConsoleLogs} = this.props;
+    const {
+      isDarkMode,
+      style,
+      bottomRow,
+      clearConsoleLogs,
+      isPhotoPrompterOpen,
+      closePhotoPrompter,
+      onPhotoPrompterFileSelected,
+      photoPrompterPromptText
+    } = this.props;
 
     return (
       <div style={style}>
@@ -172,9 +190,20 @@ class JavalabConsole extends React.Component {
             ref={el => (this._consoleLogs = el)}
             className="javalab-console"
           >
-            <div onClick={this.onLogsClick} style={styles.logs}>
-              {this.renderConsoleLogs(isDarkMode)}
-            </div>
+            {isPhotoPrompterOpen ? (
+              <PhotoSelectionView
+                promptText={photoPrompterPromptText}
+                style={styles.photoPrompter}
+                onPhotoSelected={file => {
+                  onPhotoPrompterFileSelected(file);
+                  closePhotoPrompter();
+                }}
+              />
+            ) : (
+              <div onClick={this.onLogsClick} style={styles.logs}>
+                {this.renderConsoleLogs(isDarkMode)}
+              </div>
+            )}
           </div>
           {bottomRow && [
             {...bottomRow, key: 'bottom-row'},
@@ -189,11 +218,14 @@ class JavalabConsole extends React.Component {
 export default connect(
   state => ({
     consoleLogs: state.javalab.consoleLogs,
-    isDarkMode: state.javalab.isDarkMode
+    isDarkMode: state.javalab.isDarkMode,
+    isPhotoPrompterOpen: state.javalab.isPhotoPrompterOpen,
+    photoPrompterPromptText: state.javalab.photoPrompterPromptText
   }),
   dispatch => ({
     appendInputLog: log => dispatch(appendInputLog(log)),
-    clearConsoleLogs: () => dispatch(clearConsoleLogs())
+    clearConsoleLogs: () => dispatch(clearConsoleLogs()),
+    closePhotoPrompter: () => dispatch(closePhotoPrompter())
   })
 )(JavalabConsole);
 
@@ -226,12 +258,14 @@ const styles = {
     flexGrow: 2,
     overflowY: 'auto',
     padding: 5,
-    fontFamily: 'monospace'
+    display: 'flex',
+    flexDirection: 'column'
   },
   logs: {
     lineHeight: 'normal',
     cursor: 'text',
-    whiteSpace: 'pre-wrap'
+    whiteSpace: 'pre-wrap',
+    fontFamily: 'monospace'
   },
   logLine: {
     display: 'flex'
@@ -257,5 +291,8 @@ const styles = {
   log: {
     padding: 0,
     margin: 0
+  },
+  photoPrompter: {
+    flexGrow: 1
   }
 };

--- a/apps/src/javalab/JavalabConsole.jsx
+++ b/apps/src/javalab/JavalabConsole.jsx
@@ -129,6 +129,35 @@ class JavalabConsole extends React.Component {
     });
   }
 
+  renderConsoleBody() {
+    const {
+      isPhotoPrompterOpen,
+      photoPrompterPromptText,
+      onPhotoPrompterFileSelected,
+      closePhotoPrompter,
+      isDarkMode
+    } = this.props;
+
+    if (isPhotoPrompterOpen) {
+      return (
+        <PhotoSelectionView
+          promptText={photoPrompterPromptText}
+          style={styles.photoPrompter}
+          onPhotoSelected={file => {
+            onPhotoPrompterFileSelected(file);
+            closePhotoPrompter();
+          }}
+        />
+      );
+    } else {
+      return (
+        <div onClick={this.onLogsClick} style={styles.logs}>
+          {this.renderConsoleLogs(isDarkMode)}
+        </div>
+      );
+    }
+  }
+
   onInputKeyDown = e => {
     const {appendInputLog, onInputMessage} = this.props;
     const input = e.target.value;
@@ -155,16 +184,7 @@ class JavalabConsole extends React.Component {
   };
 
   render() {
-    const {
-      isDarkMode,
-      style,
-      bottomRow,
-      clearConsoleLogs,
-      isPhotoPrompterOpen,
-      closePhotoPrompter,
-      onPhotoPrompterFileSelected,
-      photoPrompterPromptText
-    } = this.props;
+    const {isDarkMode, style, bottomRow, clearConsoleLogs} = this.props;
 
     return (
       <div style={style}>
@@ -190,20 +210,7 @@ class JavalabConsole extends React.Component {
             ref={el => (this._consoleLogs = el)}
             className="javalab-console"
           >
-            {isPhotoPrompterOpen ? (
-              <PhotoSelectionView
-                promptText={photoPrompterPromptText}
-                style={styles.photoPrompter}
-                onPhotoSelected={file => {
-                  onPhotoPrompterFileSelected(file);
-                  closePhotoPrompter();
-                }}
-              />
-            ) : (
-              <div onClick={this.onLogsClick} style={styles.logs}>
-                {this.renderConsoleLogs(isDarkMode)}
-              </div>
-            )}
+            {this.renderConsoleBody()}
           </div>
           {bottomRow && [
             {...bottomRow, key: 'bottom-row'},

--- a/apps/src/javalab/JavalabView.jsx
+++ b/apps/src/javalab/JavalabView.jsx
@@ -36,6 +36,7 @@ class JavalabView extends React.Component {
     viewMode: PropTypes.string.isRequired,
     isProjectTemplateLevel: PropTypes.bool.isRequired,
     handleClearPuzzle: PropTypes.func.isRequired,
+    onPhotoPrompterFileSelected: PropTypes.func.isRequired,
 
     // populated by redux
     isProjectLevel: PropTypes.bool.isRequired,
@@ -160,7 +161,8 @@ class JavalabView extends React.Component {
       isProjectTemplateLevel,
       handleClearPuzzle,
       canRun,
-      canTest
+      canTest,
+      onPhotoPrompterFileSelected
     } = this.props;
 
     if (isDarkMode) {
@@ -210,6 +212,7 @@ class JavalabView extends React.Component {
             bottomRightPanel={() => (
               <JavalabConsole
                 onInputMessage={onInputMessage}
+                onPhotoPrompterFileSelected={onPhotoPrompterFileSelected}
                 style={{
                   ...styles.consoleParent,
                   ...(!this.isLeftSideVisible() && {paddingBottom: 40})

--- a/apps/src/javalab/Theater.js
+++ b/apps/src/javalab/Theater.js
@@ -2,11 +2,18 @@ import {TheaterSignalType, STATUS_MESSAGE_PREFIX} from './constants';
 import javalabMsg from '@cdo/javalab/locale';
 
 export default class Theater {
-  constructor(onOutputMessage, onNewlineMessage) {
+  constructor(
+    onOutputMessage,
+    onNewlineMessage,
+    openPhotoPrompter,
+    closePhotoPrompter
+  ) {
     this.canvas = null;
     this.context = null;
     this.onOutputMessage = onOutputMessage;
     this.onNewlineMessage = onNewlineMessage;
+    this.openPhotoPrompter = openPhotoPrompter;
+    this.closePhotoPrompter = closePhotoPrompter;
     this.loadEventsFinished = 0;
   }
 
@@ -23,6 +30,11 @@ export default class Theater {
         // Preload the image. Once it's ready, start the playback
         this.getImgElement().src = data.detail.url + this.getCacheBustSuffix();
         this.getImgElement().onload = () => this.startPlayback();
+        break;
+      }
+      case TheaterSignalType.GET_IMAGE: {
+        // Open the photo prompter
+        this.openPhotoPrompter(data.detail.prompt);
         break;
       }
       default:
@@ -48,6 +60,8 @@ export default class Theater {
 
   onStop() {
     this.resetAudioAndVideo();
+    // Close the photo prompter if it is still open
+    this.closePhotoPrompter();
   }
 
   resetAudioAndVideo() {
@@ -71,9 +85,17 @@ export default class Theater {
       `${STATUS_MESSAGE_PREFIX} ${javalabMsg.programCompleted()}`
     );
     this.onNewlineMessage();
+    // Close the photo prompter if it is still open
+    this.closePhotoPrompter();
   }
 
   getCacheBustSuffix() {
     return '?=' + new Date().getTime();
+  }
+
+  onPhotoPrompterFileSelected(photo) {
+    console.log('Theater received selected photo ' + photo.name);
+    console.log(photo);
+    // TODO: Send photo file information back to Javabuilder.
   }
 }

--- a/apps/src/javalab/Theater.js
+++ b/apps/src/javalab/Theater.js
@@ -94,8 +94,6 @@ export default class Theater {
   }
 
   onPhotoPrompterFileSelected(photo) {
-    console.log('Theater received selected photo ' + photo.name);
-    console.log(photo);
     // TODO: Send photo file information back to Javabuilder.
   }
 }

--- a/apps/src/javalab/components/PhotoSelectionView.jsx
+++ b/apps/src/javalab/components/PhotoSelectionView.jsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import color from '@cdo/apps/util/color';
+
+const photoInputId = 'photoInput';
+
+/**
+ * Renders a component with a camera icon and optional prompt text
+ * which allows a user to select and upload a photo when clicking the icon.
+ */
+const PhotoSelectionView = ({promptText, onPhotoSelected, style}) => {
+  const onInputChange = event => {
+    onPhotoSelected(event.target.files[0]);
+  };
+
+  return (
+    <div style={{...styles.container, ...style}}>
+      <label
+        htmlFor={photoInputId}
+        className="fa fa-camera"
+        style={styles.label}
+      >
+        <input
+          id={photoInputId}
+          type="file"
+          accept="image/*"
+          capture="camera"
+          hidden={true}
+          onChange={onInputChange}
+        />
+      </label>
+      <div style={styles.prompt}>{promptText}</div>
+    </div>
+  );
+};
+
+PhotoSelectionView.propTypes = {
+  /**
+   * Required. Called when a photo has been selected.
+   * The file object representing the chosen file is
+   * passed to this function.
+   */
+  onPhotoSelected: PropTypes.func.isRequired,
+  /** Optional. Displays prompt text below the icon. */
+  promptText: PropTypes.string,
+  /** Optional. Additional styles to apply to the component */
+  style: PropTypes.object
+};
+
+const styles = {
+  container: {
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 20,
+    backgroundColor: color.black
+  },
+  label: {
+    fontSize: 48
+  },
+  prompt: {
+    textColor: color.white
+  }
+};
+
+export default PhotoSelectionView;

--- a/apps/src/javalab/components/PhotoSelectionView.jsx
+++ b/apps/src/javalab/components/PhotoSelectionView.jsx
@@ -8,7 +8,11 @@ const photoInputId = 'photoInput';
  * Renders a component with a camera icon and optional prompt text
  * which allows a user to select and upload a photo when clicking the icon.
  */
-const PhotoSelectionView = ({promptText, onPhotoSelected, style}) => {
+export default function PhotoSelectionView({
+  promptText,
+  onPhotoSelected,
+  style
+}) {
   const onInputChange = event => {
     onPhotoSelected(event.target.files[0]);
   };
@@ -32,7 +36,7 @@ const PhotoSelectionView = ({promptText, onPhotoSelected, style}) => {
       <div style={styles.prompt}>{promptText}</div>
     </div>
   );
-};
+}
 
 PhotoSelectionView.propTypes = {
   /**
@@ -63,5 +67,3 @@ const styles = {
     textColor: color.white
   }
 };
-
-export default PhotoSelectionView;

--- a/apps/src/javalab/constants.js
+++ b/apps/src/javalab/constants.js
@@ -70,8 +70,12 @@ export const NeighborhoodExceptionType = makeEnum(
 );
 
 export const TheaterSignalType = {
+  // This message contains the url to an audio element
   AUDIO_URL: 'AUDIO_URL',
-  VISUAL_URL: 'VISUAL_URL'
+  // This message contains the url to a visual element
+  VISUAL_URL: 'VISUAL_URL',
+  // Get an image from the user via Prompter
+  GET_IMAGE: 'GET_IMAGE'
 };
 
 export const StatusMessageType = {

--- a/apps/src/javalab/javalabRedux.js
+++ b/apps/src/javalab/javalabRedux.js
@@ -25,6 +25,8 @@ const SET_IS_START_MODE = 'javalab/SET_IS_START_MODE';
 const SET_LEVEL_NAME = 'javalab/SET_LEVEL_NAME';
 const SET_DISABLE_FINISH_BUTTON = 'javalab/SET_DISABLE_FINISH_BUTTON';
 const TOGGLE_VISUALIZATION_COLLAPSED = 'javalab/TOGGLE_VISUALIZATION_COLLAPSED';
+const OPEN_PHOTO_PROMPTER = 'javalab/OPEN_PHOTO_PROMPTER';
+const CLOSE_PHOTO_PROMPTER = 'javalab/CLOSE_PHOTO_PROMPTER';
 
 const initialState = {
   consoleLogs: [],
@@ -44,7 +46,9 @@ const initialState = {
   isStartMode: false,
   levelName: undefined,
   disableFinishButton: false,
-  isVisualizationCollapsed: false
+  isVisualizationCollapsed: false,
+  isPhotoPrompterOpen: false,
+  photoPrompterPromptText: ''
 };
 
 // Action Creators
@@ -165,6 +169,15 @@ export const setDisableFinishButton = disableFinishButton => {
     disableFinishButton
   };
 };
+
+export const openPhotoPrompter = promptText => ({
+  type: OPEN_PHOTO_PROMPTER,
+  promptText
+});
+
+export const closePhotoPrompter = () => ({
+  type: CLOSE_PHOTO_PROMPTER
+});
 
 // Selectors
 export const getSources = state => {
@@ -390,6 +403,20 @@ export default function reducer(state = initialState, action) {
     return {
       ...state,
       isVisualizationCollapsed: !state.isVisualizationCollapsed
+    };
+  }
+  if (action.type === OPEN_PHOTO_PROMPTER) {
+    return {
+      ...state,
+      isPhotoPrompterOpen: true,
+      photoPrompterPromptText: action.promptText
+    };
+  }
+  if (action.type === CLOSE_PHOTO_PROMPTER) {
+    return {
+      ...state,
+      isPhotoPrompterOpen: false,
+      photoPrompterPromptText: ''
     };
   }
   return state;

--- a/apps/test/unit/javalab/JavalabConsoleTest.js
+++ b/apps/test/unit/javalab/JavalabConsoleTest.js
@@ -99,6 +99,7 @@ describe('Java Lab Console Test', () => {
       expect(photoSelectionView.props().promptText).to.equal(prompt);
 
       store.dispatch(closePhotoPrompter());
+      wrapper.update();
       expect(wrapper.find(PhotoSelectionView)).to.be.empty;
     });
 
@@ -121,6 +122,7 @@ describe('Java Lab Console Test', () => {
       const photoSelectionView = wrapper.find(PhotoSelectionView).first();
 
       photoSelectionView.props().onPhotoSelected(file);
+      wrapper.update();
 
       sinon.assert.calledWith(onPhotoPrompterFileSelected, file);
       expect(wrapper.find(PhotoSelectionView)).to.be.empty;

--- a/apps/test/unit/javalab/TheaterTest.js
+++ b/apps/test/unit/javalab/TheaterTest.js
@@ -4,12 +4,32 @@ import {TheaterSignalType} from '@cdo/apps/javalab/constants';
 import Theater from '@cdo/apps/javalab/Theater';
 
 describe('Theater', () => {
-  let theater, playAudioSpy, imageElement, audioElement;
+  let theater,
+    playAudioSpy,
+    pauseAudioSpy,
+    imageElement,
+    audioElement,
+    onOutputMessage,
+    onNewlineMessage,
+    openPhotoPrompter,
+    closePhotoPrompter;
+
   beforeEach(() => {
+    onOutputMessage = sinon.stub();
+    onNewlineMessage = sinon.stub();
+    openPhotoPrompter = sinon.stub();
+    closePhotoPrompter = sinon.stub();
+
     playAudioSpy = sinon.spy();
+    pauseAudioSpy = sinon.spy();
     imageElement = {};
-    audioElement = {play: playAudioSpy};
-    theater = new Theater();
+    audioElement = {play: playAudioSpy, pause: pauseAudioSpy};
+    theater = new Theater(
+      onOutputMessage,
+      onNewlineMessage,
+      openPhotoPrompter,
+      closePhotoPrompter
+    );
     theater.getImgElement = () => {
       return imageElement;
     };
@@ -55,5 +75,29 @@ describe('Theater', () => {
     audioElement.oncanplaythrough();
     expect(imageElement.style.visibility).to.equal('visible');
     expect(playAudioSpy).to.have.been.called.once;
+  });
+
+  it('opens photo prompter after receiving a GET_IMAGE signal', () => {
+    const prompt = 'prompt';
+    const getImageSignal = {
+      value: TheaterSignalType.GET_IMAGE,
+      detail: {
+        prompt: prompt
+      }
+    };
+
+    theater.handleSignal(getImageSignal);
+
+    sinon.assert.calledWith(openPhotoPrompter, prompt);
+  });
+
+  it('closes photo prompter on stop', () => {
+    theater.onStop();
+    sinon.assert.calledOnce(closePhotoPrompter);
+  });
+
+  it('closes photo prompter on close', () => {
+    theater.onClose();
+    sinon.assert.calledOnce(closePhotoPrompter);
   });
 });

--- a/apps/test/unit/javalab/components/PhotoSelectionViewTest.js
+++ b/apps/test/unit/javalab/components/PhotoSelectionViewTest.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import {expect} from '../../../util/reconfiguredChai';
+import {shallow} from 'enzyme';
+import sinon from 'sinon';
+import PhotoSelectionView from '@cdo/apps/javalab/components/PhotoSelectionView';
+
+describe('PhotoSelectionView', () => {
+  const file = new File([], 'file');
+  let onPhotoSelected, promptText;
+
+  beforeEach(() => {
+    onPhotoSelected = sinon.stub();
+    promptText = 'prompt';
+  });
+
+  it('displays photo selection view with prompt if provided', () => {
+    const wrapper = shallow(
+      <PhotoSelectionView
+        onPhotoSelected={onPhotoSelected}
+        promptText={promptText}
+      />
+    );
+
+    expect(wrapper.text()).to.equal(promptText);
+  });
+
+  it('invokes onPhotoSelected callback after photo is selected', () => {
+    const wrapper = shallow(
+      <PhotoSelectionView onPhotoSelected={onPhotoSelected} />
+    );
+
+    wrapper.find('input').invoke('onChange')({target: {files: [file]}});
+
+    sinon.assert.calledWith(onPhotoSelected, file);
+  });
+});


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

This adds the UI component and front-end logic for the Theater Prompter feature in Javalab. When the Theater receives a GET_IMAGE signal, it opens a photo prompter view over the console and receives the image file once it is chosen. The next step here will be passing the file information (either the file data or a URL) back to Javabuilder.

One callout: the actual prompter component is intentionally Javalab-agnostic so it could potentially be reused as a component elsewhere. For now it resides in the javalab directory, but I put it in a component/ subdirectory to help indicate this. My thinking is that as we develop more reusable components, we can keep them in a common place so they can be eventually moved and shared if needed.

![Screen Shot 2021-10-27 at 5 06 40 PM](https://user-images.githubusercontent.com/85528507/139314350-9468a669-94bb-43af-9241-244db045378f.png)

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

JIRA: https://codedotorg.atlassian.net/browse/CSA-933

## Testing story

Testing: All the things & unit tests.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
