### PR TITLE
Add 'disable_google_blockly' DCDO flag for transitioning labs

### DIFF
--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -387,8 +387,16 @@ module LevelsHelper
       }
   end
 
+  # As we migrate labs from CDO to Google Blockly, there are multiple ways to determine which version a lab uses:
+  #  1. The corresponding inherited Level model can override Level#uses_google_blockly?. This option is for labs that
+  #     have fully transitioned to Google Blockly.
+  #  2. Setting the useGoogleBlockly view_option, usually configured by a URL parameter.
+  #  3. The 'uses_google_blockly' DCDO flag, which contains an array of strings corresponding to model class names.
+  #     This option is for labs that are in transition and need an "emergency switch" to go back to CDO Blockly.
   def use_google_blockly
-    @level.uses_google_blockly? || view_options[:useGoogleBlockly] || DCDO.get('uses_google_blockly', []).map(&:downcase).include?(@level.class.to_s.downcase)
+    return true if @level.uses_google_blockly?
+    return true if view_options[:useGoogleBlockly]
+    DCDO.get('uses_google_blockly', []).map(&:downcase).include?(@level.class.to_s.downcase)
   end
 
   # Options hash for Widget

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -369,7 +369,6 @@ module LevelsHelper
     use_blockly = !use_droplet && !use_netsim && !use_weblab && !use_javalab
     use_p5 = @level.is_a?(Gamelab)
     hide_source = app_options[:hideSource]
-    use_google_blockly = @level.uses_google_blockly? || view_options[:useGoogleBlockly]
     render partial: 'levels/apps_dependencies',
       locals: {
         app: app_options[:app],
@@ -386,6 +385,10 @@ module LevelsHelper
         preload_asset_list: @level.try(:preload_asset_list),
         static_asset_base_path: app_options[:baseUrl]
       }
+  end
+
+  def use_google_blockly
+    @level.uses_google_blockly? || view_options[:useGoogleBlockly] || DCDO.get('uses_google_blockly', []).map(&:downcase).include?(@level.class.to_s.downcase)
   end
 
   # Options hash for Widget

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -388,15 +388,17 @@ module LevelsHelper
   end
 
   # As we migrate labs from CDO to Google Blockly, there are multiple ways to determine which version a lab uses:
-  #  1. The corresponding inherited Level model can override Level#uses_google_blockly?. This option is for labs that
+  #  1. Setting the useGoogleBlockly view_option, usually configured by a URL parameter.
+  #  2. The corresponding inherited Level model can override Level#uses_google_blockly?. This option is for labs that
   #     have fully transitioned to Google Blockly.
-  #  2. Setting the useGoogleBlockly view_option, usually configured by a URL parameter.
-  #  3. The uses_google_blockly DCDO flag, which contains an array of strings corresponding to model class names.
-  #     This option is for labs that are in transition and need an "emergency switch" to go back to CDO Blockly.
+  #  3. The disable_google_blockly DCDO flag, which contains an array of strings corresponding to model class names.
+  #     This option will override #2 as an "emergency switch" to go back to CDO Blockly.
   def use_google_blockly
-    return true if @level.uses_google_blockly?
     return true if view_options[:useGoogleBlockly]
-    DCDO.get('uses_google_blockly', []).map(&:downcase).include?(@level.class.to_s.downcase)
+    return false unless @level.uses_google_blockly?
+
+    # Only check DCDO flag if level type uses Google Blockly to avoid performance hit.
+    DCDO.get('disable_google_blockly', []).map(&:downcase).exclude?(@level.class.to_s.downcase)
   end
 
   # Options hash for Widget

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -391,7 +391,7 @@ module LevelsHelper
   #  1. The corresponding inherited Level model can override Level#uses_google_blockly?. This option is for labs that
   #     have fully transitioned to Google Blockly.
   #  2. Setting the useGoogleBlockly view_option, usually configured by a URL parameter.
-  #  3. The 'uses_google_blockly' DCDO flag, which contains an array of strings corresponding to model class names.
+  #  3. The uses_google_blockly DCDO flag, which contains an array of strings corresponding to model class names.
   #     This option is for labs that are in transition and need an "emergency switch" to go back to CDO Blockly.
   def use_google_blockly
     return true if @level.uses_google_blockly?

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -369,7 +369,7 @@ module LevelsHelper
     use_blockly = !use_droplet && !use_netsim && !use_weblab && !use_javalab
     use_p5 = @level.is_a?(Gamelab)
     hide_source = app_options[:hideSource]
-    use_google_blockly = @level.is_a?(Flappy) || view_options[:useGoogleBlockly]
+    use_google_blockly = @level.uses_google_blockly? || view_options[:useGoogleBlockly]
     render partial: 'levels/apps_dependencies',
       locals: {
         app: app_options[:app],

--- a/dashboard/app/models/levels/flappy.rb
+++ b/dashboard/app/models/levels/flappy.rb
@@ -83,6 +83,10 @@ class Flappy < Blockly
     JS
   end
 
+  def uses_google_blockly?
+    true
+  end
+
   def toolbox(type)
     <<-XML.strip_heredoc.chomp
       <block type="flappy_flap"></block>

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -657,6 +657,10 @@ class Level < ApplicationRecord
     false
   end
 
+  def uses_google_blockly?
+    false
+  end
+
   # Create a copy of this level named new_name
   # @param [String] new_name
   # @param [String] editor_experiment

--- a/dashboard/app/models/levels/poetry.rb
+++ b/dashboard/app/models/levels/poetry.rb
@@ -73,6 +73,10 @@ class Poetry < GamelabJr
     )
   end
 
+  def uses_google_blockly?
+    true
+  end
+
   def common_blocks(type)
   end
 

--- a/dashboard/test/helpers/levels_helper_test.rb
+++ b/dashboard/test/helpers/levels_helper_test.rb
@@ -252,14 +252,6 @@ class LevelsHelperTest < ActionView::TestCase
     refute use_google_blockly
   end
 
-  test 'use_google_blockly is true if level.uses_google_blockly?' do
-    Level.any_instance.stubs(:uses_google_blockly?).returns(true)
-    @level = build :level
-    assert use_google_blockly
-
-    Level.unstub(:uses_google_blockly?)
-  end
-
   test 'use_google_blockly is true if useGoogleBlockly is set in view_options' do
     view_options(useGoogleBlockly: true)
     @level = build :level
@@ -268,14 +260,25 @@ class LevelsHelperTest < ActionView::TestCase
     reset_view_options
   end
 
-  test 'use_google_blockly is true if level class name is in DCDO uses_google_blockly config' do
-    DCDO.stubs(:get).with('uses_google_blockly', []).returns(['GamelabJr'])
+  test 'use_google_blockly is true if level.uses_google_blockly?' do
+    Level.any_instance.stubs(:uses_google_blockly?).returns(true)
+    @level = build :level
+    assert use_google_blockly
+
+    Level.unstub(:uses_google_blockly?)
+  end
+
+  test 'use_google_blockly is false if level.uses_google_blockly? but disable_google_blockly is set' do
+    GamelabJr.any_instance.stubs(:uses_google_blockly?).returns(true)
     @level = build :spritelab
     assert use_google_blockly
 
+    DCDO.stubs(:get).with('disable_google_blockly', []).returns(['GamelabJr'])
+    refute use_google_blockly
+
     # Should be case insensitive
-    DCDO.stubs(:get).with('uses_google_blockly', []).returns(['gamelabjr'])
-    assert use_google_blockly
+    DCDO.stubs(:get).with('disable_google_blockly', []).returns(['gamelabjr'])
+    refute use_google_blockly
 
     DCDO.unstub(:get)
   end

--- a/dashboard/test/helpers/levels_helper_test.rb
+++ b/dashboard/test/helpers/levels_helper_test.rb
@@ -247,6 +247,39 @@ class LevelsHelperTest < ActionView::TestCase
     assert_not_equal channel, get_channel_for(level, script.id)
   end
 
+  test 'uses_google_blockly is false if not set' do
+    @level = build :level
+    refute use_google_blockly
+  end
+
+  test 'use_google_blockly is true if level.uses_google_blockly?' do
+    Level.any_instance.stubs(:uses_google_blockly?).returns(true)
+    @level = build :level
+    assert use_google_blockly
+
+    Level.unstub(:uses_google_blockly?)
+  end
+
+  test 'use_google_blockly is true if useGoogleBlockly is set in view_options' do
+    view_options(useGoogleBlockly: true)
+    @level = build :level
+    assert use_google_blockly
+
+    reset_view_options
+  end
+
+  test 'use_google_blockly is true if level class name is in DCDO uses_google_blockly config' do
+    DCDO.stubs(:get).with('uses_google_blockly', []).returns(['GamelabJr'])
+    @level = build :spritelab
+    assert use_google_blockly
+
+    # Should be case insensitive
+    DCDO.stubs(:get).with('uses_google_blockly', []).returns(['gamelabjr'])
+    assert use_google_blockly
+
+    DCDO.unstub(:get)
+  end
+
   test 'applab levels should not load channel when viewing student solution of a student without a channel' do
     # two different users
     @user = create :user


### PR DESCRIPTION
Allows us to override using Google Blockly for a level type using the `disable_google_blockly` DCDO flag. Example usage of this flag and how it should be set in the Rails console:

```ruby
[development] dashboard > DCDO.set('disable_google_blockly', ["Poetry"])
=> nil
[development] dashboard > DCDO.get('disable_google_blockly', [])
=> ["Poetry"]
```

Some rules about this flag:
1. It should be used for levels/labs that are transitioning to Google Blockly; it can be thought of as an emergency/test switch in case we need to switch back to CDO Blockly immediately because it will override `Level#uses_google_blockly?`.
2. The string added to this DCDO array should match the Level subclass name you want to override.
3. It is case insensitive (e.g., either "Poetry" or "poetry" will work in the example above).

Still supports the previous cases, which are:
1. fully migrated level types (e.g., all Flappy levels should use Google Blockly)
2. `view_options[:useGoogleBlockly]`, which right now is set when you visit a level/script_level with the `?blocklyVersion=Google` URL param

The migration path to transition a level type to Google Blockly (outside of any implementation/fixes needed on the client):
1. Implement `uses_google_blockly?` on the corresponding model class to return `true`. Once this is deployed, that level type will use Google Blockly by default.
2. Add the model class name to the list of class names in `DCDO.get('disable_google_blockly', [])` in the preferred environment if you need to immediately switch back to using CDO Blockly.

## Links

- [STAR-1896](https://codedotorg.atlassian.net/browse/STAR-1896)

## Testing story

Adds unit tests.