### PR TITLE
Temporary fix for bad translation and restoration in Marathi

### DIFF
--- a/dashboard/config/locales/blocks.mr-IN.yml
+++ b/dashboard/config/locales/blocks.mr-IN.yml
@@ -842,7 +842,7 @@ mr:
             '"follow"': अनुसरण
             '"avoid"': टाळणे
       gamelab_allSpritesWithAnimation:
-        text: "[ANIMATION][0]"
+        text: "{ANIMATION}"
       gamelab_atTime:
         text: "{N} {UNIT} येथे"
         options:


### PR DESCRIPTION
Temporary fix for a bad translation and subsequent failed restoration in Marathi. This is a serious bug that blocks a students from completing the Outbreak tutorial. Change to the Crowdin string has already been done.

Tested on localhost
**Before**
![image](https://user-images.githubusercontent.com/2933346/144509649-da47b316-4c0b-4dea-9f20-26902957073e.png)

**After**
<img width="322" alt="marathi" src="https://user-images.githubusercontent.com/2933346/144509412-5274cd0c-6c55-4a44-bd94-d2785f651fde.png">

