### PR TITLE
[Google Blockly] Support button in dropdown

### DIFF
--- a/apps/src/blockly/addons/cdoFieldImageDropdown.js
+++ b/apps/src/blockly/addons/cdoFieldImageDropdown.js
@@ -22,6 +22,8 @@ export class CdoFieldImageDropdown extends FieldGridDropdown {
     );
 
     this.buttons_ = buttons;
+    this.imageWidth_ = width;
+    this.imageHeight_ = height;
   }
 
   /**
@@ -51,8 +53,8 @@ export class CdoFieldImageDropdown extends FieldGridDropdown {
       const numBlankToAdd = numInLastRow > 0 ? this.columns_ - numInLastRow : 0;
       for (let i = 0; i < numBlankToAdd; i++) {
         const item = document.createElement('div');
-        item.style.width = this.previewSize_.width + 'px';
-        item.style.height = this.previewSize_.height + 'px';
+        item.style.width = this.imageWidth_ + 'px';
+        item.style.height = this.imageHeight_ + 'px';
         const menuItem = new Blockly.MenuItem(item, '');
         menuItem.setEnabled(false);
         this.menu_.addChild(menuItem);

--- a/apps/src/blockly/addons/cdoFieldImageDropdown.js
+++ b/apps/src/blockly/addons/cdoFieldImageDropdown.js
@@ -44,16 +44,32 @@ export class CdoFieldImageDropdown extends FieldGridDropdown {
       this.menu_.openingCoords = null;
     }
 
-    this.buttons_?.forEach(button => {
-      const buttonElement = document.createElement('BUTTON');
-      buttonElement.innerHTML = button.text;
-      buttonElement.addEventListener('click', button.action);
-      const menuItem = new Blockly.MenuItem(buttonElement, button.text);
-      menuItem.setRole(Blockly.utils.aria.Role.OPTION);
-      menuItem.setRightToLeft(this.sourceBlock_.RTL);
-      menuItem.setEnabled(false);
-      this.menu_.addChild(menuItem);
-    });
+    if (this.buttons_) {
+      // Force buttons to a new row by adding blank elements if needed.
+      const numItems = this.menu_.menuItems_.length;
+      const numInLastRow = numItems % this.columns_;
+      const numBlankToAdd = numInLastRow > 0 ? this.columns_ - numInLastRow : 0;
+      for (let i = 0; i < numBlankToAdd; i++) {
+        const item = document.createElement('div');
+        item.style.width = this.previewSize_.width + 'px';
+        item.style.height = this.previewSize_.height + 'px';
+        const menuItem = new Blockly.MenuItem(item, '');
+        menuItem.setEnabled(false);
+        this.menu_.addChild(menuItem);
+      }
+
+      // Add buttons to menu
+      this.buttons_.forEach(button => {
+        const buttonElement = document.createElement('BUTTON');
+        buttonElement.innerHTML = button.text;
+        buttonElement.addEventListener('click', button.action);
+        const menuItem = new Blockly.MenuItem(buttonElement, '');
+        menuItem.setRole(Blockly.utils.aria.Role.OPTION);
+        menuItem.setRightToLeft(this.sourceBlock_.RTL);
+        menuItem.setEnabled(false);
+        this.menu_.addChild(menuItem);
+      });
+    }
 
     // Element gets created in render.
     this.menu_.render(Blockly.DropDownDiv.getContentDiv());

--- a/apps/src/blockly/addons/cdoFieldImageDropdown.js
+++ b/apps/src/blockly/addons/cdoFieldImageDropdown.js
@@ -20,10 +20,24 @@ export class CdoFieldImageDropdown extends FieldGridDropdown {
       undefined /* validator */,
       {columns: numColumns}
     );
+
+    this.buttons_ = buttons;
   }
 
   showEditor_(e = undefined) {
     super.showEditor_(e);
+
+    this.buttons_?.forEach(button => {
+      const buttonElement = document.createElement('BUTTON');
+      buttonElement.innerHTML = button.text;
+      buttonElement.addEventListener('click', button.action);
+      const menuItem = new Blockly.MenuItem(buttonElement, button.text);
+      menuItem.setRole(Blockly.utils.aria.Role.OPTION);
+      menuItem.setRightToLeft(this.sourceBlock_.RTL);
+      menuItem.setCheckable(true);
+      this.menu_.addChild(menuItem);
+      this.menu_.render(Blockly.DropDownDiv.getContentDiv());
+    });
 
     // Override so that grid dropdown is white.
     // The Blockly team is planning to update the FieldGridDropdown plugin

--- a/apps/src/blockly/addons/cdoFieldImageDropdown.js
+++ b/apps/src/blockly/addons/cdoFieldImageDropdown.js
@@ -63,6 +63,9 @@ export class CdoFieldImageDropdown extends FieldGridDropdown {
         const buttonElement = document.createElement('BUTTON');
         buttonElement.innerHTML = button.text;
         buttonElement.addEventListener('click', button.action);
+        buttonElement.addEventListener('click', () =>
+          Blockly.DropDownDiv.hideIfOwner(this, true)
+        );
         const menuItem = new Blockly.MenuItem(buttonElement, '');
         menuItem.setRole(Blockly.utils.aria.Role.OPTION);
         menuItem.setRightToLeft(this.sourceBlock_.RTL);

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -123,6 +123,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.wrapReadOnlyProperty('Input');
   blocklyWrapper.wrapReadOnlyProperty('INPUT_VALUE');
   blocklyWrapper.wrapReadOnlyProperty('js');
+  blocklyWrapper.wrapReadOnlyProperty('MenuItem');
   blocklyWrapper.wrapReadOnlyProperty('MetricsManager');
   blocklyWrapper.wrapReadOnlyProperty('modalBlockSpace');
   blocklyWrapper.wrapReadOnlyProperty('Msg');


### PR DESCRIPTION
[jira](https://codedotorg.atlassian.net/browse/STAR-1883)

This is mostly a re-implementation of the functionality added to our fork by https://github.com/code-dot-org/blockly/pull/171 and https://github.com/code-dot-org/blockly/pull/279

Adding the buttons before the menu gets rendered required duplicating the code from https://github.com/google/blockly/blob/master/core/field_dropdown.js#L290. I checked with the Google team and there's not really a better way to do this at the moment, but we're planning on talking about this at our next sync to see if there's a change we can make to enable this functionality with less duplicated code.

Before
![image](https://user-images.githubusercontent.com/8787187/140212088-a00b8c0b-048c-4b2c-ae8f-1a5ef3e0f0d8.png)


After
![image](https://user-images.githubusercontent.com/8787187/140212496-86d5bcd1-a23c-4007-a458-0260a40de928.png)
