### PR TITLE
Add image override + i18n for poetry_hoc in 'create' menu

### DIFF
--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -424,6 +424,7 @@ en:
       playlab: 'Play Lab'
       playlab_k1: 'Play Lab (Pre-reader)'
       poetry: 'Poetry'
+      poetry_hoc: 'Poetry Hour of Code'
       scratch: 'Scratch'
       sports: 'Sports'
       spritelab: 'Sprite Lab'

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -424,7 +424,7 @@ en:
       playlab: 'Play Lab'
       playlab_k1: 'Play Lab (Pre-reader)'
       poetry: 'Poetry'
-      poetry_hoc: 'Poetry Hour of Code'
+      poetry_hoc: 'Poem Art'
       scratch: 'Scratch'
       sports: 'Sports'
       spritelab: 'Sprite Lab'

--- a/lib/cdo/create_header.rb
+++ b/lib/cdo/create_header.rb
@@ -27,6 +27,9 @@ class CreateHeader
     },
     artist_k1: {
       image: "logo_artist.png"
+    },
+    poetry_hoc: {
+      image: "logo_poetry.png"
     }
   }.freeze
 


### PR DESCRIPTION
Bug fix: The image and string were missing from the "create" menu on poetry HoC projects (`/projects/poetry_hoc/:channel_id`)

After fix:
<img width="300" alt="Screen Shot 2021-11-15 at 9 22 41 AM" src="https://user-images.githubusercontent.com/9812299/141826201-c7d8174e-e66b-43b8-80fe-33f571595eb9.png">

