### PR TITLE
[Google Blockly] Support unknown blocks

### DIFF
--- a/apps/src/blockly/addons/cdoXml.js
+++ b/apps/src/blockly/addons/cdoXml.js
@@ -13,6 +13,39 @@ export default function initializeBlocklyXml(blocklyWrapper) {
     return blockXml;
   };
 
+  // Aliasing Google's domToBlockHeadless_() so that we can override it, but still be able
+  // to call Google's domToBlockHeadless_() in the override function.
+  blocklyWrapper.Xml.originalDomToBlockHeadless_ =
+    blocklyWrapper.Xml.domToBlockHeadless_;
+  // Override domToBlockHeadless_ so that we can gracefully handle unknown blocks.
+  blocklyWrapper.Xml.domToBlockHeadless_ = function(
+    xmlBlock,
+    workspace,
+    parentConnection,
+    connectedToParentNext
+  ) {
+    let block;
+    try {
+      block = blocklyWrapper.Xml.originalDomToBlockHeadless_(
+        xmlBlock,
+        workspace,
+        parentConnection,
+        connectedToParentNext
+      );
+    } catch (e) {
+      block = blocklyWrapper.Xml.originalDomToBlockHeadless_(
+        blocklyWrapper.Xml.textToDom('<block type="unknown" />'),
+        workspace,
+        parentConnection,
+        connectedToParentNext
+      );
+      block
+        .getField('NAME')
+        .setValue(`unknown block: ${xmlBlock.getAttribute('type')}`);
+    }
+    return block;
+  };
+
   // Aliasing Google's domToBlock() so that we can override it, but still be able
   // to call Google's domToBlock() in the override function.
   blocklyWrapper.Xml.originalDomToBlock = blocklyWrapper.Xml.domToBlock;

--- a/apps/src/blockly/addons/unknownBlock.js
+++ b/apps/src/blockly/addons/unknownBlock.js
@@ -1,0 +1,9 @@
+export const UNKNOWN_BLOCK = {
+  unknownBlock: true,
+  init: function() {
+    this.setHSV(0, 0, 0.8);
+    this.appendDummyInput().appendField('unknown block', 'NAME');
+    this.setPreviousStatement(true);
+    this.setNextStatement(true);
+  }
+};

--- a/apps/src/blockly/googleBlocklyWrapper.js
+++ b/apps/src/blockly/googleBlocklyWrapper.js
@@ -24,6 +24,7 @@ import CdoVerticalFlyout from './addons/cdoVerticalFlyout';
 import CdoWorkspaceSvg from './addons/cdoWorkspaceSvg';
 import initializeBlocklyXml from './addons/cdoXml';
 import initializeCss from './addons/cdoCss';
+import {UNKNOWN_BLOCK} from './addons/unknownBlock';
 
 /**
  * Wrapper class for https://github.com/google/blockly
@@ -355,6 +356,9 @@ function initializeBlocklyWrapper(blocklyInstance) {
   initializeVariables(blocklyWrapper);
   initializeCdoConstants(blocklyWrapper);
   initializeCss(blocklyWrapper);
+
+  blocklyWrapper.Blocks.unknown = UNKNOWN_BLOCK;
+  blocklyWrapper.JavaScript.unknown = () => '/* unknown block */\n';
 
   return blocklyWrapper;
 }


### PR DESCRIPTION
Similar functionality to https://github.com/code-dot-org/blockly/pull/101
[jira](https://codedotorg.atlassian.net/browse/STAR-1922)

Basically just wrap `domToBlockHeadless_`, catch any errors, and create an unknown block if we can't deserialize the block correctly.

Start blocks:
![image](https://user-images.githubusercontent.com/8787187/145315700-0d6a0f3e-06f4-4000-88a5-72157c833a10.png)

Toolbox:
![image](https://user-images.githubusercontent.com/8787187/145315731-61da5e12-eeb6-4267-b267-1a39ea6e52a3.png)

Before
![image](https://user-images.githubusercontent.com/8787187/145315879-640fb639-435c-4d17-af80-7f6e201440d1.png)


After
![image](https://user-images.githubusercontent.com/8787187/145315427-d9eae27d-8a36-4e51-a8f5-b3b45c04a2ab.png)
