### PR TITLE
Fix flakiness in ProgrammingExpressionTest

### DIFF
--- a/dashboard/test/models/programming_expression_test.rb
+++ b/dashboard/test/models/programming_expression_test.rb
@@ -63,6 +63,6 @@ class ProgrammingExpressionTest < ActiveSupport::TestCase
 
     new_exp_name = ProgrammingExpression.seed_record("config/programming_expressions/#{programming_environment.name}/file.json")
     new_exp = ProgrammingExpression.find_by_name(new_exp_name)
-    assert_equal previous_exp.attributes.except('id'), new_exp.attributes.except('id')
+    assert_equal previous_exp.attributes.except('id', 'created_at', 'updated_at'), new_exp.attributes.except('id', 'created_at', 'updated_at')
   end
 end


### PR DESCRIPTION
Reported in [slack](https://codedotorg.slack.com/archives/C02EEGWLHR8/p1639591879047500). `created_at` and `updated_at` are not set from seeding so we shouldn't be checking their equality in the seeding test.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
