### PR TITLE
Fix etags.json and changes.json bugs in sync-down and sync-out

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ dashboard/brakeman_security_report.htm
 .idea/
 jsconfig.json
 /bin/i18n/*_credentials.yml
+/bin/i18n/crowdin/*files_to_sync_out.json
 npm-debug.log
 /.dropbox.cache
 /.gdrive_session

--- a/bin/i18n/i18n_script_utils.rb
+++ b/bin/i18n/i18n_script_utils.rb
@@ -12,22 +12,30 @@ CROWDIN_PROJECTS = {
   "codeorg": {
     config_file: File.join(File.dirname(__FILE__), "codeorg_crowdin.yml"),
     identity_file: File.join(File.dirname(__FILE__), "codeorg_credentials.yml"),
-    identity_file_v2: File.join(File.dirname(__FILE__), "crowdin_credentials.yml")
+    identity_file_v2: File.join(File.dirname(__FILE__), "crowdin_credentials.yml"),
+    etags_json: File.join(File.dirname(__FILE__), "crowdin", "codeorg_etags.json"),
+    files_to_sync_out_json: File.join(File.dirname(__FILE__), "crowdin", "codeorg_files_to_sync_out.json")
   },
   "codeorg-markdown": {
     config_file: File.join(File.dirname(__FILE__), "codeorg_markdown_crowdin.yml"),
     identity_file: File.join(File.dirname(__FILE__), "codeorg_markdown_credentials.yml"),
-    identity_file_v2: File.join(File.dirname(__FILE__), "crowdin_credentials.yml")
+    identity_file_v2: File.join(File.dirname(__FILE__), "crowdin_credentials.yml"),
+    etags_json: File.join(File.dirname(__FILE__), "crowdin", "codeorg-markdown_etags.json"),
+    files_to_sync_out_json: File.join(File.dirname(__FILE__), "crowdin", "codeorg-markdown_files_to_sync_out.json")
   },
   "hour-of-code": {
     config_file: File.join(File.dirname(__FILE__), "hourofcode_crowdin.yml"),
     identity_file: File.join(File.dirname(__FILE__), "hourofcode_credentials.yml"),
-    identity_file_v2: File.join(File.dirname(__FILE__), "crowdin_credentials.yml")
+    identity_file_v2: File.join(File.dirname(__FILE__), "crowdin_credentials.yml"),
+    etags_json: File.join(File.dirname(__FILE__), "crowdin", "hour-of-code_etags.json"),
+    files_to_sync_out_json: File.join(File.dirname(__FILE__), "crowdin", "hour-of-code_files_to_sync_out.json")
   },
   "codeorg-restricted": {
     config_file: File.join(File.dirname(__FILE__), "codeorg_restricted_crowdin.yml"),
     identity_file: File.join(File.dirname(__FILE__), "codeorg_restricted_credentials.yml"),
-    identity_file_v2: File.join(File.dirname(__FILE__), "crowdin_credentials.yml")
+    identity_file_v2: File.join(File.dirname(__FILE__), "crowdin_credentials.yml"),
+    etags_json: File.join(File.dirname(__FILE__), "crowdin", "codeorg-restricted_etags.json"),
+    files_to_sync_out_json: File.join(File.dirname(__FILE__), "crowdin", "codeorg-restricted_files_to_sync_out.json")
   }
 }
 

--- a/bin/i18n/sync-down.rb
+++ b/bin/i18n/sync-down.rb
@@ -28,7 +28,8 @@ def sync_down
       project_identifier = YAML.load_file(options[:config_file])["project_identifier"]
       project = Crowdin::Project.new(project_identifier, api_key)
       options = {
-        etags_json: File.join(File.dirname(__FILE__), "crowdin", "#{project_identifier}_etags.json"),
+        etags_json: options[:etags_json],
+        files_to_sync_out_json: options[:files_to_sync_out_json],
         locales_dir: File.join(I18N_SOURCE_DIR, '..'),
         logger: logger
       }

--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -41,7 +41,7 @@ rescue => e
 end
 
 # Return true iff the specified file in the specified locale had changes
-# as of the most recent sync down.
+# since the last successful sync-out.
 #
 # @param locale [String] the locale code to check. This can be either the
 #  four-letter code used internally (ie, "es-ES", "es-MX", "it-IT", etc), OR
@@ -56,16 +56,16 @@ def file_changed?(locale, file)
   @change_datas ||= CROWDIN_PROJECTS.keys.map do |crowdin_project|
     project = Crowdin::Project.new(crowdin_project, nil)
     utils = Crowdin::Utils.new(project)
-    unless File.exist?(utils.changes_json)
+    unless File.exist?(utils.files_to_sync_out_json)
       raise <<~ERR
-        No "changes" json found at #{utils.changes_json}.
+        File not found #{utils.files_to_sync_out_json}.
 
         We expect to find a file containing a list of files changed by the most
         recent sync down; if this file does not exist, it likely means that no
         sync down has been run on this machine, so there is nothing to sync out
       ERR
     end
-    JSON.load(File.read(utils.changes_json))
+    JSON.load File.read(utils.files_to_sync_out_json)
   end
 
   crowdin_code = Languages.get_code_by_locale(locale)

--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -53,19 +53,17 @@ end
 #  "/dashboard/base.yml", "/blockly-mooc/maze.json",
 #  "/course_content/2018/coursea-2018.json", etc.
 def file_changed?(locale, file)
-  @change_datas ||= CROWDIN_PROJECTS.keys.map do |crowdin_project|
-    project = Crowdin::Project.new(crowdin_project, nil)
-    utils = Crowdin::Utils.new(project)
-    unless File.exist?(utils.files_to_sync_out_json)
+  @change_datas ||= CROWDIN_PROJECTS.map do |_project_identifier, project_options|
+    unless File.exist?(project_options[:files_to_sync_out_json])
       raise <<~ERR
-        File not found #{utils.files_to_sync_out_json}.
+        File not found #{project_options[:files_to_sync_out_json]}.
 
         We expect to find a file containing a list of files changed by the most
         recent sync down; if this file does not exist, it likely means that no
         sync down has been run on this machine, so there is nothing to sync out
       ERR
     end
-    JSON.load File.read(utils.files_to_sync_out_json)
+    JSON.load File.read(project_options[:files_to_sync_out_json])
   end
 
   crowdin_code = Languages.get_code_by_locale(locale)

--- a/lib/cdo/crowdin/utils.rb
+++ b/lib/cdo/crowdin/utils.rb
@@ -18,15 +18,17 @@ module Crowdin
 
     # @param project [Crowdin::Project]
     # @param options [Hash, nil]
-    # @param options.changes_json [String, nil] path to file where files with
-    #  changes will be written out in JSON format
-    # @param options.etags_json [String, nil] path to file where etags will be
+    # @options options [String, nil] :files_to_download_json path to file where files
+    #  should be downloaded will be written out in JSON format
+    # @options options [String, nil] :files_to_sync_out_json path to file where files
+    #  should be synced-out will be written out in JSON format
+    # @options options [String, nil] :etags_json path to file where etags will be
     #  written out in JSON format
-    # @param options.locales_dir [String, nil] path to directory where changed
+    # @options options [String, nil] :locales_dir path to directory where changed
     #  files should be downloaded
-    # @param options.locale_subdir [String, nil] name of directory within
+    # @options options [String, nil] :locale_subdir name of directory within
     #  locale-specific directory to which files should be downloaded
-    # @param options.logger [Logger, nil]
+    # @options options [Logger, nil] :logger
     def initialize(project, options={})
       @project = project
       @etags_json = options.fetch(:etags_json, "/tmp/#{project.id}_etags.json")
@@ -110,6 +112,9 @@ module Crowdin
 
         # Save incremental progress so we don't have to re-download everything
         # if the current run fails for any reason.
+        # The order of saving progress is important for recovery purpose.
+        # Since @files_to_sync_out_json depends on @files_to_download_json,
+        # which in turn depends on @etags_json, @etags_json should be updated last.
         files_to_sync_out[code] ||= {}
         files_to_sync_out[code].merge! downloaded_files
         File.write @files_to_sync_out_json, JSON.pretty_generate(files_to_sync_out)

--- a/lib/cdo/crowdin/utils.rb
+++ b/lib/cdo/crowdin/utils.rb
@@ -82,7 +82,7 @@ module Crowdin
       files_to_download = JSON.parse File.read(@files_to_download_json)
       @logger.info("#{files_to_download.keys.length} languages have changes")
 
-      etags = JSON.parse File.read(@etags_json)
+      etags = File.exist?(@etags_json) ? JSON.parse(File.read(@etags_json)) : {}
       files_to_sync_out = File.exist?(@files_to_sync_out_json) ? JSON.parse(File.read(@files_to_sync_out_json)) : {}
 
       @project.languages.each do |language|
@@ -115,6 +115,7 @@ module Crowdin
         File.write @files_to_sync_out_json, JSON.pretty_generate(files_to_sync_out)
 
         files_to_download[code].delete_if {|file, _etag| downloaded_files.key? file}
+        files_to_download.delete code if files_to_download[code].empty?
         File.write @files_to_download_json, JSON.pretty_generate(files_to_download)
 
         etags[code] ||= {}

--- a/lib/cdo/crowdin/utils.rb
+++ b/lib/cdo/crowdin/utils.rb
@@ -9,7 +9,8 @@ module Crowdin
 
   class Utils
     attr_reader :project
-    attr_reader :changes_json
+    attr_reader :files_to_download_json
+    attr_reader :files_to_sync_out_json
     attr_reader :etags_json
     attr_reader :locales_dir
     attr_reader :locale_subdir
@@ -28,23 +29,20 @@ module Crowdin
     # @param options.logger [Logger, nil]
     def initialize(project, options={})
       @project = project
-      @changes_json = options.fetch(:changes_json, "/tmp/#{project.id}_changes.json")
       @etags_json = options.fetch(:etags_json, "/tmp/#{project.id}_etags.json")
+      @files_to_download_json = options.fetch(:files_to_download_json, "/tmp/#{project.id}_files_to_download.json")
+      @files_to_sync_out_json = options.fetch(:files_to_sync_out_json, "/tmp/#{project.id}_files_to_sync_out.json")
       @locales_dir = options.fetch(:locales_dir, "/tmp/locales")
       @locale_subdir = options.fetch(:locale_subdir, nil)
       @logger = options.fetch(:logger, Logger.new(STDOUT))
     end
 
-    # Fetch from Crowdin a list of files changed since the last sync. Uses
+    # Fetch from Crowdin a list of files changed since the last download. Uses
     # etags sourced from the @etags_json file to define what we mean by "since
-    # the last sync," and writes the results out to @changes_json.
+    # the last download," and writes the results out to @files_to_download_json.
     def fetch_changes
       etags = File.exist?(@etags_json) ? JSON.parse(File.read(@etags_json)) : {}
-
-      # Clear out existing changes json if it exists
-      File.write(@changes_json, '{}')
-      changes = {}
-
+      files_to_download = {}
       languages = @project.languages
       num_languages = languages.length
       languages.each_with_index do |language, i|
@@ -69,23 +67,28 @@ module Crowdin
         end.compact
 
         next if changed_files.empty?
-
-        changes[language_code] = changed_files.to_h
-        etags[language_code].merge!(changes[language_code])
-        File.write(@etags_json, JSON.pretty_generate(etags))
-        File.write(@changes_json, JSON.pretty_generate(changes))
+        files_to_download[language_code] ||= {}
+        files_to_download[language_code].merge! changed_files.to_h
       end
+
+      File.write @files_to_download_json, JSON.pretty_generate(files_to_download)
     end
 
-    # Downloads all files referenced in @changes_json to @locales_dir
+    # Downloads all files referenced in @files_to_download_json to @locales_dir
+    # Merge the list of successfully downloaded files to @files_to_sync_out_json
+    # to signal the sync-out step to process them.
     def download_changed_files
-      raise "No existing changes json at #{@changes_json}; please run fetch_changes first" unless File.exist?(@changes_json)
-      changes = JSON.parse(File.read(@changes_json))
-      @logger.info("#{changes.keys.length} languages have changes")
+      raise "File not found #{@files_to_download_json}; please run fetch_changes first" unless File.exist?(@files_to_download_json)
+      files_to_download = JSON.parse File.read(@files_to_download_json)
+      @logger.info("#{files_to_download.keys.length} languages have changes")
+
+      etags = JSON.parse File.read(@etags_json)
+      files_to_sync_out = File.exist?(@files_to_sync_out_json) ? JSON.parse(File.read(@files_to_sync_out_json)) : {}
+
       @project.languages.each do |language|
         code = language["code"]
         name = language["name"]
-        files = changes.fetch(code, nil)
+        files = files_to_download.fetch(code, nil)
         next unless files.present?
         filenames = files.keys
 
@@ -93,7 +96,7 @@ module Crowdin
         locale_dir = File.join([@locales_dir, language["name"], @locale_subdir].compact)
 
         @logger.debug("#{name} (#{code}): #{filenames.length} files have changes")
-        Parallel.each(filenames, in_threads: MAX_THREADS) do |file|
+        downloaded_files = Parallel.map(filenames, in_threads: MAX_THREADS) do |file|
           response = @project.export_file(file, code)
           dest = File.join(locale_dir, file)
           FileUtils.mkdir_p(File.dirname(dest))
@@ -102,7 +105,21 @@ module Crowdin
           File.open(dest, "w:#{response.body.encoding}") do |destfile|
             destfile.write(response.body)
           end
-        end
+          [file, response.headers["etag"]]
+        end.to_h
+
+        # Save incremental progress so we don't have to re-download everything
+        # if the current run fails for any reason.
+        files_to_sync_out[code] ||= {}
+        files_to_sync_out[code].merge! downloaded_files
+        File.write @files_to_sync_out_json, JSON.pretty_generate(files_to_sync_out)
+
+        files_to_download[code].delete_if {|file, _etag| downloaded_files.key? file}
+        File.write @files_to_download_json, JSON.pretty_generate(files_to_download)
+
+        etags[code] ||= {}
+        etags[code].merge! downloaded_files
+        File.write @etags_json, JSON.pretty_generate(etags)
       end
     end
   end

--- a/lib/test/cdo/crowdin/test_utils.rb
+++ b/lib/test/cdo/crowdin/test_utils.rb
@@ -3,6 +3,8 @@ require 'cdo/crowdin/utils'
 require 'tempfile'
 
 class MockCrowdinProject < Minitest::Mock
+  LATEST_ETAG_VALUE = "0123"
+
   def id
     "test"
   end
@@ -17,9 +19,9 @@ class MockCrowdinProject < Minitest::Mock
 
   def export_file(file, language, etag: nil, attempts: 3, only_head: false)
     mock_response = Minitest::Mock.new
-    if etag.nil?
+    if etag.nil? || (etag != LATEST_ETAG_VALUE)
       def mock_response.body; "test"; end
-      def mock_response.headers; {"etag" => "this is an etag"}; end
+      def mock_response.headers; {"etag" => LATEST_ETAG_VALUE}; end
       def mock_response.code; 200; end
     else
       def mock_response.code; 304; end

--- a/lib/test/cdo/crowdin/test_utils.rb
+++ b/lib/test/cdo/crowdin/test_utils.rb
@@ -50,7 +50,9 @@ class CrowdinUtilsTest < Minitest::Test
     }
   end
 
-  def test_fetching_no_changes
+  def test_fetching_with_no_changes
+    # When the etag values on local are the same as the ones in Crowdin,
+    # +fetch_changes+ should not modify any local file.
     File.write @options[:etags_json], JSON.pretty_generate(@latest_crowdin_etags)
     File.write @options[:files_to_download_json], JSON.pretty_generate({})
 
@@ -61,6 +63,8 @@ class CrowdinUtilsTest < Minitest::Test
   end
 
   def test_fetching_with_empty_local_etags
+    # If the local etags_json file is empty, +fetch_changes+
+    # should return all the current files in Crowdin.
     File.write @options[:etags_json], JSON.pretty_generate({})
     File.write @options[:files_to_download_json], JSON.pretty_generate({})
 
@@ -71,6 +75,8 @@ class CrowdinUtilsTest < Minitest::Test
   end
 
   def test_fetching_is_idempotent
+    # +fetch_changes+ should return the same results (files_to_download_json)
+    # if it runs multiple times. And it should not modify its input (etags_json).
     File.write @options[:etags_json], JSON.pretty_generate({})
     File.write @options[:files_to_download_json], JSON.pretty_generate({})
 
@@ -82,6 +88,7 @@ class CrowdinUtilsTest < Minitest::Test
   end
 
   def test_fetching_respects_unchanged_files
+    # +fetch_changes+ should return only the files that have newer versions in Crowdin.
     local_etags = {
       "i1-8n" => {
         "/foo.bar" => MockCrowdinProject::LATEST_ETAG_VALUE,
@@ -102,64 +109,71 @@ class CrowdinUtilsTest < Minitest::Test
     assert_equal expected_files_to_download, JSON.parse(File.read(@options[:files_to_download_json]))
   end
 
-  def test_downloading_no_changes
-    File.write @options[:etags_json], JSON.pretty_generate({})
+  def test_downloading_with_no_changes
+    # If files_to_download_json is empty, +download_changed_files+
+    # should not modify any local file.
     File.write @options[:files_to_download_json], JSON.pretty_generate({})
     File.write @options[:files_to_sync_out_json], JSON.pretty_generate({})
+    File.write @options[:etags_json], JSON.pretty_generate({})
 
     @utils.download_changed_files
 
-    assert_equal [], Dir.glob(@options[:locales_dir] + "/**/*.*")
-    assert_equal({}, JSON.parse(File.read(@options[:etags_json])))
     assert_equal({}, JSON.parse(File.read(@options[:files_to_download_json])))
     assert_equal({}, JSON.parse(File.read(@options[:files_to_sync_out_json])))
+    assert_equal({}, JSON.parse(File.read(@options[:etags_json])))
+    assert_equal [], Dir.glob(@options[:locales_dir] + "/**/*.*")
   end
 
-  def test_downloading_updates_empty_local_state
-    File.write @options[:etags_json], JSON.pretty_generate({})
-    files_to_download = @latest_crowdin_etags
-    File.write @options[:files_to_download_json], JSON.pretty_generate(files_to_download)
+  def test_downloading_updates_local_state
+    # If +download_changed_files+ successfully downloads files from Crowdin,
+    # it should update the local state tracked by the 3 files: etags_json,
+    # files_to_sync_out_json, and files_to_download_json.
+    File.write @options[:files_to_download_json], JSON.pretty_generate(@latest_crowdin_etags)
     File.write @options[:files_to_sync_out_json], JSON.pretty_generate({})
+    File.write @options[:etags_json], JSON.pretty_generate({})
 
     @utils.download_changed_files
 
-    expected_files = [
+    assert_equal({}, JSON.parse(File.read(@options[:files_to_download_json])))
+    assert_equal @latest_crowdin_etags, JSON.parse(File.read(@options[:files_to_sync_out_json]))
+    assert_equal @latest_crowdin_etags, JSON.parse(File.read(@options[:etags_json]))
+    expected_local_files = [
       "#{@options[:locales_dir]}/Test Language/baz.bat",
       "#{@options[:locales_dir]}/Test Language/foo.bar"
     ]
-    assert_equal expected_files, Dir.glob(@options[:locales_dir] + "/**/*.*").sort
-    assert_equal files_to_download, JSON.parse(File.read(@options[:etags_json]))
-    assert_equal({}, JSON.parse(File.read(@options[:files_to_download_json])))
-    assert_equal files_to_download, JSON.parse(File.read(@options[:files_to_sync_out_json]))
+    assert_equal expected_local_files, Dir.glob(@options[:locales_dir] + "/**/*.*").sort
   end
 
-  def test_downloading_updates_non_empty_local_state
+  def test_downloading_respects_unchanged_files
+    # +download_changed_files+ should respect unchanged files that
+    # already exists in etags_json and files_to_sync_out.
+    files_to_download = {
+      "i1-8n" => {
+        "/baz.bat" => MockCrowdinProject::LATEST_ETAG_VALUE
+      }
+    }
+    files_to_sync_out = {
+      "i1-8n" => {
+        "/foo.bar" => MockCrowdinProject::LATEST_ETAG_VALUE
+      }
+    }
     local_etags = {
       "i1-8n" => {
         "/foo.bar" => MockCrowdinProject::LATEST_ETAG_VALUE,
         "/baz.bat" => "not_the_latest_etag"
       }
     }
-    File.write @options[:etags_json], JSON.pretty_generate(local_etags)
-    files_to_download = {
-      "i1-8n" => {
-        "/baz.bat" => MockCrowdinProject::LATEST_ETAG_VALUE
-      }
-    }
+
     File.write @options[:files_to_download_json], JSON.pretty_generate(files_to_download)
-    files_to_sync_out = {
-      "i1-8n" => {
-        "/foo.bar" => MockCrowdinProject::LATEST_ETAG_VALUE
-      }
-    }
     File.write @options[:files_to_sync_out_json], JSON.pretty_generate(files_to_sync_out)
+    File.write @options[:etags_json], JSON.pretty_generate(local_etags)
 
     @utils.download_changed_files
 
-    expected_files = ["#{@options[:locales_dir]}/Test Language/baz.bat"]
-    assert_equal expected_files, Dir.glob(@options[:locales_dir] + "/**/*.*")
-    assert_equal local_etags.deep_merge(files_to_download), JSON.parse(File.read(@options[:etags_json]))
     assert_equal({}, JSON.parse(File.read(@options[:files_to_download_json])))
     assert_equal files_to_sync_out.deep_merge(files_to_download), JSON.parse(File.read(@options[:files_to_sync_out_json]))
+    assert_equal local_etags.deep_merge(files_to_download), JSON.parse(File.read(@options[:etags_json]))
+    expected_local_files = ["#{@options[:locales_dir]}/Test Language/baz.bat"]
+    assert_equal expected_local_files, Dir.glob(@options[:locales_dir] + "/**/*.*")
   end
 end


### PR DESCRIPTION
Task [FND-1838](https://codedotorg.atlassian.net/browse/FND-1838). 
This PR fixes 2 related bugs we found in the sync-down and sync-out process.

## Bug 1: Downloading failures can cause missing translations.
The sync-down has 2 steps: 
1. Fetching a list of files that have changed since the last sync.
2. Then downloading the changed files.

If step 2 fails while downloading files, the next time we run a sync-down, it won't download missing files! The problem is on this line in `Crowdin::Utils.fetch_changes` function: https://github.com/code-dot-org/code-dot-org/blob/6c0f894a2e1235cea90c6231f57f677f9ef11cdf/lib/cdo/crowdin/utils.rb#L75 

We use `*etags.json` files (1 file for each Crowdin project) to remember what versions of translation files we have locally. In the code above, `*etags.json` files are updated multiple times during step 1 (before files are actually downloaded from Crowdin). We should only update etags files after step 2 succeeds. 

## Bug 2: sync-out failures can cause missing translations
Step 1 of the `sync-down` produces `*changes.json` files (1 file for each Crowdin project) that contain lists of files to download. `*changes.json` files are also consumed by the `sync-out` to determine what recently-changed files it should process. 
https://github.com/code-dot-org/code-dot-org/blob/dde87ff1e59f90b53fc3e0b19cc5cadc24c1531e/bin/i18n/sync-out.rb#L55

However, the `sync-down` wipes out and repopulates `*changes.json` every time it runs.
https://github.com/code-dot-org/code-dot-org/blob/6c0f894a2e1235cea90c6231f57f677f9ef11cdf/lib/cdo/crowdin/utils.rb#L45

So, if for some reasons the `sync-out` fails before the `sync-down` runs again, files that are not processed during the previously failed `sync-out` won’t be processed again! This results in missing translations. 

## The fix
2 main changes:
- Updating `*etags.json` files only after translation files have been downloaded (i.e. sync-down step 2 finishes). `*etags.json` will correctly represent the files we have locally.
- Splitting `*changes.json` into `*files_to_download.json` and `*files_to_sync_out.json`. `*files_to_download.json` will be used by step 2 of the `sync-down`, while `*files_to_sync_out.json` will be used by the `sync-out`. 

The sync-down (`fetch_changes` and `download_changed_files`) and sync-out flow will look like this:
<p align="center"><img src="https://user-images.githubusercontent.com/46507039/145940536-7e9706ac-c02f-4ae7-9948-ba9ed4a2af19.jpg"></p>

## Testing story
- Uni tests `bundle exec ruby -Ilib:test lib/test/cdo/crowdin/test_utils.rb`
- Did a manual test on local machine
  - Ran `Crowdin::Utils.fetch_changes` in sync-down. 
    - Verified that it created `/tmp/*files_to_download.json` and did not update `bin/i18n/crowdin/*etags.json`.
  - Ran `Crowdin::Utils.download_changed_files` in sync-down. 
    - Verified that it updated `bin/i18n/crowdin/*etags.json`, emptied `/tmp/*files_to_download.json`, and created `bin/i18n/crowdin/*files_to_sync_out.json`.
  - Run sync-out. 
    - Verified that it distributed new translations, but did not modify `bin/i18n/crowdin/*etags.json` and `bin/i18n/crowdin/*files_to_sync_out.json`.