### PR TITLE
[Google Blockly] Don't try to show/hide trashcan when there's no toolbox

### DIFF
--- a/apps/src/blockly/addons/cdoTrashcan.js
+++ b/apps/src/blockly/addons/cdoTrashcan.js
@@ -64,13 +64,16 @@ export default class CdoTrashcan extends GoogleBlockly.Trashcan {
       return;
     }
 
-    let toolboxWidth = 0;
+    let toolboxWidth;
     switch (this.workspace_.getToolboxType()) {
       case ToolboxType.CATEGORIZED:
         toolboxWidth = this.workspace_.toolbox_.width_;
         break;
       case ToolboxType.UNCATEGORIZED:
         toolboxWidth = metrics.flyoutWidth;
+        break;
+      case ToolboxType.NONE:
+        toolboxWidth = 0;
         break;
     }
 

--- a/apps/src/blockly/addons/cdoWorkspaceSvg.js
+++ b/apps/src/blockly/addons/cdoWorkspaceSvg.js
@@ -36,7 +36,7 @@ export default class WorkspaceSvg extends GoogleBlockly.WorkspaceSvg {
     } else if (this.toolbox_) {
       return ToolboxType.CATEGORIZED;
     } else {
-      return ToolboxType.UNKNOWN;
+      return ToolboxType.NONE;
     }
   }
 
@@ -98,6 +98,11 @@ export default class WorkspaceSvg extends GoogleBlockly.WorkspaceSvg {
    * it doesn't interfere with click events on the toolbox categories.
    */
   hideTrashcan() {
+    // If there's no toolbox, there's no trashcan.
+    if (this.getToolboxType() === ToolboxType.NONE) {
+      return;
+    }
+
     /**
      * NodeList.forEach() is not supported on IE. Use Array.prototype.forEach.call() as a workaround.
      * https://developer.mozilla.org/en-US/docs/Web/API/NodeList/forEach
@@ -128,6 +133,11 @@ export default class WorkspaceSvg extends GoogleBlockly.WorkspaceSvg {
   }
   setEnableToolbox() {} // TODO - called by StudioApp, not sure whether it's still needed.
   showTrashcan() {
+    // If there's no toolbox, there's no trashcan.
+    if (this.getToolboxType() === ToolboxType.NONE) {
+      return;
+    }
+
     /**
      * NodeList.forEach() is not supported on IE. Use Array.prototype.forEach.call() as a workaround.
      * https://developer.mozilla.org/en-US/docs/Web/API/NodeList/forEach

--- a/apps/src/blockly/constants.js
+++ b/apps/src/blockly/constants.js
@@ -1,3 +1,3 @@
 import {makeEnum} from '@cdo/apps/utils';
 
-export const ToolboxType = makeEnum('CATEGORIZED', 'UNCATEGORIZED', 'UNKNOWN');
+export const ToolboxType = makeEnum('CATEGORIZED', 'UNCATEGORIZED', 'NONE');


### PR DESCRIPTION
There's no trashcan if there's no toolbox, but we were still trying to hide/show the trashcan on block drag which was leading to JS errors and the inability to drag/drop blocks

Before
![image](https://user-images.githubusercontent.com/8787187/140807396-5ad025c1-359b-4d54-a723-9e2e33181e11.png)

After
![image](https://user-images.githubusercontent.com/8787187/140807785-306213ad-fe75-40ba-b828-daad32856823.png)
