### PR TITLE
Do not save match answers when loading previous answers

### DIFF
--- a/apps/src/code-studio/levels/match.js
+++ b/apps/src/code-studio/levels/match.js
@@ -158,7 +158,7 @@ export default class Match {
       });
   }
 
-  moveAnswerToSlot(slot, answer) {
+  moveAnswerToSlot(slot, answer, updateSavedAnswer = true) {
     // replace target with this new item
     slot.replaceWith(answer);
 
@@ -180,7 +180,7 @@ export default class Match {
     // Once all answers have been dropped into a slot, let anyone
     // listening know that an answer has been selected.
     if ($(this.container).find('.match_answers .answer').length === 0) {
-      onAnswerChanged(this.levelId, true);
+      onAnswerChanged(this.levelId, updateSavedAnswer);
     }
   }
 
@@ -232,7 +232,7 @@ export default class Match {
         const answer = $(this.container).find(
           `.answer[originalIndex=${originalIndex}]`
         );
-        this.moveAnswerToSlot(slot, answer);
+        this.moveAnswerToSlot(slot, answer, false);
       }
     }
   }


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Match questions have answers moved into slots by javascript (https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/code-studio/levels/match.js#L218-L239) and then since there has been a change to the answer it results in re-locking of the level.

Full disclosure, this seems to resolve the issue and other match levels still seem to work, but I don't fully understand every scenario that match questions are used in, so it's possible that I missed something.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
- jira ticket: [LP-2042](https://codedotorg.atlassian.net/browse/LP-2042)
<!--
- spec: []()

-->

## Testing story
Tested locally that test doesn't get locked when reloaded and other match questions still work as expected.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
