### PR TITLE
Do not show ProgressLessonTeacherInfo in MiniView

### DIFF
--- a/apps/src/code-studio/components/progress/MiniView.jsx
+++ b/apps/src/code-studio/components/progress/MiniView.jsx
@@ -8,69 +8,67 @@ import {hasGroups} from '@cdo/apps/code-studio/progressRedux';
 /**
  * The course progress dropdown you get when you click the arrow in the header.
  */
-class MiniView extends React.Component {
-  static propTypes = {
-    linesOfCodeText: PropTypes.string,
-    minimal: PropTypes.bool,
+function MiniView(props) {
+  const {
+    linesOfCodeText,
+    isSummaryView,
+    hasGroups,
+    scriptName,
+    hasFullProgress,
+    selectedSectionId,
+    minimal
+  } = props;
 
-    // redux backed
-    isSummaryView: PropTypes.bool.isRequired,
-    hasGroups: PropTypes.bool.isRequired,
-    scriptName: PropTypes.string.isRequired,
-    hasFullProgress: PropTypes.bool.isRequired,
-    selectedSectionId: PropTypes.string
-  };
-
-  render() {
-    const {
-      linesOfCodeText,
-      isSummaryView,
-      hasGroups,
-      scriptName,
-      hasFullProgress,
-      selectedSectionId,
-      minimal
-    } = this.props;
-
-    let body;
-    if (!hasFullProgress) {
-      // Ideally we would specify inline CSS instead of using a classname here,
-      // but the image used here gets digested by rails, and we don't know the
-      // digested path
-      body = <div className="loading" style={{height: minimal ? 100 : 400}} />;
-    } else {
-      body = (
-        <div
-          className="mini-view"
-          style={{
-            ...(!hasGroups && !isSummaryView && styles.detailView),
-            ...(hasGroups && styles.groupView)
-          }}
-        >
-          <UnitOverview
-            onOverviewPage={false}
-            excludeCsfColumnInLegend={false}
-            teacherResources={[]}
-            minimal={minimal}
-          />
-        </div>
-      );
-    }
-
-    return (
-      <div>
-        {!minimal && (
-          <MiniViewTopRow
-            scriptName={scriptName}
-            linesOfCodeText={linesOfCodeText}
-            selectedSectionId={selectedSectionId}
-          />
-        )}
-        {body}
+  let body;
+  if (!hasFullProgress) {
+    // Ideally we would specify inline CSS instead of using a classname here,
+    // but the image used here gets digested by rails, and we don't know the
+    // digested path
+    body = <div className="loading" style={{height: minimal ? 100 : 400}} />;
+  } else {
+    body = (
+      <div
+        className="mini-view"
+        style={{
+          ...(!hasGroups && !isSummaryView && styles.detailView),
+          ...(hasGroups && styles.groupView)
+        }}
+      >
+        <UnitOverview
+          onOverviewPage={false}
+          excludeCsfColumnInLegend={false}
+          teacherResources={[]}
+          minimal={minimal}
+        />
       </div>
     );
   }
+
+  return (
+    <div>
+      {!minimal && (
+        <MiniViewTopRow
+          scriptName={scriptName}
+          linesOfCodeText={linesOfCodeText}
+          selectedSectionId={selectedSectionId}
+        />
+      )}
+      {body}
+    </div>
+  );
 }
+
+MiniView.propTypes = {
+  linesOfCodeText: PropTypes.string,
+  minimal: PropTypes.bool,
+
+  // redux backed
+  isSummaryView: PropTypes.bool.isRequired,
+  hasGroups: PropTypes.bool.isRequired,
+  scriptName: PropTypes.string.isRequired,
+  hasFullProgress: PropTypes.bool.isRequired,
+  selectedSectionId: PropTypes.string
+};
 
 const styles = {
   // For the detail view (without groups) we want some margins

--- a/apps/src/code-studio/progressRedux.js
+++ b/apps/src/code-studio/progressRedux.js
@@ -27,6 +27,7 @@ const DISABLE_POST_MILESTONE = 'progress/DISABLE_POST_MILESTONE';
 const SET_IS_HOC_UNIT = 'progress/SET_IS_HOC_UNIT';
 const SET_IS_AGE_13_REQUIRED = 'progress/SET_IS_AGE_13_REQUIRED';
 const SET_IS_SUMMARY_VIEW = 'progress/SET_IS_SUMMARY_VIEW';
+const SET_IS_MINI_VIEW = 'progress/SET_IS_MINI_VIEW';
 const SET_STUDENT_DEFAULTS_SUMMARY_VIEW =
   'progress/SET_STUDENT_DEFAULTS_SUMMARY_VIEW';
 const SET_CURRENT_LESSON_ID = 'progress/SET_CURRENT_LESSON_ID';
@@ -69,6 +70,7 @@ const initialState = {
   // Do students see summary view by default?
   studentDefaultsSummaryView: true,
   isSummaryView: true,
+  isMiniView: false,
   hasFullProgress: false,
   lessonExtrasEnabled: false,
   // Note: usingDbProgress === "user is logged in". However, it is
@@ -206,6 +208,13 @@ export default function reducer(state = initialState, action) {
     return {
       ...state,
       isSummaryView: action.isSummaryView
+    };
+  }
+
+  if (action.type === SET_IS_MINI_VIEW) {
+    return {
+      ...state,
+      isMiniView: action.isMiniView
     };
   }
 
@@ -477,6 +486,10 @@ export const setIsAge13Required = isAge13Required => ({
 export const setIsSummaryView = isSummaryView => ({
   type: SET_IS_SUMMARY_VIEW,
   isSummaryView
+});
+export const setIsMiniView = isMiniView => ({
+  type: SET_IS_MINI_VIEW,
+  isMiniView
 });
 export const setStudentDefaultsSummaryView = studentDefaultsSummaryView => ({
   type: SET_STUDENT_DEFAULTS_SUMMARY_VIEW,

--- a/apps/src/sites/studio/pages/levels/show.js
+++ b/apps/src/sites/studio/pages/levels/show.js
@@ -24,7 +24,8 @@ function initPage() {
   const codeReviewEnabled = config.code_review_enabled;
   getStore().dispatch(setCodeReviewEnabled(codeReviewEnabled));
 
-  // We are viewing the unit overview components in the miniview
+  // If viewing the unit overview components on the level page it is in
+  // the mini view
   getStore().dispatch(setIsMiniView(true));
 
   const redirectDialogMountPoint = document.getElementById('redirect-dialog');

--- a/apps/src/sites/studio/pages/levels/show.js
+++ b/apps/src/sites/studio/pages/levels/show.js
@@ -8,6 +8,7 @@ import sectionData, {
   setTtsAutoplayEnabled,
   setCodeReviewEnabled
 } from '@cdo/apps/redux/sectionDataRedux';
+import {setIsMiniView} from '@cdo/apps/code-studio/progressRedux';
 
 $(document).ready(initPage);
 
@@ -22,6 +23,9 @@ function initPage() {
   getStore().dispatch(setTtsAutoplayEnabled(ttsAutoplayEnabled));
   const codeReviewEnabled = config.code_review_enabled;
   getStore().dispatch(setCodeReviewEnabled(codeReviewEnabled));
+
+  // We are viewing the unit overview components in the miniview
+  getStore().dispatch(setIsMiniView(true));
 
   const redirectDialogMountPoint = document.getElementById('redirect-dialog');
   const unversionedRedirectDialogMountPoint = document.getElementById(

--- a/apps/src/templates/progress/ProgressLesson.jsx
+++ b/apps/src/templates/progress/ProgressLesson.jsx
@@ -34,7 +34,8 @@ class ProgressLesson extends React.Component {
     lockableAuthorized: PropTypes.bool,
     lockableAuthorizedLoaded: PropTypes.bool.isRequired,
     lessonIsLockedForAllStudents: PropTypes.func.isRequired,
-    isRtl: PropTypes.bool
+    isRtl: PropTypes.bool,
+    isMiniView: PropTypes.bool
   };
 
   constructor(props) {
@@ -215,7 +216,7 @@ class ProgressLesson extends React.Component {
             />
           )}
         </div>
-        {viewAs === ViewType.Instructor && (
+        {viewAs === ViewType.Instructor && !this.props.isMiniView && (
           <ProgressLessonTeacherInfo
             lesson={lesson}
             lessonUrl={lessonUrl}
@@ -313,5 +314,6 @@ export default connect(state => ({
     lessonIsLockedForAllStudents(lessonId, state),
   selectedSectionId: state.teacherSections.selectedSectionId.toString(),
   scriptId: state.progress.scriptId,
-  isRtl: state.isRtl
+  isRtl: state.isRtl,
+  isMiniView: state.progress.isMiniView
 }))(ProgressLesson);

--- a/apps/test/unit/templates/progress/ProgressLessonTest.js
+++ b/apps/test/unit/templates/progress/ProgressLessonTest.js
@@ -24,7 +24,8 @@ describe('ProgressLesson', () => {
     lessonIsLockedForUser: () => false,
     lessonIsLockedForAllStudents: () => false,
     lockableAuthorizedLoaded: true,
-    lockableAuthorized: true
+    lockableAuthorized: true,
+    isMiniView: false
   };
 
   it('renders with gray background when not hidden', () => {
@@ -389,5 +390,29 @@ describe('ProgressLesson', () => {
     // If locked, it would have a dashed border
     assert.equal(wrapper.props().style.borderStyle, 'solid');
     assert.equal(wrapper.find('ProgressLessonContent').props().disabled, false);
+  });
+
+  it('if ProgressLesson displayed in the MiniView it does not show the ProgressLessonTeacherInfo for teacher', () => {
+    const wrapper = shallow(
+      <ProgressLesson
+        {...defaultProps}
+        viewAs={ViewType.Instructor}
+        isMiniView={true}
+      />
+    );
+
+    assert.equal(wrapper.find('Connect(ProgressLessonTeacherInfo)').length, 0);
+  });
+
+  it('if ProgressLesson displayed on UnitOverview page it shows the ProgressLessonTeacherInfo for teacher', () => {
+    const wrapper = shallow(
+      <ProgressLesson
+        {...defaultProps}
+        viewAs={ViewType.Instructor}
+        isMiniView={false}
+      />
+    );
+
+    assert.equal(wrapper.find('Connect(ProgressLessonTeacherInfo)').length, 1);
   });
 });


### PR DESCRIPTION
https://github.com/code-dot-org/code-dot-org/pull/43637/ mistakenly added the ProgressLessonTeacherInfo to the MiniView on levels for teachers. [It was caught by the eyes tests but we decided to ship with it because it was blocking getting out a fix for a regression](https://codedotorg.slack.com/archives/C0T0PNTM3/p1637288518187200).  This fixes it so that the ProgressLessonTeacherInfo does not show in the MiniView. It will still continue to working for signed out teachers using viewAs on the UnitOverview page as was added in #43637 .

<img width="1298" alt="Screen Shot 2021-11-19 at 1 22 38 PM" src="https://user-images.githubusercontent.com/208083/142672513-570eb0e4-4e79-4322-a30e-b0c3e23b475b.png">

# Tests

- Added new unit tests to make sure we keep this from happening mistakenly in the future
- Checked UnitOverview Page and MiniView manually
