### PR TITLE
Remove unsubmit button from readonly answers

### DIFF
--- a/dashboard/app/views/levels/_dialog.html.haml
+++ b/dashboard/app/views/levels/_dialog.html.haml
@@ -15,7 +15,7 @@
     - else
       %a.btn.btn-large.btn-primary.next-lesson.submitButton
         =t('submit')
-      - if @level.properties['submittable']
+      - if @level.properties['submittable'] && !Policies::InlineAnswer.visible_for_script_level?(current_user, @script_level)
         %a.btn.btn-large.btn-primary.unsubmitButton{style: 'display: none'}
           =t('unsubmit')
 .clear

--- a/dashboard/test/ui/features/learning_platform/lesson_lock.feature
+++ b/dashboard/test/ui/features/learning_platform/lesson_lock.feature
@@ -123,7 +123,6 @@ Scenario: Lock settings for students in survey
   Then element "h3:contains(Answer)" is visible
   Then element ".previousPageButton" is visible
   # in the future we will want the unsubmit button to be hidden instead.
-  Then element ".unsubmitButton" is visible
 
 Scenario: Lock settings for students who never submit
   # initially locked for student in summary view

--- a/dashboard/test/ui/features/learning_platform/lesson_lock.feature
+++ b/dashboard/test/ui/features/learning_platform/lesson_lock.feature
@@ -122,7 +122,6 @@ Scenario: Lock settings for students in survey
   And I wait until element "h2:contains(Pre-survey)" is visible
   Then element "h3:contains(Answer)" is visible
   Then element ".previousPageButton" is visible
-  # in the future we will want the unsubmit button to be hidden instead.
 
 Scenario: Lock settings for students who never submit
   # initially locked for student in summary view


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Hides the unsubmit button if user has submitted and answers are visible.

Before:
<img width="961" alt="Screen Shot 2021-12-10 at 2 05 12 PM" src="https://user-images.githubusercontent.com/24235215/145647391-1a4bee00-9196-4078-956d-421244590956.png">


After:
<img width="961" alt="Screen Shot 2021-12-10 at 2 07 06 PM" src="https://user-images.githubusercontent.com/24235215/145647567-ac1029ea-5808-4d5c-ab91-80874b3944a7.png">

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
- jira ticket: [LP-2144](https://codedotorg.atlassian.net/browse/LP-2144)
<!--
- spec: []()

-->

## Testing story
Tested locally & updated eyes test
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
