### PR TITLE
Header: fix project update updates

### DIFF
--- a/apps/src/code-studio/components/header/ProjectUpdatedAt.jsx
+++ b/apps/src/code-studio/components/header/ProjectUpdatedAt.jsx
@@ -11,8 +11,21 @@ import RetryProjectSaveDialog from './RetryProjectSaveDialog';
 class ProjectUpdatedAt extends React.Component {
   static propTypes = {
     status: PropTypes.oneOf(Object.values(statuses)),
-    updatedAt: PropTypes.string
+    updatedAt: PropTypes.string,
+    onContentUpdated: PropTypes.func
   };
+
+  componentDidMount() {
+    if (this.props.onContentUpdated) {
+      this.props.onContentUpdated();
+    }
+  }
+
+  componentDidUpdate() {
+    if (this.props.onContentUpdated) {
+      this.props.onContentUpdated();
+    }
+  }
 
   renderText() {
     if (this.props.status === statuses.error) {
@@ -35,7 +48,7 @@ class ProjectUpdatedAt extends React.Component {
       return (
         <div>
           {msg.savedToGallery()}{' '}
-          {this.props.updatedAt && (
+          {false && this.props.updatedAt && (
             <TimeAgo dateString={this.props.updatedAt} />
           )}
         </div>

--- a/apps/src/code-studio/components/header/ProjectUpdatedAt.jsx
+++ b/apps/src/code-studio/components/header/ProjectUpdatedAt.jsx
@@ -48,7 +48,7 @@ class ProjectUpdatedAt extends React.Component {
       return (
         <div>
           {msg.savedToGallery()}{' '}
-          {false && this.props.updatedAt && (
+          {this.props.updatedAt && (
             <TimeAgo dateString={this.props.updatedAt} />
           )}
         </div>

--- a/apps/src/code-studio/components/header/ScriptName.jsx
+++ b/apps/src/code-studio/components/header/ScriptName.jsx
@@ -44,6 +44,10 @@ class ScriptName extends React.Component {
     );
   }
 
+  onProjectUpdatedAtContentUpdated = () => {
+    this.setDesiredWidth();
+  };
+
   renderScriptLink() {
     let className = 'header_text';
     if (this.props.smallText) {
@@ -101,7 +105,9 @@ class ScriptName extends React.Component {
           <div style={styles.outerContainer}>
             <div style={styles.containerWithUpdatedAt}>
               {this.renderScriptLink()}
-              <ProjectUpdatedAt />
+              <ProjectUpdatedAt
+                onContentUpdated={this.onProjectUpdatedAtContentUpdated}
+              />
             </div>
           </div>
         </div>


### PR DESCRIPTION
It was recently observed that the header's `ScriptName` component -- which contains the script name and sometimes the `ProjectUpdatedAt` component below that which shows text like "Saved 2 hours ago" -- was being cropped at its right edge.

While I wasn't able to get a firm local repro, I was able to simulate the suspected issue: the `ProjectUpdatedAt` component was having its content updated, but the parent `ScriptName` component didn't know that, so it didn't tell its parent `HeaderMiddle` component about the newly-desired width.

I'm not sure whether this was always an issue, or something new in a recent React update, but the fix is pretty simple: when the `ProjectUpdatedAt` component is updated, it informs its parent `ScriptName`, which then determines the width of the resulting content, and tells its parent `HeaderMiddle`, which can go about reallocating space appropriately.

The simulation of this issue simply put a timer inside `ProjectUpdatedAt` which rendered a random length string every second.  

**Before**, we can see that `HeaderMiddle` isn't reallocating space:

https://user-images.githubusercontent.com/2205926/142585562-3ccd6753-cdb7-41c1-ac55-3aa1071e0e9d.mov

**After**, we can see that `HeaderMiddle` reallocates spaces:

https://user-images.githubusercontent.com/2205926/142585585-e361f2ce-fa5d-46b3-86f6-6871931efd85.mov

This counts as a follow-up to https://github.com/code-dot-org/code-dot-org/pull/34551.
