### PR TITLE
Remove sound sensor blocks from microbit list

### DIFF
--- a/apps/src/lib/kits/maker/boards/microBit/MicroBitConstants.js
+++ b/apps/src/lib/kits/maker/boards/microBit/MicroBitConstants.js
@@ -29,12 +29,7 @@ export const MB_COMPONENTS = [
 ];
 
 export const MB_BUTTON_VARS = ['buttonA', 'buttonB'];
-export const MB_SENSOR_VARS = [
-  'soundSensor',
-  'lightSensor',
-  'tempSensor',
-  'compass'
-];
+export const MB_SENSOR_VARS = ['lightSensor', 'tempSensor', 'compass'];
 
 // milliseconds between samples for sensors
 export const SAMPLE_INTERVAL = 50;

--- a/apps/src/lib/kits/maker/dropletConfig.js
+++ b/apps/src/lib/kits/maker/dropletConfig.js
@@ -549,36 +549,6 @@ const microBitBlocks = [
     category: MICROBIT_CATEGORY,
     type: 'property'
   },
-
-  {
-    func: 'soundSensor.start',
-    category: MICROBIT_CATEGORY,
-    noAutocomplete: true
-  },
-  {
-    func: 'soundSensor.value',
-    category: MICROBIT_CATEGORY,
-    type: 'readonlyproperty'
-  },
-  {
-    func: 'soundSensor.getAveragedValue',
-    category: MICROBIT_CATEGORY,
-    params: ['500'],
-    paletteParams: ['ms'],
-    type: 'value'
-  },
-  {
-    func: 'soundSensor.setScale',
-    category: MICROBIT_CATEGORY,
-    params: ['0', '100'],
-    paletteParams: ['low', 'high']
-  },
-  {
-    func: 'soundSensor.threshold',
-    category: MICROBIT_CATEGORY,
-    type: 'property'
-  },
-
   {
     func: 'compass.getHeading',
     category: MICROBIT_CATEGORY,


### PR DESCRIPTION
Removing the soundSensor blocks from the micro:bit API per their request. The remain in the Circuit Playground API.

Before:
![Screenshot from 2021-12-06 15-44-20](https://user-images.githubusercontent.com/2959170/144940383-d97c9e51-8512-4d26-aa53-188048d8b012.png)

After:
![Screenshot from 2021-12-06 15-36-04](https://user-images.githubusercontent.com/2959170/144940397-e1b7dc30-1997-4fe9-ae62-6ee0b59cdb70.png)

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
