### PR TITLE
remove unused isHocScript from client code

### DIFF
--- a/apps/src/code-studio/header.js
+++ b/apps/src/code-studio/header.js
@@ -38,7 +38,6 @@ var header = {};
 /**
  * @param {object} scriptData
  * @param {boolean} scriptData.disablePostMilestone
- * @param {boolean} scriptData.isHocScript
  * @param {string} scriptData.name
  * @param {object} lessonData{{
  *   script_id: number,

--- a/apps/src/code-studio/progress.js
+++ b/apps/src/code-studio/progress.js
@@ -19,7 +19,6 @@ import {
   overwriteResults,
   setScriptProgress,
   disablePostMilestone,
-  setIsHocScript,
   setIsAge13Required,
   setStudentDefaultsSummaryView,
   setLessonExtrasEnabled,
@@ -102,7 +101,7 @@ progress.generateLessonProgress = function(
 ) {
   const store = getStore();
 
-  const {name, disablePostMilestone, isHocScript, age_13_required} = scriptData;
+  const {name, disablePostMilestone, age_13_required} = scriptData;
 
   initializeStoreWithProgress(
     store,
@@ -120,8 +119,6 @@ progress.generateLessonProgress = function(
     isLessonExtras,
     currentPageNumber
   );
-
-  store.dispatch(setIsHocScript(isHocScript));
 
   if (lessonExtrasEnabled) {
     store.dispatch(setLessonExtrasEnabled(true));
@@ -243,7 +240,6 @@ function extractLevelResults(userProgressResponse) {
  * @param {object[]} scriptData.lessons
  * @param {string} scriptData.name
  * @param {boolean} scriptData.hideable_lessons
- * @param {boolean} scriptData.isHocScript
  * @param {boolean} scriptData.age_13_required
  * Render our progress on the course overview page.
  */

--- a/apps/src/code-studio/progressRedux.js
+++ b/apps/src/code-studio/progressRedux.js
@@ -24,7 +24,6 @@ const MERGE_RESULTS = 'progress/MERGE_RESULTS';
 const MERGE_PEER_REVIEW_PROGRESS = 'progress/MERGE_PEER_REVIEW_PROGRESS';
 const UPDATE_FOCUS_AREAS = 'progress/UPDATE_FOCUS_AREAS';
 const DISABLE_POST_MILESTONE = 'progress/DISABLE_POST_MILESTONE';
-const SET_IS_HOC_UNIT = 'progress/SET_IS_HOC_UNIT';
 const SET_IS_AGE_13_REQUIRED = 'progress/SET_IS_AGE_13_REQUIRED';
 const SET_IS_SUMMARY_VIEW = 'progress/SET_IS_SUMMARY_VIEW';
 const SET_IS_MINI_VIEW = 'progress/SET_IS_MINI_VIEW';
@@ -65,7 +64,6 @@ const initialState = {
   peerReviewLessonInfo: null,
   peerReviewsPerformed: [],
   postMilestoneDisabled: false,
-  isHocScript: null,
   isAge13Required: false,
   // Do students see summary view by default?
   studentDefaultsSummaryView: true,
@@ -187,13 +185,6 @@ export default function reducer(state = initialState, action) {
     return {
       ...state,
       postMilestoneDisabled: true
-    };
-  }
-
-  if (action.type === SET_IS_HOC_UNIT) {
-    return {
-      ...state,
-      isHocScript: action.isHocScript
     };
   }
 
@@ -475,10 +466,6 @@ export const updateFocusArea = (changeFocusAreaPath, focusAreaLessonIds) => ({
 });
 
 export const disablePostMilestone = () => ({type: DISABLE_POST_MILESTONE});
-export const setIsHocScript = isHocScript => ({
-  type: SET_IS_HOC_UNIT,
-  isHocScript
-});
 export const setIsAge13Required = isAge13Required => ({
   type: SET_IS_AGE_13_REQUIRED,
   isAge13Required

--- a/apps/test/unit/code-studio/progressReduxTest.js
+++ b/apps/test/unit/code-studio/progressReduxTest.js
@@ -11,7 +11,6 @@ import reducer, {
   mergeResults,
   mergePeerReviewProgress,
   disablePostMilestone,
-  setIsHocScript,
   setIsAge13Required,
   setIsSummaryView,
   setStudentDefaultsSummaryView,
@@ -338,24 +337,10 @@ describe('progressReduxTest', () => {
       assert.equal(nextState.postMilestoneDisabled, true);
     });
 
-    it('initially sets isHocScript to null', () => {
-      assert.equal(initialState.isHocScript, null);
-    });
-
-    it('can update isHocScript', () => {
-      const isHocScript = reducer(initialState, setIsHocScript(true));
-      assert.equal(isHocScript.isHocScript, true);
-
-      const isNotHocScript = reducer(initialState, setIsHocScript(false));
-      assert.equal(isNotHocScript.isHocScript, false);
-    });
-
     it('can update isAge13Required', () => {
+      assert.equal(initialState, false);
       const state = reducer(initialState, setIsAge13Required(true));
       assert.equal(state.isAge13Required, true);
-
-      const nextState = reducer(initialState, setIsHocScript(false));
-      assert.equal(nextState.isAge13Required, false);
     });
 
     it('can update isSummaryView', () => {

--- a/apps/test/unit/code-studio/progressReduxTest.js
+++ b/apps/test/unit/code-studio/progressReduxTest.js
@@ -338,7 +338,7 @@ describe('progressReduxTest', () => {
     });
 
     it('can update isAge13Required', () => {
-      assert.equal(initialState, false);
+      assert.equal(initialState.isAge13Required, false);
       const state = reducer(initialState, setIsAge13Required(true));
       assert.equal(state.isAge13Required, true);
     });


### PR DESCRIPTION
As part of cleaning up congrats + script constants, I discovered this unused code. I would like to remove it unless we expect to have an immediate use for it.

## Testing story

updated existing test coverage

## Follow-up work

remove `isHocScript` from server code