### PR TITLE
Add properties column to sections table

### DIFF
--- a/dashboard/app/models/sections/clever_section.rb
+++ b/dashboard/app/models/sections/clever_section.rb
@@ -22,6 +22,7 @@
 #  tts_autoplay_enabled :boolean          default(FALSE), not null
 #  restrict_section     :boolean          default(FALSE)
 #  code_review_enabled  :boolean          default(TRUE)
+#  properties           :text(65535)
 #
 # Indexes
 #

--- a/dashboard/app/models/sections/email_section.rb
+++ b/dashboard/app/models/sections/email_section.rb
@@ -22,6 +22,7 @@
 #  tts_autoplay_enabled :boolean          default(FALSE), not null
 #  restrict_section     :boolean          default(FALSE)
 #  code_review_enabled  :boolean          default(TRUE)
+#  properties           :text(65535)
 #
 # Indexes
 #

--- a/dashboard/app/models/sections/google_classroom_section.rb
+++ b/dashboard/app/models/sections/google_classroom_section.rb
@@ -22,6 +22,7 @@
 #  tts_autoplay_enabled :boolean          default(FALSE), not null
 #  restrict_section     :boolean          default(FALSE)
 #  code_review_enabled  :boolean          default(TRUE)
+#  properties           :text(65535)
 #
 # Indexes
 #

--- a/dashboard/app/models/sections/omni_auth_section.rb
+++ b/dashboard/app/models/sections/omni_auth_section.rb
@@ -22,6 +22,7 @@
 #  tts_autoplay_enabled :boolean          default(FALSE), not null
 #  restrict_section     :boolean          default(FALSE)
 #  code_review_enabled  :boolean          default(TRUE)
+#  properties           :text(65535)
 #
 # Indexes
 #

--- a/dashboard/app/models/sections/picture_section.rb
+++ b/dashboard/app/models/sections/picture_section.rb
@@ -22,6 +22,7 @@
 #  tts_autoplay_enabled :boolean          default(FALSE), not null
 #  restrict_section     :boolean          default(FALSE)
 #  code_review_enabled  :boolean          default(TRUE)
+#  properties           :text(65535)
 #
 # Indexes
 #

--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -22,6 +22,7 @@
 #  tts_autoplay_enabled :boolean          default(FALSE), not null
 #  restrict_section     :boolean          default(FALSE)
 #  code_review_enabled  :boolean          default(TRUE)
+#  properties           :text(65535)
 #
 # Indexes
 #

--- a/dashboard/app/models/sections/word_section.rb
+++ b/dashboard/app/models/sections/word_section.rb
@@ -22,6 +22,7 @@
 #  tts_autoplay_enabled :boolean          default(FALSE), not null
 #  restrict_section     :boolean          default(FALSE)
 #  code_review_enabled  :boolean          default(TRUE)
+#  properties           :text(65535)
 #
 # Indexes
 #

--- a/dashboard/db/migrate/20211103230247_add_properties_to_section.rb
+++ b/dashboard/db/migrate/20211103230247_add_properties_to_section.rb
@@ -1,0 +1,5 @@
+class AddPropertiesToSection < ActiveRecord::Migration[5.2]
+  def change
+    add_column :sections, :properties, :text
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_26_211629) do
+ActiveRecord::Schema.define(version: 2021_11_03_230247) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -1650,6 +1650,7 @@ ActiveRecord::Schema.define(version: 2021_10_26_211629) do
     t.boolean "tts_autoplay_enabled", default: false, null: false
     t.boolean "restrict_section", default: false
     t.boolean "code_review_enabled", default: true
+    t.text "properties"
     t.index ["code"], name: "index_sections_on_code", unique: true
     t.index ["course_id"], name: "fk_rails_20b1e5de46"
     t.index ["user_id"], name: "index_sections_on_user_id"


### PR DESCRIPTION
Adds a `properties` column to the `sections` table, initially to store a timestamp describing when code review for a section will expire. This pattern is similar to what how we use `properties` in the `User` model, where timestamps that are for very tactical use (and don't have a ton of analytic value) are stored.

## Testing story

Successfully ran locally.