### PR TITLE
Disable lazy transactions in SeamlessDatabasePool

### DIFF
--- a/dashboard/config/initializers/rails_6_compatible_seamless_database_pool.rb
+++ b/dashboard/config/initializers/rails_6_compatible_seamless_database_pool.rb
@@ -23,3 +23,13 @@ module Rails6CompatibleSeamlessDatabasePool
 end
 
 SeamlessDatabasePool.prepend Rails6CompatibleSeamlessDatabasePool
+
+module ActiveRecord
+  module ConnectionAdapters
+    class SeamlessDatabasePoolAdapter < AbstractAdapter
+      def supports_lazy_transactions?
+        false
+      end
+    end
+  end
+end


### PR DESCRIPTION
Rails 6 adds support for lazy transactions: https://github.com/rails/rails/pull/32647

Specifically, it has all adapters default to claiming to be able to support lazy transactions, and adds logic in them to actually support it.  Unfortunately, that means that the SeamlessDatabasePool adapter is now also claiming to be able to support lazy transactions, despite not having any logic added to it to do so.

We could probably go in and teach it how to correctly support lazy transactions, but since we don't currently require that functionality and because we plan to migrate off of SeamlessDatabasePool, we instead simply update the adapter to explicitly NOT support lazy transactions.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
