### PR TITLE
Only go forward in published states and do not change participant audience once launched

### DIFF
--- a/apps/src/lib/levelbuilder/CourseVersionPublishingEditor.jsx
+++ b/apps/src/lib/levelbuilder/CourseVersionPublishingEditor.jsx
@@ -33,10 +33,19 @@ export default class CourseVersionPublishingEditor extends Component {
   }
 
   handlePublishedStateChange = event => {
+    event.preventDefault();
     const newPublishedState = event.target.value;
-    this.props.updatePublishedState(newPublishedState);
-    if (newPublishedState !== PublishedState.pilot) {
-      this.props.updatePilotExperiment('');
+
+    const msg =
+      'Are you sure you want to update the published state? ' +
+      'Once you set the published state you can not go backwards.' +
+      'For example once you set the published state to beta you can not go back to in development.' +
+      'Also once a course as a published state of pilot it can not be fully launched (marked as preview or stable).';
+    if (window.confirm(msg)) {
+      this.props.updatePublishedState(newPublishedState);
+      if (newPublishedState !== PublishedState.pilot) {
+        this.props.updatePilotExperiment('');
+      }
     }
   };
 

--- a/apps/src/lib/levelbuilder/CourseVersionPublishingEditor.jsx
+++ b/apps/src/lib/levelbuilder/CourseVersionPublishingEditor.jsx
@@ -4,6 +4,26 @@ import HelpTip from '@cdo/apps/lib/ui/HelpTip';
 import color from '@cdo/apps/util/color';
 import {PublishedState} from '@cdo/apps/generated/curriculum/sharedCourseConstants';
 
+const availablePublishedStates = {
+  in_development: PublishedState,
+  pilot: {
+    pilot: 'pilot',
+    beta: 'beta',
+    preview: 'preview',
+    stable: 'stable'
+  },
+  beta: {
+    beta: 'beta',
+    preview: 'preview',
+    stable: 'stable'
+  },
+  preview: {
+    preview: 'preview',
+    stable: 'stable'
+  },
+  stable: {stable: 'stable'}
+};
+
 export default class CourseVersionPublishingEditor extends Component {
   static propTypes = {
     pilotExperiment: PropTypes.string,
@@ -17,6 +37,7 @@ export default class CourseVersionPublishingEditor extends Component {
     isCourse: PropTypes.bool,
     updateIsCourse: PropTypes.func,
     showIsCourseSelector: PropTypes.bool,
+    initialPublishedState: PropTypes.string,
     publishedState: PropTypes.oneOf(Object.values(PublishedState)).isRequired,
     updatePublishedState: PropTypes.func.isRequired,
     preventCourseVersionChange: PropTypes.bool
@@ -158,7 +179,9 @@ export default class CourseVersionPublishingEditor extends Component {
             style={styles.dropdown}
             onChange={this.handlePublishedStateChange}
           >
-            {Object.values(PublishedState).map(state => (
+            {Object.values(
+              availablePublishedStates[this.props.initialPublishedState]
+            ).map(state => (
               <option key={state} value={state}>
                 {state}
               </option>

--- a/apps/src/lib/levelbuilder/CourseVersionPublishingEditor.jsx
+++ b/apps/src/lib/levelbuilder/CourseVersionPublishingEditor.jsx
@@ -70,12 +70,7 @@ export default class CourseVersionPublishingEditor extends Component {
         PublishedState.preview,
         PublishedState.stable
       ],
-      pilot: [
-        PublishedState.pilot,
-        PublishedState.beta,
-        PublishedState.preview,
-        PublishedState.stable
-      ],
+      pilot: [PublishedState.pilot],
       beta: [
         PublishedState.beta,
         PublishedState.preview,

--- a/apps/src/lib/levelbuilder/CourseVersionPublishingEditor.jsx
+++ b/apps/src/lib/levelbuilder/CourseVersionPublishingEditor.jsx
@@ -17,7 +17,7 @@ export default class CourseVersionPublishingEditor extends Component {
     isCourse: PropTypes.bool,
     updateIsCourse: PropTypes.func,
     showIsCourseSelector: PropTypes.bool,
-    initialPublishedState: PropTypes.string,
+    initialPublishedState: PropTypes.string.isRequired,
     publishedState: PropTypes.oneOf(Object.values(PublishedState)).isRequired,
     updatePublishedState: PropTypes.func.isRequired,
     preventCourseVersionChange: PropTypes.bool

--- a/apps/src/lib/levelbuilder/CourseVersionPublishingEditor.jsx
+++ b/apps/src/lib/levelbuilder/CourseVersionPublishingEditor.jsx
@@ -38,8 +38,8 @@ export default class CourseVersionPublishingEditor extends Component {
 
     const msg =
       'Are you sure you want to update the published state? ' +
-      'Once you set the published state you can not go backwards.' +
-      'For example once you set the published state to beta you can not go back to in development.' +
+      'Once you set the published state you can not go back to this published state. ' +
+      'For example once you set the published state to beta you can not go back to in development. ' +
       'Also once a course as a published state of pilot it can not be fully launched (marked as preview or stable).';
     if (window.confirm(msg)) {
       this.props.updatePublishedState(newPublishedState);

--- a/apps/src/lib/levelbuilder/CourseVersionPublishingEditor.jsx
+++ b/apps/src/lib/levelbuilder/CourseVersionPublishingEditor.jsx
@@ -4,26 +4,6 @@ import HelpTip from '@cdo/apps/lib/ui/HelpTip';
 import color from '@cdo/apps/util/color';
 import {PublishedState} from '@cdo/apps/generated/curriculum/sharedCourseConstants';
 
-const availablePublishedStates = {
-  in_development: PublishedState,
-  pilot: {
-    pilot: 'pilot',
-    beta: 'beta',
-    preview: 'preview',
-    stable: 'stable'
-  },
-  beta: {
-    beta: 'beta',
-    preview: 'preview',
-    stable: 'stable'
-  },
-  preview: {
-    preview: 'preview',
-    stable: 'stable'
-  },
-  stable: {stable: 'stable'}
-};
-
 export default class CourseVersionPublishingEditor extends Component {
   static propTypes = {
     pilotExperiment: PropTypes.string,
@@ -73,6 +53,39 @@ export default class CourseVersionPublishingEditor extends Component {
   onFamilyNameSelect = e => {
     this.setState({selectedFamilyName: e.target.value});
     this.props.updateFamilyName(e.target.value);
+  };
+
+  /*
+   * We only want a course to be able to progress
+   * forward in published states. So as the editor updates the
+   * published start of the course the options to update in the
+   * future should get smaller.
+   */
+  getAvailablePublishedStates = currentState => {
+    const availablePublishedStates = {
+      in_development: [
+        PublishedState.in_development,
+        PublishedState.pilot,
+        PublishedState.beta,
+        PublishedState.preview,
+        PublishedState.stable
+      ],
+      pilot: [
+        PublishedState.pilot,
+        PublishedState.beta,
+        PublishedState.preview,
+        PublishedState.stable
+      ],
+      beta: [
+        PublishedState.beta,
+        PublishedState.preview,
+        PublishedState.stable
+      ],
+      preview: [PublishedState.preview, PublishedState.stable],
+      stable: [PublishedState.stable]
+    };
+
+    return availablePublishedStates[currentState];
   };
 
   render() {
@@ -179,8 +192,8 @@ export default class CourseVersionPublishingEditor extends Component {
             style={styles.dropdown}
             onChange={this.handlePublishedStateChange}
           >
-            {Object.values(
-              availablePublishedStates[this.props.initialPublishedState]
+            {this.getAvailablePublishedStates(
+              this.props.initialPublishedState
             ).map(state => (
               <option key={state} value={state}>
                 {state}

--- a/apps/src/lib/levelbuilder/CourseVersionPublishingEditor.jsx
+++ b/apps/src/lib/levelbuilder/CourseVersionPublishingEditor.jsx
@@ -33,19 +33,11 @@ export default class CourseVersionPublishingEditor extends Component {
   }
 
   handlePublishedStateChange = event => {
-    event.preventDefault();
     const newPublishedState = event.target.value;
 
-    const msg =
-      'Are you sure you want to update the published state? ' +
-      'Once you set the published state you can not go back to this published state. ' +
-      'For example once you set the published state to beta you can not go back to in development. ' +
-      'Also once a course as a published state of pilot it can not be fully launched (marked as preview or stable).';
-    if (window.confirm(msg)) {
-      this.props.updatePublishedState(newPublishedState);
-      if (newPublishedState !== PublishedState.pilot) {
-        this.props.updatePilotExperiment('');
-      }
+    this.props.updatePublishedState(newPublishedState);
+    if (newPublishedState !== PublishedState.pilot) {
+      this.props.updatePilotExperiment('');
     }
   };
 

--- a/apps/src/lib/levelbuilder/course-editor/CourseEditor.js
+++ b/apps/src/lib/levelbuilder/course-editor/CourseEditor.js
@@ -332,8 +332,8 @@ class CourseEditor extends Component {
           handleParticipantAudienceChange={e =>
             this.setState({participantAudience: e.target.value})
           }
-          cannotChangeParticipantType={
-            publishedState !== PublishedState.in_development
+          canChangeParticipantType={
+            publishedState === PublishedState.in_development
           }
         />
 

--- a/apps/src/lib/levelbuilder/course-editor/CourseEditor.js
+++ b/apps/src/lib/levelbuilder/course-editor/CourseEditor.js
@@ -57,6 +57,7 @@ class CourseEditor extends Component {
     useMigratedResources: PropTypes.bool.isRequired,
     courseVersionId: PropTypes.number,
     coursePath: PropTypes.string.isRequired,
+    hasBeenAssignable: PropTypes.bool.isRequired,
 
     // Provided by redux
     migratedTeacherResources: PropTypes.arrayOf(migratedResourceShape),
@@ -332,6 +333,7 @@ class CourseEditor extends Component {
           handleParticipantAudienceChange={e =>
             this.setState({participantAudience: e.target.value})
           }
+          cannotChangeParticipantType={this.props.hasBeenAssignable}
         />
 
         <CollapsibleEditorSection title="Publishing Settings">

--- a/apps/src/lib/levelbuilder/course-editor/CourseEditor.js
+++ b/apps/src/lib/levelbuilder/course-editor/CourseEditor.js
@@ -349,6 +349,7 @@ class CourseEditor extends Component {
             updateVersionYear={versionYear => this.setState({versionYear})}
             families={courseFamilies}
             versionYearOptions={versionYearOptions}
+            initialPublishedState={this.props.initialPublishedState}
             publishedState={publishedState}
             updatePublishedState={publishedState =>
               this.setState({publishedState})

--- a/apps/src/lib/levelbuilder/course-editor/CourseEditor.js
+++ b/apps/src/lib/levelbuilder/course-editor/CourseEditor.js
@@ -57,7 +57,6 @@ class CourseEditor extends Component {
     useMigratedResources: PropTypes.bool.isRequired,
     courseVersionId: PropTypes.number,
     coursePath: PropTypes.string.isRequired,
-    hasBeenAssignable: PropTypes.bool.isRequired,
 
     // Provided by redux
     migratedTeacherResources: PropTypes.arrayOf(migratedResourceShape),
@@ -333,7 +332,9 @@ class CourseEditor extends Component {
           handleParticipantAudienceChange={e =>
             this.setState({participantAudience: e.target.value})
           }
-          cannotChangeParticipantType={this.props.hasBeenAssignable}
+          cannotChangeParticipantType={
+            publishedState !== PublishedState.in_development
+          }
         />
 
         <CollapsibleEditorSection title="Publishing Settings">

--- a/apps/src/lib/levelbuilder/course-editor/CourseEditor.js
+++ b/apps/src/lib/levelbuilder/course-editor/CourseEditor.js
@@ -162,6 +162,22 @@ class CourseEditor extends Component {
       return;
     }
 
+    if (this.state.publishedState !== this.props.initialPublishedState) {
+      const msg =
+        'It looks like you are updating the published state. ' +
+        'Are you sure you want to update the published state? ' +
+        'Once you update the published state you can not go back to this published state. ' +
+        'For example once you set the published state to beta you can not go back to in development. ' +
+        'Also once a course as a published state of pilot it can not be fully launched (marked as preview or stable).';
+      if (!window.confirm(msg)) {
+        this.setState({
+          isSaving: false,
+          error: 'Saving cancelled.'
+        });
+        return;
+      }
+    }
+
     $.ajax({
       url: `/courses/${this.props.name}`,
       method: 'PUT',

--- a/apps/src/lib/levelbuilder/course-editor/CourseTypeEditor.jsx
+++ b/apps/src/lib/levelbuilder/course-editor/CourseTypeEditor.jsx
@@ -33,7 +33,8 @@ export default function CourseTypeEditor({
   instructionType,
   handleInstructionTypeChange,
   handleInstructorAudienceChange,
-  handleParticipantAudienceChange
+  handleParticipantAudienceChange,
+  cannotChangeParticipantType
 }) {
   return (
     <div>
@@ -108,6 +109,7 @@ export default function CourseTypeEditor({
             value={participantAudience}
             style={styles.dropdown}
             onChange={handleParticipantAudienceChange}
+            disabled={cannotChangeParticipantType}
           >
             {Object.values(ParticipantAudience).map(audience => (
               <option key={audience} value={audience}>
@@ -136,7 +138,8 @@ CourseTypeEditor.propTypes = {
   instructionType: PropTypes.oneOf(Object.values(InstructionType)).isRequired,
   handleInstructionTypeChange: PropTypes.func,
   handleInstructorAudienceChange: PropTypes.func,
-  handleParticipantAudienceChange: PropTypes.func
+  handleParticipantAudienceChange: PropTypes.func,
+  cannotChangeParticipantType: PropTypes.bool.isRequired
 };
 
 const styles = {

--- a/apps/src/lib/levelbuilder/course-editor/CourseTypeEditor.jsx
+++ b/apps/src/lib/levelbuilder/course-editor/CourseTypeEditor.jsx
@@ -34,7 +34,7 @@ export default function CourseTypeEditor({
   handleInstructionTypeChange,
   handleInstructorAudienceChange,
   handleParticipantAudienceChange,
-  cannotChangeParticipantType
+  canChangeParticipantType
 }) {
   return (
     <div>
@@ -109,7 +109,7 @@ export default function CourseTypeEditor({
             value={participantAudience}
             style={styles.dropdown}
             onChange={handleParticipantAudienceChange}
-            disabled={cannotChangeParticipantType}
+            disabled={!canChangeParticipantType}
           >
             {Object.values(ParticipantAudience).map(audience => (
               <option key={audience} value={audience}>
@@ -139,7 +139,7 @@ CourseTypeEditor.propTypes = {
   handleInstructionTypeChange: PropTypes.func,
   handleInstructorAudienceChange: PropTypes.func,
   handleParticipantAudienceChange: PropTypes.func,
-  cannotChangeParticipantType: PropTypes.bool.isRequired
+  canChangeParticipantType: PropTypes.bool.isRequired
 };
 
 const styles = {

--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -624,8 +624,8 @@ class UnitEditor extends React.Component {
             handleParticipantAudienceChange={e =>
               this.setState({participantAudience: e.target.value})
             }
-            cannotChangeParticipantType={
-              this.state.publishedState !== PublishedState.in_development
+            canChangeParticipantType={
+              this.state.publishedState === PublishedState.in_development
             }
           />
         )}

--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -94,6 +94,7 @@ class UnitEditor extends React.Component {
     initialCourseVersionId: PropTypes.number,
     initialUseLegacyLessonPlans: PropTypes.bool,
     scriptPath: PropTypes.string.isRequired,
+    hasBeenAssignable: PropTypes.bool.isRequired,
 
     // from redux
     lessonGroups: PropTypes.arrayOf(lessonGroupShape).isRequired,
@@ -624,6 +625,7 @@ class UnitEditor extends React.Component {
             handleParticipantAudienceChange={e =>
               this.setState({participantAudience: e.target.value})
             }
+            cannotChangeParticipantType={this.props.hasBeenAssignable}
           />
         )}
 

--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -256,6 +256,22 @@ class UnitEditor extends React.Component {
       return;
     }
 
+    if (this.state.publishedState !== this.props.initialPublishedState) {
+      const msg =
+        'It looks like you are updating the published state. ' +
+        'Are you sure you want to update the published state? ' +
+        'Once you update the published state you can not go back to this published state. ' +
+        'For example once you set the published state to beta you can not go back to in development. ' +
+        'Also once a course as a published state of pilot it can not be fully launched (marked as preview or stable).';
+      if (!window.confirm(msg)) {
+        this.setState({
+          isSaving: false,
+          error: 'Saving cancelled.'
+        });
+        return;
+      }
+    }
+
     let dataToSave = {
       name: this.props.name,
       family_name: this.state.familyName,

--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -729,6 +729,7 @@ class UnitEditor extends React.Component {
                     isCourse={this.state.isCourse}
                     updateIsCourse={this.handleStandaloneUnitChange}
                     showIsCourseSelector
+                    initialPublishedState={this.props.initialPublishedState}
                     publishedState={this.state.publishedState}
                     updatePublishedState={publishedState =>
                       this.setState({publishedState})

--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -94,7 +94,6 @@ class UnitEditor extends React.Component {
     initialCourseVersionId: PropTypes.number,
     initialUseLegacyLessonPlans: PropTypes.bool,
     scriptPath: PropTypes.string.isRequired,
-    hasBeenAssignable: PropTypes.bool.isRequired,
 
     // from redux
     lessonGroups: PropTypes.arrayOf(lessonGroupShape).isRequired,
@@ -625,7 +624,9 @@ class UnitEditor extends React.Component {
             handleParticipantAudienceChange={e =>
               this.setState({participantAudience: e.target.value})
             }
-            cannotChangeParticipantType={this.props.hasBeenAssignable}
+            cannotChangeParticipantType={
+              this.state.publishedState !== PublishedState.in_development
+            }
           />
         )}
 

--- a/apps/src/sites/studio/pages/courses/edit.js
+++ b/apps/src/sites/studio/pages/courses/edit.js
@@ -84,7 +84,6 @@ function showCourseEditor() {
         useMigratedResources={courseEditorData.course_summary.is_migrated}
         courseVersionId={courseEditorData.course_summary.course_version_id}
         coursePath={courseEditorData.course_summary.course_path}
-        hasBeenAssignable={courseEditorData.course_summary.has_been_assignable}
       />
     </Provider>,
     document.getElementById('course_editor')

--- a/apps/src/sites/studio/pages/courses/edit.js
+++ b/apps/src/sites/studio/pages/courses/edit.js
@@ -84,6 +84,7 @@ function showCourseEditor() {
         useMigratedResources={courseEditorData.course_summary.is_migrated}
         courseVersionId={courseEditorData.course_summary.course_version_id}
         coursePath={courseEditorData.course_summary.course_path}
+        hasBeenAssignable={courseEditorData.course_summary.has_been_assignable}
       />
     </Provider>,
     document.getElementById('course_editor')

--- a/apps/src/sites/studio/pages/scripts/edit.js
+++ b/apps/src/sites/studio/pages/scripts/edit.js
@@ -106,7 +106,6 @@ export default function initPage(unitEditorData) {
         }
         initialUseLegacyLessonPlans={scriptData.useLegacyLessonPlans || false}
         scriptPath={scriptData.scriptPath}
-        hasBeenAssignable={scriptData.hasBeenAssignable || false}
       />
     </Provider>,
     document.querySelector('.edit_container')

--- a/apps/src/sites/studio/pages/scripts/edit.js
+++ b/apps/src/sites/studio/pages/scripts/edit.js
@@ -106,6 +106,7 @@ export default function initPage(unitEditorData) {
         }
         initialUseLegacyLessonPlans={scriptData.useLegacyLessonPlans || false}
         scriptPath={scriptData.scriptPath}
+        hasBeenAssignable={scriptData.hasBeenAssignable || false}
       />
     </Provider>,
     document.querySelector('.edit_container')

--- a/apps/test/unit/lib/levelbuilder/CourseVersionPublishingEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/CourseVersionPublishingEditorTest.jsx
@@ -46,6 +46,41 @@ describe('CourseVersionPublishedStateSelector', () => {
     expect(
       wrapper.find('.publishedStateSelector').find('option').length
     ).to.equal(5);
+    expect(
+      wrapper
+        .find('.publishedStateSelector')
+        .find('option')
+        .at(0)
+        .props().value
+    ).to.equal('in_development');
+    expect(
+      wrapper
+        .find('.publishedStateSelector')
+        .find('option')
+        .at(1)
+        .props().value
+    ).to.equal('pilot');
+    expect(
+      wrapper
+        .find('.publishedStateSelector')
+        .find('option')
+        .at(2)
+        .props().value
+    ).to.equal('beta');
+    expect(
+      wrapper
+        .find('.publishedStateSelector')
+        .find('option')
+        .at(3)
+        .props().value
+    ).to.equal('preview');
+    expect(
+      wrapper
+        .find('.publishedStateSelector')
+        .find('option')
+        .at(4)
+        .props().value
+    ).to.equal('stable');
   });
 
   it('published state dropdown shows only available published states when course is pilot', () => {
@@ -58,7 +93,13 @@ describe('CourseVersionPublishedStateSelector', () => {
     );
     expect(
       wrapper.find('.publishedStateSelector').find('option').length
-    ).to.equal(4);
+    ).to.equal(1);
+    expect(
+      wrapper
+        .find('.publishedStateSelector')
+        .find('option')
+        .props().value
+    ).to.equal('pilot');
   });
 
   it('published state dropdown shows only available published states when course is beta', () => {
@@ -72,6 +113,27 @@ describe('CourseVersionPublishedStateSelector', () => {
     expect(
       wrapper.find('.publishedStateSelector').find('option').length
     ).to.equal(3);
+    expect(
+      wrapper
+        .find('.publishedStateSelector')
+        .find('option')
+        .at(0)
+        .props().value
+    ).to.equal('beta');
+    expect(
+      wrapper
+        .find('.publishedStateSelector')
+        .find('option')
+        .at(1)
+        .props().value
+    ).to.equal('preview');
+    expect(
+      wrapper
+        .find('.publishedStateSelector')
+        .find('option')
+        .at(2)
+        .props().value
+    ).to.equal('stable');
   });
 
   it('published state dropdown shows only available published states when course is preview', () => {
@@ -85,6 +147,20 @@ describe('CourseVersionPublishedStateSelector', () => {
     expect(
       wrapper.find('.publishedStateSelector').find('option').length
     ).to.equal(2);
+    expect(
+      wrapper
+        .find('.publishedStateSelector')
+        .find('option')
+        .at(0)
+        .props().value
+    ).to.equal('preview');
+    expect(
+      wrapper
+        .find('.publishedStateSelector')
+        .find('option')
+        .at(1)
+        .props().value
+    ).to.equal('stable');
   });
 
   it('published state dropdown shows only available published states when course is stable', () => {
@@ -98,6 +174,12 @@ describe('CourseVersionPublishedStateSelector', () => {
     expect(
       wrapper.find('.publishedStateSelector').find('option').length
     ).to.equal(1);
+    expect(
+      wrapper
+        .find('.publishedStateSelector')
+        .find('option')
+        .props().value
+    ).to.equal('stable');
   });
 
   it('pilot input field shows if published state is pilot', () => {

--- a/apps/test/unit/lib/levelbuilder/CourseVersionPublishingEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/CourseVersionPublishingEditorTest.jsx
@@ -30,8 +30,74 @@ describe('CourseVersionPublishedStateSelector', () => {
       updatePublishedState,
       families: ['family1', 'family2', 'family3'],
       versionYearOptions: ['1990', '1991', '1992'],
+      initialPublishedState: PublishedState.beta,
       publishedState: PublishedState.beta
     };
+  });
+
+  it('published state dropdown shows only available published states when course is in development', () => {
+    const wrapper = shallow(
+      <CourseVersionPublishingEditor
+        {...defaultProps}
+        initialPublishedState={PublishedState.in_development}
+        publishedState={PublishedState.in_development}
+      />
+    );
+    expect(
+      wrapper.find('.publishedStateSelector').find('option').length
+    ).to.equal(5);
+  });
+
+  it('published state dropdown shows only available published states when course is pilot', () => {
+    const wrapper = shallow(
+      <CourseVersionPublishingEditor
+        {...defaultProps}
+        initialPublishedState={PublishedState.pilot}
+        publishedState={PublishedState.pilot}
+      />
+    );
+    expect(
+      wrapper.find('.publishedStateSelector').find('option').length
+    ).to.equal(4);
+  });
+
+  it('published state dropdown shows only available published states when course is beta', () => {
+    const wrapper = shallow(
+      <CourseVersionPublishingEditor
+        {...defaultProps}
+        initialPublishedState={PublishedState.beta}
+        publishedState={PublishedState.beta}
+      />
+    );
+    expect(
+      wrapper.find('.publishedStateSelector').find('option').length
+    ).to.equal(3);
+  });
+
+  it('published state dropdown shows only available published states when course is preview', () => {
+    const wrapper = shallow(
+      <CourseVersionPublishingEditor
+        {...defaultProps}
+        initialPublishedState={PublishedState.preview}
+        publishedState={PublishedState.preview}
+      />
+    );
+    expect(
+      wrapper.find('.publishedStateSelector').find('option').length
+    ).to.equal(2);
+  });
+
+  it('published state dropdown shows only available published states when course is stable', () => {
+    const wrapper = shallow(
+      <CourseVersionPublishingEditor
+        {...defaultProps}
+        initialPublishedState={PublishedState.stable}
+        publishedState={PublishedState.stable}
+      />
+    );
+    expect(
+      wrapper.find('.publishedStateSelector').find('option').length
+    ).to.equal(1);
   });
 
   it('pilot input field shows if published state is pilot', () => {

--- a/apps/test/unit/lib/levelbuilder/course-editor/CourseTypeEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/course-editor/CourseTypeEditorTest.jsx
@@ -1,0 +1,39 @@
+import {assert} from '../../../../util/reconfiguredChai';
+import React from 'react';
+import {shallow} from 'enzyme';
+import {
+  InstructionType,
+  InstructorAudience,
+  ParticipantAudience
+} from '@cdo/apps/generated/curriculum/sharedCourseConstants';
+import CourseTypeEditor from '@cdo/apps/lib/levelbuilder/course-editor/CourseTypeEditor';
+
+const defaultProps = {
+  instructorAudience: InstructorAudience.teacher,
+  participantAudience: ParticipantAudience.student,
+  instructionType: InstructionType.teacher_led,
+  handleInstructionTypeChange: () => {},
+  handleInstructorAudienceChange: () => {},
+  handleParticipantAudienceChange: () => {},
+  cannotChangeParticipantType: false
+};
+
+describe('CourseTypeEditor', () => {
+  it('participant audience dropdown is disabled if cannotChangeParticipantType is true', () => {
+    const wrapper = shallow(
+      <CourseTypeEditor {...defaultProps} cannotChangeParticipantType={true} />
+    );
+    assert.equal(
+      wrapper.find('.participantAudienceSelector').props().disabled,
+      true
+    );
+  });
+
+  it('participant audience dropdown is not disabled if cannotChangeParticipantType is false', () => {
+    const wrapper = shallow(<CourseTypeEditor {...defaultProps} />);
+    assert.equal(
+      wrapper.find('.participantAudienceSelector').props().disabled,
+      false
+    );
+  });
+});

--- a/apps/test/unit/lib/levelbuilder/course-editor/CourseTypeEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/course-editor/CourseTypeEditorTest.jsx
@@ -15,11 +15,11 @@ const defaultProps = {
   handleInstructionTypeChange: () => {},
   handleInstructorAudienceChange: () => {},
   handleParticipantAudienceChange: () => {},
-  canChangeParticipantType: false
+  canChangeParticipantType: true
 };
 
 describe('CourseTypeEditor', () => {
-  it('participant audience dropdown is disabled unless canChangeParticipantType is true', () => {
+  it('participant audience dropdown is disabled if canChangeParticipantType is false', () => {
     const wrapper = shallow(
       <CourseTypeEditor {...defaultProps} canChangeParticipantType={false} />
     );
@@ -30,7 +30,9 @@ describe('CourseTypeEditor', () => {
   });
 
   it('participant audience dropdown is not disabled if canChangeParticipantType is true', () => {
-    const wrapper = shallow(<CourseTypeEditor {...defaultProps} />);
+    const wrapper = shallow(
+      <CourseTypeEditor {...defaultProps} canChangeParticipantType={true} />
+    );
     assert.equal(
       wrapper.find('.participantAudienceSelector').props().disabled,
       false

--- a/apps/test/unit/lib/levelbuilder/course-editor/CourseTypeEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/course-editor/CourseTypeEditorTest.jsx
@@ -15,13 +15,13 @@ const defaultProps = {
   handleInstructionTypeChange: () => {},
   handleInstructorAudienceChange: () => {},
   handleParticipantAudienceChange: () => {},
-  cannotChangeParticipantType: false
+  canChangeParticipantType: false
 };
 
 describe('CourseTypeEditor', () => {
-  it('participant audience dropdown is disabled if cannotChangeParticipantType is true', () => {
+  it('participant audience dropdown is disabled unless canChangeParticipantType is true', () => {
     const wrapper = shallow(
-      <CourseTypeEditor {...defaultProps} cannotChangeParticipantType={true} />
+      <CourseTypeEditor {...defaultProps} canChangeParticipantType={false} />
     );
     assert.equal(
       wrapper.find('.participantAudienceSelector').props().disabled,
@@ -29,7 +29,7 @@ describe('CourseTypeEditor', () => {
     );
   });
 
-  it('participant audience dropdown is not disabled if cannotChangeParticipantType is false', () => {
+  it('participant audience dropdown is not disabled if canChangeParticipantType is true', () => {
     const wrapper = shallow(<CourseTypeEditor {...defaultProps} />);
     assert.equal(
       wrapper.find('.participantAudienceSelector').props().disabled,

--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -101,7 +101,6 @@ class CoursesController < ApplicationController
     unit_group.persist_strings_and_units_changes(params[:scripts], params[:alternate_units], i18n_params)
     unit_group.update(course_params)
     unit_group.write_serialization
-
     CourseOffering.add_course_offering(unit_group)
     unit_group.reload
 

--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -101,6 +101,11 @@ class CoursesController < ApplicationController
     unit_group.persist_strings_and_units_changes(params[:scripts], params[:alternate_units], i18n_params)
     unit_group.update(course_params)
     unit_group.write_serialization
+
+    if [SharedCourseConstants::PUBLISHED_STATE.pilot, SharedCourseConstants::PUBLISHED_STATE.preview, SharedCourseConstants::PUBLISHED_STATE.stable].include? unit_group.published_state
+      unit_group.has_been_assignable = true
+    end
+
     CourseOffering.add_course_offering(unit_group)
     unit_group.reload
 

--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -102,10 +102,6 @@ class CoursesController < ApplicationController
     unit_group.update(course_params)
     unit_group.write_serialization
 
-    if [SharedCourseConstants::PUBLISHED_STATE.pilot, SharedCourseConstants::PUBLISHED_STATE.preview, SharedCourseConstants::PUBLISHED_STATE.stable].include? unit_group.published_state
-      unit_group.has_been_assignable = true
-    end
-
     CourseOffering.add_course_offering(unit_group)
     unit_group.reload
 

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -269,7 +269,6 @@ class Script < ApplicationRecord
     seeded_from
     is_maker_unit
     use_legacy_lesson_plans
-    has_been_assignable
   )
 
   def self.twenty_hour_unit
@@ -1002,10 +1001,6 @@ class Script < ApplicationRecord
     transaction do
       unit = fetch_unit(options)
 
-      if [SharedCourseConstants::PUBLISHED_STATE.pilot, SharedCourseConstants::PUBLISHED_STATE.preview, SharedCourseConstants::PUBLISHED_STATE.stable].include? unit.get_published_state
-        unit.has_been_assignable = true
-      end
-
       unit.prevent_duplicate_lesson_groups(raw_lesson_groups)
       Script.prevent_some_lessons_in_lesson_groups_and_some_not(raw_lesson_groups)
 
@@ -1511,7 +1506,6 @@ class Script < ApplicationRecord
     include_lessons = false
     summary = summarize(include_lessons)
     summary[:lesson_groups] = lesson_groups.map(&:summarize_for_unit_edit)
-    summary[:hasBeenAssignable] = has_been_assignable?
     summary
   end
 

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -269,6 +269,7 @@ class Script < ApplicationRecord
     seeded_from
     is_maker_unit
     use_legacy_lesson_plans
+    has_been_assignable
   )
 
   def self.twenty_hour_unit
@@ -1001,6 +1002,10 @@ class Script < ApplicationRecord
     transaction do
       unit = fetch_unit(options)
 
+      if [SharedCourseConstants::PUBLISHED_STATE.pilot, SharedCourseConstants::PUBLISHED_STATE.preview, SharedCourseConstants::PUBLISHED_STATE.stable].include? unit.get_published_state
+        unit.has_been_assignable = true
+      end
+
       unit.prevent_duplicate_lesson_groups(raw_lesson_groups)
       Script.prevent_some_lessons_in_lesson_groups_and_some_not(raw_lesson_groups)
 
@@ -1506,6 +1511,7 @@ class Script < ApplicationRecord
     include_lessons = false
     summary = summarize(include_lessons)
     summary[:lesson_groups] = lesson_groups.map(&:summarize_for_unit_edit)
+    summary[:hasBeenAssignable] = has_been_assignable?
     summary
   end
 

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -380,7 +380,7 @@ class UnitGroup < ApplicationRecord
       show_assign_button: assignable_for_user?(user),
       announcements: announcements,
       course_version_id: course_version&.id,
-      course_path: link,
+      course_path: link
     }
   end
 

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -75,6 +75,7 @@ class UnitGroup < ApplicationRecord
     version_year
     pilot_experiment
     announcements
+    has_been_assignable
   )
 
   def to_param
@@ -380,7 +381,8 @@ class UnitGroup < ApplicationRecord
       show_assign_button: assignable_for_user?(user),
       announcements: announcements,
       course_version_id: course_version&.id,
-      course_path: link
+      course_path: link,
+      has_been_assignable: has_been_assignable?
     }
   end
 

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -75,7 +75,6 @@ class UnitGroup < ApplicationRecord
     version_year
     pilot_experiment
     announcements
-    has_been_assignable
   )
 
   def to_param
@@ -382,7 +381,6 @@ class UnitGroup < ApplicationRecord
       announcements: announcements,
       course_version_id: course_version&.id,
       course_path: link,
-      has_been_assignable: has_been_assignable?
     }
   end
 


### PR DESCRIPTION
- Make it so you can't go backwards in published states (Once something is in pilot it can't go back to in development)
- Make sure pilot courses cannot become launched courses
- Make sure you can't change participant audience once you leave the in development published state

## Links

[Eng Plan](https://docs.google.com/document/d/1V61xONU0-mleMEEdHWNxhvZtYIPRCB31mT_hbUXusCQ/edit#)
[Product Spec](https://docs.google.com/document/d/1qZpc90daxQiiqpcQUiUiGV2tQoaYEQUzOA72UZzBlVE/edit#heading=h.f5x8no3lbpxy)

## Testing story

- Added unit tests
- Manual testing