### PR TITLE
Updates to the finish dialog for end of lesson

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -808,6 +808,7 @@
   "enablePeerFeedbackDescription": "When peer feedback is enabled, students may leave comments on other projects in the Review section.",
   "encrypted": "encrypted",
   "end": "end",
+  "endOfLesson": "Congratulations! You've reached the end of the lesson.",
   "englishOnly": "English-only",
   "englishOnlyWarning": "Sorry! This lesson is not available in your language. The levels in this lesson use a mix of English words and characters that can’t be translated right now. You can move on to Lesson {nextStage}.",
   "enterGroupName": "Enter a group name",

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -1652,13 +1652,6 @@ StudioApp.prototype.displayFeedback = function(options) {
   this.onFeedback(options);
 };
 
-StudioApp.prototype.isFinalFreePlayLevel = function(feedbackType, response) {
-  return (
-    this.feedback_.isFinalLevel(response) &&
-    this.feedback_.isFreePlay(feedbackType)
-  );
-};
-
 /**
  * Whether feedback should be displayed as a modal dialog or integrated
  * into the top instructions

--- a/apps/src/code-studio/appOptions.js
+++ b/apps/src/code-studio/appOptions.js
@@ -118,10 +118,11 @@
  * @property {boolean} iframeEmbedAppAndCode
  * @property {?} lastAttempt
  * @property {boolean} submittable
- * @property {boolean} final_level
  * @property {array} levelVideos
  * @property {string} mapReference
  * @property {array} referenceLinks
+ * @property {array} lastLevelInLesson
+ * @property {array} lastLevelInScript
  */
 
 /**

--- a/apps/src/code-studio/reporting.js
+++ b/apps/src/code-studio/reporting.js
@@ -281,10 +281,10 @@ reporting.sendReport = function(report) {
       postMilestone = true;
       break;
     case PostMilestoneMode.successful_runs_and_final_level_only:
-      postMilestone = report.pass || appOptions.level.final_level;
+      postMilestone = report.pass || appOptions.level.lastLevelInLesson;
       break;
     case PostMilestoneMode.final_level_only:
-      postMilestone = appOptions.level.final_level;
+      postMilestone = appOptions.level.lastLevelInLesson;
       break;
     default:
       console.error('Unexpected postMilestoneMode ' + postMilestoneMode);

--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -116,7 +116,6 @@ FeedbackUtils.prototype.displayFeedback = function(
   maxRecommendedBlocksToFlag
 ) {
   options.level = options.level || {};
-
   const {onContinue, shareLink} = options;
   const hadShareFailure = options.response && options.response.share_failure;
   const showingSharing =
@@ -147,6 +146,12 @@ FeedbackUtils.prototype.displayFeedback = function(
 
   if (feedbackMessage) {
     feedback.appendChild(feedbackMessage);
+    if (options.level.skin === 'applab' && options.level.lastLevelInLesson) {
+      var applabMessage = document.createElement('p');
+      applabMessage.id = 'finish-dialog-details';
+      applabMessage.textContent = options.appStrings.reinfFeedbackMsg;
+      feedback.appendChild(applabMessage);
+    }
   }
   if (feedbackBlocks && feedbackBlocks.div) {
     feedback.appendChild(feedbackBlocks.div);
@@ -183,7 +188,7 @@ FeedbackUtils.prototype.displayFeedback = function(
       continueText: options.continueText,
       isK1: options.level.isK1,
       freePlay: options.level.freePlay,
-      finalLevel: this.isFinalLevel(options.response)
+      finalLevel: options.level.lastLevelInLesson
     })
   );
 
@@ -721,8 +726,9 @@ FeedbackUtils.prototype.getShareFailure_ = function(options) {
 FeedbackUtils.prototype.getFeedbackMessage = function(options) {
   var message;
 
-  // If a message was explicitly passed in, use that.
-  if (
+  if (options.level.lastLevelInLesson && options.level.showEndOfLessonMsgs) {
+    message = "Congratulations! You've reached the end of the lesson.";
+  } else if (
     options.feedbackType < TestResults.ALL_PASS &&
     options.level &&
     options.level.failureMessageOverride

--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -709,7 +709,11 @@ FeedbackUtils.prototype.getFeedbackMessage = function(options) {
   // validatability is more consistent across level types, we have to check
   // multiple fields.
   var validatedLevel =
-    options.level?.validationEnabled || options.level?.requiredBlocks;
+    options.level?.validationEnabled ||
+    options.level?.requiredBlocks ||
+    // Free-play levels aren't validated for correctness, but the system does
+    // check to see if they level blocks have been changed at all.
+    options.level?.freePlay;
 
   if (validatedLevel) {
     switch (options.feedbackType) {

--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -723,21 +723,16 @@ FeedbackUtils.prototype.getShareFailure_ = function(options) {
 FeedbackUtils.prototype.getFeedbackMessage = function(options) {
   var message;
 
-  if (
-    options.level &&
-    options.level.lastLevelInLesson &&
-    options.level.showEndOfLessonMsgs
-  ) {
+  if (options.level?.lastLevelInLesson && options.level?.showEndOfLessonMsgs) {
     message = msg.endOfLesson();
   } else if (
     options.feedbackType < TestResults.ALL_PASS &&
-    options.level &&
-    options.level.failureMessageOverride
+    options.level?.failureMessageOverride
   ) {
     message = options.level.failureMessageOverride;
   } else if (options.message) {
     message = options.message;
-  } else if (options.response && options.response.share_failure) {
+  } else if (options.response?.share_failure) {
     message = msg.shareFailure();
   } else {
     // Otherwise, the message will depend on the test result.
@@ -883,7 +878,7 @@ FeedbackUtils.prototype.getFeedbackMessage = function(options) {
       case TestResults.PASS_WITH_EXTRA_TOP_BLOCKS:
         var finalLevel = this.isFinalLevel(options.response);
         var lessonCompleted = null;
-        if (options.response && options.response.lesson_changing) {
+        if (options.response?.lesson_changing) {
           lessonCompleted = options.response.lesson_changing.previous.name;
         }
         var msgParams = {
@@ -895,9 +890,7 @@ FeedbackUtils.prototype.getFeedbackMessage = function(options) {
           this.isFreePlay(options.feedbackType) &&
           !options.level.disableSharing
         ) {
-          var reinfFeedbackMsg =
-            (options.appStrings && options.appStrings.reinfFeedbackMsg) || '';
-
+          var reinfFeedbackMsg = options.appStrings?.reinfFeedbackMsg || '';
           if (options.level.disableFinalLessonMessage) {
             message = reinfFeedbackMsg;
           } else {
@@ -906,8 +899,7 @@ FeedbackUtils.prototype.getFeedbackMessage = function(options) {
           }
         } else {
           var nextLevelMsg =
-            (options.appStrings && options.appStrings.nextLevelMsg) ||
-            msg.nextLevel(msgParams);
+            options.appStrings?.nextLevelMsg || msg.nextLevel(msgParams);
           message = finalLevel
             ? msg.finalStage(msgParams)
             : lessonCompleted

--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -116,6 +116,7 @@ FeedbackUtils.prototype.displayFeedback = function(
   maxRecommendedBlocksToFlag
 ) {
   options.level = options.level || {};
+
   const {onContinue, shareLink} = options;
   const hadShareFailure = options.response && options.response.share_failure;
   const showingSharing =
@@ -713,12 +714,14 @@ FeedbackUtils.prototype.getShareFailure_ = function(options) {
 /**
  * Generates an appropriate feedback message
  * The message will be one of the following, from highest to lowest precedence:
- * 0. Failure override message specified on level (options.level.failureMessageOverride)
- * 1. Message passed in by caller (options.message).
- * 2. Header message due to dashboard text check fail (options.response.share_failure).
- * 3. Level-specific message (e.g., options.level.emptyBlocksErrorMsg) for
+ * 1. End of lesson message for last level in a lesson.
+ * 2. Failure override message specified on level
+ * (options.level.failureMessageOverride)
+ * 2. Message passed in by caller (options.message).
+ * 3. Header message due to dashboard text check fail (options.response.share_failure).
+ * 4. Level-specific message (e.g., options.level.emptyBlocksErrorMsg) for
  *    specific result type (e.g., TestResults.EMPTY_BLOCK_FAIL).
- * 4. System-wide message (e.g., msg.emptyBlocksErrorMsg()) for specific
+ * 5. System-wide message (e.g., msg.emptyBlocksErrorMsg()) for specific
  *    result type (e.g., TestResults.EMPTY_BLOCK_FAIL).
  * @param {FeedbackOptions} options
  * @return {string} message
@@ -731,7 +734,7 @@ FeedbackUtils.prototype.getFeedbackMessage = function(options) {
     options.level.lastLevelInLesson &&
     options.level.showEndOfLessonMsgs
   ) {
-    message = "Congratulations! You've reached the end of the lesson.";
+    message = msg.endOfLesson();
   } else if (
     options.feedbackType < TestResults.ALL_PASS &&
     options.level &&

--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -713,23 +713,7 @@ FeedbackUtils.prototype.getShareFailure_ = function(options) {
 FeedbackUtils.prototype.getFeedbackMessage = function(options) {
   var message;
 
-  if (!options.level?.validationEnabled) {
-    if (
-      options.level?.lastLevelInLesson &&
-      options.level?.showEndOfLessonMsgs
-    ) {
-      message = msg.endOfLesson();
-    } else if (
-      options.feedbackType < TestResults.ALL_PASS &&
-      options.level?.failureMessageOverride
-    ) {
-      message = options.level.failureMessageOverride;
-    } else if (options.message) {
-      message = options.message;
-    } else if (options.response?.share_failure) {
-      message = msg.shareFailure();
-    }
-  } else {
+  if (options.level?.validationEnabled) {
     switch (options.feedbackType) {
       case TestResults.FREE_PLAY_UNCHANGED_FAIL:
         logDialogActions('level_unchanged_failure', options, null);
@@ -905,6 +889,22 @@ FeedbackUtils.prototype.getFeedbackMessage = function(options) {
             : nextLevelMsg;
         }
         break;
+    }
+  } else {
+    if (
+      options.level?.lastLevelInLesson &&
+      options.level?.showEndOfLessonMsgs
+    ) {
+      message = msg.endOfLesson();
+    } else if (
+      options.feedbackType < TestResults.ALL_PASS &&
+      options.level?.failureMessageOverride
+    ) {
+      message = options.level.failureMessageOverride;
+    } else if (options.message) {
+      message = options.message;
+    } else if (options.response?.share_failure) {
+      message = msg.shareFailure();
     }
   }
   return message;

--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -147,12 +147,6 @@ FeedbackUtils.prototype.displayFeedback = function(
 
   if (feedbackMessage) {
     feedback.appendChild(feedbackMessage);
-    if (options.level.skin === 'applab' && options.level.lastLevelInLesson) {
-      var applabMessage = document.createElement('p');
-      applabMessage.id = 'finish-dialog-details';
-      applabMessage.textContent = options.appStrings.reinfFeedbackMsg;
-      feedback.appendChild(applabMessage);
-    }
   }
   if (feedbackBlocks && feedbackBlocks.div) {
     feedback.appendChild(feedbackBlocks.div);

--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -1973,17 +1973,6 @@ FeedbackUtils.prototype.hasExceededLimitedBlocks_ = function() {
 };
 
 /**
- * Determine if this is the final level in a progression based on server response.
- * For details, see:
- * https://github.com/code-dot-org/code-dot-org/blob/a6d3762e5756e825fef15182042845d01c05f1e6/dashboard/app/helpers/script_levels_helper.rb#L30
- * @param {Object} response
- * @returns {boolean}
- */
-FeedbackUtils.prototype.isFinalLevel = function(response) {
-  return response?.message === 'no more levels';
-};
-
-/**
  * Determine if this is a freeplay level based on level result.
  * @param {TestResults} result
  * @returns {boolean}

--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -726,7 +726,11 @@ FeedbackUtils.prototype.getShareFailure_ = function(options) {
 FeedbackUtils.prototype.getFeedbackMessage = function(options) {
   var message;
 
-  if (options.level.lastLevelInLesson && options.level.showEndOfLessonMsgs) {
+  if (
+    options.level &&
+    options.level.lastLevelInLesson &&
+    options.level.showEndOfLessonMsgs
+  ) {
     message = "Congratulations! You've reached the end of the lesson.";
   } else if (
     options.feedbackType < TestResults.ALL_PASS &&

--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -715,7 +715,7 @@ FeedbackUtils.prototype.getFeedbackMessage = function(options) {
     // check to see if they level blocks have been changed at all.
     options.level?.freePlay;
 
-  if (validatedLevel) {
+  if (!!validatedLevel) {
     switch (options.feedbackType) {
       case TestResults.FREE_PLAY_UNCHANGED_FAIL:
         logDialogActions('level_unchanged_failure', options, null);

--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -703,8 +703,15 @@ FeedbackUtils.prototype.getShareFailure_ = function(options) {
  */
 FeedbackUtils.prototype.getFeedbackMessage = function(options) {
   var message;
+  // Some levels have solutions that can be validated for correctness
+  // automatically by our system. Currently, level validation
+  // depends on different properties that vary by level type. Until
+  // validatability is more consistent across level types, we have to check
+  // multiple fields.
+  var validatedLevel =
+    options.level?.validationEnabled || options.level?.requiredBlocks;
 
-  if (options.level?.validationEnabled) {
+  if (validatedLevel) {
     switch (options.feedbackType) {
       case TestResults.FREE_PLAY_UNCHANGED_FAIL:
         logDialogActions('level_unchanged_failure', options, null);

--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -594,15 +594,6 @@ FeedbackUtils.saveThumbnail = function(image) {
     .then(() => project.saveIfSourcesChanged());
 };
 
-FeedbackUtils.isLastLevel = function() {
-  const lesson = getStore().getState().progress.lessons[0];
-  return (
-    lesson.levels[lesson.levels.length - 1].ids.indexOf(
-      window.appOptions.serverLevelId
-    ) !== -1
-  );
-};
-
 /**
  * Counts the number of blocks used.  Blocks are only counted if they are
  * not disabled, are deletable.

--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -1568,10 +1568,7 @@ export default class P5Lab {
     let msg = this.getMsg();
 
     // Allow P5Labs to decide what string should be rendered in the feedback dialog.
-    const isFinalFreePlayLevel = this.studioApp_.isFinalFreePlayLevel(
-      this.testResults,
-      this.response
-    );
+    const isFinalFreePlayLevel = level.freePlay && level.lastLevelInLesson;
     const reinfFeedbackMsg = this.getReinfFeedbackMsg(isFinalFreePlayLevel);
 
     const isSignedIn =

--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -755,14 +755,6 @@ input[type="radio"] {
   font-family: $gotham-extra-bold;
   font-weight: normal;
 }
-#finish-dialog-details {
-  $gray: #333333;
-  font-size: 18px;
-  margin: 20px 0px 20px 0px;
-  line-height: 28px;
-  color: $gray;
-  font-weight: normal;
-}
 #show-code {
   margin-bottom: 5px;
 }

--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -754,9 +754,15 @@ input[type="radio"] {
   color: #7E5BA0;
   font-family: $gotham-extra-bold;
   font-weight: normal;
-
 }
-
+#finish-dialog-details {
+  $gray: #333333;
+  font-size: 18px;
+  margin: 20px 0px 20px 0px;
+  line-height: 28px;
+  color: $gray;
+  font-weight: normal;
+}
 #show-code {
   margin-bottom: 5px;
 }

--- a/apps/style/craft/style.scss
+++ b/apps/style/craft/style.scss
@@ -267,10 +267,6 @@ body {
   }
 }
 
-//.minecraft .modal a:hover {
-//  background: transparent;
-//}
-
 #codeApp {
   top: 75px !important;
 

--- a/apps/test/unit/feedbackTest.js
+++ b/apps/test/unit/feedbackTest.js
@@ -22,7 +22,9 @@ describe('FeedbackUtils', () => {
         beforeEach(() => {
           options = {
             feedbackType: TestResults.FREE_PLAY,
-            level: {},
+            level: {
+              validationEnabled: true
+            },
             appStrings: {
               reinfFeedbackMsg: "You're finished!"
             }
@@ -47,7 +49,7 @@ describe('FeedbackUtils', () => {
           });
 
           it('returns final stage and appStrings.reinfFeedbackMsg if final level', () => {
-            options.response = {message: 'no more levels'};
+            options.level.lastLevelInLesson = true;
             assert.equal(
               feedbackUtils.getFeedbackMessage(options),
               `${finalStageMsg} ${options.appStrings.reinfFeedbackMsg}`
@@ -75,7 +77,7 @@ describe('FeedbackUtils', () => {
           });
 
           it('returns final stage message if final level', () => {
-            options.response = {message: 'no more levels'};
+            options.level.lastLevelInLesson = true;
             assert.equal(
               feedbackUtils.getFeedbackMessage(options),
               finalStageMsg

--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -39,7 +39,7 @@ class ActivitiesController < ApplicationController
     # Keep this logic in sync with code-studio/reporting#sendReport on the client.
     post_milestone = Gatekeeper.allows('postMilestone', where: {script_name: script_name}, default: true)
     post_failed_run_milestone = Gatekeeper.allows('postFailedRunMilestone', where: {script_name: script_name}, default: true)
-    final_level = @script_level.try(:final_level?)
+    final_level = @script_level.try(:end_of_lesson?)
     # We should only expect milestone posts if:
     #  - post_milestone is true, AND (we post on failed runs, or this was successful), or
     #  - this is the final level - we always post on final level

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -572,7 +572,7 @@ module LevelsHelper
     level_options['final_level'] = script_level.final_level? if script_level
     level_options['lastLevelInLesson'] = script_level.end_of_lesson? if script_level
     level_options['lastLevelInScript'] = script_level.end_of_script? if script_level
-    level_options[:showEndOfLessonMsgs] = true
+    level_options['showEndOfLessonMsgs'] = script.middle_high? if script
 
     # Edit blocks-dependent options
     if level_view_options(@level.id)[:edit_blocks]

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -569,7 +569,6 @@ module LevelsHelper
     script_level = @script_level
     level_options['puzzle_number'] = script_level ? script_level.position : 1
     level_options['lesson_total'] = script_level ? script_level.lesson_total : 1
-    level_options['final_level'] = script_level.final_level? if script_level
     level_options['lastLevelInLesson'] = script_level.end_of_lesson? if script_level
     level_options['lastLevelInScript'] = script_level.end_of_script? if script_level
     level_options['showEndOfLessonMsgs'] = script.middle_high? if script

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -570,6 +570,9 @@ module LevelsHelper
     level_options['puzzle_number'] = script_level ? script_level.position : 1
     level_options['lesson_total'] = script_level ? script_level.lesson_total : 1
     level_options['final_level'] = script_level.final_level? if script_level
+    level_options['lastLevelInLesson'] = script_level.end_of_lesson? if script_level
+    level_options['lastLevelInScript'] = script_level.end_of_script? if script_level
+    level_options[:showEndOfLessonMsgs] = true
 
     # Edit blocks-dependent options
     if level_view_options(@level.id)[:edit_blocks]

--- a/dashboard/app/helpers/script_levels_helper.rb
+++ b/dashboard/app/helpers/script_levels_helper.rb
@@ -27,8 +27,6 @@ module ScriptLevelsHelper
         end
       end
     else
-      response[:message] = 'no more levels' # used by blockly to show a different feedback message on the last level
-
       if script_level.script.wrapup_video
         response[:video_info] = wrapup_video_then_redirect_response(
           script_level.script.wrapup_video,

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -870,6 +870,12 @@ class Script < ApplicationRecord
     under_curriculum_umbrella?('CSC')
   end
 
+  # TODO: (Dani) Update to use new course types framework.
+  # Currently this grouping is used to determine whether the script should have # a custom end-of-lesson experience.
+  def middle_high?
+    csd? || csp? || csa?
+  end
+
   def hour_of_code?
     under_curriculum_umbrella?('HOC')
   end
@@ -2022,10 +2028,6 @@ class Script < ApplicationRecord
     if resources.any?(&:should_include_in_pdf?) || student_resources.any?(&:should_include_in_pdf?) || lessons.any? {|l| l.resources.any?(&:should_include_in_pdf?)}
       Services::CurriculumPdfs.get_unit_resources_url(self)
     end
-  end
-
-  def middle_high?
-    csd? || csp? || csa?
   end
 
   # To help teachers have more control over the pacing of certain scripts, we

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -2024,9 +2024,13 @@ class Script < ApplicationRecord
     end
   end
 
+  def middle_high?
+    csd? || csp? || csa?
+  end
+
   # To help teachers have more control over the pacing of certain scripts, we
   # send students on the last level of a lesson to the unit overview page.
   def show_unit_overview_between_lessons?(user)
-    (csd? || csp? || csa?) && user&.has_pilot_experiment?('end-of-lesson-redirects')
+    middle_high? && user&.has_pilot_experiment?('end-of-lesson-redirects')
   end
 end

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -144,10 +144,6 @@ class ScriptLevel < ApplicationRecord
     end
   end
 
-  def final_level?
-    !has_another_level_to_go_to?
-  end
-
   def next_level_or_redirect_path_for_user(
     user,
     extras_lesson=nil,

--- a/dashboard/test/controllers/activities_controller_test.rb
+++ b/dashboard/test/controllers/activities_controller_test.rb
@@ -41,7 +41,13 @@ class ActivitiesControllerTest < ActionController::TestCase
     @script_level_prev = create(:script_level, script: @script)
     @script_level = create(:script_level, script: @script)
     @script_level_next = create(:script_level, script: @script)
-    create(:lesson_group, lessons: [@script_level_prev.lesson, @script_level.lesson, @script_level_next.lesson], script: @script)
+
+    @lesson = create(:lesson)
+    @lesson.script_levels << @script_level_prev
+    @lesson.script_levels << @script_level
+    @lesson.script_levels << @script_level_next
+
+    create(:lesson_group, lessons: [@lesson], script: @script)
     @level = @script_level.level
 
     @blank_image = File.read('test/fixtures/artist_image_blank.png', binmode: true)

--- a/dashboard/test/ui/features/learning_platform/feedback.feature
+++ b/dashboard/test/ui/features/learning_platform/feedback.feature
@@ -33,5 +33,5 @@ Scenario: Solve without recommended blocks
   And I wait to see ".congrats"
 
   Then element ".congrats" is visible
-  And element ".congrats" has text "Congratulations! You completed Bee."
+  And element ".congrats" has text "Congratulations! You have completed the final puzzle."
   And element "#hint-request-button" does not exist


### PR DESCRIPTION
[spec](https://docs.google.com/document/d/1STMLxX2UphYMXLKIvgnctH7vuacCQPNHOB1KgS2VygA/edit#)
[LP-2092](https://codedotorg.atlassian.net/browse/LP-2092)

This updates the Finish Dialog to align with new messaging about slowing students in middle and high school courses down at the end of a lesson. For levels at the end of a lesson the dialog will now acknowledge that it is the end of a lesson with clearer messaging.

**End of lesson**
![Screen Shot 2022-01-04 at 8 26 10 PM](https://user-images.githubusercontent.com/12300669/148605714-1f784f43-9a18-4ebf-8c74-03dd51935fe3.png)

**AppLab mid-lesson** (no change)
![Screen Shot 2022-01-04 at 8 24 50 PM](https://user-images.githubusercontent.com/12300669/148262287-fdd1a007-0384-4b90-93d7-4129a6d44570.png)

**Not AppLab mid-lesson** (no change)
![Screen Shot 2022-01-04 at 8 27 07 PM](https://user-images.githubusercontent.com/12300669/148262214-8b487e3f-be47-4a9c-b531-153ec71441d1.png)

