### PR TITLE
Remove code break banner below announcement banner on homepage

### DIFF
--- a/pegasus/sites.v3/code.org/public/index.haml
+++ b/pegasus/sites.v3/code.org/public/index.haml
@@ -31,7 +31,6 @@ style_min: true
     = view :stats_homepage
   - else
     = view :homepage_below_hero_announcement
-    = view :homepage_below_hero_announcement_code_break
 
   = view :homepage_sections
   = view :homepage_gallery

--- a/pegasus/sites.v3/code.org/views/homepage_below_hero_announcement_code_break.haml
+++ b/pegasus/sites.v3/code.org/views/homepage_below_hero_announcement_code_break.haml
@@ -1,9 +1,0 @@
-%a{href: "/break", style: "color: white; font-family: 'Gotham 4r', sans-serif;"}
-  .special_2020_announcement{style: "text-align: center; background-color: #0094ca; color: white; font-size: 18px; padding: 16px; overflow: hidden; margin-bottom: 20px;"}
-    .container_responsive
-      .col-66
-        .texts{style: "text-align: left; padding-top: 7px; padding-bottom: 5px"}
-          = hoc_s(:codeorg_homepage_code_break_body)
-      .col-33
-        %button{style: "color: white; font-size: 18px; background-color: initial; border-color: white; min-width: 230px; height: 40px; padding: 0 30px;"}
-          = hoc_s(:codeorg_homepage_code_break_link_text)


### PR DESCRIPTION
**What:** This deletes the `homepage_below_hero_announcement_code_break.haml` partial and its only reference.

**Why**: We no longer want the banner to show on the code.org homepage for non-English languages.

## Links

- jira ticket: [FND-1819](https://codedotorg.atlassian.net/browse/FND-1819)


## Testing story
Tested the code.org homepage locally

Before
![Screen Shot 2021-11-23 at 1 37 57 PM](https://user-images.githubusercontent.com/48133820/143131231-1cda92f6-bc12-4d3b-bfd7-545fecb7afaf.png)


After
![Screen Shot 2021-11-23 at 3 09 56 PM](https://user-images.githubusercontent.com/48133820/143128665-46f3dab3-1cfa-4071-b9e3-496b3e567a9f.png)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
