### PR TITLE
Remove special announcement capability from project gallery

### DIFF
--- a/apps/src/sites/studio/pages/projects/index.js
+++ b/apps/src/sites/studio/pages/projects/index.js
@@ -17,7 +17,6 @@ import deleteDialogReducer from '@cdo/apps/templates/projects/deleteDialog/delet
 
 $(document).ready(() => {
   const projectsData = getScriptData('projects');
-  const specialAnnouncement = projectsData.specialAnnouncement;
   registerReducers({
     projects,
     publishDialog: publishDialogReducer,
@@ -46,7 +45,6 @@ $(document).ready(() => {
         <ProjectHeader
           canViewAdvancedTools={projectsData.canViewAdvancedTools}
           projectCount={projectsData.projectCount}
-          specialAnnouncement={specialAnnouncement}
         />
         <div className={'main container'}>
           <ProjectsGallery

--- a/apps/src/templates/projects/ProjectHeader.jsx
+++ b/apps/src/templates/projects/ProjectHeader.jsx
@@ -4,14 +4,12 @@ import React from 'react';
 import i18n from '@cdo/locale';
 import StartNewProject from '@cdo/apps/templates/projects/StartNewProject';
 import HeaderBanner from '@cdo/apps/templates/HeaderBanner';
-import {SpecialAnnouncementActionBlock} from '../studioHomepages/TwoColumnActionBlock';
 import ProjectsPromo from './ProjectsPromo';
 
 export default class ProjectHeader extends React.Component {
   static propTypes = {
     canViewAdvancedTools: PropTypes.bool,
-    projectCount: PropTypes.number,
-    specialAnnouncement: PropTypes.object
+    projectCount: PropTypes.number
   };
 
   render() {
@@ -30,12 +28,7 @@ export default class ProjectHeader extends React.Component {
           backgroundUrl={backgroundUrl}
         />
         <div className={'container main'}>
-          {!this.props.specialAnnouncement && <ProjectsPromo />}
-          {this.props.specialAnnouncement && (
-            <SpecialAnnouncementActionBlock
-              announcement={this.props.specialAnnouncement}
-            />
-          )}
+          <ProjectsPromo />
           <StartNewProject
             canViewFullList
             canViewAdvancedTools={this.props.canViewAdvancedTools}

--- a/pegasus/sites.v3/code.org/announcements.json
+++ b/pegasus/sites.v3/code.org/announcements.json
@@ -1,6 +1,5 @@
 {
   "pages": {
-    "/projects": "home-learning-2020"
   },
 
   "banners": {
@@ -11,7 +10,7 @@
       "buttonText": "View Projects",
       "buttonUrl": "https://studio.code.org/projects/public",
       "buttonId": "thankyou-details"
-    },  
+    },
     "csjourneys": {
       "image": "/images/csjourneys/teacher-banner.png",
       "title": "Explore the wide world of computer science",
@@ -68,15 +67,6 @@
       "buttonText": "Join us",
       "buttonUrl": "https://code.org/educate/professional-learning/middle-high",
       "buttonId": "teacher-apps-stillon-2020-button",
-      "backgroundColor": "#59b9dc"
-    },
-    "home-learning-2020": {
-      "image": "/images/athome/fill-970x562/app-lab.png",
-      "title": "Project Ideas for Home Learning",
-      "body": "Parents and teachers — take a look at our Project Ideas page for starter projects in Game Lab, App Lab, and Web Lab. These include project descriptions, tips, and demo projects students can remix to make their own! ",
-      "buttonText": "View Project Ideas",
-      "buttonUrl": "https://code.org/athome/project-ideas",
-      "buttonId": "view-project-ideas-2020-button",
       "backgroundColor": "#59b9dc"
     },
     "soonhoc-2020": {


### PR DESCRIPTION
Follow up to https://github.com/code-dot-org/code-dot-org/pull/43399

An override from announcement.json led to an outdated banner that links to outdated content on code.org/athome/project-ideas. This ensures we always show the evergreen version of the banner and link to the updated page. 

[Discussion](https://codedotorg.slack.com/archives/CA3KCSGTD/p1641575503012600)
