### PR TITLE
Enable NPS survey for fall 2021

### DIFF
--- a/apps/src/templates/studioHomepages/NpsSurveyBlock.jsx
+++ b/apps/src/templates/studioHomepages/NpsSurveyBlock.jsx
@@ -60,7 +60,7 @@ export default class NpsSurveyBlock extends React.Component {
   }
 
   onComplete(data) {
-    trackEvent('survey', 'nps2020', parseInt(data.nps_value));
+    trackEvent('survey', 'nps', parseInt(data.nps_value));
     this.setState({submitted: true});
   }
 

--- a/dashboard/app/helpers/survey_results_helper.rb
+++ b/dashboard/app/helpers/survey_results_helper.rb
@@ -1,6 +1,6 @@
 module SurveyResultsHelper
   DIVERSITY_SURVEY_ENABLED = false
-  NPS_SURVEY_ENABLED = false
+  NPS_SURVEY_ENABLED = true
 
   def show_diversity_survey?(kind)
     return false unless SurveyResultsHelper::DIVERSITY_SURVEY_ENABLED
@@ -21,8 +21,8 @@ module SurveyResultsHelper
   def show_nps_survey?
     return false unless SurveyResultsHelper::NPS_SURVEY_ENABLED
     return false unless current_user
-    # May 2021: only display to teachers with odd ids
-    return false unless current_user.id.odd?
+    # Nov 2021: only display to teachers with even ids
+    return false unless current_user.id.even?
     return false unless language == "en"
     return false if current_user.under_13?
     return false unless country_us?


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Turning on NPS survey for fall 2021.  It will be shown to teachers with even user ids.

![Screen Shot 2021-10-28 at 10 47 58 PM](https://user-images.githubusercontent.com/71532552/139969529-54dce411-77b2-45a4-8f3b-6cd91d62ea23.png)

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [LP-2061](https://codedotorg.atlassian.net/browse/LP-2061)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
