### PR TITLE
Disable binary logging on production Aurora database cluster

### DIFF
--- a/aws/cloudformation/db_parameters.yml.erb
+++ b/aws/cloudformation/db_parameters.yml.erb
@@ -147,18 +147,8 @@ Reporting:
 
 # System variables for the Aurora DB cluster.
 AuroraCluster: &aurora
-  # When using row-based logging, the primary database writes events to the binary log that indicate how individual table rows are changed.
-  # Replication of the primary database to a replica works by copying the events representing the changes to the table rows to the replica.
-  # ROW required for DMS Change Data Capture:
-  # https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.MySQL.html#CHAP_Source.MySQL.AmazonManaged
-  # ROW also required to use gh-ost to carry out online schema changes on large tables:
-  # https://github.com/github/gh-ost/blob/master/doc/requirements-and-limitations.md
-  binlog_format: ROW
-  # When enabled, this variable causes the primary database to write a checksum for each event in the binary log.
-  # When disabled (value NONE), write and check the event length (rather than a checksum) for each event.
-  # NONE required for DMS Change Data Capture:
-  # https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.MySQL.html#CHAP_Source.MySQL.AmazonManaged
-  binlog_checksum: NONE
+  # Disable binary logging to improve write performance.
+  binlog_format: 'OFF'
 
   # Enable GTIDs: https://aws.amazon.com/blogs/database/amazon-aurora-for-mysql-compatibility-now-supports-global-transaction-identifiers-gtids-replication/
   gtid-mode: ON_PERMISSIVE


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#44104

We temporarily enabled binary logging for `gh-ost` migration of `level_sources` table #41927. Disabling binary logging now that is complete.

### TEST

```
bundle exec rake stack:data:validate RAILS_ENV=production

Pending update for stack `DATA-production`:
Modify AuroraClusterDBParameters [AWS::RDS::DBClusterParameterGroup] Properties (Parameters)
Modify AuroraReportingClusterDBParameters [AWS::RDS::DBClusterParameterGroup] Properties (Parameters)
```

### DEPLOYMENT

```
bundle exec rake stack:data:start RAILS_ENV=production

 Stack update requested, waiting for provisioning to complete...
2022-01-03 03:28:09 UTC- DATA-production [UPDATE_IN_PROGRESS]: User Initiated
..2022-01-03 03:28:20 UTC- AuroraClusterDBParameters [UPDATE_IN_PROGRESS]
2022-01-03 03:28:20 UTC- AuroraReportingClusterDBParameters [UPDATE_IN_PROGRESS]
.........2022-01-03 03:29:22 UTC- AuroraReportingClusterDBParameters [UPDATE_COMPLETE]
2022-01-03 03:29:23 UTC- AuroraClusterDBParameters [UPDATE_COMPLETE]
2022-01-03 03:29:25 UTC- DATA-production [UPDATE_COMPLETE_CLEANUP_IN_PROGRESS]
2022-01-03 03:29:22 UTC- AuroraReportingClusterDBParameters [UPDATE_COMPLETE]
2022-01-03 03:29:23 UTC- AuroraClusterDBParameters [UPDATE_COMPLETE]
2022-01-03 03:29:25 UTC- DATA-production [UPDATE_COMPLETE_CLEANUP_IN_PROGRESS]

Stack update complete.
Outputs:
```