### PR TITLE
add option to use utf8 charset when resetting test db

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -93,8 +93,8 @@ If you get a bunch of complaints about database, like missing tables or how some
 1. `RAILS_ENV=test bundle exec rake seed:secret_pictures seed:secret_words` to seed the missing data, or
 
 2. recreate your local dashboard test db and reseed the data via:
-    * `RAILS_ENV=test bundle exec rake db:reset db:test:prepare`
-    * `echo "ALTER DATABASE dashboard_test CHARACTER SET utf8 COLLATE utf8_unicode_ci;" | mysql -uroot`
+    * `UTF8=1 RAILS_ENV=test bundle exec rake db:reset db:test:prepare`
+    * if you forgot to specify `UTF8=1`, fix it by running: `echo "ALTER DATABASE dashboard_test CHARACTER SET utf8 COLLATE utf8_unicode_ci;" | mysql -uroot`
 
 If you just want to run a single file of tests, from the dashboard directory you can run
 `bundle exec spring testunit ./path/to/your/test.rb` 

--- a/dashboard/lib/tasks/seed_in_test.rake
+++ b/dashboard/lib/tasks/seed_in_test.rake
@@ -1,8 +1,10 @@
 Rake::Task['db:test:prepare'].enhance do
-  if ENV['UTF8']
-    system('mysql -uroot -e "ALTER DATABASE dashboard_test CHARACTER SET utf8 COLLATE utf8_unicode_ci;"')
-  end
   ActiveRecord::Base.establish_connection(:test)
+  if ENV['UTF8']
+    ActiveRecord::Base.connection.execute(
+      "ALTER DATABASE #{ActiveRecord::Base.connection.current_database} CHARACTER SET utf8 COLLATE utf8_unicode_ci;"
+    )
+  end
   Rake::Task['db:fixtures:load'].invoke
   require 'cdo/db_utils'
   DBUtils.reload_proxy_backends

--- a/dashboard/lib/tasks/seed_in_test.rake
+++ b/dashboard/lib/tasks/seed_in_test.rake
@@ -1,4 +1,7 @@
 Rake::Task['db:test:prepare'].enhance do
+  if ENV['UTF8']
+    system('mysql -uroot -e "ALTER DATABASE dashboard_test CHARACTER SET utf8 COLLATE utf8_unicode_ci;"')
+  end
   ActiveRecord::Base.establish_connection(:test)
   Rake::Task['db:fixtures:load'].invoke
   require 'cdo/db_utils'


### PR DESCRIPTION
This PR makes it a bit easier to keep the right settings when resetting your local test database:

before:
```
RAILS_ENV=test bundle exec rake db:reset db:test:prepare
echo "ALTER DATABASE dashboard_test CHARACTER SET utf8 COLLATE utf8_unicode_ci;" | mysql -uroot
```

after:
```
UTF8=1 RAILS_ENV=test bundle exec rake db:reset db:test:prepare
```

## Testing story

```
Dave-MBP:~/src/cdo2/dashboard (db-reset-utf8)$ UTF8=1 RAILS_ENV=test bundle exec rake db:reset db:test:prepare
...
Dave-MBP:~/src/cdo2/dashboard (db-reset-utf8)$ mysql -uroot -e "SELECT @@character_set_database, @@collation_database;" dashboard_test
+--------------------------+----------------------+
| @@character_set_database | @@collation_database |
+--------------------------+----------------------+
| utf8                     | utf8_unicode_ci      |
+--------------------------+----------------------+
```
