### PR TITLE
Revert "Enable binary logging on production Aurora database cluster."

### DIFF
--- a/aws/cloudformation/db_parameters.yml.erb
+++ b/aws/cloudformation/db_parameters.yml.erb
@@ -147,18 +147,8 @@ Reporting:
 
 # System variables for the Aurora DB cluster.
 AuroraCluster: &aurora
-  # When using row-based logging, the primary database writes events to the binary log that indicate how individual table rows are changed.
-  # Replication of the primary database to a replica works by copying the events representing the changes to the table rows to the replica.
-  # ROW required for DMS Change Data Capture:
-  # https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.MySQL.html#CHAP_Source.MySQL.AmazonManaged
-  # ROW also required to use gh-ost to carry out online schema changes on large tables:
-  # https://github.com/github/gh-ost/blob/master/doc/requirements-and-limitations.md
-  binlog_format: ROW
-  # When enabled, this variable causes the primary database to write a checksum for each event in the binary log.
-  # When disabled (value NONE), write and check the event length (rather than a checksum) for each event.
-  # NONE required for DMS Change Data Capture:
-  # https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.MySQL.html#CHAP_Source.MySQL.AmazonManaged
-  binlog_checksum: NONE
+  # Disable binary logging to improve write performance.
+  binlog_format: 'OFF'
 
   # Enable GTIDs: https://aws.amazon.com/blogs/database/amazon-aurora-for-mysql-compatibility-now-supports-global-transaction-identifiers-gtids-replication/
   gtid-mode: ON_PERMISSIVE


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#41037

We enabled binary logging in June 2021 to support using `gh-ost` to make schema changes to some large tables. Disabling binary logging in advance of Hour of Code because it can potentially degrade write performance.

### Testing Story

```
$ export AWS_PROFILE=codeorg-admin
$ bin/aws_access
AWS access: GoogleSignInAdmin/suresh@code.org
$ bundle exec rake stack:data:validate RAILS_ENV=production

Pending update for stack `DATA-production`:
Modify AuroraClusterDBParameters [AWS::RDS::DBClusterParameterGroup] Properties (Parameters)
Modify AuroraReportingClusterDBParameters [AWS::RDS::DBClusterParameterGroup] Properties (Parameters)
Remove TableauSync [AWS::DMS::ReplicationInstance]
```

### Deployment

```
$ bundle exec rake stack:data:start RAILS_ENV=production`

Pending update for stack `DATA-production`:
Modify AuroraClusterDBParameters [AWS::RDS::DBClusterParameterGroup] Properties (Parameters)
Modify AuroraReportingClusterDBParameters [AWS::RDS::DBClusterParameterGroup] Properties (Parameters)
Remove TableauSync [AWS::DMS::ReplicationInstance]
Proceed? [y/n]
y
 Stack update requested, waiting for provisioning to complete...
2021-11-21 22:47:37 UTC- DATA-production [UPDATE_IN_PROGRESS]: User Initiated
..2021-11-21 22:47:46 UTC- AuroraReportingClusterDBParameters [UPDATE_IN_PROGRESS]
2021-11-21 22:47:46 UTC- AuroraClusterDBParameters [UPDATE_IN_PROGRESS]
.........2021-11-21 22:48:48 UTC- AuroraReportingClusterDBParameters [UPDATE_COMPLETE]
2021-11-21 22:48:49 UTC- AuroraClusterDBParameters [UPDATE_COMPLETE]
2021-11-21 22:48:52 UTC- DATA-production [UPDATE_COMPLETE_CLEANUP_IN_PROGRESS]
2021-11-21 22:48:48 UTC- AuroraReportingClusterDBParameters [UPDATE_COMPLETE]
2021-11-21 22:48:49 UTC- AuroraClusterDBParameters [UPDATE_COMPLETE]
2021-11-21 22:48:52 UTC- DATA-production [UPDATE_COMPLETE_CLEANUP_IN_PROGRESS]

Stack update complete.
Outputs:
```

This is a STATIC configuration setting and won't take effect until the database instances are restarted when their instance types are upgraded for Hour of Code.