### PR TITLE
Last set of fields for programming expressions edit page 

### DIFF
--- a/apps/src/lib/levelbuilder/code-docs-editor/ExampleEditor.jsx
+++ b/apps/src/lib/levelbuilder/code-docs-editor/ExampleEditor.jsx
@@ -1,8 +1,10 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, {useState} from 'react';
+import Button from '@cdo/apps/templates/Button';
 import color from '@cdo/apps/util/color';
 import HelpTip from '@cdo/apps/lib/ui/HelpTip';
 import TextareaWithMarkdownPreview from '@cdo/apps/lib/levelbuilder/TextareaWithMarkdownPreview';
+import UploadImageDialog from '@cdo/apps/lib/levelbuilder/lesson-editor/UploadImageDialog';
 
 const APP_DISPLAY_OPTIONS = {
   directly: 'Embed app with code directly',
@@ -10,6 +12,8 @@ const APP_DISPLAY_OPTIONS = {
 };
 
 export default function ExampleEditor({example, updateExample}) {
+  const [uploadImageDialogOpen, setUploadImageDialogOpen] = useState(false);
+
   return (
     <div>
       <label>
@@ -42,6 +46,17 @@ export default function ExampleEditor({example, updateExample}) {
         />
       </label>
       <label>
+        Image
+        <Button
+          onClick={() => setUploadImageDialogOpen(true)}
+          text="Choose Image"
+          color="gray"
+          icon="plus-circle"
+        />
+        {example.imageUrl && <span>{example.imageUrl}</span>}
+      </label>
+
+      <label>
         Example App Display Type
         <select
           value={example.appDisplayType || 'directly'}
@@ -70,6 +85,12 @@ export default function ExampleEditor({example, updateExample}) {
           style={styles.textInput}
         />{' '}
       </label>
+      <UploadImageDialog
+        isOpen={uploadImageDialogOpen}
+        handleClose={() => setUploadImageDialogOpen(false)}
+        uploadImage={imgUrl => updateExample('imageUrl', imgUrl)}
+        allowExpandable={false}
+      />
     </div>
   );
 }

--- a/apps/src/lib/levelbuilder/code-docs-editor/ParameterEditor.jsx
+++ b/apps/src/lib/levelbuilder/code-docs-editor/ParameterEditor.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import color from '@cdo/apps/util/color';
+import HelpTip from '@cdo/apps/lib/ui/HelpTip';
 import TextareaWithMarkdownPreview from '@cdo/apps/lib/levelbuilder/TextareaWithMarkdownPreview';
 
 export default function ParameterEditor({parameter, update}) {
@@ -16,6 +17,7 @@ export default function ParameterEditor({parameter, update}) {
       </label>
       <label>
         Type
+        <HelpTip>Data type, capitalized</HelpTip>
         <input
           value={parameter.type || ''}
           onChange={e => update('type', e.target.value)}

--- a/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingExpressionEditor.jsx
+++ b/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingExpressionEditor.jsx
@@ -7,6 +7,8 @@ import TextareaWithMarkdownPreview from '@cdo/apps/lib/levelbuilder/TextareaWith
 import CollapsibleEditorSection from '@cdo/apps/lib/levelbuilder/CollapsibleEditorSection';
 import HelpTip from '@cdo/apps/lib/ui/HelpTip';
 import SaveBar from '@cdo/apps/lib/levelbuilder/SaveBar';
+import Button from '@cdo/apps/templates/Button';
+import UploadImageDialog from '@cdo/apps/lib/levelbuilder/lesson-editor/UploadImageDialog';
 import {createUuid, navigateToHref} from '@cdo/apps/utils';
 import $ from 'jquery';
 import color from '@cdo/apps/util/color';
@@ -62,6 +64,7 @@ export default function ProgrammingExpressionEditor({
   const [isSaving, setIsSaving] = useState(false);
   const [lastUpdated, setLastUpdated] = useState(null);
   const [error, setError] = useState(null);
+  const [uploadImageDialogOpen, setUploadImageDialogOpen] = useState(false);
 
   const save = () => {
     if (isSaving) {
@@ -112,6 +115,18 @@ export default function ProgrammingExpressionEditor({
       <label>
         Key (Used in URLs)
         <input value={key} readOnly style={styles.textInput} />
+      </label>
+      <label>
+        Image
+        <Button
+          onClick={() => setUploadImageDialogOpen(true)}
+          text="Choose Image"
+          color="gray"
+          icon="plus-circle"
+        />
+        {programmingExpression.imageUrl && (
+          <span>{programmingExpression.imageUrl}</span>
+        )}
       </label>
       <label>
         Short Description
@@ -225,6 +240,12 @@ export default function ProgrammingExpressionEditor({
         lastSaved={lastUpdated}
         error={error}
         handleView={() => navigateToHref('/')}
+      />
+      <UploadImageDialog
+        isOpen={uploadImageDialogOpen}
+        handleClose={() => setUploadImageDialogOpen(false)}
+        uploadImage={imgUrl => updateProgrammingExpression('imageUrl', imgUrl)}
+        allowExpandable={false}
       />
     </div>
   );

--- a/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingExpressionEditor.jsx
+++ b/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingExpressionEditor.jsx
@@ -45,7 +45,8 @@ function renderExampleEditor(example, updateFunc) {
 
 export default function ProgrammingExpressionEditor({
   initialProgrammingExpression,
-  environmentCategories
+  environmentCategories,
+  videoOptions
 }) {
   // We don't want to update id or key
   const {
@@ -115,6 +116,23 @@ export default function ProgrammingExpressionEditor({
       <label>
         Key (Used in URLs)
         <input value={key} readOnly style={styles.textInput} />
+      </label>
+      <label>
+        Video
+        <select
+          value={programmingExpression.videoKey || ''}
+          onChange={e =>
+            updateProgrammingExpression('videoKey', e.target.value)
+          }
+          style={styles.selectInput}
+        >
+          <option value={''}>---</option>
+          {videoOptions.map(video => (
+            <option key={video.key} value={video.key}>
+              {video.name}
+            </option>
+          ))}
+        </select>
       </label>
       <label>
         Image
@@ -268,7 +286,8 @@ const programmingExpressionShape = PropTypes.shape({
 
 ProgrammingExpressionEditor.propTypes = {
   initialProgrammingExpression: programmingExpressionShape.isRequired,
-  environmentCategories: PropTypes.arrayOf(PropTypes.string).isRequired
+  environmentCategories: PropTypes.arrayOf(PropTypes.string).isRequired,
+  videoOptions: PropTypes.arrayOf(PropTypes.object).isRequired
 };
 
 const styles = {
@@ -287,6 +306,7 @@ const styles = {
     color: '#555',
     border: `1px solid ${color.bootstrap_border_color}`,
     borderRadius: 4,
+    marginBottom: 0,
     marginLeft: 5
   }
 };

--- a/apps/src/lib/levelbuilder/lesson-editor/UploadImageDialog.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/UploadImageDialog.jsx
@@ -7,7 +7,12 @@ import i18n from '@cdo/locale';
 import LessonEditorDialog from './LessonEditorDialog';
 import HelpTip from '@cdo/apps/lib/ui/HelpTip';
 
-export default function UploadImageDialog({isOpen, handleClose, uploadImage}) {
+export default function UploadImageDialog({
+  isOpen,
+  handleClose,
+  uploadImage,
+  allowExpandable = true
+}) {
   const [imgUrl, setImgUrl] = useState(undefined);
   const [expandable, setExpandable] = useState(false);
   const [error, setError] = useState(undefined);
@@ -79,22 +84,23 @@ export default function UploadImageDialog({isOpen, handleClose, uploadImage}) {
         </div>
       )}
 
-      <label style={styles.label}>
-        Expandable
-        <input
-          type="checkbox"
-          checked={expandable}
-          style={styles.checkbox}
-          onChange={e => setExpandable(e.target.checked)}
-        />
-        <HelpTip>
-          <p>
-            Check if you want the image to be able to be enlarged in a dialog
-            over the page when clicked.
-          </p>
-        </HelpTip>
-      </label>
-
+      {allowExpandable && (
+        <label style={styles.label}>
+          Expandable
+          <input
+            type="checkbox"
+            checked={expandable}
+            style={styles.checkbox}
+            onChange={e => setExpandable(e.target.checked)}
+          />
+          <HelpTip>
+            <p>
+              Check if you want the image to be able to be enlarged in a dialog
+              over the page when clicked.
+            </p>
+          </HelpTip>
+        </label>
+      )}
       <hr />
 
       <Button
@@ -108,6 +114,7 @@ export default function UploadImageDialog({isOpen, handleClose, uploadImage}) {
 }
 
 UploadImageDialog.propTypes = {
+  allowExpandable: PropTypes.bool,
   isOpen: PropTypes.bool.isRequired,
   handleClose: PropTypes.func.isRequired,
   uploadImage: PropTypes.func.isRequired

--- a/apps/src/sites/studio/pages/programming_expressions/edit.js
+++ b/apps/src/sites/studio/pages/programming_expressions/edit.js
@@ -15,12 +15,14 @@ $(document).ready(() => {
 
   const programmingExpression = getScriptData('programmingExpression');
   const environmentCategories = getScriptData('environmentCategories');
+  const videoOptions = getScriptData('videoOptions');
   ReactDOM.render(
     <Provider store={store}>
       <>
         <ProgrammingExpressionEditor
           initialProgrammingExpression={programmingExpression}
           environmentCategories={environmentCategories}
+          videoOptions={videoOptions}
         />
         <ExpandableImageDialog />
       </>

--- a/apps/test/unit/lib/levelbuilder/code-docs-editor/ExampleEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/code-docs-editor/ExampleEditorTest.jsx
@@ -65,6 +65,14 @@ describe('ExampleEditor', () => {
     );
   });
 
+  it('displays image upload dialog when button is pressed', () => {
+    const wrapper = shallow(<ExampleEditor {...defaultProps} />);
+    const uploadButton = wrapper.find('Button').first();
+    expect(uploadButton).to.not.be.null;
+    uploadButton.simulate('click');
+    expect(wrapper.find('UploadImageDialog').length).to.equal(1);
+  });
+
   it('displays a select for display type', () => {
     const wrapper = shallow(<ExampleEditor {...defaultProps} />);
     const displayTypeSelect = wrapper.find('select').at(0);

--- a/apps/test/unit/lib/levelbuilder/code-docs-editor/ProgrammingExpressionEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/code-docs-editor/ProgrammingExpressionEditorTest.jsx
@@ -24,7 +24,17 @@ describe('ProgrammingExpressionEditor', () => {
         parameters: [{name: 'id', type: 'string'}],
         examples: [{name: 'example 1'}]
       },
-      environmentCategories: ['Circuit', 'Variables', 'Canvas']
+      environmentCategories: ['Circuit', 'Variables', 'Canvas'],
+      videoOptions: [
+        {
+          key: 'video1',
+          name: 'Video 1'
+        },
+        {
+          key: 'video2',
+          name: 'Video 2'
+        }
+      ]
     };
     fetchSpy = sinon.stub(window, 'fetch');
   });
@@ -58,6 +68,13 @@ describe('ProgrammingExpressionEditor', () => {
         .at(1)
         .props().readOnly
     ).to.be.true;
+
+    // Video select
+    const videoSelect = wrapper.find('select').at(0);
+    expect(videoSelect.find('option').length).to.equal(3);
+    expect(
+      videoSelect.find('option').map(option => option.props().value)
+    ).to.eql(['', 'video1', 'video2']);
 
     // Image upload
     expect(

--- a/apps/test/unit/lib/levelbuilder/code-docs-editor/ProgrammingExpressionEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/code-docs-editor/ProgrammingExpressionEditorTest.jsx
@@ -59,6 +59,14 @@ describe('ProgrammingExpressionEditor', () => {
         .props().readOnly
     ).to.be.true;
 
+    // Image upload
+    expect(
+      wrapper
+        .find('Button')
+        .at(0)
+        .props().text
+    ).to.equal('Choose Image');
+
     // short description
     expect(
       wrapper
@@ -126,6 +134,14 @@ describe('ProgrammingExpressionEditor', () => {
       'Add Another Example'
     );
     expect(orderableExampleList.props().list.length).to.equal(1);
+  });
+
+  it('shows upload image dialog when choose image button is pressed', () => {
+    const wrapper = shallow(<ProgrammingExpressionEditor {...defaultProps} />);
+    const uploadButton = wrapper.find('Button').first();
+    expect(uploadButton).to.not.be.null;
+    uploadButton.simulate('click');
+    expect(wrapper.find('UploadImageDialog').length).to.equal(1);
   });
 
   it('attempts to save when save is pressed', () => {

--- a/dashboard/app/controllers/programming_expressions_controller.rb
+++ b/dashboard/app/controllers/programming_expressions_controller.rb
@@ -64,6 +64,7 @@ class ProgrammingExpressionsController < ApplicationController
     transformed_params = transformed_params.permit(
       :name,
       :category,
+      :video_key,
       :image_url,
       :short_description,
       :external_documentation,

--- a/dashboard/app/controllers/programming_expressions_controller.rb
+++ b/dashboard/app/controllers/programming_expressions_controller.rb
@@ -64,6 +64,7 @@ class ProgrammingExpressionsController < ApplicationController
     transformed_params = transformed_params.permit(
       :name,
       :category,
+      :image_url,
       :short_description,
       :external_documentation,
       :content,
@@ -71,7 +72,7 @@ class ProgrammingExpressionsController < ApplicationController
       :return_value,
       :tips,
       parameters: [:name, :type, :required, :description],
-      examples: [:name, :description, :code, :app, :appDisplayType, :appEmbedHeight]
+      examples: [:name, :description, :code, :app, :imageUrl, :appDisplayType, :appEmbedHeight]
     )
     transformed_params
   end

--- a/dashboard/app/models/programming_expression.rb
+++ b/dashboard/app/models/programming_expression.rb
@@ -38,6 +38,7 @@ class ProgrammingExpression < ApplicationRecord
     tips
     palette_params
     examples
+    video_key
   )
 
   def key_format
@@ -192,6 +193,7 @@ class ProgrammingExpression < ApplicationRecord
       category: category,
       programmingEnvironmentName: programming_environment.name,
       imageUrl: image_url,
+      videoKey: video_key,
       shortDescription: short_description || '',
       externalDocumentation: external_documentation || '',
       content: content || '',

--- a/dashboard/app/models/programming_expression.rb
+++ b/dashboard/app/models/programming_expression.rb
@@ -30,6 +30,7 @@ class ProgrammingExpression < ApplicationRecord
   serialized_attrs %w(
     color
     syntax
+    image_url
     short_description
     external_documentation
     content
@@ -190,6 +191,7 @@ class ProgrammingExpression < ApplicationRecord
       name: name,
       category: category,
       programmingEnvironmentName: programming_environment.name,
+      imageUrl: image_url,
       shortDescription: short_description || '',
       externalDocumentation: external_documentation || '',
       content: content || '',

--- a/dashboard/app/views/programming_expressions/edit.html.haml
+++ b/dashboard/app/views/programming_expressions/edit.html.haml
@@ -1,3 +1,3 @@
 %script{src: webpack_asset_path('js/programming_expressions/edit.js'),
-  data: {programmingExpression: @programming_expression.summarize_for_edit.to_json, environmentCategories: @environment_categories.to_json}}
+  data: {programmingExpression: @programming_expression.summarize_for_edit.to_json, environmentCategories: @environment_categories.to_json, videoOptions: Video.all.where(locale: 'en-US').map {|v| {key: v.key, name: v.localized_name}}.to_json}}
 #edit-container

--- a/dashboard/test/controllers/programming_expressions_controller_test.rb
+++ b/dashboard/test/controllers/programming_expressions_controller_test.rb
@@ -35,6 +35,7 @@ class ProgrammingExpressionsControllerTest < ActionController::TestCase
       key: programming_expression.key,
       name: 'new name',
       category: 'world',
+      imageUrl: 'image.code.org/foo',
       shortDescription: 'short description of code',
       externalDocumentation: 'google.com',
       content: 'a longer description of the code',
@@ -49,6 +50,7 @@ class ProgrammingExpressionsControllerTest < ActionController::TestCase
 
     assert_equal 'new name', programming_expression.name
     assert_equal 'world', programming_expression.category
+    assert_equal 'image.code.org/foo', programming_expression.image_url
     assert_equal 'short description of code', programming_expression.short_description
     assert_equal 'google.com', programming_expression.external_documentation
     assert_equal 'a longer description of the code', programming_expression.content

--- a/dashboard/test/controllers/programming_expressions_controller_test.rb
+++ b/dashboard/test/controllers/programming_expressions_controller_test.rb
@@ -35,6 +35,7 @@ class ProgrammingExpressionsControllerTest < ActionController::TestCase
       key: programming_expression.key,
       name: 'new name',
       category: 'world',
+      videoKey: 'video-key',
       imageUrl: 'image.code.org/foo',
       shortDescription: 'short description of code',
       externalDocumentation: 'google.com',
@@ -50,6 +51,7 @@ class ProgrammingExpressionsControllerTest < ActionController::TestCase
 
     assert_equal 'new name', programming_expression.name
     assert_equal 'world', programming_expression.category
+    assert_equal 'video-key', programming_expression.video_key
     assert_equal 'image.code.org/foo', programming_expression.image_url
     assert_equal 'short description of code', programming_expression.short_description
     assert_equal 'google.com', programming_expression.external_documentation


### PR DESCRIPTION
Last set of major fields for the programming expression edit page! 

Commits:
d82e92fe738c3492d513b93f11113babd96aa7b1 adds image uploads to both the programming expression itself and to the examples.
75ee40f744e0ebdb8917598596f969c65a50515b adds a dropdown of all videos on levelbuilder-studio.code.org/videos. 
75ee40f744e0ebdb8917598596f969c65a50515b adds a missing HelpTip to ParameterEditor

Video of image upload (my computer is running very slowly, so apologies for the lag)

https://user-images.githubusercontent.com/46464143/141377963-0ccf08bc-75cb-4eaa-b8be-0829d500ea61.mov


Note on videos: I decided to save `video_key` instead of creating a relationship between `ProgrammingExpression` and `Video` in order to better accommodate localized videos. A dubbed video is a separate entry into the videos table, so associating a programming expression with one video would make it more difficult to support dubbed videos in the future. Happy to chat more if anyone thinks this is the wrong direction!

[figma](https://www.figma.com/proto/oJhM1JLs2vMaKvzcrFjZds/Block-Docs?page-id=0%3A1&node-id=102%3A2&viewport=241%2C48%2C0.36&scaling=min-zoom)


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
