### PR TITLE
Pass the announcement data when saving course

### DIFF
--- a/apps/src/lib/levelbuilder/course-editor/CourseEditor.js
+++ b/apps/src/lib/levelbuilder/course-editor/CourseEditor.js
@@ -113,6 +113,7 @@ class CourseEditor extends Component {
     let dataToSave = {
       title: this.state.title,
       version_title: this.state.versionTitle,
+      announcements: JSON.stringify(this.state.announcements),
       description_short: this.state.descriptionShort,
       description_student: this.state.descriptionStudent,
       description_teacher: this.state.descriptionTeacher,


### PR DESCRIPTION
We were not sending the updated announcements down when saving the course edit page so new announcements on the course edit page were not getting saved. 

## Links

[Slack Thread](https://codedotorg.slack.com/archives/C02EEGWLHR8/p1641422579089800)

## Testing story

- I tested that this fixes things locally.
- Is there a good way to make sure we are saving all the fields we should be saving? Like a way that if we add a new field we would know if we forgot this step?