### PR TITLE
Temporarily Enable binary logging on production Aurora database cluster 

### DIFF
--- a/aws/cloudformation/db_parameters.yml.erb
+++ b/aws/cloudformation/db_parameters.yml.erb
@@ -147,8 +147,18 @@ Reporting:
 
 # System variables for the Aurora DB cluster.
 AuroraCluster: &aurora
-  # Disable binary logging to improve write performance.
-  binlog_format: 'OFF'
+  # When using row-based logging, the primary database writes events to the binary log that indicate how individual table rows are changed.
+  # Replication of the primary database to a replica works by copying the events representing the changes to the table rows to the replica.
+  # ROW required for DMS Change Data Capture:
+  # https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.MySQL.html#CHAP_Source.MySQL.AmazonManaged
+  # ROW also required to use gh-ost to carry out online schema changes on large tables:
+  # https://github.com/github/gh-ost/blob/master/doc/requirements-and-limitations.md
+  binlog_format: ROW
+  # When enabled, this variable causes the primary database to write a checksum for each event in the binary log.
+  # When disabled (value NONE), write and check the event length (rather than a checksum) for each event.
+  # NONE required for DMS Change Data Capture:
+  # https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.MySQL.html#CHAP_Source.MySQL.AmazonManaged
+  binlog_checksum: NONE
 
   # Enable GTIDs: https://aws.amazon.com/blogs/database/amazon-aurora-for-mysql-compatibility-now-supports-global-transaction-identifiers-gtids-replication/
   gtid-mode: ON_PERMISSIVE


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#43743

Temporarily re-enable MySQL binary logging on the production Aurora database cluster to support modifying the datatype of the `level_sources.id` column from `int` to `bigint` using `gh-ost` (#41927 )

### Test

```
$ bundle exec rake stack:data:validate RAILS_ENV=production

Pending update for stack `DATA-production`:
Modify AuroraClusterDBParameters [AWS::RDS::DBClusterParameterGroup] Properties (Parameters)
Modify AuroraReportingClusterDBParameters [AWS::RDS::DBClusterParameterGroup] Properties (Parameters)
```

### Deployment Steps

1. Apply the update the cluster ParameterGroup `bundle exec rake stack:data:start RAILS_ENV=production`
Completed 12/16/2021 16:30 PST:
```
Pending update for stack `DATA-production`:
Modify AuroraClusterDBParameters [AWS::RDS::DBClusterParameterGroup] Properties (Parameters)
Modify AuroraReportingClusterDBParameters [AWS::RDS::DBClusterParameterGroup] Properties (Parameters)
Proceed? [y/n]
y
 Stack update requested, waiting for provisioning to complete...
2021-12-17 00:35:10 UTC- DATA-production [UPDATE_IN_PROGRESS]: User Initiated
..2021-12-17 00:35:20 UTC- AuroraReportingClusterDBParameters [UPDATE_IN_PROGRESS]
2021-12-17 00:35:21 UTC- AuroraClusterDBParameters [UPDATE_IN_PROGRESS]
.........2021-12-17 00:36:22 UTC- AuroraReportingClusterDBParameters [UPDATE_COMPLETE]
2021-12-17 00:36:25 UTC- AuroraClusterDBParameters [UPDATE_COMPLETE]
.2021-12-17 00:36:28 UTC- DATA-production [UPDATE_COMPLETE_CLEANUP_IN_PROGRESS]

Stack update complete.
Outputs:
````

2. Restart the writer database instance (90 seconds of downtime) for the change to take effect
3. Verify that ProxySQL correctly identifies which database instance is the writer and which database instances are the readers