### PR TITLE
Seed and serialize spritelab programming expressions

### DIFF
--- a/dashboard/app/models/programming_expression.rb
+++ b/dashboard/app/models/programming_expression.rb
@@ -67,25 +67,12 @@ class ProgrammingExpression < ApplicationRecord
     environment_name = File.basename(File.dirname(path)) == 'GamelabJr' ? 'spritelab' : File.basename(File.dirname(path))
     programming_environment = ProgrammingEnvironment.find_by(name: environment_name)
     throw "Cannot find ProgrammingEnvironment #{environment_name}" unless programming_environment
-
-    if environment_name == 'spritelab'
+    expression_config.symbolize_keys.merge(
       {
-        key: expression_config['config']['docFunc'] || expression_config['config']['func'] || expression_config['config']['name'],
-        name: expression_config['config']['func'] || expression_config['config']['name'],
         programming_environment_id: programming_environment.id,
-        category: expression_config['category'],
-        color: expression_config['config']['color'],
-        syntax: expression_config['config']['func'] || expression_config['config']['name'],
-        palette_params: expression_config['paletteParams']
+        color: environment_name == 'spritelab' ? expression_config['color'] : ProgrammingExpression.get_category_color(expression_config['category'])
       }
-    else
-      expression_config.symbolize_keys.merge(
-        {
-          programming_environment_id: programming_environment.id,
-          color: ProgrammingExpression.get_category_color(expression_config['category'])
-        }
-      )
-    end
+    )
   end
 
   def self.get_syntax(config)
@@ -147,9 +134,6 @@ class ProgrammingExpression < ApplicationRecord
   def self.seed_all
     removed_records = all.pluck(:name)
     Dir.glob(Rails.root.join("config/programming_expressions/{applab,gamelab,weblab,spritelab}/*.json")).each do |path|
-      removed_records -= [ProgrammingExpression.seed_record(path)]
-    end
-    Dir.glob(Rails.root.join("config/blocks/GamelabJr/*.json")).each do |path|
       removed_records -= [ProgrammingExpression.seed_record(path)]
     end
     where(name: removed_records).destroy_all
@@ -239,8 +223,6 @@ class ProgrammingExpression < ApplicationRecord
 
   def write_serialization
     return unless Rails.application.config.levelbuilder_mode
-    # TODO: serialize spritelab docs
-    return if programming_environment.name == 'spritelab'
     file_path = Rails.root.join("config/programming_expressions/#{programming_environment.name}/#{key.parameterize(preserve_case: true)}.json")
     object_to_serialize = serialize
     File.write(file_path, JSON.pretty_generate(object_to_serialize))

--- a/dashboard/config/programming_expressions/applab/button.json
+++ b/dashboard/config/programming_expressions/applab/button.json
@@ -10,6 +10,5 @@
       "name": "text"
     }
   ],
-  "syntax": "button(id, text)",
-  "video_key": "alg_6_variables"
+  "syntax": "button(id, text)"
 }

--- a/dashboard/config/programming_expressions/applab/button.json
+++ b/dashboard/config/programming_expressions/applab/button.json
@@ -10,5 +10,6 @@
       "name": "text"
     }
   ],
-  "syntax": "button(id, text)"
+  "syntax": "button(id, text)",
+  "video_key": "alg_6_variables"
 }

--- a/dashboard/config/programming_expressions/spritelab/addTarget.json
+++ b/dashboard/config/programming_expressions/spritelab/addTarget.json
@@ -1,0 +1,6 @@
+{
+  "key": "addTarget",
+  "name": "addTarget",
+  "category": "Sprites",
+  "syntax": "addTarget"
+}

--- a/dashboard/config/programming_expressions/spritelab/atTime.json
+++ b/dashboard/config/programming_expressions/spritelab/atTime.json
@@ -1,0 +1,6 @@
+{
+  "key": "atTime",
+  "name": "atTime",
+  "category": "Events",
+  "syntax": "atTime"
+}

--- a/dashboard/config/programming_expressions/spritelab/avoidingTargets.json
+++ b/dashboard/config/programming_expressions/spritelab/avoidingTargets.json
@@ -1,0 +1,6 @@
+{
+  "key": "avoidingTargets",
+  "name": "avoidingTargets",
+  "category": "SL1",
+  "syntax": "avoidingTargets"
+}

--- a/dashboard/config/programming_expressions/spritelab/beginCollectingData.json
+++ b/dashboard/config/programming_expressions/spritelab/beginCollectingData.json
@@ -1,0 +1,6 @@
+{
+  "key": "beginCollectingData",
+  "name": "beginCollectingData",
+  "category": "Math",
+  "syntax": "beginCollectingData"
+}

--- a/dashboard/config/programming_expressions/spritelab/bounce-off.json
+++ b/dashboard/config/programming_expressions/spritelab/bounce-off.json
@@ -1,0 +1,6 @@
+{
+  "key": "bounce-off",
+  "name": "bounceOff",
+  "category": "Sprites",
+  "syntax": "bounceOff"
+}

--- a/dashboard/config/programming_expressions/spritelab/checkTouching.json
+++ b/dashboard/config/programming_expressions/spritelab/checkTouching.json
@@ -1,0 +1,6 @@
+{
+  "key": "checkTouching",
+  "name": "checkTouching",
+  "category": "Events",
+  "syntax": "checkTouching"
+}

--- a/dashboard/config/programming_expressions/spritelab/clickedOn.json
+++ b/dashboard/config/programming_expressions/spritelab/clickedOn.json
@@ -1,0 +1,6 @@
+{
+  "key": "clickedOn",
+  "name": "clickedOn",
+  "category": "Unused",
+  "syntax": "clickedOn"
+}

--- a/dashboard/config/programming_expressions/spritelab/clickedSpritePointer.json
+++ b/dashboard/config/programming_expressions/spritelab/clickedSpritePointer.json
@@ -1,0 +1,6 @@
+{
+  "key": "clickedSpritePointer",
+  "name": "clickedSpritePointer",
+  "category": "Events",
+  "syntax": "clickedSpritePointer"
+}

--- a/dashboard/config/programming_expressions/spritelab/codestudio_andOrOperator.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_andOrOperator.json
@@ -1,7 +1,6 @@
 {
+  "key": "codestudio_andOrOperator",
+  "name": "logic_operation",
   "category": "Logic",
-  "config": {
-    "docFunc": "codestudio_andOrOperator",
-    "func": "logic_operation"
-  }
+  "syntax": "logic_operation"
 }

--- a/dashboard/config/programming_expressions/spritelab/codestudio_arithmeticOperator.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_arithmeticOperator.json
@@ -1,7 +1,6 @@
 {
+  "key": "codestudio_arithmeticOperator",
+  "name": "math_arithmetic",
   "category": "Math",
-  "config": {
-    "docFunc": "codestudio_arithmeticOperator",
-    "func": "math_arithmetic"
-  }
+  "syntax": "math_arithmetic"
 }

--- a/dashboard/config/programming_expressions/spritelab/codestudio_callingFunction.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_callingFunction.json
@@ -1,7 +1,6 @@
 {
+  "key": "codestudio_callingFunction",
+  "name": "procedures_callnoreturn",
   "category": "Functions",
-  "config": {
-    "docFunc": "codestudio_callingFunction",
-    "func": "procedures_callnoreturn"
-  }
+  "syntax": "procedures_callnoreturn"
 }

--- a/dashboard/config/programming_expressions/spritelab/codestudio_changeVariable.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_changeVariable.json
@@ -1,7 +1,6 @@
 {
+  "key": "codestudio_changeVariable",
+  "name": "math_change",
   "category": "Variables",
-  "config": {
-    "docFunc": "codestudio_changeVariable",
-    "func": "math_change"
-  }
+  "syntax": "math_change"
 }

--- a/dashboard/config/programming_expressions/spritelab/codestudio_comparisonOperator.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_comparisonOperator.json
@@ -1,7 +1,6 @@
 {
+  "key": "codestudio_comparisonOperator",
+  "name": "logic_compare",
   "category": "Logic",
-  "config": {
-    "docFunc": "codestudio_comparisonOperator",
-    "func": "logic_compare"
-  }
+  "syntax": "logic_compare"
 }

--- a/dashboard/config/programming_expressions/spritelab/codestudio_definingFunction.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_definingFunction.json
@@ -1,7 +1,6 @@
 {
+  "key": "codestudio_definingFunction",
+  "name": "procedures_defnoreturn",
   "category": "Functions",
-  "config": {
-    "docFunc": "codestudio_definingFunction",
-    "func": "procedures_defnoreturn"
-  }
+  "syntax": "procedures_defnoreturn"
 }

--- a/dashboard/config/programming_expressions/spritelab/codestudio_for.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_for.json
@@ -1,7 +1,6 @@
 {
+  "key": "codestudio_for",
+  "name": "controls_for",
   "category": "Loops",
-  "config": {
-    "docFunc": "codestudio_for",
-    "func": "controls_for"
-  }
+  "syntax": "controls_for"
 }

--- a/dashboard/config/programming_expressions/spritelab/codestudio_ifStatement.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_ifStatement.json
@@ -1,7 +1,6 @@
 {
+  "key": "codestudio_ifStatement",
+  "name": "controls_if_if",
   "category": "Logic",
-  "config": {
-    "docFunc": "codestudio_ifStatement",
-    "func": "controls_if_if"
-  }
+  "syntax": "controls_if_if"
 }

--- a/dashboard/config/programming_expressions/spritelab/codestudio_join.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_join.json
@@ -1,7 +1,6 @@
 {
+  "key": "codestudio_join",
+  "name": "text_join",
   "category": "Text",
-  "config": {
-    "docFunc": "codestudio_join",
-    "func": "text_join"
-  }
+  "syntax": "text_join"
 }

--- a/dashboard/config/programming_expressions/spritelab/codestudio_number.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_number.json
@@ -1,7 +1,6 @@
 {
+  "key": "codestudio_number",
+  "name": "math_number",
   "category": "Math",
-  "config": {
-    "docFunc": "codestudio_number",
-    "func": "math_number"
-  }
+  "syntax": "math_number"
 }

--- a/dashboard/config/programming_expressions/spritelab/codestudio_randomInt.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_randomInt.json
@@ -1,7 +1,6 @@
 {
+  "key": "codestudio_randomInt",
+  "name": "math_random_int",
   "category": "Math",
-  "config": {
-    "docFunc": "codestudio_randomInt",
-    "func": "math_random_int"
-  }
+  "syntax": "math_random_int"
 }

--- a/dashboard/config/programming_expressions/spritelab/codestudio_repeat.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_repeat.json
@@ -1,7 +1,6 @@
 {
+  "key": "codestudio_repeat",
+  "name": "controls_repeat",
   "category": "Loops",
-  "config": {
-    "docFunc": "codestudio_repeat",
-    "func": "controls_repeat"
-  }
+  "syntax": "controls_repeat"
 }

--- a/dashboard/config/programming_expressions/spritelab/codestudio_setVariable.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_setVariable.json
@@ -1,7 +1,6 @@
 {
+  "key": "codestudio_setVariable",
+  "name": "variables_set",
   "category": "Variables",
-  "config": {
-    "docFunc": "codestudio_setVariable",
-    "func": "variables_set"
-  }
+  "syntax": "variables_set"
 }

--- a/dashboard/config/programming_expressions/spritelab/codestudio_spriteName.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_spriteName.json
@@ -1,7 +1,6 @@
 {
+  "key": "codestudio_spriteName",
+  "name": "sprite_variables_get",
   "category": "Sprites",
-  "config": {
-    "docFunc": "codestudio_spriteName",
-    "func": "sprite_variables_get"
-  }
+  "syntax": "sprite_variables_get"
 }

--- a/dashboard/config/programming_expressions/spritelab/codestudio_string.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_string.json
@@ -1,7 +1,6 @@
 {
+  "key": "codestudio_string",
+  "name": "text",
   "category": "Text",
-  "config": {
-    "docFunc": "codestudio_string",
-    "func": "text"
-  }
+  "syntax": "text"
 }

--- a/dashboard/config/programming_expressions/spritelab/codestudio_trueFalse.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_trueFalse.json
@@ -1,7 +1,6 @@
 {
+  "key": "codestudio_trueFalse",
+  "name": "logic_boolean",
   "category": "Logic",
-  "config": {
-    "docFunc": "codestudio_trueFalse",
-    "func": "logic_boolean"
-  }
+  "syntax": "logic_boolean"
 }

--- a/dashboard/config/programming_expressions/spritelab/codestudio_variableName.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_variableName.json
@@ -1,7 +1,6 @@
 {
+  "key": "codestudio_variableName",
+  "name": "variables_get",
   "category": "Variables",
-  "config": {
-    "docFunc": "codestudio_variableName",
-    "func": "variables_get"
-  }
+  "syntax": "variables_get"
 }

--- a/dashboard/config/programming_expressions/spritelab/costumeImage.json
+++ b/dashboard/config/programming_expressions/spritelab/costumeImage.json
@@ -1,0 +1,6 @@
+{
+  "key": "costumeImage",
+  "name": "costumeImage",
+  "category": "World",
+  "syntax": "costumeImage"
+}

--- a/dashboard/config/programming_expressions/spritelab/countByAnimation.json
+++ b/dashboard/config/programming_expressions/spritelab/countByAnimation.json
@@ -1,0 +1,6 @@
+{
+  "key": "countByAnimation",
+  "name": "countByAnimation",
+  "category": "Sprites",
+  "syntax": "countByAnimation"
+}

--- a/dashboard/config/programming_expressions/spritelab/draggable.json
+++ b/dashboard/config/programming_expressions/spritelab/draggable.json
@@ -1,0 +1,6 @@
+{
+  "key": "draggable",
+  "name": "draggable",
+  "category": "SL1",
+  "syntax": "draggable"
+}

--- a/dashboard/config/programming_expressions/spritelab/followingTargets.json
+++ b/dashboard/config/programming_expressions/spritelab/followingTargets.json
@@ -1,0 +1,6 @@
+{
+  "key": "followingTargets",
+  "name": "followingTargets",
+  "category": "SL1",
+  "syntax": "followingTargets"
+}

--- a/dashboard/config/programming_expressions/spritelab/gamelab_addBehaviorSimple.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_addBehaviorSimple.json
@@ -1,0 +1,6 @@
+{
+  "key": "gamelab_addBehaviorSimple",
+  "name": "addBehaviorSimple",
+  "category": "Behaviors",
+  "syntax": "addBehaviorSimple"
+}

--- a/dashboard/config/programming_expressions/spritelab/gamelab_allSpritesWithAnimation.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_allSpritesWithAnimation.json
@@ -1,0 +1,6 @@
+{
+  "key": "gamelab_allSpritesWithAnimation",
+  "name": "allSpritesWithAnimation",
+  "category": "Sprites",
+  "syntax": "allSpritesWithAnimation"
+}

--- a/dashboard/config/programming_expressions/spritelab/gamelab_changePropBy.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_changePropBy.json
@@ -1,0 +1,6 @@
+{
+  "key": "gamelab_changePropBy",
+  "name": "changePropBy",
+  "category": "Sprites",
+  "syntax": "changePropBy"
+}

--- a/dashboard/config/programming_expressions/spritelab/gamelab_comment.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_comment.json
@@ -1,0 +1,6 @@
+{
+  "key": "gamelab_comment",
+  "name": "comment",
+  "category": "Comments",
+  "syntax": "comment"
+}

--- a/dashboard/config/programming_expressions/spritelab/gamelab_createNewSprite.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_createNewSprite.json
@@ -1,0 +1,6 @@
+{
+  "key": "gamelab_createNewSprite",
+  "name": "createNewSprite",
+  "category": "Sprites",
+  "syntax": "createNewSprite"
+}

--- a/dashboard/config/programming_expressions/spritelab/gamelab_destroy.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_destroy.json
@@ -1,0 +1,6 @@
+{
+  "key": "gamelab_destroy",
+  "name": "destroy",
+  "category": "Sprites",
+  "syntax": "destroy"
+}

--- a/dashboard/config/programming_expressions/spritelab/gamelab_edgesDisplace.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_edgesDisplace.json
@@ -1,0 +1,6 @@
+{
+  "key": "gamelab_edgesDisplace",
+  "name": "edgesDisplace",
+  "category": "Sprites",
+  "syntax": "edgesDisplace"
+}

--- a/dashboard/config/programming_expressions/spritelab/gamelab_getProp.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_getProp.json
@@ -1,0 +1,6 @@
+{
+  "key": "gamelab_getProp",
+  "name": "getProp",
+  "category": "Sprites",
+  "syntax": "getProp"
+}

--- a/dashboard/config/programming_expressions/spritelab/gamelab_getThisSprite.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_getThisSprite.json
@@ -1,0 +1,6 @@
+{
+  "key": "gamelab_getThisSprite",
+  "name": "getThisSprite",
+  "category": "Sprites",
+  "syntax": "getThisSprite"
+}

--- a/dashboard/config/programming_expressions/spritelab/gamelab_glideTo.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_glideTo.json
@@ -1,0 +1,6 @@
+{
+  "key": "gamelab_glideTo",
+  "name": "glideTo",
+  "category": "Sprites",
+  "syntax": "glideTo"
+}

--- a/dashboard/config/programming_expressions/spritelab/gamelab_hideTitleScreen.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_hideTitleScreen.json
@@ -1,0 +1,6 @@
+{
+  "key": "gamelab_hideTitleScreen",
+  "name": "hideTitleScreen",
+  "category": "World",
+  "syntax": "hideTitleScreen"
+}

--- a/dashboard/config/programming_expressions/spritelab/gamelab_jumpTo.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_jumpTo.json
@@ -1,0 +1,6 @@
+{
+  "key": "gamelab_jumpTo",
+  "name": "jumpTo",
+  "category": "Sprites",
+  "syntax": "jumpTo"
+}

--- a/dashboard/config/programming_expressions/spritelab/gamelab_keyPressed.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_keyPressed.json
@@ -1,0 +1,6 @@
+{
+  "key": "gamelab_keyPressed",
+  "name": "keyPressed",
+  "category": "Events",
+  "syntax": "keyPressed"
+}

--- a/dashboard/config/programming_expressions/spritelab/gamelab_locationAt.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_locationAt.json
@@ -1,0 +1,6 @@
+{
+  "key": "gamelab_locationAt",
+  "name": "locationAt",
+  "category": "Location",
+  "syntax": "locationAt"
+}

--- a/dashboard/config/programming_expressions/spritelab/gamelab_locationMouse.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_locationMouse.json
@@ -1,0 +1,6 @@
+{
+  "key": "gamelab_locationMouse",
+  "name": "locationMouse",
+  "category": "Location",
+  "syntax": "locationMouse"
+}

--- a/dashboard/config/programming_expressions/spritelab/gamelab_locationOf.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_locationOf.json
@@ -1,0 +1,6 @@
+{
+  "key": "gamelab_locationOf",
+  "name": "locationOf",
+  "category": "Sprites",
+  "syntax": "locationOf"
+}

--- a/dashboard/config/programming_expressions/spritelab/gamelab_location_picker.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_location_picker.json
@@ -1,0 +1,6 @@
+{
+  "key": "gamelab_location_picker",
+  "name": "location_picker",
+  "category": "Location",
+  "syntax": "location_picker"
+}

--- a/dashboard/config/programming_expressions/spritelab/gamelab_makeNewSpriteAnon.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_makeNewSpriteAnon.json
@@ -1,0 +1,6 @@
+{
+  "key": "gamelab_makeNewSpriteAnon",
+  "name": "makeNewSpriteAnon",
+  "category": "Sprites",
+  "syntax": "makeNewSpriteAnon"
+}

--- a/dashboard/config/programming_expressions/spritelab/gamelab_moveForward.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_moveForward.json
@@ -1,0 +1,6 @@
+{
+  "key": "gamelab_moveForward",
+  "name": "moveForward",
+  "category": "Sprites",
+  "syntax": "moveForward"
+}

--- a/dashboard/config/programming_expressions/spritelab/gamelab_moveInDirection.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_moveInDirection.json
@@ -1,0 +1,6 @@
+{
+  "key": "gamelab_moveInDirection",
+  "name": "moveInDirection",
+  "category": "Sprites",
+  "syntax": "moveInDirection"
+}

--- a/dashboard/config/programming_expressions/spritelab/gamelab_moveToward.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_moveToward.json
@@ -1,0 +1,6 @@
+{
+  "key": "gamelab_moveToward",
+  "name": "moveToward",
+  "category": "Sprites",
+  "syntax": "moveToward"
+}

--- a/dashboard/config/programming_expressions/spritelab/gamelab_playSound.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_playSound.json
@@ -1,0 +1,6 @@
+{
+  "key": "gamelab_playSound",
+  "name": "playSound",
+  "category": "World",
+  "syntax": "playSound"
+}

--- a/dashboard/config/programming_expressions/spritelab/gamelab_playSoundOptions.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_playSoundOptions.json
@@ -1,0 +1,6 @@
+{
+  "key": "gamelab_playSoundOptions",
+  "name": "playSoundOptions",
+  "category": "World",
+  "syntax": "playSoundOptions"
+}

--- a/dashboard/config/programming_expressions/spritelab/gamelab_playSpeech.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_playSpeech.json
@@ -1,0 +1,6 @@
+{
+  "key": "gamelab_playSpeech",
+  "name": "playSpeech",
+  "category": "World",
+  "syntax": "playSpeech"
+}

--- a/dashboard/config/programming_expressions/spritelab/gamelab_printText.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_printText.json
@@ -1,0 +1,6 @@
+{
+  "key": "gamelab_printText",
+  "name": "printText",
+  "category": "World",
+  "syntax": "printText"
+}

--- a/dashboard/config/programming_expressions/spritelab/gamelab_randomColor.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_randomColor.json
@@ -1,0 +1,6 @@
+{
+  "key": "gamelab_randomColor",
+  "name": "randomColor",
+  "category": "World",
+  "syntax": "randomColor"
+}

--- a/dashboard/config/programming_expressions/spritelab/gamelab_randomLocation.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_randomLocation.json
@@ -1,0 +1,6 @@
+{
+  "key": "gamelab_randomLocation",
+  "name": "randomLocation",
+  "category": "Location",
+  "syntax": "randomLocation"
+}

--- a/dashboard/config/programming_expressions/spritelab/gamelab_removeAllBehaviors.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_removeAllBehaviors.json
@@ -1,0 +1,6 @@
+{
+  "key": "gamelab_removeAllBehaviors",
+  "name": "removeAllBehaviors",
+  "category": "Behaviors",
+  "syntax": "removeAllBehaviors"
+}

--- a/dashboard/config/programming_expressions/spritelab/gamelab_removeBehaviorSimple.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_removeBehaviorSimple.json
@@ -1,0 +1,6 @@
+{
+  "key": "gamelab_removeBehaviorSimple",
+  "name": "removeBehaviorSimple",
+  "category": "Behaviors",
+  "syntax": "removeBehaviorSimple"
+}

--- a/dashboard/config/programming_expressions/spritelab/gamelab_removeTint.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_removeTint.json
@@ -1,0 +1,6 @@
+{
+  "key": "gamelab_removeTint",
+  "name": "removeTint",
+  "category": "Sprites",
+  "syntax": "removeTint"
+}

--- a/dashboard/config/programming_expressions/spritelab/gamelab_setAnimation.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_setAnimation.json
@@ -1,0 +1,6 @@
+{
+  "key": "gamelab_setAnimation",
+  "name": "setAnimation",
+  "category": "Sprites",
+  "syntax": "setAnimation"
+}

--- a/dashboard/config/programming_expressions/spritelab/gamelab_setBackground.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_setBackground.json
@@ -1,0 +1,6 @@
+{
+  "key": "gamelab_setBackground",
+  "name": "setBackground",
+  "category": "World",
+  "syntax": "setBackground"
+}

--- a/dashboard/config/programming_expressions/spritelab/gamelab_setBackgroundImage.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_setBackgroundImage.json
@@ -1,0 +1,6 @@
+{
+  "key": "gamelab_setBackgroundImage",
+  "name": "setBackgroundImage",
+  "category": "Unused",
+  "syntax": "setBackgroundImage"
+}

--- a/dashboard/config/programming_expressions/spritelab/gamelab_setProp.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_setProp.json
@@ -1,0 +1,6 @@
+{
+  "key": "gamelab_setProp",
+  "name": "setProp",
+  "category": "Sprites",
+  "syntax": "setProp"
+}

--- a/dashboard/config/programming_expressions/spritelab/gamelab_setProp_dropdown.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_setProp_dropdown.json
@@ -1,0 +1,6 @@
+{
+  "key": "gamelab_setProp_dropdown",
+  "name": "setProp_dropdown",
+  "category": "Sprites",
+  "syntax": "setProp_dropdown"
+}

--- a/dashboard/config/programming_expressions/spritelab/gamelab_setTint.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_setTint.json
@@ -1,0 +1,6 @@
+{
+  "key": "gamelab_setTint",
+  "name": "setTint",
+  "category": "Sprites",
+  "syntax": "setTint"
+}

--- a/dashboard/config/programming_expressions/spritelab/gamelab_showTitleScreen.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_showTitleScreen.json
@@ -1,0 +1,6 @@
+{
+  "key": "gamelab_showTitleScreen",
+  "name": "showTitleScreen",
+  "category": "World",
+  "syntax": "showTitleScreen"
+}

--- a/dashboard/config/programming_expressions/spritelab/gamelab_spriteClicked.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_spriteClicked.json
@@ -1,0 +1,6 @@
+{
+  "key": "gamelab_spriteClicked",
+  "name": "spriteClicked",
+  "category": "Events",
+  "syntax": "spriteClicked"
+}

--- a/dashboard/config/programming_expressions/spritelab/gamelab_turn.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_turn.json
@@ -1,0 +1,6 @@
+{
+  "key": "gamelab_turn",
+  "name": "turn",
+  "category": "Sprites",
+  "syntax": "turn"
+}

--- a/dashboard/config/programming_expressions/spritelab/gamelab_whenTouching.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_whenTouching.json
@@ -1,0 +1,6 @@
+{
+  "key": "gamelab_whenTouching",
+  "name": "whenTouching",
+  "category": "Unused",
+  "syntax": "whenTouching"
+}

--- a/dashboard/config/programming_expressions/spritelab/gamelab_whileTouching.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_whileTouching.json
@@ -1,0 +1,6 @@
+{
+  "key": "gamelab_whileTouching",
+  "name": "whileTouching",
+  "category": "Unused",
+  "syntax": "whileTouching"
+}

--- a/dashboard/config/programming_expressions/spritelab/getAllSprites.json
+++ b/dashboard/config/programming_expressions/spritelab/getAllSprites.json
@@ -1,0 +1,6 @@
+{
+  "key": "getAllSprites",
+  "name": "getAllSprites",
+  "category": "Sprites",
+  "syntax": "getAllSprites"
+}

--- a/dashboard/config/programming_expressions/spritelab/getTime.json
+++ b/dashboard/config/programming_expressions/spritelab/getTime.json
@@ -1,0 +1,6 @@
+{
+  "key": "getTime",
+  "name": "getTime",
+  "category": "World",
+  "syntax": "getTime"
+}

--- a/dashboard/config/programming_expressions/spritelab/ifVarEquals.json
+++ b/dashboard/config/programming_expressions/spritelab/ifVarEquals.json
@@ -1,0 +1,6 @@
+{
+  "key": "ifVarEquals",
+  "name": "ifVarEquals",
+  "category": "Control",
+  "syntax": "ifVarEquals"
+}

--- a/dashboard/config/programming_expressions/spritelab/isCostumeEqual.json
+++ b/dashboard/config/programming_expressions/spritelab/isCostumeEqual.json
@@ -1,0 +1,6 @@
+{
+  "key": "isCostumeEqual",
+  "name": "isCostumeEqual",
+  "category": "Sprites",
+  "syntax": "isCostumeEqual"
+}

--- a/dashboard/config/programming_expressions/spritelab/isKeyPressed.json
+++ b/dashboard/config/programming_expressions/spritelab/isKeyPressed.json
@@ -1,0 +1,6 @@
+{
+  "key": "isKeyPressed",
+  "name": "isKeyPressed",
+  "category": "World",
+  "syntax": "isKeyPressed"
+}

--- a/dashboard/config/programming_expressions/spritelab/isTouchingEdges.json
+++ b/dashboard/config/programming_expressions/spritelab/isTouchingEdges.json
@@ -1,0 +1,6 @@
+{
+  "key": "isTouchingEdges",
+  "name": "isTouchingEdges",
+  "category": "Sprites",
+  "syntax": "isTouchingEdges"
+}

--- a/dashboard/config/programming_expressions/spritelab/isTouchingSprite.json
+++ b/dashboard/config/programming_expressions/spritelab/isTouchingSprite.json
@@ -1,0 +1,6 @@
+{
+  "key": "isTouchingSprite",
+  "name": "isTouchingSprite",
+  "category": "Sprites",
+  "syntax": "isTouchingSprite"
+}

--- a/dashboard/config/programming_expressions/spritelab/locationModifier.json
+++ b/dashboard/config/programming_expressions/spritelab/locationModifier.json
@@ -1,0 +1,6 @@
+{
+  "key": "locationModifier",
+  "name": "locationModifier",
+  "category": "Location",
+  "syntax": "locationModifier"
+}

--- a/dashboard/config/programming_expressions/spritelab/makeBurst.json
+++ b/dashboard/config/programming_expressions/spritelab/makeBurst.json
@@ -1,0 +1,6 @@
+{
+  "key": "makeBurst",
+  "name": "makeBurst",
+  "category": "Experimental",
+  "syntax": "makeBurst"
+}

--- a/dashboard/config/programming_expressions/spritelab/makeNumSprites.json
+++ b/dashboard/config/programming_expressions/spritelab/makeNumSprites.json
@@ -1,0 +1,6 @@
+{
+  "key": "makeNumSprites",
+  "name": "makeNumSprites",
+  "category": "Sprites",
+  "syntax": "makeNumSprites"
+}

--- a/dashboard/config/programming_expressions/spritelab/makeProjectile.json
+++ b/dashboard/config/programming_expressions/spritelab/makeProjectile.json
@@ -1,0 +1,6 @@
+{
+  "key": "makeProjectile",
+  "name": "makeProjectile",
+  "category": "Experimental",
+  "syntax": "makeProjectile"
+}

--- a/dashboard/config/programming_expressions/spritelab/mirrorSprite.json
+++ b/dashboard/config/programming_expressions/spritelab/mirrorSprite.json
@@ -1,0 +1,6 @@
+{
+  "key": "mirrorSprite",
+  "name": "mirrorSprite",
+  "category": "Sprites",
+  "syntax": "mirrorSprite"
+}

--- a/dashboard/config/programming_expressions/spritelab/mouseLocation.json
+++ b/dashboard/config/programming_expressions/spritelab/mouseLocation.json
@@ -1,0 +1,6 @@
+{
+  "key": "mouseLocation",
+  "name": "mouseLocation",
+  "category": "Location",
+  "syntax": "mouseLocation"
+}

--- a/dashboard/config/programming_expressions/spritelab/moveBackward.json
+++ b/dashboard/config/programming_expressions/spritelab/moveBackward.json
@@ -1,0 +1,6 @@
+{
+  "key": "moveBackward",
+  "name": "moveBackward",
+  "category": "Sprites",
+  "syntax": "moveBackward"
+}

--- a/dashboard/config/programming_expressions/spritelab/newSpritePointer.json
+++ b/dashboard/config/programming_expressions/spritelab/newSpritePointer.json
@@ -1,0 +1,6 @@
+{
+  "key": "newSpritePointer",
+  "name": "newSpritePointer",
+  "category": "Events",
+  "syntax": "newSpritePointer"
+}

--- a/dashboard/config/programming_expressions/spritelab/objectSpritePointer.json
+++ b/dashboard/config/programming_expressions/spritelab/objectSpritePointer.json
@@ -1,0 +1,6 @@
+{
+  "key": "objectSpritePointer",
+  "name": "objectSpritePointer",
+  "category": "Events",
+  "syntax": "objectSpritePointer"
+}

--- a/dashboard/config/programming_expressions/spritelab/patrollingUpDown.json
+++ b/dashboard/config/programming_expressions/spritelab/patrollingUpDown.json
@@ -1,0 +1,6 @@
+{
+  "key": "patrollingUpDown",
+  "name": "patrollingUpDown",
+  "category": "SL1",
+  "syntax": "patrollingUpDown"
+}

--- a/dashboard/config/programming_expressions/spritelab/pointInDirection.json
+++ b/dashboard/config/programming_expressions/spritelab/pointInDirection.json
@@ -1,0 +1,6 @@
+{
+  "key": "pointInDirection",
+  "name": "pointInDirection",
+  "category": "Sprites",
+  "syntax": "pointInDirection"
+}

--- a/dashboard/config/programming_expressions/spritelab/randColor.json
+++ b/dashboard/config/programming_expressions/spritelab/randColor.json
@@ -1,0 +1,6 @@
+{
+  "key": "randColor",
+  "name": "randColor",
+  "category": "Unused",
+  "syntax": "randColor"
+}

--- a/dashboard/config/programming_expressions/spritelab/repeatForever.json
+++ b/dashboard/config/programming_expressions/spritelab/repeatForever.json
@@ -1,0 +1,6 @@
+{
+  "key": "repeatForever",
+  "name": "repeatForever",
+  "category": "Control",
+  "syntax": "repeatForever"
+}

--- a/dashboard/config/programming_expressions/spritelab/setBackgroundImageAs.json
+++ b/dashboard/config/programming_expressions/spritelab/setBackgroundImageAs.json
@@ -1,0 +1,6 @@
+{
+  "key": "setBackgroundImageAs",
+  "name": "setBackgroundImageAs",
+  "category": "World",
+  "syntax": "setBackgroundImageAs"
+}

--- a/dashboard/config/programming_expressions/spritelab/setDefaultSpriteSize.json
+++ b/dashboard/config/programming_expressions/spritelab/setDefaultSpriteSize.json
@@ -1,0 +1,6 @@
+{
+  "key": "setDefaultSpriteSize",
+  "name": "setDefaultSpriteSize",
+  "category": "Sprites",
+  "syntax": "setDefaultSpriteSize"
+}

--- a/dashboard/config/programming_expressions/spritelab/setPrompt.json
+++ b/dashboard/config/programming_expressions/spritelab/setPrompt.json
@@ -1,0 +1,6 @@
+{
+  "key": "setPrompt",
+  "name": "setPrompt",
+  "category": "World",
+  "syntax": "setPrompt"
+}

--- a/dashboard/config/programming_expressions/spritelab/setPromptWithChoices.json
+++ b/dashboard/config/programming_expressions/spritelab/setPromptWithChoices.json
@@ -1,0 +1,6 @@
+{
+  "key": "setPromptWithChoices",
+  "name": "setPromptWithChoices",
+  "category": "World",
+  "syntax": "setPromptWithChoices"
+}

--- a/dashboard/config/programming_expressions/spritelab/setSizes.json
+++ b/dashboard/config/programming_expressions/spritelab/setSizes.json
@@ -1,0 +1,6 @@
+{
+  "key": "setSizes",
+  "name": "setSizes",
+  "category": "Unused",
+  "syntax": "setSizes"
+}

--- a/dashboard/config/programming_expressions/spritelab/setupScoreboard.json
+++ b/dashboard/config/programming_expressions/spritelab/setupScoreboard.json
@@ -1,0 +1,6 @@
+{
+  "key": "setupScoreboard",
+  "name": "setupScoreboard",
+  "category": "Experimental",
+  "syntax": "setupScoreboard"
+}

--- a/dashboard/config/programming_expressions/spritelab/setupSim.json
+++ b/dashboard/config/programming_expressions/spritelab/setupSim.json
@@ -1,0 +1,6 @@
+{
+  "key": "setupSim",
+  "name": "setupSim",
+  "category": "Experimental",
+  "syntax": "setupSim"
+}

--- a/dashboard/config/programming_expressions/spritelab/spriteSay.json
+++ b/dashboard/config/programming_expressions/spritelab/spriteSay.json
@@ -1,0 +1,6 @@
+{
+  "key": "spriteSay",
+  "name": "spriteSay",
+  "category": "Experimental",
+  "syntax": "spriteSay"
+}

--- a/dashboard/config/programming_expressions/spritelab/spriteSayTime.json
+++ b/dashboard/config/programming_expressions/spritelab/spriteSayTime.json
@@ -1,0 +1,6 @@
+{
+  "key": "spriteSayTime",
+  "name": "spriteSayTime",
+  "category": "Experimental",
+  "syntax": "spriteSayTime"
+}

--- a/dashboard/config/programming_expressions/spritelab/startAvoiding.json
+++ b/dashboard/config/programming_expressions/spritelab/startAvoiding.json
@@ -1,0 +1,6 @@
+{
+  "key": "startAvoiding",
+  "name": "startAvoiding",
+  "category": "Experimental",
+  "syntax": "startAvoiding"
+}

--- a/dashboard/config/programming_expressions/spritelab/startFollowing.json
+++ b/dashboard/config/programming_expressions/spritelab/startFollowing.json
@@ -1,0 +1,6 @@
+{
+  "key": "startFollowing",
+  "name": "startFollowing",
+  "category": "Experimental",
+  "syntax": "startFollowing"
+}

--- a/dashboard/config/programming_expressions/spritelab/startGliding.json
+++ b/dashboard/config/programming_expressions/spritelab/startGliding.json
@@ -1,0 +1,6 @@
+{
+  "key": "startGliding",
+  "name": "startGliding",
+  "category": "Experimental",
+  "syntax": "startGliding"
+}

--- a/dashboard/config/programming_expressions/spritelab/stopAvoiding.json
+++ b/dashboard/config/programming_expressions/spritelab/stopAvoiding.json
@@ -1,0 +1,6 @@
+{
+  "key": "stopAvoiding",
+  "name": "stopAvoiding",
+  "category": "Experimental",
+  "syntax": "stopAvoiding"
+}

--- a/dashboard/config/programming_expressions/spritelab/stopCollectingData.json
+++ b/dashboard/config/programming_expressions/spritelab/stopCollectingData.json
@@ -1,0 +1,6 @@
+{
+  "key": "stopCollectingData",
+  "name": "stopCollectingData",
+  "category": "Math",
+  "syntax": "stopCollectingData"
+}

--- a/dashboard/config/programming_expressions/spritelab/stopFollowing.json
+++ b/dashboard/config/programming_expressions/spritelab/stopFollowing.json
@@ -1,0 +1,6 @@
+{
+  "key": "stopFollowing",
+  "name": "stopFollowing",
+  "category": "Experimental",
+  "syntax": "stopFollowing"
+}

--- a/dashboard/config/programming_expressions/spritelab/stopGliding.json
+++ b/dashboard/config/programming_expressions/spritelab/stopGliding.json
@@ -1,0 +1,6 @@
+{
+  "key": "stopGliding",
+  "name": "stopGliding",
+  "category": "Experimental",
+  "syntax": "stopGliding"
+}

--- a/dashboard/config/programming_expressions/spritelab/subjectSpritePointer.json
+++ b/dashboard/config/programming_expressions/spritelab/subjectSpritePointer.json
@@ -1,0 +1,6 @@
+{
+  "key": "subjectSpritePointer",
+  "name": "subjectSpritePointer",
+  "category": "Events",
+  "syntax": "subjectSpritePointer"
+}

--- a/dashboard/config/programming_expressions/spritelab/textJoin.json
+++ b/dashboard/config/programming_expressions/spritelab/textJoin.json
@@ -1,0 +1,6 @@
+{
+  "key": "textJoin",
+  "name": "textJoin",
+  "category": "World",
+  "syntax": "textJoin"
+}

--- a/dashboard/config/programming_expressions/spritelab/textVariableJoin.json
+++ b/dashboard/config/programming_expressions/spritelab/textVariableJoin.json
@@ -1,0 +1,6 @@
+{
+  "key": "textVariableJoin",
+  "name": "textVariableJoin",
+  "category": "World",
+  "syntax": "textVariableJoin"
+}

--- a/dashboard/config/programming_expressions/spritelab/tumbling.json
+++ b/dashboard/config/programming_expressions/spritelab/tumbling.json
@@ -1,0 +1,6 @@
+{
+  "key": "tumbling",
+  "name": "tumbling",
+  "category": "SL1",
+  "syntax": "tumbling"
+}

--- a/dashboard/config/programming_expressions/spritelab/updateTitleWithColor.json
+++ b/dashboard/config/programming_expressions/spritelab/updateTitleWithColor.json
@@ -1,0 +1,6 @@
+{
+  "key": "updateTitleWithColor",
+  "name": "updateTitleWithColor",
+  "category": "World",
+  "syntax": "updateTitleWithColor"
+}

--- a/dashboard/config/programming_expressions/spritelab/whenAllPromptsAnswered.json
+++ b/dashboard/config/programming_expressions/spritelab/whenAllPromptsAnswered.json
@@ -1,0 +1,6 @@
+{
+  "key": "whenAllPromptsAnswered",
+  "name": "whenAllPromptsAnswered",
+  "category": "",
+  "syntax": "whenAllPromptsAnswered"
+}

--- a/dashboard/config/programming_expressions/spritelab/whenDownArrow.json
+++ b/dashboard/config/programming_expressions/spritelab/whenDownArrow.json
@@ -1,0 +1,6 @@
+{
+  "key": "whenDownArrow",
+  "name": "whenDownArrow",
+  "category": "Unused",
+  "syntax": "whenDownArrow"
+}

--- a/dashboard/config/programming_expressions/spritelab/whenKey.json
+++ b/dashboard/config/programming_expressions/spritelab/whenKey.json
@@ -1,0 +1,6 @@
+{
+  "key": "whenKey",
+  "name": "whenKey",
+  "category": "Unused",
+  "syntax": "whenKey"
+}

--- a/dashboard/config/programming_expressions/spritelab/whenLeftArrow.json
+++ b/dashboard/config/programming_expressions/spritelab/whenLeftArrow.json
@@ -1,0 +1,6 @@
+{
+  "key": "whenLeftArrow",
+  "name": "whenLeftArrow",
+  "category": "Unused",
+  "syntax": "whenLeftArrow"
+}

--- a/dashboard/config/programming_expressions/spritelab/whenPromptAnswered.json
+++ b/dashboard/config/programming_expressions/spritelab/whenPromptAnswered.json
@@ -1,0 +1,6 @@
+{
+  "key": "whenPromptAnswered",
+  "name": "whenPromptAnswered",
+  "category": "Events",
+  "syntax": "whenPromptAnswered"
+}

--- a/dashboard/config/programming_expressions/spritelab/whenRightArrow.json
+++ b/dashboard/config/programming_expressions/spritelab/whenRightArrow.json
@@ -1,0 +1,6 @@
+{
+  "key": "whenRightArrow",
+  "name": "whenRightArrow",
+  "category": "Unused",
+  "syntax": "whenRightArrow"
+}

--- a/dashboard/config/programming_expressions/spritelab/whenSpriteCreated.json
+++ b/dashboard/config/programming_expressions/spritelab/whenSpriteCreated.json
@@ -1,0 +1,6 @@
+{
+  "key": "whenSpriteCreated",
+  "name": "whenSpriteCreated",
+  "category": "Events",
+  "syntax": "whenSpriteCreated"
+}

--- a/dashboard/config/programming_expressions/spritelab/whenUpArrow.json
+++ b/dashboard/config/programming_expressions/spritelab/whenUpArrow.json
@@ -1,0 +1,6 @@
+{
+  "key": "whenUpArrow",
+  "name": "whenUpArrow",
+  "category": "Unused",
+  "syntax": "whenUpArrow"
+}

--- a/dashboard/config/programming_expressions/spritelab/whileDownArrow.json
+++ b/dashboard/config/programming_expressions/spritelab/whileDownArrow.json
@@ -1,0 +1,6 @@
+{
+  "key": "whileDownArrow",
+  "name": "whileDownArrow",
+  "category": "Unused",
+  "syntax": "whileDownArrow"
+}

--- a/dashboard/config/programming_expressions/spritelab/whileKey.json
+++ b/dashboard/config/programming_expressions/spritelab/whileKey.json
@@ -1,0 +1,6 @@
+{
+  "key": "whileKey",
+  "name": "whileKey",
+  "category": "Unused",
+  "syntax": "whileKey"
+}

--- a/dashboard/config/programming_expressions/spritelab/whileLeftArrow.json
+++ b/dashboard/config/programming_expressions/spritelab/whileLeftArrow.json
@@ -1,0 +1,6 @@
+{
+  "key": "whileLeftArrow",
+  "name": "whileLeftArrow",
+  "category": "Unused",
+  "syntax": "whileLeftArrow"
+}

--- a/dashboard/config/programming_expressions/spritelab/whileRightArrow.json
+++ b/dashboard/config/programming_expressions/spritelab/whileRightArrow.json
@@ -1,0 +1,6 @@
+{
+  "key": "whileRightArrow",
+  "name": "whileRightArrow",
+  "category": "Unused",
+  "syntax": "whileRightArrow"
+}

--- a/dashboard/config/programming_expressions/spritelab/whileUpArrow.json
+++ b/dashboard/config/programming_expressions/spritelab/whileUpArrow.json
@@ -1,0 +1,6 @@
+{
+  "key": "whileUpArrow",
+  "name": "whileUpArrow",
+  "category": "Unused",
+  "syntax": "whileUpArrow"
+}

--- a/dashboard/config/programming_expressions/spritelab/withPercentChance.json
+++ b/dashboard/config/programming_expressions/spritelab/withPercentChance.json
@@ -1,0 +1,6 @@
+{
+  "key": "withPercentChance",
+  "name": "withPercentChance",
+  "category": "Control",
+  "syntax": "withPercentChance"
+}

--- a/dashboard/config/programming_expressions/spritelab/withPercentChanceDropdown.json
+++ b/dashboard/config/programming_expressions/spritelab/withPercentChanceDropdown.json
@@ -1,0 +1,6 @@
+{
+  "key": "withPercentChanceDropdown",
+  "name": "withPercentChanceDropdown",
+  "category": "Control",
+  "syntax": "withPercentChanceDropdown"
+}

--- a/dashboard/config/programming_expressions/spritelab/xLocationOf.json
+++ b/dashboard/config/programming_expressions/spritelab/xLocationOf.json
@@ -1,0 +1,6 @@
+{
+  "key": "xLocationOf",
+  "name": "xLocationOf",
+  "category": "Sprites",
+  "syntax": "xLocationOf"
+}

--- a/dashboard/config/programming_expressions/spritelab/yLocationOf.json
+++ b/dashboard/config/programming_expressions/spritelab/yLocationOf.json
@@ -1,0 +1,6 @@
+{
+  "key": "yLocationOf",
+  "name": "yLocationOf",
+  "category": "Sprites",
+  "syntax": "yLocationOf"
+}


### PR DESCRIPTION
Seed and serialize spritelab!

My proposal, which is implemented in this PR, is to go with the same seed/serialize logic as the rest of the labs, for a few reasons:
- There are spritelab blocks that are not represented in the `blocks` table, which need a config in config/programming_expressions/spritelab. For me, this is the most compelling reason
- Consistency across all programming environments makes this feature simpler

The biggest downside is that this information already lives in a bunch of different places (in the `blocks` table, in `apps/`, in the blockly repo) and we're adding another place. For me, consistency and simplicity of this feature outweighed the desire to avoid duplication of this information, but I've open to debate here.

I considered writing this data to the files in config/blocks/GamelabJr but didn't because:
- Like I said above, this doesn't work for all spritelab blocks
- It like it would muddle the two models too much

That said, I am planning on adding a field `block_name` to ProgrammingExpression that would at least create a pointer between the two models (not as an association because, again, not all blocks have an entry in `blocks`).

Thoughts? I can write this up as a doc if folks would prefer that, but wasn't sure it quite warranted one.

For review, I would recommend viewing the [commit with code changes with whitespace hidden](https://github.com/code-dot-org/code-dot-org/pull/44071/commits/45db4a84f649fce947c1428f828de7b653ab7b76?diff=split&w=1) then skim the [commit](5740dd5dd96f187da4264e667ad4504730d5d7fc) that serializes the programming expressions.


## Testing story

serialized all programming expressions, committed those files, deleted all programming expressions, reseeded, reserialized, and ensured no diffs. #44019 added a test for this logic




## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
