### PR TITLE
Create a migration to make sure the participant type is correct on sections for assigned script

### DIFF
--- a/dashboard/db/migrate/20220108024121_update_participant_type_on_sections.rb
+++ b/dashboard/db/migrate/20220108024121_update_participant_type_on_sections.rb
@@ -1,0 +1,12 @@
+# Find all the sections that are assigned to a script that has a participant audience
+# other than students and update the participant type of those sections to match
+# the participant audience of the script they are assigned to
+class UpdateParticipantTypeOnSections < ActiveRecord::Migration[5.2]
+  def change
+    unit_ids = Script.where(participant_audience: 'teacher').map(&:id)
+    Section.where(script_id: unit_ids).update_all(participant_type: 'teacher')
+
+    unit_ids = Script.where(participant_audience: 'facilitator').map(&:id)
+    Section.where(script_id: unit_ids).update_all(participant_type: 'facilitator')
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_17_121759) do
+ActiveRecord::Schema.define(version: 2022_01_08_024121) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"


### PR DESCRIPTION
Recently `participant_type` was added to Section. It defaults to 'student' but we should double check that there are no sections assigned to scripts that have a participant type other than student. This migration will find any sections assigned to scripts which have a participant_audience of teacher or facilitator and update the participant_type for the section.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
