### PR TITLE
[Google Blockly] Fixes for edit toolbox mode

### DIFF
--- a/apps/src/blockly/addons/cdoBlockDragger.js
+++ b/apps/src/blockly/addons/cdoBlockDragger.js
@@ -14,14 +14,9 @@ export default class BlockDragger extends ScrollBlockDragger {
     // would be noticeable if this value were out of sync, even briefly.
     // This only matters if the block is not being deleted.
     if (!this.draggedConnectionManager_.wouldDeleteBlock()) {
-      const isStartMode = !!Blockly.editBlocks;
-      if (isStartMode) {
-        // Never disable blocks in start mode.
-      } else {
-        const isTopBlock = this.draggingBlock_.previousConnection === null;
-        const hasParentBlock = !!this.draggingBlock_.parentBlock_;
-        this.draggingBlock_.setEnabled(isTopBlock || hasParentBlock);
-      }
+      this.draggingBlock_.setEnabled(
+        Blockly.isStartMode || !this.draggingBlock_.isUnused()
+      );
     }
   }
 

--- a/apps/src/blockly/addons/cdoBlockDragger.js
+++ b/apps/src/blockly/addons/cdoBlockDragger.js
@@ -14,9 +14,14 @@ export default class BlockDragger extends ScrollBlockDragger {
     // would be noticeable if this value were out of sync, even briefly.
     // This only matters if the block is not being deleted.
     if (!this.draggedConnectionManager_.wouldDeleteBlock()) {
-      const isTopBlock = this.draggingBlock_.previousConnection === null;
-      const hasParentBlock = !!this.draggingBlock_.parentBlock_;
-      this.draggingBlock_.setEnabled(isTopBlock || hasParentBlock);
+      const isStartMode = !!Blockly.editBlocks;
+      if (isStartMode) {
+        // Never disable blocks in start mode.
+      } else {
+        const isTopBlock = this.draggingBlock_.previousConnection === null;
+        const hasParentBlock = !!this.draggingBlock_.parentBlock_;
+        this.draggingBlock_.setEnabled(isTopBlock || hasParentBlock);
+      }
     }
   }
 

--- a/apps/src/blockly/addons/cdoBlockSvg.js
+++ b/apps/src/blockly/addons/cdoBlockSvg.js
@@ -24,10 +24,11 @@ export default class BlockSvg extends GoogleBlockly.BlockSvg {
   }
 
   isUnused() {
-    return (
-      this.disabled ||
-      this.workspace?.currentGesture_?.blockDragger_?.draggingBlock_ === this
-    );
+    const isTopBlock = this.previousConnection === null;
+    const hasParentBlock = !!this.parentBlock_;
+    const isDragging =
+      this.workspace?.currentGesture_?.blockDragger_?.draggingBlock_ === this;
+    return isDragging || !(isTopBlock || hasParentBlock);
   }
 
   isVisible() {
@@ -42,7 +43,7 @@ export default class BlockSvg extends GoogleBlockly.BlockSvg {
 
   customContextMenu(menuOptions) {
     // Only show context menu for levelbuilders
-    if (Blockly.editBlocks) {
+    if (Blockly.isStartMode) {
       const deletable = {
         text: this.deletable_
           ? 'Make Undeletable to Users'

--- a/apps/src/blockly/addons/cdoWorkspaceSvg.js
+++ b/apps/src/blockly/addons/cdoWorkspaceSvg.js
@@ -73,8 +73,6 @@ export default class WorkspaceSvg extends GoogleBlockly.WorkspaceSvg {
     }
   }
   addUnusedBlocksHelpListener(helpClickFunc) {
-    Blockly.mainBlockSpace.addChangeListener(Blockly.Events.disableOrphans);
-
     Blockly.bindEvent_(
       Blockly.mainBlockSpace.getCanvas(),
       Blockly.BlockSpace.EVENTS.RUN_BUTTON_CLICKED,

--- a/apps/src/blockly/addons/cdoXml.js
+++ b/apps/src/blockly/addons/cdoXml.js
@@ -1,4 +1,7 @@
 export default function initializeBlocklyXml(blocklyWrapper) {
+  // Clear xml namespace
+  blocklyWrapper.utils.xml.NAME_SPACE = '';
+
   // Aliasing Google's blockToDom() so that we can override it, but still be able
   // to call Google's blockToDom() in the override function.
   blocklyWrapper.Xml.originalBlockToDom = blocklyWrapper.Xml.blockToDom;

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -331,10 +331,10 @@ function initializeBlocklyWrapper(blocklyInstance) {
     container.style.height = `calc(100% - ${
       styleConstants['workspace-headers-height']
     }px)`;
-    blocklyWrapper.editBlocks = opt_options.editBlocks;
+    blocklyWrapper.isStartMode = !!opt_options.editBlocks;
     const workspace = blocklyWrapper.blockly_.inject(container, options);
 
-    if (!options.editBlocks) {
+    if (!blocklyWrapper.isStartMode) {
       workspace.addChangeListener(Blockly.Events.disableOrphans);
     }
 

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -334,6 +334,10 @@ function initializeBlocklyWrapper(blocklyInstance) {
     blocklyWrapper.editBlocks = opt_options.editBlocks;
     const workspace = blocklyWrapper.blockly_.inject(container, options);
 
+    if (!options.editBlocks) {
+      workspace.addChangeListener(Blockly.Events.disableOrphans);
+    }
+
     document.dispatchEvent(
       utils.createEvent(Blockly.BlockSpace.EVENTS.MAIN_BLOCK_SPACE_CREATED)
     );

--- a/apps/test/unit/blockly/googleBlocklyWrapperTest.js
+++ b/apps/test/unit/blockly/googleBlocklyWrapperTest.js
@@ -108,7 +108,7 @@ describe('Google Blockly Wrapper', () => {
     const field = new Blockly.blockly_.Field(null);
     field.SERIALIZABLE = true;
     field.name = 'test';
-    const expectedXml = `<title xmlns="https://developers.google.com/blockly/xml" name="test"></title>`;
+    const expectedXml = `<title name="test"></title>`;
     expect(Blockly.Xml.domToText(Blockly.Xml.fieldToDom_(field))).to.equal(
       expectedXml
     );


### PR DESCRIPTION
Two small fixes:
1. Clear the xmlns namespace, so that the logic in [`Blockly.convert_toolbox_to_category`](https://github.com/code-dot-org/code-dot-org/blob/staging-next/dashboard/app/models/levels/blockly.rb#L175) works as expected.
2. Don't disable blocks in start mode. There's a setting in StudioApp [here](https://github.com/code-dot-org/code-dot-org/blob/staging-next/apps/src/StudioApp.js#L2804) that's used in our fork of Blockly [here](https://github.com/code-dot-org/blockly/blob/main/core/ui/block.js#L2151) to prevent disabling blocks in toolbox edit mode. In Google Blockly, we can just check if we're in edit mode before adding the `disableOrphans` event listener. We also need to check if it's edit mode in the override in `BlockDragger`.
Before
![image](https://user-images.githubusercontent.com/8787187/144507961-065f06b9-9d33-4624-9c22-827ab83177f5.png)
![image](https://user-images.githubusercontent.com/8787187/144507905-01c4fd9e-4152-4e1b-96a5-5cc109e0a745.png)

After
![image](https://user-images.githubusercontent.com/8787187/144508261-1a6a0d7f-e1e2-44c4-b876-652a5f0aae86.png)
![image](https://user-images.githubusercontent.com/8787187/144508378-2f52df61-d564-4d6e-92fa-f87c2249f23e.png)

