### PR TITLE
Javalab: fix console font disparity

### DIFF
--- a/apps/src/javalab/JavalabConsole.jsx
+++ b/apps/src/javalab/JavalabConsole.jsx
@@ -284,7 +284,8 @@ const styles = {
     padding: 0,
     fontFamily: 'monospace',
     flexGrow: 1,
-    marginTop: -2
+    marginTop: -2,
+    fontSize: 13
   },
   spacer: {
     width: 8


### PR DESCRIPTION
The font size of text in the console as it was being typed was slightly larger than text output. This sets the input text size to be the same as the rest of the tex.
## Links
- jira ticket: [CSA-1073](https://codedotorg.atlassian.net/browse/CSA-1073)

## Testing story
Tested locally.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
