### PR TITLE
Redirect www.code.org to code.org

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -205,6 +205,7 @@ Resources:
 <%=   component 'scaling_schedule' -%>
 <%  end -%>
 <% end -%>
+
 # Route53 (DNS) and CloudFront (CDN) resources:
 # TODO hourofcode.com and csedweek.org DNS/CDN resources should be added to this template.
 <%
@@ -230,13 +231,20 @@ Resources:
           TTL: <%= DNS_TTL %>
           ResourceRecords: [!GetAtt <%=daemon%>.PublicIp]
 <%   end -%>
+
 <%   if cdn_enabled -%>
   <%=app%>CDN:
     Type: AWS::CloudFront::Distribution
     Properties:
       DistributionConfig: <%= cloudfront_config(app) %>
 <%   end -%>
+
+<%   if cdn_enabled && app == 'Pegasus' -%>
+<%=    component 'www_redirect', app: app -%>
+<%  end -%>
+
 <% end -%>
+
 <% if cdn_enabled -%>
   OriginDNS:
     Type: AWS::Route53::RecordSetGroup
@@ -254,9 +262,11 @@ Resources:
           ResourceRecords: [!GetAtt <%=daemon%>.PublicIp]
 <%   end -%>
 <% end -%>
+
 <% if frontends-%>
 <%=  component 'cache'%>
 <% end -%>
+
   DaemonRole:
     Type: AWS::IAM::Role
     Properties:
@@ -415,6 +425,7 @@ Resources:
   DaemonInstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties: {Roles: [!Ref DaemonRole]}
+
 <% if daemon -%>
   <%=daemon%>:
     Type: AWS::EC2::Instance
@@ -474,6 +485,7 @@ Resources:
     DependsOn: Aurora1
 <% end -%>
 <%end-%>
+
 <% if options.console -%>
   Console:
     Type: AWS::EC2::Instance
@@ -515,12 +527,15 @@ Resources:
     DependsOn: Aurora1
 <%   end -%>
 <% end-%>
+
 <% if alarms-%>
 <%=  component 'alarms'%>
 <% end -%>
+
 <% if database-%>
 <%=  component 'database'%>
 <% end -%>
+
   ChefConfig:
     Type: AWS::SecretsManager::Secret
     Properties:
@@ -529,6 +544,7 @@ Resources:
       # Update this secret manually after the stack is created to customize Chef configuration.
       # The value should never be changed in the stack itself, since it would clobber all other changes.
       SecretString: '{}'
+
 Outputs:
   DashboardURL:
     Value: "https://<%=studio_subdomain%>"

--- a/aws/cloudformation/components/www_redirect.yml.erb
+++ b/aws/cloudformation/components/www_redirect.yml.erb
@@ -32,6 +32,11 @@
           AcmCertificateArn: !Ref <%=app%>RedirectedDomainCertificate
           SslSupportMethod: sni-only
 
+  <%
+      hostedZones = Aws::Route53::Client.new.list_hosted_zones_by_name
+      targetZone = hostedZones.detect {|z| z.name == 'code.org'}
+  -%>
+
   <%=app%>RedirectedDomainCertificate:
     Type: AWS::CertificateManager::Certificate
     Properties:
@@ -39,7 +44,7 @@
       ValidationMethod: DNS
       DomainValidationOptions:
         - DomainName: www.<%= CDO.pegasus_hostname %>
-          HostedZoneId: !GetAtt [ALB, CanonicalHostedZoneID]
+          HostedZoneId: <% targetZone.id%>
 
   <%=app%>RedirectCachePolicy:
     Type: AWS::CloudFront::CachePolicy

--- a/aws/cloudformation/components/www_redirect.yml.erb
+++ b/aws/cloudformation/components/www_redirect.yml.erb
@@ -6,11 +6,11 @@
         Comment: Redirect www to root domain
         PriceClass: PriceClass_All
         Aliases:
-          - www.<%= CDO.pegasus_hostname %>
+          - www.<%= subdomain %>
         Origins:
           # An origin is required, but will never receive traffic
           - Id: PrimaryOrigin
-            DomainName: <%= CDO.pegasus_hostname %>
+            DomainName: <%= subdomain %>
             CustomOriginConfig:
               OriginProtocolPolicy: match-viewer
         DefaultCacheBehavior:
@@ -33,23 +33,24 @@
           SslSupportMethod: sni-only
 
   <%
-      hostedZones = Aws::Route53::Client.new.list_hosted_zones_by_name
-      targetZone = hostedZones.detect {|z| z.name == 'code.org'}
+      www_redirect_hosted_zone = Aws::Route53::Client.new.list_hosted_zones_by_name(dns_name: domain).hosted_zones.first
+      raise "Could not find #{domain} in hosted zones" unless www_redirect_hosted_zone.name.delete_suffix('.') == domain
+      www_redirect_hosted_zone_id = www_redirect_hosted_zone.id.delete_prefix("/hostedzone/")
   -%>
 
-  # targetZone id: <% targetZone.id %>
-  # targetZone name: <% targetZone.name %>
-  # subdomain: <% subdomain %>
-  # pegasus_hostname: <%CDO.pegasus_hostname%>
+  # www_redirect_hosted_zone id: <%= www_redirect_hosted_zone_id %>
+  # www_redirect_hosted_zone name: <%= www_redirect_hosted_zone.name %>
+  # subdomain: <%= subdomain %>
+  # pegasus_hostname: <%= CDO.pegasus_hostname %>
 
   <%=app%>RedirectedDomainCertificate:
     Type: AWS::CertificateManager::Certificate
     Properties:
-      DomainName: www.<%= CDO.pegasus_hostname %>
+      DomainName: www.<%= subdomain %>
       ValidationMethod: DNS
       DomainValidationOptions:
-        - DomainName: www.<%= CDO.pegasus_hostname %>
-          HostedZoneId: <% targetZone.id%>
+        - DomainName: www.<%= subdomain %>
+          HostedZoneId: <%= www_redirect_hosted_zone_id %>
 
   <%=app%>RedirectCachePolicy:
     Type: AWS::CloudFront::CachePolicy
@@ -87,7 +88,7 @@
             const querystring = request.querystring;
 
             // Start building new url
-            let newUrl = 'https://<%= CDO.pegasus_hostname %>';
+            let newUrl = 'https://<%= subdomain %>';
 
             // Append path
             if (uri) newUrl += uri;

--- a/aws/cloudformation/components/www_redirect.yml.erb
+++ b/aws/cloudformation/components/www_redirect.yml.erb
@@ -38,11 +38,6 @@
       www_redirect_hosted_zone_id = www_redirect_hosted_zone.id.delete_prefix("/hostedzone/")
   -%>
 
-  # www_redirect_hosted_zone id: <%= www_redirect_hosted_zone_id %>
-  # www_redirect_hosted_zone name: <%= www_redirect_hosted_zone.name %>
-  # subdomain: <%= subdomain %>
-  # pegasus_hostname: <%= CDO.pegasus_hostname %>
-
   <%=app%>RedirectedDomainCertificate:
     Type: AWS::CertificateManager::Certificate
     Properties:

--- a/aws/cloudformation/components/www_redirect.yml.erb
+++ b/aws/cloudformation/components/www_redirect.yml.erb
@@ -37,6 +37,11 @@
       targetZone = hostedZones.detect {|z| z.name == 'code.org'}
   -%>
 
+  # targetZone id: <% targetZone.id %>
+  # targetZone name: <% targetZone.name %>
+  # subdomain: <% subdomain %>
+  # pegasus_hostname: <%CDO.pegasus_hostname%>
+
   <%=app%>RedirectedDomainCertificate:
     Type: AWS::CertificateManager::Certificate
     Properties:

--- a/aws/cloudformation/components/www_redirect.yml.erb
+++ b/aws/cloudformation/components/www_redirect.yml.erb
@@ -1,0 +1,127 @@
+  <%=app%>RedirectDistribution:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+      DistributionConfig:
+        Enabled: true
+        Comment: Redirect www to root domain
+        PriceClass: PriceClass_All
+        Aliases:
+          - www.<%= CDO.pegasus_hostname %>
+        Origins:
+          # An origin is required, but will never receive traffic
+          - Id: PrimaryOrigin
+            DomainName: <%= CDO.pegasus_hostname %>
+            CustomOriginConfig:
+              OriginProtocolPolicy: match-viewer
+        DefaultCacheBehavior:
+          TargetOriginId: PrimaryOrigin
+          LambdaFunctionAssociations:
+            # Trigging upon origin-request ensures redirect is cached
+            - EventType: origin-request
+              LambdaFunctionARN: !Ref <%=app%>WwwRedirectLambdaVersion1
+          ForwardedValues:
+            QueryString: "false"
+            Headers:
+              - Origin
+            Cookies:
+              Forward: none
+          ViewerProtocolPolicy: allow-all
+          # Use shared Realtime Log config
+          RealtimeLogConfigArn: !ImportValue AccessLogs-Config
+        ViewerCertificate:
+          AcmCertificateArn: !Ref <%=app%>RedirectedDomainCertificate
+          SslSupportMethod: sni-only
+
+  <%=app%>RedirectedDomainCertificate:
+    Type: AWS::CertificateManager::Certificate
+    Properties:
+      DomainName: www.<%= CDO.pegasus_hostname %>
+      ValidationMethod: DNS
+      DomainValidationOptions:
+        - DomainName: www.<%= CDO.pegasus_hostname %>
+          HostedZoneId: !GetAtt [ALB, CanonicalHostedZoneID]
+
+  <%=app%>RedirectCachePolicy:
+    Type: AWS::CloudFront::CachePolicy
+    Properties:
+      CachePolicyConfig:
+        Name: <%=app%>RedirectCachePolicy
+        MinTTL: 3600
+        MaxTTL: 31536000
+        DefaultTTL: 86400
+        ParametersInCacheKeyAndForwardedToOrigin:
+          EnableAcceptEncodingGzip: false
+          CookiesConfig: 
+            CookieBehavior: none
+          HeadersConfig: 
+            HeaderBehavior: whitelist
+            Headers:
+              - Origin
+          QueryStringsConfig: 
+            QueryStringBehavior: all
+
+  <%=app%>WwwRedirectLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      Runtime: nodejs14.x
+      Role: !GetAtt <%=app%>WwwRedirectLambdaRole.Arn
+      Handler: index.handler
+      Code:
+        ZipFile: |
+          'use strict';
+
+          exports.handler = (event, context, callback) => {
+            const request = event.Records[0].cf.request;
+            const uri = request.uri;
+            const host = request.headers.host[0].value;
+            const querystring = request.querystring;
+
+            // Start building new url
+            let newUrl = 'https://<%= CDO.pegasus_hostname %>';
+
+            // Append path
+            if (uri) newUrl += uri;
+            
+            // Append query string
+            if (querystring && querystring != '') newUrl += "?" + querystring;
+
+            const response = {
+              status: '302',
+              statusDescription: '302 Redirect to root domain',
+              headers: {
+                location: [{
+                  key: 'Location',
+                  value: newUrl
+                }]
+              }
+            };
+            callback(null, response);
+          };
+      Description: Redirect www traffic to root domain
+      TracingConfig:
+        Mode: Active
+
+  # To make a new version, bump the NAME of this resource and all references
+  <%=app%>WwwRedirectLambdaVersion1:
+    Type: AWS::Lambda::Version
+    Properties:
+      FunctionName: !Ref <%=app%>WwwRedirectLambda
+
+  <%=app%>WwwRedirectLambdaRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      Path: "/"
+      PermissionsBoundary: !ImportValue IAM-DevPermissions
+      ManagedPolicyArns:
+        - "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: "AllowLambdaServiceToAssumeRole"
+            Effect: "Allow"
+            Action:
+              - "sts:AssumeRole"
+            Principal:
+              Service:
+                - "lambda.amazonaws.com"
+                - "edgelambda.amazonaws.com"

--- a/lib/cdo/cloud_formation/cdo_app.rb
+++ b/lib/cdo/cloud_formation/cdo_app.rb
@@ -2,6 +2,7 @@ require_relative './stack_template'
 require_relative './vpc'
 
 require 'aws-sdk-acm'
+require 'aws-sdk-route53'
 
 require 'active_support/core_ext/numeric/bytes'
 require 'ostruct'


### PR DESCRIPTION
This creates a new cloudfront distribution, using a lambda@edge function to issue a redirect for all traffic to www.code.org to code.org - and likewise for lower environments.

## Links

- [INF-506](https://codedotorg.atlassian.net/browse/INF-506)

## Testing story

This has been tested and verified in an adhoc (note the specification of `cdn` in the rake command`)

```sh
git checkout www-redirect-3
bundle exec rake adhoc:cdn:start RAILS_ENV=adhoc
```

The working 302 redirect will be testable for a short time here: https://www.adhoc-www-redirect-3.cdn-code.org/

Deployment to staging and/or test will create the www redirect there, where it can be verified again.

Deployment to prod can be manually inspected before the next steps are performed.

## Follow-up work

- Manualy update the DNS entry for `www.code.org` to point to the new cloudfront distribution to make this new flow live.
- INF-527 Modify the load balancer configuration to block any requests NOT coming from the autoscale-prod (main) cloudfront distribution
- INF-525 Create a UI test on the test server to exercise this redirect path

## Privacy

n/a

## Security

This improves security by forcing traffic through the cloudfront distribution, protecting us from DOS attacks and allowing us to further protect by limiting load balancers (INF-527).

## Caching

This is a 302 redirect, and thus will not be cached in browsers. We can change this behavior to a 301 later, but it is very painful to convert from a 301 back to a 302, so we're easing into it with a 302 redirect.

The lambda@edge function is triggered upon `origin-request` which means individual `www.code.org/a/b/c` urls handled will have their 302 responses cached (left at the default 1 day).

## PR Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
