### PR TITLE
Handle bubble choice levels and sublevels in end-of-lesson redirects

### DIFF
--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -225,10 +225,8 @@ class ScriptLevel < ApplicationRecord
     extras_lesson=nil,
     bubble_choice_parent=false
   )
-    if bubble_choice? && !bubble_choice_parent
-      # Redirect user back to the BubbleChoice activity page from sublevels.
-      level_to_follow = self
-    elsif valid_progression_level?(user)
+
+    if valid_progression_level?(user)
       # if we're coming from an unplugged level, it's ok to continue to unplugged
       # level (example: if you start a sequence of assessments associated with an
       # unplugged level you should continue on that sequence instead of skipping to
@@ -254,6 +252,9 @@ class ScriptLevel < ApplicationRecord
           script_path(script)
         end
       end
+    elsif bubble_choice? && !bubble_choice_parent
+      # Redirect user back to the BubbleChoice activity page from sublevels.
+      build_script_level_path(self)
     elsif bonus
       # If we got to this bonus level from another lesson's lesson extras, go back
       # to that lesson

--- a/dashboard/test/models/script_level_test.rb
+++ b/dashboard/test/models/script_level_test.rb
@@ -601,9 +601,51 @@ class ScriptLevelTest < ActiveSupport::TestCase
     assert_equal "/s/#{script_level.script.name}/lessons/1/extras", script_level.next_level_or_redirect_path_for_user(nil)
   end
 
-  test 'next_level_or_redirect_path_for_user returns to bubble choice activity page for BubbleChoice levels' do
-    script_level = create_script_level_with_ancestors({levels: [create(:bubble_choice_level)]})
-    assert_equal "/s/#{script_level.script.name}/lessons/1/levels/1", script_level.next_level_or_redirect_path_for_user(nil)
+  # Bubble Choice parent levels at end of lesson redirect to unit overview.
+  test 'next_level_or_redirect_path_for_user for BubbleChoice parent levels - end of lesson' do
+    student = create :student
+    student.stubs(:has_pilot_experiment?).returns true
+    sublevel = create :level, name: 'choice1'
+    bubble_choice_level = create :bubble_choice_level, sublevels: [sublevel]
+    script_level = create_script_level_with_ancestors({levels: [bubble_choice_level]})
+    script_level.script.stubs(:show_unit_overview_between_lessons?).returns true
+    bubble_choice_parent = true
+    assert_equal "/s/#{script_level.script.name}", script_level.next_level_or_redirect_path_for_user(student, nil, bubble_choice_parent)
+  end
+
+  # Bubble Choice parent levels mid-lesson redirect to next level.
+  test 'next_level_or_redirect_path_for_user for BubbleChoice parent levels - mid lesson' do
+    student = create :student
+    student.stubs(:has_pilot_experiment?).returns true
+    script = create(:script, name: 'script1')
+    script.stubs(:show_unit_overview_between_lessons?).returns true
+    lesson_group = create(:lesson_group, script: script)
+    sublevel = create :level, name: 'choice1'
+    levels = [
+      create(:bubble_choice_level, sublevels: [sublevel]),
+      create(:level)
+    ]
+
+    script_levels = levels.map.with_index(1) do |level, pos|
+      lesson = create(:lesson, script: script, absolute_position: pos, lesson_group: lesson_group)
+      create(:script_level, script: script, lesson: lesson, position: pos, chapter: pos, levels: [level])
+    end
+
+    script_levels[0].stubs(:end_of_lesson?).returns false
+    bubble_choice_parent = true
+    assert_equal script_levels[1].path, script_levels[0].next_level_or_redirect_path_for_user(student, nil, bubble_choice_parent)
+  end
+
+  # Bubble Choice sublevels redirect to their parent level.
+  test 'next_level_or_redirect_path_for_user for BubbleChoice sublevels' do
+    student = create :student
+    student.stubs(:has_pilot_experiment?).returns true
+    sublevel = create :level, name: 'choice1'
+    bubble_choice_level = create :bubble_choice_level, sublevels: [sublevel]
+    script_level = create_script_level_with_ancestors({levels: [bubble_choice_level]})
+    script_level.script.stubs(:show_unit_overview_between_lessons?).returns true
+    bubble_choice_parent = false
+    assert_equal "/s/#{script_level.script.name}/lessons/1/levels/1", script_level.next_level_or_redirect_path_for_user(student, nil, bubble_choice_parent)
   end
 
   # For script where show_unit_overview_between_lessons? == true


### PR DESCRIPTION
[LP-2135](https://codedotorg.atlassian.net/browse/LP-2135)
[Spec](https://docs.google.com/document/d/1STMLxX2UphYMXLKIvgnctH7vuacCQPNHOB1KgS2VygA/edit#bookmark=id.h64pzxt4r0wo)
[Discussion](https://docs.google.com/document/d/1HFcPWB2bntbkWhadWxAN-Q8Jn-krAN1IbpO4DwdJ5Dk/edit#bookmark=id.kayz2v6hk0ns)
Follow up to #43174 and #43794

This PR updates the logic to handle level finish redirects for bubble choice levels. 

- Bubble choice sublevels should always redirect to the parent level. 

In CSA/CSP/CSD if the end-of-lesson-redirects experiment is on: 

- Bubble choice parent levels at the end of a lesson should redirect to the unit overview page. 
- Bubble choice parent levels at beginning or mid-lesson should continue to the next level in the lesson. 