### PR TITLE
hoc2021: Update test hoc_mode to post-hoc

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -416,7 +416,7 @@ proxy: false # If true, generated URLs will not include explicit port numbers in
 # Run dashboard-server with the level editing interface enabled (for admins)
 levelbuilder_mode:
 
-default_hoc_mode: soon-hoc  # overridden by 'hoc_mode' DCDO param, except in :test
+default_hoc_mode: post-hoc  # overridden by 'hoc_mode' DCDO param, except in :test
 default_hoc_launch: ''      # overridden by 'hoc_launch' DCDO param, except in :test
 
 # teacher_application_mode values: 'open', 'closing-soon', 'closed'


### PR DESCRIPTION
Updates the test environment's `hoc_mode` to `"post-hoc"`.
