### PR TITLE
Trigger set_application_id for previous enrollments

### DIFF
--- a/bin/oneoff/update_app_ids_in_enrollments.rb
+++ b/bin/oneoff/update_app_ids_in_enrollments.rb
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+
+require_relative '../../dashboard/config/environment'
+
+puts "Updating application_id in enrollments ...\n\n"
+
+# The method set_application_id is triggered before a save
+# Save the enrollment to update set_application_id
+Pd::Enrollment.where.not(user_id: nil).each(&:save)

--- a/bin/oneoff/update_app_ids_in_enrollments.rb
+++ b/bin/oneoff/update_app_ids_in_enrollments.rb
@@ -6,4 +6,4 @@ puts "Updating application_id in enrollments ...\n\n"
 
 # The method set_application_id is triggered before a save
 # Save the enrollment to update set_application_id
-Pd::Enrollment.where.not(user_id: nil).each(&:save)
+Pd::Enrollment.where.not(user_id: nil).each(&:save!)

--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -67,7 +67,7 @@ class Pd::Enrollment < ApplicationRecord
   validate :school_info_country_required, if: -> {!deleted? && (new_record? || school_info_id_changed?)}
 
   before_validation :autoupdate_user_field
-  before_save :set_application_id if ActiveRecord::Base.connection.column_exists?(:pd_enrollments, :application_id)
+  before_save :set_application_id
   after_create :set_default_scholarship_info
   after_save :enroll_in_corresponding_online_learning, if: -> {!deleted? && (saved_change_to_user_id? || saved_change_to_email?)}
   after_save :authorize_teacher_account
@@ -351,7 +351,7 @@ class Pd::Enrollment < ApplicationRecord
     self.user_id = nil
     self.school = nil
     self.school_info_id = nil
-    self.application_id = nil if ActiveRecord::Base.connection.column_exists?(:pd_enrollments, :application_id)
+    self.application_id = nil
     self.deleted_at = Time.now
     save!
   end


### PR DESCRIPTION
New enrollments have an application_id where possible. Old enrollments don't. This is a script to trigger set_application_id on all enrollments by calling `save!`

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

I was planning to test this on an adhoc, but instead I tested a few locally and it's working as best I can tell.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
