### PR TITLE
[Spritelab] Update feedback dialog for final/freeplay levels

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -1652,6 +1652,13 @@ StudioApp.prototype.displayFeedback = function(options) {
   this.onFeedback(options);
 };
 
+StudioApp.prototype.isFinalFreePlayLevel = function(feedbackType, response) {
+  return (
+    this.feedback_.isFinalLevel(response) &&
+    this.feedback_.isFreePlay(feedbackType)
+  );
+};
+
 /**
  * Whether feedback should be displayed as a modal dialog or integrated
  * into the top instructions

--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -1975,10 +1975,21 @@ FeedbackUtils.prototype.hasExceededLimitedBlocks_ = function() {
   return blockLimits.blockLimitExceeded && blockLimits.blockLimitExceeded();
 };
 
+/**
+ * Determine if this is the final level in a progression based on server response.
+ * See {} for details
+ * @param {Object} response
+ * @returns {boolean}
+ */
 FeedbackUtils.prototype.isFinalLevel = function(response) {
   return response?.message === 'no more levels';
 };
 
-FeedbackUtils.prototype.isFreePlay = function(feedbackType) {
-  return feedbackType === TestResults.FREE_PLAY;
+/**
+ * Determine if this is a freeplay level based on level result.
+ * @param {TestResults} result
+ * @returns {boolean}
+ */
+FeedbackUtils.prototype.isFreePlay = function(result) {
+  return result === TestResults.FREE_PLAY;
 };

--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -1977,7 +1977,8 @@ FeedbackUtils.prototype.hasExceededLimitedBlocks_ = function() {
 
 /**
  * Determine if this is the final level in a progression based on server response.
- * See {} for details
+ * For details, see:
+ * https://github.com/code-dot-org/code-dot-org/blob/a6d3762e5756e825fef15182042845d01c05f1e6/dashboard/app/helpers/script_levels_helper.rb#L30
  * @param {Object} response
  * @returns {boolean}
  */

--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -174,9 +174,6 @@ FeedbackUtils.prototype.displayFeedback = function(
 
   feedback.className += canContinue ? ' win-feedback' : ' failure-feedback';
 
-  var finalLevel =
-    options.response && options.response.message === 'no more levels';
-
   feedback.appendChild(
     this.getFeedbackButtons_({
       feedbackType: options.feedbackType,
@@ -186,7 +183,7 @@ FeedbackUtils.prototype.displayFeedback = function(
       continueText: options.continueText,
       isK1: options.level.isK1,
       freePlay: options.level.freePlay,
-      finalLevel: finalLevel
+      finalLevel: this.isFinalLevel(options.response)
     })
   );
 
@@ -877,8 +874,7 @@ FeedbackUtils.prototype.getFeedbackMessage = function(options) {
       case TestResults.FREE_PLAY:
       case TestResults.BETTER_THAN_IDEAL:
       case TestResults.PASS_WITH_EXTRA_TOP_BLOCKS:
-        var finalLevel =
-          options.response && options.response.message === 'no more levels';
+        var finalLevel = this.isFinalLevel(options.response);
         var lessonCompleted = null;
         if (options.response && options.response.lesson_changing) {
           lessonCompleted = options.response.lesson_changing.previous.name;
@@ -889,7 +885,7 @@ FeedbackUtils.prototype.getFeedbackMessage = function(options) {
           puzzleNumber: options.level.puzzle_number || 0
         };
         if (
-          options.feedbackType === TestResults.FREE_PLAY &&
+          this.isFreePlay(options.feedbackType) &&
           !options.level.disableSharing
         ) {
           var reinfFeedbackMsg =
@@ -1977,4 +1973,12 @@ FeedbackUtils.prototype.hasMatchingDescendant_ = function(node, filter) {
 FeedbackUtils.prototype.hasExceededLimitedBlocks_ = function() {
   const blockLimits = Blockly.mainBlockSpace.blockSpaceEditor.blockLimits;
   return blockLimits.blockLimitExceeded && blockLimits.blockLimitExceeded();
+};
+
+FeedbackUtils.prototype.isFinalLevel = function(response) {
+  return response?.message === 'no more levels';
+};
+
+FeedbackUtils.prototype.isFreePlay = function(feedbackType) {
+  return feedbackType === TestResults.FREE_PLAY;
 };

--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -1559,6 +1559,11 @@ export default class P5Lab {
     return this.getMsg().reinfFeedbackMsg();
   }
 
+  // Determines whether or not to show the "print" option in the feedback dialog.
+  disablePrinting() {
+    return false;
+  }
+
   /**
    * App specific displayFeedback function that calls into
    * this.studioApp_.displayFeedback when appropriate
@@ -1589,7 +1594,8 @@ export default class P5Lab {
       },
       hideXButton: true,
       saveToProjectGallery: saveToProjectGallery,
-      disableSaveToGallery: !isSignedIn
+      disableSaveToGallery: !isSignedIn,
+      disablePrinting: this.disablePrinting()
     });
   }
 

--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -1552,10 +1552,10 @@ export default class P5Lab {
   /**
    * Get the feedback message for the feedback dialog.
    * Subclasses can override this behavior.
-   * @param {boolean} _isFreePlay Unused by this implementation
+   * @param {boolean} _isFinalFreePlayLevel Unused by this implementation
    * @returns {string}
    */
-  getReinfFeedbackMsg(_isFreePlay) {
+  getReinfFeedbackMsg(_isFinalFreePlayLevel) {
     return this.getMsg().reinfFeedbackMsg();
   }
 
@@ -1572,6 +1572,13 @@ export default class P5Lab {
     var level = this.level;
     let msg = this.getMsg();
 
+    // Allow P5Labs to decide what string should be rendered in the feedback dialog.
+    const isFinalFreePlayLevel = this.studioApp_.isFinalFreePlayLevel(
+      this.testResults,
+      this.response
+    );
+    const reinfFeedbackMsg = this.getReinfFeedbackMsg(isFinalFreePlayLevel);
+
     const isSignedIn =
       getStore().getState().currentUser.signInState === SignInState.SignedIn;
 
@@ -1587,9 +1594,7 @@ export default class P5Lab {
       // feedbackImage: feedbackImageCanvas.canvas.toDataURL("image/png")
       showingSharing: !level.disableSharing && level.freePlay,
       appStrings: {
-        reinfFeedbackMsg: this.getReinfFeedbackMsg(
-          this.testResults === TestResults.FREE_PLAY
-        ),
+        reinfFeedbackMsg,
         sharingText: msg.shareGame()
       },
       hideXButton: true,

--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -1550,6 +1550,16 @@ export default class P5Lab {
   }
 
   /**
+   * Get the feedback message for the feedback dialog.
+   * Subclasses can override this behavior.
+   * @param {boolean} _isFreePlay Unused by this implementation
+   * @returns {string}
+   */
+  getReinfFeedbackMsg(_isFreePlay) {
+    return this.getMsg().reinfFeedbackMsg();
+  }
+
+  /**
    * App specific displayFeedback function that calls into
    * this.studioApp_.displayFeedback when appropriate
    */
@@ -1572,7 +1582,9 @@ export default class P5Lab {
       // feedbackImage: feedbackImageCanvas.canvas.toDataURL("image/png")
       showingSharing: !level.disableSharing && level.freePlay,
       appStrings: {
-        reinfFeedbackMsg: msg.reinfFeedbackMsg(),
+        reinfFeedbackMsg: this.getReinfFeedbackMsg(
+          this.testResults === TestResults.FREE_PLAY
+        ),
         sharingText: msg.shareGame()
       },
       hideXButton: true,

--- a/apps/src/p5lab/spritelab/SpriteLab.js
+++ b/apps/src/p5lab/spritelab/SpriteLab.js
@@ -113,4 +113,15 @@ export default class SpriteLab extends P5Lab {
       }
     });
   }
+
+  /**
+   * Determines the string rendered by the feedback dialog, which always displays
+   * another string for freeplay levels, so this implementation is coupled to
+   * that. See FeedbackUtils.prototype.getFeedbackMessage for implementation details.
+   * @param {boolean} isFreePlay
+   * @returns {string|null}
+   */
+  getReinfFeedbackMsg(isFreePlay) {
+    return isFreePlay ? null : this.getMsg().reinfFeedbackMsg();
+  }
 }

--- a/apps/src/p5lab/spritelab/SpriteLab.js
+++ b/apps/src/p5lab/spritelab/SpriteLab.js
@@ -116,13 +116,13 @@ export default class SpriteLab extends P5Lab {
 
   /**
    * Override the string rendered by the feedback dialog, which always displays
-   * another string for freeplay levels, so this implementation is coupled to
+   * another string for final freeplay levels, so this implementation is tightly coupled to
    * that. See FeedbackUtils.prototype.getFeedbackMessage for implementation details.
-   * @param {boolean} isFreePlay
+   * @param {boolean} isFinalFreePlayLevel
    * @returns {string|null}
    */
-  getReinfFeedbackMsg(isFreePlay) {
-    return isFreePlay ? null : this.getMsg().reinfFeedbackMsg();
+  getReinfFeedbackMsg(isFinalFreePlayLevel) {
+    return isFinalFreePlayLevel ? null : this.getMsg().reinfFeedbackMsg();
   }
 
   // Overrides whether or not to show the "print" option in the feedback dialog.

--- a/apps/src/p5lab/spritelab/SpriteLab.js
+++ b/apps/src/p5lab/spritelab/SpriteLab.js
@@ -115,7 +115,7 @@ export default class SpriteLab extends P5Lab {
   }
 
   /**
-   * Determines the string rendered by the feedback dialog, which always displays
+   * Override the string rendered by the feedback dialog, which always displays
    * another string for freeplay levels, so this implementation is coupled to
    * that. See FeedbackUtils.prototype.getFeedbackMessage for implementation details.
    * @param {boolean} isFreePlay
@@ -123,5 +123,10 @@ export default class SpriteLab extends P5Lab {
    */
   getReinfFeedbackMsg(isFreePlay) {
     return isFreePlay ? null : this.getMsg().reinfFeedbackMsg();
+  }
+
+  // Overrides whether or not to show the "print" option in the feedback dialog.
+  disablePrinting() {
+    return true;
   }
 }

--- a/apps/test/unit/feedbackTest.js
+++ b/apps/test/unit/feedbackTest.js
@@ -1,0 +1,105 @@
+import {assert} from '../util/reconfiguredChai';
+import sinon from 'sinon';
+import FeedbackUtils from '@cdo/apps/feedback';
+import {TestResults} from '@cdo/apps/constants';
+import msg from '@cdo/locale';
+
+describe('FeedbackUtils', () => {
+  describe('getFeedbackMessage', () => {
+    let feedbackUtils;
+
+    beforeEach(() => {
+      feedbackUtils = new FeedbackUtils({} /* studioApp */);
+    });
+
+    describe('successful test result', () => {
+      describe('on freeplay', () => {
+        let options;
+        const finalStageMsg = 'Final stage!';
+        const nextStageMsg = 'Next stage!';
+        const nextLevelMsg = 'Next level!';
+
+        beforeEach(() => {
+          options = {
+            feedbackType: TestResults.FREE_PLAY,
+            level: {},
+            appStrings: {
+              reinfFeedbackMsg: "You're finished!"
+            }
+          };
+
+          sinon.stub(msg, 'finalStage').callsFake(() => finalStageMsg);
+          sinon.stub(msg, 'nextStage').callsFake(() => nextStageMsg);
+          sinon.stub(msg, 'nextLevel').callsFake(() => nextLevelMsg);
+        });
+
+        afterEach(() => {
+          sinon.restore();
+        });
+
+        describe('with sharing enabled', () => {
+          it('returns appStrings.reinfFeedbackMsg if final lesson message disabled', () => {
+            options.level.disableFinalLessonMessage = true;
+            assert.equal(
+              feedbackUtils.getFeedbackMessage(options),
+              options.appStrings.reinfFeedbackMsg
+            );
+          });
+
+          it('returns final stage and appStrings.reinfFeedbackMsg if final level', () => {
+            options.response = {message: 'no more levels'};
+            assert.equal(
+              feedbackUtils.getFeedbackMessage(options),
+              `${finalStageMsg} ${options.appStrings.reinfFeedbackMsg}`
+            );
+
+            // Gracefully handles missing reinfFeedbackMsg.
+            options.appStrings.reinfFeedbackMsg = null;
+            assert.equal(
+              feedbackUtils.getFeedbackMessage(options),
+              `${finalStageMsg} `
+            );
+          });
+
+          it('returns appStrings.reinfFeedbackMsg if not final level', () => {
+            assert.equal(
+              feedbackUtils.getFeedbackMessage(options),
+              options.appStrings.reinfFeedbackMsg
+            );
+          });
+        });
+
+        describe('with sharing disabled', () => {
+          beforeEach(() => {
+            options.level.disableSharing = true;
+          });
+
+          it('returns final stage message if final level', () => {
+            options.response = {message: 'no more levels'};
+            assert.equal(
+              feedbackUtils.getFeedbackMessage(options),
+              finalStageMsg
+            );
+          });
+
+          it('returns next stage message if lesson completed', () => {
+            options.response = {
+              lesson_changing: {previous: {name: 'Lesson Name'}}
+            };
+            assert.equal(
+              feedbackUtils.getFeedbackMessage(options),
+              nextStageMsg
+            );
+          });
+
+          it('returns next level message if lesson not completed', () => {
+            assert.equal(
+              feedbackUtils.getFeedbackMessage(options),
+              nextLevelMsg
+            );
+          });
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Updates the finish dialog title string and print option for SpriteLab (and Poetry since it inherits from SpriteLab) only. This only affects the finish dialog for freeplay levels that are the final level in a progression.

**Note for triage meeting:** This change will likely cause some Eyes test failures.

**Before:**
<img width="657" alt="Screen Shot 2021-11-24 at 1 28 16 PM" src="https://user-images.githubusercontent.com/9812299/143314994-10817d7b-2b9e-4589-b264-dde70f2f8c58.png">

**After:**
Updates the title and removes the print button.
<img width="657" alt="Screen Shot 2021-11-24 at 9 31 25 AM" src="https://user-images.githubusercontent.com/9812299/143314047-7ad58ecb-7667-416b-85c8-85f18d153e43.png">

This change is tightly coupled to the "success" case of FeedbackUtils.prototype.getFeedbackMessage:

https://github.com/code-dot-org/code-dot-org/blob/6be244bafd471fe390edba08077acdcb0db55c9e/apps/src/feedback.js#L875-L914

I've added unit tests for that case in this PR to make sure it behaves how we expect. I made the code change (most of the diff in this PR is from unit tests) as minimal as possible to avoid changing behavior outside of Spritelab since we're so close to HoC.

## Links

- [STAR-1944](https://codedotorg.atlassian.net/browse/STAR-1944)

## Testing story

Adds unit tests for this scenario in feedback.js. This file (which is 2,000 lines and core to our progression logic) had **no** unit tests 😱 

## Follow-up Work
- [STAR-1976](https://codedotorg.atlassian.net/browse/STAR-1976)