### PR TITLE
[micro:bit] Round compass heading to integer

### DIFF
--- a/apps/src/lib/kits/maker/boards/microBit/Compass.js
+++ b/apps/src/lib/kits/maker/boards/microBit/Compass.js
@@ -1,5 +1,5 @@
 import {EventEmitter} from 'events';
-import {SENSOR_CHANNELS, roundToHundredth} from './MicroBitConstants';
+import {SENSOR_CHANNELS} from './MicroBitConstants';
 
 export default class Compass extends EventEmitter {
   constructor(board) {
@@ -27,9 +27,7 @@ export default class Compass extends EventEmitter {
         get: function() {
           let rawX = this.board.mb.analogChannel[SENSOR_CHANNELS.magX];
           let rawY = this.board.mb.analogChannel[SENSOR_CHANNELS.magY];
-          let heading = roundToHundredth(
-            Math.atan2(rawY, rawX) * (180 / Math.PI)
-          );
+          let heading = Math.round(Math.atan2(rawY, rawX) * (180 / Math.PI));
           if (heading > 360) {
             return heading - 360;
           } else if (heading < 0) {

--- a/apps/test/unit/lib/kits/maker/boards/microBit/CompassTest.js
+++ b/apps/test/unit/lib/kits/maker/boards/microBit/CompassTest.js
@@ -22,12 +22,12 @@ describe('MicroBit Compass', function() {
     expect(desc.get).to.not.be.undefined;
   });
 
-  it(`magnetometer values calculated as expected and rounded to hundredth`, () => {
+  it(`magnetometer values calculated as expected and rounded to integer`, () => {
     // Seed the x, y, z channel with milli-g data
     boardClient.analogChannel[SENSOR_CHANNELS.magX] = 3;
     boardClient.analogChannel[SENSOR_CHANNELS.magY] = 49;
 
-    expect(compass.heading).to.equal(86.49);
+    expect(compass.heading).to.equal(86);
   });
 
   it(`getHeading() returns the heading attribute`, () => {
@@ -35,8 +35,8 @@ describe('MicroBit Compass', function() {
     boardClient.analogChannel[SENSOR_CHANNELS.magX] = 3;
     boardClient.analogChannel[SENSOR_CHANNELS.magY] = 49;
 
-    expect(compass.heading).to.equal(86.49);
-    expect(compass.getHeading()).to.equal(86.49);
+    expect(compass.heading).to.equal(86);
+    expect(compass.getHeading()).to.equal(86);
   });
 
   describe(`start() and stop()`, () => {


### PR DESCRIPTION
Per micro:bit's request, this PR rounds the compass heading to an integer rather than rounding to the hundredth.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
