### PR TITLE
allow duplicate levels in different lessons within the same unit

### DIFF
--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -122,7 +122,7 @@ class LessonsController < ApplicationController
         raise msg unless @lesson.script_levels.last.assessment && @lesson.script_levels.last.level.type == 'LevelGroup'
       end
 
-      @lesson.script.prevent_duplicate_levels
+      @lesson.prevent_duplicate_levels
       @lesson.script.fix_lesson_positions
     end
 

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -937,6 +937,14 @@ class Lesson < ApplicationRecord
     "https://support.code.org/hc/en-us/requests/new?&description=#{CGI.escape(message)}"
   end
 
+  def prevent_duplicate_levels
+    unless levels.count == levels.uniq.count
+      levels_by_key = levels.map(&:key).group_by {|key| key}
+      duplicate_keys = levels_by_key.select {|_key, values| values.count > 1}.keys
+      raise "duplicate levels detected: #{duplicate_keys.to_json}"
+    end
+  end
+
   private
 
   # Finds the LessonActivity by id, or creates a new one if id is not specified.

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -157,16 +157,6 @@ class Script < ApplicationRecord
   validates :instructor_audience, acceptance: {accept: SharedCourseConstants::INSTRUCTOR_AUDIENCE.to_h.values.push(nil), message: 'must be nil, code instructor, plc reviewer, facilitator, or teacher'}
   validates :participant_audience, acceptance: {accept: SharedCourseConstants::PARTICIPANT_AUDIENCE.to_h.values.push(nil), message: 'must be nil, facilitator, teacher, or student'}
 
-  def prevent_duplicate_levels
-    reload
-
-    unless levels.count == levels.uniq.count
-      levels_by_key = levels.map(&:key).group_by {|key| key}
-      duplicate_keys = levels_by_key.select {|_key, values| values.count > 1}.keys
-      raise "duplicate levels detected: #{duplicate_keys.to_json}"
-    end
-  end
-
   include SerializedProperties
 
   after_save :generate_plc_objects

--- a/dashboard/test/controllers/lessons_controller_test.rb
+++ b/dashboard/test/controllers/lessons_controller_test.rb
@@ -1041,22 +1041,18 @@ class LessonsControllerTest < ActionController::TestCase
     assert_equal ['level-to-add'], script_level.levels.map(&:name)
   end
 
-  test 'cannot add duplicate level via lesson update' do
+  test 'cannot add duplicate level within lesson' do
     sign_in @levelbuilder
     activity = create :lesson_activity, lesson: @lesson
-    create :activity_section, lesson_activity: activity
-
-    activity2 = create :lesson_activity, lesson: @lesson2
-    section2 = create :activity_section, lesson_activity: activity2
+    section = create :activity_section, lesson_activity: activity
     existing_level = create :maze, name: 'existing-level'
-    create :script_level, activity_section: section2, activity_section_position: 1, lesson: @lesson2, script: @script, levels: [existing_level]
+    create :script_level, activity_section: section, activity_section_position: 1, lesson: @lesson, script: @script, levels: [existing_level]
 
     @lesson.reload
     activities_data = @lesson.summarize_for_lesson_edit[:activities]
     activities_data.first[:activitySections].first[:scriptLevels].push(
-      activitySectionPosition: 1,
+      activitySectionPosition: 2,
       activeId: existing_level.id,
-      assessment: true,
       levels: [{id: existing_level.id, name: existing_level.name}]
     )
 


### PR DESCRIPTION
## Background

Fixes fallout from https://codedotorg.atlassian.net/browse/PLAT-830. The problem is that the new unit editor tries to prevent adding of duplicate levels within the same unit. However, some newly-migrated units have duplicate levels, and in fact depend on the levels being repeated within the same unit. for example https://studio.code.org/s/k5-onlinepd-2021 deliberately repeats levels so that participants in this unit can see a summary of their previous work:
![Screen Shot 2021-11-04 at 8 01 13 AM](https://user-images.githubusercontent.com/8001765/140338284-d9a3f5c0-6a40-4fb4-b2d0-44adee9b7550.png)

This raises the question of why we are trying to prevent duplicate levels in the first place:
1. the lesson editor might break if there are duplicate levels within the _lesson_
2. general long-term goal of having each level occupy only one location in our curriculum

because our existing units rely on duplicate levels, it seems best to keep goal (1) and let go of goal (2) for now.

A roundup of duplicate levels in units can be seen here: [duplicate levels in units](https://docs.google.com/spreadsheets/d/1R8U_3v3qELfQX2oGTm0D9UnwfZ4rgJLfMourX4Ti5Ok/edit)

## Description

The solution is to allow duplicate levels within the unit, but prevent duplicate levels within the ~script~ lesson.

## Screenshots

This screenshot shows the old and new result of editing a lesson in k5-onlinepd-2021 which contains levels that are duplicate within the unit but not within the lesson.

![Screen Shot 2021-11-04 at 7 54 14 AM](https://user-images.githubusercontent.com/8001765/140338977-89dd61e3-a66d-44d8-9644-605238814037.png)

## Testing story

updated unit tests to reject duplicate levels within the lesson but allow duplicates within the unit.