### PR TITLE
Only check family_name/version_year on unit if it isCourse

### DIFF
--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -245,8 +245,9 @@ class UnitEditor extends React.Component {
       });
       return;
     } else if (
-      (this.state.versionYear !== '' && this.state.familyName === '') ||
-      (this.state.versionYear === '' && this.state.familyName !== '')
+      this.state.isCourse &&
+      ((this.state.versionYear !== '' && this.state.familyName === '') ||
+        (this.state.versionYear === '' && this.state.familyName !== ''))
     ) {
       this.setState({
         isSaving: false,

--- a/apps/test/unit/lib/levelbuilder/script-editor/UnitEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/UnitEditorTest.jsx
@@ -425,6 +425,51 @@ describe('UnitEditor', () => {
       $.ajax.restore();
     });
 
+    it('saves successful if unit is not a course and only version year is set', () => {
+      const wrapper = createWrapper({initialIsCourse: false});
+
+      const unitEditor = wrapper.find('UnitEditor');
+      unitEditor.setState({
+        versionYear: '1991',
+        familyName: ''
+      });
+
+      let returnData = {
+        scriptPath: '/s/test-unit'
+      };
+      let server = sinon.fakeServer.create();
+      server.respondWith('PUT', `/s/1`, [
+        200,
+        {'Content-Type': 'application/json'},
+        JSON.stringify(returnData)
+      ]);
+
+      const saveBar = wrapper.find('SaveBar');
+
+      const saveAndKeepEditingButton = saveBar.find('button').at(1);
+      expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
+        .true;
+      saveAndKeepEditingButton.simulate('click');
+
+      // check the the spinner is showing
+      expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(1);
+      expect(unitEditor.state().isSaving).to.equal(true);
+
+      clock = sinon.useFakeTimers(new Date('2020-12-01'));
+      const expectedLastSaved = Date.now();
+      server.respond();
+      clock.tick(50);
+
+      unitEditor.update();
+      expect(utils.navigateToHref).to.not.have.been.called;
+      expect(unitEditor.state().isSaving).to.equal(false);
+      expect(unitEditor.state().lastSaved).to.equal(expectedLastSaved);
+      expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(0);
+      //check that last saved message is showing
+      expect(wrapper.find('.lastSavedMessage').length).to.equal(1);
+      server.restore();
+    });
+
     it('shows error when version year is set but family name is not', () => {
       sinon.stub($, 'ajax');
       const wrapper = createWrapper({initialIsCourse: true});

--- a/apps/test/unit/lib/levelbuilder/script-editor/UnitEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/UnitEditorTest.jsx
@@ -427,7 +427,7 @@ describe('UnitEditor', () => {
 
     it('shows error when version year is set but family name is not', () => {
       sinon.stub($, 'ajax');
-      const wrapper = createWrapper({});
+      const wrapper = createWrapper({initialIsCourse: true});
 
       const unitEditor = wrapper.find('UnitEditor');
       unitEditor.setState({
@@ -462,7 +462,7 @@ describe('UnitEditor', () => {
 
     it('shows error when family name is set but version year is not', () => {
       sinon.stub($, 'ajax');
-      const wrapper = createWrapper({});
+      const wrapper = createWrapper({initialIsCourse: true});
 
       const unitEditor = wrapper.find('UnitEditor');
       unitEditor.setState({

--- a/apps/test/unit/lib/levelbuilder/script-editor/UnitEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/UnitEditorTest.jsx
@@ -425,7 +425,7 @@ describe('UnitEditor', () => {
       $.ajax.restore();
     });
 
-    it('saves successful if unit is not a course and only version year is set', () => {
+    it('saves successfully if unit is not a course and only version year is set', () => {
       const wrapper = createWrapper({initialIsCourse: false});
 
       const unitEditor = wrapper.find('UnitEditor');

--- a/dashboard/config/scripts_json/csd1-2021.script_json
+++ b/dashboard/config/scripts_json/csd1-2021.script_json
@@ -30,7 +30,6 @@
       "show_calendar": true,
       "student_detail_progress_view": true,
       "tts": true,
-      "version_year": "2021",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,

--- a/dashboard/config/scripts_json/csd2-2021.script_json
+++ b/dashboard/config/scripts_json/csd2-2021.script_json
@@ -30,7 +30,6 @@
       "show_calendar": true,
       "student_detail_progress_view": true,
       "tts": true,
-      "version_year": "2021",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,

--- a/dashboard/config/scripts_json/csd3-2021.script_json
+++ b/dashboard/config/scripts_json/csd3-2021.script_json
@@ -30,7 +30,6 @@
       "show_calendar": true,
       "student_detail_progress_view": true,
       "tts": true,
-      "version_year": "2021",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,

--- a/dashboard/config/scripts_json/csd4-2021.script_json
+++ b/dashboard/config/scripts_json/csd4-2021.script_json
@@ -23,7 +23,6 @@
       "show_calendar": true,
       "student_detail_progress_view": true,
       "tts": true,
-      "version_year": "2021",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,

--- a/dashboard/config/scripts_json/csd5-2021.script_json
+++ b/dashboard/config/scripts_json/csd5-2021.script_json
@@ -23,7 +23,6 @@
       "show_calendar": true,
       "student_detail_progress_view": true,
       "tts": true,
-      "version_year": "2021",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,

--- a/dashboard/config/scripts_json/csp1-2021.script_json
+++ b/dashboard/config/scripts_json/csp1-2021.script_json
@@ -12,7 +12,6 @@
       "is_migrated": true,
       "show_calendar": true,
       "student_detail_progress_view": true,
-      "version_year": "2021",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,

--- a/dashboard/config/scripts_json/csp10-2021.script_json
+++ b/dashboard/config/scripts_json/csp10-2021.script_json
@@ -13,7 +13,6 @@
       "project_sharing": true,
       "show_calendar": true,
       "student_detail_progress_view": true,
-      "version_year": "2021",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,

--- a/dashboard/config/scripts_json/csp2-2021.script_json
+++ b/dashboard/config/scripts_json/csp2-2021.script_json
@@ -13,7 +13,6 @@
       "project_sharing": true,
       "show_calendar": true,
       "student_detail_progress_view": true,
-      "version_year": "2021",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,

--- a/dashboard/config/scripts_json/csp3-2021.script_json
+++ b/dashboard/config/scripts_json/csp3-2021.script_json
@@ -13,7 +13,6 @@
       "project_sharing": true,
       "show_calendar": true,
       "student_detail_progress_view": true,
-      "version_year": "2021",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,

--- a/dashboard/config/scripts_json/csp4-2021.script_json
+++ b/dashboard/config/scripts_json/csp4-2021.script_json
@@ -13,7 +13,6 @@
       "project_sharing": true,
       "show_calendar": true,
       "student_detail_progress_view": true,
-      "version_year": "2021",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,

--- a/dashboard/config/scripts_json/csp5-2021.script_json
+++ b/dashboard/config/scripts_json/csp5-2021.script_json
@@ -13,7 +13,6 @@
       "project_sharing": true,
       "show_calendar": true,
       "student_detail_progress_view": true,
-      "version_year": "2021",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,

--- a/dashboard/config/scripts_json/csp6-2021.script_json
+++ b/dashboard/config/scripts_json/csp6-2021.script_json
@@ -13,7 +13,6 @@
       "project_sharing": true,
       "show_calendar": true,
       "student_detail_progress_view": true,
-      "version_year": "2021",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,

--- a/dashboard/config/scripts_json/csp7-2021.script_json
+++ b/dashboard/config/scripts_json/csp7-2021.script_json
@@ -13,7 +13,6 @@
       "project_sharing": true,
       "show_calendar": true,
       "student_detail_progress_view": true,
-      "version_year": "2021",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,

--- a/dashboard/config/scripts_json/csp8-2021.script_json
+++ b/dashboard/config/scripts_json/csp8-2021.script_json
@@ -13,7 +13,6 @@
       "project_sharing": true,
       "show_calendar": true,
       "student_detail_progress_view": true,
-      "version_year": "2021",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,

--- a/dashboard/config/scripts_json/csp9-2021.script_json
+++ b/dashboard/config/scripts_json/csp9-2021.script_json
@@ -13,7 +13,6 @@
       "project_sharing": true,
       "show_calendar": true,
       "student_detail_progress_view": true,
-      "version_year": "2021",
       "weekly_instructional_minutes": 225
     },
     "new_name": null,

--- a/dashboard/config/scripts_json/hello-world-draft.script_json
+++ b/dashboard/config/scripts_json/hello-world-draft.script_json
@@ -4,6 +4,7 @@
     "wrapup_video_id": null,
     "login_required": false,
     "properties": {
+      "is_course": "true",
       "is_migrated": true,
       "version_year": "unversioned"
     },

--- a/dashboard/config/scripts_json/k5-onlinepd-2021.script_json
+++ b/dashboard/config/scripts_json/k5-onlinepd-2021.script_json
@@ -4,8 +4,7 @@
     "wrapup_video_id": null,
     "login_required": true,
     "properties": {
-      "is_migrated": true,
-      "version_year": "2021"
+      "is_migrated": true
     },
     "new_name": null,
     "family_name": null,

--- a/dashboard/config/scripts_json/k5-onlinepd-2021.script_json
+++ b/dashboard/config/scripts_json/k5-onlinepd-2021.script_json
@@ -4,10 +4,12 @@
     "wrapup_video_id": null,
     "login_required": true,
     "properties": {
-      "is_migrated": true
+      "is_course": true,
+      "is_migrated": true,
+      "version_year": "2021"
     },
     "new_name": null,
-    "family_name": null,
+    "family_name": "k5-onlinepd",
     "serialized_at": "2021-11-22 19:57:38 UTC",
     "published_state": "beta",
     "instruction_type": "teacher_led",

--- a/dashboard/config/scripts_json/k5-onlinepd-2021.script_json
+++ b/dashboard/config/scripts_json/k5-onlinepd-2021.script_json
@@ -4,12 +4,11 @@
     "wrapup_video_id": null,
     "login_required": true,
     "properties": {
-      "is_course": true,
       "is_migrated": true,
       "version_year": "2021"
     },
     "new_name": null,
-    "family_name": "k5-onlinepd",
+    "family_name": null,
     "serialized_at": "2021-11-22 19:57:38 UTC",
     "published_state": "beta",
     "instruction_type": "teacher_led",

--- a/dashboard/config/scripts_json/peru-2019.script_json
+++ b/dashboard/config/scripts_json/peru-2019.script_json
@@ -6,10 +6,10 @@
     "properties": {
       "is_course": true,
       "is_migrated": true,
-      "version_year": "2021"
+      "version_year": "2019"
     },
     "new_name": null,
-    "family_name": null,
+    "family_name": "peru",
     "serialized_at": "2021-11-22 19:57:09 UTC",
     "published_state": "beta",
     "instruction_type": "teacher_led",

--- a/dashboard/config/scripts_json/peru-2019.script_json
+++ b/dashboard/config/scripts_json/peru-2019.script_json
@@ -4,8 +4,7 @@
     "wrapup_video_id": null,
     "login_required": false,
     "properties": {
-      "is_migrated": true,
-      "version_year": "2019"
+      "is_migrated": true
     },
     "new_name": null,
     "family_name": null,

--- a/dashboard/config/scripts_json/peru-2019.script_json
+++ b/dashboard/config/scripts_json/peru-2019.script_json
@@ -4,7 +4,9 @@
     "wrapup_video_id": null,
     "login_required": false,
     "properties": {
-      "is_migrated": true
+      "is_course": true,
+      "is_migrated": true,
+      "version_year": "2021"
     },
     "new_name": null,
     "family_name": null,

--- a/dashboard/config/scripts_json/vpl-csd-2021.script_json
+++ b/dashboard/config/scripts_json/vpl-csd-2021.script_json
@@ -5,6 +5,7 @@
     "login_required": false,
     "properties": {
       "hideable_lessons": true,
+      "is_course": true,
       "is_migrated": true,
       "pilot_experiment": "20-21-virtual-AYW-CSD",
       "student_detail_progress_view": true,
@@ -21,10 +22,11 @@
           "curriculumGuide",
           "https://docs.google.com/document/d/1myJwrDyRlAjwVNDS3gs-3JaJNhogsGMt9Swo-bpySgE/preview"
         ]
-      ]
+      ],
+      "version_year": "2021"
     },
     "new_name": null,
-    "family_name": null,
+    "family_name": "vpl-csd",
     "serialized_at": "2021-11-22 19:57:40 UTC",
     "published_state": "pilot",
     "instruction_type": "teacher_led",

--- a/dashboard/config/scripts_json/vpl-csd-2021.script_json
+++ b/dashboard/config/scripts_json/vpl-csd-2021.script_json
@@ -5,7 +5,6 @@
     "login_required": false,
     "properties": {
       "hideable_lessons": true,
-      "is_course": true,
       "is_migrated": true,
       "pilot_experiment": "20-21-virtual-AYW-CSD",
       "student_detail_progress_view": true,
@@ -26,7 +25,7 @@
       "version_year": "2021"
     },
     "new_name": null,
-    "family_name": "vpl-csd",
+    "family_name": null,
     "serialized_at": "2021-11-22 19:57:40 UTC",
     "published_state": "pilot",
     "instruction_type": "teacher_led",

--- a/dashboard/config/scripts_json/vpl-csd-2021.script_json
+++ b/dashboard/config/scripts_json/vpl-csd-2021.script_json
@@ -21,8 +21,7 @@
           "curriculumGuide",
           "https://docs.google.com/document/d/1myJwrDyRlAjwVNDS3gs-3JaJNhogsGMt9Swo-bpySgE/preview"
         ]
-      ],
-      "version_year": "2021"
+      ]
     },
     "new_name": null,
     "family_name": null,

--- a/dashboard/config/scripts_json/vpl-csp-2021.script_json
+++ b/dashboard/config/scripts_json/vpl-csp-2021.script_json
@@ -5,7 +5,6 @@
     "login_required": false,
     "properties": {
       "hideable_lessons": true,
-      "is_course": true,
       "is_migrated": true,
       "pilot_experiment": "20-21-virtual-AYW-CSP",
       "student_detail_progress_view": true,
@@ -26,7 +25,7 @@
       "version_year": "2021"
     },
     "new_name": null,
-    "family_name": "vpl-csp",
+    "family_name": null,
     "serialized_at": "2021-11-22 19:57:40 UTC",
     "published_state": "pilot",
     "instruction_type": "teacher_led",

--- a/dashboard/config/scripts_json/vpl-csp-2021.script_json
+++ b/dashboard/config/scripts_json/vpl-csp-2021.script_json
@@ -21,8 +21,7 @@
           "curriculumGuide",
           "https://docs.google.com/document/d/1k0wytFCORchnEg4G214yVFMZXJcUa2PoKaw-TrxtLjI/edit?usp=sharing"
         ]
-      ],
-      "version_year": "2021"
+      ]
     },
     "new_name": null,
     "family_name": null,

--- a/dashboard/config/scripts_json/vpl-csp-2021.script_json
+++ b/dashboard/config/scripts_json/vpl-csp-2021.script_json
@@ -5,6 +5,7 @@
     "login_required": false,
     "properties": {
       "hideable_lessons": true,
+      "is_course": true,
       "is_migrated": true,
       "pilot_experiment": "20-21-virtual-AYW-CSP",
       "student_detail_progress_view": true,
@@ -21,10 +22,11 @@
           "curriculumGuide",
           "https://docs.google.com/document/d/1k0wytFCORchnEg4G214yVFMZXJcUa2PoKaw-TrxtLjI/edit?usp=sharing"
         ]
-      ]
+      ],
+      "version_year": "2021"
     },
     "new_name": null,
-    "family_name": null,
+    "family_name": "vpl-csp",
     "serialized_at": "2021-11-22 19:57:40 UTC",
     "published_state": "pilot",
     "instruction_type": "teacher_led",


### PR DESCRIPTION
There was an [issue](https://codedotorg.slack.com/archives/C02EEGWLHR8/p1641422579089800) where csp scripts from 2021 could not be saved because they were giving an error about having to set both family_name and version_year. Bethany tracked down that those scripts had version_year set but not family_name. Since csp scripts are in a unit_group they should not have version_year or family_name set on the units just the unit_group. The new set up of the editor should prevent this issue going forward and this PR fixes up some inconsistencies in data for existing scripts. 

The following scripts had version_year set but not family_name:
k5-onlinepd-2020
peru-2019
csd1-2021
csd2-2021
csd3-2021
csd4-2021
csd5-2021
csp1-2021
csp10-2021
csp2-2021
csp3-2021
csp5-2021
csp6-2021
csp7-2021
csp8-2021
csp9-2021
csp4-2021
k5-onlinepd-2021
vpl-csd-2021
vpl-csp-2021

I ran the following to check that these were the only scripts to update

```
Script.all.each do |script|
  if script.family_name && script.version_year.nil?
    script.properties['version_year'] = nil
    script.save!
    script.write_script_json
  elsif script.family_name.nil? && script.version_year
    script.properties['version_year'] = nil
    script.save!
    script.write_script_json
  end
end
```

Also looked at where family_name and version_year are set but is_course is not:

```
Script.all.each do |script|
  if (script.family_name || script.version_year) && script.is_course.nil?
    puts script.name
  end
end
```

csd1-2017
csd1-2018
csd1-2019
csd2-2017
csd2-2018
csd2-2019
csd3-2017
csd3-2018
csd3-2019
csd4-2017
csd4-2018
csd4-2019
csd5-2017
csd5-2018
csd5-2019
csd6-2017
csd6-2018
csd6-2019
csd6-2020
csp-create-2017
csp-create-2018
csp-create-2019
csp-explore-2017
csp-explore-2018
csp-explore-2019
csp1-2017
csp1-2018
csp1-2019
csp2-2017
csp2-2018
csp2-2019
csp3-2017
csp3-2018
csp3-2019
csp4-2017
csp4-2018
csp4-2019
csp5-2017
csp5-2018
csp5-2019
csppostap-2017
csppostap-2018
csppostap-2019
csd6-2021
hello-world-draft

All of those make sense because of supporting the old redirects except for hello-world-draft which I have updated.

## Links

- [Slack Thread](https://codedotorg.slack.com/archives/C02EEGWLHR8/p1641422579089800)

## Testing story

- Update tests
- Local testing