### PR TITLE
[Google Blockly] Fix location picker on touch devices

### DIFF
--- a/apps/src/p5lab/P5LabVisualizationColumn.jsx
+++ b/apps/src/p5lab/P5LabVisualizationColumn.jsx
@@ -32,7 +32,7 @@ import {calculateOffsetCoordinates} from '@cdo/apps/utils';
 import {isMobileDevice} from '@cdo/apps/util/browser-detector';
 
 const MODAL_Z_INDEX = 1050;
-const LOCATION_PICKER_CANCEL_THRESHOLD = 250;
+const LOCATION_PICKER_CANCEL_THRESHOLD_MS = 250;
 
 class P5LabVisualizationColumn extends React.Component {
   static propTypes = {
@@ -227,7 +227,7 @@ class P5LabVisualizationColumn extends React.Component {
               // with a time threshold to avoid this issue.
               if (
                 Date.now() - this.props.requestTime <
-                LOCATION_PICKER_CANCEL_THRESHOLD
+                LOCATION_PICKER_CANCEL_THRESHOLD_MS
               ) {
                 return;
               }

--- a/apps/src/p5lab/P5LabVisualizationColumn.jsx
+++ b/apps/src/p5lab/P5LabVisualizationColumn.jsx
@@ -32,6 +32,7 @@ import {calculateOffsetCoordinates} from '@cdo/apps/utils';
 import {isMobileDevice} from '@cdo/apps/util/browser-detector';
 
 const MODAL_Z_INDEX = 1050;
+const LOCATION_PICKER_CANCEL_THRESHOLD = 250;
 
 class P5LabVisualizationColumn extends React.Component {
   static propTypes = {
@@ -47,6 +48,7 @@ class P5LabVisualizationColumn extends React.Component {
     spriteLab: PropTypes.bool.isRequired,
     awaitingContainedResponse: PropTypes.bool.isRequired,
     pickingLocation: PropTypes.bool.isRequired,
+    requestTime: PropTypes.number,
     showGrid: PropTypes.bool.isRequired,
     toggleShowGrid: PropTypes.func.isRequired,
     cancelPicker: PropTypes.func.isRequired,
@@ -219,7 +221,18 @@ class P5LabVisualizationColumn extends React.Component {
         {this.props.pickingLocation && (
           <div
             className={'modal-backdrop'}
-            onClick={() => this.props.cancelPicker()}
+            onClick={() => {
+              // On some mobile devices, we get a duplicate click event that
+              // would cancel the location picker immediately. Throttle canceling
+              // with a time threshold to avoid this issue.
+              if (
+                Date.now() - this.props.requestTime <
+                LOCATION_PICKER_CANCEL_THRESHOLD
+              ) {
+                return;
+              }
+              this.props.cancelPicker();
+            }}
           />
         )}
       </div>
@@ -245,6 +258,7 @@ export default connect(
     awaitingContainedResponse: state.runState.awaitingContainedResponse,
     showGrid: state.gridOverlay,
     pickingLocation: isPickingLocation(state.locationPicker),
+    requestTime: state.locationPicker.requestTime,
     consoleMessages: state.textConsole,
     isRtl: state.isRtl
   }),

--- a/apps/src/p5lab/redux/locationPicker.js
+++ b/apps/src/p5lab/redux/locationPicker.js
@@ -14,20 +14,25 @@ export default function locationPicker(state, action) {
   switch (action.type) {
     case REQUEST_LOCATION:
       return {
+        ...state,
         mode: LocationPickerMode.SELECTING,
         lastSelection: undefined
       };
     case CANCEL_LOCATION_SELECTION:
       return {
-        mode: LocationPickerMode.IDLE
+        ...state,
+        mode: LocationPickerMode.IDLE,
+        lastSelection: undefined
       };
     case SELECT_LOCATION:
       return {
+        ...state,
         mode: LocationPickerMode.IDLE,
         lastSelection: action.value
       };
     case UPDATE_LOCATION:
       return {
+        ...state,
         mode: LocationPickerMode.SELECTING,
         lastSelection: action.value
       };

--- a/apps/src/p5lab/redux/locationPicker.js
+++ b/apps/src/p5lab/redux/locationPicker.js
@@ -16,7 +16,8 @@ export default function locationPicker(state, action) {
       return {
         ...state,
         mode: LocationPickerMode.SELECTING,
-        lastSelection: undefined
+        lastSelection: undefined,
+        requestTime: Date.now()
       };
     case CANCEL_LOCATION_SELECTION:
       return {


### PR DESCRIPTION
Some touch devices (ex Google Pixel 3a) are firing a click event on the `modal-backdrop` div immediately when you click the pin to open the location picker, causing the location picker to close out immediately. 

My solution here is to just add a time threshold for canceling the location picker. This swallows the extra click event and makes the location picker work as expected on android touch devices. The threshold is set at 250ms, which I think is fast enough that users won't really notice it. This solution is a little bit of a bandaid because I can't quite figure out why the click events are happening since the `modal-backdrop` div doesn't exist at the time of the click event on the location pin. However, we need to fix this issue before launching on Tuesday, and I don't think it's that much of a hack. If reviewers disagree, though, just let me know, and I'll try to find a better solution.

Before (this gif doesn't really capture it that well. there's a flicker of the dark backdrop as the location picker opens, but then immediately closes)
![Nov-14-2021 20-25-46](https://user-images.githubusercontent.com/8787187/141722560-0498d0d6-5d98-4e26-a473-9fa9d6669033.gif)

After
![Nov-14-2021 20-27-31](https://user-images.githubusercontent.com/8787187/141722528-17bee8c3-ddb3-4867-bb43-2c14a7bf1f35.gif)

