### PR TITLE
remove codepaths for updating unmigrated units

### DIFF
--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -164,7 +164,6 @@ class UnitEditor extends React.Component {
       lessonDescriptions: this.props.i18nData.lessonDescriptions,
       teacherResources: teacherResources,
       hasImportedLessonDescriptions: false,
-      oldScriptText: this.props.initialLessonLevelData,
       includeStudentLessonPlans: this.props.initialIncludeStudentLessonPlans,
       useLegacyLessonPlans: this.props.initialUseLegacyLessonPlans,
       deprecated: this.props.initialDeprecated,
@@ -299,7 +298,6 @@ class UnitEditor extends React.Component {
         this.props.isMigrated && JSON.stringify(this.props.lessonGroups),
       script_text: !this.props.isMigrated && this.state.lessonLevelData,
       last_updated_at: this.state.lastUpdatedAt,
-      old_unit_text: this.state.oldScriptText,
       has_verified_resources: this.state.hasVerifiedResources,
       curriculum_path: this.state.curriculumPath,
       pilot_experiment: this.state.pilotExperiment,
@@ -348,7 +346,6 @@ class UnitEditor extends React.Component {
           this.setState({
             lastSaved: Date.now(),
             isSaving: false,
-            oldScriptText: data.lessonLevelData,
             lastUpdatedAt: data.updated_at
           });
         }

--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -273,7 +273,6 @@ class UnitEditor extends React.Component {
       lesson_extras_available: this.state.lessonExtrasAvailable,
       lesson_groups:
         this.props.isMigrated && JSON.stringify(this.props.lessonGroups),
-      script_text: false,
       last_updated_at: this.state.lastUpdatedAt,
       has_verified_resources: this.state.hasVerifiedResources,
       curriculum_path: this.state.curriculumPath,
@@ -341,7 +340,6 @@ class UnitEditor extends React.Component {
   };
 
   render() {
-    const textAreaRows = 10;
     const useMigratedTeacherResources =
       this.props.isMigrated && !this.state.teacherResources?.length;
     return (
@@ -1055,18 +1053,7 @@ class UnitEditor extends React.Component {
         )}
 
         <CollapsibleEditorSection title="Lesson Groups and Lessons">
-          {this.props.isMigrated ? (
-            <UnitCard />
-          ) : (
-            <div>
-              <textarea
-                id="script_text"
-                rows={textAreaRows}
-                style={styles.input}
-                value={''}
-              />
-            </div>
-          )}
+          <UnitCard />
         </CollapsibleEditorSection>
         <SaveBar
           handleSave={this.handleSave}

--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -35,8 +35,6 @@ import Button from '@cdo/apps/templates/Button';
 import Dialog from '@cdo/apps/templates/Dialog';
 import CourseTypeEditor from '@cdo/apps/lib/levelbuilder/course-editor/CourseTypeEditor';
 
-const VIDEO_KEY_REGEX = /video_key_for_next_level/g;
-
 /**
  * Component for editing units in unit_groups or stand alone courses
  */
@@ -216,21 +214,6 @@ class UnitEditor extends React.Component {
     event.preventDefault();
 
     this.setState({isSaving: true, lastSaved: null, error: null});
-
-    const videoKeysBefore = 0;
-    const unitText = '';
-    const videoKeysAfter = (unitText.match(VIDEO_KEY_REGEX) || []).length;
-    if (videoKeysBefore !== videoKeysAfter) {
-      if (
-        !confirm(
-          'WARNING: adding or removing video keys will also affect ' +
-            'uses of this level in other units. Are you sure you want to ' +
-            'continue?'
-        )
-      ) {
-        shouldCloseAfterSave = false;
-      }
-    }
 
     if (this.state.showCalendar && !this.state.weeklyInstructionalMinutes) {
       this.setState({

--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -68,7 +68,6 @@ class UnitEditor extends React.Component {
     initialTeacherResources: PropTypes.arrayOf(resourceShape).isRequired,
     initialLastUpdatedAt: PropTypes.string,
     initialLessonExtrasAvailable: PropTypes.bool,
-    initialLessonLevelData: PropTypes.string,
     initialHasVerifiedResources: PropTypes.bool,
     initialCurriculumPath: PropTypes.string,
     initialPilotExperiment: PropTypes.string,
@@ -144,9 +143,6 @@ class UnitEditor extends React.Component {
       projectWidgetTypes: this.props.initialProjectWidgetTypes,
       lastUpdatedAt: this.props.initialLastUpdatedAt,
       lessonExtrasAvailable: this.props.initialLessonExtrasAvailable,
-      lessonLevelData:
-        this.props.initialLessonLevelData ||
-        "lesson_group 'lesson group', display_name: 'lesson group display name'\nlesson 'new lesson', display_name: 'lesson display name', has_lesson_plan: true\n",
       hasVerifiedResources: this.props.initialHasVerifiedResources,
       curriculumPath: this.props.initialCurriculumPath,
       pilotExperiment: this.props.initialPilotExperiment,
@@ -221,10 +217,8 @@ class UnitEditor extends React.Component {
 
     this.setState({isSaving: true, lastSaved: null, error: null});
 
-    const videoKeysBefore = (
-      this.props.initialLessonLevelData.match(VIDEO_KEY_REGEX) || []
-    ).length;
-    const unitText = this.props.isMigrated ? '' : this.state.lessonLevelData;
+    const videoKeysBefore = 0;
+    const unitText = '';
     const videoKeysAfter = (unitText.match(VIDEO_KEY_REGEX) || []).length;
     if (videoKeysBefore !== videoKeysAfter) {
       if (
@@ -296,7 +290,7 @@ class UnitEditor extends React.Component {
       lesson_extras_available: this.state.lessonExtrasAvailable,
       lesson_groups:
         this.props.isMigrated && JSON.stringify(this.props.lessonGroups),
-      script_text: !this.props.isMigrated && this.state.lessonLevelData,
+      script_text: false,
       last_updated_at: this.state.lastUpdatedAt,
       has_verified_resources: this.state.hasVerifiedResources,
       curriculum_path: this.state.curriculumPath,
@@ -364,9 +358,7 @@ class UnitEditor extends React.Component {
   };
 
   render() {
-    const textAreaRows = this.state.lessonLevelData
-      ? this.state.lessonLevelData.split('\n').length + 5
-      : 10;
+    const textAreaRows = 10;
     const useMigratedTeacherResources =
       this.props.isMigrated && !this.state.teacherResources?.length;
     return (
@@ -1088,8 +1080,7 @@ class UnitEditor extends React.Component {
                 id="script_text"
                 rows={textAreaRows}
                 style={styles.input}
-                value={this.state.lessonLevelData}
-                onChange={e => this.setState({lessonLevelData: e.target.value})}
+                value={''}
               />
             </div>
           )}

--- a/apps/src/sites/studio/pages/scripts/edit.js
+++ b/apps/src/sites/studio/pages/scripts/edit.js
@@ -17,7 +17,6 @@ import UnitEditor from '@cdo/apps/lib/levelbuilder/unit-editor/UnitEditor';
 
 export default function initPage(unitEditorData) {
   const scriptData = unitEditorData.script;
-  const lessonLevelData = unitEditorData.lessonLevelData;
   const lessonGroups = mapLessonGroupDataForEditor(scriptData.lesson_groups);
 
   const locales = unitEditorData.locales;
@@ -75,7 +74,6 @@ export default function initPage(unitEditorData) {
         initialTeacherResources={teacherResources}
         initialLastUpdatedAt={scriptData.updated_at}
         initialLessonExtrasAvailable={!!scriptData.lesson_extras_available}
-        initialLessonLevelData={lessonLevelData}
         initialHasVerifiedResources={scriptData.has_verified_resources}
         initialCurriculumPath={scriptData.curriculum_path || ''}
         initialPilotExperiment={scriptData.pilot_experiment || ''}

--- a/apps/test/unit/lib/levelbuilder/script-editor/UnitEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/UnitEditorTest.jsx
@@ -85,9 +85,7 @@ describe('UnitEditor', () => {
       initialInstructorAudience: InstructorAudience.teacher,
       initialParticipantAudience: ParticipantAudience.student,
       hasCourse: false,
-      scriptPath: '/s/test-unit',
-      initialLessonLevelData:
-        "lesson_group 'lesson group', display_name: 'lesson group display name'\nlesson 'new lesson', display_name: 'lesson display name', has_lesson_plan: true\n"
+      scriptPath: '/s/test-unit'
     };
   });
 

--- a/apps/test/unit/lib/levelbuilder/script-editor/UnitEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/UnitEditorTest.jsx
@@ -125,7 +125,6 @@ describe('UnitEditor', () => {
       expect(wrapper.find('SaveBar').length).to.equal(1);
 
       expect(wrapper.find('UnitCard').length).to.equal(0);
-      expect(wrapper.find('#script_text').length).to.equal(1);
     });
 
     it('uses new unit editor for migrated unit', () => {
@@ -143,7 +142,6 @@ describe('UnitEditor', () => {
       expect(wrapper.find('CourseTypeEditor').length).to.equal(1);
 
       expect(wrapper.find('UnitCard').length).to.equal(1);
-      expect(wrapper.find('#script_text').length).to.equal(0);
     });
 
     describe('Teacher Resources', () => {

--- a/apps/test/unit/lib/levelbuilder/script-editor/UnitEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/UnitEditorTest.jsx
@@ -114,19 +114,6 @@ describe('UnitEditor', () => {
       assert.equal(wrapper.find('CourseVersionPublishingEditor').length, 1);
     });
 
-    it('uses old unit editor for non migrated unit', () => {
-      const wrapper = createWrapper({});
-
-      expect(wrapper.find('input').length).to.equal(22);
-      expect(wrapper.find('input[type="checkbox"]').length).to.equal(11);
-      expect(wrapper.find('textarea').length).to.equal(3);
-      expect(wrapper.find('select').length).to.equal(7);
-      expect(wrapper.find('CollapsibleEditorSection').length).to.equal(9);
-      expect(wrapper.find('SaveBar').length).to.equal(1);
-
-      expect(wrapper.find('UnitCard').length).to.equal(0);
-    });
-
     it('uses new unit editor for migrated unit', () => {
       const wrapper = createWrapper({
         isMigrated: true,

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -8,7 +8,6 @@ class ScriptsController < ApplicationController
   before_action :set_unit, only: [:show, :vocab, :resources, :code, :standards, :edit, :update, :destroy]
   before_action :set_redirect_override, only: [:show]
   authorize_resource
-  before_action :set_unit_file, only: [:edit, :update]
 
   def show
     if @script.redirect_to?
@@ -100,7 +99,6 @@ class ScriptsController < ApplicationController
       script: @script ? @script.summarize_for_unit_edit : {},
       has_course: @script&.unit_groups&.any?,
       i18n: @script ? @script.summarize_i18n_for_edit : {},
-      lessonLevelData: @unit_dsl_text,
       locales: options_for_locale_select,
       script_families: Script.family_names,
       version_year_options: Script.get_version_year_options,
@@ -180,10 +178,6 @@ class ScriptsController < ApplicationController
   end
 
   private
-
-  def set_unit_file
-    @unit_dsl_text = @script.is_migrated ? '' : ScriptDSL.serialize_lesson_groups(@script)
-  end
 
   def rake
     @errors = []

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -107,8 +107,8 @@ class ScriptsController < ApplicationController
   end
 
   def update
-    return head :bad_request unless @script.is_migrated
-    return head :bad_request unless general_params[:is_migrated]
+    return head :bad_request, json: {message: 'cannot update unmigrated unit'} unless @script.is_migrated
+    return head :bad_request, json: {message: 'is_migrated must be true'} unless general_params[:is_migrated]
 
     if params[:last_updated_at] && params[:last_updated_at] != @script.updated_at.to_s
       msg = "Could not update the unit because it has been modified more recently outside of this editor. Please save a copy your work, reload the page, and try saving again."

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -109,18 +109,11 @@ class ScriptsController < ApplicationController
   end
 
   def update
-    if @script.is_migrated && params[:last_updated_at] && params[:last_updated_at] != @script.updated_at.to_s
+    return head :bad_request unless @script.is_migrated
+
+    if params[:last_updated_at] && params[:last_updated_at] != @script.updated_at.to_s
       msg = "Could not update the unit because it has been modified more recently outside of this editor. Please save a copy your work, reload the page, and try saving again."
       raise msg
-    end
-
-    if !@script.is_migrated && params[:old_unit_text]
-      current_unit_text = ScriptDSL.serialize_lesson_groups(@script).strip
-      old_unit_text = params[:old_unit_text].strip
-      if old_unit_text != current_unit_text
-        msg = "Could not update the unit because the contents of one of its lessons or levels has changed outside of this editor. Reload the page and try saving again."
-        raise msg
-      end
     end
 
     raise 'Must provide family and version year for course' if params[:isCourse] && (!params[:family_name] || !params[:version_year])

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -65,7 +65,7 @@ class ScriptsController < ApplicationController
   def create
     return head :bad_request unless general_params[:is_migrated]
     @script = Script.new(unit_params)
-    if @script.save && @script.update_text(unit_params, nil, i18n_params, general_params)
+    if @script.save && @script.update_text(unit_params, i18n_params, general_params)
       redirect_to edit_script_url(@script), notice: I18n.t('crud.created', model: Script.model_name.human)
     else
       render json: @script.errors
@@ -116,7 +116,7 @@ class ScriptsController < ApplicationController
 
     raise 'Must provide family and version year for course' if params[:isCourse] && (!params[:family_name] || !params[:version_year])
 
-    if @script.update_text(unit_params, nil, i18n_params, general_params)
+    if @script.update_text(unit_params, i18n_params, general_params)
       @script.reload
       render json: @script.summarize_for_unit_edit
     else

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -65,7 +65,7 @@ class ScriptsController < ApplicationController
   def create
     return head :bad_request unless general_params[:is_migrated]
     @script = Script.new(unit_params)
-    if @script.save && @script.update_text(unit_params, params[:script_text], i18n_params, general_params)
+    if @script.save && @script.update_text(unit_params, nil, i18n_params, general_params)
       redirect_to edit_script_url(@script), notice: I18n.t('crud.created', model: Script.model_name.human)
     else
       render json: @script.errors
@@ -116,8 +116,7 @@ class ScriptsController < ApplicationController
 
     raise 'Must provide family and version year for course' if params[:isCourse] && (!params[:family_name] || !params[:version_year])
 
-    unit_text = params[:script_text]
-    if @script.update_text(unit_params, unit_text, i18n_params, general_params)
+    if @script.update_text(unit_params, nil, i18n_params, general_params)
       @script.reload
       render json: @script.summarize_for_unit_edit
     else

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -108,6 +108,7 @@ class ScriptsController < ApplicationController
 
   def update
     return head :bad_request unless @script.is_migrated
+    return head :bad_request unless general_params[:is_migrated]
 
     if params[:last_updated_at] && params[:last_updated_at] != @script.updated_at.to_s
       msg = "Could not update the unit because it has been modified more recently outside of this editor. Please save a copy your work, reload the page, and try saving again."

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1349,21 +1349,16 @@ class Script < ApplicationRecord
   end
 
   # Update strings and serialize changes to .script file
-  def update_text(unit_params, unit_text, metadata_i18n, general_params)
+  def update_text(unit_params, metadata_i18n, general_params)
     unit_name = unit_params[:name]
     # Check if TTS has been turned on for a unit. If so we will need to generate all the TTS for that unit after updating
     need_to_update_tts = general_params[:tts] && !tts
 
     begin
-      # avoid ScriptDSL path for migrated scripts
-      unit_data, i18n =
-        if general_params[:is_migrated]
-          lesson_groups = general_params[:lesson_groups]
-          raise 'lesson_groups param is required for migrated scripts' unless lesson_groups
-          [{lesson_groups: lesson_groups}, get_lesson_groups_i18n(lesson_groups)]
-        else
-          ScriptDSL.parse(unit_text, 'input', unit_name)
-        end
+      lesson_groups = general_params[:lesson_groups]
+      raise 'lesson_groups param is required for migrated scripts' unless lesson_groups
+      unit_data = {lesson_groups: lesson_groups}
+      i18n = get_lesson_groups_i18n(lesson_groups)
       Script.add_unit(
         {
           name: unit_name,

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1650,7 +1650,6 @@ class Script < ApplicationRecord
     include_lessons = false
     summary = summarize(include_lessons)
     summary[:lesson_groups] = lesson_groups.map(&:summarize_for_unit_edit)
-    summary[:lessonLevelData] = ScriptDSL.serialize_lesson_groups(self)
     summary[:preventCourseVersionChange] = prevent_course_version_change?
     summary
   end

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -311,7 +311,6 @@ class ScriptsControllerTest < ActionController::TestCase
     sign_in create(:platformization_partner)
     post :create, params: {
       script: {name: 'test-unit-create'},
-      script_text: '',
       is_migrated: true
     }
     assert_response :forbidden
@@ -337,7 +336,6 @@ class ScriptsControllerTest < ActionController::TestCase
     patch :update, params: {
       id: @coursez_2019.id,
       script: {name: @coursez_2019.name},
-      script_text: '',
     }
     assert_response :forbidden
   end
@@ -350,7 +348,6 @@ class ScriptsControllerTest < ActionController::TestCase
     patch :update, params: {
       id: @partner_unit.id,
       script: {name: @partner_unit.name},
-      script_text: '',
     }
     assert_response :success
   end
@@ -431,7 +428,6 @@ class ScriptsControllerTest < ActionController::TestCase
     post :update, params: {
       id: unit.id,
       script: {name: unit.name},
-      script_text: '',
       published_state: SharedCourseConstants::PUBLISHED_STATE.preview
     }
     assert_response :forbidden
@@ -452,7 +448,6 @@ class ScriptsControllerTest < ActionController::TestCase
     post :update, params: {
       id: unit.id,
       script: {name: unit.name},
-      script_text: '',
       published_state: SharedCourseConstants::PUBLISHED_STATE.preview
     }
     assert_response :success
@@ -473,7 +468,6 @@ class ScriptsControllerTest < ActionController::TestCase
     post :update, params: {
       id: unit.id,
       script: {name: unit.name},
-      script_text: '',
       instruction_type: SharedCourseConstants::INSTRUCTION_TYPE.self_paced
     }
     assert_response :success
@@ -494,7 +488,6 @@ class ScriptsControllerTest < ActionController::TestCase
     post :update, params: {
       id: unit.id,
       script: {name: unit.name},
-      script_text: '',
       published_state: SharedCourseConstants::PUBLISHED_STATE.in_development
     }
     assert_response :success
@@ -515,7 +508,6 @@ class ScriptsControllerTest < ActionController::TestCase
     post :update, params: {
       id: unit.id,
       script: {name: unit.name},
-      script_text: '',
       published_state: SharedCourseConstants::PUBLISHED_STATE.pilot,
       pilot_experiment: 'my-pilot'
     }
@@ -537,7 +529,6 @@ class ScriptsControllerTest < ActionController::TestCase
     post :update, params: {
       id: unit.id,
       script: {name: unit.name},
-      script_text: '',
       published_state: SharedCourseConstants::PUBLISHED_STATE.beta
     }
     assert_response :success
@@ -558,7 +549,6 @@ class ScriptsControllerTest < ActionController::TestCase
     post :update, params: {
       id: unit.id,
       script: {name: unit.name},
-      script_text: '',
       published_state: SharedCourseConstants::PUBLISHED_STATE.preview
     }
     assert_response :success
@@ -579,7 +569,6 @@ class ScriptsControllerTest < ActionController::TestCase
     post :update, params: {
       id: unit.id,
       script: {name: unit.name},
-      script_text: '',
       published_state: SharedCourseConstants::PUBLISHED_STATE.stable
     }
     assert_response :success
@@ -597,7 +586,6 @@ class ScriptsControllerTest < ActionController::TestCase
     post :update, params: {
       id: unit.id,
       script: {name: unit.name},
-      script_text: '',
       published_state: SharedCourseConstants::PUBLISHED_STATE.preview
     }
     assert_response :success
@@ -615,7 +603,6 @@ class ScriptsControllerTest < ActionController::TestCase
     post :update, params: {
       id: unit.id,
       script: {name: unit.name},
-      script_text: '',
       published_state: SharedCourseConstants::PUBLISHED_STATE.preview
     }
     assert_response :forbidden
@@ -768,7 +755,6 @@ class ScriptsControllerTest < ActionController::TestCase
     post :update, params: {
       id: unit.id,
       script: {name: unit.name},
-      script_text: '',
       resourceTypes: ['curriculum', 'vocabulary', ''],
       resourceLinks: ['/link/to/curriculum', '/link/to/vocab', '']
     }
@@ -836,7 +822,6 @@ class ScriptsControllerTest < ActionController::TestCase
     post :update, params: {
       id: unit.id,
       script: {name: unit.name},
-      script_text: '',
       pilot_experiment: 'pilot-experiment',
       published_state: SharedCourseConstants::PUBLISHED_STATE.pilot
     }
@@ -858,7 +843,6 @@ class ScriptsControllerTest < ActionController::TestCase
     post :update, params: {
       id: unit.id,
       script: {name: unit.name},
-      script_text: '',
       pilot_experiment: '',
       published_state: SharedCourseConstants::PUBLISHED_STATE.preview
     }
@@ -885,7 +869,6 @@ class ScriptsControllerTest < ActionController::TestCase
     post :update, params: {
       id: unit.id,
       script: {name: unit.name},
-      script_text: '',
       project_sharing: 'on',
       curriculum_umbrella: 'CSF',
       family_name: 'my-fam',
@@ -915,8 +898,7 @@ class ScriptsControllerTest < ActionController::TestCase
       post :update, params: {
         id: unit.id,
         script: {name: unit.name},
-        script_text: '',
-        resourceTypes: ['curriculum', 'something_else'],
+          resourceTypes: ['curriculum', 'something_else'],
         resourceLinks: ['/link/to/curriculum', 'link/to/something_else']
       }
       assert_response :success
@@ -929,7 +911,6 @@ class ScriptsControllerTest < ActionController::TestCase
     post :update, params: {
       id: unit.id,
       script: {name: unit.name},
-      script_text: '',
       resourceTypes: [''],
       resourceLinks: ['']
     }
@@ -973,7 +954,6 @@ class ScriptsControllerTest < ActionController::TestCase
     post :update, params: {
       id: unit.id,
       script: {name: unit.name},
-      script_text: '',
     }.merge(general_params)
     assert_response :success
     unit.reload
@@ -990,7 +970,6 @@ class ScriptsControllerTest < ActionController::TestCase
     post :update, params: {
       id: unit.id,
       script: {name: unit.name},
-      script_text: '',
       curriculum_path: '',
       version_year: '',
       published_state: SharedCourseConstants::PUBLISHED_STATE.beta,
@@ -1093,34 +1072,6 @@ class ScriptsControllerTest < ActionController::TestCase
 
     refute_nil unit.published_state
     assert_equal SharedCourseConstants::PUBLISHED_STATE.in_development, unit.published_state
-  end
-
-  test 'add lesson to unmigrated unit' do
-    sign_in create(:levelbuilder)
-    Rails.application.config.stubs(:levelbuilder_mode).returns true
-
-    level = create :level
-    unit = create :script, is_migrated: false
-    stub_file_writes(unit.name)
-
-    assert_empty unit.lessons
-
-    unit_text = <<~UNIT_TEXT
-      lesson 'lesson 1', display_name: 'lesson 1'
-      level '#{level.name}'
-    UNIT_TEXT
-
-    post :update, params: {
-      id: unit.id,
-      script: {name: unit.name},
-      script_text: unit_text,
-    }
-    unit.reload
-
-    assert_response :success
-    assert_equal level, unit.lessons.first.script_levels.first.level
-    assert_equal 'lesson 1', JSON.parse(@response.body)['lesson_groups'][0]['lessons'][0]['name']
-    assert_not_nil JSON.parse(@response.body)['lesson_groups'][0]['lessons'][0]['id']
   end
 
   test 'add lesson to migrated unit' do

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -336,6 +336,8 @@ class ScriptsControllerTest < ActionController::TestCase
     patch :update, params: {
       id: @coursez_2019.id,
       script: {name: @coursez_2019.name},
+      is_migrated: true,
+      lesson_groups: '[]',
     }
     assert_response :forbidden
   end
@@ -348,6 +350,8 @@ class ScriptsControllerTest < ActionController::TestCase
     patch :update, params: {
       id: @partner_unit.id,
       script: {name: @partner_unit.name},
+      is_migrated: true,
+      lesson_groups: '[]',
     }
     assert_response :success
   end
@@ -448,6 +452,8 @@ class ScriptsControllerTest < ActionController::TestCase
     post :update, params: {
       id: unit.id,
       script: {name: unit.name},
+      is_migrated: true,
+      lesson_groups: '[]',
       published_state: SharedCourseConstants::PUBLISHED_STATE.preview
     }
     assert_response :success
@@ -468,6 +474,8 @@ class ScriptsControllerTest < ActionController::TestCase
     post :update, params: {
       id: unit.id,
       script: {name: unit.name},
+      is_migrated: true,
+      lesson_groups: '[]',
       instruction_type: SharedCourseConstants::INSTRUCTION_TYPE.self_paced
     }
     assert_response :success
@@ -488,6 +496,8 @@ class ScriptsControllerTest < ActionController::TestCase
     post :update, params: {
       id: unit.id,
       script: {name: unit.name},
+      is_migrated: true,
+      lesson_groups: '[]',
       published_state: SharedCourseConstants::PUBLISHED_STATE.in_development
     }
     assert_response :success
@@ -508,6 +518,8 @@ class ScriptsControllerTest < ActionController::TestCase
     post :update, params: {
       id: unit.id,
       script: {name: unit.name},
+      is_migrated: true,
+      lesson_groups: '[]',
       published_state: SharedCourseConstants::PUBLISHED_STATE.pilot,
       pilot_experiment: 'my-pilot'
     }
@@ -529,6 +541,8 @@ class ScriptsControllerTest < ActionController::TestCase
     post :update, params: {
       id: unit.id,
       script: {name: unit.name},
+      is_migrated: true,
+      lesson_groups: '[]',
       published_state: SharedCourseConstants::PUBLISHED_STATE.beta
     }
     assert_response :success
@@ -549,6 +563,8 @@ class ScriptsControllerTest < ActionController::TestCase
     post :update, params: {
       id: unit.id,
       script: {name: unit.name},
+      is_migrated: true,
+      lesson_groups: '[]',
       published_state: SharedCourseConstants::PUBLISHED_STATE.preview
     }
     assert_response :success
@@ -569,6 +585,8 @@ class ScriptsControllerTest < ActionController::TestCase
     post :update, params: {
       id: unit.id,
       script: {name: unit.name},
+      is_migrated: true,
+      lesson_groups: '[]',
       published_state: SharedCourseConstants::PUBLISHED_STATE.stable
     }
     assert_response :success
@@ -586,6 +604,8 @@ class ScriptsControllerTest < ActionController::TestCase
     post :update, params: {
       id: unit.id,
       script: {name: unit.name},
+      is_migrated: true,
+      lesson_groups: '[]',
       published_state: SharedCourseConstants::PUBLISHED_STATE.preview
     }
     assert_response :success
@@ -603,6 +623,8 @@ class ScriptsControllerTest < ActionController::TestCase
     post :update, params: {
       id: unit.id,
       script: {name: unit.name},
+      is_migrated: true,
+      lesson_groups: '[]',
       published_state: SharedCourseConstants::PUBLISHED_STATE.preview
     }
     assert_response :forbidden
@@ -620,6 +642,8 @@ class ScriptsControllerTest < ActionController::TestCase
     post :update, params: {
       id: unit.id,
       script: {name: unit.name},
+      is_migrated: true,
+      lesson_groups: '[]',
     }
     assert_response :bad_request
   end
@@ -822,6 +846,8 @@ class ScriptsControllerTest < ActionController::TestCase
     post :update, params: {
       id: unit.id,
       script: {name: unit.name},
+      is_migrated: true,
+      lesson_groups: '[]',
       pilot_experiment: 'pilot-experiment',
       published_state: SharedCourseConstants::PUBLISHED_STATE.pilot
     }
@@ -843,6 +869,8 @@ class ScriptsControllerTest < ActionController::TestCase
     post :update, params: {
       id: unit.id,
       script: {name: unit.name},
+      is_migrated: true,
+      lesson_groups: '[]',
       pilot_experiment: '',
       published_state: SharedCourseConstants::PUBLISHED_STATE.preview
     }
@@ -869,6 +897,8 @@ class ScriptsControllerTest < ActionController::TestCase
     post :update, params: {
       id: unit.id,
       script: {name: unit.name},
+      is_migrated: true,
+      lesson_groups: '[]',
       project_sharing: 'on',
       curriculum_umbrella: 'CSF',
       family_name: 'my-fam',
@@ -954,6 +984,8 @@ class ScriptsControllerTest < ActionController::TestCase
     post :update, params: {
       id: unit.id,
       script: {name: unit.name},
+      is_migrated: true,
+      lesson_groups: '[]',
     }.merge(general_params)
     assert_response :success
     unit.reload
@@ -970,6 +1002,8 @@ class ScriptsControllerTest < ActionController::TestCase
     post :update, params: {
       id: unit.id,
       script: {name: unit.name},
+      is_migrated: true,
+      lesson_groups: '[]',
       curriculum_path: '',
       version_year: '',
       published_state: SharedCourseConstants::PUBLISHED_STATE.beta,
@@ -982,7 +1016,7 @@ class ScriptsControllerTest < ActionController::TestCase
     assert_response :success
     unit.reload
 
-    assert_equal({}, unit.properties)
+    assert_equal({'is_migrated' => true}, unit.properties)
   end
 
   test 'setting tts for unit triggers generation of tts for the unit' do
@@ -999,6 +1033,8 @@ class ScriptsControllerTest < ActionController::TestCase
     post :update, params: {
       id: unit.id,
       script: {name: unit.name},
+      is_migrated: true,
+      lesson_groups: '[]',
       tts: true
     }, as: :json
     assert_response :success
@@ -1021,6 +1057,8 @@ class ScriptsControllerTest < ActionController::TestCase
     post :update, params: {
       id: unit.id,
       script: {name: unit.name},
+      is_migrated: true,
+      lesson_groups: '[]',
       tts: false
     }, as: :json
     assert_response :success

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -432,6 +432,8 @@ class ScriptsControllerTest < ActionController::TestCase
     post :update, params: {
       id: unit.id,
       script: {name: unit.name},
+      is_migrated: true,
+      lesson_groups: '[]',
       published_state: SharedCourseConstants::PUBLISHED_STATE.preview
     }
     assert_response :forbidden
@@ -694,6 +696,7 @@ class ScriptsControllerTest < ActionController::TestCase
         id: unit.id,
         script: {name: unit.name},
         is_migrated: true,
+        lesson_groups: '[]',
         last_updated_at: timestamp
       }
     end

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -677,16 +677,13 @@ class ScriptsControllerTest < ActionController::TestCase
 
     unit.reload
     timestamp = (unit.updated_at - 1).to_s
-    old_unit_dsl = ScriptDSL.serialize_lesson_groups(unit)
 
     e = assert_raises do
       post :update, params: {
         id: unit.id,
         script: {name: unit.name},
         is_migrated: true,
-        last_updated_at: timestamp,
-        script_text: old_unit_dsl,
-        old_unit_text: old_unit_dsl
+        last_updated_at: timestamp
       }
     end
     assert_includes e.message, 'Could not update the unit because it has been modified more recently outside of this editor.'


### PR DESCRIPTION
Finishes [PLAT-1504]. The first commit removes the part of the ScriptsController#update which handles updating unmigrated units, and the rest of the PR removes newly dead code and fixes tests.

## Testing Story

* some of the updated tests were actually starting with migrated units, and the call to update them was setting them to no longer be migrated. those tests are fixed in this PR
* the removed tests were covering functionality which is now obsolete (see PR comments inline).

[PLAT-1504]: https://codedotorg.atlassian.net/browse/PLAT-1504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ