### PR TITLE
Update text asking for which grades in CSA

### DIFF
--- a/lib/cdo/shared_constants/pd/teacher_application_constants.rb
+++ b/lib/cdo/shared_constants/pd/teacher_application_constants.rb
@@ -79,8 +79,9 @@ module Pd
         ),
         csa_which_grades: clean_multiline(
           "To which grades does your school plan to offer CSA in the #{YEAR} school year?
-          Please note that the CSA Professional Learning Program is not available for grades
-          K-8 nor recommended for grade 9. (select all that apply)"
+          The Code.org CSA curriculum is recommended for those who have successfully completed
+          a first-year high school algebra course AND an introductory programming course.
+          (select all that apply)"
         ),
         csa_how_offer: 'How will you offer CSA?',
         cs_how_many_minutes: clean_multiline(


### PR DESCRIPTION
On page 2 of the application, when you select CSA we have a small content update. 

OLD: “Please note that the CSA PL program is not available for grades K-9 nor recommended for grade 9.” 

NEW: “The Code.org CSA curriculum is recommended for those who have successfully completed a first-year high school algebra course AND an introductory programming course.”

<img width="992" alt="Pasted Graphic 92" src="https://user-images.githubusercontent.com/9142121/142054281-fc4be03f-67b3-4c25-b16a-51f039b6ec63.png">


## Links

- jira ticket: [PLAT-1449](https://codedotorg.atlassian.net/browse/PLAT-1449)

## Testing story

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
