### PR TITLE
deflake more pd workshop controller tests

### DIFF
--- a/dashboard/test/controllers/api/v1/pd/workshop_summary_report_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_summary_report_controller_test.rb
@@ -46,7 +46,7 @@ class Api::V1::Pd::WorkshopSummaryReportControllerTest < ::ActionController::Tes
   ).freeze
 
   self.use_transactional_test_case = true
-  setup_all do
+  setup do
     @workshop_admin = create :workshop_admin
     @organizer = create :workshop_organizer
     @program_manager = create :program_manager

--- a/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
@@ -5,7 +5,7 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
   freeze_time
 
   self.use_transactional_test_case = true
-  setup_all do
+  setup do
     @regional_partner = create(:regional_partner)
     @program_manager = create(:program_manager, regional_partner: @regional_partner)
     @organizer = @program_manager
@@ -31,9 +31,7 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
     )
 
     @standalone_workshop = create(:workshop)
-  end
 
-  setup do
     # Don't actually call the geocoder.
     Geocoder.stubs(:search)
   end


### PR DESCRIPTION
Follow-on to https://github.com/code-dot-org/code-dot-org/pull/43881. I recently had a [drone failure](https://drone.cdn-code.org/code-dot-org/code-dot-org/13818/1/3) in which the test fixed in #43881 passed, but the two other flaky PD tests failed. I'm taking this as circumstantial evidence that the fix from #43881 may have succeeded, and now I am applying the same fix to the two remaining flaky tests. 

## Testing story

this is a speculative fix -- this one drone run passed, but I don't have any concrete confirmation that this will succeed at deflaking the test.

## Follow-up work

 if flakiness continues, we'll know to try something different.

