### PR TITLE
Speech bubble positioning

### DIFF
--- a/apps/src/p5lab/drawUtils.js
+++ b/apps/src/p5lab/drawUtils.js
@@ -23,11 +23,10 @@ export function getTextWidth(p5, text, size) {
  * Draw a speech bubble - a P5 shape comprised of a rectangle
  * with a triangle at the bottom. The x/y values will be the
  * bottom center of the bubble body, including the height added
- * by the triangle. The default triangle will have a size of 10
- * and be positioned horizontally with the bottom tip aligned
- * to the center of the bubble body. In cases where the sprite
- * is close to the app edges, the triangle size and position may
- * be adjusted.
+ * by the triangle. With the default config values, the triangle
+ * will have a size of 10 and align to the center of the bubble body.
+ * Other passed config values allow the triangle to be adjusted,
+ * such as when a sprite is close to the edge of the app canvas.
  *
  * Note: The bubble body and triangle stroke outlines will overlap if the width:triangleSize
  * ratio is too low (e.g., the width is too narrow and triangle is too large). Consider
@@ -39,8 +38,9 @@ export function getTextWidth(p5, text, size) {
  * @param {Number} y
  * @param {Number} width
  * @param {Number} height
- * @param {Number} triangleSize
- * @param {Number} triangleTipX
+ * @param {Number} config.triangleSize
+ * @param {Number} config.triangleTipX
+ * @param {Number} config.rectangleCornerRadius
  * @param {String} config.fill
  * @param {Number} config.strokeWeight
  * @param {Number} config.stroke
@@ -52,14 +52,18 @@ export function speechBubble(
   y,
   width,
   height,
-  triangleSize = 10,
-  triangleTipX = x,
-  {fill = 'white', strokeWeight = 2, stroke = 'gray'} = {}
+  {
+    triangleSize = 10,
+    triangleTipX = x,
+    rectangleCornerRadius = 8,
+    fill = 'white',
+    strokeWeight = 2,
+    stroke = 'gray'
+  } = {}
 ) {
   const minX = x - width / 2;
   const minY = y - height - triangleSize;
   const maxY = y - triangleSize;
-  const rectangleCornerRadius = 8;
 
   p5.push();
   p5.stroke(stroke);

--- a/apps/src/p5lab/drawUtils.js
+++ b/apps/src/p5lab/drawUtils.js
@@ -47,7 +47,9 @@ export function speechBubble(
   y,
   width,
   height,
-  {triangleSize = 10, fill = 'white', strokeWeight = 2, stroke = 'gray'} = {}
+  triangleSize,
+  tipX,
+  {fill = 'white', strokeWeight = 2, stroke = 'gray'} = {}
 ) {
   const minX = x - width / 2;
   const minY = y - height - triangleSize;
@@ -60,10 +62,10 @@ export function speechBubble(
   p5.beginShape();
   p5.rect(minX, minY, width, height, 8);
   p5.stroke(fill);
-  p5.triangle(x - triangleSize, maxY, x, maxY, x, y);
+  p5.triangle(tipX - triangleSize, maxY, tipX, maxY, tipX, y);
   p5.stroke(stroke);
-  p5.line(x, maxY, x, y);
-  p5.line(x, y, x - triangleSize - 1, maxY);
+  p5.line(tipX, maxY, tipX, y);
+  p5.line(tipX, y, tipX - triangleSize - 1, maxY);
   p5.endShape(p5.CLOSE);
   p5.pop();
 

--- a/apps/src/p5lab/drawUtils.js
+++ b/apps/src/p5lab/drawUtils.js
@@ -22,8 +22,12 @@ export function getTextWidth(p5, text, size) {
 /**
  * Draw a speech bubble - a P5 shape comprised of a rectangle
  * with a triangle at the bottom. The x/y values will be the
- * tip of the triangle, and the bubble body will be centered above
- * the triangle.
+ * bottom center of the bubble body, including the height added
+ * by the triangle. The default triangle will have a size of 10
+ * and be positioned horizontally with the bottom tip aligned
+ * to the center of the bubble body. In cases where the sprite
+ * is close to the app edges, the triangle size and position may
+ * be adjusted.
  *
  * Note: The bubble body and triangle stroke outlines will overlap if the width:triangleSize
  * ratio is too low (e.g., the width is too narrow and triangle is too large). Consider
@@ -35,7 +39,8 @@ export function getTextWidth(p5, text, size) {
  * @param {Number} y
  * @param {Number} width
  * @param {Number} height
- * @param {Number} config.triangleSize
+ * @param {Number} triangleSize
+ * @param {Number} triangleTipX
  * @param {String} config.fill
  * @param {Number} config.strokeWeight
  * @param {Number} config.stroke
@@ -47,25 +52,33 @@ export function speechBubble(
   y,
   width,
   height,
-  triangleSize,
-  tipX,
+  triangleSize = 10,
+  triangleTipX = x,
   {fill = 'white', strokeWeight = 2, stroke = 'gray'} = {}
 ) {
   const minX = x - width / 2;
   const minY = y - height - triangleSize;
   const maxY = y - triangleSize;
+  const rectangleCornerRadius = 8;
 
   p5.push();
   p5.stroke(stroke);
   p5.strokeWeight(strokeWeight);
   p5.fill(fill);
   p5.beginShape();
-  p5.rect(minX, minY, width, height, 8);
+  p5.rect(minX, minY, width, height, rectangleCornerRadius);
   p5.stroke(fill);
-  p5.triangle(tipX - triangleSize, maxY, tipX, maxY, tipX, y);
+  p5.triangle(
+    triangleTipX - triangleSize,
+    maxY,
+    triangleTipX,
+    maxY,
+    triangleTipX,
+    y
+  );
   p5.stroke(stroke);
-  p5.line(tipX, maxY, tipX, y);
-  p5.line(tipX, y, tipX - triangleSize - 1, maxY);
+  p5.line(triangleTipX, maxY, triangleTipX, y);
+  p5.line(triangleTipX, y, triangleTipX - triangleSize - 1, maxY);
   p5.endShape(p5.CLOSE);
   p5.pop();
 

--- a/apps/src/p5lab/spritelab/CoreLibrary.js
+++ b/apps/src/p5lab/spritelab/CoreLibrary.js
@@ -101,10 +101,11 @@ export default class CoreLibrary {
     width = Math.max(width, 50);
     const height = lines.length * textSize + padding * 2;
 
-    // x and y are located at the horizontal center and the top of the sprite, respectfully. This is the tip of the triangle.
     let triangleSize = 10;
     let tipX = x;
-    // Ensure bubble is visible.
+
+    // For the calculations below, keep in mind that x and y are located at the horizontal center and the top of the sprite, respectively.
+    // In other words, x and y indicate the default position of the bubble's triangular tip.
     if (y > 400) {
       y = 400;
     }

--- a/apps/src/p5lab/spritelab/CoreLibrary.js
+++ b/apps/src/p5lab/spritelab/CoreLibrary.js
@@ -123,15 +123,11 @@ export default class CoreLibrary {
     }
 
     // Draw bubble.
-    const {minY} = drawUtils.speechBubble(
-      this.p5,
-      x,
-      y,
-      width,
-      height,
+    const {minY} = drawUtils.speechBubble(this.p5, x, y, width, height, {
       triangleSize,
-      triangleTipX
-    );
+      triangleTipX,
+      rectangleCornerRadius
+    });
 
     // Draw text within bubble.
     drawUtils.multilineText(this.p5, lines, x, minY + padding, textSize, {

--- a/apps/src/p5lab/spritelab/CoreLibrary.js
+++ b/apps/src/p5lab/spritelab/CoreLibrary.js
@@ -103,22 +103,34 @@ export default class CoreLibrary {
 
     // x and y are located at the horizontal center and the top of the sprite, respectfully. This is the tip of the triangle.
     let triangleSize = 10;
+    let tipX = x;
     // Ensure bubble is visible.
-    if (y - height - triangleSize < 1) {
-      y = height + triangleSize;
-    }
-    if (x - width / 2 < 1) {
-      x = width / 2;
-    }
     if (y > 400) {
       y = 400;
     }
+    if (y - height - triangleSize < 1) {
+      triangleSize = Math.max(1, y - height);
+      y = height + triangleSize;
+    }
+    if (x - width / 2 < 1) {
+      tipX = Math.max(x, 8 + triangleSize);
+      x = width / 2;
+    }
     if (x + width / 2 > 400) {
+      tipX = Math.min(x, 392);
       x = 400 - width / 2;
     }
 
     // Draw bubble.
-    const {minY} = drawUtils.speechBubble(this.p5, x, y, width, height);
+    const {minY} = drawUtils.speechBubble(
+      this.p5,
+      x,
+      y,
+      width,
+      height,
+      triangleSize,
+      tipX
+    );
 
     // Draw text within bubble.
     drawUtils.multilineText(this.p5, lines, x, minY + padding, textSize, {

--- a/apps/src/p5lab/spritelab/CoreLibrary.js
+++ b/apps/src/p5lab/spritelab/CoreLibrary.js
@@ -1,6 +1,7 @@
 import {createUuid, stringToChunks, ellipsify} from '@cdo/apps/utils';
 import * as drawUtils from '@cdo/apps/p5lab/drawUtils';
 import commands from './commands/index';
+import {APP_HEIGHT, APP_WIDTH} from '../constants';
 
 export default class CoreLibrary {
   constructor(p5) {
@@ -82,7 +83,6 @@ export default class CoreLibrary {
   }
 
   drawSpeechBubble(text, x, y) {
-    //console.log(`${x}, ${y}`);
     const padding = 8;
     text = ellipsify(text, 150 /* maxLength */);
     let textSize = 10;
@@ -102,23 +102,23 @@ export default class CoreLibrary {
     const height = lines.length * textSize + padding * 2;
 
     let triangleSize = 10;
-    let tipX = x;
+    let triangleTipX = x;
+    // The number of pixels used to create the rounded corners of the speech bubble:
+    const rectangleCornerRadius = 8;
 
     // For the calculations below, keep in mind that x and y are located at the horizontal center and the top of the sprite, respectively.
     // In other words, x and y indicate the default position of the bubble's triangular tip.
-    if (y > 400) {
-      y = 400;
-    }
+    y = Math.min(y, APP_HEIGHT);
     if (y - height - triangleSize < 1) {
       triangleSize = Math.max(1, y - height);
       y = height + triangleSize;
     }
     if (x - width / 2 < 1) {
-      tipX = Math.max(x, 8 + triangleSize);
+      triangleTipX = Math.max(x, rectangleCornerRadius + triangleSize);
       x = width / 2;
     }
-    if (x + width / 2 > 400) {
-      tipX = Math.min(x, 392);
+    if (x + width / 2 > APP_WIDTH) {
+      triangleTipX = Math.min(x, APP_WIDTH - rectangleCornerRadius);
       x = 400 - width / 2;
     }
 
@@ -130,7 +130,7 @@ export default class CoreLibrary {
       width,
       height,
       triangleSize,
-      tipX
+      triangleTipX
     );
 
     // Draw text within bubble.

--- a/apps/src/p5lab/spritelab/CoreLibrary.js
+++ b/apps/src/p5lab/spritelab/CoreLibrary.js
@@ -82,6 +82,7 @@ export default class CoreLibrary {
   }
 
   drawSpeechBubble(text, x, y) {
+    //console.log(`${x}, ${y}`);
     const padding = 8;
     text = ellipsify(text, 150 /* maxLength */);
     let textSize = 10;
@@ -99,6 +100,22 @@ export default class CoreLibrary {
       drawUtils.getTextWidth(this.p5, longestLine, textSize) + padding * 2;
     width = Math.max(width, 50);
     const height = lines.length * textSize + padding * 2;
+
+    // x and y are located at the horizontal center and the top of the sprite, respectfully. This is the tip of the triangle.
+    let triangleSize = 10;
+    // Ensure bubble is visible.
+    if (y - height - triangleSize < 1) {
+      y = height + triangleSize;
+    }
+    if (x - width / 2 < 1) {
+      x = width / 2;
+    }
+    if (y > 400) {
+      y = 400;
+    }
+    if (x + width / 2 > 400) {
+      x = 400 - width / 2;
+    }
 
     // Draw bubble.
     const {minY} = drawUtils.speechBubble(this.p5, x, y, width, height);

--- a/apps/src/p5lab/spritelab/CoreLibrary.js
+++ b/apps/src/p5lab/spritelab/CoreLibrary.js
@@ -119,7 +119,7 @@ export default class CoreLibrary {
     }
     if (x + width / 2 > APP_WIDTH) {
       triangleTipX = Math.min(x, APP_WIDTH - rectangleCornerRadius);
-      x = 400 - width / 2;
+      x = APP_WIDTH - width / 2;
     }
 
     // Draw bubble.


### PR DESCRIPTION
### Summary
* Prevent speech bubbles from being drawn anywhere off of the canvas
* Shrink the bubble's triangle tip as the sprite approaches the top of the screen (min: 1px)
* Move the bubble's triangle tip to be centered with the sprite, if possible, bounded by the rectangle's border-radius (8px)

In order to resize and move the tip, we need to pass in new values into `speechBubble()`. (Previously these were hard-coded to be 10 for size and center-of-bubble for the position.)

[Slack thread for context](https://codedotorg.slack.com/archives/C946FMBGT/p1635962907001500)

_Before:_
![screenshot](https://user-images.githubusercontent.com/43474485/140183372-229d5923-5cfd-4b61-be59-93d4c7b52fd5.png)

_After:_
![screenshot](https://user-images.githubusercontent.com/43474485/140183335-28fc1378-cc99-4ab7-8af8-b69439919444.png)

![gif](https://user-images.githubusercontent.com/43474485/140183735-8742a772-79fa-4619-a78c-ba77cbc124a8.gif)

