### PR TITLE
hoc2021: Update more social metadata

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -485,6 +485,7 @@
   twitter_default_text: "I'm participating in this year's #HourOfCode, are you? @codeorg"
   twitter_donor_text: "This year's #HourOfCode is about creativity. I’m in! Are you? (Thanks %{random_donor} for supporting @codeorg)"
   twitter_donor_text_2019: "This year's #HourOfCode is about #CSforGood. I’m in! Are you? (Thanks %{random_donor} for supporting @codeorg)"
+  twitter_default_text_donor: "I'm participating in this year's #HourOfCode, are you? (Thanks %{random_donor} for supporting @codeorg)"
 
   hoc_faq_title: 'FAQs'
   hoc_faq_what_is_hoc_q: 'What is the Hour of Code?'

--- a/pegasus/sites.v3/hourofcode.com/views/promote/share_buttons.erb
+++ b/pegasus/sites.v3/hourofcode.com/views/promote/share_buttons.erb
@@ -1,8 +1,8 @@
 <%
   facebook = {:u=>"http://#{request.host}/us"}
 
-  twitter = {:url=>"http://hourofcode.com", :related=>'codeorg', :hashtags=>'', :text=>hoc_s(:twitter_donor_text).gsub(/%{random_donor}/, get_random_donor_twitter)}
-  twitter[:hashtags] = 'HourOfCode' unless hoc_s(:twitter_donor_text).include? '#HourOfCode'
+  twitter = {:url=>"http://hourofcode.com", :related=>'codeorg', :hashtags=>'', :text=>hoc_s(:twitter_default_text_donor).gsub(/%{random_donor}/, get_random_donor_twitter)}
+  twitter[:hashtags] = 'HourOfCode' unless hoc_s(:twitter_default_text_donor).include? '#HourOfCode'
 %>
 
 <%= view :share_buttons, facebook:facebook, twitter:twitter %>

--- a/pegasus/sites.v3/hourofcode.com/views/social_media_hoc.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/social_media_hoc.haml
@@ -1,4 +1,4 @@
 - facebook = {:u=>"http://#{request.host}/us"}
-- twitter = {:url=>"http://hourofcode.com", :related=>'codeorg', :hashtags=>'', :text=>hoc_s(:twitter_donor_text_2019).gsub(/%{random_donor}/, get_random_donor_twitter)}
-- twitter[:hashtags] = 'HourOfCode' unless hoc_s(:twitter_donor_text_2019).include? '#HourOfCode'
+- twitter = {:url=>"http://hourofcode.com", :related=>'codeorg', :hashtags=>'', :text=>hoc_s(:twitter_default_text_donor).gsub(/%{random_donor}/, get_random_donor_twitter)}
+- twitter[:hashtags] = 'HourOfCode' unless hoc_s(:twitter_default_text_donor).include? '#HourOfCode'
 = view :share_buttons, facebook:facebook, twitter:twitter


### PR DESCRIPTION
Updates the social metadata for Twitter shares at https://hourofcode.com/promote and https://hourofcode.com/thanks with perennial content.

Something of a follow-up to https://github.com/code-dot-org/code-dot-org/pull/43312.
