### PR TITLE
Allow editing of instructor in training field on PL courses

### DIFF
--- a/dashboard/app/models/activity_section.rb
+++ b/dashboard/app/models/activity_section.rb
@@ -86,6 +86,7 @@ class ActivitySection < ApplicationRecord
         bonus: sl_data['bonus'],
         challenge: !!sl_data['challenge'],
         variants: sl_data['variants'],
+        instructor_in_training: !!sl_data['instructor_in_training'],
         progression: progression_name.present? && progression_name
       )
       sl.update_levels(sl_data['levels'] || [])

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1573,7 +1573,7 @@ class Script < ApplicationRecord
       courseVersionId: get_course_version&.id,
       unitPath: script_path(self),
       lessonExtrasAvailableForUnit: lesson_extras_available,
-      isProfessionalLearningCourse: false #TODO(dmcavoy): update once audiences for courses are set
+      isProfessionalLearningCourse: pl_course?
     }
   end
 


### PR DESCRIPTION
Allow editing of instructor in training setting on script levels in PL courses. Also make sure we are saving the instructor_in_training value. 

## Testing story

- Tested locally