### PR TITLE
Revert "Revert "Example usage of isolate-components to replace enzyme shallow for testing hooks""

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -126,6 +126,7 @@
     "html2canvas": "^0.5.0-beta4",
     "http-server": "^0.9.0",
     "immutable": "3.8.1",
+    "isolate-components": "^1.4.0",
     "istanbul-instrumenter-loader": "^3.0.1",
     "jquery": "1.12.1",
     "jquery-ui": "^1.12.1",

--- a/apps/src/code-studio/pd/form_components_func/FormController.jsx
+++ b/apps/src/code-studio/pd/form_components_func/FormController.jsx
@@ -348,8 +348,6 @@ const FormController = props => {
         }
         setSubmitting(false);
       });
-
-    event.preventDefault();
   };
 
   /**

--- a/apps/test/unit/code-studio/pd/form_components_func/FormControllerTest.js
+++ b/apps/test/unit/code-studio/pd/form_components_func/FormControllerTest.js
@@ -132,7 +132,7 @@ describe('FormController', () => {
         let server;
 
         const triggerSubmit = () =>
-          form.findOne('form').props.onSubmit(new window.SubmitEvent('submit'));
+          form.findOne('form').props.onSubmit({preventDefault: sinon.stub()});
 
         const setupValid = () => {
           form = isolateComponent(<FormController {...defaultProps} />);

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -9169,6 +9169,18 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
+isolate-components@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/isolate-components/-/isolate-components-1.4.0.tgz#324082d596f8224b8e027b1b94a46fa13471ab57"
+  integrity sha512-kO99YeQIXZyDwR8wn45M7zFvuKVxCOl71cqCCwZ9Xzx0Ff33d3Mgd7jghkv5KpoBuBt6KkPUcubJczlC+G3+cQ==
+  dependencies:
+    isolate-hooks "^1.5.0"
+
+isolate-hooks@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/isolate-hooks/-/isolate-hooks-1.5.0.tgz#232d98ea3fb6393210a72965d67f4218e1efed59"
+  integrity sha512-IRGJvwngCuWr1FadRpI9L4V2HS+vR2pUK6O3hcNBlk3Mk/zM6VytSfV8Rpcb3/duxJHy+JUVHW7Yk4BPK4FrVA==
+
 isomorphic-fetch@^2.1.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#43325

window.SubmitEvent is not available in the test environment, so use a mock instead

example error:
```
FAILED TESTS:
    FormController
      Standard usage
        Page validation
          Submitting
            âœ– Does not submit when the last page has errors 
              HeadlessChrome 0.0.0 (Linux 0.0.0)
            TypeError: window.SubmitEvent is not a constructor
                at triggerSubmit (test/unit-tests.js:1548869:54)
                at Context.<anonymous> (test/unit-tests.js:1548893:11)
```