### PR TITLE
Reduce lesson lock UI test flakiness

### DIFF
--- a/dashboard/test/ui/features/learning_platform/lesson_lock.feature
+++ b/dashboard/test/ui/features/learning_platform/lesson_lock.feature
@@ -1,13 +1,8 @@
 Feature: Stage Locking
 
-Background:
-  Given I create an authorized teacher-associated student named "bobby"
-  Given I create an authorized teacher-associated student named "billy"
-  Given I create an authorized teacher-associated student named "babby"
-  Given I create an authorized teacher-associated student named "frank"
-
 @eyes
 Scenario: Stage Locking Dialog
+  Given I create an authorized teacher-associated student named "bobby"
   When I open my eyes to test "stage locking"
   Then I sign in as "Teacher_bobby"
   Then I am on "http://studio.code.org/s/allthethings"
@@ -20,40 +15,41 @@ Scenario: Stage Locking Dialog
   And I see no difference for "course overview for authorized teacher"
   And I close my eyes
 
-  Scenario: Readonly view does not show teacher only boxes
+Scenario: Readonly view does not show teacher only boxes
+  Given I create an authorized teacher-associated student named "bobby"
+
   # teacher marks readonly
-    And I sign in as "Teacher_bobby"
-    And I am on "http://studio.code.org/s/allthethings"
+  And I sign in as "Teacher_bobby"
+  And I am on "http://studio.code.org/s/allthethings"
   # Wait until detail view loads
-    And I wait until element "span:contains(Lesson 1: Jigsaw)" is visible
-    And I open the lesson lock dialog for lockable lesson 3
-    # need to open lesson lock dialog for right lesson
-    And I show lesson answers for students
-    And I wait until element ".modal-backdrop" is gone
+  And I wait until element "span:contains(Lesson 1: Jigsaw)" is visible
+  And I open the lesson lock dialog for lockable lesson 3
+  # need to open lesson lock dialog for right lesson
+  And I show lesson answers for students
+  And I wait until element ".modal-backdrop" is gone
 
   # now unlocked/submitted for student
 
-    When I sign in as "bobby"
-    And I am on "http://studio.code.org/s/allthethings"
-    And I wait until element "td:contains(Example CSP Assessment)" is visible
-    And I wait until jQuery Ajax requests are finished
-    Then element "td:contains(Example CSP Assessment) .fa-unlock" is visible
-    Then I verify progress for lesson 47 level 1 is "not_tried" without waiting
-    Then I verify progress for lesson 47 level 2 is "not_tried" without waiting
-    Then I verify progress for lesson 47 level 3 is "not_tried" without waiting
+  When I sign in as "bobby"
+  And I am on "http://studio.code.org/s/allthethings"
+  Then I verify the lesson named "Example CSP Assessment" is unlocked
+  Then I verify progress for lesson 47 level 1 is "not_tried" without waiting
+  Then I verify progress for lesson 47 level 2 is "not_tried" without waiting
+  Then I verify progress for lesson 47 level 3 is "not_tried" without waiting
 
-    When I am on "http://studio.code.org/s/allthethings/lockable/3/levels/1/page/3"
-    And I wait until element "h2:contains(CS Principles Unit 1 Assessment)" is visible
-    Then element "h3:contains(Answer)" is visible
-    Then element "h3:contains(For Teacher Only)" is not visible
-    Then element ".previousPageButton" is visible
+  When I am on "http://studio.code.org/s/allthethings/lockable/3/levels/1/page/3"
+  And I wait until element "h2:contains(CS Principles Unit 1 Assessment)" is visible
+  Then element "h3:contains(Answer)" is visible
+  Then element "h3:contains(For Teacher Only)" is not visible
+  Then element ".previousPageButton" is visible
 
 Scenario: Lock settings for students in survey
+  Given I create an authorized teacher-associated student named "bobby"
+
   # initially locked for student in summary view
 
   When I am on "http://studio.code.org/s/allthethings"
-  And I wait until element "td:contains(Anonymous student survey 2)" is visible
-  Then element "td:contains(Anonymous student survey 2) .fa-lock" is visible
+  Then I verify the lesson named "Anonymous student survey 2" is locked
 
   When I am on "http://studio.code.org/s/allthethings/lockable/1/levels/1/page/1"
   And I wait until element "#level-body" is visible
@@ -73,9 +69,7 @@ Scenario: Lock settings for students in survey
 
   When I sign in as "bobby"
   And I am on "http://studio.code.org/s/allthethings"
-  And I wait until element "td:contains(Anonymous student survey 2)" is visible
-  And I wait until jQuery Ajax requests are finished
-  Then element "td:contains(Anonymous student survey 2) .fa-unlock" is visible
+  Then I verify the lesson named "Anonymous student survey 2" is unlocked
   Then I verify progress for lesson 31 level 1 is "not_tried" without waiting
   Then I verify progress for lesson 31 level 2 is "not_tried" without waiting
   Then I verify progress for lesson 31 level 3 is "not_tried" without waiting
@@ -92,9 +86,7 @@ Scenario: Lock settings for students in survey
   # now locked for student
 
   When I am on "http://studio.code.org/s/allthethings"
-  And I wait until element "td:contains(Anonymous student survey 2)" is visible
-  And I wait until jQuery Ajax requests are finished
-  Then element "td:contains(Anonymous student survey 2) .fa-lock" is visible
+  Then I verify the lesson named "Anonymous student survey 2" is locked
 
   # teacher marks readonly
 
@@ -110,9 +102,7 @@ Scenario: Lock settings for students in survey
 
   When I sign in as "bobby"
   And I am on "http://studio.code.org/s/allthethings"
-  And I wait until element "td:contains(Anonymous student survey 2)" is visible
-  And I wait until jQuery Ajax requests are finished
-  Then element "td:contains(Anonymous student survey 2) .fa-unlock" is visible
+  Then I verify the lesson named "Anonymous student survey 2" is unlocked
   Then I verify progress for lesson 31 level 1 is "not_tried" without waiting
   Then I verify progress for lesson 31 level 2 is "not_tried" without waiting
   Then I verify progress for lesson 31 level 3 is "not_tried" without waiting
@@ -126,12 +116,12 @@ Scenario: Lock settings for students in survey
   Then element ".unsubmitButton" is visible
 
 Scenario: Lock settings for students who never submit
+  Given I create an authorized teacher-associated student named "billy"
+
   # initially locked for student in summary view
 
   When I am on "http://studio.code.org/s/allthethings"
-  And I wait until element "td:contains(Anonymous student survey 2)" is visible
-  And I wait until jQuery Ajax requests are finished
-  Then element "td:contains(Anonymous student survey 2) .fa-lock" is visible
+  Then I verify the lesson named "Anonymous student survey 2" is locked
 
   When I am on "http://studio.code.org/s/allthethings/lockable/1/levels/1/page/1"
   And I wait until element "#level-body" is visible
@@ -151,9 +141,7 @@ Scenario: Lock settings for students who never submit
 
   When I sign in as "billy"
   And I am on "http://studio.code.org/s/allthethings"
-  And I wait until element "td:contains(Anonymous student survey 2)" is visible
-  And I wait until jQuery Ajax requests are finished
-  Then element "td:contains(Anonymous student survey 2) .fa-unlock" is visible
+  Then I verify the lesson named "Anonymous student survey 2" is unlocked
   Then I verify progress for lesson 31 level 1 is "not_tried" without waiting
   Then I verify progress for lesson 31 level 2 is "not_tried" without waiting
   Then I verify progress for lesson 31 level 3 is "not_tried" without waiting
@@ -173,21 +161,19 @@ Scenario: Lock settings for students who never submit
 
   When I sign in as "billy"
   And I am on "http://studio.code.org/s/allthethings"
-  And I wait until element "td:contains(Anonymous student survey 2)" is visible
-  And I wait until jQuery Ajax requests are finished
-  Then element "td:contains(Anonymous student survey 2) .fa-unlock" is visible
+  Then I verify the lesson named "Anonymous student survey 2" is unlocked
   Then I verify progress for lesson 31 level 1 is "not_tried" without waiting
   Then I verify progress for lesson 31 level 2 is "not_tried" without waiting
   Then I verify progress for lesson 31 level 3 is "not_tried" without waiting
   Then I verify progress for lesson 31 level 4 is "not_tried" without waiting
 
 Scenario: Lock settings for retake not submit scenario
+  Given I create an authorized teacher-associated student named "babby"
+
   # initially locked for student in summary view
 
   When I am on "http://studio.code.org/s/allthethings"
-  And I wait until element "td:contains(Anonymous student survey 2)" is visible
-  And I wait until jQuery Ajax requests are finished
-  Then element "td:contains(Anonymous student survey 2) .fa-lock" is visible
+  Then I verify the lesson named "Anonymous student survey 2" is locked
 
   When I am on "http://studio.code.org/s/allthethings/lockable/1/levels/1/page/1"
   And I wait until element "#level-body" is visible
@@ -207,9 +193,7 @@ Scenario: Lock settings for retake not submit scenario
 
   When I sign in as "babby"
   And I am on "http://studio.code.org/s/allthethings"
-  And I wait until element "td:contains(Anonymous student survey 2)" is visible
-  And I wait until jQuery Ajax requests are finished
-  Then element "td:contains(Anonymous student survey 2) .fa-unlock" is visible
+  Then I verify the lesson named "Anonymous student survey 2" is unlocked
   Then I verify progress for lesson 31 level 1 is "not_tried" without waiting
   Then I verify progress for lesson 31 level 2 is "not_tried" without waiting
   Then I verify progress for lesson 31 level 3 is "not_tried" without waiting
@@ -229,9 +213,7 @@ Scenario: Lock settings for retake not submit scenario
 
   When I sign in as "babby"
   And I am on "http://studio.code.org/s/allthethings"
-  And I wait until element "td:contains(Anonymous student survey 2)" is visible
-  And I wait until jQuery Ajax requests are finished
-  Then element "td:contains(Anonymous student survey 2) .fa-lock" is visible
+  Then I verify the lesson named "Anonymous student survey 2" is locked
 
   # now teacher allows for retake
 
@@ -247,9 +229,7 @@ Scenario: Lock settings for retake not submit scenario
 
   When I sign in as "babby"
   And I am on "http://studio.code.org/s/allthethings"
-  And I wait until element "td:contains(Anonymous student survey 2)" is visible
-  And I wait until jQuery Ajax requests are finished
-  Then element "td:contains(Anonymous student survey 2) .fa-unlock" is visible
+  Then I verify the lesson named "Anonymous student survey 2" is unlocked
   When I am on "http://studio.code.org/s/allthethings/lockable/1/levels/1/page/4"
   And I click selector ".submitButton" once I see it
   And I wait to see a dialog titled "Submit your survey"
@@ -259,17 +239,15 @@ Scenario: Lock settings for retake not submit scenario
   # now locked for student
 
   When I am on "http://studio.code.org/s/allthethings"
-  And I wait until element "td:contains(Anonymous student survey 2)" is visible
-  And I wait until jQuery Ajax requests are finished
-  Then element "td:contains(Anonymous student survey 2) .fa-lock" is visible
+  Then I verify the lesson named "Anonymous student survey 2" is locked
 
 Scenario: Lock settings for retake after submit scenario
+  Given I create an authorized teacher-associated student named "frank"
+
   # initially locked for student in summary view
 
   When I am on "http://studio.code.org/s/allthethings"
-  And I wait until element "td:contains(Anonymous student survey 2)" is visible
-  And I wait until jQuery Ajax requests are finished
-  Then element "td:contains(Anonymous student survey 2) .fa-lock" is visible
+  Then I verify the lesson named "Anonymous student survey 2" is locked
 
   When I am on "http://studio.code.org/s/allthethings/lockable/1/levels/1/page/1"
   And I wait until element "#level-body" is visible
@@ -289,9 +267,7 @@ Scenario: Lock settings for retake after submit scenario
 
   When I sign in as "frank"
   And I am on "http://studio.code.org/s/allthethings"
-  And I wait until element "td:contains(Anonymous student survey 2)" is visible
-  And I wait until jQuery Ajax requests are finished
-  Then element "td:contains(Anonymous student survey 2) .fa-unlock" is visible
+  Then I verify the lesson named "Anonymous student survey 2" is unlocked
   Then I verify progress for lesson 31 level 1 is "not_tried" without waiting
   Then I verify progress for lesson 31 level 2 is "not_tried" without waiting
   Then I verify progress for lesson 31 level 3 is "not_tried" without waiting
@@ -305,9 +281,7 @@ Scenario: Lock settings for retake after submit scenario
   # now locked for student
 
   When I am on "http://studio.code.org/s/allthethings"
-  And I wait until element "td:contains(Anonymous student survey 2)" is visible
-  And I wait until jQuery Ajax requests are finished
-  Then element "td:contains(Anonymous student survey 2) .fa-lock" is visible
+  Then I verify the lesson named "Anonymous student survey 2" is locked
 
   # now teacher allows for retake
 
@@ -323,8 +297,6 @@ Scenario: Lock settings for retake after submit scenario
 
   When I sign in as "frank"
   And I am on "http://studio.code.org/s/allthethings"
-  And I wait until element "td:contains(Anonymous student survey 2)" is visible
-  And I wait until jQuery Ajax requests are finished
-  Then element "td:contains(Anonymous student survey 2) .fa-unlock" is visible
+  Then I verify the lesson named "Anonymous student survey 2" is unlocked
   When I am on "http://studio.code.org/s/allthethings/lockable/1/levels/1/page/4"
   Then element ".unsubmitButton" is visible

--- a/dashboard/test/ui/features/step_definitions/lesson_lock.rb
+++ b/dashboard/test/ui/features/step_definitions/lesson_lock.rb
@@ -1,0 +1,11 @@
+Then /^I verify the lesson named "([^"]*)" is (locked|unlocked)/ do |lesson_name, lock_status|
+  lesson_selector = "td:contains(#{lesson_name})"
+  lock_icon_selector = lock_status == "locked" ?
+    "td:contains(#{lesson_name}) .fa-lock" :
+    "td:contains(#{lesson_name}) .fa-unlock"
+
+  wait_short_until do
+    @browser.execute_script(jquery_is_element_visible(lesson_selector)) &&
+      @browser.execute_script(jquery_is_element_visible(lock_icon_selector))
+  end
+end


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

It looks like the lesson lock tests have become a bit flaky due to some recent changes that changed the timing of when the lock icon appears.  We now poll for the expected lock state to try to reduce the flakiness of the test.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
