### PR TITLE
Update Crowdin query params

### DIFF
--- a/bin/i18n/sync-down.rb
+++ b/bin/i18n/sync-down.rb
@@ -25,10 +25,10 @@ def sync_down
     CROWDIN_PROJECTS.each do |name, options|
       puts "Downloading translations from #{name} project"
       api_key = YAML.load_file(options[:identity_file])["api_key"]
-      project_id = YAML.load_file(options[:config_file])["project_identifier"]
-      project = Crowdin::Project.new(project_id, api_key)
+      project_identifier = YAML.load_file(options[:config_file])["project_identifier"]
+      project = Crowdin::Project.new(project_identifier, api_key)
       options = {
-        etags_json: File.join(File.dirname(__FILE__), "crowdin", "#{project_id}_etags.json"),
+        etags_json: File.join(File.dirname(__FILE__), "crowdin", "#{project_identifier}_etags.json"),
         locales_dir: File.join(I18N_SOURCE_DIR, '..'),
         logger: logger
       }

--- a/lib/cdo/crowdin/project.rb
+++ b/lib/cdo/crowdin/project.rb
@@ -8,17 +8,17 @@ module Crowdin
 
     attr_reader :id
 
-    # @param project_id [String]
+    # @param project_identifier [String]
     # @param api_key [String]
-    # @see https://crowdin.com/project/codeorg/settings#api for an example of
+    # @see https://crowdin.com/project/codeorg/integrations/api for an example of
     #  how to retrieve these values for the "code.org" project
-    def initialize(project_id, api_key)
-      @id = project_id
-      self.class.base_uri("https://api.crowdin.com/api/project/#{project_id}")
+    def initialize(project_identifier, api_key)
+      @id = project_identifier
+      self.class.base_uri("https://api.crowdin.com/api/project/#{project_identifier}")
       self.class.default_params({"account-key" => api_key, "login" => "code-org"})
     end
 
-    # @see https://support.crowdin.com/api/info/
+    # @see https://support.crowdin.com/api/api-integration-setup/#titles-project-details
     def project_info
       # cache the result; we end up calling this method quite a lot since it's
       # the source of both our lists of files and of languages, and it also
@@ -37,7 +37,7 @@ module Crowdin
     #  if it fails
     # @param only_head [Boolean, nil] whether to make a HEAD request rather
     #  than a full GET request. Defaults to false.
-    # @see https://support.crowdin.com/api/export-file/
+    # @see https://support.crowdin.com/api/api-integration-setup/#titles-export-file
     def export_file(file, language, etag: nil, attempts: 3, only_head: false)
       options = {
         query: {

--- a/lib/cdo/crowdin/project.rb
+++ b/lib/cdo/crowdin/project.rb
@@ -15,7 +15,7 @@ module Crowdin
     def initialize(project_id, api_key)
       @id = project_id
       self.class.base_uri("https://api.crowdin.com/api/project/#{project_id}")
-      self.class.default_params key: api_key
+      self.class.default_params({"account-key" => api_key, "login" => "code-org"})
     end
 
     # @see https://support.crowdin.com/api/info/


### PR DESCRIPTION
[Task FND-1835](https://codedotorg.atlassian.net/browse/FND-1835)

The sync-down on 12/13 failed because of `Requested project doesn't exist or the API key is invalid` error ([Slack thread](https://codedotorg.slack.com/archives/C99KAHFK9/p1639440623138600)).

The fix is to follow the exact API formats described in Crowdin API v1 doc ([here](https://support.crowdin.com/api/api-integration-setup/#titles-project-details) and [here](https://support.crowdin.com/api/api-integration-setup/#titles-export-file))
```
POST `https://api.crowdin.com/api/project/{project-identifier}/info?login={username}&account-key={account-key}`
GET `https://api.crowdin.com/api/project/{project-identifier}/export-file?login={username}&account-key={account-key}`
```
 
## Testing story
* Get `code-org`'s account-key from https://crowdin.com/settings#api-key.
* Use Postman to test API calls. 
* Save the account-key to `bin/i18n/<project_identifier>_credentials.yml` files.
* Run the sync-down. 

