### PR TITLE
Signed out users can only participate in student courses

### DIFF
--- a/dashboard/app/models/concerns/curriculum/course_types.rb
+++ b/dashboard/app/models/concerns/curriculum/course_types.rb
@@ -53,6 +53,8 @@ module Curriculum::CourseTypes
     # If unit is in a unit group then decide based on unit group audience
     return unit_group.can_be_participant?(user) if is_a?(Script) && unit_group
 
+    # Signed out users can only use student facing courses
+    return false if !user && participant_audience != 'student'
     return false if can_be_instructor?(user)
 
     if participant_audience == 'facilitator'

--- a/dashboard/test/models/concerns/curriculum/course_types_test.rb
+++ b/dashboard/test/models/concerns/curriculum/course_types_test.rb
@@ -207,4 +207,12 @@ class CourseTypesTests < ActiveSupport::TestCase
     refute @course_universal_instructor_to_teacher.can_be_participant?(@student)
     refute @course_plc_reviewer_to_facilitator.can_be_participant?(@student)
   end
+
+  test 'signed out users should be able to participate in courses with student as participant audience' do
+    assert @course_teacher_to_students.can_be_participant?(nil)
+
+    refute @course_facilitator_to_teacher.can_be_participant?(nil)
+    refute @course_universal_instructor_to_teacher.can_be_participant?(nil)
+    refute @course_plc_reviewer_to_facilitator.can_be_participant?(nil)
+  end
 end


### PR DESCRIPTION
Make sure signed out users can only participate in courses where the participant_audience is student. 

## Links

[Eng Plan](https://docs.google.com/document/d/1V61xONU0-mleMEEdHWNxhvZtYIPRCB31mT_hbUXusCQ/edit#)
[Product Spec](https://docs.google.com/document/d/1qZpc90daxQiiqpcQUiUiGV2tQoaYEQUzOA72UZzBlVE/edit#heading=h.f5x8no3lbpxy)

## Testing story

- Added new test