### PR TITLE
Code Review Groups: reset state on dialog open and allow facilitator piloters to see groups

### DIFF
--- a/apps/src/templates/manageStudents/CodeReviewGroupsDialog.jsx
+++ b/apps/src/templates/manageStudents/CodeReviewGroupsDialog.jsx
@@ -103,6 +103,8 @@ export default function CodeReviewGroupsDialog({
 
   const getInitialGroups = () => {
     setLoadingStatus(LOADING_STATES.LOADING);
+    setSubmitStatus(SUBMIT_STATES.DEFAULT);
+    setGroupsHaveChanged(false);
     dataApi
       .getCodeReviewGroups()
       .done(groups => {

--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -109,6 +109,7 @@ class Section < ApplicationRecord
   ADD_STUDENT_RESTRICTED = 'restricted'.freeze
 
   CSA = 'csa'.freeze
+  CSA_PILOT_FACILITATOR = 'csa-pilot-facilitator'.freeze
 
   def self.valid_login_type?(type)
     LOGIN_TYPES.include? type
@@ -421,7 +422,7 @@ class Section < ApplicationRecord
   # A section can be assigned a course (aka unit_group) without being assigned a script,
   # so we check both here.
   def assigned_csa?
-    script&.csa? || unit_group&.family_name == CSA
+    script&.csa? || [CSA, CSA_PILOT_FACILITATOR].include?(unit_group&.family_name)
   end
 
   def reset_code_review_groups(new_groups)


### PR DESCRIPTION
Two unrelated small bug fixes noticed while setting up code review groups bug bash:
1. The success/error message displayed when you submit a change to code review groups was sticking after closing/re-opening the dialog. Also, if you made a change to groups and closed the dialog, the "Confirm Changes" button remained enabled when you reopen the dialog, even though we have reset the unsaved changes you made. Made it so both of these are reset on each dialog open.
2. The facilitator pilot course has a different family name (`csa-pilot-facilitator`) than the normal pilot course (family name `csa`). This could prevent people in the facilitator pilot from seeing the code review groups button on the teacher dashboard in certain cases. 