### PR TITLE
Update and add songs to songManifest2021

### DIFF
--- a/apps/src/code-studio/dancePartySongArtistTags.js
+++ b/apps/src/code-studio/dancePartySongArtistTags.js
@@ -20,7 +20,7 @@ export const SongTitlesToArtistTwitterHandle = {
   levelup_ciara: 'Ciara',
   macarena_losdelrio: 'LosDelRioMusic',
   migente_jbalvin: 'JBalvin',
-  needyounow_ladyantebellum: 'LadyAntebellum',
+  needyounow_ladya: 'LadyA',
   notearslefttocry_arianagrande: 'ArianaGrande',
   shapeofyou_edsheeran: 'EdSheeran',
   somebodylikeyou_keithurban: 'KeithUrban',
@@ -89,5 +89,6 @@ export const SongTitlesToArtistTwitterHandle = {
   heatwaves_glassanimals: 'GlassAnimals',
   levitating_dualipa: 'DUALIPA',
   stay_thekidlaroi: 'TheKidLaroi',
-  watermelonsugar_harrystyles: 'Harry_Styles'
+  watermelonsugar_harrystyles: 'Harry_Styles',
+  higherpower_coldplay: 'Coldplay'
 };

--- a/apps/src/dance/songs.js
+++ b/apps/src/dance/songs.js
@@ -13,7 +13,7 @@ import Sounds from '../Sounds';
 export async function getSongManifest(useRestrictedSongs, manifestFilename) {
   if (!manifestFilename || manifestFilename.length === 0) {
     manifestFilename = useRestrictedSongs
-      ? 'songManifest2021_v2.json'
+      ? 'songManifest2021_v3.json'
       : 'testManifest.json';
   }
 


### PR DESCRIPTION
Had some requests to update some existing 2021 songs and add one new song for Dance Party:

## Links
Jira Tickets:
https://codedotorg.atlassian.net/browse/STAR-1984
https://codedotorg.atlassian.net/browse/STAR-2036

## Testing story
You can test these changes by going to any dance party level and using `?manifest=songManifest2021_v3.json` to test the following changes:
- Masked Wolf - Astronaut in the Ocean should now be filtered out as PG-13
- Artist name change: Lady A 
- Higher Power - Coldplay should be added 
-

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
