### PR TITLE
Add CSC assignment dropdown category to scripts.en.yml for translation

### DIFF
--- a/dashboard/config/locales/scripts.en.yml
+++ b/dashboard/config/locales/scripts.en.yml
@@ -25,6 +25,7 @@ en:
         cspexams_category_name: CS Principles Practice Test
         csp17_category_name: CS Principles ('17-'18)
         aiml_2021_category_name: AI / ML
+        csc_2021_category_name: CS Connnections ('21-'22)
         full_course_category_name: Full Courses
         hoc_category_name: Hour of Code
         math_category_name: Math


### PR DESCRIPTION
We will want the new category name for CSC courses in the assignment dropdown to be included in the translation scoop this weekend. This will set us up to add the category on Monday with this PR https://github.com/code-dot-org/code-dot-org/pull/43056/