### PR TITLE
Update user_progress and user_app_options to support teacher view for cached levels

### DIFF
--- a/apps/src/code-studio/initApp/loadApp.js
+++ b/apps/src/code-studio/initApp/loadApp.js
@@ -299,14 +299,18 @@ async function loadAppAsync(appOptions) {
     appOptions.disableSocialShare = true;
   }
 
-  const userAppOptionsRequest = $.ajax(
-    `/api/user_app_options` +
+  const userAppOptionsRequest = $.ajax({
+    url:
+      `/api/user_app_options` +
       `/${appOptions.scriptName}` +
       `/${appOptions.lessonPosition}` +
       `/${appOptions.levelPosition}` +
-      `/${appOptions.serverLevelId}` +
-      `?get_channel_id=${shouldGetChannelId}`
-  );
+      `/${appOptions.serverLevelId}`,
+    data: {
+      user_id: clientState.queryParams('user_id'),
+      get_channel_id: shouldGetChannelId
+    }
+  });
 
   const sectionId = clientState.queryParams('section_id') || '';
   const exampleSolutionsRequest = $.ajax(
@@ -324,9 +328,18 @@ async function loadAppAsync(appOptions) {
     appOptions.exampleSolutions = exampleSolutions;
     appOptions.disableSocialShare = data.disableSocialShare;
 
-    // We do not need to process data.progress here because labs do not use
-    // the level progress data directly. (The progress bubbles in the header
-    // of the level pages are rendered by header.build in header.js.)
+    if (data.isStarted) {
+      appOptions.level.isStarted = data.isStarted;
+    }
+    if (data.skipInstructionsPopup) {
+      appOptions.level.skipInstructionsPopup = data.skipInstructionsPopup;
+    }
+    if (data.readonlyWorkspace) {
+      appOptions.readonlyWorkspace = data.readonlyWorkspace;
+    }
+    if (data.callouts) {
+      appOptions.callouts = data.callouts;
+    }
 
     if (data.lastAttempt) {
       appOptions.level.lastAttempt = data.lastAttempt.source;

--- a/apps/src/code-studio/progress.js
+++ b/apps/src/code-studio/progress.js
@@ -197,7 +197,10 @@ function getLevelProgress(signedIn, progressData, scriptName) {
     case null:
       // We do not know if user is signed in or not, send a request to the server
       // to find out if the user is signed in and retrieve progress information
-      return $.ajax(`/api/user_progress/${scriptName}`)
+      return $.ajax({
+        url: `/api/user_progress/${scriptName}`,
+        data: {user_id: clientState.queryParams('user_id')}
+      })
         .then(data => {
           if (data.signedIn) {
             return {

--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -131,16 +131,6 @@ class ActivitiesController < ApplicationController
       user_level: @user_level
     )
 
-    if solved
-      slog(
-        tag: 'activity_finish',
-        script_level_id: @script_level.try(:id),
-        level_id: @level.id,
-        user_agent: request.user_agent,
-        locale: locale
-      )
-    end
-
     # log this at the end so that server errors (which might be caused by invalid input) prevent logging
     log_milestone(@level_source, params)
   end

--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -425,8 +425,14 @@ class ApiController < ApplicationController
   # Return a JSON summary of the user's progress for params[:script].
   def user_progress
     if current_user
+      if params[:user_id].present?
+        user = User.find(params[:user_id])
+        return head :forbidden unless user.student_of?(current_user)
+      else
+        user = current_user
+      end
+
       script = Script.get_from_cache(params[:script])
-      user = params[:user_id].present? ? User.find(params[:user_id]) : current_user
       teacher_viewing_student = !current_user.student? && current_user.students.include?(user)
       render json: summarize_user_progress(script, user).merge(
         {
@@ -444,8 +450,7 @@ class ApiController < ApplicationController
   # Returns app_options values that are user-specific. This is used on cached
   # levels.
   def user_app_options
-    response = user_summary(current_user)
-    response[:signedIn] = !current_user.nil?
+    response = {}
 
     script = Script.get_from_cache(params[:script])
     lesson = script.lessons[params[:lesson_position].to_i - 1]
@@ -453,55 +458,85 @@ class ApiController < ApplicationController
     level = params[:level] ? Script.cache_find_level(params[:level].to_i) : script_level.oldest_active_level
 
     if current_user
-      user_level = current_user.last_attempt(level, script)
-      level_source = user_level.try(:level_source).try(:data)
+      response[:signedIn] = true
 
-      # Temporarily return the full set of progress so we can overwrite what the sessionStorage changed
-      response[:progress] = summarize_user_progress(script, current_user)[:progress]
-      response[:isHoc] = script.hoc?
-
-      if user_level
-        response[:lastAttempt] = {
-          timestamp: user_level.updated_at.to_datetime.to_milliseconds,
-          source: level_source
-        }
-
-        # Pairing info
-        is_navigator = user_level.navigator?
-        if is_navigator
-          driver = user_level.driver
-          driver_level_source_id = user_level.driver_level_source_id
-        end
-
-        response[:isNavigator] = is_navigator
-        if driver
-          response[:pairingDriver] = driver.name
-          if driver_level_source_id
-            response[:pairingAttempt] = edit_level_source_path(driver_level_source_id)
-          elsif level.channel_backed?
-            response[:pairingChannelId] = get_channel_for(level, script.id, driver)
-          end
-        end
+      # Set `user` to the user that we should use to calculate the app_options
+      # and note if the signed-in user is viewing another user (e.g. a teacher
+      # viewing a student's work).
+      if params[:user_id].present?
+        user = User.find(params[:user_id])
+        return head :forbidden unless can?(:view_as_user, script_level, user)
+        viewing_other_user = true
+      else
+        user = current_user
+        viewing_other_user = false
       end
-    end
 
-    if level.finishable?
-      slog(
-        tag: 'activity_start',
-        script_level_id: script_level.try(:id),
-        level_id: level.contained_levels.empty? ? level.id : level.contained_levels.first.id,
-        user_agent: request.user_agent&.valid_encoding? ? request.user_agent : 'invalid_encoding',
-        locale: locale
-      )
+      if viewing_other_user
+        response[:isStarted] = level_started?(level, script, user)
+
+        # This is analogous to readonly_view_options
+        response[:skipInstructionsPopup] = true
+        response[:readonlyWorkspace] = true
+        response[:callouts] = []
+      end
+
+      # TODO: There are many other user-specific values in app_options that may
+      # need to be sent down.  See LP-2086 for a list of potential values.
+
+      response[:disableSocialShare] = !!user.under_13?
+      response.merge!(progress_app_options(script, level, user))
+    else
+      response[:signedIn] = false
+      viewing_other_user = false
     end
 
     if params[:get_channel_id] == "true"
-      response[:channel] = get_channel_for(level, script.id, current_user)
+      response[:channel] = viewing_other_user ?
+        get_channel_for(level, script.id, user) :
+        get_channel_for(level, script.id)
       response[:reduceChannelUpdates] =
         !Gatekeeper.allows("updateChannelOnSave", where: {script_name: script.name}, default: true)
     end
 
     render json: response
+  end
+
+  # Gets progress-related app_options for the given script and level for the
+  # given user. This code is analogous to parts of LevelsHelper#app_options.
+  # TODO: Eliminate this logic from LevelsHelper#app_options or refactor methods
+  # to share code.
+  def progress_app_options(script, level, user)
+    response = {}
+
+    user_level = user.last_attempt(level, script)
+    level_source = user_level.try(:level_source).try(:data)
+
+    if user_level
+      response[:lastAttempt] = {
+        timestamp: user_level.updated_at.to_datetime.to_milliseconds,
+        source: level_source
+      }
+
+      # Pairing info
+      is_navigator = user_level.navigator?
+      if is_navigator
+        driver = user_level.driver
+        driver_level_source_id = user_level.driver_level_source_id
+      end
+
+      response[:isNavigator] = is_navigator
+      if driver
+        response[:pairingDriver] = driver.name
+        if driver_level_source_id
+          response[:pairingAttempt] = edit_level_source_path(driver_level_source_id)
+        elsif level.channel_backed?
+          response[:pairingChannelId] = get_channel_for(level, script.id, driver)
+        end
+      end
+    end
+
+    response
   end
 
   # GET /api/example_solutions/:script_level_id/:level_id

--- a/dashboard/test/controllers/activities_controller_test.rb
+++ b/dashboard/test/controllers/activities_controller_test.rb
@@ -97,10 +97,6 @@ class ActivitiesControllerTest < ActionController::TestCase
   end
 
   test "logged in milestone" do
-    # Configure a fake slogger to verify that the correct data is logged.
-    slogger = FakeSlogger.new
-    CDO.set_slogger_for_test(slogger)
-
     # do all the logging
     @controller.expects :log_milestone
 
@@ -125,18 +121,6 @@ class ActivitiesControllerTest < ActionController::TestCase
 
     # created activity and userlevel with the correct script
     assert_equal @script_level.script, UserLevel.last.script
-
-    assert_equal(
-      [{
-        application: :dashboard,
-        tag: 'activity_finish',
-        script_level_id: @script_level.id,
-        level_id: @script_level.level.id,
-        user_agent: 'Rails Testing',
-        locale: :'en-US'
-      }],
-      slogger.records
-    )
   end
 
   test "successful milestone does not require script_level_id" do
@@ -231,7 +215,6 @@ class ActivitiesControllerTest < ActionController::TestCase
   test "logged in milestone with existing userlevel with script" do
     # do all the logging
     @controller.expects :log_milestone
-    @controller.expects :slog
 
     UserScript.create(user: @user, script: @script_level.script)
     UserLevel.create(level: @script_level.level, user: @user, script: @script_level.script)
@@ -252,7 +235,6 @@ class ActivitiesControllerTest < ActionController::TestCase
 
     # do all the logging
     @controller.expects :log_milestone
-    @controller.expects :slog
 
     assert_creates(Activity, UserLevel, UserScript) do
       assert_does_not_create(LevelSource) do
@@ -281,7 +263,6 @@ class ActivitiesControllerTest < ActionController::TestCase
   test "logged in milestone with panda does not crash" do
     # do all the logging
     @controller.expects :log_milestone
-    @controller.expects :slog
 
     assert_creates(Activity, UserLevel, UserScript, LevelSource) do
       assert_difference('@user.reload.total_lines', 20) do # update total lines
@@ -303,7 +284,6 @@ class ActivitiesControllerTest < ActionController::TestCase
 
   test "logged in milestone does not allow negative lines of code" do
     expect_controller_logs_milestone_regexp(/-20/)
-    @controller.expects :slog
 
     assert_creates(LevelSource, Activity, UserLevel, UserScript) do
       assert_no_difference('@user.reload.total_lines') do # update total lines
@@ -326,8 +306,6 @@ class ActivitiesControllerTest < ActionController::TestCase
 
   test "logged in milestone does not allow unreasonably high lines of code" do
     expect_controller_logs_milestone_regexp(/9999999/)
-
-    @controller.expects :slog
 
     assert_creates(LevelSource, Activity, UserLevel, UserScript) do
       assert_difference('@user.reload.total_lines', 1000) do # update total lines
@@ -395,7 +373,6 @@ class ActivitiesControllerTest < ActionController::TestCase
   test "logged in milestone with image" do
     # do all the logging
     @controller.expects :log_milestone
-    @controller.expects :slog
 
     expect_s3_upload
 
@@ -430,7 +407,6 @@ class ActivitiesControllerTest < ActionController::TestCase
   test "logged in milestone with existing level source and level source image" do
     # do all the logging
     @controller.expects :log_milestone
-    @controller.expects :slog
 
     program = "<whatever>"
 
@@ -575,7 +551,6 @@ class ActivitiesControllerTest < ActionController::TestCase
 
     # do all the logging
     @controller.expects :log_milestone
-    @controller.expects :slog
 
     # some Mocha shenanigans to simulate throwing a duplicate entry
     # error and then succeeding by returning the existing userlevel
@@ -635,7 +610,6 @@ class ActivitiesControllerTest < ActionController::TestCase
 
     # do all the logging
     @controller.expects :log_milestone
-    @controller.expects :slog
 
     assert_creates(LevelSource) do
       assert_does_not_create(Activity, UserLevel) do
@@ -659,7 +633,6 @@ class ActivitiesControllerTest < ActionController::TestCase
 
     # do all the logging
     @controller.expects :log_milestone
-    @controller.expects :slog
 
     assert_creates(LevelSource) do
       assert_does_not_create(Activity, UserLevel) do
@@ -706,7 +679,6 @@ class ActivitiesControllerTest < ActionController::TestCase
 
     # do all the logging
     @controller.expects :log_milestone
-    @controller.expects :slog
 
     expect_s3_upload
 
@@ -736,7 +708,6 @@ class ActivitiesControllerTest < ActionController::TestCase
 
     # do all the logging
     @controller.expects :log_milestone
-    @controller.expects :slog
 
     expect_s3_upload_failure
 
@@ -795,7 +766,6 @@ class ActivitiesControllerTest < ActionController::TestCase
     # allow sharing when there's an error, slog so it's possible to look up and review later
 
     ProfanityFilter.stubs(:find_potential_profanity).raises(OpenURI::HTTPError.new('something broke', 'fake io'))
-    @controller.expects(:slog).with(:tag) {|params| params[:tag] == 'activity_finish'}
 
     assert_creates(LevelSource) do
       post :milestone,
@@ -816,9 +786,6 @@ class ActivitiesControllerTest < ActionController::TestCase
 
   test 'sharing program with IO::EAGAINWaitReadable error logs' do
     ProfanityFilter.stubs(:find_potential_profanity).raises(IO::EAGAINWaitReadable)
-    # allow sharing when there's an error, slog so it's possible to look up and review later
-
-    @controller.expects(:slog).with(:tag) {|params| params[:tag] == 'activity_finish'}
 
     assert_creates(LevelSource) do
       post :milestone,

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -12,7 +12,9 @@ class ApiControllerTest < ActionController::TestCase
 
     @section = create(:section, user: @teacher, login_type: 'word')
 
-    @script = create(:script)
+    @script = create(:script, :with_levels, levels_count: 1)
+    @script_level = @script.script_levels[0]
+    @level = @script_level.level
 
     # some of our tests depend on sorting of students by name, thus we name them ourselves
     @students = []
@@ -782,83 +784,188 @@ class ApiControllerTest < ActionController::TestCase
     assert_response 403
   end
 
-  test "should get user progress" do
-    script = create(:script, :with_levels, levels_count: 2)
-
+  test "should get signed-in user's user progress" do
     user = create :user, total_lines: 2
-    create :user_level, user: user, best_result: 100, script: script, level: script.script_levels[1].level
     sign_in user
 
-    # Test user progress.
-    get :user_progress, params: {script: script.name}
+    create :user_level, user: user, best_result: 100, script: @script, level: @level
+
+    get :user_progress, params: {script: @script.name}
     assert_response :success
 
     body = JSON.parse(response.body)
+    assert_equal true, body['signedIn']
     assert_equal 2, body['linesOfCode']
-    script_level = script.script_levels[1]
-    level_id = script_level.level.id.to_s
-    assert_equal 'perfect', body['progress'][level_id]['status']
-    assert_equal 100, body['progress'][level_id]['result']
+    level_progress = body['progress'][@level.id.to_s]
+    refute_nil level_progress
+    assert_equal 'perfect', level_progress['status']
+    assert_equal 100, level_progress['result']
   end
 
-  test "should get user progress for lesson" do
-    slogger = FakeSlogger.new
-    CDO.set_slogger_for_test(slogger)
-    script = create(:script, :with_levels, levels_count: 1)
+  test "should get student's user progress if teacher of student" do
+    sign_in @teacher
 
+    create :user_level, user: @student_1, best_result: 100, script: @script, level: @level
+
+    get :user_progress, params: {script: @script.name, user_id: @student_1.id}
+    assert_response :success
+
+    body = JSON.parse(response.body)
+    level_progress = body['progress'][@level.id.to_s]
+    refute_nil level_progress
+    assert_equal 100, level_progress['result']
+  end
+
+  test "should not return student's user progress if not signed in" do
+    sign_out @teacher
+
+    create :user_level, user: @student_1, best_result: 100, script: @script, level: @level
+
+    get :user_progress, params: {script: @script.name, user_id: @student_1.id}
+    assert_response :success
+
+    body = JSON.parse(response.body)
+    assert_equal false, body['signedIn']
+    assert_nil body['progress']
+  end
+
+  test "should fail to get student's user progress if not teacher of student" do
+    user = create :user
+    sign_in user
+
+    create :user_level, user: @student_1, best_result: 100, script: @script, level: @level
+
+    get :user_progress, params: {script: @script.name, user_id: @student_1.id}
+    assert_response :forbidden
+  end
+
+  test "should get signed-in user's user app_options" do
     user = create :user, total_lines: 2
     sign_in user
 
-    script_level = script.script_levels.first
-    level = script_level.level
-    level_source = create :level_source, level: level, data: 'level source'
-
-    create :user_level, user: user, best_result: 100, script: script,
-      level: level, level_source: level_source
-    create :activity, user: user, level: level, level_source: level_source
+    level_source = create :level_source, level: @level, data: 'level source'
+    create :user_level, user: user, best_result: 100, script: @script,
+      level: @level, level_source: level_source
 
     get :user_app_options, params: {
-      script: script.name,
+      script: @script.name,
       lesson_position: 1,
-      level_position: 1
+      level_position: 1,
+      level: @level.id
     }
-    result = {"status" => "perfect", "result" => 100}
     assert_response :success
     body = JSON.parse(response.body)
     assert_equal true, body['signedIn']
-    assert_nil body['disableSocialShare']
-    assert_equal result, body['progress'][level.id.to_s]
+    assert_equal false, body['disableSocialShare']
     assert_equal 'level source', body['lastAttempt']['source']
-
-    assert_equal(
-      [
-        {
-          application: :dashboard,
-          tag: 'activity_start',
-          script_level_id: script_level.id,
-          level_id: level.id,
-          user_agent: 'Rails Testing',
-          locale: :'en-US'
-        }
-      ],
-      slogger.records
-    )
   end
 
-  test "user_app_options should return channel when param get_channel_id is true" do
-    script = create(:script, :with_levels, levels_count: 1)
-    level = script.script_levels.first.level
+  test "should get student's user app_options if teacher of student" do
+    sign_in @teacher
 
-    user = create :user, total_lines: 2
+    level_source = create :level_source, level: @level, data: 'level source'
+    create :user_level, user: @student_1, best_result: 100, script: @script,
+      level: @level, level_source: level_source
+
+    get :user_app_options, params: {
+      script: @script.name,
+      lesson_position: 1,
+      level_position: 1,
+      level: @level.id,
+      user_id: @student_1.id
+    }
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert_equal true, body['signedIn']
+    assert_equal false, body['disableSocialShare']
+    assert_equal 'level source', body['lastAttempt']['source']
+    assert_equal true, body['isStarted']
+  end
+
+  test "should not return student's user app_options if not signed in" do
+    sign_out @teacher
+
+    level_source = create :level_source, level: @level, data: 'level source'
+    create :user_level, user: @student_1, best_result: 100, script: @script,
+      level: @level, level_source: level_source
+
+    get :user_app_options, params: {
+      script: @script.name,
+      lesson_position: 1,
+      level_position: 1,
+      level: @level.id,
+      user_id: @student_1.id
+    }
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert_equal false, body['signedIn']
+    assert_nil body['lastAttempt']
+  end
+
+  test "should fail to get student's user app_options if not teacher of student" do
+    user = create :user
     sign_in user
 
-    channel_token = create :channel_token, level: level, script_id: script.id, storage_id: storage_id_for_user_id(user.id)
+    level_source = create :level_source, level: @level, data: 'level source'
+    create :user_level, user: @student_1, best_result: 100, script: @script,
+      level: @level, level_source: level_source
+
+    get :user_app_options, params: {
+      script: @script.name,
+      lesson_position: 1,
+      level_position: 1,
+      level: @level.id,
+      user_id: @student_1.id
+    }
+    assert_response :forbidden
+  end
+
+  test "user_app_options should not return readonly options when viewing self" do
+    sign_in @student_1
+
+    get :user_app_options, params: {
+      script: @script.name,
+      lesson_position: 1,
+      level_position: 1,
+      level: @level.id,
+    }
+
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert_nil body['skipInstructionsPopup']
+    assert_nil body['readonlyWorkspace']
+    assert_nil body['callouts']
+  end
+
+  test "user_app_options should return readonly options when viewing student" do
+    sign_in @teacher
+
+    get :user_app_options, params: {
+      script: @script.name,
+      lesson_position: 1,
+      level_position: 1,
+      level: @level.id,
+      user_id: @student_1.id
+    }
+
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert_equal true, body['skipInstructionsPopup']
+    assert_equal true, body['readonlyWorkspace']
+    assert_equal [], body['callouts']
+  end
+
+  test "user_app_options should return existing channel if one exists" do
+    sign_in @student_1
+
+    channel_token = create :channel_token, level: @level, script_id: @script.id, storage_id: storage_id_for_user_id(@student_1.id)
     expected_channel = channel_token.channel
 
     get :user_app_options, params: {
-      script: script.name,
+      script: @script.name,
       lesson_position: 1,
       level_position: 1,
+      level: @level.id,
       get_channel_id: true
     }
 
@@ -866,19 +973,63 @@ class ApiControllerTest < ActionController::TestCase
     assert_equal expected_channel, body['channel']
   end
 
-  test "user_app_options should not return channel when param get_channel_id is false" do
-    script = create(:script, :with_levels, levels_count: 1)
-    level = script.script_levels.first.level
-
-    user = create :user, total_lines: 2
-    sign_in user
-
-    create :channel_token, level: level, script_id: script.id, storage_id: storage_id_for_user_id(user.id)
+  test "user_app_options should create new channel if one doesn't exist" do
+    sign_in @student_1
 
     get :user_app_options, params: {
-      script: script.name,
+      script: @script.name,
       lesson_position: 1,
       level_position: 1,
+      level: @level.id,
+      get_channel_id: true
+    }
+
+    body = JSON.parse(response.body)
+    refute_nil body['channel']
+  end
+
+  test "user_app_options should not create channel when viewing student" do
+    sign_in @teacher
+
+    get :user_app_options, params: {
+      script: @script.name,
+      lesson_position: 1,
+      level_position: 1,
+      level: @level.id,
+      get_channel_id: true,
+      user_id: @student_1.id
+    }
+
+    body = JSON.parse(response.body)
+    assert_nil body['channel']
+  end
+
+  test "user_app_options should create new channel if one doesn't exist when signed out" do
+    sign_out @teacher
+
+    get :user_app_options, params: {
+      script: @script.name,
+      lesson_position: 1,
+      level_position: 1,
+      level: @level.id,
+      get_channel_id: true
+    }
+
+    body = JSON.parse(response.body)
+    refute_nil body['channel']
+  end
+
+  test "user_app_options should not return channel when param get_channel_id is false" do
+    user = @student_1
+    sign_in user
+
+    create :channel_token, level: @level, script_id: @script.id, storage_id: storage_id_for_user_id(user.id)
+
+    get :user_app_options, params: {
+      script: @script.name,
+      lesson_position: 1,
+      level_position: 1,
+      level: @level.id,
       get_channel_id: false
     }
 
@@ -888,13 +1039,10 @@ class ApiControllerTest < ActionController::TestCase
   end
 
   test "user_app_options should normally return reduceChannelUpdates false" do
-    script = create(:script, :with_levels, levels_count: 1)
-
-    user = create :user
-    sign_in user
+    sign_in @student_1
 
     get :user_app_options, params: {
-      script: script.name,
+      script: @script.name,
       lesson_position: 1,
       level_position: 1,
       get_channel_id: true
@@ -905,18 +1053,16 @@ class ApiControllerTest < ActionController::TestCase
   end
 
   test "user_app_options should return reduceChannelUpdates true in emergency mode" do
-    script = create(:script, :with_levels, levels_count: 1)
-
-    user = create :user
-    sign_in user
+    sign_in @student_1
 
     # Mimic Gatekeeper setting that's set in emergency mode
-    Gatekeeper.set('updateChannelOnSave', where: {script_name: script.name}, value: false)
+    Gatekeeper.set('updateChannelOnSave', where: {script_name: @script.name}, value: false)
 
     get :user_app_options, params: {
-      script: script.name,
+      script: @script.name,
       lesson_position: 1,
       level_position: 1,
+      level: @level.id,
       get_channel_id: true
     }
 
@@ -924,92 +1070,22 @@ class ApiControllerTest < ActionController::TestCase
     assert_equal true, body['reduceChannelUpdates']
   end
 
-  test "should slog the contained level id when present" do
-    slogger = FakeSlogger.new
-    CDO.set_slogger_for_test(slogger)
-    script = create :script
-    lesson_group = create :lesson_group, script: script
-    lesson = create :lesson, script: script, lesson_group: lesson_group
-    contained_level = create :multi, name: 'multi level'
-    level = create :maze, name: 'maze level', contained_level_names: ['multi level']
-    create :script_level, script: script, lesson: lesson, levels: [level]
-
-    user = create :user
-    sign_in user
-
-    get :user_app_options, params: {
-      script: script.name,
-      lesson_position: 1,
-      level_position: 1
-    }
-
-    assert_equal(contained_level.id, slogger.records.first[:level_id])
-  end
-
-  test "should get user progress for lesson for signed-out user" do
-    slogger = FakeSlogger.new
-    CDO.set_slogger_for_test(slogger)
-    script = create(:script, :with_levels, levels_count: 1)
-    script_level = script.script_levels[0]
-    level = script_level.level
-
-    user = create :user
-    sign_out user
-
-    get :user_app_options, params: {
-      script: script.name,
-      lesson_position: 1,
-      level_position: 1
-    }
-    assert_response :success
-    body = JSON.parse(response.body)
-    assert_equal false, body['signedIn']
-    assert_equal(
-      [
-        {
-          application: :dashboard,
-          tag: 'activity_start',
-          script_level_id: script_level.id,
-          level_id: level.id,
-          user_agent: 'Rails Testing',
-          locale: :'en-US'
-        }
-      ],
-      slogger.records
-    )
-  end
-
-  test "should get user progress for lesson with young student" do
-    script = create(:script, :with_levels, levels_count: 1)
+  test "user_app_options should return disableSocialShare true for young student" do
     young_student = create :young_student
     sign_in young_student
 
     get :user_app_options, params: {
-      script: script.name,
+      script: @script.name,
       lesson_position: 1,
-      level_position: 1
+      level_position: 1,
+      level: @level.id
     }
     assert_response :success
     body = JSON.parse(response.body)
     assert_equal true, body['disableSocialShare']
-    assert_equal({}, body['progress'])
   end
 
-  test "should get user progress for disabled milestone posts" do
-    Gatekeeper.set('postMilestone', value: false)
-    script = create(:script, :with_levels, levels_count: 1)
-    user = create :user, total_lines: 2
-    sign_in user
-
-    get :user_app_options, params: {
-      script: script.name,
-      lesson_position: 1,
-      level_position: 1
-    }
-    assert_response :success
-  end
-
-  test "should get user progress for lesson with swapped level" do
+  test "user_app_options should return previous attempt with swapped level" do
     sign_in @student_1
     script = create :script
     lesson_group = create :lesson_group, script: script
@@ -1019,7 +1095,6 @@ class ApiControllerTest < ActionController::TestCase
     level_source = create :level_source, level: level1a, data: 'level source'
     create :script_level, script: script, lesson: lesson, levels: [level1a, level1b], properties: {'maze 1': {'active': false}}
     create :user_level, user: @student_1, script: script, level: level1a, level_source: level_source
-    create :activity, user: @student_1, level: level1a, level_source: level_source
 
     get :user_app_options, params: {
       script: script.name,

--- a/dashboard/test/integration/db_query_test.rb
+++ b/dashboard/test/integration/db_query_test.rb
@@ -51,7 +51,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
       level: level.id
     )
 
-    assert_cached_queries(11) do
+    assert_cached_queries(4) do
       get user_app_options_path,
         headers: {'HTTP_USER_AGENT': 'test'}
       assert_response :success
@@ -156,7 +156,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     # Simulate all the ajax requests which the level page sends to the
     # server on page load.
 
-    assert_cached_queries(10) do
+    assert_cached_queries(2) do
       get "/api/user_app_options/#{unit.name}/1/1/#{level.id}"
       assert_response :success
     end

--- a/dashboard/test/test_helper.rb
+++ b/dashboard/test/test_helper.rb
@@ -668,20 +668,6 @@ def storage_id_for_user_id(user_id)
   Random.new(user_id.to_i).rand(1_000_000)
 end
 
-# A fake slogger implementation that captures the records written to it.
-class FakeSlogger
-  attr_reader :records
-
-  def initialize
-    @records = []
-  end
-
-  def write(json)
-    # Force application: :dashboard to ensure we don't incorrectly use the :pegasus version:
-    @records << json.merge({application: :dashboard})
-  end
-end
-
 def json_response
   JSON.parse @response.body
 end


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

This change updates ApiController#user_app_options to take a user_id, verify that the signed-in user is allowed to see the requested user progress, and returns the requested user's data.  The diff doesn't do a great job of capturing the actual changes.  Most of the logic in user_app_options is pre-existing with the following changes:
- Moved the code to get progress-related app_options to a separate method.
- Stopped sending `progress` and `isHoc` fields in the response (since they weren't being used on the client).
- Started sending `isStarted`, `skipInstructionsPopup`, `readonlyWorkspace`, and `callouts`

Some additional small changes:
- Pass through user_id in both the user_progress and user_app_options calls on the client.
- Handle new values returned by user_app_options on the client.
- Removed slogging for `activity_start` and `activity_finish` which are no longer needed ([slack](https://codedotorg.slack.com/archives/C0T0PNTM3/p1635530518124200)).
- Update ApiController#user_progress to check that signed-in user can see requested user's progress. 

With these changes, teacher view works for cached levels if you comment out the [line](https://github.com/code-dot-org/code-dot-org/blob/f26d5d6e6327d3a864d7c7062394885889f76a6e/dashboard/app/controllers/script_levels_controller.rb#L403) that returns the "Student code cannot be viewed for this activity."

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [LP-2086](https://codedotorg.atlassian.net/browse/LP-2086)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
