### PR TITLE
Update plc course ui test to have a facilitator participant

### DIFF
--- a/dashboard/test/ui/features/ed_programs/plc_course_unit_navigation.feature
+++ b/dashboard/test/ui/features/ed_programs/plc_course_unit_navigation.feature
@@ -1,7 +1,7 @@
 Feature: Basic navigation for PLC stuff
 
 Background:
-  Given I am a teacher
+  Given I am a CSD facilitator named "Test Deeper Learning Participant"
   And I am enrolled in a plc course
   Given I am on "http://studio.code.org/courses/All%20The%20PLC%20Things"
   And I wait to see ".course_unit_sections"

--- a/dashboard/test/ui/features/step_definitions/pd.rb
+++ b/dashboard/test/ui/features/step_definitions/pd.rb
@@ -16,6 +16,15 @@ Given(/^I am a workshop administrator$/) do
   }
 end
 
+Given(/^I am a CSD facilitator named "([^"]*)"$/) do |facilitator_name|
+  require_rails_env
+
+  steps %Q{
+    And there is a facilitator named "#{facilitator_name}" for course "#{Pd::Workshop::COURSE_CSD}"
+    And I sign in as "#{facilitator_name}"
+  }
+end
+
 Given /^I am a CSF facilitator named "([^"]*)" for regional partner "([^"]*)"$/ do |facilitator_name, partner_name|
   require_rails_env
 


### PR DESCRIPTION
This is to prepare for locking down courses to only be viewed by their participant and instructor audiences. It just makes it so the plc course UI test is being navigated by a facilitators (the participant for that course).

## Links

[Eng Plan](https://docs.google.com/document/d/1V61xONU0-mleMEEdHWNxhvZtYIPRCB31mT_hbUXusCQ/edit#)
[Product Spec](https://docs.google.com/document/d/1qZpc90daxQiiqpcQUiUiGV2tQoaYEQUzOA72UZzBlVE/edit#heading=h.f5x8no3lbpxy)

## Testing story

- Updating a test