### PR TITLE
Commenting out Honeybadger usage in i18n sync

### DIFF
--- a/bin/i18n/i18n_script_utils.rb
+++ b/bin/i18n/i18n_script_utils.rb
@@ -150,12 +150,7 @@ class I18nScriptUtils
     unless script.present?
       error_class = 'Could not find script in get_script_level'
       error_message = "unknown script #{route_params[:script_id].inspect} for url #{url.inspect}"
-      # [FND-1667] Uncomment this once we have enabled Honeybadger usage on the i18n-dev server.
-      # Honeybadger.notify(
-      #   error_class: error_class,
-      #   error_message: error_message
-      # )
-      puts "[#{error_class}] #{error_message}"
+      log_error(error_class, error_message)
       return nil
     end
 
@@ -176,12 +171,7 @@ class I18nScriptUtils
     else
       error_class = 'Could not identify route in get_script_level'
       error_message = "unknown route action #{route_params[:action].inspect} for url #{url.inspect}"
-      # [FND-1667] Uncomment this once we have enabled Honeybadger usage on the i18n-dev server.
-      # Honeybadger.notify(
-      #   error_class: error_class,
-      #   error_message: error_message
-      # )
-      puts "[#{error_class}] #{error_message}"
+      log_error(error_class, error_message)
       nil
     end
   end
@@ -206,23 +196,13 @@ class I18nScriptUtils
         else
           error_class = 'Could not identify route in get_level_from_url'
           error_message = "unknown route #{route_params[:controller].inspect} for url #{new_url.inspect}"
-          # [FND-1667] Uncomment this once we have enabled Honeybadger usage on the i18n-dev server.
-          # Honeybadger.notify(
-          #   error_class: error_class,
-          #   error_message: error_message
-          # )
-          puts "[#{error_class}] #{error_message}"
+          log_error(error_class, error_message)
         end
 
       unless level.present?
         error_class = 'Could not find level in get_level_from_url'
         error_message = "could not find level for url #{new_url.inspect}"
-        # [FND-1667] Uncomment this once we have enabled Honeybadger usage on the i18n-dev server.
-        # Honeybadger.notify(
-        #   error_class: error_class,
-        #   error_message: error_message
-        # )
-        puts "[#{error_class}] #{error_message}"
+        log_error(error_class, error_message)
         next
       end
 
@@ -280,12 +260,16 @@ class I18nScriptUtils
     script_name = File.basename(script_i18n_name, '.*')
     error_class = 'Destination directory for script is attempting to change'
     error_message = "Script #{script_name} wants to output strings to #{relative_new}, but #{relative_matching.join(' and ')} already exists"
+    log_error(error_class, error_message)
+    return true
+  end
+
+  def self.log_error(error_class, error_message)
     # [FND-1667] Uncomment this once we have enabled Honeybadger usage on the i18n-dev server.
     # Honeybadger.notify(
     #   error_class: error_class,
     #   error_message: error_message
     # )
     puts "[#{error_class}] #{error_message}"
-    return true
   end
 end

--- a/bin/i18n/i18n_script_utils.rb
+++ b/bin/i18n/i18n_script_utils.rb
@@ -148,10 +148,14 @@ class I18nScriptUtils
   def self.get_script_level(route_params, url)
     script = Script.get_from_cache(route_params[:script_id])
     unless script.present?
-      Honeybadger.notify(
-        error_class: 'Could not find script in get_script_level',
-        error_message: "unknown script #{route_params[:script_id].inspect} for url #{url.inspect}"
-      )
+      error_class = 'Could not find script in get_script_level'
+      error_message = "unknown script #{route_params[:script_id].inspect} for url #{url.inspect}"
+      # [FND-1667] Uncomment this once we have enabled Honeybadger usage on the i18n-dev server.
+      # Honeybadger.notify(
+      #   error_class: error_class,
+      #   error_message: error_message
+      # )
+      puts "[#{error_class}] #{error_message}"
       return nil
     end
 
@@ -170,10 +174,14 @@ class I18nScriptUtils
         Level.find_by_name(uri_params['level_name'].first)
       end
     else
-      Honeybadger.notify(
-        error_class: 'Could not identify route in get_script_level',
-        error_message: "unknown route action #{route_params[:action].inspect} for url #{url.inspect}"
-      )
+      error_class = 'Could not identify route in get_script_level'
+      error_message = "unknown route action #{route_params[:action].inspect} for url #{url.inspect}"
+      # [FND-1667] Uncomment this once we have enabled Honeybadger usage on the i18n-dev server.
+      # Honeybadger.notify(
+      #   error_class: error_class,
+      #   error_message: error_message
+      # )
+      puts "[#{error_class}] #{error_message}"
       nil
     end
   end
@@ -196,17 +204,25 @@ class I18nScriptUtils
         when "script_levels"
           get_script_level(route_params, new_url)
         else
-          Honeybadger.notify(
-            error_class: 'Could not identify route in get_level_from_url',
-            error_message: "unknown route #{route_params[:controller].inspect} for url #{new_url.inspect}"
-          )
+          error_class = 'Could not identify route in get_level_from_url'
+          error_message = "unknown route #{route_params[:controller].inspect} for url #{new_url.inspect}"
+          # [FND-1667] Uncomment this once we have enabled Honeybadger usage on the i18n-dev server.
+          # Honeybadger.notify(
+          #   error_class: error_class,
+          #   error_message: error_message
+          # )
+          puts "[#{error_class}] #{error_message}"
         end
 
       unless level.present?
-        Honeybadger.notify(
-          error_class: 'Could not find level in get_level_from_url',
-          error_message: "could not find level for url #{new_url.inspect}"
-        )
+        error_class = 'Could not find level in get_level_from_url'
+        error_message = "could not find level for url #{new_url.inspect}"
+        # [FND-1667] Uncomment this once we have enabled Honeybadger usage on the i18n-dev server.
+        # Honeybadger.notify(
+        #   error_class: error_class,
+        #   error_message: error_message
+        # )
+        puts "[#{error_class}] #{error_message}"
         next
       end
 
@@ -262,12 +278,14 @@ class I18nScriptUtils
     relative_matching = matching_files.map {|filename| Pathname.new(filename).relative_path_from(base)}
     relative_new = Pathname.new(script_i18n_filename).relative_path_from(base)
     script_name = File.basename(script_i18n_name, '.*')
+    error_class = 'Destination directory for script is attempting to change'
     error_message = "Script #{script_name} wants to output strings to #{relative_new}, but #{relative_matching.join(' and ')} already exists"
-    Honeybadger.notify(
-      error_class: 'Destination directory for script is attempting to change',
-      error_message: error_message
-    )
-    puts error_message
+    # [FND-1667] Uncomment this once we have enabled Honeybadger usage on the i18n-dev server.
+    # Honeybadger.notify(
+    #   error_class: error_class,
+    #   error_message: error_message
+    # )
+    puts "[#{error_class}] #{error_message}"
     return true
   end
 end


### PR DESCRIPTION
Occasionally we would encounter segfaults when logging messages to the do-nothing implementation of the Honeybadger API. We will enable this logging once we have proper Honeybadger credentials setup on the i18n-dev server

## Testing story
* Will test by running the i18n-sync after this is committed.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
