### PR TITLE
Enable HTTP/S access logs for load balancer

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -144,6 +144,12 @@ Resources:
       LoadBalancerAttributes:
         - Key: deletion_protection.enabled
           Value: true
+        - Key: access_logs.s3.enabled
+          Value: true
+        - Key: access_logs.s3.bucket
+          Value: cdo-logs
+        - Key: access_logs.s3.prefix
+          Value: elb-autoscale-prod
 
   HTTPListener:
     Type: AWS::ElasticLoadBalancingV2::Listener


### PR DESCRIPTION
INF-506

Enable HTTP logging to the existing cdo-logs bucket for the purpose of determining if anyone is actually using direct access to the load balancer (vs the normal route of connecting via cloudfront)

## Links

* Docs: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html#enable-access-logging
* JIRA: https://codedotorg.atlassian.net/browse/INF-506

## Testing story

The only way to test would be to enable this for a less significant load balancer first.

## Deployment strategy

Are these cfn changes picked up as part of the deploy? Or are they deployed separately? I'm not 100% certain on that yet.

## Follow-up work

Continue IMT-506 to restrict access, if this research support it.

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

N/A

## Caching
N/A
## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
