### PR TITLE
Remove Spotify Dataset Deprecation Warning

### DIFF
--- a/apps/i18n/applab/en_us.json
+++ b/apps/i18n/applab/en_us.json
@@ -19,7 +19,6 @@
   "designWorkspaceHeader": "Workspace",
   "designElementPhotoSelectClickName": "Change",
   "designElementPhotoSelectClickDescription": "Triggered when a photo is selected.",
-  "deprecatedDataset": "The {name} dataset used in this project is being removed on Dec. 1. Consider using the supported {alternative} dataset instead.",
   "dropletBlock_appendItem_description": "Append the item to the end of the array.",
   "dropletBlock_appendItem_param0_description": "The array to be modified.",
   "dropletBlock_appendItem_param1_description": "The item to add to the end of the array.",

--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -89,14 +89,6 @@ import {MB_API} from '../lib/kits/maker/boards/microBit/MicroBitConstants';
 import autogenerateML from '@cdo/apps/applab/ai';
 
 /**
- * Constants for Spotify dataset alert
- */
-const TOP_200_USA = 'Top 200 USA';
-const TOP_200_Worldwide = 'Top 200 Worldwide';
-const TOP_50_USA = 'Top 50 USA';
-const TOP_50_Worldwide = 'Top 50 Worldwide';
-
-/**
  * Create a namespace for the application.
  * @implements LogTarget
  */
@@ -954,7 +946,6 @@ function setupReduxSubscribers(store) {
       let tableName =
         typeof snapshot.key === 'function' ? snapshot.key() : snapshot.key;
       tableName = unescapeFirebaseKey(tableName);
-      checkDataSetForWarning(tableName);
       store.dispatch(addTableName(tableName, tableType.SHARED));
     });
     currentTableRef.on('child_removed', snapshot => {
@@ -964,28 +955,6 @@ function setupReduxSubscribers(store) {
       store.dispatch(deleteTableName(tableName));
     });
   }
-}
-
-/**
- * Show warning if project is using spotify datasets that will be deprecated.
- * To be removed once old datasets are removed (https://codedotorg.atlassian.net/browse/STAR-1797)
- */
-function checkDataSetForWarning(tableName) {
-  // Only two datasets will need to be handled: TOP_200_USA and TOP_200_WORLDWIDE
-  if (tableName !== TOP_200_USA && tableName !== TOP_200_Worldwide) {
-    return;
-  }
-
-  const msg = applabMsg.deprecatedDataset({
-    name: tableName === TOP_200_USA ? TOP_200_USA : TOP_200_Worldwide,
-    alternative: tableName === TOP_200_USA ? TOP_50_USA : TOP_50_Worldwide
-  });
-
-  studioApp().displayWorkspaceAlert(
-    'warning',
-    <div>{msg}</div>,
-    true /* bottom */
-  );
 }
 
 Applab.onIsRunningChange = function() {

--- a/i18n/locales/source/blockly-mooc/applab.json
+++ b/i18n/locales/source/blockly-mooc/applab.json
@@ -19,7 +19,6 @@
   "designWorkspaceHeader": "Workspace",
   "designElementPhotoSelectClickName": "Change",
   "designElementPhotoSelectClickDescription": "Triggered when a photo is selected.",
-  "deprecatedDataset": "The {name} dataset used in this project is being removed on Dec. 1. Consider using the supported {alternative} dataset instead.",
   "dropletBlock_appendItem_description": "Append the item to the end of the array.",
   "dropletBlock_appendItem_param0_description": "The array to be modified.",
   "dropletBlock_appendItem_param1_description": "The item to add to the end of the array.",


### PR DESCRIPTION
Removes code added to display a warning to users that were using the top 200 spotify dataset in their AppLab projects. 

[Previous PR to add warning](https://github.com/code-dot-org/code-dot-org/pull/43008)

## Links
[Jira Ticket](https://codedotorg.atlassian.net/browse/STAR-1797)


## Non-code Related Changes
- Top 200 datasets have been removed from the dataset manifest and are reflected in Prod 
- Top 200 datasets have been removed from firebase 

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
