### PR TITLE
change code instructor to universal instructor

### DIFF
--- a/apps/src/lib/levelbuilder/course-editor/CourseTypeEditor.jsx
+++ b/apps/src/lib/levelbuilder/course-editor/CourseTypeEditor.jsx
@@ -12,7 +12,7 @@ import CollapsibleEditorSection from '@cdo/apps/lib/levelbuilder/CollapsibleEdit
 const INSTRUCTOR_AUDIENCE_DISPLAY_NAMES = {
   [InstructorAudience.teacher]: 'Teacher',
   [InstructorAudience.facilitator]: 'Facilitator',
-  [InstructorAudience.code_instructor]: 'Code Instructor',
+  [InstructorAudience.universal_instructor]: 'Universal Instructor',
   [InstructorAudience.plc_reviewer]: 'PLC Reviewer'
 };
 

--- a/bin/oneoff/set_course_audiences.rb
+++ b/bin/oneoff/set_course_audiences.rb
@@ -28,7 +28,7 @@ def set_course_audiences
                                    SharedCourseConstants::INSTRUCTOR_AUDIENCE.plc_reviewer
                                  elsif ['k5-onlinepd-2020', 'k5-onlinepd-2021', 'self-paced-pl-csd5-2021',
                                         'self-paced-pl-csd6-2021', 'self-paced-pl-csd7-2021', 'self-paced-pl-csd8-2021'].include?(script.name)
-                                   SharedCourseConstants::INSTRUCTOR_AUDIENCE.code_instructor
+                                   SharedCourseConstants::INSTRUCTOR_AUDIENCE.universal_instructor
                                  else
                                    SharedCourseConstants::INSTRUCTOR_AUDIENCE.teacher
                                  end
@@ -64,7 +64,7 @@ def set_course_audiences
                                  elsif [].include?(course.name)
                                    SharedCourseConstants::INSTRUCTOR_AUDIENCE.plc_reviewer
                                  elsif ['self-paced-pl-csp-2021', 'self-paced-pl-csd-2021'].include?(course.name)
-                                   SharedCourseConstants::INSTRUCTOR_AUDIENCE.code_instructor
+                                   SharedCourseConstants::INSTRUCTOR_AUDIENCE.universal_instructor
                                  end
 
     course.participant_audience = if [].include?(course.name)

--- a/dashboard/app/models/concerns/curriculum/course_audiences.rb
+++ b/dashboard/app/models/concerns/curriculum/course_audiences.rb
@@ -3,7 +3,7 @@
 module Curriculum::CourseAudiences
   extend ActiveSupport::Concern
 
-  # Checks if a user can be the instructor for the course. Code instructors and levelbuilders
+  # Checks if a user can be the instructor for the course. Universal instructors and levelbuilders
   # can be the instructors of any course. Student accounts should never be able to be the instructor
   # of any course.
   def can_be_instructor?(user)
@@ -11,7 +11,7 @@ module Curriculum::CourseAudiences
     return unit_group.can_be_instructor?(user) if is_a?(Script) && unit_group
 
     return false if user.student?
-    return true if user.permission?(UserPermission::CODE_INSTRUCTOR) || user.permission?(UserPermission::LEVELBUILDER)
+    return true if user.permission?(UserPermission::UNIVERSAL_INSTRUCTOR) || user.permission?(UserPermission::LEVELBUILDER)
 
     if instructor_audience == 'plc_reviewer'
       return user.permission?(UserPermission::PLC_REVIEWER)

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -155,7 +155,7 @@ class Script < ApplicationRecord
 
   validates :published_state, acceptance: {accept: SharedCourseConstants::PUBLISHED_STATE.to_h.values.push(nil), message: 'must be nil, in_development, pilot, beta, preview or stable'}
   validates :instruction_type, acceptance: {accept: SharedCourseConstants::INSTRUCTION_TYPE.to_h.values.push(nil), message: 'must be nil, teacher_led or self_paced'}
-  validates :instructor_audience, acceptance: {accept: SharedCourseConstants::INSTRUCTOR_AUDIENCE.to_h.values.push(nil), message: 'must be nil, code instructor, plc reviewer, facilitator, or teacher'}
+  validates :instructor_audience, acceptance: {accept: SharedCourseConstants::INSTRUCTOR_AUDIENCE.to_h.values.push(nil), message: 'must be nil, universal instructor, plc reviewer, facilitator, or teacher'}
   validates :participant_audience, acceptance: {accept: SharedCourseConstants::PARTICIPANT_AUDIENCE.to_h.values.push(nil), message: 'must be nil, facilitator, teacher, or student'}
 
   def prevent_duplicate_levels

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -60,7 +60,7 @@ class UnitGroup < ApplicationRecord
 
   validates :published_state, acceptance: {accept: SharedCourseConstants::PUBLISHED_STATE.to_h.values, message: 'must be in_development, pilot, beta, preview or stable'}
   validates :instruction_type, acceptance: {accept: SharedCourseConstants::INSTRUCTION_TYPE.to_h.values, message: 'must be teacher_led or self_paced'}
-  validates :instructor_audience, acceptance: {accept: SharedCourseConstants::INSTRUCTOR_AUDIENCE.to_h.values, message: 'must be code instructor, plc reviewer, facilitator, or teacher'}
+  validates :instructor_audience, acceptance: {accept: SharedCourseConstants::INSTRUCTOR_AUDIENCE.to_h.values, message: 'must be universal instructor, plc reviewer, facilitator, or teacher'}
   validates :participant_audience, acceptance: {accept: SharedCourseConstants::PARTICIPANT_AUDIENCE.to_h.values, message: 'must be facilitator, teacher, or student'}
 
   def skip_name_format_validation

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1335,8 +1335,8 @@ class User < ApplicationRecord
   alias :verified_teacher? :authorized_teacher?
 
   def verified_instructor?
-    # You are an verified instructor if you are a code_instructor, plc_reviewer, facilitator, authorized_teacher, or levelbuiler
-    permission?(UserPermission::CODE_INSTRUCTOR) || permission?(UserPermission::PLC_REVIEWER) ||
+    # You are an verified instructor if you are a universal_instructor, plc_reviewer, facilitator, authorized_teacher, or levelbuiler
+    permission?(UserPermission::UNIVERSAL_INSTRUCTOR) || permission?(UserPermission::PLC_REVIEWER) ||
       permission?(UserPermission::FACILITATOR) || permission?(UserPermission::AUTHORIZED_TEACHER) ||
       permission?(UserPermission::LEVELBUILDER)
   end

--- a/dashboard/app/models/user_permission.rb
+++ b/dashboard/app/models/user_permission.rb
@@ -47,7 +47,7 @@ class UserPermission < ApplicationRecord
     # Grants access to review reported inaccuracies in census data
     CENSUS_REVIEWER = 'census_reviewer'.freeze,
     # Grants ability to be the instructor of any course no matter instructor_audience
-    CODE_INSTRUCTOR = 'code_instructor'.freeze,
+    UNIVERSAL_INSTRUCTOR = 'universal_instructor'.freeze,
   ].freeze
 
   # Do not log the granting/removal of these permissions to slack

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -181,11 +181,11 @@ FactoryGirl.define do
         end
       end
 
-      factory :code_instructor do
-        sequence(:name) {|n| "Code Instructor #{n}"}
-        sequence(:email) {|n| "test_code_instructor_#{n}@example.com.xx"}
-        after(:create) do |code_instructor|
-          code_instructor.permission = UserPermission::CODE_INSTRUCTOR
+      factory :universal_instructor do
+        sequence(:name) {|n| "Universal Instructor #{n}"}
+        sequence(:email) {|n| "test_universal_instructor_#{n}@example.com.xx"}
+        after(:create) do |universal_instructor|
+          universal_instructor.permission = UserPermission::UNIVERSAL_INSTRUCTOR
         end
       end
 

--- a/dashboard/test/models/concerns/curriculum/course_audiences_test.rb
+++ b/dashboard/test/models/concerns/curriculum/course_audiences_test.rb
@@ -5,7 +5,7 @@ class InstructorAndParticipantAudienceTests < ActiveSupport::TestCase
     @student = create :student
     @teacher = create :teacher
     @facilitator = create :facilitator
-    @code_instructor = create :code_instructor
+    @universal_instructor = create :universal_instructor
     @plc_reviewer = create :plc_reviewer
     @levelbuilder = create :levelbuilder
 
@@ -16,12 +16,12 @@ class InstructorAndParticipantAudienceTests < ActiveSupport::TestCase
 
     @course_teacher_to_students = create(:unit_group, name: 'course-teacher-to-student', instructor_audience: SharedCourseConstants::INSTRUCTOR_AUDIENCE.teacher, participant_audience: SharedCourseConstants::PARTICIPANT_AUDIENCE.student)
     @course_facilitator_to_teacher = create(:unit_group, name: 'course-facilitator-to-teacher', instructor_audience: SharedCourseConstants::INSTRUCTOR_AUDIENCE.facilitator, participant_audience: SharedCourseConstants::PARTICIPANT_AUDIENCE.teacher)
-    @course_code_instructor_to_teacher = create(:unit_group, name: 'course-code-instructor-to-teacher', instructor_audience: SharedCourseConstants::INSTRUCTOR_AUDIENCE.code_instructor, participant_audience: SharedCourseConstants::PARTICIPANT_AUDIENCE.teacher)
+    @course_universal_instructor_to_teacher = create(:unit_group, name: 'course-universal-instructor-to-teacher', instructor_audience: SharedCourseConstants::INSTRUCTOR_AUDIENCE.universal_instructor, participant_audience: SharedCourseConstants::PARTICIPANT_AUDIENCE.teacher)
     @course_plc_reviewer_to_facilitator = create(:unit_group, name: 'course-plc-reviewer-to-facilitator', instructor_audience: SharedCourseConstants::INSTRUCTOR_AUDIENCE.plc_reviewer, participant_audience: SharedCourseConstants::PARTICIPANT_AUDIENCE.facilitator)
 
     @unit_teacher_to_students = create(:script, name: 'unit-teacher-to-student', instructor_audience: SharedCourseConstants::INSTRUCTOR_AUDIENCE.teacher, participant_audience: SharedCourseConstants::PARTICIPANT_AUDIENCE.student)
     @unit_facilitator_to_teacher = create(:script, name: 'unit-facilitator-to-teacher', instructor_audience: SharedCourseConstants::INSTRUCTOR_AUDIENCE.facilitator, participant_audience: SharedCourseConstants::PARTICIPANT_AUDIENCE.teacher)
-    @unit_code_instructor_to_teacher = create(:script, name: 'code-instructor-to-teacher', instructor_audience: SharedCourseConstants::INSTRUCTOR_AUDIENCE.code_instructor, participant_audience: SharedCourseConstants::PARTICIPANT_AUDIENCE.teacher)
+    @unit_universal_instructor_to_teacher = create(:script, name: 'universal-instructor-to-teacher', instructor_audience: SharedCourseConstants::INSTRUCTOR_AUDIENCE.universal_instructor, participant_audience: SharedCourseConstants::PARTICIPANT_AUDIENCE.teacher)
     @unit_plc_reviewer_to_facilitator = create(:script, name: 'plc-reviewer-to-facilitator', instructor_audience: SharedCourseConstants::INSTRUCTOR_AUDIENCE.plc_reviewer, participant_audience: SharedCourseConstants::PARTICIPANT_AUDIENCE.facilitator)
   end
 
@@ -33,54 +33,54 @@ class InstructorAndParticipantAudienceTests < ActiveSupport::TestCase
     assert @unit_in_course.can_be_participant?(@student)
   end
 
-  test 'code instructor should be able to instruct any unit' do
-    assert @unit_teacher_to_students.can_be_instructor?(@code_instructor)
-    assert @unit_facilitator_to_teacher.can_be_instructor?(@code_instructor)
-    assert @unit_code_instructor_to_teacher.can_be_instructor?(@code_instructor)
-    assert @unit_plc_reviewer_to_facilitator.can_be_instructor?(@code_instructor)
-    assert @unit_code_instructor_to_teacher.can_be_instructor?(@code_instructor)
+  test 'universal instructor should be able to instruct any unit' do
+    assert @unit_teacher_to_students.can_be_instructor?(@universal_instructor)
+    assert @unit_facilitator_to_teacher.can_be_instructor?(@universal_instructor)
+    assert @unit_universal_instructor_to_teacher.can_be_instructor?(@universal_instructor)
+    assert @unit_plc_reviewer_to_facilitator.can_be_instructor?(@universal_instructor)
+    assert @unit_universal_instructor_to_teacher.can_be_instructor?(@universal_instructor)
   end
 
   test 'levelbuilder should be able to see instructor view for any unit' do
     assert @unit_teacher_to_students.can_be_instructor?(@levelbuilder)
     assert @unit_facilitator_to_teacher.can_be_instructor?(@levelbuilder)
-    assert @unit_code_instructor_to_teacher.can_be_instructor?(@levelbuilder)
+    assert @unit_universal_instructor_to_teacher.can_be_instructor?(@levelbuilder)
     assert @unit_plc_reviewer_to_facilitator.can_be_instructor?(@levelbuilder)
-    assert @unit_code_instructor_to_teacher.can_be_instructor?(@levelbuilder)
+    assert @unit_universal_instructor_to_teacher.can_be_instructor?(@levelbuilder)
   end
 
   test 'plc reviewer should be able to instruct units with plc_reviewer as instructor audience ' do
     # Since the plc reviewer is a teacher account it will also be able to teach any teacher course
     assert @unit_teacher_to_students.can_be_instructor?(@plc_reviewer)
     refute @unit_facilitator_to_teacher.can_be_instructor?(@plc_reviewer)
-    refute @unit_code_instructor_to_teacher.can_be_instructor?(@plc_reviewer)
+    refute @unit_universal_instructor_to_teacher.can_be_instructor?(@plc_reviewer)
     assert @unit_plc_reviewer_to_facilitator.can_be_instructor?(@plc_reviewer)
-    refute @unit_code_instructor_to_teacher.can_be_instructor?(@plc_reviewer)
+    refute @unit_universal_instructor_to_teacher.can_be_instructor?(@plc_reviewer)
   end
 
   test 'facilitator should be able to instruct units with facilitator as instructor audience ' do
     # Since the facilitator is a teacher account it will also be able to teach any teacher course
     assert @unit_teacher_to_students.can_be_instructor?(@facilitator)
     assert @unit_facilitator_to_teacher.can_be_instructor?(@facilitator)
-    refute @unit_code_instructor_to_teacher.can_be_instructor?(@facilitator)
+    refute @unit_universal_instructor_to_teacher.can_be_instructor?(@facilitator)
     refute @unit_plc_reviewer_to_facilitator.can_be_instructor?(@facilitator)
-    refute @unit_code_instructor_to_teacher.can_be_instructor?(@facilitator)
+    refute @unit_universal_instructor_to_teacher.can_be_instructor?(@facilitator)
   end
 
   test 'teachers should be able to instruct units with teacher as instructor audience ' do
     assert @unit_teacher_to_students.can_be_instructor?(@teacher)
     refute @unit_facilitator_to_teacher.can_be_instructor?(@teacher)
-    refute @unit_code_instructor_to_teacher.can_be_instructor?(@teacher)
+    refute @unit_universal_instructor_to_teacher.can_be_instructor?(@teacher)
     refute @unit_plc_reviewer_to_facilitator.can_be_instructor?(@teacher)
-    refute @unit_code_instructor_to_teacher.can_be_instructor?(@teacher)
+    refute @unit_universal_instructor_to_teacher.can_be_instructor?(@teacher)
   end
 
   test 'students can not instruct units' do
     refute @unit_teacher_to_students.can_be_instructor?(@student)
     refute @unit_facilitator_to_teacher.can_be_instructor?(@student)
-    refute @unit_code_instructor_to_teacher.can_be_instructor?(@student)
+    refute @unit_universal_instructor_to_teacher.can_be_instructor?(@student)
     refute @unit_plc_reviewer_to_facilitator.can_be_instructor?(@student)
-    refute @unit_code_instructor_to_teacher.can_be_instructor?(@student)
+    refute @unit_universal_instructor_to_teacher.can_be_instructor?(@student)
   end
 
   test 'facilitator should be able to participate in units with facilitator as participant audience' do
@@ -89,8 +89,8 @@ class InstructorAndParticipantAudienceTests < ActiveSupport::TestCase
 
     # Since the facilitator is a teacher account it will also be able to participate in any teacher unit
     assert @unit_facilitator_to_teacher.can_be_participant?(@facilitator)
-    assert @unit_code_instructor_to_teacher.can_be_participant?(@facilitator)
-    assert @unit_code_instructor_to_teacher.can_be_participant?(@facilitator)
+    assert @unit_universal_instructor_to_teacher.can_be_participant?(@facilitator)
+    assert @unit_universal_instructor_to_teacher.can_be_participant?(@facilitator)
 
     assert @unit_plc_reviewer_to_facilitator.can_be_participant?(@facilitator)
   end
@@ -100,8 +100,8 @@ class InstructorAndParticipantAudienceTests < ActiveSupport::TestCase
     assert @unit_teacher_to_students.can_be_participant?(@teacher)
 
     assert @unit_facilitator_to_teacher.can_be_participant?(@teacher)
-    assert @unit_code_instructor_to_teacher.can_be_participant?(@teacher)
-    assert @unit_code_instructor_to_teacher.can_be_participant?(@teacher)
+    assert @unit_universal_instructor_to_teacher.can_be_participant?(@teacher)
+    assert @unit_universal_instructor_to_teacher.can_be_participant?(@teacher)
 
     refute @unit_plc_reviewer_to_facilitator.can_be_participant?(@teacher)
   end
@@ -110,59 +110,59 @@ class InstructorAndParticipantAudienceTests < ActiveSupport::TestCase
     assert @unit_teacher_to_students.can_be_participant?(@student)
 
     refute @unit_facilitator_to_teacher.can_be_participant?(@student)
-    refute @unit_code_instructor_to_teacher.can_be_participant?(@student)
+    refute @unit_universal_instructor_to_teacher.can_be_participant?(@student)
     refute @unit_plc_reviewer_to_facilitator.can_be_participant?(@student)
-    refute @unit_code_instructor_to_teacher.can_be_participant?(@student)
+    refute @unit_universal_instructor_to_teacher.can_be_participant?(@student)
   end
 
-  test 'code instructor should be able to instruct any course' do
-    assert @course_teacher_to_students.can_be_instructor?(@code_instructor)
-    assert @course_facilitator_to_teacher.can_be_instructor?(@code_instructor)
-    assert @course_code_instructor_to_teacher.can_be_instructor?(@code_instructor)
-    assert @course_plc_reviewer_to_facilitator.can_be_instructor?(@code_instructor)
-    assert @course_code_instructor_to_teacher.can_be_instructor?(@code_instructor)
+  test 'universal instructor should be able to instruct any course' do
+    assert @course_teacher_to_students.can_be_instructor?(@universal_instructor)
+    assert @course_facilitator_to_teacher.can_be_instructor?(@universal_instructor)
+    assert @course_universal_instructor_to_teacher.can_be_instructor?(@universal_instructor)
+    assert @course_plc_reviewer_to_facilitator.can_be_instructor?(@universal_instructor)
+    assert @course_universal_instructor_to_teacher.can_be_instructor?(@universal_instructor)
   end
 
   test 'levelbuilder should be able to see instructor view for any course' do
     assert @course_teacher_to_students.can_be_instructor?(@levelbuilder)
     assert @course_facilitator_to_teacher.can_be_instructor?(@levelbuilder)
-    assert @course_code_instructor_to_teacher.can_be_instructor?(@levelbuilder)
+    assert @course_universal_instructor_to_teacher.can_be_instructor?(@levelbuilder)
     assert @course_plc_reviewer_to_facilitator.can_be_instructor?(@levelbuilder)
-    assert @course_code_instructor_to_teacher.can_be_instructor?(@levelbuilder)
+    assert @course_universal_instructor_to_teacher.can_be_instructor?(@levelbuilder)
   end
 
   test 'plc reviewer should be able to instruct courses with plc_reviewer as instructor audience ' do
     # Since the plc reviewer is a teacher account it will also be able to teach any teacher course
     assert @course_teacher_to_students.can_be_instructor?(@plc_reviewer)
     refute @course_facilitator_to_teacher.can_be_instructor?(@plc_reviewer)
-    refute @course_code_instructor_to_teacher.can_be_instructor?(@plc_reviewer)
+    refute @course_universal_instructor_to_teacher.can_be_instructor?(@plc_reviewer)
     assert @course_plc_reviewer_to_facilitator.can_be_instructor?(@plc_reviewer)
-    refute @course_code_instructor_to_teacher.can_be_instructor?(@plc_reviewer)
+    refute @course_universal_instructor_to_teacher.can_be_instructor?(@plc_reviewer)
   end
 
   test 'facilitator should be able to instruct courses with facilitator as instructor audience ' do
     # Since the facilitator is a teacher account it will also be able to teach any teacher course
     assert @course_teacher_to_students.can_be_instructor?(@facilitator)
     assert @course_facilitator_to_teacher.can_be_instructor?(@facilitator)
-    refute @course_code_instructor_to_teacher.can_be_instructor?(@facilitator)
+    refute @course_universal_instructor_to_teacher.can_be_instructor?(@facilitator)
     refute @course_plc_reviewer_to_facilitator.can_be_instructor?(@facilitator)
-    refute @course_code_instructor_to_teacher.can_be_instructor?(@facilitator)
+    refute @course_universal_instructor_to_teacher.can_be_instructor?(@facilitator)
   end
 
   test 'teachers should be able to instruct courses with teacher as instructor audience ' do
     assert @course_teacher_to_students.can_be_instructor?(@teacher)
     refute @course_facilitator_to_teacher.can_be_instructor?(@teacher)
-    refute @course_code_instructor_to_teacher.can_be_instructor?(@teacher)
+    refute @course_universal_instructor_to_teacher.can_be_instructor?(@teacher)
     refute @course_plc_reviewer_to_facilitator.can_be_instructor?(@teacher)
-    refute @course_code_instructor_to_teacher.can_be_instructor?(@teacher)
+    refute @course_universal_instructor_to_teacher.can_be_instructor?(@teacher)
   end
 
   test 'students can not instruct courses' do
     refute @course_teacher_to_students.can_be_instructor?(@student)
     refute @course_facilitator_to_teacher.can_be_instructor?(@student)
-    refute @course_code_instructor_to_teacher.can_be_instructor?(@student)
+    refute @course_universal_instructor_to_teacher.can_be_instructor?(@student)
     refute @course_plc_reviewer_to_facilitator.can_be_instructor?(@student)
-    refute @course_code_instructor_to_teacher.can_be_instructor?(@student)
+    refute @course_universal_instructor_to_teacher.can_be_instructor?(@student)
   end
 
   test 'facilitator should be able to participate in courses with facilitator as participant audience' do
@@ -171,8 +171,8 @@ class InstructorAndParticipantAudienceTests < ActiveSupport::TestCase
 
     # Since the facilitator is a teacher account it will also be able to participate in any teacher course
     assert @course_facilitator_to_teacher.can_be_participant?(@facilitator)
-    assert @course_code_instructor_to_teacher.can_be_participant?(@facilitator)
-    assert @course_code_instructor_to_teacher.can_be_participant?(@facilitator)
+    assert @course_universal_instructor_to_teacher.can_be_participant?(@facilitator)
+    assert @course_universal_instructor_to_teacher.can_be_participant?(@facilitator)
 
     assert @course_plc_reviewer_to_facilitator.can_be_participant?(@facilitator)
   end
@@ -182,8 +182,8 @@ class InstructorAndParticipantAudienceTests < ActiveSupport::TestCase
     assert @course_teacher_to_students.can_be_participant?(@teacher)
 
     assert @course_facilitator_to_teacher.can_be_participant?(@teacher)
-    assert @course_code_instructor_to_teacher.can_be_participant?(@teacher)
-    assert @course_code_instructor_to_teacher.can_be_participant?(@teacher)
+    assert @course_universal_instructor_to_teacher.can_be_participant?(@teacher)
+    assert @course_universal_instructor_to_teacher.can_be_participant?(@teacher)
 
     refute @course_plc_reviewer_to_facilitator.can_be_participant?(@teacher)
   end
@@ -192,8 +192,8 @@ class InstructorAndParticipantAudienceTests < ActiveSupport::TestCase
     assert @course_teacher_to_students.can_be_participant?(@student)
 
     refute @course_facilitator_to_teacher.can_be_participant?(@student)
-    refute @course_code_instructor_to_teacher.can_be_participant?(@student)
+    refute @course_universal_instructor_to_teacher.can_be_participant?(@student)
     refute @course_plc_reviewer_to_facilitator.can_be_participant?(@student)
-    refute @course_code_instructor_to_teacher.can_be_participant?(@student)
+    refute @course_universal_instructor_to_teacher.can_be_participant?(@student)
   end
 end

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -47,7 +47,7 @@ class UserTest < ActiveSupport::TestCase
     @teacher = create :teacher
     @student = create :student
     @facilitator = create :facilitator
-    @code_instructor = create :code_instructor
+    @universal_instructor = create :universal_instructor
     @plc_reviewer = create :plc_reviewer
     @levelbuilder = create :levelbuilder
   end
@@ -2831,9 +2831,9 @@ class UserTest < ActiveSupport::TestCase
     assert @facilitator.teacher?
     assert @facilitator.verified_instructor?
 
-    # code instructors should be verified instructors too
-    assert @code_instructor.teacher?
-    assert @code_instructor.verified_instructor?
+    # universal instructors should be verified instructors too
+    assert @universal_instructor.teacher?
+    assert @universal_instructor.verified_instructor?
 
     #plc reviewers should be verified instructors too
     assert @plc_reviewer.teacher?

--- a/lib/cdo/shared_constants/curriculum/shared_course_constants.rb
+++ b/lib/cdo/shared_constants/curriculum/shared_course_constants.rb
@@ -21,7 +21,7 @@ module SharedCourseConstants
   # Used to determine who can teach a course
   INSTRUCTOR_AUDIENCE = OpenStruct.new(
     {
-      code_instructor: "code_instructor",
+      universal_instructor: "universal_instructor",
       plc_reviewer: "plc_reviewer",
       facilitator: "facilitator",
       teacher: "teacher"


### PR DESCRIPTION
In past PRs setting up self paced PL work @jamescodeorg and @Erin007 suggested that `CODE_INSTRUCTOR` was not as clear of a permission as we wanted it to be. James suggested `UNIVERSAL_INSTRUCTOR` instead and that seem more clear to me as well so this updates to that. Nobody has been given this permission yet so it should be fine to update.

## Testing story

- Existing tests