### PR TITLE
Specify ActiveSupport Gem Version in Cookbook

### DIFF
--- a/cookbooks/cdo-apps/recipes/default.rb
+++ b/cookbooks/cdo-apps/recipes/default.rb
@@ -24,20 +24,20 @@ apt_package %w(
   fonts-noto
 )
 
-## Used by lesson plan generator.
-#pdftk_file = 'pdftk-java_3.1.1-1_all.deb'
-#pdftk_local_file = "#{Chef::Config[:file_cache_path]}/#{pdftk_file}"
-#remote_file pdftk_local_file do
-#  source "https://mirrors.kernel.org/ubuntu/pool/universe/p/pdftk-java/#{pdftk_file}"
-#  checksum "8a28ba8b100bc0b6e9f3e91c090a9b8a83a5f8a337a91150cbaadad8accb4901"
-#end
-## Dependencies of pdftk-java.
-#apt_package %w(
-#  default-jre-headless
-#  libbcprov-java
-#  libcommons-lang3-java
-#)
-#dpkg_package("pdftk-java") {source pdftk_local_file}
+# Used by lesson plan generator.
+pdftk_file = 'pdftk-java_3.1.1-1_all.deb'
+pdftk_local_file = "#{Chef::Config[:file_cache_path]}/#{pdftk_file}"
+remote_file pdftk_local_file do
+  source "https://mirrors.kernel.org/ubuntu/pool/universe/p/pdftk-java/#{pdftk_file}"
+  checksum "8a28ba8b100bc0b6e9f3e91c090a9b8a83a5f8a337a91150cbaadad8accb4901"
+end
+# Dependencies of pdftk-java.
+apt_package %w(
+  default-jre-headless
+  libbcprov-java
+  libcommons-lang3-java
+)
+dpkg_package("pdftk-java") {source pdftk_local_file}
 
 # Used by lesson plan generator.
 apt_package 'enscript'

--- a/cookbooks/cdo-apps/recipes/default.rb
+++ b/cookbooks/cdo-apps/recipes/default.rb
@@ -24,20 +24,20 @@ apt_package %w(
   fonts-noto
 )
 
-# Used by lesson plan generator.
-pdftk_file = 'pdftk-java_3.1.1-1_all.deb'
-pdftk_local_file = "#{Chef::Config[:file_cache_path]}/#{pdftk_file}"
-remote_file pdftk_local_file do
-  source "https://mirrors.kernel.org/ubuntu/pool/universe/p/pdftk-java/#{pdftk_file}"
-  checksum "8a28ba8b100bc0b6e9f3e91c090a9b8a83a5f8a337a91150cbaadad8accb4901"
-end
-# Dependencies of pdftk-java.
-apt_package %w(
-  default-jre-headless
-  libbcprov-java
-  libcommons-lang3-java
-)
-dpkg_package("pdftk-java") {source pdftk_local_file}
+## Used by lesson plan generator.
+#pdftk_file = 'pdftk-java_3.1.1-1_all.deb'
+#pdftk_local_file = "#{Chef::Config[:file_cache_path]}/#{pdftk_file}"
+#remote_file pdftk_local_file do
+#  source "https://mirrors.kernel.org/ubuntu/pool/universe/p/pdftk-java/#{pdftk_file}"
+#  checksum "8a28ba8b100bc0b6e9f3e91c090a9b8a83a5f8a337a91150cbaadad8accb4901"
+#end
+## Dependencies of pdftk-java.
+#apt_package %w(
+#  default-jre-headless
+#  libbcprov-java
+#  libcommons-lang3-java
+#)
+#dpkg_package("pdftk-java") {source pdftk_local_file}
 
 # Used by lesson plan generator.
 apt_package 'enscript'

--- a/cookbooks/cdo-secrets/recipes/app.rb
+++ b/cookbooks/cdo-secrets/recipes/app.rb
@@ -10,7 +10,10 @@
 # Install gem dependencies used by Cdo::Secrets.
 chef_gem 'aws-sdk-secretsmanager'
 chef_gem 'activesupport' do
-  # pin to current Rails version
+  # By default, this will install the very latest version of activesupport,
+  # which may or may not be compatible with our architecture. What we actually
+  # want to do here is install the same version of activesupport we use for our
+  # application, so we manually pin to that version.
   version "5.2.4.4"
 end
 

--- a/cookbooks/cdo-secrets/recipes/app.rb
+++ b/cookbooks/cdo-secrets/recipes/app.rb
@@ -9,7 +9,10 @@
 
 # Install gem dependencies used by Cdo::Secrets.
 chef_gem 'aws-sdk-secretsmanager'
-chef_gem 'activesupport'
+chef_gem 'activesupport' do
+  # pin to current Rails version
+  version "5.2.4.4"
+end
 
 ruby_block 'CDO config' do
   block do


### PR DESCRIPTION
Otherwise, we end up trying to install the latest version of the gem, which can cause issues creating adhocs when we're not up-to-date with latest Rails:

From `/var/log/cloud-init-output.log`:
```
[2022-01-05T21:52:04+00:00] INFO: Processing service[pegasus] action reload (cdo-apps::pegasus line 108)
[2022-01-05T21:52:04+00:00] ERROR: Running exception handlers
[2022-01-05T21:52:04+00:00] ERROR: Exception handlers complete
[2022-01-05T21:52:04+00:00] FATAL: Stacktrace dumped to /etc/chef/local-mode-cache/cache/chef-stacktrace.out
[2022-01-05T21:52:04+00:00] FATAL: Please provide the contents of the stacktrace.out file if you file a bug report
[2022-01-05T21:52:04+00:00] FATAL: Chef::Exceptions::MultipleFailures: Multiple failures occurred:
Mixlib::ShellOut::ShellCommandFailed occurred in Chef Infra Client run: chef_gem[activesupport] (cdo-secrets::app line 12) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '1'
---- Begin output of /opt/chef/embedded/bin/gem install activesupport -q --no-document -v "7.0.0" --source=https://www.rubygems.org ----
STDOUT: Successfully installed concurrent-ruby-1.1.9
Successfully installed i18n-1.8.11
Successfully installed tzinfo-2.0.4
STDERR: ERROR:  Error installing activesupport:
        There are no versions of activesupport (= 7.0.0) compatible with your Ruby & RubyGems
        activesupport requires Ruby version >= 2.7.0. The current ruby version is 2.6.3.62.
---- End output of /opt/chef/embedded/bin/gem install activesupport -q --no-document -v "7.0.0" --source=https://www.rubygems.org ----
Ran /opt/chef/embedded/bin/gem install activesupport -q --no-document -v "7.0.0" --source=https://www.rubygems.org returned 1
Mixlib::ShellOut::ShellCommandFailed occurred in delayed notification: execute[build-cdo] (cdo-apps::build line 13) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '1'
---- Begin output of bundle exec rake build --trace ----
STDOUT: bundler: failed to load command: rake (/usr/local/bin/rake)
STDERR: Bundler::GemNotFound: Could not find StreetAddress-1.0.6 in any of the sources
  /var/lib/gems/2.5.0/gems/bundler-1.16.1/lib/bundler/spec_set.rb:88:in `block in materialize'
  /var/lib/gems/2.5.0/gems/bundler-1.16.1/lib/bundler/spec_set.rb:82:in `map!'
  /var/lib/gems/2.5.0/gems/bundler-1.16.1/lib/bundler/spec_set.rb:82:in `materialize'
  /var/lib/gems/2.5.0/gems/bundler-1.16.1/lib/bundler/definition.rb:170:in `specs'
  /var/lib/gems/2.5.0/gems/bundler-1.16.1/lib/bundler/definition.rb:237:in `specs_for'
  /var/lib/gems/2.5.0/gems/bundler-1.16.1/lib/bundler/definition.rb:226:in `requested_specs'
  /var/lib/gems/2.5.0/gems/bundler-1.16.1/lib/bundler/runtime.rb:108:in `block in definition_method'
  /var/lib/gems/2.5.0/gems/bundler-1.16.1/lib/bundler/runtime.rb:20:in `setup'
  /var/lib/gems/2.5.0/gems/bundler-1.16.1/lib/bundler.rb:107:in `setup'
  /var/lib/gems/2.5.0/gems/bundler-1.16.1/lib/bundler/setup.rb:20:in `<top (required)>'
  /usr/local/lib/site_ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
  /usr/local/lib/site_ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
---- End output of bundle exec rake build --trace ----
Ran bundle exec rake build --trace returned 1
```
## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
