### PR TITLE
stop writing .script files

### DIFF
--- a/bin/curriculum/import_hoc_lesson_plan.rb
+++ b/bin/curriculum/import_hoc_lesson_plan.rb
@@ -126,7 +126,6 @@ def main(options)
     end
 
     unit.fix_script_level_positions
-    unit.write_script_dsl
     unit.write_script_json
 
     puts "successfully updated unit #{unit.name}"

--- a/bin/curriculum/import_unit_details.rb
+++ b/bin/curriculum/import_unit_details.rb
@@ -129,7 +129,6 @@ def main(options)
 
     script.update!(show_calendar: !!cb_unit['show_calendar'], is_migrated: true)
     script.fix_script_level_positions
-    script.write_script_dsl
     script.write_script_json
 
     puts "updated #{updated_lesson_group_count} lesson groups in unit #{script.name}"

--- a/bin/curriculum/migrate_teacher_resources.rb
+++ b/bin/curriculum/migrate_teacher_resources.rb
@@ -39,7 +39,6 @@ def migrate_resources_for_scripts
     script.teacher_resources = [] unless ScriptConstants.i18n?(script.name)
 
     script.save!
-    script.write_script_dsl
     script.write_script_json
     puts "Migrated teacher resources for #{script.name}"
   end

--- a/bin/curriculum/migrate_unit.rb
+++ b/bin/curriculum/migrate_unit.rb
@@ -91,7 +91,6 @@ def main(options)
       skip_name_format_validation: true
     )
     script.fix_script_level_positions
-    script.write_script_dsl
     script.write_script_json
 
     log "updated unit #{script.name}"

--- a/dashboard/app/dsl/script_dsl.rb
+++ b/dashboard/app/dsl/script_dsl.rb
@@ -297,6 +297,7 @@ class ScriptDSL < BaseDSL
     super(filename, name || File.basename(filename, '.script'))
   end
 
+  # TODO
   def self.serialize(script, filename)
     File.write(filename, serialize_to_string(script))
   end

--- a/dashboard/app/dsl/script_dsl.rb
+++ b/dashboard/app/dsl/script_dsl.rb
@@ -297,7 +297,6 @@ class ScriptDSL < BaseDSL
     super(filename, name || File.basename(filename, '.script'))
   end
 
-  # TODO
   def self.serialize(script, filename)
     File.write(filename, serialize_to_string(script))
   end

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1052,57 +1052,6 @@ class Script < ApplicationRecord
     get_course_version&.course_offering&.course_versions&.many?
   end
 
-  # Create or update any units, script levels and lessons specified in the
-  # script file definitions. If new_suffix is specified, create a copy of the
-  # unit and any associated levels, appending new_suffix to the name when
-  # copying. Any new_properties are merged into the properties of the new unit.
-  def self.setup(custom_files, new_suffix: nil, new_properties: {}, show_progress: false)
-    units_to_add = []
-
-    custom_i18n = {}
-    # Load custom units from Script DSL format
-    custom_files.map do |unit|
-      name = File.basename(unit, '.script')
-      base_name = Script.base_name(name)
-      name = "#{base_name}-#{new_suffix}" if new_suffix
-      unit_data, i18n =
-        begin
-          ScriptDSL.parse_file(unit, name)
-        rescue => e
-          raise e, "Error parsing script file #{unit}: #{e}"
-        end
-
-      lesson_groups = unit_data[:lesson_groups]
-      custom_i18n.deep_merge!(i18n)
-      # TODO: below is duplicated in update_text. and maybe can be refactored to pass unit_data?
-      units_to_add << [{
-        id: unit_data[:id],
-        name: name,
-        login_required: unit_data[:login_required].nil? ? false : unit_data[:login_required], # default false
-        wrapup_video: unit_data[:wrapup_video],
-        new_name: unit_data[:new_name],
-        family_name: unit_data[:family_name],
-        published_state: new_suffix ? SharedCourseConstants::PUBLISHED_STATE.in_development : unit_data[:published_state],
-        instruction_type: new_suffix ? SharedCourseConstants::INSTRUCTION_TYPE.teacher_led : unit_data[:instruction_type],
-        participant_audience: new_suffix ? SharedCourseConstants::PARTICIPANT_AUDIENCE.student : unit_data[:participant_audience],
-        instructor_audience: new_suffix ? SharedCourseConstants::INSTRUCTOR_AUDIENCE.teacher : unit_data[:instructor_audience],
-        properties: Script.build_property_hash(unit_data).merge(new_properties)
-      }, lesson_groups]
-    end
-
-    progressbar = ProgressBar.create(total: units_to_add.length, format: '%t (%c/%C): |%B|') if show_progress
-
-    # Stable sort by ID then add each unit, ensuring units with no ID end up at the end
-    added_unit_names = units_to_add.sort_by.with_index {|args, idx| [args[0][:id] || Float::INFINITY, idx]}.map do |options, _raw_lesson_groups|
-      added_unit = seed_from_json_file(options[:name])
-      progressbar.increment if show_progress
-      added_unit.name
-    rescue => e
-      raise e, "Error adding unit named '#{options[:name]}': #{e}", e.backtrace
-    end
-    [added_unit_names, custom_i18n]
-  end
-
   # if new_suffix is specified, copy the unit, hide it, and copy all its
   # levelbuilder-defined levels.
   def self.add_unit(options, raw_lesson_groups, new_suffix: nil, editor_experiment: nil)

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1223,7 +1223,6 @@ class Script < ApplicationRecord
       if Rails.application.config.levelbuilder_mode
         copy_and_write_i18n(new_name)
         copied_unit.write_script_json
-        copied_unit.write_script_dsl
       end
 
       copied_unit
@@ -1336,14 +1335,7 @@ class Script < ApplicationRecord
     begin
       if Rails.application.config.levelbuilder_mode
         unit = Script.find_by_name(unit_name)
-        # Save in our custom Script DSL format. This is how we currently sync
-        # data across environments for non-migrated units.
-        unit.write_script_dsl
-
-        # Also save in JSON format for "new seeding". This is how we currently
-        # sync data across environments for migrated units. As part of
-        # pre-launch testing, we also generate these files for legacy units in
-        # addition to the old .script files.
+        # Save in our custom JSON format. This is how we sync data across environments.
         unit.write_script_json
       end
       true
@@ -1351,11 +1343,6 @@ class Script < ApplicationRecord
       errors.add(:base, e.to_s)
       return false
     end
-  end
-
-  def write_script_dsl
-    script_dsl_filepath = "#{Rails.root}/config/scripts/#{name}.script"
-    ScriptDSL.serialize(self, script_dsl_filepath)
   end
 
   def write_script_json

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -372,7 +372,6 @@ class ScriptsControllerTest < ActionController::TestCase
   test 'create' do
     unit_name = 'test-unit-create'
     File.stubs(:write).with {|filename, _| filename.end_with? 'scripts.en.yml'}.once
-    File.stubs(:write).with("#{Rails.root}/config/scripts/#{unit_name}.script", "is_migrated true\n").once
     File.stubs(:write).with do |filename, contents|
       filename == "#{Rails.root}/config/scripts_json/#{unit_name}.script_json" && JSON.parse(contents)['script']['name'] == unit_name
     end
@@ -447,7 +446,6 @@ class ScriptsControllerTest < ActionController::TestCase
 
     unit = create :script, published_state: SharedCourseConstants::PUBLISHED_STATE.beta
     File.stubs(:write).with {|filename, _| filename.end_with? 'scripts.en.yml'}.once
-    File.stubs(:write).with {|filename, _| filename == "#{Rails.root}/config/scripts/#{unit.name}.script"}.once
     File.stubs(:write).with do |filename, contents|
       filename == "#{Rails.root}/config/scripts_json/#{unit.name}.script_json" && JSON.parse(contents)['script']['name'] == unit.name
     end
@@ -469,7 +467,6 @@ class ScriptsControllerTest < ActionController::TestCase
 
     unit = create :script, instruction_type: SharedCourseConstants::INSTRUCTION_TYPE.teacher_led
     File.stubs(:write).with {|filename, _| filename.end_with? 'scripts.en.yml'}.once
-    File.stubs(:write).with {|filename, _| filename == "#{Rails.root}/config/scripts/#{unit.name}.script"}.once
     File.stubs(:write).with do |filename, contents|
       filename == "#{Rails.root}/config/scripts_json/#{unit.name}.script_json" && JSON.parse(contents)['script']['name'] == unit.name
     end
@@ -491,7 +488,6 @@ class ScriptsControllerTest < ActionController::TestCase
 
     unit = create :script, published_state: SharedCourseConstants::PUBLISHED_STATE.beta
     File.stubs(:write).with {|filename, _| filename.end_with? 'scripts.en.yml'}.once
-    File.stubs(:write).with {|filename, _| filename == "#{Rails.root}/config/scripts/#{unit.name}.script"}.once
     File.stubs(:write).with do |filename, contents|
       filename == "#{Rails.root}/config/scripts_json/#{unit.name}.script_json" && JSON.parse(contents)['script']['name'] == unit.name
     end
@@ -513,7 +509,6 @@ class ScriptsControllerTest < ActionController::TestCase
 
     unit = create :script, published_state: SharedCourseConstants::PUBLISHED_STATE.preview
     File.stubs(:write).with {|filename, _| filename.end_with? 'scripts.en.yml'}.once
-    File.stubs(:write).with {|filename, _| filename == "#{Rails.root}/config/scripts/#{unit.name}.script"}.once
     File.stubs(:write).with do |filename, contents|
       filename == "#{Rails.root}/config/scripts_json/#{unit.name}.script_json" && JSON.parse(contents)['script']['name'] == unit.name
     end
@@ -536,7 +531,6 @@ class ScriptsControllerTest < ActionController::TestCase
 
     unit = create :script, published_state: SharedCourseConstants::PUBLISHED_STATE.preview
     File.stubs(:write).with {|filename, _| filename.end_with? 'scripts.en.yml'}.once
-    File.stubs(:write).with {|filename, _| filename == "#{Rails.root}/config/scripts/#{unit.name}.script"}.once
     File.stubs(:write).with do |filename, contents|
       filename == "#{Rails.root}/config/scripts_json/#{unit.name}.script_json" && JSON.parse(contents)['script']['name'] == unit.name
     end
@@ -558,7 +552,6 @@ class ScriptsControllerTest < ActionController::TestCase
 
     unit = create :script, published_state: SharedCourseConstants::PUBLISHED_STATE.beta
     File.stubs(:write).with {|filename, _| filename.end_with? 'scripts.en.yml'}.once
-    File.stubs(:write).with {|filename, _| filename == "#{Rails.root}/config/scripts/#{unit.name}.script"}.once
     File.stubs(:write).with do |filename, contents|
       filename == "#{Rails.root}/config/scripts_json/#{unit.name}.script_json" && JSON.parse(contents)['script']['name'] == unit.name
     end
@@ -580,7 +573,6 @@ class ScriptsControllerTest < ActionController::TestCase
 
     unit = create :script, published_state: SharedCourseConstants::PUBLISHED_STATE.beta
     File.stubs(:write).with {|filename, _| filename.end_with? 'scripts.en.yml'}.once
-    File.stubs(:write).with {|filename, _| filename == "#{Rails.root}/config/scripts/#{unit.name}.script"}.once
     File.stubs(:write).with do |filename, contents|
       filename == "#{Rails.root}/config/scripts_json/#{unit.name}.script_json" && JSON.parse(contents)['script']['name'] == unit.name
     end


### PR DESCRIPTION
continues on [PLAT-858]. I set out to remove some dead code, and then I realized that we were actually still writing .script files even though I had removed all existing .script files in https://github.com/code-dot-org/code-dot-org/pull/43933. 

This PR does the following:
* removes `write_script_dsl` and all calls to it
* removes unused `Script.setup`

While there is some more dead code in script_dsl.rb that could technically be removed right now, I'm planning to hold off until ScriptDSL is completely unused and then just remove that entire file. 

## Testing story

* existing unit test coverage
* the 3rd commit fixes all the unit tests that we're failing in the 2nd commit. I'll wait for a green drone run before merging.


[PLAT-858]: https://codedotorg.atlassian.net/browse/PLAT-858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ