### PR TITLE
Fix counting-csc-2021 not showing in assignment dropdown

### DIFF
--- a/lib/cdo/script_constants.rb
+++ b/lib/cdo/script_constants.rb
@@ -72,7 +72,7 @@ module ScriptConstants
     csc_2021: [
       POETRY_2021_NAME = 'poetry-2021'.freeze,
       AI_ETHICS_2021_NAME = 'ai-ethics-2021'.freeze,
-      COUNTING_CSC_2021_NAME = 'csc-counting-2021'.freeze,
+      COUNTING_CSC_2021_NAME = 'counting-csc-2021'.freeze,
       EXPLORE_DATA_1_2021_NAME = 'explore-data-1-2021'.freeze,
       SPELLING_BEE_2021_NAME = 'spelling-bee-2021'.freeze
     ],


### PR DESCRIPTION
<img width="402" alt="Screen Shot 2021-11-15 at 9 46 53 PM" src="https://user-images.githubusercontent.com/208083/141887085-53fcac59-0509-456d-83c0-6637bf04b4e2.png">

Counting with Laurel now shows up in the dropdown