### PR TITLE
Re-enable teacher app eyes test

### DIFF
--- a/apps/src/code-studio/pd/application/teacher/TeacherApplicationConstants.js
+++ b/apps/src/code-studio/pd/application/teacher/TeacherApplicationConstants.js
@@ -16,7 +16,7 @@ const styles = {
   },
   questionText: {
     fontSize: 14,
-    lineHeight: '20px',
+    lineHeight: 1.5,
     fontWeight: 'bold'
   },
   checkBoxAfterButtonList: {

--- a/apps/src/code-studio/pd/application/teacher/TeacherApplicationConstants.js
+++ b/apps/src/code-studio/pd/application/teacher/TeacherApplicationConstants.js
@@ -16,7 +16,7 @@ const styles = {
   },
   questionText: {
     fontSize: 14,
-    lineHeight: 20,
+    lineHeight: '20px',
     fontWeight: 'bold'
   },
   checkBoxAfterButtonList: {

--- a/dashboard/app/controllers/pd/application/principal_approval_application_controller.rb
+++ b/dashboard/app/controllers/pd/application/principal_approval_application_controller.rb
@@ -25,6 +25,7 @@ module Pd::Application
         principal_title: application_hash[:principal_title],
         principal_email: application_hash[:principal_email],
         school_id: teacher_application.school_id || "-1",
+        school_state: teacher_application.school_state,
         school_zip_code: teacher_application.school_zip_code
       }
 

--- a/dashboard/test/ui/features/ed_programs/pd/teacher_application.feature
+++ b/dashboard/test/ui/features/ed_programs/pd/teacher_application.feature
@@ -1,6 +1,5 @@
 @dashboard_db_access
 @eyes
-@skip
 
 Feature: Teacher Application
 
@@ -13,11 +12,17 @@ Scenario: Basic teacher application submission
   # Section 1
   When I wait until element "h3" contains text "Section 1: About You and Your School"
     And I press the first "input[name='country']" element
+    And I press the first "input[name='completingOnBehalfOfSomeoneElse'][value='No']" element
     And I press keys "Severus" for element "input#firstName"
     And I press keys "Snape" for element "input#lastName"
     And I press keys "5558675309" for element "input#phone"
+    And I press keys "1501 4th Ave" for element "input#streetAddress"
+    And I press keys "Seattle" for element "input#city"
+    And I select the "Washington" option in dropdown "state"
     And I press keys "98101" for element "input#zipCode"
-    And I press the first "input[name='completingOnBehalfOfSomeoneElse'][value='No']" element
+    And I press the first "input[name='previousUsedCurriculum']" element
+    And I press the first "input[name='previousYearlongCdoPd']" element
+    And I press the first "input[name='currentRole']" element
     And I press keys "nonexistent" for element "#school input"
 
   # School: select other and enter manual data
@@ -36,54 +41,50 @@ Scenario: Basic teacher application submission
   And I press keys "socks@hogwarts.edu" for element "input#principalEmail"
   And I press keys "socks@hogwarts.edu" for element "input#principalConfirmEmail"
   And I press keys "5555882300" for element "input#principalPhoneNumber"
-  And I press the first "input[name='currentRole']" element
-  And I press the first "input[name='previousYearlongCdoPd']" element
-  And I press keys "Seattle" for element "input#city"
-  And I press keys "Washington" for element "input#state"
-  And I press keys "1501 4th Ave" for element "input#streetAddress"
-  And I press the first "input[name='previousUsedCurriculum']" element
 
   Then I see no difference for "Section 1: About You and Your School"
   And I press the first "button#next" element
 
 
-  # Section 3
-  Then I wait until element "h3" contains text "Section 3: Choose Your Program"
+  # Section 2
+  Then I wait until element "h3" contains text "Section 2: Choose Your Program"
   And I press "input[name='program']:first" using jQuery
   And I press the first "input[name='csdWhichGrades']" element
   And I press keys "50" for element "input#csHowManyMinutes"
   And I press keys "5" for element "input#csHowManyDaysPerWeek"
   And I press keys "40" for element "input#csHowManyWeeksPerYear"
-  And I press the first "input[name='csdWhichUnits']" element
   And I press the first "input[name='planToTeach']" element
   And I press the first "input[name='replaceExisting']" element
   Then I wait until element "input[name='replaceWhichCourse']" is visible
     And I press the first "input[name='replaceWhichCourse']" element
 
-  Then I see no difference for "Section 3: Choose Your Program"
+  Then I see no difference for "Section 2: Choose Your Program"
+  And I press the first "button#next" element
+
+
+  # Section 3
+  Then I wait until element "h3" contains text "Section 3: Professional Learning Program Requirements"
+  Then I wait until element "input[name='committed']" is visible
+  And I press "input[name='committed']:first" using jQuery
+  And I press the first "input#understandFee" element
+  And I click selector "input[name='payFee']" if I see it
+  Then I see no difference for "Section 3: Professional Learning Program Requirements"
   And I press the first "button#next" element
 
 
   # Section 4
-  Then I wait until element "h3" contains text "Section 4: Professional Learning Program Requirements"
-  Then I wait until element "input[name='committed']" is visible
-  And I press "input[name='committed']:first" using jQuery
-  And I click selector "input[name='payFee']" if I see it
-  Then I see no difference for "Section 4: Summer Workshop"
-  And I press the first "button#next" element
-
-  # Section 5
-  Then I wait until element "h3" contains text "Section 5: Additional Demographic Information and Submission"
+  Then I wait until element "h3" contains text "Section 4: Additional Demographic Information and Submission"
   And I press "input[name='genderIdentity']:first" using jQuery
   And I press the first "input[name='race']" element
   And I press the first "input[name='howHeard']" element
   And I press the first "input#agree" element
-  Then I see no difference for "Section 5: Submission"
+  Then I see no difference for "Section 4: Additional Demographic Information and Submission"
   And I press the first "button[type='submit']" element
 
   # Confirmation page
   Then I wait until element "h1" contains text "Thank you for submitting your application!"
   Then I see no difference for "Confirmation"
+
 
   # Principal approval
   Then I sign out
@@ -93,14 +94,14 @@ Scenario: Basic teacher application submission
 
   And I press keys "nonexistent" for element "#nces_school"
   Then I wait until element ".VirtualizedSelectOption:contains('Other school not listed below')" is visible
-  And I press ".VirtualizedSelectOption:contains('Other school not listed below')" using jQuery
-  Then I wait until element "input#schoolName" is visible
-  And I press keys "Code.org" for element "input#schoolName"
-  And I press keys "1501 4th Ave" for element "input#schoolAddress"
-  And I press keys "Seattle" for element "input#schoolCity"
-  And I select the "Washington" option in dropdown "schoolState"
-  And I press keys "98101" for element "input#schoolZipCode"
-  And I press the first "input[name='schoolType'][value='Other']" element
+    And I press ".VirtualizedSelectOption:contains('Other school not listed below')" using jQuery
+    Then I wait until element "input#schoolName" is visible
+    And I press keys "Code.org" for element "input#schoolName"
+    And I press keys "1501 4th Ave" for element "input#schoolAddress"
+    And I press keys "Seattle" for element "input#schoolCity"
+    And I select the "Washington" option in dropdown "schoolState"
+    # zip code is autofilled from the teacher app data (in order to fetch the regional partner)
+    And I press the first "input[name='schoolType'][value='Other']" element
 
   Then I press keys "1000" for element "#totalStudentEnrollment"
   Then I press keys "10" for element "#freeLunchPercent"


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

This re-enables the teacher application + principal approval application eyes test. While updating, i fixed a couple of small bugs:

- spacing was weird on some labels
- the teacher app school_state should also be passed to the principal app so that the RP is loaded the same way (was just sending zip code before)

before styling:
![image](https://user-images.githubusercontent.com/82416901/142090647-bd12a83c-5304-4a08-b152-5ddd2173bd86.png)
after fix:
![image](https://user-images.githubusercontent.com/82416901/142090666-e137533a-4582-4cc7-9e26-6038aaeb2578.png)


## Testing story

Manual testing + eyes test
