### PR TITLE
Fix translation that causes string interpolation pattern error

### DIFF
--- a/dashboard/config/locales/blocks.th-TH.yml
+++ b/dashboard/config/locales/blocks.th-TH.yml
@@ -1434,9 +1434,9 @@ th:
       gamelab_whileUpArrow:
         text: ในขณะที่ลูกศรขึ้นกด
       gamelab_withPercentChance:
-        text: หากมีโอกาส {NUM}%{STATEMENT}
+        text: หากมีโอกาส {NUM}% {STATEMENT}
       gamelab_withPercentChanceDropdown:
-        text: โอกาส [NUM] ครั้ง {STATEMENT}
+        text: โอกาส {NUM} ครั้ง {STATEMENT}
         options:
           NUM:
             '10': ต่ำมาก

--- a/i18n/locales/th-TH/dashboard/blocks.yml
+++ b/i18n/locales/th-TH/dashboard/blocks.yml
@@ -1432,9 +1432,9 @@ th:
       gamelab_whileUpArrow:
         text: ในขณะที่ลูกศรขึ้นกด
       gamelab_withPercentChance:
-        text: หากมีโอกาส {NUM}%{STATEMENT}
+        text: หากมีโอกาส {NUM}% {STATEMENT}
       gamelab_withPercentChanceDropdown:
-        text: โอกาส [NUM] ครั้ง {STATEMENT}
+        text: โอกาส {NUM} ครั้ง {STATEMENT}
         options:
           NUM:
             '10': ต่ำมาก


### PR DESCRIPTION
We got 750 instances of `Interpolation Pattern present in translation in script_levels # show` Honeybadger errors since yesterday DTP.
- https://app.honeybadger.io/projects/3240/faults/83098380
- https://app.honeybadger.io/projects/3240/faults/83098392

The correct English string is here
https://github.com/code-dot-org/code-dot-org/blob/ea09f36361e1ee77cd2103746e717882152dfe73/dashboard/config/blocks/GamelabJr/gamelab_withPercentChance.json#L5

https://github.com/code-dot-org/code-dot-org/blob/ea09f36361e1ee77cd2103746e717882152dfe73/dashboard/config/locales/blocks.en.yml#L1482-L1485

I've manually fixed the bad translations in [Crowdin](https://crowdin.com/translate/codeorg/639/enus-th?filter=basic&value=3#q=gamelab_withPercentChance). 

**Testing**
This code did not throw error after the fix
`I18n.t("text", scope: [:data, :blocks, 'gamelab_withPercentChance'], default: nil, locale: :'th-TH') `
