### PR TITLE
Protect against missing tutorial strings in HOC search

### DIFF
--- a/apps/src/tutorialExplorer/tutorialExplorer.js
+++ b/apps/src/tutorialExplorer/tutorialExplorer.js
@@ -456,7 +456,7 @@ export default class TutorialExplorer extends React.Component {
         if (
           searchTerm &&
           !(
-            tutorial.name.toLowerCase().includes(cleanSearchTerm) ||
+            tutorial.name?.toLowerCase().includes(cleanSearchTerm) ||
             tutorial.longdescription?.toLowerCase().includes(cleanSearchTerm)
           )
         ) {


### PR DESCRIPTION
If there is a missing entry for a tutorial name, Search throws an error.  This change safeguards against that scenario. 