### PR TITLE
[Google Blockly][Poetry] Make location picker work on ios12

### DIFF
--- a/apps/src/p5lab/P5LabVisualizationColumn.jsx
+++ b/apps/src/p5lab/P5LabVisualizationColumn.jsx
@@ -172,6 +172,7 @@ class P5LabVisualizationColumn extends React.Component {
               onPointerMove={this.pickerPointerMove}
               onPointerUp={this.pickerPointerUp}
               elementRef={el => (this.divGameLab = el)}
+              onMouseUp={this.pickerPointerUp}
             />
             <VisualizationOverlay
               width={APP_WIDTH}


### PR DESCRIPTION
Idk how to capture a gif on my iPad but I tested locally using ngrok

iOS 12 doesn't support `PointerEvent`s which we use for the location picker. This is an issue we were aware of at one point, but forgot about: https://github.com/code-dot-org/code-dot-org/pull/38522

My solution here is to also add an event hook for `onMouseUp` which ios 12 does fire. This means that `pickerPointerUp` will be called twice for devices/browsers that support PointerEvents (pretty much everything except ios 12). I think this is okay because pickerPointerUp is idempotent and it shouldn't really have performance implications because it's just the end event (not the continuous mouse/pointer move events).

Also tested on Safari, Chrome, and Firefox and everything works as expected.