### PR TITLE
Fix check for blank lines in poems

### DIFF
--- a/apps/src/p5lab/poetry/PoetryLibrary.js
+++ b/apps/src/p5lab/poetry/PoetryLibrary.js
@@ -3,7 +3,7 @@ import _ from 'lodash';
 import {getStore} from '@cdo/apps/redux';
 import CoreLibrary from '../spritelab/CoreLibrary';
 import {POEMS} from './constants';
-import {containsAtLeastOneAlphaNumeric} from '../../utils';
+import {isBlank} from '../../utils';
 import {commands as audioCommands} from '@cdo/apps/lib/util/audioApi';
 import {commands as backgroundEffects} from './commands/backgroundEffects';
 import {commands as foregroundEffects} from './commands/foregroundEffects';
@@ -458,7 +458,7 @@ export default class PoetryLibrary extends CoreLibrary {
         x: PLAYSPACE_SIZE / 2,
         y: yCursor,
         size: lineSize,
-        isPoemBodyLine: containsAtLeastOneAlphaNumeric(line) // Used to skip blank lines in animations
+        isPoemBodyLine: !isBlank(line) // Used to skip blank lines in animations
       });
       yCursor += lineHeight;
     });
@@ -480,7 +480,7 @@ export default class PoetryLibrary extends CoreLibrary {
     renderInfo.lines.forEach(item => {
       if (
         this.poemState.text.highlightColor &&
-        containsAtLeastOneAlphaNumeric(item.text) // Don't highlight blank lines
+        !isBlank(item.text) // Don't highlight blank lines
       ) {
         this.drawTextHighlight(item);
       }

--- a/apps/src/utils.js
+++ b/apps/src/utils.js
@@ -887,8 +887,6 @@ export function tooltipifyVocabulary() {
   });
 }
 
-export function containsAtLeastOneAlphaNumeric(string) {
-  return /^.*[a-zA-Z0-9èàùìòÈÀÒÙÌéáúíóÉÁÚÍÓëäüïöËÄÜÏÖêâûîôÊÂÛÎÔç'-]+.*$/.test(
-    string
-  );
+export function isBlank(str) {
+  return !!(!str || str.trim() === '');
 }


### PR DESCRIPTION
Before we were checking for a blank line by checking that it contained at least one alphanumeric character. This caused issues with lines containing punctuation, and some non-english poems. Thing change now checks for specific blank lines. 

Before: 

https://user-images.githubusercontent.com/35442460/148107035-bc13f72b-f2a3-4b00-9825-f2e956cda2b4.mov


After:

https://user-images.githubusercontent.com/35442460/148107053-25b35bac-b851-4e54-ae79-57a5584db598.mov

https://user-images.githubusercontent.com/35442460/148107144-7438e990-2a5c-4514-a8e0-a3cf5955cefa.mov


## Links

- [jira ticket](https://codedotorg.atlassian.net/browse/STAR-1990)


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
