### PR TITLE
[Google Blockly] Rename appendTitle->appendField everywhere

### DIFF
--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -179,10 +179,10 @@ exports.generateSimpleBlock = function(blockly, generator, options) {
       this.setHSV(184, 1.0, 0.74);
       var input = this.appendDummyInput();
       if (title) {
-        input.appendTitle(title);
+        input.appendField(title);
       }
       if (titleImage) {
-        input.appendTitle(new blockly.FieldImage(titleImage));
+        input.appendField(new blockly.FieldImage(titleImage));
       }
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -684,8 +684,8 @@ const STANDARD_INPUT_TYPES = {
     addInput(blockly, block, inputConfig, currentInputRow) {
       if (inputConfig.customOptions && inputConfig.customOptions.assetUrl) {
         currentInputRow
-          .appendTitle(inputConfig.label)
-          .appendTitle(
+          .appendField(inputConfig.label)
+          .appendField(
             new Blockly.FieldImage(
               Blockly.assetUrl(inputConfig.customOptions.assetUrl),
               inputConfig.customOptions.width,
@@ -710,8 +710,8 @@ const STANDARD_INPUT_TYPES = {
     addInput(blockly, block, inputConfig, currentInputRow) {
       const dropdown = new blockly.FieldDropdown(inputConfig.options);
       currentInputRow
-        .appendTitle(inputConfig.label)
-        .appendTitle(dropdown, inputConfig.name);
+        .appendField(inputConfig.label)
+        .appendField(dropdown, inputConfig.name);
     },
     generateCode(block, inputConfig) {
       let code = block.getTitleValue(inputConfig.name);
@@ -762,8 +762,8 @@ const STANDARD_INPUT_TYPES = {
 
       // Add the variable field to the block
       currentInputRow
-        .appendTitle(inputConfig.label)
-        .appendTitle(new Blockly.FieldVariable(null), inputConfig.name);
+        .appendField(inputConfig.label)
+        .appendField(new Blockly.FieldVariable(null), inputConfig.name);
     },
     generateCode(block, inputConfig) {
       return Blockly.JavaScript.translateVarName(
@@ -779,8 +779,8 @@ const STANDARD_INPUT_TYPES = {
         getFieldInputChangeHandler(blockly, inputConfig.type)
       );
       currentInputRow
-        .appendTitle(inputConfig.label)
-        .appendTitle(field, inputConfig.name);
+        .appendField(inputConfig.label)
+        .appendField(field, inputConfig.name);
     },
     generateCode(block, inputConfig) {
       let code = block.getTitleValue(inputConfig.name);
@@ -871,7 +871,7 @@ const interpolateInputs = function(
     });
 
     // Finally append the last input's label
-    lastInput.appendTitle(lastInputConfig.label);
+    lastInput.appendField(lastInputConfig.label);
   });
 };
 exports.interpolateInputs = interpolateInputs;
@@ -1116,8 +1116,8 @@ exports.createJsWrapperBlockCreator = function(
               !window.appOptions.readonlyWorkspace)
           ) {
             this.appendDummyInput()
-              .appendTitle(toggle, 'toggle')
-              .appendTitle(' ');
+              .appendField(toggle, 'toggle')
+              .appendField(' ');
           }
           this.initMiniFlyout(miniToolboxXml);
         }

--- a/apps/src/blockly/addons/cdoInput.js
+++ b/apps/src/blockly/addons/cdoInput.js
@@ -5,10 +5,6 @@ export default class Input extends GoogleBlockly.Input {
     return super.setCheck(check);
   }
 
-  appendTitle(a, b) {
-    return super.appendField(a, b);
-  }
-
   getFieldRow() {
     return this.fieldRow;
   }

--- a/apps/src/blockly/cdoBlocklyWrapper.js
+++ b/apps/src/blockly/cdoBlocklyWrapper.js
@@ -218,6 +218,9 @@ function initializeBlocklyWrapper(blocklyInstance) {
     return this.titleRow;
   };
 
+  blocklyWrapper.Input.prototype.appendField =
+    blocklyWrapper.Input.prototype.appendTitle;
+
   return blocklyWrapper;
 }
 

--- a/apps/src/blocksCommon.js
+++ b/apps/src/blocksCommon.js
@@ -34,15 +34,15 @@ function installControlsRepeatSimplified(blockly, skin) {
       this.setHelpUrl(blockly.Msg.CONTROLS_REPEAT_HELPURL);
       this.setHSV(322, 0.9, 0.95);
       this.appendDummyInput()
-        .appendTitle(blockly.Msg.CONTROLS_REPEAT_TITLE_REPEAT)
-        .appendTitle(
+        .appendField(blockly.Msg.CONTROLS_REPEAT_TITLE_REPEAT)
+        .appendField(
           new blockly.FieldTextInput(
             '10',
             blockly.FieldTextInput.nonnegativeIntegerValidator
           ),
           'TIMES'
         );
-      this.appendStatementInput('DO').appendTitle(
+      this.appendStatementInput('DO').appendField(
         new blockly.FieldImage(skin.repeatImage)
       );
       this.setPreviousStatement(true);
@@ -57,9 +57,9 @@ function installControlsRepeatSimplified(blockly, skin) {
       this.setHelpUrl(blockly.Msg.CONTROLS_REPEAT_HELPURL);
       this.setHSV(322, 0.9, 0.95);
       this.appendDummyInput()
-        .appendTitle(blockly.Msg.CONTROLS_REPEAT_TITLE_REPEAT)
-        .appendTitle(new blockly.FieldDropdown(), 'TIMES');
-      this.appendStatementInput('DO').appendTitle(
+        .appendField(blockly.Msg.CONTROLS_REPEAT_TITLE_REPEAT)
+        .appendField(new blockly.FieldDropdown(), 'TIMES');
+      this.appendStatementInput('DO').appendField(
         new blockly.FieldImage(skin.repeatImage)
       );
       this.setPreviousStatement(true);
@@ -79,10 +79,10 @@ function installControlsRepeatDropdown(blockly) {
       this.setHelpUrl(blockly.Msg.CONTROLS_REPEAT_HELPURL);
       this.setHSV(322, 0.9, 0.95);
       this.appendDummyInput()
-        .appendTitle(blockly.Msg.CONTROLS_REPEAT_TITLE_REPEAT)
-        .appendTitle(new blockly.FieldDropdown(), 'TIMES')
-        .appendTitle(blockly.Msg.CONTROLS_REPEAT_TITLE_TIMES);
-      this.appendStatementInput('DO').appendTitle(
+        .appendField(blockly.Msg.CONTROLS_REPEAT_TITLE_REPEAT)
+        .appendField(new blockly.FieldDropdown(), 'TIMES')
+        .appendField(blockly.Msg.CONTROLS_REPEAT_TITLE_TIMES);
+      this.appendStatementInput('DO').appendField(
         blockly.Msg.CONTROLS_REPEAT_INPUT_DO
       );
       this.setPreviousStatement(true);
@@ -100,7 +100,7 @@ function installNumberDropdown(blockly) {
     init: function() {
       this.setHelpUrl(blockly.Msg.MATH_NUMBER_HELPURL);
       this.setHSV(258, 0.35, 0.62);
-      this.appendDummyInput().appendTitle(new blockly.FieldDropdown(), 'NUM');
+      this.appendDummyInput().appendField(new blockly.FieldDropdown(), 'NUM');
       this.setOutput(true, Blockly.BlockValueType.NUMBER);
       this.setTooltip(blockly.Msg.MATH_NUMBER_TOOLTIP);
     }
@@ -116,7 +116,7 @@ function installPickOne(blockly) {
       this.setHSV(322, 0.9, 0.95);
 
       // Not localized as this is only used by level builders
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         'Pick one (Use only in required blocks)'
       );
       this.appendStatementInput('PICK');
@@ -138,8 +138,8 @@ function installCategory(blockly) {
 
       // Not localized as this is only used by level builders
       this.appendDummyInput()
-        .appendTitle('Category')
-        .appendTitle(new blockly.FieldTextInput('Name'), 'CATEGORY');
+        .appendField('Category')
+        .appendField(new blockly.FieldTextInput('Name'), 'CATEGORY');
       this.setPreviousStatement(false);
       this.setNextStatement(false);
     }
@@ -163,8 +163,8 @@ function installCategory(blockly) {
       ]);
       // Not localized as this is only used by level builders
       this.appendDummyInput()
-        .appendTitle('Auto-populated Category')
-        .appendTitle(customDropdown, 'CUSTOM');
+        .appendField('Auto-populated Category')
+        .appendField(customDropdown, 'CUSTOM');
       this.setPreviousStatement(false);
       this.setNextStatement(false);
     }
@@ -183,10 +183,10 @@ function installWhenRun(blockly, skin, isK1) {
       this.setHSV(39, 1.0, 0.99);
       if (isK1) {
         this.appendDummyInput()
-          .appendTitle(commonMsg.whenRun())
-          .appendTitle(new blockly.FieldImage(skin.runArrow, 22, 26));
+          .appendField(commonMsg.whenRun())
+          .appendField(new blockly.FieldImage(skin.runArrow, 22, 26));
       } else {
-        this.appendDummyInput().appendTitle(commonMsg.whenRun());
+        this.appendDummyInput().appendField(commonMsg.whenRun());
       }
       this.setPreviousStatement(false);
       this.setNextStatement(true);
@@ -240,7 +240,7 @@ function installJoinBlock(blockly) {
         for (var i = this.inputCount; i < newInputCount; i++) {
           var input = this.appendValueInput('ADD' + i);
           if (i === 0) {
-            input.appendTitle(commonMsg.joinText());
+            input.appendField(commonMsg.joinText());
           }
         }
       } else {
@@ -310,8 +310,8 @@ function installCommentBlock(blockly) {
     init: function() {
       this.setHSV(0, 0, 0.6);
       this.appendDummyInput()
-        .appendTitle(commonMsg.commentPrefix())
-        .appendTitle(new Blockly.FieldTextInput(''), 'TEXT');
+        .appendField(commonMsg.commentPrefix())
+        .appendField(new Blockly.FieldTextInput(''), 'TEXT');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
       this.setTooltip(commonMsg.commentTooltip());

--- a/apps/src/bounce/blocks.js
+++ b/apps/src/bounce/blocks.js
@@ -30,7 +30,7 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(140, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(msg.whenLeft());
+      this.appendDummyInput().appendField(msg.whenLeft());
       this.setPreviousStatement(false);
       this.setNextStatement(true);
       this.setTooltip(msg.whenLeftTooltip());
@@ -47,7 +47,7 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(140, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(msg.whenRight());
+      this.appendDummyInput().appendField(msg.whenRight());
       this.setPreviousStatement(false);
       this.setNextStatement(true);
       this.setTooltip(msg.whenRightTooltip());
@@ -64,7 +64,7 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(140, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(msg.whenUp());
+      this.appendDummyInput().appendField(msg.whenUp());
       this.setPreviousStatement(false);
       this.setNextStatement(true);
       this.setTooltip(msg.whenUpTooltip());
@@ -81,7 +81,7 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(140, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(msg.whenDown());
+      this.appendDummyInput().appendField(msg.whenDown());
       this.setPreviousStatement(false);
       this.setNextStatement(true);
       this.setTooltip(msg.whenDownTooltip());
@@ -98,7 +98,7 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(140, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(msg.whenWallCollided());
+      this.appendDummyInput().appendField(msg.whenWallCollided());
       this.setPreviousStatement(false);
       this.setNextStatement(true);
       this.setTooltip(msg.whenWallCollidedTooltip());
@@ -115,7 +115,7 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(140, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(msg.whenBallInGoal());
+      this.appendDummyInput().appendField(msg.whenBallInGoal());
       this.setPreviousStatement(false);
       this.setNextStatement(true);
       this.setTooltip(msg.whenBallInGoalTooltip());
@@ -132,7 +132,7 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(140, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(skin.blockMsgs.paddleMiss);
+      this.appendDummyInput().appendField(skin.blockMsgs.paddleMiss);
       this.setPreviousStatement(false);
       this.setNextStatement(true);
       this.setTooltip(msg.whenBallMissesPaddleTooltip());
@@ -149,7 +149,7 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(140, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(skin.blockMsgs.paddleCollide);
+      this.appendDummyInput().appendField(skin.blockMsgs.paddleCollide);
       this.setPreviousStatement(false);
       this.setNextStatement(true);
       this.setTooltip(skin.blockMsgs.paddleCollideTooltip);
@@ -166,7 +166,7 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(msg.moveLeft());
+      this.appendDummyInput().appendField(msg.moveLeft());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
       this.setTooltip(msg.moveLeftTooltip());
@@ -183,7 +183,7 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(msg.moveRight());
+      this.appendDummyInput().appendField(msg.moveRight());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
       this.setTooltip(msg.moveRightTooltip());
@@ -200,7 +200,7 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(msg.moveUp());
+      this.appendDummyInput().appendField(msg.moveUp());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
       this.setTooltip(msg.moveUpTooltip());
@@ -217,7 +217,7 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(msg.moveDown());
+      this.appendDummyInput().appendField(msg.moveDown());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
       this.setTooltip(msg.moveDownTooltip());
@@ -234,7 +234,7 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(this.SOUNDS),
         'SOUND'
       );
@@ -270,7 +270,7 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(msg.incrementPlayerScore());
+      this.appendDummyInput().appendField(msg.incrementPlayerScore());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
       this.setTooltip(msg.incrementPlayerScoreTooltip());
@@ -287,7 +287,7 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(msg.incrementOpponentScore());
+      this.appendDummyInput().appendField(msg.incrementOpponentScore());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
       this.setTooltip(msg.incrementOpponentScoreTooltip());
@@ -304,7 +304,7 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(msg.bounceBall());
+      this.appendDummyInput().appendField(msg.bounceBall());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
       this.setTooltip(msg.bounceBallTooltip());
@@ -321,7 +321,7 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(skin.blockMsgs.launchBall);
+      this.appendDummyInput().appendField(skin.blockMsgs.launchBall);
       this.setPreviousStatement(true);
       this.setNextStatement(true);
       this.setTooltip(skin.blockMsgs.launchBallTooltip);
@@ -341,7 +341,7 @@ exports.install = function(blockly, blockInstallOptions) {
       dropdown.setValue(this.VALUES[3][1]); // default to normal
 
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(dropdown, 'VALUE');
+      this.appendDummyInput().appendField(dropdown, 'VALUE');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
       this.setTooltip(msg.setBallSpeedTooltip());
@@ -369,7 +369,7 @@ exports.install = function(blockly, blockInstallOptions) {
       dropdown.setValue(this.VALUES[3][1]); // default to normal
 
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(dropdown, 'VALUE');
+      this.appendDummyInput().appendField(dropdown, 'VALUE');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
       this.setTooltip(skin.blockMsgs.paddleSpeedTooltip);
@@ -399,7 +399,7 @@ exports.install = function(blockly, blockInstallOptions) {
       dropdown.setValue(this.VALUES[1][1]); // default to hardcourt
 
       this.setHSV(312, 0.32, 0.62);
-      this.appendDummyInput().appendTitle(dropdown, 'VALUE');
+      this.appendDummyInput().appendField(dropdown, 'VALUE');
       this.setInputsInline(true);
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -434,7 +434,7 @@ exports.install = function(blockly, blockInstallOptions) {
       }
 
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(dropdown, 'VALUE');
+      this.appendDummyInput().appendField(dropdown, 'VALUE');
       this.setInputsInline(true);
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -460,7 +460,7 @@ exports.install = function(blockly, blockInstallOptions) {
       dropdown.setValue(this.VALUES[1][1]); // default to hardcourt
 
       this.setHSV(312, 0.32, 0.62);
-      this.appendDummyInput().appendTitle(dropdown, 'VALUE');
+      this.appendDummyInput().appendField(dropdown, 'VALUE');
       this.setInputsInline(true);
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -486,7 +486,7 @@ exports.install = function(blockly, blockInstallOptions) {
       dropdown.setValue(this.VALUES[1][1]); // default to hardcourt
 
       this.setHSV(312, 0.32, 0.62);
-      this.appendDummyInput().appendTitle(dropdown, 'VALUE');
+      this.appendDummyInput().appendField(dropdown, 'VALUE');
       this.setInputsInline(true);
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -517,8 +517,8 @@ exports.install = function(blockly, blockInstallOptions) {
 
       this.setHSV(184, 1.0, 0.74);
       this.appendDummyInput()
-        .appendTitle(skin.blockMsgs.setPaddle)
-        .appendTitle(dropdown, 'VALUE');
+        .appendField(skin.blockMsgs.setPaddle)
+        .appendField(dropdown, 'VALUE');
       this.setInputsInline(true);
       this.setPreviousStatement(true);
       this.setNextStatement(true);

--- a/apps/src/craft/agent/blocks.js
+++ b/apps/src/craft/agent/blocks.js
@@ -68,7 +68,7 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldLabel(i18n.blockMoveForward())
       );
       this.setPreviousStatement(true);
@@ -84,7 +84,7 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldLabel(i18n.blockMoveBackward())
       );
       this.setPreviousStatement(true);
@@ -101,7 +101,7 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: 'http://code.google.com/p/blockly/wiki/Turn',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(this.DIRECTIONS),
         'DIR'
       );
@@ -126,7 +126,7 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldLabel(i18n.blockDestroyBlock())
       );
       this.setPreviousStatement(true);
@@ -148,10 +148,10 @@ exports.install = function(blockly, blockInstallOptions) {
       dropdown.setValue(dropdownOptions[0][1]);
       this.setHSV(196, 1.0, 0.79);
       this.appendDummyInput()
-        .appendTitle(i18n.blockIf())
-        .appendTitle(dropdown, 'TYPE')
-        .appendTitle(i18n.blockWhileXAheadAhead());
-      this.appendStatementInput('DO').appendTitle(i18n.blockWhileXAheadDo());
+        .appendField(i18n.blockIf())
+        .appendField(dropdown, 'TYPE')
+        .appendField(i18n.blockWhileXAheadAhead());
+      this.appendStatementInput('DO').appendField(i18n.blockWhileXAheadDo());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -175,8 +175,8 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(196, 1.0, 0.79);
-      this.appendDummyInput().appendTitle(i18n.blockIfLavaAhead());
-      this.appendStatementInput('DO').appendTitle(i18n.blockWhileXAheadDo());
+      this.appendDummyInput().appendField(i18n.blockIfLavaAhead());
+      this.appendStatementInput('DO').appendField(i18n.blockWhileXAheadDo());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -204,8 +204,8 @@ exports.install = function(blockly, blockInstallOptions) {
 
       this.setHSV(184, 1.0, 0.74);
       this.appendDummyInput()
-        .appendTitle(i18n.blockPlaceXPlace())
-        .appendTitle(dropdown, 'TYPE');
+        .appendField(i18n.blockPlaceXPlace())
+        .appendField(dropdown, 'TYPE');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -234,10 +234,10 @@ exports.install = function(blockly, blockInstallOptions) {
 
       this.setHSV(184, 1.0, 0.74);
       this.appendDummyInput()
-        .appendTitle(i18n.blockPlaceXPlace())
-        .appendTitle(dropdown, 'TYPE')
-        .appendTitle(' ')
-        .appendTitle(new blockly.FieldDropdown(fourDirections), 'DIR');
+        .appendField(i18n.blockPlaceXPlace())
+        .appendField(dropdown, 'TYPE')
+        .appendField(' ')
+        .appendField(new blockly.FieldDropdown(fourDirections), 'DIR');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }

--- a/apps/src/craft/code-connection/blocks.js
+++ b/apps/src/craft/code-connection/blocks.js
@@ -87,13 +87,13 @@ export const install = (blockly, blockInstallOptions) => {
       this.setHSV(mathBlockColor.h, mathBlockColor.s, mathBlockColor.v);
       this.appendValueInput('X')
         .setCheck('Number')
-        .appendTitle(new blockly.FieldLabel('X:'));
+        .appendField(new blockly.FieldLabel('X:'));
       this.appendValueInput('Y')
         .setCheck('Number')
-        .appendTitle(new blockly.FieldLabel('Y:'));
+        .appendField(new blockly.FieldLabel('Y:'));
       this.appendValueInput('Z')
         .setCheck('Number')
-        .appendTitle(new blockly.FieldLabel('Z:'));
+        .appendField(new blockly.FieldLabel('Z:'));
       this.setOutput(true, 'Number');
     }
   };
@@ -126,8 +126,8 @@ export const install = (blockly, blockInstallOptions) => {
     init: function() {
       this.setHSV(agentBlockColor.h, agentBlockColor.s, agentBlockColor.v);
       this.appendDummyInput()
-        .appendTitle(new blockly.FieldLabel(i18n.blockMove()))
-        .appendTitle(new blockly.FieldDropdown(sixDirections), 'DIR');
+        .appendField(new blockly.FieldLabel(i18n.blockMove()))
+        .appendField(new blockly.FieldDropdown(sixDirections), 'DIR');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -143,8 +143,8 @@ export const install = (blockly, blockInstallOptions) => {
     init: function() {
       this.setHSV(agentBlockColor.h, agentBlockColor.s, agentBlockColor.v);
       this.appendDummyInput()
-        .appendTitle(new blockly.FieldLabel(i18n.blockTurn()))
-        .appendTitle(new blockly.FieldDropdown(rotateDirections), 'DIR');
+        .appendField(new blockly.FieldLabel(i18n.blockTurn()))
+        .appendField(new blockly.FieldDropdown(rotateDirections), 'DIR');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -160,11 +160,11 @@ export const install = (blockly, blockInstallOptions) => {
     init: function() {
       this.setHSV(agentBlockColor.h, agentBlockColor.s, agentBlockColor.v);
       this.appendDummyInput()
-        .appendTitle(new blockly.FieldLabel(i18n.blockPlace()))
-        .appendTitle(new blockly.FieldDropdown(sixDirections), 'DIR');
+        .appendField(new blockly.FieldLabel(i18n.blockPlace()))
+        .appendField(new blockly.FieldDropdown(sixDirections), 'DIR');
       this.appendValueInput('SLOTNUM')
         .setCheck('Number')
-        .appendTitle(new blockly.FieldLabel(i18n.inSlotNumber()));
+        .appendField(new blockly.FieldLabel(i18n.inSlotNumber()));
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -185,8 +185,8 @@ export const install = (blockly, blockInstallOptions) => {
     init: function() {
       this.setHSV(agentBlockColor.h, agentBlockColor.s, agentBlockColor.v);
       this.appendDummyInput()
-        .appendTitle(new blockly.FieldLabel(i18n.blockTill()))
-        .appendTitle(new blockly.FieldDropdown(sixDirections), 'DIR');
+        .appendField(new blockly.FieldLabel(i18n.blockTill()))
+        .appendField(new blockly.FieldDropdown(sixDirections), 'DIR');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -202,8 +202,8 @@ export const install = (blockly, blockInstallOptions) => {
     init: function() {
       this.setHSV(agentBlockColor.h, agentBlockColor.s, agentBlockColor.v);
       this.appendDummyInput()
-        .appendTitle(new blockly.FieldLabel(i18n.blockActionAttack()))
-        .appendTitle(new blockly.FieldDropdown(sixDirections), 'DIR');
+        .appendField(new blockly.FieldLabel(i18n.blockActionAttack()))
+        .appendField(new blockly.FieldDropdown(sixDirections), 'DIR');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -219,8 +219,8 @@ export const install = (blockly, blockInstallOptions) => {
     init: function() {
       this.setHSV(agentBlockColor.h, agentBlockColor.s, agentBlockColor.v);
       this.appendDummyInput()
-        .appendTitle(new blockly.FieldLabel(i18n.blockDestroyBlock()))
-        .appendTitle(new blockly.FieldDropdown(sixDirections), 'DIR');
+        .appendField(new blockly.FieldLabel(i18n.blockDestroyBlock()))
+        .appendField(new blockly.FieldDropdown(sixDirections), 'DIR');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -235,7 +235,7 @@ export const install = (blockly, blockInstallOptions) => {
     helpUrl: '',
     init: function() {
       this.setHSV(agentBlockColor.h, agentBlockColor.s, agentBlockColor.v);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldLabel(i18n.blockActionCollectAll())
       );
       this.setPreviousStatement(true);
@@ -253,7 +253,7 @@ export const install = (blockly, blockInstallOptions) => {
       this.setHSV(agentBlockColor.h, agentBlockColor.s, agentBlockColor.v);
       this.appendValueInput('ITEM')
         .setCheck(ITEM_TYPE)
-        .appendTitle(new blockly.FieldLabel(i18n.blockActionCollect()));
+        .appendField(new blockly.FieldLabel(i18n.blockActionCollect()));
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -273,14 +273,14 @@ export const install = (blockly, blockInstallOptions) => {
     init: function() {
       this.setHSV(agentBlockColor.h, agentBlockColor.s, agentBlockColor.v);
       this.appendDummyInput()
-        .appendTitle(new blockly.FieldLabel(i18n.blockActionDrop()))
-        .appendTitle(new blockly.FieldDropdown(fourDirections), 'DIR');
+        .appendField(new blockly.FieldLabel(i18n.blockActionDrop()))
+        .appendField(new blockly.FieldDropdown(fourDirections), 'DIR');
       this.appendValueInput('SLOTNUM')
         .setCheck('Number')
-        .appendTitle(new blockly.FieldLabel(i18n.inSlotNumber()));
+        .appendField(new blockly.FieldLabel(i18n.inSlotNumber()));
       this.appendValueInput('QUANTITY')
         .setCheck('Number')
-        .appendTitle(new blockly.FieldLabel(i18n.quantity()));
+        .appendField(new blockly.FieldLabel(i18n.quantity()));
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -306,8 +306,8 @@ export const install = (blockly, blockInstallOptions) => {
     init: function() {
       this.setHSV(agentBlockColor.h, agentBlockColor.s, agentBlockColor.v);
       this.appendDummyInput()
-        .appendTitle(new blockly.FieldLabel(i18n.blockActionDropAll()))
-        .appendTitle(new blockly.FieldDropdown(fourDirections), 'DIR');
+        .appendField(new blockly.FieldLabel(i18n.blockActionDropAll()))
+        .appendField(new blockly.FieldDropdown(fourDirections), 'DIR');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -323,8 +323,8 @@ export const install = (blockly, blockInstallOptions) => {
     init: function() {
       this.setHSV(agentBlockColor.h, agentBlockColor.s, agentBlockColor.v);
       this.appendDummyInput()
-        .appendTitle(new blockly.FieldLabel(i18n.blockActionDetect()))
-        .appendTitle(new blockly.FieldDropdown(sixDirections), 'DIR');
+        .appendField(new blockly.FieldLabel(i18n.blockActionDetect()))
+        .appendField(new blockly.FieldDropdown(sixDirections), 'DIR');
       this.setOutput(true, Blockly.BlockValueType.BOOLEAN);
     }
   };
@@ -342,8 +342,8 @@ export const install = (blockly, blockInstallOptions) => {
     init: function() {
       this.setHSV(agentBlockColor.h, agentBlockColor.s, agentBlockColor.v);
       this.appendDummyInput()
-        .appendTitle(new blockly.FieldLabel(i18n.blockActionInspect()))
-        .appendTitle(new blockly.FieldDropdown(sixDirections), 'DIR');
+        .appendField(new blockly.FieldLabel(i18n.blockActionInspect()))
+        .appendField(new blockly.FieldDropdown(sixDirections), 'DIR');
       this.setOutput(true, Blockly.JavaScript.STRING);
     }
   };
@@ -361,8 +361,8 @@ export const install = (blockly, blockInstallOptions) => {
     init: function() {
       this.setHSV(agentBlockColor.h, agentBlockColor.s, agentBlockColor.v);
       this.appendDummyInput()
-        .appendTitle(new blockly.FieldLabel(i18n.blockActionInspectData()))
-        .appendTitle(new blockly.FieldDropdown(sixDirections), 'DIR');
+        .appendField(new blockly.FieldLabel(i18n.blockActionInspectData()))
+        .appendField(new blockly.FieldDropdown(sixDirections), 'DIR');
       this.setOutput(true, Blockly.BlockValueType.NUMBER);
     }
   };
@@ -380,8 +380,8 @@ export const install = (blockly, blockInstallOptions) => {
     init: function() {
       this.setHSV(agentBlockColor.h, agentBlockColor.s, agentBlockColor.v);
       this.appendDummyInput()
-        .appendTitle(new blockly.FieldLabel(i18n.blockActionDetectRedstone()))
-        .appendTitle(new blockly.FieldDropdown(sixDirections), 'DIR');
+        .appendField(new blockly.FieldLabel(i18n.blockActionDetectRedstone()))
+        .appendField(new blockly.FieldDropdown(sixDirections), 'DIR');
       this.setOutput(true, Blockly.BlockValueType.BOOLEAN);
     }
   };
@@ -400,7 +400,7 @@ export const install = (blockly, blockInstallOptions) => {
       this.setHSV(agentBlockColor.h, agentBlockColor.s, agentBlockColor.v);
       this.appendValueInput('SLOTNUM')
         .setCheck('Number')
-        .appendTitle(
+        .appendField(
           new blockly.FieldLabel(i18n.blockActionGetItemDetailInSlotNumber())
         );
       this.setOutput(true, Blockly.BlockValueType.STRING);
@@ -425,7 +425,7 @@ export const install = (blockly, blockInstallOptions) => {
       this.setHSV(agentBlockColor.h, agentBlockColor.s, agentBlockColor.v);
       this.appendValueInput('SLOTNUM')
         .setCheck('Number')
-        .appendTitle(
+        .appendField(
           new blockly.FieldLabel(i18n.blockActionGetItemSpaceInSlotNumber())
         );
       this.setOutput(true, Blockly.BlockValueType.NUMBER);
@@ -450,7 +450,7 @@ export const install = (blockly, blockInstallOptions) => {
       this.setHSV(agentBlockColor.h, agentBlockColor.s, agentBlockColor.v);
       this.appendValueInput('SLOTNUM')
         .setCheck('Number')
-        .appendTitle(
+        .appendField(
           new blockly.FieldLabel(i18n.blockActionGetItemCountInSlotNumber())
         );
       this.setOutput(true, Blockly.BlockValueType.NUMBER);
@@ -473,18 +473,18 @@ export const install = (blockly, blockInstallOptions) => {
     helpUrl: '',
     init: function() {
       this.setHSV(agentBlockColor.h, agentBlockColor.s, agentBlockColor.v);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldLabel(i18n.blockActionTransfer())
       );
       this.appendValueInput('SRCSLOTNUM')
         .setCheck('Number')
-        .appendTitle(new blockly.FieldLabel(i18n.inSlotNumber()));
+        .appendField(new blockly.FieldLabel(i18n.inSlotNumber()));
       this.appendValueInput('DSTSLOTNUM')
         .setCheck('Number')
-        .appendTitle(new blockly.FieldLabel(i18n.toSlotNumber()));
+        .appendField(new blockly.FieldLabel(i18n.toSlotNumber()));
       this.appendValueInput('QUANTITY')
         .setCheck('Number')
-        .appendTitle(new blockly.FieldLabel(i18n.quantity()));
+        .appendField(new blockly.FieldLabel(i18n.quantity()));
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -515,7 +515,7 @@ export const install = (blockly, blockInstallOptions) => {
     helpUrl: '',
     init: function() {
       this.setHSV(agentBlockColor.h, agentBlockColor.s, agentBlockColor.v);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldLabel(i18n.blockActionTeleportToPlayer())
       );
       this.setPreviousStatement(true);
@@ -536,15 +536,15 @@ export const install = (blockly, blockInstallOptions) => {
         customControlColor.v
       );
       this.appendDummyInput()
-        .appendTitle(new blockly.FieldLabel(i18n.blockActionWait()))
-        .appendTitle(
+        .appendField(new blockly.FieldLabel(i18n.blockActionWait()))
+        .appendField(
           new blockly.FieldTextInput(
             '1000',
             blockly.FieldTextInput.numberValidator
           ),
           'MILLISECONDS'
         )
-        .appendTitle(new blockly.FieldLabel('ms'));
+        .appendField(new blockly.FieldLabel('ms'));
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -564,16 +564,16 @@ export const install = (blockly, blockInstallOptions) => {
         nonAgentBlockColor.v
       );
       this.appendDummyInput()
-        .appendTitle(new blockly.FieldLabel(i18n.blockActionExecute()))
-        .appendTitle(new blockly.FieldTextInput(''), 'COMMAND');
+        .appendField(new blockly.FieldLabel(i18n.blockActionExecute()))
+        .appendField(new blockly.FieldTextInput(''), 'COMMAND');
       this.appendDummyInput()
-        .appendTitle(new blockly.FieldLabel(i18n.onBehalfOf()))
-        .appendTitle(new blockly.FieldTextInput(''), 'TARGET');
+        .appendField(new blockly.FieldLabel(i18n.onBehalfOf()))
+        .appendField(new blockly.FieldTextInput(''), 'TARGET');
       this.appendValueInput('VEC3')
         .setCheck('Number')
         .setAlign(Blockly.ALIGN_RIGHT)
-        .appendTitle(new blockly.FieldLabel(i18n.at()))
-        .appendTitle(new blockly.FieldDropdown(positionTypes), 'POSITIONTYPE');
+        .appendField(new blockly.FieldLabel(i18n.at()))
+        .appendField(new blockly.FieldDropdown(positionTypes), 'POSITIONTYPE');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -602,8 +602,8 @@ export const install = (blockly, blockInstallOptions) => {
         nonAgentBlockColor.v
       );
       this.appendDummyInput()
-        .appendTitle(new blockly.FieldLabel(i18n.timeSet()))
-        .appendTitle(new blockly.FieldDropdown(timeTypes), 'TIME');
+        .appendField(new blockly.FieldLabel(i18n.timeSet()))
+        .appendField(new blockly.FieldDropdown(timeTypes), 'TIME');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -623,7 +623,7 @@ export const install = (blockly, blockInstallOptions) => {
         nonAgentBlockColor.v
       );
       this.setInputsInline(true);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldLabel(i18n.timeSet())
       );
       this.appendValueInput('TIME').setCheck('Number');
@@ -651,8 +651,8 @@ export const install = (blockly, blockInstallOptions) => {
         nonAgentBlockColor.v
       );
       this.appendDummyInput()
-        .appendTitle(new blockly.FieldLabel(i18n.weather()))
-        .appendTitle(new blockly.FieldDropdown(weatherTypes), 'WEATHER');
+        .appendField(new blockly.FieldLabel(i18n.weather()))
+        .appendField(new blockly.FieldDropdown(weatherTypes), 'WEATHER');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -673,11 +673,11 @@ export const install = (blockly, blockInstallOptions) => {
       );
       this.setInputsInline(true);
       this.appendDummyInput()
-        .appendTitle(new blockly.FieldLabel(i18n.blockActionTeleport()))
-        .appendTitle(new blockly.FieldTextInput(''), 'VICTIM');
+        .appendField(new blockly.FieldLabel(i18n.blockActionTeleport()))
+        .appendField(new blockly.FieldTextInput(''), 'VICTIM');
       this.appendDummyInput()
-        .appendTitle(new blockly.FieldLabel(i18n.to()))
-        .appendTitle(new blockly.FieldTextInput(''), 'DESTINATION');
+        .appendField(new blockly.FieldLabel(i18n.to()))
+        .appendField(new blockly.FieldTextInput(''), 'DESTINATION');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -698,13 +698,13 @@ export const install = (blockly, blockInstallOptions) => {
         nonAgentBlockColor.v
       );
       this.appendDummyInput()
-        .appendTitle(new blockly.FieldLabel(i18n.blockActionTeleport()))
-        .appendTitle(new blockly.FieldTextInput(''), 'VICTIM');
+        .appendField(new blockly.FieldLabel(i18n.blockActionTeleport()))
+        .appendField(new blockly.FieldTextInput(''), 'VICTIM');
       this.appendValueInput('VEC3')
         .setCheck('Number')
         .setAlign(Blockly.ALIGN_RIGHT)
-        .appendTitle(new blockly.FieldLabel(i18n.to()))
-        .appendTitle(new blockly.FieldDropdown(positionTypes), 'POSITIONTYPE');
+        .appendField(new blockly.FieldLabel(i18n.to()))
+        .appendField(new blockly.FieldDropdown(positionTypes), 'POSITIONTYPE');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -731,28 +731,28 @@ export const install = (blockly, blockInstallOptions) => {
         nonAgentBlockColor.s,
         nonAgentBlockColor.v
       );
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldLabel(i18n.blockActionFill())
       );
       this.appendValueInput('FROM_VEC3')
         .setCheck('Number')
         .setAlign(Blockly.ALIGN_RIGHT)
-        .appendTitle(
+        .appendField(
           new blockly.FieldDropdown(positionTypes),
           'FROMPOSITIONTYPE'
         );
       this.appendValueInput('TO_VEC3')
         .setCheck('Number')
         .setAlign(Blockly.ALIGN_RIGHT)
-        .appendTitle(new blockly.FieldLabel(i18n.to()))
-        .appendTitle(
+        .appendField(new blockly.FieldLabel(i18n.to()))
+        .appendField(
           new blockly.FieldDropdown(positionTypes),
           'TOPOSITIONTYPE'
         );
       this.appendValueInput('ITEM')
         .setCheck(ITEM_TYPE)
         .setAlign(Blockly.ALIGN_RIGHT)
-        .appendTitle(new blockly.FieldLabel(i18n.blockActionWith()));
+        .appendField(new blockly.FieldLabel(i18n.blockActionWith()));
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -791,14 +791,14 @@ export const install = (blockly, blockInstallOptions) => {
       );
       this.appendValueInput('AMOUNT')
         .setCheck('Number')
-        .appendTitle(new blockly.FieldLabel(i18n.blockActionGive()));
+        .appendField(new blockly.FieldLabel(i18n.blockActionGive()));
       this.appendValueInput('ITEM')
         .setCheck(ITEM_TYPE)
         .setAlign(Blockly.ALIGN_RIGHT)
-        .appendTitle(new blockly.FieldLabel(i18n.itemsOfBlockType()));
+        .appendField(new blockly.FieldLabel(i18n.itemsOfBlockType()));
       this.appendDummyInput()
-        .appendTitle(new blockly.FieldLabel(i18n.to()))
-        .appendTitle(new blockly.FieldTextInput(''), 'PLAYER');
+        .appendField(new blockly.FieldLabel(i18n.to()))
+        .appendField(new blockly.FieldTextInput(''), 'PLAYER');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -830,8 +830,8 @@ export const install = (blockly, blockInstallOptions) => {
       );
       this.setInputsInline(true);
       this.appendDummyInput()
-        .appendTitle(new blockly.FieldLabel(i18n.blockActionKill()))
-        .appendTitle(new blockly.FieldTextInput(''), 'TARGET');
+        .appendField(new blockly.FieldLabel(i18n.blockActionKill()))
+        .appendField(new blockly.FieldTextInput(''), 'TARGET');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -850,23 +850,23 @@ export const install = (blockly, blockInstallOptions) => {
         nonAgentBlockColor.s,
         nonAgentBlockColor.v
       );
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldLabel(i18n.blockActionSetBlock())
       );
       this.appendDummyInput()
-        .appendTitle(
+        .appendField(
           new blockly.FieldDropdown(oldBlockHandlings),
           'OLDBLOCKHANDLING'
         )
-        .appendTitle(new blockly.FieldLabel(i18n.oldBlockHandling()));
+        .appendField(new blockly.FieldLabel(i18n.oldBlockHandling()));
       this.appendValueInput('VEC3')
         .setCheck('Number')
         .setAlign(Blockly.ALIGN_RIGHT)
-        .appendTitle(new blockly.FieldDropdown(positionTypes), 'POSITIONTYPE');
+        .appendField(new blockly.FieldDropdown(positionTypes), 'POSITIONTYPE');
       this.appendValueInput('ITEM')
         .setCheck(ITEM_TYPE)
         .setAlign(Blockly.ALIGN_RIGHT)
-        .appendTitle(new blockly.FieldLabel(i18n.blockActionWith()));
+        .appendField(new blockly.FieldLabel(i18n.blockActionWith()));
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -898,16 +898,16 @@ export const install = (blockly, blockInstallOptions) => {
         nonAgentBlockColor.s,
         nonAgentBlockColor.v
       );
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldLabel(i18n.blockActionSummon())
       );
       this.appendDummyInput()
-        .appendTitle(new blockly.FieldLabel(i18n.entityType()))
-        .appendTitle(new blockly.FieldTextInput(''), 'ENTITYTYPE');
+        .appendField(new blockly.FieldLabel(i18n.entityType()))
+        .appendField(new blockly.FieldTextInput(''), 'ENTITYTYPE');
       this.appendValueInput('VEC3')
         .setCheck('Number')
-        .appendTitle(new blockly.FieldLabel(i18n.at()))
-        .appendTitle(new blockly.FieldDropdown(positionTypes), 'POSITIONTYPE');
+        .appendField(new blockly.FieldLabel(i18n.at()))
+        .appendField(new blockly.FieldDropdown(positionTypes), 'POSITIONTYPE');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -934,18 +934,18 @@ export const install = (blockly, blockInstallOptions) => {
         nonAgentBlockColor.s,
         nonAgentBlockColor.v
       );
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldLabel(i18n.blockActionTestForBlock())
       );
       this.appendValueInput('VEC3')
         .setCheck('Number')
         .setAlign(Blockly.ALIGN_RIGHT)
-        .appendTitle(new blockly.FieldLabel(i18n.at()))
-        .appendTitle(new blockly.FieldDropdown(positionTypes), 'POSITIONTYPE');
+        .appendField(new blockly.FieldLabel(i18n.at()))
+        .appendField(new blockly.FieldDropdown(positionTypes), 'POSITIONTYPE');
       this.appendValueInput('ITEM')
         .setCheck(ITEM_TYPE)
         .setAlign(Blockly.ALIGN_RIGHT)
-        .appendTitle(new blockly.FieldLabel(i18n.blockIs()));
+        .appendField(new blockly.FieldLabel(i18n.blockIs()));
       this.setOutput(true, Blockly.BlockValueType.BOOLEAN);
     }
   };
@@ -979,33 +979,33 @@ export const install = (blockly, blockInstallOptions) => {
         nonAgentBlockColor.s,
         nonAgentBlockColor.v
       );
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldLabel(i18n.blockActionTestForBlocks())
       );
       this.appendValueInput('FROM_VEC3')
         .setCheck('Number')
         .setAlign(Blockly.ALIGN_RIGHT)
-        .appendTitle(new blockly.FieldLabel(i18n.from()))
-        .appendTitle(
+        .appendField(new blockly.FieldLabel(i18n.from()))
+        .appendField(
           new blockly.FieldDropdown(positionTypes),
           'FROMPOSITIONTYPE'
         );
       this.appendValueInput('TO_VEC3')
         .setCheck('Number')
         .setAlign(Blockly.ALIGN_RIGHT)
-        .appendTitle(new blockly.FieldLabel(i18n.to()))
-        .appendTitle(
+        .appendField(new blockly.FieldLabel(i18n.to()))
+        .appendField(
           new blockly.FieldDropdown(positionTypes),
           'TOPOSITIONTYPE'
         );
       this.appendValueInput('VEC3')
         .setCheck('Number')
         .setAlign(Blockly.ALIGN_RIGHT)
-        .appendTitle(new blockly.FieldLabel(i18n.destination()))
-        .appendTitle(new blockly.FieldDropdown(positionTypes), 'POSITIONTYPE');
+        .appendField(new blockly.FieldLabel(i18n.destination()))
+        .appendField(new blockly.FieldDropdown(positionTypes), 'POSITIONTYPE');
       this.appendDummyInput()
         .setAlign(Blockly.ALIGN_RIGHT)
-        .appendTitle(new blockly.FieldDropdown(testModes), 'TESTMODE');
+        .appendField(new blockly.FieldDropdown(testModes), 'TESTMODE');
       this.setOutput(true, Blockly.BlockValueType.BOOLEAN);
     }
   };
@@ -1046,36 +1046,36 @@ export const install = (blockly, blockInstallOptions) => {
         nonAgentBlockColor.s,
         nonAgentBlockColor.v
       );
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldLabel(i18n.blockActionClone())
       );
       this.appendValueInput('FROM_VEC3')
         .setCheck('Number')
         .setAlign(Blockly.ALIGN_RIGHT)
-        .appendTitle(new blockly.FieldLabel(i18n.from()))
-        .appendTitle(
+        .appendField(new blockly.FieldLabel(i18n.from()))
+        .appendField(
           new blockly.FieldDropdown(positionTypes),
           'FROMPOSITIONTYPE'
         );
       this.appendValueInput('TO_VEC3')
         .setCheck('Number')
         .setAlign(Blockly.ALIGN_RIGHT)
-        .appendTitle(new blockly.FieldLabel(i18n.to()))
-        .appendTitle(
+        .appendField(new blockly.FieldLabel(i18n.to()))
+        .appendField(
           new blockly.FieldDropdown(positionTypes),
           'TOPOSITIONTYPE'
         );
       this.appendValueInput('VEC3')
         .setCheck('Number')
         .setAlign(Blockly.ALIGN_RIGHT)
-        .appendTitle(new blockly.FieldLabel(i18n.destination()))
-        .appendTitle(new blockly.FieldDropdown(positionTypes), 'POSITIONTYPE');
+        .appendField(new blockly.FieldLabel(i18n.destination()))
+        .appendField(new blockly.FieldDropdown(positionTypes), 'POSITIONTYPE');
       this.appendDummyInput()
-        .appendTitle(new blockly.FieldLabel(i18n.maskMode()))
-        .appendTitle(new blockly.FieldDropdown(maskModes), 'MASKMODE');
+        .appendField(new blockly.FieldLabel(i18n.maskMode()))
+        .appendField(new blockly.FieldDropdown(maskModes), 'MASKMODE');
       this.appendDummyInput()
-        .appendTitle(new blockly.FieldLabel(i18n.cloneMode()))
-        .appendTitle(new blockly.FieldDropdown(cloneModes), 'CLONEMODE');
+        .appendField(new blockly.FieldLabel(i18n.cloneMode()))
+        .appendField(new blockly.FieldDropdown(cloneModes), 'CLONEMODE');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -1118,31 +1118,31 @@ export const install = (blockly, blockInstallOptions) => {
       this.appendValueInput('ITEM')
         .setCheck(ITEM_TYPE)
         .setAlign(Blockly.ALIGN_RIGHT)
-        .appendTitle(new blockly.FieldLabel(i18n.blockActionCloneFiltered()));
+        .appendField(new blockly.FieldLabel(i18n.blockActionCloneFiltered()));
       this.appendValueInput('FROM_VEC3')
         .setCheck('Number')
         .setAlign(Blockly.ALIGN_RIGHT)
-        .appendTitle(new blockly.FieldLabel(i18n.from()))
-        .appendTitle(
+        .appendField(new blockly.FieldLabel(i18n.from()))
+        .appendField(
           new blockly.FieldDropdown(positionTypes),
           'FROMPOSITIONTYPE'
         );
       this.appendValueInput('TO_VEC3')
         .setCheck('Number')
         .setAlign(Blockly.ALIGN_RIGHT)
-        .appendTitle(new blockly.FieldLabel(i18n.to()))
-        .appendTitle(
+        .appendField(new blockly.FieldLabel(i18n.to()))
+        .appendField(
           new blockly.FieldDropdown(positionTypes),
           'TOPOSITIONTYPE'
         );
       this.appendValueInput('VEC3')
         .setCheck('Number')
         .setAlign(Blockly.ALIGN_RIGHT)
-        .appendTitle(new blockly.FieldLabel(i18n.destination()))
-        .appendTitle(new blockly.FieldDropdown(positionTypes), 'POSITIONTYPE');
+        .appendField(new blockly.FieldLabel(i18n.destination()))
+        .appendField(new blockly.FieldDropdown(positionTypes), 'POSITIONTYPE');
       this.appendDummyInput()
-        .appendTitle(new blockly.FieldLabel(i18n.cloneMode()))
-        .appendTitle(new blockly.FieldDropdown(cloneModes), 'CLONEMODE');
+        .appendField(new blockly.FieldLabel(i18n.cloneMode()))
+        .appendField(new blockly.FieldDropdown(cloneModes), 'CLONEMODE');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -1185,10 +1185,10 @@ export const install = (blockly, blockInstallOptions) => {
       this.setHSV(itemBlockColor.h, itemBlockColor.s, itemBlockColor.v);
       this.appendValueInput('BLOCKTYPE')
         .setCheck(Blockly.JavaScript.STRING)
-        .appendTitle(new blockly.FieldLabel(i18n.blockType()));
+        .appendField(new blockly.FieldLabel(i18n.blockType()));
       this.appendValueInput('BLOCKDATA')
         .setCheck(Blockly.JavaScript.STRING)
-        .appendTitle(new blockly.FieldLabel(i18n.blockData()));
+        .appendField(new blockly.FieldLabel(i18n.blockData()));
       this.setOutput(true, ITEM_TYPE);
     }
   };
@@ -1214,8 +1214,8 @@ export const install = (blockly, blockInstallOptions) => {
     init: function() {
       this.setHSV(itemBlockColor.h, itemBlockColor.s, itemBlockColor.v);
       this.appendDummyInput()
-        .appendTitle(new blockly.FieldLabel(i18n.itemTypeBlock()))
-        .appendTitle(
+        .appendField(new blockly.FieldLabel(i18n.itemTypeBlock()))
+        .appendField(
           new blockly.FieldImageDropdown(items.blocks, 32, 32),
           'BLOCK'
         );
@@ -1235,8 +1235,8 @@ export const install = (blockly, blockInstallOptions) => {
     init: function() {
       this.setHSV(itemBlockColor.h, itemBlockColor.s, itemBlockColor.v);
       this.appendDummyInput()
-        .appendTitle(new blockly.FieldLabel(i18n.itemTypeMiscellaneous()))
-        .appendTitle(
+        .appendField(new blockly.FieldLabel(i18n.itemTypeMiscellaneous()))
+        .appendField(
           new blockly.FieldImageDropdown(items.miscellaneous, 32, 32),
           'ITEM'
         );
@@ -1256,8 +1256,8 @@ export const install = (blockly, blockInstallOptions) => {
     init: function() {
       this.setHSV(itemBlockColor.h, itemBlockColor.s, itemBlockColor.v);
       this.appendDummyInput()
-        .appendTitle(new blockly.FieldLabel(i18n.itemTypeDecoration()))
-        .appendTitle(
+        .appendField(new blockly.FieldLabel(i18n.itemTypeDecoration()))
+        .appendField(
           new blockly.FieldImageDropdown(items.decorations, 32, 32),
           'ITEM'
         );
@@ -1277,8 +1277,8 @@ export const install = (blockly, blockInstallOptions) => {
     init: function() {
       this.setHSV(itemBlockColor.h, itemBlockColor.s, itemBlockColor.v);
       this.appendDummyInput()
-        .appendTitle(new blockly.FieldLabel(i18n.itemTypeTool()))
-        .appendTitle(
+        .appendField(new blockly.FieldLabel(i18n.itemTypeTool()))
+        .appendField(
           new blockly.FieldImageDropdown(items.tools, 32, 32),
           'ITEM'
         );
@@ -1299,7 +1299,7 @@ export const install = (blockly, blockInstallOptions) => {
       this.setHSV(itemBlockColor.h, itemBlockColor.s, itemBlockColor.v);
       this.appendValueInput('ITEM')
         .setCheck(ITEM_TYPE)
-        .appendTitle(new blockly.FieldLabel(i18n.getnameof()));
+        .appendField(new blockly.FieldLabel(i18n.getnameof()));
       this.setOutput(true, Blockly.JavaScript.STRING);
     }
   };
@@ -1318,7 +1318,7 @@ export const install = (blockly, blockInstallOptions) => {
       this.setHSV(itemBlockColor.h, itemBlockColor.s, itemBlockColor.v);
       this.appendValueInput('ITEM')
         .setCheck(ITEM_TYPE)
-        .appendTitle(new blockly.FieldLabel(i18n.getdataof()));
+        .appendField(new blockly.FieldLabel(i18n.getdataof()));
       this.setOutput(true, Blockly.JavaScript.STRING);
     }
   };

--- a/apps/src/craft/designer/blocks.js
+++ b/apps/src/craft/designer/blocks.js
@@ -175,7 +175,7 @@ export const install = (blockly, blockInstallOptions) => {
     helpUrl: 'http://code.google.com/p/blockly/wiki/Turn',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(this.DIRECTIONS),
         'DIR'
       );
@@ -207,7 +207,7 @@ export const install = (blockly, blockInstallOptions) => {
     helpUrl: 'http://code.google.com/p/blockly/wiki/Turn',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(
           blockly.Blocks.craft_entityTurn.ENTITY_DIRECTIONS
         ),
@@ -242,7 +242,7 @@ export const install = (blockly, blockInstallOptions) => {
     helpUrl: 'http://code.google.com/p/blockly/wiki/Turn',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(
           blockly.Blocks.craft_entityTurnLR.ENTITY_DIRECTIONS
         ),
@@ -300,12 +300,12 @@ export const install = (blockly, blockInstallOptions) => {
   function blockFor(displayName, statementNames = defaultEventOrder) {
     return {
       init: function() {
-        this.appendDummyInput().appendTitle(displayName);
+        this.appendDummyInput().appendField(displayName);
         statementNames.forEach(name => {
           this.appendStatementInput(
             name,
             ENTITY_INPUT_EXTRA_SPACING
-          ).appendTitle(statementNameToDisplayName[name]);
+          ).appendField(statementNameToDisplayName[name]);
         });
         this.setColour(120);
         this.setTooltip('');
@@ -425,7 +425,7 @@ export const install = (blockly, blockInstallOptions) => {
       helpUrl: '',
       init: function() {
         this.setHSV(140, 1.0, 0.74);
-        this.appendDummyInput().appendTitle(text);
+        this.appendDummyInput().appendField(text);
         this.appendStatementInput('DO');
         this.setPreviousStatement(false);
         this.setNextStatement(false);
@@ -473,8 +473,8 @@ export const install = (blockly, blockInstallOptions) => {
 
         this.setHSV(184, 1.0, 0.74);
         this.appendDummyInput()
-          .appendTitle(new blockly.FieldLabel(blockText))
-          .appendTitle(dropdown, 'TYPE');
+          .appendField(new blockly.FieldLabel(blockText))
+          .appendField(dropdown, 'TYPE');
         this.setPreviousStatement(true);
         this.setNextStatement(true);
       }
@@ -493,7 +493,7 @@ export const install = (blockly, blockInstallOptions) => {
       helpUrl: '',
       init: function() {
         this.setHSV(184, 1.0, 0.74);
-        this.appendDummyInput().appendTitle(new blockly.FieldLabel(blockText));
+        this.appendDummyInput().appendField(new blockly.FieldLabel(blockText));
         this.setPreviousStatement(true);
         this.setNextStatement(true);
       }
@@ -521,8 +521,8 @@ export const install = (blockly, blockInstallOptions) => {
 
         this.setHSV(184, 1.0, 0.74);
         this.appendDummyInput()
-          .appendTitle(new blockly.FieldLabel(blockText))
-          .appendTitle(dropdown, 'TYPE');
+          .appendField(new blockly.FieldLabel(blockText))
+          .appendField(dropdown, 'TYPE');
         this.setPreviousStatement(true);
         this.setNextStatement(true);
       }
@@ -577,8 +577,8 @@ export const install = (blockly, blockInstallOptions) => {
     helpUrl: '',
     init: function() {
       this.setHSV(322, 0.9, 0.95);
-      this.appendDummyInput().appendTitle(i18n.forever());
-      this.appendStatementInput('DO').appendTitle(i18n.blockWhileXAheadDo());
+      this.appendDummyInput().appendField(i18n.forever());
+      this.appendStatementInput('DO').appendField(i18n.blockWhileXAheadDo());
       this.setPreviousStatement(true);
     }
   };
@@ -595,15 +595,15 @@ export const install = (blockly, blockInstallOptions) => {
     init: function() {
       this.setHSV(322, 0.9, 0.95);
       this.appendDummyInput()
-        .appendTitle(i18n.blockActionRepeat())
-        .appendTitle(
+        .appendField(i18n.blockActionRepeat())
+        .appendField(
           new blockly.FieldTextInput(
             '5',
             blockly.FieldTextInput.nonnegativeIntegerValidator
           ),
           'TIMES'
         );
-      this.appendStatementInput('DO').appendTitle(i18n.blockWhileXAheadDo());
+      this.appendStatementInput('DO').appendField(i18n.blockWhileXAheadDo());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -621,8 +621,8 @@ export const install = (blockly, blockInstallOptions) => {
     helpUrl: '',
     init: function() {
       this.setHSV(322, 0.9, 0.95);
-      this.appendDummyInput().appendTitle(i18n.blockActionRepeatRandom());
-      this.appendStatementInput('DO').appendTitle(i18n.blockWhileXAheadDo());
+      this.appendDummyInput().appendField(i18n.blockActionRepeatRandom());
+      this.appendStatementInput('DO').appendField(i18n.blockWhileXAheadDo());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -647,9 +647,9 @@ export const install = (blockly, blockInstallOptions) => {
 
       this.setHSV(322, 0.9, 0.95);
       this.appendDummyInput()
-        .appendTitle(i18n.blockActionRepeat())
-        .appendTitle(dropdown, 'TIMES');
-      this.appendStatementInput('DO').appendTitle(i18n.blockWhileXAheadDo());
+        .appendField(i18n.blockActionRepeat())
+        .appendField(dropdown, 'TIMES');
+      this.appendStatementInput('DO').appendField(i18n.blockWhileXAheadDo());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -685,10 +685,10 @@ export const install = (blockly, blockInstallOptions) => {
 
       this.setHSV(184, 1.0, 0.74);
       this.appendDummyInput()
-        .appendTitle(new blockly.FieldLabel(i18n.blockActionSpawn()))
-        .appendTitle(entityTypeDropdown, 'TYPE')
-        .appendTitle(new blockly.FieldLabel(' '))
-        .appendTitle(locationDropdown, 'DIRECTION');
+        .appendField(new blockly.FieldLabel(i18n.blockActionSpawn()))
+        .appendField(entityTypeDropdown, 'TYPE')
+        .appendField(new blockly.FieldLabel(' '))
+        .appendField(locationDropdown, 'DIRECTION');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -713,8 +713,8 @@ export const install = (blockly, blockInstallOptions) => {
 
       this.setHSV(184, 1.0, 0.74);
       this.appendDummyInput()
-        .appendTitle(new blockly.FieldLabel('spawn'))
-        .appendTitle(entityTypeDropdown, 'TYPE');
+        .appendField(new blockly.FieldLabel('spawn'))
+        .appendField(entityTypeDropdown, 'TYPE');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -729,7 +729,7 @@ export const install = (blockly, blockInstallOptions) => {
     helpUrl: '',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(new blockly.FieldLabel('move north'));
+      this.appendDummyInput().appendField(new blockly.FieldLabel('move north'));
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -743,7 +743,7 @@ export const install = (blockly, blockInstallOptions) => {
     helpUrl: '',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(new blockly.FieldLabel('move south'));
+      this.appendDummyInput().appendField(new blockly.FieldLabel('move south'));
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -757,7 +757,7 @@ export const install = (blockly, blockInstallOptions) => {
     helpUrl: '',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(new blockly.FieldLabel('move east'));
+      this.appendDummyInput().appendField(new blockly.FieldLabel('move east'));
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -771,7 +771,7 @@ export const install = (blockly, blockInstallOptions) => {
     helpUrl: '',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(new blockly.FieldLabel('move west'));
+      this.appendDummyInput().appendField(new blockly.FieldLabel('move west'));
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -803,8 +803,8 @@ export const install = (blockly, blockInstallOptions) => {
 
       this.setHSV(184, 1.0, 0.74);
       this.appendDummyInput()
-        .appendTitle(i18n.blockActionPlaySound())
-        .appendTitle(dropdown, 'TYPE');
+        .appendField(i18n.blockActionPlaySound())
+        .appendField(dropdown, 'TYPE');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -828,9 +828,9 @@ export const install = (blockly, blockInstallOptions) => {
 
       this.setHSV(184, 1.0, 0.74);
       this.appendDummyInput()
-        .appendTitle(i18n.blockActionAdd())
-        .appendTitle(dropdown, 'SCORE')
-        .appendTitle(i18n.blockActionToScore());
+        .appendField(i18n.blockActionAdd())
+        .appendField(dropdown, 'SCORE')
+        .appendField(i18n.blockActionToScore());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }

--- a/apps/src/craft/simple/blocks.js
+++ b/apps/src/craft/simple/blocks.js
@@ -68,7 +68,7 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldLabel(i18n.blockMoveForward())
       );
       this.setPreviousStatement(true);
@@ -85,7 +85,7 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: 'http://code.google.com/p/blockly/wiki/Turn',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(this.DIRECTIONS),
         'DIR'
       );
@@ -110,7 +110,7 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldLabel(i18n.blockDestroyBlock())
       );
       this.setPreviousStatement(true);
@@ -126,7 +126,7 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldLabel(i18n.blockShear())
       );
       this.setPreviousStatement(true);
@@ -148,10 +148,10 @@ exports.install = function(blockly, blockInstallOptions) {
       dropdown.setValue(dropdownOptions[0][1]);
       this.setHSV(196, 1.0, 0.79);
       this.appendDummyInput()
-        .appendTitle(i18n.blockIf())
-        .appendTitle(dropdown, 'TYPE')
-        .appendTitle(i18n.blockWhileXAheadAhead());
-      this.appendStatementInput('DO').appendTitle(i18n.blockWhileXAheadDo());
+        .appendField(i18n.blockIf())
+        .appendField(dropdown, 'TYPE')
+        .appendField(i18n.blockWhileXAheadAhead());
+      this.appendStatementInput('DO').appendField(i18n.blockWhileXAheadDo());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -175,8 +175,8 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(196, 1.0, 0.79);
-      this.appendDummyInput().appendTitle(i18n.blockIfLavaAhead());
-      this.appendStatementInput('DO').appendTitle(i18n.blockWhileXAheadDo());
+      this.appendDummyInput().appendField(i18n.blockIfLavaAhead());
+      this.appendStatementInput('DO').appendField(i18n.blockWhileXAheadDo());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -204,8 +204,8 @@ exports.install = function(blockly, blockInstallOptions) {
 
       this.setHSV(184, 1.0, 0.74);
       this.appendDummyInput()
-        .appendTitle(i18n.blockPlaceXPlace())
-        .appendTitle(dropdown, 'TYPE');
+        .appendField(i18n.blockPlaceXPlace())
+        .appendField(dropdown, 'TYPE');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -220,7 +220,7 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(i18n.blockPlaceTorch());
+      this.appendDummyInput().appendField(i18n.blockPlaceTorch());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -234,7 +234,7 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(i18n.blockPlantCrop());
+      this.appendDummyInput().appendField(i18n.blockPlantCrop());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -248,7 +248,7 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(i18n.blockTillSoil());
+      this.appendDummyInput().appendField(i18n.blockTillSoil());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -269,9 +269,9 @@ exports.install = function(blockly, blockInstallOptions) {
 
       this.setHSV(184, 1.0, 0.74);
       this.appendDummyInput()
-        .appendTitle(i18n.blockPlaceXAheadPlace())
-        .appendTitle(dropdown, 'TYPE')
-        .appendTitle(i18n.blockPlaceXAheadAhead());
+        .appendField(i18n.blockPlaceXAheadPlace())
+        .appendField(dropdown, 'TYPE')
+        .appendField(i18n.blockPlaceXAheadAhead());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }

--- a/apps/src/dance/blocks.js
+++ b/apps/src/dance/blocks.js
@@ -53,8 +53,8 @@ const customInputTypes = {
       };
 
       currentInputRow
-        .appendTitle(inputConfig.label)
-        .appendTitle(
+        .appendField(inputConfig.label)
+        .appendField(
           new Blockly.FieldVariable(
             null,
             null,
@@ -76,8 +76,8 @@ const customInputTypes = {
         columns: 3
       };
       currentInputRow
-        .appendTitle(inputConfig.label)
-        .appendTitle(
+        .appendField(inputConfig.label)
+        .appendField(
           new Blockly.FieldColour('#ff0000', undefined, options),
           'VAL'
         );
@@ -123,8 +123,8 @@ export default {
         fieldLabel.EDITABLE = true;
         this.setHelpUrl(Blockly.Msg.VARIABLES_GET_HELPURL);
         this.appendDummyInput()
-          .appendTitle(Blockly.Msg.VARIABLES_GET_TITLE)
-          .appendTitle(
+          .appendField(Blockly.Msg.VARIABLES_GET_TITLE)
+          .appendField(
             Blockly.disableVariableEditing
               ? fieldLabel
               : new Blockly.FieldVariable(
@@ -136,7 +136,7 @@ export default {
                 ),
             'VAR'
           )
-          .appendTitle(Blockly.Msg.VARIABLES_GET_TAIL);
+          .appendField(Blockly.Msg.VARIABLES_GET_TAIL);
         this.setStrictOutput(true, Blockly.BlockValueType.SPRITE);
         this.setTooltip(Blockly.Msg.VARIABLES_GET_TOOLTIP);
       },
@@ -170,9 +170,9 @@ export default {
         fieldLabel.EDITABLE = true;
         this.setHelpUrl(Blockly.Msg.VARIABLES_GET_HELPURL);
         this.appendDummyInput()
-          .appendTitle(Blockly.Msg.VARIABLES_GET_TITLE)
-          .appendTitle(fieldLabel, 'VAR')
-          .appendTitle(Blockly.Msg.VARIABLES_GET_TAIL);
+          .appendField(Blockly.Msg.VARIABLES_GET_TITLE)
+          .appendField(fieldLabel, 'VAR')
+          .appendField(Blockly.Msg.VARIABLES_GET_TAIL);
         this.setStrictOutput(true, Blockly.BlockValueType.SPRITE);
         this.setTooltip(Blockly.Msg.VARIABLES_GET_TOOLTIP);
       },
@@ -194,8 +194,8 @@ export default {
         this.setHelpUrl(Blockly.Msg.VARIABLES_GET_HELPURL);
         this.setHSV(136, 0.84, 0.8);
         const mainTitle = this.appendDummyInput()
-          .appendTitle(fieldLabel, 'VAR')
-          .appendTitle(Blockly.Msg.VARIABLES_GET_TAIL);
+          .appendField(fieldLabel, 'VAR')
+          .appendField(Blockly.Msg.VARIABLES_GET_TAIL);
 
         if (Blockly.useModalFunctionEditor) {
           var editLabel = new Blockly.FieldIcon(Blockly.Msg.FUNCTION_EDIT);
@@ -205,7 +205,7 @@ export default {
             this,
             this.openEditor
           );
-          mainTitle.appendTitle(editLabel);
+          mainTitle.appendField(editLabel);
         }
 
         this.setStrictOutput(true, Blockly.BlockValueType.BEHAVIOR);

--- a/apps/src/flappy/blocks.js
+++ b/apps/src/flappy/blocks.js
@@ -44,10 +44,10 @@ exports.install = function(blockly, blockInstallOptions) {
       this.setHSV(140, 1.0, 0.74);
       if (isK1) {
         this.appendDummyInput()
-          .appendTitle(commonMsg.when())
-          .appendTitle(new blockly.FieldImage(skin.clickIcon));
+          .appendField(commonMsg.when())
+          .appendField(new blockly.FieldImage(skin.clickIcon));
       } else {
-        this.appendDummyInput().appendTitle(msg.whenClick());
+        this.appendDummyInput().appendField(msg.whenClick());
       }
       this.setPreviousStatement(false);
       this.setNextStatement(true);
@@ -67,10 +67,10 @@ exports.install = function(blockly, blockInstallOptions) {
       this.setHSV(140, 1.0, 0.74);
       if (isK1) {
         this.appendDummyInput()
-          .appendTitle(commonMsg.when())
-          .appendTitle(new blockly.FieldImage(skin.collideGroundIcon));
+          .appendField(commonMsg.when())
+          .appendField(new blockly.FieldImage(skin.collideGroundIcon));
       } else {
-        this.appendDummyInput().appendTitle(msg.whenCollideGround());
+        this.appendDummyInput().appendField(msg.whenCollideGround());
       }
       this.setPreviousStatement(false);
       this.setNextStatement(true);
@@ -90,10 +90,10 @@ exports.install = function(blockly, blockInstallOptions) {
       this.setHSV(140, 1.0, 0.74);
       if (isK1) {
         this.appendDummyInput()
-          .appendTitle(commonMsg.when())
-          .appendTitle(new blockly.FieldImage(skin.collideObstacleIcon));
+          .appendField(commonMsg.when())
+          .appendField(new blockly.FieldImage(skin.collideObstacleIcon));
       } else {
-        this.appendDummyInput().appendTitle(msg.whenCollideObstacle());
+        this.appendDummyInput().appendField(msg.whenCollideObstacle());
       }
       this.setPreviousStatement(false);
       this.setNextStatement(true);
@@ -113,10 +113,10 @@ exports.install = function(blockly, blockInstallOptions) {
       this.setHSV(140, 1.0, 0.74);
       if (isK1) {
         this.appendDummyInput()
-          .appendTitle(commonMsg.when())
-          .appendTitle(new blockly.FieldImage(skin.enterObstacleIcon));
+          .appendField(commonMsg.when())
+          .appendField(new blockly.FieldImage(skin.enterObstacleIcon));
       } else {
-        this.appendDummyInput().appendTitle(msg.whenEnterObstacle());
+        this.appendDummyInput().appendField(msg.whenEnterObstacle());
       }
       this.setPreviousStatement(false);
       this.setNextStatement(true);
@@ -136,10 +136,10 @@ exports.install = function(blockly, blockInstallOptions) {
       this.setHSV(184, 1.0, 0.74);
       if (isK1) {
         this.appendDummyInput()
-          .appendTitle(msg.flap())
-          .appendTitle(new blockly.FieldImage(skin.flapIcon));
+          .appendField(msg.flap())
+          .appendField(new blockly.FieldImage(skin.flapIcon));
       } else {
-        this.appendDummyInput().appendTitle(msg.flap());
+        this.appendDummyInput().appendField(msg.flap());
       }
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -164,7 +164,7 @@ exports.install = function(blockly, blockInstallOptions) {
       dropdown.setValue(this.VALUES[3][1]); // default to normal
 
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(dropdown, 'VALUE');
+      this.appendDummyInput().appendField(dropdown, 'VALUE');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
       this.setTooltip(msg.flapTooltip());
@@ -205,11 +205,11 @@ exports.install = function(blockly, blockInstallOptions) {
 
       if (isK1) {
         this.appendDummyInput()
-          .appendTitle(commonMsg.play())
-          .appendTitle(new blockly.FieldImage(skin.soundIcon))
-          .appendTitle(soundDropdown, 'VALUE');
+          .appendField(commonMsg.play())
+          .appendField(new blockly.FieldImage(skin.soundIcon))
+          .appendField(soundDropdown, 'VALUE');
       } else {
-        this.appendDummyInput().appendTitle(soundDropdown, 'VALUE');
+        this.appendDummyInput().appendField(soundDropdown, 'VALUE');
       }
 
       this.setHSV(184, 1.0, 0.74);
@@ -264,10 +264,10 @@ exports.install = function(blockly, blockInstallOptions) {
       this.setHSV(184, 1.0, 0.74);
       if (isK1) {
         this.appendDummyInput()
-          .appendTitle(commonMsg.score())
-          .appendTitle(new blockly.FieldImage(skin.scoreCard));
+          .appendField(commonMsg.score())
+          .appendField(new blockly.FieldImage(skin.scoreCard));
       } else {
-        this.appendDummyInput().appendTitle(msg.incrementPlayerScore());
+        this.appendDummyInput().appendField(msg.incrementPlayerScore());
       }
 
       this.setPreviousStatement(true);
@@ -287,10 +287,10 @@ exports.install = function(blockly, blockInstallOptions) {
       this.setHSV(184, 1.0, 0.74);
       if (isK1) {
         this.appendDummyInput()
-          .appendTitle(commonMsg.end())
-          .appendTitle(new blockly.FieldImage(skin.endIcon));
+          .appendField(commonMsg.end())
+          .appendField(new blockly.FieldImage(skin.endIcon));
       } else {
-        this.appendDummyInput().appendTitle(msg.endGame());
+        this.appendDummyInput().appendField(msg.endGame());
       }
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -318,12 +318,12 @@ exports.install = function(blockly, blockInstallOptions) {
         );
         fieldImageDropdown.setValue(this.K1_VALUES[1][1]); // default to normal
         this.appendDummyInput()
-          .appendTitle(msg.setSpeed())
-          .appendTitle(fieldImageDropdown, 'VALUE');
+          .appendField(msg.setSpeed())
+          .appendField(fieldImageDropdown, 'VALUE');
       } else {
         var dropdown = new blockly.FieldDropdown(this.VALUES);
         dropdown.setValue(this.VALUES[3][1]); // default to normal
-        this.appendDummyInput().appendTitle(dropdown, 'VALUE');
+        this.appendDummyInput().appendField(dropdown, 'VALUE');
       }
       this.setInputsInline(true);
       this.setPreviousStatement(true);
@@ -361,7 +361,7 @@ exports.install = function(blockly, blockInstallOptions) {
       dropdown.setValue(this.VALUES[3][1]); // default to normal
 
       this.setHSV(312, 0.32, 0.62);
-      this.appendDummyInput().appendTitle(dropdown, 'VALUE');
+      this.appendDummyInput().appendField(dropdown, 'VALUE');
       this.setInputsInline(true);
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -392,7 +392,7 @@ exports.install = function(blockly, blockInstallOptions) {
       var dropdown;
       var input = this.appendDummyInput();
       if (isK1) {
-        input.appendTitle(msg.setBackground());
+        input.appendField(msg.setBackground());
         dropdown = new blockly.FieldImageDropdown(this.K1_CHOICES, 50, 30);
         dropdown.setValue(FLAPPY_VALUE);
       } else {
@@ -400,7 +400,7 @@ exports.install = function(blockly, blockInstallOptions) {
         dropdown.setValue(FLAPPY_VALUE);
       }
 
-      input.appendTitle(dropdown, 'VALUE');
+      input.appendField(dropdown, 'VALUE');
 
       this.setInputsInline(true);
       this.setPreviousStatement(true);
@@ -443,14 +443,14 @@ exports.install = function(blockly, blockInstallOptions) {
       var dropdown;
       var input = this.appendDummyInput();
       if (isK1) {
-        input.appendTitle(msg.setPlayer());
+        input.appendField(msg.setPlayer());
         dropdown = new blockly.FieldImageDropdown(this.K1_CHOICES, 34, 24);
         dropdown.setValue(FLAPPY_VALUE);
       } else {
         dropdown = new blockly.FieldDropdown(this.VALUES);
         dropdown.setValue(FLAPPY_VALUE);
       }
-      input.appendTitle(dropdown, 'VALUE');
+      input.appendField(dropdown, 'VALUE');
 
       this.setInputsInline(true);
       this.setPreviousStatement(true);
@@ -509,7 +509,7 @@ exports.install = function(blockly, blockInstallOptions) {
       var dropdown;
       var input = this.appendDummyInput();
       if (isK1) {
-        input.appendTitle(msg.setObstacle());
+        input.appendField(msg.setObstacle());
         dropdown = new blockly.FieldImageDropdown(this.K1_CHOICES, 50, 30);
         dropdown.setValue(FLAPPY_VALUE);
       } else {
@@ -517,7 +517,7 @@ exports.install = function(blockly, blockInstallOptions) {
         dropdown.setValue(FLAPPY_VALUE);
       }
 
-      input.appendTitle(dropdown, 'VALUE');
+      input.appendField(dropdown, 'VALUE');
       this.setInputsInline(true);
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -559,14 +559,14 @@ exports.install = function(blockly, blockInstallOptions) {
       var dropdown;
       var input = this.appendDummyInput();
       if (isK1) {
-        input.appendTitle(msg.setGround());
+        input.appendField(msg.setGround());
         dropdown = new blockly.FieldImageDropdown(this.K1_CHOICES, 50, 30);
         dropdown.setValue(FLAPPY_VALUE);
       } else {
         dropdown = new blockly.FieldDropdown(this.VALUES);
         dropdown.setValue(FLAPPY_VALUE);
       }
-      input.appendTitle(dropdown, 'VALUE');
+      input.appendField(dropdown, 'VALUE');
 
       this.setInputsInline(true);
       this.setPreviousStatement(true);
@@ -609,7 +609,7 @@ exports.install = function(blockly, blockInstallOptions) {
       dropdown.setValue(this.VALUES[3][1]); // default to normal
 
       this.setHSV(312, 0.32, 0.62);
-      this.appendDummyInput().appendTitle(dropdown, 'VALUE');
+      this.appendDummyInput().appendField(dropdown, 'VALUE');
       this.setInputsInline(true);
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -635,8 +635,8 @@ exports.install = function(blockly, blockInstallOptions) {
     init: function() {
       this.setHSV(312, 0.32, 0.62);
       this.appendDummyInput()
-        .appendTitle(msg.setScore())
-        .appendTitle(
+        .appendField(msg.setScore())
+        .appendField(
           new blockly.FieldTextInput(
             '0',
             blockly.FieldTextInput.numberValidator

--- a/apps/src/jigsaw/blocks.js
+++ b/apps/src/jigsaw/blocks.js
@@ -207,8 +207,8 @@ function generateBlankBlock(blockly, skin, name, hsv, width, label) {
     init: function() {
       this.setHSV.apply(this, hsv);
       this.appendDummyInput()
-        .appendTitle(new blockly.FieldImage(skin.blank, width, 54))
-        .appendTitle(
+        .appendField(new blockly.FieldImage(skin.blank, width, 54))
+        .appendField(
           new blockly.FieldLabel(label, {
             fixedSize: {width: width, height: 64},
             fontSize: 32
@@ -243,7 +243,7 @@ function generateJigsawBlocksForLevel(blockly, skin, options) {
       helpUrl: '',
       init: function() {
         this.setHSV.apply(this, HSV);
-        this.appendDummyInput().appendTitle(
+        this.appendDummyInput().appendField(
           new blockly.FieldImage(skin.blank, titleWidth, titleHeight)
         );
         this.setPreviousStatement(blockNum !== 1 || notchedEnds);

--- a/apps/src/maze/beeBlocks.js
+++ b/apps/src/maze/beeBlocks.js
@@ -124,10 +124,10 @@ function addIfOnlyFlower(blockly, generator) {
     helpUrl: '',
     init: function() {
       this.setHSV(196, 1.0, 0.79);
-      this.appendDummyInput().appendTitle(msg.ifCode());
-      this.appendDummyInput().appendTitle(msg.atFlower());
+      this.appendDummyInput().appendField(msg.ifCode());
+      this.appendDummyInput().appendField(msg.atFlower());
       this.setInputsInline(true);
-      this.appendStatementInput('DO').appendTitle(msg.doCode());
+      this.appendStatementInput('DO').appendField(msg.doCode());
       this.setTooltip(msg.ifOnlyFlowerTooltip());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -158,13 +158,13 @@ function addIfFlowerHive(blockly, generator) {
       ];
 
       this.setHSV(196, 1.0, 0.79);
-      this.appendDummyInput().appendTitle(msg.ifCode());
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(msg.ifCode());
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(LOCATIONS),
         'LOC'
       );
       this.setInputsInline(true);
-      this.appendStatementInput('DO').appendTitle(msg.doCode());
+      this.appendStatementInput('DO').appendField(msg.doCode());
       this.setTooltip(msg.ifFlowerTooltip());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -197,14 +197,14 @@ function addIfElseFlowerHive(blockly, generator) {
       ];
 
       this.setHSV(196, 1.0, 0.79);
-      this.appendDummyInput().appendTitle(msg.ifCode());
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(msg.ifCode());
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(LOCATIONS),
         'LOC'
       );
       this.setInputsInline(true);
-      this.appendStatementInput('DO').appendTitle(msg.doCode());
-      this.appendStatementInput('ELSE').appendTitle(msg.elseCode());
+      this.appendStatementInput('DO').appendField(msg.doCode());
+      this.appendStatementInput('ELSE').appendField(msg.elseCode());
       this.setTooltip(msg.ifelseFlowerTooltip());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -288,25 +288,25 @@ function addConditionalComparisonBlock(blockly, generator, name, type, arg1) {
           throw 'Unexpected type for addConditionalComparisonBlock';
       }
 
-      this.appendDummyInput().appendTitle(conditionalMsg);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(conditionalMsg);
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(arg1),
         'ARG1'
       );
-      this.appendDummyInput().appendTitle(' ');
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(' ');
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(Blockly.RTL ? RTL_OPERATORS : OPERATORS),
         'OP'
       );
-      this.appendDummyInput().appendTitle(' ');
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(' ');
+      this.appendDummyInput().appendField(
         new blockly.FieldTextInput('0', blockly.FieldTextInput.numberValidator),
         'ARG2'
       );
       this.setInputsInline(true);
-      this.appendStatementInput('DO').appendTitle(msg.doCode());
+      this.appendStatementInput('DO').appendField(msg.doCode());
       if (type === 'ifelse') {
-        this.appendStatementInput('ELSE').appendTitle(msg.elseCode());
+        this.appendStatementInput('ELSE').appendField(msg.elseCode());
       }
       this.setPreviousStatement(true);
       this.setNextStatement(true);

--- a/apps/src/maze/blocks.js
+++ b/apps/src/maze/blocks.js
@@ -88,12 +88,12 @@ exports.install = function(blockly, blockInstallOptions) {
         init: function() {
           this.setHSV(184, 1.0, 0.74);
           this.appendDummyInput()
-            .appendTitle(
+            .appendField(
               new blockly.FieldLabel(directionConfig.letter, {
                 fixedSize: {width: 12, height: 18}
               })
             )
-            .appendTitle(new blockly.FieldImage(directionConfig.image));
+            .appendField(new blockly.FieldImage(directionConfig.image));
           this.setPreviousStatement(true);
           this.setNextStatement(true);
           this.setTooltip(directionConfig.tooltip);
@@ -141,7 +141,7 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: 'http://code.google.com/p/blockly/wiki/Move',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(this.DIRECTIONS),
         'DIR'
       );
@@ -167,7 +167,7 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: 'http://code.google.com/p/blockly/wiki/Turn',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(this.DIRECTIONS),
         'DIR'
       );
@@ -194,7 +194,7 @@ exports.install = function(blockly, blockInstallOptions) {
     init: function() {
       this.setHSV(196, 1.0, 0.79);
       this.setOutput(true, blockly.BlockValueType.NUMBER);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(this.DIRECTIONS),
         'DIR'
       );
@@ -219,12 +219,12 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(196, 1.0, 0.79);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(this.DIRECTIONS),
         'DIR'
       );
       this.setInputsInline(true);
-      this.appendStatementInput('DO').appendTitle(msg.doCode());
+      this.appendStatementInput('DO').appendField(msg.doCode());
       this.setTooltip(msg.ifTooltip());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -247,13 +247,13 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(196, 1.0, 0.79);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(this.DIRECTIONS),
         'DIR'
       );
       this.setInputsInline(true);
-      this.appendStatementInput('DO').appendTitle(msg.doCode());
-      this.appendStatementInput('ELSE').appendTitle(msg.elseCode());
+      this.appendStatementInput('DO').appendField(msg.doCode());
+      this.appendStatementInput('ELSE').appendField(msg.elseCode());
       this.setTooltip(msg.ifelseTooltip());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -278,13 +278,13 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(196, 1.0, 0.79);
-      this.appendDummyInput().appendTitle(msg.ifCode());
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(msg.ifCode());
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(this.DIRECTIONS),
         'DIR'
       );
       this.setInputsInline(true);
-      this.appendStatementInput('DO').appendTitle(msg.doCode());
+      this.appendStatementInput('DO').appendField(msg.doCode());
       this.setTooltip(msg.ifTooltip());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -312,14 +312,14 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(196, 1.0, 0.79);
-      this.appendDummyInput().appendTitle(msg.ifCode());
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(msg.ifCode());
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(this.DIRECTIONS),
         'DIR'
       );
       this.setInputsInline(true);
-      this.appendStatementInput('DO').appendTitle(msg.doCode());
-      this.appendStatementInput('ELSE').appendTitle(msg.elseCode());
+      this.appendStatementInput('DO').appendField(msg.doCode());
+      this.appendStatementInput('ELSE').appendField(msg.elseCode());
       this.setTooltip(msg.ifelseTooltip());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -343,11 +343,11 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: 'http://code.google.com/p/blockly/wiki/Repeat',
     init: function() {
       this.setHSV(322, 0.9, 0.95);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(this.DIRECTIONS),
         'DIR'
       );
-      this.appendStatementInput('DO').appendTitle(msg.doCode());
+      this.appendStatementInput('DO').appendField(msg.doCode());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
       this.setTooltip(msg.whileTooltip());
@@ -371,8 +371,8 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: 'http://code.google.com/p/blockly/wiki/Repeat',
     init: function() {
       this.setHSV(322, 0.9, 0.95);
-      this.appendDummyInput().appendTitle(msg.repeatUntilBlocked());
-      this.appendStatementInput('DO').appendTitle(msg.doCode());
+      this.appendDummyInput().appendField(msg.repeatUntilBlocked());
+      this.appendStatementInput('DO').appendField(msg.doCode());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
       this.setTooltip(msg.whileTooltip());
@@ -392,9 +392,9 @@ exports.install = function(blockly, blockInstallOptions) {
     init: function() {
       this.setHSV(322, 0.9, 0.95);
       this.appendDummyInput()
-        .appendTitle(msg.repeatUntil())
-        .appendTitle(new blockly.FieldImage(skin.maze_forever, 35, 35));
-      this.appendStatementInput('DO').appendTitle(msg.doCode());
+        .appendField(msg.repeatUntil())
+        .appendField(new blockly.FieldImage(skin.maze_forever, 35, 35));
+      this.appendStatementInput('DO').appendField(msg.doCode());
       this.setPreviousStatement(true);
       this.setTooltip(msg.whileTooltip());
     }
@@ -414,11 +414,11 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: 'http://code.google.com/p/blockly/wiki/Repeat',
     init: function() {
       this.setHSV(322, 0.9, 0.95);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(this.DIRECTIONS),
         'DIR'
       );
-      this.appendStatementInput('DO').appendTitle(msg.doCode());
+      this.appendStatementInput('DO').appendField(msg.doCode());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
       this.setTooltip(msg.whileTooltip());

--- a/apps/src/maze/collectorBlocks.js
+++ b/apps/src/maze/collectorBlocks.js
@@ -35,11 +35,11 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(196, 1.0, 0.79);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         msg.ifCode() + ' ' + msg.collectiblePresent()
       );
       this.setInputsInline(true);
-      this.appendStatementInput('DO').appendTitle(msg.doCode());
+      this.appendStatementInput('DO').appendField(msg.doCode());
       this.setTooltip(msg.ifTooltip());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -58,10 +58,10 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: 'http://code.google.com/p/blockly/wiki/Repeat',
     init: function() {
       this.setHSV(322, 0.9, 0.95);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         msg.whileMsg() + ' ' + msg.collectiblePresent()
       );
-      this.appendStatementInput('DO').appendTitle(msg.doCode());
+      this.appendStatementInput('DO').appendField(msg.doCode());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
       this.setTooltip(msg.whileTooltip());

--- a/apps/src/maze/harvesterBlocks.js
+++ b/apps/src/maze/harvesterBlocks.js
@@ -16,11 +16,11 @@ function addIfAtSpecificCropBlock(blockly, generator, crop) {
     helpUrl: '',
     init: function() {
       this.setHSV(196, 1.0, 0.79);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         [msg.ifCode(), msg.at(), msg[crop]()].join(' ')
       );
       this.setInputsInline(true);
-      this.appendStatementInput('DO').appendTitle(msg.doCode());
+      this.appendStatementInput('DO').appendField(msg.doCode());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -41,12 +41,12 @@ function addIfAtSpecificCropElseBlock(blockly, generator, crop) {
     helpUrl: '',
     init: function() {
       this.setHSV(196, 1.0, 0.79);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         [msg.ifCode(), msg.at(), msg[crop]()].join(' ')
       );
       this.setInputsInline(true);
-      this.appendStatementInput('DO').appendTitle(msg.doCode());
-      this.appendStatementInput('ELSE').appendTitle(msg.elseCode());
+      this.appendStatementInput('DO').appendField(msg.doCode());
+      this.appendStatementInput('ELSE').appendField(msg.elseCode());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -68,11 +68,11 @@ function addUntilAtSpecificCropBlock(blockly, generator, crop) {
     helpUrl: '',
     init: function() {
       this.setHSV(322, 0.9, 0.95);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         [msg.repeatUntil(), msg.at(), msg[crop]()].join(' ')
       );
       this.setInputsInline(true);
-      this.appendStatementInput('DO').appendTitle(msg.doCode());
+      this.appendStatementInput('DO').appendField(msg.doCode());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -92,11 +92,11 @@ function addIfSpecificCropHasBlock(blockly, generator, crop) {
     helpUrl: '',
     init: function() {
       this.setHSV(196, 1.0, 0.79);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         [msg.ifCode(), msg[`has${crop}`]()].join(' ')
       );
       this.setInputsInline(true);
-      this.appendStatementInput('DO').appendTitle(msg.doCode());
+      this.appendStatementInput('DO').appendField(msg.doCode());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -117,12 +117,12 @@ function addIfSpecificCropHasElseBlock(blockly, generator, crop) {
     helpUrl: '',
     init: function() {
       this.setHSV(196, 1.0, 0.79);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         [msg.ifCode(), msg[`has${crop}`]()].join(' ')
       );
       this.setInputsInline(true);
-      this.appendStatementInput('DO').appendTitle(msg.doCode());
-      this.appendStatementInput('ELSE').appendTitle(msg.elseCode());
+      this.appendStatementInput('DO').appendField(msg.doCode());
+      this.appendStatementInput('ELSE').appendField(msg.elseCode());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -144,11 +144,11 @@ function addWhileSpecificCropHasBlock(blockly, generator, crop) {
     helpUrl: '',
     init: function() {
       this.setHSV(322, 0.9, 0.95);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         [msg.whileMsg(), msg[`has${crop}`]()].join(' ')
       );
       this.setInputsInline(true);
-      this.appendStatementInput('DO').appendTitle(msg.doCode());
+      this.appendStatementInput('DO').appendField(msg.doCode());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -170,11 +170,11 @@ function addUntilSpecificCropHasBlock(blockly, generator, crop) {
     helpUrl: '',
     init: function() {
       this.setHSV(322, 0.9, 0.95);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         [msg.repeatUntil(), msg[`has${crop}`]()].join(' ')
       );
       this.setInputsInline(true);
-      this.appendStatementInput('DO').appendTitle(msg.doCode());
+      this.appendStatementInput('DO').appendField(msg.doCode());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -232,13 +232,13 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(196, 1.0, 0.79);
-      this.appendDummyInput().appendTitle([msg.ifCode(), msg.at()].join(' '));
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField([msg.ifCode(), msg.at()].join(' '));
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(AT_OPTIONS),
         'LOC'
       );
       this.setInputsInline(true);
-      this.appendStatementInput('DO').appendTitle(msg.doCode());
+      this.appendStatementInput('DO').appendField(msg.doCode());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -255,14 +255,14 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(196, 1.0, 0.79);
-      this.appendDummyInput().appendTitle([msg.ifCode(), msg.at()].join(' '));
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField([msg.ifCode(), msg.at()].join(' '));
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(AT_OPTIONS),
         'LOC'
       );
       this.setInputsInline(true);
-      this.appendStatementInput('DO').appendTitle(msg.doCode());
-      this.appendStatementInput('ELSE').appendTitle(msg.elseCode());
+      this.appendStatementInput('DO').appendField(msg.doCode());
+      this.appendStatementInput('ELSE').appendField(msg.elseCode());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -280,15 +280,15 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(322, 0.9, 0.95);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         [msg.repeatUntil(), msg.at()].join(' ')
       );
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(AT_OPTIONS),
         'LOC'
       );
       this.setInputsInline(true);
-      this.appendStatementInput('DO').appendTitle(msg.doCode());
+      this.appendStatementInput('DO').appendField(msg.doCode());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -306,13 +306,13 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(196, 1.0, 0.79);
-      this.appendDummyInput().appendTitle(msg.ifCode());
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(msg.ifCode());
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(HAS_OPTIONS),
         'LOC'
       );
       this.setInputsInline(true);
-      this.appendStatementInput('DO').appendTitle(msg.doCode());
+      this.appendStatementInput('DO').appendField(msg.doCode());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -331,14 +331,14 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(196, 1.0, 0.79);
-      this.appendDummyInput().appendTitle(msg.ifCode());
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(msg.ifCode());
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(HAS_OPTIONS),
         'LOC'
       );
       this.setInputsInline(true);
-      this.appendStatementInput('DO').appendTitle(msg.doCode());
-      this.appendStatementInput('ELSE').appendTitle(msg.elseCode());
+      this.appendStatementInput('DO').appendField(msg.doCode());
+      this.appendStatementInput('ELSE').appendField(msg.elseCode());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -358,13 +358,13 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(322, 0.9, 0.95);
-      this.appendDummyInput().appendTitle(msg.whileMsg());
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(msg.whileMsg());
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(HAS_OPTIONS),
         'LOC'
       );
       this.setInputsInline(true);
-      this.appendStatementInput('DO').appendTitle(msg.doCode());
+      this.appendStatementInput('DO').appendField(msg.doCode());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -384,13 +384,13 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(322, 0.9, 0.95);
-      this.appendDummyInput().appendTitle(msg.repeatUntil());
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(msg.repeatUntil());
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(HAS_OPTIONS),
         'LOC'
       );
       this.setInputsInline(true);
-      this.appendStatementInput('DO').appendTitle(msg.doCode());
+      this.appendStatementInput('DO').appendField(msg.doCode());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }

--- a/apps/src/maze/planterBlocks.js
+++ b/apps/src/maze/planterBlocks.js
@@ -21,11 +21,11 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(196, 1.0, 0.79);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         [msg.ifCode(), msg.at(), msg.soil()].join(' ')
       );
       this.setInputsInline(true);
-      this.appendStatementInput('DO').appendTitle(msg.doCode());
+      this.appendStatementInput('DO').appendField(msg.doCode());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }
@@ -42,11 +42,11 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(196, 1.0, 0.79);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         [msg.ifCode(), msg.at(), msg.sprout()].join(' ')
       );
       this.setInputsInline(true);
-      this.appendStatementInput('DO').appendTitle(msg.doCode());
+      this.appendStatementInput('DO').appendField(msg.doCode());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
     }

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -75,7 +75,7 @@ const limitedColours = [
 const customInputTypes = {
   locationPicker: {
     addInput(blockly, block, inputConfig, currentInputRow) {
-      currentInputRow.appendTitle(
+      currentInputRow.appendField(
         `${inputConfig.label}(0, 0)`,
         `${inputConfig.name}_LABEL`
       );
@@ -107,7 +107,7 @@ const customInputTypes = {
           }
         }
       );
-      currentInputRow.appendTitle(button, inputConfig.name);
+      currentInputRow.appendField(button, inputConfig.name);
     },
     generateCode(block, arg) {
       return `(${block.getTitleValue(arg.name)})`;
@@ -138,9 +138,9 @@ const customInputTypes = {
       };
 
       currentInputRow
-        .appendTitle(inputConfig.label)
-        .appendTitle(Blockly.Msg.VARIABLES_GET_TITLE)
-        .appendTitle(
+        .appendField(inputConfig.label)
+        .appendField(Blockly.Msg.VARIABLES_GET_TITLE)
+        .appendField(
           new Blockly.FieldVariable(
             Blockly.Msg.VARIABLES_SET_ITEM,
             null,
@@ -150,7 +150,7 @@ const customInputTypes = {
           ),
           inputConfig.name
         )
-        .appendTitle(Blockly.Msg.VARIABLES_GET_TAIL);
+        .appendField(Blockly.Msg.VARIABLES_GET_TAIL);
     },
     generateCode(block, arg) {
       return Blockly.JavaScript.translateVarName(block.getTitleValue(arg.name));
@@ -161,7 +161,7 @@ const customInputTypes = {
       var onSelect = function(soundValue) {
         block.setTitleValue(soundValue, inputConfig.name);
       };
-      currentInputRow.appendTitle(inputConfig.label).appendTitle(
+      currentInputRow.appendField(inputConfig.label).appendField(
         new Blockly.FieldDropdown([['Choose', 'Choose']], () => {
           dashboard.assets.showAssetManager(onSelect, 'audio', null, {
             libraryOnly: true
@@ -193,8 +193,8 @@ const customInputTypes = {
         ];
       }
       currentInputRow
-        .appendTitle(inputConfig.label)
-        .appendTitle(
+        .appendField(inputConfig.label)
+        .appendField(
           new Blockly.FieldImageDropdown(sprites, 32, 32, buttons),
           inputConfig.name
         );
@@ -220,8 +220,8 @@ const customInputTypes = {
         ];
       }
       currentInputRow
-        .appendTitle(inputConfig.label)
-        .appendTitle(
+        .appendField(inputConfig.label)
+        .appendField(
           new Blockly.FieldImageDropdown(backgroundList, 40, 40, buttons),
           inputConfig.name
         );
@@ -262,8 +262,8 @@ const customInputTypes = {
       }
       block.thumbnailSize = 32;
       currentInputRow
-        .appendTitle(block.longString)
-        .appendTitle(
+        .appendField(block.longString)
+        .appendField(
           new Blockly.FieldImage('', 1, block.thumbnailSize),
           inputConfig.name
         );
@@ -317,8 +317,8 @@ const customInputTypes = {
       };
 
       currentInputRow
-        .appendTitle(inputConfig.label)
-        .appendTitle(
+        .appendField(inputConfig.label)
+        .appendField(
           new Blockly.FieldVariable(
             null,
             null,
@@ -342,8 +342,8 @@ const customInputTypes = {
         columns: 3
       };
       currentInputRow
-        .appendTitle(inputConfig.label)
-        .appendTitle(
+        .appendField(inputConfig.label)
+        .appendField(
           new Blockly.FieldColour('#ff0000', undefined, options),
           'VAL'
         );
@@ -408,8 +408,8 @@ export default {
         fieldLabel.EDITABLE = true;
         this.setHelpUrl(Blockly.Msg.VARIABLES_GET_HELPURL);
         this.appendDummyInput()
-          .appendTitle(Blockly.Msg.VARIABLES_GET_TITLE)
-          .appendTitle(
+          .appendField(Blockly.Msg.VARIABLES_GET_TITLE)
+          .appendField(
             Blockly.disableVariableEditing
               ? fieldLabel
               : new Blockly.FieldVariable(
@@ -421,7 +421,7 @@ export default {
                 ),
             'VAR'
           )
-          .appendTitle(Blockly.Msg.VARIABLES_GET_TAIL);
+          .appendField(Blockly.Msg.VARIABLES_GET_TAIL);
         this.setStrictOutput(true, Blockly.BlockValueType.SPRITE);
         this.setTooltip(Blockly.Msg.VARIABLES_GET_TOOLTIP);
       },
@@ -457,9 +457,9 @@ export default {
         fieldLabel.EDITABLE = true;
         this.setHelpUrl(Blockly.Msg.VARIABLES_GET_HELPURL);
         this.appendDummyInput()
-          .appendTitle(Blockly.Msg.VARIABLES_GET_TITLE)
-          .appendTitle(fieldLabel, 'VAR')
-          .appendTitle(Blockly.Msg.VARIABLES_GET_TAIL);
+          .appendField(Blockly.Msg.VARIABLES_GET_TITLE)
+          .appendField(fieldLabel, 'VAR')
+          .appendField(Blockly.Msg.VARIABLES_GET_TAIL);
         this.setStrictOutput(true, Blockly.BlockValueType.SPRITE);
         this.setTooltip(Blockly.Msg.VARIABLES_GET_TOOLTIP);
       },
@@ -481,8 +481,8 @@ export default {
         this.setHelpUrl(Blockly.Msg.VARIABLES_GET_HELPURL);
         this.setHSV(136, 0.84, 0.8);
         const mainTitle = this.appendDummyInput()
-          .appendTitle(fieldLabel, 'VAR')
-          .appendTitle(Blockly.Msg.VARIABLES_GET_TAIL);
+          .appendField(fieldLabel, 'VAR')
+          .appendField(Blockly.Msg.VARIABLES_GET_TAIL);
 
         let allowBehaviorEditing = Blockly.useModalFunctionEditor;
 
@@ -506,7 +506,7 @@ export default {
             this,
             this.openEditor
           );
-          mainTitle.appendTitle(editLabel);
+          mainTitle.appendField(editLabel);
         }
 
         this.setStrictOutput(true, Blockly.BlockValueType.BEHAVIOR);

--- a/apps/src/sharedFunctionalBlocks.js
+++ b/apps/src/sharedFunctionalBlocks.js
@@ -298,7 +298,7 @@ function installBoolean(blockly, generator, gensym) {
       );
       var values = blockly.Blocks.functional_boolean.VALUES;
       this.appendDummyInput()
-        .appendTitle(new blockly.FieldDropdown(values), 'VAL')
+        .appendField(new blockly.FieldDropdown(values), 'VAL')
         .setAlign(Blockly.ALIGN_CENTRE);
       this.setFunctionalOutput(true, blockly.BlockValueType.BOOLEAN);
     }
@@ -327,7 +327,7 @@ function installMathNumber(blockly, generator, gensym) {
         blockly.FunctionalTypeColors[blockly.BlockValueType.NUMBER]
       );
       this.appendDummyInput()
-        .appendTitle(
+        .appendField(
           new Blockly.FieldTextInput(
             '0',
             Blockly.FieldTextInput.numberValidator
@@ -355,7 +355,7 @@ function installMathNumber(blockly, generator, gensym) {
         blockly.FunctionalTypeColors[blockly.BlockValueType.NUMBER]
       );
       this.appendDummyInput()
-        .appendTitle(new Blockly.FieldDropdown(), 'NUM')
+        .appendField(new Blockly.FieldDropdown(), 'NUM')
         .setAlign(Blockly.ALIGN_CENTRE);
       this.setFunctionalOutput(true, blockly.BlockValueType.NUMBER);
     }
@@ -376,9 +376,9 @@ function installString(blockly, generator) {
         blockly.FunctionalTypeColors[blockly.BlockValueType.STRING]
       );
       this.appendDummyInput()
-        .appendTitle(new Blockly.FieldLabel('"'))
-        .appendTitle(new Blockly.FieldTextInput(''), 'VAL')
-        .appendTitle(new Blockly.FieldLabel('"'))
+        .appendField(new Blockly.FieldLabel('"'))
+        .appendField(new Blockly.FieldTextInput(''), 'VAL')
+        .appendField(new Blockly.FieldLabel('"'))
         .setAlign(Blockly.ALIGN_CENTRE);
       this.setFunctionalOutput(true, blockly.BlockValueType.STRING);
     }
@@ -501,10 +501,10 @@ function installCondForType(blockly, generator, type) {
       );
 
       this.appendDummyInput()
-        .appendTitle(new Blockly.FieldLabel('cond', options))
+        .appendField(new Blockly.FieldLabel('cond', options))
         .setAlign(Blockly.ALIGN_CENTRE);
 
-      this.appendDummyInput('ELSE').appendTitle(
+      this.appendDummyInput('ELSE').appendField(
         new Blockly.FieldLabel('else', options)
       );
       var defaultInput = this.appendFunctionalInput('DEFAULT').setInline(true);
@@ -514,7 +514,7 @@ function installCondForType(blockly, generator, type) {
       );
 
       this.appendDummyInput('PLUS')
-        .appendTitle(plusField)
+        .appendField(plusField)
         .setInline(true);
 
       this.setFunctionalOutput(
@@ -556,7 +556,7 @@ function installCondForType(blockly, generator, type) {
           this,
           _.bind(this.removeConditionalRow, this, id)
         );
-        minusInput.appendTitle(minusField);
+        minusInput.appendField(minusField);
       }
 
       this.moveInputBefore('MINUS' + id, 'ELSE');

--- a/apps/src/studio/blocks.js
+++ b/apps/src/studio/blocks.js
@@ -198,20 +198,20 @@ exports.install = function(blockly, blockInstallOptions) {
         if (blockInstallOptions.isK1) {
           block
             .appendDummyInput()
-            .appendTitle(startingSpriteImageDropdown(), 'SPRITE');
+            .appendField(startingSpriteImageDropdown(), 'SPRITE');
         } else {
           block
             .appendDummyInput()
-            .appendTitle(spriteNumberTextDropdown(msg.ifSpriteN), 'SPRITE');
+            .appendField(spriteNumberTextDropdown(msg.ifSpriteN), 'SPRITE');
         }
       } else {
-        block.appendDummyInput().appendTitle(msg.ifSprite());
+        block.appendDummyInput().appendField(msg.ifSprite());
       }
     } else {
       block
         .appendValueInput('SPRITE')
         .setCheck(blockly.BlockValueType.NUMBER)
-        .appendTitle(msg.ifSpriteN({spriteIndex: ''}));
+        .appendField(msg.ifSpriteN({spriteIndex: ''}));
     }
   }
 
@@ -273,10 +273,10 @@ exports.install = function(blockly, blockInstallOptions) {
       this.setHSV(140, 1.0, 0.74);
       if (isK1) {
         this.appendDummyInput()
-          .appendTitle(commonMsg.when())
-          .appendTitle(new Blockly.FieldImage(skin.whenLeft));
+          .appendField(commonMsg.when())
+          .appendField(new Blockly.FieldImage(skin.whenLeft));
       } else {
-        this.appendDummyInput().appendTitle(msg.whenLeft());
+        this.appendDummyInput().appendField(msg.whenLeft());
       }
       this.setPreviousStatement(false);
       this.setNextStatement(true);
@@ -293,10 +293,10 @@ exports.install = function(blockly, blockInstallOptions) {
       this.setHSV(140, 1.0, 0.74);
       if (isK1) {
         this.appendDummyInput()
-          .appendTitle(commonMsg.when())
-          .appendTitle(new Blockly.FieldImage(skin.whenRight));
+          .appendField(commonMsg.when())
+          .appendField(new Blockly.FieldImage(skin.whenRight));
       } else {
-        this.appendDummyInput().appendTitle(msg.whenRight());
+        this.appendDummyInput().appendField(msg.whenRight());
       }
       this.setPreviousStatement(false);
       this.setNextStatement(true);
@@ -313,10 +313,10 @@ exports.install = function(blockly, blockInstallOptions) {
       this.setHSV(140, 1.0, 0.74);
       if (isK1) {
         this.appendDummyInput()
-          .appendTitle(commonMsg.when())
-          .appendTitle(new Blockly.FieldImage(skin.whenUp));
+          .appendField(commonMsg.when())
+          .appendField(new Blockly.FieldImage(skin.whenUp));
       } else {
-        this.appendDummyInput().appendTitle(msg.whenUp());
+        this.appendDummyInput().appendField(msg.whenUp());
       }
       this.setPreviousStatement(false);
       this.setNextStatement(true);
@@ -333,10 +333,10 @@ exports.install = function(blockly, blockInstallOptions) {
       this.setHSV(140, 1.0, 0.74);
       if (isK1) {
         this.appendDummyInput()
-          .appendTitle(commonMsg.when())
-          .appendTitle(new Blockly.FieldImage(skin.whenDown));
+          .appendField(commonMsg.when())
+          .appendField(new Blockly.FieldImage(skin.whenDown));
       } else {
-        this.appendDummyInput().appendTitle(msg.whenDown());
+        this.appendDummyInput().appendField(msg.whenDown());
       }
       this.setPreviousStatement(false);
       this.setNextStatement(true);
@@ -351,14 +351,14 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(140, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(commonMsg.when());
+      this.appendDummyInput().appendField(commonMsg.when());
       if (isK1) {
-        this.appendDummyInput().appendTitle(
+        this.appendDummyInput().appendField(
           new blockly.FieldImageDropdown(this.K1_VALUES),
           'VALUE'
         );
       } else {
-        this.appendDummyInput().appendTitle(
+        this.appendDummyInput().appendField(
           new blockly.FieldDropdown(this.VALUES),
           'VALUE'
         );
@@ -392,13 +392,13 @@ exports.install = function(blockly, blockInstallOptions) {
     init: function() {
       this.setHSV(322, 0.9, 0.95);
       if (isK1) {
-        this.appendDummyInput().appendTitle(commonMsg.repeat());
-        this.appendStatementInput('DO').appendTitle(
+        this.appendDummyInput().appendField(commonMsg.repeat());
+        this.appendStatementInput('DO').appendField(
           new blockly.FieldImage(skin.repeatImage)
         );
       } else {
-        this.appendDummyInput().appendTitle(msg.repeatForever());
-        this.appendStatementInput('DO').appendTitle(msg.repeatDo());
+        this.appendDummyInput().appendField(msg.repeatForever());
+        this.appendStatementInput('DO').appendField(msg.repeatDo());
       }
       this.setPreviousStatement(false);
       this.setNextStatement(false);
@@ -419,11 +419,11 @@ exports.install = function(blockly, blockInstallOptions) {
       if (spriteCount > 1) {
         if (isK1) {
           this.appendDummyInput()
-            .appendTitle(commonMsg.when())
-            .appendTitle(new blockly.FieldImage(skin.clickIcon))
-            .appendTitle(startingSpriteImageDropdown(), 'SPRITE');
+            .appendField(commonMsg.when())
+            .appendField(new blockly.FieldImage(skin.clickIcon))
+            .appendField(startingSpriteImageDropdown(), 'SPRITE');
         } else {
-          this.appendDummyInput().appendTitle(
+          this.appendDummyInput().appendField(
             spriteNumberTextDropdown(msg.whenSpriteClickedN),
             'SPRITE'
           );
@@ -431,9 +431,9 @@ exports.install = function(blockly, blockInstallOptions) {
       } else {
         if (isK1) {
           this.appendDummyInput()
-            .appendTitle(commonMsg.when())
-            .appendTitle(new blockly.FieldImage(skin.clickIcon))
-            .appendTitle(
+            .appendField(commonMsg.when())
+            .appendField(new blockly.FieldImage(skin.clickIcon))
+            .appendField(
               new blockly.FieldImage(
                 skin[startAvatars[0]].dropdownThumbnail,
                 skin.dropdownThumbnailWidth,
@@ -441,7 +441,7 @@ exports.install = function(blockly, blockInstallOptions) {
               )
             );
         } else {
-          this.appendDummyInput().appendTitle(msg.whenSpriteClicked());
+          this.appendDummyInput().appendField(msg.whenSpriteClicked());
         }
       }
       this.setPreviousStatement(false);
@@ -458,7 +458,7 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(140, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(msg.whenTouchCharacter());
+      this.appendDummyInput().appendField(msg.whenTouchCharacter());
       this.setPreviousStatement(false);
       this.setNextStatement(true);
       this.setTooltip(msg.whenTouchCharacterTooltip());
@@ -472,7 +472,7 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(140, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(msg.whenTouchObstacle());
+      this.appendDummyInput().appendField(msg.whenTouchObstacle());
       this.setPreviousStatement(false);
       this.setNextStatement(true);
       this.setTooltip(msg.whenTouchObstacleTooltip());
@@ -486,7 +486,7 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(140, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(msg.whenTouchGoal());
+      this.appendDummyInput().appendField(msg.whenTouchGoal());
       this.setPreviousStatement(false);
       this.setNextStatement(true);
       this.setTooltip(msg.whenTouchGoalTooltip());
@@ -500,7 +500,7 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(140, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(this.VALUES),
         'VALUE'
       );
@@ -529,7 +529,7 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(140, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(msg.whenGetAllCharacters());
+      this.appendDummyInput().appendField(msg.whenGetAllCharacters());
       this.setPreviousStatement(false);
       this.setInputsInline(true);
       this.setNextStatement(true);
@@ -544,7 +544,7 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(140, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(this.VALUES),
         'VALUE'
       );
@@ -581,12 +581,12 @@ exports.install = function(blockly, blockInstallOptions) {
         dropdown1 = startingSpriteImageDropdown();
         dropdown2 = startingSpriteImageDropdown();
         this.appendDummyInput()
-          .appendTitle(commonMsg.when())
-          .appendTitle(new blockly.FieldImage(skin.collide))
-          .appendTitle(dropdown1, 'SPRITE1');
+          .appendField(commonMsg.when())
+          .appendField(new blockly.FieldImage(skin.collide))
+          .appendField(dropdown1, 'SPRITE1');
         this.appendDummyInput()
-          .appendTitle(commonMsg.and())
-          .appendTitle(dropdown2, 'SPRITE2');
+          .appendField(commonMsg.and())
+          .appendField(dropdown2, 'SPRITE2');
       } else {
         dropdown1 = spriteNumberTextDropdown(msg.whenSpriteCollidedN);
         var dropdownArray2 = [this.GROUPINGS[0]];
@@ -601,8 +601,8 @@ exports.install = function(blockly, blockInstallOptions) {
         dropdownArray2 = dropdownArray2.concat(this.GROUPINGS.slice(3, 6));
         dropdownArray2 = dropdownArray2.concat(this.EDGES);
         dropdown2 = new blockly.FieldDropdown(dropdownArray2);
-        this.appendDummyInput().appendTitle(dropdown1, 'SPRITE1');
-        this.appendDummyInput().appendTitle(dropdown2, 'SPRITE2');
+        this.appendDummyInput().appendField(dropdown1, 'SPRITE1');
+        this.appendDummyInput().appendField(dropdown2, 'SPRITE2');
       }
       if (spriteCount > 1) {
         // default second dropdown to actor 2
@@ -641,7 +641,7 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown([
           [msg.allowActorsToLeaveThePlayspace(), 'true'],
           [msg.dontAllowActorsToLeaveThePlayspace(), 'false']
@@ -667,12 +667,12 @@ exports.install = function(blockly, blockInstallOptions) {
     init: function() {
       this.setHSV(184, 1.0, 0.74);
       if (spriteCount > 1) {
-        this.appendDummyInput().appendTitle(
+        this.appendDummyInput().appendField(
           spriteNumberTextDropdown(msg.stopSpriteN),
           'SPRITE'
         );
       } else {
-        this.appendDummyInput().appendTitle(msg.stopSprite());
+        this.appendDummyInput().appendField(msg.stopSprite());
       }
       this.setPreviousStatement(true);
       this.setInputsInline(true);
@@ -688,7 +688,7 @@ exports.install = function(blockly, blockInstallOptions) {
       this.setHSV(184, 1.0, 0.74);
       this.appendValueInput('SPRITE')
         .setCheck(blockly.BlockValueType.NUMBER)
-        .appendTitle(msg.stopSpriteN({spriteIndex: ''}));
+        .appendField(msg.stopSpriteN({spriteIndex: ''}));
       this.setPreviousStatement(true);
       this.setInputsInline(true);
       this.setNextStatement(true);
@@ -718,8 +718,8 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(msg.addCharacter());
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(msg.addCharacter());
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(skin.itemChoices),
         'VALUE'
       );
@@ -750,11 +750,11 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(skin.activityChoices),
         'TYPE'
       );
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(skin.itemChoices),
         'VALUE'
       );
@@ -799,15 +799,15 @@ exports.install = function(blockly, blockInstallOptions) {
     init: function() {
       this.setHSV(184, 1.0, 0.74);
 
-      this.appendDummyInput().appendTitle(msg.setItemSpeedSet());
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(msg.setItemSpeedSet());
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(skin.itemChoices),
         'CLASS'
       );
 
       var dropdown = new blockly.FieldDropdown(this.VALUES);
       dropdown.setValue(this.VALUES[1][1]); // default to slow
-      this.appendDummyInput().appendTitle(dropdown, 'VALUE');
+      this.appendDummyInput().appendField(dropdown, 'VALUE');
 
       this.setInputsInline(true);
       this.setPreviousStatement(true);
@@ -836,13 +836,13 @@ exports.install = function(blockly, blockInstallOptions) {
     function(actorSelectDropdown) {
       this.setHSV(184, 1.0, 0.74);
       appendActorSelect(this, actorSelectDropdown);
-      this.appendDummyInput().appendTitle(msg.throwSprite());
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(msg.throwSprite());
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(skin.projectileChoices),
         'VALUE'
       );
-      this.appendDummyInput().appendTitle('\t');
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField('\t');
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(blockly.Blocks.studio_throw.DIR),
         'DIR'
       );
@@ -899,12 +899,12 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(this.VALUES),
         'VALUE'
       );
-      this.appendDummyInput().appendTitle('\t');
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField('\t');
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(this.ACTIONS),
         'ACTION'
       );
@@ -950,10 +950,10 @@ exports.install = function(blockly, blockInstallOptions) {
         this.interpolateMsg(
           msg.setSpritePosition(),
           () => {
-            this.appendDummyInput().appendTitle(spriteIndexDropdown, 'SPRITE');
+            this.appendDummyInput().appendField(spriteIndexDropdown, 'SPRITE');
           },
           () => {
-            this.appendDummyInput().appendTitle(dropdown, 'VALUE');
+            this.appendDummyInput().appendField(dropdown, 'VALUE');
           },
           blockly.ALIGN_RIGHT
         );
@@ -961,7 +961,7 @@ exports.install = function(blockly, blockInstallOptions) {
         this.interpolateMsg(
           msg.setPosition(),
           () => {
-            this.appendDummyInput().appendTitle(dropdown, 'VALUE');
+            this.appendDummyInput().appendField(dropdown, 'VALUE');
           },
           blockly.ALIGN_RIGHT
         );
@@ -998,7 +998,7 @@ exports.install = function(blockly, blockInstallOptions) {
           );
         },
         () => {
-          this.appendDummyInput().appendTitle(dropdown, 'VALUE');
+          this.appendDummyInput().appendField(dropdown, 'VALUE');
         },
         blockly.ALIGN_RIGHT
       );
@@ -1025,15 +1025,15 @@ exports.install = function(blockly, blockInstallOptions) {
       if (spriteCount > 1) {
         this.appendValueInput('SPRITE')
           .setCheck(blockly.BlockValueType.NUMBER)
-          .appendTitle(msg.moveSpriteN({spriteIndex: ''}));
+          .appendField(msg.moveSpriteN({spriteIndex: ''}));
       } else {
-        this.appendDummyInput().appendTitle(msg.setSprite());
+        this.appendDummyInput().appendField(msg.setSprite());
       }
-      this.appendDummyInput().appendTitle(msg.to());
+      this.appendDummyInput().appendField(msg.to());
       this.appendValueInput('XPOS').setCheck(blockly.BlockValueType.NUMBER);
-      this.appendDummyInput().appendTitle(commonMsg.positionAbsoluteOver());
+      this.appendDummyInput().appendField(commonMsg.positionAbsoluteOver());
       this.appendValueInput('YPOS').setCheck(blockly.BlockValueType.NUMBER);
-      this.appendDummyInput().appendTitle(commonMsg.positionAbsoluteDown());
+      this.appendDummyInput().appendField(commonMsg.positionAbsoluteDown());
       this.setPreviousStatement(true);
       this.setInputsInline(true);
       this.setNextStatement(true);
@@ -1077,7 +1077,7 @@ exports.install = function(blockly, blockInstallOptions) {
       this.interpolateMsg(
         msg.addGoalPosition(),
         () => {
-          this.appendDummyInput().appendTitle(dropdown, 'VALUE');
+          this.appendDummyInput().appendField(dropdown, 'VALUE');
         },
         blockly.ALIGN_RIGHT
       );
@@ -1107,12 +1107,12 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(msg.addGoal());
-      this.appendDummyInput().appendTitle(msg.to());
+      this.appendDummyInput().appendField(msg.addGoal());
+      this.appendDummyInput().appendField(msg.to());
       this.appendValueInput('XPOS').setCheck(blockly.BlockValueType.NUMBER);
-      this.appendDummyInput().appendTitle(commonMsg.positionAbsoluteOver());
+      this.appendDummyInput().appendField(commonMsg.positionAbsoluteOver());
       this.appendValueInput('YPOS').setCheck(blockly.BlockValueType.NUMBER);
-      this.appendDummyInput().appendTitle(commonMsg.positionAbsoluteDown());
+      this.appendDummyInput().appendField(commonMsg.positionAbsoluteDown());
       this.setPreviousStatement(true);
       this.setInputsInline(true);
       this.setNextStatement(true);
@@ -1232,19 +1232,19 @@ exports.install = function(blockly, blockInstallOptions) {
         init: function() {
           this.setHSV(184, 1.0, 0.74);
           this.appendDummyInput()
-            .appendTitle(msg.moveSprite()) // move
-            .appendTitle(new blockly.FieldImage(directionConfig.image)) // arrow
-            .appendTitle(directionConfig.letter); // NESW
+            .appendField(msg.moveSprite()) // move
+            .appendField(new blockly.FieldImage(directionConfig.image)) // arrow
+            .appendField(directionConfig.letter); // NESW
 
           if (spriteCount > 1) {
-            this.appendDummyInput().appendTitle(
+            this.appendDummyInput().appendField(
               startingSpriteImageDropdown(),
               'SPRITE'
             );
           }
 
           if (hasLengthInput) {
-            this.appendDummyInput().appendTitle(
+            this.appendDummyInput().appendField(
               new blockly.FieldImageDropdown(SimpleMove.DISTANCES),
               'DISTANCE'
             );
@@ -1300,26 +1300,26 @@ exports.install = function(blockly, blockInstallOptions) {
       if (spriteCount > 1) {
         if (isK1) {
           this.appendDummyInput()
-            .appendTitle(msg.moveSprite())
-            .appendTitle(startingSpriteImageDropdown(), 'SPRITE');
+            .appendField(msg.moveSprite())
+            .appendField(startingSpriteImageDropdown(), 'SPRITE');
         } else {
-          this.appendDummyInput().appendTitle(
+          this.appendDummyInput().appendField(
             spriteNumberTextDropdown(msg.moveSpriteN),
             'SPRITE'
           );
         }
-        this.appendDummyInput().appendTitle('\t');
+        this.appendDummyInput().appendField('\t');
       } else {
-        this.appendDummyInput().appendTitle(msg.moveSprite());
+        this.appendDummyInput().appendField(msg.moveSprite());
       }
 
       if (isK1) {
-        this.appendDummyInput().appendTitle(
+        this.appendDummyInput().appendField(
           new blockly.FieldImageDropdown(this.K1_DIR),
           'DIR'
         );
       } else {
-        this.appendDummyInput().appendTitle(
+        this.appendDummyInput().appendField(
           new blockly.FieldDropdown(this.DIR),
           'DIR'
         );
@@ -1367,49 +1367,49 @@ exports.install = function(blockly, blockInstallOptions) {
       if (options.sprite) {
         this.appendValueInput('SPRITE')
           .setCheck(blockly.BlockValueType.NUMBER)
-          .appendTitle(msg.moveSpriteN({spriteIndex: ''}));
+          .appendField(msg.moveSpriteN({spriteIndex: ''}));
       } else if (spriteCount > 1) {
         if (isK1) {
           this.appendDummyInput()
-            .appendTitle(msg.moveSprite())
-            .appendTitle(startingSpriteImageDropdown(), 'SPRITE');
+            .appendField(msg.moveSprite())
+            .appendField(startingSpriteImageDropdown(), 'SPRITE');
         } else {
-          this.appendDummyInput().appendTitle(
+          this.appendDummyInput().appendField(
             spriteNumberTextDropdown(msg.moveSpriteN),
             'SPRITE'
           );
         }
-        this.appendDummyInput().appendTitle('\t');
+        this.appendDummyInput().appendField('\t');
       } else {
-        this.appendDummyInput().appendTitle(msg.moveSprite());
+        this.appendDummyInput().appendField(msg.moveSprite());
       }
 
       if (isK1) {
-        this.appendDummyInput().appendTitle(
+        this.appendDummyInput().appendField(
           new blockly.FieldImageDropdown(this.K1_DIR),
           'DIR'
         );
       } else {
-        this.appendDummyInput().appendTitle(
+        this.appendDummyInput().appendField(
           new blockly.FieldDropdown(this.DIR),
           'DIR'
         );
       }
 
-      this.appendDummyInput().appendTitle('\t');
+      this.appendDummyInput().appendField('\t');
       if (options.params) {
         this.appendValueInput('DISTANCE').setCheck(
           blockly.BlockValueType.NUMBER
         );
-        this.appendDummyInput().appendTitle(msg.moveDistancePixels());
+        this.appendDummyInput().appendField(msg.moveDistancePixels());
       } else {
         if (isK1) {
-          this.appendDummyInput().appendTitle(
+          this.appendDummyInput().appendField(
             new blockly.FieldImageDropdown(this.K1_DISTANCE),
             'DISTANCE'
           );
         } else {
-          this.appendDummyInput().appendTitle(
+          this.appendDummyInput().appendField(
             new blockly.FieldDropdown(this.DISTANCE),
             'DISTANCE'
           );
@@ -1559,7 +1559,7 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: 'http://code.google.com/p/blockly/wiki/Move',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(this.DIRECTIONS),
         'DIR'
       );
@@ -1585,7 +1585,7 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: 'http://code.google.com/p/blockly/wiki/Turn',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(this.DIRECTIONS),
         'DIR'
       );
@@ -1634,14 +1634,14 @@ exports.install = function(blockly, blockInstallOptions) {
       this.setHSV(184, 1.0, 0.74);
       if (isK1) {
         this.appendDummyInput()
-          .appendTitle(commonMsg.play())
-          .appendTitle(new blockly.FieldImage(skin.soundIcon))
-          .appendTitle(
+          .appendField(commonMsg.play())
+          .appendField(new blockly.FieldImage(skin.soundIcon))
+          .appendField(
             new blockly.FieldDropdown(this.soundChoices(), onSoundSelected),
             'SOUND'
           );
       } else {
-        this.appendDummyInput().appendTitle(
+        this.appendDummyInput().appendField(
           new blockly.FieldDropdown(this.soundChoices(), onSoundSelected),
           'SOUND'
         );
@@ -1683,10 +1683,10 @@ exports.install = function(blockly, blockInstallOptions) {
       this.setHSV(184, 1.0, 0.74);
       if (isK1) {
         this.appendDummyInput()
-          .appendTitle(commonMsg.score())
-          .appendTitle(new blockly.FieldImage(skin.scoreCard));
+          .appendField(commonMsg.score())
+          .appendField(new blockly.FieldImage(skin.scoreCard));
       } else {
-        this.appendDummyInput().appendTitle(
+        this.appendDummyInput().appendField(
           new blockly.FieldDropdown(this.VALUES),
           'VALUE'
         );
@@ -1720,7 +1720,7 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(this.VALUES),
         'VALUE'
       );
@@ -1754,7 +1754,7 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(this.VALUES),
         'VALUE'
       );
@@ -1787,7 +1787,7 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(312, 0.32, 0.62);
-      this.appendValueInput('VALUE').appendTitle(msg.setScore());
+      this.appendValueInput('VALUE').appendField(msg.setScore());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
       this.setTooltip(msg.setScoreTooltip());
@@ -1808,7 +1808,7 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(312, 0.32, 0.62);
-      this.appendDummyInput().appendTitle(msg.score());
+      this.appendDummyInput().appendField(msg.score());
       this.setOutput(true, Blockly.BlockValueType.NUMBER);
       this.setTooltip(msg.getScoreTooltip());
     }
@@ -1825,8 +1825,8 @@ exports.install = function(blockly, blockInstallOptions) {
       this.setHSV(184, 1.0, 0.74);
       this.appendValueInput('NUM')
         .setCheck(blockly.BlockValueType.NUMBER)
-        .appendTitle(msg.add());
-      this.appendDummyInput().appendTitle(msg.points());
+        .appendField(msg.add());
+      this.appendDummyInput().appendField(msg.points());
 
       this.setInputsInline(true);
       this.setPreviousStatement(true);
@@ -1850,8 +1850,8 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendValueInput('NUM').appendTitle(msg.remove());
-      this.appendDummyInput().appendTitle(msg.points());
+      this.appendValueInput('NUM').appendField(msg.remove());
+      this.appendDummyInput().appendField(msg.points());
 
       this.setInputsInline(true);
       this.setPreviousStatement(true);
@@ -1875,7 +1875,7 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendValueInput('TEXT').appendTitle(msg.setScoreText());
+      this.appendValueInput('TEXT').appendField(msg.setScoreText());
       this.setInputsInline(true);
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -1899,7 +1899,7 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(msg.showCoordinates());
+      this.appendDummyInput().appendField(msg.showCoordinates());
       this.setInputsInline(true);
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -1919,7 +1919,7 @@ exports.install = function(blockly, blockInstallOptions) {
       this.setHSV(184, 1.0, 0.74);
       var dropdown = new blockly.FieldDropdown(this.VALUES);
       dropdown.setValue(this.VALUES[2][1]); // default to normal
-      this.appendDummyInput().appendTitle(dropdown, 'VALUE');
+      this.appendDummyInput().appendField(dropdown, 'VALUE');
       this.setInputsInline(true);
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -1953,28 +1953,28 @@ exports.install = function(blockly, blockInstallOptions) {
       if (spriteCount > 1) {
         if (isK1) {
           this.appendDummyInput()
-            .appendTitle(msg.setSprite())
-            .appendTitle(startingSpriteImageDropdown(), 'SPRITE');
+            .appendField(msg.setSprite())
+            .appendField(startingSpriteImageDropdown(), 'SPRITE');
         } else {
-          this.appendDummyInput().appendTitle(
+          this.appendDummyInput().appendField(
             spriteNumberTextDropdown(msg.setSpriteN),
             'SPRITE'
           );
         }
       } else {
-        this.appendDummyInput().appendTitle(msg.setSprite());
+        this.appendDummyInput().appendField(msg.setSprite());
       }
 
       if (isK1) {
         var fieldImageDropdown = new blockly.FieldImageDropdown(this.K1_VALUES);
         fieldImageDropdown.setValue(this.K1_VALUES[1][1]); // default to normal
         this.appendDummyInput()
-          .appendTitle(msg.speed())
-          .appendTitle(fieldImageDropdown, 'VALUE');
+          .appendField(msg.speed())
+          .appendField(fieldImageDropdown, 'VALUE');
       } else {
         var dropdown = new blockly.FieldDropdown(this.VALUES);
         dropdown.setValue(this.VALUES[3][1]); // default to normal
-        this.appendDummyInput().appendTitle(dropdown, 'VALUE');
+        this.appendDummyInput().appendField(dropdown, 'VALUE');
       }
 
       this.setInputsInline(true);
@@ -1991,10 +1991,10 @@ exports.install = function(blockly, blockInstallOptions) {
       this.setHSV(184, 1.0, 0.74);
       this.appendValueInput('SPRITE')
         .setCheck(blockly.BlockValueType.NUMBER)
-        .appendTitle(msg.setSpriteN({spriteIndex: ''}));
+        .appendField(msg.setSpriteN({spriteIndex: ''}));
       this.appendValueInput('VALUE')
         .setCheck(blockly.BlockValueType.NUMBER)
-        .appendTitle(msg.speed());
+        .appendField(msg.speed());
       this.setInputsInline(true);
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -2052,17 +2052,17 @@ exports.install = function(blockly, blockInstallOptions) {
       this.setHSV(184, 1.0, 0.74);
 
       if (spriteCount > 1) {
-        this.appendDummyInput().appendTitle(
+        this.appendDummyInput().appendField(
           spriteNumberTextDropdown(msg.setSpriteN),
           'SPRITE'
         );
       } else {
-        this.appendDummyInput().appendTitle(msg.setSprite());
+        this.appendDummyInput().appendField(msg.setSprite());
       }
 
       var dropdown = new blockly.FieldDropdown(this.VALUES);
       dropdown.setValue(this.VALUES[3][1]); // default to normal
-      this.appendDummyInput().appendTitle(dropdown, 'VALUE');
+      this.appendDummyInput().appendField(dropdown, 'VALUE');
 
       this.setInputsInline(true);
       this.setPreviousStatement(true);
@@ -2078,10 +2078,10 @@ exports.install = function(blockly, blockInstallOptions) {
       this.setHSV(184, 1.0, 0.74);
       this.appendValueInput('SPRITE')
         .setCheck(blockly.BlockValueType.NUMBER)
-        .appendTitle(msg.setSpriteN({spriteIndex: ''}));
+        .appendField(msg.setSpriteN({spriteIndex: ''}));
       this.appendValueInput('VALUE')
         .setCheck(blockly.BlockValueType.NUMBER)
-        .appendTitle(msg.size());
+        .appendField(msg.size());
       this.setInputsInline(true);
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -2150,7 +2150,7 @@ exports.install = function(blockly, blockInstallOptions) {
     init: function() {
       this.setHSV(184, 1.0, 0.74);
       const dropdown = createSpriteGroupDropdown(msg.setEverySpriteNameWander);
-      this.appendDummyInput().appendTitle(dropdown, 'VALUE');
+      this.appendDummyInput().appendField(dropdown, 'VALUE');
       this.setInputsInline(true);
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -2170,7 +2170,7 @@ exports.install = function(blockly, blockInstallOptions) {
     init: function() {
       this.setHSV(184, 1.0, 0.74);
       const dropdown = createSpriteGroupDropdown(msg.stopEverySpriteName);
-      this.appendDummyInput().appendTitle(dropdown, 'VALUE');
+      this.appendDummyInput().appendField(dropdown, 'VALUE');
       this.setInputsInline(true);
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -2192,7 +2192,7 @@ exports.install = function(blockly, blockInstallOptions) {
       const dropdown = createSpriteGroupDropdown(
         msg.setEverySpriteNameChaseActor
       );
-      this.appendDummyInput().appendTitle(dropdown, 'VALUE');
+      this.appendDummyInput().appendField(dropdown, 'VALUE');
       this.appendValueInput('SPRITE').setCheck(blockly.BlockValueType.NUMBER);
       this.setInputsInline(true);
       this.setPreviousStatement(true);
@@ -2216,7 +2216,7 @@ exports.install = function(blockly, blockInstallOptions) {
       const dropdown = createSpriteGroupDropdown(
         msg.setEverySpriteNameFleeActor
       );
-      this.appendDummyInput().appendTitle(dropdown, 'VALUE');
+      this.appendDummyInput().appendField(dropdown, 'VALUE');
       this.appendValueInput('SPRITE').setCheck(blockly.BlockValueType.NUMBER);
       this.setInputsInline(true);
       this.setPreviousStatement(true);
@@ -2238,7 +2238,7 @@ exports.install = function(blockly, blockInstallOptions) {
     init: function() {
       this.setHSV(184, 1.0, 0.74);
       const dropdown = createSpriteGroupDropdown(msg.setEverySpriteNameSpeed);
-      this.appendDummyInput().appendTitle(dropdown, 'VALUE');
+      this.appendDummyInput().appendField(dropdown, 'VALUE');
       this.appendValueInput('SPEED').setCheck(blockly.BlockValueType.NUMBER);
       this.setInputsInline(true);
       this.setPreviousStatement(true);
@@ -2264,7 +2264,7 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(msg.setActor());
+      this.appendDummyInput().appendField(msg.setActor());
       this.appendValueInput('SPRITE').setCheck(blockly.BlockValueType.NUMBER);
       let hasTargetInput = true;
       const behaviorValues = [
@@ -2293,7 +2293,7 @@ exports.install = function(blockly, blockInstallOptions) {
         },
         true
       );
-      this.appendDummyInput().appendTitle(behaviorDropdown, 'VALUE');
+      this.appendDummyInput().appendField(behaviorDropdown, 'VALUE');
       this.appendValueInput('TARGETSPRITE').setCheck(
         blockly.BlockValueType.NUMBER
       );
@@ -2330,15 +2330,15 @@ exports.install = function(blockly, blockInstallOptions) {
           )
       );
       this.appendDummyInput()
-        .appendTitle(dropdown1, 'SPRITE')
-        .appendTitle(dropdown2, 'SPRITENAME');
+        .appendField(dropdown1, 'SPRITE')
+        .appendField(dropdown2, 'SPRITENAME');
       this.appendDummyInput();
       this.appendValueInput('GROUPMEMBER')
         .setInline(true)
-        .appendTitle(msg.set());
+        .appendField(msg.set());
       this.appendDummyInput()
         .setInline(true)
-        .appendTitle(endLabel);
+        .appendField(endLabel);
 
       this.setPreviousStatement(false);
       this.setNextStatement(true);
@@ -2366,8 +2366,8 @@ exports.install = function(blockly, blockInstallOptions) {
       var dropdown1 = spriteNumberTextDropdown(msg.whenSpriteN);
       var dropdown2 = createSpriteGroupDropdown(msg.collidesWithAnySpriteName);
       this.appendDummyInput()
-        .appendTitle(dropdown1, 'SPRITE')
-        .appendTitle(dropdown2, 'SPRITENAME');
+        .appendField(dropdown1, 'SPRITE')
+        .appendField(dropdown2, 'SPRITENAME');
 
       this.setPreviousStatement(false);
       this.setNextStatement(true);
@@ -2396,12 +2396,12 @@ exports.install = function(blockly, blockInstallOptions) {
           skin.dropdownThumbnailHeight
         );
         this.appendDummyInput()
-          .appendTitle(msg.setBackground())
-          .appendTitle(dropdown, 'VALUE');
+          .appendField(msg.setBackground())
+          .appendField(dropdown, 'VALUE');
       } else {
         this.VALUES = skin.backgroundChoices;
         dropdown = new blockly.FieldDropdown(skin.backgroundChoices);
-        this.appendDummyInput().appendTitle(dropdown, 'VALUE');
+        this.appendDummyInput().appendField(dropdown, 'VALUE');
       }
       dropdown.setValue('"' + skin.defaultBackground + '"');
       this.setInputsInline(true);
@@ -2417,7 +2417,7 @@ exports.install = function(blockly, blockInstallOptions) {
       this.setHSV(312, 0.32, 0.62);
       this.VALUES = skin.backgroundChoices;
 
-      this.appendDummyInput().appendTitle(msg.setBackground());
+      this.appendDummyInput().appendField(msg.setBackground());
       this.appendValueInput('VALUE');
 
       this.setInputsInline(true);
@@ -2458,7 +2458,7 @@ exports.install = function(blockly, blockInstallOptions) {
       ]);
 
       var dropdown = new blockly.FieldDropdown(this.VALUES);
-      this.appendDummyInput().appendTitle(dropdown, 'VALUE');
+      this.appendDummyInput().appendField(dropdown, 'VALUE');
       // default to first item after random
       dropdown.setValue(skin.mapChoices[1][1]);
 
@@ -2487,13 +2487,13 @@ exports.install = function(blockly, blockInstallOptions) {
       ]);
 
       var dropdown = new blockly.FieldDropdown(this.VALUES);
-      this.appendDummyInput().appendTitle(dropdown, 'VALUE');
+      this.appendDummyInput().appendField(dropdown, 'VALUE');
       // default to first item after random
       dropdown.setValue(skin.mapChoices[1][1]);
 
       this.appendValueInput('COLOR')
         .setCheck(blockly.BlockValueType.COLOUR)
-        .appendTitle(msg.withColor());
+        .appendField(msg.withColor());
 
       this.setInputsInline(true);
       this.setPreviousStatement(true);
@@ -2522,36 +2522,36 @@ exports.install = function(blockly, blockInstallOptions) {
     block.helpUrl = '';
     block.init = function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(msg.showTitleScreen());
+      this.appendDummyInput().appendField(msg.showTitleScreen());
       if (options.params) {
         this.appendValueInput('TITLE')
           .setCheck(blockly.BlockValueType.STRING)
           .setAlign(Blockly.ALIGN_RIGHT)
-          .appendTitle(msg.showTitleScreenTitle());
+          .appendField(msg.showTitleScreenTitle());
         this.appendValueInput('TEXT')
           .setCheck(blockly.BlockValueType.STRING)
           .setAlign(Blockly.ALIGN_RIGHT)
-          .appendTitle(msg.showTitleScreenText());
+          .appendField(msg.showTitleScreenText());
       } else {
         this.appendDummyInput()
-          .appendTitle(msg.showTitleScreenTitle())
-          .appendTitle(
+          .appendField(msg.showTitleScreenTitle())
+          .appendField(
             new Blockly.FieldImage(Blockly.assetUrl('media/quote0.png'), 12, 12)
           )
-          .appendTitle(
+          .appendField(
             new Blockly.FieldTextInput(msg.showTSDefTitle()),
             'TITLE'
           )
-          .appendTitle(
+          .appendField(
             new Blockly.FieldImage(Blockly.assetUrl('media/quote1.png'), 12, 12)
           );
         this.appendDummyInput()
-          .appendTitle(msg.showTitleScreenText())
-          .appendTitle(
+          .appendField(msg.showTitleScreenText())
+          .appendField(
             new Blockly.FieldImage(Blockly.assetUrl('media/quote0.png'), 12, 12)
           )
-          .appendTitle(new Blockly.FieldTextInput(msg.showTSDefText()), 'TEXT')
-          .appendTitle(
+          .appendField(new Blockly.FieldTextInput(msg.showTSDefText()), 'TEXT')
+          .appendField(
             new Blockly.FieldImage(Blockly.assetUrl('media/quote1.png'), 12, 12)
           );
       }
@@ -2615,9 +2615,9 @@ exports.install = function(blockly, blockInstallOptions) {
         this.setHSV(312, 0.32, 0.62);
         var visibilityTextDropdown = new blockly.FieldDropdown(this.VALUES);
         visibilityTextDropdown.setValue(VISIBLE_VALUE); // default to visible
-        this.appendDummyInput().appendTitle(visibilityTextDropdown, 'VALUE');
+        this.appendDummyInput().appendField(visibilityTextDropdown, 'VALUE');
         if (spriteCount > 1) {
-          this.appendDummyInput().appendTitle(
+          this.appendDummyInput().appendField(
             startingSpriteImageDropdown(),
             'SPRITE'
           );
@@ -2644,7 +2644,7 @@ exports.install = function(blockly, blockInstallOptions) {
         this.VALUES = [].concat(skin.spriteChoices);
         this.setHSV(312, 0.32, 0.62);
         if (spriteCount > 1) {
-          this.appendDummyInput().appendTitle(
+          this.appendDummyInput().appendField(
             spriteNumberTextDropdown(msg.setSpriteN),
             'SPRITE'
           );
@@ -2662,7 +2662,7 @@ exports.install = function(blockly, blockInstallOptions) {
         var dropdown = new blockly.FieldDropdown(this.VALUES);
         // default to first item after random/hidden
         dropdown.setValue(skin.spriteChoices[2][1]);
-        this.appendDummyInput().appendTitle(dropdown, 'VALUE');
+        this.appendDummyInput().appendField(dropdown, 'VALUE');
         this.setInputsInline(true);
         this.setPreviousStatement(true);
         this.setNextStatement(true);
@@ -2682,8 +2682,8 @@ exports.install = function(blockly, blockInstallOptions) {
       this.setHSV(312, 0.32, 0.62);
       this.appendValueInput('SPRITE')
         .setCheck(blockly.BlockValueType.NUMBER)
-        .appendTitle(msg.setSpriteN({spriteIndex: ''}));
-      this.appendDummyInput().appendTitle(dropdown, 'VALUE');
+        .appendField(msg.setSpriteN({spriteIndex: ''}));
+      this.appendDummyInput().appendField(dropdown, 'VALUE');
       this.setInputsInline(true);
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -2696,12 +2696,12 @@ exports.install = function(blockly, blockInstallOptions) {
     init: function() {
       this.setHSV(312, 0.32, 0.62);
       if (spriteCount > 1) {
-        this.appendDummyInput().appendTitle(
+        this.appendDummyInput().appendField(
           spriteNumberTextDropdown(msg.setSpriteN),
           'SPRITE'
         );
       } else {
-        this.appendDummyInput().appendTitle(msg.setSprite());
+        this.appendDummyInput().appendField(msg.setSprite());
       }
       this.appendValueInput('VALUE');
       this.setInputsInline(true);
@@ -2752,16 +2752,16 @@ exports.install = function(blockly, blockInstallOptions) {
       if (spriteCount > 1) {
         if (isK1) {
           this.appendDummyInput()
-            .appendTitle(msg.setSprite())
-            .appendTitle(startingSpriteImageDropdown(), 'SPRITE');
+            .appendField(msg.setSprite())
+            .appendField(startingSpriteImageDropdown(), 'SPRITE');
         } else {
-          this.appendDummyInput().appendTitle(
+          this.appendDummyInput().appendField(
             spriteNumberTextDropdown(msg.setSpriteN),
             'SPRITE'
           );
         }
       } else {
-        this.appendDummyInput().appendTitle(msg.setSprite());
+        this.appendDummyInput().appendField(msg.setSprite());
       }
 
       if (isK1) {
@@ -2772,12 +2772,12 @@ exports.install = function(blockly, blockInstallOptions) {
         );
         fieldImageDropdown.setValue(this.K1_VALUES[0][1]); // default to normal
         this.appendDummyInput()
-          .appendTitle(msg.emotion())
-          .appendTitle(fieldImageDropdown, 'VALUE');
+          .appendField(msg.emotion())
+          .appendField(fieldImageDropdown, 'VALUE');
       } else {
         var dropdown = new blockly.FieldDropdown(this.VALUES);
         dropdown.setValue(this.VALUES[1][1]); // default to normal
-        this.appendDummyInput().appendTitle(dropdown, 'VALUE');
+        this.appendDummyInput().appendField(dropdown, 'VALUE');
       }
       this.setInputsInline(true);
       this.setPreviousStatement(true);
@@ -2792,10 +2792,10 @@ exports.install = function(blockly, blockInstallOptions) {
       this.setHSV(184, 1.0, 0.74);
       this.appendValueInput('SPRITE')
         .setCheck(blockly.BlockValueType.NUMBER)
-        .appendTitle(msg.setSpriteN({spriteIndex: ''}));
+        .appendField(msg.setSpriteN({spriteIndex: ''}));
       var dropdown = new blockly.FieldDropdown(this.VALUES);
       dropdown.setValue(this.VALUES[1][1]); // default to normal
-      this.appendDummyInput().appendTitle(dropdown, 'VALUE');
+      this.appendDummyInput().appendField(dropdown, 'VALUE');
       this.setInputsInline(true);
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -2845,21 +2845,21 @@ exports.install = function(blockly, blockInstallOptions) {
       if (options.time) {
         this.appendValueInput('SPRITE')
           .setCheck(blockly.BlockValueType.NUMBER)
-          .appendTitle(msg.actor());
-        this.appendDummyInput().appendTitle(msg.saySprite());
+          .appendField(msg.actor());
+        this.appendDummyInput().appendField(msg.saySprite());
       } else if (spriteCount > 1) {
         if (isK1) {
           this.appendDummyInput()
-            .appendTitle(msg.saySprite())
-            .appendTitle(startingSpriteImageDropdown(), 'SPRITE');
+            .appendField(msg.saySprite())
+            .appendField(startingSpriteImageDropdown(), 'SPRITE');
         } else {
-          this.appendDummyInput().appendTitle(
+          this.appendDummyInput().appendField(
             spriteNumberTextDropdown(msg.saySpriteN),
             'SPRITE'
           );
         }
       } else {
-        this.appendDummyInput().appendTitle(msg.saySprite());
+        this.appendDummyInput().appendField(msg.saySprite());
       }
       if (options.restrictedDialog) {
         var functionArray = [];
@@ -2870,30 +2870,30 @@ exports.install = function(blockly, blockInstallOptions) {
           functionElement[0] = functionElement[1] = string;
         }
         var dropdown = new blockly.FieldDropdown(functionArray);
-        this.appendDummyInput().appendTitle(dropdown, 'VALUE');
+        this.appendDummyInput().appendField(dropdown, 'VALUE');
       } else if (options.params) {
         this.appendValueInput('TEXT');
       } else {
         var quotedTextInput = this.appendDummyInput();
         if (isK1) {
-          quotedTextInput.appendTitle(
+          quotedTextInput.appendField(
             new Blockly.FieldImage(skin.speechBubble)
           );
         }
         quotedTextInput
-          .appendTitle(
+          .appendField(
             new Blockly.FieldImage(Blockly.assetUrl('media/quote0.png'), 12, 12)
           )
-          .appendTitle(new Blockly.FieldTextInput(msg.defaultSayText()), 'TEXT')
-          .appendTitle(
+          .appendField(new Blockly.FieldTextInput(msg.defaultSayText()), 'TEXT')
+          .appendField(
             new Blockly.FieldImage(Blockly.assetUrl('media/quote1.png'), 12, 12)
           );
       }
       if (options.time) {
         this.appendValueInput('TIME')
           .setCheck(blockly.BlockValueType.NUMBER)
-          .appendTitle(msg.for());
-        this.appendDummyInput().appendTitle(msg.waitSeconds());
+          .appendField(msg.for());
+        this.appendDummyInput().appendField(msg.waitSeconds());
       }
       this.setInputsInline(true);
       this.setPreviousStatement(true);
@@ -2994,9 +2994,9 @@ exports.install = function(blockly, blockInstallOptions) {
     block.init = function() {
       this.setHSV(184, 1.0, 0.74);
       if (options.params) {
-        this.appendDummyInput().appendTitle(msg.waitFor());
+        this.appendDummyInput().appendField(msg.waitFor());
         this.appendValueInput('VALUE').setCheck(blockly.BlockValueType.NUMBER);
-        this.appendDummyInput().appendTitle(msg.waitSeconds());
+        this.appendDummyInput().appendField(msg.waitSeconds());
       } else {
         if (isK1) {
           let dropdown = new blockly.FieldDropdown(
@@ -3007,15 +3007,15 @@ exports.install = function(blockly, blockInstallOptions) {
           );
           dropdown.setValue('1000');
           this.appendDummyInput()
-            .appendTitle(msg.wait())
-            .appendTitle(new blockly.FieldImage(skin.clockIcon))
-            .appendTitle(dropdown, 'VALUE')
-            .appendTitle(msg.waitSeconds());
+            .appendField(msg.wait())
+            .appendField(new blockly.FieldImage(skin.clockIcon))
+            .appendField(dropdown, 'VALUE')
+            .appendField(msg.waitSeconds());
         } else {
           let dropdown = new blockly.FieldDropdown(this.VALUES);
           dropdown.setValue(this.VALUES[2][1]); // default to half second
 
-          this.appendDummyInput().appendTitle(dropdown, 'VALUE');
+          this.appendDummyInput().appendField(dropdown, 'VALUE');
         }
       }
       this.setInputsInline(true);
@@ -3070,7 +3070,7 @@ exports.install = function(blockly, blockInstallOptions) {
       this.setHSV(184, 1.0, 0.74);
       var dropdown = new blockly.FieldDropdown(this.VALUES);
       dropdown.setValue(this.VALUES[0][1]); // default to win
-      this.appendDummyInput().appendTitle(dropdown, 'VALUE');
+      this.appendDummyInput().appendField(dropdown, 'VALUE');
       this.setInputsInline(true);
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -3185,7 +3185,7 @@ exports.install = function(blockly, blockInstallOptions) {
       };
 
       this.appendDummyInput()
-        .appendTitle(new Blockly.FieldLabel('game_funcs', options))
+        .appendField(new Blockly.FieldLabel('game_funcs', options))
         .setAlign(Blockly.ALIGN_LEFT);
 
       var rows = [
@@ -3201,7 +3201,7 @@ exports.install = function(blockly, blockInstallOptions) {
 
       rows.forEach(function(row) {
         if (typeof row === 'string') {
-          this.appendDummyInput().appendTitle(new Blockly.FieldLabel(row));
+          this.appendDummyInput().appendField(new Blockly.FieldLabel(row));
         } else {
           row.forEach(function(blockArg, index) {
             var input = this.appendFunctionalInput(blockArg.name);
@@ -3360,7 +3360,7 @@ exports.install = function(blockly, blockInstallOptions) {
       this.setHSV(184, 1.0, 0.74);
       this.appendValueInput('SPRITE')
         .setCheck(blockly.BlockValueType.NUMBER)
-        .appendTitle(msg.vanishActorN({spriteIndex: ''}));
+        .appendField(msg.vanishActorN({spriteIndex: ''}));
       this.setPreviousStatement(true);
       this.setInputsInline(true);
       this.setNextStatement(true);
@@ -3395,7 +3395,7 @@ exports.install = function(blockly, blockInstallOptions) {
         skin.dropdownThumbnailHeight
       );
 
-      this.appendDummyInput().appendTitle(dropdown, 'SPRITE_INDEX');
+      this.appendDummyInput().appendField(dropdown, 'SPRITE_INDEX');
 
       this.setFunctionalOutput(true);
     }
@@ -3424,7 +3424,7 @@ exports.install = function(blockly, blockInstallOptions) {
         skin.dropdownThumbnailHeight
       );
 
-      this.appendDummyInput().appendTitle(dropdown, 'BACKGROUND');
+      this.appendDummyInput().appendField(dropdown, 'BACKGROUND');
 
       this.setFunctionalOutput(true);
     }
@@ -3470,26 +3470,26 @@ exports.install = function(blockly, blockInstallOptions) {
       // Must be marked EDITABLE so that cloned blocks share the same var name
       fieldLabel.EDITABLE = true;
       this.setHSV(312, 0.32, 0.62);
-      this.appendDummyInput().appendTitle(msg.ask());
+      this.appendDummyInput().appendField(msg.ask());
       this.setInputsInline(true);
       this.appendDummyInput()
-        .appendTitle(
+        .appendField(
           new Blockly.FieldImage(Blockly.assetUrl('media/quote0.png'), 12, 12)
         )
-        .appendTitle(new Blockly.FieldTextInput(''), 'TEXT')
-        .appendTitle(
+        .appendField(new Blockly.FieldTextInput(''), 'TEXT')
+        .appendField(
           new Blockly.FieldImage(Blockly.assetUrl('media/quote1.png'), 12, 12)
         );
-      this.appendDummyInput().appendTitle(msg.toSet());
+      this.appendDummyInput().appendField(msg.toSet());
       this.appendDummyInput()
-        .appendTitle(Blockly.Msg.VARIABLES_GET_TITLE)
-        .appendTitle(
+        .appendField(Blockly.Msg.VARIABLES_GET_TITLE)
+        .appendField(
           Blockly.disableVariableEditing
             ? fieldLabel
             : new Blockly.FieldVariable(Blockly.Msg.VARIABLES_GET_ITEM),
           'VAR'
         )
-        .appendTitle(Blockly.Msg.VARIABLES_GET_TAIL);
+        .appendField(Blockly.Msg.VARIABLES_GET_TAIL);
       this.setPreviousStatement(true);
       this.setNextStatement(true);
       // This block handles generation of nextConnection descendants (in order
@@ -3533,13 +3533,13 @@ function installVanish(
       this.setHSV(184, 1.0, 0.74);
       if (blockInstallOptions.isK1) {
         this.appendDummyInput()
-          .appendTitle(msg.vanish())
-          .appendTitle(
+          .appendField(msg.vanish())
+          .appendField(
             new blockly.FieldImage(blockInstallOptions.skin.explosionThumbnail)
           )
-          .appendTitle(startingSpriteImageDropdown(), 'SPRITE');
+          .appendField(startingSpriteImageDropdown(), 'SPRITE');
       } else {
-        this.appendDummyInput().appendTitle(
+        this.appendDummyInput().appendField(
           spriteNumberTextDropdown(msg.vanishActorN),
           'SPRITE'
         );
@@ -3615,7 +3615,7 @@ function installConditionals(
     'ifActorHasEmotion',
     function(actorSelectDropdown, includeElseStatement) {
       this.setHSV(196, 1.0, 0.79);
-      this.appendDummyInput().appendTitle(commonMsg.ifCode());
+      this.appendDummyInput().appendField(commonMsg.ifCode());
 
       appendActorSelect(this, actorSelectDropdown);
 
@@ -3627,18 +3627,18 @@ function installConditionals(
         );
         fieldImageDropdown.setValue(K1_EMOTION_VALUES[0][1]); // default to normal
         this.appendDummyInput()
-          .appendTitle(msg.emotion())
-          .appendTitle(fieldImageDropdown, 'EMOTION');
+          .appendField(msg.emotion())
+          .appendField(fieldImageDropdown, 'EMOTION');
       } else {
         const dropdown = new blockly.FieldDropdown(EMOTION_VALUES);
         dropdown.setValue(EMOTION_VALUES[1][1]); // default to normal
-        this.appendDummyInput().appendTitle(dropdown, 'EMOTION');
+        this.appendDummyInput().appendField(dropdown, 'EMOTION');
       }
 
       this.appendStatementInput('DO');
 
       if (includeElseStatement) {
-        this.appendStatementInput('ELSE').appendTitle(msg.elseCode());
+        this.appendStatementInput('ELSE').appendField(msg.elseCode());
       }
 
       this.setTooltip(Blockly.Msg.CONTROLS_IF_IF_TOOLTIP);
@@ -3694,26 +3694,26 @@ function installConditionals(
           ];
 
       this.setHSV(196, 1.0, 0.79);
-      this.appendDummyInput().appendTitle(commonMsg.ifCode());
+      this.appendDummyInput().appendField(commonMsg.ifCode());
 
       appendActorSelect(this, actorSelectDropdown);
 
-      this.appendDummyInput().appendTitle(' ');
+      this.appendDummyInput().appendField(' ');
 
       const positionDropdown = new blockly.FieldDropdown(POSITION_VALUES);
       positionDropdown.setValue(POSITION_VALUES[0][1]);
 
-      this.appendDummyInput().appendTitle(positionDropdown, 'POSITION');
+      this.appendDummyInput().appendField(positionDropdown, 'POSITION');
 
       const operatorDropdown = new Blockly.FieldDropdown(OPERATORS);
-      this.appendDummyInput().appendTitle(operatorDropdown, 'OPERATOR');
+      this.appendDummyInput().appendField(operatorDropdown, 'OPERATOR');
 
       this.appendValueInput('COMPARED_VALUE');
 
       this.appendStatementInput('DO');
 
       if (includeElseStatement) {
-        this.appendStatementInput('ELSE').appendTitle(msg.elseCode());
+        this.appendStatementInput('ELSE').appendField(msg.elseCode());
       }
 
       this.setTooltip(Blockly.Msg.CONTROLS_IF_IF_TOOLTIP);
@@ -3767,19 +3767,19 @@ function installConditionals(
     'ifActorIsVisible',
     function(actorSelectDropdown, includeElseStatement) {
       this.setHSV(196, 1.0, 0.79);
-      this.appendDummyInput().appendTitle(commonMsg.ifCode());
+      this.appendDummyInput().appendField(commonMsg.ifCode());
 
       appendActorSelect(this, actorSelectDropdown);
 
       const dropdown = new blockly.FieldDropdown(VISIBILITY_VALUES);
       dropdown.setValue(VISIBILITY_VALUES[0][1]);
 
-      this.appendDummyInput().appendTitle(dropdown, 'VISIBILITY');
+      this.appendDummyInput().appendField(dropdown, 'VISIBILITY');
 
       this.appendStatementInput('DO');
 
       if (includeElseStatement) {
-        this.appendStatementInput('ELSE').appendTitle(msg.elseCode());
+        this.appendStatementInput('ELSE').appendField(msg.elseCode());
       }
 
       this.setTooltip(Blockly.Msg.CONTROLS_IF_IF_TOOLTIP);
@@ -3821,19 +3821,19 @@ function installConditionals(
     'ifActorIsSprite',
     function(actorSelectDropdown, includeElseStatement) {
       this.setHSV(196, 1.0, 0.79);
-      this.appendDummyInput().appendTitle(commonMsg.ifCode());
+      this.appendDummyInput().appendField(commonMsg.ifCode());
 
       appendActorSelect(this, actorSelectDropdown);
 
       const dropdown = new blockly.FieldDropdown(SPRITE_VALUES);
       dropdown.setValue(SPRITE_VALUES[0][1]);
 
-      this.appendDummyInput().appendTitle(dropdown, 'VALUE');
+      this.appendDummyInput().appendField(dropdown, 'VALUE');
 
       this.appendStatementInput('DO');
 
       if (includeElseStatement) {
-        this.appendStatementInput('ELSE').appendTitle(msg.elseCode());
+        this.appendStatementInput('ELSE').appendField(msg.elseCode());
       }
 
       this.setTooltip(Blockly.Msg.CONTROLS_IF_IF_TOOLTIP);

--- a/apps/src/turtle/blocks.js
+++ b/apps/src/turtle/blocks.js
@@ -127,19 +127,19 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(MOVE_BY_DIRECTION_VALUES),
         'DIR'
       );
       this.appendDummyInput()
-        .appendTitle(
+        .appendField(
           new blockly.FieldTextInput(
             '100',
             blockly.FieldTextInput.numberValidator
           ),
           'VALUE'
         )
-        .appendTitle(msg.dots());
+        .appendField(msg.dots());
       this.setInputsInline(true);
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -152,13 +152,13 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(MOVE_BY_DIRECTION_VALUES),
         'DIR'
       );
       this.appendDummyInput()
-        .appendTitle(new blockly.FieldDropdown(), 'VALUE')
-        .appendTitle(msg.dots());
+        .appendField(new blockly.FieldDropdown(), 'VALUE')
+        .appendField(msg.dots());
       this.setInputsInline(true);
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -187,19 +187,19 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(TURN_BY_DIRECTION_VALUES),
         'DIR'
       );
       this.appendDummyInput()
-        .appendTitle(
+        .appendField(
           new blockly.FieldAngleDropdown({
             directionTitleName: 'DIR',
             menuGenerator: this.VALUE
           }),
           'VALUE'
         )
-        .appendTitle(msg.degrees());
+        .appendField(msg.degrees());
       this.setInputsInline(true);
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -240,18 +240,18 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(TURN_BY_DIRECTION_VALUES),
         'DIR'
       );
       this.appendDummyInput()
-        .appendTitle(
+        .appendField(
           new blockly.FieldAngleTextInput('90', {
             directionTitle: 'DIR'
           }),
           'VALUE'
         )
-        .appendTitle(msg.degrees());
+        .appendField(msg.degrees());
       this.setInputsInline(true);
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -264,18 +264,18 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(TURN_BY_DIRECTION_VALUES),
         'DIR'
       );
       this.appendDummyInput()
-        .appendTitle(
+        .appendField(
           new blockly.FieldAngleDropdown({
             directionTitleName: 'DIR'
           }),
           'VALUE'
         )
-        .appendTitle(msg.degrees());
+        .appendField(msg.degrees());
       this.setInputsInline(true);
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -318,19 +318,19 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(TURN_BY_DIRECTION_VALUES),
         'DIR'
       );
       this.appendDummyInput()
-        .appendTitle(
+        .appendField(
           new blockly.FieldAngleDropdown({
             directionTitleName: 'DIR',
             menuGenerator: this.VALUE
           }),
           'VALUE'
         )
-        .appendTitle(msg.degrees());
+        .appendField(msg.degrees());
       this.setInputsInline(true);
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -371,18 +371,18 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(TURN_BY_DIRECTION_VALUES),
         'DIR'
       );
       this.appendDummyInput()
-        .appendTitle(
+        .appendField(
           new blockly.FieldAngleTextInput('90', {
             directionTitle: 'DIR'
           }),
           'VALUE'
         )
-        .appendTitle(msg.degrees());
+        .appendField(msg.degrees());
       this.setInputsInline(true);
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -399,7 +399,7 @@ exports.install = function(blockly, blockInstallOptions) {
         this.setInputsInline(true);
         this.setNextStatement(true);
         this.setTooltip(msg.pointTo());
-        this.appendDummyInput().appendTitle(msg.pointTo());
+        this.appendDummyInput().appendField(msg.pointTo());
         if (onInit) {
           onInit(this);
         }
@@ -411,13 +411,13 @@ exports.install = function(blockly, blockInstallOptions) {
     // Block for pointing to a specified direction
     block
       .appendDummyInput()
-      .appendTitle(
+      .appendField(
         new blockly.FieldAngleTextInput('0', {
           direction: 'turnRight'
         }),
         'DIRECTION'
       )
-      .appendTitle(msg.degrees());
+      .appendField(msg.degrees());
   });
 
   generator.point_to = function() {
@@ -434,7 +434,7 @@ exports.install = function(blockly, blockInstallOptions) {
         block,
         direction: 'turnRight'
       });
-    block.appendDummyInput().appendTitle(msg.degrees());
+    block.appendDummyInput().appendField(msg.degrees());
   });
 
   generator.point_to_param = function() {
@@ -451,14 +451,14 @@ exports.install = function(blockly, blockInstallOptions) {
   ) {
     block
       .appendDummyInput()
-      .appendTitle(
+      .appendField(
         new blockly.FieldAngleDropdown({
           direction: 'turnRight',
           menuGenerator: block.VALUE
         }),
         'VALUE'
       )
-      .appendTitle(msg.degrees());
+      .appendField(msg.degrees());
   });
 
   blockly.Blocks.point_to_by_constant_restricted.VALUE = [
@@ -501,8 +501,8 @@ exports.install = function(blockly, blockInstallOptions) {
     init: function() {
       this.setHSV(312, 0.32, 0.62);
       this.appendDummyInput()
-        .appendTitle(blockly.Msg.VARIABLES_GET_TITLE)
-        .appendTitle(new blockly.FieldLabel(msg.loopVariable()), 'VAR');
+        .appendField(blockly.Msg.VARIABLES_GET_TITLE)
+        .appendField(new blockly.FieldLabel(msg.loopVariable()), 'VAR');
       this.setOutput(true);
       this.setTooltip(blockly.Msg.VARIABLES_GET_TOOLTIP);
     },
@@ -518,8 +518,8 @@ exports.install = function(blockly, blockInstallOptions) {
     init: function() {
       this.setHSV(312, 0.32, 0.62);
       this.appendDummyInput()
-        .appendTitle(blockly.Msg.VARIABLES_GET_TITLE)
-        .appendTitle(new blockly.FieldLabel(msg.lengthParameter()), 'VAR');
+        .appendField(blockly.Msg.VARIABLES_GET_TITLE)
+        .appendField(new blockly.FieldLabel(msg.lengthParameter()), 'VAR');
       this.setOutput(true);
       this.setTooltip(blockly.Msg.VARIABLES_GET_TOOLTIP);
     },
@@ -535,8 +535,8 @@ exports.install = function(blockly, blockInstallOptions) {
     init: function() {
       this.setHSV(312, 0.32, 0.62);
       this.appendDummyInput()
-        .appendTitle(blockly.Msg.VARIABLES_GET_TITLE)
-        .appendTitle(new blockly.FieldLabel('sides'), 'VAR');
+        .appendField(blockly.Msg.VARIABLES_GET_TITLE)
+        .appendField(new blockly.FieldLabel('sides'), 'VAR');
       this.setOutput(true);
       this.setTooltip(blockly.Msg.VARIABLES_GET_TOOLTIP);
     },
@@ -551,11 +551,11 @@ exports.install = function(blockly, blockInstallOptions) {
     // Draw a square.
     init: function() {
       this.setHSV(94, 0.84, 0.6);
-      this.appendDummyInput().appendTitle(msg.drawASquare());
+      this.appendDummyInput().appendField(msg.drawASquare());
       this.appendValueInput('VALUE')
         .setAlign(blockly.ALIGN_RIGHT)
         .setCheck(blockly.BlockValueType.NUMBER)
-        .appendTitle(msg.lengthParameter() + ':');
+        .appendField(msg.lengthParameter() + ':');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
       this.setInputsInline(true);
@@ -585,11 +585,11 @@ exports.install = function(blockly, blockInstallOptions) {
     // Draw a circle in front of the turtle, ending up on the opposite side.
     init: function() {
       this.setHSV(94, 0.84, 0.6);
-      this.appendDummyInput().appendTitle(msg.drawASnowman());
+      this.appendDummyInput().appendField(msg.drawASnowman());
       this.appendValueInput('VALUE')
         .setAlign(blockly.ALIGN_RIGHT)
         .setCheck(blockly.BlockValueType.NUMBER)
-        .appendTitle(msg.lengthParameter() + ':');
+        .appendField(msg.lengthParameter() + ':');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
       this.setTooltip('');
@@ -661,8 +661,8 @@ exports.install = function(blockly, blockInstallOptions) {
     init: function() {
       this.setHSV(322, 0.9, 0.95);
       this.appendDummyInput()
-        .appendTitle(blockly.Msg.CONTROLS_FOR_INPUT_WITH)
-        .appendTitle(new blockly.FieldLabel(msg.loopVariable()), 'VAR');
+        .appendField(blockly.Msg.CONTROLS_FOR_INPUT_WITH)
+        .appendField(new blockly.FieldLabel(msg.loopVariable()), 'VAR');
       this.interpolateMsg(
         blockly.Msg.CONTROLS_FOR_INPUT_FROM_TO_BY,
         ['FROM', 'Number', blockly.ALIGN_RIGHT],
@@ -670,7 +670,7 @@ exports.install = function(blockly, blockInstallOptions) {
         ['BY', 'Number', blockly.ALIGN_RIGHT],
         blockly.ALIGN_RIGHT
       );
-      this.appendStatementInput('DO').appendTitle(
+      this.appendStatementInput('DO').appendField(
         Blockly.Msg.CONTROLS_FOR_INPUT_DO
       );
       this.setPreviousStatement(true);
@@ -715,7 +715,7 @@ exports.install = function(blockly, blockInstallOptions) {
       this.interpolateMsg(
         msg.moveDirectionByPixels(),
         () => {
-          this.appendDummyInput().appendTitle(
+          this.appendDummyInput().appendField(
             new blockly.FieldDropdown(DIRECTION_VALUES),
             'DIR'
           );
@@ -753,7 +753,7 @@ exports.install = function(blockly, blockInstallOptions) {
       this.interpolateMsg(
         msg.jumpByDirection(),
         () => {
-          this.appendDummyInput().appendTitle(
+          this.appendDummyInput().appendField(
             new blockly.FieldDropdown(JUMP_DIRECTION_VALUES),
             'DIR'
           );
@@ -977,16 +977,16 @@ exports.install = function(blockly, blockInstallOptions) {
           this.setHSV(184, 1.0, 0.74);
           var input = this.appendDummyInput();
           if (directionConfig.isJump) {
-            input.appendTitle(commonMsg.jump());
+            input.appendField(commonMsg.jump());
           }
-          input.appendTitle(
+          input.appendField(
             new blockly.FieldLabel(directionConfig.title, {
               fixedSize: {width: directionLetterWidth, height: 18}
             })
           );
 
           if (directionConfig.imageDimensions) {
-            input.appendTitle(
+            input.appendField(
               new blockly.FieldImage(
                 directionConfig.image,
                 directionConfig.imageDimensions.width,
@@ -994,7 +994,7 @@ exports.install = function(blockly, blockInstallOptions) {
               )
             );
           } else {
-            input.appendTitle(new blockly.FieldImage(directionConfig.image));
+            input.appendField(new blockly.FieldImage(directionConfig.image));
           }
           this.setPreviousStatement(true);
           this.setNextStatement(true);
@@ -1004,7 +1004,7 @@ exports.install = function(blockly, blockInstallOptions) {
               directionConfig.lengths
             );
             dropdown.setValue(directionConfig.defaultDropdownValue);
-            input.appendTitle(dropdown, 'length');
+            input.appendField(dropdown, 'length');
           }
         }
       };
@@ -1054,19 +1054,19 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(JUMP_BY_DIRECTION_VALUES),
         'DIR'
       );
       this.appendDummyInput()
-        .appendTitle(
+        .appendField(
           new blockly.FieldTextInput(
             '100',
             blockly.FieldTextInput.numberValidator
           ),
           'VALUE'
         )
-        .appendTitle(msg.dots());
+        .appendField(msg.dots());
       this.setInputsInline(true);
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -1080,13 +1080,13 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(JUMP_BY_DIRECTION_VALUES),
         'DIR'
       );
       this.appendDummyInput()
-        .appendTitle(new blockly.FieldDropdown(), 'VALUE')
-        .appendTitle(msg.dots());
+        .appendField(new blockly.FieldDropdown(), 'VALUE')
+        .appendField(msg.dots());
       this.setInputsInline(true);
       this.setPreviousStatement(true);
       this.setNextStatement(true);
@@ -1120,7 +1120,7 @@ exports.install = function(blockly, blockInstallOptions) {
       this.interpolateMsg(
         msg.jumpToPosition(),
         () => {
-          this.appendDummyInput().appendTitle(dropdown, 'VALUE');
+          this.appendDummyInput().appendField(dropdown, 'VALUE');
         },
         blockly.ALIGN_RIGHT
       );
@@ -1152,7 +1152,7 @@ exports.install = function(blockly, blockInstallOptions) {
       this.interpolateMsg(
         msg.jumpToOverDown(),
         () => {
-          this.appendDummyInput().appendTitle(
+          this.appendDummyInput().appendField(
             new blockly.FieldTextInput(
               '0',
               blockly.FieldTextInput.numberValidator
@@ -1161,7 +1161,7 @@ exports.install = function(blockly, blockInstallOptions) {
           );
         },
         () => {
-          this.appendDummyInput().appendTitle(
+          this.appendDummyInput().appendField(
             new blockly.FieldTextInput(
               '0',
               blockly.FieldTextInput.numberValidator
@@ -1192,7 +1192,7 @@ exports.install = function(blockly, blockInstallOptions) {
       this.interpolateMsg(
         msg.turnDirection(),
         () => {
-          this.appendDummyInput().appendTitle(
+          this.appendDummyInput().appendField(
             new blockly.FieldDropdown(TURN_DIRECTION_VALUES),
             'DIR'
           );
@@ -1239,7 +1239,7 @@ exports.install = function(blockly, blockInstallOptions) {
       this.setHSV(184, 1.0, 0.74);
       this.appendValueInput('WIDTH')
         .setCheck(blockly.BlockValueType.NUMBER)
-        .appendTitle(msg.setWidth());
+        .appendField(msg.setWidth());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
       this.setTooltip(msg.widthTooltip());
@@ -1260,8 +1260,8 @@ exports.install = function(blockly, blockInstallOptions) {
     init: function() {
       this.setHSV(184, 1.0, 0.74);
       this.setInputsInline(true);
-      this.appendDummyInput().appendTitle(msg.setWidth());
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(msg.setWidth());
+      this.appendDummyInput().appendField(
         new blockly.FieldTextInput('1', blockly.FieldTextInput.numberValidator),
         'WIDTH'
       );
@@ -1282,7 +1282,7 @@ exports.install = function(blockly, blockInstallOptions) {
     helpUrl: '',
     init: function() {
       this.setHSV(184, 1.0, 0.74);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(this.STATE),
         'PEN'
       );
@@ -1311,7 +1311,7 @@ exports.install = function(blockly, blockInstallOptions) {
       this.setHSV(196, 1.0, 0.79);
       this.appendValueInput('COLOUR')
         .setCheck(blockly.BlockValueType.COLOUR)
-        .appendTitle(msg.setColour());
+        .appendField(msg.setColour());
       this.setPreviousStatement(true);
       this.setNextStatement(true);
       this.setTooltip(msg.colourTooltip());
@@ -1326,7 +1326,7 @@ exports.install = function(blockly, blockInstallOptions) {
     init: function() {
       this.appendValueInput('VALUE')
         .setCheck('Number')
-        .appendTitle(msg.setAlpha());
+        .appendField(msg.setAlpha());
       this.setPreviousStatement(true, null);
       this.setNextStatement(true, null);
       this.setHSV(196, 1.0, 0.79);
@@ -1368,8 +1368,8 @@ exports.install = function(blockly, blockInstallOptions) {
       this.setHSV(196, 1.0, 0.79);
       var colourField = new Blockly.FieldColourDropdown(colours, 45, 35);
       this.appendDummyInput()
-        .appendTitle(msg.setColour())
-        .appendTitle(colourField, 'COLOUR');
+        .appendField(msg.setColour())
+        .appendField(colourField, 'COLOUR');
       this.setPreviousStatement(true);
       this.setNextStatement(true);
       this.setTooltip(msg.colourTooltip());
@@ -1390,8 +1390,8 @@ exports.install = function(blockly, blockInstallOptions) {
       this.setPreviousStatement(true, null);
       this.setNextStatement(true, null);
       this.appendDummyInput()
-        .appendTitle(msg.setPattern())
-        .appendTitle(
+        .appendField(msg.setPattern())
+        .appendField(
           new blockly.FieldImageDropdown(skin.lineStylePatternOptions, 150, 20),
           'VALUE'
         );
@@ -1413,7 +1413,7 @@ exports.install = function(blockly, blockInstallOptions) {
       this.setHSV(184, 1.0, 0.74);
       this.setPreviousStatement(true, null);
       this.setNextStatement(true, null);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(this.STATE),
         'VISIBILITY'
       );
@@ -1436,7 +1436,7 @@ exports.install = function(blockly, blockInstallOptions) {
       this.setHSV(184, 1.0, 0.74);
       this.setPreviousStatement(true, null);
       this.setNextStatement(true, null);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(this.STATE),
         'VISIBILITY'
       );
@@ -1467,7 +1467,7 @@ exports.install = function(blockly, blockInstallOptions) {
         this.setHSV(184, 1.0, 0.74);
         var dropdown;
         var input = this.appendDummyInput();
-        input.appendTitle(msg.drawSticker());
+        input.appendField(msg.drawSticker());
         this.setInputsInline(true);
         this.setPreviousStatement(true);
         this.setNextStatement(true);
@@ -1480,7 +1480,7 @@ exports.install = function(blockly, blockInstallOptions) {
         }
         dropdown = new blockly.FieldImageDropdown(values, 40, 40);
 
-        input.appendTitle(dropdown, 'VALUE');
+        input.appendField(dropdown, 'VALUE');
 
         appendToDrawStickerBlock(blockName, this);
       }
@@ -1490,22 +1490,22 @@ exports.install = function(blockly, blockInstallOptions) {
   // Add size input to the draw sticker block (text input & socket)
   function appendToDrawStickerBlock(blockName, block) {
     if (blockName === 'turtle_sticker_with_size') {
-      block.appendDummyInput().appendTitle(msg.withSize());
+      block.appendDummyInput().appendField(msg.withSize());
       block.appendValueInput('SIZE').setCheck(blockly.BlockValueType.NUMBER);
-      block.appendDummyInput().appendTitle(msg.pixels());
+      block.appendDummyInput().appendField(msg.pixels());
       block.setTooltip(msg.drawStickerWithSize());
     } else if (blockName === 'turtle_sticker_with_size_non_param') {
-      block.appendDummyInput().appendTitle(msg.withSize());
+      block.appendDummyInput().appendField(msg.withSize());
       block
         .appendDummyInput()
-        .appendTitle(
+        .appendField(
           new blockly.FieldTextInput(
             '0',
             blockly.FieldTextInput.numberValidator
           ),
           'SIZE'
         )
-        .appendTitle(msg.pixels());
+        .appendField(msg.pixels());
       block.setTooltip(msg.drawStickerWithSize());
     } else {
       block.setTooltip(msg.drawSticker());
@@ -1560,7 +1560,7 @@ exports.install = function(blockly, blockInstallOptions) {
         }),
         artist
       ]);
-      this.appendDummyInput().appendTitle(
+      this.appendDummyInput().appendField(
         new blockly.FieldDropdown(values),
         'VALUE'
       );

--- a/apps/src/turtle/customLevelBlocks.js
+++ b/apps/src/turtle/customLevelBlocks.js
@@ -59,13 +59,13 @@ function makeBlockInitializer(title, parameter) {
     init: function() {
       this.setHSV(94, 0.84, 0.6);
 
-      this.appendDummyInput().appendTitle(title);
+      this.appendDummyInput().appendField(title);
 
       if (parameter !== undefined) {
         this.appendValueInput('VALUE')
           .setAlign(Blockly.ALIGN_RIGHT)
           .setCheck(Blockly.BlockValueType.NUMBER)
-          .appendTitle(parameter + ':');
+          .appendField(parameter + ':');
       }
 
       this.setPreviousStatement(true);
@@ -580,7 +580,7 @@ function installCreateASnowflakeDropdown(blockly, generator, gensym) {
       this.setHSV(94, 0.84, 0.6);
 
       var title = new blockly.FieldDropdown(snowflakes);
-      this.appendDummyInput().appendTitle(title, 'TYPE');
+      this.appendDummyInput().appendField(title, 'TYPE');
 
       this.setPreviousStatement(true);
       this.setNextStatement(true);


### PR DESCRIPTION
The new Google Blockly release makes it impossible to override private classes, so all of our customizations need to find new homes. Instead of adding `appendTitle` to `Blockly.Input`, we should change all of our usage to `appendField` and add `appendField` to the Cdo Blockly Wrapper for backwards compatibility