### PR TITLE
[Sprite Lab] Add support for numbers to speech bubbles

### DIFF
--- a/apps/src/p5lab/spritelab/CoreLibrary.js
+++ b/apps/src/p5lab/spritelab/CoreLibrary.js
@@ -84,6 +84,13 @@ export default class CoreLibrary {
 
   drawSpeechBubble(text, x, y) {
     const padding = 8;
+    if (typeof text === 'number') {
+      text = text.toString();
+    }
+    //protect against crashes in the unlikely event that a non-string or non-number was passed
+    if (typeof text !== 'string') {
+      text = '';
+    }
     text = ellipsify(text, 150 /* maxLength */);
     let textSize;
     let charsPerLine;

--- a/dashboard/config/blocks/GamelabJr/gamelab_spriteSayTime.json
+++ b/dashboard/config/blocks/GamelabJr/gamelab_spriteSayTime.json
@@ -10,7 +10,6 @@
       },
       {
         "name": "TEXT1",
-        "type": "String",
         "field": false
       },
       {


### PR DESCRIPTION
**Bug fix. Can wait until after CSEdWeek**

Using variables, it is currently possible to pass non-string numbers into spriteSayTime. However, addSpeechBubbles assumes the text argument will always be a string. It is desirable for speech bubbles to work with numbers from the standpoint of parity with other blocks (e.g. `print` and `show title screen`), and the feature is also needed by the curriculum team for new lessons. 
This change now converts numbers to strings and also includes a safety net for the unlikely event that another type is passed. Because speech bubbles will support numbers, the blockly block `spriteSayTime` no longer needs to enforce strings.

*Before:*
![image (110)](https://user-images.githubusercontent.com/43474485/144655046-dcdae0f2-0275-4777-bda7-ff06719d5671.png)

*After:*
![image](https://user-images.githubusercontent.com/43474485/144655017-dfdc0897-37b4-4910-b97a-c700f1312435.png)


<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

[Slack thread](https://codedotorg.slack.com/archives/C1B3PNDL7/p1638552515157200)


