### PR TITLE
Teacher Panel - refactor & load students async

### DIFF
--- a/apps/src/code-studio/progress.js
+++ b/apps/src/code-studio/progress.js
@@ -373,14 +373,7 @@ function queryUserProgress(store, scriptData, currentLevelId) {
         ? pageTypes.level
         : pageTypes.scriptOverview;
 
-      renderTeacherPanel(
-        store,
-        scriptData.id,
-        scriptData.section,
-        scriptData.name,
-        pageType,
-        onOverviewPage
-      );
+      renderTeacherPanel(store, scriptData.id, scriptData.name, pageType);
     }
   });
 }

--- a/apps/src/code-studio/progress.js
+++ b/apps/src/code-studio/progress.js
@@ -36,7 +36,7 @@ import {
 import googlePlatformApi, {
   loadGooglePlatformApi
 } from '@cdo/apps/templates/progress/googlePlatformApiRedux';
-import {queryLockStatus, renderTeacherPanel} from './teacherPanelHelpers';
+import {renderTeacherPanel} from './teacherPanelHelpers';
 
 var progress = module.exports;
 
@@ -369,8 +369,10 @@ function queryUserProgress(store, scriptData, currentLevelId) {
       (data.isTeacher || data.teacherViewingStudent) &&
       !data.professionalLearningCourse
     ) {
-      const pageType = currentLevelId ? 'level' : 'script_overview';
-      queryLockStatus(store, scriptData.id, pageType);
+      const pageType = currentLevelId
+        ? pageTypes.level
+        : pageTypes.scriptOverview;
+
       renderTeacherPanel(
         store,
         scriptData.id,

--- a/apps/src/code-studio/teacherPanelHelpers.js
+++ b/apps/src/code-studio/teacherPanelHelpers.js
@@ -7,11 +7,10 @@ import {
 import {Provider} from 'react-redux';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {reload} from '@cdo/apps/utils';
-import {updateQueryParam} from '@cdo/apps/code-studio/utils';
 import {setStudentsForCurrentSection} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
-import {queryUserProgress} from '@cdo/apps/code-studio/progressRedux';
 import TeacherPanel from './components/progress/teacherPanel/TeacherPanel';
+import $ from 'jquery';
+import {queryParams} from '@cdo/apps/code-studio/utils';
 
 /**
  * Render our teacher panel that shows up on our course overview page.
@@ -21,35 +20,17 @@ export function renderTeacherPanel(
   scriptId,
   section,
   scriptName,
-  pageType = null,
-  isAsync = false
+  pageType = null
 ) {
   const div = document.createElement('div');
   div.setAttribute('id', 'teacher-panel-container');
 
-  if (section && section.students) {
-    store.dispatch(setStudentsForCurrentSection(section.id, section.students));
-  }
-
-  const onSelectUser = id => {
-    updateQueryParam('user_id', id);
-    isAsync ? store.dispatch(queryUserProgress(id)) : reload();
-  };
-
-  const getSelectedUserId = () => {
-    const userIdStr = queryString.parse(location.search).user_id;
-    const selectedUserId = userIdStr ? parseInt(userIdStr, 10) : null;
-    return selectedUserId;
-  };
+  queryStudentsForSection(store);
+  queryLockStatus(store, scriptId, pageType);
 
   ReactDOM.render(
     <Provider store={store}>
-      <TeacherPanel
-        onSelectUser={onSelectUser}
-        scriptName={scriptName}
-        getSelectedUserId={getSelectedUserId}
-        pageType={pageType}
-      />
+      <TeacherPanel scriptName={scriptName} pageType={pageType} />
     </Provider>,
     div
   );
@@ -60,7 +41,7 @@ export function renderTeacherPanel(
  * Query the server for lock status of this teacher's students
  * @returns {Promise} when finished
  */
-export function queryLockStatus(store, scriptId, pageType) {
+function queryLockStatus(store, scriptId, pageType) {
   return new Promise((resolve, reject) => {
     $.ajax('/api/lock_status', {
       data: {script_id: scriptId}
@@ -86,4 +67,23 @@ export function queryLockStatus(store, scriptId, pageType) {
       resolve();
     });
   });
+}
+
+function queryStudentsForSection(store) {
+  const sectionId = queryParams('section_id');
+
+  let request = '/api/teacher_panel_section';
+  if (sectionId) {
+    request += `?section_id=${sectionId}`;
+  }
+
+  $.ajax(request)
+    .success(section => {
+      store.dispatch(
+        setStudentsForCurrentSection(section.id, section.students)
+      );
+    })
+    .fail(err => {
+      console.log(err);
+    });
 }

--- a/apps/src/code-studio/teacherPanelHelpers.js
+++ b/apps/src/code-studio/teacherPanelHelpers.js
@@ -18,7 +18,6 @@ import {queryParams} from '@cdo/apps/code-studio/utils';
 export function renderTeacherPanel(
   store,
   scriptId,
-  section,
   scriptName,
   pageType = null
 ) {
@@ -30,7 +29,7 @@ export function renderTeacherPanel(
 
   ReactDOM.render(
     <Provider store={store}>
-      <TeacherPanel scriptName={scriptName} pageType={pageType} />
+      <TeacherPanel unitName={scriptName} pageType={pageType} />
     </Provider>,
     div
   );

--- a/apps/src/code-studio/teacherPanelHelpers.js
+++ b/apps/src/code-studio/teacherPanelHelpers.js
@@ -77,10 +77,12 @@ function queryStudentsForSection(store) {
   }
 
   $.ajax(request)
-    .success(section => {
-      store.dispatch(
-        setStudentsForCurrentSection(section.id, section.students)
-      );
+    .success((section, status) => {
+      if (status !== 'nocontent') {
+        store.dispatch(
+          setStudentsForCurrentSection(section.id, section.students)
+        );
+      }
     })
     .fail(err => {
       console.log(err);

--- a/apps/src/sites/studio/pages/levels/_teacher_panel.js
+++ b/apps/src/sites/studio/pages/levels/_teacher_panel.js
@@ -33,7 +33,6 @@ function initPage() {
   renderTeacherPanel(
     store,
     teacherPanelData.script_id,
-    teacherPanelData.section,
     teacherPanelData.script_name,
     teacherPanelData.page_type
   );

--- a/apps/src/sites/studio/pages/levels/_teacher_panel.js
+++ b/apps/src/sites/studio/pages/levels/_teacher_panel.js
@@ -9,10 +9,7 @@ import {Provider} from 'react-redux';
 import ReactDOM from 'react-dom';
 import TeacherContentToggle from '@cdo/apps/code-studio/components/TeacherContentToggle';
 import {getHiddenLessons} from '@cdo/apps/code-studio/hiddenLessonRedux';
-import {
-  renderTeacherPanel,
-  queryLockStatus
-} from '@cdo/apps/code-studio/teacherPanelHelpers';
+import {renderTeacherPanel} from '@cdo/apps/code-studio/teacherPanelHelpers';
 import {setVerified} from '@cdo/apps/code-studio/verifiedTeacherRedux';
 
 $(document).ready(initPage);
@@ -24,11 +21,7 @@ function initPage() {
   const store = getStore();
 
   initViewAs(store);
-  queryLockStatus(
-    store,
-    teacherPanelData.script_id,
-    teacherPanelData.page_type
-  );
+
   store.dispatch(getHiddenLessons(teacherPanelData.script_name, false));
   if (teacherPanelData.is_verified_teacher) {
     store.dispatch(setVerified());

--- a/apps/test/unit/code-studio/components/progress/teacherPanel/TeacherPanelTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/teacherPanel/TeacherPanelTest.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import {shallow} from 'enzyme';
+import {shallow, mount} from 'enzyme';
 import {expect} from '../../../../../util/reconfiguredChai';
 import {UnconnectedTeacherPanel as TeacherPanel} from '@cdo/apps/code-studio/components/progress/teacherPanel/TeacherPanel';
-import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
+import viewAs, {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import SectionSelector from '@cdo/apps/code-studio/components/progress/SectionSelector';
 import ViewAsToggle from '@cdo/apps/code-studio/components/progress/ViewAsToggle';
 import i18n from '@cdo/locale';
@@ -12,12 +12,14 @@ import {LevelStatus} from '@cdo/apps/util/sharedConstants';
 import {pageTypes} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import $ from 'jquery';
 import sinon from 'sinon';
+import * as utils from '@cdo/apps/code-studio/utils';
+import {Provider} from 'react-redux';
+import {createStore, combineReducers} from 'redux';
 
 const students = [{id: 1, name: 'Student 1'}, {id: 2, name: 'Student 2'}];
 
 const DEFAULT_PROPS = {
-  onSelectUser: () => {},
-  getSelectedUserId: () => {},
+  selectUser: () => {},
   unitName: 'A unit',
   pageType: pageTypes.level,
   viewAs: ViewType.Student,
@@ -159,6 +161,57 @@ describe('TeacherPanel', () => {
       });
       expect(wrapper.find(StudentTable)).to.have.length(0);
     });
+
+    it('calls selectUser when user is clicked with isAsync true when on overview page', () => {
+      const store = createStore(combineReducers({viewAs}), {
+        viewAs: ViewType.Teacher
+      });
+
+      const selectUserStub = sinon.stub();
+      const overrideProps = {
+        selectUser: selectUserStub,
+        viewAs: ViewType.Teacher,
+        students: students,
+        pageType: pageTypes.scriptOverview
+      };
+      const props = {...DEFAULT_PROPS, ...overrideProps};
+
+      const wrapper = mount(
+        <Provider store={store}>
+          <TeacherPanel {...props} />
+        </Provider>
+      );
+
+      const secondStudentInTable = wrapper.find('tr').at(1);
+      secondStudentInTable.simulate('click');
+
+      expect(selectUserStub).to.have.been.calledWith(1, true);
+    });
+
+    it('calls selectUser when user is clicked with isAsync false when on level page', () => {
+      const store = createStore(combineReducers({viewAs}), {
+        viewAs: ViewType.Teacher
+      });
+
+      const selectUserStub = sinon.stub();
+      const overrideProps = {
+        selectUser: selectUserStub,
+        viewAs: ViewType.Teacher,
+        students: students,
+        pageType: pageTypes.level
+      };
+      const props = {...DEFAULT_PROPS, ...overrideProps};
+      const wrapper = mount(
+        <Provider store={store}>
+          <TeacherPanel {...props} />
+        </Provider>
+      );
+
+      const secondStudentInTable = wrapper.find('tr').at(1);
+      secondStudentInTable.simulate('click');
+
+      expect(selectUserStub).to.have.been.calledWith(1, false);
+    });
   });
 
   describe('SelectedStudentInfo', () => {
@@ -173,10 +226,14 @@ describe('TeacherPanel', () => {
     });
 
     it('on level displays SelectedStudentInfo when students have loaded, passes expected props', () => {
+      sinon
+        .stub(utils, 'queryParams')
+        .withArgs('user_id')
+        .returns('1');
+
       const wrapper = setUp({
         viewAs: ViewType.Teacher,
         students: students,
-        getSelectedUserId: () => 1,
         teacherId: 5
       });
 
@@ -184,6 +241,8 @@ describe('TeacherPanel', () => {
       expect(selectedStudentComponent).to.have.length(1);
       expect(selectedStudentComponent.props().teacherId).to.equal(5);
       expect(selectedStudentComponent.props().selectedUserId).to.equal(1);
+
+      utils.queryParams.restore();
     });
   });
 

--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -383,16 +383,20 @@ class ApiController < ApplicationController
 
   # Get /api/teacher_panel_section
   def teacher_panel_section
-    section_id = params[:section_id] ? params[:section_id].to_i : nil
-    section = "null"
+    section_id = params[:section_id].present? ? params[:section_id].to_i : nil
 
     if section_id
-      section = current_user.sections.find_by(id: section_id).summarize
+      section = current_user.sections.find_by(id: section_id)
+      if section.present?
+        render json: section.summarize if section.present?
+        return
+      end
     elsif current_user.sections.length == 1
-      section = current_user.sections[0].summarize
+      render json: current_user.sections[0].summarize
+      return
     end
 
-    render json: section
+    head :no_content
   end
 
   def script_structure

--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -383,16 +383,23 @@ class ApiController < ApplicationController
 
   # Get /api/teacher_panel_section
   def teacher_panel_section
+    teacher_sections = current_user&.sections
+
+    if teacher_sections.blank?
+      head :no_content
+      return
+    end
+
     section_id = params[:section_id].present? ? params[:section_id].to_i : nil
 
     if section_id
-      section = current_user.sections.find_by(id: section_id)
+      section = teacher_sections.find_by(id: section_id)
       if section.present?
         render json: section.summarize if section.present?
         return
       end
-    elsif current_user.sections.length == 1
-      render json: current_user.sections[0].summarize
+    elsif teacher_sections.length == 1
+      render json: teacher_sections[0].summarize
       return
     end
 

--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -381,6 +381,20 @@ class ApiController < ApplicationController
     render json: student_progress.unshift(teacher_progress)
   end
 
+  # Get /api/teacher_panel_section
+  def teacher_panel_section
+    section_id = params[:section_id] ? params[:section_id].to_i : nil
+    section = "null"
+
+    if section_id
+      section = current_user.sections.find_by(id: section_id).summarize
+    elsif current_user.sections.length == 1
+      section = current_user.sections[0].summarize
+    end
+
+    render json: section
+  end
+
   def script_structure
     script = Script.get_from_cache(params[:script])
     overview_path = CDO.studio_url(script_path(script))

--- a/dashboard/app/views/levels/_teacher_panel.html.haml
+++ b/dashboard/app/views/levels/_teacher_panel.html.haml
@@ -1,7 +1,6 @@
 - data = {}
 - data[:script_name] = @script.name
 - data[:script_id] = @script.id
-- data[:section] = @section&.summarize
 - data[:lesson_extra] = @lesson_extras
 - data[:is_verified_teacher] = @current_user.authorized_teacher?
 

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -720,6 +720,7 @@ Dashboard::Application.routes.draw do
   get '/dashboardapi/script_standards/:script', to: 'api#script_standards'
   get '/api/section_progress/:section_id', to: 'api#section_progress', as: 'section_progress'
   get '/api/teacher_panel_progress/:section_id', to: 'api#teacher_panel_progress'
+  get '/api/teacher_panel_section', to: 'api#teacher_panel_section'
   get '/dashboardapi/section_level_progress/:section_id', to: 'api#section_level_progress', as: 'section_level_progress'
   get '/api/user_progress/:script', to: 'api#user_progress', as: 'user_progress'
   get '/api/user_app_options/:script/:lesson_position/:level_position/:level', to: 'api#user_app_options', as: 'user_app_options'

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -1379,6 +1379,21 @@ class ApiControllerTest < ActionController::TestCase
     assert_response :no_content
   end
 
+  test "teacher_panel_section returns no_content when teacher has no sections" do
+    teacher = create :teacher
+    sign_in teacher
+
+    get :teacher_panel_section
+
+    assert_response :no_content
+  end
+
+  test "teacher_panel_section returns no_content when no user is logged in" do
+    get :teacher_panel_section
+
+    assert_response :no_content
+  end
+
   test "script_structure returns summarized script" do
     overview_path = 'http://script.overview/path'
     CDO.stubs(:studio_url).returns(overview_path)


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This is a piece of the larger effort to make the teacher panel load on cached pages https://github.com/code-dot-org/code-dot-org/pull/43126

- Adds a teacher_panel_section endpoint which will return the section for the teacher panel
- Load section for the teacher panel async
- Refactor teacher panel components

## Testing story
Tested manually that teacher panel loads as expected and added tests.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
