### PR TITLE
Add whitespace between ArrowButtons and CompletionButton

### DIFF
--- a/apps/src/craft/agent/CraftVisualizationColumn.jsx
+++ b/apps/src/craft/agent/CraftVisualizationColumn.jsx
@@ -20,6 +20,8 @@ var CraftVisualizationColumn = function(props) {
       <GameButtons>
         <ArrowButtons />
 
+        {' ' /* Explicitly insert whitespace*/}
+
         {props.showFinishButton && (
           <div id="right-button-cell">
             <button

--- a/apps/src/p5lab/P5LabVisualizationColumn.jsx
+++ b/apps/src/p5lab/P5LabVisualizationColumn.jsx
@@ -202,7 +202,7 @@ class P5LabVisualizationColumn extends React.Component {
             />
           )}
           <ArrowButtons />
-
+          {' ' /* Explicitly insert whitespace*/}
           <CompletionButton />
 
           {!isSpritelab && !isShareView && this.renderGridCheckbox()}

--- a/apps/src/studio/StudioVisualizationColumn.jsx
+++ b/apps/src/studio/StudioVisualizationColumn.jsx
@@ -27,6 +27,8 @@ var StudioVisualizationColumn = function(props) {
       <GameButtons>
         <ArrowButtons />
 
+        {' ' /* Explicitly insert whitespace*/}
+
         {props.finishButton && (
           <div id="share-cell" className="share-cell-none">
             <button type="button" id="finishButton" className="share">

--- a/apps/src/templates/ArrowButtons.jsx
+++ b/apps/src/templates/ArrowButtons.jsx
@@ -56,7 +56,7 @@ class ArrowButtons extends React.Component {
 
 const styles = {
   hidden: {display: 'none'},
-  visible: {display: 'inline-block'}
+  visible: {display: 'inline-block', marginRight: '10px'}
 };
 
 export default connect(state => ({

--- a/apps/src/templates/ArrowButtons.jsx
+++ b/apps/src/templates/ArrowButtons.jsx
@@ -56,7 +56,7 @@ class ArrowButtons extends React.Component {
 
 const styles = {
   hidden: {display: 'none'},
-  visible: {display: 'inline-block', marginRight: '10px'}
+  visible: {display: 'inline-block'}
 };
 
 export default connect(state => ({


### PR DESCRIPTION
Add whitespace to create some breathing room between `ArrowButtons` and `CompletionButton` in p5Lab (Sprite Lab), studio (Play Lab), and agent (Minecraft) levels. This fix works for both LTR and RTL languages.

**Before:**
![before](https://user-images.githubusercontent.com/43474485/145238265-9dbfd28a-5783-45ab-a938-9f4f6e1678b3.gif)

**After:**
![ltr](https://user-images.githubusercontent.com/43474485/145420806-f96ee2d0-466d-4be2-84b6-60f47ab30c52.gif) ![rtl](https://user-images.githubusercontent.com/43474485/145420827-8669056f-afd5-46dd-862c-824e04bb1941.gif)


**Before/After in studio/agent:**
<img src="https://user-images.githubusercontent.com/43474485/145421396-98fed456-b07e-4070-aafa-bc1dd193ee86.png" width=200/><img src="https://user-images.githubusercontent.com/43474485/145421362-79b1c038-47a6-4893-b175-db751f7648c9.png" width=200/><img src="https://user-images.githubusercontent.com/43474485/145421462-840d8c6f-9a37-4b82-b8c4-10b92e7770b4.png" width=200/><img src="https://user-images.githubusercontent.com/43474485/145421432-488ddc7f-f28d-45c6-b919-6754ae68b7c9.png" width=200/>
Note that this change also works in Game Lab and Poetry, but neither of these labs have levels with arrow buttons



## Links

- jira ticket: [STAR-1641](https://codedotorg.atlassian.net/browse/STAR-1641)

