### PR TITLE
Fix alternative Spotify chart names

### DIFF
--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -93,8 +93,8 @@ import autogenerateML from '@cdo/apps/applab/ai';
  */
 const TOP_200_USA = 'Top 200 USA';
 const TOP_200_Worldwide = 'Top 200 Worldwide';
-const TOP_50_USA = 'Top 200 USA';
-const TOP_50_Worldwide = 'Top 200 Worldwide';
+const TOP_50_USA = 'Top 50 USA';
+const TOP_50_Worldwide = 'Top 50 Worldwide';
 
 /**
  * Create a namespace for the application.


### PR DESCRIPTION
Before:
![image (3)](https://user-images.githubusercontent.com/35442460/142289757-c397dd57-a840-4bc3-a8ce-1b7425dd6a28.png)

With these changes:

![image](https://user-images.githubusercontent.com/35442460/142290019-e5095165-7f3c-44b0-a1a8-531a791d65ef.png)


