### PR TITLE
Remove front end code review groups experiment

### DIFF
--- a/apps/src/templates/manageStudents/ManageStudentsTable.jsx
+++ b/apps/src/templates/manageStudents/ManageStudentsTable.jsx
@@ -48,7 +48,6 @@ import copyToClipboard from '@cdo/apps/util/copyToClipboard';
 import {teacherDashboardUrl} from '@cdo/apps/templates/teacherDashboard/urlHelpers';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
 import SafeMarkdown from '../SafeMarkdown';
-import experiments from '@cdo/apps/util/experiments';
 
 const LOGIN_TYPES_WITH_PASSWORD_COLUMN = [
   SectionLoginType.word,
@@ -808,13 +807,12 @@ class ManageStudentsTable extends Component {
             but is otherwise similar to other button/modal components here.
             Despite being unused in this component, we pass the dataApi object
             so that it can be more easily stubbed in tests. */}
-          {isSectionAssignedCSA &&
-            experiments.isEnabled(experiments.CODE_REVIEW_GROUPS) && (
-              <CodeReviewGroupsDialog
-                dataApi={new CodeReviewGroupsDataApi(sectionId)}
-                buttonContainerStyle={styles.button}
-              />
-            )}
+          {isSectionAssignedCSA && (
+            <CodeReviewGroupsDialog
+              dataApi={new CodeReviewGroupsDataApi(sectionId)}
+              buttonContainerStyle={styles.button}
+            />
+          )}
           {LOGIN_TYPES_WITH_PASSWORD_COLUMN.includes(loginType) && (
             <div
               style={styles.sectionCodeBox}

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -37,7 +37,6 @@ experiments.BYPASS_DIALOG_POPUP = 'bypass-dialog-popup';
 experiments.SPECIAL_TOPIC = 'special-topic';
 experiments.CLEARER_SIGN_UP_USER_TYPE = 'clearerSignUpUserType';
 experiments.OPT_IN_EMAIL_REG_PARTNER = 'optInEmailRegPartner';
-experiments.CODE_REVIEW_GROUPS = 'codeReviewGroups';
 experiments.JAVALAB_UNIT_TESTS = 'javalabUnitTests';
 
 /**

--- a/apps/test/unit/templates/manageStudents/ManageStudentsTableTest.js
+++ b/apps/test/unit/templates/manageStudents/ManageStudentsTableTest.js
@@ -9,7 +9,6 @@ import {
 import i18n from '@cdo/locale';
 import {expect} from '../../../util/deprecatedChai';
 import {shallow, mount} from 'enzyme';
-import experiments from '@cdo/apps/util/experiments';
 import ManageStudentsTable, {
   UnconnectedManageStudentsTable,
   sortRows
@@ -70,17 +69,6 @@ describe('ManageStudentsTable', () => {
       transferStatus: {}
     };
 
-    // TO DO: remove these before and after each calls once
-    // code review groups has been fully released.
-    // Added permalink to this in https://codedotorg.atlassian.net/browse/CSA-1008
-    beforeEach(() => {
-      experiments.setEnabled(experiments.CODE_REVIEW_GROUPS, true);
-    });
-
-    afterEach(() => {
-      experiments.setEnabled(experiments.CODE_REVIEW_GROUPS, false);
-    });
-
     it('does not render MoveStudents if loginType is google_classroom', () => {
       const wrapper = shallow(
         <UnconnectedManageStudentsTable {...DEFAULT_PROPS} />
@@ -102,15 +90,6 @@ describe('ManageStudentsTable', () => {
         <UnconnectedManageStudentsTable
           {...{...DEFAULT_PROPS, ...{isSectionAssignedCSA: false}}}
         />
-      );
-      expect(wrapper.find(CodeReviewGroupsDialog).exists()).to.be.false;
-    });
-
-    it('does not render Code Review Groups Dialog (and button) if code review comments experiment is not enabled', () => {
-      experiments.setEnabled(experiments.CODE_REVIEW_GROUPS, false);
-
-      const wrapper = shallow(
-        <UnconnectedManageStudentsTable {...DEFAULT_PROPS} />
       );
       expect(wrapper.find(CodeReviewGroupsDialog).exists()).to.be.false;
     });


### PR DESCRIPTION
Removes experiment flag hiding code review groups from teachers. CSA teachers will see the UI to manage code review groups in the teacher dashboard after this PR is merged.

## Testing story

Tested manually.

## Deployment strategy

This is the first step in rolling out the new code review groups feature. Merging it will allow teachers to manage code review groups, but will not actually put these groups to use in managing access to code review.

## Follow-up work

1. Flip DCDO flag to start using code review groups to manage access to code review.
2. [Remove the current "enable peer feedback?" option](https://github.com/code-dot-org/code-dot-org/pull/44309) that manages access to code review from the section edit/update form.