### PR TITLE
Fix `lang/locale` browser caching

### DIFF
--- a/dashboard/app/controllers/home_controller.rb
+++ b/dashboard/app/controllers/home_controller.rb
@@ -18,11 +18,11 @@ class HomeController < ApplicationController
 
   def set_locale
     set_locale_cookie(params[:locale]) if params[:locale]
+    # Query parameter for browser cache to be avoided and load new locale
     if params[:i18npath]
-      # Query parameter for browser cache to be avoided and load new locale
       redirect_to "/#{params[:i18npath]}?lang=#{params[:locale]}"
     elsif params[:user_return_to]
-      redirect_to URI.parse(params[:user_return_to].to_s).path
+      redirect_to "#{URI.parse(params[:user_return_to].to_s).path}?lang=#{params[:locale]}"
     else
       redirect_to '/'
     end

--- a/dashboard/app/controllers/home_controller.rb
+++ b/dashboard/app/controllers/home_controller.rb
@@ -19,7 +19,8 @@ class HomeController < ApplicationController
   def set_locale
     set_locale_cookie(params[:locale]) if params[:locale]
     if params[:i18npath]
-      redirect_to "/#{params[:i18npath]}"
+      # Query parameter for browser cache to be avoided and load new locale
+      redirect_to "/#{params[:i18npath]}?lang=#{params[:locale]}"
     elsif params[:user_return_to]
       redirect_to URI.parse(params[:user_return_to].to_s).path
     else

--- a/dashboard/app/controllers/home_controller.rb
+++ b/dashboard/app/controllers/home_controller.rb
@@ -18,14 +18,16 @@ class HomeController < ApplicationController
 
   def set_locale
     set_locale_cookie(params[:locale]) if params[:locale]
+    redirect_path = if params[:i18npath]
+                      "/#{params[:i18npath]}"
+                    elsif params[:user_return_to]
+                      URI.parse(params[:user_return_to].to_s).path
+                    else
+                      '/'
+                    end
     # Query parameter for browser cache to be avoided and load new locale
-    if params[:i18npath]
-      redirect_to "/#{params[:i18npath]}?lang=#{params[:locale]}"
-    elsif params[:user_return_to]
-      redirect_to "#{URI.parse(params[:user_return_to].to_s).path}?lang=#{params[:locale]}"
-    else
-      redirect_to '/'
-    end
+    redirect_path = "#{redirect_path}?lang=#{params[:locale]}" if params[:locale]
+    redirect_to redirect_path
   rescue URI::InvalidURIError
     redirect_to '/'
   end

--- a/dashboard/test/controllers/home_controller_test.rb
+++ b/dashboard/test/controllers/home_controller_test.rb
@@ -169,7 +169,7 @@ class HomeControllerTest < ActionController::TestCase
 
     assert_equal "es-ES", cookies[:language_]
     assert_match "language_=es-ES; domain=.code.org; path=/; expires=#{10.years.from_now.rfc2822}"[0..-15], @response.headers["Set-Cookie"]
-    assert_redirected_to 'http://studio.code.org/blahblah'
+    assert_redirected_to 'http://studio.code.org/blahblah?lang=es-ES'
   end
 
   test "handle nonsense in user_return_to by returning to home" do
@@ -188,13 +188,13 @@ class HomeControllerTest < ActionController::TestCase
       user_return_to: "http://blah.com/blerg",
       locale: "es-ES"
     }
-    assert_redirected_to 'http://studio.code.org/blerg'
+    assert_redirected_to 'http://studio.code.org/blerg?lang=es-ES'
   end
 
   test "if user_return_to in set_locale is nil redirects to homepage" do
     request.host = "studio.code.org"
     get :set_locale, params: {user_return_to: nil, locale: "es-ES"}
-    assert_redirected_to ''
+    assert_redirected_to '?lang=es-ES'
   end
 
   test "should get index with edmodo header" do

--- a/dashboard/test/controllers/home_controller_test.rb
+++ b/dashboard/test/controllers/home_controller_test.rb
@@ -194,7 +194,7 @@ class HomeControllerTest < ActionController::TestCase
   test "if user_return_to in set_locale is nil redirects to homepage" do
     request.host = "studio.code.org"
     get :set_locale, params: {user_return_to: nil, locale: "es-ES"}
-    assert_redirected_to '?lang=es-ES'
+    assert_redirected_to 'http://studio.code.org?lang=es-ES'
   end
 
   test "should get index with edmodo header" do

--- a/dashboard/test/integration/redirects_test.rb
+++ b/dashboard/test/integration/redirects_test.rb
@@ -50,10 +50,10 @@ class RedirectsTest < ActionDispatch::IntegrationTest
     assert_redirected_to '/'
 
     get '/s/frozen/lang/es'
-    assert_redirected_to '/s/frozen'
+    assert_redirected_to '/s/frozen?lang=es'
 
     get '/s/course1/lessons/1/levels/1/lang/es'
-    assert_redirected_to '/s/course1/lessons/1/levels/1'
+    assert_redirected_to '/s/course1/lessons/1/levels/1?lang=es'
   end
 
   test 'redirects urls with stage and puzzle to lessons and levels' do

--- a/dashboard/test/integration/redirects_test.rb
+++ b/dashboard/test/integration/redirects_test.rb
@@ -36,18 +36,18 @@ class RedirectsTest < ActionDispatch::IntegrationTest
 
   test 'redirects cartoon network quick links' do
     get '/flappy/lang/ar'
-    assert_redirected_to '/flappy/1'
+    assert_redirected_to '/flappy/1?lang=ar-SA'
 
     get '/playlab/lang/ar'
-    assert_redirected_to '/s/playlab/lessons/1/levels/1'
+    assert_redirected_to '/s/playlab/lessons/1/levels/1?lang=ar-SA'
 
     get '/artist/lang/ar'
-    assert_redirected_to '/s/artist/lessons/1/levels/1'
+    assert_redirected_to '/s/artist/lessons/1/levels/1?lang=ar-SA'
   end
 
   test 'redirects lang parameter' do
     get '/lang/es'
-    assert_redirected_to '/'
+    assert_redirected_to '/?lang=es'
 
     get '/s/frozen/lang/es'
     assert_redirected_to '/s/frozen?lang=es'

--- a/dashboard/test/ui/features/foundations/hamburger.feature
+++ b/dashboard/test/ui/features/foundations/hamburger.feature
@@ -118,7 +118,7 @@ Scenario: Signed out user viewing help dropdown in Spanish on desktop
 Scenario: Student viewing help dropdown in Spanish on desktop
   Given I create a student named "Eva Estudiante"
   Given I am on "http://studio.code.org/home/lang/es"
-  Then I wait until I am on "http://studio.code.org/home"
+  Then I wait until I am on "http://studio.code.org/home?lang=es"
   And I wait to see "#help-contents"
   Then I click selector "#help-icon"
   Then I wait to see "#help-contents"
@@ -132,7 +132,7 @@ Scenario: Student viewing help dropdown in Spanish on desktop
 Scenario: Teacher viewing help dropdown in Spanish on desktop
   Given I create a teacher named "Pabla Profesora"
   Given I am on "http://studio.code.org/home/lang/es"
-  Then I wait until I am on "http://studio.code.org/home"
+  Then I wait until I am on "http://studio.code.org/home?lang=es"
   Then I wait to see "#help-icon"
   Then I click selector "#help-icon"
   Then I wait to see "#help-contents"
@@ -145,7 +145,7 @@ Scenario: Teacher viewing help dropdown in Spanish on desktop
 Scenario: Student viewing help dropdown in Spanish on desktop on level
   Given I create a student named "Eva Estudiante"
   Given I am on "http://studio.code.org/s/allthethings/lessons/1/levels/1/lang/es"
-  Then I wait until I am on "http://studio.code.org/s/allthethings/lessons/1/levels/1"
+  Then I wait until I am on "http://studio.code.org/s/allthethings/lessons/1/levels/1?lang=es"
   Then I wait to see "#help-icon"
   Then I click selector "#help-icon"
   Then I wait to see "#help-contents"
@@ -157,7 +157,7 @@ Scenario: Student viewing help dropdown in Spanish on desktop on level
 Scenario: Teacher viewing help dropdown in Spanish on desktop on level
   Given I create a teacher named "Pabla Profesora"
   Given I am on "http://studio.code.org/s/allthethings/lessons/1/levels/1/lang/es"
-  Then I wait until I am on "http://studio.code.org/s/allthethings/lessons/1/levels/1"
+  Then I wait until I am on "http://studio.code.org/s/allthethings/lessons/1/levels/1?lang=es"
   Then I wait to see "#help-icon"
   Then I click selector "#help-icon"
   Then I wait to see "#help-contents"

--- a/dashboard/test/ui/features/foundations/header.feature
+++ b/dashboard/test/ui/features/foundations/header.feature
@@ -55,7 +55,7 @@ Scenario: Signed out user in Spanish should see 3 header links
 Scenario: Student in Spanish should see 3 header links
   Given I create a student named "Eva Estudiante"
   Given I am on "http://studio.code.org/courses/lang/es"
-  Then check that I am on "http://studio.code.org/courses"
+  Then check that I am on "http://studio.code.org/courses?lang=es"
   And I wait to see ".headerlinks"
   And I see "#header-student-courses"
   And element "#header-student-courses" has "es" text from key "nav.header.course_catalog"
@@ -67,7 +67,7 @@ Scenario: Student in Spanish should see 3 header links
 Scenario: Teacher in Spanish should see 5 header links
   Given I create a teacher named "Pabla Profesora"
   Given I am on "http://studio.code.org/home/lang/es"
-  Then check that I am on "http://studio.code.org/home"
+  Then check that I am on "http://studio.code.org/home?lang=es"
   And I wait to see ".headerlinks"
   And I see "#header-teacher-home"
   And element "#header-teacher-home" has "es" text from key "nav.header.my_dashboard"

--- a/dashboard/test/ui/features/learning_platform/courses_eyes.feature
+++ b/dashboard/test/ui/features/learning_platform/courses_eyes.feature
@@ -28,7 +28,7 @@ Scenario: Teacher courses
 Scenario: Student courses, non-english
   When I open my eyes to test "student courses non-english"
   Given I am on "http://studio.code.org/home/lang/es"
-  Then I wait until I am on "http://studio.code.org/home"
+  Then I wait until I am on "http://studio.code.org/home?lang=es"
   And I wait to see ".headerlinks"
   And I see "#header-student-courses"
   And I press "header-student-courses"


### PR DESCRIPTION
**What**: Adding a query parameter to the redirect URL when using our `lang/{locale}` paths.

**Why**:
- Currently certain browsers (Chrome, IE, Firefox confirmed) use the cached page containing the previous locale after we set the new `language_` cookie. We want this redirect to display the new language, so using a query parameter will cause the browser to avoid using the cache.
- This browser behavior caused a set of UI tests(`i18n.feature`) to be flaky. This change fixes that.

**Adhoc:**
https://adhoc-fnd-1789-fix-set-locale-caching-bug-studio.cdn-code.org

## Links

- jira ticket: [FND-1789](https://codedotorg.atlassian.net/browse/FND-1789)


## Testing story

- Tested switching languages locally
- Tested switching languages and ran the `i18n.feature` UI test against the adhoc

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
