### PR TITLE
Check for maker on config level for start mode

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -2279,7 +2279,8 @@ StudioApp.prototype.handleEditCode_ = function(config) {
   }
 
   // Remove maker API blocks from palette, unless maker APIs are enabled.
-  if (!project.getMakerAPIs()) {
+  // Also check config.level to ensure maker toolkit shows when editing start mode
+  if (!project.getMakerAPIs() && !config.level.makerlabEnabled) {
     // Remove maker blocks from the palette
     if (config.level.codeFunctions) {
       configCircuitPlayground.blocks.forEach(block => {

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -2278,9 +2278,12 @@ StudioApp.prototype.handleEditCode_ = function(config) {
     return;
   }
 
-  // Remove maker API blocks from palette, unless maker APIs are enabled.
-  // Also check config.level to ensure maker toolkit shows when editing start mode
-  if (!project.getMakerAPIs() && !config.level.makerlabEnabled) {
+  // Remove maker API blocks from palette, unless project has maker enabled
+  // or level is in edit start mode and maker is enabled
+  if (
+    !project.getMakerAPIs() &&
+    !(config.isStartMode && config.level.makerlabEnabled)
+  ) {
     // Remove maker blocks from the palette
     if (config.level.codeFunctions) {
       configCircuitPlayground.blocks.forEach(block => {


### PR DESCRIPTION
Previously, maker toolkit blocks weren't showing when editing in start mode even though the maker toolkit API was enabled. This change ensures that maker toolkit shows in start mode. 

## Links
- [jira ticket](https://codedotorg.atlassian.net/browse/STAR-1688)

## Testing story
Open to ideas of how to add a UI test for this change. 

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
