### PR TITLE
Pegasus: Documentation for partials with parameters

### DIFF
--- a/pegasus/sites.v3/code.org/public/editing/concepts.md.erb
+++ b/pegasus/sites.v3/code.org/public/editing/concepts.md.erb
@@ -76,6 +76,27 @@ For example, I can include [the testimonials template](https://github.com/code-d
 
 <%= view :testimonials %>
 
+## Partials with parameters
+
+The above concept can be extended with the use of parameters.  A template that accepts parameters must be implemented in HTML, with a `.html` file extension, and must contain strings like `%parameter_name%` which will be replaced with the parameter values.
+
+For example, the following can be placed in an `.md.partial` file, and will include [this template](https://github.com/code-dot-org/code-dot-org/blob/cc99e4a86f5f2ebaa443339f3c93244f63a50b35/pegasus/sites.v3/code.org/views/featured_project.html):
+
+### Code:
+
+```
+{{ featured_project, title: "Afternoon", author: "M", age: "13+", image: "images/csc/poetry/cscpoetry_afternoon.gif", url: "https://studio.code.org/projects" }}
+```
+
+### Result:
+
+<!--
+  As above, this is using the ERB view syntax, but in this case to include a
+  template that in turn uses a partial with parameters.
+-->
+
+<%= view :editing_concepts_partial_example %>
+
 ## Advanced Partials
 
 If the view you want to include requires arguments, you can simply create an intermediary view. For example, to use the `about_people` view (which requires a `people` argument) you can create a view `about_team.erb`:

--- a/pegasus/sites.v3/code.org/views/editing_concepts_partial_example.md.partial
+++ b/pegasus/sites.v3/code.org/views/editing_concepts_partial_example.md.partial
@@ -1,0 +1,3 @@
+{{ featured_project, title: "Afternoon", author: "M", age: "13+", image: "/images/csc/poetry/cscpoetry_afternoon.gif", url: "https://studio.code.org/projects" }}
+
+{{ clearfix}}


### PR DESCRIPTION
This adds some quick documentation to the existing page at https://code.org/editing/concepts, covering the new ability for `{{}}`-style partials to have parameters.

This relates to work begun in https://github.com/code-dot-org/code-dot-org/pull/42618 and continued in several PRs that link back to it.

### screenshot:
<img width="831" alt="Screen Shot 2021-11-24 at 4 59 05 PM" src="https://user-images.githubusercontent.com/2205926/143183720-2f85d353-621a-493e-a9b0-d38e1031cd03.png">

Keywords: hoc2021