### PR TITLE
Updating `_crowdin.yml` configs to match Crowdin CLI V3

### DIFF
--- a/bin/i18n/SETUP.md
+++ b/bin/i18n/SETUP.md
@@ -1,6 +1,6 @@
 # I18n Sync Setup
 
-These scripts all require [the Crowdin CLI tool][1] version 2.0.17. Follow the
+These scripts all require [the Crowdin CLI tool][1] version 3.7.2. Follow the
 instructions there to install for your system.
 
 These scripts also require some dependencies to be installed using NPM. Run the
@@ -9,12 +9,10 @@ following command while in this directory
 npm install
 ```
 
-You will additionally need to add a `codeorg_credentials.yml` file to this
-directory (`{project root}/bin/i18n/`) containing the API key for the code.org
-project, an `hourofcode_credentials.yml` file containing the API key for the
-Hour of Code project, and a `codeorg_markdown_credentials.yml` file containing
-the API key for the Code.org - Markdown project.  See [the crowdin documentation][2]
-for more details; the API keys themselves can be found on the project settings page
+You will additionally need to add a `crowdin_credentials.yml` file to this
+directory (`{project root}/bin/i18n/`) containing the personal API token for the code.org
+Crowdin account. You should create a personal token labeled with your name. See [the crowdin documentation][2]
+for more details; th
 
 [1]: https://support.crowdin.com/cli-tool/
-[2]: https://support.crowdin.com/configuration-file/#split-project-configuration-and-api-credentials
+[2]: https://crowdin.com/settings#api-key 

--- a/bin/i18n/codeorg-testing_crowdin.yml
+++ b/bin/i18n/codeorg-testing_crowdin.yml
@@ -1,12 +1,12 @@
 #
 # Your crowdin's credentials
 #
-"project_id" : "26074"
+"project_id" : "346087"
 "base_path" : "../../i18n/locales"
 
 # API Credentials must be loaded from a separate identity file. See
 # https://support.crowdin.com/configuration-file/#split-project-configuration-and-api-credentials
-"api_key" : ""
+"api_token" : ""
 
 #
 # Files configuration

--- a/bin/i18n/codeorg-testing_crowdin.yml
+++ b/bin/i18n/codeorg-testing_crowdin.yml
@@ -1,6 +1,7 @@
 #
 # Your crowdin's credentials
 #
+"project_identifier" : "codeorg-testing"
 "project_id" : "346087"
 "base_path" : "../../i18n/locales"
 

--- a/bin/i18n/codeorg_crowdin.yml
+++ b/bin/i18n/codeorg_crowdin.yml
@@ -1,6 +1,7 @@
 #
 # Your crowdin's credentials
 #
+"project_identifier" : "codeorg"
 "project_id" : "26074"
 "base_path" : "../../i18n/locales"
 

--- a/bin/i18n/codeorg_markdown_crowdin.yml
+++ b/bin/i18n/codeorg_markdown_crowdin.yml
@@ -1,4 +1,4 @@
-"project_identifier" : "codeorg-markdown"
+"project_id" : "314545"
 "base_path" : "../.."
 
 # API Credentials must be loaded from a separate identity file. See

--- a/bin/i18n/codeorg_markdown_crowdin.yml
+++ b/bin/i18n/codeorg_markdown_crowdin.yml
@@ -1,3 +1,4 @@
+"project_identifier" : "codeorg-markdown"
 "project_id" : "314545"
 "base_path" : "../.."
 

--- a/bin/i18n/codeorg_restricted_crowdin.yml
+++ b/bin/i18n/codeorg_restricted_crowdin.yml
@@ -1,3 +1,4 @@
+"project_identifier" : "codeorg-restricted"
 "project_id" : "464582"
 "base_path" : "../../i18n/locales/source"
 "preserve_hierarchy": true

--- a/bin/i18n/codeorg_restricted_crowdin.yml
+++ b/bin/i18n/codeorg_restricted_crowdin.yml
@@ -1,4 +1,4 @@
-"project_identifier" : "codeorg-restricted"
+"project_id" : "464582"
 "base_path" : "../../i18n/locales/source"
 "preserve_hierarchy": true
 

--- a/bin/i18n/hourofcode_crowdin.yml
+++ b/bin/i18n/hourofcode_crowdin.yml
@@ -1,6 +1,7 @@
 #
 # Your crowdin's credentials
 #
+"project_identifier" : "hour-of-code"
 "project_id" : "55536"
 "base_path" : "../../i18n/locales"
 

--- a/bin/i18n/hourofcode_crowdin.yml
+++ b/bin/i18n/hourofcode_crowdin.yml
@@ -1,7 +1,7 @@
 #
 # Your crowdin's credentials
 #
-"project_identifier" : "hour-of-code"
+"project_id" : "55536"
 "base_path" : "../../i18n/locales"
 
 # API Credentials must be loaded from a separate identity file. See

--- a/bin/i18n/i18n_script_utils.rb
+++ b/bin/i18n/i18n_script_utils.rb
@@ -11,19 +11,19 @@ I18N_SOURCE_DIR = "i18n/locales/source"
 CROWDIN_PROJECTS = {
   "codeorg": {
     config_file: File.join(File.dirname(__FILE__), "codeorg_crowdin.yml"),
-    identity_file: File.join(File.dirname(__FILE__), "codeorg_credentials.yml")
+    identity_file: File.join(File.dirname(__FILE__), "crowdin_credentials.yml")
   },
   "codeorg-markdown": {
     config_file: File.join(File.dirname(__FILE__), "codeorg_markdown_crowdin.yml"),
-    identity_file: File.join(File.dirname(__FILE__), "codeorg_markdown_credentials.yml")
+    identity_file: File.join(File.dirname(__FILE__), "crowdin_credentials.yml")
   },
   "hour-of-code": {
     config_file: File.join(File.dirname(__FILE__), "hourofcode_crowdin.yml"),
-    identity_file: File.join(File.dirname(__FILE__), "hourofcode_credentials.yml")
+    identity_file: File.join(File.dirname(__FILE__), "crowdin_credentials.yml")
   },
   "codeorg-restricted": {
     config_file: File.join(File.dirname(__FILE__), "codeorg_restricted_crowdin.yml"),
-    identity_file: File.join(File.dirname(__FILE__), "codeorg_restricted_credentials.yml")
+    identity_file: File.join(File.dirname(__FILE__), "crowdin_credentials.yml")
   }
 }
 

--- a/bin/i18n/i18n_script_utils.rb
+++ b/bin/i18n/i18n_script_utils.rb
@@ -11,19 +11,23 @@ I18N_SOURCE_DIR = "i18n/locales/source"
 CROWDIN_PROJECTS = {
   "codeorg": {
     config_file: File.join(File.dirname(__FILE__), "codeorg_crowdin.yml"),
-    identity_file: File.join(File.dirname(__FILE__), "crowdin_credentials.yml")
+    identity_file: File.join(File.dirname(__FILE__), "codeorg_credentials.yml"),
+    identity_file_v2: File.join(File.dirname(__FILE__), "crowdin_credentials.yml")
   },
   "codeorg-markdown": {
     config_file: File.join(File.dirname(__FILE__), "codeorg_markdown_crowdin.yml"),
-    identity_file: File.join(File.dirname(__FILE__), "crowdin_credentials.yml")
+    identity_file: File.join(File.dirname(__FILE__), "codeorg_markdown_credentials.yml"),
+    identity_file_v2: File.join(File.dirname(__FILE__), "crowdin_credentials.yml")
   },
   "hour-of-code": {
     config_file: File.join(File.dirname(__FILE__), "hourofcode_crowdin.yml"),
-    identity_file: File.join(File.dirname(__FILE__), "crowdin_credentials.yml")
+    identity_file: File.join(File.dirname(__FILE__), "hourofcode_credentials.yml"),
+    identity_file_v2: File.join(File.dirname(__FILE__), "crowdin_credentials.yml")
   },
   "codeorg-restricted": {
     config_file: File.join(File.dirname(__FILE__), "codeorg_restricted_crowdin.yml"),
-    identity_file: File.join(File.dirname(__FILE__), "crowdin_credentials.yml")
+    identity_file: File.join(File.dirname(__FILE__), "codeorg_restricted_credentials.yml"),
+    identity_file_v2: File.join(File.dirname(__FILE__), "crowdin_credentials.yml")
   }
 }
 

--- a/bin/i18n/sync-down.rb
+++ b/bin/i18n/sync-down.rb
@@ -25,7 +25,7 @@ def sync_down
     CROWDIN_PROJECTS.each do |name, options|
       puts "Downloading translations from #{name} project"
       api_token = YAML.load_file(options[:identity_file])["api_token"]
-      project_id = YAML.load_file(options[:config_file])["project_id"]
+      project_id = YAML.load_file(options[:config_file])["project_identifier"]
       project = Crowdin::Project.new(project_id, api_token)
       options = {
         etags_json: File.join(File.dirname(__FILE__), "crowdin", "#{project_id}_etags.json"),

--- a/bin/i18n/sync-down.rb
+++ b/bin/i18n/sync-down.rb
@@ -24,9 +24,9 @@ def sync_down
 
     CROWDIN_PROJECTS.each do |name, options|
       puts "Downloading translations from #{name} project"
-      api_key = YAML.load_file(options[:identity_file])["api_key"]
-      project_id = YAML.load_file(options[:config_file])["project_identifier"]
-      project = Crowdin::Project.new(project_id, api_key)
+      api_token = YAML.load_file(options[:identity_file])["api_token"]
+      project_id = YAML.load_file(options[:config_file])["project_id"]
+      project = Crowdin::Project.new(project_id, api_token)
       options = {
         etags_json: File.join(File.dirname(__FILE__), "crowdin", "#{project_id}_etags.json"),
         locales_dir: File.join(I18N_SOURCE_DIR, '..'),

--- a/bin/i18n/sync-down.rb
+++ b/bin/i18n/sync-down.rb
@@ -24,9 +24,9 @@ def sync_down
 
     CROWDIN_PROJECTS.each do |name, options|
       puts "Downloading translations from #{name} project"
-      api_token = YAML.load_file(options[:identity_file])["api_token"]
+      api_key = YAML.load_file(options[:identity_file])["api_key"]
       project_id = YAML.load_file(options[:config_file])["project_identifier"]
-      project = Crowdin::Project.new(project_id, api_token)
+      project = Crowdin::Project.new(project_id, api_key)
       options = {
         etags_json: File.join(File.dirname(__FILE__), "crowdin", "#{project_id}_etags.json"),
         locales_dir: File.join(I18N_SOURCE_DIR, '..'),

--- a/bin/i18n/sync-up.rb
+++ b/bin/i18n/sync-up.rb
@@ -13,7 +13,7 @@ def sync_up
     puts "Sync up starting"
     CROWDIN_PROJECTS.each do |name, options|
       puts "Uploading source strings to #{name} project"
-      command = "crowdin upload sources --config #{options[:config_file]} --identity #{options[:identity_file]}"
+      command = "crowdin upload sources --config #{options[:config_file]} --identity #{options[:identity_file_v2]}"
       Open3.popen2(command) do |_stdin, stdout, status_thread|
         while line = stdout.gets
           # skip lines detailing individual file upload, unless that file

--- a/bin/i18n/sync-up.rb
+++ b/bin/i18n/sync-up.rb
@@ -13,7 +13,7 @@ def sync_up
     puts "Sync up starting"
     CROWDIN_PROJECTS.each do |name, options|
       puts "Uploading source strings to #{name} project"
-      command = "crowdin --config #{options[:config_file]} --identity #{options[:identity_file]} upload sources"
+      command = "crowdin upload sources --config #{options[:config_file]} --identity #{options[:identity_file]}"
       Open3.popen2(command) do |_stdin, stdout, status_thread|
         while line = stdout.gets
           # skip lines detailing individual file upload, unless that file


### PR DESCRIPTION
The Crowdin API v1 is being deprecated in favor of Crowdin API v2. We need to update the Crowdin CLI to v3 because that uses Crowdin API v2.

## Links
* [JIRA](https://codedotorg.atlassian.net/browse/FND-1837)

## Testing story
* SHH'd into the `i18n-dev` server and ran `crowdin upload sources --config codeorg-testing_crowdin.yml --identity crowdin_credentials.yml`

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy
* Already applied to the `i18n-dev` server.
* Will ping the #foundations slack channel once we are done with v2 upgrades.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
