### PR TITLE
Create edit page for programming environments

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -632,6 +632,8 @@ describe('entry tests', () => {
     'levels/editors/_studio':
       './src/sites/studio/pages/levels/editors/_studio.js',
     'libraries/edit': './src/sites/studio/pages/libraries/edit.js',
+    'programming_environments/edit':
+      './src/sites/studio/pages/programming_environments/edit.js',
     'programming_expressions/new':
       './src/sites/studio/pages/programming_expressions/new.js',
     'programming_expressions/edit':

--- a/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingEnvironmentEditor.jsx
+++ b/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingEnvironmentEditor.jsx
@@ -85,6 +85,23 @@ export default function ProgrammingEnvironmentEditor({
         <input value={name} style={styles.textInput} readOnly />
       </label>
       <label>
+        How should this document render?
+        <select
+          value={programmingEnvironment.editorType || EDITOR_TYPES[0]}
+          onChange={e =>
+            updateProgrammingEnvironment('editorType', e.target.value)
+          }
+          style={styles.selectInput}
+        >
+          {EDITOR_TYPES.map(type => (
+            <option key={type} value={type}>
+              {type}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label>
         Image
         <Button
           onClick={() => setUploadImageDialogOpen(true)}
@@ -105,22 +122,6 @@ export default function ProgrammingEnvironmentEditor({
         }
         features={{imageUpload: true}}
       />
-      <label>
-        How should this document render?
-        <select
-          value={programmingEnvironment.editorType || EDITOR_TYPES[0]}
-          onChange={e =>
-            updateProgrammingEnvironment('editorType', e.target.value)
-          }
-          style={styles.selectInput}
-        >
-          {EDITOR_TYPES.map(type => (
-            <option key={type} value={type}>
-              {type}
-            </option>
-          ))}
-        </select>
-      </label>
       <SaveBar
         handleSave={save}
         isSaving={isSaving}

--- a/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingEnvironmentEditor.jsx
+++ b/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingEnvironmentEditor.jsx
@@ -67,6 +67,11 @@ export default function ProgrammingEnvironmentEditor({
 
   return (
     <div>
+      <h1>{`Editing ${name}`}</h1>
+      <h2>
+        This feature is in development. Please continue to use curriculum
+        builder to edit code documentation.
+      </h2>
       <label>
         Title
         <input

--- a/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingEnvironmentEditor.jsx
+++ b/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingEnvironmentEditor.jsx
@@ -1,5 +1,6 @@
 import React, {useState} from 'react';
 import PropTypes from 'prop-types';
+import $ from 'jquery';
 import color from '@cdo/apps/util/color';
 import TextareaWithMarkdownPreview from '@cdo/apps/lib/levelbuilder/TextareaWithMarkdownPreview';
 import Button from '@cdo/apps/templates/Button';
@@ -23,10 +24,14 @@ const useProgrammingEnvironment = initialProgrammingEnvironment => {
 export default function ProgrammingEnvironmentEditor({
   initialProgrammingEnvironment
 }) {
+  const {
+    name,
+    ...remainingProgrammingEnvironment
+  } = initialProgrammingEnvironment;
   const [
     programmingEnvironment,
     updateProgrammingEnvironment
-  ] = useProgrammingEnvironment(initialProgrammingEnvironment);
+  ] = useProgrammingEnvironment(remainingProgrammingEnvironment);
   const [uploadImageDialogOpen, setUploadImageDialogOpen] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [lastUpdated, setLastUpdated] = useState(null);
@@ -37,7 +42,7 @@ export default function ProgrammingEnvironmentEditor({
       return;
     }
     setIsSaving(true);
-    fetch(`/programming_environments/${initialProgrammingEnvironment.name}`, {
+    fetch(`/programming_environments/${name}`, {
       method: 'PUT',
       headers: {
         'content-type': 'application/json',
@@ -72,12 +77,7 @@ export default function ProgrammingEnvironmentEditor({
       </label>
       <label>
         IDE URL (Slug)
-        <input
-          value={programmingEnvironment.name || ''}
-          onChange={e => updateProgrammingEnvironment('name', e.target.value)}
-          style={styles.textInput}
-          readOnly
-        />
+        <input value={name} style={styles.textInput} readOnly />
       </label>
       <label>
         Image
@@ -103,11 +103,11 @@ export default function ProgrammingEnvironmentEditor({
       <label>
         How should this document render?
         <select
-          value={programmingEnvironment.editorType}
+          value={programmingEnvironment.editorType || EDITOR_TYPES[0]}
           onChange={e =>
             updateProgrammingEnvironment('editorType', e.target.value)
           }
-          style={styles.selectStyle}
+          style={styles.selectInput}
         >
           {EDITOR_TYPES.map(type => (
             <option key={type} value={type}>

--- a/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingEnvironmentEditor.jsx
+++ b/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingEnvironmentEditor.jsx
@@ -1,0 +1,119 @@
+import React, {useState} from 'react';
+import PropTypes from 'prop-types';
+import color from '@cdo/apps/util/color';
+import TextareaWithMarkdownPreview from '@cdo/apps/lib/levelbuilder/TextareaWithMarkdownPreview';
+import Button from '@cdo/apps/templates/Button';
+import UploadImageDialog from '@cdo/apps/lib/levelbuilder/lesson-editor/UploadImageDialog';
+
+const EDITOR_TYPES = ['blockly', 'droplet', 'text'];
+
+const useProgrammingEnvironment = initialProgrammingEnvironment => {
+  const [programmingEnvironment, setProgrammingEnvironment] = useState(
+    initialProgrammingEnvironment
+  );
+  const updateProgrammingEnvironment = (key, value) => {
+    setProgrammingEnvironment({...programmingEnvironment, [key]: value});
+  };
+
+  return [programmingEnvironment, updateProgrammingEnvironment];
+};
+
+export default function ProgrammingEnvironmentEditor({
+  initialProgrammingEnvironment
+}) {
+  const [
+    programmingEnvironment,
+    updateProgrammingEnvironment
+  ] = useProgrammingEnvironment(initialProgrammingEnvironment);
+  const [uploadImageDialogOpen, setUploadImageDialogOpen] = useState(false);
+
+  return (
+    <div>
+      <label>
+        Title
+        <input
+          value={programmingEnvironment.title || ''}
+          onChange={e => updateProgrammingEnvironment('title', e.target.value)}
+          style={styles.textInput}
+        />
+      </label>
+      <label>
+        IDE URL (Slug)
+        <input
+          value={programmingEnvironment.name || ''}
+          onChange={e => updateProgrammingEnvironment('name', e.target.value)}
+          style={styles.textInput}
+          readOnly
+        />
+      </label>
+      <label>
+        Image
+        <Button
+          onClick={() => setUploadImageDialogOpen(true)}
+          text="Choose Image"
+          color="gray"
+          icon="plus-circle"
+        />
+        {programmingEnvironment.imageUrl && (
+          <span>{programmingEnvironment.imageUrl}</span>
+        )}
+      </label>
+
+      <TextareaWithMarkdownPreview
+        markdown={programmingEnvironment.description || ''}
+        label={'Description'}
+        handleMarkdownChange={e =>
+          updateProgrammingEnvironment('description', e.target.value)
+        }
+        features={{imageUpload: true}}
+      />
+      <label>
+        How should this document render?
+        <select
+          value={programmingEnvironment.editor_type}
+          onChange={e =>
+            updateProgrammingEnvironment('editorType', e.target.value)
+          }
+          style={styles.selectStyle}
+        >
+          {EDITOR_TYPES.map(type => (
+            <option key={type} value={type}>
+              {type}
+            </option>
+          ))}
+        </select>
+      </label>
+      <UploadImageDialog
+        isOpen={uploadImageDialogOpen}
+        handleClose={() => setUploadImageDialogOpen(false)}
+        uploadImage={imgUrl => updateProgrammingEnvironment('imageUrl', imgUrl)}
+        allowExpandable={false}
+      />
+    </div>
+  );
+}
+
+ProgrammingEnvironmentEditor.propTypes = {
+  initialProgrammingEnvironment: PropTypes.object.isRequired
+};
+
+const styles = {
+  textInput: {
+    width: '100%',
+    boxSizing: 'border-box',
+    padding: '4px 6px',
+    color: '#555',
+    border: `1px solid ${color.bootstrap_border_color}`,
+    borderRadius: 4,
+    margin: 0
+  },
+  selectInput: {
+    boxSizing: 'border-box',
+    padding: '4px 6px',
+    color: '#555',
+    border: `1px solid ${color.bootstrap_border_color}`,
+    borderRadius: 4,
+    marginBottom: 0,
+    marginLeft: 5
+  }
+};

--- a/apps/src/sites/studio/pages/programming_environments/edit.js
+++ b/apps/src/sites/studio/pages/programming_environments/edit.js
@@ -8,6 +8,7 @@ import {getStore, registerReducers} from '@cdo/apps/redux';
 import {Provider} from 'react-redux';
 
 $(document).ready(() => {
+  // instructionsDialog reducer is needed for the ExpandableImageDialog
   registerReducers({
     instructionsDialog
   });

--- a/apps/src/sites/studio/pages/programming_environments/edit.js
+++ b/apps/src/sites/studio/pages/programming_environments/edit.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import getScriptData from '@cdo/apps/util/getScriptData';
+import ProgrammingEnvironmentEditor from '@cdo/apps/lib/levelbuilder/code-docs-editor/ProgrammingEnvironmentEditor';
+import ExpandableImageDialog from '@cdo/apps/templates/lessonOverview/ExpandableImageDialog';
+import instructionsDialog from '@cdo/apps/redux/instructionsDialog';
+import {getStore, registerReducers} from '@cdo/apps/redux';
+import {Provider} from 'react-redux';
+
+$(document).ready(() => {
+  registerReducers({
+    instructionsDialog
+  });
+  const store = getStore();
+
+  const programmingEnvironment = getScriptData('programmingEnvironment');
+  ReactDOM.render(
+    <Provider store={store}>
+      <>
+        <ProgrammingEnvironmentEditor
+          initialProgrammingEnvironment={programmingEnvironment}
+        />
+        <ExpandableImageDialog />
+      </>
+    </Provider>,
+    document.getElementById('edit-container')
+  );
+});

--- a/apps/test/unit/lib/levelbuilder/code-docs-editor/ProgrammingEnvironmentEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/code-docs-editor/ProgrammingEnvironmentEditorTest.jsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import {shallow, mount} from 'enzyme';
+import {expect} from '../../../../util/reconfiguredChai';
+import ProgrammingEnvironmentEditor from '@cdo/apps/lib/levelbuilder/code-docs-editor/ProgrammingEnvironmentEditor';
+import {getStore} from '@cdo/apps/redux';
+import {Provider} from 'react-redux';
+import sinon from 'sinon';
+
+describe('ProgrammingEnvironmentEditor', () => {
+  let defaultProps, fetchSpy;
+
+  beforeEach(() => {
+    defaultProps = {
+      initialProgrammingEnvironment: {
+        name: 'spritelab',
+        title: 'Spritelab',
+        imageUrl: 'images.code.org/spritelab',
+        description: 'A description of spritelab',
+        editorType: 'blockly'
+      }
+    };
+    fetchSpy = sinon.stub(window, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchSpy.restore();
+  });
+
+  it('uses initial values in fields', () => {
+    const wrapper = shallow(<ProgrammingEnvironmentEditor {...defaultProps} />);
+
+    const titleInput = wrapper.find('input').at(0);
+    expect(titleInput.props().value).to.equal('Spritelab');
+
+    const nameInput = wrapper.find('input').at(1);
+    expect(nameInput.props().value).to.equal('spritelab');
+    expect(nameInput.props().readOnly).to.be.true;
+
+    const descriptionMarkdownInput = wrapper
+      .find('TextareaWithMarkdownPreview')
+      .at(0);
+    expect(descriptionMarkdownInput.props().markdown).to.equal(
+      'A description of spritelab'
+    );
+
+    const editorTypeSelect = wrapper.find('select').at(0);
+    expect(editorTypeSelect.props().value).to.equal('blockly');
+    expect(editorTypeSelect.find('option').length).to.equal(3);
+  });
+
+  it('shows upload image dialog when choose image button is pressed', () => {
+    const wrapper = shallow(<ProgrammingEnvironmentEditor {...defaultProps} />);
+    const uploadButton = wrapper.find('Button').first();
+    expect(uploadButton).to.not.be.null;
+    uploadButton.simulate('click');
+    expect(wrapper.find('UploadImageDialog').length).to.equal(1);
+  });
+
+  it('attempts to save when save is pressed', () => {
+    const store = getStore();
+    const wrapper = mount(
+      <Provider store={store}>
+        <ProgrammingEnvironmentEditor {...defaultProps} />
+      </Provider>
+    );
+
+    fetchSpy.returns(Promise.resolve({ok: true}));
+    const saveBar = wrapper.find('SaveBar');
+
+    const saveAndCloseButton = saveBar.find('button').at(2);
+    expect(saveAndCloseButton.contains('Save and Close')).to.be.true;
+    saveAndCloseButton.simulate('click');
+
+    expect(fetchSpy).to.be.called.once;
+    const fetchCall = fetchSpy.getCall(0);
+    expect(fetchCall.args[0]).to.equal('/programming_environments/spritelab');
+    const fetchCallBody = JSON.parse(fetchCall.args[1].body);
+    expect(Object.keys(fetchCallBody).sort()).to.eql(
+      ['title', 'description', 'editorType', 'imageUrl'].sort()
+    );
+    expect(fetchCallBody.title).to.equal('Spritelab');
+    expect(fetchCallBody.description).to.equal('A description of spritelab');
+    expect(fetchCallBody.editorType).to.equal('blockly');
+    expect(fetchCallBody.imageUrl).to.equal('images.code.org/spritelab');
+  });
+});

--- a/dashboard/app/controllers/programming_environments_controller.rb
+++ b/dashboard/app/controllers/programming_environments_controller.rb
@@ -7,4 +7,32 @@ class ProgrammingEnvironmentsController < ApplicationController
     @programming_environment = ProgrammingEnvironment.find_by_name(params[:name])
     return render :not_found unless @programming_environment
   end
+
+  def update
+    programming_environment = ProgrammingEnvironment.find_by_name(params[:name])
+    unless programming_environment
+      render :not_found
+      return
+    end
+    programming_environment.assign_attributes(programming_environment_params)
+    begin
+      programming_environment.save! if programming_environment.changed?
+      render json: programming_environment.summarize_for_edit.to_json
+    rescue ActiveRecord::RecordInvalid => e
+      render(status: :not_acceptable, plain: e.message)
+    end
+  end
+
+  private
+
+  def programming_environment_params
+    transformed_params = params.transform_keys(&:underscore)
+    transformed_params = transformed_params.permit(
+      :title,
+      :description,
+      :editor_type,
+      :image_url
+    )
+    transformed_params
+  end
 end

--- a/dashboard/app/controllers/programming_environments_controller.rb
+++ b/dashboard/app/controllers/programming_environments_controller.rb
@@ -1,0 +1,10 @@
+class ProgrammingEnvironmentsController < ApplicationController
+  load_and_authorize_resource
+
+  before_action :require_levelbuilder_mode_or_test_env
+
+  def edit
+    @programming_environment = ProgrammingEnvironment.find_by_name(params[:name])
+    return render :not_found unless @programming_environment
+  end
+end

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -339,6 +339,7 @@ class Ability
         Game,
         Level,
         Lesson,
+        ProgrammingEnvironment,
         ProgrammingExpression,
         UnitGroup,
         Resource,

--- a/dashboard/app/models/programming_environment.rb
+++ b/dashboard/app/models/programming_environment.rb
@@ -22,6 +22,9 @@ class ProgrammingEnvironment < ApplicationRecord
   # @attr [String] editor_type - Type of editor one of the following: 'text-based', 'droplet', 'blockly'
   serialized_attrs %w(
     editor_type
+    title
+    description
+    image_url
   )
 
   def self.properties_from_file(content)
@@ -49,6 +52,16 @@ class ProgrammingEnvironment < ApplicationRecord
 
   def summarize_for_lesson_edit
     {id: id, name: name}
+  end
+
+  def summarize_for_edit
+    {
+      name: name,
+      title: title,
+      imageUrl: image_url,
+      description: description,
+      editorType: editor_type
+    }
   end
 
   def categories

--- a/dashboard/app/views/programming_environments/edit.html.haml
+++ b/dashboard/app/views/programming_environments/edit.html.haml
@@ -1,0 +1,3 @@
+%script{src: webpack_asset_path('js/programming_environments/edit.js'), data: {programmingEnvironment: @programming_environment.attributes.to_json}}
+
+#edit-container

--- a/dashboard/app/views/programming_environments/edit.html.haml
+++ b/dashboard/app/views/programming_environments/edit.html.haml
@@ -1,3 +1,3 @@
-%script{src: webpack_asset_path('js/programming_environments/edit.js'), data: {programmingEnvironment: @programming_environment.attributes.to_json}}
+%script{src: webpack_asset_path('js/programming_environments/edit.js'), data: {programmingEnvironment: @programming_environment.summarize_for_edit.to_json}}
 
 #edit-container

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -324,7 +324,7 @@ Dashboard::Application.routes.draw do
     end
   end
 
-  resources :programming_environments, param: 'name' do
+  resources :programming_environments, only: [:edit], param: 'name' do
     resources :programming_expressions, param: 'programming_expression_key' do
       member do
         get :show, to: 'programming_expressions#show_by_keys'

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -324,7 +324,7 @@ Dashboard::Application.routes.draw do
     end
   end
 
-  resources :programming_environments, only: [:edit], param: 'name' do
+  resources :programming_environments, only: [:edit, :update], param: 'name' do
     resources :programming_expressions, param: 'programming_expression_key' do
       member do
         get :show, to: 'programming_expressions#show_by_keys'

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -1427,7 +1427,7 @@ ActiveRecord::Schema.define(version: 2021_12_17_121759) do
     t.index ["school_district_id"], name: "index_regional_partners_school_districts_on_school_district_id"
   end
 
-  create_table "resources", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "resources", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.string "url", null: false
     t.string "key", null: false
@@ -1437,13 +1437,6 @@ ActiveRecord::Schema.define(version: 2021_12_17_121759) do
     t.integer "course_version_id", null: false
     t.index ["course_version_id", "key"], name: "index_resources_on_course_version_id_and_key", unique: true
     t.index ["name", "url"], name: "index_resources_on_name_and_url", type: :fulltext
-  end
-
-  create_table "resources_scripts", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
-    t.bigint "script_id", null: false
-    t.bigint "resource_id", null: false
-    t.index ["resource_id", "script_id"], name: "index_resources_scripts_on_resource_id_and_script_id"
-    t.index ["script_id", "resource_id"], name: "index_resources_scripts_on_script_id_and_resource_id", unique: true
   end
 
   create_table "reviewable_projects", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -1427,7 +1427,7 @@ ActiveRecord::Schema.define(version: 2021_12_17_121759) do
     t.index ["school_district_id"], name: "index_regional_partners_school_districts_on_school_district_id"
   end
 
-  create_table "resources", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+  create_table "resources", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name"
     t.string "url", null: false
     t.string "key", null: false
@@ -1437,6 +1437,13 @@ ActiveRecord::Schema.define(version: 2021_12_17_121759) do
     t.integer "course_version_id", null: false
     t.index ["course_version_id", "key"], name: "index_resources_on_course_version_id_and_key", unique: true
     t.index ["name", "url"], name: "index_resources_on_name_and_url", type: :fulltext
+  end
+
+  create_table "resources_scripts", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+    t.bigint "script_id", null: false
+    t.bigint "resource_id", null: false
+    t.index ["resource_id", "script_id"], name: "index_resources_scripts_on_resource_id_and_script_id"
+    t.index ["script_id", "resource_id"], name: "index_resources_scripts_on_script_id_and_resource_id", unique: true
   end
 
   create_table "reviewable_projects", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|

--- a/dashboard/test/controllers/programming_environments_controller_test.rb
+++ b/dashboard/test/controllers/programming_environments_controller_test.rb
@@ -1,0 +1,78 @@
+require 'test_helper'
+
+class ProgrammingEnvironmentsControllerTest < ActionController::TestCase
+  include Devise::Test::ControllerHelpers
+
+  setup do
+    @levelbuilder = create :levelbuilder
+    Rails.application.config.stubs(:levelbuilder_mode).returns true
+  end
+
+  test 'data is passed down to edit page' do
+    sign_in @levelbuilder
+
+    programming_environment = create :programming_environment
+
+    get :edit, params: {name: programming_environment.name}
+    assert_response :ok
+
+    edit_data = JSON.parse(css_select('script[data-programmingenvironment]').first.attribute('data-programmingenvironment').to_s)
+    assert_equal programming_environment.name, edit_data['name']
+  end
+
+  test 'returns not_found if editing a non-existant programming environment' do
+    sign_in @levelbuilder
+
+    post :edit, params: {
+      name: 'fake_name'
+    }
+    assert_response :not_found
+  end
+
+  test 'can update programming expression from params' do
+    sign_in @levelbuilder
+
+    programming_environment = create :programming_environment
+    post :update, params: {
+      name: programming_environment.name,
+      title: 'title',
+      description: 'description',
+      editorType: 'blockly'
+    }
+    assert_response :ok
+
+    programming_environment.reload
+    assert_equal 'title', programming_environment.title
+    assert_equal 'description', programming_environment.description
+    assert_equal 'blockly', programming_environment.editor_type
+  end
+
+  test 'returns not_found if updating a non-existant programming environment' do
+    sign_in @levelbuilder
+
+    post :update, params: {
+      name: 'fake_name',
+      title: 'title'
+    }
+    assert_response :not_found
+  end
+
+  class AccessTests < ActionController::TestCase
+    setup do
+      File.stubs(:write)
+      @programming_environment = create :programming_environment
+
+      @update_params = {name: @programming_environment.name, title: 'new title'}
+    end
+
+    test_user_gets_response_for :edit, params: -> {{name: @programming_environment.name}}, user: nil, response: :redirect, redirected_to: '/users/sign_in'
+    test_user_gets_response_for :edit, params: -> {{name: @programming_environment.name}}, user: :student, response: :forbidden
+    test_user_gets_response_for :edit, params: -> {{name: @programming_environment.name}}, user: :teacher, response: :forbidden
+    test_user_gets_response_for :edit, params: -> {{name: @programming_environment.name}}, user: :levelbuilder, response: :success
+
+    test_user_gets_response_for :update, params: -> {{name: @programming_environment.name}}, user: nil, response: :redirect, redirected_to: '/users/sign_in'
+    test_user_gets_response_for :update, params: -> {@update_params}, user: :student, response: :forbidden
+    test_user_gets_response_for :update, params: -> {@update_params}, user: :teacher, response: :forbidden
+    test_user_gets_response_for :update, params: -> {@update_params}, user: :levelbuilder, response: :success
+  end
+end


### PR DESCRIPTION
First of 3 PRs to allow editing of programming environments.

1. (This PR) Set up a UI to edit programming environments, other than categories
2. Allow editing and saving of categories
3. Serialize ProgrammingEnvironment on change


<img width="1424" alt="Screen Shot 2022-01-04 at 3 13 45 PM" src="https://user-images.githubusercontent.com/46464143/148252786-1f476c3c-b558-4959-b419-bd5970afec86.png">


## Links

[spec](https://docs.google.com/document/d/1CuMG8vlECM0xLs8kq5hocUS5ToyPWipjTGU841W2wvs/edit#bookmark=id.3clq79obh8yw)

## Testing story

unit tests, manually tested




## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
