### PR TITLE
Enable TTS for 7 HOC scripts

### DIFF
--- a/dashboard/config/scripts_json/ai-ethics-2021.script_json
+++ b/dashboard/config/scripts_json/ai-ethics-2021.script_json
@@ -7,6 +7,7 @@
       "curriculum_umbrella": "CSC",
       "is_course": true,
       "is_migrated": true,
+      "tts": true,
       "version_year": "2021"
     },
     "new_name": null,

--- a/dashboard/config/scripts_json/counting-csc-2021.script_json
+++ b/dashboard/config/scripts_json/counting-csc-2021.script_json
@@ -9,6 +9,7 @@
       "include_student_lesson_plans": true,
       "is_course": true,
       "is_migrated": true,
+      "tts": true,
       "version_year": "2021"
     },
     "new_name": null,

--- a/dashboard/config/scripts_json/explore-data-1-2021.script_json
+++ b/dashboard/config/scripts_json/explore-data-1-2021.script_json
@@ -7,6 +7,7 @@
       "curriculum_umbrella": "CSC",
       "is_course": true,
       "is_migrated": true,
+      "tts": true,
       "version_year": "2021"
     },
     "new_name": null,

--- a/dashboard/config/scripts_json/hello-world-animals-2021.script_json
+++ b/dashboard/config/scripts_json/hello-world-animals-2021.script_json
@@ -8,6 +8,7 @@
       "curriculum_umbrella": "CSC",
       "is_course": true,
       "is_migrated": true,
+      "tts": true,
       "version_year": "2021"
     },
     "new_name": null,

--- a/dashboard/config/scripts_json/hello-world-emoji-2021.script_json
+++ b/dashboard/config/scripts_json/hello-world-emoji-2021.script_json
@@ -8,6 +8,7 @@
       "curriculum_umbrella": "CSC",
       "is_course": true,
       "is_migrated": true,
+      "tts": true,
       "version_year": "2021"
     },
     "new_name": null,

--- a/dashboard/config/scripts_json/hello-world-retro-2021.script_json
+++ b/dashboard/config/scripts_json/hello-world-retro-2021.script_json
@@ -8,6 +8,7 @@
       "curriculum_umbrella": "CSC",
       "is_course": true,
       "is_migrated": true,
+      "tts": true,
       "version_year": "2021"
     },
     "new_name": null,

--- a/dashboard/config/scripts_json/spelling-bee-2021.script_json
+++ b/dashboard/config/scripts_json/spelling-bee-2021.script_json
@@ -8,6 +8,7 @@
       "has_verified_resources": true,
       "is_course": true,
       "is_migrated": true,
+      "tts": true,
       "version_year": "2021"
     },
     "new_name": null,


### PR DESCRIPTION
We did not set TTS on 7 of the HOC scripts before the lockdown. This marks tts: true on those 7 scripts so that they will show the generated TTS. See [thread](https://codedotorg.slack.com/archives/C02EEGWLHR8/p1637630443317200) for more details.