### PR TITLE
Added mini app type to the jwt

### DIFF
--- a/apps/src/javalab/JavabuilderConnection.js
+++ b/apps/src/javalab/JavabuilderConnection.js
@@ -19,7 +19,8 @@ export default class JavabuilderConnection {
     onNewlineMessage,
     setIsRunning,
     setIsTesting,
-    executionType
+    executionType,
+    miniAppType
   ) {
     this.channelId = project.getCurrentId();
     this.javabuilderUrl = javabuilderUrl;
@@ -31,6 +32,7 @@ export default class JavabuilderConnection {
     this.setIsRunning = setIsRunning;
     this.setIsTesting = setIsTesting;
     this.executionType = executionType;
+    this.miniAppType = miniAppType;
   }
 
   // Get the access token to connect to javabuilder and then open the websocket connection.
@@ -55,7 +57,8 @@ export default class JavabuilderConnection {
         projectVersion: project.getCurrentSourceVersionId(),
         levelId: this.levelId,
         options: this.options,
-        executionType: this.executionType
+        executionType: this.executionType,
+        miniAppType: this.miniAppType
       }
     })
       .done(result => this.establishWebsocketConnection(result.token))

--- a/apps/src/javalab/Javalab.js
+++ b/apps/src/javalab/Javalab.js
@@ -347,7 +347,8 @@ Javalab.prototype.executeJavabuilder = function(executionType) {
     this.onNewlineMessage,
     this.setIsRunning,
     this.setIsTesting,
-    executionType
+    executionType,
+    this.level.csaViewMode
   );
   project.autosave(() => {
     this.javabuilderConnection.connectJavabuilder();

--- a/apps/src/javalab/constants.js
+++ b/apps/src/javalab/constants.js
@@ -1,3 +1,7 @@
+/**
+ * NOTE: Constants in this file are generally shared by Javabuilder.
+ * Check their use in the Javabuilder repo before editing.
+ */
 import {makeEnum} from '@cdo/apps/utils';
 
 export const CsaViewMode = {

--- a/apps/test/unit/javalab/JavabuilderConnectionTest.js
+++ b/apps/test/unit/javalab/JavabuilderConnectionTest.js
@@ -5,7 +5,8 @@ import {
   WebSocketMessageType,
   StatusMessageType,
   STATUS_MESSAGE_PREFIX,
-  ExecutionType
+  ExecutionType,
+  CsaViewMode
 } from '@cdo/apps/javalab/constants';
 import * as ExceptionHandler from '@cdo/apps/javalab/javabuilderExceptionHandler';
 import project from '@cdo/apps/code-studio/initApp/project';
@@ -28,7 +29,8 @@ describe('JavabuilderConnection', () => {
       sinon.stub(),
       setIsRunning,
       setIsTesting,
-      ExecutionType.RUN
+      ExecutionType.RUN,
+      CsaViewMode.NEIGHBORHOOD
     );
   });
 
@@ -120,7 +122,8 @@ describe('JavabuilderConnection', () => {
         sinon.stub(),
         setIsRunning,
         setIsTesting,
-        executionType
+        executionType,
+        CsaViewMode.NEIGHBORHOOD
       );
     }
   });

--- a/dashboard/app/controllers/javabuilder_sessions_controller.rb
+++ b/dashboard/app/controllers/javabuilder_sessions_controller.rb
@@ -17,8 +17,9 @@ class JavabuilderSessionsController < ApplicationController
     level_id = params[:levelId]
     options = params[:options]
     execution_type = params[:executionType]
+    mini_app_type = params[:miniAppType]
     options = options ? options.to_json : '{}'
-    if !channel_id || !project_version || !project_url || !execution_type
+    if !channel_id || !project_version || !project_url || !execution_type || !mini_app_type
       return render status: :bad_request, json: {}
     end
 
@@ -45,6 +46,7 @@ class JavabuilderSessionsController < ApplicationController
       project_url: project_url,
       level_id: level_id,
       execution_type: execution_type,
+      mini_app_type: mini_app_type,
       options: options
     }
 

--- a/dashboard/test/controllers/javabuilder_sessions_controller_test.rb
+++ b/dashboard/test/controllers/javabuilder_sessions_controller_test.rb
@@ -16,14 +16,14 @@ class JavabuilderSessionsControllerTest < ActionController::TestCase
     user: :student,
     response: :forbidden
   test_user_gets_response_for :get_access_token,
-    params: {channelId: storage_encrypt_channel_id(1, 1), projectVersion: 123, projectUrl: URL, executionType: 'RUN'},
+    params: {channelId: storage_encrypt_channel_id(1, 1), projectVersion: 123, projectUrl: URL, executionType: 'RUN', miniAppType: 'console'},
     user: :levelbuilder,
     response: :success
 
   test 'can decode jwt token' do
     levelbuilder = create :levelbuilder
     sign_in(levelbuilder)
-    get :get_access_token, params: {channelId: @fake_channel_id, projectVersion: 123, projectUrl: URL, levelId: 261, executionType: 'RUN'}
+    get :get_access_token, params: {channelId: @fake_channel_id, projectVersion: 123, projectUrl: URL, levelId: 261, executionType: 'RUN', miniAppType: 'console'}
 
     response = JSON.parse(@response.body)
     token = response['token']
@@ -43,7 +43,8 @@ class JavabuilderSessionsControllerTest < ActionController::TestCase
       projectVersion: 123,
       projectUrl: URL,
       executionType: 'RUN',
-      options: {'useNeighborhood': true}
+      options: {'useNeighborhood': true},
+      miniAppType: 'console'
     }
 
     response = JSON.parse(@response.body)
@@ -58,7 +59,7 @@ class JavabuilderSessionsControllerTest < ActionController::TestCase
     user = create :user
     create(:single_user_experiment, min_user_id: user.id, name: CSA_PILOT)
     sign_in(user)
-    get :get_access_token, params: {channelId: @fake_channel_id, projectVersion: 123, projectUrl: URL, executionType: 'RUN'}
+    get :get_access_token, params: {channelId: @fake_channel_id, projectVersion: 123, projectUrl: URL, executionType: 'RUN', miniAppType: 'console'}
     assert_response :success
   end
 
@@ -68,7 +69,7 @@ class JavabuilderSessionsControllerTest < ActionController::TestCase
     section = create(:section, user: teacher, login_type: 'word')
     student_1 = create(:follower, section: section).student_user
     sign_in(student_1)
-    get :get_access_token, params: {channelId: @fake_channel_id, projectVersion: 123, projectUrl: URL, executionType: 'RUN'}
+    get :get_access_token, params: {channelId: @fake_channel_id, projectVersion: 123, projectUrl: URL, executionType: 'RUN', miniAppType: 'console'}
     assert_response :success
     section.destroy
   end
@@ -79,7 +80,7 @@ class JavabuilderSessionsControllerTest < ActionController::TestCase
     section = create(:section, user: teacher, login_type: 'word')
     student_1 = create(:follower, section: section).student_user
     sign_in(student_1)
-    get :get_access_token, params: {channelId: @fake_channel_id, projectVersion: 123, projectUrl: URL, executionType: 'RUN'}
+    get :get_access_token, params: {channelId: @fake_channel_id, projectVersion: 123, projectUrl: URL, executionType: 'RUN', miniAppType: 'console'}
     assert_response :success
     section.destroy
   end
@@ -90,7 +91,7 @@ class JavabuilderSessionsControllerTest < ActionController::TestCase
     section = create(:section, user: teacher, login_type: 'word')
     student_1 = create(:follower, section: section).student_user
     sign_in(student_1)
-    get :get_access_token, params: {channelId: @fake_channel_id, projectVersion: 123, projectUrl: URL, executionType: 'RUN'}
+    get :get_access_token, params: {channelId: @fake_channel_id, projectVersion: 123, projectUrl: URL, executionType: 'RUN', miniAppType: 'console'}
     assert_response :forbidden
     section.destroy
   end
@@ -98,28 +99,35 @@ class JavabuilderSessionsControllerTest < ActionController::TestCase
   test 'param for channel id is required' do
     levelbuilder = create :levelbuilder
     sign_in(levelbuilder)
-    get :get_access_token, params: {projectVersion: 123, projectUrl: URL, executionType: 'RUN'}
+    get :get_access_token, params: {projectVersion: 123, projectUrl: URL, executionType: 'RUN', miniAppType: 'console'}
     assert_response :bad_request
   end
 
   test 'param for project version is required' do
     levelbuilder = create :levelbuilder
     sign_in(levelbuilder)
-    get :get_access_token, params: {channelId: @fake_channel_id, projectUrl: URL, executionType: 'RUN'}
+    get :get_access_token, params: {channelId: @fake_channel_id, projectUrl: URL, executionType: 'RUN', miniAppType: 'console'}
     assert_response :bad_request
   end
 
   test 'param project_url is required' do
     levelbuilder = create :levelbuilder
     sign_in(levelbuilder)
-    get :get_access_token, params: {channelId: @fake_channel_id, projectVersion: 123, executionType: 'RUN'}
+    get :get_access_token, params: {channelId: @fake_channel_id, projectVersion: 123, executionType: 'RUN', miniAppType: 'console'}
     assert_response :bad_request
   end
 
   test 'param for execution type is required' do
     levelbuilder = create :levelbuilder
     sign_in(levelbuilder)
-    get :get_access_token, params: {channelId: @fake_channel_id, projectVersion: 123, projectUrl: URL}
+    get :get_access_token, params: {channelId: @fake_channel_id, projectVersion: 123, projectUrl: URL, miniAppType: 'console'}
+    assert_response :bad_request
+  end
+
+  test 'param for mini-app type is required' do
+    levelbuilder = create :levelbuilder
+    sign_in(levelbuilder)
+    get :get_access_token, params: {channelId: @fake_channel_id, projectVersion: 123, projectUrl: URL, executionType: 'RUN'}
     assert_response :bad_request
   end
 end


### PR DESCRIPTION
When Java Lab issues the connection request to Javabuilder, it always triggers the same lambda, despite very different configurations and needs between the various mini-apps. In order to differentiate the lambda that is triggered, we're adding the mini-app type to the JWT. Javabuilder's API Gateway WebSocket Connect lambda can then trigger a different BuildAndRun lambda based on mini-app type.

This will be used in a future PR to the Javabuilder Repo.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [CSA-1050](https://codedotorg.atlassian.net/browse/CSA-1050)


## Testing story
Updated tests. And confirmed that the mini_app_type was being correctly set in the JWT
![image](https://user-images.githubusercontent.com/8324574/144320742-a41f1e92-0e39-4b41-9a10-202d5adbdeb1.png)


<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
