### PR TITLE
Update migration in case someone does not have scripts or course versions

### DIFF
--- a/dashboard/db/migrate/20211111185031_update_version_year_on_unversioned_hoc_scripts2021.rb
+++ b/dashboard/db/migrate/20211111185031_update_version_year_on_unversioned_hoc_scripts2021.rb
@@ -3,10 +3,12 @@ class UpdateVersionYearOnUnversionedHocScripts2021 < ActiveRecord::Migration[5.2
     unless rack_env?(:test)
       ['spelling-bee', 'counting-csc', 'explore-data-1', 'hello-world-food', 'hello-world-animals', 'hello-world-emoji', 'hello-world-retro'].each do |script_name|
         script = Script.find_by(name: script_name)
+        next unless script
         script.properties[:version_year] = "unversioned"
         script.save!
 
         script.course_version
+        next unless script.course_version
         script.course_version.display_name = "unversioned"
         script.course_version.key = "unversioned"
         script.course_version.save!
@@ -18,10 +20,12 @@ class UpdateVersionYearOnUnversionedHocScripts2021 < ActiveRecord::Migration[5.2
     unless rack_env?(:test)
       ['spelling-bee', 'counting-csc', 'explore-data-1', 'hello-world-food', 'hello-world-animals', 'hello-world-emoji', 'hello-world-retro'].each do |script_name|
         script = Script.find_by(name: script_name)
+        next unless script
         script.properties[:version_year] = "2021"
         script.save!
 
         script.course_version
+        next unless script.course_version
         script.course_version.display_name = "2021"
         script.course_version.key = "2021"
         script.course_version.save!


### PR DESCRIPTION
If someone does not have the scripts or course_versions for the scripts in this migration db:migrate will fail. See [slack thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1636684038427500).  This updates the migration to skip the steps if it can't find the script or course_version.

