### PR TITLE
Even more Teacher Application bug fixes

### DIFF
--- a/apps/src/code-studio/pd/application/teacher/AboutYou.jsx
+++ b/apps/src/code-studio/pd/application/teacher/AboutYou.jsx
@@ -221,7 +221,7 @@ const AboutYou = props => {
           </p>
           <LabeledInput name="streetAddress" />
           <LabeledInput name="city" />
-          <LabeledInput name="state" />
+          <LabeledSelect name="state" placeholder="Select a state" />
           <LabeledInput name="zipCode" />
 
           <LabeledCheckBoxes name="previousUsedCurriculum" />

--- a/apps/src/code-studio/pd/components/useRegionalPartner.jsx
+++ b/apps/src/code-studio/pd/components/useRegionalPartner.jsx
@@ -55,32 +55,39 @@ export const useRegionalPartner = data => {
   const [loadingPartner, setLoadingPartner] = useState(true);
   const [loadError, setLoadError] = useState(false);
   const [partner, setPartner] = useState(null);
-  // cache this debounced function so that it is more easily testable
-  const debouncedFetch = useCallback(
-    debounce(
-      data =>
-        fetchRegionalPartner(data)
-          .then(partner => {
-            // Update state with all the partner workshop data to display
-            setLoadingPartner(false);
-            setLoadError(false);
-            // the api returns an object with all fields set to null if not found
-            setPartner(partner.id === null ? null : partner); // TODO(tim): potential issue where requests are fulfilled out of order
-          })
-          .catch(() => {
-            setLoadingPartner(false);
-            setLoadError(true);
-          }),
-      500,
-      {leading: true}
-    ),
-    []
-  );
+  const [searchTerm, setSearchTerm] = useState({
+    program,
+    schoolZipCode,
+    schoolState,
+    school
+  });
+  const debouncedSetSearchTerm = useCallback(debounce(setSearchTerm, 500), [
+    setSearchTerm
+  ]);
+  useEffect(() => {
+    debouncedSetSearchTerm({
+      program,
+      schoolZipCode,
+      schoolState,
+      school
+    });
+  }, [program, schoolZipCode, schoolState, school]);
 
   // load regional partner whenever parameters change
   useEffect(() => {
-    debouncedFetch(data);
-  }, [program, schoolZipCode, schoolState, school]);
+    fetchRegionalPartner(searchTerm)
+      .then(partner => {
+        // Update state with all the partner workshop data to display
+        setLoadingPartner(false);
+        setLoadError(false);
+        // the api returns an object with all fields set to null if not found
+        setPartner(partner.id === null ? null : partner);
+      })
+      .catch(() => {
+        setLoadingPartner(false);
+        setLoadError(true);
+      });
+  }, [searchTerm]);
 
   return [loadingPartner ? undefined : partner, loadError];
 };

--- a/apps/src/code-studio/pd/components/useRegionalPartner.jsx
+++ b/apps/src/code-studio/pd/components/useRegionalPartner.jsx
@@ -75,18 +75,26 @@ export const useRegionalPartner = data => {
 
   // load regional partner whenever parameters change
   useEffect(() => {
+    let cancelled = false;
     fetchRegionalPartner(searchTerm)
       .then(partner => {
         // Update state with all the partner workshop data to display
-        setLoadingPartner(false);
-        setLoadError(false);
-        // the api returns an object with all fields set to null if not found
-        setPartner(partner.id === null ? null : partner);
+        if (!cancelled) {
+          setLoadingPartner(false);
+          setLoadError(false);
+          // the api returns an object with all fields set to null if not found
+          setPartner(partner.id === null ? null : partner);
+        }
       })
       .catch(() => {
-        setLoadingPartner(false);
-        setLoadError(true);
+        if (!cancelled) {
+          setLoadingPartner(false);
+          setLoadError(true);
+        }
       });
+    return () => {
+      cancelled = true;
+    };
   }, [searchTerm]);
 
   return [loadingPartner ? undefined : partner, loadError];

--- a/apps/src/code-studio/pd/components/useRegionalPartner.jsx
+++ b/apps/src/code-studio/pd/components/useRegionalPartner.jsx
@@ -55,12 +55,9 @@ export const useRegionalPartner = data => {
   const [loadingPartner, setLoadingPartner] = useState(true);
   const [loadError, setLoadError] = useState(false);
   const [partner, setPartner] = useState(null);
-  const [searchTerm, setSearchTerm] = useState({
-    program,
-    schoolZipCode,
-    schoolState,
-    school
-  });
+
+  // debounce the search term to prevent making too many calls as input changes
+  const [searchTerm, setSearchTerm] = useState(null);
   const debouncedSetSearchTerm = useCallback(debounce(setSearchTerm, 500), [
     setSearchTerm
   ]);
@@ -75,6 +72,9 @@ export const useRegionalPartner = data => {
 
   // load regional partner whenever parameters change
   useEffect(() => {
+    if (searchTerm === null) {
+      return;
+    }
     let cancelled = false;
     fetchRegionalPartner(searchTerm)
       .then(partner => {

--- a/apps/src/templates/RegionalPartnerSearch.jsx
+++ b/apps/src/templates/RegionalPartnerSearch.jsx
@@ -58,7 +58,7 @@ class RegionalPartnerSearch extends Component {
     // (versus the regional partner's own application close date)
     $.ajax({
       method: 'GET',
-      url: `/dashboardapi/v1/pd/applications/applications_closed`,
+      url: `/dashboardapi/v1/pd/application/applications_closed`,
       dataType: 'json'
     }).done(data => {
       this.setState({

--- a/apps/test/unit/code-studio/pd/components/useRegionalPartnerTest.js
+++ b/apps/test/unit/code-studio/pd/components/useRegionalPartnerTest.js
@@ -25,7 +25,7 @@ const getRegionalPartnerData = () => {
   return [regionalPartnerData, regionalPartnerError];
 };
 
-const GOOD_RESPONSE = {name: 'reginald partner'};
+const GOOD_RESPONSE = {id: 1, name: 'reginald partner'};
 
 const mockApiResponse = (status = 200, body = {}) => {
   return new window.Response(JSON.stringify(body), {
@@ -37,6 +37,8 @@ const mockApiResponse = (status = 200, body = {}) => {
 describe('useRegionalPartner tests', () => {
   let clock, fetchStub, debounceStub;
   beforeEach(() => {
+    regionalPartnerData = undefined;
+    regionalPartnerError = false;
     clock = sinon.useFakeTimers();
     fetchStub = sinon.stub(window, 'fetch');
     debounceStub = sinon.stub(_, 'debounce').callsFake(f => f);
@@ -113,6 +115,7 @@ describe('useRegionalPartner tests', () => {
       );
       await clock.runAllAsync();
     });
+
     const [regionalPartner, regionalPartnerError] = getRegionalPartnerData(
       rendered
     );

--- a/dashboard/app/controllers/api/v1/pd/applications_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/applications_controller.rb
@@ -203,13 +203,6 @@ module Api::V1::Pd
       render json: filtered_applications, each_serializer: ApplicationSearchSerializer
     end
 
-    # GET /api/v1/pd/applications/applications_closed
-    def applications_closed
-      # true when teacher applications are closed site-wide
-      closed = Rails.env.production? && !current_user.try(:workshop_admin?) && Gatekeeper.disallows('pd_teacher_application')
-      render json: closed
-    end
-
     private
 
     def get_applications_by_role(role, include_associations: true)

--- a/dashboard/app/controllers/pd/professional_learning_landing_controller.rb
+++ b/dashboard/app/controllers/pd/professional_learning_landing_controller.rb
@@ -25,4 +25,10 @@ class Pd::ProfessionalLearningLandingController < ApplicationController
       summarized_plc_enrollments: summarized_plc_enrollments
     }.compact
   end
+
+  def applications_closed
+    # true when teacher applications are closed site-wide
+    closed = Rails.env.production? && !current_user.try(:workshop_admin?) && Gatekeeper.disallows('pd_teacher_application')
+    render json: closed
+  end
 end

--- a/dashboard/app/models/pd/application/application_constants.rb
+++ b/dashboard/app/models/pd/application/application_constants.rb
@@ -2,7 +2,8 @@ module Pd::Application
   module ApplicationConstants
     COURSE_NAMES = {
       csd: 'Computer Science Discoveries',
-      csp: 'Computer Science Principles'
+      csp: 'Computer Science Principles',
+      csa: 'Computer Science A'
     }.stringify_keys
 
     YES = 'Yes'.freeze

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -583,7 +583,6 @@ Dashboard::Application.routes.draw do
           get :cohort_view
           get :search
           get :fit_cohort
-          get :applications_closed
         end
       end
 
@@ -604,7 +603,7 @@ Dashboard::Application.routes.draw do
 
   get '/dashboardapi/v1/regional_partners/find', to: 'api/v1/regional_partners#find'
   get '/dashboardapi/v1/regional_partners/show/:partner_id', to: 'api/v1/regional_partners#show'
-  get '/dashboardapi/v1/pd/applications/applications_closed', to: 'api/v1/pd/applications#applications_closed'
+  get '/dashboardapi/v1/pd/application/applications_closed', to: 'pd/professional_learning_landing#applications_closed'
   post '/dashboardapi/v1/pd/regional_partner_mini_contacts', to: 'api/v1/pd/regional_partner_mini_contacts#create'
   post '/dashboardapi/v1/amazon_future_engineer_submit', to: 'api/v1/amazon_future_engineer#submit'
 

--- a/lib/cdo/shared_constants/pd/teacher_application_constants.rb
+++ b/lib/cdo/shared_constants/pd/teacher_application_constants.rb
@@ -264,6 +264,7 @@ module Pd
       # Minimum requirements
       csd_which_grades: YES_NO,
       csp_which_grades: YES_NO,
+      csa_which_grades: YES_NO,
       committed: YES_NO,
       plan_to_teach: YES_NO,
       previous_yearlong_cdo_pd: YES_NO,
@@ -292,6 +293,15 @@ module Pd
       ],
       criteria_score_questions_csp: [
         :csp_which_grades,
+        :committed,
+        :plan_to_teach,
+        :previous_yearlong_cdo_pd,
+        :replace_existing,
+        :principal_approval,
+        :principal_schedule_confirmed,
+      ],
+      criteria_score_questions_csa: [
+        :csa_which_grades,
         :committed,
         :plan_to_teach,
         :previous_yearlong_cdo_pd,


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

This set of changes fixes:
- application banner was not appearing on the regional partner zip code search page due to the `applications_closed` api endpoint not being accessible to teachers.
- makes the debounced rp hook more reliable by tying the promise resolution to the fetch call and not the result of the debounced function.
- replaces home state field input with a dropdown so that we don't run into Washington vs WA validation issues.
- Adds some missing constants to fix the csa application dashboard


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- spec: [content doc](https://docs.google.com/document/d/1rshrcpg7J45BfrgiEl6ALwysDeQiwLQcAErFthocJug/edit)
- bug bash doc: [doc](https://docs.google.com/document/d/1Nu30LM1QRFdnXjmbukjdsERBrYGiDx70hBhPTmLI_d0/edit#)

## Testing story

Manual testing. In a next PR I'm going to fix up and reenable the teacher application eyes test also

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->
