### PR TITLE
Add migration to update application id in enrollments

### DIFF
--- a/dashboard/db/migrate/20211217121759_update_application_id_in_pd_enrollment.rb
+++ b/dashboard/db/migrate/20211217121759_update_application_id_in_pd_enrollment.rb
@@ -1,0 +1,11 @@
+class UpdateApplicationIdInPdEnrollment < ActiveRecord::Migration[5.2]
+  def change
+    Pd::Enrollment.where.not(user_id: nil).each do |enrollment|
+      Pd::Application::ApplicationBase.where(user_id: enrollment.user_id).each do |application|
+        if application.try(:pd_workshop_id) == enrollment.pd_workshop_id
+          enrollment.update_attribute(:application_id, application.id)
+        end
+      end
+    end
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_15_025455) do
+ActiveRecord::Schema.define(version: 2021_12_17_121759) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"


### PR DESCRIPTION
I did a migration https://github.com/code-dot-org/code-dot-org/pull/44007 to add application_id in enrollments. That added the column but didn't update the application_id correctly.

This migration is to update the application_id correctly. I tested it locally.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: [PLAT-1505](https://codedotorg.atlassian.net/browse/PLAT-1505)
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

Will still need to merge in https://github.com/code-dot-org/code-dot-org/pull/44042 once all of this is working.

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
