### PR TITLE
new unassign dialog test file

### DIFF
--- a/apps/src/templates/UnassignSectionDialog.jsx
+++ b/apps/src/templates/UnassignSectionDialog.jsx
@@ -34,7 +34,7 @@ class UnassignSectionDialog extends Component {
             courseName: courseName || i18n.thisUnit()
           })}
         </h2>
-        <div style={styles.confirm}>
+        <div id="unassign-dialog-body" style={styles.confirm}>
           {i18n.unassignSectionConfirm({
             sectionName: sectionName,
             courseName: courseName || i18n.thisUnit()

--- a/apps/test/unit/templates/UnassignSectionDialogTest.jsx
+++ b/apps/test/unit/templates/UnassignSectionDialogTest.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import {mount} from 'enzyme';
+import sinon from 'sinon';
+import UnassignSectionDialog from '@cdo/apps/templates/UnassignSectionDialog';
+import {expect} from 'chai';
+
+const DEFAULT_PROPS = {
+  isOpen: true,
+  sectionId: 1,
+  onClose: () => {},
+  unassignSection: () => {},
+  courseName: 'myCourse',
+  sectionName: 'mySection'
+};
+
+const setUp = overrideProps => {
+  const props = {...DEFAULT_PROPS, ...overrideProps};
+  return mount(<UnassignSectionDialog {...props} />);
+};
+
+describe('UnassignSectionDialog', () => {
+  it('calls unassign function when unassign button clicked', () => {
+    const unassignSpy = sinon.spy();
+    const wrapper = setUp({unassignSection: unassignSpy});
+
+    const button = wrapper.find('Button').at(1);
+
+    button.simulate('click');
+    expect(unassignSpy).to.have.been.calledOnce;
+  });
+
+  it('calls close function when user clicks cancel', () => {
+    const closeSpy = sinon.spy();
+    const wrapper = setUp({onClose: closeSpy});
+    const button = wrapper.find('Button').at(0);
+
+    button.simulate('click');
+    expect(closeSpy).to.have.been.calledOnce;
+  });
+
+  it('displays the right section and unit text', () => {
+    const wrapper = setUp();
+
+    expect(
+      wrapper
+        .find({id: 'unassign-dialog-body'})
+        .contains(
+          'Your students in mySection will no longer be taken to myCourse when they sign in.'
+        )
+    ).to.be.true;
+
+    expect(wrapper.text().includes('Unassign myCourse')).to.be.true;
+  });
+});


### PR DESCRIPTION
This PR just adds a unit test file to the UnassignSectionDialog component. This is work a followup to https://github.com/code-dot-org/code-dot-org/pull/42796, which added this dialog component and was pushed through with only feature tests to prevent the branch from becoming too stale.

## Links

- jira ticket: https://codedotorg.atlassian.net/browse/LP-2080

## Testing story

The text in the dialog is tested (in both the header and the body of the dialog), as are the cancel and confirm button clicks.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
