### PR TITLE
Code Review Groups: Rename code review groups components

### DIFF
--- a/apps/src/templates/codeReviewGroups/CodeReviewGroupsManager.jsx
+++ b/apps/src/templates/codeReviewGroups/CodeReviewGroupsManager.jsx
@@ -2,7 +2,7 @@ import React, {useState} from 'react';
 import PropTypes from 'prop-types';
 import {DragDropContext} from 'react-beautiful-dnd';
 import _ from 'lodash';
-import CodeReviewGroup from './CodeReviewGroup';
+import StudentGroup from './StudentGroup';
 
 const DROPPABLE_ID_PREFIX = 'groupId';
 const DROPPABLE_ID_UNASSIGNED = 'unassigned';
@@ -73,7 +73,7 @@ export default function CodeReviewGroupsManager({initialGroups}) {
     <div>
       <DragDropContext onDragEnd={onDragEnd}>
         <div style={styles.dragAndDropContainer}>
-          <CodeReviewGroup
+          <StudentGroup
             droppableId={getUnassignedGroup().droppableId}
             members={getUnassignedGroup().members}
           />
@@ -88,7 +88,7 @@ export default function CodeReviewGroupsManager({initialGroups}) {
             </button>
             {getAssignedGroups().map(group => {
               return (
-                <CodeReviewGroup
+                <StudentGroup
                   droppableId={group.droppableId}
                   members={group.members}
                   key={group.droppableId}

--- a/apps/src/templates/codeReviewGroups/Student.jsx
+++ b/apps/src/templates/codeReviewGroups/Student.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {Draggable} from 'react-beautiful-dnd';
-import {grid} from './CodeReviewGroup';
+import {grid} from './StudentGroup';
 
 // A CodeReviewGroupMember is a component that
 // can be dragged between CodeReviewGroups
@@ -9,7 +9,7 @@ import {grid} from './CodeReviewGroup';
 // These are called "Draggables" in the package we're using (React Beautiful DnD).
 // More information on React Beautiful DnD can be found here:
 // https://github.com/atlassian/react-beautiful-dnd
-export default function CodeReviewGroupMember({followerId, name, index}) {
+export default function Student({followerId, name, index}) {
   return (
     <Draggable
       key={followerId}
@@ -41,7 +41,7 @@ export default function CodeReviewGroupMember({followerId, name, index}) {
   );
 }
 
-CodeReviewGroupMember.propTypes = {
+Student.propTypes = {
   followerId: PropTypes.number.isRequired,
   name: PropTypes.string.isRequired,
   index: PropTypes.number.isRequired

--- a/apps/src/templates/codeReviewGroups/StudentGroup.jsx
+++ b/apps/src/templates/codeReviewGroups/StudentGroup.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {Droppable} from 'react-beautiful-dnd';
-import CodeReviewGroupMember from './CodeReviewGroupMember';
+import Student from './Student';
 
 // A CodeReviewGroup is a component that
 // CodeReviewGroupMembers can be dragged between as teachers are arranging students
@@ -9,7 +9,7 @@ import CodeReviewGroupMember from './CodeReviewGroupMember';
 // These are called "Droppables" in the package we're using (React Beautiful DnD).
 // More information on React Beautiful DnD can be found here:
 // https://github.com/atlassian/react-beautiful-dnd
-export default function CodeReviewGroup({droppableId, members}) {
+export default function StudentGroup({droppableId, members}) {
   return (
     <Droppable key={droppableId} droppableId={droppableId}>
       {(provided, snapshot) => (
@@ -19,7 +19,7 @@ export default function CodeReviewGroup({droppableId, members}) {
           {...provided.droppableProps}
         >
           {members.map((member, index) => (
-            <CodeReviewGroupMember
+            <Student
               followerId={member.followerId}
               name={member.name}
               index={index}
@@ -35,7 +35,7 @@ export default function CodeReviewGroup({droppableId, members}) {
 
 // Each group needs a unique droppableId (rather than a database-provided group ID)
 // so that we can create new groups on the fly without any interaction with our backend.
-CodeReviewGroup.propTypes = {
+StudentGroup.propTypes = {
   droppableId: PropTypes.string.isRequired,
   members: PropTypes.array.isRequired
 };


### PR DESCRIPTION
Renames components for code review groups to align with description here:

https://github.com/code-dot-org/code-dot-org/pull/43175.

Doing as standalone PR to avoid confusing GitHub if I were to combine with other changes.