### PR TITLE
HoC supported languages cleanup

### DIFF
--- a/apps/src/tutorialExplorer/tutorialDetail.jsx
+++ b/apps/src/tutorialExplorer/tutorialDetail.jsx
@@ -355,10 +355,6 @@ const styles = {
   tutorialDetailDisabledIcon: {
     color: '#d9534f'
   },
-  tutorialDetailLanguages: {
-    overflowY: 'auto',
-    maxHeight: '110px'
-  },
   tutorialDetailsTable: {
     marginTop: 20,
     width: '100%'

--- a/pegasus/helpers/hourofcode_helpers.rb
+++ b/pegasus/helpers/hourofcode_helpers.rb
@@ -119,7 +119,7 @@ def hoc_get_locale_code
   Languages.get_hoc_locale_by_unique_language(@language)
 end
 
-# hourofcode.com calls this to translate tutorial's languages attribute
+# code.org and hourofcode.com's /learn pages call this to translate tutorial's languages attribute
 def hoc_language(lang_codes_str)
   return '' unless lang_codes_str
 

--- a/pegasus/sites.v3/code.org/public/learn/index.haml
+++ b/pegasus/sites.v3/code.org/public/learn/index.haml
@@ -147,7 +147,7 @@ style_min: false
     - tutorial[:name]                                 = hoc_s(prefix + "name")
     - tutorial[:shortdescription]                     = hoc_s(prefix + "shortdescription")
     - tutorial[:longdescription]                      = hoc_s(prefix + "longdescription")
-    - tutorial[:language]                             = hoc_s(prefix + "language")
+    - tutorial[:language]                             = hoc_language(tutorial[:languages_supported])
     - tutorial[:string_detail_grades]                 = hoc_s(prefix + "string_detail_grades")
     - tutorial[:string_platforms]                     = hoc_s(prefix + "string_platforms")
     - tutorial[:string_detail_platforms]              = hoc_s(prefix + "string_detail_platforms")


### PR DESCRIPTION
**What:** Fix `code.org/learn` tutorial languages. This was not updated in [this PR ](https://github.com/code-dot-org/code-dot-org/pull/43096) and should've been. Updated docs and remove remnant style from that PR as well.

## Testing story

Tested both domain's (code.org and hourofcode.com) learn pages locally.

HoC

<img width="1076" alt="Screen Shot 2021-11-08 at 5 26 07 PM" src="https://user-images.githubusercontent.com/48133820/140834373-ee4a7c7f-5c11-4195-b125-2fc4de56646d.png">

Code.org

<img width="1075" alt="Screen Shot 2021-11-08 at 5 14 12 PM" src="https://user-images.githubusercontent.com/48133820/140834431-5e94ca7e-b595-4aa8-9313-b86155807800.png">


## Follow up work
https://github.com/code-dot-org/code-dot-org/pull/43096#issuecomment-961528622

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
