### PR TITLE
CSC: Fix for partials with parameters, for translations

### DIFF
--- a/pegasus/router.rb
+++ b/pegasus/router.rb
@@ -411,7 +411,7 @@ class Documents < Sinatra::Base
           locals = split[1].scan(/("(?:\\.|[^"])*"|[^\s]*):\s*("(?:\\.|[^"])*"|[^\s]*)/).
             map(&:compact).
             to_h.
-            transform_values {|v| @actionview.sanitize(v.undump)}
+            transform_values {|v| @actionview.sanitize(v.delete_prefix('"').delete_suffix('"').gsub('\"', '"'))}
 
           if locals.present?
             path = resolve_view_template(uri)


### PR DESCRIPTION
When we reviewed pages with translated content, we discovered a problem with the use of `{{ }}`-style partials with parameters in some cases.  The use of `.undump` to unescape the string was throwing an exception when the string contained non-ASCII characters, though that exception was being [silenced](https://github.com/code-dot-org/code-dot-org/pull/43877/files#diff-543cd211743d9130206a2ca39fdde6741634dc32eac769de9490592acfbc4c97R425-R426) immediately.

The quick solution here is to no longer use `.undump` to unescape the string, and instead to explicitly remove the surrounding `"`s, and to replace all `\"`s with `"`s.

This is a follow-up to work begun in https://github.com/code-dot-org/code-dot-org/pull/42618.  It's a highly-targeted fix since we need it for Hour of Code which occurs next week.

## Examples with this change

### helloworld - Italian

![localhost code org_3000_helloworld (8)](https://user-images.githubusercontent.com/2205926/144327172-2885851e-b436-43cd-b1ff-63c365e9324e.png)

### educate/csc - Italian

![localhost code org_3000_educate_csc (8)](https://user-images.githubusercontent.com/2205926/144327208-d2bd8abc-b766-4852-83e8-f15898fec5d0.png)

### helloworld - Vietnamese

![localhost code org_3000_helloworld (9)](https://user-images.githubusercontent.com/2205926/144327247-fbf04f9d-822a-4fad-8677-8cf0a138c784.png)

### educate/csc - Vietnamese

![localhost code org_3000_educate_csc (9)](https://user-images.githubusercontent.com/2205926/144327262-071e43a1-0505-4488-80dc-b4905be582f7.png)

Keywords: `hoc2021`