### PR TITLE
Add DCDO flag for contact rollups

### DIFF
--- a/bin/cron/build_contact_rollups_v2
+++ b/bin/cron/build_contact_rollups_v2
@@ -22,7 +22,7 @@ ensure
 end
 
 def main
-  return false unless DCDO.get('contact_rollups_active', true)
+  return unless DCDO.get('contact_rollups_active', true)
   run_contact_rollups
 end
 

--- a/bin/cron/build_contact_rollups_v2
+++ b/bin/cron/build_contact_rollups_v2
@@ -5,7 +5,7 @@ abort 'Script already running' unless only_one_running?(__FILE__)
 require_relative '../../dashboard/config/environment'
 require_relative '../../dashboard/lib/contact_rollups_v2'
 
-def main
+def run_contact_rollups
   # To avoid accidentally syncing bad data to Pardot, this script should run
   # only in production. In other environments, it has to be in dry-run mode.
   force_dry_run = !CDO.rack_env?(:production)
@@ -19,6 +19,11 @@ def main
   contact_rollups.build_and_sync
 ensure
   contact_rollups.report_results
+end
+
+def main
+  return false unless DCDO.get('contact_rollups_active', true)
+  run_contact_rollups
 end
 
 main


### PR DESCRIPTION
This adds a DCDO flag for contact rollups if we need to turn them off during HOC. I set the flag in production, but not in the other environments (it shouldn't be run in other environments) besides my local environment.

The flag name is `'contact_rollups_active'`. It is currently set to `true`––to turn off contact rollups, set the flag to `false`.

## Links

- jira ticket: [PLAT-1445](https://codedotorg.atlassian.net/browse/PLAT-1445)

## Testing story

I tested on my local environment, setting the DCDO flag in my local dashboard-console. You can also see the flag in AWS.

## Deployment strategy

## Follow-up work

Question: Do I need to add a task for removing this flag after HOC?

## Privacy

## Security

## Caching

## PR Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
