### PR TITLE
Create new helper method to distinguish between old and new PL courses

### DIFF
--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -192,7 +192,7 @@ module UsersHelper
   private def merge_script_progress(user_data, user, script, exclude_level_progress = false)
     return user_data unless user
 
-    if script.professional_learning_course?
+    if script.old_professional_learning_course?
       user_data[:professionalLearningCourse] = true
       unit_assignment = Plc::EnrollmentUnitAssignment.find_by(user: user, plc_course_unit: script.plc_course_unit)
       if unit_assignment

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -162,7 +162,7 @@ class Ability
         end
         can :read, Plc::UserCourseEnrollment, user_id: user.id
         can :view_level_solutions, Script do |script|
-          !script.professional_learning_course?
+          !script.old_professional_learning_course?
         end
         can [:read, :find], :regional_partner_workshops
         can [:new, :create, :read], FACILITATOR_APPLICATION_CLASS, user_id: user.id

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -189,8 +189,20 @@ class Script < ApplicationRecord
     UNIT_JSON_DIRECTORY
   end
 
+  # We have two different ways to create professional learning courses
+  # You can create them in the normal curriculum model or you can create
+  # them using the PLC course models(which build on top of the normal curriculum model).
+  # We are moving toward everything being on the normal curriculum model. Until
+  # then the only courses that should be on the PLC course models are ones previous created
+  # and new courses that need the peer review system which is part of the PLC course models.
+  #
+  # This returns true if a course uses the PLC course models.
+  def old_professional_learning_course?
+    !professional_learning_course.nil?
+  end
+
   def generate_plc_objects
-    if professional_learning_course?
+    if old_professional_learning_course?
       unit_group = UnitGroup.find_by_name(professional_learning_course)
       unless unit_group
         unit_group = UnitGroup.new(name: professional_learning_course)
@@ -1572,7 +1584,7 @@ class Script < ApplicationRecord
       instructorAudience: get_instructor_audience,
       participantAudience: get_participant_audience,
       loginRequired: login_required,
-      plc: professional_learning_course?,
+      plc: old_professional_learning_course?,
       hideable_lessons: hideable_lessons?,
       disablePostMilestone: disable_post_milestone?,
       isHocScript: hoc?,
@@ -1629,7 +1641,7 @@ class Script < ApplicationRecord
     # Filter out lessons that have a visible_after date in the future
     filtered_lessons = lessons.select {|lesson| lesson.published?(user)}
     summary[:lessons] = filtered_lessons.map {|lesson| lesson.summarize(include_bonus_levels)} if include_lessons
-    summary[:professionalLearningCourse] = professional_learning_course if professional_learning_course?
+    summary[:professionalLearningCourse] = professional_learning_course if old_professional_learning_course?
     summary[:wrapupVideo] = wrapup_video.key if wrapup_video
     summary[:calendarLessons] = filtered_lessons.map(&:summarize_for_calendar)
 

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -208,7 +208,7 @@ class ScriptLevel < ApplicationRecord
   end
 
   def has_another_level_to_go_to?
-    if script.professional_learning_course?
+    if script.old_professional_learning_course?
       !end_of_lesson?
     else
       next_progression_level
@@ -239,7 +239,7 @@ class ScriptLevel < ApplicationRecord
       level_to_follow = level_to_follow.next_level while level_to_follow.try(:locked_or_hidden?, user)
     end
 
-    if script.professional_learning_course?
+    if script.old_professional_learning_course?
       if level.try(:plc_evaluation?)
         if Plc::EnrollmentUnitAssignment.exists?(user: user, plc_course_unit: script.plc_course_unit)
           script_preview_assignments_path(script)

--- a/dashboard/app/views/layouts/_header.html.haml
+++ b/dashboard/app/views/layouts/_header.html.haml
@@ -118,7 +118,7 @@
       text = @lesson.localized_title
     else
       lesson = @lesson || @script_level.lesson
-      text = @script.professional_learning_course? ? lesson.localized_name : lesson.localized_title
+      text = @script.old_professional_learning_course? ? lesson.localized_name : lesson.localized_title
     end
 
     # Pass along section_id param so that when teacher moves between lesson

--- a/dashboard/app/views/levels/_external.html.haml
+++ b/dashboard/app/views/levels/_external.html.haml
@@ -16,7 +16,7 @@
 .external
   - postcontent = capture_haml do
     - unless in_level_group || @level.has_submit_button?
-      - if @script.try(:professional_learning_course?) && @script_level
+      - if @script.try(:old_professional_learning_course?) && @script_level
         = link_to @script_level.end_of_lesson? ? t('done_with_module') : t('next_resource'), @script_level.next_level_or_redirect_path_for_user(current_user), class: 'btn btn-large pull-right btn-primary submitButton'
       - elsif !(video && use_large_video_player)
         %a.btn.btn-large.btn-primary.next-lesson.submitButton.pull-right= t('continue')

--- a/dashboard/app/views/levels/show.html.haml
+++ b/dashboard/app/views/levels/show.html.haml
@@ -71,5 +71,5 @@
 
 = render partial: 'levels/admin'
 
-- if @script && current_user.try(:teacher?) && !@script.professional_learning_course? && !@level.is_a?(NetSim)
+- if @script && current_user.try(:teacher?) && !@script.old_professional_learning_course? && !@level.is_a?(NetSim)
   = render partial: 'levels/teacher_panel'

--- a/dashboard/app/views/peer_reviews/show.html.haml
+++ b/dashboard/app/views/peer_reviews/show.html.haml
@@ -3,7 +3,7 @@
 .peer-review
   - reviewed = @peer_review.review_completed?
 
-  - if @peer_review.script.professional_learning_course?
+  - if @peer_review.script.old_professional_learning_course?
     #breadcrumb
     - course_unit = @peer_review.script.plc_course_unit
     - react_props = {unit_name: course_unit.unit_name, unit_view_path: script_path(course_unit.script), course_view_path: course_path(course_unit.plc_course.unit_group), page_name: I18n.t('peer_review.peer_review')}

--- a/dashboard/app/views/scripts/lesson_extras.html.haml
+++ b/dashboard/app/views/scripts/lesson_extras.html.haml
@@ -6,5 +6,5 @@
   - project_widget_types = script_info[:project_widget_types]
 %script{src: webpack_asset_path('js/scripts/lesson_extras.js'), data: {extras: @lesson_extras.to_json, widget: {visible: project_widget_visible.to_json, types: project_widget_types.to_json}, viewer: {section_id: @section&.id, show_lesson_extras_warning: @show_lesson_extras_warning, user_id: @user&.id}.to_json}}
 
-- if @script && current_user.try(:teacher?) && !@script.professional_learning_course?
+- if @script && current_user.try(:teacher?) && !@script.old_professional_learning_course?
   = render partial: 'levels/teacher_panel'

--- a/dashboard/app/views/scripts/show.html.haml
+++ b/dashboard/app/views/scripts/show.html.haml
@@ -18,7 +18,7 @@
                             course_title: @script.course_title || I18n.t('view_all_units'),
                             sections: @sections_with_assigned_info}
 - scriptOverviewData = {scriptData: script_data.merge(additional_script_data)}
-- if @script.professional_learning_course? && @current_user && Plc::UserCourseEnrollment.exists?(user: @current_user, plc_course: @script.plc_course_unit.plc_course)
+- if @script.old_professional_learning_course? && @current_user && Plc::UserCourseEnrollment.exists?(user: @current_user, plc_course: @script.plc_course_unit.plc_course)
   -  scriptOverviewData[:plcBreadcrumb] = {unit_name: @script.plc_course_unit.unit_name, course_view_path: course_path(@script.plc_course_unit.plc_course.unit_group)}
 - lesson_plans = @script.is_migrated && @script.use_legacy_lesson_plans && @script.lessons.select(&:has_lesson_plan).map {|lesson| {name: lesson.name, url: lesson.get_uncached_show_path}}
 - content_for(:head) do

--- a/dashboard/lib/policies/inline_answer.rb
+++ b/dashboard/lib/policies/inline_answer.rb
@@ -14,7 +14,7 @@ class Policies::InlineAnswer
     script = script_level.try(:script)
     return true if user.authorized_teacher? &&
       script &&
-      !script.professional_learning_course?
+      !script.old_professional_learning_course?
 
     # For CSF scripts teachers should be able to see teacher only markdown and answers
     # even if they are not authorized

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -905,9 +905,9 @@ class ScriptTest < ActiveSupport::TestCase
     assert_nil Script.find_by_name('csf1').banner_image
   end
 
-  test 'professional_learning_course?' do
-    refute Script.find_by_name('flappy').professional_learning_course?
-    assert Script.find_by_name('ECSPD').professional_learning_course?
+  test 'old_professional_learning_course?' do
+    refute Script.find_by_name('flappy').old_professional_learning_course?
+    assert Script.find_by_name('ECSPD').old_professional_learning_course?
   end
 
   test 'should summarize migrated unit' do
@@ -1440,7 +1440,7 @@ class ScriptTest < ActiveSupport::TestCase
     I18n.backend.store_translations I18n.locale, custom_i18n['en']
 
     unit.save! # Need to trigger an update because i18n strings weren't loaded
-    assert unit.professional_learning_course?
+    assert unit.old_professional_learning_course?
     assert_equal 'Test plc course', unit.professional_learning_course
     assert_equal 42, unit.peer_reviews_to_complete
 
@@ -1477,7 +1477,7 @@ class ScriptTest < ActiveSupport::TestCase
     unit_names, _custom_i18n = Script.setup([unit_file])
     unit = Script.find_by!(name: unit_names.first)
 
-    assert unit.professional_learning_course?
+    assert unit.old_professional_learning_course?
     assert_equal 'Test plc course', unit.professional_learning_course
     assert_equal 42, unit.peer_reviews_to_complete
 


### PR DESCRIPTION
We have two "types" of professional learning courses:

1. Courses created using the PLC Course Models (We are trying to move away from PLC Course Model courses going forward. Only courses that need the peer review system of the PLC Course Model will be built in this way at this point.)
2. Courses created using the normal Curriculum Models

We want to make the difference between these two types of professional learning courses clear and be able to check for each in the right places. I'm proposing we move to:

Courses created using the PLC Course Models -> `old_profressional_learning_course?`
Courses created using the normal Curriculum Models -> `professional_learning_course?`

This PR updates the existing checks for PLC Course Model courses to follow this pattern.

## Links

 - [Eng Plan](https://docs.google.com/document/d/1V61xONU0-mleMEEdHWNxhvZtYIPRCB31mT_hbUXusCQ/edit#heading=h.ltm8vp8ke2s)
 - [Product Spec](https://docs.google.com/document/d/1qZpc90daxQiiqpcQUiUiGV2tQoaYEQUzOA72UZzBlVE/edit#heading=h.qv29hwce61yz)
 - [Jira](https://codedotorg.atlassian.net/browse/PLAT-1343)

## Testing story

- Existing Tests
