### PR TITLE
modify test to pass in staging-next

### DIFF
--- a/pegasus/test/fixtures/deliverer/expected/class_submission_receipt/body.html
+++ b/pegasus/test/fixtures/deliverer/expected/class_submission_receipt/body.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
 <html><body>
-<p>Thank you for submitting a school/activity. After review, it will appear on our site. If necessary, you can make changes by clicking here: <a href="http://test.code.org/schools/edit/unique-secret-for-ClassSubmission">http://test.code.org/schools/edit/unique-secret-for-ClassSubmission</a>.</p>
+<p>Thank you for submitting a school/activity. After review, it will appear on our site. If necessary, you can make changes by clicking here: <a href="http://staging-next.code.org/schools/edit/unique-secret-for-ClassSubmission">http://staging-next.code.org/schools/edit/unique-secret-for-ClassSubmission</a>.</p>
 
 <p>Thanks again for your support,</p>
 


### PR DESCRIPTION
It's a stupid idea, but it works! This test will fail when we merge back into `staging`, and can be reverted then.

The test could be made less brittle, but I wanted to get a solution out there that opens up `staging-next`.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
