### PR TITLE
add margin-inline-end rule

### DIFF
--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -232,8 +232,8 @@ button.arrow {
   border: 1px solid #FFA000;
   background-color: #FFA000;
   color: #fff;
-  margin-left: 9px;
-  margin-right: 0px;
+  margin: 5px 0px;
+  margin-inline-end: 9px;
   display: none;
 }
 button.arrow>img {
@@ -251,7 +251,6 @@ button.arrow:disabled {
 #soft-buttons {
   display: inline-block;
   vertical-align: top;
-  margin-left: -9px;
   -webkit-touch-callout: none;
   &.soft-buttons-compact {
     margin: 0;


### PR DESCRIPTION
**What:** Rework margins on `arrow` buttons and `soft-buttons` area to create breathing room for the finish button and to remove some tech debt. 
**How:** Add a logical inline end margin after each arrow button which maps to a physical margin depending on the text direction (LTR or RTL). Remove a margin of `-9px` from the soft-buttons area.
**Why:** Following internal HoC playtesting, it was requested that we add some space between the arrow buttons and the finish button. 

Looking into the CSS more closely revealed that the parent element has included a `-9px` left-margin to offset a `9px` left-margin in the child element. This has been required to keep the edge of the button flush with the Run button and the canvas.
![image](https://user-images.githubusercontent.com/43474485/145885652-5d67c68b-24b5-43be-9beb-7d6036e494ce.png)![image](https://user-images.githubusercontent.com/43474485/145885697-ade05ec1-0acb-4a73-b453-1ddb4a4b2c55.png)
![image](https://user-images.githubusercontent.com/43474485/145887119-70d2629e-a09b-49ac-87b9-30975e02e6c6.png)![image](https://user-images.githubusercontent.com/43474485/145885840-29312494-f4fb-46fe-a713-99f5ebfb3243.png)
![image](https://user-images.githubusercontent.com/43474485/145887650-7a7b8c9c-1451-4e79-bab6-7e25e1303745.png) (RTL language example)

Moving the margin to the right will add some space before the Finish button. Using [`margin-inline-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-inline-end) allows us to shift the margin to the right, but only in LTR languages. (In RTL languages, the physical margin is on the left.) We can now remove the bizarre negative margin from the parent element as a bonus.
![image](https://user-images.githubusercontent.com/43474485/145888154-1fa3ca79-41f1-4219-a97e-c613cee31ada.png)![image](https://user-images.githubusercontent.com/43474485/145888184-913ca1bd-337e-4499-88f9-245dd0b6d0e7.png)
![image](https://user-images.githubusercontent.com/43474485/145888253-2deef3de-fc6b-4843-9441-c789bc4e4818.png)![image](https://user-images.githubusercontent.com/43474485/145888284-5f407b0f-a4ee-4d47-b1a2-ddc1d1320e0b.png)
![image](https://user-images.githubusercontent.com/43474485/145888367-066789f0-6422-4712-8662-d94cd8c86356.png) (RTL language example)

Note that an [earlier proposed fix](https://github.com/code-dot-org/code-dot-org/pull/43983), now reverted, would have explicitly added whitespace between these elements. In some browsers, this had unintended side effects which resulted in the pause button also being moved in some level configurations.  
## Links

- jira ticket: [STAR-1641](https://codedotorg.atlassian.net/browse/STAR-1641)


## Testing story

Other views and level types were tested:
*Play Lab (studio):*
![image](https://user-images.githubusercontent.com/43474485/145889355-7b1a30ba-a3b3-4770-8703-8e0ced44b6d3.png)
*Minecraft (agent):*
![image](https://user-images.githubusercontent.com/43474485/145889478-adc3a134-a583-4265-9b0b-cab6dfe59a29.png)
*Sprite Lab share view:*
![image](https://user-images.githubusercontent.com/43474485/145890189-84fcdacc-72aa-4e96-ab09-c527de3b154b.png)

The change was also tested in Safari. Note that IE does not support `margin-inline-end`.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
