### PR TITLE
Send project error firehose events before reloading page

### DIFF
--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -1138,22 +1138,23 @@ var projects = (module.exports = {
         function(err, response) {
           if (err) {
             if (err.message.includes('httpStatusCode: 401')) {
-              this.showSaveError_(
+              this.showSaveError_();
+              this.logError_(
                 'unauthorized-save-sources-reload',
                 saveSourcesErrorCount,
                 err.message
-              );
-              utils.reload();
+              ).finally(() => utils.reload());
             } else if (err.message.includes('httpStatusCode: 409')) {
-              this.showSaveError_(
+              this.showSaveError_();
+              this.logError_(
                 'conflict-save-sources-reload',
                 saveSourcesErrorCount,
                 err.message
-              );
-              utils.reload();
+              ).finally(() => utils.reload());
             } else {
               saveSourcesErrorCount++;
-              this.showSaveError_(
+              this.showSaveError_();
+              this.logError_(
                 'save-sources-error',
                 saveSourcesErrorCount,
                 err.message
@@ -1372,16 +1373,15 @@ var projects = (module.exports = {
     name = name || appOptions.level.name;
     return name;
   },
-  showSaveError_(errorType, errorCount, errorText) {
+  showSaveError_() {
     header.showProjectSaveError();
-    this.logError_(errorType, errorCount, errorText);
   },
   logError_: function(errorType, errorCount, errorText) {
     // Share URLs only make sense for standalone app types.
     // This includes most app types, but excludes pixelation.
     const shareUrl = this.getStandaloneApp() ? this.getShareUrl() : '';
 
-    firehoseClient.putRecord(
+    return firehoseClient.putRecord(
       {
         study: 'project-data-integrity',
         study_group: 'v4',
@@ -1408,11 +1408,8 @@ var projects = (module.exports = {
     const {shouldNavigate} = options;
     if (err) {
       saveChannelErrorCount++;
-      this.showSaveError_(
-        'save-channel-error',
-        saveChannelErrorCount,
-        err + ''
-      );
+      this.showSaveError_();
+      this.logError_('save-channel-error', saveChannelErrorCount, err + '');
       if (saveChannelErrorCount >= NUM_ERRORS_BEFORE_WARNING) {
         header.showTryAgainDialog();
       }

--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -1162,8 +1162,8 @@ var projects = (module.exports = {
               if (saveSourcesErrorCount >= NUM_ERRORS_BEFORE_WARNING) {
                 header.showTryAgainDialog();
               }
-              return;
             }
+            return;
           } else if (saveSourcesErrorCount > 0) {
             // If the previous errors occurred due to network problems, we may not
             // have been able to report them. Try to report them once more, now that

--- a/apps/src/lib/util/firehose.js
+++ b/apps/src/lib/util/firehose.js
@@ -375,13 +375,13 @@ function getSingleton() {
 }
 
 function putRecord(data, options) {
-  getSingleton().then(firehoseClient =>
+  return getSingleton().then(firehoseClient =>
     firehoseClient.putRecord(data, options)
   );
 }
 
 function putRecordBatch(data, options) {
-  getSingleton().then(firehoseClient =>
+  return getSingleton().then(firehoseClient =>
     firehoseClient.putRecordBatch(data, options)
   );
 }


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

There were some error scenarios where we tried to post a debug event to firehose but then immediately reloaded the page before the event could be sent.  This change fixes two specific instances of this by waiting for the Promise from sending the debug event to resolve before reloading the page.

Also, fixed an issue where we weren't exiting the `sources.put` callback function in all error cases and the "error saving project" banner would appear very briefly and then be immediately overwritten.  This wasn't noticeable before this change because the page would be immediately reloaded but is visible now that there is a small delay before the page is reloaded.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [LP-2130](https://codedotorg.atlassian.net/browse/LP-2130)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
