### PR TITLE
Revert "Temporarily stop installing and running rbspy"

### DIFF
--- a/aws/cloudformation/bootstrap_frontend.sh.erb
+++ b/aws/cloudformation/bootstrap_frontend.sh.erb
@@ -14,11 +14,7 @@ popd
 # Run rbspy for 2 minutes on 3 dashboard worker processes at startup.
 # We're doing this temporarily to help debug our deployment unavailability issue.
 # Find 3 dashboard worker process IDs and feed them to 3 rbspy invocations, in parallel using xargs.
-
-# Temporarily stop running rbspy on server startup because the current version of Chef client we use can't install rbyspy
-# because Chef client bundles a version of OpenSSL
-# that does not include the root certificate that the github.com site's SSL certificate is signed by.
-# ps aux | grep "cluster worker" | grep dashboard | head -n 3 | tr --squeeze-repeats ' ' | cut -d ' ' -f 2 | xargs -P 3 -I {} sudo rbspy record --silent --duration 120 --pid {} &
+ps aux | grep "cluster worker" | grep dashboard | head -n 3 | tr --squeeze-repeats ' ' | cut -d ' ' -f 2 | xargs -P 3 -I {} sudo rbspy record --silent --duration 120 --pid {} &
 
 # Increase EC2 instance metadata service retries/timeouts.
 export AWS_METADATA_SERVICE_TIMEOUT=30

--- a/cookbooks/cdo-apps/recipes/default.rb
+++ b/cookbooks/cdo-apps/recipes/default.rb
@@ -138,8 +138,6 @@ include_recipe 'cdo-tippecanoe' if node['cdo-apps']['daemon']
 # Patch to fix issue with systemd-resolved: https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1805183
 include_recipe 'cdo-apps::resolved'
 
-# Temporarily stop installing rbspy because the current version of Chef client we use bundles a version of OpenSSL
-# that does not include the root certificate that the github.com site's SSL certificate is signed by.
-#include_recipe 'cdo-apps::rbspy'
+include_recipe 'cdo-apps::rbspy'
 
 include_recipe 'cdo-apps::syslog_permissions'


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#43045, restoring https://github.com/code-dot-org/code-dot-org/pull/32846 now that https://github.com/code-dot-org/code-dot-org/pull/43370 has been merged.