### PR TITLE
Example usage of isolate-components to replace enzyme shallow for testing hooks

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -126,6 +126,7 @@
     "html2canvas": "^0.5.0-beta4",
     "http-server": "^0.9.0",
     "immutable": "3.8.1",
+    "isolate-components": "^1.4.0",
     "istanbul-instrumenter-loader": "^3.0.1",
     "jquery": "1.12.1",
     "jquery-ui": "^1.12.1",

--- a/apps/src/code-studio/pd/form_components_func/FormController.jsx
+++ b/apps/src/code-studio/pd/form_components_func/FormController.jsx
@@ -342,8 +342,6 @@ const FormController = props => {
         }
         setSubmitting(false);
       });
-
-    event.preventDefault();
   };
 
   /**

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -9160,6 +9160,18 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
+isolate-components@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/isolate-components/-/isolate-components-1.4.0.tgz#324082d596f8224b8e027b1b94a46fa13471ab57"
+  integrity sha512-kO99YeQIXZyDwR8wn45M7zFvuKVxCOl71cqCCwZ9Xzx0Ff33d3Mgd7jghkv5KpoBuBt6KkPUcubJczlC+G3+cQ==
+  dependencies:
+    isolate-hooks "^1.5.0"
+
+isolate-hooks@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/isolate-hooks/-/isolate-hooks-1.5.0.tgz#232d98ea3fb6393210a72965d67f4218e1efed59"
+  integrity sha512-IRGJvwngCuWr1FadRpI9L4V2HS+vR2pUK6O3hcNBlk3Mk/zM6VytSfV8Rpcb3/duxJHy+JUVHW7Yk4BPK4FrVA==
+
 isomorphic-fetch@^2.1.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Background: Enzyme's `shallow` renderer doesn't trigger `useEffect` hooks in newer functional components, so you would normally need to use `mount` instead which imposes some performance penalties and potentially has side effects that don't need to affect this component under test.
isolate-components provides an alternative shallow renderer that does trigger `useEffect`. It has a slightly different but equivalent api. This PR shows an example of refactoring a test that previously used `mount`.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

isolate-components [docs](https://davidmfoley.github.io/isolate-components/api/index.html)
isolate-components [npm](https://www.npmjs.com/package/isolate-components)
Enzyme [issue](https://github.com/enzymejs/enzyme/issues/2086)

## Testing story

Test passes!

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Follow-up work

Communicate this alternative to team, progressively refactor mount tests and use in future tests against useEffect.