### PR TITLE
[Google Blockly] Don't account for dragging in isUnused()

### DIFF
--- a/apps/src/blockly/addons/cdoBlockSvg.js
+++ b/apps/src/blockly/addons/cdoBlockSvg.js
@@ -26,9 +26,7 @@ export default class BlockSvg extends GoogleBlockly.BlockSvg {
   isUnused() {
     const isTopBlock = this.previousConnection === null;
     const hasParentBlock = !!this.parentBlock_;
-    const isDragging =
-      this.workspace?.currentGesture_?.blockDragger_?.draggingBlock_ === this;
-    return isDragging || !(isTopBlock || hasParentBlock);
+    return !(isTopBlock || hasParentBlock);
   }
 
   isVisible() {


### PR DESCRIPTION
This was a regression introduced by https://github.com/code-dot-org/code-dot-org/pull/43908
We don't need to account for whether a block is dragging in `isUnused` and it breaks in the case where the drag is about to end- the block will be counted as unused even if it's in the process of being dropped. This resulted in top blocks always being marked as unused, and other blocks looking disabled for a fraction of a second before being re-enabled

Before
![Dec-13-2021 11-41-01](https://user-images.githubusercontent.com/8787187/145877313-f45549ad-0904-456c-bafb-ff6bc51ae46c.gif)

After
![Dec-13-2021 11-37-46](https://user-images.githubusercontent.com/8787187/145877327-e8b2c16d-d7a1-4704-8851-9ebc9861eeb1.gif)
 