### PR TITLE
Fix title->field for editing toolboxes

### DIFF
--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -179,14 +179,14 @@ class Blockly < Level
     xml.child << default_category
     xml.xpath('/xml/block').each do |block|
       if block.attr('type') == 'category'
-        category_name = block.xpath('title').text
+        category_name = block.xpath('field').text
         category_node = Nokogiri::XML("<category name='#{category_name}'>").child
         category_node['custom'] = 'PROCEDURE' if category_name == 'Functions'
         category_node['custom'] = 'VARIABLE' if category_name == 'Variables'
         xml.child << category_node
         block.remove
       elsif block.attr('type') == 'custom_category'
-        custom_type = block.xpath('title').text
+        custom_type = block.xpath('field').text
         category_name = CATEGORY_CUSTOM_NAMES[custom_type.to_sym]
         category_node = Nokogiri::XML("<category name='#{category_name}'>").child
         category_node['custom'] = custom_type


### PR DESCRIPTION
Issue with editing categorized toolboxes using start mode reported in [slack thread](https://codedotorg.slack.com/archives/C1B3PNDL7/p1641242693294900)

This is related to https://github.com/code-dot-org/code-dot-org/pull/43934, which changed the XML format for both Google Blockly and Cdo Blockly.
As a result, there is no `<title>` tag for the category blocks. Updated the xml parsing code to look for `<field>` instead.
Tested locally, and this fixes the issue Mike was seeing.