### PR TITLE
hoc2021: Alternate code.org/ homepage string to get more translations

### DIFF
--- a/pegasus/sites.v3/code.org/views/homepage_hero.haml
+++ b/pegasus/sites.v3/code.org/views/homepage_hero.haml
@@ -32,7 +32,7 @@
   - if show_single_hero == "csc"
     .hero-message-line1{style: "color: #4D575F; font-size: 28px; line-height: 28px; padding-bottom: 20px; font-family: 'Gotham 4r', sans-serif", dir: "auto"}
       - if hoc_mode == 'actual-hoc'
-        = hoc_s(:social_hoc2018_hoc_here)
+        = I18n.t(:og_title_here)
       - else
         = hoc_s(:codeorg_homepage_hoc_is_coming)
     %div{style: "padding-bottom: 20px; text-align: center"}


### PR DESCRIPTION
This uses an alternate entry from our string tables so that the https://code.org/ homepage text - "The Hour of Code is here!" - remains [the same](https://github.com/code-dot-org/code-dot-org/pull/43847) for `hoc_mode` of `"actual-hoc"`, but we get the benefit of more existing translations.
