### PR TITLE
INF-534 Update ALB config to match manual edits

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -144,6 +144,14 @@ Resources:
       LoadBalancerAttributes:
         - Key: deletion_protection.enabled
           Value: true
+        - Key: access_logs.s3.enabled
+          Value: true
+        - Key: access_logs.s3.bucket
+          Value: cdo-logs
+        - Key: access_logs.s3.prefix
+          Value: !Sub ${AWS::StackName}-alb-access-logs
+        - Key: waf.fail_open.enabled
+          Value: true
 
   HTTPListener:
     Type: AWS::ElasticLoadBalancingV2::Listener


### PR DESCRIPTION
Update cloudformation to match manual changes made during HoC. Future changes can be made here (when not under restricted deployments or in need of an urgent fix).

## Links

- Jira: INF-534

## Testing story

## Deployment strategy

Update requires no interruption. Can be deployed via normal process.

## Follow-up work

WAF fail open may change once the associated AWS support case is resolved: INF-537

## Privacy

n/a

## Security

WAF fail open causes traffic to pass through the ALB in the event that WAF cannot be contacted. If we are using WAF for critical security (we're only using it for observability and DDOS protection at the moment) then this setting may need to change.

## Caching

## PR Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
