### PR TITLE
don't clone deprecated blockly levels

### DIFF
--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -656,6 +656,9 @@ class Level < ApplicationRecord
 
     return Level.find_by_name(new_name) if Level.find_by_name(new_name)
 
+    # explicitly don't clone blockly levels (will cause a validation failure on non-unique level_num)
+    return self if key.start_with?('blockly:')
+
     level = clone_with_name(new_name, editor_experiment: editor_experiment)
 
     update_params = {name_suffix: new_suffix}

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -650,14 +650,14 @@ class Level < ApplicationRecord
   # @param [String] editor_experiment Optional value to set the
   #   editor_experiment property to on the newly-created level.
   def clone_with_suffix(new_suffix, editor_experiment: nil)
+    # explicitly don't clone blockly levels (will cause a validation failure on non-unique level_num)
+    return self if key.start_with?('blockly:')
+
     # Make sure we don't go over the 70 character limit.
     max_index = 70 - new_suffix.length - 1
     new_name = "#{base_name[0..max_index]}#{new_suffix}"
 
     return Level.find_by_name(new_name) if Level.find_by_name(new_name)
-
-    # explicitly don't clone blockly levels (will cause a validation failure on non-unique level_num)
-    return self if key.start_with?('blockly:')
 
     level = clone_with_name(new_name, editor_experiment: editor_experiment)
 

--- a/dashboard/test/models/level_test.rb
+++ b/dashboard/test/models/level_test.rb
@@ -851,6 +851,12 @@ class LevelTest < ActiveSupport::TestCase
     assert_equal ' copy', new_level.name_suffix
   end
 
+  test 'doesnt clone with suffix deprecated blockly levels' do
+    old_level = create :level, name: 'blockly', level_num: 'blockly_level', start_blocks: '<xml>foo</xml>'
+    new_level = old_level.clone_with_suffix(' copy')
+    assert_equal old_level, new_level
+  end
+
   test 'clone with suffix replaces old suffix' do
     level_1 = create :level, name: 'my_level_1'
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Deprecated blockly levels cause problems when cloned, and should be skipped (here, we return the old blockly level)
Specifically, they cause a validation failure on uniqueness of the level_num field:
https://github.com/code-dot-org/code-dot-org/blob/5aad68f3d427feee9d1794044f329b8d4c41a8a0/dashboard/app/models/levels/level.rb#L48-L54

See: https://docs.google.com/document/d/1rS1ekCEVU1Q49ckh2S9lfq0tQo-m-G5KJLiEalAzPts/edit#heading=h.2buyj1ahym0m

## Testing story

Couldn't repro locally, but tested with these changes in levelbuilder for `pre-express` and looks good!

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->
