### PR TITLE
Reorder the control buttons list to match the display order

### DIFF
--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -833,8 +833,8 @@ module LevelsHelper
     [
       SoftButton.new('Left', 'leftButton'),
       SoftButton.new('Right', 'rightButton'),
-      SoftButton.new('Down', 'downButton'),
       SoftButton.new('Up', 'upButton'),
+      SoftButton.new('Down', 'downButton'),
     ]
   end
 


### PR DESCRIPTION
This change is for a potential quick win to add consistency to the levelbuilder experience. On levels that support them, curriculum writers select which arrow buttons to include. The order in the list does not match the final order that the button elements are added to the DOM. Swapping "Down" and "Up" will make this consistent.

![image](https://user-images.githubusercontent.com/43474485/148294701-a05ced16-8887-488a-9a93-8dcac0035bf3.png)
![image (112)](https://user-images.githubusercontent.com/43474485/148294823-bc8e7e24-df65-4ec0-9276-e1b70c7a699c.png)

