### PR TITLE
Default Sprites in AnimationList Migration

### DIFF
--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -276,7 +276,7 @@ export default class P5Lab {
       getStore().dispatch(
         setInitialAnimationList(
           this.startAnimations,
-          null /* shouldRunV3Migration */,
+          null /* spritesForV3Migration */,
           this.isBlockly
         )
       );
@@ -486,7 +486,7 @@ export default class P5Lab {
     getStore().dispatch(
       setInitialAnimationList(
         initialAnimationList,
-        defaultSprites /* shouldRunV3Migration */,
+        defaultSprites /* spritesForV3Migration */,
         this.isBlockly
       )
     );

--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -276,7 +276,7 @@ export default class P5Lab {
       getStore().dispatch(
         setInitialAnimationList(
           this.startAnimations,
-          false /* shouldRunV3Migration */,
+          null /* shouldRunV3Migration */,
           this.isBlockly
         )
       );
@@ -486,7 +486,7 @@ export default class P5Lab {
     getStore().dispatch(
       setInitialAnimationList(
         initialAnimationList,
-        this.isBlockly /* shouldRunV3Migration */,
+        defaultSprites /* shouldRunV3Migration */,
         this.isBlockly
       )
     );

--- a/apps/src/p5lab/redux/animationList.js
+++ b/apps/src/p5lab/redux/animationList.js
@@ -21,7 +21,6 @@ import {
   getCurrentId
 } from '@cdo/apps/code-studio/initApp/project';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
-import defaultSprites from '../spritelab/defaultSprites.json';
 import trackEvent from '@cdo/apps/util/trackEvent';
 
 // TODO: Overwrite version ID within session
@@ -260,11 +259,12 @@ function generateAnimationName(baseName, animationList) {
 
 /**
  * @param {!SerializedAnimationList} serializedAnimationList
+ * @param {object} spritesForV3Migration - optional - sprites passed to replace /v3/ sprites
  * @returns {function()}
  */
 export function setInitialAnimationList(
   serializedAnimationList,
-  shouldRunV3Migration,
+  spritesForV3Migration,
   isSpriteLab
 ) {
   // Set default empty animation list if none was provided
@@ -286,7 +286,7 @@ export function setInitialAnimationList(
   }
 
   // TODO (from 2020): Tear out this migration when it hasn't been used for at least 3 consecutive non-summer months.
-  if (shouldRunV3Migration) {
+  if (spritesForV3Migration) {
     serializedAnimationList.orderedKeys.forEach(loadedKey => {
       let animation = serializedAnimationList.propsByKey[loadedKey];
       if (
@@ -300,10 +300,10 @@ export function setInitialAnimationList(
       if (animation.sourceUrl.includes('/v3/')) {
         // We want to replace this sprite with the /v1/ sprite
         let details = `name=${animation.name};key=${loadedKey}`;
-        if (defaultSprites.propsByKey[loadedKey]) {
+        if (spritesForV3Migration.propsByKey[loadedKey]) {
           // The key is the same in the main.json and in default sprites. Do a simple replacement.
           serializedAnimationList.propsByKey[loadedKey] =
-            defaultSprites.propsByKey[loadedKey];
+            spritesForV3Migration.propsByKey[loadedKey];
           trackEvent('Research', 'ReplacedSpriteByKey', details);
         } else {
           // We were unable to find a replacement for the /v3/ sprite

--- a/apps/test/unit/p5lab/redux/animationListTest.js
+++ b/apps/test/unit/p5lab/redux/animationListTest.js
@@ -227,6 +227,27 @@ describe('animationList', function() {
     return {orderedKeys: orderedKeys, propsByKey: propsByKey};
   };
 
+  let createAnimationListToMigrate = function(count) {
+    let orderedKeys = [];
+    let propsByKey = {};
+    let baseKey = 'animation';
+    for (let i = 1; i <= count; i++) {
+      let key = baseKey + '_' + i;
+      orderedKeys.push(key);
+
+      propsByKey[key] = {
+        name: key,
+        sourceUrl: 'source/v3/url',
+        frameSize: {x: 100, y: 100},
+        frameCount: 1,
+        looping: true,
+        frameDelay: 4,
+        version: null
+      };
+    }
+    return {orderedKeys: orderedKeys, propsByKey: propsByKey};
+  };
+
   describe('action: set initial animationList', function() {
     let server, store;
     beforeEach(function() {
@@ -301,6 +322,19 @@ describe('animationList', function() {
       expect(
         store.getState().animationList.propsByKey['animation_3'].name
       ).to.equal('images (1).jpg_1_2');
+    });
+
+    it('when animationList has migratable animations, check that animation is substituted', function() {
+      let animationList = createAnimationListToMigrate(2);
+      let defaultSprites = createAnimationList(2);
+      defaultSprites.propsByKey['animation_1'].sourceUrl = 'cat';
+
+      store.dispatch(
+        setInitialAnimationList(animationList, true, true, defaultSprites)
+      );
+      expect(
+        store.getState().animationList.propsByKey['animation_1'].sourceUrl
+      ).to.equal('cat');
     });
   });
 

--- a/apps/test/unit/p5lab/redux/animationListTest.js
+++ b/apps/test/unit/p5lab/redux/animationListTest.js
@@ -206,7 +206,7 @@ describe('animationList', function() {
     });
   });
 
-  let createAnimationList = function(count) {
+  let createAnimationList = function(count, v3Sources = false) {
     let orderedKeys = [];
     let propsByKey = {};
     let baseKey = 'animation';
@@ -216,28 +216,7 @@ describe('animationList', function() {
 
       propsByKey[key] = {
         name: key,
-        sourceUrl: null,
-        frameSize: {x: 100, y: 100},
-        frameCount: 1,
-        looping: true,
-        frameDelay: 4,
-        version: null
-      };
-    }
-    return {orderedKeys: orderedKeys, propsByKey: propsByKey};
-  };
-
-  let createAnimationListToMigrate = function(count) {
-    let orderedKeys = [];
-    let propsByKey = {};
-    let baseKey = 'animation';
-    for (let i = 1; i <= count; i++) {
-      let key = baseKey + '_' + i;
-      orderedKeys.push(key);
-
-      propsByKey[key] = {
-        name: key,
-        sourceUrl: 'source/v3/url',
+        sourceUrl: v3Sources ? 'source/v3/url' : null,
         frameSize: {x: 100, y: 100},
         frameCount: 1,
         looping: true,
@@ -251,7 +230,7 @@ describe('animationList', function() {
   describe('action: set initial animationList', function() {
     let server, store;
     beforeEach(function() {
-      project.getCurrentId.returns('');
+      project.getCurrentId.returns('123');
       server = sinon.fakeServer.create();
       server.respondWith('imageBody');
       store = createStore(
@@ -325,7 +304,7 @@ describe('animationList', function() {
     });
 
     it('when animationList has migratable animations, check that animation is substituted', function() {
-      let animationList = createAnimationListToMigrate(2);
+      let animationList = createAnimationList(2, true);
       let defaultSprites = createAnimationList(2);
       defaultSprites.propsByKey['animation_1'].sourceUrl = 'cat';
 

--- a/apps/test/unit/p5lab/redux/animationListTest.js
+++ b/apps/test/unit/p5lab/redux/animationListTest.js
@@ -330,7 +330,7 @@ describe('animationList', function() {
       defaultSprites.propsByKey['animation_1'].sourceUrl = 'cat';
 
       store.dispatch(
-        setInitialAnimationList(animationList, true, true, defaultSprites)
+        setInitialAnimationList(animationList, defaultSprites, true)
       );
       expect(
         store.getState().animationList.propsByKey['animation_1'].sourceUrl


### PR DESCRIPTION
Part of breaking off chunks of this PR: https://github.com/code-dot-org/code-dot-org/pull/42835

The goal of this PR is to remove the defaultSprites JSON file reference from animationList, by passing that information through to setInitialAnimationList. The defaultSprites is only used in animationList in a specific condition of setInitialAnimationList, which is indicated behind a boolean flag. I turned that boolean into an object of defaultSprites and now calls to setInitialAnimationList can either pass an object with defaultSprites or a null object.

The only place setInitialAnimationList is given the parameter to perform the migration (and thus use defaultSprites) is a location where we already have defaultSprites in scope in P5Lab.js. So although we will still need to find a way to get that defaultSprites reference to call on S3, P5Lab.js is the only place we will need to reference defaultSprites, after this PR.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
