### PR TITLE
Add Code Review groups client-side API for updating groups and setting enabled status

### DIFF
--- a/apps/src/templates/codeReviewGroups/CodeReviewGroupsDataApi.js
+++ b/apps/src/templates/codeReviewGroups/CodeReviewGroupsDataApi.js
@@ -8,6 +8,48 @@ export default class CodeReviewGroupsDataApi {
   getCodeReviewGroups() {
     return $.getJSON(
       `/api/v1/sections/${this.sectionId}/code_review_groups`
-    ).then(response => response.groups);
+    ).then(response => this.convertGroupsToCamelCase(response.groups));
   }
+
+  setCodeReviewGroups(groups) {
+    return $.post(`/api/v1/sections/${this.sectionId}/code_review_groups`, {
+      groups: this.convertGroupsToSnakeCase(groups)
+    });
+  }
+
+  setCodeReviewEnabled(enabled) {
+    return $.post(`/api/v1/sections/${this.sectionId}/code_review_enabled`, {
+      enabled
+    });
+  }
+
+  /**
+   * Converts code review groups JSON data from the server by performing
+   * any necessary JSON key conversions from snake case to camel case
+   */
+  convertGroupsToCamelCase = groups => {
+    for (let group of groups) {
+      group.members = group.members.map(member => {
+        let converted = {...member, followerId: member.follower_id};
+        delete converted.follower_id;
+        return converted;
+      });
+    }
+    return groups;
+  };
+
+  /**
+   * Converts code review groups data from the client into server-friendly
+   * snake case
+   */
+  convertGroupsToSnakeCase = groups => {
+    for (let group of groups) {
+      group.members = group.members.map(member => {
+        let converted = {...member, follower_id: member.followerId};
+        delete converted.followerId;
+        return converted;
+      });
+    }
+    return groups;
+  };
 }

--- a/apps/src/templates/codeReviewGroups/CodeReviewGroupsDataApi.js
+++ b/apps/src/templates/codeReviewGroups/CodeReviewGroupsDataApi.js
@@ -12,16 +12,30 @@ export default class CodeReviewGroupsDataApi {
   }
 
   setCodeReviewGroups(groups) {
-    return $.post(`/api/v1/sections/${this.sectionId}/code_review_groups`, {
-      groups: this.convertGroupsToSnakeCase(groups)
-    });
+    return this.postJSON(
+      `/api/v1/sections/${this.sectionId}/code_review_groups`,
+      {
+        groups: this.convertGroupsToSnakeCase(groups)
+      }
+    );
   }
 
   setCodeReviewEnabled(enabled) {
-    return $.post(`/api/v1/sections/${this.sectionId}/code_review_enabled`, {
-      enabled
-    });
+    return this.postJSON(
+      `/api/v1/sections/${this.sectionId}/code_review_enabled`,
+      {
+        enabled
+      }
+    );
   }
+
+  postJSON = (url, data) =>
+    $.ajax({
+      url,
+      type: 'POST',
+      contentType: 'application/json',
+      data: JSON.stringify(data)
+    });
 
   /**
    * Converts code review groups JSON data from the server by performing

--- a/apps/src/templates/codeReviewGroups/CodeReviewGroupsLoader.jsx
+++ b/apps/src/templates/codeReviewGroups/CodeReviewGroupsLoader.jsx
@@ -11,7 +11,7 @@ export default function CodeReviewGroupsLoader({sectionId}) {
         const api = new CodeReviewGroupsDataApi(sectionId);
         api
           .getCodeReviewGroups()
-          .then(groups => onLoadSuccess([convertGroupData(groups)]))
+          .then(groups => onLoadSuccess([groups]))
           .fail(error => onLoadError());
       }}
       loadArgs={[sectionId]}
@@ -20,21 +20,6 @@ export default function CodeReviewGroupsLoader({sectionId}) {
       )}
     />
   );
-}
-
-/**
- * Converts code review groups JSON data from the server by performing
- * any necessary JSON key conversions from snake case to camel case
- */
-function convertGroupData(groups) {
-  for (let group of groups) {
-    group.members = group.members.map(member => {
-      let converted = {...member, followerId: member.follower_id};
-      delete converted.follower_id;
-      return converted;
-    });
-  }
-  return groups;
 }
 
 CodeReviewGroupsLoader.propTypes = {

--- a/apps/test/unit/templates/codeReviewGroups/CodeReviewGroupsDataApiTest.js
+++ b/apps/test/unit/templates/codeReviewGroups/CodeReviewGroupsDataApiTest.js
@@ -1,0 +1,90 @@
+import {expect} from '../../../util/reconfiguredChai';
+import $ from 'jquery';
+import sinon from 'sinon';
+import CodeReviewGroupsDataApi from '@cdo/apps/templates/codeReviewGroups/CodeReviewGroupsDataApi';
+
+describe('CodeReviewGroupsDataApi', () => {
+  const sectionId = 101;
+  let serverGroupsResponse, clientGroupsList, post, getJSON, api;
+
+  beforeEach(() => {
+    serverGroupsResponse = {
+      groups: [
+        {
+          unassigned: true,
+          members: [
+            {follower_id: 1, name: 'student1'},
+            {follower_id: 2, name: 'student2'}
+          ]
+        },
+        {
+          id: 1,
+          name: 'group1',
+          members: [{follower_id: 3, name: 'student3'}]
+        }
+      ]
+    };
+    clientGroupsList = [
+      {
+        unassigned: true,
+        members: [
+          {followerId: 1, name: 'student1'},
+          {followerId: 2, name: 'student2'}
+        ]
+      },
+      {
+        id: 1,
+        name: 'group1',
+        members: [{followerId: 3, name: 'student3'}]
+      }
+    ];
+    post = sinon.stub($, 'post');
+    getJSON = sinon.stub($, 'getJSON');
+    api = new CodeReviewGroupsDataApi(sectionId);
+  });
+
+  afterEach(() => {
+    post.restore();
+    getJSON.restore();
+  });
+
+  it('makes a GET request and converts group data when calling getCodeReviewGroups', () => {
+    let convertedResponse;
+
+    getJSON.returns({
+      then: callback => {
+        convertedResponse = callback(serverGroupsResponse);
+      }
+    });
+    api.getCodeReviewGroups();
+
+    sinon.assert.calledWith(
+      getJSON,
+      `/api/v1/sections/${sectionId}/code_review_groups`
+    );
+
+    expect(clientGroupsList).to.deep.equal(convertedResponse);
+  });
+
+  it('makes a POST request with converted group data when calling setCodeReviewGroups', () => {
+    api.setCodeReviewGroups(clientGroupsList);
+
+    sinon.assert.calledWith(
+      post,
+      `/api/v1/sections/${sectionId}/code_review_groups`
+    );
+
+    const data = post.getCall(0).args[1];
+    expect(serverGroupsResponse).to.deep.equal(data);
+  });
+
+  it('makes a POST request with enabled value when calling setCodeReviewEnabled', () => {
+    api.setCodeReviewEnabled(true);
+
+    sinon.assert.calledWith(
+      post,
+      `/api/v1/sections/${sectionId}/code_review_enabled`,
+      {enabled: true}
+    );
+  });
+});

--- a/apps/test/unit/templates/codeReviewGroups/CodeReviewGroupsDataApiTest.js
+++ b/apps/test/unit/templates/codeReviewGroups/CodeReviewGroupsDataApiTest.js
@@ -5,7 +5,7 @@ import CodeReviewGroupsDataApi from '@cdo/apps/templates/codeReviewGroups/CodeRe
 
 describe('CodeReviewGroupsDataApi', () => {
   const sectionId = 101;
-  let serverGroupsResponse, clientGroupsList, post, getJSON, api;
+  let serverGroupsResponse, clientGroupsList, postJSON, getJSON, api;
 
   beforeEach(() => {
     serverGroupsResponse = {
@@ -38,13 +38,14 @@ describe('CodeReviewGroupsDataApi', () => {
         members: [{followerId: 3, name: 'student3'}]
       }
     ];
-    post = sinon.stub($, 'post');
+
+    postJSON = sinon.stub();
     getJSON = sinon.stub($, 'getJSON');
     api = new CodeReviewGroupsDataApi(sectionId);
+    api.postJSON = postJSON;
   });
 
   afterEach(() => {
-    post.restore();
     getJSON.restore();
   });
 
@@ -70,11 +71,11 @@ describe('CodeReviewGroupsDataApi', () => {
     api.setCodeReviewGroups(clientGroupsList);
 
     sinon.assert.calledWith(
-      post,
+      postJSON,
       `/api/v1/sections/${sectionId}/code_review_groups`
     );
 
-    const data = post.getCall(0).args[1];
+    const data = postJSON.getCall(0).args[1];
     expect(serverGroupsResponse).to.deep.equal(data);
   });
 
@@ -82,7 +83,7 @@ describe('CodeReviewGroupsDataApi', () => {
     api.setCodeReviewEnabled(true);
 
     sinon.assert.calledWith(
-      post,
+      postJSON,
       `/api/v1/sections/${sectionId}/code_review_enabled`,
       {enabled: true}
     );

--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -413,12 +413,12 @@ class Section < ApplicationRecord
   def reset_code_review_groups(new_groups)
     ActiveRecord::Base.transaction do
       code_review_groups.destroy_all
-      new_groups.each do |group|
+      new_groups.each do |_, group|
         # skip any unassigned members
         next if group[:unassigned]
         new_group = CodeReviewGroup.create!(name: group[:name], section_id: id)
         next unless group[:members]
-        group[:members].each do |member|
+        group[:members].each do |_, member|
           CodeReviewGroupMember.create!(follower_id: member[:follower_id], code_review_group_id: new_group.id)
         end
       end

--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -413,12 +413,12 @@ class Section < ApplicationRecord
   def reset_code_review_groups(new_groups)
     ActiveRecord::Base.transaction do
       code_review_groups.destroy_all
-      new_groups.each do |_, group|
+      new_groups.each do |group|
         # skip any unassigned members
         next if group[:unassigned]
         new_group = CodeReviewGroup.create!(name: group[:name], section_id: id)
         next unless group[:members]
-        group[:members].each do |_, member|
+        group[:members].each do |member|
           CodeReviewGroupMember.create!(follower_id: member[:follower_id], code_review_group_id: new_group.id)
         end
       end

--- a/dashboard/test/models/sections/section_test.rb
+++ b/dashboard/test/models/sections/section_test.rb
@@ -585,11 +585,10 @@ class SectionTest < ActiveSupport::TestCase
     end
     group_1_name = 'new_group_1'
     group_2_name = 'new_group_2'
-    # Parameters are represented as hashes
-    new_groups = {
-      '0' => {name: group_1_name, members: {'0' => {follower_id: followers[0].id}}},
-      '1' => {name: group_2_name, members: {'0' => {follower_id: followers[2].id}, '1' => {follower_id: followers[3].id}}}
-    }
+    new_groups = [
+      {name: group_1_name, members: [{follower_id: followers[0].id}]},
+      {name: group_2_name, members: [{follower_id: followers[2].id}, {follower_id: followers[3].id}]}
+    ]
     code_review_group_section.reset_code_review_groups(new_groups)
     code_review_group_section.reload
 
@@ -602,10 +601,9 @@ class SectionTest < ActiveSupport::TestCase
     set_up_code_review_groups
 
     new_group_name = 'new_group'
-    # Parameters are represented as hashes
-    new_groups = {
-      '0' => {name: new_group_name, members: {'0' => {follower_id: @followers[0].id}, '1' => {follower_id: @followers[1].id}}},
-    }
+    new_groups = [
+      {name: new_group_name, members: [{follower_id: @followers[0].id}, {follower_id: @followers[1].id}]},
+    ]
 
     @code_review_group_section.reset_code_review_groups(new_groups)
     @code_review_group_section.reload

--- a/dashboard/test/models/sections/section_test.rb
+++ b/dashboard/test/models/sections/section_test.rb
@@ -585,10 +585,11 @@ class SectionTest < ActiveSupport::TestCase
     end
     group_1_name = 'new_group_1'
     group_2_name = 'new_group_2'
-    new_groups = [
-      {name: group_1_name, members: [{follower_id: followers[0].id}]},
-      {name: group_2_name, members: [{follower_id: followers[2].id}, {follower_id: followers[3].id}]}
-    ]
+    # Parameters are represented as hashes
+    new_groups = {
+      '0' => {name: group_1_name, members: {'0' => {follower_id: followers[0].id}}},
+      '1' => {name: group_2_name, members: {'0' => {follower_id: followers[2].id}, '1' => {follower_id: followers[3].id}}}
+    }
     code_review_group_section.reset_code_review_groups(new_groups)
     code_review_group_section.reload
 
@@ -601,9 +602,10 @@ class SectionTest < ActiveSupport::TestCase
     set_up_code_review_groups
 
     new_group_name = 'new_group'
-    new_groups = [
-      {name: new_group_name, members: [{follower_id: @followers[0].id}, {follower_id: @followers[1].id}]},
-    ]
+    # Parameters are represented as hashes
+    new_groups = {
+      '0' => {name: new_group_name, members: {'0' => {follower_id: @followers[0].id}, '1' => {follower_id: @followers[1].id}}},
+    }
 
     @code_review_group_section.reset_code_review_groups(new_groups)
     @code_review_group_section.reload


### PR DESCRIPTION
This adds the remaining client API calls (set code review groups, set enabled status) for code review groups plus some refactoring to put all the data conversion logic in once place. I also noticed while testing that rails turns JSON params with lists into hashes, so I modified the controller a bit accordingly.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

https://codedotorg.atlassian.net/browse/CSA-948

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Local (all the things) + unit.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
