### PR TITLE
Make sure instructor and participant audiences are not equal

### DIFF
--- a/dashboard/app/models/concerns/curriculum/course_types.rb
+++ b/dashboard/app/models/concerns/curriculum/course_types.rb
@@ -13,6 +13,13 @@ module Curriculum::CourseTypes
     validates :instruction_type, acceptance: {accept: SharedCourseConstants::INSTRUCTION_TYPE.to_h.values, message: 'must be teacher_led or self_paced'}
     validates :instructor_audience, acceptance: {accept: SharedCourseConstants::INSTRUCTOR_AUDIENCE.to_h.values, message: 'must be universal instructor, plc reviewer, facilitator, or teacher'}
     validates :participant_audience, acceptance: {accept: SharedCourseConstants::PARTICIPANT_AUDIENCE.to_h.values, message: 'must be facilitator, teacher, or student'}
+
+    validate :cannot_have_same_audiences
+  end
+
+  # Instructor and Participant Audience can not be equal unless they are nil
+  def cannot_have_same_audiences
+    errors.add(:instructor_audience, 'You cannot have the same instructor and participant audiences.') if !instructor_audience.nil? && instructor_audience == participant_audience
   end
 
   # Checks if a user can be the instructor for the course. universal instructors and levelbuilders

--- a/dashboard/test/models/concerns/curriculum/course_types_test.rb
+++ b/dashboard/test/models/concerns/curriculum/course_types_test.rb
@@ -25,6 +25,19 @@ class CourseTypesTests < ActiveSupport::TestCase
     @unit_plc_reviewer_to_facilitator = create(:script, name: 'plc-reviewer-to-facilitator', instructor_audience: SharedCourseConstants::INSTRUCTOR_AUDIENCE.plc_reviewer, participant_audience: SharedCourseConstants::PARTICIPANT_AUDIENCE.facilitator)
   end
 
+  test 'create unit_group with same audiences raises error' do
+    e = assert_raises do
+      create(:unit_group, name: 'same-audiences', instructor_audience: SharedCourseConstants::INSTRUCTOR_AUDIENCE.teacher, participant_audience: SharedCourseConstants::PARTICIPANT_AUDIENCE.teacher)
+    end
+    assert_equal "Validation failed: Instructor audience You cannot have the same instructor and participant audiences.", e.message
+  end
+  test 'create script with same audiences raises error' do
+    e = assert_raises do
+      create(:script, name: 'same-audiences', instructor_audience: SharedCourseConstants::INSTRUCTOR_AUDIENCE.teacher, participant_audience: SharedCourseConstants::PARTICIPANT_AUDIENCE.teacher)
+    end
+    assert_equal "Validation failed: Instructor audience You cannot have the same instructor and participant audiences.", e.message
+  end
+
   test 'unit in course should check course for if it is a pl course' do
     assert_equal @unit_group.pl_course?, @unit_in_course.pl_course?
     refute @unit_in_course.pl_course?


### PR DESCRIPTION
Add a validation to make sure that someone doesn't make the instructor audience the same as the participant audience for a course.

## Testing story

- Added unit tests