### PR TITLE
Re-enabling previously flaky tests

### DIFF
--- a/dashboard/test/ui/features/learning_platform/level_types/bubble_choice.feature
+++ b/dashboard/test/ui/features/learning_platform/level_types/bubble_choice.feature
@@ -1,4 +1,3 @@
-@no_firefox
 Feature: BubbleChoice
   Scenario: Viewing BubbleChoice progress
     Given I create a teacher-associated student named "Alice"

--- a/dashboard/test/ui/features/learning_platform/projects/prevent_report_abuse_spam.feature
+++ b/dashboard/test/ui/features/learning_platform/projects/prevent_report_abuse_spam.feature
@@ -63,7 +63,7 @@ Scenario: Report Abuse link hidden if the user already reported Game Lab project
   And element ".ui-test-how-it-works" is visible
   And element ".ui-test-report-abuse" is not visible
 
-@no_ie @no_chrome
+@no_ie
 Scenario: Abuse reports block a project for other viewers
   Given I create a student named "Creator"
   And I make a "applab" project named "Regular Project"
@@ -94,7 +94,7 @@ Scenario: Abuse reports block a project for other viewers
   And I navigate to the last shared URL
   And I wait until element ".exclamation-abuse" is visible
 
-@no_ie @no_chrome
+@no_ie
 Scenario: Projects made by project validators are protected from abuse reports
   Given I create a teacher named "Project Validator"
   And I give user "Project Validator" project validator permission


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Re-enabling some tests that were previously disabled due to being flaky.  I've run them a few times and couldn't repro the flakiness so I'm going to just turn them back on and keep an eye on them.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira tickets: [LP-1703](https://codedotorg.atlassian.net/browse/LP-1703), [LP-787](https://codedotorg.atlassian.net/browse/LP-787)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
