### PR TITLE
[Poetry] Add warning to poem editor modal

### DIFF
--- a/apps/i18n/poetry/en_us.json
+++ b/apps/i18n/poetry/en_us.json
@@ -2,6 +2,7 @@
   "alexanderLines": "What happened to a dream destroyed?\n\nDoes it sink\nlike a wrecked ship in the sea?\n\nOr wade in the water\nLike a boy overboard?\n\nMaybe it just floats\nAround and around...\n\nOr does it drown?",
   "alexanderTitle": "Dream Destroyed",
   "author": "Author:",
+  "authorWarning": "Do not enter your full name; use a nickname or initials instead.",
   "backgroundOrTextEffect": "You need to add a background or text effect.",
   "carroll2Lines": "How doth the little crocodile\nImprove his shining tail,\nAnd pour the waters of the Nile\nOn every golden scale!\n\nHow cheerfully he seems to grin,\nHow neatly spreads his claws,\nAnd welcomes little fishes in,\nWith gently smiling jaws!",
   "carroll2Title": "Crocodile",

--- a/apps/src/p5lab/poetry/PoemSelector.jsx
+++ b/apps/src/p5lab/poetry/PoemSelector.jsx
@@ -56,6 +56,12 @@ export function PoemEditor(props) {
           onChange={event => setAuthor(event.target.value)}
         />
       </div>
+      <div style={{...styles.modalContainer, paddingTop: 0}}>
+        <div style={styles.label} />
+        <div style={{...styles.input, ...styles.warning}}>
+          {msg.authorWarning()}
+        </div>
+      </div>
       <div style={styles.modalContainer}>
         <label style={styles.label}>{msg.poem()}</label>
         <textarea
@@ -214,6 +220,9 @@ const styles = {
     fontStyle: 'italic',
     textAlign: 'right',
     marginRight: 5
+  },
+  warning: {
+    fontFamily: '"Gotham 5r", sans-serif'
   }
 };
 


### PR DESCRIPTION
We want to discourage students from providing identifying information in this modal.
Before
![image](https://user-images.githubusercontent.com/8787187/140162604-ad88973e-b5d8-4328-8111-452b6744b27b.png)

After
![image](https://user-images.githubusercontent.com/8787187/140162510-6d9ff452-f929-4d10-a632-da7614b1f088.png)
