### PR TITLE
Fixes script overview - teacher viewing student

### DIFF
--- a/apps/src/code-studio/components/progress/teacherPanel/TeacherPanel.jsx
+++ b/apps/src/code-studio/components/progress/teacherPanel/TeacherPanel.jsx
@@ -70,7 +70,10 @@ class TeacherPanel extends React.Component {
 
   componentDidMount() {
     const initialViewAs = queryParams('viewAs') || ViewType.Instructor;
-    this.props.setViewType(initialViewAs);
+
+    if (this.props.viewAs !== initialViewAs) {
+      this.props.setViewType(initialViewAs);
+    }
 
     this.loadInitialData();
   }

--- a/apps/src/templates/progress/ProgressPill.jsx
+++ b/apps/src/templates/progress/ProgressPill.jsx
@@ -6,6 +6,7 @@ import color from '@cdo/apps/util/color';
 import {levelWithProgressType} from './progressTypes';
 import {levelProgressStyle, hoverStyle} from './progressStyles';
 import {stringifyQueryParams} from '../../utils';
+import {queryParams} from '@cdo/apps/code-studio/utils';
 import {isLevelAssessment} from './progressHelpers';
 import {connect} from 'react-redux';
 import {ReviewStates} from '@cdo/apps/templates/feedback/types';
@@ -50,12 +51,18 @@ class ProgressPill extends React.Component {
     }
 
     let url = levels[0].url;
+    let params = {};
 
     if (selectedSectionId) {
-      url += stringifyQueryParams({section_id: selectedSectionId});
+      params['section_id'] = selectedSectionId;
     }
 
-    return url;
+    const userId = queryParams('user_id');
+    if (userId) {
+      params['user_id'] = userId;
+    }
+
+    return (url += stringifyQueryParams(params));
   }
 
   getTooltipProps() {

--- a/apps/test/unit/templates/progress/ProgressPillTest.js
+++ b/apps/test/unit/templates/progress/ProgressPillTest.js
@@ -6,6 +6,8 @@ import {LevelStatus, LevelKind} from '@cdo/apps/util/sharedConstants';
 import ReactTooltip from 'react-tooltip';
 import {ReviewStates} from '@cdo/apps/templates/feedback/types';
 import BubbleBadge, {BadgeType} from '@cdo/apps/templates/progress/BubbleBadge';
+import * as utils from '@cdo/apps/code-studio/utils';
+import sinon from 'sinon';
 
 const unpluggedLevel = {
   id: '1',
@@ -82,6 +84,26 @@ describe('ProgressPill', () => {
       <ProgressPill levels={[levelWithUrl]} text="Unplugged Activity" />
     );
     assert.equal(wrapper.find('a').props().href, '/foo/bar');
+  });
+
+  it('includes section in href when selectedSectionId is present', () => {
+    const wrapper = shallow(
+      <ProgressPill
+        levels={[levelWithUrl]}
+        text="Unplugged Activity"
+        selectedSectionId="1234"
+      />
+    );
+    assert.equal(wrapper.find('a').props().href, '/foo/bar?section_id=1234');
+  });
+
+  it('includes user_id in href when user_id query param is present', () => {
+    sinon.stub(utils, 'queryParams').returns('123');
+    const wrapper = shallow(
+      <ProgressPill levels={[levelWithUrl]} text="Unplugged Activity" />
+    );
+    assert.equal(wrapper.find('a').props().href, '/foo/bar?user_id=123');
+    utils.queryParams.restore();
   });
 
   it('does not have an href when disabled', () => {

--- a/dashboard/test/ui/features/learning_platform/script_overview.feature
+++ b/dashboard/test/ui/features/learning_platform/script_overview.feature
@@ -26,9 +26,9 @@ Feature: Script overview page
     And element "td:contains(2. Maze)" is visible
     Then I verify progress for lesson 2 level 1 is "perfect"
     Then I verify progress for lesson 2 level 2 is "not_tried"
+    # verify when teacher is viewing student, script overview page loads in summary view
     And I reload the page
-    # verify name format in summary view
-    And element "td:contains(2. Maze)" is visible
+    And I wait to see ".uitest-summary-progress-table"
 
     # Make sure we only see student progress, not teacher progress.
     Then I verify progress for lesson 29 level 4 is "not_tried"

--- a/dashboard/test/ui/features/learning_platform/script_overview.feature
+++ b/dashboard/test/ui/features/learning_platform/script_overview.feature
@@ -22,8 +22,13 @@ Feature: Script overview page
     Then I verify progress for lesson 29 level 4 in detail view is "perfect"
     When I click selector ".teacher-panel table td:contains(Sally)" once I see it
     And I wait until element "td:contains(Maze)" is visible
+    # verify name format in summary view
+    And element "td:contains(2. Maze)" is visible
     Then I verify progress for lesson 2 level 1 is "perfect"
     Then I verify progress for lesson 2 level 2 is "not_tried"
+    And I reload the page
+    # verify name format in summary view
+    And element "td:contains(2. Maze)" is visible
 
     # Make sure we only see student progress, not teacher progress.
     Then I verify progress for lesson 29 level 4 is "not_tried"


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR fixes a couple of problems brought to our attention through Zendesk.
1. Progress Pills on script overview detail view do not include user_id in link URL when they should
2. Script overview page is defaulting to detail view when the teacher is viewing student work. This was introduced during refactors done to the TeacherPanel while we were working on getting the teacher panel to load on cached pages. The redux view type was being set again by the teacher panel after summary view had already been set and was overriding the value. The changes in this PR update the TeacherPanel not to set the view type again if it's already been set correctly. (Ideally the TeacherPanel owns setting that value in redux and the pages don't set it in other places, but I didn't want to go down that rabbit hole right now).

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
- jira ticket: [LP-2178](https://codedotorg.atlassian.net/browse/LP-2178)
<!--
- spec: []()

-->

## Testing story
- Tested locally
- Updated unit tests
- Added to script overview feature test to verify summary view is displayed properly on load
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
