### PR TITLE
replace test-bad-plc-module.script fixture with seed test using factories

### DIFF
--- a/dashboard/test/fixtures/test-bad-plc-module.script
+++ b/dashboard/test/fixtures/test-bad-plc-module.script
@@ -1,5 +1,0 @@
-professional_learning_course 'true'
-
-lesson_group 'bad_module_type', display_name: 'Bad Module Type'
-lesson 'Sample Module', display_name: 'Sample Module'
-level 'Level 1'

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1492,13 +1492,6 @@ class ScriptTest < ActiveSupport::TestCase
     assert_equal Plc::LearningModule::CONTENT_MODULE, lm.module_type
   end
 
-  test 'expect error on bad module types' do
-    unit_file = File.join(self.class.fixture_path, 'test-bad-plc-module.script')
-    assert_raises ActiveRecord::RecordInvalid do
-      Script.setup([unit_file])
-    end
-  end
-
   test 'unit name format validation' do
     assert_raises ActiveRecord::RecordInvalid do
       create :script, name: 'abc 123'


### PR DESCRIPTION
Finishes [PLAT-1425]. This PR adds a unit test which covers the same functionality for new script seeding. the old test and test fixture can be removed once our production (i.e. non-test) units have all been migrated.


[PLAT-1425]: https://codedotorg.atlassian.net/browse/PLAT-1425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ