### PR TITLE
[Google Blockly] Implement translateVarName

### DIFF
--- a/apps/src/blockly/addons/cdoGenerator.js
+++ b/apps/src/blockly/addons/cdoGenerator.js
@@ -1,4 +1,11 @@
 export default function initializeGenerator(blocklyWrapper) {
+  blocklyWrapper.JavaScript.translateVarName = function(name) {
+    return Blockly.JavaScript.nameDB_.getName(
+      name,
+      Blockly.VARIABLE_CATEGORY_NAME
+    );
+  };
+
   // This function was a custom addition in CDO Blockly, so we need to add it here
   // so that our code generation logic still works with Google Blockly
   blocklyWrapper.Generator.blockSpaceToCode = function(name, opt_typeFilter) {

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -146,6 +146,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.wrapReadOnlyProperty('Toolbox');
   blocklyWrapper.wrapReadOnlyProperty('Touch');
   blocklyWrapper.wrapReadOnlyProperty('Trashcan');
+  blocklyWrapper.wrapReadOnlyProperty('VARIABLE_CATEGORY_NAME');
   blocklyWrapper.wrapReadOnlyProperty('Variables');
   blocklyWrapper.wrapReadOnlyProperty('VariableMap');
   blocklyWrapper.wrapReadOnlyProperty('weblab_locale');

--- a/apps/test/unit/blockly/googleBlocklyWrapperTest.js
+++ b/apps/test/unit/blockly/googleBlocklyWrapperTest.js
@@ -1,4 +1,5 @@
 /* global Blockly */
+import sinon from 'sinon';
 import GoogleBlockly from 'blockly/core';
 import initializeGoogleBlocklyWrapper from '@cdo/apps/blockly/googleBlocklyWrapper';
 import {expect} from '../../util/reconfiguredChai';
@@ -7,6 +8,7 @@ import '@cdo/apps/flappy/flappy'; // Importing the app forces the test to load B
 describe('Google Blockly Wrapper', () => {
   const cdoBlockly = Blockly;
   beforeEach(() => {
+    GoogleBlockly.JavaScript = sinon.spy();
     Blockly = initializeGoogleBlocklyWrapper(GoogleBlockly); // eslint-disable-line no-global-assign
   });
   afterEach(() => {


### PR DESCRIPTION
The Cdo Blockly function is [here](https://github.com/code-dot-org/blockly/blob/main/generators/javascript.js#L191)
Google Blockly has a pretty different internal representation of variables, so the wrapper logic is different, but the functionality is still to get the generated code name for the variable.

Before
![image](https://user-images.githubusercontent.com/8787187/140809250-d3949e88-6e6c-4893-86ac-8c4299c40d8e.png)

After
![image](https://user-images.githubusercontent.com/8787187/140809219-d583a56c-e7f0-4844-9768-77f2442a8671.png)


Also confirmed that it still generates the right code for special characters, keywords, etc:
![image](https://user-images.githubusercontent.com/8787187/140810041-98299721-ce5d-4999-b8bc-232965845e2c.png)
![image](https://user-images.githubusercontent.com/8787187/140810076-93865de4-3d3d-4159-b7ae-4587211ddcf5.png)
