### PR TITLE
Update resource and vocab markdown on lesson clone

### DIFF
--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -881,6 +881,10 @@ class Lesson < ApplicationRecord
     Services::MarkdownPreprocessor.sub_vocab_definitions!(copied_lesson.overview, update_vocab_definition_on_clone) if copied_lesson.overview
     Services::MarkdownPreprocessor.sub_resource_links!(copied_lesson.student_overview, update_resource_link_on_clone) if copied_lesson.student_overview
     Services::MarkdownPreprocessor.sub_vocab_definitions!(copied_lesson.student_overview, update_vocab_definition_on_clone) if copied_lesson.student_overview
+    Services::MarkdownPreprocessor.sub_resource_links!(copied_lesson.preparation, update_resource_link_on_clone) if copied_lesson.preparation
+    Services::MarkdownPreprocessor.sub_vocab_definitions!(copied_lesson.preparation, update_vocab_definition_on_clone) if copied_lesson.preparation
+    Services::MarkdownPreprocessor.sub_resource_links!(copied_lesson.assessment_opportunities, update_resource_link_on_clone) if copied_lesson.assessment_opportunities
+    Services::MarkdownPreprocessor.sub_vocab_definitions!(copied_lesson.assessment_opportunities, update_vocab_definition_on_clone) if copied_lesson.assessment_opportunities
 
     # Copy lesson activities, activity sections, and script levels
     copied_lesson.lesson_activities = lesson_activities.map do |original_lesson_activity|

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -877,6 +877,11 @@ class Lesson < ApplicationRecord
       new_vocab ? Services::GloballyUniqueIdentifiers.build_vocab_key(new_vocab) : Services::GloballyUniqueIdentifiers.build_vocab_key(vocab)
     end
 
+    Services::MarkdownPreprocessor.sub_resource_links!(copied_lesson.overview, update_resource_link_on_clone) if copied_lesson.overview
+    Services::MarkdownPreprocessor.sub_vocab_definitions!(copied_lesson.overview, update_vocab_definition_on_clone) if copied_lesson.overview
+    Services::MarkdownPreprocessor.sub_resource_links!(copied_lesson.student_overview, update_resource_link_on_clone) if copied_lesson.student_overview
+    Services::MarkdownPreprocessor.sub_vocab_definitions!(copied_lesson.student_overview, update_vocab_definition_on_clone) if copied_lesson.student_overview
+
     # Copy lesson activities, activity sections, and script levels
     copied_lesson.lesson_activities = lesson_activities.map do |original_lesson_activity|
       copied_lesson_activity = original_lesson_activity.dup
@@ -887,11 +892,9 @@ class Lesson < ApplicationRecord
         copied_activity_section = original_activity_section.dup
         copied_activity_section.key = SecureRandom.uuid
         copied_activity_section.lesson_activity_id = copied_lesson_activity.id
-        if original_activity_section.description
-          new_description = original_activity_section.description.dup
-          Services::MarkdownPreprocessor.sub_resource_links!(new_description, update_resource_link_on_clone)
-          Services::MarkdownPreprocessor.sub_vocab_definitions!(new_description, update_vocab_definition_on_clone)
-          copied_activity_section.description = new_description
+        if copied_activity_section.description
+          Services::MarkdownPreprocessor.sub_resource_links!(copied_activity_section.description, update_resource_link_on_clone)
+          Services::MarkdownPreprocessor.sub_vocab_definitions!(copied_activity_section.description, update_vocab_definition_on_clone)
         end
         copied_activity_section.save!
         sl_data = original_activity_section.script_levels.map.with_index(1) do |original_script_level, pos|
@@ -924,7 +927,6 @@ class Lesson < ApplicationRecord
     copied_lesson.standards = standards
     copied_lesson.opportunity_standards = opportunity_standards
 
-    copied_lesson.save!
     Script.merge_and_write_i18n(copied_lesson.i18n_hash, destination_unit.name)
     destination_unit.fix_script_level_positions
     destination_unit.write_script_json

--- a/dashboard/app/models/vocabulary.rb
+++ b/dashboard/app/models/vocabulary.rb
@@ -128,7 +128,7 @@ class Vocabulary < ApplicationRecord
   def copy_to_course_version(destination_course_version)
     return self if course_version == destination_course_version
     persisted_vocab = Vocabulary.where(word: word, course_version_id: destination_course_version.id).first
-    if persisted_vocab && !!persisted_vocab.common_sense_media == !!original_vocab.common_sense_media
+    if persisted_vocab && !!persisted_vocab.common_sense_media == !!common_sense_media
       persisted_vocab
     else
       copied_vocab = Vocabulary.create!(word: word, definition: definition, common_sense_media: common_sense_media, course_version_id: destination_course_version.id)

--- a/dashboard/app/models/vocabulary.rb
+++ b/dashboard/app/models/vocabulary.rb
@@ -125,6 +125,17 @@ class Vocabulary < ApplicationRecord
     end
   end
 
+  def copy_to_course_version(destination_course_version)
+    return self if course_version == destination_course_version
+    persisted_vocab = Vocabulary.where(word: word, course_version_id: destination_course_version.id).first
+    if persisted_vocab && !!persisted_vocab.common_sense_media == !!original_vocab.common_sense_media
+      persisted_vocab
+    else
+      copied_vocab = Vocabulary.create!(word: word, definition: definition, common_sense_media: common_sense_media, course_version_id: destination_course_version.id)
+      copied_vocab
+    end
+  end
+
   private
 
   # A simple helper function to encapsulate creating a unique key, since this

--- a/dashboard/lib/services/markdown_preprocessor.rb
+++ b/dashboard/lib/services/markdown_preprocessor.rb
@@ -37,29 +37,32 @@ module Services
       end
     end
 
+    VOCAB_HTML = proc {|vocab| "<span class=\"vocab\" title=#{vocab.definition.inspect}>#{vocab.word}</span>"}
     # Returns a copy of `content` with all occurrences of Vocabulary references
     # substituted with the equivalent HTML span.
     #
     # Vocabulary references take the form of:
     # `[v vocab_key/course_offering_key/course_version_key]`
     # For example: `[v loops/coursea/2020]`
-    def self.sub_vocab_definitions(content)
-      sub_vocab_definitions!(content.dup)
+    def self.sub_vocab_definitions(content, replace_func = VOCAB_HTML)
+      sub_vocab_definitions!(content.dup, replace_func)
     end
 
     # Performs the substitutions of MarkdownPreprocessor#sub_vocab_definitions
     # in place
-    def self.sub_vocab_definitions!(content)
+    def self.sub_vocab_definitions!(content, replace_func = VOCAB_HTML)
       @@vocab_def_re ||= /\[v (?<key>#{Services::GloballyUniqueIdentifiers.vocab_key_re})\]/
       content.gsub!(@@vocab_def_re) do |match|
         vocab = Services::GloballyUniqueIdentifiers.find_vocab($~[:key])
         if vocab.present?
-          "<span class=\"vocab\" title=#{vocab.definition.inspect}>#{vocab.word}</span>"
+          replace_func.call(vocab)
         else
           match
         end
       end
     end
+
+    RESOURCE_LINK_MARKDOWN = proc {|resource| "[#{resource.name}](#{resource.url})"}
 
     # Returns a copy of `content` with all occurrences of Resource links
     # substituted with the equivalent Markdown links
@@ -67,18 +70,18 @@ module Services
     # Resource links take the form of:
     # `[r resource_key/course_offering_key/course_version_key]`
     # For example: `[r example-video/csd/2021]`
-    def self.sub_resource_links(content)
-      sub_resource_links!(content.dup)
+    def self.sub_resource_links(content, replace_func = RESOURCE_LINK_MARKDOWN)
+      sub_resource_links!(content.dup, replace_func)
     end
 
     # Performs the substitutions of MarkdownPreprocessor#sub_resource_links in
     # place
-    def self.sub_resource_links!(content)
+    def self.sub_resource_links!(content, replace_func = RESOURCE_LINK_MARKDOWN)
       @@resource_link_re ||= /\[r (?<key>#{Services::GloballyUniqueIdentifiers.resource_key_re})\]/
       content.gsub!(@@resource_link_re) do |match|
         resource = Services::GloballyUniqueIdentifiers.find_resource($~[:key])
         if resource.present?
-          "[#{resource.name}](#{resource.url})"
+          replace_func.call(resource)
         else
           match
         end

--- a/dashboard/test/lib/services/markdown_preprocessor_test.rb
+++ b/dashboard/test/lib/services/markdown_preprocessor_test.rb
@@ -104,6 +104,15 @@ class Services::MarkdownPreprocessorTest < ActiveSupport::TestCase
     assert_equal expected, result
   end
 
+  test 'sub_resource_links can substitute using a provided proc' do
+    input = "this string has a resource [r first-resource/test-course/1999] link. And a [regular](link)"
+    replace_proc = proc {|r| "RESOURCE: #{r.name}"}
+    expected = "this string has a resource RESOURCE: First Resource link. And a [regular](link)"
+
+    result = Services::MarkdownPreprocessor.sub_resource_links(input, replace_proc)
+    assert_equal expected, result
+  end
+
   test 'sub_resource_links can handle multiple resource links in a single string' do
     input = "this string has [r second-resource/test-course/1999] two resource [r first-resource/test-course/1999] links"
     expected = "this string has [Second Resource](example.com/second) two resource [First Resource](example.com/first) links"
@@ -218,5 +227,14 @@ class Services::MarkdownPreprocessorTest < ActiveSupport::TestCase
     input = "this string has a vocab [v nonexistent_vocab/test-course/1999] definition."
     result = Services::MarkdownPreprocessor.sub_vocab_definitions(input)
     assert_equal input, result
+  end
+
+  test 'sub_vocab_definitions uses passed in proc if one provided' do
+    input = "this string has a vocab [v first_vocab/test-course/1999] definition."
+    replace_proc = proc {|v| "VOCABULARY: #{v.word}"}
+    expected = "this string has a vocab VOCABULARY: First Vocabulary definition."
+
+    result = Services::MarkdownPreprocessor.sub_vocab_definitions(input, replace_proc)
+    assert_equal expected, result
   end
 end

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -1010,18 +1010,20 @@ class LessonTest < ActiveSupport::TestCase
 
       @original_script = create :script, is_migrated: true
       @original_script.expects(:write_script_json).never
-      @original_course_version = create :course_version, content_root: @original_script, version_year: 2021
+      course_offering = create :course_offering
+      @original_course_version = create :course_version, course_offering: course_offering, content_root: @original_script, version_year: 2021
       @original_lesson_group = create :lesson_group, script: @original_script
       @original_lesson = create :lesson, lesson_group: @original_lesson_group, script: @original_script, has_lesson_plan: true
 
       @destination_script = create :script, is_migrated: true
-      @destination_course_version = create :course_version, content_root: @destination_script, version_year: 2021
+      course_offering = create :course_offering
+      @destination_course_version = create :course_version, course_offering: course_offering, content_root: @destination_script, version_year: 2021
       @destination_lesson_group = create :lesson_group, script: @destination_script
     end
 
     test "can clone lesson into another script" do
       lesson_activity = create :lesson_activity, lesson: @original_lesson
-      activity_section = create :activity_section, lesson_activity: lesson_activity
+      activity_section = create :activity_section, lesson_activity: lesson_activity, description: "[r resource1/#{@original_course_version.course_offering.key}/#{@original_course_version.key}]"
       level1 = create :maze, name: 'level 1'
       level2 = create :maze, name: 'level 2'
       create :script_level, script: @original_script, lesson: @original_lesson, levels: [level1],
@@ -1052,6 +1054,11 @@ class LessonTest < ActiveSupport::TestCase
       assert_equal @original_lesson.standards, copied_lesson.standards
       assert_equal @original_lesson.opportunity_standards, copied_lesson.opportunity_standards
       assert_equal @original_lesson.programming_expressions, copied_lesson.programming_expressions
+      puts @original_script.course_version.course_offering.inspect
+      puts @original_script.course_version.inspect
+      puts @destination_script.course_version.course_offering.inspect
+      puts @destination_script.course_version.inspect
+      puts @destination_script.lessons.last.lesson_activities.map {|la| la.activity_sections.map(&:description)}
     end
 
     test "variants are removed when cloning lesson into another script" do


### PR DESCRIPTION
Finishes [PLAT-1447](https://codedotorg.atlassian.net/browse/PLAT-1447).

When we clone scripts, we also clone resource and vocab. This means that the resource and vocab markdown becomes outdated.

We already find and replace this markdown when we serve this content so I just reused that logic here. I extended that functionality to be able to pass in a custom replace function that looks up the cloned resource/vocab and inserts that markdown there.

A few decisions I made:
- We can't assume the keys for resources and vocab always match across course version, so I created a map so we can find the new one
- It's possible for a lesson to reference a resource that isn't in that lesson. In that case, I just copied it to the destination course version.
- Because we need to know the cloned resource/vocab's new key, it's hard to do this same update to the script overview. I'm currently thinking, at least for now, that curriculum can spot check that field




## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
