### PR TITLE
[Spritelab] Cap makeNumSprites at 500

### DIFF
--- a/apps/src/p5lab/spritelab/commands/spriteCommands.js
+++ b/apps/src/p5lab/spritelab/commands/spriteCommands.js
@@ -2,6 +2,11 @@ import {commands as locationCommands} from './locationCommands';
 import {commands as behaviorCommands} from './behaviorCommands';
 import * as utils from '@cdo/apps/p5lab/utils';
 
+// Big numbers in some blocks can cause performance issues. Combined with live-preview,
+// this results in hanging the tab and students unable to edit their blocks. We should
+// guard against this by silently capping numbers where needed.
+const BIG_NUMBER_GUARD = 500;
+
 export const commands = {
   countByAnimation(spriteArg) {
     let sprites = this.getSpriteArray(spriteArg);
@@ -65,6 +70,7 @@ export const commands = {
   },
 
   makeNumSprites(num, animation) {
+    num = Math.min(num, BIG_NUMBER_GUARD);
     for (let i = 0; i < num; i++) {
       this.addSprite({
         animation,
@@ -80,11 +86,7 @@ export const commands = {
       rain: behaviorCommands.rainFunc,
       spiral: behaviorCommands.spiralFunc
     };
-    // Cap created sprites
-    const spriteCountCap = 100;
-    if (num > spriteCountCap) {
-      num = spriteCountCap;
-    }
+    num = Math.min(num, BIG_NUMBER_GUARD);
     //Makes sure that same-frame multiple spiral effects start at a different angles
     const spiralRandomizer = utils.randomInt(0, 359);
     for (let i = 0; i < num; i++) {

--- a/apps/test/unit/p5lab/spritelab/spriteCommandsTest.js
+++ b/apps/test/unit/p5lab/spritelab/spriteCommandsTest.js
@@ -131,4 +131,20 @@ describe('Sprite Commands', () => {
 
     expect(coreLibrary.getAnimationsInUse()).to.deep.equal(['costume_label']);
   });
+
+  describe('makeNumSprites', () => {
+    it('creates multiple sprites with the same costume', () => {
+      commands.makeNumSprites.apply(coreLibrary, [10, 'costume_label']);
+      expect(
+        coreLibrary.getSpriteArray({costume: 'costume_label'}).length
+      ).to.equal(10);
+    });
+
+    it('caps at 500 sprites', () => {
+      commands.makeNumSprites.apply(coreLibrary, [100000000, 'costume_label']);
+      expect(
+        coreLibrary.getSpriteArray({costume: 'costume_label'}).length
+      ).to.equal(500);
+    });
+  });
 });


### PR DESCRIPTION
Follow up to https://codedotorg.atlassian.net/browse/STAR-1999
I fixed the student's project but we should prevent this situation from happening again by just capping the number of sprites that can be created using that block.