### PR TITLE
initial cleanup of ScriptConstants uses

### DIFF
--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -6,7 +6,6 @@ require 'cdo/script_constants'
 class ScriptLevelsController < ApplicationController
   check_authorization
   include LevelsHelper
-  include ScriptConstants
   include VersionRedirectOverrider
 
   # Default s-maxage to use for script level pages which are configured as

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -781,7 +781,14 @@ class Script < ApplicationRecord
 
   # Legacy levels have different video and title logic in LevelsHelper.
   def legacy_curriculum?
-    [TWENTY_HOUR_NAME, HOC_2013_NAME, EDIT_CODE_NAME, TWENTY_FOURTEEN_NAME, FLAPPY_NAME, JIGSAW_NAME].include? name
+    [
+      Script::TWENTY_HOUR_NAME,
+      Script::HOC_2013_NAME,
+      Script::EDIT_CODE_NAME,
+      Script::TWENTY_FOURTEEN_NAME,
+      Script::FLAPPY_NAME,
+      Script::JIGSAW_NAME
+    ].include? name
   end
 
   def twenty_hour?

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -803,10 +803,6 @@ class Script < ApplicationRecord
     ScriptConstants.unit_in_category?(:flappy, name)
   end
 
-  def minecraft?
-    ScriptConstants.unit_in_category?(:minecraft, name)
-  end
-
   def k5_draft_course?
     ScriptConstants.unit_in_category?(:csf2_draft, name)
   end

--- a/lib/cdo/script_constants.rb
+++ b/lib/cdo/script_constants.rb
@@ -349,12 +349,6 @@ module ScriptConstants
     return CATEGORIES[category].include? script
   end
 
-  def self.script_in_any_category?(script)
-    CATEGORIES.keys.any? do |category|
-      unit_in_category?(category, script)
-    end
-  end
-
   def self.categories(script)
     CATEGORIES.select {|_, scripts| scripts.include? script}.
         map {|category, _| category.to_s}

--- a/lib/test/test_script_constants.rb
+++ b/lib/test/test_script_constants.rb
@@ -132,17 +132,6 @@ class ScriptConstantsTest < Minitest::Test
     assert_nil ScriptConstants.csf_next_course_recommendation("something-unknown")
   end
 
-  describe 'ScriptConstants::script_in_any_category?' do
-    it 'finds artist and csd1' do
-      assert ScriptConstants.script_in_any_category?('artist')
-      assert ScriptConstants.script_in_any_category?('csd1-2017')
-    end
-
-    it 'does not find nonexistent scripts' do
-      refute ScriptConstants.script_in_any_category?('foo')
-    end
-  end
-
   describe 'ScriptConstants::i18n' do
     it 'finds course1 in i18n' do
       assert ScriptConstants.i18n?('course1')


### PR DESCRIPTION
starts [PLAT-1144]. This PR takes a few initial steps toward cleaning up our use of ScriptConstants:
1. remove dead code
2. stop including ScriptConstants in ScriptLevelsController, to make it clear that there are no hidden uses in there
3. make sure that all uses of ScriptConstants outside of script_constants.rb have either the ScriptConstants:: or Script:: prefix, to make them easier to find (053ba6fb345750d5aa7bf324092f05f601a0b6f6)

ideally we'd stop including ScriptConstants into script.rb as well, but there are so many places which refer to those constants using the Script:: prefix (e.g. `Script::HOC_NAME`) that it doesn't seem worth updating all of them, especially since script_constants.rb might need to be explicitly included into many of those places. step 3 above seemed like the better option.

## Testing story

Existing test coverage

## Deployment strategy

merge to staging once it is open

## Follow-up work

make a plan + estimates before getting too much further into the script constants + congrats page work.

[PLAT-1144]: https://codedotorg.atlassian.net/browse/PLAT-1144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ