### PR TITLE
Make everything used verified_teacher instead of authorized_teacher

### DIFF
--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -83,7 +83,7 @@ class ActivitiesController < ApplicationController
       end
     end
 
-    if current_user && !current_user.authorized_teacher? && @script_level && @script_level.lesson.lockable?
+    if current_user && !current_user.verified_teacher? && @script_level && @script_level.lesson.lockable?
       user_level = UserLevel.find_by(
         user_id: current_user.id,
         level_id: @script_level.level.id,

--- a/dashboard/app/controllers/api/v1/assessments_controller.rb
+++ b/dashboard/app/controllers/api/v1/assessments_controller.rb
@@ -24,7 +24,7 @@ class Api::V1::AssessmentsController < Api::V1::JsonApiController
   # GET '/dashboardapi/assessments'
   def index
     # Only authorized teachers have access to locked question and answer data.
-    render status: :forbidden unless current_user&.authorized_teacher?
+    render status: :forbidden unless current_user&.verified_teacher?
 
     assessment_script_levels = @script.get_assessment_script_levels
 

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -295,7 +295,7 @@ module LevelsHelper
 
     @app_options[:serverScriptLevelId] = @script_level.id if @script_level
     @app_options[:serverScriptId] = @script.id if @script
-    @app_options[:verifiedTeacher] = current_user && current_user.authorized_teacher?
+    @app_options[:verifiedTeacher] = current_user && current_user.verified_teacher?
 
     if @script_level && (@level.can_have_feedback? || @level.can_have_code_review?)
       @app_options[:canHaveFeedbackReviewState] = @level.can_have_feedback_review_state?

--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -114,9 +114,9 @@ module UsersHelper
     user_data = {}
     if user
       user_data[:disableSocialShare] = true if user.under_13?
-      user_data[:lockableAuthorized] = user.teacher? ? user.authorized_teacher? : user.student_of_authorized_teacher?
+      user_data[:lockableAuthorized] = user.teacher? ? user.verified_teacher? : user.student_of_verified_teacher?
       user_data[:isTeacher] = true if user.teacher?
-      user_data[:isVerifiedTeacher] = true if user.authorized_teacher?
+      user_data[:isVerifiedTeacher] = true if user.verified_teacher?
       user_data[:linesOfCode] = user.total_lines
       user_data[:linesOfCodeText] = I18n.t('nav.popup.lines', lines: user_data[:linesOfCode])
     end

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -505,7 +505,7 @@ class Lesson < ApplicationRecord
       purpose: render_property(:purpose),
       preparation: render_property(:preparation),
       activities: lesson_activities.map {|la| la.summarize_for_lesson_show(can_view_teacher_markdown, user)},
-      resources: resources_for_lesson_plan(user&.authorized_teacher?),
+      resources: resources_for_lesson_plan(user&.verified_teacher?),
       vocabularies: vocabularies.sort_by(&:word).map(&:summarize_for_lesson_show),
       programmingExpressions: programming_expressions.sort_by {|pe| pe.syntax || ''}.map(&:summarize_for_lesson_show),
       objectives: objectives.sort_by(&:description).map(&:summarize_for_lesson_show),
@@ -515,7 +515,7 @@ class Lesson < ApplicationRecord
       assessmentOpportunities: Services::MarkdownPreprocessor.process(assessment_opportunities),
       lessonPlanPdfUrl: lesson_plan_pdf_url,
       courseVersionStandardsUrl: course_version_standards_url,
-      isVerifiedTeacher: user&.authorized_teacher?,
+      isVerifiedTeacher: user&.verified_teacher?,
       hasVerifiedResources: lockable || lesson_plan_has_verified_resources,
       scriptResourcesPdfUrl: script.get_unit_resources_pdf_url
     }
@@ -527,7 +527,7 @@ class Lesson < ApplicationRecord
       position: relative_position,
       displayName: localized_name,
       preparation: render_property(:preparation),
-      resources: resources_for_lesson_plan(user&.authorized_teacher?),
+      resources: resources_for_lesson_plan(user&.verified_teacher?),
       vocabularies: vocabularies.sort_by(&:word).map(&:summarize_for_lesson_show),
       programmingExpressions: programming_expressions.sort_by {|pe| pe.syntax || ''}.map(&:summarize_for_lesson_show),
       objectives: objectives.sort_by(&:description).map(&:summarize_for_lesson_show),

--- a/dashboard/app/models/plc/user_course_enrollment.rb
+++ b/dashboard/app/models/plc/user_course_enrollment.rb
@@ -97,7 +97,7 @@ class Plc::UserCourseEnrollment < ApplicationRecord
   private
 
   def create_authorized_teacher_user_permission
-    unless user.authorized_teacher?
+    unless user.verified_teacher?
       user.permission = UserPermission::AUTHORIZED_TEACHER
     end
   end

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -309,7 +309,7 @@ class ScriptLevel < ApplicationRecord
 
   def locked?(user)
     return false unless lesson.lockable?
-    return false if user.authorized_teacher?
+    return false if user.verified_teacher?
 
     # All levels in a lesson key their lock state off of the last script_level
     # in the lesson, which is an assessment. Thus, to answer the question of

--- a/dashboard/app/models/teacher_feedback.rb
+++ b/dashboard/app/models/teacher_feedback.rb
@@ -122,7 +122,7 @@ class TeacherFeedback < ApplicationRecord
       seen_on_feedback_page_at: nil,
       student_first_visited_at: nil
     ).select do |feedback|
-      User.find(feedback.teacher_id).authorized_teacher?
+      User.find(feedback.teacher_id).verified_teacher?
     end
 
     all_unseen_feedbacks.count

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1322,7 +1322,7 @@ class User < ApplicationRecord
     user_type == TYPE_TEACHER
   end
 
-  def authorized_teacher?
+  def verified_teacher?
     # You are an authorized teacher if you are an admin, have the AUTHORIZED_TEACHER or the
     # LEVELBUILDER permission.
     return true if admin?
@@ -1332,8 +1332,6 @@ class User < ApplicationRecord
     false
   end
 
-  alias :verified_teacher? :authorized_teacher?
-
   def verified_instructor?
     # You are an verified instructor if you are a universal_instructor, plc_reviewer, facilitator, authorized_teacher, or levelbuiler
     permission?(UserPermission::UNIVERSAL_INSTRUCTOR) || permission?(UserPermission::PLC_REVIEWER) ||
@@ -1341,8 +1339,8 @@ class User < ApplicationRecord
       permission?(UserPermission::LEVELBUILDER)
   end
 
-  def student_of_authorized_teacher?
-    teachers.any?(&:authorized_teacher?)
+  def student_of_verified_teacher?
+    teachers.any?(&:verified_teacher?)
   end
 
   def student_of?(teacher)

--- a/dashboard/app/models/user_permission.rb
+++ b/dashboard/app/models/user_permission.rb
@@ -25,7 +25,7 @@ class UserPermission < ApplicationRecord
     HIDDEN_SCRIPT_ACCESS = 'hidden_script_access'.freeze,
     # Grants access to managing (e.g., editing) levels, lessons, scripts, etc.
     # Also grants access to viewing extra links related to editing these.
-    # Also makes the account satisfy authorized_teacher?.
+    # Also makes the account satisfy verified_teacher?.
     LEVELBUILDER = 'levelbuilder'.freeze,
     # Grants ability to (un)feature projects in the the public project gallery.
     # Also, grants access to resetting (to 0) the abuse score for projects,

--- a/dashboard/app/views/courses/show.html.haml
+++ b/dashboard/app/views/courses/show.html.haml
@@ -8,7 +8,7 @@
 - data[:course_summary] = unit_group.summarize(@current_user, for_edit: false)
 - data[:sections] = @sections_with_assigned_info || []
 - data[:is_teacher] = @current_user.try(:teacher?) || false
-- data[:is_verified_teacher] = @current_user.try(:authorized_teacher?) || false
+- data[:is_verified_teacher] = @current_user.try(:verified_teacher?) || false
 - data[:hidden_scripts] = @current_user.try(:get_hidden_script_ids, unit_group)
 - data[:show_version_warning] = unit_group.has_older_version_progress?(@current_user) && !unit_group.has_dismissed_version_warning?(@current_user)
 - data[:show_redirect_warning] = redirect_warning

--- a/dashboard/app/views/scripts/show.html.haml
+++ b/dashboard/app/views/scripts/show.html.haml
@@ -11,7 +11,7 @@
                             user_type: current_user&.user_type,
                             user_id: current_user&.id,
                             user_providers: current_user&.providers,
-                            is_verified_teacher: current_user&.authorized_teacher?,
+                            is_verified_teacher: current_user&.verified_teacher?,
                             locale: Script.locale_english_name_map[request.locale],
                             locale_code: request.locale,
                             course_link: @script.course_link(params[:section_id]),

--- a/dashboard/test/models/concerns/user_permission_grantee_test.rb
+++ b/dashboard/test/models/concerns/user_permission_grantee_test.rb
@@ -67,11 +67,11 @@ class UserPermissionGranteeTest < ActiveSupport::TestCase
     refute user.levelbuilder?
   end
 
-  test 'authorized_teacher?' do
+  test 'verified_teacher?' do
     user = create :teacher
-    refute user.authorized_teacher?
+    refute user.verified_teacher?
     user.permission = UserPermission::AUTHORIZED_TEACHER
-    assert user.authorized_teacher?
+    assert user.verified_teacher?
   end
 
   test 'census_reviewer?' do

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -2789,22 +2789,22 @@ class UserTest < ActiveSupport::TestCase
   test "authorized teacher" do
     # you can't just create your own authorized teacher account
     assert @teacher.teacher?
-    refute @teacher.authorized_teacher?
+    refute @teacher.verified_teacher?
 
     # you have to be in a cohort
     real_teacher = create(:teacher)
     real_teacher.permission = UserPermission::AUTHORIZED_TEACHER
     assert real_teacher.teacher?
-    assert real_teacher.authorized_teacher?
+    assert real_teacher.verified_teacher?
 
     # or you have to be in a plc course
     create(:plc_user_course_enrollment, user: (plc_teacher = create :teacher), plc_course: create(:plc_course))
     assert plc_teacher.teacher?
-    assert plc_teacher.authorized_teacher?
+    assert plc_teacher.verified_teacher?
 
     # admins should be authorized teachers too
     assert @admin.teacher?
-    assert @admin.authorized_teacher?
+    assert @admin.verified_teacher?
   end
 
   test "verified instructor" do


### PR DESCRIPTION
We had an alias so you could check either `verified_teacher?` or `authorized_teacher?`. Instead of having multiple ways to check this lets just have one. Moving everything over to `verified_teacher?`. 

This helps make updates for self-paced pl easier.

## Testing story

- Existing test coverage