### PR TITLE
[Sprite Lab][HOC] Speech bubble small fixes

### DIFF
--- a/apps/src/p5lab/spritelab/CoreLibrary.js
+++ b/apps/src/p5lab/spritelab/CoreLibrary.js
@@ -136,6 +136,12 @@ export default class CoreLibrary {
   }
 
   addSpeechBubble(sprite, text, seconds = null) {
+    // Sprites can only have one speech bubble at a time so first filter out
+    // any existing speech bubbles for this sprite
+    this.speechBubbles = this.speechBubbles.filter(
+      bubble => bubble.sprite !== sprite
+    );
+
     const id = createUuid();
     const removeAt = seconds ? this.getAdjustedWorldTime() + seconds : null;
     // Note: renderFrame is used by validation code.

--- a/apps/src/p5lab/spritelab/CoreLibrary.js
+++ b/apps/src/p5lab/spritelab/CoreLibrary.js
@@ -86,21 +86,26 @@ export default class CoreLibrary {
     const padding = 8;
     text = ellipsify(text, 150 /* maxLength */);
     let textSize;
-    let maxLength;
+    let charsPerLine;
     if (text.length < 50) {
       textSize = 20;
-      maxLength = 16;
+      charsPerLine = 16;
     } else if (text.length < 75) {
       textSize = 15;
-      maxLength = 20;
+      charsPerLine = 20;
     } else {
       textSize = 10;
-      maxLength = 28;
+      charsPerLine = 28;
     }
 
-    const lines = stringToChunks(text, maxLength);
+    const lines = stringToChunks(text, charsPerLine);
+    // Since it's not a fixed-width font, we can't just use line length to
+    // determine the longest line, we have to actually calculate each width.
     const longestLine = [...lines].sort((a, b) =>
-      a.length < b.length ? 1 : -1
+      drawUtils.getTextWidth(this.p5, a, textSize) <
+      drawUtils.getTextWidth(this.p5, b, textSize)
+        ? 1
+        : -1
     )[0];
     let width =
       drawUtils.getTextWidth(this.p5, longestLine, textSize) + padding * 2;

--- a/apps/src/p5lab/spritelab/CoreLibrary.js
+++ b/apps/src/p5lab/spritelab/CoreLibrary.js
@@ -69,6 +69,10 @@ export default class CoreLibrary {
     // bubbles that have expired.
     this.removeExpiredSpeechBubbles();
 
+    if (this.speechBubbles.length === 0 || this.isPreviewFrame()) {
+      return;
+    }
+
     this.speechBubbles.forEach(({text, sprite}) => {
       this.drawSpeechBubble(
         text,

--- a/apps/src/p5lab/spritelab/CoreLibrary.js
+++ b/apps/src/p5lab/spritelab/CoreLibrary.js
@@ -138,9 +138,7 @@ export default class CoreLibrary {
   addSpeechBubble(sprite, text, seconds = null) {
     // Sprites can only have one speech bubble at a time so first filter out
     // any existing speech bubbles for this sprite
-    this.speechBubbles = this.speechBubbles.filter(
-      bubble => bubble.sprite !== sprite
-    );
+    this.removeSpeechBubblesForSprite(sprite);
 
     const id = createUuid();
     const removeAt = seconds ? this.getAdjustedWorldTime() + seconds : null;
@@ -153,6 +151,12 @@ export default class CoreLibrary {
       renderFrame: this.currentFrame()
     });
     return id;
+  }
+
+  removeSpeechBubblesForSprite(sprite) {
+    this.speechBubbles = this.speechBubbles.filter(
+      bubble => bubble.sprite !== sprite
+    );
   }
 
   removeExpiredSpeechBubbles() {

--- a/apps/src/p5lab/spritelab/CoreLibrary.js
+++ b/apps/src/p5lab/spritelab/CoreLibrary.js
@@ -120,17 +120,17 @@ export default class CoreLibrary {
     // For the calculations below, keep in mind that x and y are located at the horizontal center and the top of the sprite, respectively.
     // In other words, x and y indicate the default position of the bubble's triangular tip.
     y = Math.min(y, APP_HEIGHT);
-    let originalX = x;
+    const spriteX = x;
     if (y - height - triangleSize < 1) {
       triangleSize = Math.max(1, y - height);
       y = height + triangleSize;
     }
-    if (originalX - width / 2 < 1) {
-      triangleTipX = Math.max(originalX, rectangleCornerRadius + triangleSize);
+    if (spriteX - width / 2 < 1) {
+      triangleTipX = Math.max(spriteX, rectangleCornerRadius + triangleSize);
       x = width / 2;
     }
-    if (originalX + width / 2 > APP_WIDTH) {
-      triangleTipX = Math.min(originalX, APP_WIDTH - rectangleCornerRadius);
+    if (spriteX + width / 2 > APP_WIDTH) {
+      triangleTipX = Math.min(spriteX, APP_WIDTH - rectangleCornerRadius);
       x = APP_WIDTH - width / 2;
     }
 

--- a/apps/src/p5lab/spritelab/CoreLibrary.js
+++ b/apps/src/p5lab/spritelab/CoreLibrary.js
@@ -69,10 +69,6 @@ export default class CoreLibrary {
     // bubbles that have expired.
     this.removeExpiredSpeechBubbles();
 
-    if (this.speechBubbles.length === 0 || this.isPreviewFrame()) {
-      return;
-    }
-
     this.speechBubbles.forEach(({text, sprite}) => {
       this.drawSpeechBubble(
         text,

--- a/apps/src/p5lab/spritelab/CoreLibrary.js
+++ b/apps/src/p5lab/spritelab/CoreLibrary.js
@@ -120,16 +120,17 @@ export default class CoreLibrary {
     // For the calculations below, keep in mind that x and y are located at the horizontal center and the top of the sprite, respectively.
     // In other words, x and y indicate the default position of the bubble's triangular tip.
     y = Math.min(y, APP_HEIGHT);
+    let originalX = x;
     if (y - height - triangleSize < 1) {
       triangleSize = Math.max(1, y - height);
       y = height + triangleSize;
     }
-    if (x - width / 2 < 1) {
-      triangleTipX = Math.max(x, rectangleCornerRadius + triangleSize);
+    if (originalX - width / 2 < 1) {
+      triangleTipX = Math.max(originalX, rectangleCornerRadius + triangleSize);
       x = width / 2;
     }
-    if (x + width / 2 > APP_WIDTH) {
-      triangleTipX = Math.min(x, APP_WIDTH - rectangleCornerRadius);
+    if (originalX + width / 2 > APP_WIDTH) {
+      triangleTipX = Math.min(originalX, APP_WIDTH - rectangleCornerRadius);
       x = APP_WIDTH - width / 2;
     }
 

--- a/apps/src/p5lab/spritelab/CoreLibrary.js
+++ b/apps/src/p5lab/spritelab/CoreLibrary.js
@@ -85,14 +85,20 @@ export default class CoreLibrary {
   drawSpeechBubble(text, x, y) {
     const padding = 8;
     text = ellipsify(text, 150 /* maxLength */);
-    let textSize = 10;
+    let textSize;
+    let maxLength;
     if (text.length < 50) {
       textSize = 20;
+      maxLength = 16;
     } else if (text.length < 75) {
       textSize = 15;
+      maxLength = 20;
+    } else {
+      textSize = 10;
+      maxLength = 28;
     }
 
-    const lines = stringToChunks(text, 16 /* maxLength */);
+    const lines = stringToChunks(text, maxLength);
     const longestLine = [...lines].sort((a, b) =>
       a.length < b.length ? 1 : -1
     )[0];

--- a/apps/src/p5lab/spritelab/commands/spriteCommands.js
+++ b/apps/src/p5lab/spritelab/commands/spriteCommands.js
@@ -13,6 +13,7 @@ export const commands = {
     sprites.forEach(sprite => {
       sprite.destroy();
       this.removeAllBehaviors(sprite);
+      this.removeSpeechBubblesForSprite(sprite);
       this.deleteSprite(sprite.id);
     });
   },


### PR DESCRIPTION
[jira](https://codedotorg.atlassian.net/browse/STAR-1933)

Only one speech bubble per sprite
Before
![image](https://user-images.githubusercontent.com/8787187/142323357-2ef919d0-3153-4656-8b7b-1c68414e074b.png)

After
![image](https://user-images.githubusercontent.com/8787187/142322992-d29c7ed0-d46a-47a6-a377-27f9c9b9ae11.png)


Delete speech bubble when sprite deleted
Before
![image](https://user-images.githubusercontent.com/8787187/142324105-09696a05-8d6c-43e0-b581-fe77d1fd58db.png)

After
![image](https://user-images.githubusercontent.com/8787187/142323748-5a930f4d-c389-4a48-9d4a-ac8acbb74b96.png)


Line wrapping based on text size
Before
![image](https://user-images.githubusercontent.com/8787187/142322337-a473c56c-8624-4bad-a46f-f7dbe3d89c9a.png)

After
![image](https://user-images.githubusercontent.com/8787187/142321147-06f6abb7-7aff-47bf-9786-c6cc50535a86.png)


~Speech bubbles show in preview~ edit: holding on this for now. See [slack thread](https://codedotorg.slack.com/archives/C946FMBGT/p1637191791005700)
Before
![image](https://user-images.githubusercontent.com/8787187/142321898-94a16087-a804-43aa-8692-37ba953ad9e2.png)

After
![image](https://user-images.githubusercontent.com/8787187/142322084-c84ca6b0-801d-447b-8a8f-622b79b9e1b8.png)
