### PR TITLE
Add block names for (almost all) spritelab block docs

### DIFF
--- a/dashboard/config/programming_expressions/spritelab/addTarget.json
+++ b/dashboard/config/programming_expressions/spritelab/addTarget.json
@@ -2,5 +2,6 @@
   "key": "addTarget",
   "name": "addTarget",
   "category": "Sprites",
+  "block_name": "gamelab_addTarget",
   "syntax": "addTarget"
 }

--- a/dashboard/config/programming_expressions/spritelab/atTime.json
+++ b/dashboard/config/programming_expressions/spritelab/atTime.json
@@ -2,5 +2,6 @@
   "key": "atTime",
   "name": "atTime",
   "category": "Events",
+  "block_name": "gamelab_atTime",
   "syntax": "atTime"
 }

--- a/dashboard/config/programming_expressions/spritelab/avoidingTargets.json
+++ b/dashboard/config/programming_expressions/spritelab/avoidingTargets.json
@@ -2,5 +2,6 @@
   "key": "avoidingTargets",
   "name": "avoidingTargets",
   "category": "SL1",
+  "block_name": "gamelab_avoidingTargets",
   "syntax": "avoidingTargets"
 }

--- a/dashboard/config/programming_expressions/spritelab/beginCollectingData.json
+++ b/dashboard/config/programming_expressions/spritelab/beginCollectingData.json
@@ -2,5 +2,6 @@
   "key": "beginCollectingData",
   "name": "beginCollectingData",
   "category": "Math",
+  "block_name": "gamelab_beginCollectingData",
   "syntax": "beginCollectingData"
 }

--- a/dashboard/config/programming_expressions/spritelab/bounce-off.json
+++ b/dashboard/config/programming_expressions/spritelab/bounce-off.json
@@ -2,5 +2,6 @@
   "key": "bounce-off",
   "name": "bounceOff",
   "category": "Sprites",
+  "block_name": "gamelab_bounceOff",
   "syntax": "bounceOff"
 }

--- a/dashboard/config/programming_expressions/spritelab/checkTouching.json
+++ b/dashboard/config/programming_expressions/spritelab/checkTouching.json
@@ -2,5 +2,6 @@
   "key": "checkTouching",
   "name": "checkTouching",
   "category": "Events",
+  "block_name": "gamelab_checkTouching",
   "syntax": "checkTouching"
 }

--- a/dashboard/config/programming_expressions/spritelab/clickedOn.json
+++ b/dashboard/config/programming_expressions/spritelab/clickedOn.json
@@ -2,5 +2,6 @@
   "key": "clickedOn",
   "name": "clickedOn",
   "category": "Unused",
+  "block_name": "gamelab_clickedOn",
   "syntax": "clickedOn"
 }

--- a/dashboard/config/programming_expressions/spritelab/clickedSpritePointer.json
+++ b/dashboard/config/programming_expressions/spritelab/clickedSpritePointer.json
@@ -2,5 +2,6 @@
   "key": "clickedSpritePointer",
   "name": "clickedSpritePointer",
   "category": "Events",
+  "block_name": "gamelab_clickedSpritePointer",
   "syntax": "clickedSpritePointer"
 }

--- a/dashboard/config/programming_expressions/spritelab/codestudio_andOrOperator.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_andOrOperator.json
@@ -2,5 +2,6 @@
   "key": "codestudio_andOrOperator",
   "name": "logic_operation",
   "category": "Logic",
+  "block_name": "logic_operation",
   "syntax": "logic_operation"
 }

--- a/dashboard/config/programming_expressions/spritelab/codestudio_arithmeticOperator.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_arithmeticOperator.json
@@ -2,5 +2,6 @@
   "key": "codestudio_arithmeticOperator",
   "name": "math_arithmetic",
   "category": "Math",
+  "block_name": "math_arithmetic",
   "syntax": "math_arithmetic"
 }

--- a/dashboard/config/programming_expressions/spritelab/codestudio_callingFunction.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_callingFunction.json
@@ -2,6 +2,5 @@
   "key": "codestudio_callingFunction",
   "name": "procedures_callnoreturn",
   "category": "Functions",
-  "block_name": "procedures_callnoreturn",
   "syntax": "procedures_callnoreturn"
 }

--- a/dashboard/config/programming_expressions/spritelab/codestudio_callingFunction.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_callingFunction.json
@@ -2,5 +2,6 @@
   "key": "codestudio_callingFunction",
   "name": "procedures_callnoreturn",
   "category": "Functions",
+  "block_name": "procedures_callnoreturn",
   "syntax": "procedures_callnoreturn"
 }

--- a/dashboard/config/programming_expressions/spritelab/codestudio_changeVariable.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_changeVariable.json
@@ -2,5 +2,6 @@
   "key": "codestudio_changeVariable",
   "name": "math_change",
   "category": "Variables",
+  "block_name": "math_change",
   "syntax": "math_change"
 }

--- a/dashboard/config/programming_expressions/spritelab/codestudio_comparisonOperator.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_comparisonOperator.json
@@ -2,5 +2,6 @@
   "key": "codestudio_comparisonOperator",
   "name": "logic_compare",
   "category": "Logic",
+  "block_name": "logic_compare",
   "syntax": "logic_compare"
 }

--- a/dashboard/config/programming_expressions/spritelab/codestudio_definingFunction.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_definingFunction.json
@@ -2,5 +2,6 @@
   "key": "codestudio_definingFunction",
   "name": "procedures_defnoreturn",
   "category": "Functions",
+  "block_name": "procedures_defnoreturn",
   "syntax": "procedures_defnoreturn"
 }

--- a/dashboard/config/programming_expressions/spritelab/codestudio_for.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_for.json
@@ -2,5 +2,6 @@
   "key": "codestudio_for",
   "name": "controls_for",
   "category": "Loops",
+  "block_name": "controls_for",
   "syntax": "controls_for"
 }

--- a/dashboard/config/programming_expressions/spritelab/codestudio_ifStatement.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_ifStatement.json
@@ -2,5 +2,6 @@
   "key": "codestudio_ifStatement",
   "name": "controls_if_if",
   "category": "Logic",
+  "block_name": "controls_if_if",
   "syntax": "controls_if_if"
 }

--- a/dashboard/config/programming_expressions/spritelab/codestudio_join.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_join.json
@@ -2,5 +2,6 @@
   "key": "codestudio_join",
   "name": "text_join",
   "category": "Text",
+  "block_name": "text_join",
   "syntax": "text_join"
 }

--- a/dashboard/config/programming_expressions/spritelab/codestudio_number.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_number.json
@@ -2,5 +2,6 @@
   "key": "codestudio_number",
   "name": "math_number",
   "category": "Math",
+  "block_name": "math_number",
   "syntax": "math_number"
 }

--- a/dashboard/config/programming_expressions/spritelab/codestudio_randomInt.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_randomInt.json
@@ -2,5 +2,6 @@
   "key": "codestudio_randomInt",
   "name": "math_random_int",
   "category": "Math",
+  "block_name": "math_random_int",
   "syntax": "math_random_int"
 }

--- a/dashboard/config/programming_expressions/spritelab/codestudio_repeat.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_repeat.json
@@ -2,5 +2,6 @@
   "key": "codestudio_repeat",
   "name": "controls_repeat",
   "category": "Loops",
+  "block_name": "controls_repeat",
   "syntax": "controls_repeat"
 }

--- a/dashboard/config/programming_expressions/spritelab/codestudio_setVariable.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_setVariable.json
@@ -2,5 +2,6 @@
   "key": "codestudio_setVariable",
   "name": "variables_set",
   "category": "Variables",
+  "block_name": "variables_set",
   "syntax": "variables_set"
 }

--- a/dashboard/config/programming_expressions/spritelab/codestudio_string.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_string.json
@@ -2,5 +2,6 @@
   "key": "codestudio_string",
   "name": "text",
   "category": "Text",
+  "block_name": "text",
   "syntax": "text"
 }

--- a/dashboard/config/programming_expressions/spritelab/codestudio_trueFalse.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_trueFalse.json
@@ -2,5 +2,6 @@
   "key": "codestudio_trueFalse",
   "name": "logic_boolean",
   "category": "Logic",
+  "block_name": "logic_boolean",
   "syntax": "logic_boolean"
 }

--- a/dashboard/config/programming_expressions/spritelab/codestudio_variableName.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_variableName.json
@@ -2,5 +2,6 @@
   "key": "codestudio_variableName",
   "name": "variables_get",
   "category": "Variables",
+  "block_name": "variables_get",
   "syntax": "variables_get"
 }

--- a/dashboard/config/programming_expressions/spritelab/costumeImage.json
+++ b/dashboard/config/programming_expressions/spritelab/costumeImage.json
@@ -2,5 +2,6 @@
   "key": "costumeImage",
   "name": "costumeImage",
   "category": "World",
+  "block_name": "gamelab_costumeImage",
   "syntax": "costumeImage"
 }

--- a/dashboard/config/programming_expressions/spritelab/countByAnimation.json
+++ b/dashboard/config/programming_expressions/spritelab/countByAnimation.json
@@ -2,5 +2,6 @@
   "key": "countByAnimation",
   "name": "countByAnimation",
   "category": "Sprites",
+  "block_name": "gamelab_countByAnimation",
   "syntax": "countByAnimation"
 }

--- a/dashboard/config/programming_expressions/spritelab/draggable.json
+++ b/dashboard/config/programming_expressions/spritelab/draggable.json
@@ -2,5 +2,6 @@
   "key": "draggable",
   "name": "draggable",
   "category": "SL1",
+  "block_name": "gamelab_draggable",
   "syntax": "draggable"
 }

--- a/dashboard/config/programming_expressions/spritelab/followingTargets.json
+++ b/dashboard/config/programming_expressions/spritelab/followingTargets.json
@@ -2,5 +2,6 @@
   "key": "followingTargets",
   "name": "followingTargets",
   "category": "SL1",
+  "block_name": "gamelab_followingTargets",
   "syntax": "followingTargets"
 }

--- a/dashboard/config/programming_expressions/spritelab/gamelab_addBehaviorSimple.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_addBehaviorSimple.json
@@ -2,5 +2,6 @@
   "key": "gamelab_addBehaviorSimple",
   "name": "addBehaviorSimple",
   "category": "Behaviors",
+  "block_name": "gamelab_addBehaviorSimple",
   "syntax": "addBehaviorSimple"
 }

--- a/dashboard/config/programming_expressions/spritelab/gamelab_allSpritesWithAnimation.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_allSpritesWithAnimation.json
@@ -2,5 +2,6 @@
   "key": "gamelab_allSpritesWithAnimation",
   "name": "allSpritesWithAnimation",
   "category": "Sprites",
+  "block_name": "gamelab_allSpritesWithAnimation",
   "syntax": "allSpritesWithAnimation"
 }

--- a/dashboard/config/programming_expressions/spritelab/gamelab_changePropBy.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_changePropBy.json
@@ -2,5 +2,6 @@
   "key": "gamelab_changePropBy",
   "name": "changePropBy",
   "category": "Sprites",
+  "block_name": "gamelab_changePropBy",
   "syntax": "changePropBy"
 }

--- a/dashboard/config/programming_expressions/spritelab/gamelab_comment.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_comment.json
@@ -2,5 +2,6 @@
   "key": "gamelab_comment",
   "name": "comment",
   "category": "Comments",
+  "block_name": "gamelab_comment",
   "syntax": "comment"
 }

--- a/dashboard/config/programming_expressions/spritelab/gamelab_createNewSprite.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_createNewSprite.json
@@ -2,5 +2,6 @@
   "key": "gamelab_createNewSprite",
   "name": "createNewSprite",
   "category": "Sprites",
+  "block_name": "gamelab_createNewSprite",
   "syntax": "createNewSprite"
 }

--- a/dashboard/config/programming_expressions/spritelab/gamelab_destroy.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_destroy.json
@@ -2,5 +2,6 @@
   "key": "gamelab_destroy",
   "name": "destroy",
   "category": "Sprites",
+  "block_name": "gamelab_destroy",
   "syntax": "destroy"
 }

--- a/dashboard/config/programming_expressions/spritelab/gamelab_edgesDisplace.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_edgesDisplace.json
@@ -2,5 +2,6 @@
   "key": "gamelab_edgesDisplace",
   "name": "edgesDisplace",
   "category": "Sprites",
+  "block_name": "gamelab_edgesDisplace",
   "syntax": "edgesDisplace"
 }

--- a/dashboard/config/programming_expressions/spritelab/gamelab_getProp.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_getProp.json
@@ -2,5 +2,6 @@
   "key": "gamelab_getProp",
   "name": "getProp",
   "category": "Sprites",
+  "block_name": "gamelab_getProp",
   "syntax": "getProp"
 }

--- a/dashboard/config/programming_expressions/spritelab/gamelab_getThisSprite.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_getThisSprite.json
@@ -2,5 +2,6 @@
   "key": "gamelab_getThisSprite",
   "name": "getThisSprite",
   "category": "Sprites",
+  "block_name": "gamelab_getThisSprite",
   "syntax": "getThisSprite"
 }

--- a/dashboard/config/programming_expressions/spritelab/gamelab_glideTo.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_glideTo.json
@@ -2,5 +2,6 @@
   "key": "gamelab_glideTo",
   "name": "glideTo",
   "category": "Sprites",
+  "block_name": "gamelab_glideTo",
   "syntax": "glideTo"
 }

--- a/dashboard/config/programming_expressions/spritelab/gamelab_hideTitleScreen.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_hideTitleScreen.json
@@ -2,5 +2,6 @@
   "key": "gamelab_hideTitleScreen",
   "name": "hideTitleScreen",
   "category": "World",
+  "block_name": "gamelab_hideTitleScreen",
   "syntax": "hideTitleScreen"
 }

--- a/dashboard/config/programming_expressions/spritelab/gamelab_jumpTo.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_jumpTo.json
@@ -2,5 +2,6 @@
   "key": "gamelab_jumpTo",
   "name": "jumpTo",
   "category": "Sprites",
+  "block_name": "gamelab_jumpTo",
   "syntax": "jumpTo"
 }

--- a/dashboard/config/programming_expressions/spritelab/gamelab_keyPressed.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_keyPressed.json
@@ -2,5 +2,6 @@
   "key": "gamelab_keyPressed",
   "name": "keyPressed",
   "category": "Events",
+  "block_name": "gamelab_keyPressed",
   "syntax": "keyPressed"
 }

--- a/dashboard/config/programming_expressions/spritelab/gamelab_locationAt.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_locationAt.json
@@ -2,5 +2,6 @@
   "key": "gamelab_locationAt",
   "name": "locationAt",
   "category": "Location",
+  "block_name": "gamelab_locationAt",
   "syntax": "locationAt"
 }

--- a/dashboard/config/programming_expressions/spritelab/gamelab_locationMouse.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_locationMouse.json
@@ -2,5 +2,6 @@
   "key": "gamelab_locationMouse",
   "name": "locationMouse",
   "category": "Location",
+  "block_name": "gamelab_locationMouse",
   "syntax": "locationMouse"
 }

--- a/dashboard/config/programming_expressions/spritelab/gamelab_locationOf.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_locationOf.json
@@ -2,5 +2,6 @@
   "key": "gamelab_locationOf",
   "name": "locationOf",
   "category": "Sprites",
+  "block_name": "gamelab_locationOf",
   "syntax": "locationOf"
 }

--- a/dashboard/config/programming_expressions/spritelab/gamelab_location_picker.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_location_picker.json
@@ -2,5 +2,6 @@
   "key": "gamelab_location_picker",
   "name": "location_picker",
   "category": "Location",
+  "block_name": "gamelab_location_picker",
   "syntax": "location_picker"
 }

--- a/dashboard/config/programming_expressions/spritelab/gamelab_makeNewSpriteAnon.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_makeNewSpriteAnon.json
@@ -2,5 +2,6 @@
   "key": "gamelab_makeNewSpriteAnon",
   "name": "makeNewSpriteAnon",
   "category": "Sprites",
+  "block_name": "gamelab_makeNewSpriteAnon",
   "syntax": "makeNewSpriteAnon"
 }

--- a/dashboard/config/programming_expressions/spritelab/gamelab_moveForward.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_moveForward.json
@@ -2,5 +2,6 @@
   "key": "gamelab_moveForward",
   "name": "moveForward",
   "category": "Sprites",
+  "block_name": "gamelab_moveForward",
   "syntax": "moveForward"
 }

--- a/dashboard/config/programming_expressions/spritelab/gamelab_moveInDirection.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_moveInDirection.json
@@ -2,5 +2,6 @@
   "key": "gamelab_moveInDirection",
   "name": "moveInDirection",
   "category": "Sprites",
+  "block_name": "gamelab_moveInDirection",
   "syntax": "moveInDirection"
 }

--- a/dashboard/config/programming_expressions/spritelab/gamelab_moveToward.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_moveToward.json
@@ -2,5 +2,6 @@
   "key": "gamelab_moveToward",
   "name": "moveToward",
   "category": "Sprites",
+  "block_name": "gamelab_moveToward",
   "syntax": "moveToward"
 }

--- a/dashboard/config/programming_expressions/spritelab/gamelab_playSound.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_playSound.json
@@ -2,5 +2,6 @@
   "key": "gamelab_playSound",
   "name": "playSound",
   "category": "World",
+  "block_name": "gamelab_playSound",
   "syntax": "playSound"
 }

--- a/dashboard/config/programming_expressions/spritelab/gamelab_playSoundOptions.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_playSoundOptions.json
@@ -2,5 +2,6 @@
   "key": "gamelab_playSoundOptions",
   "name": "playSoundOptions",
   "category": "World",
+  "block_name": "gamelab_playSoundOptions",
   "syntax": "playSoundOptions"
 }

--- a/dashboard/config/programming_expressions/spritelab/gamelab_playSpeech.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_playSpeech.json
@@ -2,5 +2,6 @@
   "key": "gamelab_playSpeech",
   "name": "playSpeech",
   "category": "World",
+  "block_name": "gamelab_playSpeech",
   "syntax": "playSpeech"
 }

--- a/dashboard/config/programming_expressions/spritelab/gamelab_printText.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_printText.json
@@ -2,5 +2,6 @@
   "key": "gamelab_printText",
   "name": "printText",
   "category": "World",
+  "block_name": "gamelab_printText",
   "syntax": "printText"
 }

--- a/dashboard/config/programming_expressions/spritelab/gamelab_randomColor.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_randomColor.json
@@ -2,5 +2,6 @@
   "key": "gamelab_randomColor",
   "name": "randomColor",
   "category": "World",
+  "block_name": "gamelab_randomColor",
   "syntax": "randomColor"
 }

--- a/dashboard/config/programming_expressions/spritelab/gamelab_randomLocation.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_randomLocation.json
@@ -2,5 +2,6 @@
   "key": "gamelab_randomLocation",
   "name": "randomLocation",
   "category": "Location",
+  "block_name": "gamelab_randomLocation",
   "syntax": "randomLocation"
 }

--- a/dashboard/config/programming_expressions/spritelab/gamelab_removeAllBehaviors.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_removeAllBehaviors.json
@@ -2,5 +2,6 @@
   "key": "gamelab_removeAllBehaviors",
   "name": "removeAllBehaviors",
   "category": "Behaviors",
+  "block_name": "gamelab_removeAllBehaviors",
   "syntax": "removeAllBehaviors"
 }

--- a/dashboard/config/programming_expressions/spritelab/gamelab_removeBehaviorSimple.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_removeBehaviorSimple.json
@@ -2,5 +2,6 @@
   "key": "gamelab_removeBehaviorSimple",
   "name": "removeBehaviorSimple",
   "category": "Behaviors",
+  "block_name": "gamelab_removeBehaviorSimple",
   "syntax": "removeBehaviorSimple"
 }

--- a/dashboard/config/programming_expressions/spritelab/gamelab_removeTint.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_removeTint.json
@@ -2,5 +2,6 @@
   "key": "gamelab_removeTint",
   "name": "removeTint",
   "category": "Sprites",
+  "block_name": "gamelab_removeTint",
   "syntax": "removeTint"
 }

--- a/dashboard/config/programming_expressions/spritelab/gamelab_setAnimation.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_setAnimation.json
@@ -2,5 +2,6 @@
   "key": "gamelab_setAnimation",
   "name": "setAnimation",
   "category": "Sprites",
+  "block_name": "gamelab_setAnimation",
   "syntax": "setAnimation"
 }

--- a/dashboard/config/programming_expressions/spritelab/gamelab_setBackground.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_setBackground.json
@@ -2,5 +2,6 @@
   "key": "gamelab_setBackground",
   "name": "setBackground",
   "category": "World",
+  "block_name": "gamelab_setBackground",
   "syntax": "setBackground"
 }

--- a/dashboard/config/programming_expressions/spritelab/gamelab_setBackgroundImage.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_setBackgroundImage.json
@@ -2,5 +2,6 @@
   "key": "gamelab_setBackgroundImage",
   "name": "setBackgroundImage",
   "category": "Unused",
+  "block_name": "gamelab_setBackgroundImage",
   "syntax": "setBackgroundImage"
 }

--- a/dashboard/config/programming_expressions/spritelab/gamelab_setProp.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_setProp.json
@@ -2,5 +2,6 @@
   "key": "gamelab_setProp",
   "name": "setProp",
   "category": "Sprites",
+  "block_name": "gamelab_setProp",
   "syntax": "setProp"
 }

--- a/dashboard/config/programming_expressions/spritelab/gamelab_setProp_dropdown.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_setProp_dropdown.json
@@ -2,5 +2,6 @@
   "key": "gamelab_setProp_dropdown",
   "name": "setProp_dropdown",
   "category": "Sprites",
+  "block_name": "gamelab_setProp_dropdown",
   "syntax": "setProp_dropdown"
 }

--- a/dashboard/config/programming_expressions/spritelab/gamelab_setTint.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_setTint.json
@@ -2,5 +2,6 @@
   "key": "gamelab_setTint",
   "name": "setTint",
   "category": "Sprites",
+  "block_name": "gamelab_setTint",
   "syntax": "setTint"
 }

--- a/dashboard/config/programming_expressions/spritelab/gamelab_showTitleScreen.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_showTitleScreen.json
@@ -2,5 +2,6 @@
   "key": "gamelab_showTitleScreen",
   "name": "showTitleScreen",
   "category": "World",
+  "block_name": "gamelab_showTitleScreen",
   "syntax": "showTitleScreen"
 }

--- a/dashboard/config/programming_expressions/spritelab/gamelab_spriteClicked.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_spriteClicked.json
@@ -2,5 +2,6 @@
   "key": "gamelab_spriteClicked",
   "name": "spriteClicked",
   "category": "Events",
+  "block_name": "gamelab_spriteClicked",
   "syntax": "spriteClicked"
 }

--- a/dashboard/config/programming_expressions/spritelab/gamelab_turn.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_turn.json
@@ -2,5 +2,6 @@
   "key": "gamelab_turn",
   "name": "turn",
   "category": "Sprites",
+  "block_name": "gamelab_turn",
   "syntax": "turn"
 }

--- a/dashboard/config/programming_expressions/spritelab/gamelab_whenTouching.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_whenTouching.json
@@ -2,5 +2,6 @@
   "key": "gamelab_whenTouching",
   "name": "whenTouching",
   "category": "Unused",
+  "block_name": "gamelab_whenTouching",
   "syntax": "whenTouching"
 }

--- a/dashboard/config/programming_expressions/spritelab/gamelab_whileTouching.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_whileTouching.json
@@ -2,5 +2,6 @@
   "key": "gamelab_whileTouching",
   "name": "whileTouching",
   "category": "Unused",
+  "block_name": "gamelab_whileTouching",
   "syntax": "whileTouching"
 }

--- a/dashboard/config/programming_expressions/spritelab/getAllSprites.json
+++ b/dashboard/config/programming_expressions/spritelab/getAllSprites.json
@@ -2,5 +2,6 @@
   "key": "getAllSprites",
   "name": "getAllSprites",
   "category": "Sprites",
+  "block_name": "gamelab_getAllSprites",
   "syntax": "getAllSprites"
 }

--- a/dashboard/config/programming_expressions/spritelab/getTime.json
+++ b/dashboard/config/programming_expressions/spritelab/getTime.json
@@ -2,5 +2,6 @@
   "key": "getTime",
   "name": "getTime",
   "category": "World",
+  "block_name": "gamelab_getTime",
   "syntax": "getTime"
 }

--- a/dashboard/config/programming_expressions/spritelab/ifVarEquals.json
+++ b/dashboard/config/programming_expressions/spritelab/ifVarEquals.json
@@ -2,5 +2,6 @@
   "key": "ifVarEquals",
   "name": "ifVarEquals",
   "category": "Control",
+  "block_name": "gamelab_ifVarEquals",
   "syntax": "ifVarEquals"
 }

--- a/dashboard/config/programming_expressions/spritelab/isCostumeEqual.json
+++ b/dashboard/config/programming_expressions/spritelab/isCostumeEqual.json
@@ -2,5 +2,6 @@
   "key": "isCostumeEqual",
   "name": "isCostumeEqual",
   "category": "Sprites",
+  "block_name": "gamelab_isCostumeEqual",
   "syntax": "isCostumeEqual"
 }

--- a/dashboard/config/programming_expressions/spritelab/isKeyPressed.json
+++ b/dashboard/config/programming_expressions/spritelab/isKeyPressed.json
@@ -2,5 +2,6 @@
   "key": "isKeyPressed",
   "name": "isKeyPressed",
   "category": "World",
+  "block_name": "gamelab_isKeyPressed",
   "syntax": "isKeyPressed"
 }

--- a/dashboard/config/programming_expressions/spritelab/isTouchingEdges.json
+++ b/dashboard/config/programming_expressions/spritelab/isTouchingEdges.json
@@ -2,5 +2,6 @@
   "key": "isTouchingEdges",
   "name": "isTouchingEdges",
   "category": "Sprites",
+  "block_name": "gamelab_isTouchingEdges",
   "syntax": "isTouchingEdges"
 }

--- a/dashboard/config/programming_expressions/spritelab/isTouchingSprite.json
+++ b/dashboard/config/programming_expressions/spritelab/isTouchingSprite.json
@@ -2,5 +2,6 @@
   "key": "isTouchingSprite",
   "name": "isTouchingSprite",
   "category": "Sprites",
+  "block_name": "gamelab_isTouchingSprite",
   "syntax": "isTouchingSprite"
 }

--- a/dashboard/config/programming_expressions/spritelab/locationModifier.json
+++ b/dashboard/config/programming_expressions/spritelab/locationModifier.json
@@ -2,5 +2,6 @@
   "key": "locationModifier",
   "name": "locationModifier",
   "category": "Location",
+  "block_name": "gamelab_locationModifier",
   "syntax": "locationModifier"
 }

--- a/dashboard/config/programming_expressions/spritelab/makeBurst.json
+++ b/dashboard/config/programming_expressions/spritelab/makeBurst.json
@@ -2,5 +2,6 @@
   "key": "makeBurst",
   "name": "makeBurst",
   "category": "Experimental",
+  "block_name": "gamelab_makeBurst",
   "syntax": "makeBurst"
 }

--- a/dashboard/config/programming_expressions/spritelab/makeNumSprites.json
+++ b/dashboard/config/programming_expressions/spritelab/makeNumSprites.json
@@ -2,5 +2,6 @@
   "key": "makeNumSprites",
   "name": "makeNumSprites",
   "category": "Sprites",
+  "block_name": "gamelab_makeNumSprites",
   "syntax": "makeNumSprites"
 }

--- a/dashboard/config/programming_expressions/spritelab/makeProjectile.json
+++ b/dashboard/config/programming_expressions/spritelab/makeProjectile.json
@@ -2,5 +2,6 @@
   "key": "makeProjectile",
   "name": "makeProjectile",
   "category": "Experimental",
+  "block_name": "gamelab_makeProjectile",
   "syntax": "makeProjectile"
 }

--- a/dashboard/config/programming_expressions/spritelab/mirrorSprite.json
+++ b/dashboard/config/programming_expressions/spritelab/mirrorSprite.json
@@ -2,5 +2,6 @@
   "key": "mirrorSprite",
   "name": "mirrorSprite",
   "category": "Sprites",
+  "block_name": "gamelab_mirrorSprite",
   "syntax": "mirrorSprite"
 }

--- a/dashboard/config/programming_expressions/spritelab/mouseLocation.json
+++ b/dashboard/config/programming_expressions/spritelab/mouseLocation.json
@@ -2,5 +2,6 @@
   "key": "mouseLocation",
   "name": "mouseLocation",
   "category": "Location",
+  "block_name": "gamelab_mouseLocation",
   "syntax": "mouseLocation"
 }

--- a/dashboard/config/programming_expressions/spritelab/moveBackward.json
+++ b/dashboard/config/programming_expressions/spritelab/moveBackward.json
@@ -2,5 +2,6 @@
   "key": "moveBackward",
   "name": "moveBackward",
   "category": "Sprites",
+  "block_name": "gamelab_moveBackward",
   "syntax": "moveBackward"
 }

--- a/dashboard/config/programming_expressions/spritelab/newSpritePointer.json
+++ b/dashboard/config/programming_expressions/spritelab/newSpritePointer.json
@@ -2,5 +2,6 @@
   "key": "newSpritePointer",
   "name": "newSpritePointer",
   "category": "Events",
+  "block_name": "gamelab_newSpritePointer",
   "syntax": "newSpritePointer"
 }

--- a/dashboard/config/programming_expressions/spritelab/objectSpritePointer.json
+++ b/dashboard/config/programming_expressions/spritelab/objectSpritePointer.json
@@ -2,5 +2,6 @@
   "key": "objectSpritePointer",
   "name": "objectSpritePointer",
   "category": "Events",
+  "block_name": "gamelab_objectSpritePointer",
   "syntax": "objectSpritePointer"
 }

--- a/dashboard/config/programming_expressions/spritelab/patrollingUpDown.json
+++ b/dashboard/config/programming_expressions/spritelab/patrollingUpDown.json
@@ -2,5 +2,6 @@
   "key": "patrollingUpDown",
   "name": "patrollingUpDown",
   "category": "SL1",
+  "block_name": "gamelab_patrollingUpDown",
   "syntax": "patrollingUpDown"
 }

--- a/dashboard/config/programming_expressions/spritelab/pointInDirection.json
+++ b/dashboard/config/programming_expressions/spritelab/pointInDirection.json
@@ -2,5 +2,6 @@
   "key": "pointInDirection",
   "name": "pointInDirection",
   "category": "Sprites",
+  "block_name": "gamelab_pointInDirection",
   "syntax": "pointInDirection"
 }

--- a/dashboard/config/programming_expressions/spritelab/randColor.json
+++ b/dashboard/config/programming_expressions/spritelab/randColor.json
@@ -2,5 +2,6 @@
   "key": "randColor",
   "name": "randColor",
   "category": "Unused",
+  "block_name": "gamelab_randColor",
   "syntax": "randColor"
 }

--- a/dashboard/config/programming_expressions/spritelab/repeatForever.json
+++ b/dashboard/config/programming_expressions/spritelab/repeatForever.json
@@ -2,5 +2,6 @@
   "key": "repeatForever",
   "name": "repeatForever",
   "category": "Control",
+  "block_name": "gamelab_repeatForever",
   "syntax": "repeatForever"
 }

--- a/dashboard/config/programming_expressions/spritelab/setBackgroundImageAs.json
+++ b/dashboard/config/programming_expressions/spritelab/setBackgroundImageAs.json
@@ -2,5 +2,6 @@
   "key": "setBackgroundImageAs",
   "name": "setBackgroundImageAs",
   "category": "World",
+  "block_name": "gamelab_setBackgroundImageAs",
   "syntax": "setBackgroundImageAs"
 }

--- a/dashboard/config/programming_expressions/spritelab/setDefaultSpriteSize.json
+++ b/dashboard/config/programming_expressions/spritelab/setDefaultSpriteSize.json
@@ -2,5 +2,6 @@
   "key": "setDefaultSpriteSize",
   "name": "setDefaultSpriteSize",
   "category": "Sprites",
+  "block_name": "gamelab_setDefaultSpriteSize",
   "syntax": "setDefaultSpriteSize"
 }

--- a/dashboard/config/programming_expressions/spritelab/setPrompt.json
+++ b/dashboard/config/programming_expressions/spritelab/setPrompt.json
@@ -2,5 +2,6 @@
   "key": "setPrompt",
   "name": "setPrompt",
   "category": "World",
+  "block_name": "gamelab_setPrompt",
   "syntax": "setPrompt"
 }

--- a/dashboard/config/programming_expressions/spritelab/setPromptWithChoices.json
+++ b/dashboard/config/programming_expressions/spritelab/setPromptWithChoices.json
@@ -2,5 +2,6 @@
   "key": "setPromptWithChoices",
   "name": "setPromptWithChoices",
   "category": "World",
+  "block_name": "gamelab_setPromptWithChoices",
   "syntax": "setPromptWithChoices"
 }

--- a/dashboard/config/programming_expressions/spritelab/setSizes.json
+++ b/dashboard/config/programming_expressions/spritelab/setSizes.json
@@ -2,5 +2,6 @@
   "key": "setSizes",
   "name": "setSizes",
   "category": "Unused",
+  "block_name": "gamelab_setSizes",
   "syntax": "setSizes"
 }

--- a/dashboard/config/programming_expressions/spritelab/setupScoreboard.json
+++ b/dashboard/config/programming_expressions/spritelab/setupScoreboard.json
@@ -2,5 +2,6 @@
   "key": "setupScoreboard",
   "name": "setupScoreboard",
   "category": "Experimental",
+  "block_name": "gamelab_setupScoreboard",
   "syntax": "setupScoreboard"
 }

--- a/dashboard/config/programming_expressions/spritelab/setupSim.json
+++ b/dashboard/config/programming_expressions/spritelab/setupSim.json
@@ -2,5 +2,6 @@
   "key": "setupSim",
   "name": "setupSim",
   "category": "Experimental",
+  "block_name": "gamelab_setupSim",
   "syntax": "setupSim"
 }

--- a/dashboard/config/programming_expressions/spritelab/spriteSay.json
+++ b/dashboard/config/programming_expressions/spritelab/spriteSay.json
@@ -2,5 +2,6 @@
   "key": "spriteSay",
   "name": "spriteSay",
   "category": "Experimental",
+  "block_name": "gamelab_spriteSay",
   "syntax": "spriteSay"
 }

--- a/dashboard/config/programming_expressions/spritelab/spriteSayTime.json
+++ b/dashboard/config/programming_expressions/spritelab/spriteSayTime.json
@@ -2,5 +2,6 @@
   "key": "spriteSayTime",
   "name": "spriteSayTime",
   "category": "Experimental",
+  "block_name": "gamelab_spriteSayTime",
   "syntax": "spriteSayTime"
 }

--- a/dashboard/config/programming_expressions/spritelab/startAvoiding.json
+++ b/dashboard/config/programming_expressions/spritelab/startAvoiding.json
@@ -2,5 +2,6 @@
   "key": "startAvoiding",
   "name": "startAvoiding",
   "category": "Experimental",
+  "block_name": "gamelab_startAvoiding",
   "syntax": "startAvoiding"
 }

--- a/dashboard/config/programming_expressions/spritelab/startFollowing.json
+++ b/dashboard/config/programming_expressions/spritelab/startFollowing.json
@@ -2,5 +2,6 @@
   "key": "startFollowing",
   "name": "startFollowing",
   "category": "Experimental",
+  "block_name": "gamelab_startFollowing",
   "syntax": "startFollowing"
 }

--- a/dashboard/config/programming_expressions/spritelab/startGliding.json
+++ b/dashboard/config/programming_expressions/spritelab/startGliding.json
@@ -2,5 +2,6 @@
   "key": "startGliding",
   "name": "startGliding",
   "category": "Experimental",
+  "block_name": "gamelab_startGliding",
   "syntax": "startGliding"
 }

--- a/dashboard/config/programming_expressions/spritelab/stopAvoiding.json
+++ b/dashboard/config/programming_expressions/spritelab/stopAvoiding.json
@@ -2,5 +2,6 @@
   "key": "stopAvoiding",
   "name": "stopAvoiding",
   "category": "Experimental",
+  "block_name": "gamelab_stopAvoiding",
   "syntax": "stopAvoiding"
 }

--- a/dashboard/config/programming_expressions/spritelab/stopCollectingData.json
+++ b/dashboard/config/programming_expressions/spritelab/stopCollectingData.json
@@ -2,5 +2,6 @@
   "key": "stopCollectingData",
   "name": "stopCollectingData",
   "category": "Math",
+  "block_name": "gamelab_stopCollectingData",
   "syntax": "stopCollectingData"
 }

--- a/dashboard/config/programming_expressions/spritelab/stopFollowing.json
+++ b/dashboard/config/programming_expressions/spritelab/stopFollowing.json
@@ -2,5 +2,6 @@
   "key": "stopFollowing",
   "name": "stopFollowing",
   "category": "Experimental",
+  "block_name": "gamelab_stopFollowing",
   "syntax": "stopFollowing"
 }

--- a/dashboard/config/programming_expressions/spritelab/stopGliding.json
+++ b/dashboard/config/programming_expressions/spritelab/stopGliding.json
@@ -2,5 +2,6 @@
   "key": "stopGliding",
   "name": "stopGliding",
   "category": "Experimental",
+  "block_name": "gamelab_stopGliding",
   "syntax": "stopGliding"
 }

--- a/dashboard/config/programming_expressions/spritelab/subjectSpritePointer.json
+++ b/dashboard/config/programming_expressions/spritelab/subjectSpritePointer.json
@@ -2,5 +2,6 @@
   "key": "subjectSpritePointer",
   "name": "subjectSpritePointer",
   "category": "Events",
+  "block_name": "gamelab_subjectSpritePointer",
   "syntax": "subjectSpritePointer"
 }

--- a/dashboard/config/programming_expressions/spritelab/textJoin.json
+++ b/dashboard/config/programming_expressions/spritelab/textJoin.json
@@ -2,5 +2,6 @@
   "key": "textJoin",
   "name": "textJoin",
   "category": "World",
+  "block_name": "gamelab_textJoin",
   "syntax": "textJoin"
 }

--- a/dashboard/config/programming_expressions/spritelab/textVariableJoin.json
+++ b/dashboard/config/programming_expressions/spritelab/textVariableJoin.json
@@ -2,5 +2,6 @@
   "key": "textVariableJoin",
   "name": "textVariableJoin",
   "category": "World",
+  "block_name": "gamelab_textVariableJoin",
   "syntax": "textVariableJoin"
 }

--- a/dashboard/config/programming_expressions/spritelab/tumbling.json
+++ b/dashboard/config/programming_expressions/spritelab/tumbling.json
@@ -2,5 +2,6 @@
   "key": "tumbling",
   "name": "tumbling",
   "category": "SL1",
+  "block_name": "gamelab_tumbling",
   "syntax": "tumbling"
 }

--- a/dashboard/config/programming_expressions/spritelab/updateTitleWithColor.json
+++ b/dashboard/config/programming_expressions/spritelab/updateTitleWithColor.json
@@ -2,5 +2,6 @@
   "key": "updateTitleWithColor",
   "name": "updateTitleWithColor",
   "category": "World",
+  "block_name": "gamelab_updateTitleWithColor",
   "syntax": "updateTitleWithColor"
 }

--- a/dashboard/config/programming_expressions/spritelab/whenAllPromptsAnswered.json
+++ b/dashboard/config/programming_expressions/spritelab/whenAllPromptsAnswered.json
@@ -2,5 +2,6 @@
   "key": "whenAllPromptsAnswered",
   "name": "whenAllPromptsAnswered",
   "category": "",
+  "block_name": "gamelab_whenAllPromptsAnswered",
   "syntax": "whenAllPromptsAnswered"
 }

--- a/dashboard/config/programming_expressions/spritelab/whenDownArrow.json
+++ b/dashboard/config/programming_expressions/spritelab/whenDownArrow.json
@@ -2,5 +2,6 @@
   "key": "whenDownArrow",
   "name": "whenDownArrow",
   "category": "Unused",
+  "block_name": "gamelab_whenDownArrow",
   "syntax": "whenDownArrow"
 }

--- a/dashboard/config/programming_expressions/spritelab/whenKey.json
+++ b/dashboard/config/programming_expressions/spritelab/whenKey.json
@@ -2,5 +2,6 @@
   "key": "whenKey",
   "name": "whenKey",
   "category": "Unused",
+  "block_name": "gamelab_whenKey",
   "syntax": "whenKey"
 }

--- a/dashboard/config/programming_expressions/spritelab/whenLeftArrow.json
+++ b/dashboard/config/programming_expressions/spritelab/whenLeftArrow.json
@@ -2,5 +2,6 @@
   "key": "whenLeftArrow",
   "name": "whenLeftArrow",
   "category": "Unused",
+  "block_name": "gamelab_whenLeftArrow",
   "syntax": "whenLeftArrow"
 }

--- a/dashboard/config/programming_expressions/spritelab/whenPromptAnswered.json
+++ b/dashboard/config/programming_expressions/spritelab/whenPromptAnswered.json
@@ -2,5 +2,6 @@
   "key": "whenPromptAnswered",
   "name": "whenPromptAnswered",
   "category": "Events",
+  "block_name": "gamelab_whenPromptAnswered",
   "syntax": "whenPromptAnswered"
 }

--- a/dashboard/config/programming_expressions/spritelab/whenRightArrow.json
+++ b/dashboard/config/programming_expressions/spritelab/whenRightArrow.json
@@ -2,5 +2,6 @@
   "key": "whenRightArrow",
   "name": "whenRightArrow",
   "category": "Unused",
+  "block_name": "gamelab_whenRightArrow",
   "syntax": "whenRightArrow"
 }

--- a/dashboard/config/programming_expressions/spritelab/whenSpriteCreated.json
+++ b/dashboard/config/programming_expressions/spritelab/whenSpriteCreated.json
@@ -2,5 +2,6 @@
   "key": "whenSpriteCreated",
   "name": "whenSpriteCreated",
   "category": "Events",
+  "block_name": "gamelab_whenSpriteCreated",
   "syntax": "whenSpriteCreated"
 }

--- a/dashboard/config/programming_expressions/spritelab/whenUpArrow.json
+++ b/dashboard/config/programming_expressions/spritelab/whenUpArrow.json
@@ -2,5 +2,6 @@
   "key": "whenUpArrow",
   "name": "whenUpArrow",
   "category": "Unused",
+  "block_name": "gamelab_whenUpArrow",
   "syntax": "whenUpArrow"
 }

--- a/dashboard/config/programming_expressions/spritelab/whileDownArrow.json
+++ b/dashboard/config/programming_expressions/spritelab/whileDownArrow.json
@@ -2,5 +2,6 @@
   "key": "whileDownArrow",
   "name": "whileDownArrow",
   "category": "Unused",
+  "block_name": "gamelab_whileDownArrow",
   "syntax": "whileDownArrow"
 }

--- a/dashboard/config/programming_expressions/spritelab/whileKey.json
+++ b/dashboard/config/programming_expressions/spritelab/whileKey.json
@@ -2,5 +2,6 @@
   "key": "whileKey",
   "name": "whileKey",
   "category": "Unused",
+  "block_name": "gamelab_whileKey",
   "syntax": "whileKey"
 }

--- a/dashboard/config/programming_expressions/spritelab/whileLeftArrow.json
+++ b/dashboard/config/programming_expressions/spritelab/whileLeftArrow.json
@@ -2,5 +2,6 @@
   "key": "whileLeftArrow",
   "name": "whileLeftArrow",
   "category": "Unused",
+  "block_name": "gamelab_whileLeftArrow",
   "syntax": "whileLeftArrow"
 }

--- a/dashboard/config/programming_expressions/spritelab/whileRightArrow.json
+++ b/dashboard/config/programming_expressions/spritelab/whileRightArrow.json
@@ -2,5 +2,6 @@
   "key": "whileRightArrow",
   "name": "whileRightArrow",
   "category": "Unused",
+  "block_name": "gamelab_whileRightArrow",
   "syntax": "whileRightArrow"
 }

--- a/dashboard/config/programming_expressions/spritelab/whileUpArrow.json
+++ b/dashboard/config/programming_expressions/spritelab/whileUpArrow.json
@@ -2,5 +2,6 @@
   "key": "whileUpArrow",
   "name": "whileUpArrow",
   "category": "Unused",
+  "block_name": "gamelab_whileUpArrow",
   "syntax": "whileUpArrow"
 }

--- a/dashboard/config/programming_expressions/spritelab/withPercentChance.json
+++ b/dashboard/config/programming_expressions/spritelab/withPercentChance.json
@@ -2,5 +2,6 @@
   "key": "withPercentChance",
   "name": "withPercentChance",
   "category": "Control",
+  "block_name": "gamelab_withPercentChance",
   "syntax": "withPercentChance"
 }

--- a/dashboard/config/programming_expressions/spritelab/withPercentChanceDropdown.json
+++ b/dashboard/config/programming_expressions/spritelab/withPercentChanceDropdown.json
@@ -2,5 +2,6 @@
   "key": "withPercentChanceDropdown",
   "name": "withPercentChanceDropdown",
   "category": "Control",
+  "block_name": "gamelab_withPercentChanceDropdown",
   "syntax": "withPercentChanceDropdown"
 }

--- a/dashboard/config/programming_expressions/spritelab/xLocationOf.json
+++ b/dashboard/config/programming_expressions/spritelab/xLocationOf.json
@@ -2,5 +2,6 @@
   "key": "xLocationOf",
   "name": "xLocationOf",
   "category": "Sprites",
+  "block_name": "gamelab_xLocationOf",
   "syntax": "xLocationOf"
 }

--- a/dashboard/config/programming_expressions/spritelab/yLocationOf.json
+++ b/dashboard/config/programming_expressions/spritelab/yLocationOf.json
@@ -2,5 +2,6 @@
   "key": "yLocationOf",
   "name": "yLocationOf",
   "category": "Sprites",
+  "block_name": "gamelab_yLocationOf",
   "syntax": "yLocationOf"
 }


### PR DESCRIPTION
Add block_name to spritelab programming expressions! 

Generated by running in dashboard-console (based on my notes from https://github.com/code-dot-org/code-dot-org/pull/44071#issuecomment-996298711):
```
ProgrammingEnvironment.find_by_name('spritelab').programming_expressions.each {|exp| exp.block_name = Block.find_by_name(exp.key)&.name || Block.find_by_name("gamelab_" + exp.key)&.name ; exp.save! ; exp.write_serialization }
# bounce-off isn't caught by the line above but still have a block defined in the blocks table
ProgrammingExpression.find_by_key('bounce-off').update(block_name: 'gamelab_bounceOff')
ProgrammingExpression.find_by_key('bounce-off').write_serialization
# These blocks are defined in JS and, apart from one, their syntax equals their block name
ProgrammingEnvironment.find_by_name('spritelab').programming_expressions.select {|exp| exp.block_name.nil? }.each {|exp| exp.block_name = exp.syntax ; exp.save! ; exp.write_serialization } 
# This block is defined in spritelab/blocks.js and embedding doesn't work, so block_name should be nil
ProgrammingExpression.find_by_key('codestudio_spriteName').update(block_name: nil)
ProgrammingExpression.find_by_key('codestudio_spriteName').write_serialization
```

One programming expression (codestudio_spriteName, which is the block sprite_variables_get) doesn't have a block name as it's defined in `spritelab/blocks.js`, which isn't loaded into the code docs. I don't believe we use this block much and I'm not sure if it's worth the effort to figure out how to get this one block working.

This is the block:
<img width="350" alt="Screen Shot 2022-01-07 at 1 56 02 PM" src="https://user-images.githubusercontent.com/46464143/148612962-a4a69b87-227b-4f15-bbee-416f41b02d21.png">

I doubled checked all of the other codestudio_ blocks and they all work.

A couple maybe aren't super useful as an embedded block because they don't really describe what they're doing. For example, codestudio_ifStatement just doesn't give a whole lot of context.

<img width="255" alt="Screen Shot 2022-01-07 at 2 00 47 PM" src="https://user-images.githubusercontent.com/46464143/148613130-acf3c1f5-c257-4342-b09c-b7d9c5d604d4.png">

Some expressions that have corresponding blocks in the block pool have the same problem. If you scroll through https://levelbuilder-studio.code.org/pools/GamelabJr/blocks you can see that a few aren't obvious from just the preview. `codestudio_callingFunction` also had this problem but we don't use a block image in [curriculumbuilder](https://curriculum.code.org/docs/spritelab/codestudio_callingFunction/), so I removed the block name.

## Testing story

spot checked a bunch, but these will all get a pass so very low risk



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
