### PR TITLE
INF-506 provide additional aliases in production

### DIFF
--- a/aws/cloudformation/components/www_redirect.yml.erb
+++ b/aws/cloudformation/components/www_redirect.yml.erb
@@ -12,8 +12,7 @@
         Enabled: true
         Comment: Redirect www to root domain
         PriceClass: PriceClass_All
-        Aliases:
-          - www.<%= subdomain %>
+        Aliases: <%= redirectedDomains.to_json %>
         Origins:
           # An origin is required, but will never receive traffic
           - Id: PrimaryOrigin
@@ -49,6 +48,10 @@
     Type: AWS::CertificateManager::Certificate
     Properties:
       DomainName: www.<%= subdomain %>
+      <%- if rack_env?(:production) -%>
+      SubjectAlternativeNames:
+        - "www.<%=CDO.pegasus_hostname%>"
+      <%- end -%>
       ValidationMethod: DNS
       DomainValidationOptions:
         - DomainName: www.<%= subdomain %>


### PR DESCRIPTION
In production, we were only creating the redirect distribution for www.autoscale-prod.code.org. This mirrors the PegasusCDN distribution configuraiton and adds www.code.org if we're in prod.

autoscale-prod is akin to staging and test, but because our official production domain doesn't use a subdomain, we have to handle the bare code.org domain as a special case.

This makes no changes to user experience in prod, just creates a updates an unused cloudfront distribution (using it is the next step)

## Links

Jira Ticket: INF-506

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
