### PR TITLE
Update redirect logic for students when they sign in (in terms of live/archived sections)

### DIFF
--- a/dashboard/app/controllers/home_controller.rb
+++ b/dashboard/app/controllers/home_controller.rb
@@ -81,15 +81,11 @@ class HomeController < ApplicationController
   def should_redirect_to_script_overview?
     current_user.student? &&
     current_user.can_access_most_recently_assigned_script? &&
+    current_user.most_recent_script_in_live_section? &&
     (
       !current_user.user_script_with_most_recent_progress ||
-      (
-        current_user.most_recent_script_in_live_section? &&
-        (
-          current_user.most_recent_progress_in_recently_assigned_script? ||
-          current_user.last_assignment_after_most_recent_progress?
-        )
-      )
+      current_user.most_recent_progress_in_recently_assigned_script? ||
+      current_user.last_assignment_after_most_recent_progress?
     )
   end
 

--- a/dashboard/app/controllers/home_controller.rb
+++ b/dashboard/app/controllers/home_controller.rb
@@ -85,22 +85,13 @@ class HomeController < ApplicationController
     # Ensure user is student and can access their most recently assigned script
     current_user.student? &&
     current_user.can_access_most_recently_assigned_script? &&
-    # Check if either the user has not made recent progress in a script,
-    #       if the user's most recently assigned script is not only associated
-    #         with archived sections they are assigned to,
-    #       or if the user's most recent progress was in a script not only
-    #         associated with archived sections they are assigned to.
+    # Check if the user's most recently assigned script is associated with a
+    #         live section they are enrolled in,
+    #       or if the user's most recent progress was in a script associated
+    #         with a live section they are assigned to.
     (
-      !current_user.user_script_with_most_recent_progress ||
-      (
-        (
-          current_user.most_recent_progress_in_recently_assigned_script? ||
-          current_user.last_assignment_after_most_recent_progress?
-        ) &&
-        current_user.most_recent_assigned_script_not_only_in_archived_sections?
-      ) || (
-        current_user.most_recent_progress_script_not_only_in_archived_sections?
-      )
+      current_user.most_recent_assigned_script_in_live_section? ||
+      current_user.most_recent_progress_script_in_live_section?
     )
   end
 

--- a/dashboard/app/controllers/home_controller.rb
+++ b/dashboard/app/controllers/home_controller.rb
@@ -81,6 +81,7 @@ class HomeController < ApplicationController
   def should_redirect_to_script_overview?
     current_user.student? &&
     current_user.can_access_most_recently_assigned_script? &&
+    current_user.most_recent_script_in_live_section? &&
     (
       !current_user.user_script_with_most_recent_progress ||
       current_user.most_recent_progress_in_recently_assigned_script? ||

--- a/dashboard/app/controllers/home_controller.rb
+++ b/dashboard/app/controllers/home_controller.rb
@@ -78,14 +78,29 @@ class HomeController < ApplicationController
 
   private
 
+  # Determine whether student should be redirected to script overview
+  # true - redirect to script overview page
+  # false - redirect to home page
   def should_redirect_to_script_overview?
+    # Ensure user is student and can access their most recently assigned script
     current_user.student? &&
     current_user.can_access_most_recently_assigned_script? &&
-    current_user.most_recent_script_in_live_section? &&
+    # Check if either the user has not made recent progress in a script,
+    #       if the user's most recently assigned script is not only associated
+    #         with archived sections they are assigned to,
+    #       or if the user's most recent progress was in a script not only
+    #         associated with archived sections they are assigned to.
     (
       !current_user.user_script_with_most_recent_progress ||
-      current_user.most_recent_progress_in_recently_assigned_script? ||
-      current_user.last_assignment_after_most_recent_progress?
+      (
+        (
+          current_user.most_recent_progress_in_recently_assigned_script? ||
+          current_user.last_assignment_after_most_recent_progress?
+        ) &&
+        current_user.most_recent_assigned_script_not_only_in_archived_sections?
+      ) || (
+        current_user.most_recent_progress_script_not_only_in_archived_sections?
+      )
     )
   end
 

--- a/dashboard/app/controllers/home_controller.rb
+++ b/dashboard/app/controllers/home_controller.rb
@@ -81,11 +81,15 @@ class HomeController < ApplicationController
   def should_redirect_to_script_overview?
     current_user.student? &&
     current_user.can_access_most_recently_assigned_script? &&
-    current_user.most_recent_script_in_live_section? &&
     (
       !current_user.user_script_with_most_recent_progress ||
-      current_user.most_recent_progress_in_recently_assigned_script? ||
-      current_user.last_assignment_after_most_recent_progress?
+      (
+        current_user.most_recent_script_in_live_section? &&
+        (
+          current_user.most_recent_progress_in_recently_assigned_script? ||
+          current_user.last_assignment_after_most_recent_progress?
+        )
+      )
     )
   end
 

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1645,18 +1645,15 @@ class User < ApplicationRecord
     user_script_with_most_recent_progress[:last_progress_at]
   end
 
-  # Check if the user's most recently assigned script is not only associated with
-  # archived sections they are enrolled in.
-  def most_recent_assigned_script_not_only_in_archived_sections?
-    (
-      sections_as_student.empty? ||
-      sections_as_student.any? {|section| section.script_id == most_recently_assigned_script.id && section.hidden == false}
-    )
+  # Check if the user's most recently assigned script is associated with at least
+  # 1 live section they are enrolled in.
+  def most_recent_assigned_script_in_live_section?
+    sections_as_student.any? {|section| section.script_id == most_recently_assigned_script.id && section.hidden == false}
   end
 
-  # Check if the last progress made by the user was not in a script only associated
-  # with archived sections they are enrolled in.
-  def most_recent_progress_script_not_only_in_archived_sections?
+  # Check if the most recent progress made by the user was in a script associated
+  # with at least 1 live section they are enrolled in.
+  def most_recent_progress_script_in_live_section?
     sections_as_student.any? {|section| section.script_id == script_with_most_recent_progress.id && section.hidden == false}
   end
 

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1633,8 +1633,8 @@ class User < ApplicationRecord
   end
 
   def most_recent_script_in_live_section?
-    recent_script = last_assignment_after_most_recent_progress? ? most_recently_assigned_user_script&.script : user_script_with_most_recent_progress&.script
-    sections_as_student.any? {|section| section.hidden == false && section.script_id == recent_script.id}
+    last_assignment_after_most_recent_progress? ||
+    sections_as_student.any? {|section| section.hidden == false && section.script_id == script_with_most_recent_progress.id}
   end
 
   # Checks if there are any launched scripts or courses assigned to the user.

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1632,6 +1632,11 @@ class User < ApplicationRecord
     user_script_with_most_recent_progress[:last_progress_at]
   end
 
+  def most_recent_script_in_live_section?
+    recent_script = most_recently_assigned_user_script&.script
+    sections_as_student.any? {|section| section.hidden == false && section.script_id == recent_script.id}
+  end
+
   # Checks if there are any launched scripts or courses assigned to the user.
   # @return [Boolean]
   def assigned_course_or_script?

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1633,7 +1633,7 @@ class User < ApplicationRecord
   end
 
   def most_recent_script_in_live_section?
-    recent_script = most_recently_assigned_user_script&.script
+    recent_script = last_assignment_after_most_recent_progress? ? most_recently_assigned_user_script&.script : user_script_with_most_recent_progress&.script
     sections_as_student.any? {|section| section.hidden == false && section.script_id == recent_script.id}
   end
 


### PR DESCRIPTION
Previously, when students logged in, they would be redirected to the script page they most recently worked on. However, this did not take into account whether the section the student was in (that was associated with the given script page) was archived or not. This meant that students logging in might be immediately redirected to an archived section.

Now, students are only redirected to the script page they most recently worked on or the script page they were most recently assigned to if it that script is associated with at least one non-archived section they are enrolled in. If not, they are just sent to the student home page.

Here is the logic's general pseudo-code:
if (most recently worked on or assigned script is associated with a live (non-archived) section the student is enrolled in):
&nbsp;&nbsp;&nbsp;&nbsp;redirect student to their most recently worked on or assigned script's overview page (whichever was more recent)
else
&nbsp;&nbsp;&nbsp;&nbsp;redirect student to their home page
end

There are 11 scenarios with the following desired outcomes according to [the spec](https://docs.google.com/document/d/1bSG8FV6OpBZBQPLA63tTN9oJ9gCk7vkC_S-neQ7Dnws/edit#):
| Sections & Their Scripts | Most recently assigned script | Script with most recent progress | Desired redirect | Video demo | 
| ------------- | ------------- | ------------- | ------------- | ------------- |
| No sections | None | None | Student home page | 1 |
| 1 live section running 'Script A' | Script A | Script A | Script A's script page | 2 |
| 1 archived section running 'Script B' | Script B | Script B | Student homepage | 3 |
| 2 live sections, running 'Script A' and 'Script B' respectively (where Script B is assigned after last progress on Script A) | Script B | Script A | Script B's script page | 4 |
| 2 live sections, running 'Script A' and 'Script B' respectively (where Script B is assigned before last progress on Script A) | Script B | Script A | Script A's script page | 5 |
| 1 live section running 'Script A' & 1 archived section running 'Script B' (<ins>different</ins> scripts) | Script A | Script A | Script A's script page | 6 |
| 1 live section running 'Script A' & 1 archived section running 'Script B' (<ins>different</ins> scripts) | Script A | Script B | Student home page | 7 |
| 1 live section running 'Script A' & 1 archived section running 'Script B' (<ins>different</ins> scripts) | Script B | Script A | Script A's script page | 8 |
| 1 live section running 'Script A' & 1 archived section running 'Script B' (<ins>different</ins> scripts) | Script B | Script B | Student home page | 9 |
| 1 live section running 'Script A' & 1 archived section running 'Script A' (<ins>same</ins> scripts) | Script A | Script A | Script A's script page | 10 |
| No sections (but student making progress in unassigned script, 'Script C') | None | Script C | Student home page | 11 |
| 1 live section running 'Script A' (but student making recent progress in unassigned script, 'Script C') | Script A | Script C | Student home page | 12 |
| 1 archived section running 'Script B' (but student making recent progress in unassigned script, 'Script C') | Script B | Script C | Student home page | 13 |

Due to the complicated redirect logic, I added comments to the components of `user.rb` that I used so that they will hopefully be easier to work with in the future.

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/browse/FND-1706?atlOrigin=eyJpIjoiMDk0MWFmMTFmNmZhNGFkMmE0MDJiNWFiZDcwODE1ZDIiLCJwIjoiaiJ9)
Spec: [Requirement 2 of the "Make section remove/archive match what teachers expect it to do" spec](https://docs.google.com/document/d/1bSG8FV6OpBZBQPLA63tTN9oJ9gCk7vkC_S-neQ7Dnws/edit#)

## Testing story
Manually tested the multiple scenarios listed above to ensure that students were properly redirected to the right section's script page (with the student's progress shown) or the student homepage in different browsers and on mobile.

## Follow-up work
Continue the following requirements listed in the ["Make section remove/archive match what teachers expect it to do" spec](https://docs.google.com/document/d/1bSG8FV6OpBZBQPLA63tTN9oJ9gCk7vkC_S-neQ7Dnws/edit#).

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
