### PR TITLE
[Google Blockly] Integrate scroll options plugin

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -219,6 +219,7 @@
     "webpack-stats-plugin": "^0.2.1"
   },
   "dependencies": {
+    "@blockly/plugin-scroll-options": "^1.0.4",
     "@code-dot-org/js-interpreter": "1.3.13",
     "@code-dot-org/remark-plugins": "^1.1.0",
     "@codemirror/closebrackets": "^0.19.0",

--- a/apps/src/blockly/addons/cdoBlockDragger.js
+++ b/apps/src/blockly/addons/cdoBlockDragger.js
@@ -1,6 +1,6 @@
-import GoogleBlockly from 'blockly/core';
+import {ScrollBlockDragger} from '@blockly/plugin-scroll-options';
 
-export default class BlockDragger extends GoogleBlockly.BlockDragger {
+export default class BlockDragger extends ScrollBlockDragger {
   /** Show trashcan over toolbox while dragging
    * @override
    */

--- a/apps/src/blockly/addons/cdoMetricsManager.js
+++ b/apps/src/blockly/addons/cdoMetricsManager.js
@@ -1,6 +1,6 @@
-import GoogleBlockly from 'blockly/core';
+import {ScrollMetricsManager} from '@blockly/plugin-scroll-options';
 
-export default class MetricsManager extends GoogleBlockly.MetricsManager {
+export default class MetricsManager extends ScrollMetricsManager {
   /** Force content to start in top-left corner, not scroll in all directions.
    * @override
    */

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -1,3 +1,4 @@
+import {ScrollOptions} from '@blockly/plugin-scroll-options';
 import {BlocklyVersion} from '@cdo/apps/constants';
 import styleConstants from '@cdo/apps/styleConstants';
 import CdoBlockDragger from './addons/cdoBlockDragger';
@@ -146,7 +147,6 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.wrapReadOnlyProperty('WorkspaceSvg');
   blocklyWrapper.wrapReadOnlyProperty('Xml');
 
-  blocklyWrapper.blockly_.BlockDragger = CdoBlockDragger;
   blocklyWrapper.blockly_.BlockSvg = CdoBlockSvg;
   blocklyWrapper.blockly_.FieldButton = CdoFieldButton;
   blocklyWrapper.blockly_.FieldDropdown = CdoFieldDropdown;
@@ -154,25 +154,10 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.blockly_.FieldLabel = CdoFieldLabel;
   blocklyWrapper.blockly_.FunctionEditor = FunctionEditor;
   blocklyWrapper.blockly_.Input = CdoInput;
-  blocklyWrapper.blockly_.MetricsManager = CdoMetricsManager;
   blocklyWrapper.geras.PathObject = CdoPathObject;
   blocklyWrapper.blockly_.Trashcan = CdoTrashcan;
   blocklyWrapper.blockly_.VariableMap = CdoVariableMap;
   blocklyWrapper.blockly_.WorkspaceSvg = CdoWorkspaceSvg;
-
-  blocklyWrapper.blockly_.registry.register(
-    blocklyWrapper.blockly_.registry.Type.METRICS_MANAGER,
-    blocklyWrapper.blockly_.registry.DEFAULT,
-    CdoMetricsManager,
-    true /* opt_allowOverrides */
-  );
-
-  blocklyWrapper.blockly_.registry.register(
-    blocklyWrapper.blockly_.registry.Type.BLOCK_DRAGGER,
-    blocklyWrapper.blockly_.registry.DEFAULT,
-    CdoBlockDragger,
-    true /* opt_allowOverrides */
-  );
 
   // These are also wrapping read only properties, but can't use wrapReadOnlyProperty
   // because the alias name is not the same as the underlying property name.
@@ -284,6 +269,10 @@ function initializeBlocklyWrapper(blocklyInstance) {
           vertical: true,
           horizontal: false
         }
+      },
+      plugins: {
+        blockDragger: CdoBlockDragger,
+        metricsManager: CdoMetricsManager
       }
     };
 
@@ -296,7 +285,10 @@ function initializeBlocklyWrapper(blocklyInstance) {
       styleConstants['workspace-headers-height']
     }px)`;
     blocklyWrapper.editBlocks = opt_options.editBlocks;
-    return blocklyWrapper.blockly_.inject(container, options);
+    const workspace = blocklyWrapper.blockly_.inject(container, options);
+
+    const scrollOptionsPlugin = new ScrollOptions(workspace);
+    scrollOptionsPlugin.init();
   };
 
   // Used by StudioApp to tell Blockly to resize for Mobile Safari.

--- a/apps/webpack.js
+++ b/apps/webpack.js
@@ -13,6 +13,7 @@ var toTranspileWithinNodeModules = [
   // playground-io ships in ES6 as of 0.3.0
   path.resolve(__dirname, 'node_modules', 'playground-io'),
   path.resolve(__dirname, 'node_modules', 'json-parse-better-errors'),
+  path.resolve(__dirname, 'node_modules', '@blockly', 'plugin-scroll-options'),
   path.resolve(__dirname, 'node_modules', '@code-dot-org', 'dance-party'),
   path.resolve(__dirname, 'node_modules', '@code-dot-org', 'remark-plugins'),
   path.resolve(__dirname, 'node_modules', '@code-dot-org', 'snack-sdk'),

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1574,6 +1574,11 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
+"@blockly/plugin-scroll-options@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@blockly/plugin-scroll-options/-/plugin-scroll-options-1.0.4.tgz#ea85f8c3b2f0cbe8f273f89a56a306b3bb868795"
+  integrity sha512-Aex5zpSmWDvTBRGNJWwI12qYWhXG+u0bnb74LD917EdE94tsz4P2p7B/tby3NZdsE4DvNHjUG0dxCwxTbcitHg==
+
 "@cdo/interpreted@link:../dashboard/config/libraries":
   version "0.0.0"
   uid ""


### PR DESCRIPTION
This gets us scroll-on-drag and scroll-on-mouse-wheel-while-dragging
https://github.com/google/blockly-samples/tree/master/plugins/scroll-options

A little hard to tell in the gif so might be worth pulling and playing around with it locally, but basically, this change will scroll the workspace when you drag a block towards the edge and when you use the mouse wheel even when you're dragging a block.
![Nov-01-2021 17-28-34](https://user-images.githubusercontent.com/8787187/139760368-e7eb00bb-cbeb-448a-b9aa-7dd96b66d518.gif)


