### PR TITLE
conditionally use dashboard certificate api on dashboard congrats page

### DIFF
--- a/apps/src/sites/studio/pages/congrats/index.js
+++ b/apps/src/sites/studio/pages/congrats/index.js
@@ -6,6 +6,7 @@ import {Provider} from 'react-redux';
 import {getStore} from '@cdo/apps/redux';
 import queryString from 'query-string';
 import {tryGetLocalStorage} from '@cdo/apps/utils';
+import experiments from '@cdo/apps/util/experiments';
 
 $(document).ready(function() {
   const store = getStore();
@@ -30,7 +31,9 @@ $(document).ready(function() {
   } catch (e) {}
 
   const mcShareLink = tryGetLocalStorage('craftHeroShareLink', '');
-
+  const showStudioCertificate = experiments.isEnabled(
+    experiments.STUDIO_CERTIFICATE
+  );
   ReactDOM.render(
     <Provider store={store}>
       <Congrats
@@ -42,6 +45,7 @@ $(document).ready(function() {
         MCShareLink={mcShareLink}
         randomDonorTwitter={randomDonorTwitter}
         hideDancePartyFollowUp={hideDancePartyFollowUp}
+        showStudioCertificate={showStudioCertificate}
       />
     </Provider>,
     document.getElementById('congrats-container')

--- a/apps/src/templates/Certificate.jsx
+++ b/apps/src/templates/Certificate.jsx
@@ -49,6 +49,9 @@ function Certificate(props) {
     });
   };
 
+  const getCertificate = () =>
+    `${dashboard.CODE_ORG_URL}/api/hour/certificate/${certificate}.jpg`;
+
   const {
     responsiveSize,
     tutorial,
@@ -59,9 +62,7 @@ function Certificate(props) {
   } = props;
 
   const certificate = certificateId || 'blank';
-  const personalizedCertificate = `${
-    dashboard.CODE_ORG_URL
-  }/api/hour/certificate/${certificate}.jpg`;
+  const personalizedCertificate = getCertificate();
   const blankCertificate =
     blankCertificates[tutorial] || blankCertificates.hourOfCode;
   const imgSrc = personalized ? personalizedCertificate : blankCertificate;

--- a/apps/src/templates/Certificate.jsx
+++ b/apps/src/templates/Certificate.jsx
@@ -156,7 +156,8 @@ Certificate.propTypes = {
   randomDonorTwitter: PropTypes.string,
   responsiveSize: PropTypes.oneOf(['lg', 'md', 'sm', 'xs']).isRequired,
   under13: PropTypes.bool,
-  children: PropTypes.node
+  children: PropTypes.node,
+  showStudioCertificate: PropTypes.bool
 };
 
 const styles = {

--- a/apps/src/templates/Certificate.jsx
+++ b/apps/src/templates/Certificate.jsx
@@ -25,6 +25,7 @@ const blankCertificates = {
 
 function Certificate(props) {
   const [personalized, setPersonalized] = useState(false);
+  const [studentName, setStudentName] = useState();
   const nameInputRef = useRef(null);
 
   const isMinecraft = () =>
@@ -44,13 +45,26 @@ function Certificate(props) {
       }
     }).done(response => {
       if (response.certificate_sent) {
+        setStudentName(response['name']);
         setPersonalized(true);
       }
     });
   };
 
-  const getCertificate = () =>
-    `${dashboard.CODE_ORG_URL}/api/hour/certificate/${certificate}.jpg`;
+  const getCertificate = () => {
+    if (!props.showStudioCertificate) {
+      return `${
+        dashboard.CODE_ORG_URL
+      }/api/hour/certificate/${certificate}.jpg`;
+    }
+
+    const data = {
+      name: studentName,
+      course: props.tutorial
+    };
+    const filename = btoa(JSON.stringify(data));
+    return `/certificate_images/${filename}.jpg`;
+  };
 
   const {
     responsiveSize,

--- a/apps/src/templates/Certificate.jsx
+++ b/apps/src/templates/Certificate.jsx
@@ -51,7 +51,7 @@ function Certificate(props) {
     });
   };
 
-  const getCertificate = () => {
+  const getCertificatePath = () => {
     if (!props.showStudioCertificate) {
       return `${
         dashboard.CODE_ORG_URL
@@ -76,7 +76,7 @@ function Certificate(props) {
   } = props;
 
   const certificate = certificateId || 'blank';
-  const personalizedCertificate = getCertificate();
+  const personalizedCertificate = getCertificatePath();
   const blankCertificate =
     blankCertificates[tutorial] || blankCertificates.hourOfCode;
   const imgSrc = personalized ? personalizedCertificate : blankCertificate;

--- a/apps/src/templates/Congrats.jsx
+++ b/apps/src/templates/Congrats.jsx
@@ -30,7 +30,8 @@ export default function Congrats(props) {
     under13,
     language,
     randomDonorTwitter,
-    hideDancePartyFollowUp
+    hideDancePartyFollowUp,
+    showStudioCertificate
   } = props;
   const isEnglish = language === 'en';
   const tutorialType = getTutorialType(tutorial);
@@ -42,6 +43,7 @@ export default function Congrats(props) {
         certificateId={certificateId}
         randomDonorTwitter={randomDonorTwitter}
         under13={under13}
+        showStudioCertificate={showStudioCertificate}
       />
       {userType === 'teacher' && isEnglish && <TeachersBeyondHoc />}
       <StudentsBeyondHoc
@@ -65,7 +67,8 @@ Congrats.propTypes = {
   under13: PropTypes.bool,
   language: PropTypes.string.isRequired,
   randomDonorTwitter: PropTypes.string,
-  hideDancePartyFollowUp: PropTypes.bool
+  hideDancePartyFollowUp: PropTypes.bool,
+  showStudioCertificate: PropTypes.bool
 };
 
 const styles = {

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -38,6 +38,7 @@ experiments.SPECIAL_TOPIC = 'special-topic';
 experiments.CLEARER_SIGN_UP_USER_TYPE = 'clearerSignUpUserType';
 experiments.OPT_IN_EMAIL_REG_PARTNER = 'optInEmailRegPartner';
 experiments.JAVALAB_UNIT_TESTS = 'javalabUnitTests';
+experiments.STUDIO_CERTIFICATE = 'studioCertificate';
 
 /**
  * This was a gamified version of the finish dialog, built in 2018,

--- a/apps/test/unit/templates/CertificateTest.js
+++ b/apps/test/unit/templates/CertificateTest.js
@@ -6,6 +6,7 @@ import Certificate from '@cdo/apps/templates/Certificate';
 import {combineReducers, createStore} from 'redux';
 import responsive from '@cdo/apps/code-studio/responsiveRedux';
 import isRtl from '@cdo/apps/code-studio/isRtlRedux';
+import sinon from 'sinon';
 
 const store = createStore(combineReducers({responsive, isRtl}));
 
@@ -63,6 +64,90 @@ describe('Certificate', () => {
     ['applab-intro', 'dance', 'flappy', 'frozen'].forEach(tutorial => {
       const wrapper = wrapperWithParams({tutorial});
       expect(wrapper.find('img').html()).to.include('hour_of_code_certificate');
+    });
+  });
+
+  describe('personalized certificate', () => {
+    let server;
+
+    beforeEach(() => {
+      server = sinon.fakeServer.create();
+    });
+
+    afterEach(() => {
+      server.restore();
+    });
+
+    it('renders using pegasus without experiment', () => {
+      const data = {
+        certificate_sent: true,
+        name: 'Student'
+      };
+      server.respondWith('POST', `/v2/certificate`, [
+        200,
+        {'Content-Type': 'application/json'},
+        JSON.stringify(data)
+      ]);
+
+      const wrapper = wrapperWithParams({
+        tutorial: 'dance',
+        certificateId: 'sessionId'
+      });
+      let image = wrapper.find('#uitest-certificate img');
+      expect(image.prop('src')).to.match(
+        /^\/_karma_webpack_\/hour_of_code_certificate/
+      );
+
+      const input = wrapper.find('input#name');
+      input.simulate('change', {target: {value: 'Student'}});
+      const submitButton = wrapper
+        .find('button')
+        .filterWhere(button => button.text() === 'Submit');
+      submitButton.simulate('click');
+      server.respond();
+
+      wrapper.update();
+      image = wrapper.find('#uitest-certificate img');
+      expect(image.prop('src')).to.equal(
+        'https://code.org/api/hour/certificate/sessionId.jpg'
+      );
+    });
+
+    it('renders using code studio with experiment', () => {
+      const data = {
+        certificate_sent: true,
+        name: 'Student'
+      };
+      server.respondWith('POST', `/v2/certificate`, [
+        200,
+        {'Content-Type': 'application/json'},
+        JSON.stringify(data)
+      ]);
+
+      const wrapper = wrapperWithParams({
+        tutorial: 'dance',
+        certificateId: 'sessionId',
+        showStudioCertificate: true
+      });
+      let image = wrapper.find('#uitest-certificate img');
+      expect(image.prop('src')).to.match(
+        /^\/_karma_webpack_\/hour_of_code_certificate/
+      );
+
+      const input = wrapper.find('input#name');
+      input.simulate('change', {target: {value: 'Student'}});
+      const submitButton = wrapper
+        .find('button')
+        .filterWhere(button => button.text() === 'Submit');
+      submitButton.simulate('click');
+      server.respond();
+
+      wrapper.update();
+      image = wrapper.find('#uitest-certificate img');
+      const expectedData = {name: 'Student', course: 'dance'};
+      const expectedFilename = btoa(JSON.stringify(expectedData));
+      const expectedSrc = `/certificate_images/${expectedFilename}.jpg`;
+      expect(image.prop('src')).to.equal(expectedSrc);
     });
   });
 });

--- a/apps/test/unit/templates/CertificateTest.js
+++ b/apps/test/unit/templates/CertificateTest.js
@@ -9,10 +9,10 @@ import isRtl from '@cdo/apps/code-studio/isRtlRedux';
 
 const store = createStore(combineReducers({responsive, isRtl}));
 
-function wrapperWithTutorial(tutorial) {
+function wrapperWithParams(params) {
   return mount(
     <Provider store={store}>
-      <Certificate tutorial={tutorial} />
+      <Certificate {...params} />
     </Provider>
   );
 }
@@ -32,28 +32,28 @@ describe('Certificate', () => {
   });
 
   it('renders Minecraft certificate for Minecraft Adventurer', () => {
-    const wrapper = wrapperWithTutorial('mc');
+    const wrapper = wrapperWithParams({tutorial: 'mc'});
     expect(wrapper.find('img').html()).to.include(
       'MC_Hour_Of_Code_Certificate'
     );
   });
 
   it('renders Minecraft certificate for Minecraft Designer', () => {
-    const wrapper = wrapperWithTutorial('minecraft');
+    const wrapper = wrapperWithParams({tutorial: 'minecraft'});
     expect(wrapper.find('img').html()).to.include(
       'MC_Hour_Of_Code_Certificate'
     );
   });
 
   it("renders unique certificate for Minecraft Hero's Journey", () => {
-    const wrapper = wrapperWithTutorial('hero');
+    const wrapper = wrapperWithParams({tutorial: 'hero'});
     expect(wrapper.find('img').html()).to.include(
       'MC_Hour_Of_Code_Certificate_Hero'
     );
   });
 
   it('renders unique certificate for Minecraft Voyage Aquatic', () => {
-    const wrapper = wrapperWithTutorial('aquatic');
+    const wrapper = wrapperWithParams({tutorial: 'aquatic'});
     expect(wrapper.find('img').html()).to.include(
       'MC_Hour_Of_Code_Certificate_Aquatic'
     );
@@ -61,7 +61,7 @@ describe('Certificate', () => {
 
   it('renders default certificate for all other tutorials', () => {
     ['applab-intro', 'dance', 'flappy', 'frozen'].forEach(tutorial => {
-      const wrapper = wrapperWithTutorial(tutorial);
+      const wrapper = wrapperWithParams({tutorial});
       expect(wrapper.find('img').html()).to.include('hour_of_code_certificate');
     });
   });


### PR DESCRIPTION
Continues [PLAT-1531]. Depends on https://github.com/code-dot-org/code-dot-org/pull/44241 . See [work plan](https://docs.google.com/document/d/1wTObDFZdWS6RzpM3R6wEm04ToY2fM1B5Kb2rUHCNq28/edit) for details.

https://user-images.githubusercontent.com/8001765/148619479-ad628c1c-efe6-4b00-96e9-55246f4cbc6d.mov


## Testing story

new unit tests verify that the experiment flag controls whether to hit the old or new certificate image api, and that the url to the new image api is correct. screen capture shows customizing the certificate is working and is hitting the new api.

[PLAT-1531]: https://codedotorg.atlassian.net/browse/PLAT-1531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ