### PR TITLE
Hide handouts pdf if there are no handouts in it

### DIFF
--- a/apps/test/unit/templates/lessonOverview/LessonOverviewTest.js
+++ b/apps/test/unit/templates/lessonOverview/LessonOverviewTest.js
@@ -316,6 +316,28 @@ describe('LessonOverview', () => {
     ]);
   });
 
+  it('renders dropdown button with lessonPlanPdf if no scriptResourcesPdfUrl provided and not pilot or in development', () => {
+    const lesson = {
+      ...defaultProps.lesson,
+      lessonPlanPdfUrl: '/link/to/lesson_plan.pdf',
+      scriptResourcesPdfUrl: null
+    };
+    const wrapper = shallow(
+      <LessonOverview {...defaultProps} lesson={lesson} />
+    );
+    expect(wrapper.find(DropdownButton).length).to.equal(1);
+    const dropdownLinks = wrapper
+      .find(DropdownButton)
+      .first()
+      .props().children;
+    expect(dropdownLinks.map(link => link.props.href)).to.eql([
+      '/link/to/lesson_plan.pdf'
+    ]);
+    expect(dropdownLinks.map(link => link.props.children)).to.eql([
+      'Print Lesson Plan'
+    ]);
+  });
+
   it('does not render overview printing option in dropdown for pilot course', () => {
     const unit = {
       ...defaultProps.lesson.unit,

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -325,12 +325,6 @@ class Lesson < ApplicationRecord
     end
   end
 
-  def unit_resource_pdf_url
-    if script.is_migrated?
-      Services::CurriculumPdfs.get_unit_resources_url(script)
-    end
-  end
-
   def lesson_plan_base_url
     CDO.code_org_url "/curriculum/#{script.name}/#{relative_position}"
   end
@@ -524,7 +518,7 @@ class Lesson < ApplicationRecord
       courseVersionStandardsUrl: course_version_standards_url,
       isVerifiedTeacher: user&.authorized_teacher?,
       hasVerifiedResources: lockable || lesson_plan_has_verified_resources,
-      scriptResourcesPdfUrl: unit_resource_pdf_url
+      scriptResourcesPdfUrl: script.get_unit_resources_pdf_url
     }
   end
 

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -2155,7 +2155,11 @@ class Script < ApplicationRecord
   end
 
   def get_unit_resources_pdf_url
-    if is_migrated? && !use_legacy_lesson_plans?
+    return nil unless is_migrated?
+    return nil if use_legacy_lesson_plans?
+
+    # Check if there are any resources that would be included in the rollup PDF, and, therefore, if there's a useful PDF to surface to users
+    if resources.any?(&:should_include_in_pdf?) || student_resources.any?(&:should_include_in_pdf?) || lessons.any? {|l| l.resources.any?(&:should_include_in_pdf?)}
       Services::CurriculumPdfs.get_unit_resources_url(self)
     end
   end

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -917,25 +917,6 @@ class LessonTest < ActiveSupport::TestCase
     )
   end
 
-  test 'unit_resource_pdf_url gets url to script resources pdf for migrated script' do
-    script = create :script, name: 'test-script', is_migrated: true, seeded_from: Time.at(0)
-    lesson_group = create :lesson_group, script: script
-    lesson = create :lesson, lesson_group: lesson_group, script: script, has_lesson_plan: true
-
-    assert_equal(
-      "https://lesson-plans.code.org/#{script.name}/#{Time.parse(script.seeded_from).to_s(:number)}/#{script.name}+-+Resources.pdf",
-      lesson.unit_resource_pdf_url
-    )
-  end
-
-  test 'unit_resource_pdf_url is nil for non-migrated script' do
-    script = create :script, name: 'test-script', is_migrated: false, seeded_from: Time.at(0)
-    lesson_group = create :lesson_group, script: script
-    lesson = create :lesson, lesson_group: lesson_group, script: script, has_lesson_plan: true
-
-    assert_nil lesson.unit_resource_pdf_url
-  end
-
   test 'no student_lesson_plan_pdf_url for non-migrated scripts' do
     script = create :script, include_student_lesson_plans: true, is_migrated: false
     new_lesson = create :lesson, script: script, key: 'Some Verbose Lesson Name', has_lesson_plan: true

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -916,6 +916,7 @@ class ScriptTest < ActiveSupport::TestCase
     lesson = create(:lesson, script: unit, name: 'lesson 1', lesson_group: lesson_group)
     create(:script_level, script: unit, lesson: lesson)
     unit.teacher_resources = [['curriculum', '/link/to/curriculum']]
+    create :resource, lessons: [lesson], include_in_pdf: true
     Services::CurriculumPdfs.stubs(:get_script_overview_url).returns('/overview-pdf-url')
     Services::CurriculumPdfs.stubs(:get_unit_resources_url).returns('/resources-pdf-url')
     summary = unit.summarize

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -932,6 +932,16 @@ class ScriptTest < ActiveSupport::TestCase
     assert_equal '/resources-pdf-url', summary[:scriptResourcesPdfUrl]
   end
 
+  test 'get_unit_resources_pdf_url returns nil if no resources in script or lessons' do
+    Services::CurriculumPdfs.stubs(:get_unit_resources_url).returns('/resources-pdf-url')
+    unit = create(:script, name: 'single-lesson-script', instruction_type: SharedCourseConstants::INSTRUCTION_TYPE.teacher_led, instructor_audience: SharedCourseConstants::INSTRUCTOR_AUDIENCE.teacher, participant_audience: SharedCourseConstants::PARTICIPANT_AUDIENCE.student)
+    lesson_group = create(:lesson_group, key: 'key1', script: unit)
+    lesson = create(:lesson, script: unit, name: 'lesson 1', lesson_group: lesson_group)
+    create(:script_level, script: unit, lesson: lesson)
+
+    assert_nil unit.get_unit_resources_pdf_url
+  end
+
   test 'should summarize migrated unit in unit group' do
     unit_group = create(:unit_group, instruction_type: SharedCourseConstants::INSTRUCTION_TYPE.self_paced, instructor_audience: SharedCourseConstants::INSTRUCTOR_AUDIENCE.facilitator, participant_audience: SharedCourseConstants::PARTICIPANT_AUDIENCE.teacher)
     unit = create(:script, name: 'single-lesson-script', is_migrated: true)

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -934,10 +934,10 @@ class ScriptTest < ActiveSupport::TestCase
 
   test 'get_unit_resources_pdf_url returns nil if no resources in script or lessons' do
     Services::CurriculumPdfs.stubs(:get_unit_resources_url).returns('/resources-pdf-url')
-    unit = create(:script, name: 'single-lesson-script', instruction_type: SharedCourseConstants::INSTRUCTION_TYPE.teacher_led, instructor_audience: SharedCourseConstants::INSTRUCTOR_AUDIENCE.teacher, participant_audience: SharedCourseConstants::PARTICIPANT_AUDIENCE.student)
-    lesson_group = create(:lesson_group, key: 'key1', script: unit)
-    lesson = create(:lesson, script: unit, name: 'lesson 1', lesson_group: lesson_group)
-    create(:script_level, script: unit, lesson: lesson)
+    unit = create :script
+    lesson_group = create :lesson_group, script: unit
+    lesson = create :lesson, script: unit, lesson_group: lesson_group
+    create :script_level, script: unit, lesson: lesson
 
     assert_nil unit.get_unit_resources_pdf_url
   end


### PR DESCRIPTION
We got a report that the "Print Handouts" button on the new HOC lessons showed a blank PDF, which makes sense as there aren't any handouts. In this PR, we will pass down a nil URL for the handouts pdf, which the frontend already deals with correctly (I also added a test).

I checked:
- /s/hello-world-food-2021/lessons/1 and /s/hello-world-food-2021 no longer have a handout link
- /s/coursea-2021/lessons/1 and /s/coursea-2021/ still have a handout link

Let me know if there are any other cases to check!

Also spent this opportunity to deduplicate some code.


## Testing story

unit tests



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
