### PR TITLE
Set up for using application id column in enrollments

### DIFF
--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -322,9 +322,6 @@ class Pd::Enrollment < ApplicationRecord
   end
 
   # [MEG] TODO: Delete after migration is complete
-  alias application_id application_id_deprecated unless ActiveRecord::Base.connection.column_exists?(:pd_enrollments, :application_id)
-
-  # [MEG] TODO: Delete after migration is complete
   def application_id_deprecated
     find_application_id(user_id, pd_workshop_id)
   end
@@ -336,6 +333,9 @@ class Pd::Enrollment < ApplicationRecord
     end
     nil
   end
+
+  # [MEG] TODO: Delete after migration is complete
+  alias application_id application_id_deprecated unless ActiveRecord::Base.connection.column_exists?(:pd_enrollments, :application_id)
 
   # Finds the application a user used for a workshop.
   # Returns the id if (a) the course listed on their application

--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -345,7 +345,7 @@ class Pd::Enrollment < ApplicationRecord
     application_id = nil
     Pd::Application::ApplicationBase.where(user_id: user_id, application_year: APPLICATION_CURRENT_YEAR).each do |application|
       application_id = application.id if
-        COURSE_NAME_MAP(application.try(:course)) == Pd::Workshop.where(id: pd_workshop_id).try(:course) ||
+        Pd::Application::ApplicationBase::COURSE_NAME_MAP.dig(application.try(:course)) == Pd::Workshop.where(id: pd_workshop_id).try(:course) ||
           application.try(:pd_workshop_id) == pd_workshop_id
       break if application_id
     end

--- a/dashboard/app/serializers/api/v1/pd/workshop_enrollment_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/workshop_enrollment_serializer.rb
@@ -12,7 +12,12 @@ class Api::V1::Pd::WorkshopEnrollmentSerializer < ActiveModel::Serializer
   end
 
   def alternate_email
-    application_id = object.application_id
+    # [MEG] TODO: Eliminate column_exists after migration
+    application_id = if ActiveRecord::Base.connection.column_exists?(:pd_enrollments, :application_id)
+                       object.try(:application_id)
+                     else
+                       object.application_id
+                     end
     return unless application_id
 
     # Note: Use dig instead of [] because RuboCop doesn't like chaining ordinary method call after safe navigation operator.

--- a/dashboard/test/models/pd/enrollment_test.rb
+++ b/dashboard/test/models/pd/enrollment_test.rb
@@ -649,43 +649,40 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
   test 'the application id exists when the course from their application matches the workshop course' do
     teacher = create :teacher
     application = create :pd_teacher_application, course: 'csp', user: teacher
-    workshop = create :workshop, course: 'CS Principles'
+    workshop = create :workshop, course: Pd::SharedWorkshopConstants::COURSE_CSP
     enrollment = create :pd_enrollment, user: teacher, workshop: workshop
 
     # [MEG] TODO: Delete after migration is complete––want to check only if a course matches
     application.update(pd_workshop_id: workshop.id) unless
       ActiveRecord::Base.connection.column_exists?(:pd_enrollments, :application_id)
 
+    # [MEG] TODO: Update asserts below to not use column_exists check
     assert_equal application.id, enrollment.application_id unless ActiveRecord::Base.connection.column_exists?(:pd_enrollments, :application_id)
-    assert_equal application.id, enrollment.try(:application_id)
   end
 
   test 'the application id exists when their application has a matching workshop id' do
     teacher = create :teacher
-    workshop = create :workshop, course: 'CS Principles'
+    workshop = create :workshop, course: Pd::SharedWorkshopConstants::COURSE_CSP
     application = create :pd_teacher_application, course: 'csd', pd_workshop_id: workshop.id, user: teacher
     enrollment = create :pd_enrollment, user: teacher, workshop: workshop
 
     assert_equal application.id, enrollment.application_id unless ActiveRecord::Base.connection.column_exists?(:pd_enrollments, :application_id)
-    assert_equal application.id, enrollment.try(:application_id)
   end
 
   test 'no application id exists when there is no course match nor an id match' do
     teacher = create :teacher
-    workshop = create :workshop, course: 'CS Principles'
+    workshop = create :workshop, course: Pd::SharedWorkshopConstants::COURSE_CSP
     create :pd_teacher_application, course: 'csd', pd_workshop_id: workshop.id + 1, user: teacher
     enrollment = create :pd_enrollment, user: teacher, workshop: workshop
 
     assert_nil enrollment.application_id unless ActiveRecord::Base.connection.column_exists?(:pd_enrollments, :application_id)
-    assert_nil enrollment.try(:application_id)
   end
 
   test 'no application id exists when there is no application for that user' do
     teacher = create :teacher
-    workshop = create :workshop, course: 'CS Principles'
+    workshop = create :workshop, course: Pd::SharedWorkshopConstants::COURSE_CSP
     enrollment = create :pd_enrollment, user: teacher, workshop: workshop
 
     assert_nil enrollment.application_id unless ActiveRecord::Base.connection.column_exists?(:pd_enrollments, :application_id)
-    assert_nil enrollment.try(:application_id)
   end
 end

--- a/dashboard/test/models/pd/enrollment_test.rb
+++ b/dashboard/test/models/pd/enrollment_test.rb
@@ -656,8 +656,7 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
     application.update(pd_workshop_id: workshop.id) unless
       ActiveRecord::Base.connection.column_exists?(:pd_enrollments, :application_id)
 
-    # [MEG] TODO: Update asserts below to not use column_exists check
-    assert_equal application.id, enrollment.application_id unless ActiveRecord::Base.connection.column_exists?(:pd_enrollments, :application_id)
+    assert_equal application.id, enrollment.application_id
   end
 
   test 'the application id exists when their application has a matching workshop id' do
@@ -666,7 +665,7 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
     application = create :pd_teacher_application, course: 'csd', pd_workshop_id: workshop.id, user: teacher
     enrollment = create :pd_enrollment, user: teacher, workshop: workshop
 
-    assert_equal application.id, enrollment.application_id unless ActiveRecord::Base.connection.column_exists?(:pd_enrollments, :application_id)
+    assert_equal application.id, enrollment.application_id
   end
 
   test 'no application id exists when there is no course match nor an id match' do
@@ -675,7 +674,7 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
     create :pd_teacher_application, course: 'csd', pd_workshop_id: workshop.id + 1, user: teacher
     enrollment = create :pd_enrollment, user: teacher, workshop: workshop
 
-    assert_nil enrollment.application_id unless ActiveRecord::Base.connection.column_exists?(:pd_enrollments, :application_id)
+    assert_nil enrollment.application_id
   end
 
   test 'no application id exists when there is no application for that user' do
@@ -683,6 +682,6 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
     workshop = create :workshop, course: Pd::SharedWorkshopConstants::COURSE_CSP
     enrollment = create :pd_enrollment, user: teacher, workshop: workshop
 
-    assert_nil enrollment.application_id unless ActiveRecord::Base.connection.column_exists?(:pd_enrollments, :application_id)
+    assert_nil enrollment.application_id
   end
 end

--- a/dashboard/test/models/pd/enrollment_test.rb
+++ b/dashboard/test/models/pd/enrollment_test.rb
@@ -646,17 +646,46 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
     assert_equal enrollment.scholarship_status, Pd::ScholarshipInfoConstants::YES_CDO
   end
 
-  test 'find matching application for an enrollment' do
-    workshop = create :workshop
+  test 'the application id exists when the course from their application matches the workshop course' do
     teacher = create :teacher
+    application = create :pd_teacher_application, course: 'csp', user: teacher
+    workshop = create :workshop, course: 'CS Principles'
     enrollment = create :pd_enrollment, user: teacher, workshop: workshop
-    application = create :pd_teacher_application, user: teacher
 
-    assert_nil enrollment.application_id
+    # [MEG] TODO: Delete after migration is complete––want to check only if a course matches
+    application.update(pd_workshop_id: workshop.id) unless
+      ActiveRecord::Base.connection.column_exists?(:pd_enrollments, :application_id)
 
-    application.update(pd_workshop_id: workshop.id)
+    assert_equal application.id, enrollment.application_id unless ActiveRecord::Base.connection.column_exists?(:pd_enrollments, :application_id)
+    assert_equal application.id, enrollment.try(:application_id)
+  end
 
-    # Can only link an enrollment to an application when the application is assigned to the same workshop
-    assert_equal application.id, enrollment.application_id
+  test 'the application id exists when their application has a matching workshop id' do
+    teacher = create :teacher
+    workshop = create :workshop, course: 'CS Principles'
+    application = create :pd_teacher_application, course: 'csd', pd_workshop_id: workshop.id, user: teacher
+    enrollment = create :pd_enrollment, user: teacher, workshop: workshop
+
+    assert_equal application.id, enrollment.application_id unless ActiveRecord::Base.connection.column_exists?(:pd_enrollments, :application_id)
+    assert_equal application.id, enrollment.try(:application_id)
+  end
+
+  test 'no application id exists when there is no course match nor an id match' do
+    teacher = create :teacher
+    workshop = create :workshop, course: 'CS Principles'
+    create :pd_teacher_application, course: 'csd', pd_workshop_id: workshop.id + 1, user: teacher
+    enrollment = create :pd_enrollment, user: teacher, workshop: workshop
+
+    assert_nil enrollment.application_id unless ActiveRecord::Base.connection.column_exists?(:pd_enrollments, :application_id)
+    assert_nil enrollment.try(:application_id)
+  end
+
+  test 'no application id exists when there is no application for that user' do
+    teacher = create :teacher
+    workshop = create :workshop, course: 'CS Principles'
+    enrollment = create :pd_enrollment, user: teacher, workshop: workshop
+
+    assert_nil enrollment.application_id unless ActiveRecord::Base.connection.column_exists?(:pd_enrollments, :application_id)
+    assert_nil enrollment.try(:application_id)
   end
 end


### PR DESCRIPTION
This prepares us for when we have an `application_id` column in enrollments (see https://github.com/code-dot-org/code-dot-org/pull/44007). We will need to remove some code after the migration happens (see https://github.com/code-dot-org/code-dot-org/pull/44042).

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [PLAT-1505](https://codedotorg.atlassian.net/browse/PLAT-1505)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

There is some follow-up to remove the unneeded code after the migration since we won't need to check for the column at that point. See https://github.com/code-dot-org/code-dot-org/pull/44042

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
