### PR TITLE
[Poetry] Fix inline glideTo block

### DIFF
--- a/apps/src/p5lab/poetry/PoetryLibrary.js
+++ b/apps/src/p5lab/poetry/PoetryLibrary.js
@@ -104,6 +104,10 @@ export default class PoetryLibrary extends CoreLibrary {
         spritelabCommands.destroy.call(this, {costume});
       },
 
+      glideTo(costume, location) {
+        spritelabCommands.glideTo.call(this, {costume}, location);
+      },
+
       playMusic(url) {
         if (this.poemState.backgroundMusic) {
           audioCommands.stopSound({url: this.poemState.backgroundMusic});


### PR DESCRIPTION
This block should have the same functionality as the spritelab guide block, but with inline arguments.
The generated code for the costume picker is just the name of the costume as a string:
![image](https://user-images.githubusercontent.com/8787187/141826905-8dd4cbea-c030-4d1b-9e2a-7823930238ea.png)
But the spritelab command expects the argument to be `{costume: "costumeName"}`, so this just adds a wrapper function in the poetry library that calls through to the spritelab command.
Basically the same logic as https://github.com/code-dot-org/code-dot-org/pull/43100