### PR TITLE
replace test-fixture-visible-after.script with factory calls

### DIFF
--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -1657,60 +1657,62 @@ class ScriptsControllerTest < ActionController::TestCase
     refute response.body.include? 'visible after'
   end
 
-  test "levelbuilder does not see visible after warning if lesson has visible_after property that is in the past" do
-    Timecop.freeze(Time.new(2020, 4, 2))
-    sign_in create(:levelbuilder)
+  class LessonVisibleAfterTest < ActionController::TestCase
+    test "levelbuilder does not see visible after warning if lesson has visible_after property that is in the past" do
+      Timecop.freeze(Time.new(2020, 4, 2))
+      sign_in create(:levelbuilder)
 
-    create(:level, name: "Level 1")
-    unit_file = File.join(self.class.fixture_path, "test-fixture-visible-after.script")
-    Script.setup([unit_file])
+      create(:level, name: "Level 1")
+      unit_file = File.join(self.class.fixture_path, "test-fixture-visible-after.script")
+      Script.setup([unit_file])
 
-    get :show, params: {id: 'test-fixture-visible-after'}
-    assert_response :success
-    refute response.body.include? 'visible after'
-    Timecop.return
-  end
+      get :show, params: {id: 'test-fixture-visible-after'}
+      assert_response :success
+      refute response.body.include? 'visible after'
+      Timecop.return
+    end
 
-  test "levelbuilder sees visible after warning if lesson has visible_after property that is in the future" do
-    Timecop.freeze(Time.new(2020, 3, 27))
-    sign_in create(:levelbuilder)
+    test "levelbuilder sees visible after warning if lesson has visible_after property that is in the future" do
+      Timecop.freeze(Time.new(2020, 3, 27))
+      sign_in create(:levelbuilder)
 
-    create(:level, name: "Level 1")
-    unit_file = File.join(self.class.fixture_path, "test-fixture-visible-after.script")
-    Script.setup([unit_file])
+      create(:level, name: "Level 1")
+      unit_file = File.join(self.class.fixture_path, "test-fixture-visible-after.script")
+      Script.setup([unit_file])
 
-    get :show, params: {id: 'test-fixture-visible-after'}
-    assert_response :success
-    assert response.body.include? 'The lesson lesson 1 will be visible after'
-    Timecop.return
-  end
+      get :show, params: {id: 'test-fixture-visible-after'}
+      assert_response :success
+      assert response.body.include? 'The lesson lesson 1 will be visible after'
+      Timecop.return
+    end
 
-  test "student does not see visible after warning if lesson has visible_after property" do
-    Timecop.freeze(Time.new(2020, 3, 27))
-    sign_in create(:student)
+    test "student does not see visible after warning if lesson has visible_after property" do
+      Timecop.freeze(Time.new(2020, 3, 27))
+      sign_in create(:student)
 
-    create(:level, name: "Level 1")
-    unit_file = File.join(self.class.fixture_path, "test-fixture-visible-after.script")
-    Script.setup([unit_file])
+      create(:level, name: "Level 1")
+      unit_file = File.join(self.class.fixture_path, "test-fixture-visible-after.script")
+      Script.setup([unit_file])
 
-    get :show, params: {id: 'test-fixture-visible-after'}
-    assert_response :success
-    refute response.body.include? 'visible after'
-    Timecop.return
-  end
+      get :show, params: {id: 'test-fixture-visible-after'}
+      assert_response :success
+      refute response.body.include? 'visible after'
+      Timecop.return
+    end
 
-  test "teacher does not see visible after warning if lesson has visible_after property" do
-    Timecop.freeze(Time.new(2020, 3, 27))
-    sign_in create(:teacher)
+    test "teacher does not see visible after warning if lesson has visible_after property" do
+      Timecop.freeze(Time.new(2020, 3, 27))
+      sign_in create(:teacher)
 
-    create(:level, name: "Level 1")
-    unit_file = File.join(self.class.fixture_path, "test-fixture-visible-after.script")
-    Script.setup([unit_file])
+      create(:level, name: "Level 1")
+      unit_file = File.join(self.class.fixture_path, "test-fixture-visible-after.script")
+      Script.setup([unit_file])
 
-    get :show, params: {id: 'test-fixture-visible-after'}
-    assert_response :success
-    refute response.body.include? 'visible after'
-    Timecop.return
+      get :show, params: {id: 'test-fixture-visible-after'}
+      assert_response :success
+      refute response.body.include? 'visible after'
+      Timecop.return
+    end
   end
 
   test_user_gets_response_for :vocab, response: :success, user: :teacher, params: -> {{id: @migrated_unit.name}}

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -1649,15 +1649,15 @@ class ScriptsControllerTest < ActionController::TestCase
     assert_redirected_to "/s/dogs2"
   end
 
-  test "levelbuilder does not see visible after warning if lesson does not have visible_after property" do
-    sign_in create(:levelbuilder)
-
-    get :show, params: {id: 'course1'}
-    assert_response :success
-    refute response.body.include? 'visible after'
-  end
-
   class LessonVisibleAfterTest < ActionController::TestCase
+    test "levelbuilder does not see visible after warning if lesson does not have visible_after property" do
+      sign_in create(:levelbuilder)
+
+      get :show, params: {id: 'course1'}
+      assert_response :success
+      refute response.body.include? 'visible after'
+    end
+
     test "levelbuilder does not see visible after warning if lesson has visible_after property that is in the past" do
       Timecop.freeze(Time.new(2020, 4, 2))
       sign_in create(:levelbuilder)

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -1650,6 +1650,16 @@ class ScriptsControllerTest < ActionController::TestCase
   end
 
   class LessonVisibleAfterTest < ActionController::TestCase
+    setup do
+      @unit = create :script
+      lesson_group = create :lesson_group, script: @unit
+      lesson = create :lesson, name: 'lesson 1', lesson_group: lesson_group, script: @unit, visible_after: '2020-04-01 08:00:00 -0700'
+      activity = create :lesson_activity, lesson: lesson
+      section = create :activity_section, lesson_activity: activity
+      level = create :level
+      create :script_level, lesson: lesson, activity_section: section, activity_section_position: 1, levels: [level]
+    end
+
     test "levelbuilder does not see visible after warning if lesson does not have visible_after property" do
       sign_in create(:levelbuilder)
 
@@ -1662,11 +1672,7 @@ class ScriptsControllerTest < ActionController::TestCase
       Timecop.freeze(Time.new(2020, 4, 2))
       sign_in create(:levelbuilder)
 
-      create(:level, name: "Level 1")
-      unit_file = File.join(self.class.fixture_path, "test-fixture-visible-after.script")
-      Script.setup([unit_file])
-
-      get :show, params: {id: 'test-fixture-visible-after'}
+      get :show, params: {id: @unit.name}
       assert_response :success
       refute response.body.include? 'visible after'
       Timecop.return
@@ -1676,11 +1682,7 @@ class ScriptsControllerTest < ActionController::TestCase
       Timecop.freeze(Time.new(2020, 3, 27))
       sign_in create(:levelbuilder)
 
-      create(:level, name: "Level 1")
-      unit_file = File.join(self.class.fixture_path, "test-fixture-visible-after.script")
-      Script.setup([unit_file])
-
-      get :show, params: {id: 'test-fixture-visible-after'}
+      get :show, params: {id: @unit.name}
       assert_response :success
       assert response.body.include? 'The lesson lesson 1 will be visible after'
       Timecop.return
@@ -1690,11 +1692,7 @@ class ScriptsControllerTest < ActionController::TestCase
       Timecop.freeze(Time.new(2020, 3, 27))
       sign_in create(:student)
 
-      create(:level, name: "Level 1")
-      unit_file = File.join(self.class.fixture_path, "test-fixture-visible-after.script")
-      Script.setup([unit_file])
-
-      get :show, params: {id: 'test-fixture-visible-after'}
+      get :show, params: {id: @unit.name}
       assert_response :success
       refute response.body.include? 'visible after'
       Timecop.return
@@ -1704,11 +1702,7 @@ class ScriptsControllerTest < ActionController::TestCase
       Timecop.freeze(Time.new(2020, 3, 27))
       sign_in create(:teacher)
 
-      create(:level, name: "Level 1")
-      unit_file = File.join(self.class.fixture_path, "test-fixture-visible-after.script")
-      Script.setup([unit_file])
-
-      get :show, params: {id: 'test-fixture-visible-after'}
+      get :show, params: {id: @unit.name}
       assert_response :success
       refute response.body.include? 'visible after'
       Timecop.return

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -1663,7 +1663,9 @@ class ScriptsControllerTest < ActionController::TestCase
     test "levelbuilder does not see visible after warning if lesson does not have visible_after property" do
       sign_in create(:levelbuilder)
 
-      get :show, params: {id: 'course1'}
+      @unit.lessons.first.update!(visible_after: nil)
+
+      get :show, params: {id: @unit.name}
       assert_response :success
       refute response.body.include? 'visible after'
     end

--- a/dashboard/test/fixtures/test-fixture-visible-after.script
+++ b/dashboard/test/fixtures/test-fixture-visible-after.script
@@ -1,2 +1,0 @@
-lesson 'lesson 1', display_name: 'lesson 1', visible_after: '2020-04-01 08:00:00 -0700'
-level 'Level 1'


### PR DESCRIPTION
Starts [PLAT-1425]. Because the existing test was not really testing any seeding functionality, seeding can be removed from the test and the fixture can be replaced with factory calls. 

## Testing story

all tests passing after removing the fixture

[PLAT-1425]: https://codedotorg.atlassian.net/browse/PLAT-1425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ