### PR TITLE
Always treat instructors as instructors

### DIFF
--- a/dashboard/app/models/concerns/curriculum/course_types.rb
+++ b/dashboard/app/models/concerns/curriculum/course_types.rb
@@ -60,6 +60,17 @@ module Curriculum::CourseTypes
     false
   end
 
+  # Checks if a user is acting as a participant in a course. This is because someone
+  # might be able to be a participant based on permissions but we will treat them like
+  # an instructor if they can be an instructor
+  #
+  # Example: A course taught by facilitators for teachers. `can_be_participant?` would
+  # return true for the facilitator but `participant?` would return false because
+  # `can_be_instructor?` is true.
+  def participant?(user)
+    can_be_participant?(user) && !can_be_instructor?(user)
+  end
+
   # A course is a professional learning course if the participant audience is something
   # other than students(it teaches adults)
   #

--- a/dashboard/test/models/concerns/curriculum/course_types_test.rb
+++ b/dashboard/test/models/concerns/curriculum/course_types_test.rb
@@ -57,6 +57,11 @@ class CourseTypesTests < ActiveSupport::TestCase
     assert @course_plc_reviewer_to_facilitator.pl_course?
   end
 
+  test 'a signed out user can not be an instructor' do
+    refute @unit_group.can_be_instructor?(nil)
+    refute @unit_teacher_to_students.can_be_instructor?(nil)
+  end
+
   test 'unit in course should check course for participant and instructor audience' do
     assert_equal @unit_group.can_be_instructor?(@teacher), @unit_in_course.can_be_instructor?(@teacher)
     assert @unit_in_course.can_be_instructor?(@teacher)
@@ -109,62 +114,16 @@ class CourseTypesTests < ActiveSupport::TestCase
     refute @unit_plc_reviewer_to_facilitator.can_be_instructor?(@student)
   end
 
-  test 'correctly identifies when facilitator is acting as participant in unit' do
-    refute @unit_teacher_to_students.participant?(@facilitator)
-    refute @unit_facilitator_to_teacher.participant?(@facilitator)
-    assert @unit_universal_instructor_to_teacher.participant?(@facilitator)
-    assert @unit_plc_reviewer_to_facilitator.participant?(@facilitator)
-  end
-
-  test 'correctly identifies when teacher is acting as participant in unit' do
-    refute @unit_teacher_to_students.participant?(@teacher)
-    assert @unit_facilitator_to_teacher.participant?(@teacher)
-    assert @unit_universal_instructor_to_teacher.participant?(@teacher)
-    refute @unit_plc_reviewer_to_facilitator.participant?(@teacher) # is this an issue?
-  end
-
-  test 'correctly identifies when student is acting as participant in unit' do
-    assert @unit_teacher_to_students.participant?(@student)
-    refute @unit_facilitator_to_teacher.participant?(@student)
-    refute @unit_universal_instructor_to_teacher.participant?(@student)
-    refute @unit_plc_reviewer_to_facilitator.participant?(@student) # is this an issue?
-  end
-
-  test 'correctly identifies when facilitator is acting as participant in course' do
-    refute @course_teacher_to_students.participant?(@facilitator)
-    refute @course_facilitator_to_teacher.participant?(@facilitator)
-    assert @course_universal_instructor_to_teacher.participant?(@facilitator)
-    assert @course_plc_reviewer_to_facilitator.participant?(@facilitator)
-  end
-
-  test 'correctly identifies when teacher is acting as participant in course' do
-    refute @course_teacher_to_students.participant?(@teacher)
-    assert @course_facilitator_to_teacher.participant?(@teacher)
-    assert @course_universal_instructor_to_teacher.participant?(@teacher)
-    refute @course_plc_reviewer_to_facilitator.participant?(@teacher) # is this an issue?
-  end
-
-  test 'correctly identifies when student is acting as participant in course' do
-    assert @course_teacher_to_students.participant?(@student)
-    refute @course_facilitator_to_teacher.participant?(@student)
-    refute @course_universal_instructor_to_teacher.participant?(@student)
-    refute @course_plc_reviewer_to_facilitator.participant?(@student) # is this an issue?
-  end
-
   test 'facilitator should be able to participate in units with facilitator as participant audience' do
-    # anyone can be a participant in a student unit
-    assert @unit_teacher_to_students.can_be_participant?(@facilitator)
+    refute @unit_teacher_to_students.can_be_participant?(@facilitator)
+    refute @unit_facilitator_to_teacher.can_be_participant?(@facilitator)
 
-    # Since the facilitator is a teacher account it will also be able to participate in any teacher unit
-    assert @unit_facilitator_to_teacher.can_be_participant?(@facilitator)
     assert @unit_universal_instructor_to_teacher.can_be_participant?(@facilitator)
-
     assert @unit_plc_reviewer_to_facilitator.can_be_participant?(@facilitator)
   end
 
   test 'teacher should be able to participate in units with teacher as participant audience' do
-    # anyone can be a participant in a student unit
-    assert @unit_teacher_to_students.can_be_participant?(@teacher)
+    refute @unit_teacher_to_students.can_be_participant?(@teacher)
 
     assert @unit_facilitator_to_teacher.can_be_participant?(@teacher)
     assert @unit_universal_instructor_to_teacher.can_be_participant?(@teacher)
@@ -225,19 +184,15 @@ class CourseTypesTests < ActiveSupport::TestCase
   end
 
   test 'facilitator should be able to participate in courses with facilitator as participant audience' do
-    # anyone can be a participant in a student course
-    assert @course_teacher_to_students.can_be_participant?(@facilitator)
+    refute @course_teacher_to_students.can_be_participant?(@facilitator)
+    refute @course_facilitator_to_teacher.can_be_participant?(@facilitator)
 
-    # Since the facilitator is a teacher account it will also be able to participate in any teacher course
-    assert @course_facilitator_to_teacher.can_be_participant?(@facilitator)
     assert @course_universal_instructor_to_teacher.can_be_participant?(@facilitator)
-
     assert @course_plc_reviewer_to_facilitator.can_be_participant?(@facilitator)
   end
 
   test 'teacher should be able to participate in courses with teacher as participant audience' do
-    # anyone can be a participant in a student course
-    assert @course_teacher_to_students.can_be_participant?(@teacher)
+    refute @course_teacher_to_students.can_be_participant?(@teacher)
 
     assert @course_facilitator_to_teacher.can_be_participant?(@teacher)
     assert @course_universal_instructor_to_teacher.can_be_participant?(@teacher)

--- a/dashboard/test/models/concerns/curriculum/course_types_test.rb
+++ b/dashboard/test/models/concerns/curriculum/course_types_test.rb
@@ -48,7 +48,6 @@ class CourseTypesTests < ActiveSupport::TestCase
     assert @unit_facilitator_to_teacher.pl_course?
     assert @unit_universal_instructor_to_teacher.pl_course?
     assert @unit_plc_reviewer_to_facilitator.pl_course?
-    assert @unit_universal_instructor_to_teacher.pl_course?
   end
 
   test 'pl_course? returns true for any course that does not have students as participants' do
@@ -56,7 +55,6 @@ class CourseTypesTests < ActiveSupport::TestCase
     assert @course_facilitator_to_teacher.pl_course?
     assert @course_universal_instructor_to_teacher.pl_course?
     assert @course_plc_reviewer_to_facilitator.pl_course?
-    assert @course_universal_instructor_to_teacher.pl_course?
   end
 
   test 'unit in course should check course for participant and instructor audience' do
@@ -72,7 +70,6 @@ class CourseTypesTests < ActiveSupport::TestCase
     assert @unit_facilitator_to_teacher.can_be_instructor?(@universal_instructor)
     assert @unit_universal_instructor_to_teacher.can_be_instructor?(@universal_instructor)
     assert @unit_plc_reviewer_to_facilitator.can_be_instructor?(@universal_instructor)
-    assert @unit_universal_instructor_to_teacher.can_be_instructor?(@universal_instructor)
   end
 
   test 'levelbuilder should be able to see instructor view for any unit' do
@@ -80,7 +77,6 @@ class CourseTypesTests < ActiveSupport::TestCase
     assert @unit_facilitator_to_teacher.can_be_instructor?(@levelbuilder)
     assert @unit_universal_instructor_to_teacher.can_be_instructor?(@levelbuilder)
     assert @unit_plc_reviewer_to_facilitator.can_be_instructor?(@levelbuilder)
-    assert @unit_universal_instructor_to_teacher.can_be_instructor?(@levelbuilder)
   end
 
   test 'plc reviewer should be able to instruct units with plc_reviewer as instructor audience ' do
@@ -89,7 +85,6 @@ class CourseTypesTests < ActiveSupport::TestCase
     refute @unit_facilitator_to_teacher.can_be_instructor?(@plc_reviewer)
     refute @unit_universal_instructor_to_teacher.can_be_instructor?(@plc_reviewer)
     assert @unit_plc_reviewer_to_facilitator.can_be_instructor?(@plc_reviewer)
-    refute @unit_universal_instructor_to_teacher.can_be_instructor?(@plc_reviewer)
   end
 
   test 'facilitator should be able to instruct units with facilitator as instructor audience ' do
@@ -98,7 +93,6 @@ class CourseTypesTests < ActiveSupport::TestCase
     assert @unit_facilitator_to_teacher.can_be_instructor?(@facilitator)
     refute @unit_universal_instructor_to_teacher.can_be_instructor?(@facilitator)
     refute @unit_plc_reviewer_to_facilitator.can_be_instructor?(@facilitator)
-    refute @unit_universal_instructor_to_teacher.can_be_instructor?(@facilitator)
   end
 
   test 'teachers should be able to instruct units with teacher as instructor audience ' do
@@ -106,7 +100,6 @@ class CourseTypesTests < ActiveSupport::TestCase
     refute @unit_facilitator_to_teacher.can_be_instructor?(@teacher)
     refute @unit_universal_instructor_to_teacher.can_be_instructor?(@teacher)
     refute @unit_plc_reviewer_to_facilitator.can_be_instructor?(@teacher)
-    refute @unit_universal_instructor_to_teacher.can_be_instructor?(@teacher)
   end
 
   test 'students can not instruct units' do
@@ -114,7 +107,48 @@ class CourseTypesTests < ActiveSupport::TestCase
     refute @unit_facilitator_to_teacher.can_be_instructor?(@student)
     refute @unit_universal_instructor_to_teacher.can_be_instructor?(@student)
     refute @unit_plc_reviewer_to_facilitator.can_be_instructor?(@student)
-    refute @unit_universal_instructor_to_teacher.can_be_instructor?(@student)
+  end
+
+  test 'correctly identifies when facilitator is acting as participant in unit' do
+    refute @unit_teacher_to_students.participant?(@facilitator)
+    refute @unit_facilitator_to_teacher.participant?(@facilitator)
+    assert @unit_universal_instructor_to_teacher.participant?(@facilitator)
+    assert @unit_plc_reviewer_to_facilitator.participant?(@facilitator)
+  end
+
+  test 'correctly identifies when teacher is acting as participant in unit' do
+    refute @unit_teacher_to_students.participant?(@teacher)
+    assert @unit_facilitator_to_teacher.participant?(@teacher)
+    assert @unit_universal_instructor_to_teacher.participant?(@teacher)
+    refute @unit_plc_reviewer_to_facilitator.participant?(@teacher) # is this an issue?
+  end
+
+  test 'correctly identifies when student is acting as participant in unit' do
+    assert @unit_teacher_to_students.participant?(@student)
+    refute @unit_facilitator_to_teacher.participant?(@student)
+    refute @unit_universal_instructor_to_teacher.participant?(@student)
+    refute @unit_plc_reviewer_to_facilitator.participant?(@student) # is this an issue?
+  end
+
+  test 'correctly identifies when facilitator is acting as participant in course' do
+    refute @course_teacher_to_students.participant?(@facilitator)
+    refute @course_facilitator_to_teacher.participant?(@facilitator)
+    assert @course_universal_instructor_to_teacher.participant?(@facilitator)
+    assert @course_plc_reviewer_to_facilitator.participant?(@facilitator)
+  end
+
+  test 'correctly identifies when teacher is acting as participant in course' do
+    refute @course_teacher_to_students.participant?(@teacher)
+    assert @course_facilitator_to_teacher.participant?(@teacher)
+    assert @course_universal_instructor_to_teacher.participant?(@teacher)
+    refute @course_plc_reviewer_to_facilitator.participant?(@teacher) # is this an issue?
+  end
+
+  test 'correctly identifies when student is acting as participant in course' do
+    assert @course_teacher_to_students.participant?(@student)
+    refute @course_facilitator_to_teacher.participant?(@student)
+    refute @course_universal_instructor_to_teacher.participant?(@student)
+    refute @course_plc_reviewer_to_facilitator.participant?(@student) # is this an issue?
   end
 
   test 'facilitator should be able to participate in units with facilitator as participant audience' do
@@ -123,7 +157,6 @@ class CourseTypesTests < ActiveSupport::TestCase
 
     # Since the facilitator is a teacher account it will also be able to participate in any teacher unit
     assert @unit_facilitator_to_teacher.can_be_participant?(@facilitator)
-    assert @unit_universal_instructor_to_teacher.can_be_participant?(@facilitator)
     assert @unit_universal_instructor_to_teacher.can_be_participant?(@facilitator)
 
     assert @unit_plc_reviewer_to_facilitator.can_be_participant?(@facilitator)
@@ -135,7 +168,6 @@ class CourseTypesTests < ActiveSupport::TestCase
 
     assert @unit_facilitator_to_teacher.can_be_participant?(@teacher)
     assert @unit_universal_instructor_to_teacher.can_be_participant?(@teacher)
-    assert @unit_universal_instructor_to_teacher.can_be_participant?(@teacher)
 
     refute @unit_plc_reviewer_to_facilitator.can_be_participant?(@teacher)
   end
@@ -146,7 +178,6 @@ class CourseTypesTests < ActiveSupport::TestCase
     refute @unit_facilitator_to_teacher.can_be_participant?(@student)
     refute @unit_universal_instructor_to_teacher.can_be_participant?(@student)
     refute @unit_plc_reviewer_to_facilitator.can_be_participant?(@student)
-    refute @unit_universal_instructor_to_teacher.can_be_participant?(@student)
   end
 
   test 'universal instructor should be able to instruct any course' do
@@ -154,7 +185,6 @@ class CourseTypesTests < ActiveSupport::TestCase
     assert @course_facilitator_to_teacher.can_be_instructor?(@universal_instructor)
     assert @course_universal_instructor_to_teacher.can_be_instructor?(@universal_instructor)
     assert @course_plc_reviewer_to_facilitator.can_be_instructor?(@universal_instructor)
-    assert @course_universal_instructor_to_teacher.can_be_instructor?(@universal_instructor)
   end
 
   test 'levelbuilder should be able to see instructor view for any course' do
@@ -162,7 +192,6 @@ class CourseTypesTests < ActiveSupport::TestCase
     assert @course_facilitator_to_teacher.can_be_instructor?(@levelbuilder)
     assert @course_universal_instructor_to_teacher.can_be_instructor?(@levelbuilder)
     assert @course_plc_reviewer_to_facilitator.can_be_instructor?(@levelbuilder)
-    assert @course_universal_instructor_to_teacher.can_be_instructor?(@levelbuilder)
   end
 
   test 'plc reviewer should be able to instruct courses with plc_reviewer as instructor audience ' do
@@ -171,7 +200,6 @@ class CourseTypesTests < ActiveSupport::TestCase
     refute @course_facilitator_to_teacher.can_be_instructor?(@plc_reviewer)
     refute @course_universal_instructor_to_teacher.can_be_instructor?(@plc_reviewer)
     assert @course_plc_reviewer_to_facilitator.can_be_instructor?(@plc_reviewer)
-    refute @course_universal_instructor_to_teacher.can_be_instructor?(@plc_reviewer)
   end
 
   test 'facilitator should be able to instruct courses with facilitator as instructor audience ' do
@@ -180,7 +208,6 @@ class CourseTypesTests < ActiveSupport::TestCase
     assert @course_facilitator_to_teacher.can_be_instructor?(@facilitator)
     refute @course_universal_instructor_to_teacher.can_be_instructor?(@facilitator)
     refute @course_plc_reviewer_to_facilitator.can_be_instructor?(@facilitator)
-    refute @course_universal_instructor_to_teacher.can_be_instructor?(@facilitator)
   end
 
   test 'teachers should be able to instruct courses with teacher as instructor audience ' do
@@ -188,7 +215,6 @@ class CourseTypesTests < ActiveSupport::TestCase
     refute @course_facilitator_to_teacher.can_be_instructor?(@teacher)
     refute @course_universal_instructor_to_teacher.can_be_instructor?(@teacher)
     refute @course_plc_reviewer_to_facilitator.can_be_instructor?(@teacher)
-    refute @course_universal_instructor_to_teacher.can_be_instructor?(@teacher)
   end
 
   test 'students can not instruct courses' do
@@ -196,7 +222,6 @@ class CourseTypesTests < ActiveSupport::TestCase
     refute @course_facilitator_to_teacher.can_be_instructor?(@student)
     refute @course_universal_instructor_to_teacher.can_be_instructor?(@student)
     refute @course_plc_reviewer_to_facilitator.can_be_instructor?(@student)
-    refute @course_universal_instructor_to_teacher.can_be_instructor?(@student)
   end
 
   test 'facilitator should be able to participate in courses with facilitator as participant audience' do
@@ -205,7 +230,6 @@ class CourseTypesTests < ActiveSupport::TestCase
 
     # Since the facilitator is a teacher account it will also be able to participate in any teacher course
     assert @course_facilitator_to_teacher.can_be_participant?(@facilitator)
-    assert @course_universal_instructor_to_teacher.can_be_participant?(@facilitator)
     assert @course_universal_instructor_to_teacher.can_be_participant?(@facilitator)
 
     assert @course_plc_reviewer_to_facilitator.can_be_participant?(@facilitator)
@@ -217,7 +241,6 @@ class CourseTypesTests < ActiveSupport::TestCase
 
     assert @course_facilitator_to_teacher.can_be_participant?(@teacher)
     assert @course_universal_instructor_to_teacher.can_be_participant?(@teacher)
-    assert @course_universal_instructor_to_teacher.can_be_participant?(@teacher)
 
     refute @course_plc_reviewer_to_facilitator.can_be_participant?(@teacher)
   end
@@ -228,6 +251,5 @@ class CourseTypesTests < ActiveSupport::TestCase
     refute @course_facilitator_to_teacher.can_be_participant?(@student)
     refute @course_universal_instructor_to_teacher.can_be_participant?(@student)
     refute @course_plc_reviewer_to_facilitator.can_be_participant?(@student)
-    refute @course_universal_instructor_to_teacher.can_be_participant?(@student)
   end
 end


### PR DESCRIPTION
Updates the helper method that checks if a user is acting as a participant in a course to check if the person is able to be an instructor. If someone is able to be an instructor for a course we will treat them as an instructor and therefore can_be_participant should be false.  All make sure we always return false for can_be_instructor if a user is signed out.

## Testing story

- Updated existing tests.