### PR TITLE
[Flappy][Google Blockly] Make setScore a number field

### DIFF
--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -103,6 +103,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.wrapReadOnlyProperty('FieldImage');
   blocklyWrapper.wrapReadOnlyProperty('FieldImageDropdown');
   blocklyWrapper.wrapReadOnlyProperty('FieldLabel');
+  blocklyWrapper.wrapReadOnlyProperty('FieldNumber');
   blocklyWrapper.wrapReadOnlyProperty('FieldParameter');
   blocklyWrapper.wrapReadOnlyProperty('FieldRectangularDropdown');
   blocklyWrapper.wrapReadOnlyProperty('FieldTextInput');

--- a/apps/src/flappy/blocks.js
+++ b/apps/src/flappy/blocks.js
@@ -636,13 +636,7 @@ exports.install = function(blockly, blockInstallOptions) {
       this.setHSV(312, 0.32, 0.62);
       this.appendDummyInput()
         .appendTitle(msg.setScore())
-        .appendTitle(
-          new blockly.FieldTextInput(
-            '0',
-            blockly.FieldTextInput.numberValidator
-          ),
-          'VALUE'
-        );
+        .appendTitle(new blockly.FieldNumber(0), 'VALUE');
       this.setInputsInline(true);
       this.setPreviousStatement(true);
       this.setNextStatement(true);


### PR DESCRIPTION
Similar to https://github.com/code-dot-org/code-dot-org/pull/43439

This field should be a `FieldNumber` not a `FieldTextInput`.

I'm just changing the constructor directly here since Flappy has been fully using Google Blockly for almost a year now so we're probably not going to ever flip it back to Cdo Blockly. However, if we *did* switch it back, this would cause a JS error because `FieldNumber` is not defined in Cdo Blockly. I think it's okay and we should be comfortable with assuming Flappy will always use Google Blockly, but if people disagree I can change it to relying on the wrapper to ensure it would work with either blockly version.