### PR TITLE
Revert "Add whitespace between ArrowButtons and CompletionButton"

### DIFF
--- a/apps/src/craft/agent/CraftVisualizationColumn.jsx
+++ b/apps/src/craft/agent/CraftVisualizationColumn.jsx
@@ -20,8 +20,6 @@ var CraftVisualizationColumn = function(props) {
       <GameButtons>
         <ArrowButtons />
 
-        {' ' /* Explicitly insert whitespace*/}
-
         {props.showFinishButton && (
           <div id="right-button-cell">
             <button

--- a/apps/src/p5lab/P5LabVisualizationColumn.jsx
+++ b/apps/src/p5lab/P5LabVisualizationColumn.jsx
@@ -202,7 +202,7 @@ class P5LabVisualizationColumn extends React.Component {
             />
           )}
           <ArrowButtons />
-          {' ' /* Explicitly insert whitespace*/}
+
           <CompletionButton />
 
           {!isSpritelab && !isShareView && this.renderGridCheckbox()}

--- a/apps/src/studio/StudioVisualizationColumn.jsx
+++ b/apps/src/studio/StudioVisualizationColumn.jsx
@@ -27,8 +27,6 @@ var StudioVisualizationColumn = function(props) {
       <GameButtons>
         <ArrowButtons />
 
-        {' ' /* Explicitly insert whitespace*/}
-
         {props.finishButton && (
           <div id="share-cell" className="share-cell-none">
             <button type="button" id="finishButton" className="share">


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#43983

Causing unexpected eyes diff on some browsers/platforms

![image (111)](https://user-images.githubusercontent.com/43474485/145636646-521ef9cf-066d-4fd1-a153-3e7f9d31359e.png)
