### PR TITLE
Allow existing duplicate levels within unit when updating lesson

### DIFF
--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -107,6 +107,7 @@ class LessonsController < ApplicationController
     standards = fetch_standards(lesson_params['standards'] || [])
     opportunity_standards = fetch_standards(lesson_params['opportunity_standards'] || [])
     programming_expressions = fetch_programming_expressions(lesson_params['programming_expressions'] || [])
+    old_dup_level_keys = @lesson.script.duplicate_level_keys
     ActiveRecord::Base.transaction do
       @lesson.resources = resources.compact
       @lesson.vocabularies = vocabularies.compact
@@ -122,7 +123,7 @@ class LessonsController < ApplicationController
         raise msg unless @lesson.script_levels.last.assessment && @lesson.script_levels.last.level.type == 'LevelGroup'
       end
 
-      @lesson.script.prevent_duplicate_levels
+      @lesson.script.prevent_new_duplicate_levels(old_dup_level_keys)
       @lesson.script.fix_lesson_positions
     end
 

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -159,12 +159,14 @@ class Script < ApplicationRecord
 
   def prevent_duplicate_levels
     reload
+    duplicate_keys = duplicate_level_keys
+    raise "duplicate levels detected: #{duplicate_keys.to_json}" unless duplicate_keys.empty?
+  end
 
-    unless levels.count == levels.uniq.count
-      levels_by_key = levels.map(&:key).group_by {|key| key}
-      duplicate_keys = levels_by_key.select {|_key, values| values.count > 1}.keys
-      raise "duplicate levels detected: #{duplicate_keys.to_json}"
-    end
+  def duplicate_level_keys
+    return [] if levels.count == levels.uniq.count
+    levels_by_key = levels.map(&:key).group_by {|key| key}
+    levels_by_key.select {|_key, values| values.count > 1}.keys
   end
 
   include SerializedProperties

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -157,10 +157,9 @@ class Script < ApplicationRecord
   validates :instructor_audience, acceptance: {accept: SharedCourseConstants::INSTRUCTOR_AUDIENCE.to_h.values.push(nil), message: 'must be nil, code instructor, plc reviewer, facilitator, or teacher'}
   validates :participant_audience, acceptance: {accept: SharedCourseConstants::PARTICIPANT_AUDIENCE.to_h.values.push(nil), message: 'must be nil, facilitator, teacher, or student'}
 
-  def prevent_duplicate_levels
-    reload
-    duplicate_keys = duplicate_level_keys
-    raise "duplicate levels detected: #{duplicate_keys.to_json}" unless duplicate_keys.empty?
+  def prevent_new_duplicate_levels(old_dup_level_keys = [])
+    new_dup_level_keys = duplicate_level_keys - old_dup_level_keys
+    raise "new duplicate levels detected in unit: #{new_dup_level_keys}" if new_dup_level_keys.any?
   end
 
   def duplicate_level_keys

--- a/dashboard/test/controllers/lessons_controller_test.rb
+++ b/dashboard/test/controllers/lessons_controller_test.rb
@@ -1041,7 +1041,7 @@ class LessonsControllerTest < ActionController::TestCase
     assert_equal ['level-to-add'], script_level.levels.map(&:name)
   end
 
-  test 'cannot add duplicate level via lesson update' do
+  test 'cannot add new duplicate level to unit via lesson update' do
     sign_in @levelbuilder
     activity = create :lesson_activity, lesson: @lesson
     create :activity_section, lesson_activity: activity
@@ -1056,7 +1056,6 @@ class LessonsControllerTest < ActionController::TestCase
     activities_data.first[:activitySections].first[:scriptLevels].push(
       activitySectionPosition: 1,
       activeId: existing_level.id,
-      assessment: true,
       levels: [{id: existing_level.id, name: existing_level.name}]
     )
 
@@ -1066,6 +1065,32 @@ class LessonsControllerTest < ActionController::TestCase
       put :update, params: @update_params
     end
     assert_includes error.message, 'duplicate levels detected'
+  end
+
+  test 'can update lesson when duplicate levels already exist in unit' do
+    sign_in @levelbuilder
+    activity = create :lesson_activity, lesson: @lesson
+    section = create :activity_section, lesson_activity: activity
+    existing_level = create :maze, name: 'existing-level'
+    create :script_level, activity_section: section, activity_section_position: 1, lesson: @lesson, script: @script, levels: [existing_level]
+
+    activity2 = create :lesson_activity, lesson: @lesson2
+    section2 = create :activity_section, lesson_activity: activity2
+    create :script_level, activity_section: section2, activity_section_position: 2, lesson: @lesson2, script: @script, levels: [existing_level]
+
+    @lesson.reload
+    new_level = create :level
+    activities_data = @lesson.summarize_for_lesson_edit[:activities]
+    activities_data.first[:activitySections].first[:scriptLevels].push(
+      activitySectionPosition: 2,
+      activeId: new_level.id,
+      levels: [{id: new_level.id, name: new_level.name}]
+    )
+
+    @update_params['activities'] = activities_data.to_json
+
+    put :update, params: @update_params
+    assert_response :success
   end
 
   test 'add anonymous survey level via lesson update' do


### PR DESCRIPTION
## Background

2nd attempt at fixing fallout from https://codedotorg.atlassian.net/browse/PLAT-830. Supercedes https://github.com/code-dot-org/code-dot-org/pull/43377, see that PR for background. Also see discussion with LP in [slack](https://codedotorg.slack.com/archives/CA3KCSGTD/p1636132531041100).

## Description

The new solution is to allow _existing_ duplicate levels within the unit, but prevent _new_ duplicate levels from being introduced.

## Screenshots

I can update a lesson in k5-onlinepd-2021 without adding any levels, even though the unit contains duplicates:

![Screen Shot 2021-11-05 at 4 10 18 PM](https://user-images.githubusercontent.com/8001765/140588287-ee72168b-cd88-4e89-b144-d14fc7c70144.png)

I cannot add a new duplicate level:

![Screen Shot 2021-11-05 at 4 09 40 PM](https://user-images.githubusercontent.com/8001765/140588162-58240435-c52d-4d49-bd78-20d040060863.png)

## Testing story

updated unit tests to reject new duplicate levels within the unit, but allow existing duplicates.