### PR TITLE
Javalab: show left side of JavalabPanels when instructions contain level

### DIFF
--- a/apps/src/javalab/JavalabView.jsx
+++ b/apps/src/javalab/JavalabView.jsx
@@ -121,7 +121,7 @@ class JavalabView extends React.Component {
     // anything to show on the left side.
     return (
       this.props.viewMode !== CsaViewMode.CONSOLE ||
-      !!hasInstructions(shortInstructions, longInstructions, hasContainedLevels)
+      hasInstructions(shortInstructions, longInstructions, hasContainedLevels)
     );
   };
 

--- a/apps/src/javalab/JavalabView.jsx
+++ b/apps/src/javalab/JavalabView.jsx
@@ -54,7 +54,6 @@ class JavalabView extends React.Component {
     canRun: PropTypes.bool,
     canTest: PropTypes.bool,
     showProjectTemplateWorkspaceIcon: PropTypes.bool.isRequired,
-    shortInstructions: PropTypes.string,
     longInstructions: PropTypes.string,
     hasContainedLevels: PropTypes.bool,
     awaitingContainedResponse: PropTypes.bool,
@@ -112,16 +111,12 @@ class JavalabView extends React.Component {
   };
 
   isLeftSideVisible = () => {
-    const {
-      shortInstructions,
-      longInstructions,
-      hasContainedLevels
-    } = this.props;
+    const {longInstructions, hasContainedLevels} = this.props;
     // It's possible that a console level without instructions won't have
     // anything to show on the left side.
     return (
       this.props.viewMode !== CsaViewMode.CONSOLE ||
-      hasInstructions(shortInstructions, longInstructions, hasContainedLevels)
+      hasInstructions(null, longInstructions, hasContainedLevels)
     );
   };
 
@@ -313,7 +308,6 @@ export default connect(
     showProjectTemplateWorkspaceIcon: !!state.pageConstants
       .showProjectTemplateWorkspaceIcon,
     editorColumnHeight: state.javalab.editorColumnHeight,
-    shortInstructions: state.instructions.shortInstructions,
     longInstructions: state.instructions.longInstructions,
     hasContainedLevels: state.pageConstants.hasContainedLevels,
     awaitingContainedResponse: state.runState.awaitingContainedResponse,

--- a/apps/src/javalab/JavalabView.jsx
+++ b/apps/src/javalab/JavalabView.jsx
@@ -15,6 +15,7 @@ import StudioAppWrapper from '@cdo/apps/templates/StudioAppWrapper';
 import TopInstructions, {
   TabType
 } from '@cdo/apps/templates/instructions/TopInstructions';
+import {hasInstructions} from '@cdo/apps/templates/instructions/utils';
 import {VIEWING_CODE_REVIEW_URL_PARAM} from '@cdo/apps/templates/instructions/ReviewTab';
 import ControlButtons from './ControlButtons';
 import {CsaViewMode} from './constants';
@@ -53,7 +54,9 @@ class JavalabView extends React.Component {
     canRun: PropTypes.bool,
     canTest: PropTypes.bool,
     showProjectTemplateWorkspaceIcon: PropTypes.bool.isRequired,
+    shortInstructions: PropTypes.string,
     longInstructions: PropTypes.string,
+    hasContainedLevels: PropTypes.bool,
     awaitingContainedResponse: PropTypes.bool,
     isSubmittable: PropTypes.bool,
     isSubmitted: PropTypes.bool
@@ -109,11 +112,16 @@ class JavalabView extends React.Component {
   };
 
   isLeftSideVisible = () => {
+    const {
+      shortInstructions,
+      longInstructions,
+      hasContainedLevels
+    } = this.props;
     // It's possible that a console level without instructions won't have
     // anything to show on the left side.
     return (
       this.props.viewMode !== CsaViewMode.CONSOLE ||
-      !!this.props.longInstructions
+      !!hasInstructions(shortInstructions, longInstructions, hasContainedLevels)
     );
   };
 
@@ -305,7 +313,9 @@ export default connect(
     showProjectTemplateWorkspaceIcon: !!state.pageConstants
       .showProjectTemplateWorkspaceIcon,
     editorColumnHeight: state.javalab.editorColumnHeight,
+    shortInstructions: state.instructions.shortInstructions,
     longInstructions: state.instructions.longInstructions,
+    hasContainedLevels: state.pageConstants.hasContainedLevels,
     awaitingContainedResponse: state.runState.awaitingContainedResponse,
     disableFinishButton: state.javalab.disableFinishButton,
     isSubmittable: state.pageConstants.isSubmittable,


### PR DESCRIPTION
We have a bug report on a "predict" console-only level in Javalab, where the "Finish" button does not appear on the screen and our general panel layout looks wonky (see "Before fix" below).

Our layout manager (`JavalabPanels`) decides whether to render the left side of the lab (instructions, visualization area, left/right resizer) based on whether there are any instructions for that level -- this logic did not cover situations where we have no instructions, but have a "contained level" that is being rendered in the instructions area. I found a util function (`hasInstructions`) that broadens the logic for whether a level has instructions or not, which fixed this issue.

**Before fix**

![image](https://user-images.githubusercontent.com/25372625/144939538-ddd0e44b-5725-4ad5-bc70-ad37941940b6.png)

**After fix**

![image](https://user-images.githubusercontent.com/25372625/144939476-0ba4a7f6-751a-431c-aa43-28ac679e3021.png)

## Links

- jira ticket: [CSA-1087](https://codedotorg.atlassian.net/browse/CSA-1087)

## Testing story

Tested manually that this fixed a level where this issue was reported (/s/csa4-pilot/lessons/1/levels/1), and did not regress another predict level where we do not have this issue (/s/allthethings/lessons/44/levels/2).