### PR TITLE
Fixed failed render due to returning undefined rather than null

### DIFF
--- a/apps/src/templates/InlineDropdownMenu.jsx
+++ b/apps/src/templates/InlineDropdownMenu.jsx
@@ -57,7 +57,7 @@ export class InlineDropdownMenu extends Component {
     const {children, icon} = this.props;
     const {isOpen} = this.state;
     if (children === undefined || children.length === 0) {
-      return;
+      return null;
     }
 
     return (


### PR DESCRIPTION
In the case where no inline dropdown menu should render, such as when reviewing another student's code, the InlineDropdownMenu would return undefined rather than null. This caused the React Error https://reactjs.org/docs/error-decoder.html/?invariant=152&args[]=e to be thrown which translates to the following message:

`e(...): Nothing was returned from render. This usually means a return statement is missing. Or, to render nothing, return null.`

This caused the parent elements to all unmount, causing a blank screen.

This was reported during a call with CSA pilot teachers.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
