### PR TITLE
Rename verifiedTeacherRedux to verifiedInstructorRedux

### DIFF
--- a/apps/src/code-studio/components/TeacherContentToggle.js
+++ b/apps/src/code-studio/components/TeacherContentToggle.js
@@ -136,7 +136,7 @@ export const mapStateToProps = state => {
       selectedSectionId,
       currentLessonId
     );
-  } else if (!state.verifiedTeacher.isVerified) {
+  } else if (!state.verifiedInstructor.isVerified) {
     // if not-authorized teacher
     isLockedLesson = state.progress.lessons.some(
       lesson => lesson.id === currentLessonId && lesson.lockable

--- a/apps/src/code-studio/components/progress/UnitOverviewHeader.jsx
+++ b/apps/src/code-studio/components/progress/UnitOverviewHeader.jsx
@@ -272,7 +272,7 @@ export default connect(state => ({
   betaTitle: state.progress.betaTitle,
   isSignedIn: state.currentUser.signInState === SignInState.SignedIn,
   viewAs: state.viewAs,
-  isVerifiedTeacher: state.verifiedTeacher.isVerified,
-  hasVerifiedResources: state.verifiedTeacher.hasVerifiedResources,
+  isVerifiedTeacher: state.verifiedInstructor.isVerified,
+  hasVerifiedResources: state.verifiedInstructor.hasVerifiedResources,
   localeCode: state.locales.localeCode
 }))(UnitOverviewHeader);

--- a/apps/src/code-studio/header.js
+++ b/apps/src/code-studio/header.js
@@ -22,7 +22,7 @@ import {
   setUserSignedIn,
   setInitialData
 } from '@cdo/apps/templates/currentUserRedux';
-import {setVerified} from '@cdo/apps/code-studio/verifiedTeacherRedux';
+import {setVerified} from '@cdo/apps/code-studio/verifiedInstructorRedux';
 
 import {PUZZLE_PAGE_NONE} from '@cdo/apps/templates/progress/progressTypes';
 import HeaderMiddle from '@cdo/apps/code-studio/components/header/HeaderMiddle';

--- a/apps/src/code-studio/progress.js
+++ b/apps/src/code-studio/progress.js
@@ -26,7 +26,7 @@ import {
   queryUserProgress as reduxQueryUserProgress,
   useDbProgress
 } from './progressRedux';
-import {setVerified} from '@cdo/apps/code-studio/verifiedTeacherRedux';
+import {setVerified} from '@cdo/apps/code-studio/verifiedInstructorRedux';
 import {
   selectSection,
   setSections,

--- a/apps/src/code-studio/progressRedux.js
+++ b/apps/src/code-studio/progressRedux.js
@@ -13,7 +13,7 @@ import {
   getLevelResult
 } from '@cdo/apps/templates/progress/progressHelpers';
 import {PUZZLE_PAGE_NONE} from '@cdo/apps/templates/progress/progressTypes';
-import {setVerified} from '@cdo/apps/code-studio/verifiedTeacherRedux';
+import {setVerified} from '@cdo/apps/code-studio/verifiedInstructorRedux';
 import {authorizeLockable} from './lessonLockRedux';
 
 // Action types

--- a/apps/src/code-studio/redux.js
+++ b/apps/src/code-studio/redux.js
@@ -12,7 +12,7 @@ import isRtl from './isRtlRedux';
 import responsive from './responsiveRedux';
 import publishDialog from '../templates/projects/publishDialog/publishDialogRedux';
 import projects from '../templates/projects/projectsRedux';
-import verifiedTeacher from './verifiedTeacherRedux';
+import verifiedInstructor from './verifiedInstructorRedux';
 import currentUser from '@cdo/apps/templates/currentUserRedux';
 import arrowDisplay from '@cdo/apps/templates/arrowDisplayRedux';
 import teacherPanel from '@cdo/apps/code-studio/teacherPanelRedux';
@@ -31,7 +31,7 @@ registerReducers({
   responsive,
   publishDialog,
   projects,
-  verifiedTeacher,
+  verifiedInstructor,
   currentUser,
   arrowDisplay
 });

--- a/apps/src/code-studio/verifiedInstructorRedux.js
+++ b/apps/src/code-studio/verifiedInstructorRedux.js
@@ -1,5 +1,5 @@
-const SET_VERIFIED = 'verifiedTeacher/SET_VERIFIED';
-const SET_VERIFIED_RESOURCES = 'verifiedTeacher/SET_VERIFIED_RESOURCES';
+const SET_VERIFIED = 'verifiedInstructor/SET_VERIFIED';
+const SET_VERIFIED_RESOURCES = 'verifiedInstructor/SET_VERIFIED_RESOURCES';
 
 export const setVerified = () => ({type: SET_VERIFIED});
 export const setVerifiedResources = hasVerifiedResources => ({
@@ -13,7 +13,7 @@ const initialState = {
   hasVerifiedResources: false
 };
 
-export default function verifiedTeacher(state = initialState, action) {
+export default function verifiedInstructor(state = initialState, action) {
   if (action.type === SET_VERIFIED) {
     return {
       ...state,

--- a/apps/src/sites/studio/pages/courses/show.js
+++ b/apps/src/sites/studio/pages/courses/show.js
@@ -22,7 +22,7 @@ import {setUserSignedIn} from '@cdo/apps/templates/currentUserRedux';
 import {
   setVerified,
   setVerifiedResources
-} from '@cdo/apps/code-studio/verifiedTeacherRedux';
+} from '@cdo/apps/code-studio/verifiedInstructorRedux';
 import {setViewType, ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import {tooltipifyVocabulary} from '@cdo/apps/utils';
 

--- a/apps/src/sites/studio/pages/lessons/show.js
+++ b/apps/src/sites/studio/pages/lessons/show.js
@@ -16,7 +16,7 @@ import {registerReducers} from '@cdo/apps/redux';
 import {
   setVerified,
   setVerifiedResources
-} from '@cdo/apps/code-studio/verifiedTeacherRedux';
+} from '@cdo/apps/code-studio/verifiedInstructorRedux';
 import {setViewType, ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import {tooltipifyVocabulary} from '@cdo/apps/utils';
 

--- a/apps/src/sites/studio/pages/scripts/show.js
+++ b/apps/src/sites/studio/pages/scripts/show.js
@@ -12,7 +12,7 @@ import {renderCourseProgress} from '@cdo/apps/code-studio/progress';
 import {
   setVerified,
   setVerifiedResources
-} from '@cdo/apps/code-studio/verifiedTeacherRedux';
+} from '@cdo/apps/code-studio/verifiedInstructorRedux';
 import {tooltipifyVocabulary} from '@cdo/apps/utils';
 
 import locales, {setLocaleCode} from '../../../../redux/localesRedux';

--- a/apps/src/templates/courseOverview/CourseOverview.js
+++ b/apps/src/templates/courseOverview/CourseOverview.js
@@ -286,7 +286,7 @@ export default connect((state, ownProps) => ({
   ),
   isSignedIn: state.currentUser.signInState === SignInState.SignedIn,
   viewAs: state.viewAs,
-  isVerifiedTeacher: state.verifiedTeacher.isVerified,
-  hasVerifiedResources: state.verifiedTeacher.hasVerifiedResources,
+  isVerifiedTeacher: state.verifiedInstructor.isVerified,
+  hasVerifiedResources: state.verifiedInstructor.hasVerifiedResources,
   announcements: state.announcements || []
 }))(CourseOverview);

--- a/apps/src/templates/instructions/teacherFeedback/EditableTeacherFeedback.jsx
+++ b/apps/src/templates/instructions/teacherFeedback/EditableTeacherFeedback.jsx
@@ -292,7 +292,8 @@ export const UnconnectedEditableTeacherFeedback = EditableTeacherFeedback;
 
 export default connect(
   state => ({
-    verifiedTeacher: state.verifiedTeacher && state.verifiedTeacher.isVerified,
+    verifiedTeacher:
+      state.verifiedInstructor && state.verifiedInstructor.isVerified,
     selectedSectionId:
       state.teacherSections && state.teacherSections.selectedSectionId,
     canHaveFeedbackReviewState:

--- a/apps/src/templates/lessonOverview/LessonOverview.jsx
+++ b/apps/src/templates/lessonOverview/LessonOverview.jsx
@@ -368,6 +368,6 @@ export default connect(state => ({
   announcements: state.announcements || [],
   isSignedIn: state.currentUser.signInState === SignInState.SignedIn,
   viewAs: state.viewAs,
-  isVerifiedTeacher: state.verifiedTeacher.isVerified,
-  hasVerifiedResources: state.verifiedTeacher.hasVerifiedResources
+  isVerifiedTeacher: state.verifiedInstructor.isVerified,
+  hasVerifiedResources: state.verifiedInstructor.hasVerifiedResources
 }))(LessonOverview);

--- a/apps/test/unit/code-studio/TeacherContentToggleTest.js
+++ b/apps/test/unit/code-studio/TeacherContentToggleTest.js
@@ -364,7 +364,7 @@ describe('TeacherContentToggle', () => {
         progress: {},
         teacherSections: {},
         hiddenLesson: {},
-        verifiedTeacher: {}
+        verifiedInstructor: {}
       };
 
       it('sets locked hidden to true when locked and hidden', () => {
@@ -409,14 +409,14 @@ describe('TeacherContentToggle', () => {
         },
         teacherSections: {},
         hiddenLesson: {},
-        verifiedTeacher: {
+        verifiedInstructor: {
           isVerified: true
         }
       };
 
       const stateUnverified = {
         ...state,
-        verifiedTeacher: {
+        verifiedInstructor: {
           isVerified: false
         }
       };

--- a/apps/test/unit/code-studio/progressReduxTest.js
+++ b/apps/test/unit/code-studio/progressReduxTest.js
@@ -1375,7 +1375,7 @@ describe('progressReduxTest', () => {
 
       const expectedDispatchActions = [
         'progress/CLEAR_RESULTS',
-        'verifiedTeacher/SET_VERIFIED',
+        'verifiedInstructor/SET_VERIFIED',
         'progress/SET_IS_SUMMARY_VIEW',
         'progress/UPDATE_FOCUS_AREAS',
         'lessonLock/AUTHORIZE_LOCKABLE',

--- a/apps/test/unit/code-studio/verifiedInstructorReduxTest.js
+++ b/apps/test/unit/code-studio/verifiedInstructorReduxTest.js
@@ -2,9 +2,9 @@ import {assert} from 'chai';
 import reducer, {
   setVerified,
   setVerifiedResources
-} from '@cdo/apps/code-studio/verifiedTeacherRedux';
+} from '@cdo/apps/code-studio/verifiedInstructorRedux';
 
-describe('verifiedTeacherRedux', () => {
+describe('verifiedInstructorRedux', () => {
   it('begins with teachers unverified', () => {
     const state = reducer(undefined, {});
     assert.strictEqual(state.isVerified, false);


### PR DESCRIPTION
Renames verifiedTeacherRedux to verifiedInstructorRedux. This is part of the move to using instructor instead of teacher in order to be able to have PL courses as part of our normal curriculum models. 


## Links

[Eng Plan](https://docs.google.com/document/d/1V61xONU0-mleMEEdHWNxhvZtYIPRCB31mT_hbUXusCQ/edit#)
[Product Spec](https://docs.google.com/document/d/1qZpc90daxQiiqpcQUiUiGV2tQoaYEQUzOA72UZzBlVE/edit#heading=h.n0ym0xihxqcm)

## Testing story

- Existing tests