### PR TITLE
removing special Korean HoC certificates as they are no longer needed

### DIFF
--- a/apps/src/templates/Congrats.jsx
+++ b/apps/src/templates/Congrats.jsx
@@ -4,8 +4,6 @@ import Certificate from './Certificate';
 import StudentsBeyondHoc from './StudentsBeyondHoc';
 import TeachersBeyondHoc from './TeachersBeyondHoc';
 import styleConstants from '../styleConstants';
-import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
-import color from '../util/color';
 
 export default class Congrats extends Component {
   static propTypes = {
@@ -35,40 +33,6 @@ export default class Congrats extends Component {
       oceans: 'oceans'
     }[tutorial] || 'other');
 
-  /**
-   * Renders links to certificate alternatives when there is a special event going on.
-   * @param {string} language The language code related to the special event i.e. 'en', 'es', 'ko', etc
-   * @param {string} tutorial The type of tutorial the student finished i.e. 'dance', 'oceans', etc
-   * @returns {HTMLElement} HTML for rendering the extra certificate links.
-   */
-  renderExtraCertificateLinks = (language, tutorial) => {
-    let extraLinkUrl, extraLinkText;
-    // https://codedotorg.atlassian.net/browse/FND-1749
-    // these can be removed after November 21 2021
-    if (language === 'ko') {
-      if (/oceans/.test(tutorial)) {
-        extraLinkUrl = pegasus('/files/online-coding-party-2021-oceans.pdf');
-        extraLinkText =
-          '온라인 코딩 파티 인증서 받으러 가기! (과학기술정보통신부 인증)';
-      } else if (/dance/.test(tutorial)) {
-        extraLinkUrl = pegasus('/files/online-coding-party-2021-dance.pdf');
-        extraLinkText =
-          '온라인 코딩 파티 인증서 받으러 가기! (과학기술정보통신부 인증)';
-      }
-    }
-    if (!extraLinkUrl || !extraLinkText) {
-      // There are no extra links to render.
-      return;
-    }
-    return (
-      <div style={styles.extraLinkContainer}>
-        <a href={extraLinkUrl} target={'_blank'} style={styles.extraLink}>
-          {extraLinkText}
-        </a>
-      </div>
-    );
-  };
-
   render() {
     const {
       tutorial,
@@ -90,9 +54,7 @@ export default class Congrats extends Component {
           certificateId={certificateId}
           randomDonorTwitter={randomDonorTwitter}
           under13={under13}
-        >
-          {this.renderExtraCertificateLinks(language, tutorial)}
-        </Certificate>
+        />
         {userType === 'teacher' && isEnglish && <TeachersBeyondHoc />}
         <StudentsBeyondHoc
           completedTutorialType={tutorialType}
@@ -114,13 +76,5 @@ const styles = {
     maxWidth: styleConstants['content-width'],
     marginLeft: 'auto',
     marginRight: 'auto'
-  },
-  extraLinkContainer: {
-    clear: 'both',
-    paddingTop: 20
-  },
-  extraLink: {
-    color: color.teal,
-    fontSize: 14
   }
 };


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR removes the special links for Korean HoC tutorials, as our partner's promotion has ended and they are no longer required.

Previous PR: https://github.com/code-dot-org/code-dot-org/pull/41025
Jira: https://codedotorg.atlassian.net/browse/FND-1750
## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
