### PR TITLE
[Google Blockly] Make trashcan work with categorized toolboxes

### DIFF
--- a/apps/src/blockly/addons/cdoToolbox.js
+++ b/apps/src/blockly/addons/cdoToolbox.js
@@ -1,0 +1,22 @@
+import GoogleBlockly from 'blockly/core';
+
+export default class Toolbox extends GoogleBlockly.Toolbox {
+  createDom_(workspace) {
+    const container = super.createDom_(workspace);
+
+    // Add the trashcan inside a holder svg element.
+    const trashcanHolder = Blockly.utils.dom.createSvgElement(
+      'svg',
+      {
+        id: 'trashcanHolder',
+        width: 70,
+        height: 90,
+        style: 'position: absolute'
+      },
+      container
+    );
+    trashcanHolder.appendChild(workspace.trashcan.svgGroup_);
+
+    return container;
+  }
+}

--- a/apps/src/blockly/addons/cdoToolbox.js
+++ b/apps/src/blockly/addons/cdoToolbox.js
@@ -5,18 +5,24 @@ export default class Toolbox extends GoogleBlockly.Toolbox {
     const container = super.createDom_(workspace);
 
     // Add the trashcan inside a holder svg element.
-    const trashcanHolder = Blockly.utils.dom.createSvgElement(
-      'svg',
-      {
-        id: 'trashcanHolder',
-        width: 70,
-        height: 90,
-        style: 'position: absolute'
-      },
-      container
-    );
-    trashcanHolder.appendChild(workspace.trashcan.svgGroup_);
+    this.trashcanHolder = Blockly.utils.dom.createSvgElement('svg', {
+      id: 'trashcanHolder',
+      height: 125,
+      style: 'position: absolute; display: none;'
+    });
+
+    // Add the trashcan as the first child of the toolbox container. If it's the
+    // second child after the categories, the trashcan renders "behind" the
+    // categories and appears clipped.
+    container.insertBefore(this.trashcanHolder, container.firstElementChild);
+
+    this.trashcanHolder.appendChild(workspace.trashcan.svgGroup_);
 
     return container;
+  }
+
+  position() {
+    this.trashcanHolder?.setAttribute('width', this.width_);
+    return super.position();
   }
 }

--- a/apps/src/blockly/addons/cdoTrashcan.js
+++ b/apps/src/blockly/addons/cdoTrashcan.js
@@ -1,4 +1,5 @@
 import GoogleBlockly from 'blockly/core';
+import {ToolboxType} from '../constants';
 
 export default class CdoTrashcan extends GoogleBlockly.Trashcan {
   /** Use our trash png and add circle with line through it for undeletable blocks
@@ -49,7 +50,7 @@ export default class CdoTrashcan extends GoogleBlockly.Trashcan {
     this.notAllowed_ = null;
   }
 
-  /** Position over the toolbox instead of the bottom corner
+  /** Position over the toolbox area instead of the bottom corner.
    * @override
    */
   position() {
@@ -63,7 +64,17 @@ export default class CdoTrashcan extends GoogleBlockly.Trashcan {
       return;
     }
 
-    this.left_ = Math.round(metrics.flyoutWidth / 2 - this.WIDTH_ / 2);
+    let toolboxWidth = 0;
+    switch (this.workspace_.getToolboxType()) {
+      case ToolboxType.CATEGORIZED:
+        toolboxWidth = this.workspace_.toolbox_.width_;
+        break;
+      case ToolboxType.UNCATEGORIZED:
+        toolboxWidth = metrics.flyoutWidth;
+        break;
+    }
+
+    this.left_ = Math.round(toolboxWidth / 2 - this.WIDTH_ / 2);
     this.top_ = this.MARGIN_VERTICAL_ * 2;
 
     this.svgGroup_.setAttribute(

--- a/apps/src/blockly/addons/cdoWorkspaceSvg.js
+++ b/apps/src/blockly/addons/cdoWorkspaceSvg.js
@@ -16,7 +16,11 @@ export default class WorkspaceSvg extends GoogleBlockly.WorkspaceSvg {
     }
   }
 
-  /** Add trashcan to flyout instead of block canvas
+  /** Instantiate trashcan, but don't add it to the workspace SVG.
+   * If the toolbox is categorized, the toolbox will add the trashcan to its SVG
+   * when its DOM element is created (see CdoToolbox.js). If the toolbox is not
+   * categorized, the flyout will already be initialized, so we can go ahead and
+   * add the trashcan to the flyout SVG group now.
    * @override
    */
   addTrashcan() {

--- a/apps/src/blockly/addons/cdoWorkspaceSvg.js
+++ b/apps/src/blockly/addons/cdoWorkspaceSvg.js
@@ -1,4 +1,5 @@
 import GoogleBlockly from 'blockly/core';
+import {ToolboxType} from '../constants';
 
 export default class WorkspaceSvg extends GoogleBlockly.WorkspaceSvg {
   registerGlobalVariables(variableList) {
@@ -16,11 +17,30 @@ export default class WorkspaceSvg extends GoogleBlockly.WorkspaceSvg {
     }
   }
 
+  /**
+   * The way toolboxes work in Blockly is kind of confusing, this helper function
+   * is intended to make it easier to tell what kind of toolbox is in use.
+   * Part of the issue is that the word "toolbox" is slightly overloaded to encompass
+   * both Toolbox and Flyout objects. In this description I use lower-case toolbox
+   * to refer to the area of the workspace where blocks come from and upper-case
+   * Toolbox to refer to instances of the Toolbox class.
+   * There are two kinds of toolboxes we use in levels: categorized and uncategorized.
+   * Categorized toolboxes are instances of the Toolbox class. When a category
+   * is selected, the Toolbox opens a Flyout that displays the blocks in that category.
+   * Uncategorized toolboxes are instances of the Flyout class that just display
+   * all of the available blocks.
+   */
+  getToolboxType() {
+    if (this.flyout_) {
+      return ToolboxType.UNCATEGORIZED;
+    } else if (this.toolbox_) {
+      return ToolboxType.CATEGORIZED;
+    } else {
+      return ToolboxType.UNKNOWN;
+    }
+  }
+
   /** Instantiate trashcan, but don't add it to the workspace SVG.
-   * If the toolbox is categorized, the toolbox will add the trashcan to its SVG
-   * when its DOM element is created (see CdoToolbox.js). If the toolbox is not
-   * categorized, the flyout will already be initialized, so we can go ahead and
-   * add the trashcan to the flyout SVG group now.
    * @override
    */
   addTrashcan() {
@@ -30,8 +50,23 @@ export default class WorkspaceSvg extends GoogleBlockly.WorkspaceSvg {
     /** @type {Blockly.Trashcan} */
     this.trashcan = new Blockly.Trashcan(this);
     var svgTrashcan = this.trashcan.createDom();
-    this.flyout_?.svgGroup_?.appendChild(svgTrashcan);
-    this.hideTrashcan();
+
+    switch (this.getToolboxType()) {
+      case ToolboxType.UNCATEGORIZED: {
+        const trashcanHolder = Blockly.utils.dom.createSvgElement('svg', {
+          id: 'trashcanHolder',
+          height: 125,
+          style: 'position: absolute; display: none;'
+        });
+        trashcanHolder.appendChild(svgTrashcan);
+        this.flyout_.svgGroup_.appendChild(trashcanHolder);
+        break;
+      }
+      case ToolboxType.CATEGORIZED:
+        // The Toolbox will add the trashcan to its SVG when its DOM element
+        // is created (see CdoToolbox.js).
+        break;
+    }
   }
   addUnusedBlocksHelpListener(helpClickFunc) {
     Blockly.mainBlockSpace.addChangeListener(Blockly.Events.disableOrphans);
@@ -75,11 +110,13 @@ export default class WorkspaceSvg extends GoogleBlockly.WorkspaceSvg {
      * https://developer.mozilla.org/en-US/docs/Web/API/NodeList/forEach
      */
     Array.prototype.forEach.call(
-      document.querySelectorAll('.blocklyTrash'),
+      document.querySelectorAll('.blocklyToolboxContents'),
       function(x) {
-        x.style.visibility = 'hidden';
+        x.style.visibility = 'visible';
       }
     );
+
+    document.querySelector('#trashcanHolder').style.display = 'none';
   }
 
   isReadOnly() {
@@ -103,11 +140,13 @@ export default class WorkspaceSvg extends GoogleBlockly.WorkspaceSvg {
      * https://developer.mozilla.org/en-US/docs/Web/API/NodeList/forEach
      */
     Array.prototype.forEach.call(
-      document.querySelectorAll('.blocklyTrash'),
+      document.querySelectorAll('.blocklyToolboxContents'),
       function(x) {
-        x.style.visibility = 'visible';
+        x.style.visibility = 'hidden';
       }
     );
+
+    document.querySelector('#trashcanHolder').style.display = 'block';
   }
   traceOn() {} // TODO
 }

--- a/apps/src/blockly/addons/cdoWorkspaceSvg.js
+++ b/apps/src/blockly/addons/cdoWorkspaceSvg.js
@@ -91,8 +91,12 @@ export default class WorkspaceSvg extends GoogleBlockly.WorkspaceSvg {
     return Blockly.mainBlockSpace.getMetrics().toolboxWidth;
   }
 
-  // Use visibility:hidden not display:none to hide the trashcan so that it still takes up space, which is important
-  // for how the lid opening works.
+  /**
+   * Use visibility:hidden not display:none for the toolbox contents so that
+   * Blockly's metrics calculations for toolbox dimensions still work as expected.
+   * Use display:none not visibility:hidden for the trashcan element so that
+   * it doesn't interfere with click events on the toolbox categories.
+   */
   hideTrashcan() {
     /**
      * NodeList.forEach() is not supported on IE. Use Array.prototype.forEach.call() as a workaround.

--- a/apps/src/blockly/constants.js
+++ b/apps/src/blockly/constants.js
@@ -1,0 +1,3 @@
+import {makeEnum} from '@cdo/apps/utils';
+
+export const ToolboxType = makeEnum('CATEGORIZED', 'UNCATEGORIZED', 'UNKNOWN');

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -14,6 +14,7 @@ import CdoInput from './addons/cdoInput';
 import CdoMetricsManager from './addons/cdoMetricsManager';
 import CdoPathObject from './addons/cdoPathObject';
 import CdoTheme from './addons/cdoTheme';
+import CdoToolbox from './addons/cdoToolbox';
 import initializeTouch from './addons/cdoTouch';
 import CdoTrashcan from './addons/cdoTrashcan';
 import initializeVariables from './addons/cdoVariables';
@@ -137,6 +138,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.wrapReadOnlyProperty('useContractEditor');
   blocklyWrapper.wrapReadOnlyProperty('useModalFunctionEditor');
   blocklyWrapper.wrapReadOnlyProperty('utils');
+  blocklyWrapper.wrapReadOnlyProperty('Toolbox');
   blocklyWrapper.wrapReadOnlyProperty('Touch');
   blocklyWrapper.wrapReadOnlyProperty('Trashcan');
   blocklyWrapper.wrapReadOnlyProperty('Variables');
@@ -155,9 +157,17 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.blockly_.FunctionEditor = FunctionEditor;
   blocklyWrapper.blockly_.Input = CdoInput;
   blocklyWrapper.geras.PathObject = CdoPathObject;
+  blocklyWrapper.blockly_.Toolbox = CdoToolbox;
   blocklyWrapper.blockly_.Trashcan = CdoTrashcan;
   blocklyWrapper.blockly_.VariableMap = CdoVariableMap;
   blocklyWrapper.blockly_.WorkspaceSvg = CdoWorkspaceSvg;
+
+  blocklyWrapper.blockly_.registry.register(
+    blocklyWrapper.blockly_.registry.Type.TOOLBOX,
+    blocklyWrapper.blockly_.registry.DEFAULT,
+    CdoToolbox,
+    true /* opt_allowOverrides */
+  );
 
   // These are also wrapping read only properties, but can't use wrapReadOnlyProperty
   // because the alias name is not the same as the underlying property name.

--- a/apps/style/blockly.scss
+++ b/apps/style/blockly.scss
@@ -7,3 +7,12 @@
   transition: opacity 2s;
   opacity: 0.8;
 }
+
+/* 
+Google Blockly moves dragging blocks to a separate SVG called the block drag
+surface. When you drag a block over the toolbox area, we want the dragging
+block to be on top of the toolbox. The toolbox has a z-index of 70.
+*/
+.blocklyBlockDragSurface {
+  z-index: 80;
+}


### PR DESCRIPTION
[jira](https://codedotorg.atlassian.net/browse/STAR-1781)

This PR has a few components:
- Add the trashcan SVG group to the toolbox DOM element. Unfortunately, this has to happen in a slightly different order depending on whether the toolbox is categorized or uncategorized. `Workspace.addTrashcan` is called as part of initializing the workspace [here](https://github.com/google/blockly/blob/master/core/inject.js#L175).
  - For categorized toolboxes, the toolbox is created after the workspace has fully loaded, so the toolbox element does not yet exist at the time `addTrashcan` is called. The solution for categorized toolboxes is to create the trashcan element in `Workspace.addTrashcan` but not put it in the DOM yet. Then we can add the trashcan element to the toolbox element as part of `Toolbox.createDom`.
  - For uncategorized toolboxes (Flyouts), the flyout is created *before* the workspace has fully loaded, and importantly, before `Workspace.addTrashcan` is called. That means the trashcan element won't exist yet when `Flyout.createDom` is called, so we can't do the same thing as we do for categorized toolboxes. Rather, we can assume the flyout is fully initialized by the time we get to `Workspace.addTrashcan`, so we can add the trashcan element to the flyout element as part of `Workspace.addTrashcan`
- Modify the width calculation in `Traschan.position` to account for whether the toolbox element is a Toolbox instance or a Flyout instance.
- Show/hide the trashcan with `display` none/block rather than `visibility` hidden/visible. `display: none` removes the element from the page, which is necessary so that click events on the toolbox categories still work correctly. The categories and flyout contents are still shown/hidden with `visibility` hidden/visible. This is important because `visibility: hidden` elements still take up space in the DOM, so Blockly's internal metrics of things like toolbox height/width are still correct (which they wouldn't be if we used `display: none`).
- Increase the z-index of the block drag surface so that dragging blocks move over the toolbox area rather than underneath

Before:
![Nov-03-2021 12-03-21](https://user-images.githubusercontent.com/8787187/140175849-37e37d03-eaa5-46aa-9411-4987206d6d9e.gif)

After:
![Nov-03-2021 12-04-19](https://user-images.githubusercontent.com/8787187/140175982-01481430-e15a-48f5-825e-521ec3bec9f2.gif)

