### PR TITLE
[Poetry] Support example solutions

### DIFF
--- a/dashboard/app/models/levels/poetry.rb
+++ b/dashboard/app/models/levels/poetry.rb
@@ -32,13 +32,8 @@ class Poetry < GamelabJr
     standalone_app_name
   )
 
-  STANDALONE_APP_NAMES = {
-    poetry: 'poetry',
-    poetry_hoc: 'poetry_hoc'
-  }.with_indifferent_access.freeze
-
   def check_default_poem
-    self.default_poem = nil unless standalone_app_name == STANDALONE_APP_NAMES[:poetry_hoc]
+    self.default_poem = nil unless standalone_app_name == 'poetry_hoc'
   end
 
   # Poetry levels use the same shared_functions as GamelabJr
@@ -47,7 +42,7 @@ class Poetry < GamelabJr
   end
 
   def self.standalone_app_names
-    [['Poetry', STANDALONE_APP_NAMES[:poetry]], ['Poetry HOC', STANDALONE_APP_NAMES[:poetry_hoc]]]
+    [['Poetry', 'poetry'], ['Poetry HOC', 'poetry_hoc']]
   end
 
   def self.skins
@@ -72,7 +67,7 @@ class Poetry < GamelabJr
           hide_animation_mode: true,
           show_type_hints: true,
           use_modal_function_editor: true,
-          standalone_app_name: STANDALONE_APP_NAMES[:poetry]
+          standalone_app_name: 'poetry'
         }
       )
     )

--- a/dashboard/app/models/levels/poetry.rb
+++ b/dashboard/app/models/levels/poetry.rb
@@ -32,8 +32,13 @@ class Poetry < GamelabJr
     standalone_app_name
   )
 
+  STANDALONE_APP_NAMES = {
+    poetry: 'poetry',
+    poetry_hoc: 'poetry_hoc'
+  }.with_indifferent_access.freeze
+
   def check_default_poem
-    self.default_poem = nil unless standalone_app_name == 'poetry_hoc'
+    self.default_poem = nil unless standalone_app_name == STANDALONE_APP_NAMES[:poetry_hoc]
   end
 
   # Poetry levels use the same shared_functions as GamelabJr
@@ -42,7 +47,7 @@ class Poetry < GamelabJr
   end
 
   def self.standalone_app_names
-    [['Poetry', 'poetry'], ['Poetry HOC', 'poetry_hoc']]
+    [['Poetry', STANDALONE_APP_NAMES[:poetry]], ['Poetry HOC', STANDALONE_APP_NAMES[:poetry_hoc]]]
   end
 
   def self.skins
@@ -67,7 +72,7 @@ class Poetry < GamelabJr
           hide_animation_mode: true,
           show_type_hints: true,
           use_modal_function_editor: true,
-          standalone_app_name: 'poetry'
+          standalone_app_name: STANDALONE_APP_NAMES[:poetry]
         }
       )
     )

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -757,6 +757,8 @@ class ScriptLevel < ApplicationRecord
         # final state - a string representation of the URL of the exemplar level: studio.code.org/s/<course>/...
         if level.is_a?(Dancelab)
           send("#{'dance'}_project_view_projects_url".to_sym, channel_id: example, host: 'studio.code.org', port: 443, protocol: :https)
+        elsif level.is_a?(Poetry)
+          send("#{level.standalone_app_name}_project_view_projects_url".to_sym, channel_id: example, host: 'studio.code.org', port: 443, protocol: :https)
         elsif level.is_a?(GamelabJr)
           send("#{'spritelab'}_project_view_projects_url".to_sym, channel_id: example, host: 'studio.code.org', port: 443, protocol: :https)
         elsif level.is_a?(Artist)

--- a/dashboard/app/views/levels/editors/_poetry.html.haml
+++ b/dashboard/app/views/levels/editors/_poetry.html.haml
@@ -10,6 +10,7 @@
 = render partial: 'levels/editors/fields/debugger', locals: {f: f}
 = render partial: 'levels/editors/fields/control_buttons', locals: {f: f}
 = render partial: 'levels/editors/fields/animation', locals: {f: f}
+= render partial: 'levels/editors/fields/encrypted_examples', locals: {f: f, level_type: @level.standalone_app_name}
 
 = render partial: 'levels/editors/fields/preload_assets', locals: {f: f}
 = render partial: 'levels/editors/fields/sharing', locals: {f: f}

--- a/dashboard/app/views/levels/editors/_poetry.html.haml
+++ b/dashboard/app/views/levels/editors/_poetry.html.haml
@@ -1,7 +1,7 @@
 :ruby
   warnings = {
-    level_type: "Example solutions are dependent on the level type field for generating solution URLs. If you change the level type, any existing example solution URLs will break.",
-    encrypted_examples: "For Poetry levels, the project URL for example solutions depends on the level type. Any existing example solutions will break if you change the level type without updating the channel tokens here."
+    level_type: "Example solutions are dependent on this field for generating solution URLs. If you change the level subtype, any existing example solution URLs will break.",
+    encrypted_examples: "For Poetry levels, the project URL for example solutions depends on the level subtype (Poetry or Poetry HOC). Any existing example solutions will break if you change the level subtype without updating the channel tokens here."
   }
 
 = render partial: 'levels/editors/fields/instructions_area', locals: {f: f}

--- a/dashboard/app/views/levels/editors/_poetry.html.haml
+++ b/dashboard/app/views/levels/editors/_poetry.html.haml
@@ -10,7 +10,7 @@
 = render partial: 'levels/editors/fields/debugger', locals: {f: f}
 = render partial: 'levels/editors/fields/control_buttons', locals: {f: f}
 = render partial: 'levels/editors/fields/animation', locals: {f: f}
-= render partial: 'levels/editors/fields/encrypted_examples', locals: {f: f, level_type: @level.standalone_app_name}
+= render partial: 'levels/editors/fields/encrypted_examples', locals: {f: f, level_type: @level.standalone_app_name, warning: "For Poetry levels, the project URL for example solutions depends on the level type. Any existing example solutions will break if you change the level type without updating the channel tokens here."}
 
 = render partial: 'levels/editors/fields/preload_assets', locals: {f: f}
 = render partial: 'levels/editors/fields/sharing', locals: {f: f}

--- a/dashboard/app/views/levels/editors/_poetry.html.haml
+++ b/dashboard/app/views/levels/editors/_poetry.html.haml
@@ -1,3 +1,9 @@
+:ruby
+  warnings = {
+    level_type: "Example solutions are dependent on the level type field for generating solution URLs. If you change the level type, any existing example solution URLs will break.",
+    encrypted_examples: "For Poetry levels, the project URL for example solutions depends on the level type. Any existing example solutions will break if you change the level type without updating the channel tokens here."
+  }
+
 = render partial: 'levels/editors/fields/instructions_area', locals: {f: f}
 = render partial: 'levels/editors/fields/teacher_only_markdown', locals: {f: f}
 = render partial: 'levels/editors/fields/code_area', locals: {f: f}
@@ -5,12 +11,12 @@
 = render partial: 'levels/editors/fields/bubble_choice_sublevel', locals: {f: f}
 = render partial: 'levels/editors/fields/special_level_types', locals: {f: f}
 
-= render partial: 'levels/editors/fields/poetry_fields', locals: {f: f}
+= render partial: 'levels/editors/fields/poetry_fields', locals: {f: f, warning: warnings[:level_type]}
 
 = render partial: 'levels/editors/fields/debugger', locals: {f: f}
 = render partial: 'levels/editors/fields/control_buttons', locals: {f: f}
 = render partial: 'levels/editors/fields/animation', locals: {f: f}
-= render partial: 'levels/editors/fields/encrypted_examples', locals: {f: f, level_type: @level.standalone_app_name, warning: "For Poetry levels, the project URL for example solutions depends on the level type. Any existing example solutions will break if you change the level type without updating the channel tokens here."}
+= render partial: 'levels/editors/fields/encrypted_examples', locals: {f: f, level_type: @level.standalone_app_name, warning: warnings[:encrypted_examples]}
 
 = render partial: 'levels/editors/fields/preload_assets', locals: {f: f}
 = render partial: 'levels/editors/fields/sharing', locals: {f: f}

--- a/dashboard/app/views/levels/editors/fields/_encrypted_examples.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_encrypted_examples.html.haml
@@ -11,8 +11,10 @@
     to build your example, then copy the channel token (the sequence of letters and numbers after
     = "/#{level_type}"
     ).
+
   - if local_assigns[:warning]
     %p= "WARNING: #{warning}"
+
   %p
     Need more help? View this
     = link_to 'screencast', 'https://www.dropbox.com/s/zpmszi9eenvwql7/applab%20example%20screencast.mp4?dl=0', target: '_blank'

--- a/dashboard/app/views/levels/editors/fields/_encrypted_examples.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_encrypted_examples.html.haml
@@ -11,6 +11,8 @@
     to build your example, then copy the channel token (the sequence of letters and numbers after
     = "/#{level_type}"
     ).
+  - if local_assigns[:warning]
+    %p= "WARNING: #{warning}"
   %p
     Need more help? View this
     = link_to 'screencast', 'https://www.dropbox.com/s/zpmszi9eenvwql7/applab%20example%20screencast.mp4?dl=0', target: '_blank'

--- a/dashboard/app/views/levels/editors/fields/_poetry_fields.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_poetry_fields.html.haml
@@ -5,7 +5,8 @@
   .field
     = f.label :standalone_app_name, 'Level Type'
     %p Poetry HOC levels have a poem dropdown above the playspace and auto-animate the poem.
-    %p WARNING: Example solutions are dependent on the level type field for generating solution URLs. If you change the level type, any existing example solution URLs will break.
+    - if local_assigns[:warning]
+      %p= "WARNING: #{warning}"
     = f.select :standalone_app_name, options_for_select(@level.class.standalone_app_names, @level.standalone_app_name), {}, onchange: 'toggleFields(this.value);'
 
   #defaultPoem{class: ('collapse' if @level.standalone_app_name != 'poetry_hoc')}

--- a/dashboard/app/views/levels/editors/fields/_poetry_fields.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_poetry_fields.html.haml
@@ -3,7 +3,7 @@
 
 #poetry_fields
   .field
-    = f.label :standalone_app_name, 'Level Type'
+    = f.label :standalone_app_name, 'Level Subtype'
     %p Poetry HOC levels have a poem dropdown above the playspace and auto-animate the poem.
     - if local_assigns[:warning]
       %p= "WARNING: #{warning}"

--- a/dashboard/app/views/levels/editors/fields/_poetry_fields.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_poetry_fields.html.haml
@@ -5,6 +5,7 @@
   .field
     = f.label :standalone_app_name, 'Level Type'
     %p Poetry HOC levels have a poem dropdown above the playspace and auto-animate the poem.
+    %p WARNING: Example solutions are dependent on the level type field for generating solution URLs. If you change the level type, any existing example solution URLs will break.
     = f.select :standalone_app_name, options_for_select(@level.class.standalone_app_names, @level.standalone_app_name), {}, onchange: 'toggleFields(this.value);'
 
   #defaultPoem{class: ('collapse' if @level.standalone_app_name != 'poetry_hoc')}


### PR DESCRIPTION
This creates support for example solutions in two ways:
1. Renders the "Example Solutions" partial on the levelbuilder edit page for Poetry levels
2. Adds support for Poetry levels in `ScriptLevel#get_example_solutions` so that the generated URLs for Poetry example solutions are correct. (By default, they were generating `/projects/spritelab` URLs.)

**Relevant parts of the levelbuilder edit page:**
<img width="991" alt="Screen Shot 2021-11-18 at 10 27 35 AM" src="https://user-images.githubusercontent.com/9812299/142475201-a3bf3630-44fa-499c-a565-be3b9803c74d.png">

There is a necessary dependency between a Poetry level's `standalone_app_name` (called "Level Type" in the levelbuilder UI) and its `examples`. This is because the two standalone apps have different standalone project URLs (`/projects/poetry` and `/projects/poetry_hoc`) and examples are an array of channel tokens. This means if you change the `standalone_app_name` without updating that level's `examples`, all example solutions will be in a weird state because the project will load as a 'poetry' project rather than a 'poetry_hoc' project, and vice versa.

Javalab is a special case where `examples` are an array of URLs, which I think is the ideal setup for all level examples and would prevent broken URLs (although the examples would point to a different flavor of Poetry level). However, it seemed confusing to have Poetry levels match this special case since no other GamelabJr levels have that behavior.

## Links

- [STAR-1926](https://codedotorg.atlassian.net/browse/STAR-1926)