### PR TITLE
Revert "Fixes spacing in level bubble display; removes empty line if no description"

### DIFF
--- a/apps/src/templates/progress/ProgressLessonContent.jsx
+++ b/apps/src/templates/progress/ProgressLessonContent.jsx
@@ -45,14 +45,13 @@ export default class ProgressLessonContent extends React.Component {
         />
       ));
     }
+
     return (
       <div>
-        {description && (
-          <div style={styles.summary}>
-            <SafeMarkdown markdown={description} />
-          </div>
-        )}
-        <div> {bubbles} </div>
+        <div style={styles.summary}>
+          <SafeMarkdown markdown={description || ''} />
+        </div>
+        {bubbles}
       </div>
     );
   }


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#43920

It turns out this change also affects other places where level bubbles are shown (e.g. the script overview page).  Reverting for now to give us more time to determine whether those changes are desirable or not.