### PR TITLE
remove special case isCraft for WorkspaceAlert

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -3106,7 +3106,6 @@ StudioApp.prototype.displayWorkspaceAlert = function(
         ReactDOM.unmountComponentAtNode(container[0]);
       },
       isBlockly: this.usingBlockly_,
-      isCraft: this.config && this.config.app === 'craft',
       displayBottom: bottom
     },
     alertContents

--- a/apps/src/code-studio/components/WorkspaceAlert.jsx
+++ b/apps/src/code-studio/components/WorkspaceAlert.jsx
@@ -9,26 +9,15 @@ export default class WorkspaceAlert extends React.Component {
     children: PropTypes.element.isRequired,
     onClose: PropTypes.func.isRequired,
     isBlockly: PropTypes.bool,
-    isCraft: PropTypes.bool,
     displayBottom: PropTypes.bool
   };
 
   render() {
-    const {
-      displayBottom,
-      isBlockly,
-      isCraft,
-      onClose,
-      type,
-      children
-    } = this.props;
+    const {displayBottom, isBlockly, onClose, type, children} = this.props;
     var toolbarWidth;
-    if (isBlockly && isCraft) {
-      // craft has a slightly different way of constructing the toolbox so we need to use
-      // the toolbox header's width to get the width of the actual toolbox.
+    if (isBlockly) {
+      // use the toolbox header's width to get the width of the actual toolbox.
       toolbarWidth = $('#toolbox-header').width();
-    } else if (isBlockly) {
-      toolbarWidth = $('.blocklyToolboxDiv').width();
     } else {
       toolbarWidth =
         $('.droplet-palette-element').width() + $('.droplet-gutter').width();

--- a/apps/test/unit/code-studio/components/WorkspaceAlertTest.js
+++ b/apps/test/unit/code-studio/components/WorkspaceAlertTest.js
@@ -24,7 +24,6 @@ describe('WorkspaceAlert', () => {
         type="warning"
         onClose={() => {}}
         isBlockly={true}
-        isCraft={false}
         displayBottom={false}
       >
         <span>This is a top alert</span>
@@ -46,7 +45,6 @@ describe('WorkspaceAlert', () => {
         type="warning"
         onClose={() => {}}
         isBlockly={true}
-        isCraft={false}
         displayBottom={true}
       >
         <span>This is a bottom alert</span>
@@ -60,44 +58,20 @@ describe('WorkspaceAlert', () => {
     ).to.equal(0);
   });
 
-  it('isBlockly and isCraft uses #toolbox-header for left', () => {
-    jQueryWidth.onCall(0).returns(1);
-    const isBlocklyAndisCraft = mount(
-      <WorkspaceAlert
-        type="warning"
-        onClose={() => {}}
-        isBlockly={true}
-        isCraft={true}
-        displayBottom={true}
-      >
-        <span>This is a craft and blockly alert</span>
-      </WorkspaceAlert>
-    );
-    expect(jQueryWidth.callCount).to.equal(1);
-    expect(jQueryWidth.thisValues[0].selector).to.equal('#toolbox-header');
-    expect(
-      isBlocklyAndisCraft
-        .find('div')
-        .first()
-        .props().style.left
-    ).to.equal(1);
-  });
-
-  it('isBlockly and not isCraft uses .blocklyToolboxDiv for left', () => {
+  it('isBlockly uses #toolbox-header for left', () => {
     jQueryWidth.onCall(0).returns(1);
     const isBlockly = mount(
       <WorkspaceAlert
         type="warning"
         onClose={() => {}}
         isBlockly={true}
-        isCraft={false}
         displayBottom={true}
       >
         <span>This is a blockly alert</span>
       </WorkspaceAlert>
     );
     expect(jQueryWidth.callCount).to.equal(1);
-    expect(jQueryWidth.thisValues[0].selector).to.equal('.blocklyToolboxDiv');
+    expect(jQueryWidth.thisValues[0].selector).to.equal('#toolbox-header');
     expect(
       isBlockly
         .find('div')
@@ -106,7 +80,7 @@ describe('WorkspaceAlert', () => {
     ).to.equal(1);
   });
 
-  it('not isBlockly and not isCraft uses .droplet-gutter and .droplet-palette-element for left', () => {
+  it('not isBlockly uses .droplet-gutter and .droplet-palette-element for left', () => {
     jQueryWidth
       .onCall(0)
       .returns(1)
@@ -116,10 +90,9 @@ describe('WorkspaceAlert', () => {
         type="warning"
         onClose={() => {}}
         isBlockly={false}
-        isCraft={false}
         displayBottom={true}
       >
-        <span>This is a neither craft nor blockly alert</span>
+        <span>This is not a blockly alert</span>
       </WorkspaceAlert>
     );
     expect(


### PR DESCRIPTION
Fix a reported UI bug where the “you changed your code” notification doesn’t stretch across the entire bottom of the workspace, or stretches over the toolbox (depending on window size). Reported for Sprite Lab but also found in other Blockly lab-types. The bug was not found in Minecraft or non-Blockly labs.

**Before:**
*Sprite Lab (bug):*
![image](https://user-images.githubusercontent.com/43474485/144056716-f2571a7d-026f-40d3-bc8d-05f03107c69d.png)
![image](https://user-images.githubusercontent.com/43474485/144053904-42d3ece3-45d9-4619-a97a-c9ee1aac07ac.png)
*Frozen (bug):*
![image](https://user-images.githubusercontent.com/43474485/144054048-777cf205-e175-48a4-973b-772cc7bfb439.png)
*Play Lab (bug):*
![image](https://user-images.githubusercontent.com/43474485/144054130-857ef31f-19aa-4d8d-89bf-d1607d0bc420.png)
*Minecraft (no bug):*
![image](https://user-images.githubusercontent.com/43474485/144054303-3179aecc-870d-4458-ad86-d8eab923489d.png)
*App Lab (no bug):*
![image](https://user-images.githubusercontent.com/43474485/144054260-c4067c79-142f-4a88-9b5e-9bedf338f003.png)

Until now we've had a special case for `isBlocky` and `isCraft` levels where we would jquery for id `#toolbox-header` for left. In non-`isCraft` levels, we were looking for class `.blocklyToolboxDiv`, however, no elements of this class could be found on the page. This is probably due to some other change on the site that re-worked the classes used on Blockly pages. Because all Blockly pages do have an element with id `#toolbox-header`, we can use that for left in all of these cases and no longer need a special case for `isCraft`. This change also removes the `isCraft` property from `WorkspaceAlert` and its associated special case for setting `toolbarWidth`.
It should be noted that the previous logic relied on somewhat fragile queries and that this change does not fix that underlying issue. The good news is that this change fixes the bug while also simplifying the code slightly.

**After:**
*Sprite Lab (showing uncategorized and categorized toolboxes):*
![image](https://user-images.githubusercontent.com/43474485/144056456-a7779f6e-a66b-487b-8dac-225fe590763c.png)
![image](https://user-images.githubusercontent.com/43474485/144056527-a63b7ef8-ae79-480e-8d05-bbf0d4c201d8.png)

*Frozen:*
![image](https://user-images.githubusercontent.com/43474485/144056083-edf19908-69a1-49d8-bd22-63d9f7a80696.png)

*Play Lab:*
![image](https://user-images.githubusercontent.com/43474485/144056203-26c256ec-00c0-449a-b46f-39bb77e74e00.png)

*Minecraft:*
![image](https://user-images.githubusercontent.com/43474485/144056240-a881ab29-22bb-406a-82a4-ef4a4b5b9d1f.png)

*App Lab:*
![image](https://user-images.githubusercontent.com/43474485/144056040-f1ff40e9-d20c-4dcf-b581-c456d0c52ff8.png)


## Links

- jira ticket: [STAR-1950](https://codedotorg.atlassian.net/browse/STAR-1950)

## Testing story

This change removes the `isCraft` property from WorkspaceAlertTest and re-works tests related to i`sBlockly` and `isCraft` to align to the change described above.