### PR TITLE
Refactor and rename SetUpMessage component

### DIFF
--- a/apps/src/templates/studioHomepages/BorderedCallToAction.jsx
+++ b/apps/src/templates/studioHomepages/BorderedCallToAction.jsx
@@ -37,7 +37,6 @@ const BorderedCallToAction = props => {
         text={buttonText}
         style={[styles.button, buttonLocaleStyle]}
       />
-      <div style={styles.clear} />
     </div>
   );
 };
@@ -66,7 +65,8 @@ const styles = {
     borderColor: color.border_gray,
     boxSizing: 'border-box',
     marginBottom: 20,
-    float: 'left'
+    display: 'flex',
+    justifyContent: 'space-between'
   },
   solidBorder: {
     borderStyle: 'solid',
@@ -77,7 +77,6 @@ const styles = {
     borderWidth: 5
   },
   wordBox: {
-    width: styleConstants['content-width'] - 285,
     paddingLeft: 25,
     paddingRight: 25
   },
@@ -91,23 +90,15 @@ const styles = {
   description: {
     fontSize: 14,
     color: color.charcoal,
-    width: styleConstants['content-width'] - 280,
     paddingTop: 5,
     paddingBottom: 25
   },
   button: {
     marginTop: 28,
     marginLeft: 25,
-    marginRight: 25
-  },
-  left: {
-    float: 'left'
-  },
-  right: {
-    float: 'right'
-  },
-  clear: {
-    clear: 'both'
+    marginRight: 25,
+    paddingLeft: 25,
+    paddingRight: 25
   }
 };
 

--- a/apps/src/templates/studioHomepages/BorderedCallToAction.jsx
+++ b/apps/src/templates/studioHomepages/BorderedCallToAction.jsx
@@ -43,7 +43,6 @@ BorderedCallToAction.defaultProps = {
 };
 
 BorderedCallToAction.propTypes = {
-  isRtl: PropTypes.bool,
   headingText: PropTypes.string.isRequired,
   descriptionText: PropTypes.string.isRequired,
   className: PropTypes.string,

--- a/apps/src/templates/studioHomepages/BorderedCallToAction.jsx
+++ b/apps/src/templates/studioHomepages/BorderedCallToAction.jsx
@@ -6,18 +6,16 @@ import styleConstants from '@cdo/apps/styleConstants';
 import Button from '@cdo/apps/templates/Button';
 import {navigateToHref} from '@cdo/apps/utils';
 
-const BorderedCallToAction = props => {
-  const {
-    headingText,
-    descriptionText,
-    className,
-    buttonText,
-    buttonUrl,
-    buttonClass,
-    onClick,
-    solidBorder
-  } = props;
-
+const BorderedCallToAction = ({
+  headingText,
+  descriptionText,
+  className,
+  buttonText,
+  buttonUrl,
+  buttonClass,
+  onClick,
+  solidBorder
+}) => {
   const borderStyle = solidBorder ? styles.solidBorder : styles.dashedBorder;
 
   return (

--- a/apps/src/templates/studioHomepages/BorderedCallToAction.jsx
+++ b/apps/src/templates/studioHomepages/BorderedCallToAction.jsx
@@ -7,7 +7,7 @@ import styleConstants from '../../styleConstants';
 import Button from '../Button';
 import {navigateToHref} from '@cdo/apps/utils';
 
-const SetUpMessage = props => {
+const BorderedCallToAction = props => {
   const {
     isRtl,
     headingText,
@@ -42,11 +42,11 @@ const SetUpMessage = props => {
   );
 };
 
-SetUpMessage.defaultProps = {
+BorderedCallToAction.defaultProps = {
   buttonColor: Button.ButtonColor.gray
 };
 
-SetUpMessage.propTypes = {
+BorderedCallToAction.propTypes = {
   isRtl: PropTypes.bool,
   headingText: PropTypes.string.isRequired,
   descriptionText: PropTypes.string.isRequired,
@@ -111,8 +111,8 @@ const styles = {
   }
 };
 
-export const UnconnectedSetUpMessage = SetUpMessage;
+export const UnconnectedBorderedCallToAction = BorderedCallToAction;
 
 export default connect(state => ({
   isRtl: state.isRtl
-}))(Radium(SetUpMessage));
+}))(Radium(BorderedCallToAction));

--- a/apps/src/templates/studioHomepages/BorderedCallToAction.jsx
+++ b/apps/src/templates/studioHomepages/BorderedCallToAction.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Radium from 'radium';
-import {connect} from 'react-redux';
 import color from '../../util/color';
 import styleConstants from '../../styleConstants';
 import Button from '../Button';
@@ -9,7 +8,6 @@ import {navigateToHref} from '@cdo/apps/utils';
 
 const BorderedCallToAction = props => {
   const {
-    isRtl,
     headingText,
     descriptionText,
     className,
@@ -20,22 +18,20 @@ const BorderedCallToAction = props => {
     solidBorder
   } = props;
 
-  const localeStyle = isRtl ? styles.right : styles.left;
-  const buttonLocaleStyle = isRtl ? styles.left : styles.right;
   const borderStyle = solidBorder ? styles.solidBorder : styles.dashedBorder;
 
   return (
     <div style={[styles.outerBox, borderStyle]} className={className}>
-      <div style={[styles.wordBox, localeStyle]}>
-        <div style={[styles.heading, localeStyle]}>{headingText}</div>
-        <div style={[styles.description, localeStyle]}>{descriptionText}</div>
+      <div style={styles.wordBox}>
+        <div style={styles.heading}>{headingText}</div>
+        <div style={styles.description}>{descriptionText}</div>
       </div>
       <Button
         onClick={onClick || (() => navigateToHref(buttonUrl))}
         className={buttonClass}
         color={Button.ButtonColor.gray}
         text={buttonText}
-        style={[styles.button, buttonLocaleStyle]}
+        style={styles.button}
       />
     </div>
   );
@@ -104,6 +100,4 @@ const styles = {
 
 export const UnconnectedBorderedCallToAction = BorderedCallToAction;
 
-export default connect(state => ({
-  isRtl: state.isRtl
-}))(Radium(BorderedCallToAction));
+export default Radium(BorderedCallToAction);

--- a/apps/src/templates/studioHomepages/BorderedCallToAction.jsx
+++ b/apps/src/templates/studioHomepages/BorderedCallToAction.jsx
@@ -15,6 +15,10 @@ const BorderedCallToAction = ({
   onClick,
   solidBorder
 }) => {
+  if (!buttonUrl && !onClick) {
+    throw new Error('Expect at least one of buttonUrl / onClick');
+  }
+
   const borderStyle = solidBorder ? styles.solidBorder : styles.dashedBorder;
 
   return (

--- a/apps/src/templates/studioHomepages/BorderedCallToAction.jsx
+++ b/apps/src/templates/studioHomepages/BorderedCallToAction.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Radium from 'radium';
-import color from '../../util/color';
-import styleConstants from '../../styleConstants';
-import Button from '../Button';
+import color from '@cdo/apps/util/color';
+import styleConstants from '@cdo/apps/styleConstants';
+import Button from '@cdo/apps/templates/Button';
 import {navigateToHref} from '@cdo/apps/utils';
 
 const BorderedCallToAction = props => {

--- a/apps/src/templates/studioHomepages/BorderedCallToAction.jsx
+++ b/apps/src/templates/studioHomepages/BorderedCallToAction.jsx
@@ -54,6 +54,8 @@ BorderedCallToAction.propTypes = {
   solidBorder: PropTypes.bool
 };
 
+const extraSpace = 25;
+
 const styles = {
   outerBox: {
     width: styleConstants['content-width'],
@@ -73,28 +75,28 @@ const styles = {
     borderWidth: 5
   },
   wordBox: {
-    paddingLeft: 25,
-    paddingRight: 25
+    paddingLeft: extraSpace,
+    paddingRight: extraSpace
   },
   heading: {
     fontSize: 20,
     fontFamily: 'Gotham 5r',
     fontWeight: 'bold',
     color: color.teal,
-    paddingTop: 25
+    paddingTop: extraSpace
   },
   description: {
     fontSize: 14,
     color: color.charcoal,
     paddingTop: 5,
-    paddingBottom: 25
+    paddingBottom: extraSpace
   },
   button: {
     marginTop: 28,
-    marginLeft: 25,
-    marginRight: 25,
-    paddingLeft: 25,
-    paddingRight: 25
+    marginLeft: extraSpace,
+    marginRight: extraSpace,
+    paddingLeft: extraSpace,
+    paddingRight: extraSpace
   }
 };
 

--- a/apps/src/templates/studioHomepages/BorderedCallToAction.jsx
+++ b/apps/src/templates/studioHomepages/BorderedCallToAction.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Radium from 'radium';
 import color from '@cdo/apps/util/color';
 import styleConstants from '@cdo/apps/styleConstants';
 import Button from '@cdo/apps/templates/Button';
@@ -19,7 +18,7 @@ const BorderedCallToAction = ({
   const borderStyle = solidBorder ? styles.solidBorder : styles.dashedBorder;
 
   return (
-    <div style={[styles.outerBox, borderStyle]} className={className}>
+    <div style={{...styles.outerBox, ...borderStyle}} className={className}>
       <div style={styles.wordBox}>
         <div style={styles.heading}>{headingText}</div>
         <div style={styles.description}>{descriptionText}</div>
@@ -98,6 +97,4 @@ const styles = {
   }
 };
 
-export const UnconnectedBorderedCallToAction = BorderedCallToAction;
-
-export default Radium(BorderedCallToAction);
+export default BorderedCallToAction;

--- a/apps/src/templates/studioHomepages/SetUpCourses.jsx
+++ b/apps/src/templates/studioHomepages/SetUpCourses.jsx
@@ -1,10 +1,10 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import i18n from '@cdo/locale';
-import SetUpMessage from './SetUpMessage';
+import BorderedCallToAction from './BorderedCallToAction';
 
 const SetUpCourses = ({isTeacher, hasCourse}) => (
-  <SetUpMessage
+  <BorderedCallToAction
     type="courses"
     headingText={hasCourse ? i18n.findCourse() : i18n.startLearning()}
     descriptionText={

--- a/apps/src/templates/studioHomepages/SetUpMessage.jsx
+++ b/apps/src/templates/studioHomepages/SetUpMessage.jsx
@@ -5,6 +5,7 @@ import {connect} from 'react-redux';
 import color from '../../util/color';
 import styleConstants from '../../styleConstants';
 import Button from '../Button';
+import {navigateToHref} from '@cdo/apps/utils';
 
 class SetUpMessage extends Component {
   static propTypes = {
@@ -44,9 +45,7 @@ class SetUpMessage extends Component {
           <div style={[styles.description, localeStyle]}>{descriptionText}</div>
         </div>
         <Button
-          __useDeprecatedTag
-          href={buttonUrl}
-          onClick={onClick}
+          onClick={onClick || (() => navigateToHref(buttonUrl))}
           className={buttonClass}
           color={buttonColor}
           text={buttonText}

--- a/apps/src/templates/studioHomepages/SetUpMessage.jsx
+++ b/apps/src/templates/studioHomepages/SetUpMessage.jsx
@@ -8,19 +8,6 @@ import Button from '../Button';
 import {navigateToHref} from '@cdo/apps/utils';
 
 class SetUpMessage extends Component {
-  static propTypes = {
-    isRtl: PropTypes.bool,
-    headingText: PropTypes.string.isRequired,
-    descriptionText: PropTypes.string.isRequired,
-    className: PropTypes.string,
-    buttonText: PropTypes.string.isRequired,
-    buttonUrl: PropTypes.string,
-    buttonClass: PropTypes.string,
-    buttonColor: PropTypes.oneOf(Object.keys(Button.ButtonColor)),
-    onClick: PropTypes.func,
-    solidBorder: PropTypes.bool
-  };
-
   render() {
     const {
       isRtl,
@@ -59,6 +46,19 @@ class SetUpMessage extends Component {
 
 SetUpMessage.defaultProps = {
   buttonColor: Button.ButtonColor.gray
+};
+
+SetUpMessage.propTypes = {
+  isRtl: PropTypes.bool,
+  headingText: PropTypes.string.isRequired,
+  descriptionText: PropTypes.string.isRequired,
+  className: PropTypes.string,
+  buttonText: PropTypes.string.isRequired,
+  buttonUrl: PropTypes.string,
+  buttonClass: PropTypes.string,
+  buttonColor: PropTypes.oneOf(Object.keys(Button.ButtonColor)),
+  onClick: PropTypes.func,
+  solidBorder: PropTypes.bool
 };
 
 const styles = {

--- a/apps/src/templates/studioHomepages/SetUpMessage.jsx
+++ b/apps/src/templates/studioHomepages/SetUpMessage.jsx
@@ -110,6 +110,8 @@ const styles = {
   }
 };
 
+export const UnconnectedSetUpMessage = SetUpMessage;
+
 export default connect(state => ({
   isRtl: state.isRtl
 }))(Radium(SetUpMessage));

--- a/apps/src/templates/studioHomepages/SetUpMessage.jsx
+++ b/apps/src/templates/studioHomepages/SetUpMessage.jsx
@@ -19,6 +19,8 @@ const SetUpMessage = props => {
     onClick,
     solidBorder
   } = props;
+  // If the site is right-to-left, set word styles ("localeStyle") to the right
+  // and place the button ("buttonLocaleStyle") on the left
   const localeStyle = isRtl ? styles.rtl : styles.ltr;
   const buttonLocaleStyle = isRtl ? styles.ltr : styles.rtl;
   const borderStyle = solidBorder ? styles.solidBorder : styles.dashedBorder;

--- a/apps/src/templates/studioHomepages/SetUpMessage.jsx
+++ b/apps/src/templates/studioHomepages/SetUpMessage.jsx
@@ -19,10 +19,9 @@ const SetUpMessage = props => {
     onClick,
     solidBorder
   } = props;
-  // If the site is right-to-left, set word styles ("localeStyle") to the right
-  // and place the button ("buttonLocaleStyle") on the left
-  const localeStyle = isRtl ? styles.rtl : styles.ltr;
-  const buttonLocaleStyle = isRtl ? styles.ltr : styles.rtl;
+
+  const localeStyle = isRtl ? styles.right : styles.left;
+  const buttonLocaleStyle = isRtl ? styles.left : styles.right;
   const borderStyle = solidBorder ? styles.solidBorder : styles.dashedBorder;
 
   return (
@@ -101,10 +100,10 @@ const styles = {
     marginLeft: 25,
     marginRight: 25
   },
-  ltr: {
+  left: {
     float: 'left'
   },
-  rtl: {
+  right: {
     float: 'right'
   },
   clear: {

--- a/apps/src/templates/studioHomepages/SetUpMessage.jsx
+++ b/apps/src/templates/studioHomepages/SetUpMessage.jsx
@@ -1,4 +1,4 @@
-import React, {Component} from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import Radium from 'radium';
 import {connect} from 'react-redux';
@@ -7,42 +7,39 @@ import styleConstants from '../../styleConstants';
 import Button from '../Button';
 import {navigateToHref} from '@cdo/apps/utils';
 
-class SetUpMessage extends Component {
-  render() {
-    const {
-      isRtl,
-      headingText,
-      descriptionText,
-      className,
-      buttonText,
-      buttonUrl,
-      buttonClass,
-      buttonColor,
-      onClick,
-      solidBorder
-    } = this.props;
-    const localeStyle = isRtl ? styles.rtl : styles.ltr;
-    const buttonLocaleStyle = isRtl ? styles.ltr : styles.rtl;
-    const borderStyle = solidBorder ? styles.solidBorder : styles.dashedBorder;
+const SetUpMessage = props => {
+  const {
+    isRtl,
+    headingText,
+    descriptionText,
+    className,
+    buttonText,
+    buttonUrl,
+    buttonClass,
+    onClick,
+    solidBorder
+  } = props;
+  const localeStyle = isRtl ? styles.rtl : styles.ltr;
+  const buttonLocaleStyle = isRtl ? styles.ltr : styles.rtl;
+  const borderStyle = solidBorder ? styles.solidBorder : styles.dashedBorder;
 
-    return (
-      <div style={[styles.outerBox, borderStyle]} className={className}>
-        <div style={[styles.wordBox, localeStyle]}>
-          <div style={[styles.heading, localeStyle]}>{headingText}</div>
-          <div style={[styles.description, localeStyle]}>{descriptionText}</div>
-        </div>
-        <Button
-          onClick={onClick || (() => navigateToHref(buttonUrl))}
-          className={buttonClass}
-          color={buttonColor}
-          text={buttonText}
-          style={[styles.button, buttonLocaleStyle]}
-        />
-        <div style={styles.clear} />
+  return (
+    <div style={[styles.outerBox, borderStyle]} className={className}>
+      <div style={[styles.wordBox, localeStyle]}>
+        <div style={[styles.heading, localeStyle]}>{headingText}</div>
+        <div style={[styles.description, localeStyle]}>{descriptionText}</div>
       </div>
-    );
-  }
-}
+      <Button
+        onClick={onClick || (() => navigateToHref(buttonUrl))}
+        className={buttonClass}
+        color={Button.ButtonColor.gray}
+        text={buttonText}
+        style={[styles.button, buttonLocaleStyle]}
+      />
+      <div style={styles.clear} />
+    </div>
+  );
+};
 
 SetUpMessage.defaultProps = {
   buttonColor: Button.ButtonColor.gray

--- a/apps/src/templates/studioHomepages/SetUpSections.jsx
+++ b/apps/src/templates/studioHomepages/SetUpSections.jsx
@@ -3,7 +3,7 @@ import React, {Component} from 'react';
 import {connect} from 'react-redux';
 import i18n from '@cdo/locale';
 import {beginEditingNewSection} from '../teacherDashboard/teacherSectionsRedux';
-import SetUpMessage from './SetUpMessage';
+import BorderedCallToAction from './BorderedCallToAction';
 
 class SetUpSections extends Component {
   static propTypes = {
@@ -20,7 +20,7 @@ class SetUpSections extends Component {
       : i18n.setUpClassroom();
 
     return (
-      <SetUpMessage
+      <BorderedCallToAction
         type="sections"
         headingText={headingText}
         descriptionText={i18n.createNewClassroom()}

--- a/apps/src/templates/studioHomepages/TeacherHomepage.jsx
+++ b/apps/src/templates/studioHomepages/TeacherHomepage.jsx
@@ -17,7 +17,7 @@ import i18n from '@cdo/locale';
 import CensusTeacherBanner from '../census2017/CensusTeacherBanner';
 import DonorTeacherBanner from '@cdo/apps/templates/DonorTeacherBanner';
 import {beginGoogleImportRosterFlow} from '../teacherDashboard/teacherSectionsRedux';
-import SetUpMessage from '@cdo/apps/templates/studioHomepages/SetUpMessage';
+import BorderedCallToAction from '@cdo/apps/templates/studioHomepages/BorderedCallToAction';
 import Button from '@cdo/apps/templates/Button';
 
 export const UnconnectedTeacherHomepage = ({
@@ -176,7 +176,7 @@ export const UnconnectedTeacherHomepage = ({
         )}
         {!showAnnouncement && <br />}
         {showFinishTeacherApplication && (
-          <SetUpMessage
+          <BorderedCallToAction
             headingText="Return to Your Application"
             descriptionText="Finish applying for our Professional Learning Program"
             buttonText="Finish Application"

--- a/apps/src/templates/studioHomepages/ViewFeedback.jsx
+++ b/apps/src/templates/studioHomepages/ViewFeedback.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import i18n from '@cdo/locale';
-import SetUpMessage from './SetUpMessage';
+import BorderedCallToAction from './BorderedCallToAction';
 
 const ViewFeedback = () => (
-  <SetUpMessage
+  <BorderedCallToAction
     type="feedback"
     headingText={i18n.viewFeedback()}
     descriptionText={i18n.viewFeedbackDescription()}

--- a/apps/test/unit/templates/studioHomepages/BorderedCallToActionTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/BorderedCallToActionTest.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import {expect} from '../../../util/reconfiguredChai';
 import {isolateComponent} from 'isolate-components';
-import {UnconnectedSetUpMessage} from '@cdo/apps/templates/studioHomepages/SetUpMessage';
+import {UnconnectedBorderedCallToAction} from '@cdo/apps/templates/studioHomepages/BorderedCallToAction';
 import sinon from 'sinon';
 import * as utils from '@cdo/apps/utils';
 
-describe('SetUpMessage', () => {
+describe('BorderedCallToAction', () => {
   const headingText = 'Do Something';
   const descriptionText = 'Get started now';
   const buttonText = 'Get to it';
@@ -18,22 +18,22 @@ describe('SetUpMessage', () => {
   };
 
   describe('default behavior', () => {
-    const setUpMessage = isolateComponent(
-      <UnconnectedSetUpMessage {...defaultProps} />
+    const borderedCtA = isolateComponent(
+      <UnconnectedBorderedCallToAction {...defaultProps} />
     );
     it('renders a heading', () => {
-      expect(setUpMessage.content()).contains(descriptionText);
+      expect(borderedCtA.content()).contains(descriptionText);
     });
     it('renders a description', () => {
-      expect(setUpMessage.content()).contains(descriptionText);
+      expect(borderedCtA.content()).contains(descriptionText);
     });
     it('renders a gray button with text', () => {
-      const button = setUpMessage.findOne('Button');
+      const button = borderedCtA.findOne('Button');
       expect(button.props.text).to.equal(buttonText);
       expect(button.props.color).to.equal('gray');
     });
     it('has a dashed border', () => {
-      expect(setUpMessage.findAll('div')[0].props.style).to.contain({
+      expect(borderedCtA.findAll('div')[0].props.style).to.contain({
         borderStyle: 'dashed',
         borderWidth: 5
       });
@@ -42,7 +42,7 @@ describe('SetUpMessage', () => {
       const path = '/my/path';
       sinon.stub(utils, 'navigateToHref');
 
-      const button = setUpMessage.findOne('Button');
+      const button = borderedCtA.findOne('Button');
       button.props.onClick();
 
       expect(utils.navigateToHref).to.have.been.calledWith(path);
@@ -52,10 +52,10 @@ describe('SetUpMessage', () => {
   });
   describe('custom behavior', () => {
     it('can have a solid border', () => {
-      const setUpMessage = isolateComponent(
-        <UnconnectedSetUpMessage {...defaultProps} solidBorder />
+      const borderedCtA = isolateComponent(
+        <UnconnectedBorderedCallToAction {...defaultProps} solidBorder />
       );
-      expect(setUpMessage.findAll('div')[0].props.style).to.contain({
+      expect(borderedCtA.findAll('div')[0].props.style).to.contain({
         borderStyle: 'solid',
         borderWidth: 1
       });
@@ -63,11 +63,14 @@ describe('SetUpMessage', () => {
     it('can use a custom onClick, which ignores buttonUrl', () => {
       const onClickSpy = sinon.spy();
       sinon.stub(utils, 'navigateToHref');
-      const setUpMessage = isolateComponent(
-        <UnconnectedSetUpMessage {...defaultProps} onClick={onClickSpy} />
+      const borderedCtA = isolateComponent(
+        <UnconnectedBorderedCallToAction
+          {...defaultProps}
+          onClick={onClickSpy}
+        />
       );
 
-      const button = setUpMessage.findOne('Button');
+      const button = borderedCtA.findOne('Button');
       button.props.onClick();
 
       expect(utils.navigateToHref).not.to.have.been.called;

--- a/apps/test/unit/templates/studioHomepages/BorderedCallToActionTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/BorderedCallToActionTest.jsx
@@ -21,6 +21,7 @@ describe('BorderedCallToAction', () => {
     const borderedCtA = isolateComponent(
       <BorderedCallToAction {...defaultProps} />
     );
+
     it('renders a heading', () => {
       expect(borderedCtA.content()).contains(descriptionText);
     });

--- a/apps/test/unit/templates/studioHomepages/BorderedCallToActionTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/BorderedCallToActionTest.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {expect} from '../../../util/reconfiguredChai';
 import {isolateComponent} from 'isolate-components';
-import {UnconnectedBorderedCallToAction} from '@cdo/apps/templates/studioHomepages/BorderedCallToAction';
+import BorderedCallToAction from '@cdo/apps/templates/studioHomepages/BorderedCallToAction';
 import sinon from 'sinon';
 import * as utils from '@cdo/apps/utils';
 
@@ -19,7 +19,7 @@ describe('BorderedCallToAction', () => {
 
   describe('default behavior', () => {
     const borderedCtA = isolateComponent(
-      <UnconnectedBorderedCallToAction {...defaultProps} />
+      <BorderedCallToAction {...defaultProps} />
     );
     it('renders a heading', () => {
       expect(borderedCtA.content()).contains(descriptionText);
@@ -53,7 +53,7 @@ describe('BorderedCallToAction', () => {
   describe('custom behavior', () => {
     it('can have a solid border', () => {
       const borderedCtA = isolateComponent(
-        <UnconnectedBorderedCallToAction {...defaultProps} solidBorder />
+        <BorderedCallToAction {...defaultProps} solidBorder />
       );
       expect(borderedCtA.findAll('div')[0].props.style).to.contain({
         borderStyle: 'solid',
@@ -64,10 +64,7 @@ describe('BorderedCallToAction', () => {
       const onClickSpy = sinon.spy();
       sinon.stub(utils, 'navigateToHref');
       const borderedCtA = isolateComponent(
-        <UnconnectedBorderedCallToAction
-          {...defaultProps}
-          onClick={onClickSpy}
-        />
+        <BorderedCallToAction {...defaultProps} onClick={onClickSpy} />
       );
 
       const button = borderedCtA.findOne('Button');

--- a/apps/test/unit/templates/studioHomepages/BorderedCallToActionTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/BorderedCallToActionTest.jsx
@@ -25,20 +25,24 @@ describe('BorderedCallToAction', () => {
     it('renders a heading', () => {
       expect(borderedCtA.content()).contains(descriptionText);
     });
+
     it('renders a description', () => {
       expect(borderedCtA.content()).contains(descriptionText);
     });
+
     it('renders a gray button with text', () => {
       const button = borderedCtA.findOne('Button');
       expect(button.props.text).to.equal(buttonText);
       expect(button.props.color).to.equal('gray');
     });
+
     it('has a dashed border', () => {
       expect(borderedCtA.findAll('div')[0].props.style).to.contain({
         borderStyle: 'dashed',
         borderWidth: 5
       });
     });
+
     it('button goes to url when clicked', () => {
       const path = '/my/path';
       sinon.stub(utils, 'navigateToHref');
@@ -60,6 +64,7 @@ describe('BorderedCallToAction', () => {
         );
       }).to.throw(Error);
     });
+
     it('can have a solid border', () => {
       const borderedCtA = isolateComponent(
         <BorderedCallToAction {...defaultProps} solidBorder />
@@ -69,6 +74,7 @@ describe('BorderedCallToAction', () => {
         borderWidth: 1
       });
     });
+
     it('can use a custom onClick, which ignores buttonUrl', () => {
       const onClickSpy = sinon.spy();
       sinon.stub(utils, 'navigateToHref');

--- a/apps/test/unit/templates/studioHomepages/BorderedCallToActionTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/BorderedCallToActionTest.jsx
@@ -50,7 +50,15 @@ describe('BorderedCallToAction', () => {
       utils.navigateToHref.restore();
     });
   });
+
   describe('custom behavior', () => {
+    it('must have either a buttonUrl or onClick', () => {
+      expect(() => {
+        isolateComponent(
+          <BorderedCallToAction {...defaultProps} buttonUrl={undefined} />
+        );
+      }).to.throw(Error);
+    });
     it('can have a solid border', () => {
       const borderedCtA = isolateComponent(
         <BorderedCallToAction {...defaultProps} solidBorder />

--- a/apps/test/unit/templates/studioHomepages/SetUpCoursesTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/SetUpCoursesTest.jsx
@@ -2,14 +2,14 @@ import React from 'react';
 import {shallow} from 'enzyme';
 import {assert} from '../../../util/reconfiguredChai';
 import SetUpCourses from '@cdo/apps/templates/studioHomepages/SetUpCourses';
-import SetUpMessage from '@cdo/apps/templates/studioHomepages/SetUpMessage';
+import BorderedCallToAction from '@cdo/apps/templates/studioHomepages/BorderedCallToAction';
 
 describe('SetUpCourses', () => {
   it('renders as expected for a teacher', () => {
     const wrapper = shallow(<SetUpCourses isTeacher={true} />);
     assert(
       wrapper.containsMatchingElement(
-        <SetUpMessage
+        <BorderedCallToAction
           type="courses"
           headingText="Start learning"
           descriptionText="Assign a course to your classroom or start your own course."
@@ -24,7 +24,7 @@ describe('SetUpCourses', () => {
     const wrapper = shallow(<SetUpCourses isTeacher={false} />);
     assert(
       wrapper.containsMatchingElement(
-        <SetUpMessage
+        <BorderedCallToAction
           type="courses"
           headingText="Start learning"
           descriptionText="Browse Code.org's courses to find your next challenge."

--- a/apps/test/unit/templates/studioHomepages/SetUpMessageTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/SetUpMessageTest.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import {expect} from '../../../util/reconfiguredChai';
+import {isolateComponent} from 'isolate-components';
+import {UnconnectedSetUpMessage} from '@cdo/apps/templates/studioHomepages/SetUpMessage';
+
+describe('SetUpMessage', () => {
+  const headingText = 'Do Something';
+  const descriptionText = 'Get started now';
+  const buttonText = 'Get to it';
+  const defaultProps = {
+    headingText,
+    descriptionText,
+    buttonText
+  };
+
+  describe('default behavior', () => {
+    const setUpMessage = isolateComponent(
+      <UnconnectedSetUpMessage {...defaultProps} />
+    );
+    it('renders a heading', () => {
+      expect(setUpMessage.content()).contains(descriptionText);
+    });
+    it('renders a description', () => {
+      expect(setUpMessage.content()).contains(descriptionText);
+    });
+    it('renders a gray button with text', () => {
+      const button = setUpMessage.findOne('Button');
+      expect(button.props.text).to.equal(buttonText);
+      expect(button.props.color).to.equal('gray');
+    });
+  });
+});

--- a/apps/test/unit/templates/studioHomepages/SetUpMessageTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/SetUpMessageTest.jsx
@@ -28,5 +28,11 @@ describe('SetUpMessage', () => {
       expect(button.props.text).to.equal(buttonText);
       expect(button.props.color).to.equal('gray');
     });
+    it('has a dashed border', () => {
+      expect(setUpMessage.findAll('div')[0].props.style).to.contain({
+        borderStyle: 'dashed',
+        borderWidth: 5
+      });
+    });
   });
 });

--- a/apps/test/unit/templates/studioHomepages/SetUpMessageTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/SetUpMessageTest.jsx
@@ -2,15 +2,19 @@ import React from 'react';
 import {expect} from '../../../util/reconfiguredChai';
 import {isolateComponent} from 'isolate-components';
 import {UnconnectedSetUpMessage} from '@cdo/apps/templates/studioHomepages/SetUpMessage';
+import sinon from 'sinon';
+import * as utils from '@cdo/apps/utils';
 
 describe('SetUpMessage', () => {
   const headingText = 'Do Something';
   const descriptionText = 'Get started now';
   const buttonText = 'Get to it';
+  const buttonUrl = '/my/path';
   const defaultProps = {
     headingText,
     descriptionText,
-    buttonText
+    buttonText,
+    buttonUrl
   };
 
   describe('default behavior', () => {
@@ -33,6 +37,17 @@ describe('SetUpMessage', () => {
         borderStyle: 'dashed',
         borderWidth: 5
       });
+    });
+    it('button goes to url when clicked', () => {
+      const path = '/my/path';
+      sinon.stub(utils, 'navigateToHref');
+
+      const button = setUpMessage.findOne('Button');
+      button.props.onClick();
+
+      expect(utils.navigateToHref).to.have.been.calledWith(path);
+
+      utils.navigateToHref.restore();
     });
   });
   describe('custom behavior', () => {

--- a/apps/test/unit/templates/studioHomepages/SetUpMessageTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/SetUpMessageTest.jsx
@@ -60,5 +60,20 @@ describe('SetUpMessage', () => {
         borderWidth: 1
       });
     });
+    it('can use a custom onClick, which ignores buttonUrl', () => {
+      const onClickSpy = sinon.spy();
+      sinon.stub(utils, 'navigateToHref');
+      const setUpMessage = isolateComponent(
+        <UnconnectedSetUpMessage {...defaultProps} onClick={onClickSpy} />
+      );
+
+      const button = setUpMessage.findOne('Button');
+      button.props.onClick();
+
+      expect(utils.navigateToHref).not.to.have.been.called;
+      expect(onClickSpy).to.have.been.calledOnce;
+
+      utils.navigateToHref.restore();
+    });
   });
 });

--- a/apps/test/unit/templates/studioHomepages/SetUpMessageTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/SetUpMessageTest.jsx
@@ -35,4 +35,15 @@ describe('SetUpMessage', () => {
       });
     });
   });
+  describe('custom behavior', () => {
+    it('can have a solid border', () => {
+      const setUpMessage = isolateComponent(
+        <UnconnectedSetUpMessage {...defaultProps} solidBorder />
+      );
+      expect(setUpMessage.findAll('div')[0].props.style).to.contain({
+        borderStyle: 'solid',
+        borderWidth: 1
+      });
+    });
+  });
 });

--- a/apps/test/unit/templates/studioHomepages/SetUpSectionsTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/SetUpSectionsTest.jsx
@@ -4,7 +4,7 @@ import {shallow, mount} from 'enzyme';
 import sinon from 'sinon';
 import {expect} from '../../../util/reconfiguredChai';
 import Button from '@cdo/apps/templates/Button';
-import SetUpMessage from '@cdo/apps/templates/studioHomepages/SetUpMessage';
+import BorderedCallToAction from '@cdo/apps/templates/studioHomepages/BorderedCallToAction';
 import {UnconnectedSetUpSections as SetUpSections} from '@cdo/apps/templates/studioHomepages/SetUpSections';
 import {combineReducers, createStore} from 'redux';
 import isRtl from '@cdo/apps/code-studio/isRtlRedux';
@@ -18,7 +18,7 @@ describe('SetUpSections', () => {
 
     expect(
       wrapper.containsMatchingElement(
-        <SetUpMessage
+        <BorderedCallToAction
           type="sections"
           headingText="Set up your classroom"
           descriptionText="Create a new classroom section to start assigning courses and seeing your student progress."

--- a/apps/test/unit/templates/studioHomepages/SetUpSectionsTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/SetUpSectionsTest.jsx
@@ -1,13 +1,10 @@
 import React from 'react';
-import {Provider} from 'react-redux';
 import {shallow, mount} from 'enzyme';
 import sinon from 'sinon';
 import {expect} from '../../../util/reconfiguredChai';
 import Button from '@cdo/apps/templates/Button';
 import BorderedCallToAction from '@cdo/apps/templates/studioHomepages/BorderedCallToAction';
 import {UnconnectedSetUpSections as SetUpSections} from '@cdo/apps/templates/studioHomepages/SetUpSections';
-import {combineReducers, createStore} from 'redux';
-import isRtl from '@cdo/apps/code-studio/isRtlRedux';
 
 describe('SetUpSections', () => {
   it('renders as expected', () => {
@@ -30,13 +27,8 @@ describe('SetUpSections', () => {
   });
 
   it('calls beginEditingNewSection with no arguments when button is clicked', () => {
-    const store = createStore(combineReducers({isRtl}));
     const spy = sinon.spy();
-    const wrapper = mount(
-      <Provider store={store}>
-        <SetUpSections beginEditingNewSection={spy} />
-      </Provider>
-    );
+    const wrapper = mount(<SetUpSections beginEditingNewSection={spy} />);
     expect(spy).not.to.have.been.called;
 
     wrapper.find(Button).simulate('click', {fake: 'event'});

--- a/apps/test/unit/templates/studioHomepages/TeacherHomepageTest.js
+++ b/apps/test/unit/templates/studioHomepages/TeacherHomepageTest.js
@@ -63,7 +63,7 @@ describe('TeacherHomepage', () => {
   it('renders a Finish Application call to action if showFinishTeacherApplication is true', () => {
     const wrapper = setUp({showFinishTeacherApplication: true});
     assert.equal(
-      wrapper.find('Connect(BorderedCallToAction)').props().buttonText,
+      wrapper.find('BorderedCallToAction').props().buttonText,
       'Finish Application'
     );
   });

--- a/apps/test/unit/templates/studioHomepages/TeacherHomepageTest.js
+++ b/apps/test/unit/templates/studioHomepages/TeacherHomepageTest.js
@@ -63,7 +63,7 @@ describe('TeacherHomepage', () => {
   it('renders a Finish Application call to action if showFinishTeacherApplication is true', () => {
     const wrapper = setUp({showFinishTeacherApplication: true});
     assert.equal(
-      wrapper.find('Connect(SetUpMessage)').props().buttonText,
+      wrapper.find('Connect(BorderedCallToAction)').props().buttonText,
       'Finish Application'
     );
   });


### PR DESCRIPTION
I'm using SetUpMessage for a call to action to resume incomplete teacher applications in https://github.com/code-dot-org/code-dot-org/pull/44119.

The main goals of this refactor are to (a) make this component more accessible by using the Button element without the deprecated tag, (b) add test coverage, and (c) allow the browser to handle right-to-left vs. left-to-right styling. 

I also renamed the component for broader usage.

Rtl version:
<img width="998" alt="Classroom Sections" src="https://user-images.githubusercontent.com/9142121/148101248-6bd60e59-aafa-4b98-aee5-203657cfd430.png">

In Storybook:
<img width="1316" alt="Pasted Graphic 22" src="https://user-images.githubusercontent.com/9142121/148101226-166c6064-c355-4c6a-a7c8-9abce2a0954d.png">


## Links

[Flexbox with RTL styling](https://rtlstyling.com/posts/rtl-styling/#flexbox-layout-module)

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

See `BorderedCallToActionTest.jsx` file for tests.

Refactored `SetUpSectionsTest.jsx` to not need `isRtl` state.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
