### PR TITLE
Adding manual translation fix for gamelab_allSpritesWithAnimation block in el-GR, is-IS, and mr-IN

### DIFF
--- a/dashboard/config/locales/blocks.el-GR.yml
+++ b/dashboard/config/locales/blocks.el-GR.yml
@@ -956,7 +956,7 @@ el:
           OPT:
             '"avoid"': Απόφυγε
       gamelab_allSpritesWithAnimation:
-        text: aalab όλοι {ANIMATION}
+        text: "{ANIMATION}"
       gamelab_atTime:
         options:
           UNIT:
@@ -1336,7 +1336,7 @@ el:
             "{x: randomNumber(53, 350), y: randomNumber(50, 350)}": δεν είναι η ετικέτα
               μου
       Mikelab_allSpritesWithAnimation:
-        text: aalab όλοι {ANIMATION}
+        text: "{ANIMATION}"
       Mikelab_changePropBy:
         options:
           PROPERTY:

--- a/dashboard/config/locales/blocks.is-IS.yml
+++ b/dashboard/config/locales/blocks.is-IS.yml
@@ -957,7 +957,7 @@ is:
           OPT:
             '"avoid"': forðast
       gamelab_allSpritesWithAnimation:
-        text: aalab allar {ANIMATION}
+        text: "{ANIMATION}"
       gamelab_atTime:
         text: á tíma {N} {UNIT}
         options:
@@ -1373,7 +1373,7 @@ is:
             "{x: randomNumber(50, 350), y: randomNumber(50, 350)}": mitt-merki
             "{x: randomNumber(53, 350), y: randomNumber(50, 350)}": ekki mitt-merki
       Mikelab_allSpritesWithAnimation:
-        text: aalab allar {ANIMATION}
+        text: "{ANIMATION}"
       Mikelab_beginDataCollection:
         text: biðja notanda {QUESTION} um breytu {VAR} með valkosti {A}{B}{C}
       Mikelab_changePropBy:

--- a/dashboard/config/locales/blocks.mr-IN.yml
+++ b/dashboard/config/locales/blocks.mr-IN.yml
@@ -842,7 +842,7 @@ mr:
             '"follow"': अनुसरण
             '"avoid"': टाळणे
       gamelab_allSpritesWithAnimation:
-        text: "[ANIMATION][0]"
+        text: "{ANIMATION}"
       gamelab_atTime:
         text: "{N} {UNIT} येथे"
         options:


### PR DESCRIPTION
_Bug_ - Many of the Outbreak levels are not loading for the Greek locale (`el-GR`).
_Cause_ - A translator mistakenly added text to a blockly block which was only expecting a single item. The blockly rendered would look for the Sprite block (`{ANIMATION}`) at the zero'th index of the string `gamelab_allSpritesWithAnimation.text`. However, the translator added some text before the Sprite image, so the zero'th index ended up pointing at some Greek text rather than a Sprite block.
_Fix_ - Remove the bad content.

* Fixed a similar issue for the locales: `is-IS`, `mr-IN`

## Links
* [JIRA](https://codedotorg.atlassian.net/browse/FND-1828)

## Testing story
* Compare the changes in this PR to the English source string: https://github.com/code-dot-org/code-dot-org/blob/55230d58258e364907c1737776c995a9a4a98f58/dashboard/config/locales/blocks.en.yml#L1001
* Verified on localhost at http://localhost-studio.code.org:3000/s/outbreak/lessons/1/levels/3

## Screenshots 
### Before
Note the missing Sprite images and the text to the left of the Sprites
![image](https://user-images.githubusercontent.com/1372238/144527056-5e347ead-6e0b-44c7-a69e-2ff3635a75fa.png)

### After
Note the sprite images now show in the block. This indicates it is loading correctly
![image](https://user-images.githubusercontent.com/1372238/144526954-97743096-5d35-4eed-a595-15dee6b8455f.png)

## Deployment strategy
Will be reviewed in Friday's Restricted deployment.