### PR TITLE
Add esversion to jshintrc

### DIFF
--- a/shared/js/.jshintrc
+++ b/shared/js/.jshintrc
@@ -1,6 +1,7 @@
 {
   "browser": true,
   "curly": true,
+  "esversion": 6,
   "globals": {
     "$": true,
     "jQuery": true


### PR DESCRIPTION
My IDE was complaining about a setting in jshints (not allowing `export` unless `esversion` was set to `6`). I updated the `.jshintrc` file accordingly.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
