### PR TITLE
Fix logo spacing inconsistency bug without disturbing other parts of the header

### DIFF
--- a/shared/css/header.scss
+++ b/shared/css/header.scss
@@ -41,13 +41,12 @@
 
     #logo-wrapper {
       display: inline-block;
-      padding: 4px 0 4px 16px;
+      padding: 4px 16px 4px 6px;
       float: left;
 
       #logo {
         width: 42px;
         height: 42px;
-        margin-left: 5px;
       }
 
       #logo-uk {

--- a/shared/css/header.scss
+++ b/shared/css/header.scss
@@ -22,7 +22,7 @@
 
     .content {
       width: 100%;
-      padding: 0 10px;
+      padding-right: 10px;
       overflow: visible;
       box-sizing: border-box;
     }
@@ -41,7 +41,7 @@
 
     #logo-wrapper {
       display: inline-block;
-      padding: 4px 16px 4px 6px;
+      padding: 4px 16px;
       float: left;
 
       #logo {


### PR DESCRIPTION
Make the same functional changes from [the original PR](https://github.com/code-dot-org/code-dot-org/pull/43332) to fix the logo spacing bug. However, [the original PR](https://github.com/code-dot-org/code-dot-org/pull/43332) was reverted due to [an eyes test issue](https://eyes.applitools.com/app/test-results/00000251765557450495/00000251765557444541/steps/1?accountId=mG4DoRfv0ntEgI3XIYBulrKxlZqrHtGwbP3V103ojvLFU110&mode=step-editor) (also shown below) on advocacy.code.org. This PR, however, unifies the logo spacing while making sure it does not mess up the spacing on advocacy.code.org and/or in other languages (namely ones that read right-to-left).

### Eyes Test Issue
![Eyes fail on advocacy](https://user-images.githubusercontent.com/56283563/142084071-4151c37d-00f4-4ce3-a970-5a1389ab387b.JPG)

### Eyes Test Fix
![Fix advocacy labeled](https://user-images.githubusercontent.com/56283563/142084257-3467f266-521a-4ea1-94d4-72ac30da855f.JPG)

## Links
Original PR: [here](https://github.com/code-dot-org/code-dot-org/pull/43332)
Revert PR: [here](https://github.com/code-dot-org/code-dot-org/pull/43585)
Eyes test issue: [here](https://eyes.applitools.com/app/test-results/00000251765557450495/00000251765557444541/steps/1?accountId=mG4DoRfv0ntEgI3XIYBulrKxlZqrHtGwbP3V103ojvLFU110&mode=step-editor)

## Testing story
Same testing story as the one listed in the [original PR](https://github.com/code-dot-org/code-dot-org/pull/43332), as well as manual testing in multiple browsers, languages, and on mobile on advocacy.code.org to ensure the issue was fixed.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
