### PR TITLE
Application idempotency fix

### DIFF
--- a/dashboard/app/controllers/api/v1/pd/forms_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/forms_controller.rb
@@ -12,7 +12,7 @@ class Api::V1::Pd::FormsController < ::ApplicationController
 
     # Check for idempotence
     existing_form = form.check_idempotency
-    return render json: {id: existing_form.id}, status: :ok if existing_form
+    return render json: {id: existing_form.id}, status: :conflict if existing_form
 
     if form.save
       render json: {id: form.id}, status: :created

--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -86,7 +86,6 @@ module Pd::Application
 
     validates :status, exclusion: {in: ['interview'], message: '%{value} is reserved for facilitator applications.'}
     validates :course, presence: true, inclusion: {in: VALID_COURSES}
-    validates_uniqueness_of :user_id
     validate :workshop_present_if_required_for_status, if: -> {status_changed?}
 
     before_validation :set_course_from_program
@@ -762,7 +761,7 @@ module Pd::Application
 
     # @override
     def check_idempotency
-      TeacherApplication.find_by(user: user)
+      TeacherApplication.where(application_year: APPLICATION_CURRENT_YEAR).find_by(user: user)
     end
 
     def assigned_workshop


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

When submitting an application, we were still checking for uniqueness of user id and that we don't conflict with any application for that user. We actually want to filter by application year first. This was missed when doing the larger teacher application refactoring.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- slack thread: [slack](https://codedotorg.slack.com/archives/C02EEGWLHR8/p1638373985378300)

## Testing story

Tested locally with a manually created older application associated with the user.
testing steps:
- Submitted an application with logged in user.
- Went into dashboard-console and manually changed the application_year to a previous year ("2021-2022") and verified that it allowed me to start creating a new application
- Verified that submitting another application brought us back to the first page with the data cleared
- Made the fixes
- Verified that submitting another application rendered the application submitted page instead

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy
