### PR TITLE
Careers Page: remove the future/general application link

### DIFF
--- a/pegasus/sites.v3/code.org/public/about/careers.md.erb
+++ b/pegasus/sites.v3/code.org/public/about/careers.md.erb
@@ -89,10 +89,6 @@ Code.org is based in Seattle, but many of our team members are remote; remote ca
 </script>
 <script type='text/javascript' src='https://andreasmb.github.io/lever-jobs-embed/index.js'></script>
 
-<div class="careers__future">
-  We're always on the lookout for people who want to help make our vision a reality! Even if we don't have a job posted right now that matches your skills, we'd still love to hear from you via <a href="https://jobs.lever.co/code.org/6ca7d2c4-9965-4cf0-960e-de58e3d0d829">this application</a>.
-</div>
-
 <h2 class="careers-header">Get Involved</h2>
 
 <a href="https://code.org/educate/professional-learning/facilitator">Join the Facilitator Development Program</a><br />

--- a/pegasus/sites.v3/code.org/public/css/careers.css
+++ b/pegasus/sites.v3/code.org/public/css/careers.css
@@ -200,11 +200,6 @@ ul li:before {
   content: "";
 }
 
-.careers__future {
-  margin: 10px 0;
-  margin-bottom: 0;
-}
-
 .careers__team-photos {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
This removes the paragraph that includes a link to apply to a generic job application on our [careers page](https://code.org/about/careers). People Ops has taken this down and are exploring other ways to do something similar. The request to remove this can be found [here](https://codedotorg.slack.com/archives/CPYRQLNHX/p1634052440046300).

<img width="664" alt="Screen Shot 2022-01-12 at 11 13 03 AM" src="https://user-images.githubusercontent.com/12141607/149188960-e0eeca93-09fb-4db9-b45f-092569f86eb8.png">
