### PR TITLE
stop using level.user_id field in production

### DIFF
--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -238,10 +238,6 @@ class Level < ApplicationRecord
   def self.palette_categories
   end
 
-  def self.custom_levels
-    Naturally.sort_by(Level.where(level_num: 'custom'), :name)
-  end
-
   # Custom levels are built in levelbuilder. Legacy levels are defined in .js.
   # All custom levels will have a 'custom' level_num, except for DSLDefined levels.
   def custom?

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -232,7 +232,7 @@ class Level < ApplicationRecord
   end
 
   def self.custom_levels
-    Naturally.sort_by(Level.where.not(level_num: 'custom'), :name)
+    Naturally.sort_by(Level.where(level_num: 'custom'), :name)
   end
 
   # Custom levels are built in levelbuilder. Legacy levels are defined in .js.

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -44,7 +44,6 @@ class Level < ApplicationRecord
 
   validates_length_of :name, within: 1..70
   validate :reject_illegal_chars
-  validates_uniqueness_of :name, case_sensitive: false, conditions: -> {where.not(user_id: nil)}
   validates_uniqueness_of :name, case_sensitive: false, conditions: -> {where(level_num: ['custom', nil])}
   validates_uniqueness_of :level_num, scope: :game, conditions: -> {where.not(level_num: ['custom', nil])}
   validate :validate_game, on: [:create, :update]
@@ -233,13 +232,13 @@ class Level < ApplicationRecord
   end
 
   def self.custom_levels
-    Naturally.sort_by(Level.where.not(user_id: nil), :name)
+    Naturally.sort_by(Level.where.not(level_num: 'custom'), :name)
   end
 
   # Custom levels are built in levelbuilder. Legacy levels are defined in .js.
-  # All custom levels will have a user_id, except for DSLDefined levels.
+  # All custom levels will have a 'custom' level_num, except for DSLDefined levels.
   def custom?
-    user_id.present? || is_a?(DSLDefined)
+    level_num == 'custom' || is_a?(DSLDefined)
   end
 
   def should_localize?

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -44,8 +44,15 @@ class Level < ApplicationRecord
 
   validates_length_of :name, within: 1..70
   validate :reject_illegal_chars
+
+  # Together, these validations prevent collisions between level keys, including
+  # level keys which differ only by case, between all 3 categories of levels:
+  # custom levels, DSLDefined levels, and deprecated blockly levels. For more
+  # context on these categories and level keys, see:
+  # https://docs.google.com/document/d/1rS1ekCEVU1Q49ckh2S9lfq0tQo-m-G5KJLiEalAzPts/edit
   validates_uniqueness_of :name, case_sensitive: false, conditions: -> {where(level_num: ['custom', nil])}
   validates_uniqueness_of :level_num, scope: :game, conditions: -> {where.not(level_num: ['custom', nil])}
+
   validate :validate_game, on: [:create, :update]
 
   after_save :write_custom_level_file

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -572,7 +572,7 @@ class LevelsControllerTest < ActionController::TestCase
   end
 
   test "should not edit level if not custom level" do
-    level = create(:level, user_id: nil)
+    level = create(:deprecated_blockly_level, user_id: nil)
     refute Ability.new(@levelbuilder).can? :edit, level
 
     post :update_blocks, params: @default_update_blocks_params.merge(
@@ -969,7 +969,7 @@ class LevelsControllerTest < ActionController::TestCase
   end
 
   test "cannot clone hard-coded levels" do
-    old = create(:level, game_id: Game.first.id, name: "Fun Level", user_id: nil)
+    old = create(:deprecated_blockly_level, game_id: Game.first.id, name: "Fun Level", user_id: nil)
     refute old.custom?
     refute_creates(Level) do
       post :clone, params: {id: old.id, name: "Fun Level (copy 1)"}
@@ -1005,7 +1005,7 @@ class LevelsControllerTest < ActionController::TestCase
     sign_out @levelbuilder
     sign_in @platformization_partner
 
-    old = create(:level, game_id: Game.first.id, name: "Fun Level", user_id: nil)
+    old = create(:deprecated_blockly_level, game_id: Game.first.id, name: "Fun Level", user_id: nil)
     refute old.custom?
     refute_creates(Level) do
       post :clone, params: {id: old.id, name: "Fun Level (copy 1)"}

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -959,7 +959,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   test "with callout defined should define callout JS" do
     script = create(:script)
     lesson_group = create(:lesson_group, script: script)
-    level = create(:level, :blockly, user_id: nil)
+    level = create :deprecated_blockly_level
     lesson = create(:lesson, script: script, lesson_group: lesson_group)
     script_level = create(:script_level, script: script, levels: [level], lesson: lesson)
 

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -503,8 +503,6 @@ FactoryGirl.define do
     sequence(:name) {|n| "Level_#{n}"}
     level_num 'custom'
 
-    # User id must be non-nil for custom level
-    user_id '1'
     game
 
     trait :with_autoplay_video do

--- a/dashboard/test/helpers/levels_helper_test.rb
+++ b/dashboard/test/helpers/levels_helper_test.rb
@@ -149,7 +149,7 @@ class LevelsHelperTest < ActionView::TestCase
 
   test "should select only callouts for current script level" do
     script = create(:script)
-    @level = create(:level, :blockly, user_id: nil)
+    @level = create(:deprecated_blockly_level)
     lesson = create(:lesson, script: script)
     @script_level = create(:script_level, script: script, levels: [@level], lesson: lesson)
 
@@ -166,7 +166,7 @@ class LevelsHelperTest < ActionView::TestCase
 
   test "should localize callouts" do
     script = create(:script)
-    @level = create(:level, :blockly, user_id: nil)
+    @level = create(:deprecated_blockly_level)
     lesson = create(:lesson, script: script)
     @script_level = create(:script_level, script: script, levels: [@level], lesson: lesson)
 

--- a/dashboard/test/models/blockly_test.rb
+++ b/dashboard/test/models/blockly_test.rb
@@ -491,7 +491,7 @@ XML
 
     level = Level.create(
       name: level_name,
-      user: create(:user),
+      level_num: 'custom',
       type: 'Maze',
       authored_hints: JSON.generate(
         [

--- a/dashboard/test/models/level_test.rb
+++ b/dashboard/test/models/level_test.rb
@@ -114,12 +114,6 @@ class LevelTest < ActiveSupport::TestCase
     end
   end
 
-  test "get custom levels" do
-    custom_levels = Level.custom_levels
-    assert custom_levels.include?(@custom_level)
-    assert_not custom_levels.include?(@level)
-  end
-
   test "should not allow pairing with levelgroup type levels" do
     level = Level.create({type: "LevelGroup"})
     assert_equal level.should_allow_pairing?(0), false

--- a/dashboard/test/models/level_test.rb
+++ b/dashboard/test/models/level_test.rb
@@ -650,7 +650,7 @@ class LevelTest < ActiveSupport::TestCase
 
     level = Level.create(
       name: level_name,
-      user: create(:user),
+      level_num: 'custom',
       callout_json: JSON.generate(
         [
           {"callout_text": "first english markdown", "localization_key": "first"},
@@ -672,7 +672,7 @@ class LevelTest < ActiveSupport::TestCase
 
     level = Level.create(
       name: level_name,
-      user: create(:user),
+      level_num: 'custom',
       callout_json: JSON.generate(
         [
           {"callout_text": "first english markdown", "localization_key": "first"},


### PR DESCRIPTION
Finishes [PLAT-1409]. Depends on https://github.com/code-dot-org/code-dot-org/pull/43336, see that PR for context.

This PR makes the switch from looking at level.user_id to looking at level.level_num to determine whether a level is a custom level. This gets us to the point where our _production_, user-facing code does not depend on user_id any more. however, level.user_id will live on so that we can show the level author in the level editing UIs on levelbuilder, including https://levelbuilder-studio.code.org/levels and the AddLevelDialog in the lesson editor.

## Analysis

After manually cleaning up a few levels in levelbuilder and production, I ran the following commands to confirm that the old and new ways of determining custom level status are equivalent:

```
[levelbuilder] dashboard > Level.all.select {|l| (l.level_num == 'custom') != (!!l.user_id)}
=> []

[production] dashboard > Level.all.select {|l| (l.level_num == 'custom') != (!!l.user_id)}
=> []
```

## Testing story

updated existing test coverage

[PLAT-1409]: https://codedotorg.atlassian.net/browse/PLAT-1409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ