### PR TITLE
Edit brew install command with cask

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -162,7 +162,7 @@ After setup, read about our [code styleguide](./STYLEGUIDE.md), our [test suites
       If it complains `xcode-select: error: command line tools are already installed, use "Software Update" to install updates`, check to make sure XCode is downloaded and up to date manually.
     </details>
 
-1. Install the Java 8 JDK: `brew cask install adoptopenjdk/openjdk/adoptopenjdk8`. More info [here](http://www.oracle.com/technetwork/java/javase/downloads/index.html).
+1. Install the Java 8 JDK: `brew install --cask adoptopenjdk/openjdk/adoptopenjdk8`. More info [here](http://www.oracle.com/technetwork/java/javase/downloads/index.html).
 
 1. [Download](https://www.google.com/chrome/) and install Google Chrome, if you have not already. This is needed in order to be able to run apps tests locally.
 


### PR DESCRIPTION
When I was following the setup docs, the command `brew cask install adoptopenjdk/openjdk/adoptopenjdk8` failed.

It looks like `cask` is no longer a `brew command` ([source](https://github.com/Homebrew/discussions/discussions/902)), and AdoptOpenJDK [shows](https://github.com/AdoptOpenJDK/homebrew-openjdk) using the `--cask` option instead. I think `--cask` [is implied with](https://github.com/Homebrew/homebrew-cask/blob/master/USAGE.md#frequently-used-commands) `brew install` given the thing we're installing is a Cask, so another option is to leave it out all together, but I went with what was in the OpenJDK docs.

## PR Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
