### PR TITLE
assert_nil to make Drone logs slightly more user-friendly 

### DIFF
--- a/dashboard/test/controllers/featured_projects_controller_test.rb
+++ b/dashboard/test/controllers/featured_projects_controller_test.rb
@@ -9,7 +9,7 @@ class FeaturedProjectsControllerTest < ActionController::TestCase
   end
 
   test 'project validators can feature projects' do
-    skip 'Investigate flaky test failures'
+    skip 'Investigate flaky test'
     sign_in @project_validator
     @controller.expects(:storage_decrypt_channel_id).with("789").returns([123, 654])
     put :feature, params: {project_id: "789"}
@@ -36,7 +36,7 @@ class FeaturedProjectsControllerTest < ActionController::TestCase
   end
 
   test 'featuring a never featured project creates a new feature project' do
-    skip 'Investigate flaky test failures'
+    skip 'Investigate flaky test'
     sign_in @project_validator
     @controller.expects(:storage_decrypt_channel_id).with("789").returns([123, 654])
     assert_creates(FeaturedProject) do
@@ -48,7 +48,7 @@ class FeaturedProjectsControllerTest < ActionController::TestCase
   end
 
   test 'featuring a currently unfeatured project should update the correct featured project' do
-    skip 'Investigate flaky test failures'
+    skip 'Investigate flaky test'
     sign_in @project_validator
     @controller.expects(:storage_decrypt_channel_id).with("789").returns([123, 456])
     @featured_project.update! unfeatured_at: DateTime.now

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -993,7 +993,7 @@ class ScriptsControllerTest < ActionController::TestCase
     assert_response :success
     unit.reload
 
-    assert_equal nil, unit.tts
+    assert_nil unit.tts
   end
 
   test 'published_state is set to nil for script within course' do

--- a/dashboard/test/integration/lessons_test.rb
+++ b/dashboard/test/integration/lessons_test.rb
@@ -171,7 +171,7 @@ class LessonsTest < ActionDispatch::IntegrationTest
 
     @script_level.reload
     assert @script_level.assessment
-    assert_equal nil, @script_level.bonus
+    assert_nil @script_level.bonus
     refute @script_level.challenge
     assert_equal 1, @script_level.levels.count
     assert_equal [@level], @script_level.levels.all

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -206,7 +206,7 @@ class LessonTest < ActiveSupport::TestCase
     lesson1_summary = lesson1.summarize
     lesson2_summary = lesson2.summarize
     assert_equal '//test.code.org/curriculum/test-script/1/Teacher', lesson1_summary[:lesson_plan_html_url]
-    assert_equal nil, lesson2_summary[:lesson_plan_html_url]
+    assert_nil lesson2_summary[:lesson_plan_html_url]
   end
 
   test 'can summarize lesson with code studio lesson plans in migrated script' do
@@ -222,9 +222,9 @@ class LessonTest < ActiveSupport::TestCase
     lesson3_summary = lesson3.summarize
     lesson4_summary = lesson4.summarize
     assert_equal "/s/#{script.name}/lessons/#{lesson1.relative_position}", lesson1_summary[:lesson_plan_html_url]
-    assert_equal nil, lesson2_summary[:lesson_plan_html_url]
+    assert_nil lesson2_summary[:lesson_plan_html_url]
     assert_equal "/s/#{script.name}/lessons/#{lesson3.relative_position}", lesson3_summary[:lesson_plan_html_url]
-    assert_equal nil, lesson4_summary[:lesson_plan_html_url]
+    assert_nil lesson4_summary[:lesson_plan_html_url]
   end
 
   test 'can summarize lesson with legacy lesson plan link in migrated script' do
@@ -240,9 +240,9 @@ class LessonTest < ActiveSupport::TestCase
     lesson3_summary = lesson3.summarize
     lesson4_summary = lesson4.summarize
     assert_equal '//test.code.org/curriculum/test-script/1/Teacher', lesson1_summary[:lesson_plan_html_url]
-    assert_equal nil, lesson2_summary[:lesson_plan_html_url]
+    assert_nil lesson2_summary[:lesson_plan_html_url]
     assert_equal '//test.code.org/curriculum/test-script/3/Teacher', lesson3_summary[:lesson_plan_html_url]
-    assert_equal nil, lesson4_summary[:lesson_plan_html_url]
+    assert_nil lesson4_summary[:lesson_plan_html_url]
   end
 
   test 'can summarize lesson for lesson plan' do


### PR DESCRIPTION
Drone logs can be tricky to parse. One strategy is to search `fail` to try to find the error in a failing run. Doing so shows a handful of deprecation warnings, for example: 

```DEPRECATED: Use assert_nil if expecting nil from test/controllers/scripts_controller_test.rb:996. This will fail in Minitest 6.```

To reduce noise and thereby make it slightly easier to find the real failures, I've updated offending tests to use `assert_nil` and updated a few of the skip messages we left for ourselves. 