### PR TITLE
Code review groups: add enable/disable controller

### DIFF
--- a/dashboard/app/controllers/api/v1/sections_controller.rb
+++ b/dashboard/app/controllers/api/v1/sections_controller.rb
@@ -237,6 +237,13 @@ class Api::V1::SectionsController < Api::V1::JsonApiController
     render json: {result: 'invalid groups'}, status: 400
   end
 
+  # POST /api/v1/sections/<id>/code_review_enabled
+  def set_code_review_enabled
+    enable_code_review = params[:enabled]
+    @section.update_code_review_expiration(enable_code_review)
+    render json: {result: 'success', expiration: @section.code_review_expires_at}
+  end
+
   private
 
   def find_follower

--- a/dashboard/app/controllers/api/v1/sections_controller.rb
+++ b/dashboard/app/controllers/api/v1/sections_controller.rb
@@ -239,7 +239,7 @@ class Api::V1::SectionsController < Api::V1::JsonApiController
 
   # POST /api/v1/sections/<id>/code_review_enabled
   def set_code_review_enabled
-    enable_code_review = params[:enabled]
+    enable_code_review = params[:enabled].to_bool
     @section.update_code_review_expiration(enable_code_review)
     render json: {result: 'success', expiration: @section.code_review_expires_at}
   end

--- a/dashboard/app/controllers/api/v1/sections_controller.rb
+++ b/dashboard/app/controllers/api/v1/sections_controller.rb
@@ -241,6 +241,7 @@ class Api::V1::SectionsController < Api::V1::JsonApiController
   def set_code_review_enabled
     enable_code_review = params[:enabled].to_bool
     @section.update_code_review_expiration(enable_code_review)
+    @section.save
     render json: {result: 'success', expiration: @section.code_review_expires_at}
   end
 

--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -36,6 +36,7 @@ require 'cdo/code_generation'
 require 'cdo/safe_names'
 
 class Section < ApplicationRecord
+  include SerializedProperties
   self.inheritance_column = :login_type
 
   class << self
@@ -76,6 +77,8 @@ class Section < ApplicationRecord
   # We want to replace uses of "stage" with "lesson" when possible, since "lesson" is the term used by curriculum team.
   # Use an alias here since it's not worth renaming the column in the database. Use "lesson_extras" when possible.
   alias_attribute :lesson_extras, :stage_extras
+
+  serialized_attrs %w(code_review_expires_at)
 
   # This list is duplicated as SECTION_LOGIN_TYPE in shared_constants.rb and should be kept in sync.
   LOGIN_TYPES = [
@@ -423,6 +426,10 @@ class Section < ApplicationRecord
         end
       end
     end
+  end
+
+  def update_code_review_expiration(enable_code_review)
+    self.code_review_expires_at = enable_code_review ? DateTime.now + 90.days : nil
   end
 
   private

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -91,6 +91,7 @@ Dashboard::Application.routes.draw do
         get 'student_script_ids'
         get 'code_review_groups'
         post 'code_review_groups', to: 'sections#set_code_review_groups'
+        post 'code_review_enabled', to: 'sections#set_code_review_enabled'
       end
       collection do
         get 'membership'

--- a/dashboard/test/controllers/api/v1/sections_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/sections_controller_test.rb
@@ -1126,6 +1126,24 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
     assert_response 400
   end
 
+  test 'can set code review enabled to true' do
+    sign_in @teacher
+    @section.code_review_expires_at = nil
+    @section.save
+    post :set_code_review_enabled, params: {id: @section.id, enabled: true}
+    assert_response :success
+    assert_not_nil json_response["expiration"]
+  end
+
+  test 'can set code review enabled to false' do
+    sign_in @teacher
+    @section.code_review_expires_at = DateTime.now
+    @section.save
+    post :set_code_review_enabled, params: {id: @section.id, enabled: false}
+    assert_response :success
+    assert_nil json_response["expiration"]
+  end
+
   private
 
   def set_up_code_review_groups

--- a/dashboard/test/controllers/api/v1/sections_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/sections_controller_test.rb
@@ -1131,8 +1131,10 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
     @section.code_review_expires_at = nil
     @section.save
     post :set_code_review_enabled, params: {id: @section.id, enabled: true}
+    @section.reload
     assert_response :success
     assert_not_nil json_response["expiration"]
+    assert_equal @section.code_review_expires_at, json_response["expiration"]
   end
 
   test 'can set code review enabled to false' do
@@ -1140,8 +1142,10 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
     @section.code_review_expires_at = DateTime.now
     @section.save
     post :set_code_review_enabled, params: {id: @section.id, enabled: false}
+    @section.reload
     assert_response :success
     assert_nil json_response["expiration"]
+    assert_nil @section.code_review_expires_at
   end
 
   private

--- a/dashboard/test/models/sections/section_test.rb
+++ b/dashboard/test/models/sections/section_test.rb
@@ -614,6 +614,24 @@ class SectionTest < ActiveSupport::TestCase
     assert_equal 2, new_groups.first.members.count
   end
 
+  test 'update_code_review_expiration resets expiration time when enabling code review' do
+    @section.update_code_review_expiration(true)
+    @section.save
+    assert_not_nil @section.code_review_expires_at
+    # check the expiration date was set to a time greater than now.
+    assert DateTime.parse(@section.code_review_expires_at) > DateTime.now
+  end
+
+  test 'update_code_review_expiration sets expiration time to nil when disabling code review' do
+    # set expiration to a non-nil time
+    @section.code_review_expires_at = DateTime.now
+    @section.save
+
+    @section.update_code_review_expiration(false)
+    @section.save
+    assert_nil @section.code_review_expires_at
+  end
+
   def set_up_code_review_groups
     # create a new section to avoid extra unassigned students
     @code_review_group_section = create(:section, user: @teacher, login_type: 'word')


### PR DESCRIPTION
Add a new controller to enable/disable code review. New route is: POST `/api/v1/sections/<id>/code_review_enabled`, with param `{enabled: <boolean>}`.
On enable, the new property `code_review_expires_at` will be set to 90 days in the future. On disable, it will be set to nil.

## Links

- spec: [Code review groups](https://docs.google.com/document/d/1-fX3o1rT38aWaT2f8lSbTwZadMzeeOhFZZ6c6KCCw3I/edit#)
- jira ticket: [CSA-1005](https://codedotorg.atlassian.net/browse/CSA-1005)


## Testing story
Added unit tests.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
