### PR TITLE
[Accessibility] Make PaneHeader button a semantic button

### DIFF
--- a/apps/src/templates/PaneHeader.jsx
+++ b/apps/src/templates/PaneHeader.jsx
@@ -196,19 +196,13 @@ export const PaneButton = Radium(function(props) {
     }
   }
 
-  function onClickIfEnabled() {
-    if (props.isDisabled) {
-      return;
-    }
-    props.onClick();
-  }
-
   return (
     <button
       type="button"
       id={props.id}
       style={buttonStyle}
-      onClick={onClickIfEnabled}
+      disabled={props.isDisabled}
+      onClick={props.onClick}
     >
       <span style={styles.headerButtonSpan}>
         {props.hiddenImage}

--- a/apps/src/templates/PaneHeader.jsx
+++ b/apps/src/templates/PaneHeader.jsx
@@ -62,7 +62,11 @@ const styles = {
     lineHeight: '18px',
     ':hover': {
       backgroundColor: color.cyan
-    }
+    },
+    fontSize: 13,
+    padding: 0,
+    color: 'inherit',
+    border: 0
   },
   headerButtonRtl: {
     float: 'left',
@@ -153,7 +157,7 @@ export const PaneSection = Radium(
  * has focus
  */
 export const PaneButton = Radium(function(props) {
-  const divStyle = {
+  const buttonStyle = {
     ...styles.headerButton,
     ...(props.isRtl !== !!props.leftJustified && styles.headerButtonRtl),
     ...(props.isMinecraft && styles.headerButtonMinecraft),
@@ -192,18 +196,26 @@ export const PaneButton = Radium(function(props) {
     }
   }
 
+  function onClickIfEnabled() {
+    if (props.isDisabled) {
+      return;
+    }
+    props.onClick();
+  }
+
   return (
-    <div
+    <button
+      type="button"
       id={props.id}
-      style={divStyle}
-      onClick={props.isDisabled ? () => {} : props.onClick}
+      style={buttonStyle}
+      onClick={onClickIfEnabled}
     >
       <span style={styles.headerButtonSpan}>
         {props.hiddenImage}
         {renderIcon()}
         <span style={styles.noPadding}>{label}</span>
       </span>
-    </div>
+    </button>
   );
 });
 PaneButton.propTypes = {


### PR DESCRIPTION
This PR makes the PaneButton in the PaneHeader a semantic button, which makes it tab-navigable and easier for screen readers to identify. The PaneButton is used on things like the "Version History" button, the "Show Text/Blocks", and "Clear". The video below shows me switching back and forth between development and prod showing that the buttons look the same after this change.

![BeforeAfterButton](https://user-images.githubusercontent.com/2959170/143334508-d15e24e7-a571-40a5-910d-fb9d15cba2fa.gif)


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
