### PR TITLE
Move marketing banners up the page

### DIFF
--- a/apps/src/templates/census2017/YourSchool.jsx
+++ b/apps/src/templates/census2017/YourSchool.jsx
@@ -100,8 +100,6 @@ class YourSchool extends Component {
               width="100%"
             />
           )}
-        <h1 style={styles.heading}>{i18n.yourSchoolHeading()}</h1>
-        <h3 style={styles.description}>{i18n.yourSchoolDescription()}</h3>
         {this.props.showProfessionalLearningBanner && (
           <ProfessionalLearningApplyBanner
             nominated={false}
@@ -110,6 +108,8 @@ class YourSchool extends Component {
             teacherApplicationMode={this.props.teacherApplicationMode}
           />
         )}
+        <h1 style={styles.heading}>{i18n.yourSchoolHeading()}</h1>
+        <h3 style={styles.description}>{i18n.yourSchoolDescription()}</h3>
         <YourSchoolResources />
         {!this.props.hideMap && (
           <div id="map">

--- a/pegasus/sites.v3/code.org/public/educate/curriculum/middle-school.md.erb
+++ b/pegasus/sites.v3/code.org/public/educate/curriculum/middle-school.md.erb
@@ -4,6 +4,8 @@ video_player: true
 theme: responsive
 ---
 
+ <%= view :professional_learning_apply_banner, :link_suffix => "program-information" %>
+
 [solid-block-header]
 
 Middle School
@@ -11,8 +13,6 @@ Middle School
 [/solid-block-header]
 
 Our curriculum is available at [no cost](/commitment) for anyone, anywhere to teach. You can read more about our [curriculum values here](/educate/curriculum/values).
-
- <%= view :professional_learning_apply_banner, :link_suffix => "program-information", :style => {"paddingTop" => "22px"} %>
 
 <hr>
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Eric asked me to move the banners on /yourschool and /middle-school to the top of the page.

Now:
<img width="1228" alt="Screen Shot 2022-01-10 at 6 22 38 PM" src="https://user-images.githubusercontent.com/24235215/148870271-b9787b03-ca7d-4777-9956-2d4d9ec10b0c.png">
<img width="1302" alt="Screen Shot 2022-01-10 at 6 22 49 PM" src="https://user-images.githubusercontent.com/24235215/148870279-5b59adf9-d5be-4794-9f6c-cbe81c9a9942.png">


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
