### PR TITLE
[Poetry] Don't let scale go past 0

### DIFF
--- a/apps/src/p5lab/poetry/commands/behaviors.js
+++ b/apps/src/p5lab/poetry/commands/behaviors.js
@@ -99,6 +99,9 @@ export const commands = {
       return;
     }
     sprite.setScale(sprite.getScale() - 1 / 100);
+    if (sprite.scale < 0) {
+      sprite.scale = 0;
+    }
   },
 
   spinning_left(spriteArg) {


### PR DESCRIPTION
If scale goes negative, the sprite will get bigger but be mirrored. For the shrinking behavior, we don't want this, so just guard against `scale < 0` and stay at 0 in that case.

Before
![Nov-21-2021 12-34-06](https://user-images.githubusercontent.com/8787187/142778000-bc1e2121-7ce9-42a1-b9f7-06f11405a1ec.gif)

After
![Nov-21-2021 12-34-19](https://user-images.githubusercontent.com/8787187/142778001-37a62f6c-ef28-4969-92e6-016337a7dcf2.gif)

