### PR TITLE
deflake Pd::SessionAttendanceControllerTest, and run all dashboard tests in UTC

### DIFF
--- a/dashboard/test/controllers/pd/session_attendance_controller_test.rb
+++ b/dashboard/test/controllers/pd/session_attendance_controller_test.rb
@@ -5,6 +5,8 @@ class Pd::SessionAttendanceControllerTest < ::ActionController::TestCase
   self.use_transactional_test_case = true
   setup_all do
     @workshop = create :workshop, num_sessions: 1
+    puts "setup_all run at #{Time.now}"
+
     @workshop.start!
     @session = @workshop.sessions.first
 
@@ -49,6 +51,7 @@ class Pd::SessionAttendanceControllerTest < ::ActionController::TestCase
   end
 
   test 'attend too late renders too_late view' do
+    puts "test case run at #{Time.now}"
     sign_in @teacher
     Pd::Session.any_instance.expects(:too_late_for_attendance?).returns(true)
     get :attend, params: {session_code: @session.code}

--- a/dashboard/test/controllers/pd/session_attendance_controller_test.rb
+++ b/dashboard/test/controllers/pd/session_attendance_controller_test.rb
@@ -6,8 +6,6 @@ class Pd::SessionAttendanceControllerTest < ::ActionController::TestCase
 
   setup do
     @workshop = create :workshop, num_sessions: 1
-    puts "setup_all run at #{Time.now}"
-
     @workshop.start!
     @session = @workshop.sessions.first
 
@@ -49,7 +47,6 @@ class Pd::SessionAttendanceControllerTest < ::ActionController::TestCase
   end
 
   test 'attend too late renders too_late view' do
-    puts "test case run at #{Time.now}"
     sign_in @teacher
     Pd::Session.any_instance.expects(:too_late_for_attendance?).returns(true)
     get :attend, params: {session_code: @session.code}

--- a/dashboard/test/controllers/pd/session_attendance_controller_test.rb
+++ b/dashboard/test/controllers/pd/session_attendance_controller_test.rb
@@ -3,7 +3,8 @@ class Pd::SessionAttendanceControllerTest < ::ActionController::TestCase
   freeze_time
 
   self.use_transactional_test_case = true
-  setup_all do
+
+  setup do
     @workshop = create :workshop, num_sessions: 1
     puts "setup_all run at #{Time.now}"
 
@@ -11,9 +12,6 @@ class Pd::SessionAttendanceControllerTest < ::ActionController::TestCase
     @session = @workshop.sessions.first
 
     @teacher = create :teacher
-  end
-
-  setup do
   end
 
   test_redirect_to_sign_in_for :attend, params: -> {{session_code: @session.code}}

--- a/dashboard/test/test_helper.rb
+++ b/dashboard/test/test_helper.rb
@@ -29,6 +29,7 @@ Minitest::Reporters.use! reporters unless ENV['RM_INFO']
 ENV["UNIT_TEST"] = 'true'
 ENV["RAILS_ENV"] = "test"
 ENV["RACK_ENV"] = "test"
+ENV['TZ'] = 'UTC'
 
 # deal with some ordering issues -- sometimes environment is loaded
 # before test_helper and sometimes after. The CDO stuff uses RACK_ENV,


### PR DESCRIPTION
in this problematic test, it looks like there is a discrepancy between the current date when the workshop is created in setup_all, and when other things are created during test cases. the following commands were run on my local machine between 5 and 6pm Pacific Standard Time. both test runs passed.

after the first commit:
```
bundle exec spring testunit ./test/controllers/pd/session_attendance_controller_test.rb --name test_attend_too_late_renders_too_late_view
setup_all run at 2021-12-01 17:23:19 -0800
test case run at 2021-12-02 01:00:00 -0800
...
```
after the second commit:
```
bundle exec spring testunit ./test/controllers/pd/session_attendance_controller_test.rb --name test_attend_too_late_renders_too_late_view
setup_all run at 2021-12-02 01:00:00 -0800
test case run at 2021-12-02 01:00:00 -0800
...
```

I can't explain exactly why this would lead to the flakiness we've been observing, so I'm proposing merging this as a speculative fix and seeing if it happens to fix our problems with the test.
