### PR TITLE
[Google Blockly][Poetry] call blockToCode with opt_thisOnly

### DIFF
--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -1219,7 +1219,7 @@ exports.createJsWrapperBlockCreator = function(
       if (eventBlock) {
         const nextBlock =
           this.nextConnection && this.nextConnection.targetBlock();
-        let handlerCode = Blockly.JavaScript.blockToCode(nextBlock, true);
+        let handlerCode = Blockly.JavaScript.blockToCode(nextBlock, false);
         handlerCode = Blockly.Generator.prefixLines(handlerCode, '  ');
         if (callbackParams) {
           let params = callbackParams.join(',');

--- a/apps/src/blockly/cdoBlocklyWrapper.js
+++ b/apps/src/blockly/cdoBlocklyWrapper.js
@@ -194,6 +194,18 @@ function initializeBlocklyWrapper(blocklyInstance) {
     return strip(code);
   };
 
+  // The second argument to Google Blockly's blockToCode specifies whether to
+  // generate code for the whole block stack or just the single block. The
+  // second argument to Cdo Blockly's blockToCode specifies whether to generate
+  // code for hidden blocks. However, across all apps code, opt_showHidden is
+  // always true. So we can just ignore the second argument and pass true to Cdo
+  // Blockly, which allows us to change the usage across apps code to treat the
+  // second argument as opt_thisOnly rather than opt_showHidden.
+  const originalBlockToCode = blocklyWrapper.JavaScript.blockToCode;
+  blocklyWrapper.JavaScript.blockToCode = function(block, opt_thisOnly) {
+    return originalBlockToCode.call(this, block, true /* opt_showHidden */);
+  };
+
   blocklyWrapper.Input.prototype.getFieldRow = function() {
     return this.titleRow;
   };


### PR DESCRIPTION
Follow up to https://github.com/code-dot-org/code-dot-org/pull/43195

![image](https://user-images.githubusercontent.com/8787187/140626842-835cd120-e962-47fa-87a5-1fcc5313d473.png)

Before
![image](https://user-images.githubusercontent.com/8787187/140626839-99fcce61-a8e4-419c-a306-88d6b4ec3ca4.png)


After
![image](https://user-images.githubusercontent.com/8787187/140626829-7be9ff9e-7db3-498e-b4c1-08ab46db3659.png)

There was an issue where the code generated for events would only include the first block under the event block, not the full stack. It turns out, Google's `blockToCode` and Cdo's `blockToCode` both take a boolean as the second argument, but the booleans represent entirely different things 😬  In Google Blockly, `true` indicates that code should only be generated for the single block, not any of its children. In Cdo Blockly, `true` indicates that code should be generated for hidden blocks as well as visible blocks. So in the event code generation code, we were calling with `true`, but that was causing Google Blockly to not generate code for any of the children ( the second block under the event stack). Thankfully, we always call Cdo's `blockToCode` with `opt_showHidden = true` so it's simple enough to just set that in the wrapper layer. This enables us to change the argument to `false` to work with Google Blockly without changing the Cdo Blockly behavior.


All usages of `blockToCode` in apps:
![image](https://user-images.githubusercontent.com/8787187/140626913-0823bd0f-48bd-4648-9b9e-a4932b12037e.png)
