### PR TITLE
Clearer Sign-up User Type Switch from Experiment Flags to Local Storage

### DIFF
--- a/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
+++ b/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
@@ -52,6 +52,7 @@ $(document).ready(() => {
   const inClearerUserTypeOptExp =
     localStorage.getItem('inClearerUserTypeOptExpLS') === 'true';
 
+  let userType = $('#user_user_type')[0].value;
   init();
 
   function init() {
@@ -68,7 +69,7 @@ $(document).ready(() => {
         'width:220px;';
     }
     // TO-DELETE ONCE CLEARER USER TYPE BUTTONS OPTIMIZELY-EXPERIMENT IS COMPLETE (end)
-    setUserType(getUserType());
+    setUserType(userType);
     renderSchoolInfo();
     renderParentSignUpSection();
   }
@@ -83,9 +84,8 @@ $(document).ready(() => {
       return false;
     }
 
-    // Optimizely-related code for new sign-up user-type buttons (start)
-    optimizelyCountUserTypeSelection(getUserType());
-    // Optimizely-related code for new sign-up user-type buttons (end)
+    // Trigger Optimizely counter for user type selection
+    optimizelyCountUserTypeSelection(userType);
 
     // Optimizely-related code for teacher opting to share email with regional partner (start)
     optimizelyCountSuccessSignupWithRegPartnerOpt();
@@ -93,7 +93,7 @@ $(document).ready(() => {
 
     alreadySubmitted = true;
     // Clean up school data and set age for teachers.
-    if (getUserType() === 'teacher') {
+    if (userType === 'teacher') {
       cleanSchoolInfo();
       $('#user_age').val('21+');
     }
@@ -119,7 +119,7 @@ $(document).ready(() => {
   $('#user_parent_email_preference_opt_in_required').change(function() {
     // If the user_type is currently blank, switch the user_type to 'student' because that is the only user_type which
     // allows the parent sign up section of the form.
-    if (getUserType() === '') {
+    if (userType === '') {
       $('#user_user_type')
         .val('student')
         .change();
@@ -138,16 +138,13 @@ $(document).ready(() => {
     }
   }
 
-  // Keep if sign-up user type experiment favors variant (start)
   // Event listeners for changing the user type
   document.addEventListener('selectUserTypeTeacher', e => {
     $('#user_user_type').val('teacher');
-    styleSelectedUserTypeButton('teacher');
     setUserType('teacher');
   });
   document.addEventListener('selectUserTypeStudent', e => {
     $('#user_user_type').val('student');
-    styleSelectedUserTypeButton('student');
     setUserType('student');
   });
 
@@ -160,9 +157,8 @@ $(document).ready(() => {
       teacherButton.classList.remove('select-user-type-button-selected');
     }
   }
-  // Keep if sign-up user type experiment favors variant (end)
 
-  // Optimizely-related code for new sign-up user-type buttons
+  // Optimizely metric for seeing which user type new users select
   function optimizelyCountUserTypeSelection(userType) {
     window['optimizely'] = window['optimizely'] || [];
     window['optimizely'].push({type: 'event', eventName: userType});
@@ -180,23 +176,21 @@ $(document).ready(() => {
     setUserType(value);
   });
 
-  function getUserType() {
-    var value = $('#user_user_type')[0].value;
-    styleSelectedUserTypeButton(value);
-    return value;
-  }
-
-  function setUserType(userType) {
-    if (userType) {
-      trackUserType(userType);
+  function setUserType(newUserType) {
+    if (newUserType) {
+      trackUserType(newUserType);
     }
 
-    if (userType === 'teacher') {
+    if (newUserType === 'teacher') {
       switchToTeacher();
     } else {
       // Show student fields by default.
       switchToStudent();
     }
+    if (inClearerUserTypeOptExp) {
+      styleSelectedUserTypeButton(newUserType);
+    }
+    userType = newUserType;
   }
 
   function switchToTeacher() {

--- a/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
+++ b/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
@@ -48,11 +48,15 @@ let userInOptimizelyVariant = experiments.isEnabled(
 
 $(document).ready(() => {
   const schoolInfoMountPoint = document.getElementById('school-info-inputs');
+
+  const inClearerUserTypeOptExp =
+    localStorage.getItem('inClearerUserTypeOptExpLS') === 'true';
+
   init();
 
   function init() {
     // TO-DELETE ONCE CLEARER USER TYPE BUTTONS OPTIMIZELY-EXPERIMENT IS COMPLETE (start)
-    if (experiments.isEnabled(experiments.CLEARER_SIGN_UP_USER_TYPE)) {
+    if (inClearerUserTypeOptExp) {
       // If in variant, toggle large buttons
       document.getElementById('select-user-type-original').style.cssText =
         'display:none;';

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -32,7 +32,6 @@ experiments.I18N_TRACKING = 'i18n-tracking';
 experiments.TIME_SPENT = 'time-spent';
 experiments.BYPASS_DIALOG_POPUP = 'bypass-dialog-popup';
 experiments.SPECIAL_TOPIC = 'special-topic';
-experiments.CLEARER_SIGN_UP_USER_TYPE = 'clearerSignUpUserType';
 experiments.OPT_IN_EMAIL_REG_PARTNER = 'optInEmailRegPartner';
 experiments.MULTISELECT = 'multiselect';
 experiments.CODE_REVIEW_GROUPS = 'codeReviewGroups';


### PR DESCRIPTION
Removed experiment flags from the Clearer Sign-Up User Type experiment for changing the user type selection in the sign-up page to large buttons that describe the abilities students and teachers have. The [Optimizely experiment for this](https://app.optimizely.com/v2/projects/12977480133/results/20603050402/experiments/20592950647?previousView=VARIATIONS) showed that there was no statistically significant decrease in user sign-ups due to the user type button changes so we can safely start to roll it out.

The rollout will be by language once the translations are in (not all of them are in yet so we only want to roll this change out to languages that are fully translated) so we are going to continue to use Optimizely but for choosing which audiences see which version rather than for tracking data. I am switching from experiment flags to local storage (in the variable `inClearerUserTypeOptExpLS`) because it will be more reliable when doing the rollout. It should be a safe rollout since this change defaults to the original drop-down selection of user type so if anything goes wrong with localStorage or Optimizely, it will simply just show the original.

Some changes were also made to `_finish_sign_up.js` to simplify some of the logic between both the original and the variation since they share a lot of functionality. This way, it will hopefully be easier to remove the original code once enough/all languages have been translated successfully for this change.

## Links
- [Original PR this relates to](https://github.com/code-dot-org/code-dot-org/pull/41608)
- [Optimizely experiment results](https://app.optimizely.com/v2/projects/12977480133/results/20603050402/experiments/20592950647?previousView=VARIATIONS)

## Testing story
I manually ensured the behavior was identical to the results of [the original](https://github.com/code-dot-org/code-dot-org/pull/41608) and manually tested by switching between Student and Teacher account types and made an account with both successfully in multiple browsers. Also checked that the user cannot create an account without explicitly clicking either 'Student' or 'Teacher.'

I also ensured that by default the user sees the original unless the localStorage variable is set otherwise.

## Follow-up work
- Set up Optimizely experiment to only let people who are using a language that has been translated for this change actually see it
- As translations come in, add those languages to groups that can see the change

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
