### PR TITLE
Stop allocating channels for prediction levels

### DIFF
--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -181,7 +181,22 @@ module LevelsHelper
 
     view_options(public_caching: @public_caching)
 
-    level_requires_channel = (@level.channel_backed? && params[:action] != 'edit_blocks') || @level.is_a?(Javalab)
+    # In general, we need to allocate a channel if a level is channel-backed.
+    # As an optimization, we can skip allocating the channel in the following
+    # two special cases where we know the channel will not be written to:
+    # - For levels with contained levels, the outer level is read-only and does
+    #   not write to the channel. (We currently do not support inner levels that
+    #   are channel-backed.)
+    # - In edit_blocks mode, the source code is saved as a level property and
+    #   is not written to the channel.
+    #
+    # Note that Javalab requires a channel to _execute_ the code on Javabuilder
+    # so it always needs a channel, regardless of whether it will be written to.
+    level_requires_channel = @level.is_a?(Javalab) ||
+        (@level.channel_backed? &&
+          !@level.try(:contained_levels).present? &&
+          params[:action] != 'edit_blocks')
+
     # If the level is cached, the channel is loaded client-side in loadApp.js
     if level_requires_channel && !@public_caching
       view_options(

--- a/dashboard/test/helpers/levels_helper_test.rb
+++ b/dashboard/test/helpers/levels_helper_test.rb
@@ -222,8 +222,40 @@ class LevelsHelperTest < ActionView::TestCase
     assert_nil app_options['channel']
   end
 
+  test "app_options sets level_requires_channel to false if level is not channel backed" do
+    @level = create :artist
+    assert_equal false, app_options['levelRequiresChannel']
+  end
+
   test "app_options sets level_requires_channel to true if level is channel backed" do
     @level = create :applab
+    assert_equal true, app_options['levelRequiresChannel']
+  end
+
+  test "app_options sets level_requires_channel to false if level is channel backed with contained levels" do
+    @level = create :applab
+    contained_level = create :level
+    @level.update(contained_level_names: [contained_level.name])
+    assert_equal false, app_options['levelRequiresChannel']
+  end
+
+  test "app_options sets level_requires_channel to false if in edit_blocks mode" do
+    @level = create :applab
+    @controller.stubs(:params).returns({action: 'edit_blocks'})
+    assert_equal false, app_options['levelRequiresChannel']
+  end
+
+  test "app_options sets level_requires_channel to true for Javalab with contained levels" do
+    @level = create :javalab
+    contained_level = create :level
+    @level.update(contained_level_names: [contained_level.name])
+    @controller.stubs(:params).returns({action: 'edit_blocks'})
+    assert_equal true, app_options['levelRequiresChannel']
+  end
+
+  test "app_options sets level_requires_channel to true for Javalab in edit_blocks mode" do
+    @level = create :javalab
+    @controller.stubs(:params).returns({action: 'edit_blocks'})
     assert_equal true, app_options['levelRequiresChannel']
   end
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Stop allocating channels for non-Javalab prediction levels.  They are not needed because the "outer" level never writes to the channel.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [LP-2116](https://codedotorg.atlassian.net/browse/LP-2116)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
