### PR TITLE
[Poetry] Guard against deleted sprite in behavior funcs

### DIFF
--- a/apps/src/p5lab/poetry/commands/behaviors.js
+++ b/apps/src/p5lab/poetry/commands/behaviors.js
@@ -7,21 +7,41 @@ import * as utils from './utils';
 export const commands = {
   fluttering(spriteArg) {
     const sprite = this.getSpriteArray(spriteArg)[0];
+    if (!sprite) {
+      // This happens if the sprite was deleted within the same frame, so we
+      // should just no-op
+      return;
+    }
     sprite.y += utils.randomInt(-1, 1);
   },
 
   growing(spriteArg) {
     const sprite = this.getSpriteArray(spriteArg)[0];
+    if (!sprite) {
+      // This happens if the sprite was deleted within the same frame, so we
+      // should just no-op
+      return;
+    }
     sprite.setScale(sprite.getScale() + 1 / 100);
   },
 
   jittering(spriteArg) {
     const sprite = this.getSpriteArray(spriteArg)[0];
+    if (!sprite) {
+      // This happens if the sprite was deleted within the same frame, so we
+      // should just no-op
+      return;
+    }
     sprite.setScale(sprite.getScale() + utils.randomInt(-1, 1) / 100);
   },
 
   moving_north_and_looping(spriteArg) {
     const sprite = this.getSpriteArray(spriteArg)[0];
+    if (!sprite) {
+      // This happens if the sprite was deleted within the same frame, so we
+      // should just no-op
+      return;
+    }
     sprite.y -= sprite.speed;
     if (sprite.y < -50) {
       sprite.y = 450;
@@ -30,6 +50,11 @@ export const commands = {
 
   moving_south_and_looping(spriteArg) {
     const sprite = this.getSpriteArray(spriteArg)[0];
+    if (!sprite) {
+      // This happens if the sprite was deleted within the same frame, so we
+      // should just no-op
+      return;
+    }
     sprite.y += sprite.speed;
     if (sprite.y > 450) {
       sprite.y = -50;
@@ -38,6 +63,11 @@ export const commands = {
 
   moving_east_and_looping(spriteArg) {
     const sprite = this.getSpriteArray(spriteArg)[0];
+    if (!sprite) {
+      // This happens if the sprite was deleted within the same frame, so we
+      // should just no-op
+      return;
+    }
     sprite.mirrorX(1);
 
     sprite.x += sprite.speed;
@@ -48,6 +78,11 @@ export const commands = {
 
   moving_west_and_looping(spriteArg) {
     const sprite = this.getSpriteArray(spriteArg)[0];
+    if (!sprite) {
+      // This happens if the sprite was deleted within the same frame, so we
+      // should just no-op
+      return;
+    }
     sprite.mirrorX(-1);
 
     sprite.x -= sprite.speed;
@@ -58,16 +93,31 @@ export const commands = {
 
   shrinking(spriteArg) {
     const sprite = this.getSpriteArray(spriteArg)[0];
+    if (!sprite) {
+      // This happens if the sprite was deleted within the same frame, so we
+      // should just no-op
+      return;
+    }
     sprite.setScale(sprite.getScale() - 1 / 100);
   },
 
   spinning_left(spriteArg) {
     const sprite = this.getSpriteArray(spriteArg)[0];
+    if (!sprite) {
+      // This happens if the sprite was deleted within the same frame, so we
+      // should just no-op
+      return;
+    }
     sprite.rotation -= 6;
   },
 
   spinning_right(spriteArg) {
     const sprite = this.getSpriteArray(spriteArg)[0];
+    if (!sprite) {
+      // This happens if the sprite was deleted within the same frame, so we
+      // should just no-op
+      return;
+    }
     sprite.rotation += 6;
   },
 
@@ -77,6 +127,11 @@ export const commands = {
     }
 
     const sprite = this.getSpriteArray(spriteArg)[0];
+    if (!sprite) {
+      // This happens if the sprite was deleted within the same frame, so we
+      // should just no-op
+      return;
+    }
     if (sprite.direction === 0) {
       sprite.mirrorX(1);
     } else if (sprite.direction === 180) {
@@ -98,6 +153,11 @@ export const commands = {
     }
 
     const sprite = this.getSpriteArray(spriteArg)[0];
+    if (!sprite) {
+      // This happens if the sprite was deleted within the same frame, so we
+      // should just no-op
+      return;
+    }
     if (utils.randomInt(0, 100) < 20) {
       sprite.direction = (sprite.direction + utils.randomInt(-25, 25)) % 360;
     }
@@ -119,6 +179,11 @@ export const commands = {
 
   wobbling(spriteArg) {
     const sprite = this.getSpriteArray(spriteArg)[0];
+    if (!sprite) {
+      // This happens if the sprite was deleted within the same frame, so we
+      // should just no-op
+      return;
+    }
     if (utils.randomInt(0, 100) < 50) {
       sprite.rotation = utils.randomInt(-1, 1);
     }

--- a/apps/src/p5lab/poetry/commands/behaviors.js
+++ b/apps/src/p5lab/poetry/commands/behaviors.js
@@ -1,45 +1,53 @@
 import * as utils from './utils';
 
+function getSprite(spriteArg) {
+  const sprites = this.getSpriteArray(spriteArg);
+  if (sprites.length === 0) {
+    // This happens if the sprite was deleted within the same frame, so we
+    // should just no-op
+    return;
+  } else if (sprites.length > 1) {
+    // This shouldn't happen because we call behaviors by sprite id so there
+    // should only be one sprite.
+    console.warn('Multiple sprites for behavior');
+    return;
+  } else {
+    return sprites[0];
+  }
+}
+
 // These functions are duplicated from https://levelbuilder-studio.code.org/functions
 // In Sprite Lab, behaviors are defined using blockly so that students can edit
 // the behavior functions. In Poetry, we just need the function definitions, we don't
 // need them to be editable by students.
 export const commands = {
   fluttering(spriteArg) {
-    const sprite = this.getSpriteArray(spriteArg)[0];
+    const sprite = getSprite.call(this, spriteArg);
     if (!sprite) {
-      // This happens if the sprite was deleted within the same frame, so we
-      // should just no-op
       return;
     }
     sprite.y += utils.randomInt(-1, 1);
   },
 
   growing(spriteArg) {
-    const sprite = this.getSpriteArray(spriteArg)[0];
+    const sprite = getSprite.call(this, spriteArg);
     if (!sprite) {
-      // This happens if the sprite was deleted within the same frame, so we
-      // should just no-op
       return;
     }
     sprite.setScale(sprite.getScale() + 1 / 100);
   },
 
   jittering(spriteArg) {
-    const sprite = this.getSpriteArray(spriteArg)[0];
+    const sprite = getSprite.call(this, spriteArg);
     if (!sprite) {
-      // This happens if the sprite was deleted within the same frame, so we
-      // should just no-op
       return;
     }
     sprite.setScale(sprite.getScale() + utils.randomInt(-1, 1) / 100);
   },
 
   moving_north_and_looping(spriteArg) {
-    const sprite = this.getSpriteArray(spriteArg)[0];
+    const sprite = getSprite.call(this, spriteArg);
     if (!sprite) {
-      // This happens if the sprite was deleted within the same frame, so we
-      // should just no-op
       return;
     }
     sprite.y -= sprite.speed;
@@ -49,10 +57,8 @@ export const commands = {
   },
 
   moving_south_and_looping(spriteArg) {
-    const sprite = this.getSpriteArray(spriteArg)[0];
+    const sprite = getSprite.call(this, spriteArg);
     if (!sprite) {
-      // This happens if the sprite was deleted within the same frame, so we
-      // should just no-op
       return;
     }
     sprite.y += sprite.speed;
@@ -62,10 +68,8 @@ export const commands = {
   },
 
   moving_east_and_looping(spriteArg) {
-    const sprite = this.getSpriteArray(spriteArg)[0];
+    const sprite = getSprite.call(this, spriteArg);
     if (!sprite) {
-      // This happens if the sprite was deleted within the same frame, so we
-      // should just no-op
       return;
     }
     sprite.mirrorX(1);
@@ -77,10 +81,8 @@ export const commands = {
   },
 
   moving_west_and_looping(spriteArg) {
-    const sprite = this.getSpriteArray(spriteArg)[0];
+    const sprite = getSprite.call(this, spriteArg);
     if (!sprite) {
-      // This happens if the sprite was deleted within the same frame, so we
-      // should just no-op
       return;
     }
     sprite.mirrorX(-1);
@@ -92,46 +94,38 @@ export const commands = {
   },
 
   shrinking(spriteArg) {
-    const sprite = this.getSpriteArray(spriteArg)[0];
+    const sprite = getSprite.call(this, spriteArg);
     if (!sprite) {
-      // This happens if the sprite was deleted within the same frame, so we
-      // should just no-op
       return;
     }
     sprite.setScale(sprite.getScale() - 1 / 100);
   },
 
   spinning_left(spriteArg) {
-    const sprite = this.getSpriteArray(spriteArg)[0];
+    const sprite = getSprite.call(this, spriteArg);
     if (!sprite) {
-      // This happens if the sprite was deleted within the same frame, so we
-      // should just no-op
       return;
     }
     sprite.rotation -= 6;
   },
 
   spinning_right(spriteArg) {
-    const sprite = this.getSpriteArray(spriteArg)[0];
+    const sprite = getSprite.call(this, spriteArg);
     if (!sprite) {
-      // This happens if the sprite was deleted within the same frame, so we
-      // should just no-op
       return;
     }
     sprite.rotation += 6;
   },
 
   swimming_left_and_right(spriteArg) {
+    const sprite = getSprite.call(this, spriteArg);
+    if (!sprite) {
+      return;
+    }
     if (!this.p5.edges) {
       this.p5.createEdgeSprites();
     }
 
-    const sprite = this.getSpriteArray(spriteArg)[0];
-    if (!sprite) {
-      // This happens if the sprite was deleted within the same frame, so we
-      // should just no-op
-      return;
-    }
     if (sprite.direction === 0) {
       sprite.mirrorX(1);
     } else if (sprite.direction === 180) {
@@ -148,16 +142,14 @@ export const commands = {
   },
 
   wandering(spriteArg) {
+    const sprite = getSprite.call(this, spriteArg);
+    if (!sprite) {
+      return;
+    }
     if (!this.p5.edges) {
       this.p5.createEdgeSprites();
     }
 
-    const sprite = this.getSpriteArray(spriteArg)[0];
-    if (!sprite) {
-      // This happens if the sprite was deleted within the same frame, so we
-      // should just no-op
-      return;
-    }
     if (utils.randomInt(0, 100) < 20) {
       sprite.direction = (sprite.direction + utils.randomInt(-25, 25)) % 360;
     }
@@ -178,10 +170,8 @@ export const commands = {
   },
 
   wobbling(spriteArg) {
-    const sprite = this.getSpriteArray(spriteArg)[0];
+    const sprite = getSprite.call(this, spriteArg);
     if (!sprite) {
-      // This happens if the sprite was deleted within the same frame, so we
-      // should just no-op
       return;
     }
     if (utils.randomInt(0, 100) < 50) {


### PR DESCRIPTION
Bug reported in [slack](https://codedotorg.slack.com/archives/C02GRH2PYB1/p1636418042095700)

The issue seems to occur in the frame that a sprite is deleted. Basically, the behavior function runs one more time after the sprite is deleted. We just need to guard against this case and no-op the behavior. I think this is not an issue with Sprite Lab behaviors because they are implemented with Blockly Blocks (so the code is all Blockly generated code), which is pretty good at guarding against wrong/missing arguments.

Before
![image](https://user-images.githubusercontent.com/8787187/140849274-cafab0ac-50ed-492b-82c9-300e507bdcac.png)

After
![image](https://user-images.githubusercontent.com/8787187/140849050-74b53cb0-e4e7-41f9-83ba-5eff1dbceba1.png)
(no JS errors)