### PR TITLE
Multi-select Exit Modal - Backdrop Extension Change

### DIFF
--- a/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
@@ -127,6 +127,7 @@ class AnimationPicker extends React.Component {
         <StylizedBaseDialog
           title={msg.animationPicker_leaveSelectionTitle()}
           isOpen={this.state.exitingDialog}
+          //backdropExtension={15}
           hideCloseButton={true}
           handleClose={() => {
             this.setState({exitingDialog: false});

--- a/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
@@ -127,7 +127,7 @@ class AnimationPicker extends React.Component {
         <StylizedBaseDialog
           title={msg.animationPicker_leaveSelectionTitle()}
           isOpen={this.state.exitingDialog}
-          //backdropExtension={15}
+          backdropExtension={15}
           hideCloseButton={true}
           handleClose={() => {
             this.setState({exitingDialog: false});

--- a/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
@@ -127,7 +127,12 @@ class AnimationPicker extends React.Component {
         <StylizedBaseDialog
           title={msg.animationPicker_leaveSelectionTitle()}
           isOpen={this.state.exitingDialog}
-          backdropExtension={15}
+          backdropStyle={{
+            top: -15,
+            right: -15,
+            bottom: -15,
+            left: -15
+          }}
           hideCloseButton={true}
           handleClose={() => {
             this.setState({exitingDialog: false});

--- a/apps/src/templates/BaseDialog.jsx
+++ b/apps/src/templates/BaseDialog.jsx
@@ -31,7 +31,8 @@ export default class BaseDialog extends React.Component {
     bodyClassName: PropTypes.string,
     style: PropTypes.object,
     soundPlayer: PropTypes.object,
-    overflow: PropTypes.string
+    overflow: PropTypes.string,
+    backdropExtension: PropTypes.number
   };
 
   componentDidMount() {
@@ -151,6 +152,17 @@ export default class BaseDialog extends React.Component {
       .filter(className => !!className)
       .join(' ');
 
+    let modalBackdrop;
+    let backdropExtension = this.props.backdropExtension;
+    if (backdropExtension) {
+      modalBackdrop = {
+        top: -backdropExtension,
+        right: -backdropExtension,
+        bottom: -backdropExtension,
+        left: -backdropExtension
+      };
+    }
+
     let body = (
       <div
         style={bodyStyle}
@@ -193,7 +205,7 @@ export default class BaseDialog extends React.Component {
       <div className={wrapperClassNames}>
         <div
           className={modalBackdropClassNames}
-          style={styles.modalBackdrop}
+          style={modalBackdrop}
           onClick={this.closeDialog}
         />
         {body}
@@ -201,12 +213,3 @@ export default class BaseDialog extends React.Component {
     );
   }
 }
-
-const styles = {
-  modalBackdrop: {
-    top: -15,
-    right: -15,
-    bottom: -15,
-    left: -15
-  }
-};

--- a/apps/src/templates/BaseDialog.jsx
+++ b/apps/src/templates/BaseDialog.jsx
@@ -32,6 +32,7 @@ export default class BaseDialog extends React.Component {
     style: PropTypes.object,
     soundPlayer: PropTypes.object,
     overflow: PropTypes.string,
+    // Temporary prop until AnimationPickerBody is redesigned
     backdropStyle: PropTypes.object
   };
 

--- a/apps/src/templates/BaseDialog.jsx
+++ b/apps/src/templates/BaseDialog.jsx
@@ -32,7 +32,7 @@ export default class BaseDialog extends React.Component {
     style: PropTypes.object,
     soundPlayer: PropTypes.object,
     overflow: PropTypes.string,
-    backdropExtension: PropTypes.number
+    backdropStyle: PropTypes.object
   };
 
   componentDidMount() {
@@ -152,17 +152,6 @@ export default class BaseDialog extends React.Component {
       .filter(className => !!className)
       .join(' ');
 
-    let modalBackdrop;
-    let backdropExtension = this.props.backdropExtension;
-    if (backdropExtension) {
-      modalBackdrop = {
-        top: -backdropExtension,
-        right: -backdropExtension,
-        bottom: -backdropExtension,
-        left: -backdropExtension
-      };
-    }
-
     let body = (
       <div
         style={bodyStyle}
@@ -205,7 +194,7 @@ export default class BaseDialog extends React.Component {
       <div className={wrapperClassNames}>
         <div
           className={modalBackdropClassNames}
-          style={modalBackdrop}
+          style={this.props.backdropStyle}
           onClick={this.closeDialog}
         />
         {body}


### PR DESCRIPTION
Follow-up to this change: https://github.com/code-dot-org/code-dot-org/pull/43383

This change makes it so that extending the backdrop is optional via prop, which takes in the number of pixels to extend the backdrop modal.

![Screenshot from 2021-11-09 09-10-59](https://user-images.githubusercontent.com/2959170/141027150-1ffb5201-1195-4176-b052-b3dd05f2dee3.png)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
