### PR TITLE
[Blockly] render blocks with fields correctly in instructions

### DIFF
--- a/apps/src/templates/SafeMarkdown.jsx
+++ b/apps/src/templates/SafeMarkdown.jsx
@@ -45,6 +45,7 @@ const blocklyTags = [
   'next',
   'statement',
   'title',
+  'field',
   'value',
   'xml'
 ];

--- a/apps/src/templates/instructions/utils.js
+++ b/apps/src/templates/instructions/utils.js
@@ -139,7 +139,12 @@ export function convertXmlToBlockly(xmlContainer) {
       // so if our container is a span it should be inline-block
       blockSpaceContainer.style.display = 'inline-block';
     }
-    xml.appendChild(blockSpaceContainer);
+
+    xml.parentNode.insertBefore(blockSpaceContainer, xml);
+
+    // Don't render the raw XML
+    xml.style.display = 'none';
+
     const blockSpace = Blockly.BlockSpace.createReadOnlyBlockSpace(
       blockSpaceContainer,
       xml,


### PR DESCRIPTION
Reported in [slack](https://codedotorg.slack.com/archives/C1B3PNDL7/p1641574308011900)

Before
![image](https://user-images.githubusercontent.com/8787187/148609239-aa59a8c7-18c5-453f-a3c4-ff17672cdc92.png)

After
![image](https://user-images.githubusercontent.com/8787187/148608586-3da07ba9-ee98-4634-8267-35c84ea57238.png)
