### PR TITLE
Add ability for Java Lab to upload a prompter image to the signed S3 URL

### DIFF
--- a/apps/src/javalab/Javalab.js
+++ b/apps/src/javalab/Javalab.js
@@ -136,7 +136,8 @@ Javalab.prototype.init = function(config) {
         this.onOutputMessage,
         this.onNewlineMessage,
         this.openPhotoPrompter,
-        this.closePhotoPrompter
+        this.closePhotoPrompter,
+        onJavabuilderMessage
       );
       this.visualization = <TheaterVisualizationColumn />;
       break;

--- a/apps/src/javalab/Theater.js
+++ b/apps/src/javalab/Theater.js
@@ -106,7 +106,6 @@ export default class Theater {
     if (!this.prompterUploadUrl) {
       // The upload URL should be provided when opening the prompter, so if
       // it is somehow not set, we are in an invalid scenario.
-      console.warn('No upload URL available. Cannot upload prompter image.');
       this.onJavabuilderMessage(
         InputMessageType.THEATER,
         InputMessage.UPLOAD_ERROR

--- a/apps/src/javalab/Theater.js
+++ b/apps/src/javalab/Theater.js
@@ -1,13 +1,10 @@
 import {
   TheaterSignalType,
   STATUS_MESSAGE_PREFIX,
-  InputMessageType
+  InputMessageType,
+  InputMessage
 } from './constants';
 import javalabMsg from '@cdo/javalab/locale';
-
-// Exported for tests
-export const UPLOAD_SUCCESS_MESSAGE = 'UPLOAD_SUCCESS';
-export const UPLOAD_ERROR_MESSAGE = 'UPLOAD_ERROR';
 
 export default class Theater {
   constructor(
@@ -110,7 +107,10 @@ export default class Theater {
       // The upload URL should be provided when opening the prompter, so if
       // it is somehow not set, we are in an invalid scenario.
       console.warn('No upload URL available. Cannot upload prompter image.');
-      this.onJavabuilderMessage(InputMessageType.THEATER, UPLOAD_ERROR_MESSAGE);
+      this.onJavabuilderMessage(
+        InputMessageType.THEATER,
+        InputMessage.UPLOAD_ERROR
+      );
       return;
     }
 
@@ -120,13 +120,13 @@ export default class Theater {
       xhr => {
         this.onJavabuilderMessage(
           InputMessageType.THEATER,
-          UPLOAD_SUCCESS_MESSAGE
+          InputMessage.UPLOAD_SUCCESS
         );
       },
       xhr => {
         this.onJavabuilderMessage(
           InputMessageType.THEATER,
-          UPLOAD_ERROR_MESSAGE
+          InputMessage.UPLOAD_ERROR
         );
       }
     );

--- a/apps/src/javalab/Theater.js
+++ b/apps/src/javalab/Theater.js
@@ -5,8 +5,9 @@ import {
 } from './constants';
 import javalabMsg from '@cdo/javalab/locale';
 
-const UPLOAD_SUCCESS_MESSAGE = 'UPLOAD_SUCCESS';
-const UPLOAD_ERROR_MESSAGE = 'UPLOAD_ERROR';
+// Exported for tests
+export const UPLOAD_SUCCESS_MESSAGE = 'UPLOAD_SUCCESS';
+export const UPLOAD_ERROR_MESSAGE = 'UPLOAD_ERROR';
 
 export default class Theater {
   constructor(
@@ -108,7 +109,7 @@ export default class Theater {
     if (!this.prompterUploadUrl) {
       // The upload URL should be provided when opening the prompter, so if
       // it is somehow not set, we are in an invalid scenario.
-      console.error('No upload URL available. Cannot upload prompter image.');
+      console.warn('No upload URL available. Cannot upload prompter image.');
       this.onJavabuilderMessage(InputMessageType.THEATER, UPLOAD_ERROR_MESSAGE);
       return;
     }

--- a/apps/src/javalab/constants.js
+++ b/apps/src/javalab/constants.js
@@ -92,6 +92,12 @@ export const InputMessageType = {
   THEATER: 'THEATER'
 };
 
+export const InputMessage = {
+  // Theater-specific messages
+  UPLOAD_SUCCESS: 'UPLOAD_SUCCESS',
+  UPLOAD_ERROR: 'UPLOAD_ERROR'
+};
+
 export const SoundExceptionType = makeEnum(
   'INVALID_AUDIO_FILE_FORMAT',
   'MISSING_AUDIO_DATA'

--- a/apps/src/javalab/constants.js
+++ b/apps/src/javalab/constants.js
@@ -88,7 +88,8 @@ export const StatusMessageType = {
 
 export const InputMessageType = {
   SYSTEM_IN: 'SYSTEM_IN',
-  PLAYGROUND: 'PLAYGROUND'
+  PLAYGROUND: 'PLAYGROUND',
+  THEATER: 'THEATER'
 };
 
 export const SoundExceptionType = makeEnum(

--- a/apps/test/unit/javalab/TheaterTest.js
+++ b/apps/test/unit/javalab/TheaterTest.js
@@ -1,10 +1,11 @@
 import sinon from 'sinon';
 import {expect} from '../../util/reconfiguredChai';
-import {TheaterSignalType, InputMessageType} from '@cdo/apps/javalab/constants';
-import Theater, {
-  UPLOAD_SUCCESS_MESSAGE,
-  UPLOAD_ERROR_MESSAGE
-} from '@cdo/apps/javalab/Theater';
+import {
+  TheaterSignalType,
+  InputMessageType,
+  InputMessage
+} from '@cdo/apps/javalab/constants';
+import Theater from '@cdo/apps/javalab/Theater';
 
 describe('Theater', () => {
   let theater,
@@ -135,7 +136,7 @@ describe('Theater', () => {
     sinon.assert.calledWith(
       onJavabuilderMessage,
       InputMessageType.THEATER,
-      UPLOAD_ERROR_MESSAGE
+      InputMessage.UPLOAD_ERROR
     );
   });
 
@@ -159,7 +160,7 @@ describe('Theater', () => {
     sinon.assert.calledWith(
       onJavabuilderMessage,
       InputMessageType.THEATER,
-      UPLOAD_SUCCESS_MESSAGE
+      InputMessage.UPLOAD_SUCCESS
     );
 
     onJavabuilderMessage.reset();
@@ -167,7 +168,7 @@ describe('Theater', () => {
     sinon.assert.calledWith(
       onJavabuilderMessage,
       InputMessageType.THEATER,
-      UPLOAD_ERROR_MESSAGE
+      InputMessage.UPLOAD_ERROR
     );
   });
 });

--- a/apps/test/unit/javalab/TheaterTest.js
+++ b/apps/test/unit/javalab/TheaterTest.js
@@ -1,7 +1,10 @@
 import sinon from 'sinon';
 import {expect} from '../../util/reconfiguredChai';
-import {TheaterSignalType} from '@cdo/apps/javalab/constants';
-import Theater from '@cdo/apps/javalab/Theater';
+import {TheaterSignalType, InputMessageType} from '@cdo/apps/javalab/constants';
+import Theater, {
+  UPLOAD_SUCCESS_MESSAGE,
+  UPLOAD_ERROR_MESSAGE
+} from '@cdo/apps/javalab/Theater';
 
 describe('Theater', () => {
   let theater,
@@ -12,23 +15,29 @@ describe('Theater', () => {
     onOutputMessage,
     onNewlineMessage,
     openPhotoPrompter,
-    closePhotoPrompter;
+    closePhotoPrompter,
+    onJavabuilderMessage,
+    uploadFile;
 
   beforeEach(() => {
     onOutputMessage = sinon.stub();
     onNewlineMessage = sinon.stub();
     openPhotoPrompter = sinon.stub();
     closePhotoPrompter = sinon.stub();
+    onJavabuilderMessage = sinon.stub();
 
     playAudioSpy = sinon.spy();
     pauseAudioSpy = sinon.spy();
     imageElement = {};
     audioElement = {play: playAudioSpy, pause: pauseAudioSpy};
+    uploadFile = sinon.stub();
+
     theater = new Theater(
       onOutputMessage,
       onNewlineMessage,
       openPhotoPrompter,
-      closePhotoPrompter
+      closePhotoPrompter,
+      onJavabuilderMessage
     );
     theater.getImgElement = () => {
       return imageElement;
@@ -36,6 +45,7 @@ describe('Theater', () => {
     theater.getAudioElement = () => {
       return audioElement;
     };
+    theater.uploadFile = uploadFile;
   });
 
   it('sets audio detail when handleSignal with audio is called', () => {
@@ -99,5 +109,65 @@ describe('Theater', () => {
   it('closes photo prompter on close', () => {
     theater.onClose();
     sinon.assert.calledOnce(closePhotoPrompter);
+  });
+
+  it('uploads photo file when file selected if URL is available', () => {
+    const uploadUrl = 'upload.url';
+    const photoFile = new File([], 'file');
+
+    theater.handleSignal({
+      value: TheaterSignalType.GET_IMAGE,
+      detail: {
+        prompt: 'prompt',
+        uploadUrl: uploadUrl
+      }
+    });
+
+    theater.onPhotoPrompterFileSelected(photoFile);
+
+    sinon.assert.calledWith(uploadFile, uploadUrl, photoFile);
+  });
+
+  it('does not upload and sends error message if no upload URL is present', () => {
+    theater.onPhotoPrompterFileSelected(new File([], 'file'));
+
+    sinon.assert.notCalled(uploadFile);
+    sinon.assert.calledWith(
+      onJavabuilderMessage,
+      InputMessageType.THEATER,
+      UPLOAD_ERROR_MESSAGE
+    );
+  });
+
+  it('sends success or failure message based on upload result', () => {
+    theater.handleSignal({
+      value: TheaterSignalType.GET_IMAGE,
+      detail: {
+        prompt: 'prompt',
+        uploadUrl: 'upload.url'
+      }
+    });
+    theater.onPhotoPrompterFileSelected(new File([], 'file'));
+    sinon.assert.calledOnce(uploadFile);
+
+    // Get callbacks
+    const onSuccess = uploadFile.getCall(0).args[2];
+    const onError = uploadFile.getCall(0).args[3];
+
+    onJavabuilderMessage.reset();
+    onSuccess();
+    sinon.assert.calledWith(
+      onJavabuilderMessage,
+      InputMessageType.THEATER,
+      UPLOAD_SUCCESS_MESSAGE
+    );
+
+    onJavabuilderMessage.reset();
+    onError();
+    sinon.assert.calledWith(
+      onJavabuilderMessage,
+      InputMessageType.THEATER,
+      UPLOAD_ERROR_MESSAGE
+    );
   });
 });


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Java Lab uploads the file selected via the prompter using the provided upload URL, and sends a status message back to Javabuilder. Currently, Javabuilder doesn't consume these messages, but following this change Javabuilder will download the uploaded image from S3 once it receives a success message (or handle the error accordingly).

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

JIRA: https://codedotorg.atlassian.net/browse/CSA-1053

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Tested using local Java Lab + deployed Javabuilder with postman. As testing against a deployed instance of Javabuilder doesn't currently work on localhost, this was tested by manually providing an valid upload URL to Javalab, and ensuring the correct messages were sent back across the websocket.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
