### PR TITLE
Use translated progression_name in lesson plans

### DIFF
--- a/dashboard/app/models/activity_section.rb
+++ b/dashboard/app/models/activity_section.rb
@@ -43,6 +43,7 @@ class ActivitySection < ApplicationRecord
   )
 
   def summarize
+    localized_progression_name = Services::I18n::CurriculumSyncUtils.get_localized_property(self, :progression_name) if progression_name
     {
       id: id,
       position: position,
@@ -51,7 +52,7 @@ class ActivitySection < ApplicationRecord
       remarks: remarks,
       description: Services::I18n::CurriculumSyncUtils.get_localized_property(self, :description),
       tips: tips,
-      progressionName: progression_name
+      progressionName: localized_progression_name
     }
   end
 


### PR DESCRIPTION
I noticed this during the bug bash and it was bothering me so I decided to fix it quickly. We already collect translations for progression_name so we should just ...use them.

Before (lesson 1 of outbreak in Polish):
<img width="1087" alt="Screen Shot 2021-12-01 at 2 22 24 PM" src="https://user-images.githubusercontent.com/46464143/144323907-2923f4d8-b256-41cb-b485-6152b2cb13ab.png">

After: 
<img width="1055" alt="Screen Shot 2021-12-01 at 2 22 06 PM" src="https://user-images.githubusercontent.com/46464143/144323932-0cab767e-34d6-49de-919a-5835a12fc78e.png">


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
