### PR TITLE
Fixes spacing in level bubble display; removes empty line if no description

### DIFF
--- a/apps/src/templates/progress/ProgressLessonContent.jsx
+++ b/apps/src/templates/progress/ProgressLessonContent.jsx
@@ -46,14 +46,18 @@ export default class ProgressLessonContent extends React.Component {
       ));
     }
 
-    return (
-      <div>
-        <div style={styles.summary}>
-          <SafeMarkdown markdown={description || ''} />
+    if (description) {
+      return (
+        <div>
+          <div style={styles.summary}>
+            <SafeMarkdown markdown={description} />
+          </div>
+          {bubbles}
         </div>
-        {bubbles}
-      </div>
-    );
+      );
+    } else {
+      return <div>{bubbles}</div>;
+    }
   }
 }
 

--- a/apps/src/templates/progress/ProgressLessonContent.jsx
+++ b/apps/src/templates/progress/ProgressLessonContent.jsx
@@ -45,19 +45,16 @@ export default class ProgressLessonContent extends React.Component {
         />
       ));
     }
-
-    if (description) {
-      return (
-        <div>
+    return (
+      <div>
+        {description && (
           <div style={styles.summary}>
             <SafeMarkdown markdown={description} />
           </div>
-          {bubbles}
-        </div>
-      );
-    } else {
-      return <div>{bubbles}</div>;
-    }
+        )}
+        <div> {bubbles} </div>
+      </div>
+    );
   }
 }
 


### PR DESCRIPTION
This is a minor fix in spacing in ProgressLessonContent. Because there was a styling on the description line with margins, even rendering an empty line would still take up a lot of space. Only rendering this line if there's a description removes the unnecessary space. See images for comparison as these bubbles appear under the "Levels" header on the student resources page:

Before:
<img width="612" alt="Screen Shot 2021-12-02 at 10 36 34 PM" src="https://user-images.githubusercontent.com/37230822/144556805-5f7174c6-3cd6-457d-b046-00f34e854ec2.png">

After:
<img width="603" alt="Screen Shot 2021-12-02 at 10 35 32 PM" src="https://user-images.githubusercontent.com/37230822/144556728-435286c2-54c2-4289-aec0-c9ebd2e29577.png">

## Links

- jira ticket: https://codedotorg.atlassian.net/browse/LP-2145

## Testing story

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
