### PR TITLE
[Google Blockly] Set max width for flyout

### DIFF
--- a/apps/src/blockly/addons/cdoVerticalFlyout.js
+++ b/apps/src/blockly/addons/cdoVerticalFlyout.js
@@ -1,0 +1,87 @@
+import GoogleBlockly from 'blockly/core';
+
+export default class VerticalFlyout extends GoogleBlockly.VerticalFlyout {
+  /**
+   * @override
+   * This is copied almost entirely from
+   * https://github.com/google/blockly/blob/master/core/flyout_vertical.js#L322
+   * We override flyoutWidth to constrain it to be at most 40% of the total
+   * workspace space.
+   * Once https://github.com/google/blockly/issues/5684 is resolved, we can
+   * remove this duplicated code and use the API to set the max width of the flyout.
+   **/
+  reflowInternal_() {
+    this.workspace_.scale = this.getFlyoutScale();
+    var flyoutWidth = 0;
+    var blocks = this.workspace_.getTopBlocks(false);
+    for (let i = 0, block; (block = blocks[i]); i++) {
+      var width = block.getHeightWidth().width;
+      if (block.outputConnection) {
+        width -= this.tabWidth_;
+      }
+      flyoutWidth = Math.max(flyoutWidth, width);
+    }
+    for (let i = 0, button; (button = this.buttons_[i]); i++) {
+      flyoutWidth = Math.max(flyoutWidth, button.width);
+    }
+    flyoutWidth += this.MARGIN * 1.5 + this.tabWidth_;
+    flyoutWidth *= this.workspace_.scale;
+    flyoutWidth += Blockly.Scrollbar.scrollbarThickness;
+
+    /* Begin CDO Customization */
+    // Constrain the flyout to not be wider than 40% of the total workspace space.
+    flyoutWidth = Math.min(
+      flyoutWidth,
+      this.targetWorkspace.metricsManager_.getSvgMetrics().width * 0.4
+    );
+    /* End CDO Customization */
+
+    if (this.width_ !== flyoutWidth) {
+      for (let i = 0, block; (block = blocks[i]); i++) {
+        if (this.RTL) {
+          // With the flyoutWidth known, right-align the blocks.
+          var oldX = block.getRelativeToSurfaceXY().x;
+          var newX = flyoutWidth / this.workspace_.scale - this.MARGIN;
+          if (!block.outputConnection) {
+            newX -= this.tabWidth_;
+          }
+          block.moveBy(newX - oldX, 0);
+        }
+        if (block.flyoutRect_) {
+          this.moveRectToBlock_(block.flyoutRect_, block);
+        }
+      }
+      if (this.RTL) {
+        // With the flyoutWidth known, right-align the buttons.
+        for (let i = 0, button; (button = this.buttons_[i]); i++) {
+          var y = button.getPosition().y;
+          var x =
+            flyoutWidth / this.workspace_.scale -
+            button.width -
+            this.MARGIN -
+            this.tabWidth_;
+          button.moveTo(x, y);
+        }
+      }
+
+      if (
+        this.targetWorkspace.toolboxPosition === this.toolboxPosition_ &&
+        this.toolboxPosition_ === Blockly.utils.toolbox.Position.LEFT &&
+        !this.targetWorkspace.getToolbox()
+      ) {
+        // This flyout is a simple toolbox. Reposition the workspace so that (0,0)
+        // is in the correct position relative to the new absolute edge (ie
+        // toolbox edge).
+        this.targetWorkspace.translate(
+          this.targetWorkspace.scrollX + flyoutWidth,
+          this.targetWorkspace.scrollY
+        );
+      }
+
+      // Record the width for workspace metrics and .position.
+      this.width_ = flyoutWidth;
+      this.position();
+      this.targetWorkspace.recordDragTargets();
+    }
+  }
+}

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -19,6 +19,7 @@ import initializeTouch from './addons/cdoTouch';
 import CdoTrashcan from './addons/cdoTrashcan';
 import initializeVariables from './addons/cdoVariables';
 import CdoVariableMap from './addons/cdoVariableMap';
+import CdoVerticalFlyout from './addons/cdoVerticalFlyout';
 import CdoWorkspaceSvg from './addons/cdoWorkspaceSvg';
 import initializeBlocklyXml from './addons/cdoXml';
 import initializeCss from './addons/cdoCss';
@@ -169,6 +170,13 @@ function initializeBlocklyWrapper(blocklyInstance) {
     blocklyWrapper.blockly_.registry.Type.TOOLBOX,
     blocklyWrapper.blockly_.registry.DEFAULT,
     CdoToolbox,
+    true /* opt_allowOverrides */
+  );
+
+  blocklyWrapper.blockly_.registry.register(
+    blocklyWrapper.blockly_.registry.Type.FLYOUTS_VERTICAL_TOOLBOX,
+    blocklyWrapper.blockly_.registry.DEFAULT,
+    CdoVerticalFlyout,
     true /* opt_allowOverrides */
   );
 


### PR DESCRIPTION
This is similar functionality to https://github.com/code-dot-org/blockly/pull/220, though totally different logic.
Per @alschmiedt 's suggestion, I'm overriding VerticalFlyout.reflowInternal_ to make sure the new `flyoutWidth` doesn't exceed 40% of the target workspace width. Abby opened https://github.com/google/blockly/issues/5684 based on our use-case, so once that API is added, we can remove the override here and use the new API.

Before
![image](https://user-images.githubusercontent.com/8787187/140628290-26ac48e5-09a8-4b82-b472-01e8404872de.png)

After
![image](https://user-images.githubusercontent.com/8787187/140628275-e971ef35-b505-4517-9d9b-7596cffdeff6.png)

CDO Blockly
![image](https://user-images.githubusercontent.com/8787187/140628304-f861f647-0a23-4c10-bff5-3a1202c55447.png)
