### PR TITLE
Autoload subdirectories of `dashboard/lib`

### DIFF
--- a/dashboard/config/application.rb
+++ b/dashboard/config/application.rb
@@ -137,6 +137,11 @@ module Dashboard
     # well as some subdirectories of the models dir that we use for organization.
 
     config.autoload_paths << Rails.root.join('lib')
+    config.autoload_paths << Rails.root.join('lib', 'api')
+    config.autoload_paths << Rails.root.join('lib', 'pd')
+    config.autoload_paths << Rails.root.join('lib', 'policies')
+    config.autoload_paths << Rails.root.join('lib', 'queries')
+    config.autoload_paths << Rails.root.join('lib', 'services')
     config.autoload_paths << Rails.root.join('app', 'models', 'experiments')
     config.autoload_paths << Rails.root.join('app', 'models', 'levels')
     config.autoload_paths << Rails.root.join('app', 'models', 'sections')


### PR DESCRIPTION
The rails autoload config doesn't automatically load entire directory structures, just the specific directories that it's given.

This is another speculative fix to address deploys being risky to do during times of high traffic.

## Links

jira ticket: https://codedotorg.atlassian.net/browse/INF-508

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
