### PR TITLE
Add incomplete status to application dashboard

### DIFF
--- a/apps/src/code-studio/pd/application_dashboard/constants.js
+++ b/apps/src/code-studio/pd/application_dashboard/constants.js
@@ -17,6 +17,10 @@ export const StatusColors = {
     backgroundColor: color.charcoal,
     color: color.white
   },
+  incomplete: {
+    backgroundColor: color.lightest_cyan,
+    color: color.black
+  },
   pending: {
     backgroundColor: color.lighter_orange,
     color: color.black
@@ -79,6 +83,7 @@ export function getApplicationStatuses(type, addAutoEmail = true) {
   if (type === 'teacher') {
     return {
       unreviewed: 'Unreviewed',
+      incomplete: 'Incomplete',
       pending: 'Pending',
       waitlisted: `Waitlisted${autoEmailText(addAutoEmail)}`,
       declined: `Declined${autoEmailText(addAutoEmail)}`,

--- a/apps/test/unit/code-studio/pd/application_dashboard/detail_view_contentsTest.js
+++ b/apps/test/unit/code-studio/pd/application_dashboard/detail_view_contentsTest.js
@@ -445,13 +445,10 @@ describe('DetailViewContents', () => {
       });
     }
 
-    for (const applicationStatus of [
-      'unreviewed',
-      'pending',
-      'waitlisted',
-      'declined',
-      'withdrawn'
-    ]) {
+    for (const applicationStatus of _.difference(
+      Object.keys(getApplicationStatuses('teacher')),
+      ScholarshipStatusRequiredStatuses
+    )) {
       it(`is not required to set application status to ${applicationStatus}`, () => {
         detailView = mountDetailView('Teacher', {
           applicationData: {


### PR DESCRIPTION
Addresses _Req 3: While an application is incomplete it can be accessed by Regional Partners via a status titled “Incomplete”_.

I went ahead and did this one because I needed to create fake incomplete applications for Req 1.

I did the following:
- Added a teacher application status of "incomplete" to constants. The components do the rest of the work.
- I also updated a test that I don't think should need to be updated any time there's a status change that doesn't affect scholarships ... potentially a bit pedantic.
- See questions about testing below.

<img width="644" alt="Incomplete" src="https://user-images.githubusercontent.com/9142121/144691677-dd441d1b-9b29-43ec-90b0-85799e80c480.png">
<img width="848" alt="Actions" src="https://user-images.githubusercontent.com/9142121/144691683-9de58b6d-9282-45ba-a503-74317bbe4bb4.png">
<img width="876" alt="Filter by Status" src="https://user-images.githubusercontent.com/9142121/144691685-da1c7915-80f9-4742-83c1-f0b16c261ad1.png">

## Links

- spec: [Saving Progress and Reopening Applications](https://docs.google.com/document/d/1kbRAQ3To-MHVmz2KHnyaN6Mh6EiJk8F_zRNS1F8kSK8/edit?pli=1#heading=h.86qvf1hodt)
- jira ticket: [PLAT-1468](https://codedotorg.atlassian.net/browse/PLAT-1468)

## Testing story

I didn't find a great place for tests to go. Some options:
- Add to `'computes total applications'` test in `summary_table_test` by adding an incomplete application (inconsistent with only testing 'unreviewed' and 'accepted' right now)
- Modify `'Renders 1 table with the returned applications'` test in `quick_viewTest` and add more applications (currently tests with 1 unreviewed application)
- Something else? Test the filter in `quick_view_table`?

## Deployment strategy

## Follow-up work

## Privacy

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
