### PR TITLE
Fix FRL cookie for marketing

### DIFF
--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -2371,7 +2371,7 @@ class User < ApplicationRecord
       curriculums: curriculums_being_taught.any? ? curriculums_being_taught.to_json : nil,
       has_attended_pd: has_attended_pd?,
       within_us: within_united_states?,
-      school_percent_frl_40_plus: school_stats.present? ? school_stats.frl_eligible_percent >= 40 : nil,
+      school_percent_frl_40_plus: school_stats&.frl_eligible_percent.present? ? school_stats.frl_eligible_percent >= 40 : nil,
       school_title_i: school_stats&.title_i_status
     }
   end

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -2371,13 +2371,13 @@ class User < ApplicationRecord
       curriculums: curriculums_being_taught.any? ? curriculums_being_taught.to_json : nil,
       has_attended_pd: has_attended_pd?,
       within_us: within_united_states?,
-      school_percent_frl: school_stats&.frl_eligible_total,
+      school_percent_frl_40_plus: school_stats.present? ? school_stats.frl_eligible_percent >= 40 : nil,
       school_title_i: school_stats&.title_i_status
     }
   end
 
   def self.marketing_segment_data_keys
-    %w(locale account_age_in_years grades curriculums has_attended_pd within_us school_percent_frl school_title_i)
+    %w(locale account_age_in_years grades curriculums has_attended_pd within_us school_percent_frl_40_plus school_title_i)
   end
 
   private

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -4636,13 +4636,18 @@ class UserTest < ActiveSupport::TestCase
     assert teacher.marketing_segment_data[:within_us]
   end
 
-  test 'marketing_segment_data returns expected value for school_percent_frl' do
-    frl_eligible_total = 35
+  test 'marketing_segment_data returns expected value for school_percent_frl_40_plus' do
+    frl_eligible_total = 45
     school = create :school
-    create :school_stats_by_year, school: school, frl_eligible_total: frl_eligible_total
+    create :school_stats_by_year, school: school, frl_eligible_total: frl_eligible_total, students_total: 100
     school_info = create :school_info, school: school
     teacher = create :teacher, school_info: school_info
-    assert_equal frl_eligible_total, teacher.marketing_segment_data[:school_percent_frl]
+    assert teacher.marketing_segment_data[:school_percent_frl_40_plus]
+  end
+
+  test 'marketing_segment_data returns expected value for school_percent_frl_40_plus when no school stats' do
+    teacher = create :teacher
+    assert_nil teacher.marketing_segment_data[:school_percent_frl_40_plus]
   end
 
   test 'marketing_segment_data returns expected value for school_title_i' do


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
There were 2 problems with the old cookie, 
1. It wasn't a percentage
2. There wasn't an easy way to filter by the value in Optimizely even if it was a percentage

After talking to Eric, what they want to segment on is if the FRL percentage is >=40. So I've updated the cookie to be a boolean with that information, which will be easy to segment on in Optimizely.

## Testing story
Added/updated unit tests
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
