### PR TITLE
Add requirements content with no regional partner

### DIFF
--- a/apps/src/code-studio/pd/application/teacher/ProfessionalLearningProgramRequirements.jsx
+++ b/apps/src/code-studio/pd/application/teacher/ProfessionalLearningProgramRequirements.jsx
@@ -24,6 +24,10 @@ import {FormContext} from '../../form_components_func/FormComponent';
 const ProfessionalLearningProgramRequirements = props => {
   const {data} = props;
   const [regionalPartner, regionalPartnerError] = useRegionalPartner(data);
+  const hasNoProgramSelected = () => data.program === undefined;
+  const hasNoSchoolInformation = () => !data.school;
+  const hasNotLoadedRegionalPartner = () => regionalPartner === undefined;
+  const hasNoRegionalPartner = () => regionalPartner === null;
 
   const renderAssignedWorkshopList = () => {
     if (regionalPartner.workshops?.length === 0) {
@@ -151,8 +155,7 @@ const ProfessionalLearningProgramRequirements = props => {
   };
 
   const renderContents = () => {
-    if (data.program === undefined) {
-      // teacher hasn't chosen their program
+    if (hasNoProgramSelected()) {
       return (
         <div style={styles.error}>
           <p>
@@ -161,8 +164,7 @@ const ProfessionalLearningProgramRequirements = props => {
           </p>
         </div>
       );
-    } else if (!data.school) {
-      // teacher hasn't entered information about their school
+    } else if (hasNoSchoolInformation()) {
       return (
         <div style={styles.error}>
           <p>
@@ -171,8 +173,7 @@ const ProfessionalLearningProgramRequirements = props => {
           </p>
         </div>
       );
-    } else if (regionalPartner === undefined) {
-      // regional partner information is loading
+    } else if (hasNotLoadedRegionalPartner()) {
       return <Spinner />;
     } else if (regionalPartnerError) {
       return (
@@ -189,11 +190,9 @@ const ProfessionalLearningProgramRequirements = props => {
           </p>
         </div>
       );
-    } else if (regionalPartner === null) {
-      // no regional partner and is not errored
+    } else if (hasNoRegionalPartner()) {
       return renderProgramRequirements(false);
     } else {
-      // regional partner exists and is not errored
       return renderProgramRequirements(true);
     }
   };

--- a/apps/src/code-studio/pd/application/teacher/ProfessionalLearningProgramRequirements.jsx
+++ b/apps/src/code-studio/pd/application/teacher/ProfessionalLearningProgramRequirements.jsx
@@ -90,7 +90,7 @@ const ProfessionalLearningProgramRequirements = props => {
     } else {
       return (
         <label>
-          Once you are matched with a partner, they may have scholarships
+          When you are matched with a partner, they may have scholarships
           available to cover the cost of the program. Let us know if your school
           or district would be able to pay the fee or if you need to be
           considered for a scholarship.

--- a/apps/src/code-studio/pd/application/teacher/ProfessionalLearningProgramRequirements.jsx
+++ b/apps/src/code-studio/pd/application/teacher/ProfessionalLearningProgramRequirements.jsx
@@ -63,8 +63,96 @@ const ProfessionalLearningProgramRequirements = props => {
     }
   };
 
+  const renderCostNote = hasRegionalPartner => {
+    if (hasRegionalPartner) {
+      return (
+        <label>
+          {regionalPartner.name} may have scholarships available to cover the
+          cost of the program.{' '}
+          <a
+            href={
+              pegasus('/educate/professional-learning/program-information') +
+              (!!data.schoolZipCode ? '?zip=' + data.schoolZipCode : '')
+            }
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Click here to check the fees and discounts for your program
+          </a>
+          . Let us know if your school or district would be able to pay the fee
+          or if you need to be considered for a scholarship.
+        </label>
+      );
+    } else {
+      return (
+        <label>
+          Once you are matched with a partner, they may have scholarships
+          available to cover the cost of the program. Let us know if your school
+          or district would be able to pay the fee or if you need to be
+          considered for a scholarship.
+        </label>
+      );
+    }
+  };
+
+  const renderProgramRequirements = hasRegionalPartner => {
+    return (
+      <div>
+        <p>
+          Code.org’s Professional Learning Program is a yearlong program
+          starting in the summer and concluding in the spring. Workshops can be
+          held in-person, virtually, or as a combination of both throughout the
+          year.
+          {hasRegionalPartner && (
+            <span>
+              {' '}
+              Refer to {`${regionalPartner.name}'s `}
+              <a
+                href={
+                  pegasus(
+                    '/educate/professional-learning/program-information'
+                  ) + (!!data.schoolZipCode ? '?zip=' + data.schoolZipCode : '')
+                }
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                landing page
+              </a>{' '}
+              for more information about the schedule and delivery model.
+            </span>
+          )}
+        </p>
+        <LabeledRadioButtonsWithAdditionalTextFields
+          name="committed"
+          textFieldMap={{
+            [TextFields.noExplain]: 'other'
+          }}
+        />
+        {hasRegionalPartner ? (
+          renderAssignedWorkshopList()
+        ) : (
+          <p style={styles.marginBottom}>
+            <strong>
+              Once you have been matched with a partner, they will be in touch
+              regarding Summer Workshop dates.
+            </strong>
+          </p>
+        )}
+        <div>
+          {renderCostNote(hasRegionalPartner)}
+          <LabeledSingleCheckbox name="understandFee" />
+          <LabeledRadioButtons name="payFee" />
+          {data.payFee === TextFields.noPayFee && (
+            <LabeledLargeInput name="scholarshipReasons" />
+          )}
+        </div>
+      </div>
+    );
+  };
+
   const renderContents = () => {
     if (data.program === undefined) {
+      // teacher hasn't chosen their program
       return (
         <div style={styles.error}>
           <p>
@@ -74,6 +162,7 @@ const ProfessionalLearningProgramRequirements = props => {
         </div>
       );
     } else if (!data.school) {
+      // teacher hasn't entered information about their school
       return (
         <div style={styles.error}>
           <p>
@@ -83,6 +172,7 @@ const ProfessionalLearningProgramRequirements = props => {
         </div>
       );
     } else if (regionalPartner === undefined) {
+      // regional partner information is loading
       return <Spinner />;
     } else if (regionalPartnerError) {
       return (
@@ -100,77 +190,11 @@ const ProfessionalLearningProgramRequirements = props => {
         </div>
       );
     } else if (regionalPartner === null) {
-      return (
-        <>
-          <p>
-            <strong>
-              There is no Regional Partner in your region at this time
-            </strong>
-          </p>
-          <p>
-            Code.org will review your application and contact you with options
-            for joining the program hosted by a Regional Partner from a
-            different region. Please note that we are not able to guarantee a
-            space for you with another Regional Partner, and you will be
-            responsible for the costs associated with traveling to that location
-            if a virtual option is not available.
-          </p>
-        </>
-      );
+      // no regional partner and is not errored
+      return renderProgramRequirements(false);
     } else {
       // regional partner exists and is not errored
-      return (
-        <div>
-          <p>
-            Code.org’s Professional Learning Program is a yearlong program
-            starting in the summer and concluding in the spring. Workshops can
-            be held in-person, virtually, or as a combination of both throughout
-            the year. Refer to {`${regionalPartner.name}'s `}
-            <a
-              href={
-                pegasus('/educate/professional-learning/program-information') +
-                (!!data.schoolZipCode ? '?zip=' + data.schoolZipCode : '')
-              }
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              landing page
-            </a>{' '}
-            for more information about the schedule and delivery model.
-          </p>
-          <LabeledRadioButtonsWithAdditionalTextFields
-            name="committed"
-            textFieldMap={{
-              [TextFields.noExplain]: 'other'
-            }}
-          />
-          {renderAssignedWorkshopList()}
-          <div>
-            <label>
-              {regionalPartner.name} may have scholarships available to cover
-              the cost of the program.{' '}
-              <a
-                href={
-                  pegasus(
-                    '/educate/professional-learning/program-information'
-                  ) + (!!data.schoolZipCode ? '?zip=' + data.schoolZipCode : '')
-                }
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Click here to check the fees and discounts for your program
-              </a>
-              . Let us know if your school or district would be able to pay the
-              fee or if you need to be considered for a scholarship.
-            </label>
-            <LabeledSingleCheckbox name="understandFee" />
-            <LabeledRadioButtons name="payFee" />
-            {data.payFee === TextFields.noPayFee && (
-              <LabeledLargeInput name="scholarshipReasons" />
-            )}
-          </div>
-        </div>
-      );
+      return renderProgramRequirements(true);
     }
   };
 

--- a/apps/src/code-studio/pd/application/teacher/ProfessionalLearningProgramRequirements.jsx
+++ b/apps/src/code-studio/pd/application/teacher/ProfessionalLearningProgramRequirements.jsx
@@ -24,10 +24,11 @@ import {FormContext} from '../../form_components_func/FormComponent';
 const ProfessionalLearningProgramRequirements = props => {
   const {data} = props;
   const [regionalPartner, regionalPartnerError] = useRegionalPartner(data);
-  const hasNoProgramSelected = () => data.program === undefined;
-  const hasNoSchoolInformation = () => !data.school;
-  const hasNotLoadedRegionalPartner = () => regionalPartner === undefined;
-  const hasNoRegionalPartner = () => regionalPartner === null;
+  const hasNoProgramSelected = data.program === undefined;
+  const hasNoSchoolInformation = !data.school;
+  const hasNotLoadedRegionalPartner = regionalPartner === undefined;
+  const hasRegionalPartner =
+    !hasNotLoadedRegionalPartner && regionalPartner !== null;
 
   const renderAssignedWorkshopList = () => {
     if (regionalPartner.workshops?.length === 0) {
@@ -67,7 +68,7 @@ const ProfessionalLearningProgramRequirements = props => {
     }
   };
 
-  const renderCostNote = hasRegionalPartner => {
+  const renderCostNote = () => {
     if (hasRegionalPartner) {
       return (
         <label>
@@ -99,7 +100,7 @@ const ProfessionalLearningProgramRequirements = props => {
     }
   };
 
-  const renderProgramRequirements = hasRegionalPartner => {
+  const renderProgramRequirements = () => {
     return (
       <div>
         <p>
@@ -155,7 +156,7 @@ const ProfessionalLearningProgramRequirements = props => {
   };
 
   const renderContents = () => {
-    if (hasNoProgramSelected()) {
+    if (hasNoProgramSelected) {
       return (
         <div style={styles.error}>
           <p>
@@ -164,7 +165,7 @@ const ProfessionalLearningProgramRequirements = props => {
           </p>
         </div>
       );
-    } else if (hasNoSchoolInformation()) {
+    } else if (hasNoSchoolInformation) {
       return (
         <div style={styles.error}>
           <p>
@@ -173,7 +174,7 @@ const ProfessionalLearningProgramRequirements = props => {
           </p>
         </div>
       );
-    } else if (hasNotLoadedRegionalPartner()) {
+    } else if (hasNotLoadedRegionalPartner) {
       return <Spinner />;
     } else if (regionalPartnerError) {
       return (
@@ -183,17 +184,14 @@ const ProfessionalLearningProgramRequirements = props => {
             workshop information.
           </p>
           <p>
-            Refresh the page to try again. If this persists, please
-            contact&nbsp;
+            Refresh the page to try again. If this persists, please contact{' '}
             <a href="https://support.code.org/hc/en-us/requests/new">support</a>
             .
           </p>
         </div>
       );
-    } else if (hasNoRegionalPartner()) {
-      return renderProgramRequirements(false);
     } else {
-      return renderProgramRequirements(true);
+      return renderProgramRequirements();
     }
   };
 


### PR DESCRIPTION
Currently, when there is no regional partner selected, page 3––asking questions about the program costs––is blank. We want to show those questions regardless, which means updating the text slightly for no partner.

With partner (no change):
![image](https://user-images.githubusercontent.com/9142121/141952350-c169de95-dfbe-43c7-a917-9c7155c1b96f.png)

Without partner (updated):
![image](https://user-images.githubusercontent.com/9142121/141952537-2f7f0d10-308f-4e69-b21d-c5e35a19f3db.png)

## Links

- jira ticket: [PLAT-1448](https://codedotorg.atlassian.net/browse/PLAT-1448)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

Tested locally. Will work with folks to figure out what kind of testing we want to do for the teacher application form.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
