### PR TITLE
Set hide-as-student content appropriately 

### DIFF
--- a/apps/src/code-studio/components/progress/ViewAsToggle.jsx
+++ b/apps/src/code-studio/components/progress/ViewAsToggle.jsx
@@ -19,11 +19,20 @@ class ViewAsToggle extends React.Component {
   };
 
   componentDidMount() {
-    // Upon loading, toggle hide-as-student appropriately (this is so that if we
-    // load a page with ?viewAs=Participant we still hide stuff)
-    const {viewAs} = this.props;
-    $('.hide-as-student').toggle(viewAs === ViewType.Instructor);
+    this.setHideAsStudent(this.props.viewAs);
   }
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.viewAs !== this.props.viewAs) {
+      this.setHideAsStudent(nextProps.viewAs);
+    }
+  }
+
+  setHideAsStudent = viewAs => {
+    // Toggle hide-as-student appropriately (this is so that if we
+    // load a page with ?viewAs=Participant we still hide teacher-only content)
+    $('.hide-as-student').toggle(viewAs === ViewType.Instructor);
+  };
 
   onChange = viewType => {
     const {changeViewType} = this.props;

--- a/apps/src/code-studio/components/progress/ViewAsToggle.jsx
+++ b/apps/src/code-studio/components/progress/ViewAsToggle.jsx
@@ -5,7 +5,7 @@ import {connect} from 'react-redux';
 import commonMsg from '@cdo/locale';
 import ToggleGroup from '@cdo/apps/templates/ToggleGroup';
 import {ViewType, changeViewType} from '../../viewAsRedux';
-import {queryParams, updateQueryParam} from '@cdo/apps/code-studio/utils';
+import {updateQueryParam} from '@cdo/apps/code-studio/utils';
 
 /**
  * Toggle that lets us change between seeing a page as a teacher, or as the
@@ -19,40 +19,30 @@ class ViewAsToggle extends React.Component {
   };
 
   componentDidMount() {
-    this.setHideAsStudent(this.props.viewAs);
+    this.toggleHideAsStudent(this.props.viewAs);
   }
 
   componentWillReceiveProps(nextProps) {
     if (nextProps.viewAs !== this.props.viewAs) {
-      this.setHideAsStudent(nextProps.viewAs);
+      this.toggleHideAsStudent(nextProps.viewAs);
     }
   }
 
-  setHideAsStudent = viewAs => {
+  toggleHideAsStudent = viewAs => {
     // Toggle hide-as-student appropriately (this is so that if we
     // load a page with ?viewAs=Participant we still hide teacher-only content)
     $('.hide-as-student').toggle(viewAs === ViewType.Instructor);
   };
 
   onChange = viewType => {
-    const {changeViewType} = this.props;
+    const {changeViewType, logToFirehose} = this.props;
 
     updateQueryParam('viewAs', viewType);
 
-    if (viewType === ViewType.Participant && queryParams('user_id')) {
-      // In this case, the changeViewType thunk is going to do a reload and we dont
-      // want to change our UI.
-    } else {
-      // Ideally all the things we would want to hide would be redux backed, and
-      // would just update automatically. However, we're not in such a world. Instead,
-      // explicitly hide or show elements with this class name based on new toggle state.
-      $('.hide-as-student').toggle(viewType === ViewType.Instructor);
-    }
-
     changeViewType(viewType);
 
-    if (this.props.logToFirehose) {
-      this.props.logToFirehose('toggle_view', {view_type: viewType});
+    if (logToFirehose) {
+      logToFirehose('toggle_view', {view_type: viewType});
     }
   };
 

--- a/apps/src/code-studio/components/progress/ViewAsToggle.jsx
+++ b/apps/src/code-studio/components/progress/ViewAsToggle.jsx
@@ -4,7 +4,7 @@ import React from 'react';
 import {connect} from 'react-redux';
 import commonMsg from '@cdo/locale';
 import ToggleGroup from '@cdo/apps/templates/ToggleGroup';
-import {ViewType, changeViewType} from '../../viewAsRedux';
+import {ViewType, changeViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import {updateQueryParam} from '@cdo/apps/code-studio/utils';
 
 /**

--- a/apps/test/unit/code-studio/components/progress/ViewAsToggleTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/ViewAsToggleTest.jsx
@@ -1,19 +1,60 @@
 import React from 'react';
+import $ from 'jquery';
 import {shallow} from 'enzyme';
 import sinon from 'sinon';
 import {expect} from '../../../../util/reconfiguredChai';
 import {UnconnectedViewAsToggle as ViewAsToggle} from '@cdo/apps/code-studio/components/progress/ViewAsToggle';
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 
+const DEFAULT_PROPS = {
+  viewAs: ViewType.Participant,
+  changeViewType: () => {},
+  logToFirehose: () => {}
+};
+
+const setUp = (overrideProps = {}) => {
+  const props = {...DEFAULT_PROPS, ...overrideProps};
+  return shallow(<ViewAsToggle {...props} />);
+};
+
 describe('ViewAsToggle', () => {
   it('calls changeViewType when ToggleGroup changes', () => {
     const spy = sinon.spy();
-    const wrapper = shallow(
-      <ViewAsToggle viewAs={ViewType.Participant} changeViewType={spy} />
-    );
+    const wrapper = setUp({changeViewType: spy});
     expect(spy).not.to.have.been.called;
 
     wrapper.find('Connect(ToggleGroup)').prop('onChange')(ViewType.Instructor);
     expect(spy).to.have.been.calledOnce.and.calledWith(ViewType.Instructor);
+  });
+
+  describe('toggle hide-as-student', () => {
+    let toggleSpy;
+    beforeEach(() => {
+      toggleSpy = sinon.spy($.fn, 'toggle');
+    });
+
+    afterEach(() => {
+      $.fn.toggle.restore();
+    });
+
+    it('calls toggle(true) if viewAs=Instructor', async () => {
+      setUp({viewAs: ViewType.Instructor});
+      expect(toggleSpy).to.have.been.calledWith(true);
+    });
+
+    it('calls toggle(false) if viewAs=Participant', async () => {
+      setUp({viewAs: ViewType.Participant});
+      expect(toggleSpy).to.have.been.calledWith(false);
+    });
+
+    it('calls toggle(true) if viewAs is updated to Instructor from Participant', async () => {
+      const wrapper = setUp({viewAs: ViewType.Participant});
+
+      expect(toggleSpy).to.have.been.calledWith(false);
+
+      wrapper.setProps({viewAs: ViewType.Instructor});
+
+      expect(toggleSpy).to.have.been.calledWith(true);
+    });
   });
 });


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
https://github.com/code-dot-org/code-dot-org/pull/43522 updated redux viewAs to be set a bit later (in componentDidMount of TeacherPanel instead of on load). The ViewAsToggle component was relying on `viewAs` to be set when the component mounted to toggle teacher-only content on pages rendered by haml. Since `viewAs` is now set a bit later, the ViewAsToggle component needed to be updated to handle changes to the `viewAs` prop.

Thanks @dmcavoy for catching this issue!



https://user-images.githubusercontent.com/24235215/145083613-922503af-a327-4a9c-8e4b-25a00f8d13f8.mov



## Links
Breaking PR: https://github.com/code-dot-org/code-dot-org/pull/43522
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
I've tested that this works as expected on a submit level manually. This would have been caught by eyes tests if they had been running on staging-next.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
