### PR TITLE
Javalab: Level starter assets do not carry over on remix

### DIFF
--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -381,6 +381,7 @@ class ProjectsController < ApplicationController
       remix_parent_id: remix_parent_id,
     )
     AssetBucket.new.copy_files src_channel_id, new_channel_id if uses_asset_bucket?(project_type)
+    AssetBucket.new.copy_level_starter_assets src_channel_id, new_channel_id if uses_starter_assets?(project_type)
     animation_list = uses_animation_bucket?(project_type) ? AnimationBucket.new.copy_files(src_channel_id, new_channel_id) : []
     SourceBucket.new.remix_source src_channel_id, new_channel_id, animation_list
     FileBucket.new.copy_files src_channel_id, new_channel_id if uses_file_bucket?(project_type)
@@ -397,6 +398,10 @@ class ProjectsController < ApplicationController
 
   private def uses_file_bucket?(project_type)
     %w(weblab).include? project_type
+  end
+
+  private def uses_starter_assets?(project_type)
+    %w(javalab).include? project_type
   end
 
   def export_create_channel

--- a/dashboard/test/integration/remix_test.rb
+++ b/dashboard/test/integration/remix_test.rb
@@ -122,8 +122,8 @@ class RemixTest < ActionDispatch::IntegrationTest
     assert_only_remixes_sources 'eval'
   end
 
-  test 'javalab only remixes Sources and Assets buckets' do
-    assert_only_remixes_sources_assets 'javalab'
+  test 'javalab only remixes Sources and Assets buckets, and starter assets' do
+    assert_only_remixes_sources_assets_starter_assets 'javalab'
   end
 
   def assert_only_remixes_sources(project_type)
@@ -133,6 +133,7 @@ class RemixTest < ActionDispatch::IntegrationTest
     SourceBucket.any_instance.expects(:remix_source)
 
     AssetBucket.any_instance.expects(:copy_files).never
+    AssetBucket.any_instance.expects(:copy_level_starter_assets).never
     AnimationBucket.any_instance.expects(:copy_files).never
     FileBucket.any_instance.expects(:copy_files).never
 
@@ -147,6 +148,7 @@ class RemixTest < ActionDispatch::IntegrationTest
     SourceBucket.any_instance.expects(:remix_source)
     AssetBucket.any_instance.expects(:copy_files)
 
+    AssetBucket.any_instance.expects(:copy_level_starter_assets).never
     AnimationBucket.any_instance.expects(:copy_files).never
     FileBucket.any_instance.expects(:copy_files).never
 
@@ -162,6 +164,7 @@ class RemixTest < ActionDispatch::IntegrationTest
     AssetBucket.any_instance.expects(:copy_files)
     AnimationBucket.any_instance.expects(:copy_files).returns([])
 
+    AssetBucket.any_instance.expects(:copy_level_starter_assets).never
     FileBucket.any_instance.expects(:copy_files).never
 
     new_channel_id = remix_a_project project_type, original_channel_id
@@ -176,7 +179,23 @@ class RemixTest < ActionDispatch::IntegrationTest
     FileBucket.any_instance.expects(:copy_files)
 
     AssetBucket.any_instance.expects(:copy_files).never
+    AssetBucket.any_instance.expects(:copy_level_starter_assets).never
     AnimationBucket.any_instance.expects(:copy_files).never
+
+    new_channel_id = remix_a_project project_type, original_channel_id
+    refute_equal original_channel_id, new_channel_id
+  end
+
+  def assert_only_remixes_sources_assets_starter_assets(project_type)
+    stub_project_level project_type
+    original_channel_id = create_a_new_project project_type
+
+    SourceBucket.any_instance.expects(:remix_source)
+    AssetBucket.any_instance.expects(:copy_files)
+    AssetBucket.any_instance.expects(:copy_level_starter_assets)
+
+    AnimationBucket.any_instance.expects(:copy_files).never
+    FileBucket.any_instance.expects(:copy_files).never
 
     new_channel_id = remix_a_project project_type, original_channel_id
     refute_equal original_channel_id, new_channel_id

--- a/shared/middleware/helpers/asset_bucket.rb
+++ b/shared/middleware/helpers/asset_bucket.rb
@@ -14,4 +14,22 @@ class AssetBucket < BucketHelper
   def cache_duration_seconds
     3600
   end
+
+  def copy_level_starter_assets(src_channel, dest_channel)
+    src_owner_id, src_storage_app_id = storage_decrypt_channel_id(src_channel)
+
+    channel = ChannelToken.find_by(storage_id: src_owner_id, storage_app_id: src_storage_app_id)
+    return unless channel
+
+    level = Level.cache_find(channel.level_id)
+    return unless level
+
+    dest_owner_id, dest_storage_app_id = storage_decrypt_channel_id(dest_channel)
+
+    (level&.project_template_level&.starter_assets || level.starter_assets || []).map do |friendly_name, uuid_name|
+      src = "#{@bucket}/#{LevelStarterAssetsController::S3_PREFIX}#{uuid_name}"
+      dest = s3_path dest_owner_id, dest_storage_app_id, friendly_name
+      s3.copy_object(bucket: @bucket, key: dest, copy_source: URI.encode(src), metadata_directive: 'REPLACE')
+    end
+  end
 end


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

This copies level starter assets (if present) when remixing Javalab projects. The starter assets are just copied into the new project's assets directory, since starter assets are tied to levels and not specific projects. Including Star Labs and LP to take a look as well since this overlaps with StarLabs/LP's areas of expertise

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

JIRA: https://codedotorg.atlassian.net/browse/CSA-1097

## Testing story

Tested locally on Javalab levels with and without starter assets.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked