### PR TITLE
[Poetry][HOC] Make cloud tiles bigger

### DIFF
--- a/apps/src/p5lab/poetry/commands/backgroundEffects.js
+++ b/apps/src/p5lab/poetry/commands/backgroundEffects.js
@@ -366,7 +366,7 @@ export const commands = {
         break;
       }
       case 'clouds': {
-        const tileSize = 8;
+        const tileSize = 20;
         const noiseScale = 0.05;
         const speed = 0.015;
         const tiles = [];


### PR DESCRIPTION
Performance improvement for clouds background. Make the cloud tiles bigger so there are only 400 per frame, not 2500
Before
![Nov-15-2021 15-51-27](https://user-images.githubusercontent.com/8787187/141870882-f2f8aa2b-ce5e-44a2-8ff1-57c56391b237.gif)

After
![Nov-15-2021 15-30-55](https://user-images.githubusercontent.com/8787187/141869657-c32e7d5d-78c1-42dd-bba6-bc524e013d28.gif)

