### PR TITLE
Refactor SaveBar with hide Show button

### DIFF
--- a/apps/src/lib/levelbuilder/SaveBar.jsx
+++ b/apps/src/lib/levelbuilder/SaveBar.jsx
@@ -18,11 +18,7 @@ export default function SaveBar({
       className="btn"
       type="button"
       style={styles.saveButton}
-      onClick={
-        handleView ||
-        (pathForShowButton && (() => navigateToHref(pathForShowButton))) ||
-        (() => {})
-      }
+      onClick={handleView || (() => navigateToHref(pathForShowButton))}
       disabled={isSaving}
     >
       Show

--- a/apps/src/lib/levelbuilder/SaveBar.jsx
+++ b/apps/src/lib/levelbuilder/SaveBar.jsx
@@ -74,11 +74,8 @@ SaveBar.propTypes = {
 };
 
 SaveBar.defaultProps = {
-  error: undefined,
-  handleView: undefined,
   isSaving: false,
-  lastSaved: 0,
-  pathForShowButton: undefined
+  lastSaved: 0
 };
 
 const styles = {

--- a/apps/src/lib/levelbuilder/SaveBar.jsx
+++ b/apps/src/lib/levelbuilder/SaveBar.jsx
@@ -70,7 +70,7 @@ SaveBar.propTypes = {
 };
 
 SaveBar.defaultProps = {
-  error: false,
+  error: undefined,
   handleView: undefined,
   isSaving: false,
   lastSaved: 0,

--- a/apps/src/lib/levelbuilder/SaveBar.jsx
+++ b/apps/src/lib/levelbuilder/SaveBar.jsx
@@ -1,68 +1,63 @@
 import PropTypes from 'prop-types';
-import React, {Component} from 'react';
+import React from 'react';
 import color from '@cdo/apps/util/color';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import {navigateToHref} from '@cdo/apps/utils';
 
-export default class SaveBar extends Component {
-  handleView = () =>
-    this.props.handleView || navigateToHref(this.props.pathForShowButton);
+export default function SaveBar({
+  error,
+  handleSave,
+  handleView,
+  isSaving,
+  lastSaved,
+  pathForShowButton
+}) {
+  const isShowButtonRendered = handleView || pathForShowButton !== '/';
 
-  isShowButtonRendered =
-    this.props.handleView || this.props.pathForShowButton !== '/';
-
-  render() {
-    return (
-      <div style={styles.saveButtonBackground} className="saveBar">
+  return (
+    <div style={styles.saveButtonBackground} className="saveBar">
+      <button
+        className="btn"
+        type="button"
+        style={isShowButtonRendered ? styles.saveButton : styles.hide}
+        onClick={handleView || (() => navigateToHref(pathForShowButton))}
+        disabled={isSaving}
+      >
+        Show
+      </button>
+      <div style={styles.saveButtonArea}>
+        {lastSaved && !error && (
+          <div style={styles.lastSaved} className="lastSavedMessage">
+            {`Last saved at: ${new Date(lastSaved).toLocaleString()}`}
+          </div>
+        )}
+        {error && <div style={styles.error}>{`Error Saving: ${error}`}</div>}
+        {isSaving && (
+          <div style={styles.spinner}>
+            <FontAwesome icon="spinner" className="fa-spin" />
+          </div>
+        )}
         <button
           className="btn"
           type="button"
-          style={this.isShowButtonRendered ? styles.saveButton : styles.hide}
-          onClick={this.handleView}
-          disabled={this.props.isSaving}
+          style={styles.saveButton}
+          onClick={e => handleSave(e, false)}
+          disabled={isSaving}
         >
-          Show
+          Save and Keep Editing
         </button>
-        <div style={styles.saveButtonArea}>
-          {this.props.lastSaved && !this.props.error && (
-            <div style={styles.lastSaved} className="lastSavedMessage">
-              {`Last saved at: ${new Date(
-                this.props.lastSaved
-              ).toLocaleString()}`}
-            </div>
-          )}
-          {this.props.error && (
-            <div style={styles.error}>{`Error Saving: ${
-              this.props.error
-            }`}</div>
-          )}
-          {this.props.isSaving && (
-            <div style={styles.spinner}>
-              <FontAwesome icon="spinner" className="fa-spin" />
-            </div>
-          )}
-          <button
-            className="btn"
-            type="button"
-            style={styles.saveButton}
-            onClick={e => this.props.handleSave(e, false)}
-            disabled={this.props.isSaving}
-          >
-            Save and Keep Editing
-          </button>
-          <button
-            className="btn btn-primary"
-            type="submit"
-            style={styles.saveButton}
-            onClick={e => this.props.handleSave(e, true)}
-            disabled={this.props.isSaving}
-          >
-            Save and Close
-          </button>
-        </div>
+        <button
+          className="btn btn-primary"
+          type="submit"
+          style={styles.saveButton}
+          onClick={e => handleSave(e, true)}
+          disabled={isSaving}
+        >
+          Save and Close
+        </button>
       </div>
-    );
-  }
+    </div>
+  );
 }
 
 SaveBar.propTypes = {

--- a/apps/src/lib/levelbuilder/SaveBar.jsx
+++ b/apps/src/lib/levelbuilder/SaveBar.jsx
@@ -2,27 +2,27 @@ import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import color from '@cdo/apps/util/color';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
-import {linkWithQueryParams, navigateToHref} from '@cdo/apps/utils';
+import {navigateToHref} from '@cdo/apps/utils';
 
 export default class SaveBar extends Component {
   handleView = () =>
-    this.props.handleView ||
-    navigateToHref(linkWithQueryParams(this.props.pathForShowButton));
+    this.props.handleView || navigateToHref(this.props.pathForShowButton);
+
+  isShowButtonRendered =
+    this.props.handleView || this.props.pathForShowButton !== '/';
 
   render() {
     return (
       <div style={styles.saveButtonBackground} className="saveBar">
-        {this.props.pathForShowButton !== '/' && (
-          <button
-            className="btn"
-            type="button"
-            style={styles.saveButton}
-            onClick={this.handleView}
-            disabled={this.props.isSaving}
-          >
-            Show
-          </button>
-        )}
+        <button
+          className="btn"
+          type="button"
+          style={this.isShowButtonRendered ? styles.saveButton : styles.hide}
+          onClick={this.handleView}
+          disabled={this.props.isSaving}
+        >
+          Show
+        </button>
         <div style={styles.saveButtonArea}>
           {this.props.lastSaved && !this.props.error && (
             <div style={styles.lastSaved} className="lastSavedMessage">
@@ -99,6 +99,9 @@ const styles = {
   },
   saveButton: {
     margin: '10px 50px 10px 20px'
+  },
+  hide: {
+    visibility: 'hidden'
   },
   spinner: {
     fontSize: 25,

--- a/apps/src/lib/levelbuilder/SaveBar.jsx
+++ b/apps/src/lib/levelbuilder/SaveBar.jsx
@@ -12,15 +12,19 @@ export default function SaveBar({
   lastSaved,
   pathForShowButton
 }) {
-  const isShowButtonRendered = handleView || pathForShowButton !== '/';
+  const isShowButtonVisible = handleView || pathForShowButton;
 
   return (
     <div style={styles.saveButtonBackground} className="saveBar">
       <button
         className="btn"
         type="button"
-        style={isShowButtonRendered ? styles.saveButton : styles.hide}
-        onClick={handleView || (() => navigateToHref(pathForShowButton))}
+        style={isShowButtonVisible ? styles.saveButton : styles.hide}
+        onClick={
+          handleView ||
+          (pathForShowButton && (() => navigateToHref(pathForShowButton))) ||
+          (() => {})
+        }
         disabled={isSaving}
       >
         Show
@@ -74,7 +78,7 @@ SaveBar.defaultProps = {
   handleView: undefined,
   isSaving: false,
   lastSaved: 0,
-  pathForShowButton: '/'
+  pathForShowButton: undefined
 };
 
 const styles = {

--- a/apps/src/lib/levelbuilder/SaveBar.jsx
+++ b/apps/src/lib/levelbuilder/SaveBar.jsx
@@ -13,22 +13,25 @@ export default function SaveBar({
   pathForShowButton
 }) {
   const isShowButtonVisible = handleView || pathForShowButton;
+  const renderShowButton = () => (
+    <button
+      className="btn"
+      type="button"
+      style={styles.saveButton}
+      onClick={
+        handleView ||
+        (pathForShowButton && (() => navigateToHref(pathForShowButton))) ||
+        (() => {})
+      }
+      disabled={isSaving}
+    >
+      Show
+    </button>
+  );
 
   return (
     <div style={styles.saveButtonBackground} className="saveBar">
-      <button
-        className="btn"
-        type="button"
-        style={isShowButtonVisible ? styles.saveButton : styles.hide}
-        onClick={
-          handleView ||
-          (pathForShowButton && (() => navigateToHref(pathForShowButton))) ||
-          (() => {})
-        }
-        disabled={isSaving}
-      >
-        Show
-      </button>
+      {isShowButtonVisible ? renderShowButton() : <span />}
       <div style={styles.saveButtonArea}>
         {lastSaved && !error && (
           <div style={styles.lastSaved} className="lastSavedMessage">
@@ -99,9 +102,6 @@ const styles = {
   },
   saveButton: {
     margin: '10px 50px 10px 20px'
-  },
-  hide: {
-    visibility: 'hidden'
   },
   spinner: {
     fontSize: 25,

--- a/apps/src/lib/levelbuilder/SaveBar.jsx
+++ b/apps/src/lib/levelbuilder/SaveBar.jsx
@@ -75,6 +75,10 @@ SaveBar.propTypes = {
 };
 
 SaveBar.defaultProps = {
+  error: false,
+  handleView: undefined,
+  isSaving: false,
+  lastSaved: 0,
   pathForShowButton: '/'
 };
 

--- a/apps/src/lib/levelbuilder/SaveBar.jsx
+++ b/apps/src/lib/levelbuilder/SaveBar.jsx
@@ -2,20 +2,27 @@ import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import color from '@cdo/apps/util/color';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
+import {linkWithQueryParams, navigateToHref} from '@cdo/apps/utils';
 
 export default class SaveBar extends Component {
+  handleView = () =>
+    this.props.handleView ||
+    navigateToHref(linkWithQueryParams(this.props.pathForShowButton));
+
   render() {
     return (
       <div style={styles.saveButtonBackground} className="saveBar">
-        <button
-          className="btn"
-          type="button"
-          style={styles.saveButton}
-          onClick={this.props.handleView}
-          disabled={this.props.isSaving}
-        >
-          Show
-        </button>
+        {this.props.pathForShowButton !== '/' && (
+          <button
+            className="btn"
+            type="button"
+            style={styles.saveButton}
+            onClick={this.handleView}
+            disabled={this.props.isSaving}
+          >
+            Show
+          </button>
+        )}
         <div style={styles.saveButtonArea}>
           {this.props.lastSaved && !this.props.error && (
             <div style={styles.lastSaved} className="lastSavedMessage">
@@ -61,9 +68,14 @@ export default class SaveBar extends Component {
 SaveBar.propTypes = {
   error: PropTypes.string,
   handleSave: PropTypes.func.isRequired,
-  handleView: PropTypes.func.isRequired,
+  handleView: PropTypes.func,
   isSaving: PropTypes.bool,
-  lastSaved: PropTypes.number
+  lastSaved: PropTypes.number,
+  pathForShowButton: PropTypes.string
+};
+
+SaveBar.defaultProps = {
+  pathForShowButton: '/'
 };
 
 const styles = {

--- a/apps/src/lib/levelbuilder/SaveBar.jsx
+++ b/apps/src/lib/levelbuilder/SaveBar.jsx
@@ -4,14 +4,6 @@ import color from '@cdo/apps/util/color';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 
 export default class SaveBar extends Component {
-  static propTypes = {
-    lastSaved: PropTypes.number,
-    error: PropTypes.string,
-    handleSave: PropTypes.func.isRequired,
-    handleView: PropTypes.func.isRequired,
-    isSaving: PropTypes.bool
-  };
-
   render() {
     return (
       <div style={styles.saveButtonBackground} className="saveBar">
@@ -65,6 +57,14 @@ export default class SaveBar extends Component {
     );
   }
 }
+
+SaveBar.propTypes = {
+  error: PropTypes.string,
+  handleSave: PropTypes.func.isRequired,
+  handleView: PropTypes.func.isRequired,
+  isSaving: PropTypes.bool,
+  lastSaved: PropTypes.number
+};
 
 const styles = {
   saveButtonBackground: {

--- a/apps/src/lib/levelbuilder/SaveBar.jsx
+++ b/apps/src/lib/levelbuilder/SaveBar.jsx
@@ -12,22 +12,27 @@ export default function SaveBar({
   lastSaved,
   pathForShowButton
 }) {
-  const isShowButtonVisible = handleView || pathForShowButton;
-  const renderShowButton = () => (
-    <button
-      className="btn"
-      type="button"
-      style={styles.saveButton}
-      onClick={handleView || (() => navigateToHref(pathForShowButton))}
-      disabled={isSaving}
-    >
-      Show
-    </button>
-  );
+  const renderShowButtonOrPlaceholder = () => {
+    const isShowButtonVisible = handleView || pathForShowButton;
+
+    const renderShowButton = () => (
+      <button
+        className="btn"
+        type="button"
+        style={styles.saveButton}
+        onClick={handleView || (() => navigateToHref(pathForShowButton))}
+        disabled={isSaving}
+      >
+        Show
+      </button>
+    );
+
+    return isShowButtonVisible ? renderShowButton() : <span />;
+  };
 
   return (
     <div style={styles.saveButtonBackground} className="saveBar">
-      {isShowButtonVisible ? renderShowButton() : <span />}
+      {renderShowButtonOrPlaceholder()}
       <div style={styles.saveButtonArea}>
         {lastSaved && !error && (
           <div style={styles.lastSaved} className="lastSavedMessage">

--- a/apps/src/lib/levelbuilder/course-editor/CourseEditor.js
+++ b/apps/src/lib/levelbuilder/course-editor/CourseEditor.js
@@ -104,10 +104,6 @@ class CourseEditor extends Component {
     this.setState({announcements: newAnnouncements});
   };
 
-  handleView = () => {
-    navigateToHref(linkWithQueryParams(this.props.coursePath));
-  };
-
   handleSave = (event, shouldCloseAfterSave) => {
     event.preventDefault();
 
@@ -396,10 +392,10 @@ class CourseEditor extends Component {
         </CollapsibleEditorSection>
         <SaveBar
           handleSave={this.handleSave}
-          handleView={this.handleView}
           error={this.state.error}
           isSaving={this.state.isSaving}
           lastSaved={this.state.lastSaved}
+          pathForShowButton={this.props.coursePath}
         />
       </div>
     );

--- a/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
@@ -73,13 +73,6 @@ class LessonEditor extends Component {
     };
   }
 
-  handleView = () => {
-    this.state.hasLessonPlan &&
-      navigateToHref(
-        linkWithQueryParams(this.state.originalLessonData.lessonPath)
-      );
-  };
-
   handleSave = (event, shouldCloseAfterSave) => {
     event.preventDefault();
 
@@ -458,10 +451,14 @@ class LessonEditor extends Component {
 
         <SaveBar
           handleSave={this.handleSave}
-          handleView={this.handleView}
           error={this.state.error}
           isSaving={this.state.isSaving}
           lastSaved={this.state.lastSaved}
+          pathForShowButton={
+            this.props.initialLessonData.hasLessonPlan
+              ? this.state.originalLessonData.lessonPath
+              : undefined
+          }
         />
       </div>
     );

--- a/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
@@ -74,9 +74,10 @@ class LessonEditor extends Component {
   }
 
   handleView = () => {
-    navigateToHref(
-      linkWithQueryParams(this.state.originalLessonData.lessonPath)
-    );
+    this.state.hasLessonPlan &&
+      navigateToHref(
+        linkWithQueryParams(this.state.originalLessonData.lessonPath)
+      );
   };
 
   handleSave = (event, shouldCloseAfterSave) => {

--- a/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
@@ -62,8 +62,8 @@ class LessonEditor extends Component {
       unplugged: this.props.initialLessonData.unplugged,
       lockable: this.props.initialLessonData.lockable,
       hasLessonPlan: this.props.initialLessonData.hasLessonPlan,
-      creativeCommonsLicense: this.props.initialLessonData
-        .creativeCommonsLicense,
+      creativeCommonsLicense:
+        this.props.initialLessonData.creativeCommonsLicense || '',
       assessment: this.props.initialLessonData.assessment,
       purpose: this.props.initialLessonData.purpose || '',
       preparation: this.props.initialLessonData.preparation || '',

--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -216,10 +216,6 @@ class UnitEditor extends React.Component {
     }
   };
 
-  handleView = () => {
-    navigateToHref(linkWithQueryParams(this.props.scriptPath));
-  };
-
   handleSave = (event, shouldCloseAfterSave) => {
     event.preventDefault();
 
@@ -1102,10 +1098,10 @@ class UnitEditor extends React.Component {
         </CollapsibleEditorSection>
         <SaveBar
           handleSave={this.handleSave}
-          handleView={this.handleView}
           error={this.state.error}
           isSaving={this.state.isSaving}
           lastSaved={this.state.lastSaved}
+          pathForShowButton={this.props.scriptPath}
         />
       </div>
     );

--- a/apps/test/unit/lib/levelbuilder/SaveBarTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/SaveBarTest.jsx
@@ -3,29 +3,28 @@ import {shallow} from 'enzyme';
 import {expect} from '../../../util/reconfiguredChai';
 import sinon from 'sinon';
 import SaveBar from '@cdo/apps/lib/levelbuilder/SaveBar';
+import * as utils from '@cdo/apps/utils';
 
 describe('SaveBar', () => {
-  let defaultProps, handleSave, handleView;
+  let handleSave;
   beforeEach(() => {
     handleSave = sinon.spy();
-    handleView = sinon.spy();
-    defaultProps = {
-      isSaving: false,
-      error: null,
-      lastSaved: null,
-      handleSave,
-      handleView
-    };
   });
 
   it('renders default props', () => {
-    const wrapper = shallow(<SaveBar {...defaultProps} />);
+    const wrapper = shallow(<SaveBar handleSave={handleSave} />);
     expect(wrapper.find('button').length).to.equal(3);
+
+    // show button is hidden by default
+    const showButton = wrapper.find('button').at(0);
+    expect(showButton.props().style).to.have.property('visibility', 'hidden');
+
     expect(wrapper.find('FontAwesome').length).to.equal(0); //spinner isn't showing
   });
 
   it('can save and keep editing', () => {
-    const wrapper = shallow(<SaveBar {...defaultProps} />);
+    const handleSave = sinon.spy();
+    const wrapper = shallow(<SaveBar handleSave={handleSave} />);
 
     const saveAndKeepEditingButton = wrapper.find('button').at(1);
     expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
@@ -36,7 +35,9 @@ describe('SaveBar', () => {
   });
 
   it('shows spinner when isSaving is true', () => {
-    const wrapper = shallow(<SaveBar {...defaultProps} isSaving={true} />);
+    const wrapper = shallow(
+      <SaveBar handleSave={handleSave} isSaving={true} />
+    );
 
     // check the the spinner is showing
     expect(wrapper.find('FontAwesome').length).to.equal(1);
@@ -44,7 +45,7 @@ describe('SaveBar', () => {
 
   it('shows lastSaved when there is no error', () => {
     const wrapper = shallow(
-      <SaveBar {...defaultProps} lastSaved={Date.now()} />
+      <SaveBar handleSave={handleSave} lastSaved={Date.now()} />
     );
 
     expect(wrapper.find('.lastSavedMessage').text()).to.include(
@@ -54,7 +55,7 @@ describe('SaveBar', () => {
 
   it('shows error when props error is set', () => {
     const wrapper = shallow(
-      <SaveBar {...defaultProps} error={'There was an error'} />
+      <SaveBar handleSave={handleSave} error={'There was an error'} />
     );
     expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(0);
     expect(
@@ -63,7 +64,8 @@ describe('SaveBar', () => {
   });
 
   it('can save and close', () => {
-    const wrapper = shallow(<SaveBar {...defaultProps} />);
+    const handleSave = sinon.spy();
+    const wrapper = shallow(<SaveBar handleSave={handleSave} />);
 
     const saveAndCloseButton = wrapper.find('button').at(2);
     expect(saveAndCloseButton.contains('Save and Close')).to.be.true;
@@ -72,13 +74,42 @@ describe('SaveBar', () => {
     expect(handleSave).to.have.been.calledOnce;
   });
 
-  it('can go to item with show', () => {
-    const wrapper = shallow(<SaveBar {...defaultProps} />);
+  it('can show with custom handleView, even if path is given', () => {
+    const handleView = sinon.spy();
+    sinon.stub(utils, 'navigateToHref');
+    const wrapper = shallow(
+      <SaveBar
+        handleSave={handleSave}
+        handleView={handleView}
+        pathForShowButton={'/my/path'}
+      />
+    );
 
-    const saveAndCloseButton = wrapper.find('button').at(0);
-    expect(saveAndCloseButton.contains('Show')).to.be.true;
-    saveAndCloseButton.simulate('click');
+    const showButton = wrapper.find('button').at(0);
+    expect(showButton.props().style).not.to.have.property('visibility');
+    expect(showButton.contains('Show')).to.be.true;
+    showButton.simulate('click');
 
+    expect(utils.navigateToHref).not.to.have.been.called;
     expect(handleView).to.have.been.calledOnce;
+
+    utils.navigateToHref.restore();
+  });
+
+  it('can show with custom path', () => {
+    const path = '/my/path';
+    sinon.stub(utils, 'navigateToHref');
+    const wrapper = shallow(
+      <SaveBar handleSave={handleSave} pathForShowButton={path} />
+    );
+
+    const showButton = wrapper.find('button').at(0);
+    expect(showButton.props().style).not.to.have.property('visibility');
+    expect(showButton.contains('Show')).to.be.true;
+    showButton.simulate('click');
+
+    expect(utils.navigateToHref).to.have.been.calledWith(path);
+
+    utils.navigateToHref.restore();
   });
 });

--- a/apps/test/unit/lib/levelbuilder/SaveBarTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/SaveBarTest.jsx
@@ -13,12 +13,7 @@ describe('SaveBar', () => {
 
   it('renders default props', () => {
     const wrapper = shallow(<SaveBar handleSave={handleSave} />);
-    expect(wrapper.find('button').length).to.equal(3);
-
-    // show button is hidden by default
-    const showButton = wrapper.find('button').at(0);
-    expect(showButton.props().style).to.have.property('visibility', 'hidden');
-
+    expect(wrapper.find('button').length).to.equal(2); // show button not rendered
     expect(wrapper.find('FontAwesome').length).to.equal(0); //spinner isn't showing
   });
 
@@ -26,7 +21,7 @@ describe('SaveBar', () => {
     const handleSave = sinon.spy();
     const wrapper = shallow(<SaveBar handleSave={handleSave} />);
 
-    const saveAndKeepEditingButton = wrapper.find('button').at(1);
+    const saveAndKeepEditingButton = wrapper.find('button').at(0);
     expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
       .true;
     saveAndKeepEditingButton.simulate('click');
@@ -67,7 +62,7 @@ describe('SaveBar', () => {
     const handleSave = sinon.spy();
     const wrapper = shallow(<SaveBar handleSave={handleSave} />);
 
-    const saveAndCloseButton = wrapper.find('button').at(2);
+    const saveAndCloseButton = wrapper.find('button').at(1);
     expect(saveAndCloseButton.contains('Save and Close')).to.be.true;
     saveAndCloseButton.simulate('click');
 
@@ -86,7 +81,6 @@ describe('SaveBar', () => {
     );
 
     const showButton = wrapper.find('button').at(0);
-    expect(showButton.props().style).not.to.have.property('visibility');
     expect(showButton.contains('Show')).to.be.true;
     showButton.simulate('click');
 
@@ -104,7 +98,6 @@ describe('SaveBar', () => {
     );
 
     const showButton = wrapper.find('button').at(0);
-    expect(showButton.props().style).not.to.have.property('visibility');
     expect(showButton.contains('Show')).to.be.true;
     showButton.simulate('click');
 


### PR DESCRIPTION
Hides the "show" button on the Lesson Edit page if there's no lesson plan. On the Lesson Edit side, I checked for a lesson plan inside initialLessonData––this doesn't ensure the path actually works.

On the SaveBar side, I did the following:
1) Provided a default handleView to use if a path is given (default does not use linkWithQueryParams)
2) Allow a custom handleView to be passed in––uses that if given.
3) Hides the Show button if a path isn't given and if no handleView is given.
4) Refactored component to use DefaultProps and be a function component.

I updated CourseEditor, LessonEditor, and UnitEditor to take into account these changes. I didn't change ProgrammingExpressionsEditor.

I suppose it's possible someone will want to show the button even if they don't pass in a function or a path. Do we want to allow more control to show/hide it?

## Links

- jira ticket: [PLAT-1435](https://codedotorg.atlassian.net/browse/PLAT-1435)

## Testing story

I tested manually and added/refactored some unit tests.

## Deployment strategy

## Follow-up work

## Privacy

## Security

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
