### PR TITLE
Fixing login card printing

### DIFF
--- a/apps/src/templates/teacherDashboard/SectionLoginInfo.jsx
+++ b/apps/src/templates/teacherDashboard/SectionLoginInfo.jsx
@@ -193,29 +193,26 @@ class WordOrPictureLogins extends React.Component {
     // Popup blockers cause issues with creating a new window for printing.
     // Creating a hidden iframe temporarily on the page as a workaround.
     const printIframe = document.createElement('iframe');
+    // The iframe will be embedded in the page but we don't want the user to actually see it.
     printIframe.style.display = 'none';
-
-    // Wrapping `write` calls in an onload event listener
-    // to allow contentDocument/contentWindow initialization.
-    printIframe.addEventListener('load', event => {
-      printIframe.contentDocument.open();
-      printIframe.contentDocument.write(
-        `<html><head><title>${i18n.printLoginCards_windowTitle({
-          sectionName: section.name
-        })}</title></head>
-        <body>${printArea}</body></html>`
-      );
-      printIframe.contentDocument.close();
-      printIframe.contentWindow.print();
-    });
+    // Append the iframe to the document so it's  content is initialized.
     document.body.appendChild(printIframe);
-
-    // `onafterprint` event handling isn't consistent across browsers.
-    // Using a timeout allows the iframe `print()` to block before
-    // deleting the iframe.
-    setTimeout(function() {
+    // Print the content of the iframe after all the content has been loaded.
+    printIframe.addEventListener('load', event => {
+      printIframe.contentWindow.print();
+      // Remove the temporary, hidden iframe from the main page.
       printIframe.remove();
-    }, 1000);
+    });
+    // Write the content we want to print to the iframe document.
+    printIframe.contentDocument.open();
+    printIframe.contentDocument.write(
+      `<html><head><title>${i18n.printLoginCards_windowTitle({
+        sectionName: section.name
+      })}</title></head>
+        <body>${printArea}</body></html>`
+    );
+    // Flush the written html and trigger content/images to be loaded in the iframe.
+    printIframe.contentDocument.close();
   };
 
   render() {

--- a/apps/src/templates/teacherDashboard/SectionLoginInfo.jsx
+++ b/apps/src/templates/teacherDashboard/SectionLoginInfo.jsx
@@ -199,9 +199,13 @@ class WordOrPictureLogins extends React.Component {
     document.body.appendChild(printIframe);
     // Print the content of the iframe after all the content has been loaded.
     printIframe.addEventListener('load', event => {
-      printIframe.contentWindow.print();
-      // Remove the temporary, hidden iframe from the main page.
-      printIframe.remove();
+      // [Hack] Since Safari sends the 'load' event before all the images are loaded, we will delay
+      // the print request so the iframe has enough time to load the images.
+      setTimeout(() => {
+        printIframe.contentWindow.print();
+        // Remove the temporary, hidden iframe from the main page.
+        printIframe.remove();
+      }, 100);
     });
     // Write the content we want to print to the iframe document.
     printIframe.contentDocument.open();


### PR DESCRIPTION
_Bug_: When a teacher in the Chrome browser would try to print picture login cards for their young students, the secret image would not show up. See before & after screenshots below.
_Cause_: We were not waiting for the images to be loaded into the iframe before calling `.print()` on it.
_Fix_: Wait for the `load` event to be signaled on the iframe. This indicates all HTML, images, CSS, etc have been loaded.

## Links
* [JIRA](https://codedotorg.atlassian.net/browse/FND-1841)

## Screenshots


### Before
Note that that we expect some cartoony secret images to be inside the dotted squares.
![image](https://user-images.githubusercontent.com/1372238/146462923-cde37a25-f903-40ff-b2d8-b68b6ad5b779.png)

-----------
### After
## Testing story
![image](https://user-images.githubusercontent.com/1372238/146462975-ee027b83-e231-4155-abc2-259c1fd4c7c2.png)

-----------

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
