### PR TITLE
Update CSA entry on Course Explorer

### DIFF
--- a/shared/haml/course_explorer_table.haml
+++ b/shared/haml/course_explorer_table.haml
@@ -46,6 +46,8 @@
 :ruby
   courses = []
 
+  csp_pl_link = CDO.code_org_url('/educate/professional-learning/middle-high')
+
   courses << {
     id: "csa",
     name: "CSA",
@@ -58,20 +60,19 @@
     link: CDO.code_org_url('/educate/csa'),
     img: "/shared/images/teacher-announcement/csa-upsell.png",
     announcement: "<i>Coming in 2022</i>",
-    description: "
-      <p>In Computer Science A, students learn object-oriented
-      programming using Java. Students take on the role of software engineers,
-      and practice skills that are used in the field.</p>
-
-      <p>The Code.org CSA course is designed for any high school student who
-      wishes to continue their computer science education after completing an
-      introductory course such as Computer Science Principles (CSP) or Computer
-      Science Discoveries (CSD).</p>
-
-      <p>More information coming soon!</p>"
+    description: "Computer Science A invites students to learn programming using Java and can be taken after completing an introductory course such as Computer Science Principles or Computer Science Discoveries.
+      <ul>
+        <li> <strong>Audience:</strong> High school students, grades 9 - 12</li>
+        <li> <strong>Curriculum length:</strong> A minimum of 140 class hours; should be taught as a full-year course. Contains 9 units, which includes an AP Exam Prep unit.</li>
+        <li> <strong>Prior knowledge:</strong> For students, Computer Science Principles, Computer Science Discoveries, and/or a similar introductory computer science course. Teachers who are able to independently write and debug an error-free function (or procedure) with one or more parameters and that uses conditional logic, loops, and an array (or a list) will be best positioned to use our CSA curriculum with students.
+        </li>
+        <li> <strong>Optional <a href='#{csp_pl_link}'>professional learning</a>:</strong> Our year-long program is intended to support both teachers experienced with Code.org curriculum and tools and teachers who are new to Code.org.  Read more about the robust support structure for teachers in our Professional Learning program on the <a href='#{csp_pl_link}'>Professional Learning page</a>.
+        </li>
+        <li> <strong>Cost to use curriculum:</strong> None</li>
+        <li> <strong>Languages:</strong> English only</li>
+      </ul>"
   }
 
-  csp_pl_link = CDO.code_org_url('/educate/professional-learning/middle-high')
   courses << {
     id: "csp",
     name: "CS Principles",


### PR DESCRIPTION
[LP-2131](https://codedotorg.atlassian.net/browse/LP-2131)

Updates the Course Explorer entry for CSA with more details in preparation for Dec. 1 application launch, based on a [request](https://codedotorg.slack.com/archives/CA3KCSGTD/p1637623160077000) from the Ed Programs team. 

![Screen Shot 2021-11-23 at 12 11 48 PM](https://user-images.githubusercontent.com/12300669/143071816-fe9f6ff2-b388-4f44-b518-1bc595ec3b79.png)

