### PR TITLE
Remove code review enabled from section redux

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -805,8 +805,6 @@
   "enableMakerDialogDescription": "Maker Toolkit is a feature used in the Computer Science Discoveries curriculum. See the setup page for more details:",
   "enableMakerDialogSetupPageLinkText": "Maker Toolkit Setup",
   "enablePairProgramming": "Allow students to Pair Program?",
-  "enablePeerFeedback": "Enable Peer Feedback?",
-  "enablePeerFeedbackDescription": "When peer feedback is enabled, students may leave comments on other projects in the Review section.",
   "encrypted": "encrypted",
   "end": "end",
   "englishOnly": "English-only",

--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -805,6 +805,8 @@
   "enableMakerDialogDescription": "Maker Toolkit is a feature used in the Computer Science Discoveries curriculum. See the setup page for more details:",
   "enableMakerDialogSetupPageLinkText": "Maker Toolkit Setup",
   "enablePairProgramming": "Allow students to Pair Program?",
+  "enablePeerFeedback": "Enable Peer Feedback?",
+  "enablePeerFeedbackDescription": "When peer feedback is enabled, students may leave comments on other projects in the Review section.",
   "encrypted": "encrypted",
   "end": "end",
   "englishOnly": "English-only",

--- a/apps/src/redux/sectionDataRedux.js
+++ b/apps/src/redux/sectionDataRedux.js
@@ -12,6 +12,11 @@ import PropTypes from 'prop-types';
  * different shape than some other places we use sections. For now, I'm just
  * going to document the parts of section that we use here
  */
+// codeReviewEnabled can get out of sync with codeReviewExpiresAt
+// while editing code review groups on the teacher dashboard.
+// This doesn't affect functionality, as codeReviewEnabled
+// is used on level pages to determine whether the functionality
+// should be active or not, but it is confusing.
 export const sectionDataPropType = PropTypes.shape({
   id: PropTypes.number.isRequired,
   script: PropTypes.object,

--- a/apps/src/redux/sectionDataRedux.js
+++ b/apps/src/redux/sectionDataRedux.js
@@ -56,7 +56,6 @@ export const setSection = section => {
     id: section.id,
     script: section.script,
     students: sortedStudents,
-    codeReviewEnabled: section.code_review_enabled,
     isAssignedCSA: section.is_assigned_csa,
     lessonExtras: section.lesson_extras,
     ttsAutoplayEnabled: section.tts_autoplay_enabled,

--- a/apps/src/redux/sectionDataRedux.js
+++ b/apps/src/redux/sectionDataRedux.js
@@ -21,7 +21,6 @@ export const sectionDataPropType = PropTypes.shape({
       name: PropTypes.string.isRequired
     })
   ).isRequired,
-  codeReviewEnabled: PropTypes.bool,
   isAssignedCSA: PropTypes.bool,
   lessonExtras: PropTypes.bool,
   ttsAutoplayEnabled: PropTypes.bool,

--- a/apps/src/redux/sectionDataRedux.js
+++ b/apps/src/redux/sectionDataRedux.js
@@ -12,11 +12,6 @@ import PropTypes from 'prop-types';
  * different shape than some other places we use sections. For now, I'm just
  * going to document the parts of section that we use here
  */
-// codeReviewEnabled can get out of sync with codeReviewExpiresAt
-// while editing code review groups on the teacher dashboard.
-// This doesn't affect functionality, as codeReviewEnabled
-// is used on level pages to determine whether the functionality
-// should be active or not, but it is confusing.
 export const sectionDataPropType = PropTypes.shape({
   id: PropTypes.number.isRequired,
   script: PropTypes.object,

--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
@@ -18,8 +18,7 @@ const USER_EDITABLE_SECTION_PROPS = [
   'scriptId',
   'grade',
   'hidden',
-  'restrictSection',
-  'codeReviewEnabled'
+  'restrictSection'
 ];
 
 /** @const {number} ID for a new section that has not been saved */
@@ -577,8 +576,7 @@ function newSectionData(id, courseId, scriptId, loginType) {
     scriptId: scriptId || null,
     hidden: false,
     isAssigned: undefined,
-    restrictSection: false,
-    codeReviewEnabled: true
+    restrictSection: false
   };
 }
 
@@ -1170,7 +1168,6 @@ export const sectionFromServerSection = serverSection => ({
   hidden: serverSection.hidden,
   isAssigned: serverSection.isAssigned,
   restrictSection: serverSection.restrict_section,
-  codeReviewEnabled: serverSection.code_review_enabled,
   postMilestoneDisabled: serverSection.post_milestone_disabled
 });
 
@@ -1202,8 +1199,7 @@ export function serverSectionFromSection(section) {
     sharing_disabled: section.sharingDisabled,
     course_id: section.courseId,
     script: section.scriptId ? {id: section.scriptId} : undefined,
-    restrict_section: section.restrictSection,
-    code_review_enabled: section.codeReviewEnabled
+    restrict_section: section.restrictSection
   };
 }
 

--- a/apps/test/unit/redux/sectionDataReduxTest.js
+++ b/apps/test/unit/redux/sectionDataReduxTest.js
@@ -19,7 +19,6 @@ const fakeSectionData = {
   },
   lesson_extras: false,
   tts_autoplay_enabled: false,
-  code_review_enabled: true,
   is_assigned_csa: false,
   codeReviewExpiresAt: null
 };
@@ -40,7 +39,6 @@ const sortedFakeSectionData = {
     id: 300,
     name: 'csp2'
   },
-  codeReviewEnabled: true,
   isAssignedCSA: false,
   lessonExtras: false,
   ttsAutoplayEnabled: false,

--- a/apps/test/unit/templates/teacherDashboard/teacherSectionsReduxTest.js
+++ b/apps/test/unit/templates/teacherDashboard/teacherSectionsReduxTest.js
@@ -74,7 +74,6 @@ const sections = [
     studentCount: 10,
     hidden: false,
     restrict_section: false,
-    code_review_enabled: true,
     post_milestone_disabled: false
   },
   {
@@ -97,7 +96,6 @@ const sections = [
     studentCount: 1,
     hidden: false,
     restrict_section: false,
-    code_review_enabled: true,
     post_milestone_disabled: false
   },
   {
@@ -120,7 +118,6 @@ const sections = [
     studentCount: 0,
     hidden: false,
     restrict_section: false,
-    code_review_enabled: true,
     post_milestone_disabled: false
   }
 ];
@@ -617,8 +614,7 @@ describe('teacherSectionsRedux', () => {
         scriptId: null,
         hidden: false,
         isAssigned: undefined,
-        restrictSection: false,
-        codeReviewEnabled: true
+        restrictSection: false
       });
     });
   });
@@ -646,7 +642,6 @@ describe('teacherSectionsRedux', () => {
         hidden: false,
         isAssigned: undefined,
         restrictSection: false,
-        codeReviewEnabled: true,
         postMilestoneDisabled: false
       });
     });
@@ -769,7 +764,6 @@ describe('teacherSectionsRedux', () => {
       createdAt: createdAt,
       hidden: false,
       restrict_section: false,
-      code_review_enabled: true,
       post_milestone_disabled: false
     };
 
@@ -922,7 +916,6 @@ describe('teacherSectionsRedux', () => {
           hidden: false,
           isAssigned: undefined,
           restrictSection: false,
-          codeReviewEnabled: true,
           postMilestoneDisabled: false
         }
       });
@@ -979,7 +972,6 @@ describe('teacherSectionsRedux', () => {
       script_id: null,
       hidden: false,
       restrict_section: false,
-      code_review_enabled: true,
       post_milestone_disabled: false
     };
 
@@ -1213,7 +1205,6 @@ describe('teacherSectionsRedux', () => {
       studentCount: 10,
       hidden: false,
       restrict_section: false,
-      code_review_enabled: true,
       post_milestone_disabled: false
     };
 
@@ -1239,10 +1230,6 @@ describe('teacherSectionsRedux', () => {
       assert.strictEqual(
         section.restrict_section,
         serverSection.restrictSection
-      );
-      assert.strictEqual(
-        section.code_review_enabled,
-        serverSection.codeReviewEnabled
       );
       assert.strictEqual(
         section.post_milestone_disabled,


### PR DESCRIPTION
Small follow-up to https://github.com/code-dot-org/code-dot-org/pull/44309 to clean up Redux associated with code review, but broke out because it was confusing to wrap my head around.

Some notes for future reference:
- We store `codeReviewEnabled` in `sectionDataRedux` [when loading a level page](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/sites/studio/pages/levels/show.js#L25). This is particularly confusing because the variable [code_review_enabled that is used tacks on some additional logic ](https://github.com/code-dot-org/code-dot-org/blob/f30f0cea24802227e829c9e79840f1c5d1b0675d/dashboard/app/controllers/script_levels_controller.rb#L516) and is different than the section method `code_review_enabled?`. In the context of a level, we only care about whether code review is enabled or not (not the expiration date).
- We also store `codeReviewExpiresAt` in `sectionDataRedux` when loading the teacher dashboard, such that we can display the enable/disable code review toggle and show the amount of time remaining until a teacher's groups expire.
- We do not use `teacherSectionsRedux` for code review at the moment.

## Testing story

Tested manually that updating of section data (eg, name) does not result in any sort of override of code review enable/disable status.

## Deployment strategy

Should be deployed [after (or with) the PR to remove the "Enable Peer Feedback?"](https://github.com/code-dot-org/code-dot-org/pull/44309) option from the section update/edit form.