### PR TITLE
[Google Blockly] Add setStrictCheck to wrapper

### DIFF
--- a/apps/src/blockly/addons/cdoInput.js
+++ b/apps/src/blockly/addons/cdoInput.js
@@ -1,6 +1,10 @@
 import GoogleBlockly from 'blockly/core';
 
 export default class Input extends GoogleBlockly.Input {
+  setStrictCheck(check) {
+    return super.setCheck(check);
+  }
+
   appendTitle(a, b) {
     return super.appendField(a, b);
   }


### PR DESCRIPTION
The glide block was added last minute to Poetry levels which is causing JS errors on LB

Before
![image](https://user-images.githubusercontent.com/8787187/141378993-855fb744-2050-4910-8fb5-50eaeb9361af.png)


After
![image](https://user-images.githubusercontent.com/8787187/141378902-1c6b2c34-a9ae-4ba4-859e-ab1fdc87f8f8.png)

I'll fix the UI issues with the block as a follow up, but this at least gets the page loading.