### PR TITLE
Always create a course offering when creating a course version with factories

### DIFF
--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -11,6 +11,7 @@ FactoryGirl.define do
   factory :course_version do
     sequence(:key) {|n| "202#{n - 1}"}
     sequence(:display_name) {|n| "2#{n - 1}-2#{n}"}
+    association :course_offering
     with_unit_group
 
     trait :with_unit_group do
@@ -19,10 +20,6 @@ FactoryGirl.define do
 
     trait :with_unit do
       association(:content_root, factory: :script, is_course: true)
-    end
-
-    trait :with_course_offering do
-      association :course_offering
     end
   end
 

--- a/dashboard/test/models/course_version_test.rb
+++ b/dashboard/test/models/course_version_test.rb
@@ -20,7 +20,7 @@ class CourseVersionTest < ActiveSupport::TestCase
   end
 
   test "add_course_version updates existing CourseVersion for script if properties change" do
-    course_version = create :course_version, :with_unit, :with_course_offering
+    course_version = create :course_version, :with_unit
     script = course_version.content_root
     offering = course_version.course_offering
 
@@ -35,7 +35,7 @@ class CourseVersionTest < ActiveSupport::TestCase
   end
 
   test "add_course_version deletes CourseVersion for script if is_course is changed to false" do
-    course_version = create :course_version, :with_unit, :with_course_offering
+    course_version = create :course_version, :with_unit
     script = course_version.content_root
     offering = course_version.course_offering
 
@@ -59,7 +59,7 @@ class CourseVersionTest < ActiveSupport::TestCase
   end
 
   test "destroy_and_destroy_parent_if_empty destroys version and offering for offering with one version" do
-    course_version = create :course_version, :with_course_offering
+    course_version = create :course_version
     offering = course_version.course_offering
 
     course_version.destroy_and_destroy_parent_if_empty
@@ -68,7 +68,7 @@ class CourseVersionTest < ActiveSupport::TestCase
   end
 
   test "destroy_and_destroy_parent_if_empty destroys version only for offering with multiple versions" do
-    course_version = create :course_version, :with_course_offering
+    course_version = create :course_version
     offering = course_version.course_offering
     create :course_version, course_offering: offering
 

--- a/dashboard/test/models/course_version_test.rb
+++ b/dashboard/test/models/course_version_test.rb
@@ -79,7 +79,7 @@ class CourseVersionTest < ActiveSupport::TestCase
 
   test "destroy_and_destroy_parent_if_empty destroys version for version with no offering" do
     # This case shouldn't occur normally, but may exist temporarily because the CourseOffering model was added after CourseVersion.
-    course_version = create :course_version
+    course_version = create :course_version, course_offering: nil
     assert_nil course_version.course_offering
 
     course_version.destroy_and_destroy_parent_if_empty

--- a/dashboard/test/models/resource_test.rb
+++ b/dashboard/test/models/resource_test.rb
@@ -156,7 +156,7 @@ class ResourceTest < ActiveSupport::TestCase
     custom_i18n = {
       "data" => {
         "resources" => {
-          resource.key => {
+          Services::GloballyUniqueIdentifiers.build_resource_key(resource) => {
             "name" => "Translated name"
           }
         }


### PR DESCRIPTION
Our application in general expects a course offering to be present on course versions, so this is just codifying this in test.

I did this because I was annoyed by the 
```
Resource object "fake_name" is missing course version and/or offering
Resource object "fake_name" is missing course version and/or offering
Resource object "fake_name" is missing course version and/or offering
Resource object "fake_name" is missing course version and/or offering
Vocabulary object "vocab_a" is missing course version and/or offering
Vocabulary object "vocab_a" is missing course version and/or offering
...
```
messages in testing (locally, drone, test). This PR fixes most of those. There is one test (caching_test) that uses fixtures, which also create course versions with nil course offerings, but I decided not to fix those in this PR.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->




## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
