### PR TITLE
Update csa alert and fix styling

### DIFF
--- a/apps/src/code-studio/pd/application/teacher/ChooseYourProgram.jsx
+++ b/apps/src/code-studio/pd/application/teacher/ChooseYourProgram.jsx
@@ -93,16 +93,18 @@ const ChooseYourProgram = props => {
           <h3>Section 2: {SectionHeaders.chooseYourProgram}</h3>
           <LabeledRadioButtons name="program" />
 
-          {data.program === PROGRAM_CSA && !isOffered && (
+          {data.program === PROGRAM_CSA && regionalPartner && !isOffered && (
             <p style={styles.error}>
-              The Computer Science A Professional Learning Program is not yet
-              offered in your region for the {Year} academic year. We are
-              working with our national network of Regional Partners to expand
-              the program to all regions by 2023-24.{' '}
-              {regionalPartner &&
-                `Consider applying for an
-              alternative program or reach out to ${regionalPartner.name} to let
-              them know you’re interested in joining the program next year!`}
+              <strong>
+                The Regional Partner in your region is not offering Computer
+                Science A at this time.{' '}
+              </strong>
+              Code.org will review your application and contact you with options
+              for joining a national cohort of Computer Science A teachers. If
+              accepted into the program, travel may be required to attend a
+              weeklong in-person summer workshop. If so, travel and
+              accommodation will be provided by Code.org. Academic year
+              workshops for the national cohort will be hosted virtually.
             </p>
           )}
 

--- a/apps/style/code-studio/pd.scss
+++ b/apps/style/code-studio/pd.scss
@@ -207,8 +207,6 @@ form .form-required-field {
   font-family: "Gotham 4r", sans-serif;
 }
 
-#application-container .form-control {
-  display: inline-block;
-  height: 20px;
-  padding: 4px 6px;
+#application-container .form-group {
+  margin-bottom: 0px
 }


### PR DESCRIPTION
Updates the alert if a teacher selects CSA, has a regional partner, but the regional partner doesn't offer the CSA workshop. If there's no RP, don't show the alert.
<img width="975" alt="Section 2 Choose Your Program" src="https://user-images.githubusercontent.com/9142121/141535754-c5109bf5-0903-4e72-af08-2d964fd08b45.png">


Also fixed a styling issue coming through with the state. Also makes the text boxes bigger for Course Hours boxes.
<img width="558" alt="Arizona" src="https://user-images.githubusercontent.com/9142121/141535767-a473f28a-a0a7-4494-b78d-69b6513aa9b7.png">

<img width="920" alt="number of minutes you meet per class period)" src="https://user-images.githubusercontent.com/9142121/141535802-4a2d0588-df7c-442a-8819-5458408dc099.png">

## Links

- jira ticket: [PLAT-1415](https://codedotorg.atlassian.net/browse/PLAT-1415)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
