### PR TITLE
Fix sharing image for poem art

### DIFF
--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -325,7 +325,7 @@ class ProjectsController < ApplicationController
       disallowed_html_tags: disallowed_html_tags
     )
 
-    if ['artist', 'spritelab'].include? params[:key]
+    if [Game::ARTIST, Game::SPRITELAB, Game::POETRY].include? @game.app
       @project_image = CDO.studio_url "/v3/files/#{@view_options['channel']}/.metadata/thumbnail.png", 'https:'
     end
 

--- a/dashboard/test/controllers/level_sources_controller_test.rb
+++ b/dashboard/test/controllers/level_sources_controller_test.rb
@@ -171,7 +171,7 @@ class LevelSourcesControllerTest < ActionController::TestCase
     assert_response :success
     assert_sharing_meta_tags(
       url: "http://test.host/c/#{level_source.id}",
-      image_url: 'http://test.host/sharing_drawing.png',
+      image_url: 'http://test.host/assets/sharing_drawing.png',
       image_width: 400,
       image_height: 400,
       small_thumbnail: true
@@ -186,7 +186,7 @@ class LevelSourcesControllerTest < ActionController::TestCase
 
     assert_sharing_meta_tags(
       url: "http://test.host/c/#{level_source.id}",
-      image_url: 'http://test.host/studio_sharing_drawing.png',
+      image_url: 'http://test.host/assets/studio_sharing_drawing.png',
       image_width: 400,
       image_height: 400,
       apple_mobile_web_app: true

--- a/dashboard/test/controllers/level_sources_controller_test.rb
+++ b/dashboard/test/controllers/level_sources_controller_test.rb
@@ -171,7 +171,7 @@ class LevelSourcesControllerTest < ActionController::TestCase
     assert_response :success
     assert_sharing_meta_tags(
       url: "http://test.host/c/#{level_source.id}",
-      image: 'http://test.host/assets/sharing_drawing.png',
+      image_url: 'http://test.host/sharing_drawing.png',
       image_width: 400,
       image_height: 400,
       small_thumbnail: true
@@ -186,7 +186,7 @@ class LevelSourcesControllerTest < ActionController::TestCase
 
     assert_sharing_meta_tags(
       url: "http://test.host/c/#{level_source.id}",
-      image: 'http://test.host/assets/sharing_drawing.png',
+      image_url: 'http://test.host/studio_sharing_drawing.png',
       image_width: 400,
       image_height: 400,
       apple_mobile_web_app: true

--- a/dashboard/test/controllers/projects_controller_test.rb
+++ b/dashboard/test/controllers/projects_controller_test.rb
@@ -142,7 +142,7 @@ class ProjectsControllerTest < ActionController::TestCase
     assert_response :success
     assert_sharing_meta_tags(
       url: "http://test.host/projects/applab/#{channel}",
-      image_url: 'http://test.host/applab_sharing_drawing.png',
+      image_url: 'http://test.host/assets/applab_sharing_drawing.png',
       image_width: 400,
       image_height: 400,
       apple_mobile_web_app: true
@@ -160,7 +160,7 @@ class ProjectsControllerTest < ActionController::TestCase
     assert_response :success
     assert_sharing_meta_tags(
       url: "http://test.host/projects/playlab/#{channel}",
-      image_url: 'http://test.host/studio_sharing_drawing.png',
+      image_url: 'http://test.host/assets/studio_sharing_drawing.png',
       image_width: 400,
       image_height: 400,
       apple_mobile_web_app: true

--- a/dashboard/test/controllers/projects_controller_test.rb
+++ b/dashboard/test/controllers/projects_controller_test.rb
@@ -90,21 +90,59 @@ class ProjectsControllerTest < ActionController::TestCase
     assert_response :success
     assert_sharing_meta_tags(
       url: "http://test.host/projects/artist/#{channel}",
-      image: 'http://test.host/assets/sharing_drawing.png',
+      image_url: "https://test-studio.code.org/v3/files/#{channel}/.metadata/thumbnail.png",
       image_width: 400,
       image_height: 400,
       small_thumbnail: true
     )
   end
 
+  test 'spritelab project level has sharing meta tags' do
+    spritelab_level = Level.where(name: ProjectsController::STANDALONE_PROJECTS[:spritelab][:name])
+    # populate level with correct game
+    spritelab_level.update(game: Game.create(app: Game::SPRITELAB))
+
+    channel = 'fake-channel'
+    get :show, params: {key: 'spritelab', channel_id: channel, share: true}
+
+    assert_response :success
+    assert_sharing_meta_tags(
+      url: "http://test.host/projects/spritelab/#{channel}",
+      image_url: "https://test-studio.code.org/v3/files/#{channel}/.metadata/thumbnail.png",
+      image_width: 400,
+      image_height: 400
+    )
+  end
+
+  test 'poetry_hoc project level has sharing meta tags' do
+    poetry_hoc_level = Level.where(name: ProjectsController::STANDALONE_PROJECTS[:poetry_hoc][:name])
+    # populate level with correct game
+    poetry_hoc_level.update(game: Game.create(app: Game::POETRY))
+
+    channel = 'fake-channel'
+    get :show, params: {key: 'poetry_hoc', channel_id: channel, share: true}
+
+    assert_response :success
+    assert_sharing_meta_tags(
+      url: "http://test.host/projects/poetry_hoc/#{channel}",
+      image_url: "https://test-studio.code.org/v3/files/#{channel}/.metadata/thumbnail.png",
+      image_width: 400,
+      image_height: 400
+    )
+  end
+
   test 'applab project level has sharing meta tags' do
+    applab_level = Level.where(name: ProjectsController::STANDALONE_PROJECTS[:applab][:name])
+    # populate level with correct game
+    applab_level.update(game: Game.create(app: Game::APPLAB))
+
     channel = 'fake-channel'
     get :show, params: {key: 'applab', channel_id: channel, share: true}
 
     assert_response :success
     assert_sharing_meta_tags(
       url: "http://test.host/projects/applab/#{channel}",
-      image: 'http://test.host/assets/sharing_drawing.png',
+      image_url: 'http://test.host/applab_sharing_drawing.png',
       image_width: 400,
       image_height: 400,
       apple_mobile_web_app: true
@@ -112,13 +150,17 @@ class ProjectsControllerTest < ActionController::TestCase
   end
 
   test 'playlab project level has sharing meta tags' do
+    playlab_level = Level.where(name: ProjectsController::STANDALONE_PROJECTS[:playlab][:name])
+    # populate level with correct game
+    playlab_level.update(game: Game.create(app: Game::PLAYLAB))
+
     channel = 'fake-channel'
     get :show, params: {key: 'playlab', channel_id: channel, share: true}
 
     assert_response :success
     assert_sharing_meta_tags(
       url: "http://test.host/projects/playlab/#{channel}",
-      image: 'http://test.host/assets/sharing_drawing.png',
+      image_url: 'http://test.host/studio_sharing_drawing.png',
       image_width: 400,
       image_height: 400,
       apple_mobile_web_app: true


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Why this wasn't working:
Here's an example link for sharing poem art HOC: `/projects/poetry_hoc/oCWdWjoon_TCHu6JmJuInQ`, in this case the `params[:key]` is `poetry_hoc` which is not `artist` or `spritelab`, so we were not setting a `@project_image`.

The change in this PR sets the project image based off of the game app rather than relying on the URL


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
- jira ticket: [LP-2176](https://codedotorg.atlassian.net/browse/LP-2176)
<!--
- spec: []()

-->

## Testing story
Verified locally:

My project to share:
<img width="1509" alt="Screen Shot 2022-01-07 at 11 11 15 AM" src="https://user-images.githubusercontent.com/24235215/148595403-4b5ac01e-efd3-4f2c-b8db-aeca2e3ca139.png">

The og:image tag viewed in the page source:
<img width="1030" alt="Screen Shot 2022-01-07 at 11 10 12 AM" src="https://user-images.githubusercontent.com/24235215/148595451-b3cbbc5b-94d9-4079-b2b7-c26fa8a03313.png">

The image the og tag references:
<img width="1241" alt="Screen Shot 2022-01-07 at 11 10 49 AM" src="https://user-images.githubusercontent.com/24235215/148595478-4437eabc-8095-4bd9-94b1-40d435b8033c.png">

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
