### PR TITLE
DMS Engine Upgrade from 3.3.3 to 3.4.5

### DIFF
--- a/aws/cloudformation/data.yml.erb
+++ b/aws/cloudformation/data.yml.erb
@@ -65,7 +65,7 @@ Resources:
       PreferredMaintenanceWindow: 'Tue:01:00-Tue:01:30'
       PubliclyAccessible: true
       VpcSecurityGroupIds: [!ImportValue VPC-RedshiftSecurityGroup]
-  TableauSync:
+  DMSReplicationInstance:
     Type: AWS::DMS::ReplicationInstance
     Properties:
       AllowMajorVersionUpgrade: true
@@ -152,7 +152,7 @@ Resources:
     Type: AWS::DMS::ReplicationTask
     Properties:
       MigrationType: full-load
-      ReplicationInstanceArn: !Ref TableauSync
+      ReplicationInstanceArn: !Ref DMSReplicationInstance
       ReplicationTaskIdentifier: <%= task_name %>-task
       SourceEndpointArn: !Ref AuroraCloneEndpoint
       TargetEndpointArn: !Ref RedshiftEndpoint

--- a/aws/cloudformation/data.yml.erb
+++ b/aws/cloudformation/data.yml.erb
@@ -77,6 +77,18 @@ Resources:
       ReplicationInstanceIdentifier: !Ref AWS::StackName
       ReplicationSubnetGroupIdentifier: !ImportValue VPC-DMSSubnetGroup
       VpcSecurityGroupIds: [!ImportValue VPC-DMSSecurityGroup]
+  TableauSync:
+    Type: AWS::DMS::ReplicationInstance
+    Properties:
+      AllowMajorVersionUpgrade: true
+      AllocatedStorage: 250
+      EngineVersion: 3.3.3
+      MultiAZ: true
+      PubliclyAccessible: false
+      ReplicationInstanceClass: dms.r4.4xlarge
+      ReplicationInstanceIdentifier: !Ref AWS::StackName
+      ReplicationSubnetGroupIdentifier: !ImportValue VPC-DMSSubnetGroup
+      VpcSecurityGroupIds: [!ImportValue VPC-DMSSecurityGroup]
   # Note that this is an incomplete set of Policies attached to the
   # redshift-s3 Role. The Role itself and other Policies were generated manually
   # in the AWS Console, and we should continue to move these Resources here over time.

--- a/aws/cloudformation/data.yml.erb
+++ b/aws/cloudformation/data.yml.erb
@@ -70,7 +70,7 @@ Resources:
     Properties:
       AllowMajorVersionUpgrade: true
       AllocatedStorage: 250
-      EngineVersion: 3.3.3
+      EngineVersion: 3.4.5
       MultiAZ: true
       PubliclyAccessible: false
       ReplicationInstanceClass: dms.r4.4xlarge

--- a/aws/cloudformation/data.yml.erb
+++ b/aws/cloudformation/data.yml.erb
@@ -68,14 +68,13 @@ Resources:
   DMSReplicationInstance:
     Type: AWS::DMS::ReplicationInstance
     Properties:
-      ResourceIdentifier: export-mysql-to-redshift
+      ReplicationInstanceIdentifier: export-mysql-to-redshift
       AllowMajorVersionUpgrade: true
       AllocatedStorage: 250
       EngineVersion: 3.4.5
       MultiAZ: true
       PubliclyAccessible: false
       ReplicationInstanceClass: dms.r4.4xlarge
-      ReplicationInstanceIdentifier: !Ref AWS::StackName
       ReplicationSubnetGroupIdentifier: !ImportValue VPC-DMSSubnetGroup
       VpcSecurityGroupIds: [!ImportValue VPC-DMSSecurityGroup]
   # Note that this is an incomplete set of Policies attached to the
@@ -154,7 +153,7 @@ Resources:
     Properties:
       MigrationType: full-load
       ReplicationInstanceArn: !Ref DMSReplicationInstance
-      ReplicationTaskIdentifier: <%= task_name %>-task
+      ReplicationTaskIdentifier: <%= task_name %>
       SourceEndpointArn: !Ref AuroraCloneEndpoint
       TargetEndpointArn: !Ref RedshiftEndpoint
       ReplicationTaskSettings: !Sub |

--- a/aws/cloudformation/data.yml.erb
+++ b/aws/cloudformation/data.yml.erb
@@ -68,21 +68,10 @@ Resources:
   DMSReplicationInstance:
     Type: AWS::DMS::ReplicationInstance
     Properties:
+      ResourceIdentifier: export-mysql-to-redshift
       AllowMajorVersionUpgrade: true
       AllocatedStorage: 250
       EngineVersion: 3.4.5
-      MultiAZ: true
-      PubliclyAccessible: false
-      ReplicationInstanceClass: dms.r4.4xlarge
-      ReplicationInstanceIdentifier: !Ref AWS::StackName
-      ReplicationSubnetGroupIdentifier: !ImportValue VPC-DMSSubnetGroup
-      VpcSecurityGroupIds: [!ImportValue VPC-DMSSecurityGroup]
-  TableauSync:
-    Type: AWS::DMS::ReplicationInstance
-    Properties:
-      AllowMajorVersionUpgrade: true
-      AllocatedStorage: 250
-      EngineVersion: 3.3.3
       MultiAZ: true
       PubliclyAccessible: false
       ReplicationInstanceClass: dms.r4.4xlarge


### PR DESCRIPTION
This PR upgrades the Database Migration Service (DMS) engine from 3.3.3 to 3.4.5. We use DMS to migrate data daily from an on-demand RDS cluster to RedShift. On 10/13/21 we started to notice a performance degradation on our DMS instance (arn:aws:dms:us-east-1:475661607190:rep:7455AZ27Z7R4JMC2WRJC2TQLQI). After logging a ticket with AWS (see links) they are recommending to upgrade the engine to help remediate the issue.

## Links

[AWS Case ID 9112119101](https://console.aws.amazon.com/support/home#/case/?displayId=9112119101&language=en)

JIRA [INF-496](https://codedotorg.atlassian.net/browse/INF-496)

## Testing story

In the case of this upgrade failing, we will revert the change to the previous version. 

```

$ export AWS_PROFILE=codeorg-admin
$ bin/aws_access
AWS access: GoogleSignInAdmin/suresh@code.org
$ bundle exec rake stack:data:validate RAILS_ENV=production

Pending update for stack `DATA-production`:
Modify DMSCronLevelSourcesPii [AWS::DMS::ReplicationTask] Properties Replacement: Conditional (ReplicationInstanceArn, ReplicationInstanceArn)
Modify DMSCronPii [AWS::DMS::ReplicationTask] Properties Replacement: Conditional (ReplicationInstanceArn, ReplicationInstanceArn)
Modify DMSCronUserHierarchyPii [AWS::DMS::ReplicationTask] Properties Replacement: Conditional (ReplicationInstanceArn, ReplicationInstanceArn)
Modify DMSCronUserHierarchy [AWS::DMS::ReplicationTask] Properties Replacement: Conditional (ReplicationInstanceArn, ReplicationInstanceArn)
Modify DMSCronUserLevels [AWS::DMS::ReplicationTask] Properties Replacement: Conditional (ReplicationInstanceArn, ReplicationInstanceArn)
Modify DMSCron [AWS::DMS::ReplicationTask] Properties Replacement: Conditional (ReplicationInstanceArn, ReplicationInstanceArn)
Add DMSReplicationInstance [AWS::DMS::ReplicationInstance]
Remove TableauSync [AWS::DMS::ReplicationInstance]
```

### Deployment

This change was deployed 2021-11-5 around 17:00 PDT
`$ bundle exec rake stack:data:validate RAILS_ENV=production`