### PR TITLE
Fix immersive reader rendering under instructions

### DIFF
--- a/apps/src/util/immersive_reader.js
+++ b/apps/src/util/immersive_reader.js
@@ -41,7 +41,7 @@ export default function handleLaunchImmersiveReader(locale, title, text) {
           }
         ]
       };
-      launchAsync(token, subdomain, data, {});
+      launchAsync(token, subdomain, data, {uiZIndex: 2113});
     })
     .catch(function(error) {
       console.error(error);

--- a/locals.yml.default
+++ b/locals.yml.default
@@ -114,3 +114,9 @@ use_my_apps: true
 #twilio_sid:
 #twilio_auth:
 #twilio_messaging_service:
+
+# Tokens for immersive reader
+# imm_reader_tenant_id:     ''
+# imm_reader_client_id:     ''
+# imm_reader_client_secret: ''
+# imm_reader_subdomain:     'cdo-immersive-reader-staging'


### PR DESCRIPTION
Add immersive reader token templates to locals.yml.default.
Add z-index to immersive reader so it always renders on top of the instructions.

## Links

- jira ticket: [FND-1832](https://codedotorg.atlassian.net/browse/FND-1832)
