### PR TITLE
Make Instructor and Participant redirect to Teacher and Student

### DIFF
--- a/apps/src/code-studio/viewAsRedux.js
+++ b/apps/src/code-studio/viewAsRedux.js
@@ -14,6 +14,12 @@ export const SET_VIEW_TYPE = 'viewAs/SET_VIEW_TYPE';
 export default function reducer(state = ViewType.Student, action) {
   if (action.type === SET_VIEW_TYPE) {
     let viewType = action.viewType;
+    /* These redirects are temporary. They will allow us to move over to
+     * Participant and Instructor as the main ViewTypes without a risk
+     * of breaking something for users if we have to revert. We should have
+     * moved over to Instructor and Participant as the main ViewTypes by
+     * Jan 2022
+     */
     if (viewType === 'Instructor') {
       viewType = 'Teacher';
       updateQueryParam('viewAs', 'Teacher');

--- a/apps/src/code-studio/viewAsRedux.js
+++ b/apps/src/code-studio/viewAsRedux.js
@@ -24,7 +24,7 @@ export default function reducer(state = ViewType.Student, action) {
       throw new Error('unknown ViewType: ' + viewType);
     }
 
-    return action.viewType;
+    return viewType;
   }
 
   return state;

--- a/apps/src/code-studio/viewAsRedux.js
+++ b/apps/src/code-studio/viewAsRedux.js
@@ -13,8 +13,14 @@ export const SET_VIEW_TYPE = 'viewAs/SET_VIEW_TYPE';
 
 export default function reducer(state = ViewType.Student, action) {
   if (action.type === SET_VIEW_TYPE) {
-    const viewType = action.viewType;
-    if (!ViewType[viewType]) {
+    let viewType = action.viewType;
+    if (viewType === 'Instructor') {
+      viewType = 'Teacher';
+      updateQueryParam('viewAs', 'Teacher');
+    } else if (viewType === 'Participant') {
+      viewType = 'Student';
+      updateQueryParam('viewAs', 'Student');
+    } else if (!ViewType[viewType]) {
       throw new Error('unknown ViewType: ' + viewType);
     }
 

--- a/apps/test/unit/code-studio/viewAsReduxTest.js
+++ b/apps/test/unit/code-studio/viewAsReduxTest.js
@@ -80,7 +80,6 @@ describe('viewAs redux', () => {
     after(() => {
       appsUtils.reload.restore();
       codeStudioUtils.queryParams.restore();
-      codeStudioUtils.updateQueryParam.restore();
     });
 
     it('changes the window location when changing to Student with user_id', () => {

--- a/apps/test/unit/code-studio/viewAsReduxTest.js
+++ b/apps/test/unit/code-studio/viewAsReduxTest.js
@@ -1,5 +1,5 @@
 import {assert} from 'chai';
-import {stub} from 'sinon';
+import sinon, {stub} from 'sinon';
 import reducer, {
   ViewType,
   changeViewType
@@ -12,6 +12,7 @@ import {
 } from '@cdo/apps/redux';
 import * as appsUtils from '@cdo/apps/utils';
 import * as codeStudioUtils from '@cdo/apps/code-studio/utils';
+import {expect} from '../../util/reconfiguredChai';
 
 describe('viewAs redux', () => {
   // Create a store so that we get the benefits of our thunk middleware
@@ -20,9 +21,12 @@ describe('viewAs redux', () => {
     stubRedux();
     registerReducers({viewAs: reducer});
     store = getStore();
+
+    sinon.stub(codeStudioUtils, 'updateQueryParam');
   });
 
   afterEach(() => {
+    codeStudioUtils.updateQueryParam.restore();
     restoreRedux();
   });
 
@@ -33,11 +37,31 @@ describe('viewAs redux', () => {
     assert.equal(nextState.viewAs, ViewType.Teacher);
   });
 
+  it('setting instructor redirects to teacher', () => {
+    const action = changeViewType('Instructor');
+    store.dispatch(action);
+    const nextState = store.getState();
+    assert.equal(nextState.viewAs, ViewType.Teacher);
+    expect(
+      codeStudioUtils.updateQueryParam
+    ).to.have.been.calledOnce.and.calledWith('viewAs', 'Teacher');
+  });
+
   it('can set as student', () => {
     const action = changeViewType(ViewType.Student);
     store.dispatch(action);
     const nextState = store.getState();
     assert.equal(nextState.viewAs, ViewType.Student);
+  });
+
+  it('setting participant redirects to student', () => {
+    const action = changeViewType('Participant');
+    store.dispatch(action);
+    const nextState = store.getState();
+    assert.equal(nextState.viewAs, ViewType.Student);
+    expect(
+      codeStudioUtils.updateQueryParam
+    ).to.have.been.calledOnce.and.calledWith('viewAs', 'Student');
   });
 
   it('does not allow for invalid view types', () => {
@@ -51,7 +75,6 @@ describe('viewAs redux', () => {
     before(() => {
       stub(appsUtils, 'reload');
       stub(codeStudioUtils, 'queryParams').callsFake(() => 'fake_user_id');
-      stub(codeStudioUtils, 'updateQueryParam');
     });
 
     after(() => {


### PR DESCRIPTION
A first step toward updating viewAsRedux to use participant and instructor instead of teacher and student. This PR will make it so you can use `viewAs=Instructor` and `viewAs=Participant` and they will redirect to Teacher and Student views. This should make it safer to merge https://github.com/code-dot-org/code-dot-org/pull/43432

## Links

- [Eng Plan](https://docs.google.com/document/d/1V61xONU0-mleMEEdHWNxhvZtYIPRCB31mT_hbUXusCQ/edit#heading=h.fk6t1p96qqdl)
- [Product Spec](https://docs.google.com/document/d/1qZpc90daxQiiqpcQUiUiGV2tQoaYEQUzOA72UZzBlVE/edit#heading=h.qv29hwce61yz)
- [Jira](https://codedotorg.atlassian.net/browse/PLAT-1343)

## Testing story

- Added new Unit tests