### PR TITLE
[Poetry] Clear the canvas at the start of each frame

### DIFF
--- a/apps/src/p5lab/poetry/PoetryLibrary.js
+++ b/apps/src/p5lab/poetry/PoetryLibrary.js
@@ -57,6 +57,9 @@ export default class PoetryLibrary extends CoreLibrary {
 
       // Override the draw loop
       executeDrawLoopAndCallbacks() {
+        // Make sure we start each frame with a clean slate.
+        this.p5.background('white');
+
         this.backgroundEffect();
         this.runBehaviors();
         this.runEvents();


### PR DESCRIPTION
We've had a few issues with backgrounds being semi-transparent, causing the old background to show through.
We previously fixed this by just changing the background assets to by fully opaque, but it's just one more thing to keep track of when adding assets.
This PR makes it so that we reset the canvas to white at the start of each frame, so even if there is a semi-transparent background, it will just be white showing through.

Before
![image](https://user-images.githubusercontent.com/8787187/140977209-392fe277-dd70-4e56-a4eb-a1b202f61fdc.png)

After
![image](https://user-images.githubusercontent.com/8787187/140977239-a276b165-03d0-49f9-8f28-1eb524e1c0bb.png)
