### PR TITLE
[Google Blockly] Use FieldNumber for number fields

### DIFF
--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -773,13 +773,14 @@ const STANDARD_INPUT_TYPES = {
   },
   [FIELD_INPUT]: {
     addInput(blockly, block, inputConfig, currentInputRow) {
-      const fieldTextInput = new blockly.FieldTextInput(
+      const BlocklyField = Blockly.getFieldForInputType(inputConfig.type);
+      const field = new BlocklyField(
         '',
         getFieldInputChangeHandler(blockly, inputConfig.type)
       );
       currentInputRow
         .appendTitle(inputConfig.label)
-        .appendTitle(fieldTextInput, inputConfig.name);
+        .appendTitle(field, inputConfig.name);
     },
     generateCode(block, inputConfig) {
       let code = block.getTitleValue(inputConfig.name);

--- a/apps/src/blockly/cdoBlocklyWrapper.js
+++ b/apps/src/blockly/cdoBlocklyWrapper.js
@@ -152,6 +152,10 @@ function initializeBlocklyWrapper(blocklyInstance) {
 
   blocklyWrapper.BlockSpace.prototype.registerGlobalVariables = function() {}; // Not implemented.
 
+  blocklyWrapper.getFieldForInputType = function(type) {
+    return blocklyWrapper.FieldTextInput;
+  };
+
   blocklyWrapper.getGenerator = function() {
     return blocklyWrapper.Generator.get('JavaScript');
   };

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -103,6 +103,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.wrapReadOnlyProperty('FieldImage');
   blocklyWrapper.wrapReadOnlyProperty('FieldImageDropdown');
   blocklyWrapper.wrapReadOnlyProperty('FieldLabel');
+  blocklyWrapper.wrapReadOnlyProperty('FieldNumber');
   blocklyWrapper.wrapReadOnlyProperty('FieldParameter');
   blocklyWrapper.wrapReadOnlyProperty('FieldRectangularDropdown');
   blocklyWrapper.wrapReadOnlyProperty('FieldTextInput');
@@ -219,6 +220,13 @@ function initializeBlocklyWrapper(blocklyInstance) {
 
   blocklyWrapper.getWorkspaceCode = function() {
     return Blockly.JavaScript.workspaceToCode(Blockly.mainBlockSpace);
+  };
+
+  blocklyWrapper.getFieldForInputType = function(type) {
+    if (type === 'Number') {
+      return blocklyWrapper.FieldNumber;
+    }
+    return blocklyWrapper.FieldTextInput;
   };
 
   // TODO - used for spritelab behavior blocks


### PR DESCRIPTION
In Cdo Blockly, we use `Blockly.FieldTextInput.numberValidator` to make sure students can't enter non-numeric values into number fields.
In Google Blockly, this should be accomplished using a `FieldNumber` instead of a `FieldTextInput`

This PR creates a function on both Blockly wrappers to get the appropriate Field constructor and use it when creating fields.

Before
![image](https://user-images.githubusercontent.com/8787187/140665167-e9666587-5287-40f2-a160-9eb1eeea220f.png)

After
Red indicator in the input field while you're typing:
![image](https://user-images.githubusercontent.com/8787187/140665175-2a118202-c4ce-4114-ba26-2e729a0868c9.png)
And the value doesn't save when you click out of the field:
![image](https://user-images.githubusercontent.com/8787187/140665177-20bcfb9f-2af0-4201-9124-1db54f6fd928.png)
Setting number values works as expected:
![image](https://user-images.githubusercontent.com/8787187/140665201-8bc0da8d-ae75-44ef-98ab-61c5c4880737.png)

