### PR TITLE
migrate course version UI test units

### DIFF
--- a/dashboard/config/scripts_json/ui-test-script-in-course-2017.script_json
+++ b/dashboard/config/scripts_json/ui-test-script-in-course-2017.script_json
@@ -1,0 +1,145 @@
+{
+  "script": {
+    "name": "ui-test-script-in-course-2017",
+    "wrapup_video_id": null,
+    "login_required": false,
+    "properties": {
+      "is_migrated": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "serialized_at": "2021-11-06 22:52:04 UTC",
+    "published_state": "stable",
+    "instruction_type": null,
+    "instructor_audience": null,
+    "participant_audience": null,
+    "seeding_key": {
+      "script.name": "ui-test-script-in-course-2017"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "lg_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "lg_1",
+        "script.name": "ui-test-script-in-course-2017"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Lesson",
+      "name": "Lesson",
+      "absolute_position": 1,
+      "lockable": false,
+      "has_lesson_plan": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson",
+        "lesson_group.key": "lg_1",
+        "script.name": "ui-test-script-in-course-2017"
+      }
+    }
+  ],
+  "lesson_activities": [
+    {
+      "key": "452fd021-800d-4072-97c6-81446c4adaa6",
+      "position": 1,
+      "properties": {
+        "name": "Levels"
+      },
+      "seeding_key": {
+        "lesson_activity.key": "452fd021-800d-4072-97c6-81446c4adaa6",
+        "lesson.key": "Lesson",
+        "lesson_group.key": "lg_1",
+        "script.name": "ui-test-script-in-course-2017"
+      }
+    }
+  ],
+  "activity_sections": [
+    {
+      "key": "1b9c2aae-7014-467b-beb2-901d8ee78346",
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "activity_section.key": "1b9c2aae-7014-467b-beb2-901d8ee78346",
+        "lesson_activity.key": "452fd021-800d-4072-97c6-81446c4adaa6"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L1 Student Lesson Introduction"
+        ],
+        "lesson.key": "Lesson",
+        "lesson_group.key": "lg_1",
+        "script.name": "ui-test-script-in-course-2017",
+        "activity_section.key": "1b9c2aae-7014-467b-beb2-901d8ee78346"
+      },
+      "level_keys": [
+        "U1L1 Student Lesson Introduction"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "U1L1 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U1L1 Student Lesson Introduction"
+        ],
+        "lesson.key": "Lesson",
+        "lesson_group.key": "lg_1",
+        "script.name": "ui-test-script-in-course-2017",
+        "activity_section.key": "1b9c2aae-7014-467b-beb2-901d8ee78346"
+      }
+    }
+  ],
+  "resources": [
+
+  ],
+  "lessons_resources": [
+
+  ],
+  "scripts_resources": [
+
+  ],
+  "scripts_student_resources": [
+
+  ],
+  "vocabularies": [
+
+  ],
+  "lessons_vocabularies": [
+
+  ],
+  "lessons_programming_expressions": [
+
+  ],
+  "objectives": [
+
+  ],
+  "lessons_standards": [
+
+  ],
+  "lessons_opportunity_standards": [
+
+  ]
+}

--- a/dashboard/config/scripts_json/ui-test-script-in-course-2019.script_json
+++ b/dashboard/config/scripts_json/ui-test-script-in-course-2019.script_json
@@ -1,0 +1,145 @@
+{
+  "script": {
+    "name": "ui-test-script-in-course-2019",
+    "wrapup_video_id": null,
+    "login_required": false,
+    "properties": {
+      "is_migrated": true
+    },
+    "new_name": null,
+    "family_name": null,
+    "serialized_at": "2021-11-06 22:53:56 UTC",
+    "published_state": "stable",
+    "instruction_type": null,
+    "instructor_audience": null,
+    "participant_audience": null,
+    "seeding_key": {
+      "script.name": "ui-test-script-in-course-2019"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "lg_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "lg_1",
+        "script.name": "ui-test-script-in-course-2019"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Lesson",
+      "name": "Lesson",
+      "absolute_position": 1,
+      "lockable": false,
+      "has_lesson_plan": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson",
+        "lesson_group.key": "lg_1",
+        "script.name": "ui-test-script-in-course-2019"
+      }
+    }
+  ],
+  "lesson_activities": [
+    {
+      "key": "9ca80a74-e401-4b31-afce-045d72077aca",
+      "position": 1,
+      "properties": {
+        "name": "Levels"
+      },
+      "seeding_key": {
+        "lesson_activity.key": "9ca80a74-e401-4b31-afce-045d72077aca",
+        "lesson.key": "Lesson",
+        "lesson_group.key": "lg_1",
+        "script.name": "ui-test-script-in-course-2019"
+      }
+    }
+  ],
+  "activity_sections": [
+    {
+      "key": "634599d1-5c6f-4a76-81d0-651ebb2b2cc7",
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "activity_section.key": "634599d1-5c6f-4a76-81d0-651ebb2b2cc7",
+        "lesson_activity.key": "9ca80a74-e401-4b31-afce-045d72077aca"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "U1L1 Student Lesson Introduction"
+        ],
+        "lesson.key": "Lesson",
+        "lesson_group.key": "lg_1",
+        "script.name": "ui-test-script-in-course-2019",
+        "activity_section.key": "634599d1-5c6f-4a76-81d0-651ebb2b2cc7"
+      },
+      "level_keys": [
+        "U1L1 Student Lesson Introduction"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "U1L1 Student Lesson Introduction",
+        "script_level.level_keys": [
+          "U1L1 Student Lesson Introduction"
+        ],
+        "lesson.key": "Lesson",
+        "lesson_group.key": "lg_1",
+        "script.name": "ui-test-script-in-course-2019",
+        "activity_section.key": "634599d1-5c6f-4a76-81d0-651ebb2b2cc7"
+      }
+    }
+  ],
+  "resources": [
+
+  ],
+  "lessons_resources": [
+
+  ],
+  "scripts_resources": [
+
+  ],
+  "scripts_student_resources": [
+
+  ],
+  "vocabularies": [
+
+  ],
+  "lessons_vocabularies": [
+
+  ],
+  "lessons_programming_expressions": [
+
+  ],
+  "objectives": [
+
+  ],
+  "lessons_standards": [
+
+  ],
+  "lessons_opportunity_standards": [
+
+  ]
+}

--- a/dashboard/config/scripts_json/ui-test-versioned-script-2017.script_json
+++ b/dashboard/config/scripts_json/ui-test-versioned-script-2017.script_json
@@ -1,0 +1,147 @@
+{
+  "script": {
+    "name": "ui-test-versioned-script-2017",
+    "wrapup_video_id": null,
+    "login_required": false,
+    "properties": {
+      "is_course": true,
+      "is_migrated": true,
+      "version_year": "2017"
+    },
+    "new_name": null,
+    "family_name": "ui-test-versioned-script",
+    "serialized_at": "2021-11-06 22:53:56 UTC",
+    "published_state": "stable",
+    "instruction_type": null,
+    "instructor_audience": null,
+    "participant_audience": null,
+    "seeding_key": {
+      "script.name": "ui-test-versioned-script-2017"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "lg_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "lg_1",
+        "script.name": "ui-test-versioned-script-2017"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Lesson",
+      "name": "Lesson",
+      "absolute_position": 1,
+      "lockable": false,
+      "has_lesson_plan": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson",
+        "lesson_group.key": "lg_1",
+        "script.name": "ui-test-versioned-script-2017"
+      }
+    }
+  ],
+  "lesson_activities": [
+    {
+      "key": "ba2e6a35-7e87-4091-a43c-9056c9c2eb91",
+      "position": 1,
+      "properties": {
+        "name": "Levels"
+      },
+      "seeding_key": {
+        "lesson_activity.key": "ba2e6a35-7e87-4091-a43c-9056c9c2eb91",
+        "lesson.key": "Lesson",
+        "lesson_group.key": "lg_1",
+        "script.name": "ui-test-versioned-script-2017"
+      }
+    }
+  ],
+  "activity_sections": [
+    {
+      "key": "dcf1b324-b38b-43b4-a3d7-7d4357dcc7c5",
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "activity_section.key": "dcf1b324-b38b-43b4-a3d7-7d4357dcc7c5",
+        "lesson_activity.key": "ba2e6a35-7e87-4091-a43c-9056c9c2eb91"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_video_Unspotted"
+        ],
+        "lesson.key": "Lesson",
+        "lesson_group.key": "lg_1",
+        "script.name": "ui-test-versioned-script-2017",
+        "activity_section.key": "dcf1b324-b38b-43b4-a3d7-7d4357dcc7c5"
+      },
+      "level_keys": [
+        "courseB_video_Unspotted"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "courseB_video_Unspotted",
+        "script_level.level_keys": [
+          "courseB_video_Unspotted"
+        ],
+        "lesson.key": "Lesson",
+        "lesson_group.key": "lg_1",
+        "script.name": "ui-test-versioned-script-2017",
+        "activity_section.key": "dcf1b324-b38b-43b4-a3d7-7d4357dcc7c5"
+      }
+    }
+  ],
+  "resources": [
+
+  ],
+  "lessons_resources": [
+
+  ],
+  "scripts_resources": [
+
+  ],
+  "scripts_student_resources": [
+
+  ],
+  "vocabularies": [
+
+  ],
+  "lessons_vocabularies": [
+
+  ],
+  "lessons_programming_expressions": [
+
+  ],
+  "objectives": [
+
+  ],
+  "lessons_standards": [
+
+  ],
+  "lessons_opportunity_standards": [
+
+  ]
+}

--- a/dashboard/config/scripts_json/ui-test-versioned-script-2019.script_json
+++ b/dashboard/config/scripts_json/ui-test-versioned-script-2019.script_json
@@ -1,0 +1,147 @@
+{
+  "script": {
+    "name": "ui-test-versioned-script-2019",
+    "wrapup_video_id": null,
+    "login_required": false,
+    "properties": {
+      "is_course": true,
+      "is_migrated": true,
+      "version_year": "2019"
+    },
+    "new_name": null,
+    "family_name": "ui-test-versioned-script",
+    "serialized_at": "2021-11-06 22:53:56 UTC",
+    "published_state": "stable",
+    "instruction_type": null,
+    "instructor_audience": null,
+    "participant_audience": null,
+    "seeding_key": {
+      "script.name": "ui-test-versioned-script-2019"
+    }
+  },
+  "lesson_groups": [
+    {
+      "key": "lg_1",
+      "user_facing": true,
+      "position": 1,
+      "properties": {
+        "display_name": "Content"
+      },
+      "seeding_key": {
+        "lesson_group.key": "lg_1",
+        "script.name": "ui-test-versioned-script-2019"
+      }
+    }
+  ],
+  "lessons": [
+    {
+      "key": "Lesson",
+      "name": "Lesson",
+      "absolute_position": 1,
+      "lockable": false,
+      "has_lesson_plan": false,
+      "relative_position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "lesson.key": "Lesson",
+        "lesson_group.key": "lg_1",
+        "script.name": "ui-test-versioned-script-2019"
+      }
+    }
+  ],
+  "lesson_activities": [
+    {
+      "key": "84b86ddf-92fb-4ecc-b83a-1e06bff61fed",
+      "position": 1,
+      "properties": {
+        "name": "Levels"
+      },
+      "seeding_key": {
+        "lesson_activity.key": "84b86ddf-92fb-4ecc-b83a-1e06bff61fed",
+        "lesson.key": "Lesson",
+        "lesson_group.key": "lg_1",
+        "script.name": "ui-test-versioned-script-2019"
+      }
+    }
+  ],
+  "activity_sections": [
+    {
+      "key": "19040849-5799-4bee-ad15-75a640abb43d",
+      "position": 1,
+      "properties": {
+      },
+      "seeding_key": {
+        "activity_section.key": "19040849-5799-4bee-ad15-75a640abb43d",
+        "lesson_activity.key": "84b86ddf-92fb-4ecc-b83a-1e06bff61fed"
+      }
+    }
+  ],
+  "script_levels": [
+    {
+      "chapter": 1,
+      "position": 1,
+      "activity_section_position": 1,
+      "assessment": false,
+      "properties": {
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "courseB_video_Unspotted"
+        ],
+        "lesson.key": "Lesson",
+        "lesson_group.key": "lg_1",
+        "script.name": "ui-test-versioned-script-2019",
+        "activity_section.key": "19040849-5799-4bee-ad15-75a640abb43d"
+      },
+      "level_keys": [
+        "courseB_video_Unspotted"
+      ]
+    }
+  ],
+  "levels_script_levels": [
+    {
+      "seeding_key": {
+        "level.key": "courseB_video_Unspotted",
+        "script_level.level_keys": [
+          "courseB_video_Unspotted"
+        ],
+        "lesson.key": "Lesson",
+        "lesson_group.key": "lg_1",
+        "script.name": "ui-test-versioned-script-2019",
+        "activity_section.key": "19040849-5799-4bee-ad15-75a640abb43d"
+      }
+    }
+  ],
+  "resources": [
+
+  ],
+  "lessons_resources": [
+
+  ],
+  "scripts_resources": [
+
+  ],
+  "scripts_student_resources": [
+
+  ],
+  "vocabularies": [
+
+  ],
+  "lessons_vocabularies": [
+
+  ],
+  "lessons_programming_expressions": [
+
+  ],
+  "objectives": [
+
+  ],
+  "lessons_standards": [
+
+  ],
+  "lessons_opportunity_standards": [
+
+  ]
+}

--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -65,6 +65,11 @@ namespace :seed do
   end
 
   SCRIPTS_GLOB = Dir.glob('config/scripts/**/*.script').sort.flatten.freeze
+  # TODO(dave): when we switch to seeding .script_json files directly without
+  # looking at a .script file first, the corresponding .script_json files for
+  # these units should be moved from dashboard/config/scripts_json to
+  # dashboard/test/ui/config/scripts_json, to ensure that they do not get seeded
+  # outside of the test environment.
   SPECIAL_UI_TEST_SCRIPTS = [
     'ui-test-script-in-course-2017',
     'ui-test-script-in-course-2019',

--- a/dashboard/test/ui/config/scripts/ui-test-script-in-course-2017.script
+++ b/dashboard/test/ui/config/scripts/ui-test-script-in-course-2017.script
@@ -1,5 +1,1 @@
-published_state 'stable'
-
-lesson_group 'lg_1', display_name: 'Content'
-lesson 'Lesson', display_name: 'Lesson'
-level 'U1L1 Student Lesson Introduction'
+is_migrated true

--- a/dashboard/test/ui/config/scripts/ui-test-script-in-course-2019.script
+++ b/dashboard/test/ui/config/scripts/ui-test-script-in-course-2019.script
@@ -1,5 +1,1 @@
-published_state 'stable'
-
-lesson_group 'lg_1', display_name: 'Content'
-lesson 'Lesson', display_name: 'Lesson'
-level 'U1L1 Student Lesson Introduction'
+is_migrated true

--- a/dashboard/test/ui/config/scripts/ui-test-versioned-script-2017.script
+++ b/dashboard/test/ui/config/scripts/ui-test-versioned-script-2017.script
@@ -1,8 +1,1 @@
-family_name 'ui-test-versioned-script'
-version_year '2017'
-published_state 'stable'
-is_course true
-
-lesson_group 'lg_1', display_name: 'Content'
-lesson 'Lesson', display_name: 'Lesson'
-level 'courseB_video_Unspotted'
+is_migrated true

--- a/dashboard/test/ui/config/scripts/ui-test-versioned-script-2019.script
+++ b/dashboard/test/ui/config/scripts/ui-test-versioned-script-2019.script
@@ -1,8 +1,1 @@
-family_name 'ui-test-versioned-script'
-version_year '2019'
-published_state 'stable'
-is_course true
-
-lesson_group 'lg_1', display_name: 'Content'
-lesson 'Lesson', display_name: 'Lesson'
-level 'courseB_video_Unspotted'
+is_migrated true


### PR DESCRIPTION
Finishes [PLAT-1424].

To migrate these units, I ran `rake seed:scripts_ui_tests` to get these test-only units into my local DB, then ran migrate_unit.rb on them.

One thing worth noting here is that the .script files are stored separately in dashboard/test/ui/config (near other test-only config files), but the .script_json files are stored in dashboard/config (near production config files). This was the shortest path I could find to getting the test-only .script files to seed in just the test environment. This inconsistency will go away when we get rid of .script files. at that point, we'll be forced to move these new files from dashboard/config to dashboard/test/ui/config, or course_versions.feature UI tests won't pass.

## Testing story

test-only change. affected tests are passing

## Follow-up work



[PLAT-1424]: https://codedotorg.atlassian.net/browse/PLAT-1424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ