### PR TITLE
[Poetry][HOC] Poem selector and editor updates

### DIFF
--- a/apps/i18n/poetry/en_us.json
+++ b/apps/i18n/poetry/en_us.json
@@ -8,6 +8,7 @@
   "carroll2Title": "Crocodile",
   "carroll3Lines": "'Twas brillig, and the slithy toves\nDid gyre and gimble in the wabe;\nAll mimsy were the borogoves,\nAnd the mome raths outgrabe.\n\n“Beware the Jabberwock, my son!\nThe jaws that bite, the claws that catch!\nBeware the Jubjub bird, and shun\nThe frumious Bandersnatch!”",
   "carroll3Title": "Jabberwocky",
+  "chooseAPoem": "Choose a Poem",
   "chooseSound": "This poem doesn't have any sound yet. Choose a music or sound block to add to your code. \n<xml><block type=\"Poetry_playSound\"><title name=\"SOUND\">\"sound://category_background/typewriter.mp3\"</title></block></xml>  \n<xml><block type=\"Poetry_playMusic\"><title name=\"SOUND\">\"sound://category_background/fire_burning.mp3\"</title></block></xml>",
   "editCustomPoem": "Edit Custom Poem",
   "effectWithEvent": "Try using a new foreground or background effect under your `when line shows` event block.",

--- a/apps/src/p5lab/poetry/PoemSelector.jsx
+++ b/apps/src/p5lab/poetry/PoemSelector.jsx
@@ -16,10 +16,18 @@ import {POEMS, PoetryStandaloneApp} from './constants';
 import {getPoem} from './poem';
 import * as utils from '@cdo/apps/utils';
 
+const poemShape = PropTypes.shape({
+  key: PropTypes.string,
+  title: PropTypes.string,
+  author: PropTypes.string,
+  lines: PropTypes.arrayOf(PropTypes.string)
+});
+
 export function PoemEditor(props) {
-  const [title, setTitle] = useState('');
-  const [author, setAuthor] = useState('');
-  const [poem, setPoem] = useState('');
+  const {initialPoem} = props;
+  const [title, setTitle] = useState(initialPoem.title || '');
+  const [author, setAuthor] = useState(initialPoem.author || '');
+  const [poem, setPoem] = useState(initialPoem.lines?.join('\n') || '');
   const [error, setError] = useState(null);
 
   // Reset error if poem state changes.
@@ -126,7 +134,11 @@ export function PoemEditor(props) {
 
 PoemEditor.propTypes = {
   isOpen: PropTypes.bool.isRequired,
-  handleClose: PropTypes.func.isRequired
+  handleClose: PropTypes.func.isRequired,
+  initialPoem: poemShape
+};
+PoemEditor.defaultProps = {
+  initialPoem: {}
 };
 
 function PoemSelector(props) {
@@ -184,9 +196,19 @@ function PoemSelector(props) {
     return options;
   };
 
+  const initialEditorPoem = () => {
+    if (props.selectedPoem?.key === msg.enterMyOwn()) {
+      return props.selectedPoem;
+    }
+  };
+
   return (
     <div id="poemSelector" style={styles.container}>
-      <PoemEditor isOpen={isOpen} handleClose={handleClose} />
+      <PoemEditor
+        isOpen={isOpen}
+        handleClose={handleClose}
+        initialPoem={initialEditorPoem()}
+      />
       <label>
         <b>{msg.selectPoem()}</b>
       </label>
@@ -205,7 +227,7 @@ function PoemSelector(props) {
 
 PoemSelector.propTypes = {
   // from Redux
-  selectedPoem: PropTypes.object.isRequired,
+  selectedPoem: poemShape.isRequired,
   onChangePoem: PropTypes.func.isRequired
 };
 

--- a/apps/src/p5lab/poetry/PoemSelector.jsx
+++ b/apps/src/p5lab/poetry/PoemSelector.jsx
@@ -182,8 +182,6 @@ function PoemSelector(props) {
     }
   };
 
-  const getDropdownValue = () => props.selectedPoem.key;
-
   const getPoemOptions = () => {
     const options = Object.keys(POEMS)
       .map(poemKey => getPoem(poemKey))
@@ -214,7 +212,7 @@ function PoemSelector(props) {
       </label>
       <div style={styles.selector}>
         <Select
-          value={getDropdownValue()}
+          value={props.selectedPoem.key}
           clearable={false}
           searchable={false}
           onChange={onChange}

--- a/apps/src/p5lab/poetry/PoemSelector.jsx
+++ b/apps/src/p5lab/poetry/PoemSelector.jsx
@@ -75,7 +75,12 @@ export function PoemEditor(props) {
 
   const onSave = () => {
     const closeAndSave = () =>
-      props.handleClose({title, author, lines: poem.split('\n')});
+      props.handleClose({
+        key: msg.enterMyOwn(),
+        title,
+        author,
+        lines: poem.split('\n')
+      });
 
     utils
       .findProfanity(
@@ -142,24 +147,30 @@ function PoemSelector(props) {
 
   const onChange = e => {
     const poemKey = e.value;
-    const poem = getPoem(poemKey);
-
     if (poemKey === msg.enterMyOwn()) {
       setIsOpen(true);
-    } else if (poem) {
+      return;
+    }
+
+    let poem;
+    if (poemKey === msg.chooseAPoem()) {
+      poem = {
+        key: msg.chooseAPoem(),
+        author: '',
+        title: '',
+        lines: []
+      };
+    } else {
+      poem = getPoem(poemKey);
+    }
+
+    if (poem) {
       props.onChangePoem(poem);
       project.saveSelectedPoem(poem);
     }
   };
 
-  const getDropdownValue = () => {
-    const poem = getPoem(props.selectedPoem.key);
-    if (poem) {
-      return poem.key;
-    } else {
-      return msg.enterMyOwn();
-    }
-  };
+  const getDropdownValue = () => props.selectedPoem.key;
 
   const getPoemOptions = () => {
     const options = Object.keys(POEMS)
@@ -168,6 +179,8 @@ function PoemSelector(props) {
       .map(poem => ({value: poem.key, label: poem.title}));
     // Add option to create your own poem to the top of the dropdown.
     options.unshift({value: msg.enterMyOwn(), label: msg.enterMyOwn()});
+    // Add blank option that just says "Choose a Poem" to the top of the dropdown.
+    options.unshift({value: msg.chooseAPoem(), label: msg.chooseAPoem()});
     return options;
   };
 

--- a/apps/src/p5lab/poetry/Poetry.js
+++ b/apps/src/p5lab/poetry/Poetry.js
@@ -1,7 +1,7 @@
 import msg from '@cdo/poetry/locale';
 import {getStore} from '@cdo/apps/redux';
 import trackEvent from '@cdo/apps/util/trackEvent';
-import {setPoem} from '../redux/poetry';
+import {setPoem, hasSelectedPoemChanged} from '../redux/poetry';
 import {P5LabType} from '../constants';
 import SpriteLab from '../spritelab/SpriteLab';
 import PoetryLibrary from './PoetryLibrary';
@@ -116,10 +116,7 @@ export default class Poetry extends SpriteLab {
       const lastState = state;
       state = store.getState();
 
-      if (
-        lastState.poetry &&
-        lastState.poetry.selectedPoem.title !== state.poetry.selectedPoem.title
-      ) {
+      if (hasSelectedPoemChanged(lastState, state)) {
         this.reset();
       }
     });

--- a/apps/src/p5lab/poetry/Poetry.js
+++ b/apps/src/p5lab/poetry/Poetry.js
@@ -116,7 +116,7 @@ export default class Poetry extends SpriteLab {
       const lastState = state;
       state = store.getState();
 
-      if (hasSelectedPoemChanged(lastState, state)) {
+      if (lastState.poetry && hasSelectedPoemChanged(lastState, state)) {
         this.reset();
       }
     });

--- a/apps/src/p5lab/redux/poetry.js
+++ b/apps/src/p5lab/redux/poetry.js
@@ -37,3 +37,14 @@ export function setPoem(poem) {
     ...poem
   };
 }
+
+/**
+ * Helpers
+ */
+
+export function hasSelectedPoemChanged(prevState = {}, currentState = {}) {
+  return !_.isEqual(
+    prevState.poetry?.selectedPoem,
+    currentState.poetry?.selectedPoem
+  );
+}

--- a/apps/src/p5lab/redux/poetry.js
+++ b/apps/src/p5lab/redux/poetry.js
@@ -1,4 +1,14 @@
+import _ from 'lodash';
+
+/**
+ * Action keys
+ */
+
 const SET_POEM = 'poetry/SET_POEM';
+
+/**
+ * Reducer
+ */
 
 export default function poetry(state, action) {
   state = state || {selectedPoem: {key: '', title: '', author: '', lines: []}};
@@ -16,6 +26,10 @@ export default function poetry(state, action) {
       return state;
   }
 }
+
+/**
+ * Action creators
+ */
 
 export function setPoem(poem) {
   return {

--- a/apps/test/unit/p5lab/poetry/PoemSelectorTest.js
+++ b/apps/test/unit/p5lab/poetry/PoemSelectorTest.js
@@ -8,6 +8,44 @@ import {PoemEditor} from '@cdo/apps/p5lab/poetry/PoemSelector';
 import * as utils from '@cdo/apps/utils';
 
 describe('PoemEditor', () => {
+  // PoemEditor pulls this string from i18n, but we'll hardcode it in tests for simplicity.
+  const enterMyOwn = 'Enter my own';
+
+  describe('with initialPoem', () => {
+    it('populates inputs with initial values', () => {
+      const wrapper = mount(
+        <PoemEditor
+          isOpen
+          handleClose={() => {}}
+          initialPoem={{
+            title: 'My title',
+            // Intentionally leave author blank.
+            lines: ['this is', 'a good poem']
+          }}
+        />
+      );
+
+      expect(
+        wrapper
+          .find('input')
+          .at(0)
+          .props().value
+      ).to.equal('My title');
+      expect(
+        wrapper
+          .find('input')
+          .at(1)
+          .props().value
+      ).to.be.empty;
+      expect(
+        wrapper
+          .find('textarea')
+          .at(0)
+          .props().value
+      ).to.equal('this is\na good poem');
+    });
+  });
+
   describe('saving', () => {
     let mockAppOptions, handleCloseSpy;
 
@@ -39,6 +77,7 @@ describe('PoemEditor', () => {
         mockAppOptions.authenticityToken
       );
       expect(handleCloseSpy).to.have.been.calledOnceWith({
+        key: enterMyOwn,
         title: 'title',
         author: 'author',
         lines: ['my', 'poem']
@@ -59,6 +98,7 @@ describe('PoemEditor', () => {
         mockAppOptions.authenticityToken
       );
       expect(handleCloseSpy).to.have.been.calledOnceWith({
+        key: enterMyOwn,
         title: 'title',
         author: 'author',
         lines: ['poem']


### PR DESCRIPTION
Includes 2 bug fixes and an update to the poem selector and "create your own" editor.

1. Bug fix: custom poem would only update in visualization space if the title had changed. It now updates if any part of the poem has changed.
2. Added an empty "Choose a Poem" option as the first option in the selector (screenshot below).
3. Bug fix: Previously, if you loaded a project with a custom poem, the editor was empty when opened. Now, it will populate with your poem (screenshot below).

**New "Choose a Poem" default option:**
![image](https://user-images.githubusercontent.com/8787187/141536574-9deda733-6a58-4695-b8d7-334c22d54763.png)

**Populate custom poem in editor on initial load:**
This is the "after" screenshot. Previously, this form was empty if you loaded a project with a custom poem and opened this editor by clicking the "Enter my own" option in the poem selector.
<img width="719" alt="Screen Shot 2021-11-12 at 4 36 45 PM" src="https://user-images.githubusercontent.com/9812299/141598602-f911336d-7178-4b8d-8bc0-2bc1f042b111.png">
