### PR TITLE
Serialize programming environment on save

### DIFF
--- a/dashboard/app/controllers/programming_environments_controller.rb
+++ b/dashboard/app/controllers/programming_environments_controller.rb
@@ -16,8 +16,10 @@ class ProgrammingEnvironmentsController < ApplicationController
     end
     programming_environment.assign_attributes(programming_environment_params)
     begin
-      programming_environment.save! if programming_environment.changed?
-      programming_environment.write_serialization
+      if programming_environment.changed?
+        programming_environment.save!
+        programming_environment.write_serialization
+      end
       render json: programming_environment.summarize_for_edit.to_json
     rescue ActiveRecord::RecordInvalid => e
       render(status: :not_acceptable, plain: e.message)

--- a/dashboard/app/controllers/programming_environments_controller.rb
+++ b/dashboard/app/controllers/programming_environments_controller.rb
@@ -17,6 +17,7 @@ class ProgrammingEnvironmentsController < ApplicationController
     programming_environment.assign_attributes(programming_environment_params)
     begin
       programming_environment.save! if programming_environment.changed?
+      programming_environment.write_serialization
       render json: programming_environment.summarize_for_edit.to_json
     rescue ActiveRecord::RecordInvalid => e
       render(status: :not_acceptable, plain: e.message)

--- a/dashboard/app/models/programming_environment.rb
+++ b/dashboard/app/models/programming_environment.rb
@@ -15,7 +15,7 @@
 class ProgrammingEnvironment < ApplicationRecord
   include SerializedProperties
 
-  validates_uniqueness_of :name
+  validates_uniqueness_of :name, case_sensitive: false
 
   has_many :programming_expressions
 
@@ -29,10 +29,7 @@ class ProgrammingEnvironment < ApplicationRecord
 
   def self.properties_from_file(content)
     environment_config = JSON.parse(content)
-    {
-      name: environment_config['name'],
-      editor_type: environment_config['editorType']
-    }
+    environment_config.symbolize_keys
   end
 
   def self.seed_all(glob="config/programming_environments/*.json")
@@ -48,6 +45,17 @@ class ProgrammingEnvironment < ApplicationRecord
     environment = ProgrammingEnvironment.find_or_initialize_by(name: properties[:name])
     environment.update! properties
     environment.name
+  end
+
+  def serialize
+    {name: name}.merge(properties.sort.to_h)
+  end
+
+  def write_serialization
+    return unless Rails.application.config.levelbuilder_mode
+
+    file_path = Rails.root.join("config/programming_environments/#{name.parameterize}.json")
+    File.write(file_path, JSON.pretty_generate(serialize))
   end
 
   def summarize_for_lesson_edit

--- a/dashboard/config/programming_environments/applab.json
+++ b/dashboard/config/programming_environments/applab.json
@@ -1,4 +1,4 @@
 {
   "name": "applab",
-  "editorType": "droplet"
+  "editor_type": "droplet"
 }

--- a/dashboard/config/programming_environments/gamelab.json
+++ b/dashboard/config/programming_environments/gamelab.json
@@ -1,4 +1,4 @@
 {
   "name": "gamelab",
-  "editorType": "droplet"
+  "editor_type": "droplet"
 }

--- a/dashboard/config/programming_environments/spritelab.json
+++ b/dashboard/config/programming_environments/spritelab.json
@@ -1,4 +1,4 @@
 {
   "name": "spritelab",
-  "editorType": "blockly"
+  "editor_type": "blockly"
 }

--- a/dashboard/config/programming_environments/weblab.json
+++ b/dashboard/config/programming_environments/weblab.json
@@ -1,4 +1,4 @@
 {
   "name": "weblab",
-  "editorType": "text"
+  "editor_type": "text"
 }

--- a/dashboard/test/controllers/programming_environments_controller_test.rb
+++ b/dashboard/test/controllers/programming_environments_controller_test.rb
@@ -4,6 +4,7 @@ class ProgrammingEnvironmentsControllerTest < ActionController::TestCase
   include Devise::Test::ControllerHelpers
 
   setup do
+    File.stubs(:write)
     @levelbuilder = create :levelbuilder
     Rails.application.config.stubs(:levelbuilder_mode).returns true
   end
@@ -33,6 +34,7 @@ class ProgrammingEnvironmentsControllerTest < ActionController::TestCase
     sign_in @levelbuilder
 
     programming_environment = create :programming_environment
+    File.expects(:write).with {|filename, _| filename.to_s.end_with? "#{programming_environment.name}.json"}.once
     post :update, params: {
       name: programming_environment.name,
       title: 'title',

--- a/dashboard/test/models/programming_environment_test.rb
+++ b/dashboard/test/models/programming_environment_test.rb
@@ -5,4 +5,17 @@ class ProgrammingEnvironmentTest < ActiveSupport::TestCase
     programming_environment = create :programming_environment
     assert programming_environment.name
   end
+
+  test "can serialize and seed programming environment" do
+    env = create :programming_environment, name: 'ide', editor_type: 'droplet', title: 'IDE', description: 'A description of the IDE.', image_url: 'images.code.org/ide'
+    serialization = env.serialize
+    previous_env = env.freeze
+    env.destroy!
+
+    File.stubs(:read).returns(serialization.to_json)
+
+    new_env_name = ProgrammingEnvironment.seed_record("config/programming_environments/ide.json")
+    new_env = ProgrammingEnvironment.find_by_name(new_env_name)
+    assert_equal previous_env.attributes.except('id', 'created_at', 'updated_at'), new_env.attributes.except('id', 'created_at', 'updated_at')
+  end
 end


### PR DESCRIPTION
Adds serialization logic for programming environments and seeds more fields. Also changes editorType to editor_type because that seemed more consistent with the rest of our Rails config.

7abc63a03924a698cc933e839e362ecf461f1ff9 adds the new logic
c5e5217962918fb082d44f046cbc0cfb76fb56af updates the programming_environments configs

## Testing story

tested locally and unit tests


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
