### PR TITLE
remove level variant experiment levels from allthethings unit

### DIFF
--- a/dashboard/config/scripts/allthethings.script
+++ b/dashboard/config/scripts/allthethings.script
@@ -199,10 +199,6 @@ variants
   level '4-5 Maze 3'
   level '4-5 Maze 6', active: false
 endvariants
-variants
-  level 'csp_socialBelonging_intervention', experiments: ["socialBelongingTest"]
-  level 'csp_socialBelonging_control'
-endvariants
 
 lesson 'Anonymous student survey', display_name: 'Anonymous student survey', has_lesson_plan: false
 level 'Test anonymous student survey', assessment: true


### PR DESCRIPTION
See #43361 for background.

## Testing story

Nothing to test here, because this removes levels from a test-only unit, and It looks like there were no UI tests depending on this level.