### PR TITLE
Move Multi-Select Icon into Button

### DIFF
--- a/apps/src/p5lab/AnimationPicker/AnimationPickerListItem.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPickerListItem.jsx
@@ -111,17 +111,17 @@ class AnimationPickerListItem extends React.Component {
               />
             )}
           </div>
+          {animationProps &&
+            loaded &&
+            (hover || selected) &&
+            multiSelectEnabled && (
+              <i
+                className={multiSelectIconClassName}
+                style={multiSelectIconStyle}
+              />
+            )}
         </button>
         {label && <div style={labelStyle}>{label}</div>}
-        {animationProps &&
-          loaded &&
-          (hover || selected) &&
-          multiSelectEnabled && (
-            <i
-              className={multiSelectIconClassName}
-              style={multiSelectIconStyle}
-            />
-          )}
       </div>
     );
   }
@@ -186,6 +186,7 @@ const styles = {
     position: 'absolute',
     borderStyle: 'solid',
     borderWidth: '2px',
+    fontSize: HOVER_PLUS_SIZE,
     height: HOVER_PLUS_SIZE,
     width: HOVER_PLUS_SIZE,
     borderRadius: 5,


### PR DESCRIPTION
Previously, when you clicked on the icon for multi-select, nothing would happen - you had to click on the button around the icon. This PR moves the multi-select icon into the button element, so that the icon is also 'clickable'. This resulted in needing a few sizing changes, also in this PR.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
