### PR TITLE
Fix incorrectly displayed unsupported browser banner

### DIFF
--- a/apps/src/util/browser-detector.js
+++ b/apps/src/util/browser-detector.js
@@ -16,10 +16,9 @@ function isUnsupportedIE() {
 // We support Chrome 33.x +
 function isUnsupportedChrome() {
   var isChrome = navigator.userAgent.lastIndexOf('Chrome/') !== -1;
-  var chromeVersion = navigator.userAgent.substr(
-    navigator.userAgent.lastIndexOf('Chrome/') + 7,
-    2
-  );
+  var chromeVersion = navigator.userAgent
+    .substring(navigator.userAgent.lastIndexOf('Chrome/') + 7)
+    .split('.')[0];
   var unsupported = isChrome && chromeVersion < 33;
   return unsupported;
 }
@@ -27,10 +26,9 @@ function isUnsupportedChrome() {
 // We support Safari 7.0.x +
 function isUnsupportedSafari() {
   var isSafari = navigator.userAgent.indexOf('Safari/') !== -1;
-  var safariVersion = navigator.userAgent.substr(
-    navigator.userAgent.lastIndexOf('Version/') + 8,
-    2
-  );
+  var safariVersion = navigator.userAgent
+    .substring(navigator.userAgent.lastIndexOf('Version/') + 8)
+    .split('.')[0];
   var unsupported = isSafari && safariVersion < 7;
   return unsupported;
 }
@@ -38,10 +36,9 @@ function isUnsupportedSafari() {
 // We support Firefox 25.x +
 function isUnsupportedFirefox() {
   var isFirefox = navigator.userAgent.indexOf('Firefox') !== -1;
-  var firefoxVersion = navigator.userAgent.substr(
-    navigator.userAgent.lastIndexOf('Firefox/') + 8,
-    2
-  );
+  var firefoxVersion = navigator.userAgent
+    .substring(navigator.userAgent.lastIndexOf('Firefox/') + 8)
+    .split('.')[0];
   var unsupported = isFirefox && firefoxVersion < 25;
   return unsupported;
 }


### PR DESCRIPTION
**What:** 
- Parse the version number from the browser user agent string up to the first decimal point instead of taking the first two digits.
- Use `substring` function throughout our support functions.

**Why:** Using the first two digits of the version number has caused Chrome version `100` to be detected as `10`. This fixes that as well as replaces the use of the `substr` function throughout our browser detection because `substr` is deprecated. Along with deprecation, the browser compatibility of `substring()` actually has [better browser support](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring#browser_compatibility).

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [FND-1858](https://codedotorg.atlassian.net/browse/FND-1858)

## Testing story

- Tested unsupported user agent strings on their respective browsers(Firefox, Safari, and Chrome)
- Tested Chrome before and after locally

**Before**

<img width="815" alt="Screen Shot 2022-01-03 at 11 14 20 AM" src="https://user-images.githubusercontent.com/48133820/147967177-c8ffb7c5-e820-4fc6-a68b-5f6f1d796d62.png">
<img width="789" alt="Screen Shot 2022-01-03 at 11 14 59 AM" src="https://user-images.githubusercontent.com/48133820/147967183-6abd73a3-0ce3-451d-b8ef-dd0c2ca22efd.png">

**After**

<img width="786" alt="Screen Shot 2022-01-03 at 11 16 28 AM" src="https://user-images.githubusercontent.com/48133820/147967226-c01a5437-44f6-4a51-88de-3ce13943615d.png">

<img width="787" alt="Screen Shot 2022-01-03 at 11 17 04 AM" src="https://user-images.githubusercontent.com/48133820/147967231-f87573c4-5c9c-4ef1-ae79-f5390d18372e.png">


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
