### PR TITLE
Use flexbox for GameButtons component

### DIFF
--- a/apps/src/containedLevels.js
+++ b/apps/src/containedLevels.js
@@ -133,7 +133,7 @@ export function initializeContainedLevel() {
     const disabledRunButtonHandler = e => {
       $(window).trigger('attemptedRunButtonClick');
     };
-    $('#runButtonWrapper').bind('click', disabledRunButtonHandler);
+    $('#runButton').bind('click', disabledRunButtonHandler);
 
     callouts.addCallouts([
       {
@@ -165,7 +165,7 @@ export function initializeContainedLevel() {
       stepButton.prop('disabled', !validResult);
       if (validResult) {
         runButton.qtip('hide');
-        $('#runButtonWrapper').unbind('click', disabledRunButtonHandler);
+        $('#runButton').unbind('click', disabledRunButtonHandler);
       }
       getStore().dispatch(setAwaitingContainedResponse(!validResult));
     });

--- a/apps/src/templates/CompletionButton.jsx
+++ b/apps/src/templates/CompletionButton.jsx
@@ -41,27 +41,22 @@ class CompletionButton extends Component {
     }
 
     return (
-      <ProtectedStatefulDiv style={styles.main}>
-        <div id="share-cell" className={divClass}>
-          <button
-            type="button"
-            id={id}
-            className="share"
-            style={[this.props.playspacePhoneFrame && styles.phoneFrameButton]}
-          >
-            <img src="/blockly/media/1x1.gif" />
-            {contents}
-          </button>
-        </div>
+      <ProtectedStatefulDiv id="share-cell" className={divClass}>
+        <button
+          type="button"
+          id={id}
+          className="share"
+          style={[this.props.playspacePhoneFrame && styles.phoneFrameButton]}
+        >
+          <img src="/blockly/media/1x1.gif" />
+          {contents}
+        </button>
       </ProtectedStatefulDiv>
     );
   }
 }
 
 const styles = {
-  main: {
-    display: 'inline'
-  },
   // The way that this works in the non-phone frame world is use media queries to
   // set runButton's min-width to be 111px at >1051, and 45px otherwise. When
   // min-width was 45px, we would actually render at 105px.

--- a/apps/src/templates/GameButtons.jsx
+++ b/apps/src/templates/GameButtons.jsx
@@ -13,9 +13,6 @@ import blankImg from '../../static/common_images/1x1.gif';
 
 const styles = {
   main: {
-    // common.scss provides an :after selector that ends up adding 18px of height
-    // to gameButtons. We want to get rid of that
-    //marginBottom: -18,
     display: 'flex',
     flexWrap: 'wrap',
     columnGap: 9,

--- a/apps/src/templates/GameButtons.jsx
+++ b/apps/src/templates/GameButtons.jsx
@@ -15,7 +15,7 @@ const styles = {
   main: {
     // common.scss provides an :after selector that ends up adding 18px of height
     // to gameButtons. We want to get rid of that
-    marginBottom: -18,
+    //marginBottom: -18,
     display: 'flex',
     flexWrap: 'wrap',
     columnGap: 9,
@@ -32,21 +32,15 @@ export const FinishButton = () => (
 );
 
 export const RunButton = Radium(props => (
-  <span id="runButtonWrapper">
-    <button
-      type="button"
-      id="runButton"
-      className={classNames([
-        'launch',
-        'blocklyLaunch',
-        props.hidden && 'hide'
-      ])}
-      style={props.style}
-    >
-      <div>{props.runButtonText || msg.runProgram()}</div>
-      <img src={blankImg} className="run26" />
-    </button>
-  </span>
+  <button
+    type="button"
+    id="runButton"
+    className={classNames(['launch', 'blocklyLaunch', props.hidden && 'hide'])}
+    style={props.style}
+  >
+    <div>{props.runButtonText || msg.runProgram()}</div>
+    <img src={blankImg} className="run26" />
+  </button>
 ));
 RunButton.propTypes = {
   hidden: PropTypes.bool,
@@ -87,6 +81,7 @@ export const UnconnectedGameButtons = props => (
   <div>
     <ProtectedStatefulDiv id="gameButtons" style={styles.main}>
       <RunButton
+        id="runButtonWrapper"
         hidden={props.hideRunButton}
         runButtonText={props.runButtonText}
       />

--- a/apps/src/templates/GameButtons.jsx
+++ b/apps/src/templates/GameButtons.jsx
@@ -78,7 +78,6 @@ export const UnconnectedGameButtons = props => (
   <div>
     <ProtectedStatefulDiv id="gameButtons" style={styles.main}>
       <RunButton
-        id="runButtonWrapper"
         hidden={props.hideRunButton}
         runButtonText={props.runButtonText}
       />

--- a/apps/src/templates/GameButtons.jsx
+++ b/apps/src/templates/GameButtons.jsx
@@ -11,16 +11,6 @@ import {connect} from 'react-redux';
 
 import blankImg from '../../static/common_images/1x1.gif';
 
-const styles = {
-  main: {
-    display: 'flex',
-    flexWrap: 'wrap',
-    columnGap: 9,
-    rowGap: 0,
-    justifyContent: 'space-between'
-  }
-};
-
 export const FinishButton = () => (
   <button type="button" id="finishButton" className="share">
     <img src="/blockly/media/1x1.gif" />
@@ -76,7 +66,7 @@ ResetButton.displayName = 'ResetButton';
  */
 export const UnconnectedGameButtons = props => (
   <div>
-    <ProtectedStatefulDiv id="gameButtons" style={styles.main}>
+    <ProtectedStatefulDiv id="gameButtons">
       <RunButton
         hidden={props.hideRunButton}
         runButtonText={props.runButtonText}

--- a/apps/src/templates/GameButtons.jsx
+++ b/apps/src/templates/GameButtons.jsx
@@ -15,7 +15,12 @@ const styles = {
   main: {
     // common.scss provides an :after selector that ends up adding 18px of height
     // to gameButtons. We want to get rid of that
-    marginBottom: -18
+    marginBottom: -18,
+    display: 'flex',
+    flexWrap: 'wrap',
+    columnGap: 9,
+    rowGap: 0,
+    justifyContent: 'space-between'
   }
 };
 

--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -623,7 +623,6 @@ button.disabled:hover>img {
 }
 button.disabled {
   display: none;
-  margin-inline-end: 0px;
 }
 button.notext {
   font-size: 10%;

--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -255,11 +255,15 @@ button.arrow:disabled {
   &.soft-buttons-compact {
     margin: 0;
     button {
-      margin: 0 4px 0 0;
+      margin: 0;
+      margin-inline-end: 4px;
     }
   }
   :last-child{
     margin-inline-end: 0px;
+  }
+  @supports not (gap: 0 9px) {
+    padding-inline-end: 9px;
   }
 }
 
@@ -669,6 +673,15 @@ input[type="radio"] {
   text-align: justify;
   -ms-text-justify: distribute-all-lines;
   text-justify: distribute-all-lines;
+
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+
+  @supports (gap: 0 9px) {
+    gap: 0 9px;
+  }
+  
 }
 
 #gameButtons:after{

--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -266,22 +266,18 @@ button.arrow:disabled {
 .soft-buttons-1 {
   display: table-cell;
   vertical-align: top;
-  //min-width: 51px;
 }
 .soft-buttons-2 {
   display: table-cell;
   vertical-align: top;
-  //min-width: 102px;
 }
 .soft-buttons-3 {
   display: table-cell;
   vertical-align: top;
-  //min-width: 153px;
 }
 .soft-buttons-4 {
   display: table-cell;
   vertical-align: top;
-  //min-width: 204px;
 }
 
 /* Set z-index to one here so that .droplet-dropdown (z-index 500) appears in front of
@@ -501,7 +497,7 @@ html[dir='rtl'] div#visualizationResizeBar {
   @include karel-counter(32px, 2px);
 
   #soft-buttons {
-    margin: 5px -8px 0 0;
+    margin: 5px 0 0 0;
     button {
       margin: 0 4px 0 0;
     }
@@ -627,6 +623,7 @@ button.disabled:hover>img {
 }
 button.disabled {
   display: none;
+  margin-inline-end: 0px;
 }
 button.notext {
   font-size: 10%;

--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -258,27 +258,30 @@ button.arrow:disabled {
       margin: 0 4px 0 0;
     }
   }
+  :last-child{
+    margin-inline-end: 0px;
+  }
 }
 
 .soft-buttons-1 {
   display: table-cell;
   vertical-align: top;
-  min-width: 51px;
+  //min-width: 51px;
 }
 .soft-buttons-2 {
   display: table-cell;
   vertical-align: top;
-  min-width: 102px;
+  //min-width: 102px;
 }
 .soft-buttons-3 {
   display: table-cell;
   vertical-align: top;
-  min-width: 153px;
+  //min-width: 153px;
 }
 .soft-buttons-4 {
   display: table-cell;
   vertical-align: top;
-  min-width: 204px;
+  //min-width: 204px;
 }
 
 /* Set z-index to one here so that .droplet-dropdown (z-index 500) appears in front of

--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -677,11 +677,7 @@ input[type="radio"] {
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
-
-  @supports (gap: 0 9px) {
-    gap: 0 9px;
-  }
-  
+  gap: 0 9px;
 }
 
 #gameButtons:after{

--- a/apps/test/unit/containedLevelsTest.js
+++ b/apps/test/unit/containedLevelsTest.js
@@ -147,7 +147,6 @@ describe('getContainedLevelResultInfo', () => {
     codeStudioLevels.hasValidContainedLevelResult.returns(false);
     initializeContainedLevel();
     const runButton = $('#runButton');
-    const runButtonWrapper = $('#runButtonWrapper');
     const gameButtons = $('#gameButtons');
     assert.isTrue(callouts.addCallouts.calledOnce);
     assert.isTrue(runButton.prop('disabled'));
@@ -155,7 +154,7 @@ describe('getContainedLevelResultInfo', () => {
     gameButtons.click();
     assert.isFalse(attemptedRunButtonClickListener.called);
 
-    runButtonWrapper.click();
+    runButton.click();
     assert.isTrue(attemptedRunButtonClickListener.calledOnce);
 
     // Change answer to valid, should re-enable run button and unbind click listener.
@@ -164,7 +163,7 @@ describe('getContainedLevelResultInfo', () => {
     assert.isFalse(runButton.prop('disabled'));
 
     attemptedRunButtonClickListener.resetHistory();
-    runButtonWrapper.click();
+    runButton.click();
     assert.isFalse(attemptedRunButtonClickListener.called);
   });
 });


### PR DESCRIPTION
We can clear some tech debt and improve the spacing of various buttons by implementing flexbox. This change is compatible with other recent work done to add spacing between ArrowButtons and CompletionButton ([#44033](https://github.com/code-dot-org/code-dot-org/pull/44033)) and also addresses eyes diffs ([slack thread](https://codedotorg.slack.com/archives/C1B3PNDL7/p1639529513261100)) that were caused by that work.

Examples with different button arrangements across various labs:
![image](https://user-images.githubusercontent.com/43474485/146258452-c89604e6-22e5-4471-a5c8-886ec19984ba.png)
![image](https://user-images.githubusercontent.com/43474485/146258537-67292076-ad83-43ec-a2e8-f400b882888b.png)
![image](https://user-images.githubusercontent.com/43474485/146258634-c96e2462-f5f5-48d5-bc7d-250f702e779a.png)
![image](https://user-images.githubusercontent.com/43474485/146258738-6c7105c9-7d41-44fd-a3bf-90437bbe69eb.png)
![image](https://user-images.githubusercontent.com/43474485/146258780-9de10ccb-3c99-4616-b5ec-57bbdaef7e03.png)
![image](https://user-images.githubusercontent.com/43474485/146261176-658623d2-decc-4f74-8988-90b7e4341b14.png)
![image](https://user-images.githubusercontent.com/43474485/146260823-dfc67c0a-e04e-48de-a877-2854b001fd91.png)
![image](https://user-images.githubusercontent.com/43474485/146261113-e35ef6b4-f8ef-435a-b089-d179d7d13c2e.png)


An extra note for @KylieModen that this change affects the button layout on the "share" view, but we think this change is more consistent and actually an improvement:
![image](https://user-images.githubusercontent.com/43474485/146258600-51dd03ba-e852-483b-970c-cc5aee9350e0.png)
*Current (before) layout, for comparison:*
![image](https://user-images.githubusercontent.com/43474485/146261324-144966ef-5819-48b5-b108-b0e70a705ce7.png)


## Links

[slack thread](https://codedotorg.slack.com/archives/C1B3PNDL7/p1639529513261100)

## Follow-up work

[STAR-2008](https://codedotorg.atlassian.net/browse/STAR-2008) - This change introduces one very minor regression affecting the margin following arrow buttons in Bounce levels that don't contain _all four_ arrow buttons.
![image](https://user-images.githubusercontent.com/43474485/146258711-8074b01c-3059-42a4-88cf-eb0b450fa105.png)
![image](https://user-images.githubusercontent.com/43474485/146260888-4449c6e2-94c9-48ba-92b1-cb55e6f3c6c7.png)


