### PR TITLE
Update Pegasus HoC helper to use i18n backend

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -344,7 +344,7 @@ build_apps: false
 
 # Whether dashboard should use your local build of the apps package.
 # If false, dashboard will try to use a prepackaged version from S3.
-use_my_apps:
+use_my_apps: true
 
 optimize_webpack_assets: true
 
@@ -354,7 +354,7 @@ optimize_rails_assets: true
 # If false, choosing a locale other than English will have no effect.
 # Note: You may need to be in an incognito window to see changes
 # due to a difference in the language cookie between production and localhost.
-load_locales:
+load_locales: true
 
 # Whether to skip the slow `rake seed:all` command during `rake build`.
 # Until you manually run `rake seed:all` or disable this flag, you won't

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -344,7 +344,7 @@ build_apps: false
 
 # Whether dashboard should use your local build of the apps package.
 # If false, dashboard will try to use a prepackaged version from S3.
-use_my_apps: true
+use_my_apps:
 
 optimize_webpack_assets: true
 
@@ -354,7 +354,7 @@ optimize_rails_assets: true
 # If false, choosing a locale other than English will have no effect.
 # Note: You may need to be in an incognito window to see changes
 # due to a difference in the language cookie between production and localhost.
-load_locales: true
+load_locales:
 
 # Whether to skip the slow `rake seed:all` command during `rake build`.
 # Until you manually run `rake seed:all` or disable this flag, you won't

--- a/pegasus/helpers/hourofcode_helpers.rb
+++ b/pegasus/helpers/hourofcode_helpers.rb
@@ -47,8 +47,10 @@ def hoc_canonicalized_i18n_path(uri, query_string)
   end
 
   if @country || @company
-    if possible_language && I18n.backend.translations[possible_language.to_sym]
-      @user_language = possible_language
+    if possible_language && I18n.backend.translations.key?(possible_language[0..1].to_sym)
+      # HOC uses two-letter language code. The full list of language codes is
+      # in the unique_language_s column in Pegasus.cdo_languages table.
+      @user_language = possible_language[0..1]
     else
       path = File.join([possible_language, path].reject(&:nil_or_empty?))
     end
@@ -97,12 +99,12 @@ def hoc_detect_country
   country_code
 end
 
+# Get browser language from HTTP_ACCEPT_LANGUAGE header, then return a two-letter
+# language code or nil if we don't have translation for that language.
 def hoc_detect_language
-  language = request.env['rack.locale']
-  return language if I18n.backend.translations[language.to_sym]
+  language = request.env['rack.locale'] || ''
   language_short = language[0..1]
-  return language_short if I18n.backend.translations[language_short.to_sym]
-  nil
+  return I18n.backend.translations.key?(language_short.to_sym) ? language_short : nil
 end
 
 # Called by pages on hourofcode.com to convert the current two-letter language (stored

--- a/pegasus/helpers/hourofcode_helpers.rb
+++ b/pegasus/helpers/hourofcode_helpers.rb
@@ -57,7 +57,7 @@ def hoc_canonicalized_i18n_path(uri, query_string)
 
   if @country || @company
     if possible_language && I18n.backend.translations[possible_language.to_sym]
-      @user_language = possible_language[0..1]
+      @user_language = possible_language
     else
       path = File.join([possible_language, path].reject(&:nil_or_empty?))
     end
@@ -106,13 +106,11 @@ def hoc_detect_country
   country_code
 end
 
-# Used to set @language instance variable in short format (ex. 'en')
 def hoc_detect_language
   language = request.env['rack.locale']
-  return nil unless language
-  language = language[0..1]
-
   return language if I18n.backend.translations[language.to_sym]
+  language_short = language[0..1]
+  return language_short if I18n.backend.translations[language_short.to_sym]
   nil
 end
 

--- a/pegasus/helpers/hourofcode_helpers.rb
+++ b/pegasus/helpers/hourofcode_helpers.rb
@@ -7,15 +7,6 @@ def hoc_load_countries
 end
 HOC_COUNTRIES = hoc_load_countries
 
-def hoc_load_i18n
-  i18n = {}
-  Dir.glob(hoc_dir('i18n/*.yml')).each do |string_file|
-    i18n.merge!(YAML.load_file(string_file))
-  end
-  i18n
-end
-HOC_I18N = hoc_load_i18n
-
 # Can be called by pages on hourofcode.com, code.org, or csedweek.org to retrieve
 # a string from the hourofcode.com translations.
 # When called on hourofcode.com, it uses @language.

--- a/pegasus/src/env.rb
+++ b/pegasus/src/env.rb
@@ -24,6 +24,10 @@ def sites_v3_dir(*paths)
   pegasus_dir('sites.v3', *paths)
 end
 
+def hoc_dir(*paths)
+  pegasus_dir('sites.v3', 'hourofcode.com', *paths)
+end
+
 def src_dir(*paths)
   pegasus_dir('src', *paths)
 end
@@ -51,9 +55,12 @@ def load_pegasus_settings
   I18n.fallbacks = I18n::Locale::Fallbacks.new(['en-US'])
   if rack_env?(:development) && !CDO.load_locales
     I18n.load_path += Dir[cache_dir('i18n/en-US.yml')]
+    I18n.load_path += Dir[hoc_dir('i18n/en.yml')]
     I18n.load_path += Dir[cache_dir('i18n/es-ES.yml')]
+    I18n.load_path += Dir[hoc_dir('i18n/es.yml')]
   else
     I18n.load_path += Dir[cache_dir('i18n/*.yml')]
+    I18n.load_path += Dir[hoc_dir('i18n/*.yml')]
   end
   I18n.enforce_available_locales = false
   I18n.backend.load_translations

--- a/pegasus/src/env.rb
+++ b/pegasus/src/env.rb
@@ -58,6 +58,7 @@ def load_pegasus_settings
     I18n.load_path += Dir[cache_dir('i18n/es-ES.yml')]
     I18n.load_path += Dir[hoc_dir('i18n/en.yml')]
     I18n.load_path += Dir[hoc_dir('i18n/es.yml')]
+    I18n.load_path += Dir[hoc_dir('i18n/fr.yml')]
   else
     I18n.load_path += Dir[cache_dir('i18n/*.yml')]
     I18n.load_path += Dir[hoc_dir('i18n/*.yml')]

--- a/pegasus/src/env.rb
+++ b/pegasus/src/env.rb
@@ -55,8 +55,8 @@ def load_pegasus_settings
   I18n.fallbacks = I18n::Locale::Fallbacks.new(['en-US'])
   if (rack_env?(:development) || rack_env?(:test)) && !CDO.load_locales
     I18n.load_path += Dir[cache_dir('i18n/en-US.yml')]
-    I18n.load_path += Dir[hoc_dir('i18n/en.yml')]
     I18n.load_path += Dir[cache_dir('i18n/es-ES.yml')]
+    I18n.load_path += Dir[hoc_dir('i18n/en.yml')]
     I18n.load_path += Dir[hoc_dir('i18n/es.yml')]
   else
     I18n.load_path += Dir[cache_dir('i18n/*.yml')]

--- a/pegasus/src/env.rb
+++ b/pegasus/src/env.rb
@@ -53,7 +53,7 @@ def load_pegasus_settings
   I18n.backend = CDO.i18n_backend
   I18n.backend.class.send(:include, I18n::Backend::Fallbacks)
   I18n.fallbacks = I18n::Locale::Fallbacks.new(['en-US'])
-  if rack_env?(:development) && !CDO.load_locales
+  if (rack_env?(:development) || rack_env?(:test)) && !CDO.load_locales
     I18n.load_path += Dir[cache_dir('i18n/en-US.yml')]
     I18n.load_path += Dir[hoc_dir('i18n/en.yml')]
     I18n.load_path += Dir[cache_dir('i18n/es-ES.yml')]

--- a/pegasus/src/env.rb
+++ b/pegasus/src/env.rb
@@ -53,6 +53,10 @@ def load_pegasus_settings
   I18n.backend = CDO.i18n_backend
   I18n.backend.class.send(:include, I18n::Backend::Fallbacks)
   I18n.fallbacks = I18n::Locale::Fallbacks.new(['en-US'])
+
+  # We don't load all translations in dev and test environment.
+  # Loading translations from files is slow, more than 60s sometimes. That can
+  # cause unrelated eyes tests to fail because of command timeout.
   if (rack_env?(:development) || rack_env?(:test)) && !CDO.load_locales
     I18n.load_path += Dir[cache_dir('i18n/en-US.yml')]
     I18n.load_path += Dir[cache_dir('i18n/es-ES.yml')]

--- a/pegasus/test/test_hoc_s.rb
+++ b/pegasus/test/test_hoc_s.rb
@@ -24,60 +24,60 @@ class HocI18nTest < Minitest::Test
   end
 
   def test_html_escaped
-    HOC_I18N['en']['test'] = "string with <strong>embedded html</strong>"
+    I18n.backend.store_translations 'en', {"test" => "string with <strong>embedded html</strong>"}
     resp = get('/hoc_s/generic')
     assert_equal 200, resp.status
     assert_match "<h1>string with &lt;strong&gt;embedded html&lt;/strong&gt;</h1>", resp.body
   end
 
   def test_interpolation
-    HOC_I18N['en']['test'] = "%{first}"
+    I18n.backend.store_translations 'en', {"test" => "%{first}"}
     resp = get('/hoc_s/interpolation')
     assert_equal 200, resp.status
     assert_match "<h1>primary</h1>", resp.body
 
-    HOC_I18N['en']['test'] = "%{first} %{second}"
+    I18n.backend.store_translations 'en', {"test" => "%{first} %{second}"}
     resp = get('/hoc_s/interpolation')
     assert_equal 200, resp.status
     assert_match "<h1>primary secondary</h1>", resp.body
 
-    HOC_I18N['en']['test'] = "%{first} %{second} %{first} again"
+    I18n.backend.store_translations 'en', {"test" => "%{first} %{second} %{first} again"}
     resp = get('/hoc_s/interpolation')
     assert_equal 200, resp.status
     assert_match "<h1>primary secondary primary again</h1>", resp.body
   end
 
   def test_markdown
-    HOC_I18N['en']['test'] = "string with **some** _basic_ formatting"
+    I18n.backend.store_translations 'en', {"test" => "string with **some** _basic_ formatting"}
     resp = get('/hoc_s/markdown')
     assert_equal 200, resp.status
     assert_match "<h1><p>string with <strong>some</strong> <em>basic</em> formatting</p>\n</h1>", resp.body
 
-    HOC_I18N['en']['test'] = "string with <strong>embedded html</strong>"
+    I18n.backend.store_translations 'en', {"test" => "string with <strong>embedded html</strong>"}
     resp = get('/hoc_s/markdown')
     assert_equal 200, resp.status
     assert_match "<h1><p>string with &lt;strong&gt;embedded html&lt;/strong&gt;</p>\n</h1>", resp.body
   end
 
   def test_interpolated_markdown
-    HOC_I18N['en']['test'] = "string with an [interpolated link](%{url})"
+    I18n.backend.store_translations 'en', {"test" => "string with an [interpolated link](%{url})"}
     resp = get('/hoc_s/interpolated_markdown')
     assert_equal 200, resp.status
     assert_match "<h1><p>string with an <a href=\"http://test.com\">interpolated link</a></p>\n</h1>", resp.body
   end
 
   def test_inline_markdown
-    HOC_I18N['en']['test'] = "basic string"
+    I18n.backend.store_translations 'en', {"test" => "basic string"}
     resp = get('/hoc_s/inline_markdown')
     assert_equal 200, resp.status
     assert_match "<h1>basic string</h1>", resp.body
 
-    HOC_I18N['en']['test'] = "string with\n\n- some\n- block\n\nmarkdown"
+    I18n.backend.store_translations 'en', {"test" => "string with\n\n- some\n- block\n\nmarkdown"}
     resp = get('/hoc_s/inline_markdown')
     assert_equal 200, resp.status
     assert_match "<h1>string withsome\nblock\nmarkdown</h1>", resp.body
 
-    HOC_I18N['en']['test'] = "string with <strong>embedded html</strong>"
+    I18n.backend.store_translations 'en', {"test" => "string with <strong>embedded html</strong>"}
     resp = get('/hoc_s/inline_markdown')
     assert_equal 200, resp.status
     assert_match "<h1>string with embedded html</h1>", resp.body

--- a/pegasus/test/test_hourofcode_helpers.rb
+++ b/pegasus/test/test_hourofcode_helpers.rb
@@ -46,10 +46,10 @@ class HourOfCodeHelpersTest < Minitest::Test
     response = get '/xyz', {}, {'REMOTE_ADDR' => cloudfront_ip}
     assert_equal 'http://hourofcode.com/fr/xyz', response.headers['Location']
 
-    header 'ACCEPT_LANGUAGE', 'it'
-    # French geo, Italian browser language
+    header 'ACCEPT_LANGUAGE', 'es'
+    # French geo, Spanish browser language
     response = get '/xyz', {}, {'REMOTE_ADDR' => cloudfront_ip}
-    assert_equal 'http://hourofcode.com/fr/it/xyz', response.headers['Location']
+    assert_equal 'http://hourofcode.com/fr/es/xyz', response.headers['Location']
   end
 
   # Ensure redirect goes to original (spoofable) IP-address location,

--- a/pegasus/test/test_i18n_hoc_routes.rb
+++ b/pegasus/test/test_i18n_hoc_routes.rb
@@ -13,6 +13,7 @@ class I18nHocRoutesTest < Minitest::Test
     header 'Host', 'hourofcode.com'
     languages = DB[:cdo_languages].select(:unique_language_s).where(supported_hoc_b: 1)
     subpages = load_hoc_subpages
+    load_all_hoc_translations
 
     languages.collect {|x| x[:unique_language_s]}.each do |lang|
       # Tests the homepage
@@ -48,5 +49,10 @@ class I18nHocRoutesTest < Minitest::Test
     Dir.glob(pegasus_dir('sites.v3/hourofcode.com/public/', '**/*.md')).map do |path|
       path[/public(.*)\.md/, 1]
     end
+  end
+
+  def load_all_hoc_translations
+    files = Dir[pegasus_dir('sites.v3/hourofcode.com/i18n/*.yml')]
+    I18n.backend.load_translations files
   end
 end

--- a/pegasus/test/test_volunteer_forms.rb
+++ b/pegasus/test/test_volunteer_forms.rb
@@ -8,9 +8,9 @@ class VolunteerFormsTest < Minitest::Test
     old_locale = I18n.locale
     I18n.locale = 'en-US'
     en_experiences = VolunteerEngineerSubmission2015.experiences
-    I18n.locale = 'ro-RO'
-    ro_experiences = VolunteerEngineerSubmission2015.experiences
+    I18n.locale = 'es-ES'
+    es_experiences = VolunteerEngineerSubmission2015.experiences
     I18n.locale = old_locale
-    refute_equal en_experiences['unspecified'], ro_experiences['unspecified']
+    refute_equal en_experiences['unspecified'], es_experiences['unspecified']
   end
 end


### PR DESCRIPTION
**What:** Replace the `HOC_I18N` constant we use in our `hourofcode_helpers.rb` file to instead use our shared I18n backend. This requires us to load the extra i18n translation files in the `/sites.v3/hourofcode.com` directory into the i18n backend.

**Why:** This reduces tech debt by removing the one off implementation of pulling the HoC translation files into a hash, and instead sharing the i18n logic we have across the rest of the codebase. Using our universal i18n module also provides us [string tracking](https://github.com/code-dot-org/code-dot-org/blob/fnd-1816-hoc-string-tracking/lib/cdo/i18n_string_url_tracker.rb#L12) on the hourofcode.com domain.

## Links

- jira ticket: [FND-1816](https://codedotorg.atlassian.net/browse/FND-1816)

## Testing story

- Placed a breakpoint in our [string tracking log method](https://github.com/code-dot-org/code-dot-org/blob/fnd-1816-hoc-string-tracking/lib/cdo/i18n_string_url_tracker.rb#L65) and made sure the buffer was populated correctly
- Updated relevant tests and they passed with no logical changes.
- Tested `campaign_date` method locally by visiting a page that calls it in the partial.
- Tested `hoc_s` locally by visiting several pages. Also placed a breakpoint if the old i18n string wasn't equal to the new string. Actually found that we referenced strings that weren't included in the old implementation. So this added translations.
- Tested a few paths touching more branches of our `hoc_canonicalized_i18n_path` function.
```
/it/how-to/districts
/us/pt/promote/resources
/us/it
```

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
