### PR TITLE
Change hour-of-code-logo.zip download to use https

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/public/promote/resources.md.partial
+++ b/pegasus/sites.v3/hourofcode.com/public/promote/resources.md.partial
@@ -43,7 +43,7 @@ A new poster set is available featuring Malala, Stephen Curry, Shakira and more!
 [![image]({{ hoc_logo_fit_200 }})]({{ hoc_logo }})
 [![image]({{ hdc_logo_fit_200 }})]({{ hdc_logo }})
 
-[Download hi-res versions](http://images.code.org/share/hour-of-code-logo.zip)
+[Download hi-res versions](https://images.code.org/share/hour-of-code-logo.zip)
 
 **"Hour of Code" and "Hora del Código" are trademarked. We don't want to prevent their usage, but we do want to make sure usage fits within a few limits:**
 


### PR DESCRIPTION
Users were receiving a warning message when trying to download the HoC logos on https://hourofcode.com/us/promote/resources#logo in Edge. On Chrome, it seems to be blocked entirely. On Firefox, it is flagged as a potential security risk.

Changing the link to https instead of http seems to address this.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
