### PR TITLE
For new User Type Button Rollout: Switch from localStorage to sessionStorage for Optimizely tracking

### DIFF
--- a/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
+++ b/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
@@ -50,7 +50,7 @@ $(document).ready(() => {
   const schoolInfoMountPoint = document.getElementById('school-info-inputs');
 
   const inClearerUserTypeOptExp =
-    localStorage.getItem('inClearerUserTypeOptExpLS') === 'true';
+    sessionStorage.getItem('inClearerUserTypeOptExpLS') === 'true';
 
   let userType = $('#user_user_type')[0].value;
   init();


### PR DESCRIPTION
Follow-up work from [this PR](https://github.com/code-dot-org/code-dot-org/pull/43346) related to updating how the user selects their user type ("Student" or "Teacher") in the sign-up process. The only difference is switching from localStorage usage to sessionStorage. Since it just affects someone going through the process of signing up, sessionStorage is more appropriate and Optimizely is able to interact with it (it has worked in the past like with [this PR](https://github.com/code-dot-org/code-dot-org/pull/40384)).

## Links
PR this is following up from: [here](https://github.com/code-dot-org/code-dot-org/pull/43346)

## Testing story
Manually checked the same scenarios as the PR this is following up from to ensure the same behavior occurred.

## Follow-up work
Start the Optimizely experiment to rollout this change only to users who are viewing the site in a language that has been translated for the new User Type buttons.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
