### PR TITLE
Update places to use ViewType that should

### DIFF
--- a/apps/src/code-studio/components/progress/Announcements.jsx
+++ b/apps/src/code-studio/components/progress/Announcements.jsx
@@ -31,10 +31,10 @@ export default class Announcements extends Component {
 
   isVisible = (currentView, element) =>
     element.visibility === VisibilityType.teacherAndStudent ||
-    (currentView === 'Teacher' &&
+    (currentView === ViewType.Teacher &&
       (element.visibility === VisibilityType.teacher ||
         element.visibility === undefined)) ||
-    (currentView === 'Student' &&
+    (currentView === ViewType.Student &&
       element.visibility === VisibilityType.student);
 
   render() {

--- a/apps/src/lib/levelbuilder/announcementsEditor/AnnouncementsEditor.jsx
+++ b/apps/src/lib/levelbuilder/announcementsEditor/AnnouncementsEditor.jsx
@@ -8,6 +8,7 @@ import Announcements from '@cdo/apps/code-studio/components/progress/Announcemen
 import {NotificationType} from '@cdo/apps/templates/Notification';
 import HelpTip from '@cdo/apps/lib/ui/HelpTip';
 import Announcement from '@cdo/apps/lib/levelbuilder/announcementsEditor/Announcement';
+import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 
 export default class AnnouncementsEditor extends Component {
   static propTypes = {
@@ -77,11 +78,17 @@ export default class AnnouncementsEditor extends Component {
           <div>
             <div style={styles.preview}>
               <div>Teacher Preview:</div>
-              <Announcements announcements={announcements} viewAs={'Teacher'} />
+              <Announcements
+                announcements={announcements}
+                viewAs={ViewType.Teacher}
+              />
             </div>
             <div style={styles.preview}>
               <div>Student Preview:</div>
-              <Announcements announcements={announcements} viewAs={'Student'} />
+              <Announcements
+                announcements={announcements}
+                viewAs={ViewType.Student}
+              />
             </div>
           </div>
         )}

--- a/apps/src/templates/instructions/teacherFeedback/FeedbackStatus.jsx
+++ b/apps/src/templates/instructions/teacherFeedback/FeedbackStatus.jsx
@@ -8,7 +8,7 @@ import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 
 class FeedbackStatus extends Component {
   static propTypes = {
-    viewAs: PropTypes.oneOf(['Teacher', 'Student']).isRequired,
+    viewAs: PropTypes.oneOf(Object.values(ViewType)).isRequired,
     latestFeedback: PropTypes.object.isRequired
   };
 

--- a/apps/src/templates/instructions/teacherFeedback/Rubric.jsx
+++ b/apps/src/templates/instructions/teacherFeedback/Rubric.jsx
@@ -19,7 +19,7 @@ class TeacherFeedbackRubric extends Component {
     performance: PropTypes.string,
     isEditable: PropTypes.bool,
     onRubricChange: PropTypes.func.isRequired,
-    viewAs: PropTypes.oneOf(['Teacher', 'Student']).isRequired
+    viewAs: PropTypes.oneOf(Object.values(ViewType)).isRequired
   };
 
   render() {

--- a/apps/src/templates/instructions/teacherFeedback/TeacherFeedback.jsx
+++ b/apps/src/templates/instructions/teacherFeedback/TeacherFeedback.jsx
@@ -38,7 +38,7 @@ export class TeacherFeedback extends Component {
     latestFeedback: teacherFeedbackShape,
     token: PropTypes.string,
     //Provided by Redux
-    viewAs: PropTypes.oneOf(['Teacher', 'Student']).isRequired,
+    viewAs: PropTypes.oneOf(Object.values(ViewType)).isRequired,
     verifiedTeacher: PropTypes.bool,
     selectedSectionId: PropTypes.string,
     updateUserProgress: PropTypes.func.isRequired,

--- a/apps/test/unit/code-studio/TeacherContentToggleTest.js
+++ b/apps/test/unit/code-studio/TeacherContentToggleTest.js
@@ -38,7 +38,7 @@ describe('TeacherContentToggle', () => {
     const component = mount(
       <TeacherContentToggle
         isBlocklyOrDroplet={true}
-        viewAs="Teacher"
+        viewAs={ViewType.Teacher}
         hiddenLessonsInitialized={false}
         sectionsAreLoaded={false}
         isHiddenLesson={false}
@@ -78,7 +78,7 @@ describe('TeacherContentToggle', () => {
     const component = mount(
       <TeacherContentToggle
         isBlocklyOrDroplet={true}
-        viewAs="Teacher"
+        viewAs={ViewType.Teacher}
         hiddenLessonsInitialized={false}
         sectionsAreLoaded={false}
         isHiddenLesson={false}
@@ -104,7 +104,7 @@ describe('TeacherContentToggle', () => {
     const component = mount(
       <TeacherContentToggle
         isBlocklyOrDroplet={false}
-        viewAs="Teacher"
+        viewAs={ViewType.Teacher}
         hiddenLessonsInitialized={true}
         sectionsAreLoaded={true}
         isHiddenLesson={false}
@@ -130,7 +130,7 @@ describe('TeacherContentToggle', () => {
     const component = mount(
       <TeacherContentToggle
         isBlocklyOrDroplet={false}
-        viewAs="Teacher"
+        viewAs={ViewType.Teacher}
         hiddenLessonsInitialized={true}
         sectionsAreLoaded={true}
         isHiddenLesson={false}
@@ -156,7 +156,7 @@ describe('TeacherContentToggle', () => {
     const component = mount(
       <TeacherContentToggle
         isBlocklyOrDroplet={true}
-        viewAs="Student"
+        viewAs={ViewType.Student}
         hiddenLessonsInitialized={false}
         sectionsAreLoaded={false}
         isHiddenLesson={false}
@@ -183,7 +183,7 @@ describe('TeacherContentToggle', () => {
     const component = mount(
       <TeacherContentToggle
         isBlocklyOrDroplet={true}
-        viewAs="Student"
+        viewAs={ViewType.Student}
         hiddenLessonsInitialized={false}
         sectionsAreLoaded={false}
         isHiddenLesson={false}
@@ -230,7 +230,7 @@ describe('TeacherContentToggle', () => {
     const component = mount(
       <TeacherContentToggle
         isBlocklyOrDroplet={true}
-        viewAs="Student"
+        viewAs={ViewType.Student}
         hiddenLessonsInitialized={false}
         sectionsAreLoaded={false}
         isHiddenLesson={false}
@@ -277,7 +277,7 @@ describe('TeacherContentToggle', () => {
     const component = mount(
       <TeacherContentToggle
         isBlocklyOrDroplet={true}
-        viewAs="Student"
+        viewAs={ViewType.Student}
         hiddenLessonsInitialized={false}
         sectionsAreLoaded={false}
         isHiddenLesson={false}
@@ -315,7 +315,7 @@ describe('TeacherContentToggle', () => {
     const component = mount(
       <TeacherContentToggle
         isBlocklyOrDroplet={true}
-        viewAs="Student"
+        viewAs={ViewType.Student}
         hiddenLessonsInitialized={false}
         sectionsAreLoaded={false}
         isHiddenLesson={false}

--- a/apps/test/unit/code-studio/progressTest.js
+++ b/apps/test/unit/code-studio/progressTest.js
@@ -58,32 +58,32 @@ describe('initViewAs', function() {
 
   it('defaults to Student', function() {
     initViewAs(mockStore, {});
-    assert(mockSetViewType.calledWith('Student'));
+    assert(mockSetViewType.calledWith(viewAsRedux.ViewType.Student));
   });
 
   it('defaults to Teacher iff current user is a teacher', function() {
     initViewAs(mockStore, {user_type: 'teacher'});
-    assert(mockSetViewType.calledWith('Teacher'));
+    assert(mockSetViewType.calledWith(viewAsRedux.ViewType.Teacher));
   });
 
   it('prevents overriding default if current user is a student', function() {
-    mockQueryStringParse.returns({viewAs: 'Teacher'});
+    mockQueryStringParse.returns({viewAs: viewAsRedux.ViewType.Teacher});
     initViewAs(mockStore, {user_type: 'student'});
-    assert(mockSetViewType.calledWith('Student'));
+    assert(mockSetViewType.calledWith(viewAsRedux.ViewType.Student));
   });
 
   it('allows overriding default if current user is not a student', function() {
-    mockQueryStringParse.returns({viewAs: 'Teacher'});
+    mockQueryStringParse.returns({viewAs: viewAsRedux.ViewType.Teacher});
 
     initViewAs(mockStore, {});
-    assert(mockSetViewType.calledWith('Teacher'));
+    assert(mockSetViewType.calledWith(viewAsRedux.ViewType.Teacher));
 
     initViewAs(mockStore, {user_type: 'teacher'});
-    assert(mockSetViewType.calledWith('Teacher'));
+    assert(mockSetViewType.calledWith(viewAsRedux.ViewType.Teacher));
 
-    mockQueryStringParse.returns({viewAs: 'Student'});
+    mockQueryStringParse.returns({viewAs: viewAsRedux.ViewType.Student});
 
     initViewAs(mockStore, {user_type: 'teacher'});
-    assert(mockSetViewType.calledWith('Student'));
+    assert(mockSetViewType.calledWith(viewAsRedux.ViewType.Student));
   });
 });

--- a/apps/test/unit/templates/instructions/TopInstructionsTest.jsx
+++ b/apps/test/unit/templates/instructions/TopInstructionsTest.jsx
@@ -6,6 +6,7 @@ import {
   TabType
 } from '@cdo/apps/templates/instructions/TopInstructions';
 import TopInstructionsHeader from '@cdo/apps/templates/instructions/TopInstructionsHeader';
+import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 
 const DEFAULT_PROPS = {
   isEmbedView: false,
@@ -20,7 +21,7 @@ const DEFAULT_PROPS = {
   setInstructionsHeight: () => {},
   setInstructionsRenderedHeight: () => {},
   setInstructionsMaxHeightNeeded: () => {},
-  viewAs: 'Teacher',
+  viewAs: ViewType.Teacher,
   readOnlyWorkspace: false,
   serverLevelId: 123,
   user: 5,
@@ -177,7 +178,7 @@ describe('TopInstructions', () => {
     describe('as a student', () => {
       it('passes displayFeedback = true to TopInstructionsHeader on a level where the teacher has given feedback', () => {
         const wrapper = shallow(
-          <TopInstructions {...DEFAULT_PROPS} viewAs={'Student'} />
+          <TopInstructions {...DEFAULT_PROPS} viewAs={ViewType.Student} />
         );
 
         wrapper.setState({
@@ -211,7 +212,7 @@ describe('TopInstructions', () => {
 
       it('passes displayFeedback = false to TopInstructionsHeader on a level where the teacher has not given feedback and there is no rubric', () => {
         const wrapper = shallow(
-          <TopInstructions {...DEFAULT_PROPS} viewAs={'Student'} />
+          <TopInstructions {...DEFAULT_PROPS} viewAs={ViewType.Student} />
         );
 
         wrapper.setState({

--- a/apps/test/unit/templates/instructions/teacherFeedback/TeacherFeedbackTest.jsx
+++ b/apps/test/unit/templates/instructions/teacherFeedback/TeacherFeedbackTest.jsx
@@ -19,7 +19,7 @@ const DEFAULT_PROPS = {
   serverLevelId: 123,
   teacher: 5,
   latestFeedback: null,
-  viewAs: 'Teacher',
+  viewAs: ViewType.Teacher,
   verifiedTeacher: true,
   selectedSectionId: '789',
   canHaveFeedbackReviewState: true,
@@ -106,7 +106,7 @@ describe('TeacherFeedback', () => {
         const wrapper = setUp({latestFeedback});
         const statusComponent = wrapper.find(FeedbackStatus);
         expect(statusComponent).to.have.length(1);
-        expect(statusComponent.props().viewAs).to.equal('Teacher');
+        expect(statusComponent.props().viewAs).to.equal(ViewType.Teacher);
         expect(statusComponent.props().latestFeedback).to.equal(latestFeedback);
       });
 
@@ -201,7 +201,7 @@ describe('TeacherFeedback', () => {
 
   describe('viewed as a Student', () => {
     const STUDENT_PROPS = {
-      viewAs: 'Student',
+      viewAs: ViewType.Student,
       isEditable: false
     };
     describe('without previous feedback given', () => {
@@ -264,7 +264,7 @@ describe('TeacherFeedback', () => {
 
         const statusComponent = wrapper.find(FeedbackStatus);
         expect(statusComponent).to.have.length(1);
-        expect(statusComponent.props().viewAs).to.equal('Student');
+        expect(statusComponent.props().viewAs).to.equal(ViewType.Student);
         expect(statusComponent.props().latestFeedback).to.equal(latestFeedback);
       });
 


### PR DESCRIPTION
Changes places where we had hard coded 'Teacher' or 'Student' but meant `ViewType.Teacher` or `ViewType.Student`. This will make it easier to make the changes in https://github.com/code-dot-org/code-dot-org/pull/43432 which will move from Teacher and Student to Instructor and Participant for viewAs

## Links

- [Eng Plan](https://docs.google.com/document/d/1V61xONU0-mleMEEdHWNxhvZtYIPRCB31mT_hbUXusCQ/edit#heading=h.fk6t1p96qqdl)
- [Product Spec](https://docs.google.com/document/d/1qZpc90daxQiiqpcQUiUiGV2tQoaYEQUzOA72UZzBlVE/edit#heading=h.qv29hwce61yz)
- [Jira](https://codedotorg.atlassian.net/browse/PLAT-1343)

## Testing story

- Existing tests