### PR TITLE
Stop saving certificate attachments to poste

### DIFF
--- a/lib/cdo/poste.rb
+++ b/lib/cdo/poste.rb
@@ -479,6 +479,8 @@ module Poste2
     timestamp = DateTime.now.strftime('%Y%m%d_%H%M_%S%L')
     {}.tap do |saved|
       attachments.each do |name, content|
+        # Prevent saving certificates - they are unecessarily filling storage.
+        next if name.include?('certificate')
         filename = File.expand_path "#{attachment_dir}/#{timestamp}-#{name}"
         File.open(filename, 'w+b') {|f| f.write content}
         saved[name] = filename


### PR DESCRIPTION
In October the Infrastructure team [noted ](https://codedotorg.slack.com/archives/CA3KCSGTD/p1634595952206100) that we'd triggered a CloudWatch Alarm because storage utilization on production-daemon exceeded 70%. They determined the directory /home/ubuntu/poste-attachments consumed ~33GiB, the bulk of which were certificates emailed at the end of professional development trainings or Hour of Code.  

Prior to 2021 Hour of Code Learning Platform did a one-time clean up of that directory to clear space using the process documented in [LP-2085](https://codedotorg.atlassian.net/browse/LP-2085). 

This PR [LP-2085](https://codedotorg.atlassian.net/browse/LP-2085 ) is a low-lift intermediary step to avoid saving certificates because they are the bulk of what's being saved, but we don't need them for anything. This will prevent the poste-attachements storage from filling as quickly while a longer term plan for s3 buckets with a defined lifecycle policy can be implemented; tracked in [FND-1779](https://codedotorg.atlassian.net/browse/FND-1779).