### PR TITLE
Update redirect logic for students when they sign in (in terms of live/archived sections)

### DIFF
--- a/dashboard/app/controllers/home_controller.rb
+++ b/dashboard/app/controllers/home_controller.rb
@@ -81,13 +81,21 @@ class HomeController < ApplicationController
 
   private
 
+  # Determine whether student should be redirected to script overview
+  # true - redirect to script overview page
+  # false - redirect to home page
   def should_redirect_to_script_overview?
+    # Ensure user is student and can access their most recently assigned script
     current_user.student? &&
     current_user.can_access_most_recently_assigned_script? &&
+    # Check if the user's most recently assigned script is associated with a
+    #         live section they are enrolled in,
+    #       or if the user's most recent progress was in a script associated
+    #         with a live section they are assigned to.
     (
       !current_user.user_script_with_most_recent_progress ||
-      current_user.most_recent_progress_in_recently_assigned_script? ||
-      current_user.last_assignment_after_most_recent_progress?
+      current_user.most_recent_assigned_script_in_live_section? ||
+      current_user.most_recent_progress_script_in_live_section?
     )
   end
 

--- a/dashboard/app/controllers/home_controller.rb
+++ b/dashboard/app/controllers/home_controller.rb
@@ -88,12 +88,12 @@ class HomeController < ApplicationController
     # Ensure user is student and can access their most recently assigned script
     current_user.student? &&
     current_user.can_access_most_recently_assigned_script? &&
-    # Check if the user's most recently assigned script is associated with a
-    #         live section they are enrolled in,
-    #       or if the user's most recent progress was in a script associated
-    #         with a live section they are assigned to.
     (
       !current_user.user_script_with_most_recent_progress ||
+      # Check if the user's most recently assigned script is associated with a
+      #         live section they are enrolled in,
+      #       or if the user's most recent progress was in a script associated
+      #         with a live section they are assigned to.
       current_user.most_recent_assigned_script_in_live_section? ||
       current_user.most_recent_progress_script_in_live_section?
     )

--- a/dashboard/app/controllers/home_controller.rb
+++ b/dashboard/app/controllers/home_controller.rb
@@ -81,21 +81,20 @@ class HomeController < ApplicationController
 
   private
 
-  # Determine whether student should be redirected to script overview
-  # true - redirect to script overview page
-  # false - redirect to home page
+  # Determine where student should be redirected upon logging in:
+  # true (redirect to script overview page) - if the user is a student && can access the script
+  #   they were most recently assigned && they either have no recorded recent progress, their most
+  #   recent progress was in the most recently assigned script, or they were assigned the script
+  #   more recently than their last progress in another section.
+  # false (redirect to student homepage) - otherwise.
   def should_redirect_to_script_overview?
-    # Ensure user is student and can access their most recently assigned script
     current_user.student? &&
     current_user.can_access_most_recently_assigned_script? &&
+    current_user.most_recent_assigned_script_in_live_section? &&
     (
       !current_user.user_script_with_most_recent_progress ||
-      # Check if the user's most recently assigned script is associated with a
-      #         live section they are enrolled in,
-      #       or if the user's most recent progress was in a script associated
-      #         with a live section they are assigned to.
-      current_user.most_recent_assigned_script_in_live_section? ||
-      current_user.most_recent_progress_script_in_live_section?
+      current_user.most_recent_progress_in_recently_assigned_script? ||
+      current_user.last_assignment_after_most_recent_progress?
     )
   end
 

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1593,6 +1593,7 @@ class User < ApplicationRecord
     visible_assigned_scripts.any?
   end
 
+  # Query to get the user_script the user was most recently assigned.
   def most_recently_assigned_user_script
     user_scripts.
     where("assigned_at").
@@ -1600,6 +1601,8 @@ class User < ApplicationRecord
     first
   end
 
+  # Get script object of the user_script the user was most recently
+  # assigned.
   def most_recently_assigned_script
     most_recently_assigned_user_script.script
   end
@@ -1610,6 +1613,8 @@ class User < ApplicationRecord
     !script.pilot? || script.has_pilot_access?(self)
   end
 
+  # Query to get the user_script the user made the most recent progress
+  # in.
   def user_script_with_most_recent_progress
     user_scripts.
     where("last_progress_at").
@@ -1617,17 +1622,35 @@ class User < ApplicationRecord
     first
   end
 
+  # Get script object of the user_script the user made the most recent
+  # progress in.
   def script_with_most_recent_progress
     user_script_with_most_recent_progress.script
   end
 
+  # Check if the user's most recently-assigned script is the same one
+  # that they've most recently made progress in.
   def most_recent_progress_in_recently_assigned_script?
     script_with_most_recent_progress == most_recently_assigned_script
   end
 
+  # Check if the user has been assigned a new script since their most
+  # recent progress in any other script.
   def last_assignment_after_most_recent_progress?
     most_recently_assigned_user_script[:assigned_at] >=
     user_script_with_most_recent_progress[:last_progress_at]
+  end
+
+  # Check if the user's most recently assigned script is associated with at least
+  # 1 live section they are enrolled in.
+  def most_recent_assigned_script_in_live_section?
+    sections_as_student.any? {|section| section.script_id == most_recently_assigned_script.id && section.hidden == false}
+  end
+
+  # Check if the most recent progress made by the user was in a script associated
+  # with at least 1 live section they are enrolled in.
+  def most_recent_progress_script_in_live_section?
+    sections_as_student.any? {|section| section.script_id == script_with_most_recent_progress.id && section.hidden == false}
   end
 
   # Checks if there are any launched scripts or courses assigned to the user.

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1644,13 +1644,15 @@ class User < ApplicationRecord
   # Check if the user's most recently assigned script is associated with at least
   # 1 live section they are enrolled in.
   def most_recent_assigned_script_in_live_section?
-    sections_as_student.any? {|section| section.script_id == most_recently_assigned_script.id && section.hidden == false}
+    recent_assigned_script_id = most_recently_assigned_script.id
+    sections_as_student.any? {|section| section.script_id == recent_assigned_script_id && section.hidden == false}
   end
 
   # Check if the most recent progress made by the user was in a script associated
   # with at least 1 live section they are enrolled in.
   def most_recent_progress_script_in_live_section?
-    sections_as_student.any? {|section| section.script_id == script_with_most_recent_progress.id && section.hidden == false}
+    recent_progress_script_id = script_with_most_recent_progress.id
+    sections_as_student.any? {|section| section.script_id == recent_progress_script_id && section.hidden == false}
   end
 
   # Checks if there are any launched scripts or courses assigned to the user.

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1635,7 +1635,7 @@ class User < ApplicationRecord
   end
 
   # Check if the user has been assigned a new script since their most
-  # recent progress in any other script.
+  # recent progress in a script.
   def last_assignment_after_most_recent_progress?
     most_recently_assigned_user_script[:assigned_at] >=
     user_script_with_most_recent_progress[:last_progress_at]
@@ -1646,13 +1646,6 @@ class User < ApplicationRecord
   def most_recent_assigned_script_in_live_section?
     recent_assigned_script_id = most_recently_assigned_script.id
     sections_as_student.any? {|section| section.script_id == recent_assigned_script_id && section.hidden == false}
-  end
-
-  # Check if the most recent progress made by the user was in a script associated
-  # with at least 1 live section they are enrolled in.
-  def most_recent_progress_script_in_live_section?
-    recent_progress_script_id = script_with_most_recent_progress.id
-    sections_as_student.any? {|section| section.script_id == recent_progress_script_id && section.hidden == false}
   end
 
   # Checks if there are any launched scripts or courses assigned to the user.

--- a/dashboard/test/controllers/home_controller_test.rb
+++ b/dashboard/test/controllers/home_controller_test.rb
@@ -53,12 +53,13 @@ class HomeControllerTest < ActionController::TestCase
   end
 
   test "student with assigned script and no progress is redirected to course overview" do
-    student = create :student
     script = create :script
+    section = create :section, script: script
+    student = create(:follower, section: section).student_user
     sign_in student
-    student.assign_script(script)
     assert_equal script, student.most_recently_assigned_script
     assert_nil student.user_script_with_most_recent_progress
+
     get :index
 
     assert_redirected_to script_path(script)
@@ -95,10 +96,10 @@ class HomeControllerTest < ActionController::TestCase
   end
 
   test "student with assigned script then recent progress in that script will go to script overview" do
-    student = create :student
     script = create :script
+    section = create :section, script: script
+    student = create(:follower, section: section).student_user
     sign_in student
-    student.assign_script(script)
     User.any_instance.stubs(:script_with_most_recent_progress).returns(script)
     assert_equal script, student.most_recently_assigned_script
     assert_equal script, student.script_with_most_recent_progress
@@ -109,16 +110,16 @@ class HomeControllerTest < ActionController::TestCase
   end
 
   test "student with assigned course or script and no age is still redirected to course overview" do
-    student = create :student
+    assigned_script = create :script
+    assigned_section = create :section, script: assigned_script
+    student = create(:follower, section: assigned_section).student_user
     student.birthday = nil
     student.age = nil
     student.save(validate: false)
-    script = create :script
     sign_in student
-    student.assign_script(script)
     get :index
 
-    assert_redirected_to script_path(script)
+    assert_redirected_to script_path(assigned_script)
   end
 
   test "student without pilot access will go to index" do

--- a/dashboard/test/controllers/home_controller_test.rb
+++ b/dashboard/test/controllers/home_controller_test.rb
@@ -80,18 +80,18 @@ class HomeControllerTest < ActionController::TestCase
   end
 
   test "student with recent progress then an assigned script should go to the assigned script overview" do
-    student = create :student
-    sign_in student
-    assigned_user_script = create :user_script, user: student, assigned_at: 1.day.ago
+    assigned_script = create :script
+    assigned_section = create :section, script: assigned_script
+    student = create(:follower, section: assigned_section).student_user
     user_script_with_progress = create :user_script, user: student, last_progress_at: 2.days.ago
-    User.any_instance.stubs(:user_script_with_most_recent_progress).returns(user_script_with_progress)
-    User.any_instance.stubs(:most_recently_assigned_user_script).returns(assigned_user_script)
+    sign_in student
+
     student.most_recently_assigned_user_script
     assert_equal user_script_with_progress, student.user_script_with_most_recent_progress
 
     get :index
 
-    assert_redirected_to script_path(assigned_user_script.script)
+    assert_redirected_to script_path(assigned_script)
   end
 
   test "student with assigned script then recent progress in that script will go to script overview" do


### PR DESCRIPTION
**_Previous behavior_**:
Previously, when students logged in, they would be redirected either to the script overview page of the script they were most recently assigned or to the student homepage. The pseudo-code looked like the following:
![old pseudocode](https://user-images.githubusercontent.com/56283563/148293490-e8493af8-3d85-4dac-b479-e0861d8df9d8.JPG)
However, this did not take into account whether the script overview page was associated with any live (non-archived) sections the student was enrolled in. This meant that students logging in might be immediately redirected to a script not associated with any of their live sections (or any of their sections at all).



**_Current behavior_**:
Now, students are redirected with the same logic only if the most recently assigned script is associated with any live section they are enrolled in.Here is the logic's new general pseudo-code:
![new pseudocode](https://user-images.githubusercontent.com/56283563/148293510-6836a1b8-89f1-48d6-96d2-f08da4adbbb3.JPG)

Based on the different factors the logic checks when deciding where to redirect the students, there are 15 scenarios. Some of these scenarios are somewhat redundant and many do not involve any changed behavior from previously, but I wanted to lay out these scenarios to pinpoint which ones are changing. If a scenario has new behavior compared to how it was originally, then that scenario has an 'X' mark in the "Different behavior than before" column. Also, I used Script A and Script B for the scenarios but those scripts were arbitrarily chosen.


_Scenarios 1-5_:
These are the simple scenarios where a student is in 0-1 sections.
| Scenario | Sections student is enrolled in | Most recently assigned script | Script with most recent progress | Was most recent script assignment after most recent progress? | Desired redirect | Different behavior than before | Video demo | 
| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
| 1 | No sections | None | None | N/A | Student home page |  | [Demo 1](https://user-images.githubusercontent.com/56283563/148304182-71439e64-c56a-4fee-9579-830c40d7ba5e.mp4) |
| 2 | 1 live section running Script A | Script A | No progress made | Yes (since no progress was made) | Script A's page |  | [Demo 2](https://user-images.githubusercontent.com/56283563/148304238-afc3aae4-11d3-463a-8963-d1179a88e7c2.mp4) |
| 3 | 1 live section running Script A | Script A| Script A | No | Script A's page |  | [Demo 3](https://user-images.githubusercontent.com/56283563/148304295-a759453b-059f-460a-baf0-e9312921ba16.mp4) |
| 4 | 1 archived section running Script A | Script A| No progress made | Yes (since no progress was made) | Student home page | X | [Demo 4](https://user-images.githubusercontent.com/56283563/148304320-a9571e39-5315-496a-a53d-53c442dc5cc8.mp4) |
| 5 | 1 archived section running Script A | Script A| Script A | No | Student home page | X | [Demo 5](https://user-images.githubusercontent.com/56283563/148304345-c1bd79ff-7c4d-41a4-84df-96d53c4973bc.mp4) |


_Scenarios 6-10_:
These are some of the scenarios where the student is enrolled in 2+ sections with different scripts (if they were al the same script, they would parallel the behavior of scenarios 2-5). In these 5, they all have the same section setup. The student is enrolled in 2 sections: 1 **_live_** running Script A and 1 either live or archived (irrelevant since Script A is always the most recently assigned one in these scenarios) running Script B. Also, in each of these, the most recently assigned script **_is_** associated with at least 1 live section.

_Note: None of these scenarios have a different behavior than the original but I wanted to list them out still here to be thorough._
| Scenario | Most recently assigned script | Script with most recent progress | Was most recent script assignment after most recent progress? | Desired redirect | Different behavior than before | Video demo | 
| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
| 6 | Script A | No progress made | Yes (since no progress was made) | Script A's page |  | [Demo 6](https://user-images.githubusercontent.com/56283563/148852960-e3fa1cbf-819c-4257-a55d-0a05dd84325f.mp4) |
| 7 | Script A | Script A | No | Script A's page |  | [Demo 7](https://user-images.githubusercontent.com/56283563/148852321-85a5e548-eb1e-4bd0-8396-8150a07f8eac.mp4) |
| 8 | Script A| Script A | Yes | Script A's page |  | [Demo 8](https://user-images.githubusercontent.com/56283563/148852336-ffb35602-3568-4327-ab7c-ea9d1fd3ebc3.mp4) |
| 9 | Script A| Script B | No | Student home page | | [Demo 9](https://user-images.githubusercontent.com/56283563/148852354-e9befc1d-d524-4378-b7b7-ad8e5f9d2458.mp4) |
| 10 | Script A| Script B | Yes | Script A's page | | [Demo 10](https://user-images.githubusercontent.com/56283563/148852976-674e3550-394c-42f4-bd51-4c1e432be9dc.mp4) |

_Scenarios 11-15_:
These are some of the scenarios where the student is enrolled in 2+ sections with different scripts (if they were al the same script, they would parallel the behavior of scenarios 2-5). In these 5, they all have the same section setup. The student is enrolled in 2 sections: 1 **_archived_** running Script A and 1 either live or archived (irrelevant since Script A is always the most recently assigned one in these scenarios) running Script B. Also, in each of these, the most recently assigned script **_is not_** associated with at least 1 live section.

| Scenario | Most recently assigned script | Script with most recent progress | Was most recent script assignment after most recent progress? | Desired redirect | Different behavior than before | Video demo | 
| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
| 11 | Script A | No progress made | Yes (since no progress was made) | Student homepage | X | [Demo 11](https://user-images.githubusercontent.com/56283563/148854387-4f2165b1-eaa0-4d0a-9577-ee3fa70f70d4.mp4) |
| 12 | Script A | Script A | No | Student homepage | X | [Demo 12](https://user-images.githubusercontent.com/56283563/148854450-a54a2db6-2eb9-4f9e-a26b-4a54e81abb5c.mp4) |
| 13 | Script A| Script A | Yes | Student homepage | X | [Demo 13](https://user-images.githubusercontent.com/56283563/148854472-617885c1-a495-4884-a193-21c25e4eea44.mp4) |
| 14 | Script A| Script B | No | Student home page | | [Demo 14](https://user-images.githubusercontent.com/56283563/148854489-1172adab-8c1f-4116-bc26-36b94027216d.mp4) |
| 15 | Script A| Script B | Yes | Student homepage | X | [Demo 15](https://user-images.githubusercontent.com/56283563/148854498-12fef245-b80c-476a-847d-fd5ca34db707.mp4) |

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/browse/FND-1706?atlOrigin=eyJpIjoiMDk0MWFmMTFmNmZhNGFkMmE0MDJiNWFiZDcwODE1ZDIiLCJwIjoiaiJ9)
Spec: [Requirement 2 of the "Make section remove/archive match what teachers expect it to do" spec](https://docs.google.com/document/d/1bSG8FV6OpBZBQPLA63tTN9oJ9gCk7vkC_S-neQ7Dnws/edit#)

## Testing story
Manually tested the multiple scenarios listed above to ensure that students were properly redirected to the right section's script page (with the student's progress shown) or the student homepage in different browsers and on mobile.

For some of the existing tests checking student redirects, I had them enroll a student in a section with the given script and scenaraio of the test instead of just having the student make progress in the script. The tests still have the same checks but they just needed a section to associate with the script so that the when the logic searches for a non-archived section associated with the given script it could find one. I also added unit tests to cover the new scenarios.

## Follow-up work
Continue the following requirements listed in the ["Make section remove/archive match what teachers expect it to do" spec](https://docs.google.com/document/d/1bSG8FV6OpBZBQPLA63tTN9oJ9gCk7vkC_S-neQ7Dnws/edit#).

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
