### PR TITLE
INF-538 limit access to docker on drone agents

### DIFF
--- a/aws/cloudformation/drone-stack.yml
+++ b/aws/cloudformation/drone-stack.yml
@@ -488,8 +488,7 @@ Resources:
           IpProtocol: tcp
           FromPort: 2376
           ToPort: 2376
-          # TODO: (suresh) Restrict to Drone Autoscaler.
-          CidrIp: 0.0.0.0/0
+          SourceSecurityGroupId: !GetAtt DroneAutoscalerEcsSecurityGroup.GroupId
         # Enable SSH to EC2 Instances hosting Drone Runner from gateway
         -
           IpProtocol: tcp


### PR DESCRIPTION
fixes INF-538

Only allow traffic from the drone autoscaler's security group on the docker API port.

## Links

- jira ticket: [INF-538](https://codedotorg.atlassian.net/browse/INF-538)

## Testing story

Will manually test this rule first, then update this text before merging.

## Deployment strategy

First, manually try this rule, so we can immediately disable it if it causes problems. Then revert the manual change and merge this.

## Follow-up work

n/a

## Privacy

n/a

## PR Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
