### PR TITLE
Added fallback message and translation for video length messages

### DIFF
--- a/apps/i18n/javalab/en_us.json
+++ b/apps/i18n/javalab/en_us.json
@@ -70,7 +70,6 @@
   "internalRuntimeException": "Oops. We hit an error on our side while running your program. Try running it again. If this error continues, contact us at support@code.org. Be sure to include the connection ID {connectionId} in your message.",
   "invalidJavaFilename": "Invalid file name. Java file names cannot have spaces.",
   "invalidJavaFilenameFormat": "Invalid file name. A Java file name must be in the format 'ClassName.java'.",
-  "generatingResults": "Generating results...",
   "generatingProgress": "{progressTime} seconds generated...",
   "javaExtensionMissing": "Invalid file name. File names must end in '.java'.",
   "javabuilderInvalidClassError": "{causeMessage} is not supported by Java Lab.",

--- a/apps/i18n/javalab/en_us.json
+++ b/apps/i18n/javalab/en_us.json
@@ -51,6 +51,8 @@
   "errorSoundMissingAudioData": "The sound file provided did not have any audio data.",
   "errorTheaterDuplicatePlayCommand": "The play() method can only be called once per execution of the program.",
   "errorTheaterInvalidShape": "A shape needs to contain an even number of values to represent (x,y) coordinates, and must include at least 4 values.",
+  "errorTheaterVideoTooLarge": "Your video is too large. Please decrease the number of frames in your video and try again.",
+  "errorTheaterVideoTooLong": "Your video exceeded the maximum playback time. Please decrease the length of your video and try again.",
   "feedbackBeginning": "This is the beginning of feedback for your project.",
   "feedbackBeginningPeer": "This is the beginning of feedback for {peerName}'s project.",
   "illegalMethodAccess": "You tried to access a method that is blocked by our security policy.\n{cause}",

--- a/apps/src/javalab/JavabuilderConnection.js
+++ b/apps/src/javalab/JavabuilderConnection.js
@@ -105,11 +105,6 @@ export default class JavabuilderConnection {
         message = javalabMsg.running();
         lineBreakCount = 2;
         break;
-      // TODO: Remove this case once Javabuilder stops sending these messages
-      case StatusMessageType.GENERATING_RESULTS:
-        message = javalabMsg.generatingResults();
-        lineBreakCount = 1;
-        break;
       case StatusMessageType.GENERATING_PROGRESS:
         message = javalabMsg.generatingProgress({
           progressTime: detail.progressTime

--- a/apps/src/javalab/constants.js
+++ b/apps/src/javalab/constants.js
@@ -117,7 +117,9 @@ export const MediaExceptionType = makeEnum('IMAGE_LOAD_ERROR');
 
 export const TheaterExceptionType = makeEnum(
   'DUPLICATE_PLAY_COMMAND',
-  'INVALID_SHAPE'
+  'INVALID_SHAPE',
+  'VIDEO_TOO_LONG',
+  'VIDEO_TOO_LARGE'
 );
 
 export const PlaygroundExceptionType = {

--- a/apps/src/javalab/javabuilderExceptionHandler.js
+++ b/apps/src/javalab/javabuilderExceptionHandler.js
@@ -11,7 +11,7 @@ import {
 
 export function handleException(exceptionDetails, callback) {
   const type = exceptionDetails.value;
-  const {connectionId, cause, causeMessage} =
+  const {connectionId, cause, causeMessage, fallbackMessage} =
     exceptionDetails.detail && exceptionDetails.detail;
   let error;
   switch (type) {
@@ -108,6 +108,12 @@ export function handleException(exceptionDetails, callback) {
     case TheaterExceptionType.INVALID_SHAPE:
       error = msg.errorTheaterInvalidShape();
       break;
+    case TheaterExceptionType.VIDEO_TOO_LONG:
+      error = msg.errorTheaterVideoTooLong();
+      break;
+    case TheaterExceptionType.VIDEO_TOO_LARGE:
+      error = msg.errorTheaterVideoTooLarge();
+      break;
 
     // Playground exceptions
     case PlaygroundExceptionType.PLAYGROUND_RUNNING:
@@ -121,7 +127,11 @@ export function handleException(exceptionDetails, callback) {
       break;
 
     default:
-      error = msg.unknownError({type, connectionId});
+      if (fallbackMessage) {
+        error = fallbackMessage;
+      } else {
+        error = msg.unknownError({type, connectionId});
+      }
       break;
   }
   error = `${EXCEPTION_PREFIX} ${error}`;

--- a/apps/src/javalab/javabuilderExceptionHandler.js
+++ b/apps/src/javalab/javabuilderExceptionHandler.js
@@ -127,11 +127,7 @@ export function handleException(exceptionDetails, callback) {
       break;
 
     default:
-      if (fallbackMessage) {
-        error = fallbackMessage;
-      } else {
-        error = msg.unknownError({type, connectionId});
-      }
+      error = fallbackMessage || msg.unknownError({type, connectionId});
       break;
   }
   error = `${EXCEPTION_PREFIX} ${error}`;


### PR DESCRIPTION
This does a couple of cleanup fixes as well as a quality of life improvement:

1. Add translations for messages from Javabuilder indicating that a video is too long or too large.
2. Remove the Generating Results message as it's no longer needed.
3. Add support for fallback messages so errors can be added to Javabuilder without a DTP.

This is paired with https://github.com/code-dot-org/javabuilder/pull/182 from the Javabuilder repo. This PR should be merged first.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [CSA-1108](https://codedotorg.atlassian.net/browse/CSA-1108)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
