### PR TITLE
Do not overwrite code review setting if not provided

### DIFF
--- a/dashboard/app/controllers/api/v1/sections_controller.rb
+++ b/dashboard/app/controllers/api/v1/sections_controller.rb
@@ -53,8 +53,7 @@ class Api::V1::SectionsController < Api::V1::JsonApiController
         lesson_extras: params['lesson_extras'] || false,
         pairing_allowed: params[:pairing_allowed].nil? ? true : params[:pairing_allowed],
         tts_autoplay_enabled: params[:tts_autoplay_enabled].nil? ? false : params[:tts_autoplay_enabled],
-        restrict_section: params[:restrict_section].nil? ? false : params[:restrict_section],
-        code_review_enabled: params[:code_review_enabled].nil? ? true : params[:code_review_enabled]
+        restrict_section: params[:restrict_section].nil? ? false : params[:restrict_section]
       }
     )
     render head :bad_request unless section
@@ -102,7 +101,6 @@ class Api::V1::SectionsController < Api::V1::JsonApiController
     fields[:tts_autoplay_enabled] = params[:tts_autoplay_enabled] unless params[:tts_autoplay_enabled].nil?
     fields[:hidden] = params[:hidden] unless params[:hidden].nil?
     fields[:restrict_section] = params[:restrict_section] unless params[:restrict_section].nil?
-    fields[:code_review_enabled] = params[:code_review_enabled].nil? ? true : params[:code_review_enabled]
 
     section.update!(fields)
     if script_id

--- a/dashboard/test/controllers/api/v1/sections_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/sections_controller_test.rb
@@ -393,16 +393,6 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
     assert_equal false, returned_section.lesson_extras
   end
 
-  test 'default code_review_enabled value is TRUE' do
-    sign_in @teacher
-    post :create, params: {
-      login_type: Section::LOGIN_TYPE_EMAIL
-    }
-
-    assert returned_json['code_review_enabled']
-    assert returned_section.code_review_enabled
-  end
-
   test 'cannot set lesson_extras to an invalid value' do
     sign_in @teacher
     post :create, params: {


### PR DESCRIPTION
Apologies for all of the small PRs here.

An update to any piece of section info that uses the `update` action (eg, when submitting an update to a section name via the section edit form) that does not include `code_review_enabled` as a param would result in `code_review_enabled` being set to true. This would be the case if we were to remove the code review toggle from the section edit form without including this change.

## Testing story

Tested manually that prior to this change (but with the code review enabled toggle removed from the section edit form), a section with code review disabled ended up with code review enabled. After this change, edits could be made via the section edit without affecting the code review.

In practice, this shouldn't really matter because we're not going to remove the enable/disable button from the section edit form until we're no longer relying on `code_review_enabled` to control access to code review, so if data were corrupted it wouldn't particularly matter. Seems like good practice though to not accidentally edit user data.