### PR TITLE
Javalab: add default java file name

### DIFF
--- a/apps/i18n/javalab/en_us.json
+++ b/apps/i18n/javalab/en_us.json
@@ -66,6 +66,7 @@
   "internalException": "Oops. We hit an error on our side. Try running your program again. If this error continues, contact us at support@code.org. Be sure to include the connection ID {connectionId} in your message.",
   "internalRuntimeException": "Oops. We hit an error on our side while running your program. Try running it again. If this error continues, contact us at support@code.org. Be sure to include the connection ID {connectionId} in your message.",
   "invalidJavaFilename": "Invalid file name. Java file names cannot have spaces.",
+  "invalidJavaFilenameFormat": "Invalid file name. A Java file name must be in the format 'ClassName.java'.",
   "generatingResults": "Generating results...",
   "javaExtensionMissing": "Invalid file name. File names must end in '.java'.",
   "javabuilderInvalidClassError": "{causeMessage} is not supported by Java Lab.",

--- a/apps/src/javalab/JavalabEditor.jsx
+++ b/apps/src/javalab/JavalabEditor.jsx
@@ -46,6 +46,7 @@ const Dialog = makeEnum(
   'CREATE_FILE',
   'COMMIT_FILES'
 );
+const DEFAULT_FILE_NAME = '.java';
 
 class JavalabEditor extends React.Component {
   static propTypes = {
@@ -313,6 +314,13 @@ class JavalabEditor extends React.Component {
 
     if (!filename) {
       errorMessage = javalabMsg.missingFilenameError();
+    } else if (
+      filename === '.java' ||
+      (filename.toLowerCase().endsWith('.java') && !filename.endsWith('.java'))
+    ) {
+      // if filename is either only '.java' or ends with a non-lowercase casing of '.java',
+      // give an error with an example Java filename.
+      errorMessage = javalabMsg.invalidJavaFilenameFormat();
     } else if (filename.endsWith('.java') && /\s/g.test(filename)) {
       // Java file names cannot contains spaces
       errorMessage = javalabMsg.invalidJavaFilename();
@@ -728,6 +736,7 @@ class JavalabEditor extends React.Component {
           inputLabel="Create new file"
           saveButtonText="Create"
           errorMessage={newFileError}
+          filename={DEFAULT_FILE_NAME}
         />
         <CommitDialog
           isOpen={openDialog === Dialog.COMMIT_FILES}


### PR DESCRIPTION
Add a default file name of '.java' in Javalab, and add an error if the user tries to save a file that is either named '.java' or ends with '.java' in an incorrect casing (anything but all lower case). This will help with the issue we are seeing where students are using incorrect casing of '.java' in their filenames.

New error message:
<img width="530" alt="Screen Shot 2021-12-06 at 3 57 09 PM" src="https://user-images.githubusercontent.com/33666587/144941487-c8353107-26a8-4663-bf27-e1c2ffe09797.png">

## Links

- jira ticket: [CSA-963](https://codedotorg.atlassian.net/browse/CSA-963)

## Testing story
Tested locally

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
