### PR TITLE
[Poetry][HOC] Enable version history for poetry

### DIFF
--- a/apps/src/code-studio/initApp/loadApp.js
+++ b/apps/src/code-studio/initApp/loadApp.js
@@ -62,6 +62,7 @@ export function setupApp(appOptions) {
         appOptions.app === 'applab' ||
         appOptions.app === 'gamelab' ||
         appOptions.app === 'spritelab' ||
+        appOptions.app === 'poetry' ||
         appOptions.app === 'weblab'
       ) {
         $('#clear-puzzle-header').hide();

--- a/apps/src/p5lab/poetry/Poetry.js
+++ b/apps/src/p5lab/poetry/Poetry.js
@@ -9,11 +9,12 @@ import {getPoem} from './poem';
 
 export default class Poetry extends SpriteLab {
   init(config) {
-    super.init(config);
+    const loader = super.init(config);
     const poem = config.level.selectedPoem || getPoem(this.level.defaultPoem);
     if (poem) {
       getStore().dispatch(setPoem(poem));
     }
+    return loader;
   }
 
   getAvatarUrl(levelInstructor) {


### PR DESCRIPTION
No change to version history logic, so I didn't check it too carefully, but I created a new Poetry project and was able to make changes, create a new version, and go back to a previous version.

Before
![image](https://user-images.githubusercontent.com/8787187/139315809-0455fb80-8176-449e-9007-38ebf91d5132.png)

After
![image](https://user-images.githubusercontent.com/8787187/139315765-61fcbbab-967e-4199-b8e8-316628eeabb6.png)
![image](https://user-images.githubusercontent.com/8787187/139315781-8c8e0f77-aa2c-4330-9d29-59ddc51f943a.png)
