### PR TITLE
Load verified teacher async

### DIFF
--- a/apps/src/code-studio/components/TeachersOnly.jsx
+++ b/apps/src/code-studio/components/TeachersOnly.jsx
@@ -1,0 +1,9 @@
+import {connect} from 'react-redux';
+
+const TeachersOnly = ({isTeacher, children}) => {
+  return isTeacher ? children : null;
+};
+
+export default connect(state => ({
+  isTeacher: state.currentUser.userType === 'teacher'
+}))(TeachersOnly);

--- a/apps/src/code-studio/components/progress/teacherPanel/TeacherPanel.jsx
+++ b/apps/src/code-studio/components/progress/teacherPanel/TeacherPanel.jsx
@@ -47,11 +47,13 @@ class TeacherPanel extends React.Component {
     loadLevelsWithProgress: PropTypes.func.isRequired,
     teacherId: PropTypes.number,
     exampleSolutions: PropTypes.array,
-    selectUser: PropTypes.func.isRequired
+    selectUser: PropTypes.func.isRequired,
+    isTeacher: PropTypes.bool.isRequired
   };
 
   UNSAFE_componentWillReceiveProps(nextProps) {
     if (
+      this.props.isTeacher &&
       this.props.pageType !== pageTypes.scriptOverview && // no progress is shown on script overview page in teacher panel
       nextProps.selectedSection?.id !== this.props.selectedSection?.id
     ) {
@@ -99,8 +101,13 @@ class TeacherPanel extends React.Component {
       levelsWithProgress,
       pageType,
       teacherId,
-      exampleSolutions
+      exampleSolutions,
+      isTeacher
     } = this.props;
+
+    if (!isTeacher) {
+      return null;
+    }
 
     const selectedUserId = this.getSelectedUserId();
 
@@ -292,7 +299,8 @@ export default connect(
       isLoadingLevelsWithProgress:
         state.teacherPanel.isLoadingLevelsWithProgress,
       teacherId: state.currentUser.userId,
-      exampleSolutions: state.pageConstants?.exampleSolutions
+      exampleSolutions: state.pageConstants?.exampleSolutions,
+      isTeacher: state.currentUser.userType === 'teacher'
     };
   },
   dispatch => ({

--- a/apps/src/code-studio/components/progress/teacherPanel/TeacherPanel.jsx
+++ b/apps/src/code-studio/components/progress/teacherPanel/TeacherPanel.jsx
@@ -30,7 +30,10 @@ import {
 import {reload} from '@cdo/apps/utils';
 import {updateQueryParam, queryParams} from '@cdo/apps/code-studio/utils';
 import {studentShape, levelWithProgress} from './types';
-import {getStudentsForSection, queryLockStatus} from './teacherPanelData';
+import {
+  getStudentsForSection,
+  queryLockStatus
+} from '@cdo/apps/code-studio/components/progress/teacherPanel/teacherPanelData';
 
 class TeacherPanel extends React.Component {
   static propTypes = {

--- a/apps/src/code-studio/components/progress/teacherPanel/TeacherPanel.jsx
+++ b/apps/src/code-studio/components/progress/teacherPanel/TeacherPanel.jsx
@@ -5,10 +5,18 @@ import TeacherPanelContainer from '@cdo/apps/code-studio/components/progress/tea
 import SectionSelector from '../SectionSelector';
 import ViewAsToggle from '@cdo/apps/code-studio/components/progress/ViewAsToggle';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
-import {fullyLockedLessonMapping} from '@cdo/apps/code-studio/lessonLockRedux';
+import {
+  fullyLockedLessonMapping,
+  setSectionLockStatus
+} from '@cdo/apps/code-studio/lessonLockRedux';
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import {loadLevelsWithProgress} from '@cdo/apps/code-studio/teacherPanelRedux';
-import {pageTypes} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
+import {
+  pageTypes,
+  setStudentsForCurrentSection,
+  setSections,
+  selectSection
+} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import StudentTable from '@cdo/apps/code-studio/components/progress/teacherPanel/StudentTable';
 import {teacherDashboardUrl} from '@cdo/apps/templates/teacherDashboard/urlHelpers';
 import SelectedStudentInfo from '@cdo/apps/code-studio/components/progress/teacherPanel/SelectedStudentInfo';
@@ -22,9 +30,11 @@ import {
 import {reload} from '@cdo/apps/utils';
 import {updateQueryParam, queryParams} from '@cdo/apps/code-studio/utils';
 import {studentShape, levelWithProgress} from './types';
+import {getStudentsForSection, queryLockStatus} from './teacherPanelData';
 
 class TeacherPanel extends React.Component {
   static propTypes = {
+    scriptId: PropTypes.number,
     unitName: PropTypes.string,
     pageType: PropTypes.oneOf([
       pageTypes.level,
@@ -48,18 +58,46 @@ class TeacherPanel extends React.Component {
     teacherId: PropTypes.number,
     exampleSolutions: PropTypes.array,
     selectUser: PropTypes.func.isRequired,
-    isTeacher: PropTypes.bool.isRequired
+    setStudentsForCurrentSection: PropTypes.func.isRequired,
+    setSections: PropTypes.func.isRequired,
+    setSectionLockStatus: PropTypes.func.isRequired,
+    selectSection: PropTypes.func.isRequired
   };
+
+  componentDidMount() {
+    this.loadInitialData();
+  }
 
   UNSAFE_componentWillReceiveProps(nextProps) {
     if (
-      this.props.isTeacher &&
       this.props.pageType !== pageTypes.scriptOverview && // no progress is shown on script overview page in teacher panel
       nextProps.selectedSection?.id !== this.props.selectedSection?.id
     ) {
       this.props.loadLevelsWithProgress();
     }
   }
+
+  loadInitialData = () => {
+    getStudentsForSection().then(section => {
+      section &&
+        this.props.setStudentsForCurrentSection(section.id, section.students);
+    });
+
+    queryLockStatus(this.props.scriptId).then(result => {
+      const {teacherSections, sectionLockStatus} = result;
+      // Don't dispatch setSections on script overview pages because setSections
+      // has already been dispatched on those pages with data specific to which
+      // sections are assigned to the script for the TeacherSectionSeletor.
+      if (this.props.pageType !== 'script_overview') {
+        this.props.setSections(teacherSections);
+
+        const sectionId = queryParams('section_id');
+        sectionId && this.props.selectSection(sectionId);
+      }
+
+      this.props.setSectionLockStatus(sectionLockStatus);
+    });
+  };
 
   logToFirehose = (eventName, overrideData = {}) => {
     const sectionId =
@@ -101,13 +139,8 @@ class TeacherPanel extends React.Component {
       levelsWithProgress,
       pageType,
       teacherId,
-      exampleSolutions,
-      isTeacher
+      exampleSolutions
     } = this.props;
-
-    if (!isTeacher) {
-      return null;
-    }
 
     const selectedUserId = this.getSelectedUserId();
 
@@ -299,8 +332,7 @@ export default connect(
       isLoadingLevelsWithProgress:
         state.teacherPanel.isLoadingLevelsWithProgress,
       teacherId: state.currentUser.userId,
-      exampleSolutions: state.pageConstants?.exampleSolutions,
-      isTeacher: state.currentUser.userType === 'teacher'
+      exampleSolutions: state.pageConstants?.exampleSolutions
     };
   },
   dispatch => ({
@@ -308,6 +340,16 @@ export default connect(
     selectUser: (userId, isAsync = false) => {
       updateQueryParam('user_id', userId);
       isAsync ? dispatch(queryUserProgress(userId)) : reload();
-    }
+    },
+    setStudentsForCurrentSection: (sectionId, students) => {
+      dispatch(setStudentsForCurrentSection(sectionId, students));
+    },
+    setSections: teacherSections => {
+      dispatch(setSections(teacherSections));
+    },
+    setSectionLockStatus: data => {
+      dispatch(setSectionLockStatus(data));
+    },
+    selectSection: sectionId => dispatch(selectSection(sectionId))
   })
 )(TeacherPanel);

--- a/apps/src/code-studio/components/progress/teacherPanel/teacherPanelData.js
+++ b/apps/src/code-studio/components/progress/teacherPanel/teacherPanelData.js
@@ -1,0 +1,42 @@
+import {queryParams} from '@cdo/apps/code-studio/utils';
+
+export const getStudentsForSection = async () => {
+  const sectionId = queryParams('section_id');
+
+  let request = '/api/teacher_panel_section';
+  if (sectionId) {
+    request += `?section_id=${sectionId}`;
+  }
+
+  try {
+    const response = await fetch(request);
+    // This API returns with "No Content" when there is no section to be loaded
+    // for the teacher panel, checking "OK" ensures a section was returned
+    if (response.statusText === 'OK') {
+      return response.json();
+    }
+  } catch (err) {
+    console.log(err);
+  }
+};
+
+// Query the server for lock status of this teacher's students
+export const queryLockStatus = async scriptId => {
+  try {
+    const response = await fetch(`/api/lock_status?script_id=${scriptId}`);
+    const data = await response.json();
+
+    // Extract the state that teacherSectionsRedux cares about
+    const teacherSections = Object.values(data).map(section => ({
+      id: section.section_id,
+      name: section.section_name
+    }));
+
+    return {
+      teacherSections,
+      sectionLockStatus: data
+    };
+  } catch (err) {
+    console.log(err);
+  }
+};

--- a/apps/src/code-studio/header.js
+++ b/apps/src/code-studio/header.js
@@ -19,7 +19,11 @@ import ReactDOM from 'react-dom';
 import {Provider} from 'react-redux';
 import progress from './progress';
 import {getStore} from '../redux';
-import {asyncLoadUserData} from '@cdo/apps/templates/currentUserRedux';
+import {
+  setUserSignedIn,
+  setInitialData
+} from '@cdo/apps/templates/currentUserRedux';
+import {setVerified} from '@cdo/apps/code-studio/verifiedTeacherRedux';
 
 import {PUZZLE_PAGE_NONE} from '@cdo/apps/templates/progress/progressTypes';
 import HeaderMiddle from '@cdo/apps/code-studio/components/header/HeaderMiddle';
@@ -168,7 +172,18 @@ function setupReduxSubscribers(store) {
 setupReduxSubscribers(getStore());
 
 function setUpGlobalData(store) {
-  store.dispatch(asyncLoadUserData());
+  fetch('/api/v1/users/current')
+    .then(response => response.json())
+    .then(data => {
+      store.dispatch(setUserSignedIn(data.is_signed_in));
+      if (data.is_signed_in) {
+        store.dispatch(setInitialData(data));
+        data.is_verified_teacher && store.dispatch(setVerified());
+      }
+    })
+    .catch(err => {
+      console.log(err);
+    });
 }
 setUpGlobalData(getStore());
 

--- a/apps/src/code-studio/teacherPanelHelpers.js
+++ b/apps/src/code-studio/teacherPanelHelpers.js
@@ -1,16 +1,8 @@
-import queryString from 'query-string';
-import {setSectionLockStatus} from './lessonLockRedux';
-import {
-  setSections,
-  selectSection
-} from '../templates/teacherDashboard/teacherSectionsRedux';
 import {Provider} from 'react-redux';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {setStudentsForCurrentSection} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import TeacherPanel from './components/progress/teacherPanel/TeacherPanel';
-import $ from 'jquery';
-import {queryParams} from '@cdo/apps/code-studio/utils';
+import TeachersOnly from '@cdo/apps/code-studio/components/TeachersOnly';
 
 /**
  * Render our teacher panel that shows up on our course overview page.
@@ -24,67 +16,17 @@ export function renderTeacherPanel(
   const div = document.createElement('div');
   div.setAttribute('id', 'teacher-panel-container');
 
-  queryStudentsForSection(store);
-  queryLockStatus(store, scriptId, pageType);
-
   ReactDOM.render(
     <Provider store={store}>
-      <TeacherPanel unitName={scriptName} pageType={pageType} />
+      <TeachersOnly>
+        <TeacherPanel
+          unitName={scriptName}
+          pageType={pageType}
+          scriptId={scriptId}
+        />
+      </TeachersOnly>
     </Provider>,
     div
   );
   document.body.appendChild(div);
-}
-
-/**
- * Query the server for lock status of this teacher's students
- * @returns {Promise} when finished
- */
-function queryLockStatus(store, scriptId, pageType) {
-  return new Promise((resolve, reject) => {
-    $.ajax('/api/lock_status', {
-      data: {script_id: scriptId}
-    }).done(data => {
-      // Extract the state that teacherSectionsRedux cares about
-      const teacherSections = Object.values(data).map(section => ({
-        id: section.section_id,
-        name: section.section_name
-      }));
-
-      // Don't dispatch setSections on script overview pages because setSections
-      // has already been dispatched on those pages with data specific to which
-      // sections are assigned to the script for the TeacherSectionSeletor.
-      if (pageType !== 'script_overview') {
-        store.dispatch(setSections(teacherSections));
-        const query = queryString.parse(location.search);
-        if (query.section_id) {
-          store.dispatch(selectSection(query.section_id));
-        }
-      }
-
-      store.dispatch(setSectionLockStatus(data));
-      resolve();
-    });
-  });
-}
-
-function queryStudentsForSection(store) {
-  const sectionId = queryParams('section_id');
-
-  let request = '/api/teacher_panel_section';
-  if (sectionId) {
-    request += `?section_id=${sectionId}`;
-  }
-
-  $.ajax(request)
-    .success((section, status) => {
-      if (status !== 'nocontent') {
-        store.dispatch(
-          setStudentsForCurrentSection(section.id, section.students)
-        );
-      }
-    })
-    .fail(err => {
-      console.log(err);
-    });
 }

--- a/apps/src/sites/studio/pages/levels/_teacher_panel.js
+++ b/apps/src/sites/studio/pages/levels/_teacher_panel.js
@@ -10,6 +10,7 @@ import ReactDOM from 'react-dom';
 import TeacherContentToggle from '@cdo/apps/code-studio/components/TeacherContentToggle';
 import {getHiddenLessons} from '@cdo/apps/code-studio/hiddenLessonRedux';
 import {renderTeacherPanel} from '@cdo/apps/code-studio/teacherPanelHelpers';
+import TeachersOnly from '@cdo/apps/code-studio/components/TeachersOnly';
 
 $(document).ready(initPage);
 
@@ -19,25 +20,23 @@ function initPage() {
 
   const store = getStore();
 
-  initViewAs(store);
+  const query = queryString.parse(location.search);
+  const initialViewAs = query.viewAs || ViewType.Teacher;
+  store.dispatch(setViewType(initialViewAs));
+
   store.dispatch(getHiddenLessons(teacherPanelData.script_name, false));
 
   // Lesson Extras fail to load with this
   if (!teacherPanelData.lesson_extra) {
     renderTeacherContentToggle(store);
   }
+
   renderTeacherPanel(
     store,
     teacherPanelData.script_id,
     teacherPanelData.script_name,
     teacherPanelData.page_type
   );
-}
-
-function initViewAs(store) {
-  const query = queryString.parse(location.search);
-  const initialViewAs = query.viewAs || ViewType.Teacher;
-  store.dispatch(setViewType(initialViewAs));
 }
 
 function renderTeacherContentToggle(store) {
@@ -48,8 +47,10 @@ function renderTeacherContentToggle(store) {
   const isBlocklyOrDroplet = !!(window.appOptions && appOptions.app);
 
   ReactDOM.render(
-    <Provider store={getStore()}>
-      <TeacherContentToggle isBlocklyOrDroplet={isBlocklyOrDroplet} />
+    <Provider store={store}>
+      <TeachersOnly>
+        <TeacherContentToggle isBlocklyOrDroplet={isBlocklyOrDroplet} />
+      </TeachersOnly>
     </Provider>,
     element
   );

--- a/apps/src/sites/studio/pages/levels/_teacher_panel.js
+++ b/apps/src/sites/studio/pages/levels/_teacher_panel.js
@@ -10,7 +10,6 @@ import ReactDOM from 'react-dom';
 import TeacherContentToggle from '@cdo/apps/code-studio/components/TeacherContentToggle';
 import {getHiddenLessons} from '@cdo/apps/code-studio/hiddenLessonRedux';
 import {renderTeacherPanel} from '@cdo/apps/code-studio/teacherPanelHelpers';
-import {setVerified} from '@cdo/apps/code-studio/verifiedTeacherRedux';
 
 $(document).ready(initPage);
 
@@ -21,11 +20,8 @@ function initPage() {
   const store = getStore();
 
   initViewAs(store);
-
   store.dispatch(getHiddenLessons(teacherPanelData.script_name, false));
-  if (teacherPanelData.is_verified_teacher) {
-    store.dispatch(setVerified());
-  }
+
   // Lesson Extras fail to load with this
   if (!teacherPanelData.lesson_extra) {
     renderTeacherContentToggle(store);

--- a/apps/src/templates/currentUserRedux.js
+++ b/apps/src/templates/currentUserRedux.js
@@ -23,7 +23,10 @@ export const setUserSignedIn = isSignedIn => ({
   isSignedIn
 });
 export const setUserType = userType => ({type: SET_USER_TYPE, userType});
-const setInitialData = serverUser => ({type: SET_INITIAL_DATA, serverUser});
+export const setInitialData = serverUser => ({
+  type: SET_INITIAL_DATA,
+  serverUser
+});
 
 const initialState = {
   userId: null,
@@ -73,28 +76,3 @@ export default function currentUser(state = initialState, action) {
 
   return state;
 }
-
-export const asyncLoadUserData = () => dispatch => {
-  currentUserFromServer(dispatch);
-};
-
-const currentUserFromServer = dispatch => {
-  return fetch('/api/v1/users/current')
-    .then(response => response.json())
-    .then(data => {
-      dispatch(setUserSignedIn(data.is_signed_in));
-      if (data.is_signed_in) {
-        dispatch(setInitialData(data));
-      }
-    })
-    .catch(err => {
-      console.log(err);
-    });
-};
-
-// export private function(s) to expose to unit testing
-export const __testonly__ = IN_UNIT_TEST
-  ? {
-      currentUserFromServer
-    }
-  : {};

--- a/apps/test/unit/code-studio/currentUserReduxTest.js
+++ b/apps/test/unit/code-studio/currentUserReduxTest.js
@@ -1,12 +1,11 @@
 import {assert} from '../../util/reconfiguredChai';
-import sinon from 'sinon';
 import currentUser, {
   SignInState,
   setUserSignedIn,
   setUserType,
   setCurrentUserHasSeenStandardsReportInfo,
   setCurrentUserName,
-  __testonly__
+  setInitialData
 } from '@cdo/apps/templates/currentUserRedux';
 
 describe('currentUserRedux', () => {
@@ -52,40 +51,20 @@ describe('currentUserRedux', () => {
     });
   });
 
-  describe('asyncLoadUserData', () => {
-    const {currentUserFromServer} = __testonly__;
-
-    it('calls /users/current and sets user data to state', async () => {
-      const dispatchSpy = sinon.spy();
+  describe('setInitialData', () => {
+    it('can set the standards info dialog to seen', () => {
       const serverUser = {
         id: 1,
         username: 'test_user',
         user_type: 'teacher',
         is_signed_in: true
       };
+      const action = setInitialData(serverUser);
+      const nextState = currentUser(initialState, action);
 
-      function mockApiResponse() {
-        return new window.Response(JSON.stringify(serverUser), {
-          status: 200,
-          headers: {'Content-type': 'application/json'}
-        });
-      }
-
-      const fetchStub = sinon.stub(window, 'fetch');
-      fetchStub
-        .withArgs('/api/v1/users/current')
-        .returns(Promise.resolve(mockApiResponse()));
-
-      await currentUserFromServer(dispatchSpy);
-
-      const dispatchCalls = dispatchSpy.getCalls();
-      const action1 = dispatchCalls[0].args[0];
-      assert.equal('currentUser/SET_USER_SIGNED_IN', action1.type);
-      assert.equal(true, action1.isSignedIn);
-
-      const action2 = dispatchCalls[1].args[0];
-      assert.equal('currentUser/SET_INITIAL_DATA', action2.type);
-      assert.deepEqual(serverUser, action2.serverUser);
+      assert.equal(nextState.userId, 1);
+      assert.equal(nextState.userName, 'test_user');
+      assert.equal(nextState.userType, 'teacher');
     });
   });
 });

--- a/dashboard/app/controllers/api/v1/users_controller.rb
+++ b/dashboard/app/controllers/api/v1/users_controller.rb
@@ -20,7 +20,8 @@ class Api::V1::UsersController < Api::V1::JsonApiController
         id: current_user.id,
         username: current_user.username,
         user_type: current_user.user_type,
-        is_signed_in: true
+        is_signed_in: true,
+        is_verified_teacher: current_user.verified_teacher?
       }
     else
       render json: {

--- a/dashboard/app/views/levels/_teacher_panel.html.haml
+++ b/dashboard/app/views/levels/_teacher_panel.html.haml
@@ -2,7 +2,6 @@
 - data[:script_name] = @script.name
 - data[:script_id] = @script.id
 - data[:lesson_extra] = @lesson_extras
-- data[:is_verified_teacher] = @current_user.authorized_teacher?
 
 - if @lesson_extras
   - data[:page_type] = 'lesson_extras'

--- a/dashboard/app/views/levels/show.html.haml
+++ b/dashboard/app/views/levels/show.html.haml
@@ -71,5 +71,5 @@
 
 = render partial: 'levels/admin'
 
-- if @script && !@script.professional_learning_course? && !@level.is_a?(NetSim)
+- if @script && current_user.try(:teacher?) && !@script.professional_learning_course? && !@level.is_a?(NetSim)
   = render partial: 'levels/teacher_panel'

--- a/dashboard/app/views/levels/show.html.haml
+++ b/dashboard/app/views/levels/show.html.haml
@@ -71,5 +71,5 @@
 
 = render partial: 'levels/admin'
 
-- if @script && current_user.try(:teacher?) && !@script.professional_learning_course? && !@level.is_a?(NetSim)
+- if @script && !@script.professional_learning_course? && !@level.is_a?(NetSim)
   = render partial: 'levels/teacher_panel'

--- a/dashboard/app/views/scripts/lesson_extras.html.haml
+++ b/dashboard/app/views/scripts/lesson_extras.html.haml
@@ -6,5 +6,5 @@
   - project_widget_types = script_info[:project_widget_types]
 %script{src: webpack_asset_path('js/scripts/lesson_extras.js'), data: {extras: @lesson_extras.to_json, widget: {visible: project_widget_visible.to_json, types: project_widget_types.to_json}, viewer: {section_id: @section&.id, show_lesson_extras_warning: @show_lesson_extras_warning, user_id: @user&.id}.to_json}}
 
-- if @script && !@script.professional_learning_course?
+- if @script && current_user.try(:teacher?) && !@script.professional_learning_course?
   = render partial: 'levels/teacher_panel'

--- a/dashboard/app/views/scripts/lesson_extras.html.haml
+++ b/dashboard/app/views/scripts/lesson_extras.html.haml
@@ -6,5 +6,5 @@
   - project_widget_types = script_info[:project_widget_types]
 %script{src: webpack_asset_path('js/scripts/lesson_extras.js'), data: {extras: @lesson_extras.to_json, widget: {visible: project_widget_visible.to_json, types: project_widget_types.to_json}, viewer: {section_id: @section&.id, show_lesson_extras_warning: @show_lesson_extras_warning, user_id: @user&.id}.to_json}}
 
-- if @script && current_user.try(:teacher?) && !@script.professional_learning_course?
+- if @script && !@script.professional_learning_course?
   = render partial: 'levels/teacher_panel'

--- a/dashboard/test/controllers/api/v1/users_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/users_controller_test.rb
@@ -182,6 +182,7 @@ class Api::V1::UsersControllerTest < ActionController::TestCase
     assert_equal teacher.id, response["id"]
     assert_equal teacher.username, response["username"]
     assert_equal "teacher", response["user_type"]
+    assert_equal false, response["is_verified_teacher"]
   end
 
   test "a get request to get school_name returns school object" do


### PR DESCRIPTION
This is part of the larger effort to load teacher panel on cached pages (full set of changes mapped out [here](https://github.com/code-dot-org/code-dot-org/pull/43126))

- Load verified teacher info with current user in header and set to redux for every page
- Refactor teacher panel to render if current user is a teacher in redux in preparation for rendering it on cached pages.
- Move queries for the teacher panel to the TeacherPanel component

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links
- jira ticket: [LP-2084](https://codedotorg.atlassian.net/browse/LP-2084)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()

-->

## Testing story
Added unit tests and tested locally
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
