### PR TITLE
Code Review Groups: add new code review access control behind DCDO flag

### DIFF
--- a/dashboard/app/controllers/reviewable_projects_controller.rb
+++ b/dashboard/app/controllers/reviewable_projects_controller.rb
@@ -62,12 +62,22 @@ class ReviewableProjectsController < ApplicationController
   end
 
   def for_level
-    peer_user_ids = current_user.
-      sections_as_student.
-      map(&:followers).
-      flatten.
-      pluck(:student_user_id).
-      select {|student_user_id| current_user.id != student_user_id}
+    peer_user_ids = if DCDO.get('code_review_groups_enabled', false)
+                      current_user.
+                        code_review_groups.
+                        map(&:members).
+                        flatten.
+                        map(&:follower).
+                        pluck(:student_user_id).
+                        select {|student_user_id| current_user.id != student_user_id}
+                    else
+                      current_user.
+                        sections_as_student.
+                        map(&:followers).
+                        flatten.
+                        pluck(:student_user_id).
+                        select {|student_user_id| current_user.id != student_user_id}
+                    end
 
     peers_ready_for_review = ReviewableProject.where(
       user_id: peer_user_ids,

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -514,6 +514,9 @@ class ScriptLevelsController < ApplicationController
       )
     end
 
+    # Figure out what is going on here.
+    # Vague recollection this doesn't actually get used.
+    # But, if it does, we don't want to check that all sections that a student is enrolled in has code review enabled.
     @code_review_enabled = @level.is_a?(Javalab) &&
       current_user.present? &&
       (current_user.teacher? || current_user&.sections_as_student&.all?(&:code_review_enabled?))

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -515,7 +515,7 @@ class ScriptLevelsController < ApplicationController
     end
 
     # To do: rename this variable, as it gets passed into redux as sectionData.section.codeReviewEnabled,
-    # which is confusing there is a section-level method (used below, code_review_enabled?)
+    # which is confusing as there is a section-level method (used below, code_review_enabled?)
     # that is different from what is returned here.
     @code_review_enabled = if DCDO.get('code_review_groups_enabled', false)
                              @level.is_a?(Javalab) &&

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -514,12 +514,18 @@ class ScriptLevelsController < ApplicationController
       )
     end
 
-    # Figure out what is going on here.
-    # Vague recollection this doesn't actually get used.
-    # But, if it does, we don't want to check that all sections that a student is enrolled in has code review enabled.
-    @code_review_enabled = @level.is_a?(Javalab) &&
-      current_user.present? &&
-      (current_user.teacher? || current_user&.sections_as_student&.all?(&:code_review_enabled?))
+    # To do: rename this variable, as it gets passed into redux as sectionData.section.codeReviewEnabled,
+    # which is confusing there is a section-level method (used below, code_review_enabled?)
+    # that is different from what is returned here.
+    @code_review_enabled = if DCDO.get('code_review_groups_enabled', false)
+                             @level.is_a?(Javalab) &&
+                               current_user.present? &&
+                               (current_user.teacher? || (current_user&.sections_as_student&.any?(&:code_review_enabled?) && !current_user.code_review_groups.empty?))
+                           else
+                             @level.is_a?(Javalab) &&
+                               current_user.present? &&
+                               (current_user.teacher? || current_user&.sections_as_student&.all?(&:code_review_enabled?))
+                           end
 
     view_options(
       full_width: true,

--- a/dashboard/app/models/code_review_comment.rb
+++ b/dashboard/app/models/code_review_comment.rb
@@ -39,6 +39,7 @@ class CodeReviewComment < ApplicationRecord
     return true if project_owner.student_of?(potential_reviewer)
     # peers can only review projects where code review has been enabled, which creates a ReviewableProject
     return false unless ReviewableProject.project_reviewable?(storage_app_id, project_owner.id, level_id, script_id)
+    # Need to update this
     return false if project_owner.sections_as_student.any? {|s| !s.code_review_enabled?}
     return false if potential_reviewer.sections_as_student.any? {|s| !s.code_review_enabled?}
 

--- a/dashboard/app/models/code_review_comment.rb
+++ b/dashboard/app/models/code_review_comment.rb
@@ -41,6 +41,8 @@ class CodeReviewComment < ApplicationRecord
     return false unless ReviewableProject.project_reviewable?(storage_app_id, project_owner.id, level_id, script_id)
     return false if project_owner.sections_as_student.any? {|s| !s.code_review_enabled?}
     return false if potential_reviewer.sections_as_student.any? {|s| !s.code_review_enabled?}
+
+    return (project_owner.code_review_groups & potential_reviewer.code_review_groups).any? if DCDO.get('code_review_groups_enabled', false)
     return (project_owner.sections_as_student & potential_reviewer.sections_as_student).any?
   end
 

--- a/dashboard/app/models/code_review_comment.rb
+++ b/dashboard/app/models/code_review_comment.rb
@@ -39,12 +39,19 @@ class CodeReviewComment < ApplicationRecord
     return true if project_owner.student_of?(potential_reviewer)
     # peers can only review projects where code review has been enabled, which creates a ReviewableProject
     return false unless ReviewableProject.project_reviewable?(storage_app_id, project_owner.id, level_id, script_id)
-    # Need to update this
-    return false if project_owner.sections_as_student.any? {|s| !s.code_review_enabled?}
-    return false if potential_reviewer.sections_as_student.any? {|s| !s.code_review_enabled?}
 
-    return (project_owner.code_review_groups & potential_reviewer.code_review_groups).any? if DCDO.get('code_review_groups_enabled', false)
-    return (project_owner.sections_as_student & potential_reviewer.sections_as_student).any?
+    if DCDO.get('code_review_groups_enabled', false)
+      return false if (project_owner.sections_as_student & potential_reviewer.sections_as_student).all? {|s| !s.code_review_enabled?}
+    else
+      return false if project_owner.sections_as_student.any? {|s| !s.code_review_enabled?}
+      return false if potential_reviewer.sections_as_student.any? {|s| !s.code_review_enabled?}
+    end
+
+    if DCDO.get('code_review_groups_enabled', false)
+      return (project_owner.code_review_groups & potential_reviewer.code_review_groups).any?
+    else
+      return (project_owner.sections_as_student & potential_reviewer.sections_as_student).any?
+    end
   end
 
   def compute_is_from_teacher

--- a/dashboard/app/models/code_review_group.rb
+++ b/dashboard/app/models/code_review_group.rb
@@ -15,4 +15,5 @@
 class CodeReviewGroup < ApplicationRecord
   # use dependent: :delete_all here because code_review_group_members is a join table and has no id column.
   has_many :members, class_name: 'CodeReviewGroupMember', dependent: :delete_all
+  belongs_to :section
 end

--- a/dashboard/app/models/follower.rb
+++ b/dashboard/app/models/follower.rb
@@ -24,6 +24,7 @@ class Follower < ApplicationRecord
   has_one :user, through: :section
   belongs_to :student_user, foreign_key: "student_user_id", class_name: 'User'
   has_one :code_review_group_member, dependent: :delete
+  has_one :code_review_group, through: :code_review_group_member
 
   accepts_nested_attributes_for :student_user
 

--- a/dashboard/app/models/reviewable_project.rb
+++ b/dashboard/app/models/reviewable_project.rb
@@ -19,6 +19,7 @@ class ReviewableProject < ApplicationRecord
   belongs_to :level
   belongs_to :script
 
+  # Need to update this
   def self.user_can_mark_project_reviewable?(project_owner, user)
     project_owner == user && project_owner.sections_as_student.all?(&:code_review_enabled?)
   end

--- a/dashboard/app/models/reviewable_project.rb
+++ b/dashboard/app/models/reviewable_project.rb
@@ -19,9 +19,14 @@ class ReviewableProject < ApplicationRecord
   belongs_to :level
   belongs_to :script
 
-  # Need to update this
   def self.user_can_mark_project_reviewable?(project_owner, user)
-    project_owner == user && project_owner.sections_as_student.all?(&:code_review_enabled?)
+    if DCDO.get('code_review_groups_enabled', false)
+      return project_owner == user &&
+        project_owner.sections_as_student.any?(&:code_review_enabled?) &&
+        !project_owner.code_review_groups.empty?
+    else
+      return project_owner == user && project_owner.sections_as_student.all?(&:code_review_enabled?)
+    end
   end
 
   def self.project_reviewable?(storage_app_id, user_id, level_id, script_id)

--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -404,7 +404,12 @@ class Section < ApplicationRecord
   end
 
   def code_review_enabled?
-    code_review_enabled.nil? ? true : code_review_enabled
+    if DCDO.get('code_review_groups_enabled', false)
+      return false if code_review_expires_at.nil?
+      return code_review_expires_at > Time.now.utc
+    else
+      return code_review_enabled.nil? ? true : code_review_enabled
+    end
   end
 
   # A section can be assigned a course (aka unit_group) without being assigned a script,
@@ -429,7 +434,7 @@ class Section < ApplicationRecord
   end
 
   def update_code_review_expiration(enable_code_review)
-    self.code_review_expires_at = enable_code_review ? DateTime.now + 90.days : nil
+    self.code_review_expires_at = enable_code_review ? Time.now.utc + 90.days : nil
   end
 
   private

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -2380,6 +2380,10 @@ class User < ApplicationRecord
     %w(locale account_age_in_years grades curriculums has_attended_pd within_us school_percent_frl school_title_i)
   end
 
+  def code_review_groups
+    followeds.map(&:code_review_group).compact
+  end
+
   private
 
   def account_age_in_years

--- a/dashboard/test/controllers/api/v1/sections_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/sections_controller_test.rb
@@ -1161,11 +1161,11 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
     end
 
     # Create 2 code review groups
-    @group1 = CodeReviewGroup.create(section_id: @code_review_group_section.id, name: "group1")
-    @group2 = CodeReviewGroup.create(section_id: @code_review_group_section.id, name: "group2")
+    @group1 = create :code_review_group, section: @code_review_group_section
+    @group2 = create :code_review_group, section: @code_review_group_section
     # put student 0 and 1 in group 1, and student 2 in group 2
-    CodeReviewGroupMember.create(follower_id: @followers[0].id, code_review_group_id: @group1.id)
-    CodeReviewGroupMember.create(follower_id: @followers[1].id, code_review_group_id: @group1.id)
-    CodeReviewGroupMember.create(follower_id: @followers[2].id, code_review_group_id: @group2.id)
+    create :code_review_group_member, follower: @followers[0], code_review_group: @group1
+    create :code_review_group_member, follower: @followers[1], code_review_group: @group1
+    create :code_review_group_member, follower: @followers[2], code_review_group: @group2
   end
 end

--- a/dashboard/test/controllers/reviewable_projects_controller_test.rb
+++ b/dashboard/test/controllers/reviewable_projects_controller_test.rb
@@ -12,11 +12,12 @@ class ReviewableProjectsControllerTest < ActionController::TestCase
     @project_storage_app_id = 78
 
     @teacher = create :teacher
-    @section = create :section, user: @teacher, code_review_enabled: true
+
+    @section = create :section, user: @teacher, code_review_expires_at: Time.now.utc + 1.day
     @another_student = create :student
 
-    create :follower, student_user: @project_owner, section: @section
-    create :follower, student_user: @another_student, section: @section
+    @project_owner_follower = create :follower, student_user: @project_owner, section: @section
+    @another_student_follower = create :follower, student_user: @another_student, section: @section
   end
 
   test 'signed out cannot create ReviewableProject' do
@@ -182,7 +183,12 @@ class ReviewableProjectsControllerTest < ActionController::TestCase
     end
   end
 
-  test 'student in same section project available for review gets project metadata' do
+  test 'student in section with project available for review gets list of peers' do
+    # This is default behavior so stub is unnecessary, but adding this
+    # so when can search for the DCDO string to clean up
+    # we remember to delete this test at that time.
+    DCDO.stubs(:get).with('code_review_groups_enabled', false).returns(false)
+
     create :reviewable_project,
       user_id: @project_owner.id,
       level_id: @project_level_id,
@@ -195,6 +201,11 @@ class ReviewableProjectsControllerTest < ActionController::TestCase
   end
 
   test 'student does not get projects available for review if project available but not in same section' do
+    # This is default behavior so stub is unnecessary, but adding this
+    # so when can search for the DCDO string to clean up
+    # we remember to delete this test at that time.
+    DCDO.stubs(:get).with('code_review_groups_enabled', false).returns(false)
+
     student = create :student
 
     create :reviewable_project,
@@ -203,6 +214,58 @@ class ReviewableProjectsControllerTest < ActionController::TestCase
       script_id: @project_script_id
 
     sign_in student
+    get :for_level, params: {level_id: @project_level_id, script_id: @project_script_id}
+
+    assert_equal [], JSON.parse(response.body)
+  end
+
+  test 'student in code review group with project available for review gets list of peers' do
+    DCDO.stubs(:get).with('code_review_groups_enabled', false).returns(true)
+
+    code_review_group = CodeReviewGroup.create!(name: 'test', section: @section)
+    CodeReviewGroupMember.create!(follower: @another_student_follower, code_review_group: code_review_group)
+    CodeReviewGroupMember.create!(follower: @project_owner_follower, code_review_group: code_review_group)
+
+    create :reviewable_project,
+      user_id: @project_owner.id,
+      level_id: @project_level_id,
+      script_id: @project_script_id
+
+    sign_in @another_student
+    get :for_level, params: {level_id: @project_level_id, script_id: @project_script_id}
+
+    assert_equal [{'id' => @project_owner.id, 'name' => @project_owner.name}], JSON.parse(response.body)
+  end
+
+  test 'student in code review group with only own project available for review gets empty list of peers' do
+    DCDO.stubs(:get).with('code_review_groups_enabled', false).returns(true)
+
+    code_review_group = CodeReviewGroup.create!(name: 'test', section: @section)
+    CodeReviewGroupMember.create!(follower: @project_owner_follower, code_review_group: code_review_group)
+
+    create :reviewable_project,
+      user_id: @project_owner.id,
+      level_id: @project_level_id,
+      script_id: @project_script_id
+
+    sign_in @project_owner
+    get :for_level, params: {level_id: @project_level_id, script_id: @project_script_id}
+
+    assert_equal [], JSON.parse(response.body)
+  end
+
+  test 'student not in code review group gets empty list of peers' do
+    DCDO.stubs(:get).with('code_review_groups_enabled', false).returns(true)
+
+    code_review_group = CodeReviewGroup.create!(name: 'test', section: @section)
+    CodeReviewGroupMember.create!(follower: @project_owner_follower, code_review_group: code_review_group)
+
+    create :reviewable_project,
+      user_id: @project_owner.id,
+      level_id: @project_level_id,
+      script_id: @project_script_id
+
+    sign_in @another_student
     get :for_level, params: {level_id: @project_level_id, script_id: @project_script_id}
 
     assert_equal [], JSON.parse(response.body)

--- a/dashboard/test/controllers/reviewable_projects_controller_test.rb
+++ b/dashboard/test/controllers/reviewable_projects_controller_test.rb
@@ -222,9 +222,9 @@ class ReviewableProjectsControllerTest < ActionController::TestCase
   test 'student in code review group with project available for review gets list of peers' do
     DCDO.stubs(:get).with('code_review_groups_enabled', false).returns(true)
 
-    code_review_group = CodeReviewGroup.create!(name: 'test', section: @section)
-    CodeReviewGroupMember.create!(follower: @another_student_follower, code_review_group: code_review_group)
-    CodeReviewGroupMember.create!(follower: @project_owner_follower, code_review_group: code_review_group)
+    code_review_group = create :code_review_group, section: @section
+    create :code_review_group_member, follower: @another_student_follower, code_review_group: code_review_group
+    create :code_review_group_member, follower:  @project_owner_follower, code_review_group: code_review_group
 
     create :reviewable_project,
       user_id: @project_owner.id,
@@ -240,8 +240,8 @@ class ReviewableProjectsControllerTest < ActionController::TestCase
   test 'student in code review group with only own project available for review gets empty list of peers' do
     DCDO.stubs(:get).with('code_review_groups_enabled', false).returns(true)
 
-    code_review_group = CodeReviewGroup.create!(name: 'test', section: @section)
-    CodeReviewGroupMember.create!(follower: @project_owner_follower, code_review_group: code_review_group)
+    code_review_group = create :code_review_group, section: @section
+    create :code_review_group_member, follower: @project_owner_follower, code_review_group: code_review_group
 
     create :reviewable_project,
       user_id: @project_owner.id,
@@ -256,9 +256,6 @@ class ReviewableProjectsControllerTest < ActionController::TestCase
 
   test 'student not in code review group gets empty list of peers' do
     DCDO.stubs(:get).with('code_review_groups_enabled', false).returns(true)
-
-    code_review_group = CodeReviewGroup.create!(name: 'test', section: @section)
-    CodeReviewGroupMember.create!(follower: @project_owner_follower, code_review_group: code_review_group)
 
     create :reviewable_project,
       user_id: @project_owner.id,

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -1466,6 +1466,16 @@ FactoryGirl.define do
     comment 'a comment about your project'
   end
 
+  factory :code_review_group do
+    sequence(:name) {|n| "group_name_#{n}"}
+    association :section
+  end
+
+  factory :code_review_group_member do
+    association :follower
+    association :code_review_group
+  end
+
   factory :reviewable_project do
     sequence(:storage_app_id)
     association :user, factory: :student

--- a/dashboard/test/models/code_review_comment_test.rb
+++ b/dashboard/test/models/code_review_comment_test.rb
@@ -120,9 +120,10 @@ class CodeReviewCommentTest < ActiveSupport::TestCase
       storage_app_id: @project_storage_app_id,
       level_id: @project_level_id,
       script_id: @project_script_id
-    code_review_group = CodeReviewGroup.create!(name: 'test', section: section)
-    CodeReviewGroupMember.create!(follower: project_owner_follower, code_review_group: code_review_group)
-    CodeReviewGroupMember.create!(follower: reviewer_follower, code_review_group: code_review_group)
+
+    code_review_group = create :code_review_group, section: section
+    create :code_review_group_member, follower: project_owner_follower, code_review_group: code_review_group
+    create :code_review_group_member, follower: reviewer_follower, code_review_group: code_review_group
 
     assert CodeReviewComment.user_can_review_project?(project_owner, reviewer, @project_storage_app_id, @project_level_id, @project_script_id)
   end
@@ -168,9 +169,9 @@ class CodeReviewCommentTest < ActiveSupport::TestCase
       storage_app_id: @project_storage_app_id,
       level_id: @project_level_id,
       script_id: @project_script_id
-    code_review_group = CodeReviewGroup.create!(name: 'test', section: section)
-    CodeReviewGroupMember.create!(follower: project_owner_follower, code_review_group: code_review_group)
-    CodeReviewGroupMember.create!(follower: reviewer_follower, code_review_group: code_review_group)
+    code_review_group = create :code_review_group, section: section
+    create :code_review_group_member, follower: project_owner_follower, code_review_group: code_review_group
+    create :code_review_group_member, follower: reviewer_follower, code_review_group: code_review_group
 
     refute CodeReviewComment.user_can_review_project?(project_owner, reviewer, @project_storage_app_id, @project_level_id, @project_script_id)
   end
@@ -209,10 +210,11 @@ class CodeReviewCommentTest < ActiveSupport::TestCase
       storage_app_id: @project_storage_app_id,
       level_id: @project_level_id,
       script_id: @project_script_id
-    reviewer_code_review_group = CodeReviewGroup.create!(name: 'reviewer group', section: reviewer_section)
-    project_owner_code_review_group = CodeReviewGroup.create!(name: 'project owner group', section: section)
-    CodeReviewGroupMember.create!(follower: project_owner_follower, code_review_group: project_owner_code_review_group)
-    CodeReviewGroupMember.create!(follower: reviewer_follower, code_review_group: reviewer_code_review_group)
+
+    reviewer_code_review_group = create :code_review_group, section: reviewer_section
+    project_owner_code_review_group = create :code_review_group, section: section
+    create :code_review_group_member, follower: project_owner_follower, code_review_group: project_owner_code_review_group
+    create :code_review_group_member, follower: reviewer_follower, code_review_group: reviewer_code_review_group
 
     refute CodeReviewComment.user_can_review_project?(project_owner, reviewer, @project_storage_app_id, @project_level_id, @project_script_id)
   end

--- a/dashboard/test/models/code_review_comment_test.rb
+++ b/dashboard/test/models/code_review_comment_test.rb
@@ -35,12 +35,17 @@ class CodeReviewCommentTest < ActiveSupport::TestCase
   test 'teacher can review own students project' do
     project_owner = create :student
     teacher = create :teacher
-    section = create :section, code_review_enabled: true, teacher: teacher
+    section = create :section, code_review_enabled: Time.now.utc + 1.day, teacher: teacher
     create :follower, section: section, student_user: project_owner
     assert CodeReviewComment.user_can_review_project?(project_owner, teacher, nil)
   end
 
   test 'teacher can review own students project when code_review_enabled is false' do
+    # This is default behavior so stub is unnecessary, but adding this
+    # so when can search for the DCDO string to clean up
+    # we remember to delete this test at that time.
+    DCDO.stubs(:get).with('code_review_groups_enabled', false).returns(false)
+
     project_owner = create :student
     teacher = create :teacher
     section = create :section, code_review_enabled: false, teacher: teacher
@@ -48,7 +53,22 @@ class CodeReviewCommentTest < ActiveSupport::TestCase
     assert CodeReviewComment.user_can_review_project?(project_owner, teacher, nil)
   end
 
+  test 'teacher can review own students project when code_review_enabled is false and code review groups enabled' do
+    DCDO.stubs(:get).with('code_review_groups_enabled', false).returns(true)
+
+    project_owner = create :student
+    teacher = create :teacher
+    section = create :section, code_review_expires_at: Time.now.utc + 1.day, teacher: teacher
+    create :follower, section: section, student_user: project_owner
+    assert CodeReviewComment.user_can_review_project?(project_owner, teacher, nil)
+  end
+
   test 'teacher cannot review project of a student in another section' do
+    # This is default behavior so stub is unnecessary, but adding this
+    # so when can search for the DCDO string to clean up
+    # we remember to delete this test at that time.
+    DCDO.stubs(:get).with('code_review_groups_enabled', false).returns(false)
+
     project_owner = create :student
     teacher = create :teacher
     create :section, code_review_enabled: true, teacher: teacher
@@ -57,7 +77,23 @@ class CodeReviewCommentTest < ActiveSupport::TestCase
     refute CodeReviewComment.user_can_review_project?(project_owner, teacher, nil)
   end
 
+  test 'teacher cannot review project of a student in another section with code review groups enabled' do
+    DCDO.stubs(:get).with('code_review_groups_enabled', false).returns(true)
+
+    project_owner = create :student
+    teacher = create :teacher
+    create :section, code_review_expires_at: Time.now.utc + 1.day, teacher: teacher
+    student_section = create :section, code_review_expires_at: Time.now.utc + 1.day
+    create :follower, section: student_section, student_user: project_owner
+    refute CodeReviewComment.user_can_review_project?(project_owner, teacher, nil)
+  end
+
   test 'can review peers project if code_review is enabled' do
+    # This is default behavior so stub is unnecessary, but adding this
+    # so when can search for the DCDO string to clean up
+    # we remember to delete this test at that time.
+    DCDO.stubs(:get).with('code_review_groups_enabled', false).returns(false)
+
     project_owner = create :student
     reviewer = create :student
     section = create :section, code_review_enabled: true
@@ -71,6 +107,26 @@ class CodeReviewCommentTest < ActiveSupport::TestCase
     assert CodeReviewComment.user_can_review_project?(project_owner, reviewer, @project_storage_app_id, @project_level_id, @project_script_id)
   end
 
+  test 'can review peers project if in same section and in same code review group' do
+    DCDO.stubs(:get).with('code_review_groups_enabled', false).returns(true)
+
+    project_owner = create :student
+    reviewer = create :student
+    section = create :section, code_review_expires_at: Time.now.utc + 1.day
+    project_owner_follower = create :follower, section: section, student_user: project_owner
+    reviewer_follower = create :follower, section: section, student_user: reviewer
+    create :reviewable_project,
+      user_id: project_owner.id,
+      storage_app_id: @project_storage_app_id,
+      level_id: @project_level_id,
+      script_id: @project_script_id
+    code_review_group = CodeReviewGroup.create!(name: 'test', section: section)
+    CodeReviewGroupMember.create!(follower: project_owner_follower, code_review_group: code_review_group)
+    CodeReviewGroupMember.create!(follower: reviewer_follower, code_review_group: code_review_group)
+
+    assert CodeReviewComment.user_can_review_project?(project_owner, reviewer, @project_storage_app_id, @project_level_id, @project_script_id)
+  end
+
   test 'cannot review peers project if there is no reviewable project' do
     project_owner = create :student
     reviewer = create :student
@@ -81,6 +137,11 @@ class CodeReviewCommentTest < ActiveSupport::TestCase
   end
 
   test 'cannot review peers project if code_review is disabled' do
+    # This is default behavior so stub is unnecessary, but adding this
+    # so when can search for the DCDO string to clean up
+    # we remember to delete this test at that time.
+    DCDO.stubs(:get).with('code_review_groups_enabled', false).returns(false)
+
     project_owner = create :student
     reviewer = create :student
     section = create :section, code_review_enabled: false
@@ -94,7 +155,32 @@ class CodeReviewCommentTest < ActiveSupport::TestCase
     refute CodeReviewComment.user_can_review_project?(project_owner, reviewer, @project_storage_app_id, @project_level_id, @project_script_id)
   end
 
+  test 'cannot review peers project if code_review is disabled and students are in same code review group' do
+    DCDO.stubs(:get).with('code_review_groups_enabled', false).returns(true)
+
+    project_owner = create :student
+    reviewer = create :student
+    section = create :section, code_review_expires_at: nil
+    project_owner_follower = create :follower, section: section, student_user: project_owner
+    reviewer_follower = create :follower, section: section, student_user: reviewer
+    create :reviewable_project,
+      user_id: project_owner.id,
+      storage_app_id: @project_storage_app_id,
+      level_id: @project_level_id,
+      script_id: @project_script_id
+    code_review_group = CodeReviewGroup.create!(name: 'test', section: section)
+    CodeReviewGroupMember.create!(follower: project_owner_follower, code_review_group: code_review_group)
+    CodeReviewGroupMember.create!(follower: reviewer_follower, code_review_group: code_review_group)
+
+    refute CodeReviewComment.user_can_review_project?(project_owner, reviewer, @project_storage_app_id, @project_level_id, @project_script_id)
+  end
+
   test 'cannot review project of student in a different section' do
+    # This is default behavior so stub is unnecessary, but adding this
+    # so when can search for the DCDO string to clean up
+    # we remember to delete this test at that time.
+    DCDO.stubs(:get).with('code_review_groups_enabled', false).returns(false)
+
     project_owner = create :student
     reviewer = create :student
     section = create :section, code_review_enabled: true
@@ -106,6 +192,28 @@ class CodeReviewCommentTest < ActiveSupport::TestCase
       storage_app_id: @project_storage_app_id,
       level_id: @project_level_id,
       script_id: @project_script_id
+    refute CodeReviewComment.user_can_review_project?(project_owner, reviewer, @project_storage_app_id, @project_level_id, @project_script_id)
+  end
+
+  test 'cannot review project of student in a different section even if both in code review groups' do
+    DCDO.stubs(:get).with('code_review_groups_enabled', false).returns(true)
+
+    project_owner = create :student
+    reviewer = create :student
+    section = create :section, code_review_expires_at: Time.now.utc + 1.day
+    reviewer_section = create :section, code_review_expires_at: Time.now.utc + 1.day
+    project_owner_follower = create :follower, section: section, student_user: project_owner
+    reviewer_follower = create :follower, section: reviewer_section, student_user: reviewer
+    create :reviewable_project,
+      user_id: project_owner.id,
+      storage_app_id: @project_storage_app_id,
+      level_id: @project_level_id,
+      script_id: @project_script_id
+    reviewer_code_review_group = CodeReviewGroup.create!(name: 'reviewer group', section: reviewer_section)
+    project_owner_code_review_group = CodeReviewGroup.create!(name: 'project owner group', section: section)
+    CodeReviewGroupMember.create!(follower: project_owner_follower, code_review_group: project_owner_code_review_group)
+    CodeReviewGroupMember.create!(follower: reviewer_follower, code_review_group: reviewer_code_review_group)
+
     refute CodeReviewComment.user_can_review_project?(project_owner, reviewer, @project_storage_app_id, @project_level_id, @project_script_id)
   end
 end

--- a/dashboard/test/models/code_review_comment_test.rb
+++ b/dashboard/test/models/code_review_comment_test.rb
@@ -58,7 +58,7 @@ class CodeReviewCommentTest < ActiveSupport::TestCase
 
     project_owner = create :student
     teacher = create :teacher
-    section = create :section, code_review_expires_at: Time.now.utc + 1.day, teacher: teacher
+    section = create :section, code_review_expires_at: Time.now.utc - 1.day, teacher: teacher
     create :follower, section: section, student_user: project_owner
     assert CodeReviewComment.user_can_review_project?(project_owner, teacher, nil)
   end

--- a/dashboard/test/models/follower_test.rb
+++ b/dashboard/test/models/follower_test.rb
@@ -69,8 +69,8 @@ class FollowerTest < ActiveSupport::TestCase
   end
 
   test 'deleting a follower deletes the associated code review group member' do
-    code_review_group = CodeReviewGroup.create(section_id: @laurel_section.id, name: 'test_group')
-    CodeReviewGroupMember.create(follower_id: @follower.id, code_review_group_id: code_review_group.id)
+    code_review_group = create :code_review_group, section: @laurel_section
+    create :code_review_group_member, follower: @follower, code_review_group: code_review_group
     @follower.destroy
     refute CodeReviewGroupMember.exists?(follower_id: @follower.id, code_review_group_id: code_review_group.id)
   end

--- a/dashboard/test/models/reviewable_project_test.rb
+++ b/dashboard/test/models/reviewable_project_test.rb
@@ -27,7 +27,7 @@ class ReviewableProjectTest < ActiveSupport::TestCase
     refute ReviewableProject.user_can_mark_project_reviewable?(project_owner, project_owner)
   end
 
-  test 'project owner can mark project reviewable if in code review group and section with code review enabled' do
+  test 'project owner cannot mark project reviewable if not in code review group' do
     DCDO.stubs(:get).with('code_review_groups_enabled', false).returns(true)
 
     project_owner = create :student
@@ -37,7 +37,7 @@ class ReviewableProjectTest < ActiveSupport::TestCase
     refute ReviewableProject.user_can_mark_project_reviewable?(project_owner, project_owner)
   end
 
-  test 'project owner cannot mark project reviewable if not in code review group' do
+  test 'project owner can mark project reviewable if in code review group and section with code review enabled' do
     DCDO.stubs(:get).with('code_review_groups_enabled', false).returns(true)
 
     project_owner = create :student

--- a/dashboard/test/models/reviewable_project_test.rb
+++ b/dashboard/test/models/reviewable_project_test.rb
@@ -43,8 +43,8 @@ class ReviewableProjectTest < ActiveSupport::TestCase
     project_owner = create :student
     section = create :section, code_review_expires_at: Time.now.utc + 1.day
     follower = create :follower, section: section, student_user: project_owner
-    code_review_group = CodeReviewGroup.create!(name: 'test', section: section)
-    CodeReviewGroupMember.create!(follower: follower, code_review_group: code_review_group)
+    code_review_group = create :code_review_group, section: section
+    create :code_review_group_member, follower: follower, code_review_group: code_review_group
 
     assert ReviewableProject.user_can_mark_project_reviewable?(project_owner, project_owner)
   end

--- a/dashboard/test/models/reviewable_project_test.rb
+++ b/dashboard/test/models/reviewable_project_test.rb
@@ -2,6 +2,11 @@ require 'test_helper'
 
 class ReviewableProjectTest < ActiveSupport::TestCase
   test 'only project owner can mark project reviewable' do
+    # This is default behavior so stub is unnecessary, but adding this
+    # so when can search for the DCDO string to clean up
+    # we remember to delete this test at that time.
+    DCDO.stubs(:get).with('code_review_groups_enabled', false).returns(false)
+
     project_owner = create :student
     another_student = create :student
 
@@ -10,8 +15,45 @@ class ReviewableProjectTest < ActiveSupport::TestCase
   end
 
   test 'project owner cannot mark project reviewable if in a section with code review disabled' do
+    # This is default behavior so stub is unnecessary, but adding this
+    # so when can search for the DCDO string to clean up
+    # we remember to delete this test at that time.
+    DCDO.stubs(:get).with('code_review_groups_enabled', false).returns(false)
+
     project_owner = create :student
     section = create :section, code_review_enabled: false
+    create :follower, section: section, student_user: project_owner
+
+    refute ReviewableProject.user_can_mark_project_reviewable?(project_owner, project_owner)
+  end
+
+  test 'project owner can mark project reviewable if in code review group and section with code review enabled' do
+    DCDO.stubs(:get).with('code_review_groups_enabled', false).returns(true)
+
+    project_owner = create :student
+    section = create :section, code_review_expires_at: Time.now.utc + 1.day
+    create :follower, section: section, student_user: project_owner
+
+    refute ReviewableProject.user_can_mark_project_reviewable?(project_owner, project_owner)
+  end
+
+  test 'project owner cannot mark project reviewable if not in code review group' do
+    DCDO.stubs(:get).with('code_review_groups_enabled', false).returns(true)
+
+    project_owner = create :student
+    section = create :section, code_review_expires_at: Time.now.utc + 1.day
+    follower = create :follower, section: section, student_user: project_owner
+    code_review_group = CodeReviewGroup.create!(name: 'test', section: section)
+    CodeReviewGroupMember.create!(follower: follower, code_review_group: code_review_group)
+
+    assert ReviewableProject.user_can_mark_project_reviewable?(project_owner, project_owner)
+  end
+
+  test 'project owner cannot mark project reviewable if section has code review disabled' do
+    DCDO.stubs(:get).with('code_review_groups_enabled', false).returns(true)
+
+    project_owner = create :student
+    section = create :section, code_review_expires_at: Time.now.utc - 1.day
     create :follower, section: section, student_user: project_owner
 
     refute ReviewableProject.user_can_mark_project_reviewable?(project_owner, project_owner)

--- a/dashboard/test/models/sections/section_test.rb
+++ b/dashboard/test/models/sections/section_test.rb
@@ -575,6 +575,27 @@ class SectionTest < ActiveSupport::TestCase
     refute Section.valid_grade?("56")
   end
 
+  test 'code review disabled for sections with no code review expiration' do
+    DCDO.stubs(:get).with('code_review_groups_enabled', false).returns(true)
+    section = create :section
+
+    refute section.code_review_enabled?
+  end
+
+  test 'code review enabled for sections with code review expiration later than current time' do
+    DCDO.stubs(:get).with('code_review_groups_enabled', false).returns(true)
+    section = create :section, code_review_expires_at: Time.now.utc + 100.years
+
+    assert section.code_review_enabled?
+  end
+
+  test 'code review disabled for sections with code review expiration before current time' do
+    DCDO.stubs(:get).with('code_review_groups_enabled', false).returns(true)
+    section = create :section, code_review_expires_at: Time.now.utc - 1.day
+
+    refute section.code_review_enabled?
+  end
+
   test 'reset_code_review_groups creates new code review groups' do
     code_review_group_section = create(:section, user: @teacher, login_type: 'word')
     # Create 5 students

--- a/dashboard/test/models/sections/section_test.rb
+++ b/dashboard/test/models/sections/section_test.rb
@@ -664,8 +664,8 @@ class SectionTest < ActiveSupport::TestCase
     end
 
     # Create 2 code review groups
-    @group1 = CodeReviewGroup.create(section_id: @code_review_group_section.id, name: "group1")
-    @group2 = CodeReviewGroup.create(section_id: @code_review_group_section.id, name: "group2")
+    @group1 = create :code_review_group, section: @code_review_group_section
+    @group2 = create :code_review_group, section: @code_review_group_section
     # put student 0 and 1 in group 1, and student 2 in group 2
     CodeReviewGroupMember.create(follower_id: @followers[0].id, code_review_group_id: @group1.id)
     CodeReviewGroupMember.create(follower_id: @followers[1].id, code_review_group_id: @group1.id)

--- a/dashboard/test/models/sections/section_test.rb
+++ b/dashboard/test/models/sections/section_test.rb
@@ -584,7 +584,7 @@ class SectionTest < ActiveSupport::TestCase
 
   test 'code review enabled for sections with code review expiration later than current time' do
     DCDO.stubs(:get).with('code_review_groups_enabled', false).returns(true)
-    section = create :section, code_review_expires_at: Time.now.utc + 100.years
+    section = create :section, code_review_expires_at: Time.now.utc + 1.day
 
     assert section.code_review_enabled?
   end


### PR DESCRIPTION
Puts new logic for gating access to code review using code review groups behind a DCDO flag (`code_review_groups_enabled`). This PR should not introduce any new behavior in production until we set this DCDO flag to `true`.

Reviewing this PR, you can look at everything in `else` statements as representing the (unchanged) existing logic, and anything in the true condition of each if statement as the new logic.

## Links

- code review groups [product spec](https://docs.google.com/document/d/1yUbfW9urFgieFhyLSoqBO35J-uOJwUWFjpSEd0KQxRI/edit#)
- code review groups [tech spec](https://docs.google.com/document/d/1-fX3o1rT38aWaT2f8lSbTwZadMzeeOhFZZ6c6KCCw3I/edit#)
- jira ticket: [CSA-1007](https://codedotorg.atlassian.net/browse/CSA-1007)

## Testing story

Added unit tests to cover new behavior. I explicitly marked tests that test on the old access logic by setting the DCDO flag to `false` explicitly, although that is already the default value. Once we flip the flag to true, we can delete these tests.

I hand tested that the core functionality works without any flag set, and that the same functionality (peers can review other peer's code when marked ready for review, teacher can leave comments, project owner can leave and resolve comments). That said, there are a lot of cases, so I did not hand test them all.

## Deployment strategy

As mentioned above, this PR shouldn't introduce any new behavior as-is. We'll want to bug bash this behavior first (and likely plumb through this flag to the front end to hide the enable/disable code review control that exists in the section edit form) before we flip the flag to show it to teachers.

## Follow-up work

Noted one (should be small) cleanup item to rename a variable (`@code_review_enabled`) that gets set in the script levels controller. [Jira ticket here](https://codedotorg.atlassian.net/browse/CSA-1067).