### PR TITLE
set proxysql weight to 1 for hosts named 'reporting'

### DIFF
--- a/cookbooks/cdo-mysql/files/default/README.md
+++ b/cookbooks/cdo-mysql/files/default/README.md
@@ -1,0 +1,52 @@
+# CDO Mysql Files
+
+The sql queries in this cookbook contain important logic, so testing them is
+important. There are not automated tests, but the following steps will allow you
+to set up a local testing environment.
+
+Note that while AWS Aurora uses MySql syntax, the ProxySQL server uses SQLite
+syntax.
+
+## Manual testing
+
+Create an ephemeral local sqlite instance.
+
+```sh
+docker run --rm -t keinos/sqlite3
+```
+
+Create a table.
+
+```sql
+CREATE TABLE `mysql_servers` (
+  `hostgroup_id` int(11) DEFAULT NULL,
+  `hostname` varchar(45) DEFAULT NULL,
+  `port` int(11) DEFAULT NULL,
+  `status` varchar(45) DEFAULT NULL,
+  `weight` int(11) DEFAULT NULL,
+  PRIMARY KEY (`hostgroup_id`, `hostname`));
+```
+
+Populate the table with a prod-like configuration.
+
+```sql
+INSERT INTO mysql_servers
+VALUES
+  (0, 'writer', 3306, 'fine', 10000000),
+  (1, 'writer', 3306, 'fine', 1),
+  (1, 'reader', 3306, 'fine', 10000000),
+  (1, 'reporting', 3306, 'fine', 1),
+  (2, 'writer', 3306, 'fine', 10000000),
+  (2, 'reader', 3306, 'fine', 1),
+  (2, 'reporting', 3306, 'fine', 1),
+  (3, 'reporting', 3306, 'fine', 1);
+```
+
+Inspect the table.
+
+```sql
+SELECT * FROM mysql_servers;
+```
+
+Edit values and then run the queries in
+[update_servers.sql](./update_servers.sql) to test the logic.

--- a/cookbooks/cdo-mysql/files/default/update_servers.sql
+++ b/cookbooks/cdo-mysql/files/default/update_servers.sql
@@ -22,7 +22,7 @@ UPDATE `mysql_servers` SET `weight` = CASE
     -- Set writer weight low for HG1, high for HG2.
     CASE WHEN (`hostgroup_id` = 1) THEN 1 ELSE 10000000 END
   WHEN ( -- If row is a reporting-reader (hostname in HG3 or named 'reporting' in case of issues populating HG3)
-    `hostname` IN (SELECT `hostname` FROM `mysql_servers` WHERE (`hostgroup_id` = 3) OR (`hostname` LIKE "reporting%"))
+    `hostname` IN (SELECT `hostname` FROM `mysql_servers` WHERE (`hostgroup_id` = 3) OR (`hostname` LIKE 'reporting%'))
   ) THEN
     1 -- Set reporting-reader weight low for all HG.
   ELSE

--- a/cookbooks/cdo-mysql/files/default/update_servers.sql
+++ b/cookbooks/cdo-mysql/files/default/update_servers.sql
@@ -1,11 +1,18 @@
 -- This script maintains 'fallback' servers within reader hostgroups
 -- by setting `weight` values high for primary and low for fallback servers.
---
+
+-- The 'reporting' instance is included in the reader hostgroup(s), and it is
+-- critical that it not be given a priority weight in those hostgroups.
+
+-- Host Groups:
 -- * HG0 (writer) and HG1 (reader) are hostgroups managed by existing monitors.
 -- * HG1 weights are updated to favor readers with a fallback to the writer.
 -- * HG2 is created as a 'primary-reader' hostgroup, with the same servers as HG1
 --   but weights inverted, so it favors the writer with a fallback to readers.
--- * HG3 is a reporting-reader hostgroup with instances isolated from regular read/write splitting.
+-- * HG3 is a reporting-reader hostgroup with instances isolated from regular
+--   read/write splitting. The instance is included in the reader hostgroup(s)
+--   too, and it is critical that it not be given a priority weight in those
+--   hostgroups.
 
 -- Note: although the ProxySQL admin interface uses the MySQL client protocol,
 -- it uses the SQLite dialect for its SQL-query syntax.
@@ -18,14 +25,14 @@ REPLACE INTO `mysql_servers` (hostgroup_id, hostname, port, status, weight)
 UPDATE `mysql_servers` SET `weight` = CASE
   WHEN ( -- If row is a writer (hostname in HG0)
     `hostname` IN (SELECT `hostname` FROM `mysql_servers` WHERE (`hostgroup_id` = 0))
-  ) THEN
-    -- Set writer weight low for HG1, high for HG2.
+  ) THEN -- Set writer weight low for HG1, high for HG2.
     CASE WHEN (`hostgroup_id` = 1) THEN 1 ELSE 10000000 END
-  WHEN ( -- If row is a reporting-reader (hostname in HG3 or named 'reporting' in case of issues populating HG3)
-    `hostname` IN (SELECT `hostname` FROM `mysql_servers` WHERE (`hostgroup_id` = 3) OR (`hostname` LIKE 'reporting%'))
-  ) THEN
-    1 -- Set reporting-reader weight low for all HG.
-  ELSE
+  WHEN ( -- If row is a reporting-reader (hostname in HG3 or named 'reporting*')
+    `hostname` LIKE 'reporting%'
+    OR `hostname` IN (SELECT `hostname` FROM `mysql_servers` WHERE (`hostgroup_id` = 3))
+  ) THEN -- Set reporting-reader weight low for all HG's.
+    1
+  ELSE -- If row is a reader (not a writer or reporting-reader)
     -- Set reader weight high for HG1, low for HG2.
     CASE WHEN (`hostgroup_id` = 1) THEN 10000000 ELSE 1 END
   END;

--- a/cookbooks/cdo-mysql/files/default/update_servers.sql
+++ b/cookbooks/cdo-mysql/files/default/update_servers.sql
@@ -21,8 +21,8 @@ UPDATE `mysql_servers` SET `weight` = CASE
   ) THEN
     -- Set writer weight low for HG1, high for HG2.
     CASE WHEN (`hostgroup_id` = 1) THEN 1 ELSE 10000000 END
-  WHEN ( -- If row is a reporting-reader (hostname in HG3)
-    `hostname` IN (SELECT `hostname` FROM `mysql_servers` WHERE (`hostgroup_id` = 3))
+  WHEN ( -- If row is a reporting-reader (hostname in HG3 or named 'reporting' in case of issues populating HG3)
+    `hostname` IN (SELECT `hostname` FROM `mysql_servers` WHERE (`hostgroup_id` = 3) OR (`hostname` LIKE "reporting%"))
   ) THEN
     1 -- Set reporting-reader weight low for all HG.
   ELSE

--- a/cookbooks/cdo-mysql/files/default/update_servers.sql
+++ b/cookbooks/cdo-mysql/files/default/update_servers.sql
@@ -1,5 +1,6 @@
 -- This script maintains 'fallback' servers within reader hostgroups
 -- by setting `weight` values high for primary and low for fallback servers.
+-- See ./README.md for additional details.
 
 -- The 'reporting' instance is included in the reader hostgroup(s), and it is
 -- critical that it not be given a priority weight in those hostgroups.


### PR DESCRIPTION
Original logic was inferring that any Aurora instance in host group 3 was necessarily the 'reporting' instance, and therefore should be weighted at '1' to avoid traffic. However, due to some issue with ProxySQL not always identifying the instance, it might not see it in host group 3, and therefore weight it at '10000000' and allowing it to take on half of our traffic.

This solution adds to that rule by also identifying instances with a name `LIKE 'reporting%'`, allowing the correct weighting to occur even if above issue occurs.

Hardcoding the name is a bit of a code smell, but it's at least straightforward. Very interested in suggestions on how the comments could be clearer here.

## Links

- Jira ticket: [INF-503](https://codedotorg.atlassian.net/browse/INF-503)
- CoE: https://docs.google.com/document/d/1nrfc36ccL3Q1HCcvlK3l8FZ_HZhzT8rpftEV6xZOQko/edit?usp=sharing

## Testing story

The SQL logic has been manually tested with a local SQLite database. Our plan is to test this with a detatched EC2 instance in AWS to see it working on prod-like resource.

## Deployment strategy

...

## PR Checklist:

- [ ] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
