### PR TITLE
[Applab][Maker Toolkit] Board-specific lint ignores

### DIFF
--- a/apps/src/lib/kits/maker/dropletConfig.js
+++ b/apps/src/lib/kits/maker/dropletConfig.js
@@ -12,6 +12,7 @@ import {
 
 import {
   MB_BUTTON_VARS,
+  MB_SENSOR_VARS,
   MB_COMPONENT_EVENTS
 } from './boards/microBit/MicroBitConstants';
 
@@ -63,11 +64,6 @@ function getBoardEventDropdownForParam(firstParam, componentEvents) {
     .value();
 }
 config.getBoardEventDropdownForParam = getBoardEventDropdownForParam;
-
-// We don't want these to show up as blocks (because that interferes with
-// parameter dropdowns) but we also don't want them to generate "_ is not
-// defined" warnings from the linter.
-config.additionalPredefValues = Object.keys(CP_COMPONENT_EVENTS);
 
 // Block properties we'll reuse in multiple entries
 const createLedProps = {
@@ -583,7 +579,8 @@ export let configMicrobit = {
       blocks: []
     }
   },
-  blocks: [...makerBlocks, ...microBitBlocks]
+  blocks: [...makerBlocks, ...microBitBlocks],
+  additionalPredefValues: [...MB_BUTTON_VARS, ...MB_SENSOR_VARS]
 };
 
 export let configCircuitPlayground = {
@@ -594,5 +591,6 @@ export let configCircuitPlayground = {
       blocks: []
     }
   },
-  blocks: [...makerBlocks, ...circuitPlaygroundBlocks]
+  blocks: [...makerBlocks, ...circuitPlaygroundBlocks],
+  additionalPredefValues: Object.keys(CP_COMPONENT_EVENTS)
 };


### PR DESCRIPTION
Eliminate lint errors for `buttonA`, `buttonB`, and `compass` for micro:bit projects

Before
micro:bit
![image](https://user-images.githubusercontent.com/8787187/145104924-f12608bd-1ed8-4412-81e6-cf219bc863e1.png)
circuit playground
![image](https://user-images.githubusercontent.com/8787187/145105033-0cd50868-8a1a-4b56-b3d8-dd9fa8ac9217.png)

After
micro:bit
![image](https://user-images.githubusercontent.com/8787187/145104805-ce831ec9-f4ba-4d7d-8257-6ef3e1246ac4.png)
circuit playground
![image](https://user-images.githubusercontent.com/8787187/145104843-bfc9c9e8-dc76-473e-9b4a-52d26cbc1a40.png)
