### PR TITLE
[Google Blockly] Don't override FieldLabel

### DIFF
--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -1083,9 +1083,9 @@ exports.createJsWrapperBlockCreator = function(
           // On button click, open/close the horizontal flyout, toggle button text between +/-, and re-render the block.
           Blockly.bindEvent_(toggle.fieldGroup_, 'mousedown', this, () => {
             if (this.isMiniFlyoutOpen) {
-              toggle.setText('+');
+              toggle.setValue('+');
             } else {
-              toggle.setText('-');
+              toggle.setValue('-');
             }
             this.isMiniFlyoutOpen = !this.isMiniFlyoutOpen;
             this.render();

--- a/apps/src/blockly/addons/cdoFieldLabel.js
+++ b/apps/src/blockly/addons/cdoFieldLabel.js
@@ -1,7 +1,0 @@
-import GoogleBlockly from 'blockly/core';
-
-export default class FieldLabel extends GoogleBlockly.FieldLabel {
-  setText(text) {
-    return super.setValue(text);
-  }
-}

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -8,7 +8,6 @@ import initializeCdoConstants from './addons/cdoConstants';
 import CdoFieldButton from './addons/cdoFieldButton';
 import CdoFieldDropdown from './addons/cdoFieldDropdown';
 import {CdoFieldImageDropdown} from './addons/cdoFieldImageDropdown';
-import CdoFieldLabel from './addons/cdoFieldLabel';
 import CdoFieldVariable from './addons/cdoFieldVariable';
 import FunctionEditor from './addons/functionEditor';
 import initializeGenerator from './addons/cdoGenerator';
@@ -162,7 +161,6 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.blockly_.FieldButton = CdoFieldButton;
   blocklyWrapper.blockly_.FieldDropdown = CdoFieldDropdown;
   blocklyWrapper.blockly_.FieldImageDropdown = CdoFieldImageDropdown;
-  blocklyWrapper.blockly_.FieldLabel = CdoFieldLabel;
   blocklyWrapper.blockly_.FieldVariable = CdoFieldVariable;
   blocklyWrapper.blockly_.FunctionEditor = FunctionEditor;
   blocklyWrapper.blockly_.Input = CdoInput;

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -98,7 +98,7 @@ const customInputTypes = {
           if (value) {
             try {
               const loc = JSON.parse(value);
-              label.setText(
+              label.setValue(
                 `${inputConfig.label}(${loc.x}, ${APP_HEIGHT - loc.y})`
               );
             } catch (e) {

--- a/apps/src/studio/blocks.js
+++ b/apps/src/studio/blocks.js
@@ -2325,7 +2325,7 @@ exports.install = function(blockly, blockInstallOptions) {
       var dropdown2 = createSpriteGroupDropdown(
         msg.collidesWithAnySpriteName,
         value =>
-          endLabel.setText(
+          endLabel.setValue(
             msg.toTouchedSpriteName({spriteName: stripQuotes(value)})
           )
       );


### PR DESCRIPTION
This override was added by https://github.com/code-dot-org/code-dot-org/pull/43119 so that we could alias `setText` to `setValue`.

However, the Cdo Blockly version of `Field` already aliases `setValue` to `setText`. See https://github.com/code-dot-org/blockly/blob/main/core/ui/fields/field.js#L321

So we can just change the usages in the rest of the codebase to use `setValue`, and when using Cdo Blockly, `setText` will still be called.

![image](https://user-images.githubusercontent.com/8787187/144310166-ee2a8d9f-1b0e-40a6-8733-b8130ef57efd.png)
the results in javalab, applab, and hoc_event_map are not Blockly FieldLabels. The results in studio, p5lab, and block_utils have been updated to use `setValue`.