### PR TITLE
warning banner on script overview when saving is paused

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1284,6 +1284,8 @@
   "noLibrariesInClass": "No one in your class has published a library. Try adding one from an ID.",
   "noMenuItemsAvailable": "No menu items available.",
   "nominateATeacher": "Nominate a Teacher",
+  "noSaveWarning": "Progress may not save.",
+  "noSaveWarningDetails": "We are currently experiencing high traffic. During this time, new progress in this course may not be saved.",
   "noStudentsInSection": "There are no other students in this section.",
   "exceededPairProgrammingMax": "You cannot pair with more than 4 people.",
   "noPersonalProjects": "You currently have no projects. Click on one of the buttons above to start a project.",

--- a/apps/src/code-studio/components/progress/UnitOverview.jsx
+++ b/apps/src/code-studio/components/progress/UnitOverview.jsx
@@ -62,6 +62,7 @@ class UnitOverview extends React.Component {
     scriptOverviewPdfUrl: PropTypes.string,
     scriptResourcesPdfUrl: PropTypes.string,
     showUnversionedRedirectWarning: PropTypes.bool,
+    showNoSaveWarning: PropTypes.bool,
 
     // redux provided
     perLevelResults: PropTypes.object.isRequired,
@@ -132,7 +133,8 @@ class UnitOverview extends React.Component {
       isMigrated,
       scriptOverviewPdfUrl,
       scriptResourcesPdfUrl,
-      showUnversionedRedirectWarning
+      showUnversionedRedirectWarning,
+      showNoSaveWarning
     } = this.props;
 
     const displayRedirectDialog =
@@ -184,6 +186,7 @@ class UnitOverview extends React.Component {
               versions={versions}
               courseName={courseName}
               userId={userId}
+              showNoSaveWarning={showNoSaveWarning}
             />
             {showCalendar && viewAs === ViewType.Teacher && (
               <div className="unit-calendar-for-printing print-only">

--- a/apps/src/code-studio/components/progress/UnitOverviewHeader.jsx
+++ b/apps/src/code-studio/components/progress/UnitOverviewHeader.jsx
@@ -39,6 +39,7 @@ class UnitOverviewHeader extends Component {
     showScriptVersionWarning: PropTypes.bool,
     showRedirectWarning: PropTypes.bool,
     showHiddenUnitWarning: PropTypes.bool,
+    showNoSaveWarning: PropTypes.bool,
     courseName: PropTypes.string,
     versions: PropTypes.arrayOf(assignmentVersionShape).isRequired,
     userId: PropTypes.number,
@@ -109,7 +110,8 @@ class UnitOverviewHeader extends Component {
       courseName,
       userId,
       isVerifiedTeacher,
-      hasVerifiedResources
+      hasVerifiedResources,
+      showNoSaveWarning
     } = this.props;
 
     const displayVerifiedResources =
@@ -154,6 +156,14 @@ class UnitOverviewHeader extends Component {
               script_id: scriptId,
               user_id: userId
             }}
+          />
+        )}
+        {showNoSaveWarning && (
+          <Notification
+            type={NotificationType.failure}
+            notice={i18n.noSaveWarning()}
+            details={i18n.noSaveWarningDetails()}
+            dismissible={false}
           />
         )}
         {userId && <StudentFeedbackNotification studentId={userId} />}

--- a/apps/src/code-studio/progress.js
+++ b/apps/src/code-studio/progress.js
@@ -307,6 +307,7 @@ progress.renderCourseProgress = function(scriptData) {
         showUnversionedRedirectWarning={
           scriptData.show_unversioned_redirect_warning
         }
+        showNoSaveWarning={scriptData.show_no_save_warning}
       />
     </Provider>,
     mountPoint

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -49,6 +49,7 @@ class ScriptsController < ApplicationController
       @sections_with_assigned_info = sections&.map {|section| section.merge!({"isAssigned" => section[:script_id] == @script.id})}
     end
 
+    @show_no_save_warning = !Gatekeeper.allows('postMilestone', where: {script_name: @script.name}, default: true)
     @show_unversioned_redirect_warning = !!session[:show_unversioned_redirect_warning] && !@script.is_course
     session[:show_unversioned_redirect_warning] = false
 

--- a/dashboard/app/views/scripts/show.html.haml
+++ b/dashboard/app/views/scripts/show.html.haml
@@ -16,7 +16,8 @@
                             locale_code: request.locale,
                             course_link: @script.course_link(params[:section_id]),
                             course_title: @script.course_title || I18n.t('view_all_units'),
-                            sections: @sections_with_assigned_info}
+                            sections: @sections_with_assigned_info,
+                            show_no_save_warning: @show_no_save_warning}
 - scriptOverviewData = {scriptData: script_data.merge(additional_script_data)}
 - if @script.old_professional_learning_course? && @current_user && Plc::UserCourseEnrollment.exists?(user: @current_user, plc_course: @script.plc_course_unit.plc_course)
   -  scriptOverviewData[:plcBreadcrumb] = {unit_name: @script.plc_course_unit.unit_name, course_view_path: course_path(@script.plc_course_unit.plc_course.unit_group)}


### PR DESCRIPTION
[LP-2109](https://codedotorg.atlassian.net/browse/LP-2109), partial of [LP-2082](https://codedotorg.atlassian.net/browse/LP-2082)

When we are in `emergency` FeatureMode to protect site stability during extremely high usage, we stop saving progress for CSF and HOC scripts. This PR adds a warning banner on the script overview page for scripts in which progress is not being saved. 

![Screen Shot 2021-11-12 at 12 43 33 PM](https://user-images.githubusercontent.com/12300669/141511952-f8d0e1c6-42ab-4ffd-9983-a94b8f9d8b79.png)


