### PR TITLE
Revert "Bump @code-dot-org/piskel to 0.13.0-cdo.8"

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -60,7 +60,7 @@
     "@code-dot-org/ml-activities": "0.0.26",
     "@code-dot-org/ml-playground": "0.0.39",
     "@code-dot-org/p5.play": "^1.3.20-cdo",
-    "@code-dot-org/piskel": "0.13.0-cdo.8",
+    "@code-dot-org/piskel": "0.13.0-cdo.7",
     "@code-dot-org/redactable-markdown": "0.4.0",
     "@react-bootstrap/pagination": "^1.0.0",
     "@storybook/addon-actions": "^4.1.16",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1688,10 +1688,10 @@
     opentype.js "^0.4.9"
     reqwest "^1.1.5"
 
-"@code-dot-org/piskel@0.13.0-cdo.8":
-  version "0.13.0-cdo.8"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/piskel/-/piskel-0.13.0-cdo.8.tgz#085226f893790d36c56bef010659f2144093c6a9"
-  integrity sha512-cVfDjshCctXNtCU+VKKf2RZGXABkal59K06ZTBhfBWd7qAJGx6BL1yeRx4iO8tsKrSK425rNrXiIHO+IDLEV5A==
+"@code-dot-org/piskel@0.13.0-cdo.7":
+  version "0.13.0-cdo.7"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/piskel/-/piskel-0.13.0-cdo.7.tgz#b7793889485ac953af0b268fa5545dad7c6078db"
+  integrity sha512-sdPuYTksDB2oLG/SFmCOpGf2IudUuHI30SwMyyHb6AxOUkrx+CwT6vIzqvy20Ejt6f0rK4J15HSLuojfelGqkw==
   dependencies:
     messageformat "^2.3.0"
 


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#43429

See [Slack thread](https://codedotorg.slack.com/archives/C1B3PNDL7/p1636735425031200). Didn't end up needing a revert -- the issue was users' browsers were caching the old version of Piskel, but I prepped this before we root-caused just in case.