### PR TITLE
[Spritelab] Make mini toolbox readonly in instructions

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -50,7 +50,7 @@
     "@babel/preset-react": "^7.0.0",
     "@cdo/interpreted": "link:../dashboard/config/libraries",
     "@code-dot-org/artist": "0.2.1",
-    "@code-dot-org/blockly": "4.0.3",
+    "@code-dot-org/blockly": "4.0.4",
     "@code-dot-org/craft": "0.2.2",
     "@code-dot-org/dance-party": "1.0.3",
     "@code-dot-org/johnny-five": "0.11.1-cdo.2",

--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -1071,7 +1071,13 @@ exports.createJsWrapperBlockCreator = function(
           this.setPreviousStatement(true);
         }
 
-        if (miniToolboxBlocks) {
+        // Use window.appOptions, not global appOptions, because the levelbuilder
+        // block page doesn't have appOptions, but we *do* want to show the mini-toolbox
+        // there
+        if (
+          miniToolboxBlocks &&
+          (!window.appOptions || window.appOptions.level.miniToolbox)
+        ) {
           var toggle = new Blockly.FieldIcon('+');
           if (this.blockSpace.isReadOnly()) {
             toggle.setReadOnly();

--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -1073,6 +1073,10 @@ exports.createJsWrapperBlockCreator = function(
 
         if (miniToolboxBlocks) {
           var toggle = new Blockly.FieldIcon('+');
+          if (this.blockSpace.isReadOnly()) {
+            toggle.setReadOnly();
+          }
+
           var miniToolboxXml = '<xml>';
           miniToolboxBlocks.forEach(block => {
             miniToolboxXml += `\n <block type="${block}"></block>`;
@@ -1082,6 +1086,10 @@ exports.createJsWrapperBlockCreator = function(
           this.isMiniFlyoutOpen = false;
           // On button click, open/close the horizontal flyout, toggle button text between +/-, and re-render the block.
           Blockly.bindEvent_(toggle.fieldGroup_, 'mousedown', this, () => {
+            if (this.blockSpace.isReadOnly()) {
+              return;
+            }
+
             if (this.isMiniFlyoutOpen) {
               toggle.setValue('+');
             } else {
@@ -1107,18 +1115,11 @@ exports.createJsWrapperBlockCreator = function(
               });
             }
           });
-          // Use window.appOptions, not global appOptions, because the levelbuilder
-          // block page doesn't have appOptions, but we *do* want to show the mini-toolbox
-          // there
-          if (
-            !window.appOptions ||
-            (window.appOptions.level.miniToolbox &&
-              !window.appOptions.readonlyWorkspace)
-          ) {
-            this.appendDummyInput()
-              .appendTitle(toggle, 'toggle')
-              .appendTitle(' ');
-          }
+
+          this.appendDummyInput()
+            .appendTitle(toggle, 'toggle')
+            .appendTitle(' ');
+
           this.initMiniFlyout(miniToolboxXml);
         }
 

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1592,10 +1592,10 @@
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@code-dot-org/artist/-/artist-0.2.1.tgz#fcfe7ea5cfb3f19ddb6b912e70e922ba4b7ef0b1"
 
-"@code-dot-org/blockly@4.0.3":
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/blockly/-/blockly-4.0.3.tgz#7a76ae946d29ed4999cbe50700ccf3ec45ab9017"
-  integrity sha512-ipj30/Qol3GH4lVs0JsMJKre5KtULpy70h307zGzN2kA5OgfRAMTsQZYegMduW1Rn77kn1wlXaIxRSCegXJMcQ==
+"@code-dot-org/blockly@4.0.4":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/blockly/-/blockly-4.0.4.tgz#21f536ecc5d246b2b64024d8223e05a768af2d93"
+  integrity sha512-mErd2a+vn0Dzcw93g3Pvs8flstgq+UnvB5AbxEo3XDsup9knNoyzgBJgm4oMPgc95OsARtTNzkK5nUCqUkyPtQ==
 
 "@code-dot-org/craft@0.2.2":
   version "0.2.2"


### PR DESCRIPTION
Bumps Blockly to `4.0.4` to pull in https://github.com/code-dot-org/blockly/pull/289
Kind of hard to take screenshots that capture hover behavior, so I suggest pulling to test locally.

Before
1. Normal: hover UI, pointer cursor, can open and close mini toolbox
2. Embedded in instructions: hover UI, pointer cursor, can open and close mini toolbox
3. View only workspace: no mini toolbox button
![image](https://user-images.githubusercontent.com/8787187/147986360-90cb3907-30e0-4c68-bb8e-4d5b808a3297.png)


After
1. Normal: hover UI, pointer cursor, can open and close mini toolbox
2. Embedded in instructions: regular cursor, no highlight on hover, clicking the button does nothing
3. View only workspace: regular cursor, no highlight on hover, clicking the button does nothing
![image](https://user-images.githubusercontent.com/8787187/147986514-dbd16c93-f5aa-4b1e-8118-e0898bbd7d87.png)
