### PR TITLE
Remove blank objectives

### DIFF
--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -713,11 +713,12 @@ class Lesson < ApplicationRecord
     return unless objectives
 
     self.objectives = objectives.map do |objective|
+      next nil unless objective['description'].present?
       persisted_objective = objective['id'].blank? ? Objective.new(key: SecureRandom.uuid) : Objective.find(objective['id'])
       persisted_objective.description = objective['description']
       persisted_objective.save!
       persisted_objective
-    end
+    end.compact
   end
 
   # Used for seeding from JSON. Returns the full set of information needed to

--- a/dashboard/config/scripts_json/coursef-2021.script_json
+++ b/dashboard/config/scripts_json/coursef-2021.script_json
@@ -10032,15 +10032,6 @@
       }
     },
     {
-      "key": "7a69d6de-1a75-41da-a511-9cb735e02a5c",
-      "properties": {
-      },
-      "seeding_key": {
-        "lesson.key": "lesson-2",
-        "objective.key": "7a69d6de-1a75-41da-a511-9cb735e02a5c"
-      }
-    },
-    {
       "key": "7a7f6249-ea7c-40df-a0a6-e4a3f5c61d9f",
       "properties": {
         "description": "Develop programs that respond to user input."

--- a/dashboard/test/controllers/lessons_controller_test.rb
+++ b/dashboard/test/controllers/lessons_controller_test.rb
@@ -1008,6 +1008,25 @@ class LessonsControllerTest < ActionController::TestCase
     assert_equal 'edited description', objective.description
   end
 
+  test 'objectives with empty description are removed' do
+    sign_in @levelbuilder
+    objective_to_keep = create :objective, description: 'to keep', lesson: @lesson
+    objective_to_remove = create :objective, description: 'to remove', lesson: @lesson
+    assert_equal 2, @lesson.objectives.count
+
+    objectives_data = @lesson.summarize_for_lesson_edit[:objectives]
+    objectives_data[1][:description] = ''
+    objectives_data.push(id: nil, description: '')
+
+    new_update_params = @update_params.merge({objectives: [objective_to_keep.summarize_for_edit].to_json})
+    put :update, params: new_update_params
+    @lesson.reload
+
+    assert_equal 1, @lesson.objectives.count
+    assert_nil Objective.find_by_id(objective_to_remove.id)
+    assert_not_nil objective_to_keep.reload
+  end
+
   test 'add script level via lesson update' do
     sign_in @levelbuilder
     activity = create :lesson_activity, lesson: @lesson


### PR DESCRIPTION
Starts [PLAT-1390].

* Step 1 (this PR): remove existing blank objectives, and prevent more from being added via levelbuilder UI
* Step 2 (https://github.com/code-dot-org/code-dot-org/pull/43711): add validation preventing blank objectives from being added more generally

What i did in this step:
* `Objective.all.reject(&:description).count` returned 1 in development, levelbuilder and production
* used lesson edit page locally to remove the one problem objective, and added the resulting .script_json changes to this PR
* updated the lesson save path to never add blank objectives. 
  * I couldn't provide a default value of `''` when storing the description in the database, because that gets transformed to `nil` somewhere, possibly in [serialized_properties.rb](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/concerns/serialized_properties.rb)

## Testing story

* new unit test
* manually verified that after entering a blank objective and saving the lesson edit page and then reloading it, the blank objective is gone

## Deployment strategy

* merge step 1
* wait for it to reach levelbuilder and production
* check that levelbuilder and production do not contain blank objectives
* merge step 2


[PLAT-1390]: https://codedotorg.atlassian.net/browse/PLAT-1390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ