### PR TITLE
Fix example solutions endpoint

### DIFF
--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -306,7 +306,7 @@ module LevelsHelper
     end
 
     if @level && @script_level
-      @app_options[:exampleSolutions] = @script_level.get_example_solutions(@level, current_user, @section.id)
+      @app_options[:exampleSolutions] = @script_level.get_example_solutions(@level, current_user, @section&.id)
     end
 
     # Blockly caches level properties, whereas this field depends on the user

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -306,7 +306,7 @@ module LevelsHelper
     end
 
     if @level && @script_level
-      @app_options[:exampleSolutions] = @script_level.get_example_solutions(@level, current_user, @section)
+      @app_options[:exampleSolutions] = @script_level.get_example_solutions(@level, current_user, @section.id)
     end
 
     # Blockly caches level properties, whereas this field depends on the user

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -717,7 +717,7 @@ class ScriptLevel < ApplicationRecord
     end
   end
 
-  def get_example_solutions(level, current_user, section=nil)
+  def get_example_solutions(level, current_user, section_id=nil)
     level_example_links = []
 
     return [] if !current_user&.teacher? || CDO.properties_encryption_key.blank?
@@ -748,7 +748,7 @@ class ScriptLevel < ApplicationRecord
         end
       end
     elsif level.ideal_level_source_id && script # old style 'solutions' for blockly-type levels
-      level_example_links.push(build_script_level_url(self, {solution: true}.merge(section ? {section_id: section.id} : {})))
+      level_example_links.push(build_script_level_url(self, {solution: true}.merge(section_id ? {section_id: section_id} : {})))
     end
 
     level_example_links


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Fixes the [this error](https://app.honeybadger.io/projects/3240/faults/82307235)

This happened because in the [new example_solutions endpoint](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/controllers/api_controller.rb#L483) I passed script id instead of the whole script to `get_example_solutions`. The changes here update `get_example_solutions` to take script_id instead of the whole script since that's the only part being used in the method.
## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
