### PR TITLE
Remove MultiSelect flag to enable permanently

### DIFF
--- a/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
@@ -206,8 +206,8 @@ export default connect(
     onPickNewAnimation() {
       dispatch(pickNewAnimation());
     },
-    onPickLibraryAnimation(animation, isMultiSelectEnabled) {
-      dispatch(pickLibraryAnimation(animation, isMultiSelectEnabled));
+    onPickLibraryAnimation(animation) {
+      dispatch(pickLibraryAnimation(animation));
     },
     onUploadStart(data) {
       if (data.files[0].size >= MAX_UPLOAD_SIZE) {

--- a/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
@@ -272,6 +272,7 @@ export default class AnimationPickerBody extends React.Component {
         {(searchQuery !== '' || categoryQuery !== '') && (
           <div style={styles.footer}>
             <Button
+              className="ui-test-selector-done-button"
               text={msg.done()}
               onClick={onAnimationSelectionComplete}
               color={Button.ButtonColor.orange}

--- a/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
@@ -12,7 +12,6 @@ import {
   searchAssets,
   filterOutBackgrounds
 } from '@cdo/apps/code-studio/assets/searchAssets';
-import experiments from '@cdo/apps/util/experiments';
 import Button from '@cdo/apps/templates/Button';
 import {AnimationProps} from '@cdo/apps/p5lab/shapes';
 import {isMobileDevice} from '@cdo/apps/util/browser-detector';
@@ -45,7 +44,6 @@ export default class AnimationPickerBody extends React.Component {
 
   componentDidMount() {
     this.scrollListContainer = React.createRef();
-    this.multiSelectEnabled_ = experiments.isEnabled(experiments.MULTISELECT);
   }
 
   UNSAFE_componentWillReceiveProps(nextProps) {
@@ -168,23 +166,17 @@ export default class AnimationPickerBody extends React.Component {
     ));
   }
 
-  animationItemsRendering(animations, isMultiSelectEnabled) {
+  animationItemsRendering(animations) {
     return animations.map(animationProps => (
       <AnimationPickerListItem
         key={animationProps.sourceUrl}
         label={this.props.hideAnimationNames ? undefined : animationProps.name}
         animationProps={animationProps}
-        onClick={() =>
-          this.props.onPickLibraryAnimation(
-            animationProps,
-            isMultiSelectEnabled
-          )
-        }
+        onClick={() => this.props.onPickLibraryAnimation(animationProps)}
         playAnimations={this.props.playAnimations}
         selected={this.props.selectedAnimations.some(
           e => e.sourceUrl === animationProps.sourceUrl
         )}
-        multiSelectEnabled={this.multiSelectEnabled_}
       />
     ));
   }
@@ -204,8 +196,7 @@ export default class AnimationPickerBody extends React.Component {
 
     // Display second "Done" button. Useful for mobile, where the original "done" button might not be on screen when
     // animation picker is loaded. 600 pixels is minimum height of the animation picker.
-    const shouldDisplaySecondDoneButton =
-      this.multiSelectEnabled_ && isMobileDevice();
+    const shouldDisplaySecondDoneButton = isMobileDevice();
 
     return (
       <div style={{marginBottom: 10}}>
@@ -275,22 +266,18 @@ export default class AnimationPickerBody extends React.Component {
               categoryQuery === '' &&
               this.animationCategoriesRendering()}
             {(searchQuery !== '' || categoryQuery !== '') &&
-              this.animationItemsRendering(
-                results || [],
-                this.multiSelectEnabled_
-              )}
+              this.animationItemsRendering(results || [])}
           </ScrollableList>
         </div>
-        {this.multiSelectEnabled_ &&
-          (searchQuery !== '' || categoryQuery !== '') && (
-            <div style={styles.footer}>
-              <Button
-                text={msg.done()}
-                onClick={onAnimationSelectionComplete}
-                color={Button.ButtonColor.orange}
-              />
-            </div>
-          )}
+        {(searchQuery !== '' || categoryQuery !== '') && (
+          <div style={styles.footer}>
+            <Button
+              text={msg.done()}
+              onClick={onAnimationSelectionComplete}
+              color={Button.ButtonColor.orange}
+            />
+          </div>
+        )}
       </div>
     );
   }

--- a/apps/src/p5lab/AnimationPicker/AnimationPickerListItem.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPickerListItem.jsx
@@ -19,8 +19,7 @@ class AnimationPickerListItem extends React.Component {
     onClick: PropTypes.func,
     playAnimations: PropTypes.bool,
     category: PropTypes.string,
-    selected: PropTypes.bool,
-    multiSelectEnabled: PropTypes.bool
+    selected: PropTypes.bool
   };
 
   state = {
@@ -36,8 +35,7 @@ class AnimationPickerListItem extends React.Component {
       onClick,
       playAnimations,
       label,
-      selected,
-      multiSelectEnabled
+      selected
     } = this.props;
     const {loaded, hover} = this.state;
     const rootStyle = [styles.root, !label && styles.noLabel];
@@ -111,15 +109,12 @@ class AnimationPickerListItem extends React.Component {
               />
             )}
           </div>
-          {animationProps &&
-            loaded &&
-            (hover || selected) &&
-            multiSelectEnabled && (
-              <i
-                className={multiSelectIconClassName}
-                style={multiSelectIconStyle}
-              />
-            )}
+          {animationProps && loaded && (hover || selected) && (
+            <i
+              className={multiSelectIconClassName}
+              style={multiSelectIconStyle}
+            />
+          )}
         </button>
         {label && <div style={labelStyle}>{label}</div>}
       </div>

--- a/apps/src/p5lab/redux/animationPicker.js
+++ b/apps/src/p5lab/redux/animationPicker.js
@@ -271,11 +271,9 @@ export function pickNewAnimation() {
  * process. Dispatch root gamelab action to add appropriate metadata and then
  * close the animation picker.
  * @param {!AnimationProps} animation
- * @param {!boolean} isMultiSelectEnabled - boolean determines if we are in the multiselect experiment. Will
- *    be removed after experiment
  * @returns {function}
  */
-export function pickLibraryAnimation(animation, isMultiSelectEnabled = false) {
+export function pickLibraryAnimation(animation) {
   firehoseClient.putRecord({
     study: 'sprite-use',
     study_group: 'before-update-v2',
@@ -289,22 +287,13 @@ export function pickLibraryAnimation(animation, isMultiSelectEnabled = false) {
     const goal = getState().animationPicker.goal;
     const selectedAnimations = getState().animationPicker.selectedAnimations;
     if (goal === Goal.NEW_ANIMATION) {
-      if (isMultiSelectEnabled) {
-        if (!!selectedAnimations[animation.sourceUrl]) {
-          dispatch(removeSelectedAnimation(animation));
-        } else {
-          dispatch(addSelectedAnimation(animation));
-        }
+      if (!!selectedAnimations[animation.sourceUrl]) {
+        dispatch(removeSelectedAnimation(animation));
       } else {
-        dispatch(
-          addLibraryAnimation(animation, getState().animationPicker.isSpriteLab)
-        );
+        dispatch(addSelectedAnimation(animation));
       }
     } else if (goal === Goal.NEW_FRAME) {
       dispatch(appendLibraryFrames(animation));
-    }
-    if (!isMultiSelectEnabled) {
-      dispatch(hide());
     }
   };
 }

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -34,7 +34,6 @@ experiments.BYPASS_DIALOG_POPUP = 'bypass-dialog-popup';
 experiments.SPECIAL_TOPIC = 'special-topic';
 experiments.CLEARER_SIGN_UP_USER_TYPE = 'clearerSignUpUserType';
 experiments.OPT_IN_EMAIL_REG_PARTNER = 'optInEmailRegPartner';
-experiments.MULTISELECT = 'multiselect';
 experiments.CODE_REVIEW_GROUPS = 'codeReviewGroups';
 experiments.JAVALAB_UNIT_TESTS = 'javalabUnitTests';
 experiments.P5LAB_TEACHER_UPLOAD = 'p5labTeacherUpload';

--- a/apps/test/unit/p5lab/redux/animationPickerTest.js
+++ b/apps/test/unit/p5lab/redux/animationPickerTest.js
@@ -202,31 +202,15 @@ describe('animationPicker', function() {
       restoreRedux();
     });
 
-    it('adds to the selectedAnimations object when called with multiSelect', function() {
-      getStore().dispatch(pickLibraryAnimation(testAnimation, true));
-
-      let newState = getStore().getState().animationPicker;
-      expect(Object.keys(newState.selectedAnimations).length).to.equal(1);
-    });
-
-    it('does not add to the selectedAnimation object when multiSelect is not provided', function() {
+    it('adds to the selectedAnimations object', function() {
       getStore().dispatch(pickLibraryAnimation(testAnimation));
-      let newState = getStore().getState().animationPicker;
-      expect(Object.keys(newState.selectedAnimations).length).to.equal(0);
-    });
 
-    it('removes from the selectedAnimations object when called with multiSelect', function() {
-      getStore().dispatch(pickLibraryAnimation(testAnimation, true));
       let newState = getStore().getState().animationPicker;
       expect(Object.keys(newState.selectedAnimations).length).to.equal(1);
-
-      getStore().dispatch(pickLibraryAnimation(testAnimation, true));
-      newState = getStore().getState().animationPicker;
-      expect(Object.keys(newState.selectedAnimations).length).to.equal(0);
     });
 
-    it('does not remove from the selectedAnimation object when multiSelect is not provided', function() {
-      getStore().dispatch(pickLibraryAnimation(testAnimation, true));
+    it('removes from the selectedAnimations object', function() {
+      getStore().dispatch(pickLibraryAnimation(testAnimation));
       let newState = getStore().getState().animationPicker;
       expect(Object.keys(newState.selectedAnimations).length).to.equal(1);
 

--- a/dashboard/test/ui/features/step_definitions/gamelab.rb
+++ b/dashboard/test/ui/features/step_definitions/gamelab.rb
@@ -66,6 +66,10 @@ Then /^I select the bear animal head animation from the animal category$/ do
   @browser.execute_script("$(\"img[src*='/category_animals/animalhead_bear.png']\")[0].click();")
 end
 
+Then /^I select the animation picker 'done' button$/ do
+  steps 'Then I click selector ".ui-test-selector-done-button" once I see it'
+end
+
 Then /^I add a new, blank animation$/ do
   steps <<-STEPS
     And I open the animation picker
@@ -78,6 +82,7 @@ Then /^I add the bear animal head animation from the library$/ do
     And I open the animation picker
     And I select the animal category of the animation library
     And I select the bear animal head animation from the animal category
+    And I select the animation picker 'done' button
   STEPS
 end
 


### PR DESCRIPTION
Removing the experiment flag for multi-select to enable permanently.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
