### PR TITLE
[Google Blockly] Enable setting the blockly version to Cdo with url param

### DIFF
--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -134,7 +134,7 @@ class LevelsController < ApplicationController
       full_width: true,
       small_footer: @game.uses_small_footer? || @level.enable_scrolling?,
       has_i18n: @game.has_i18n?,
-      useGoogleBlockly: params[:blocklyVersion] == "Google"
+      blocklyVersion: params[:blocklyVersion]
     )
   end
 

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -530,7 +530,7 @@ class ScriptLevelsController < ApplicationController
       has_i18n: @game.has_i18n?,
       is_challenge_level: @script_level.challenge,
       is_bonus_level: @script_level.bonus,
-      useGoogleBlockly: params[:blocklyVersion] == "Google",
+      blocklyVersion: params[:blocklyVersion],
       azure_speech_service_voices: azure_speech_service_options[:voices],
       authenticity_token: form_authenticity_token,
       disallowed_html_tags: disallowed_html_tags

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -390,8 +390,8 @@ module LevelsHelper
   #  3. The disable_google_blockly DCDO flag, which contains an array of strings corresponding to model class names.
   #     This option will override #2 as an "emergency switch" to go back to CDO Blockly.
   def use_google_blockly
-    return true if view_options[:blocklyVersion] == 'Google'
-    return false if view_options[:blocklyVersion] == 'Cdo'
+    return true if view_options[:blocklyVersion]&.downcase == 'google'
+    return false if view_options[:blocklyVersion]&.downcase == 'cdo'
     return false unless @level.uses_google_blockly?
 
     # Only check DCDO flag if level type uses Google Blockly to avoid performance hit.

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -390,7 +390,8 @@ module LevelsHelper
   #  3. The disable_google_blockly DCDO flag, which contains an array of strings corresponding to model class names.
   #     This option will override #2 as an "emergency switch" to go back to CDO Blockly.
   def use_google_blockly
-    return true if view_options[:useGoogleBlockly]
+    return true if view_options[:blocklyVersion] == 'Google'
+    return false if view_options[:blocklyVersion] == 'Cdo'
     return false unless @level.uses_google_blockly?
 
     # Only check DCDO flag if level type uses Google Blockly to avoid performance hit.

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -384,7 +384,7 @@ module LevelsHelper
   end
 
   # As we migrate labs from CDO to Google Blockly, there are multiple ways to determine which version a lab uses:
-  #  1. Setting the useGoogleBlockly view_option, usually configured by a URL parameter.
+  #  1. Setting the blocklyVersion view_option, usually configured by a URL parameter.
   #  2. The corresponding inherited Level model can override Level#uses_google_blockly?. This option is for labs that
   #     have fully transitioned to Google Blockly.
   #  3. The disable_google_blockly DCDO flag, which contains an array of strings corresponding to model class names.

--- a/dashboard/app/helpers/view_options_helper.rb
+++ b/dashboard/app/helpers/view_options_helper.rb
@@ -38,7 +38,7 @@ module ViewOptionsHelper
     :signed_replay_log_url,
     :azure_speech_service_voices,
     :authenticity_token,
-    :useGoogleBlockly,
+    :blocklyVersion,
     :disallowed_html_tags,
     :backpack_channel,
     :level_requires_channel,

--- a/dashboard/test/helpers/levels_helper_test.rb
+++ b/dashboard/test/helpers/levels_helper_test.rb
@@ -249,10 +249,18 @@ class LevelsHelperTest < ActionView::TestCase
     refute use_google_blockly
   end
 
-  test 'use_google_blockly is true if useGoogleBlockly is set in view_options' do
-    view_options(useGoogleBlockly: true)
+  test 'use_google_blockly is true if blocklyVersion is set to Google in view_options' do
+    view_options(blocklyVersion: 'google')
     @level = build :level
     assert use_google_blockly
+
+    reset_view_options
+  end
+
+  test 'use_google_blockly is false if blocklyVersion is set to Cdo in view_options' do
+    view_options(blocklyVersion: 'cdo')
+    @level = build :level
+    refute use_google_blockly
 
     reset_view_options
   end


### PR DESCRIPTION
For development, it's sometimes helpful to be able to force a level to load with Cdo Blockly even for labs that have been fully switched to Google Blockly.

Flappy (prod uses Google Blockly)
| URL  | Blockly Version  |
| ------------- | ------------- | 
| http://localhost-studio.code.org:3000/flappy/9  | Google  | 
| http://localhost-studio.code.org:3000/flappy/9?blocklyVersion=Google  | Google  | 
| http://localhost-studio.code.org:3000/flappy/9?blocklyVersion=Cdo  | Cdo  | 
| http://localhost-studio.code.org:3000/flappy/9?blocklyVersion=unknown  | Google  | 

Poem Art (prod uses Google Blockly)
| URL  | Blockly Version  |
| ------------- | ------------- | 
| http://localhost-studio.code.org:3000/s/poem-art/lessons/1/levels/1  | Google  | 
| http://localhost-studio.code.org:3000/s/poem-art/lessons/1/levels/1?blocklyVersion=Google  | Google  | 
| http://localhost-studio.code.org:3000/s/poem-art/lessons/1/levels/1?blocklyVersion=Cdo  | Cdo  | 
| http://localhost-studio.code.org:3000/s/poem-art/lessons/1/levels/1?blocklyVersion=unknown  | Google  | 

Basketball (prod uses Cdo Blockly)
| URL  | Blockly Version  |
| ------------- | ------------- | 
| http://localhost-studio.code.org:3000/s/basketball/lessons/1/levels/4  | Cdo  | 
| http://localhost-studio.code.org:3000/s/basketball/lessons/1/levels/4?blocklyVersion=Google  | Google  | 
| http://localhost-studio.code.org:3000/s/basketball/lessons/1/levels/4?blocklyVersion=Cdo  | Cdo  | 
| http://localhost-studio.code.org:3000/s/basketball/lessons/1/levels/4?blocklyVersion=unknown  | Cdo  | 