### PR TITLE
UploadImageDialog: disable save before upload

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/UploadImageDialog.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/UploadImageDialog.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 
 import Button from '@cdo/apps/templates/Button';
+import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import i18n from '@cdo/locale';
 
 import LessonEditorDialog from './LessonEditorDialog';
@@ -78,7 +79,12 @@ export default function UploadImageDialog({
       <h2>Upload Image</h2>
 
       {imgUrl && <img src={imgUrl} />}
-      <input type="file" name="file" onChange={handleChange} />
+      <input
+        type="file"
+        name="file"
+        onChange={handleChange}
+        disabled={isUploading}
+      />
 
       {error && (
         <div className="alert alert-error" role="alert">
@@ -104,14 +110,20 @@ export default function UploadImageDialog({
         </label>
       )}
       <hr />
-
-      <Button
-        text={i18n.closeAndSave()}
-        onClick={handleCloseAndSave}
-        color={Button.ButtonColor.orange}
-        className="save-upload-image-button"
-        disabled={isUploading}
-      />
+      <div style={{display: 'flex'}}>
+        <Button
+          text={i18n.closeAndSave()}
+          onClick={handleCloseAndSave}
+          color={Button.ButtonColor.orange}
+          className="save-upload-image-button"
+          disabled={isUploading}
+        />{' '}
+        {isUploading && (
+          <div style={styles.spinner}>
+            <FontAwesome icon="spinner" className="fa-spin" />
+          </div>
+        )}
+      </div>
     </LessonEditorDialog>
   );
 }
@@ -129,5 +141,9 @@ const styles = {
   },
   label: {
     margin: '10px 0'
+  },
+  spinner: {
+    fontSize: 25,
+    padding: 10
   }
 };

--- a/apps/src/lib/levelbuilder/lesson-editor/UploadImageDialog.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/UploadImageDialog.jsx
@@ -16,6 +16,7 @@ export default function UploadImageDialog({
   const [imgUrl, setImgUrl] = useState(undefined);
   const [expandable, setExpandable] = useState(false);
   const [error, setError] = useState(undefined);
+  const [isUploading, setIsUploading] = useState(false);
 
   const resetState = () => {
     setImgUrl(undefined);
@@ -25,6 +26,7 @@ export default function UploadImageDialog({
 
   const handleChange = e => {
     resetState();
+    setIsUploading(true);
 
     // assemble upload data
     const formData = new FormData();
@@ -41,21 +43,21 @@ export default function UploadImageDialog({
     })
       .then(response => response.json())
       .then(handleResult)
-      .catch(handleError);
+      .catch(err => {
+        setError(err);
+        setIsUploading(false);
+      });
   };
 
   const handleResult = result => {
     if (result && result.newAssetUrl) {
       setImgUrl(result.newAssetUrl);
     } else if (result && result.message) {
-      handleError(result.message);
+      setError(result.message);
     } else {
-      handleError(result);
+      setError(result);
     }
-  };
-
-  const handleError = error => {
-    setError(error);
+    setIsUploading(false);
   };
 
   const handleDialogClose = () => {
@@ -108,6 +110,7 @@ export default function UploadImageDialog({
         onClick={handleCloseAndSave}
         color={Button.ButtonColor.orange}
         className="save-upload-image-button"
+        disabled={isUploading}
       />
     </LessonEditorDialog>
   );

--- a/apps/src/lib/levelbuilder/lesson-editor/UploadImageDialog.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/UploadImageDialog.jsx
@@ -27,7 +27,7 @@ export default function UploadImageDialog({
 
   const handleChange = e => {
     if (!e.target.files[0]) {
-      setError(undefined);
+      resetState();
       return;
     }
     resetState();

--- a/apps/src/lib/levelbuilder/lesson-editor/UploadImageDialog.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/UploadImageDialog.jsx
@@ -26,6 +26,10 @@ export default function UploadImageDialog({
   };
 
   const handleChange = e => {
+    if (!e.target.files[0]) {
+      setError(undefined);
+      return;
+    }
     resetState();
     setIsUploading(true);
 

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/UploadImageDialogTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/UploadImageDialogTest.jsx
@@ -52,10 +52,17 @@ describe('UploadImageDialog', () => {
       .simulate('change', {target: {files: ['filedata']}});
     expect(
       wrapper
+        .find('input')
+        .first()
+        .props().disabled
+    ).to.be.true;
+    expect(
+      wrapper
         .find('Button')
         .last()
         .props().disabled
     ).to.be.true;
+    expect(wrapper.find('FontAwesome').length).to.equal(1);
 
     expect(handleClose.callCount).to.equal(0);
     expect(uploadImage.callCount).to.equal(0);

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/UploadImageDialogTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/UploadImageDialogTest.jsx
@@ -50,6 +50,13 @@ describe('UploadImageDialog', () => {
       .find('input')
       .first()
       .simulate('change', {target: {files: ['filedata']}});
+    expect(
+      wrapper
+        .find('Button')
+        .last()
+        .props().disabled
+    ).to.be.true;
+
     expect(handleClose.callCount).to.equal(0);
     expect(uploadImage.callCount).to.equal(0);
 

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/UploadImageDialogTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/UploadImageDialogTest.jsx
@@ -78,4 +78,47 @@ describe('UploadImageDialog', () => {
       fetchStub.restore();
     });
   });
+
+  it('doesnt try to upload undefined image', () => {
+    const handleClose = sinon.fake();
+    const uploadImage = sinon.fake();
+    const wrapper = shallow(
+      <UploadImageDialog
+        isOpen={true}
+        handleClose={handleClose}
+        uploadImage={uploadImage}
+      />
+    );
+    const returnData = {newAssetUrl: 'http://example.com/img.png'};
+    const fetchStub = sinon
+      .stub(window, 'fetch')
+      .returns(Promise.resolve({ok: true, json: () => returnData}));
+
+    wrapper
+      .find('input')
+      .first()
+      .simulate('change', {target: {files: ['filedata']}});
+    expect(
+      wrapper
+        .find('input')
+        .first()
+        .props().disabled
+    ).to.be.true;
+    expect(
+      wrapper
+        .find('Button')
+        .last()
+        .props().disabled
+    ).to.be.true;
+    expect(wrapper.find('FontAwesome').length).to.equal(1);
+
+    return new Promise(resolve => setImmediate(resolve)).then(() => {
+      wrapper
+        .find('input')
+        .first()
+        .simulate('change', {target: {files: []}});
+      expect(fetchStub.callCount).equals(1);
+      fetchStub.restore();
+    });
+  });
 });


### PR DESCRIPTION
Grays out the save button on the UploadImageDialog when the file is uploading. I didn't realize I needed to wait and thought I had a bug when testing a feature using this. 🙃 


https://user-images.githubusercontent.com/46464143/141513176-33a779c5-e1dc-4693-b4e5-e174eb338143.mov



## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
