### PR TITLE
Lesson Extras in middle/high courses should hit unit overview speed bump

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -846,6 +846,7 @@
   "extrasCreateSomething": "Create Something",
   "extrasNextLesson": "Go on to Lesson {number}",
   "extrasNextFinish": "Finish the Unit",
+  "extrasNextUnitOverview": "View the Unit",
   "extrasNoBonusLevels": "There are no bonus levels for this lesson.",
   "extraTopBlocks": "You have unattached blocks.",
   "extraTopBlocksWhenRun": "You have unattached blocks. Did you mean to attach these to the \"when run\" block?",

--- a/apps/src/code-studio/components/lessonExtras/LessonExtras.jsx
+++ b/apps/src/code-studio/components/lessonExtras/LessonExtras.jsx
@@ -33,16 +33,12 @@ export default class LessonExtras extends React.Component {
       showLessonExtrasWarning
     } = this.props;
 
-    let nextMessage = '';
-    switch (true) {
-      case /lessons/.test(nextLevelPath):
-        nextMessage = i18n.extrasNextLesson({number: nextLessonNumber});
-        break;
-      case /congrats/.test(nextLevelPath):
-        nextMessage = i18n.extrasNextFinish();
-        break;
-      default:
-        nextMessage = i18n.extrasNextUnitOverview();
+    let nextMessage = i18n.extrasNextUnitOverview();
+
+    if (/lessons/.test(nextLevelPath)) {
+      nextMessage = i18n.extrasNextLesson({number: nextLessonNumber});
+    } else if (/congrats/.test(nextLevelPath)) {
+      nextMessage = i18n.extrasNextFinish();
     }
 
     return (

--- a/apps/src/code-studio/components/lessonExtras/LessonExtras.jsx
+++ b/apps/src/code-studio/components/lessonExtras/LessonExtras.jsx
@@ -32,9 +32,18 @@ export default class LessonExtras extends React.Component {
       projectTypes,
       showLessonExtrasWarning
     } = this.props;
-    const nextMessage = /stage/.test(nextLevelPath)
-      ? i18n.extrasNextLesson({number: nextLessonNumber})
-      : i18n.extrasNextFinish();
+
+    let nextMessage = '';
+    switch (true) {
+      case /lessons/.test(nextLevelPath):
+        nextMessage = i18n.extrasNextLesson({number: nextLessonNumber});
+        break;
+      case /s/.test(nextLevelPath):
+        nextMessage = i18n.extrasNextUnitOverview();
+        break;
+      default:
+        i18n.extrasNextFinish();
+    }
 
     return (
       <div>

--- a/apps/src/code-studio/components/lessonExtras/LessonExtras.jsx
+++ b/apps/src/code-studio/components/lessonExtras/LessonExtras.jsx
@@ -38,11 +38,11 @@ export default class LessonExtras extends React.Component {
       case /lessons/.test(nextLevelPath):
         nextMessage = i18n.extrasNextLesson({number: nextLessonNumber});
         break;
-      case /s/.test(nextLevelPath):
-        nextMessage = i18n.extrasNextUnitOverview();
+      case /congrats/.test(nextLevelPath):
+        nextMessage = i18n.extrasNextFinish();
         break;
       default:
-        i18n.extrasNextFinish();
+        nextMessage = i18n.extrasNextUnitOverview();
     }
 
     return (

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -663,6 +663,8 @@ class Lesson < ApplicationRecord
   end
 
   def next_level_path_for_lesson_extras(user)
+    return script_path(script) if
+    script.show_unit_overview_between_lessons?(user)
     next_level = next_level_for_lesson_extras(user)
     next_level ?
       build_script_level_path(next_level) : script_completion_redirect(script)

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -663,8 +663,9 @@ class Lesson < ApplicationRecord
   end
 
   def next_level_path_for_lesson_extras(user)
-    return script_path(script) if
-    script.show_unit_overview_between_lessons?(user)
+    if script.show_unit_overview_between_lessons?(user)
+      return script_path(script)
+    end
     next_level = next_level_for_lesson_extras(user)
     next_level ?
       build_script_level_path(next_level) : script_completion_redirect(script)

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -2166,7 +2166,7 @@ class Script < ApplicationRecord
 
   # To help teachers have more control over the pacing of certain scripts, we
   # send students on the last level of a lesson to the unit overview page.
-  def show_unit_overview_between_lessons?
-    csd? || csp? || csa?
+  def show_unit_overview_between_lessons?(user)
+    (csd? || csp? || csa?) && user.has_pilot_experiment?('end-of-lesson-redirects')
   end
 end

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -2167,6 +2167,6 @@ class Script < ApplicationRecord
   # To help teachers have more control over the pacing of certain scripts, we
   # send students on the last level of a lesson to the unit overview page.
   def show_unit_overview_between_lessons?(user)
-    (csd? || csp? || csa?) && user.has_pilot_experiment?('end-of-lesson-redirects')
+    (csd? || csp? || csa?) && user&.has_pilot_experiment?('end-of-lesson-redirects')
   end
 end

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -262,7 +262,7 @@ class ScriptLevel < ApplicationRecord
       # To help teachers have more control over the pacing of certain
       # scripts, we send students on the last level of a lesson to the unit
       # overview page.
-      if end_of_lesson? && show_unit_overview_between_lessons?(user)
+      if end_of_lesson? && script.show_unit_overview_between_lessons?(user)
         if script.lesson_extras_available
           script_lesson_extras_path(script.name, (extras_lesson || lesson).relative_position)
         else

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -262,9 +262,7 @@ class ScriptLevel < ApplicationRecord
       # To help teachers have more control over the pacing of certain
       # scripts, we send students on the last level of a lesson to the unit
       # overview page.
-      if end_of_lesson? &&
-        script.show_unit_overview_between_lessons? &&
-        user.has_pilot_experiment?('end-of-lesson-redirects')
+      if end_of_lesson? && show_unit_overview_between_lessons?(user)
         if script.lesson_extras_available
           script_lesson_extras_path(script.name, (extras_lesson || lesson).relative_position)
         else

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -170,6 +170,21 @@ class LessonTest < ActiveSupport::TestCase
     assert_equal '/', lesson2.next_level_path_for_lesson_extras(@student)
   end
 
+  test "next_level_path_for_lesson_extras show unit overview" do
+    script = create :script
+    script.stubs(:show_unit_overview_between_lessons?).returns true
+    lesson_group = create :lesson_group, script: script
+    lesson1 = create :lesson, script: script, lesson_group: lesson_group
+    create :script_level, script: script, lesson: lesson1
+    create :script_level, script: script, lesson: lesson1
+    lesson2 = create :lesson, script: script, lesson_group: lesson_group
+    create :script_level, script: script, lesson: lesson2
+    create :script_level, script: script, lesson: lesson2
+
+    assert_equal "/s/#{script.name}", lesson1.next_level_path_for_lesson_extras(@student)
+    assert_equal "/s/#{script.name}", lesson2.next_level_path_for_lesson_extras(@student)
+  end
+
   test 'can summarize lesson with no levels' do
     script = create :script
     lesson_group = create :lesson_group, script: script

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -156,6 +156,9 @@ class LessonTest < ActiveSupport::TestCase
     assert_equal last_script_level, lesson.last_progression_script_level
   end
 
+  # NOTE: The LessonExtras component changes the "next" button text depending
+  # on the path for the next level. LessonExtras may need to be updated if
+  # there are changes to what next_level_path_for_lesson_extras returns.
   test "next_level_path_for_lesson_extras" do
     script = create :script
     lesson_group = create :lesson_group, script: script


### PR DESCRIPTION
[Spec](https://docs.google.com/document/d/1STMLxX2UphYMXLKIvgnctH7vuacCQPNHOB1KgS2VygA/edit#bookmark=id.h64pzxt4r0wo)
[LP-2072](https://codedotorg.atlassian.net/browse/LP-2072), follow up to #43174 

In CSD, CSP and CSA scripts we want to redirect students to the unit overview page at the end of a lesson as a way of slowing them down and giving teachers more control and clarity regarding how their students are progressing through the course. This "speed bump" to redirect students to the unit overview page now also applies to mid-unit Lesson Extras for CSD, CSP and CSA.

Additionally, all mid-unit Lesson Extras "continue" buttons were incorrectly saying "Finish the Unit" due to a regression that popped up when we changed the urls to include "lessons" rather than "stage". Button text has been updated for all mid-unit Lesson Extras.  

**Lesson Extras in CSD/CSP/CSA, mid-unit --> unit overview page (NEW behavior)** 

![CSD mid-unit redirect to unit overview](https://user-images.githubusercontent.com/12300669/143159266-425809d4-404d-40f5-81b5-3eed5f9d5cf8.png)

**Lesson Extras in CSF, mid-unit -->  next lesson in progression (updated button text)**

![csf mid-unit ](https://user-images.githubusercontent.com/12300669/143160382-6ae939c4-31c8-4a9e-9c5a-fef5c1e8e01f.png)

**Lesson Extras in CSF, end of unit --> congrats (no change)**
![CSF end of unit ](https://user-images.githubusercontent.com/12300669/143160187-f430929f-0379-497a-86c9-01b456f7f3c6.png)
)
