### PR TITLE
[Poetry] Disable dropdown when code is running

### DIFF
--- a/apps/src/p5lab/poetry/PoemSelector.jsx
+++ b/apps/src/p5lab/poetry/PoemSelector.jsx
@@ -217,6 +217,7 @@ function PoemSelector(props) {
           searchable={false}
           onChange={onChange}
           options={getPoemOptions()}
+          disabled={props.isRunning}
         />
       </div>
     </div>
@@ -226,6 +227,7 @@ function PoemSelector(props) {
 PoemSelector.propTypes = {
   // from Redux
   selectedPoem: poemShape.isRequired,
+  isRunning: PropTypes.bool.isRequired,
   onChangePoem: PropTypes.func.isRequired
 };
 
@@ -261,7 +263,8 @@ const styles = {
 
 export default connect(
   state => ({
-    selectedPoem: state.poetry.selectedPoem
+    selectedPoem: state.poetry.selectedPoem,
+    isRunning: state.runState.isRunning
   }),
   dispatch => ({
     onChangePoem(poem) {


### PR DESCRIPTION
Changing the poem while the program is running causes issues, and probably shouldn't be possible anyways. Solution here is just to disable the dropdown (similar to what we do for the song dropdown in dance party)

[jira](https://codedotorg.atlassian.net/browse/STAR-1938)

Before
![image](https://user-images.githubusercontent.com/8787187/142494767-e1ab8cda-3481-4ee9-abf8-66fa350dcf6b.png)


After
![image](https://user-images.githubusercontent.com/8787187/142494614-f16907cb-065b-4fde-82ba-3e9785f3f4b5.png)
