### PR TITLE
remove level variant experiments from user-facing units

### DIFF
--- a/dashboard/config/scripts/csp1-2017.script
+++ b/dashboard/config/scripts/csp1-2017.script
@@ -18,8 +18,8 @@ lesson 'Personal Innovations', display_name: 'Personal Innovations', has_lesson_
 level 'U1L1 Student Lesson Introduction', progression: 'Lesson Vocabulary & Resources'
 level 'Computer Science is Changing Everything', progression: 'Computer Science is Changing Everything'
 variants
-  level 'csp_socialBelonging_intervention', experiments: ["rene-belonging-control","rene-belonging-affirmation"], progression: 'Reflection: starting out in computer science'
-  level 'csp_socialBelonging_control', active: true, experiments: ["rene-control-control","rene-control-affirmation"], progression: 'Reflection: starting out in computer science'
+  level 'csp_socialBelonging_intervention', active: false, progression: 'Reflection: starting out in computer science'
+  level 'csp_socialBelonging_control', progression: 'Reflection: starting out in computer science'
 endvariants
 
 lesson 'Sending Binary Messages', display_name: 'Sending Binary Messages', has_lesson_plan: true
@@ -128,8 +128,8 @@ level 'v2 U1L14 Student Lesson Introduction', progression: 'Lesson Vocabulary & 
 
 lesson 'Unit 1 Chapter 2 Assessment', display_name: 'Unit 1 Chapter 2 Assessment', lockable: true, has_lesson_plan: false
 variants
-  level 'csp_affirmation_intervention', experiments: ["rene-control-affirmation","rene-belonging-affirmation"], progression: 'Pre-test reflection'
-  level 'csp_affirmation_control', active: true, experiments: ["rene-control-control","rene-belonging-control"], progression: 'Pre-test reflection'
+  level 'csp_affirmation_intervention', active: false, progression: 'Pre-test reflection'
+  level 'csp_affirmation_control', progression: 'Pre-test reflection'
 endvariants
 level 'CSP Unit 1 Ch2 Cumulative Assessment MC Group', assessment: true
 

--- a/dashboard/config/scripts/csp2-2017.script
+++ b/dashboard/config/scripts/csp2-2017.script
@@ -111,8 +111,8 @@ level 'v2 U2L15 Student Lesson Introduction', progression: 'Lesson Vocabulary & 
 
 lesson 'Unit 2 Chapter 2 Assessment', display_name: 'Unit 2 Chapter 2 Assessment', lockable: true, has_lesson_plan: false
 variants
-  level 'csp_affirmation_intervention_2', experiments: ["rene-control-affirmation","rene-belonging-affirmation"], progression: 'Pre-test reflection'
-  level 'csp_affirmation_control_2', active: true, experiments: ["rene-control-control","rene-belonging-control"], progression: 'Pre-test reflection'
+  level 'csp_affirmation_intervention_2', active: false, progression: 'Pre-test reflection'
+  level 'csp_affirmation_control_2', progression: 'Pre-test reflection'
 endvariants
 level 'CSP Unit 2 Ch2 Cumulative Assessment MC', assessment: true
 

--- a/dashboard/config/scripts/csp3-2017.script
+++ b/dashboard/config/scripts/csp3-2017.script
@@ -128,8 +128,8 @@ level 'U3L08 - digitalScene', progression: 'Challenge: Design Your Digital Scene
 lesson_group 'cspAssessment', display_name: 'Chapter Assessment'
 lesson 'Unit 3 Chapter 1 Assessment', display_name: 'Unit 3 Chapter 1 Assessment', lockable: true, has_lesson_plan: false
 variants
-  level 'csp_affirmation_intervention_3', experiments: ["rene-control-affirmation","rene-belonging-affirmation"], progression: 'Pre-test reflection'
-  level 'csp_affirmation_control_3', active: true, experiments: ["rene-control-control","rene-belonging-control"], progression: 'Pre-test reflection'
+  level 'csp_affirmation_intervention_3', active: false, progression: 'Pre-test reflection'
+  level 'csp_affirmation_control_3', progression: 'Pre-test reflection'
 endvariants
 level 'CSP Unit 3 Ch1 Cumulative Assessment MC Group', assessment: true
 

--- a/dashboard/config/scripts/csp3-research-mxghyt.script
+++ b/dashboard/config/scripts/csp3-research-mxghyt.script
@@ -127,8 +127,8 @@ level 'U3L08 - digitalScene', progression: 'Challenge: Design Your Digital Scene
 lesson_group 'cspAssessment', display_name: 'Chapter Assessment'
 lesson 'Unit 3 Chapter 1 Assessment', display_name: 'Unit 3 Chapter 1 Assessment', lockable: true, has_lesson_plan: false
 variants
-  level 'csp_affirmation_intervention_3', experiments: ["rene-control-affirmation","rene-belonging-affirmation"], progression: 'Pre-test reflection'
-  level 'csp_affirmation_control_3', active: true, experiments: ["rene-control-control","rene-belonging-control"], progression: 'Pre-test reflection'
+  level 'csp_affirmation_intervention_3', active: false, progression: 'Pre-test reflection'
+  level 'csp_affirmation_control_3', progression: 'Pre-test reflection'
 endvariants
 level 'CSP Unit 3 Ch1 Cumulative Assessment MC Group', assessment: true
 

--- a/dashboard/config/scripts/csp3-staging.script
+++ b/dashboard/config/scripts/csp3-staging.script
@@ -123,8 +123,8 @@ level 'U3L08 - digitalScene', progression: 'Challenge: Design Your Digital Scene
 lesson_group 'cspAssessment', display_name: 'Chapter Assessment'
 lesson 'Unit 3 Chapter 1 Assessment', display_name: 'Unit 3 Chapter 1 Assessment', lockable: true, has_lesson_plan: false
 variants
-  level 'csp_affirmation_intervention_3', experiments: ["rene-control-affirmation","rene-belonging-affirmation"], progression: 'Pre-test reflection'
-  level 'csp_affirmation_control_3', active: true, experiments: ["rene-control-control","rene-belonging-control"], progression: 'Pre-test reflection'
+  level 'csp_affirmation_intervention_3', active: false, progression: 'Pre-test reflection'
+  level 'csp_affirmation_control_3', progression: 'Pre-test reflection'
 endvariants
 level 'CSP Unit 3 Ch1 Cumulative Assessment MC Group', assessment: true
 

--- a/dashboard/config/scripts/csp4-2017.script
+++ b/dashboard/config/scripts/csp4-2017.script
@@ -84,8 +84,8 @@ level 'Unit 4 Lesson 9 Introduction', progression: 'Lesson Vocabulary & Resource
 lesson_group 'cspAssessment', display_name: 'Chapter Assessment'
 lesson 'Unit 4 Chapter 1 Assessment', display_name: 'Unit 4 Chapter 1 Assessment', lockable: true, has_lesson_plan: false
 variants
-  level 'csp_affirmation_intervention_4', experiments: ["rene-control-affirmation","rene-belonging-affirmation"], progression: 'Pre-test reflection'
-  level 'csp_affirmation_control_4', active: true, experiments: ["rene-control-control","rene-belonging-control"], progression: 'Pre-test reflection'
+  level 'csp_affirmation_intervention_4', active: false, progression: 'Pre-test reflection'
+  level 'csp_affirmation_control_4', progression: 'Pre-test reflection'
 endvariants
 level 'CSP Unit 4 Ch1 Cumulative Assessment MC', assessment: true
 

--- a/dashboard/config/scripts/csp5-2017.script
+++ b/dashboard/config/scripts/csp5-2017.script
@@ -115,8 +115,8 @@ level 'U5 AP Create Practice onEvent Doesnt Count', progression: '(new) AP Pract
 
 lesson 'Unit 5 Assessment 1', display_name: 'Unit 5 Assessment 1', lockable: true, has_lesson_plan: false
 variants
-  level 'csp_affirmation_intervention_5', experiments: ["rene-control-affirmation","rene-belonging-affirmation"], progression: 'Pre-test reflection'
-  level 'csp_affirmation_control_5', active: true, experiments: ["rene-control-control","rene-belonging-control"], progression: 'Pre-test reflection'
+  level 'csp_affirmation_intervention_5', active: false, progression: 'Pre-test reflection'
+  level 'csp_affirmation_control_5', progression: 'Pre-test reflection'
 endvariants
 level 'CSP Unit 5 Cumulative Assessment 1 MC', assessment: true
 
@@ -212,8 +212,8 @@ level 'U5 AP Practice Create Algorithm Color Sleuth', progression: '(new) AP Pra
 
 lesson 'Unit 5 Assessment 2', display_name: 'Unit 5 Assessment 2', lockable: true, has_lesson_plan: false
 variants
-  level 'csp_affirmation_intervention_5', experiments: ["rene-control-affirmation","rene-belonging-affirmation"], progression: 'Pre-test reflection'
-  level 'csp_affirmation_control_5', active: true, experiments: ["rene-control-control","rene-belonging-control"], progression: 'Pre-test reflection'
+  level 'csp_affirmation_intervention_5', active: false, progression: 'Pre-test reflection'
+  level 'csp_affirmation_control_5', progression: 'Pre-test reflection'
 endvariants
 level 'CSP Unit 5 Cumulative Assessment 2 MC', assessment: true
 

--- a/dashboard/config/scripts/csppostap-2018.script
+++ b/dashboard/config/scripts/csppostap-2018.script
@@ -54,8 +54,8 @@ level 'CSP U2L15 SFLP', progression: 'Lesson Overview'
 
 lesson 'Chapter 1 Assessment', display_name: 'Chapter 1 Assessment', lockable: true, has_lesson_plan: false
 variants
-  level 'csp_affirmation_control_2_2018', active: true, experiments: ["rene-control-control","rene-belonging-control"], progression: 'Pre-test reflection'
-  level 'csp_affirmation_intervention_2_2018', experiments: ["rene-control-affirmation","rene-belonging-affirmation"], progression: 'Pre-test reflection'
+  level 'csp_affirmation_control_2_2018', progression: 'Pre-test reflection'
+  level 'csp_affirmation_intervention_2_2018', active: false, progression: 'Pre-test reflection'
 endvariants
 level 'CSP Unit 2 Ch2 Cumulative Assessment MC_2018', assessment: true
 


### PR DESCRIPTION
## Background

In order to migrate units which use level variants, I have to take a detour to deal with level variant _experiments_. level variants work in one of two ways:

1. simple level substitution: https://github.com/code-dot-org/code-dot-org/blob/71d4239af1d7dc0bb6402e4a680a86688861bf1e/dashboard/config/scripts/allthethings.script#L170-L173

    the user gets the "active" variant, unless they had progress in the inactive variant: https://github.com/code-dot-org/code-dot-org/blob/f26d5d6e6327d3a864d7c7062394885889f76a6e/dashboard/app/controllers/script_levels_controller.rb#L475-L476

2. experiment-based level substitution: https://github.com/code-dot-org/code-dot-org/blob/adeb392d76ea6b1736f970723e42a5fa1be22f5b/dashboard/config/scripts/csp1-2017.script#L130-L133

    the user gets the inactive variant if they are in the corresponding experiment: https://github.com/code-dot-org/code-dot-org/blob/f26d5d6e6327d3a864d7c7062394885889f76a6e/dashboard/app/controllers/script_levels_controller.rb#L467-L468

Today, in the migrated unit editor, we support adding variants only via the command line, and the lesson editor does just enough preserve level variant info when editing a lesson containing variants. We do not support level variant experiments  at all. rather than adding that support, the time has come to remove level variant experiments from our product, to reduce its complexity rather than adding to it.


## Work plan

1. (this PR) remove level variant experiments from all user-facing units
2. https://github.com/code-dot-org/code-dot-org/pull/43366. at this point, migrating old scripts is unblocked
3. remove implementation and unit tests for level variant experiments.

## Description

this PR simply level variant experiments by editing the .script files directly, taking care to preserve which level is active by default. note that the "active" marking needs to be updated because the rules are different for experiment and non-experiment variants: https://github.com/code-dot-org/code-dot-org/blob/eba24570482a2b916bdc95408afb00494347b2bf/dashboard/app/dsl/script_dsl.rb#L234-L236

## Analysis

Because users might be using these levels, I did some analysis to see how many. The short version is that there appear to be very low current usage in the level variants, less than 10 user levels last updated each month in 2021. Here are the results: https://docs.google.com/spreadsheets/d/1norPjSWqRJ4xm0AR8iKwOwq4xSuRaN5E5SWp7QIwgwM/edit#gid=1137785086

Baker confirmed that the RED team is no longer using these experiments for anything: https://codedotorg.slack.com/archives/C0SUN2W3D/p1635973620030100

Since the number of affected users is small, and we provide a reasonable new behavior (students will not see their work disappear), the downsides of doing this seem low.

## Testing story

manually verified on csp1-2017:
- [x] the correct level is visible when a user without progress goes to the script level
- [x] users with progress in the active level still sees the active level
- [x] user in the experiment with progress in the _inactive_ level still sees the inactive level
- [x] user in the experiment without progress now sees the active level

original [drone run](https://drone.cdn-code.org/code-dot-org/code-dot-org/12004/2/4) passing except for [one failure](https://cucumber-logs.s3.amazonaws.com/circle/12004/Chrome_learning_platform_level_types_contained_levels_eyes_output.html?versionId=cUjewoaiHvXXGqPoAUyNwdrNp4JWzVBR) which looks unrelated.