### PR TITLE
[Sprite Lab] Deletion modal update text

### DIFF
--- a/apps/src/p5lab/AnimationTab/AnimationList.jsx
+++ b/apps/src/p5lab/AnimationTab/AnimationList.jsx
@@ -19,7 +19,8 @@ class AnimationList extends React.Component {
     selectedAnimation: shapes.AnimationKey,
     onNewItemClick: PropTypes.func.isRequired,
     spriteLab: PropTypes.bool.isRequired,
-    hideBackgrounds: PropTypes.bool.isRequired
+    hideBackgrounds: PropTypes.bool.isRequired,
+    labType: PropTypes.string.isRequired
   };
 
   render() {
@@ -48,6 +49,7 @@ class AnimationList extends React.Component {
             animationProps={this.props.animationList.propsByKey[key]}
             isSelected={key === this.props.selectedAnimation}
             animationList={this.props.animationList}
+            labType={this.props.labType}
           />
         ))}
         {!this.props.spriteLab && addAnimation}

--- a/apps/src/p5lab/AnimationTab/AnimationListItem.jsx
+++ b/apps/src/p5lab/AnimationTab/AnimationListItem.jsx
@@ -38,7 +38,8 @@ class AnimationListItem extends React.Component {
     children: PropTypes.node,
     style: PropTypes.object,
     allAnimationsSingleFrame: PropTypes.bool.isRequired,
-    spriteLab: PropTypes.bool.isRequired
+    spriteLab: PropTypes.bool.isRequired,
+    labType: PropTypes.string.isRequired
   };
 
   getAnimationProps(props) {
@@ -218,6 +219,7 @@ class AnimationListItem extends React.Component {
               this.state.frameDelay
             )}
             singleFrameAnimation={this.props.allAnimationsSingleFrame}
+            labType={this.props.labType}
           />
         )}
       </button>

--- a/apps/src/p5lab/AnimationTab/AnimationTab.jsx
+++ b/apps/src/p5lab/AnimationTab/AnimationTab.jsx
@@ -46,7 +46,10 @@ class AnimationTab extends React.Component {
         >
           <div style={styles.animationsColumn}>
             <P5LabVisualizationHeader labType={this.props.labType} />
-            <AnimationList hideBackgrounds={this.props.hideBackgrounds} />
+            <AnimationList
+              hideBackgrounds={this.props.hideBackgrounds}
+              labType={this.props.labType}
+            />
           </div>
           <div style={styles.editorColumn}>
             <PiskelEditor style={styles.piskelEl} />

--- a/apps/src/p5lab/AnimationTab/DeleteAnimationDialog.jsx
+++ b/apps/src/p5lab/AnimationTab/DeleteAnimationDialog.jsx
@@ -8,16 +8,29 @@ export default class DeleteAnimationDialog extends React.Component {
   static propTypes = {
     onDelete: PropTypes.func.isRequired,
     onCancel: PropTypes.func.isRequired,
-    isOpen: PropTypes.bool.isRequired
+    isOpen: PropTypes.bool.isRequired,
+    labType: PropTypes.string.isRequired
   };
 
   render() {
+    let assetType;
+    switch (this.props.labType) {
+      case 'GAMELAB':
+        assetType = i18n.animation();
+        break;
+      case 'SPRITELAB':
+        assetType = i18n.costume();
+        break;
+      case 'POETRY':
+        assetType = i18n.costume();
+        break;
+    }
     return (
       <Dialog
         isOpen={this.props.isOpen}
         handleClose={this.props.onCancel}
-        title={i18n.deleteAsset({assetType: i18n.animation()})}
-        body={i18n.deleteAssetConfirm({assetType: i18n.animation()})}
+        title={i18n.deleteAsset({assetType})}
+        body={i18n.deleteAssetConfirm({assetType})}
       >
         <Buttons>
           <Cancel onClick={this.props.onCancel}>{i18n.cancel()}</Cancel>

--- a/apps/src/p5lab/AnimationTab/DeleteAnimationDialog.jsx
+++ b/apps/src/p5lab/AnimationTab/DeleteAnimationDialog.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Dialog, {Buttons, Cancel, Confirm} from '@cdo/apps/templates/Dialog';
 import i18n from '@cdo/locale';
+import {P5LabType} from '../constants';
 
 export default class DeleteAnimationDialog extends React.Component {
   static propTypes = {
@@ -13,16 +14,15 @@ export default class DeleteAnimationDialog extends React.Component {
   };
 
   render() {
-    const P5LabType = this.props.labType;
     let assetType;
-    switch (P5LabType) {
-      case 'GAMELAB':
+    switch (this.props.labType) {
+      case P5LabType.GAMELAB:
         assetType = i18n.animation();
         break;
-      case 'SPRITELAB':
+      case P5LabType.SPRITELAB:
         assetType = i18n.costume();
         break;
-      case 'POETRY':
+      case P5LabType.POETRY:
         assetType = i18n.costume();
         break;
     }

--- a/apps/src/p5lab/AnimationTab/DeleteAnimationDialog.jsx
+++ b/apps/src/p5lab/AnimationTab/DeleteAnimationDialog.jsx
@@ -13,8 +13,9 @@ export default class DeleteAnimationDialog extends React.Component {
   };
 
   render() {
+    const P5LabType = this.props.labType;
     let assetType;
-    switch (this.props.labType) {
+    switch (P5LabType) {
       case 'GAMELAB':
         assetType = i18n.animation();
         break;

--- a/apps/src/p5lab/AnimationTab/ListItemButtons.jsx
+++ b/apps/src/p5lab/AnimationTab/ListItemButtons.jsx
@@ -24,7 +24,8 @@ class ListItemButtons extends React.Component {
     looping: PropTypes.bool.isRequired,
     onFrameDelayChanged: PropTypes.func.isRequired,
     frameDelay: PropTypes.number.isRequired,
-    singleFrameAnimation: PropTypes.bool.isRequired
+    singleFrameAnimation: PropTypes.bool.isRequired,
+    labType: PropTypes.string.isRequired
   };
 
   state = {isDeleteDialogOpen: false};
@@ -93,6 +94,7 @@ class ListItemButtons extends React.Component {
           onDelete={this.onDeleteItem}
           onCancel={this.closeDeleteDialog}
           isOpen={this.state.isDeleteDialogOpen}
+          labType={this.props.labType}
         />
       </div>
     );


### PR DESCRIPTION
[STAR-1642](https://codedotorg.atlassian.net/browse/STAR-1642) Update modal text in Sprite lab to say costume deleted instead of animation

**Sprite Lab before:** *(Incorrectly refers to "animation")*
![image-20211102-133605](https://user-images.githubusercontent.com/43474485/141135705-d7830ee4-4d4b-4b6c-b796-01accf418e18.png)

An earlier PR first updated the deletion dialog to make it translatable. ([#43341](https://github.com/code-dot-org/code-dot-org/pull/43341))
In order to check if this is a Game Lab, Sprite Lab, or Poetry level, I needed to make sure this information got passed all the way to the DeleteAnimationDialog class. I traced the parent/child path, finding that AnimationTab was the last place to track the lab type.

**Game Lab after:** *(same appearance, but translatable)*
![image](https://user-images.githubusercontent.com/43474485/141137084-5c12bdbf-92b6-4d1d-94a9-9b8b8fd3e3bb.png)


**Sprite Lab after:**
![image](https://user-images.githubusercontent.com/43474485/141136961-deb5da5b-8646-4dad-afe6-7fb418be7a3a.png)

**Poetry after:**
![image](https://user-images.githubusercontent.com/43474485/141137014-9a5e42c9-3ce3-4b1c-9e4e-929bc1994ed7.png)
