### PR TITLE
Lock dialog refreshes lock data when opened

### DIFF
--- a/apps/src/code-studio/lessonLockRedux.js
+++ b/apps/src/code-studio/lessonLockRedux.js
@@ -322,17 +322,12 @@ const refreshSectionLockStatus = (sections, sectionId) => ({
   sectionId
 });
 
-export const refetchSectionLockStatus = sectionId => {
-  return (dispatch, getState) => {
-    const state = getState();
-    const scriptId = state.progress.scriptId;
-
-    return $.ajax('/api/lock_status', {
+export const refetchSectionLockStatus = (sectionId, scriptId) => {
+  return dispatch => {
+    $.ajax('/api/lock_status', {
       data: {script_id: scriptId}
     })
       .done(data => {
-        console.log('maureen data');
-        console.log(data);
         dispatch(refreshSectionLockStatus(data, sectionId));
       })
       .fail(err => {

--- a/apps/src/code-studio/lessonLockRedux.js
+++ b/apps/src/code-studio/lessonLockRedux.js
@@ -21,6 +21,7 @@ export const BEGIN_SAVE = 'lessonLock/BEGIN_SAVE';
 export const FINISH_SAVE = 'lessonLock/FINISH_SAVE';
 const AUTHORIZE_LOCKABLE = 'lessonLock/AUTHORIZE_LOCKABLE';
 const SET_SECTION_LOCK_STATUS = 'lessonLock/SET_SECTION_LOCK_STATUS';
+const REFRESH_SECTION_LOCK_STATUS = 'lessonLock/REFRESH_SECTION_LOCK_STATUS';
 
 const initialState = {
   lessonsBySectionId: {},
@@ -51,6 +52,32 @@ export default function reducer(state = initialState, action) {
         action.sections,
         section => section.lessons
       )
+    };
+  }
+
+  if (action.type === REFRESH_SECTION_LOCK_STATUS) {
+    const lessonsBySectionId = _.mapValues(
+      action.sections,
+      section => section.lessons
+    );
+
+    const {lockDialogLessonId} = state;
+    if (lockDialogLessonId) {
+      const lockStatus = lockStatusForLesson(
+        lessonsBySectionId[action.sectionId],
+        lockDialogLessonId
+      );
+
+      return {
+        ...state,
+        lessonsBySectionId,
+        lockStatus
+      };
+    }
+
+    return {
+      ...state,
+      lessonsBySectionId
     };
   }
 
@@ -285,3 +312,29 @@ export const setSectionLockStatus = sections => ({
   type: SET_SECTION_LOCK_STATUS,
   sections
 });
+
+/**
+ * Set the lock status for students in sections based on data from server
+ */
+export const refreshSectionLockStatus = (sections, sectionId) => ({
+  type: REFRESH_SECTION_LOCK_STATUS,
+  sections,
+  sectionId
+});
+
+export const refetchSectionLockStatus = sectionId => {
+  return (dispatch, getState) => {
+    const state = getState();
+    const scriptId = state.progress.scriptId;
+
+    return $.ajax('/api/lock_status', {
+      data: {script_id: scriptId}
+    })
+      .done(data => {
+        dispatch(refreshSectionLockStatus(data, sectionId));
+      })
+      .fail(err => {
+        console.log(err);
+      });
+  };
+};

--- a/apps/src/code-studio/lessonLockRedux.js
+++ b/apps/src/code-studio/lessonLockRedux.js
@@ -331,6 +331,8 @@ export const refetchSectionLockStatus = sectionId => {
       data: {script_id: scriptId}
     })
       .done(data => {
+        console.log('maureen data');
+        console.log(data);
         dispatch(refreshSectionLockStatus(data, sectionId));
       })
       .fail(err => {

--- a/apps/src/code-studio/lessonLockRedux.js
+++ b/apps/src/code-studio/lessonLockRedux.js
@@ -316,7 +316,7 @@ export const setSectionLockStatus = sections => ({
 /**
  * Set the lock status for students in sections based on data from server
  */
-export const refreshSectionLockStatus = (sections, sectionId) => ({
+const refreshSectionLockStatus = (sections, sectionId) => ({
   type: REFRESH_SECTION_LOCK_STATUS,
   sections,
   sectionId

--- a/apps/src/templates/progress/LessonLock.jsx
+++ b/apps/src/templates/progress/LessonLock.jsx
@@ -10,7 +10,8 @@ import i18n from '@cdo/locale';
 import LessonLockDialog from '@cdo/apps/code-studio/components/progress/LessonLockDialog';
 import {
   openLockDialog,
-  closeLockDialog
+  closeLockDialog,
+  refetchSectionLockStatus
 } from '@cdo/apps/code-studio/lessonLockRedux';
 import {lessonType} from './progressTypes';
 
@@ -23,11 +24,18 @@ class LessonLock extends React.Component {
     sectionsAreLoaded: PropTypes.bool.isRequired,
     saving: PropTypes.bool.isRequired,
     openLockDialog: PropTypes.func.isRequired,
-    closeLockDialog: PropTypes.func.isRequired
+    closeLockDialog: PropTypes.func.isRequired,
+    refetchSectionLockStatus: PropTypes.func.isRequired
   };
 
   openLockDialog = () => {
-    const {openLockDialog, sectionId, lesson} = this.props;
+    const {
+      openLockDialog,
+      sectionId,
+      lesson,
+      refetchSectionLockStatus
+    } = this.props;
+    refetchSectionLockStatus(sectionId);
     openLockDialog(sectionId, lesson.id);
   };
 
@@ -78,5 +86,5 @@ export default connect(
     sectionsAreLoaded: state.teacherSections.sectionsAreLoaded,
     saving: state.lessonLock.saving
   }),
-  {openLockDialog, closeLockDialog}
+  {openLockDialog, closeLockDialog, refetchSectionLockStatus}
 )(LessonLock);

--- a/apps/src/templates/progress/LessonLock.jsx
+++ b/apps/src/templates/progress/LessonLock.jsx
@@ -23,6 +23,7 @@ class LessonLock extends React.Component {
     sectionId: PropTypes.string.isRequired,
     sectionsAreLoaded: PropTypes.bool.isRequired,
     saving: PropTypes.bool.isRequired,
+    scriptId: PropTypes.number.isRequired,
     openLockDialog: PropTypes.func.isRequired,
     closeLockDialog: PropTypes.func.isRequired,
     refetchSectionLockStatus: PropTypes.func.isRequired
@@ -32,10 +33,11 @@ class LessonLock extends React.Component {
     const {
       openLockDialog,
       sectionId,
+      scriptId,
       lesson,
       refetchSectionLockStatus
     } = this.props;
-    refetchSectionLockStatus(sectionId);
+    refetchSectionLockStatus(sectionId, scriptId);
     openLockDialog(sectionId, lesson.id);
   };
 
@@ -84,7 +86,8 @@ export default connect(
   state => ({
     sectionId: state.teacherSections.selectedSectionId.toString(),
     sectionsAreLoaded: state.teacherSections.sectionsAreLoaded,
-    saving: state.lessonLock.saving
+    saving: state.lessonLock.saving,
+    scriptId: state.progress.scriptId
   }),
   {openLockDialog, closeLockDialog, refetchSectionLockStatus}
 )(LessonLock);

--- a/apps/test/unit/code-studio/fakeSectionData.js
+++ b/apps/test/unit/code-studio/fakeSectionData.js
@@ -3,6 +3,7 @@
 const section1Id = 42;
 const section2Id = 43;
 const lesson1Id = 12;
+export const scriptId = 3000;
 
 const fakeSectionData = {
   [section1Id]: {
@@ -17,7 +18,7 @@ const fakeSectionData = {
           user_level_data: {
             user_id: 1001,
             level_id: 2000,
-            script_id: 3000
+            script_id: scriptId
           },
           readonly_answers: false
         },
@@ -28,7 +29,7 @@ const fakeSectionData = {
           user_level_data: {
             user_id: 1002,
             level_id: 2000,
-            script_id: 3000
+            script_id: scriptId
           },
           readonly_answers: false
         },
@@ -39,7 +40,7 @@ const fakeSectionData = {
           user_level_data: {
             user_id: 1003,
             level_id: 2000,
-            script_id: 3000
+            script_id: scriptId
           },
           readonly_answers: true
         }
@@ -57,7 +58,7 @@ const fakeSectionData = {
           user_level_data: {
             user_id: 1004,
             level_id: 2000,
-            script_id: 3000
+            script_id: scriptId
           },
           readonly_answers: false
         }

--- a/apps/test/unit/code-studio/lessonLockReduxTest.js
+++ b/apps/test/unit/code-studio/lessonLockReduxTest.js
@@ -2,7 +2,7 @@ import {assert} from 'chai';
 import _ from 'lodash';
 import $ from 'jquery';
 import sinon from 'sinon';
-import fakeSectionData from './fakeSectionData';
+import fakeSectionData, {scriptId} from './fakeSectionData';
 import {
   stubRedux,
   restoreRedux,
@@ -428,15 +428,13 @@ describe('fullyLockedLessonMapping', () => {
 
 describe('refetchSectionLockStatus', () => {
   let store;
-  let reducerSpy;
   const lockStatusResponse = _.cloneDeep(fakeSectionData);
   lockStatusResponse[section1Id]['lessons'][lesson1Id][1].locked = true;
 
   // Intercept all XHR requests, storing the last one
   beforeEach(() => {
-    reducerSpy = sinon.spy(reducer);
     stubRedux();
-    registerReducers({lessonLock: reducerSpy});
+    registerReducers({lessonLock: reducer});
     store = getStore();
 
     sinon.stub($, 'ajax').returns({
@@ -452,15 +450,16 @@ describe('refetchSectionLockStatus', () => {
     $.ajax.restore();
   });
 
-  it('updates lessonsBySectionId', () => {
+  it('updates lessonsBySectionId', async () => {
+    // Initial set up of lessonLockRedux with fakeSectionData
     store.dispatch(setSectionLockStatus(fakeSectionData));
-    console.log(store.getState().lessonLock);
     let student2 = store.getState().lessonLock.lessonsBySectionId[section1Id][
       lesson1Id
     ][1];
     assert.equal(student2.locked, false);
 
-    store.dispatch(refetchSectionLockStatus(section1Id));
+    // Refetch lessonLock data with updated lock status for lesson1 student 2
+    store.dispatch(refetchSectionLockStatus(section1Id, scriptId));
     student2 = store.getState().lessonLock.lessonsBySectionId[section1Id][
       lesson1Id
     ][1];

--- a/apps/test/unit/templates/progress/LessonLockTest.jsx
+++ b/apps/test/unit/templates/progress/LessonLockTest.jsx
@@ -9,6 +9,7 @@ import i18n from '@cdo/locale';
 
 const FAKE_SECTION_ID = 'fake-section-id';
 const FAKE_LESSON_ID = 33;
+const FAKE_SCRIPT_ID = 1;
 const DEFAULT_PROPS = {
   lesson: {
     name: '',
@@ -19,6 +20,7 @@ const DEFAULT_PROPS = {
   sectionId: FAKE_SECTION_ID,
   sectionsAreLoaded: false,
   saving: false,
+  scriptId: FAKE_SCRIPT_ID,
   openLockDialog: () => {},
   closeLockDialog: () => {},
   refetchSectionLockStatus: () => {}
@@ -87,6 +89,9 @@ describe('LessonLock', () => {
       FAKE_SECTION_ID,
       FAKE_LESSON_ID
     );
-    expect(refetchSpy).to.have.been.calledOnce.and.calledWith(FAKE_SECTION_ID);
+    expect(refetchSpy).to.have.been.calledOnce.and.calledWith(
+      FAKE_SECTION_ID,
+      FAKE_SCRIPT_ID
+    );
   });
 });

--- a/apps/test/unit/templates/progress/LessonLockTest.jsx
+++ b/apps/test/unit/templates/progress/LessonLockTest.jsx
@@ -20,19 +20,24 @@ const DEFAULT_PROPS = {
   sectionsAreLoaded: false,
   saving: false,
   openLockDialog: () => {},
-  closeLockDialog: () => {}
+  closeLockDialog: () => {},
+  refetchSectionLockStatus: () => {}
+};
+
+const setUp = (overrideProps = {}) => {
+  const props = {...DEFAULT_PROPS, ...overrideProps};
+  return shallow(<LessonLock {...props} />);
 };
 
 describe('LessonLock', () => {
   it('renders a loading message before sections are loaded', () => {
-    const wrapper = shallow(<LessonLock {...DEFAULT_PROPS} />);
+    const wrapper = setUp();
     expect(wrapper).to.containMatchingElement(<div>{i18n.loading()}</div>);
   });
 
   it('renders a button and dialog after sections are loaded', () => {
-    const wrapper = shallow(
-      <LessonLock {...DEFAULT_PROPS} sectionsAreLoaded={true} />
-    );
+    const wrapper = setUp({sectionsAreLoaded: true});
+
     expect(wrapper).to.containMatchingElement(
       <div>
         <div>
@@ -49,9 +54,8 @@ describe('LessonLock', () => {
   });
 
   it('changes button text while saving', () => {
-    const wrapper = shallow(
-      <LessonLock {...DEFAULT_PROPS} sectionsAreLoaded={true} saving={true} />
-    );
+    const wrapper = setUp({sectionsAreLoaded: true, saving: true});
+
     expect(wrapper).to.containMatchingElement(
       <Button __useDeprecatedTag text={i18n.saving()} icon="lock" />
     );
@@ -60,14 +64,13 @@ describe('LessonLock', () => {
   it('hooks up callbacks correctly', () => {
     const openSpy = sinon.spy();
     const closeSpy = sinon.spy();
-    const wrapper = shallow(
-      <LessonLock
-        {...DEFAULT_PROPS}
-        sectionsAreLoaded={true}
-        openLockDialog={openSpy}
-        closeLockDialog={closeSpy}
-      />
-    );
+    const refetchSpy = sinon.spy();
+    const wrapper = setUp({
+      sectionsAreLoaded: true,
+      openLockDialog: openSpy,
+      closeLockDialog: closeSpy,
+      refetchSectionLockStatus: refetchSpy
+    });
 
     // Close callback gets passed through to the dialog unchanged.
     expect(wrapper).to.containMatchingElement(
@@ -84,5 +87,6 @@ describe('LessonLock', () => {
       FAKE_SECTION_ID,
       FAKE_LESSON_ID
     );
+    expect(refetchSpy).to.have.been.calledOnce.and.calledWith(FAKE_SECTION_ID);
   });
 });


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Teacher complaint: "I unlock the assessment for the whole class, then a student takes it, then decides to retake based on their score. If I click the “lock settings” button, the assessment shows as unlocked under Individual Student Control. I.e. the status in the “lock settings” window is not current. If I refresh the page before clicking the “lock settings” button, then the statuses in Individual Student Control reflects the correct status of locked for my students who have completed the assessment. So, in order to unlock an assessment for a student who completed the assessment, I first have to “lock” them, hit save, then unlock them and hit save again (or refresh the unit screen first, then unlock the student)."

TL;DR -> The lock dialog does not refresh when re-opened and the lock status has changed.

I've added a lock dialog refresh method which will re-query lock status when the dialog is opened. It may take a moment for the lock status to update since it depends on an ajax request and I didn't want to wait to render the dialog, but ultimately each time the dialog is opened, the lock statuses should be up-to-date.

Video shows lock dialog with editable assessment, student re-takes assessment, lock dialog re-opened and now assessment is locked:

https://user-images.githubusercontent.com/24235215/143093004-a971d6ae-a0ae-424b-8a69-16d3fc049722.mov





## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
- jira ticket: [LP-1932](https://codedotorg.atlassian.net/browse/LP-1932)
<!--
- spec: []()

-->

## Testing story
Tested locally and added unit tests
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Follow-up work
Are we okay with a slight delay for updates to lock status or do we want a loading UI state?

Also - I created https://codedotorg.atlassian.net/browse/LP-2133 to add an unsubmit button to top of assessment to make it easier for the student to retake. We've had reports about issues with unsubmit and I found the current state annoying when I was walking through the steps to lock and unlock assessments while testing.
<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
