### PR TITLE
[Google Blockly] Correctly calculate toolbox width

### DIFF
--- a/apps/src/blockly/addons/cdoWorkspaceSvg.js
+++ b/apps/src/blockly/addons/cdoWorkspaceSvg.js
@@ -92,7 +92,15 @@ export default class WorkspaceSvg extends GoogleBlockly.WorkspaceSvg {
     return super.getAllBlocks().filter(block => !block.disabled);
   }
   getToolboxWidth() {
-    return Blockly.mainBlockSpace.getMetrics().toolboxWidth;
+    const metrics = this.getMetrics();
+    switch (this.getToolboxType()) {
+      case ToolboxType.CATEGORIZED:
+        return metrics.toolboxWidth;
+      case ToolboxType.UNCATEGORIZED:
+        return metrics.flyoutWidth;
+      case ToolboxType.NONE:
+        return 0;
+    }
   }
 
   /**


### PR DESCRIPTION
This function was initially added to the google blockly wrapper code here: https://github.com/code-dot-org/code-dot-org/blob/956ee723c4ee00c77fdfa069c9859439fd83c13d/apps/src/sites/studio/pages/googleBlocklyWrapper.js#L210 and as far I can recall, I think it just never properly accounted for uncategorized toolboxes.
The function is only used here: https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/StudioApp.js#L1512 to calculate the width of the toolbox to show the blocks header
Before
![image](https://user-images.githubusercontent.com/8787187/141010133-aefe7958-2fe0-4293-b1b2-aa361c7c75a5.png)
![image](https://user-images.githubusercontent.com/8787187/141010224-7ad93d8e-1db5-45f4-ba13-aad31db643bf.png)
Already working with categorized toolbox:
![image](https://user-images.githubusercontent.com/8787187/141010417-189fd54d-2ed5-4f92-a3cf-68ff2981ca34.png)


After
![image](https://user-images.githubusercontent.com/8787187/141010012-c2b279a1-334a-4440-b058-a9092eff06bd.png)
![image](https://user-images.githubusercontent.com/8787187/141010043-2c80f636-0ebc-442e-a334-5fc326c0cb4a.png)
Still working with categorized toolbox:
![image](https://user-images.githubusercontent.com/8787187/141010389-ff9a9ff6-d589-4f5b-a525-3d462ea6b145.png)
