### PR TITLE
Refactor and delay displaying lesson lock

### DIFF
--- a/apps/src/code-studio/lessonLockRedux.js
+++ b/apps/src/code-studio/lessonLockRedux.js
@@ -25,6 +25,7 @@ const REFRESH_SECTION_LOCK_STATUS = 'lessonLock/REFRESH_SECTION_LOCK_STATUS';
 
 const initialState = {
   lessonsBySectionId: {},
+  lessonsBySectionIdLoaded: false,
   lockDialogLessonId: null,
   // The locking info for the currently selected section/lesson
   lockStatus: [],
@@ -51,7 +52,8 @@ export default function reducer(state = initialState, action) {
       lessonsBySectionId: _.mapValues(
         action.sections,
         section => section.lessons
-      )
+      ),
+      lessonsBySectionIdLoaded: true
     };
   }
 

--- a/apps/src/code-studio/progressRedux.js
+++ b/apps/src/code-studio/progressRedux.js
@@ -57,6 +57,7 @@ const initialState = {
   // unitProgress is of type unitProgressType (a map of levelId ->
   // studentLevelProgressType)
   unitProgress: {},
+  unitProgressHasLoaded: false,
   // levelResults is a map of levelId -> TestResult
   // note: eventually, we expect usage of this field to be replaced with unitProgress
   levelResults: {},
@@ -115,7 +116,8 @@ export default function reducer(state = initialState, action) {
   if (action.type === SET_UNIT_PROGRESS) {
     return {
       ...state,
-      unitProgress: processServerStudentProgress(action.unitProgress)
+      unitProgress: processServerStudentProgress(action.unitProgress),
+      unitProgressHasLoaded: true
     };
   }
 

--- a/apps/src/templates/progress/ProgressLesson.jsx
+++ b/apps/src/templates/progress/ProgressLesson.jsx
@@ -28,14 +28,16 @@ class ProgressLesson extends React.Component {
     scriptId: PropTypes.number,
     currentLessonId: PropTypes.number,
     viewAs: PropTypes.oneOf(Object.values(ViewType)).isRequired,
-    lessonIsVisible: PropTypes.func.isRequired,
-    lessonIsLockedForUser: PropTypes.func.isRequired,
+    isVisible: PropTypes.bool.isRequired,
+    hiddenForStudents: PropTypes.bool.isRequired,
+    isLockedForUser: PropTypes.bool.isRequired,
     selectedSectionId: PropTypes.string,
     lockableAuthorized: PropTypes.bool,
     lockableAuthorizedLoaded: PropTypes.bool.isRequired,
-    lessonIsLockedForAllStudents: PropTypes.func.isRequired,
+    isLockedForAllStudents: PropTypes.bool.isRequired,
     isRtl: PropTypes.bool,
-    isMiniView: PropTypes.bool
+    isMiniView: PropTypes.bool,
+    lockStatusLoaded: PropTypes.bool.isRequired
   };
 
   constructor(props) {
@@ -85,22 +87,19 @@ class ProgressLesson extends React.Component {
       lesson,
       levels,
       viewAs,
-      lessonIsVisible,
-      lessonIsLockedForUser,
-      lessonIsLockedForAllStudents,
+      isVisible,
+      hiddenForStudents, // Is this a hidden lesson that we still render because we're a instructor
+      isLockedForUser,
+      isLockedForAllStudents,
       selectedSectionId,
       isRtl
     } = this.props;
 
-    if (!lessonIsVisible(lesson, viewAs)) {
+    if (!isVisible) {
       return null;
     }
 
-    // Is this a hidden lesson that we still render because we're a instructor
-    const hiddenForStudents = !lessonIsVisible(lesson, ViewType.Participant);
-    const isLockedForUser = lessonIsLockedForUser(lesson, levels, viewAs);
-    const isLockedForSection = lessonIsLockedForAllStudents(lesson.id);
-    const showAsLocked = isLockedForUser || isLockedForSection;
+    const showAsLocked = isLockedForUser || isLockedForAllStudents;
 
     const title = lesson.lessonNumber
       ? i18n.lessonNumbered({
@@ -162,7 +161,7 @@ class ProgressLesson extends React.Component {
               {hiddenForStudents && (
                 <FontAwesome icon="eye-slash" style={styles.icon} />
               )}
-              {lesson.lockable && (
+              {lesson.lockable && this.props.lockStatusLoaded && (
                 <span data-tip data-for={lockedTooltipId}>
                   <FontAwesome
                     icon={showAsLocked ? 'lock' : 'unlock'}
@@ -307,18 +306,32 @@ const styles = {
 
 export const UnconnectedProgressLesson = ProgressLesson;
 
-export default connect(state => ({
+export default connect((state, ownProps) => ({
   currentLessonId: state.progress.currentLessonId,
   viewAs: state.viewAs,
   lockableAuthorized: state.lessonLock.lockableAuthorized,
   lockableAuthorizedLoaded: state.lessonLock.lockableAuthorizedLoaded,
-  lessonIsVisible: (lesson, viewAs) => lessonIsVisible(lesson, state, viewAs),
-  lessonIsLockedForUser: (lesson, levels, viewAs) =>
-    lessonIsLockedForUser(lesson, levels, state, viewAs),
-  lessonIsLockedForAllStudents: lessonId =>
-    lessonIsLockedForAllStudents(lessonId, state),
+  isVisible: lessonIsVisible(ownProps.lesson, state, state.viewAs),
+  hiddenForStudents: !lessonIsVisible(
+    ownProps.lesson,
+    state,
+    ViewType.Participant
+  ),
+  isLockedForUser: lessonIsLockedForUser(
+    ownProps.lesson,
+    ownProps.levels,
+    state,
+    state.viewAs
+  ),
+  isLockedForAllStudents: lessonIsLockedForAllStudents(
+    ownProps.lesson.id,
+    state
+  ),
   selectedSectionId: state.teacherSections.selectedSectionId.toString(),
   scriptId: state.progress.scriptId,
   isRtl: state.isRtl,
-  isMiniView: state.progress.isMiniView
+  isMiniView: state.progress.isMiniView,
+  lockStatusLoaded:
+    state.progress.unitProgressHasLoaded &&
+    state.lessonLock.lessonsBySectionIdLoaded
 }))(ProgressLesson);

--- a/apps/src/templates/progress/ProgressLesson.story.jsx
+++ b/apps/src/templates/progress/ProgressLesson.story.jsx
@@ -25,11 +25,13 @@ const defaultProps = {
     }
   ],
   viewAs: ViewType.Instructor,
-  lessonIsVisible: () => true,
-  lessonIsLockedForUser: () => false,
-  lessonIsLockedForAllStudents: () => false,
+  isVisible: true,
+  isLockedForUser: false,
+  isLockedForAllStudents: false,
   lockableAuthorized: true,
-  lockableAuthorizedLoaded: true
+  lockableAuthorizedLoaded: true,
+  hiddenForStudents: false,
+  lockStatusLoaded: true
 };
 
 const initialState = {
@@ -133,12 +135,7 @@ export default storybook => {
       {
         name: 'hidden progress lesson as instructor',
         description: 'should be white with full opacity',
-        story: () => (
-          <ProgressLesson
-            {...defaultProps}
-            lessonIsVisible={(lesson, viewAs) => viewAs === ViewType.Instructor}
-          />
-        )
+        story: () => <ProgressLesson {...defaultProps} isVisible={true} />
       },
       {
         name: 'hidden progress lesson as participant',
@@ -146,9 +143,8 @@ export default storybook => {
         story: () => (
           <ProgressLesson
             {...defaultProps}
-            lessonIsVisible={(lesson, viewAs) =>
-              viewAs === ViewType.Participant
-            }
+            hiddenForStudents={true}
+            isVisible={true}
           />
         )
       },
@@ -159,7 +155,7 @@ export default storybook => {
             {...defaultProps}
             lesson={fakeLesson('Assessment Number One', 1, true)}
             levels={fakeLevels(5, {named: false})}
-            lessonIsLockedForAllStudents={() => true}
+            isLockedForAllStudents={true}
           />
         )
       },
@@ -170,7 +166,7 @@ export default storybook => {
             {...defaultProps}
             lesson={fakeLesson('Asessment Number One', 1, true)}
             levels={fakeLevels(5, {named: false})}
-            lessonIsLockedForAllStudents={() => false}
+            isLockedForAllStudents={false}
           />
         )
       },
@@ -181,7 +177,7 @@ export default storybook => {
             {...defaultProps}
             lesson={fakeLesson('Asessment Number One', 1, true)}
             levels={fakeLevels(5, {named: false})}
-            lessonIsLockedForUser={() => true}
+            isLockedForUser={true}
             lockableAuthorized={false}
           />
         )
@@ -194,7 +190,7 @@ export default storybook => {
             viewAs={ViewType.Participant}
             lesson={fakeLesson('Asessment Number One', 1, true)}
             levels={fakeLevels(5, {named: false})}
-            lessonIsLockedForUser={() => true}
+            isLockedForUser={true}
           />
         )
       },
@@ -209,7 +205,7 @@ export default storybook => {
               ...level,
               isLocked: true
             }))}
-            lessonIsLockedForUser={() => true}
+            isLockedForUser={true}
           />
         )
       },

--- a/apps/src/templates/progress/SummaryProgressTable.jsx
+++ b/apps/src/templates/progress/SummaryProgressTable.jsx
@@ -6,7 +6,6 @@ import {groupedLessonsType} from './progressTypes';
 import SummaryProgressRow, {styles as rowStyles} from './SummaryProgressRow';
 import {connect} from 'react-redux';
 import {lessonIsVisible} from './progressHelpers';
-import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 
 class SummaryProgressTable extends React.Component {
   static propTypes = {
@@ -14,12 +13,11 @@ class SummaryProgressTable extends React.Component {
     minimal: PropTypes.bool,
 
     // redux provided
-    viewAs: PropTypes.oneOf(Object.keys(ViewType)),
     lessonIsVisible: PropTypes.func.isRequired
   };
 
   render() {
-    const {viewAs, minimal} = this.props;
+    const {minimal} = this.props;
     const {lessons, levelsByLesson} = this.props.groupedLesson;
 
     if (lessons.length !== levelsByLesson.length) {
@@ -45,7 +43,7 @@ class SummaryProgressTable extends React.Component {
             every other (remaining) one dark */
           lessons
             .map((lesson, index) => ({unfilteredIndex: index, lesson}))
-            .filter(item => this.props.lessonIsVisible(item.lesson, viewAs))
+            .filter(item => this.props.lessonIsVisible(item.lesson))
             .map((item, filteredIndex) => (
               <SummaryProgressRow
                 key={item.unfilteredIndex}
@@ -76,6 +74,5 @@ const styles = {
 
 export const UnconnectedSummaryProgressTable = SummaryProgressTable;
 export default connect(state => ({
-  viewAs: state.viewAs,
-  lessonIsVisible: (lesson, viewAs) => lessonIsVisible(lesson, state, viewAs)
+  lessonIsVisible: lesson => lessonIsVisible(lesson, state, state.viewAs)
 }))(SummaryProgressTable);

--- a/apps/src/templates/progress/progressTestHelpers.js
+++ b/apps/src/templates/progress/progressTestHelpers.js
@@ -85,7 +85,8 @@ export const createStoreWithHiddenLesson = (viewAs, lessonId) => {
         '11': {}
       },
       lockableAuthorized: false,
-      lockableAuthorizedLoaded: true
+      lockableAuthorizedLoaded: true,
+      lessonsBySectionIdLoaded: true
     },
     viewAs: viewAs,
     teacherSections: {
@@ -114,7 +115,8 @@ export const createStoreWithHiddenLesson = (viewAs, lessonId) => {
       }
     }),
     progress: {
-      scriptName: 'script-name'
+      scriptName: 'script-name',
+      unitProgressHasLoaded: true
     },
     currentUser: {
       userId: 1
@@ -136,6 +138,7 @@ export const createStoreWithLockedLesson = (
       lessonsBySectionId: {
         '11': {}
       },
+      lessonsBySectionIdLoaded: true,
       lockableAuthorized: lockableAuthorized,
       lockableAuthorizedLoaded: true
     },
@@ -148,7 +151,9 @@ export const createStoreWithLockedLesson = (
         '11': {[lessonId]: true}
       }
     }),
-    progress: {},
+    progress: {
+      unitProgressHasLoaded: true
+    },
     currentUser: {
       userId: 1
     }

--- a/apps/test/unit/templates/progress/LessonGroupTest.jsx
+++ b/apps/test/unit/templates/progress/LessonGroupTest.jsx
@@ -18,7 +18,7 @@ const DEFAULT_PROPS = {
     lessons: [fakeLesson('lesson1', 1)],
     levelsByLesson: []
   },
-  lessonIsVisible: () => true,
+  hasVisibleLesson: true,
   viewAs: ViewType.Instructor
 };
 
@@ -53,20 +53,7 @@ describe('LessonGroup', () => {
     const props = {
       ...DEFAULT_PROPS,
       isSummaryView: true,
-      lessonIsVisible: () => false,
-      viewAs: ViewType.Participant
-    };
-    const wrapper = shallow(<LessonGroup {...props} />);
-    expect(wrapper.get(0)).to.be.null;
-  });
-  it('does not render in participant view if there are no lessons', () => {
-    const props = {
-      ...DEFAULT_PROPS,
-      groupedLesson: {
-        ...DEFAULT_PROPS.groupedLesson,
-        lessons: []
-      },
-      isSummaryView: true,
+      hasVisibleLesson: false,
       viewAs: ViewType.Participant
     };
     const wrapper = shallow(<LessonGroup {...props} />);

--- a/apps/test/unit/templates/progress/ProgressLessonTest.js
+++ b/apps/test/unit/templates/progress/ProgressLessonTest.js
@@ -26,7 +26,8 @@ describe('ProgressLesson', () => {
     isLockedForAllStudents: false,
     lockableAuthorizedLoaded: true,
     lockableAuthorized: true,
-    isMiniView: false
+    isMiniView: false,
+    lockStatusLoaded: true
   };
 
   it('renders with gray background when not hidden', () => {

--- a/apps/test/unit/templates/progress/ProgressLessonTest.js
+++ b/apps/test/unit/templates/progress/ProgressLessonTest.js
@@ -20,9 +20,10 @@ describe('ProgressLesson', () => {
     levels: fakeLevels(3),
     lessonNumber: 3,
     viewAs: ViewType.Instructor,
-    lessonIsVisible: () => true,
-    lessonIsLockedForUser: () => false,
-    lessonIsLockedForAllStudents: () => false,
+    isVisible: true,
+    hiddenForStudents: false,
+    isLockedForUser: false,
+    isLockedForAllStudents: false,
     lockableAuthorizedLoaded: true,
     lockableAuthorized: true,
     isMiniView: false
@@ -33,11 +34,12 @@ describe('ProgressLesson', () => {
     assert.equal(wrapper.props().style.background, color.lightest_gray);
   });
 
-  it('does not render when lessonIsVisible is false', () => {
+  it('does not render when isVisible is false', () => {
     const wrapper = shallow(
       <ProgressLesson
         {...defaultProps}
-        lessonIsVisible={() => false}
+        isVisible={false}
+        hiddenForStudents={true}
         viewAs={ViewType.Participant}
       />
     );
@@ -49,7 +51,8 @@ describe('ProgressLesson', () => {
     const wrapper = shallow(
       <ProgressLesson
         {...defaultProps}
-        lessonIsVisible={(lesson, viewAs) => viewAs !== ViewType.Participant}
+        hiddenForStudents={true}
+        isVisible={true}
       />
     );
     assert.equal(wrapper.props().style.background, color.lightest_gray);
@@ -69,7 +72,7 @@ describe('ProgressLesson', () => {
       <ProgressLesson
         {...defaultProps}
         lesson={fakeLesson('lesson1', 1, true)}
-        lessonIsLockedForUser={() => true}
+        isLockedForUser={true}
       />
     );
     assert.equal(wrapper.props().style.background, color.lightest_gray);
@@ -89,7 +92,7 @@ describe('ProgressLesson', () => {
       <ProgressLesson
         {...defaultProps}
         lesson={fakeLesson('lesson1', 1, true)}
-        lessonIsLockedForAllStudents={() => true}
+        isLockedForAllStudents={true}
       />
     );
     assert.equal(wrapper.props().style.background, color.lightest_gray);
@@ -109,29 +112,31 @@ describe('ProgressLesson', () => {
       <ProgressLesson
         {...defaultProps}
         lesson={fakeLesson('lesson1', 1, true)}
-        lessonIsLockedForUser={() => true}
+        isLockedForUser={true}
       />
     );
     assert.equal(wrapper.find('ProgressLessonContent').props().disabled, true);
   });
 
-  it('renders with gray background when lesson is lockable but unlocked', () => {
+  it('renders with gray background when lesson is lockable but unlocked and lockStatusLoaded', () => {
     const wrapper = shallow(
       <ProgressLesson
         {...defaultProps}
         lesson={fakeLesson('lesson1', 1, true)}
-        lessonIsLockedForUser={() => false}
+        isLockedForUser={false}
+        lockStatusLoaded={true}
       />
     );
     assert.equal(wrapper.props().style.background, color.lightest_gray);
   });
 
-  it('has an unlocked icon when lesson is lockable but unlocked', () => {
+  it('has an unlocked icon when lesson is lockable but unlocked and lockStatusLoaded', () => {
     const wrapper = shallow(
       <ProgressLesson
         {...defaultProps}
         lesson={fakeLesson('lesson1', 1, true)}
-        lessonIsLockedForUser={() => false}
+        isLockedForUser={false}
+        lockStatusLoaded={true}
       />
     );
     assert.equal(
@@ -150,12 +155,13 @@ describe('ProgressLesson', () => {
     );
   });
 
-  it('has a locked icon when lesson is lockable and locked', () => {
+  it('has a locked icon when lesson is lockable and locked and lockStatusLoaded', () => {
     const wrapper = shallow(
       <ProgressLesson
         {...defaultProps}
         lesson={fakeLesson('lesson1', 1, true)}
-        lessonIsLockedForUser={() => true}
+        isLockedForUser={true}
+        lockStatusLoaded={true}
       />
     );
     assert.equal(
@@ -174,13 +180,15 @@ describe('ProgressLesson', () => {
     );
   });
 
-  it('has both a hidden and a locked icon for instructor when lesson is lockable and locked and hidden', () => {
+  it('has both a hidden and a locked icon for instructor when lesson is lockable and locked and hidden and lockStatusLoaded', () => {
     const wrapper = shallow(
       <ProgressLesson
         {...defaultProps}
         lesson={fakeLesson('lesson1', 1, true)}
-        lessonIsVisible={(lesson, viewAs) => viewAs !== ViewType.Participant}
-        lessonIsLockedForUser={() => true}
+        isVisible={true}
+        hiddenForStudents={true}
+        isLockedForUser={true}
+        lockStatusLoaded={true}
       />
     );
     assert.equal(
@@ -298,7 +306,7 @@ describe('ProgressLesson', () => {
         lesson={fakeLesson('lesson1', 1, true)}
         lockableAuthorizedLoaded={true}
         lockableAuthorized={false}
-        lessonIsLockedForUser={() => true}
+        isLockedForUser={true}
       />
     );
     expect(wrapper.text()).to.include(


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Hide the lock icon before the status has been determined. I considered adding a loading state but this is tiny enough that I think just hiding it initially is fine. There is also some refactor in this PR in an attempt to minimize the number of times props change and simplify the logic.

Before (notice how the lock icon toggles several times):


https://user-images.githubusercontent.com/24235215/146623384-efe1e78a-829d-4b0b-b827-5c79e5540a61.mov




After:

https://user-images.githubusercontent.com/24235215/146623227-6536169e-db18-4abe-8c5b-e7e77c7b8ac0.mov


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
- jira ticket: [LP-2173](https://codedotorg.atlassian.net/browse/LP-2173)
<!--
- spec: []()

-->

## Testing story
Tested locally and updated unit tests.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
