### PR TITLE
Create migration to update unversioned hoc scripts

### DIFF
--- a/dashboard/config/scripts_json/counting-csc.script_json
+++ b/dashboard/config/scripts_json/counting-csc.script_json
@@ -10,11 +10,11 @@
       "is_course": true,
       "is_migrated": true,
       "tts": true,
-      "version_year": "2021"
+      "version_year": "unversioned"
     },
     "new_name": null,
     "family_name": "counting-csc",
-    "serialized_at": "2021-11-03 17:13:56 UTC",
+    "serialized_at": "2021-11-11 18:58:21 UTC",
     "published_state": "in_development",
     "instruction_type": "teacher_led",
     "instructor_audience": "teacher",

--- a/dashboard/config/scripts_json/explore-data-1.script_json
+++ b/dashboard/config/scripts_json/explore-data-1.script_json
@@ -7,13 +7,15 @@
       "curriculum_umbrella": "CSC",
       "is_course": true,
       "is_migrated": true,
-      "version_year": "2021"
+      "version_year": "unversioned"
     },
     "new_name": null,
     "family_name": "explore-data-1",
-    "serialized_at": "2021-10-25 22:55:01 UTC",
+    "serialized_at": "2021-11-11 18:58:21 UTC",
     "published_state": "in_development",
     "instruction_type": null,
+    "instructor_audience": null,
+    "participant_audience": null,
     "seeding_key": {
       "script.name": "explore-data-1"
     }

--- a/dashboard/config/scripts_json/explore-data-1.script_json
+++ b/dashboard/config/scripts_json/explore-data-1.script_json
@@ -11,7 +11,7 @@
     },
     "new_name": null,
     "family_name": "explore-data-1",
-    "serialized_at": "2021-11-11 18:58:21 UTC",
+    "serialized_at": "2021-11-11 21:10:19 UTC",
     "published_state": "in_development",
     "instruction_type": null,
     "instructor_audience": null,
@@ -141,7 +141,7 @@
       "key": "51210a6a-e15c-41b4-a995-544dd2b61c56",
       "position": 1,
       "properties": {
-        "description": "<i class=\"fa fa-list-alt\" aria-hidden=\"true\"></i> **Video:** Watch the \n[r data_visualizer_in_app_lab_part_1/explore-data-1/2021]",
+        "description": "<i class=\"fa fa-list-alt\" aria-hidden=\"true\"></i> **Video:** Watch the \n[r data_visualizer_in_app_lab_part_1/explore-data-1/unversioned]",
         "name": "Making Bar Charts and Histograms",
         "progression_name": "Video: Data Visualizer in App Lab Part 1"
       },
@@ -154,7 +154,7 @@
       "key": "52ed69a5-ec3b-4e88-9a4f-8367bb910f0e",
       "position": 2,
       "properties": {
-        "description": "<i class=\"fa fa-list-alt\" aria-hidden=\"true\"></i> **Distribute:** Give students access to [r exploring_bar_charts_and_histograms_2/explore-data-1/2021] - ideally in digital form.\n\n<i class=\"fa fa-list-alt\" aria-hidden=\"true\"></i> **Code Studio:** Have students log into their Code.org accounts to access the second level of this lesson.",
+        "description": "<i class=\"fa fa-list-alt\" aria-hidden=\"true\"></i> **Distribute:** Give students access to [r exploring_bar_charts_and_histograms_2/explore-data-1/unversioned] - ideally in digital form.\n\n<i class=\"fa fa-list-alt\" aria-hidden=\"true\"></i> **Code Studio:** Have students log into their Code.org accounts to access the second level of this lesson.",
         "progression_name": "Data Visualizer",
         "tips": [
           {

--- a/dashboard/config/scripts_json/spelling-bee.script_json
+++ b/dashboard/config/scripts_json/spelling-bee.script_json
@@ -9,11 +9,11 @@
       "is_course": true,
       "is_migrated": true,
       "tts": true,
-      "version_year": "2021"
+      "version_year": "unversioned"
     },
     "new_name": null,
     "family_name": "spelling-bee",
-    "serialized_at": "2021-11-03 16:54:27 UTC",
+    "serialized_at": "2021-11-11 18:58:21 UTC",
     "published_state": "in_development",
     "instruction_type": "teacher_led",
     "instructor_audience": "teacher",

--- a/dashboard/db/migrate/20211111185031_update_version_year_on_unversioned_hoc_scripts2021.rb
+++ b/dashboard/db/migrate/20211111185031_update_version_year_on_unversioned_hoc_scripts2021.rb
@@ -1,0 +1,33 @@
+class UpdateVersionYearOnUnversionedHocScripts2021 < ActiveRecord::Migration[5.2]
+  def up
+    ['spelling-bee', 'counting-csc', 'explore-data-1'].each do |script_name|
+      script = Script.find_by(name: script_name)
+      script.properties[:version_year] = "unversioned"
+      script.save!
+
+      script.course_version
+      script.course_version.display_name = "unversioned"
+      script.course_version.key = "unversioned"
+      script.course_version.save!
+
+      script.reload
+      script.write_script_json
+    end
+  end
+
+  def down
+    ['spelling-bee', 'counting-csc', 'explore-data-1'].each do |script_name|
+      script = Script.find_by(name: script_name)
+      script.properties[:version_year] = "2021"
+      script.save!
+
+      script.course_version
+      script.course_version.display_name = "2021"
+      script.course_version.key = "2021"
+      script.course_version.save!
+
+      script.reload
+      script.write_script_json
+    end
+  end
+end

--- a/dashboard/db/migrate/20211111185031_update_version_year_on_unversioned_hoc_scripts2021.rb
+++ b/dashboard/db/migrate/20211111185031_update_version_year_on_unversioned_hoc_scripts2021.rb
@@ -1,6 +1,6 @@
 class UpdateVersionYearOnUnversionedHocScripts2021 < ActiveRecord::Migration[5.2]
   def up
-    ['spelling-bee', 'counting-csc', 'explore-data-1'].each do |script_name|
+    ['spelling-bee', 'counting-csc', 'explore-data-1', 'hello-world-food', 'hello-world-animals', 'hello-world-emoji', 'hello-world-retro'].each do |script_name|
       script = Script.find_by(name: script_name)
       script.properties[:version_year] = "unversioned"
       script.save!
@@ -13,7 +13,7 @@ class UpdateVersionYearOnUnversionedHocScripts2021 < ActiveRecord::Migration[5.2
   end
 
   def down
-    ['spelling-bee', 'counting-csc', 'explore-data-1'].each do |script_name|
+    ['spelling-bee', 'counting-csc', 'explore-data-1', 'hello-world-food', 'hello-world-animals', 'hello-world-emoji', 'hello-world-retro'].each do |script_name|
       script = Script.find_by(name: script_name)
       script.properties[:version_year] = "2021"
       script.save!

--- a/dashboard/db/migrate/20211111185031_update_version_year_on_unversioned_hoc_scripts2021.rb
+++ b/dashboard/db/migrate/20211111185031_update_version_year_on_unversioned_hoc_scripts2021.rb
@@ -9,9 +9,6 @@ class UpdateVersionYearOnUnversionedHocScripts2021 < ActiveRecord::Migration[5.2
       script.course_version.display_name = "unversioned"
       script.course_version.key = "unversioned"
       script.course_version.save!
-
-      script.reload
-      script.write_script_json
     end
   end
 
@@ -25,9 +22,6 @@ class UpdateVersionYearOnUnversionedHocScripts2021 < ActiveRecord::Migration[5.2
       script.course_version.display_name = "2021"
       script.course_version.key = "2021"
       script.course_version.save!
-
-      script.reload
-      script.write_script_json
     end
   end
 end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_03_230247) do
+ActiveRecord::Schema.define(version: 2021_11_11_185031) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"

--- a/dashboard/db/schema_cache.yml
+++ b/dashboard/db/schema_cache.yml
@@ -26344,4 +26344,4 @@ data_sources:
   users_view: true
   videos: true
   vocabularies: true
-version: 20211103230247
+version: 20211111185031


### PR DESCRIPTION
We created a bunch of HOC scripts without version years in the URL (ex. spelling-bee). We want the final scripts for HOC to have `-2021` in the url. We are doing this by making copies of the old script and adding `-2021` to the URL. The old scripts should have `unversioned` as their version_year and the new ones should have `2021`. We were able to do this for 7/[10 scripts ](https://docs.google.com/spreadsheets/d/1mFFYScB9wmGL59rqXF8uEcQl-IYhB9duH8nBc4P4A0g/edit#gid=0)we wanted [by following these steps](by following these steps ) because their `version_year` was `unversioned` or we were able to set it to `unversioned` because they had no resources or vocab. The remaining 3 scripts have vocab and/or resources and a version_year of 2021. In order to make copies of these scripts we need to get their version_year to be `unversioned`. The only way to do this is to update the version_year on the script and key and display_name on the course_version directly on each environment. The safest way to do that is with a migration.

## Testing story

- Ran the migration
- Ran `bundle exec rake build`