### PR TITLE
[Google Blockly] Change dropdown arrow character

### DIFF
--- a/apps/src/blockly/addons/cdoFieldDropdown.js
+++ b/apps/src/blockly/addons/cdoFieldDropdown.js
@@ -3,6 +3,8 @@ import GoogleBlockly from 'blockly/core';
 const EMPTY_OPTION = '???';
 
 export default class FieldDropdown extends GoogleBlockly.FieldDropdown {
+  static ARROW_CHAR = '\u25BC';
+
   /** Turn changeHandler into validator
    * @override
    */


### PR DESCRIPTION
Very simple override, outlined in the blockly docs here: https://developers.google.com/blockly/guides/create-custom-blocks/fields/built-in-fields/dropdown#creation

[jira](https://codedotorg.atlassian.net/browse/STAR-1901)

Before
![image](https://user-images.githubusercontent.com/8787187/141608259-fa402b13-4c9b-46e0-8030-fe8e9cfbee09.png)

After

![image](https://user-images.githubusercontent.com/8787187/141608264-cc8d6483-6452-4665-8231-70f02df96009.png)
