### PR TITLE
add class(es) to softButtons

### DIFF
--- a/apps/src/bounce/bounce.js
+++ b/apps/src/bounce/bounce.js
@@ -925,9 +925,22 @@ Bounce.reset = function(first) {
   // Soft buttons
   var softButtonCount = 0;
   for (i = 0; i < Bounce.softButtons_.length; i++) {
-    document.getElementById(Bounce.softButtons_[i]).style.display = 'inline';
+    document.getElementById(Bounce.softButtons_[i]).classList.add('visible');
     softButtonCount++;
   }
+  // We need to apply a unique margin rule to the last visible button displayed.
+  // softButtons_ can include any of ['leftButton', 'rightButton', 'downButton', 'upButton']
+  // The #downButton element is always displayed last, despite the above order.
+  // If the level uses a 'downButton', this will be the last button.
+  // If not, it will be the last item in the array.
+  if (Bounce.softButtons_.includes('downButton')) {
+    document.getElementById('downButton').classList.add('last');
+  } else {
+    document
+      .getElementById(Bounce.softButtons_[softButtonCount - 1])
+      .classList.add('last');
+  }
+
   if (softButtonCount) {
     var softButtonsCell = document.getElementById('soft-buttons');
     getStore().dispatch(showArrowButtons());

--- a/apps/src/dance/Dance.js
+++ b/apps/src/dance/Dance.js
@@ -446,9 +446,22 @@ Dance.prototype.reset = function() {
 
   var softButtonCount = 0;
   for (var i = 0; i < this.level.softButtons.length; i++) {
-    document.getElementById(this.level.softButtons[i]).style.display = 'inline';
+    document.getElementById(this.level.softButtons[i]).classList.add('visible');
     softButtonCount++;
   }
+  // We need to apply a unique margin rule to the last visible button displayed.
+  // softButtons can include any of ['leftButton', 'rightButton', 'downButton', 'upButton']
+  // The #downButton element is always displayed last, despite the above order.
+  // If the level uses a 'downButton', this will be the last button.
+  // If not, it will be the last item in the array.
+  if (this.level.softButtons.includes('downButton')) {
+    document.getElementById('downButton').classList.add('last');
+  } else {
+    document
+      .getElementById(this.level.softButtons[softButtonCount - 1])
+      .classList.add('last');
+  }
+
   if (softButtonCount) {
     getStore().dispatch(showArrowButtons());
     $('#soft-buttons').addClass('soft-buttons-' + softButtonCount);

--- a/apps/src/studio/studio.js
+++ b/apps/src/studio/studio.js
@@ -2648,8 +2648,20 @@ Studio.reset = function(first) {
   // Soft buttons
   var softButtonCount = 0;
   for (i = 0; i < Studio.softButtons_.length; i++) {
-    document.getElementById(Studio.softButtons_[i]).style.display = 'inline';
+    document.getElementById(Studio.softButtons_[i]).classList.add('visible');
     softButtonCount++;
+  }
+  // We need to apply a unique margin rule to the last visible button displayed.
+  // softButtons_ can include any of ['leftButton', 'rightButton', 'downButton', 'upButton']
+  // The #downButton element is always displayed last, despite the above order.
+  // If the level uses a 'downButton', this will be the last button.
+  // If not, it will be the last item in the array.
+  if (Studio.softButtons_.includes('downButton')) {
+    document.getElementById('downButton').classList.add('last');
+  } else {
+    document
+      .getElementById(Studio.softButtons_[softButtonCount - 1])
+      .classList.add('last');
   }
   if (softButtonCount) {
     getStore().dispatch(showArrowButtons());

--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -236,6 +236,12 @@ button.arrow {
   margin-inline-end: 9px;
   display: none;
 }
+button.visible {
+  display: inline;
+}
+button.visible.last {
+  margin-inline-end: 0px;
+}
 button.arrow>img {
   opacity: 1;
   vertical-align: text-bottom;


### PR DESCRIPTION
A small extra margin shows up to the right of the arrow buttons in Bounce levels such as [this one](https://studio.code.org/s/allthethings/lessons/8/levels/1). This change removes the extra margin by adding a new class to whichever button will be the last one displayed.
**Before:**
![image](https://user-images.githubusercontent.com/43474485/148289567-4bc49710-9c7d-4f41-895e-a1f9053e8998.png)
**After:**
![image](https://user-images.githubusercontent.com/43474485/148289665-e3d0adb6-81f6-4095-a981-0eec6b78a76c.png)
Note that regardless of which buttons are hidden/visible, all four arrow buttons always show up in the DOM, which makes it impossible to solve this problem with a simpler method like styling the `:last-child` element.
This change was made for `studio` (Play Lab), `dance`, and `bounce` levels.  

A similar issue is theoretically possible with `P5Lab` (Game Lab, Sprite Lab, and Poetry) or `craft` (Minecraft) levels. Game Lab and Poetry never use the buttons. When Sprite Lab and Minecraft use the buttons, all four are always used. No further action is recommended to address this.


## Links

- jira ticket: [STAR-2008](https://codedotorg.atlassian.net/browse/STAR-2008)
