### PR TITLE
Update Cdo::Config to work with Rails 3

### DIFF
--- a/lib/cdo/config.rb
+++ b/lib/cdo/config.rb
@@ -8,11 +8,15 @@ module Cdo
     # Soft-freeze: Don't allow any config items to be created/modified,
     # but allow stubbing for unit tests.
     def freeze
-      @table.each_key(&method(:new_ostruct_member!))
+      # Some implementation changes in OpenStruct in Ruby 3.0 affect behavior
+      # that this class is relying on, so we need to include some special logic
+      # here. See https://bugs.ruby-lang.org/issues/15409#note-9
+      @table.each_key {|k| new_ostruct_member!(k.to_sym)}
       @frozen = true
     end
 
     def method_missing(key, *args)
+      return self[key.to_sym] if args.empty? && defined?(key.to_sym) # accommodate https://bugs.ruby-lang.org/issues/15409#note-9
       raise ArgumentError, "Undefined #{self.class} reference: #{key}", caller(1) if @frozen
       super
     end

--- a/lib/cdo/config.rb
+++ b/lib/cdo/config.rb
@@ -16,7 +16,7 @@ module Cdo
     end
 
     def method_missing(key, *args)
-      return self[key.to_sym] if args.empty? && defined?(key.to_sym) # accommodate https://bugs.ruby-lang.org/issues/15409#note-9
+      return self[key.to_sym] if args.empty? && @table.key?(key.to_sym) # accommodate https://bugs.ruby-lang.org/issues/15409#note-9
       raise ArgumentError, "Undefined #{self.class} reference: #{key}", caller(1) if @frozen
       super
     end


### PR DESCRIPTION
Some implementation changes in OpenStruct in Ruby 3.0 affect behavior that this class is relying on. See https://bugs.ruby-lang.org/issues/15409#note-9

Thanks @wjordan for figuring this out and writing the change itself!

This is necessary for the ongoing work to upgrade to Chef 17. Specifically, Chef 17 requires Ruby 3.0, and although this config object is primarily used by our Rails server which is still using Ruby 2.5, it is also incidentally loaded by Chef and so must also work on Ruby 3.0. We are also planning to eventually upgrade our Rails server to Ruby 3.0, so this could also be considered to be getting a head start on that!

Without this change, adhoc creation fails with the following error:

```
Recipe: cdo-secrets::app
  * chef_gem[aws-sdk-secretsmanager] action install (up to date)
  * chef_gem[activesupport] action install
    - install version 6.1.4.1 of package activesupport
  * ruby_block[CDO config] action run

    ================================================================================
    Error executing action `run` on resource 'ruby_block[CDO config]'
    ================================================================================

    Psych::SyntaxError
    ------------------
    (/home/ubuntu/adhoc/config.yml.erb): mapping values are not allowed in this context at line 10 column 13

    Cookbook Trace: (most recent call first)
    ----------------------------------------
    /etc/chef/local-mode-cache/cache/cookbooks/cdo-secrets/recipes/app.rb:17:in `block (2 levels) in from_file'

    Resource Declaration:
    ---------------------
    # In /etc/chef/local-mode-cache/cache/cookbooks/cdo-secrets/recipes/app.rb

     14: ruby_block 'CDO config' do
     15:   block do
     16:     ENV['BUNDLE_GEMFILE'] = '' # Disable Bundler
     17:     require "#{node['cdo-repository']['git_path']}/deployment"
     18:   end
     19: end
```

[Full error log here.](https://github.com/code-dot-org/code-dot-org/files/7488967/chef-bootstrap-debug.without-config-fix.log)

The problem as we understand it is that `cdo-secrets` manually requires `deployment.rb`: https://github.com/code-dot-org/code-dot-org/blob/ef4fc3ed4accdefdb4541f8a078533a22d30c56e/cookbooks/cdo-secrets/recipes/app.rb#L17

Which requires `lib/cdo`: https://github.com/code-dot-org/code-dot-org/blob/ef4fc3ed4accdefdb4541f8a078533a22d30c56e/deployment.rb#L10

Which implicitly initializes a instance: https://github.com/code-dot-org/code-dot-org/blob/ef4fc3ed4accdefdb4541f8a078533a22d30c56e/lib/cdo.rb#L285

Which attempts to render the config yml: https://github.com/code-dot-org/code-dot-org/blob/ef4fc3ed4accdefdb4541f8a078533a22d30c56e/lib/cdo.rb#L38

The problem we get at this point is that on Rails 3.0, `self.env` returns `nil`; we are expected to use `self[:env]` instead. So https://github.com/code-dot-org/code-dot-org/blob/ef4fc3ed4accdefdb4541f8a078533a22d30c56e/config.yml.erb#L10 in the rendered yml ends up as 

```
rack_env:   :
```

This change simply adds some logic so that direct access of properties from this config object will continue to work.

## Testing story

Deployed an adhoc based on this branch plus a workaround to the `pdftk` issue and confirmed that this change doesn't negatively impact our ability to deploy on Chef 12.

Also deployed an adhoc which bundled this change together with other fixes and the upgrade to Chef 17 to confirm that this change does positively impact our ability to deploy on Chef 17

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
