### PR TITLE
Update k5-onlinepd and vpl scripts course version information

### DIFF
--- a/dashboard/config/scripts_json/K5-OnlinePD.script_json
+++ b/dashboard/config/scripts_json/K5-OnlinePD.script_json
@@ -13,11 +13,13 @@
           "visibility": "Teacher-only"
         }
       ],
+      "is_course": true,
       "is_migrated": true,
-      "professional_learning_course": "K5 Support"
+      "professional_learning_course": "K5 Support",
+      "version_year": "2018"
     },
     "new_name": null,
-    "family_name": null,
+    "family_name": "k5-onlinepd",
     "serialized_at": "2021-11-22 19:55:41 UTC",
     "published_state": "beta",
     "instruction_type": "teacher_led",

--- a/dashboard/config/scripts_json/k5-onlinepd-2019.script_json
+++ b/dashboard/config/scripts_json/k5-onlinepd-2019.script_json
@@ -4,10 +4,12 @@
     "wrapup_video_id": null,
     "login_required": true,
     "properties": {
-      "is_migrated": true
+      "is_course": true,
+      "is_migrated": true,
+      "version_year": "2019"
     },
     "new_name": null,
-    "family_name": null,
+    "family_name": "k5-onlinepd",
     "serialized_at": "2021-11-22 19:57:04 UTC",
     "published_state": "beta",
     "instruction_type": "teacher_led",

--- a/dashboard/config/scripts_json/k5-onlinepd-2020.script_json
+++ b/dashboard/config/scripts_json/k5-onlinepd-2020.script_json
@@ -4,11 +4,12 @@
     "wrapup_video_id": null,
     "login_required": true,
     "properties": {
+      "is_course": true,
       "is_migrated": true,
       "version_year": "2020"
     },
     "new_name": null,
-    "family_name": null,
+    "family_name": "k5-onlinepd",
     "serialized_at": "2021-11-22 19:57:04 UTC",
     "published_state": "beta",
     "instruction_type": "teacher_led",

--- a/dashboard/config/scripts_json/k5-onlinepd-2021.script_json
+++ b/dashboard/config/scripts_json/k5-onlinepd-2021.script_json
@@ -4,11 +4,12 @@
     "wrapup_video_id": null,
     "login_required": true,
     "properties": {
+      "is_course": true,
       "is_migrated": true,
       "version_year": "2021"
     },
     "new_name": null,
-    "family_name": null,
+    "family_name": "k5-onlinepd",
     "serialized_at": "2021-11-22 19:57:38 UTC",
     "published_state": "beta",
     "instruction_type": "teacher_led",

--- a/dashboard/config/scripts_json/vpl-csd-2020.script_json
+++ b/dashboard/config/scripts_json/vpl-csd-2020.script_json
@@ -5,6 +5,7 @@
     "login_required": false,
     "properties": {
       "hideable_lessons": true,
+      "is_course": true,
       "is_migrated": true,
       "pilot_experiment": "20-21-virtual-AYW-CSD",
       "student_detail_progress_view": true,
@@ -25,10 +26,11 @@
           "professionalLearning",
           "/link/to/professional/learning"
         ]
-      ]
+      ],
+      "version_year": "2020"
     },
     "new_name": null,
-    "family_name": null,
+    "family_name": "vpl-csd",
     "serialized_at": "2021-11-22 19:57:19 UTC",
     "published_state": "pilot",
     "instruction_type": "teacher_led",

--- a/dashboard/config/scripts_json/vpl-csd-2021.script_json
+++ b/dashboard/config/scripts_json/vpl-csd-2021.script_json
@@ -25,7 +25,7 @@
       "version_year": "2021"
     },
     "new_name": null,
-    "family_name": null,
+    "family_name": "vpl-csd",
     "serialized_at": "2021-11-22 19:57:40 UTC",
     "published_state": "pilot",
     "instruction_type": "teacher_led",

--- a/dashboard/config/scripts_json/vpl-csp-2020.script_json
+++ b/dashboard/config/scripts_json/vpl-csp-2020.script_json
@@ -5,12 +5,14 @@
     "login_required": false,
     "properties": {
       "hideable_lessons": true,
+      "is_course": true,
       "is_migrated": true,
       "pilot_experiment": "20-21-virtual-AYW-CSP",
-      "student_detail_progress_view": true
+      "student_detail_progress_view": true,
+      "version_year": "2020"
     },
     "new_name": null,
-    "family_name": null,
+    "family_name": "vpl-csp",
     "serialized_at": "2021-11-22 19:57:19 UTC",
     "published_state": "pilot",
     "instruction_type": "teacher_led",

--- a/dashboard/config/scripts_json/vpl-csp-2021.script_json
+++ b/dashboard/config/scripts_json/vpl-csp-2021.script_json
@@ -25,7 +25,7 @@
       "version_year": "2021"
     },
     "new_name": null,
-    "family_name": null,
+    "family_name": "vpl-csp",
     "serialized_at": "2021-11-22 19:57:40 UTC",
     "published_state": "pilot",
     "instruction_type": "teacher_led",


### PR DESCRIPTION
Came out of a conversation on #44219

Update virtual pl scripts and k5 online pd scripts so that they have family names and version years. In addition they are marked as standalone units (is_course).

Looks like [PL is fine with this change](https://codedotorg.slack.com/archives/CL0LNHHN2/p1641505088002400).

Running the following command shows that there are still a lot of scripts that are not in a unit_group or marked as is_course. We should probably make a plan for those.

```
Script.all.each do |script|
  if script.unit_group.nil? && script.is_course.nil?
    puts script.name
  end
end
```

## Testing story

Ran `bundle exec rake build` to make sure things will still seed ok