### PR TITLE
use new chef-provided helper method to execute git commands in cookbooks

### DIFF
--- a/cookbooks/cdo-repository/libraries/git.rb
+++ b/cookbooks/cdo-repository/libraries/git.rb
@@ -20,41 +20,43 @@ module Cdo
         converge_by("clone from #{@new_resource.repository} into #{@new_resource.destination}") do
           remote = @new_resource.remote
 
-          args = []
+          args = ["clone"]
           args << "-o #{remote}" unless remote == "origin"
           args << "--depth #{@new_resource.depth}" if @new_resource.depth
           # PATCH: Use --branch to checkout at clone time to avoid separate checkout step.
           args << "--branch #{@new_resource.checkout_branch}" unless @new_resource.enable_checkout
           # PATCH: Remove --no-single-branch to support shallow-clones.
           # args << "--no-single-branch" if @new_resource.depth and git_minor_version >= Gem::Version.new("1.7.10")
+          args << @new_resource.repository.inspect
+          args << @new_resource.destination.inspect
 
           Chef::Log.info "#{@new_resource} cloning repo #{@new_resource.repository} to #{@new_resource.destination}"
-          shell_out!("git clone #{args.join(' ')} \"#{@new_resource.repository}\" \"#{@new_resource.destination}\"", run_options)
+          git(args)
         end
       end
 
       def fetch_updates
         setup_remote_tracking_branches(@new_resource.remote, @new_resource.repository)
         update_fetch_refs
-        run_opts = run_options(cwd: @new_resource.destination)
+        run_opts = {cwd: @new_resource.destination}
         # PATCH: support shallow fetch.
         converge_by("fetch updates for #{@new_resource.remote}") do
-          shell_out!("git fetch #{@new_resource.remote}", run_opts)
+          git("fetch #{@new_resource.remote}", run_opts)
         end
         # PATCH: support switching to a new checkout branch after the initial clone.
         if @new_resource.checkout_branch != current_branch
           converge_by "Checking out branch #{@new_resource.checkout_branch}" do
-            shell_out!("git checkout #{@new_resource.checkout_branch}", run_opts)
+            git("checkout #{@new_resource.checkout_branch}", run_opts)
           end
         end
         # since we're in a local branch already, just reset to specified revision rather than merge
         converge_by "Resetting to revision #{target_revision}" do
-          shell_out!("git reset --hard #{target_revision}", run_opts)
+          git("reset --hard #{target_revision}", run_opts)
         end
       end
 
       def current_branch
-        shell_out!('git rev-parse --abbrev-ref HEAD', run_options(cwd: @new_resource.destination)).stdout
+        git('rev-parse --abbrev-ref HEAD', {cwd: @new_resource.destination}).stdout
       end
 
       # PATCH: Expand the remote.origin.fetch config to include the specified branch if needed.


### PR DESCRIPTION
On Chef 17, these helper methods are failing with the following error:

```
Recipe: cdo-github-access::default
  * apt_repository[git-core] action add
    * execute[apt-cache gencaches] action nothing (skipped due to action :nothing)
    * apt_update[git-core] action nothing (skipped due to action :nothing)
    * execute[install-key E1DD270288B4E6030699E45FA1715D88E1DF1F24] action run
      [execute] Warning: apt-key output should not be parsed (stdout is not a terminal)
                Executing: /tmp/apt-key-gpghome.pXL6VBEvzu/gpg.1.sh --no-tty --recv --keyserver hkp://keyserver.ubuntu.com:80 E1DD270288B4E6030699E45FA1715D88E1DF1F24
                gpg: key A1715D88E1DF1F24: public key "Launchpad PPA for Ubuntu Git Maintainers" imported
                gpg: Total number processed: 1
                gpg:               imported: 1
      - execute apt-key adv --no-tty --recv --keyserver hkp://keyserver.ubuntu.com:80 E1DD270288B4E6030699E45FA1715D88E1DF1F24
    * execute[apt-cache gencaches] action run
      [execute] Reading package lists...
      - execute ["apt-cache", "gencaches"]
    * file[/etc/apt/sources.list.d/git-core.list] action create
      - create new file /etc/apt/sources.list.d/git-core.list
      - update content in file /etc/apt/sources.list.d/git-core.list from none to bcb9ca
      --- /etc/apt/sources.list.d/git-core.list 2021-11-04 18:53:26.668492621 +0000
      +++ /etc/apt/sources.list.d/.chef-git-core20211104-28057-5wajze.list      2021-11-04 18:53:26.668492621 +0000
      @@ -1 +1,2 @@
      +deb      http://ppa.launchpad.net/git-core/ppa/ubuntu trusty main
      - change mode from '' to '0644'
      - change owner from '' to 'root'
      - change group from '' to 'root'
    * execute[apt-cache gencaches] action run
      [execute] Reading package lists...
      - execute ["apt-cache", "gencaches"]
    * apt_update[git-core] action update
      * directory[/var/lib/apt/periodic] action create (up to date)
      * directory[/etc/apt/apt.conf.d] action create (up to date)
      * file[/etc/apt/apt.conf.d/15update-stamp] action create_if_missing (up to date)
      * execute[apt-get -q update] action run
        [execute] Hit:1 http://us-east-1.ec2.archive.ubuntu.com/ubuntu bionic InRelease
                  Hit:2 http://us-east-1.ec2.archive.ubuntu.com/ubuntu bionic-updates InRelease
                  Get:3 http://us-east-1.ec2.archive.ubuntu.com/ubuntu bionic-backports InRelease [74.6 kB]
                  Hit:4 http://security.ubuntu.com/ubuntu bionic-security InRelease
                  Hit:5 http://ppa.launchpad.net/brightbox/ruby-ng/ubuntu bionic InRelease
                  Get:6 http://ppa.launchpad.net/git-core/ppa/ubuntu trusty InRelease [20.8 kB]
                  Get:7 http://ppa.launchpad.net/git-core/ppa/ubuntu trusty/main amd64 Packages [3,474 B]
                  Get:8 http://ppa.launchpad.net/git-core/ppa/ubuntu trusty/main Translation-en [2,588 B]
                  Fetched 101 kB in 1s (113 kB/s)
                  Reading package lists...
        - execute ["apt-get", "-q", "update"]
      - force update new lists of packages

  * apt_package[git] action install (up to date)
  * cookbook_file[/home/ubuntu/.gitconfig] action create
    - create new file /home/ubuntu/.gitconfig
    - update content in file /home/ubuntu/.gitconfig from none to ca2874
    --- /home/ubuntu/.gitconfig 2021-11-04 18:53:31.032464380 +0000
    +++ /home/ubuntu/.chef-.gitconfig20211104-28057-o5bocz.gitconfig    2021-11-04 18:53:31.032464380 +0000
    @@ -1 +1,13 @@
    +[push]
    +   default = simple
    +[user]
    +   name = Continuous Integration
    +   email = dev@code.org
    +
    +# https://git-scm.com/docs/git-gc#_configuration
    +[gc]
    +    # Make git gc --auto return immediately and run in background if the system supports it. Default is true.
    +    #
    +    # Set false to prevent gc --auto from being interrupted by server shutdown, leaving behind large temp files.
    +    autoDetach = false
    - change mode from '' to '0644'
    - change owner from '' to 'ubuntu'
    - change group from '' to 'ubuntu'
  * directory[/home/ubuntu/.ssh] action create (up to date)
  * template[/home/ubuntu/.ssh/config] action create (skipped due to not_if)
  * template[/home/ubuntu/.ssh/id_rsa] action create (skipped due to not_if)
  * template[/home/ubuntu/.ssh/id_rsa.pub] action create (skipped due to not_if)
Recipe: cdo-repository::default
  * git[/home/ubuntu/adhoc] action checkout

    ================================================================================
    Error executing action `checkout` on resource 'git[/home/ubuntu/adhoc]'
    ================================================================================

    Errno::ENOENT
    -------------
    No such file or directory - git clone --depth 1 --branch chef-17-without-git-fix "https://github.com/code-dot-org/code-dot-org.git" "/home/ubuntu/adhoc"

    Cookbook Trace: (most recent call first)
    ----------------------------------------
    /etc/chef/local-mode-cache/cache/cookbooks/cdo-repository/libraries/git.rb:32:in `block in clone'
    /etc/chef/local-mode-cache/cache/cookbooks/cdo-repository/libraries/git.rb:20:in `clone'
```

[Full error log here](https://github.com/code-dot-org/code-dot-org/files/7488394/chef-bootstrap-debug.without-git-fix.log)

This does appear to be a filesystem issue, but I have reason to believe it's actually a problem with the `shell_out!` command. Mostly because we encountered the exact same problem in https://github.com/code-dot-org/code-dot-org/pull/43296. And we implement the same fix! Specifically, rather than invoke `shell_out!` directly, we invoke [the `git` helper method, which as far as I can tell **does the exact same thing.**](
https://github.com/chef/chef/blob/f15e98a4c5fae7720fc56731404331307e194551/lib/chef/provider/git.rb#L387-L391) And yet, this change is necessary to get this functionality working on Chef 17. No idea why.

## Testing story

Deployed an adhoc based on this branch plus a workaround to the `pdftk` issue and confirmed that this change doesn't negatively impact our ability to deploy on Chef 12.

Also deployed an adhoc which bundled this change together with other fixes and the upgrade to Chef 17 to confirm that this change does positively impact our ability to deploy on Chef 17

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
