### PR TITLE
Check response.status instead of statusText

### DIFF
--- a/apps/src/code-studio/components/progress/teacherPanel/teacherPanelData.js
+++ b/apps/src/code-studio/components/progress/teacherPanel/teacherPanelData.js
@@ -10,10 +10,10 @@ export const getStudentsForSection = async () => {
 
   try {
     const response = await fetch(request, {credentials: 'same-origin'});
-    // This API returns with "No Content" when there is no section to be loaded
-    // for the teacher panel, checking "OK" ensures a section was returned
-    if (response.statusText === 'OK') {
-      return await response.json();
+    // This API returns with  204 - No Content when there is no section to be loaded
+    // for the teacher panel, checking 200 ensures a section was returned
+    if (response.status === 200) {
+      return response.json();
     }
   } catch (err) {
     console.log(err);


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
I used `response.statusText` because the value was present locally, however once I merged to staging the statusText was an empty string. After a little investigation (https://stackoverflow.com/questions/41632077/why-is-the-statustext-of-my-xhr-empty) I determined I should be using `status` instead. 

Response on staging:

![Screen Shot 2021-11-30 at 12 13 39 PM](https://user-images.githubusercontent.com/24235215/144121006-6d857254-adf8-4d32-b5aa-40d2cc98f16d.png)

## Testing story
Tested locally that the teacher panel still works as expected
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
