### PR TITLE
Disable printing by default for all level types except Artist

### DIFF
--- a/apps/src/dance/Dance.js
+++ b/apps/src/dance/Dance.js
@@ -691,7 +691,6 @@ Dance.prototype.displayFeedback_ = function() {
     appStrings: {
       reinfFeedbackMsg: 'TODO: localized feedback message.'
     },
-    disablePrinting: true,
     twitter: {text: twitterText}
   };
 

--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -1559,11 +1559,6 @@ export default class P5Lab {
     return this.getMsg().reinfFeedbackMsg();
   }
 
-  // Determines whether or not to show the "print" option in the feedback dialog.
-  disablePrinting() {
-    return false;
-  }
-
   /**
    * App specific displayFeedback function that calls into
    * this.studioApp_.displayFeedback when appropriate
@@ -1599,8 +1594,7 @@ export default class P5Lab {
       },
       hideXButton: true,
       saveToProjectGallery: saveToProjectGallery,
-      disableSaveToGallery: !isSignedIn,
-      disablePrinting: this.disablePrinting()
+      disableSaveToGallery: !isSignedIn
     });
   }
 

--- a/apps/src/p5lab/spritelab/SpriteLab.js
+++ b/apps/src/p5lab/spritelab/SpriteLab.js
@@ -124,9 +124,4 @@ export default class SpriteLab extends P5Lab {
   getReinfFeedbackMsg(isFinalFreePlayLevel) {
     return isFinalFreePlayLevel ? null : this.getMsg().reinfFeedbackMsg();
   }
-
-  // Overrides whether or not to show the "print" option in the feedback dialog.
-  disablePrinting() {
-    return true;
-  }
 }

--- a/apps/src/studio/levels.js
+++ b/apps/src/studio/levels.js
@@ -3729,7 +3729,6 @@ levels.js_hoc2015_event_free = {
     reinfFeedbackMsg: msg.hoc2015_reinfFeedbackMsg,
     sharingText: msg.hoc2015_shareGame
   },
-  disablePrinting: true,
   playStartSound: false
 };
 

--- a/apps/src/studio/studio.js
+++ b/apps/src/studio/studio.js
@@ -3050,7 +3050,6 @@ Studio.displayFeedback = function() {
     const saveToProjectGallery = PUBLISHABLE_SKINS.includes(skin.id);
     const isSignedIn =
       getStore().getState().currentUser.signInState === SignInState.SignedIn;
-
     studioApp().displayFeedback({
       feedbackType: Studio.testResults,
       executionError: Studio.executionError,
@@ -3070,7 +3069,8 @@ Studio.displayFeedback = function() {
       disableSaveToGallery: !isSignedIn,
       message: Studio.message,
       appStrings: appStrings,
-      disablePrinting: level.disablePrinting
+      // Currently only true for Artist levels
+      enablePrinting: level.enablePrinting
     });
   }
 };

--- a/apps/src/templates/sharing.html.ejs
+++ b/apps/src/templates/sharing.html.ejs
@@ -6,7 +6,6 @@
   <div class="sharing-content no-image">
 <% } %>
 
-
 <% if (options.shareLink) { %>
   <% if (options.appStrings && options.appStrings.sharingText) { %>
     <div><%= options.appStrings.sharingText %></div>
@@ -30,7 +29,7 @@
         </button>
       </a>
     <% } -%>
-    <% if (!options.onMainPage && !options.disablePrinting) { %>
+    <% if (!options.onMainPage && options.enablePrinting) { %>
       <button id="print-button">
         <i class="fa fa-print fa-lg"></i>
       </button>

--- a/apps/src/turtle/artist.js
+++ b/apps/src/turtle/artist.js
@@ -1344,7 +1344,8 @@ Artist.prototype.displayFeedback_ = function() {
     appStrings: {
       reinfFeedbackMsg: turtleMsg.reinfFeedbackMsg(),
       sharingText: turtleMsg.shareDrawing()
-    }
+    },
+    enablePrinting: true
   });
 };
 


### PR DESCRIPTION
[LP-2121](https://codedotorg.atlassian.net/browse/LP-2121)
Sort of follow up to #43805 

Printing should only be available for Artist levels and by extension Frozen levels. 

The option to print a thumbnail shows up in (at least?) two places: 1.) the share dialog accessed from a project header and 2.) the share icons in the finish dialog shown at the end of a level. 
The `ShareAllowedDialog` that appears when you click the share button in a project header [already restricts printing to Artist](https://github.com/code-dot-org/code-dot-org/blob/cc99e4a86f5f2ebaa443339f3c93244f63a50b35/apps/src/code-studio/headerShare.js#L51). 

Similarly, we no longer want the print option to show in the finish dialog unless it's an Artist level. Currently printing is available to any level where `disablePrinting == true`. However, given that printing is a special case, rather than the norm, this change sets `enablePrinting == true` for Artist only and removes references to `disablePrinting` from other level types as it is now unecessary. 