### PR TITLE
Fix standalone level lookup in sync-out

### DIFF
--- a/bin/i18n/i18n_script_utils.rb
+++ b/bin/i18n/i18n_script_utils.rb
@@ -194,7 +194,7 @@ class I18nScriptUtils
       level =
         case route_params[:controller]
         when "projects"
-          Level.find_by_name(ProjectsController::STANDALONE_PROJECTS.dig(route_params[:key], :name))
+          Level.find_by_name(route_params[:key])
         when "script_levels"
           get_script_level(route_params, new_url)
         else


### PR DESCRIPTION
[Task FND-1835](https://codedotorg.atlassian.net/browse/FND-1835)

We got a barrage of ["could not find level for url"](https://codedotorg.slack.com/archives/C99KAHFK9/p1639482234221600) errors during the recent sync-out. 
<img width="562" alt="Screen Shot 2021-12-15 at 12 20 04 PM" src="https://user-images.githubusercontent.com/46507039/146259295-d43f2380-16f5-4754-a663-47e191067eef.png">

The issue is in this level lookup code, specifically line 197.
https://github.com/code-dot-org/code-dot-org/blob/c181dff83ebbabba6833fae0f693bf5d3fafeb2f/bin/i18n/i18n_script_utils.rb#L191-L197

I don't know what has changed but `route_params[:key]` returns a level name, not a key in `ProjectsController::STANDALONE_PROJECTS` hash. We can just use `route_params[:key]` to find a level by name.

## Testing story
```ruby
# In a rails console
require_relative '../bin/i18n/i18n_script_utils'
url = "https://studio.code.org/p/poetry"
route_params = Rails.application.routes.recognize_path(url)  
# Result: {:key=>"New Poetry Project", :controller=>"projects", :action=>"redirect_legacy"}
Level.find_by_name(route_params[:key])
# Result: #<Poetry id: 35241, ...>
```