### PR TITLE
Add check for prewiredComponents

### DIFF
--- a/apps/src/lib/kits/maker/boards/circuitPlayground/CircuitPlaygroundBoard.js
+++ b/apps/src/lib/kits/maker/boards/circuitPlayground/CircuitPlaygroundBoard.js
@@ -266,10 +266,12 @@ export default class CircuitPlaygroundBoard extends EventEmitter {
       this.logWithFirehose('serial-port-undefined');
     }
 
-    cleanupCircuitPlaygroundComponents(
-      this.prewiredComponents_,
-      false /* shouldDestroyComponents */
-    );
+    if (this.prewiredComponents_) {
+      cleanupCircuitPlaygroundComponents(
+        this.prewiredComponents_,
+        false /* shouldDestroyComponents */
+      );
+    }
   }
 
   /**


### PR DESCRIPTION
Follow up from: [only clear serial port if defined](https://github.com/code-dot-org/code-dot-org/pull/43732)

After fixing the issue with the null serial port, we were getting a different issue where `cleanupCircuitPlaygroundComponents` was erroring out because `this.prewiredComponents_` was null. 

Elsewhere in the `CircuitPlaygroundBoard` code, `cleanupCircuitPlaygroundComponents` is in side an if statement that checks that prewiredComponents is not null so we are continuing that pattern here to fix the issue. 

## Deployment strategy
- This will be deployed to `staging-next` and we will test the fix in that environment once it's merged (since we cannot repro locally) 
- If this change causes other issues we will make sure to revert by Friday, Dec 10 so that the changes aren't deployed once we return back to non-restricted deploys

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
