### PR TITLE
Correct dates in teacher app

### DIFF
--- a/apps/script/generateSharedConstants.rb
+++ b/apps/script/generateSharedConstants.rb
@@ -45,6 +45,8 @@ def generate_constants(shared_const_name, source_module: SharedConstants, transf
   rescue JSON::ParserError
     if raw.is_a?(String)
       "export const #{shared_const_name.downcase.camelize} = '#{raw}';"
+    else
+      raise "unrecognized raw type: #{raw.class}"
     end
   end
 end

--- a/apps/src/code-studio/pd/application/principalApproval/PrincipalApprovalComponent.jsx
+++ b/apps/src/code-studio/pd/application/principalApproval/PrincipalApprovalComponent.jsx
@@ -4,12 +4,13 @@ import {
   PageLabels,
   TextFields
 } from '@cdo/apps/generated/pd/principalApprovalApplicationConstants';
+import {Year} from '@cdo/apps/generated/pd/teacherApplicationConstants';
 import LabeledFormComponent from '../../form_components/LabeledFormComponent';
 import PrivacyDialog from '../PrivacyDialog';
 import {PrivacyDialogMode} from '../../constants';
 import SchoolAutocompleteDropdown from '@cdo/apps/templates/SchoolAutocompleteDropdown';
 import {isInt, isPercent, isZipCode} from '@cdo/apps/util/formatValidation';
-import {YEAR, styles} from '../teacher/TeacherApplicationConstants';
+import {styles} from '../teacher/TeacherApplicationConstants';
 
 const MANUAL_SCHOOL_FIELDS = [
   'schoolName',
@@ -129,7 +130,7 @@ export default class PrincipalApprovalComponent extends LabeledFormComponent {
     let showPayFeeNote =
       this.props.data.committedToMasterSchedule &&
       !this.props.data.committedToMasterSchedule.includes(
-        `Yes, I plan to include this course in the ${YEAR} master schedule`
+        `Yes, I plan to include this course in the ${Year} master schedule`
       ) &&
       this.props.data.payFee &&
       this.props.data.payFee.includes('No, ');
@@ -165,7 +166,7 @@ export default class PrincipalApprovalComponent extends LabeledFormComponent {
             label: `Are you committed to including ${
               this.props.teacherApplication.course
             }
-                    on the master schedule in ${YEAR} if ${
+                    on the master schedule in ${Year} if ${
               this.props.teacherApplication.name
             }
                     is accepted into the program? Note: the program may be listed under a different
@@ -215,8 +216,8 @@ export default class PrincipalApprovalComponent extends LabeledFormComponent {
             <div>
               <p style={styles.red}>
                 Note: To be eligible for scholarship support, your school must
-                commit to including this course in the {YEAR} master schedule.
-                If you are able to commit to offering this course in {YEAR} ,
+                commit to including this course in the {Year} master schedule.
+                If you are able to commit to offering this course in {Year} ,
                 please update your answer above before submitting in order to
                 retain scholarship eligibility.
               </p>
@@ -305,7 +306,7 @@ export default class PrincipalApprovalComponent extends LabeledFormComponent {
           >
             {this.props.teacherApplication.course} curriculum
           </a>{' '}
-          during the {YEAR} school year. We know that administrative support is
+          during the {Year} school year. We know that administrative support is
           essential to a teacher’s ability to fully commit to a) participating
           in a yearlong Professional Learning program and b) teaching a new
           course. That’s why your approval is required for the teacher's
@@ -339,7 +340,7 @@ export default class PrincipalApprovalComponent extends LabeledFormComponent {
             label: `Do you approve of ${
               this.props.teacherApplication.name
             } participating
-                    in Code.org's ${YEAR} Professional Learning Program?`
+                    in Code.org's ${Year} Professional Learning Program?`
           }
         )}
         {this.props.data.doYouApprove !== 'No' &&

--- a/apps/src/code-studio/pd/application/teacher/ChooseYourProgram.jsx
+++ b/apps/src/code-studio/pd/application/teacher/ChooseYourProgram.jsx
@@ -1,18 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {FormGroup, Row, Col} from 'react-bootstrap';
+import color from '@cdo/apps/util/color';
 import {
   PageLabels,
   SectionHeaders,
-  TextFields
+  TextFields,
+  Year
 } from '@cdo/apps/generated/pd/teacherApplicationConstants';
-import {FormGroup, Row, Col} from 'react-bootstrap';
 import {
   PROGRAM_CSD,
   PROGRAM_CSP,
-  PROGRAM_CSA,
-  YEAR
+  PROGRAM_CSA
 } from './TeacherApplicationConstants';
-import color from '@cdo/apps/util/color';
 import {LabelsContext} from '../../form_components_func/LabeledFormComponent';
 import {LabeledCheckBoxes} from '../../form_components_func/labeled/LabeledCheckBoxes';
 import {LabeledNumberInput} from '../../form_components_func/labeled/LabeledInput';
@@ -85,7 +85,7 @@ const ChooseYourProgram = props => {
           {data.program === PROGRAM_CSA && !isOffered && (
             <p style={styles.error}>
               The Computer Science A Professional Learning Program is not yet
-              offered in your region for the {YEAR} academic year. We are
+              offered in your region for the {Year} academic year. We are
               working with our national network of Regional Partners to expand
               the program to all regions by 2023-24.{' '}
               {regionalPartner &&
@@ -193,7 +193,7 @@ const ChooseYourProgram = props => {
               Note: {minCourseHours} or more hours of instruction per{' '}
               {programInfo.name} section are strongly recommended. We suggest
               checking with your school administration to see if additional time
-              can be allotted for this course in {YEAR}.
+              can be allotted for this course in {Year}.
             </p>
           )}
 
@@ -206,9 +206,9 @@ const ChooseYourProgram = props => {
           {showTeachingPlansNote && (
             <p style={styles.error}>
               Note: This program is designed to work best for teachers who are
-              teaching this course in the {YEAR} school year. Scholarship
+              teaching this course in the {Year} school year. Scholarship
               eligibility is dependent on whether or not you will be teaching
-              the course during the {YEAR} school year.
+              the course during the {Year} school year.
             </p>
           )}
 

--- a/apps/src/code-studio/pd/application/teacher/TeacherApplicationConstants.js
+++ b/apps/src/code-studio/pd/application/teacher/TeacherApplicationConstants.js
@@ -7,8 +7,6 @@ const PROGRAM_CSP =
 const PROGRAM_CSA =
   'Computer Science A (appropriate for 10th - 12th grade, and can be implemented as an AP or non-AP introductory Java programming course)';
 
-const YEAR = '2021-2022';
-
 const styles = {
   indented: {
     marginLeft: 20
@@ -18,7 +16,7 @@ const styles = {
   },
   questionText: {
     fontSize: 14,
-    lineHeight: '20px',
+    lineHeight: 20,
     fontWeight: 'bold'
   },
   checkBoxAfterButtonList: {
@@ -37,4 +35,4 @@ const styles = {
   }
 };
 
-export {PROGRAM_CSD, PROGRAM_CSP, PROGRAM_CSA, YEAR, styles};
+export {PROGRAM_CSD, PROGRAM_CSP, PROGRAM_CSA, styles};


### PR DESCRIPTION
The years on the teacher application form were coming in for this current school year (2021-2022), rather than the future one (2022-2023). The red in the error messages are inconsistent (PR coming ...), but the year should be correct.

Old version:
<img width="992" alt="Section 2 Choose Your Program" src="https://user-images.githubusercontent.com/9142121/140776634-f06743d9-9ad8-4b6b-ac08-7b56e101d4e6.png">

New:
![image](https://user-images.githubusercontent.com/9142121/140791921-d121890c-b558-4261-b82d-2f0a18b5fa51.png)


## Links

Many JS strings to be automatically generated are JSON-encoded representations of an object or array. The year is *not* one of those. I used https://gist.github.com/ascendbruce/7070951 as a starting point to convert the year string. If you have a different strategy that's simpler, please share!

- spec: [content doc](https://docs.google.com/document/d/1rshrcpg7J45BfrgiEl6ALwysDeQiwLQcAErFthocJug/edit)
- bug bash doc: [doc](https://docs.google.com/document/d/1Nu30LM1QRFdnXjmbukjdsERBrYGiDx70hBhPTmLI_d0/edit#)

## Testing story

I didn't see a testing file for generateSharedConstants. I manually tested these (details below), but I'm all ears if there are other suggested testing strategies.

To see the years coming through:
1) The only zip code offering a CSA workshop is 98103 (Washington). To get the error message on page 2, choose a school with a different zip code.
2) On page 2, you’ll see an error message if the total number of course hours is less than 100.
3) On page 2, if you select that you are either not plan to teach this course this year, or if you’re not sure if you’ll teach this course, you should get an error message.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
