### PR TITLE
make objective description required

### DIFF
--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -485,7 +485,7 @@ class Lesson < ApplicationRecord
       resources: resources.map(&:summarize_for_lesson_edit),
       vocabularies: vocabularies.sort_by(&:word).map(&:summarize_for_lesson_edit),
       programmingExpressions: programming_expressions.sort_by {|pe| pe.syntax || ''}.map(&:summarize_for_lesson_edit),
-      objectives: objectives.sort_by {|o| o.description || ''}.map(&:summarize_for_edit),
+      objectives: objectives.sort_by(&:description).map(&:summarize_for_edit),
       standards: lesson_standards.map(&:summarize_for_lesson_edit),
       frameworks: Framework.all.map(&:summarize_for_lesson_edit),
       opportunityStandards: opportunity_standards.map(&:summarize_for_lesson_edit),
@@ -509,7 +509,7 @@ class Lesson < ApplicationRecord
       resources: resources_for_lesson_plan(user&.authorized_teacher?),
       vocabularies: vocabularies.sort_by(&:word).map(&:summarize_for_lesson_show),
       programmingExpressions: programming_expressions.sort_by {|pe| pe.syntax || ''}.map(&:summarize_for_lesson_show),
-      objectives: objectives.sort_by {|o| o.description || ''}.map(&:summarize_for_lesson_show),
+      objectives: objectives.sort_by(&:description).map(&:summarize_for_lesson_show),
       standards: standards.map(&:summarize_for_lesson_show),
       opportunityStandards: opportunity_standards.map(&:summarize_for_lesson_show),
       is_teacher: user&.teacher?,
@@ -531,7 +531,7 @@ class Lesson < ApplicationRecord
       resources: resources_for_lesson_plan(user&.authorized_teacher?),
       vocabularies: vocabularies.sort_by(&:word).map(&:summarize_for_lesson_show),
       programmingExpressions: programming_expressions.sort_by {|pe| pe.syntax || ''}.map(&:summarize_for_lesson_show),
-      objectives: objectives.sort_by {|o| o.description || ''}.map(&:summarize_for_lesson_show),
+      objectives: objectives.sort_by(&:description).map(&:summarize_for_lesson_show),
       standards: standards.map(&:summarize_for_lesson_show),
       link: script_lesson_path(script, self)
     }

--- a/dashboard/app/models/objective.rb
+++ b/dashboard/app/models/objective.rb
@@ -27,6 +27,8 @@ class Objective < ApplicationRecord
     description
   )
 
+  validates_presence_of :description
+
   def summarize_for_edit
     {id: id, description: description, key: key}
   end

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -119,7 +119,7 @@ class LessonTest < ActiveSupport::TestCase
     lesson_group = create :lesson_group, script: script
     lesson = create :lesson, script: script, lesson_group: lesson_group, name: 'My Lesson'
     lesson.objectives.push(create(:objective))
-    lesson.objectives.push(create(:objective, description: nil))
+    lesson.objectives.push(create(:objective))
     lesson.vocabularies.push(create(:vocabulary))
     lesson.vocabularies.push(create(:vocabulary))
     lesson.resources.push(create(:resource))

--- a/dashboard/test/models/objective_test.rb
+++ b/dashboard/test/models/objective_test.rb
@@ -40,4 +40,10 @@ class ObjectiveTest < ActiveSupport::TestCase
     assert_equal("Translated description", objective.summarize_for_lesson_show[:description])
     I18n.locale = I18n.default_locale
   end
+
+  test 'description is required' do
+    assert_raises ActiveRecord::RecordInvalid do
+      create :objective, description: nil
+    end
+  end
 end


### PR DESCRIPTION
Finishes [PLAT-1390].  Step 2 of #43710.

Makes objective description required, and removes special cases for handling blank descriptions from the seed logic.

## Testing story

* new unit test
* manually verified that blank objectives are removed when saving lessons

## Deployment strategy

See #43710. I've updated this to point to staging-next, but will still wait until empty objectives are gone from other environments before merging this PR.


[PLAT-1390]: https://codedotorg.atlassian.net/browse/PLAT-1390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ