### PR TITLE
[Google Blockly] Show/hide with Blockly.Events.BlockDrag

### DIFF
--- a/apps/src/blockly/addons/cdoBlockDragger.js
+++ b/apps/src/blockly/addons/cdoBlockDragger.js
@@ -1,6 +1,25 @@
 import {ScrollBlockDragger} from '@blockly/plugin-scroll-options';
 
 export default class BlockDragger extends ScrollBlockDragger {
+  /**
+   * Make sure disabled state is updated immediately.
+   * @override
+   */
+  endDrag(e, currentDragDeltaXY) {
+    super.endDrag(e, currentDragDeltaXY);
+
+    // Core Blockly logic will eventually update the block's disabled state, but
+    // we want to update it immediately. We rely on this value to skip
+    // code generation for disabled blocks, and since we have live-preview, it
+    // would be noticeable if this value were out of sync, even briefly.
+    // This only matters if the block is not being deleted.
+    if (!this.draggedConnectionManager_.wouldDeleteBlock()) {
+      const isTopBlock = this.draggingBlock_.previousConnection === null;
+      const hasParentBlock = !!this.draggingBlock_.parentBlock_;
+      this.draggingBlock_.setEnabled(isTopBlock || hasParentBlock);
+    }
+  }
+
   /** Open trashcan lid whenever the block is over the toolbox, not only if it's over the trashcan itself.
    * @override
    */

--- a/apps/src/blockly/addons/cdoBlockDragger.js
+++ b/apps/src/blockly/addons/cdoBlockDragger.js
@@ -1,61 +1,6 @@
 import {ScrollBlockDragger} from '@blockly/plugin-scroll-options';
 
 export default class BlockDragger extends ScrollBlockDragger {
-  /** Show trashcan over toolbox while dragging
-   * @override
-   */
-  drag(e, currentDragDeltaXY) {
-    super.drag(e, currentDragDeltaXY);
-    const isDraggingFromFlyout_ = !!Blockly.mainBlockSpace.currentGesture_
-      .flyout_;
-
-    if (isDraggingFromFlyout_) {
-      this.workspace_.hideTrashcan();
-    } else {
-      this.workspace_.showTrashcan();
-      if (this.draggingBlock_.isDeletable()) {
-        this.workspace_.trashcan.setDisabled(false);
-      } else {
-        this.workspace_.trashcan.setDisabled(true);
-      }
-    }
-  }
-
-  /** Hide trashcan when drag ends.
-   * Also prevent blocks from ending with a negative position. Google allows the workspace to scroll in any direction,
-   * so negative block coordinates are valid, but we want to keep everything flowing down and to the right from (0,0).
-   * @override
-   */
-  endDrag(e, currentDragDeltaXY) {
-    const wouldDeleteBlock = this.draggedConnectionManager_.wouldDeleteBlock();
-    // Don't let the block end with a negative position, unless it's getting deleted.
-    if (!wouldDeleteBlock) {
-      const endPosition = this.draggingBlock_.getRelativeToSurfaceXY();
-      if (endPosition.x < 0) {
-        currentDragDeltaXY.x -= endPosition.x;
-      }
-      if (endPosition.y < 0) {
-        currentDragDeltaXY.y -= endPosition.y;
-      }
-    }
-
-    super.endDrag(e, currentDragDeltaXY);
-    this.workspace_.trashcan.setDisabled(false);
-    this.workspace_.trashcan.setLidOpen(false);
-    this.workspace_.hideTrashcan();
-
-    // Core Blockly logic will eventually update the block's disabled state, but
-    // we want to update it immediately. We rely on this value to skip
-    // code generation for disabled blocks, and since we have live-preview, it
-    // would be noticeable if this value were out of sync, even briefly.
-    // This only matters if the block is not being deleted.
-    if (!wouldDeleteBlock) {
-      const isTopBlock = this.draggingBlock_.previousConnection === null;
-      const hasParentBlock = !!this.draggingBlock_.parentBlock_;
-      this.draggingBlock_.setEnabled(isTopBlock || hasParentBlock);
-    }
-  }
-
   /** Open trashcan lid whenever the block is over the toolbox, not only if it's over the trashcan itself.
    * @override
    */

--- a/apps/src/blockly/addons/cdoTrashcan.js
+++ b/apps/src/blockly/addons/cdoTrashcan.js
@@ -2,6 +2,52 @@ import GoogleBlockly from 'blockly/core';
 import {ToolboxType} from '../constants';
 
 export default class CdoTrashcan extends GoogleBlockly.Trashcan {
+  /**
+   * @override
+   */
+  init() {
+    super.init();
+    this.workspace_.addChangeListener(this.workspaceChangeHandler.bind(this));
+  }
+
+  workspaceChangeHandler(blocklyEvent) {
+    if (blocklyEvent.type === Blockly.Events.BLOCK_DRAG) {
+      let trashcanDisplay = 'none';
+      let toolboxVisibility = 'visible';
+      const isDraggingFromFlyout_ = !!Blockly.mainBlockSpace?.currentGesture_
+        ?.flyout_;
+      if (!isDraggingFromFlyout_ && blocklyEvent.isStart) {
+        trashcanDisplay = 'block';
+        toolboxVisibility = 'hidden';
+      }
+
+      /**
+       * NodeList.forEach() is not supported on IE. Use Array.prototype.forEach.call() as a workaround.
+       * https://developer.mozilla.org/en-US/docs/Web/API/NodeList/forEach
+       */
+      Array.prototype.forEach.call(
+        // query selector for uncategorized toolbox contents
+        document.querySelectorAll('.blocklyFlyout .blocklyWorkspace'),
+        function(x) {
+          x.style.visibility = toolboxVisibility;
+        }
+      );
+      Array.prototype.forEach.call(
+        // query selector for categorized toolbox contents
+        document.querySelectorAll('.blocklyToolboxContents'),
+        function(x) {
+          x.style.visibility = toolboxVisibility;
+        }
+      );
+
+      document.querySelector('#trashcanHolder').style.display = trashcanDisplay;
+      const isDeletable = blocklyEvent.blocks.every(block =>
+        block.isDeletable()
+      );
+      this.notAllowed_.style.visibility = isDeletable ? 'hidden' : 'visible';
+    }
+  }
+
   /** Use our trash png and add circle with line through it for undeletable blocks
    * @override
    */
@@ -86,11 +132,6 @@ export default class CdoTrashcan extends GoogleBlockly.Trashcan {
     );
   }
 
-  setDisabled(disabled) {
-    const visibility = disabled ? 'visible' : 'hidden';
-    this.notAllowed_.setAttribute('visibility', visibility);
-  }
-
   /** Open the lid the opposite direction
    * @override
    */
@@ -106,16 +147,6 @@ export default class CdoTrashcan extends GoogleBlockly.Trashcan {
         (this.LID_HEIGHT_ - 2) +
         ')'
     );
-  }
-
-  /** Also hide trashcan on delete
-   * @override
-   */
-  onDelete_(event) {
-    if (event.type === Blockly.Events.BLOCK_DELETE) {
-      this.workspace_.hideTrashcan();
-    }
-    super.onDelete_(event);
   }
 }
 

--- a/apps/src/blockly/addons/cdoTrashcan.js
+++ b/apps/src/blockly/addons/cdoTrashcan.js
@@ -14,9 +14,10 @@ export default class CdoTrashcan extends GoogleBlockly.Trashcan {
     if (blocklyEvent.type === Blockly.Events.BLOCK_DRAG) {
       let trashcanDisplay = 'none';
       let toolboxVisibility = 'visible';
-      const isDraggingFromFlyout_ = !!Blockly.mainBlockSpace?.currentGesture_
+      // Don't show the trashcan if the block is being dragged out of the toolbox.
+      const isDraggingFromToolbox = !!Blockly.mainBlockSpace?.currentGesture_
         ?.flyout_;
-      if (!isDraggingFromFlyout_ && blocklyEvent.isStart) {
+      if (!isDraggingFromToolbox && blocklyEvent.isStart) {
         trashcanDisplay = 'block';
         toolboxVisibility = 'hidden';
       }

--- a/apps/src/blockly/addons/cdoWorkspaceSvg.js
+++ b/apps/src/blockly/addons/cdoWorkspaceSvg.js
@@ -103,77 +103,10 @@ export default class WorkspaceSvg extends GoogleBlockly.WorkspaceSvg {
     }
   }
 
-  /**
-   * Use visibility:hidden not display:none for the toolbox contents so that
-   * Blockly's metrics calculations for toolbox dimensions still work as expected.
-   * Use display:none not visibility:hidden for the trashcan element so that
-   * it doesn't interfere with click events on the toolbox categories.
-   */
-  hideTrashcan() {
-    // If there's no toolbox, there's no trashcan.
-    if (this.getToolboxType() === ToolboxType.NONE) {
-      return;
-    }
-
-    /**
-     * NodeList.forEach() is not supported on IE. Use Array.prototype.forEach.call() as a workaround.
-     * https://developer.mozilla.org/en-US/docs/Web/API/NodeList/forEach
-     */
-    Array.prototype.forEach.call(
-      document.querySelectorAll('.blocklyFlyout .blocklyWorkspace'),
-      function(x) {
-        x.style.visibility = 'visible';
-      }
-    );
-
-    /**
-     * NodeList.forEach() is not supported on IE. Use Array.prototype.forEach.call() as a workaround.
-     * https://developer.mozilla.org/en-US/docs/Web/API/NodeList/forEach
-     */
-    Array.prototype.forEach.call(
-      document.querySelectorAll('.blocklyToolboxContents'),
-      function(x) {
-        x.style.visibility = 'visible';
-      }
-    );
-
-    document.querySelector('#trashcanHolder').style.display = 'none';
-  }
-
   isReadOnly() {
     return false; // TODO - used for feedback
   }
   setEnableToolbox() {} // TODO - called by StudioApp, not sure whether it's still needed.
-  showTrashcan() {
-    // If there's no toolbox, there's no trashcan.
-    if (this.getToolboxType() === ToolboxType.NONE) {
-      return;
-    }
-
-    /**
-     * NodeList.forEach() is not supported on IE. Use Array.prototype.forEach.call() as a workaround.
-     * https://developer.mozilla.org/en-US/docs/Web/API/NodeList/forEach
-     */
-    Array.prototype.forEach.call(
-      document.querySelectorAll('.blocklyFlyout .blocklyWorkspace'),
-      function(x) {
-        x.style.visibility = 'hidden';
-      }
-    );
-
-    /**
-     * NodeList.forEach() is not supported on IE. Use Array.prototype.forEach.call() as a workaround.
-     * https://developer.mozilla.org/en-US/docs/Web/API/NodeList/forEach
-     */
-    Array.prototype.forEach.call(
-      document.querySelectorAll('.blocklyToolboxContents'),
-      function(x) {
-        x.style.visibility = 'hidden';
-      }
-    );
-
-    document.querySelector('#trashcanHolder').style.display = 'block';
-  }
   traceOn() {} // TODO
 }
 


### PR DESCRIPTION
Pure refactor with no user-visible changes

Instead of overriding and hooking into the `BlockDragger` directly, we can control the visibility of the trashcan by listening for [`Blockly.Events.BlockDrag`](https://developers.google.com/blockly/reference/js/Blockly.Events.BlockDrag?hl=en) events.