### PR TITLE
improve factories for curriculum data objects

### DIFF
--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -34,6 +34,7 @@ class Lesson < ApplicationRecord
   belongs_to :script, inverse_of: :lessons
   belongs_to :lesson_group
   has_many :lesson_activities, -> {order(:position)}, dependent: :destroy
+  has_many :activity_sections, through: :lesson_activities
   has_many :script_levels, -> {order(:chapter)}, foreign_key: 'stage_id', dependent: :destroy
   has_many :levels, through: :script_levels
   has_and_belongs_to_many :resources, join_table: :lessons_resources

--- a/dashboard/test/controllers/activities_controller_test.rb
+++ b/dashboard/test/controllers/activities_controller_test.rb
@@ -880,7 +880,6 @@ class ActivitiesControllerTest < ActionController::TestCase
     ScriptLevel.class_variable_set(:@@script_level_map, nil)
     script = create :script, :with_levels, lessons_count: 2, name: 'Milestone Script', skip_name_format_validation: true
     script.lessons.first.update!(key: 'Milestone Lesson 1', name: 'Milestone Lesson 1')
-    # script.lessons.last.update!(key: 'Milestone Lesson 2', display_name: 'Milestone Lesson 2')
     script.reload
 
     last_level_in_first_lesson = script.lessons.first.script_levels.last

--- a/dashboard/test/controllers/activities_controller_test.rb
+++ b/dashboard/test/controllers/activities_controller_test.rb
@@ -878,13 +878,10 @@ class ActivitiesControllerTest < ActionController::TestCase
 
   test 'milestone changes to next lesson in custom script' do
     ScriptLevel.class_variable_set(:@@script_level_map, nil)
-    game = create(:game)
-    (1..3).each {|n| create(:level, name: "Level #{n}", game: game)}
-    script_dsl = ScriptDSL.parse(
-      "lesson 'Milestone Lesson 1', display_name: 'Milestone Lesson 1'; level 'Level 1'; level 'Level 2'; lesson 'Milestone Lesson 2', display_name: 'Milestone Lesson 2'; level 'Level 3'",
-      "a filename"
-    )
-    script = Script.add_unit({name: 'Milestone Script'}, script_dsl[0][:lesson_groups])
+    script = create :script, :with_levels, lessons_count: 2, name: 'Milestone Script', skip_name_format_validation: true
+    script.lessons.first.update!(key: 'Milestone Lesson 1', name: 'Milestone Lesson 1')
+    # script.lessons.last.update!(key: 'Milestone Lesson 2', display_name: 'Milestone Lesson 2')
+    script.reload
 
     last_level_in_first_lesson = script.lessons.first.script_levels.last
     post :milestone,

--- a/dashboard/test/controllers/lessons_controller_test.rb
+++ b/dashboard/test/controllers/lessons_controller_test.rb
@@ -456,13 +456,8 @@ class LessonsControllerTest < ActionController::TestCase
     sign_in @levelbuilder
     Rails.application.config.stubs(:levelbuilder_mode).returns true
 
-    unit = create :script, :with_lessons, lessons_count: 1
+    unit = create :script, :with_levels
     lesson = unit.lessons.first
-    create(
-      :script_level,
-      activity_section: lesson.activity_sections.first,
-      levels: [create(:level)]
-    )
 
     error = assert_raises RuntimeError do
       post :update, params: {

--- a/dashboard/test/controllers/lessons_controller_test.rb
+++ b/dashboard/test/controllers/lessons_controller_test.rb
@@ -9,17 +9,13 @@ class LessonsControllerTest < ActionController::TestCase
     # stub writes so that we dont actually make updates to filesystem
     File.stubs(:write)
 
-    @script = create :script, name: 'unit-1', is_migrated: true
+    @script = create :script, name: 'unit-1'
     lesson_group = create :lesson_group, script: @script
     @lesson = create(
       :lesson,
-      script_id: @script.id,
       lesson_group: lesson_group,
       name: 'lesson display name',
-      absolute_position: 1,
-      relative_position: 1,
       has_lesson_plan: true,
-      lockable: false,
       properties: {
         overview: 'lesson overview',
         student_overview: 'student overview'
@@ -28,13 +24,9 @@ class LessonsControllerTest < ActionController::TestCase
 
     @lesson2 = create(
       :lesson,
-      script_id: @script.id,
       lesson_group: lesson_group,
       name: 'second lesson',
       has_lesson_plan: false,
-      lockable: false,
-      absolute_position: 2,
-      relative_position: 2
     )
 
     @script_title = 'Script Display Name'
@@ -464,18 +456,12 @@ class LessonsControllerTest < ActionController::TestCase
     sign_in @levelbuilder
     Rails.application.config.stubs(:levelbuilder_mode).returns true
 
-    script = create :script
-    lesson_group = create :lesson_group, script: script
-    lesson = create :lesson, script: script, lesson_group: lesson_group
-    lesson_activity = create :lesson_activity, lesson: lesson
-    activity_section = create :activity_section, lesson_activity: lesson_activity
+    unit = create :script, :with_lessons, lessons_count: 1
+    lesson = unit.lessons.first
     create(
       :script_level,
-      script: script,
-      activity_section: activity_section,
-      activity_section_position: 1,
-      lesson: lesson,
-      levels: [create(:maze)]
+      activity_section: lesson.activity_sections.first,
+      levels: [create(:level)]
     )
 
     error = assert_raises RuntimeError do
@@ -493,18 +479,12 @@ class LessonsControllerTest < ActionController::TestCase
     sign_in @levelbuilder
     Rails.application.config.stubs(:levelbuilder_mode).returns true
 
-    script = create :script
-    lesson_group = create :lesson_group, script: script
-    lesson = create :lesson, script: script, lesson_group: lesson_group
-    lesson_activity = create :lesson_activity, lesson: lesson
-    activity_section = create :activity_section, lesson_activity: lesson_activity
+    unit = create :script, :with_lessons, lessons_count: 1
+    lesson = unit.lessons.first
     create(
       :script_level,
-      script: script,
       assessment: true,
-      activity_section: activity_section,
-      activity_section_position: 1,
-      lesson: lesson,
+      activity_section: lesson.activity_sections.first,
       levels: [create(:level_group, name: 'levelgroup 1')]
     )
 

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -707,21 +707,7 @@ class ScriptsControllerTest < ActionController::TestCase
     sign_in create(:levelbuilder)
     Rails.application.config.stubs(:levelbuilder_mode).returns true
 
-    unit = create :script, name: 'migrated', is_migrated: true
-    lesson_group = create :lesson_group, script: unit
-    lesson = create :lesson, script: unit, lesson_group: lesson_group
-    activity = create :lesson_activity, lesson: lesson
-    section = create :activity_section, lesson_activity: activity
-
-    # A migrated script level is one with an activity section.
-    create(
-      :script_level,
-      script: unit,
-      lesson: lesson,
-      activity_section: section,
-      activity_section_position: 1,
-      levels: [create(:applab)]
-    )
+    unit = create :script, :with_levels, name: 'migrated'
 
     stub_file_writes(unit.name)
     unit.reload

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -757,6 +757,19 @@ FactoryGirl.define do
     participant_audience "student"
     instructor_audience "teacher"
 
+    trait :with_lessons do
+      transient do
+        lessons_count 2
+      end
+
+      after(:create) do |script, evaluator|
+        lesson_group = create :lesson_group, script: script
+        evaluator.lessons_count.times do
+          create :lesson, :with_activity_section, lesson_group: lesson_group
+        end
+      end
+    end
+
     trait :with_levels do
       transient do
         lessons_count 1

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -770,7 +770,7 @@ FactoryGirl.define do
           section = lesson.lesson_activities.first.activity_sections.first
           evaluator.levels_count.times do
             level = create(:level)
-            create :script_level, levels: [level], script: script, lesson: lesson, activity_section: section
+            create :script_level, levels: [level], lesson: lesson, activity_section: section
           end
         end
       end
@@ -831,15 +831,15 @@ FactoryGirl.define do
   end
 
   factory :script_level do
-    script
+    script do |script_level|
+      script_level.lesson&.script || create(:script)
+    end
 
     trait :assessment do
       assessment true
     end
 
-    lesson do |script_level|
-      create(:lesson, script: script_level.script)
-    end
+    lesson
 
     trait :with_autoplay_video do
       levels {[create(:level, :with_autoplay_video)]}

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -759,7 +759,7 @@ FactoryGirl.define do
 
     trait :with_levels do
       transient do
-        levels_count 0
+        levels_count 2
       end
 
       after(:create) do |script, evaluator|

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -759,17 +759,20 @@ FactoryGirl.define do
 
     trait :with_levels do
       transient do
+        lessons_count 1
         levels_count 2
       end
 
       after(:create) do |script, evaluator|
         lesson_group = create :lesson_group, script: script
-        lesson = create :lesson, lesson_group: lesson_group, script: script, relative_position: 1, absolute_position: 1
-        activity = create :lesson_activity, lesson: lesson
-        section = create :activity_section, lesson_activity: activity
-        evaluator.levels_count.times do |i|
-          level = create(:level)
-          create :script_level, levels: [level], script: script, lesson: lesson, activity_section: section, activity_section_position: i + 1
+        evaluator.lessons_count.times do |i|
+          lesson = create :lesson, lesson_group: lesson_group, script: script, relative_position: i + 1, absolute_position: i + 1
+          activity = create :lesson_activity, lesson: lesson
+          section = create :activity_section, lesson_activity: activity
+          evaluator.levels_count.times do |j|
+            level = create(:level)
+            create :script_level, levels: [level], script: script, lesson: lesson, activity_section: section, activity_section_position: j + 1
+          end
         end
       end
     end

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -768,9 +768,9 @@ FactoryGirl.define do
         evaluator.lessons_count.times do
           lesson = create :lesson, :with_activity_section, lesson_group: lesson_group, script: script
           section = lesson.lesson_activities.first.activity_sections.first
-          evaluator.levels_count.times do |j|
+          evaluator.levels_count.times do
             level = create(:level)
-            create :script_level, levels: [level], script: script, lesson: lesson, activity_section: section, activity_section_position: j + 1
+            create :script_level, levels: [level], script: script, lesson: lesson, activity_section: section
           end
         end
       end
@@ -865,6 +865,12 @@ FactoryGirl.define do
 
     position do |script_level|
       (script_level.lesson.script_levels.maximum(:position) || 0) + 1 if script_level.lesson
+    end
+
+    activity_section_position do |script_level|
+      section = script_level.activity_section
+      next nil unless section
+      (section.script_levels.maximum(:activity_section_position) || 0) + 1
     end
 
     properties do |script_level|

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -766,7 +766,7 @@ FactoryGirl.define do
       after(:create) do |script, evaluator|
         lesson_group = create :lesson_group, script: script
         evaluator.lessons_count.times do
-          lesson = create :lesson, :with_activity_section, lesson_group: lesson_group, script: script
+          lesson = create :lesson, :with_activity_section, lesson_group: lesson_group
           section = lesson.lesson_activities.first.activity_sections.first
           evaluator.levels_count.times do
             level = create(:level)
@@ -906,7 +906,9 @@ FactoryGirl.define do
     sequence(:name) {|n| "Bogus Lesson #{n}"}
     sequence(:key) {|n| "Bogus-Lesson-#{n}"}
     has_lesson_plan false
-    script
+    script do |lesson|
+      lesson.lesson_group&.script || create(:script)
+    end
 
     absolute_position do |lesson|
       (lesson.script.lessons.maximum(:absolute_position) || 0) + 1

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -767,10 +767,9 @@ FactoryGirl.define do
         lesson_group = create :lesson_group, script: script
         evaluator.lessons_count.times do
           lesson = create :lesson, :with_activity_section, lesson_group: lesson_group
-          section = lesson.lesson_activities.first.activity_sections.first
           evaluator.levels_count.times do
             level = create(:level)
-            create :script_level, levels: [level], activity_section: section
+            create :script_level, levels: [level], activity_section: lesson.activity_sections.first
           end
         end
       end

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -764,7 +764,7 @@ FactoryGirl.define do
 
       after(:create) do |script, evaluator|
         lesson_group = create :lesson_group, script: script
-        lesson = create :lesson, lesson_group: lesson_group, script: script
+        lesson = create :lesson, lesson_group: lesson_group, script: script, relative_position: 1, absolute_position: 1
         activity = create :lesson_activity, lesson: lesson
         section = create :activity_section, lesson_activity: activity
         evaluator.levels_count.times do |i|

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -765,8 +765,8 @@ FactoryGirl.define do
 
       after(:create) do |script, evaluator|
         lesson_group = create :lesson_group, script: script
-        evaluator.lessons_count.times do |i|
-          lesson = create :lesson, :with_activity_section, lesson_group: lesson_group, script: script, relative_position: i + 1, absolute_position: i + 1
+        evaluator.lessons_count.times do
+          lesson = create :lesson, :with_activity_section, lesson_group: lesson_group, script: script
           section = lesson.lesson_activities.first.activity_sections.first
           evaluator.levels_count.times do |j|
             level = create(:level)

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -770,7 +770,7 @@ FactoryGirl.define do
           section = lesson.lesson_activities.first.activity_sections.first
           evaluator.levels_count.times do
             level = create(:level)
-            create :script_level, levels: [level], lesson: lesson, activity_section: section
+            create :script_level, levels: [level], activity_section: section
           end
         end
       end
@@ -832,14 +832,16 @@ FactoryGirl.define do
 
   factory :script_level do
     script do |script_level|
-      script_level.lesson&.script || create(:script)
+      script_level.activity_section&.lesson&.script || script_level.lesson&.script || create(:script)
     end
 
     trait :assessment do
       assessment true
     end
 
-    lesson
+    lesson do |script_level|
+      script_level.activity_section&.lesson || create(:lesson)
+    end
 
     trait :with_autoplay_video do
       levels {[create(:level, :with_autoplay_video)]}

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -766,9 +766,8 @@ FactoryGirl.define do
       after(:create) do |script, evaluator|
         lesson_group = create :lesson_group, script: script
         evaluator.lessons_count.times do |i|
-          lesson = create :lesson, lesson_group: lesson_group, script: script, relative_position: i + 1, absolute_position: i + 1
-          activity = create :lesson_activity, lesson: lesson
-          section = create :activity_section, lesson_activity: activity
+          lesson = create :lesson, :with_activity_section, lesson_group: lesson_group, script: script, relative_position: i + 1, absolute_position: i + 1
+          section = lesson.lesson_activities.first.activity_sections.first
           evaluator.levels_count.times do |j|
             level = create(:level)
             create :script_level, levels: [level], script: script, lesson: lesson, activity_section: section, activity_section_position: j + 1
@@ -912,6 +911,13 @@ FactoryGirl.define do
     # from all other lessons, which is what we normally do for relative position.
     relative_position do |lesson|
       ((lesson.script.lessons.maximum(:absolute_position) || 0) + 1).to_s
+    end
+
+    trait :with_activity_section do
+      after(:create) do |lesson|
+        activity = create :lesson_activity, lesson: lesson
+        create :activity_section, lesson_activity: activity
+      end
     end
   end
 

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -763,10 +763,13 @@ FactoryGirl.define do
       end
 
       after(:create) do |script, evaluator|
-        evaluator.levels_count.times do
+        lesson_group = create :lesson_group, script: script
+        lesson = create :lesson, lesson_group: lesson_group, script: script
+        activity = create :lesson_activity, lesson: lesson
+        section = create :activity_section, lesson_activity: activity
+        evaluator.levels_count.times do |i|
           level = create(:level)
-          script_level = create(:script_level, levels: [level], script: script)
-          create(:lesson_group, lessons: [script_level.lesson], script: script)
+          create :script_level, levels: [level], script: script, lesson: lesson, activity_section: section, activity_section_position: i + 1
         end
       end
     end

--- a/dashboard/test/integration/db_query_test.rb
+++ b/dashboard/test/integration/db_query_test.rb
@@ -139,6 +139,10 @@ class DBQueryTest < ActionDispatch::IntegrationTest
       published_state: SharedCourseConstants::PUBLISHED_STATE.stable
     )
     CourseOffering.add_course_offering(unit)
+
+    # make sure the new unit is in the cache
+    setup_script_cache
+
     level = unit.levels.first
 
     teacher = create :teacher

--- a/dashboard/test/integration/db_query_test.rb
+++ b/dashboard/test/integration/db_query_test.rb
@@ -148,7 +148,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
     student.assign_script(unit)
     sign_in student
 
-    assert_cached_queries(20) do
+    assert_cached_queries(19) do
       get "/s/#{unit.name}/lessons/1/levels/1"
       assert_response :success
     end

--- a/dashboard/test/lib/services/script_seed_test.rb
+++ b/dashboard/test/lib/services/script_seed_test.rb
@@ -1118,13 +1118,8 @@ module Services
     end
 
     test 'seed rejects bad plc module name' do
-      unit = create :script
-      lesson_group = create :lesson_group, script: unit, key: 'bad_module_type', display_name: "Bad Module Type"
-      lesson = create :lesson, lesson_group: lesson_group, script: unit
-      activity = create :lesson_activity, lesson: lesson
-      section = create :activity_section, lesson_activity: activity
-      level = create :level
-      create :script_level, script: unit, lesson: lesson, activity_section: section, activity_section_position: 1, levels: [level]
+      unit = create :script, :with_levels
+      unit.lesson_groups.first.update!(key: 'bad_module_type',  display_name: "Bad Module Type")
 
       # must skip callbacks, or generate_plc_objects will fail.
       unit.update_columns(properties: unit.properties.merge(professional_learning_course: true))

--- a/dashboard/test/models/activity_section_test.rb
+++ b/dashboard/test/models/activity_section_test.rb
@@ -34,7 +34,7 @@ class ActivitySectionTest < ActiveSupport::TestCase
     level1 = create :maze, name: 'level 1'
     error = assert_raises do
       create :script_level, script: script, lesson: lesson, levels: [level1],
-             activity_section: activity_section
+             activity_section: activity_section, activity_section_position: nil
     end
     assert_includes error.message, 'activity_section_position is required'
   end

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -471,15 +471,10 @@ class LessonTest < ActiveSupport::TestCase
   end
 
   test 'summarize for script edit includes bonus levels' do
-    script = create :script, is_migrated: true
-    lesson_group = create :lesson_group, script: script
-    lesson = create :lesson, lesson_group: lesson_group, script: script, name: 'Lesson 1', key: 'lesson-1', relative_position: 1, absolute_position: 1
-    activity = create :lesson_activity, lesson: lesson
-    section = create :activity_section, lesson_activity: activity
-    level1 = create :level
-    level2 = create :level
-    create :script_level, script: script, lesson: lesson, activity_section: section, activity_section_position: 1, levels: [level1]
-    create :script_level, script: script, lesson: lesson, activity_section: section, activity_section_position: 2, levels: [level2], bonus: true
+    script = create :script, :with_levels
+    lesson = script.lessons.first
+    lesson.script_levels.last.update!(bonus: true)
+    lesson.reload
 
     levels_data = lesson.summarize_for_unit_edit[:levels]
     assert_equal 2, levels_data.length

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1231,53 +1231,43 @@ class ScriptTest < ActiveSupport::TestCase
   end
 
   test 'names lessons appropriately when unit has lockable lessons' do
-    create :level, name: 'LockableAssessment1'
-    create :level, name: 'NonLockableAssessment1'
-    create :level, name: 'NonLockableAssessment2'
-    create :level, name: 'NonLockableAssessment3'
+    lockable1 = create :level, name: 'LockableAssessment1'
+    level1 = create :level, name: 'NonLockableAssessment1'
+    level2 = create :level, name: 'NonLockableAssessment2'
+    level3 = create :level, name: 'NonLockableAssessment3'
 
-    input_dsl = <<-DSL.gsub(/^\s+/, '')
-      lesson 'NonLockable1', display_name: 'NonLockable1'
-      assessment 'NonLockableAssessment1';
-      lesson 'NonLockable2', display_name: 'NonLockable2'
-      assessment 'NonLockableAssessment2';
-      lesson 'NonLockable3', display_name: 'NonLockable3'
-      assessment 'NonLockableAssessment3';
-    DSL
-    unit_data, _ = ScriptDSL.parse(input_dsl, 'a filename')
-    unit = Script.add_unit({name: 'test_script'}, unit_data[:lesson_groups])
+    unit = create :script, :with_lessons, lessons_count: 3
+    create :script_level, levels: [level1], activity_section: unit.lessons[0].activity_sections.first, assessment: true
+    create :script_level, levels: [level2], activity_section: unit.lessons[1].activity_sections.first, assessment: true
+    create :script_level, levels: [level3], activity_section: unit.lessons[2].activity_sections.first, assessment: true
 
     # Everything has Lesson <number> when nothing is lockable
     assert (/^Lesson 1:/.match(unit.lessons[0].localized_title))
     assert (/^Lesson 2:/.match(unit.lessons[1].localized_title))
     assert (/^Lesson 3:/.match(unit.lessons[2].localized_title))
 
-    input_dsl = <<-DSL.gsub(/^\s+/, '')
-      lesson 'Lockable1', display_name: 'Lockable1', lockable: true
-      assessment 'LockableAssessment1';
-      lesson 'NonLockable1', display_name: 'NonLockable1'
-      assessment 'NonLockableAssessment1';
-      lesson 'NonLockable2', display_name: 'NonLockable2'
-      assessment 'NonLockableAssessment2';
-    DSL
-    unit_data, _ = ScriptDSL.parse(input_dsl, 'a filename')
-    unit = Script.add_unit({name: 'test_script'}, unit_data[:lesson_groups])
+    unit = create :script
+    lesson_group = create :lesson_group, script: unit
+    create :lesson, lesson_group: lesson_group, relative_position: 1, lockable: true, key: 'Lockable', name: 'Lockable'
+    create :lesson, lesson_group: lesson_group, relative_position: 1
+    create :lesson, lesson_group: lesson_group, relative_position: 2
+    create :script_level, levels: [lockable1], activity_section: unit.lessons[0].activity_sections.first, assessment: true
+    create :script_level, levels: [level1], activity_section: unit.lessons[1].activity_sections.first, assessment: true
+    create :script_level, levels: [level2], activity_section: unit.lessons[2].activity_sections.first, assessment: true
 
     # When first lesson is lockable, it has no lesson number, and the next lesson starts at 1
     assert (/^Lesson/.match(unit.lessons[0].localized_title).nil?)
     assert (/^Lesson 1:/.match(unit.lessons[1].localized_title))
     assert (/^Lesson 2:/.match(unit.lessons[2].localized_title))
 
-    input_dsl = <<-DSL.gsub(/^\s+/, '')
-      lesson 'NonLockable1', display_name: 'NonLockable1'
-      assessment 'NonLockableAssessment1';
-      lesson 'Lockable1', display_name: 'Lockable1', lockable: true
-      assessment 'LockableAssessment1';
-      lesson 'NonLockable2', display_name: 'NonLockable2'
-      assessment 'NonLockableAssessment2';
-    DSL
-    unit_data, _ = ScriptDSL.parse(input_dsl, 'a filename')
-    unit = Script.add_unit({name: 'test_script'}, unit_data[:lesson_groups])
+    unit = create :script
+    lesson_group = create :lesson_group, script: unit
+    create :lesson, lesson_group: lesson_group, relative_position: 1
+    create :lesson, lesson_group: lesson_group, relative_position: 1, lockable: true, key: 'Lockable', name: 'Lockable'
+    create :lesson, lesson_group: lesson_group, relative_position: 2
+    create :script_level, levels: [level1], activity_section: unit.lessons[0].activity_sections.first, assessment: true
+    create :script_level, levels: [lockable1], activity_section: unit.lessons[1].activity_sections.first, assessment: true
+    create :script_level, levels: [level2], activity_section: unit.lessons[2].activity_sections.first, assessment: true
 
     # When only second lesson is lockable, we count non-lockable lessons appropriately
     assert (/^Lesson 1:/.match(unit.lessons[0].localized_title))

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -3776,7 +3776,7 @@ class UserTest < ActiveSupport::TestCase
     test 'can get next_unpassed_visible_progression_level, progress, hidden' do
       student = create :student
       teacher = create :teacher
-      script = create(:script, :with_levels, levels_count: 3)
+      script = create(:script, :with_levels, lessons_count: 3, levels_count: 1)
 
       # User completed the first lesson
       script.lessons[0].script_levels.each do |sl|
@@ -3802,7 +3802,7 @@ class UserTest < ActiveSupport::TestCase
     test 'can get next_unpassed_visible_progression_level, last level complete, but script not complete, first hidden' do
       student = create :student
       teacher = create :teacher
-      script = create(:script, :with_levels, levels_count: 3)
+      script = create(:script, :with_levels, lessons_count: 3, levels_count: 1)
 
       refute_empty student.visible_script_levels(script)
 


### PR DESCRIPTION
## Background

Unblocks work on [PLAT-1506]. there are 47 test cases in script_test.rb which use ScriptDSL.parse, usually in combination with Script.add_unit. These fall into 3 categories:
1. testing ScriptDSL.parse logic
2. testing Script.add_unit logic
3. setting up objects to test other functionality

the test cases in category 1 can simply be removed. the goal of this PR is to make it easier to move categories 2 and 3 onto factories instead.

## Description

Here is an overview of the kinds of changes in this PR.

1. improve factories
    * update `:with_levels` trait to add lesson activities and activity sections
    * add `:with_lessons` and `lessons_count`
    * infer more position values and parent object relationships when possible
2. update tests
    * fix tests broken by factory changes
    * clean up and shorten existing uses of factories
    * convert 1-2 new tests in script_test.rb to start using the improved factories

If it's not clear why a test is being updated, please feel free to comment on it and I'll be happy to add more details.

## Testing story

* existing + updated unit test coverage
* the only change which is not test-only is the added association on the lesson model, which seems relatively safe

[PLAT-1506]: https://codedotorg.atlassian.net/browse/PLAT-1506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ