### PR TITLE
Limit abilities granted to levelbuilders in production

### DIFF
--- a/dashboard/app/views/courses/show.html.haml
+++ b/dashboard/app/views/courses/show.html.haml
@@ -20,7 +20,7 @@
 
 #course_overview
 
-- if can? :edit, unit_group
+- if current_user.try(:levelbuilder?)
   = render layout: 'shared/extra_links' do
     %strong= unit_group.name
     %ul

--- a/dashboard/app/views/lessons/show.html.haml
+++ b/dashboard/app/views/lessons/show.html.haml
@@ -8,7 +8,7 @@
 
 #show-container
 
-- if can? :edit, @lesson
+- if current_user.try(:levelbuilder?)
   = render layout: 'shared/extra_links' do
     %strong= @lesson.name
     %ul

--- a/dashboard/app/views/scripts/show.html.haml
+++ b/dashboard/app/views/scripts/show.html.haml
@@ -60,7 +60,7 @@
         %br/
         %br/
 
-  - if can? :edit, @script
+  - if current_user.try(:levelbuilder?)
     -# Show all the levels, their names, and instructions in the extra links box.
     = render layout: 'shared/extra_links' do
       %strong= @script.name


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

This is a quick-fix for a permissions issue reported by Dan where levelbuilders can view the level page as any student.  We now only grant levelbuilders broad permissions on curriculum objects in levelbuilder_mode and in the test environment.

To allow levelbuilders to continue to see the "Extra Links" in the admin panel in production, the check for rendering the links has been changed to just check for the levelbuilder permission.

As noted in the comments, the levelbuilder permission will behave more similiarly to levelbuilder_mode than to production in unit tests.  This means that there may be breaks in production that the unit tests will not catch.  Hopefully, some of the longer-term fixes linked to the Jira ticket below will be able to mitigate this difference.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [LP-2142](https://codedotorg.atlassian.net/browse/LP-2142)
- [slack thread](https://codedotorg.slack.com/archives/C02EEGWLHR8/p1638462149419900)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
