### PR TITLE
Revert "Merge pull request #44231 from code-dot-org/ben/javalab/center-headers"

### DIFF
--- a/apps/src/javalab/JavalabConsole.jsx
+++ b/apps/src/javalab/JavalabConsole.jsx
@@ -192,28 +192,17 @@ class JavalabConsole extends React.Component {
     return (
       <div style={style}>
         <PaneHeader id="pane-header" style={styles.header} hasFocus>
-          <PaneSection
-            className={'pane-header-section pane-header-section-left'}
+          <PaneButton
+            id="javalab-console-clear"
+            headerHasFocus
+            isRtl={false}
+            onClick={() => {
+              clearConsoleLogs();
+            }}
+            iconClass="fa fa-eraser"
+            label={javalabMsg.clearConsole()}
           />
-          <PaneSection
-            className={'pane-header-section pane-header-section-center'}
-          >
-            {javalabMsg.console()}
-          </PaneSection>
-          <PaneSection
-            className={'pane-header-section pane-header-section-right'}
-          >
-            <PaneButton
-              id="javalab-console-clear"
-              headerHasFocus
-              isRtl={false}
-              onClick={() => {
-                clearConsoleLogs();
-              }}
-              iconClass="fa fa-eraser"
-              label={javalabMsg.clearConsole()}
-            />
-          </PaneSection>
+          <PaneSection>{javalabMsg.console()}</PaneSection>
         </PaneHeader>
         <div style={styles.container}>
           <div
@@ -310,8 +299,7 @@ const styles = {
     position: 'absolute',
     textAlign: 'center',
     lineHeight: '30px',
-    width: '100%',
-    display: 'flex'
+    width: '100%'
   },
   log: {
     padding: 0,

--- a/apps/src/javalab/JavalabEditor.jsx
+++ b/apps/src/javalab/JavalabEditor.jsx
@@ -565,58 +565,48 @@ class JavalabEditor extends React.Component {
             isOpen={versionHistoryOpen}
           />
         )}
-        <PaneHeader hasFocus style={{display: 'flex'}}>
-          <PaneSection
-            className={'pane-header-section pane-header-section-left'}
-          >
-            <PaneButton
-              id="javalab-editor-create-file"
-              iconClass="fa fa-plus-circle"
-              onClick={() => this.setState({openDialog: Dialog.CREATE_FILE})}
-              headerHasFocus
-              isRtl={false}
-              label={javalabMsg.newFile()}
-              leftJustified
+        <PaneHeader hasFocus>
+          <PaneButton
+            id="javalab-editor-create-file"
+            iconClass="fa fa-plus-circle"
+            onClick={() => this.setState({openDialog: Dialog.CREATE_FILE})}
+            headerHasFocus
+            isRtl={false}
+            label={javalabMsg.newFile()}
+            leftJustified
+            isDisabled={isReadOnlyWorkspace}
+          />
+          <PaneSection style={styles.backpackSection}>
+            <Backpack
+              id={'javalab-editor-backpack'}
+              displayTheme={displayTheme}
               isDisabled={isReadOnlyWorkspace}
+              onImport={this.onImportFile}
             />
-            <PaneSection style={styles.backpackSection}>
-              <Backpack
-                id={'javalab-editor-backpack'}
-                displayTheme={displayTheme}
-                isDisabled={isReadOnlyWorkspace}
-                onImport={this.onImportFile}
-              />
-            </PaneSection>
           </PaneSection>
-          <PaneSection
-            className={'pane-header-section pane-header-section-center'}
-          >
+          <PaneButton
+            id="data-mode-versions-header"
+            iconClass="fa fa-clock-o"
+            label={msg.showVersionsHeader()}
+            headerHasFocus
+            isRtl={false}
+            onClick={() => this.handleVersionHistory()}
+            isDisabled={isReadOnlyWorkspace}
+          />
+          <PaneButton
+            id="javalab-editor-save"
+            iconClass="fa fa-check-circle"
+            onClick={this.onOpenCommitDialog}
+            headerHasFocus
+            isRtl={false}
+            label={javalabMsg.commitCode()}
+            isDisabled={isReadOnlyWorkspace}
+          />
+          <PaneSection>
             {showProjectTemplateWorkspaceIcon && (
               <ProjectTemplateWorkspaceIcon />
             )}
             {this.editorHeaderText()}
-          </PaneSection>
-          <PaneSection
-            className={'pane-header-section pane-header-section-right'}
-          >
-            <PaneButton
-              id="javalab-editor-save"
-              iconClass="fa fa-check-circle"
-              onClick={this.onOpenCommitDialog}
-              headerHasFocus
-              isRtl={false}
-              label={javalabMsg.commitCode()}
-              isDisabled={isReadOnlyWorkspace}
-            />
-            <PaneButton
-              id="data-mode-versions-header"
-              iconClass="fa fa-clock-o"
-              label={msg.showVersionsHeader()}
-              headerHasFocus
-              isRtl={false}
-              onClick={() => this.handleVersionHistory()}
-              isDisabled={isReadOnlyWorkspace}
-            />
           </PaneSection>
         </PaneHeader>
         <Tab.Container

--- a/apps/src/javalab/PreviewPaneHeader.jsx
+++ b/apps/src/javalab/PreviewPaneHeader.jsx
@@ -18,56 +18,44 @@ export default function PreviewPaneHeader({
   showPreviewTitle = true
 }) {
   return (
-    <PaneHeader hasFocus style={{display: 'flex'}}>
-      <PaneSection className={'pane-header-section pane-header-section-left'}>
+    <PaneHeader hasFocus>
+      <PaneButton
+        headerHasFocus
+        icon={<CollapserIcon isCollapsed={isCollapsed} />}
+        onClick={toggleVisualizationCollapsed}
+        label=""
+        isRtl={false}
+        style={styles.transparent}
+        leftJustified
+      />
+      {showPreviewTitle && (
+        <PaneSection style={styles.headerTitle}>{i18n.preview()}</PaneSection>
+      )}
+      {/* TODO: Uncomment fullscreen button when we are ready to implement fullscreen.
+      <PaneButton
+        headerHasFocus
+        iconClass={isFullscreen ? 'fa fa-compress' : 'fa fa-arrows-alt'}
+        onClick={() => {}}
+        label=""
+        isRtl={false}
+        style={styles.transparent}
+      />
+       */}
+      {showAssetManagerButton && (
         <PaneButton
           headerHasFocus
-          icon={<CollapserIcon isCollapsed={isCollapsed} />}
-          onClick={toggleVisualizationCollapsed}
-          label=""
+          onClick={() =>
+            assets.showAssetManager(null, null, null, {
+              customAllowedExtensions: '.wav, .jpg, .jpeg, .jfif, .png',
+              recordingFileType: RecordingFileType.WAV
+            })
+          }
+          iconClass="fa fa-upload"
+          label={i18n.manageAssets()}
           isRtl={false}
-          style={styles.transparent}
-          leftJustified
+          isDisabled={disableAssetManagerButton}
         />
-      </PaneSection>
-      <PaneSection className={'pane-header-section pane-header-section-center'}>
-        {showPreviewTitle && (
-          <PaneSection style={styles.headerTitle}>{i18n.preview()}</PaneSection>
-        )}
-      </PaneSection>
-      {/* This overflowX styling should ideally be in style.scss.
-          See that file for more details.
-       */}
-      <PaneSection
-        className={'pane-header-section pane-header-section-right'}
-        style={{overflowX: 'visible'}}
-      >
-        {/* TODO: Uncomment fullscreen button when we are ready to implement fullscreen.
-        <PaneButton
-          headerHasFocus
-          iconClass={isFullscreen ? 'fa fa-compress' : 'fa fa-arrows-alt'}
-          onClick={() => {}}
-          label=""
-          isRtl={false}
-          style={styles.transparent}
-        />
-       */}
-        {showAssetManagerButton && (
-          <PaneButton
-            headerHasFocus
-            onClick={() =>
-              assets.showAssetManager(null, null, null, {
-                customAllowedExtensions: '.wav, .jpg, .jpeg, .jfif, .png',
-                recordingFileType: RecordingFileType.WAV
-              })
-            }
-            iconClass="fa fa-upload"
-            label={i18n.manageAssets()}
-            isRtl={false}
-            isDisabled={disableAssetManagerButton}
-          />
-        )}
-      </PaneSection>
+      )}
     </PaneHeader>
   );
 }

--- a/apps/style/javalab/style.scss
+++ b/apps/style/javalab/style.scss
@@ -125,25 +125,3 @@ div#visualizationResizeBar {
     transform-origin: 0 0;
   }
 }
-
-.pane-header-section {
-  flex: 1;
-  display: flex;
-  align-items: center;
-};
-
-.pane-header-section-left {
-  justify-content: flex-start;
-};
-
-.pane-header-section-center {
-  justify-content: center;
-};
-
-// Note that in PreviewPaneHeader,
-// we (in addition to what is in the class below)
-// add element-specific styling of overflow-x to the right header section
-// to override some element-specific styling in PaneSection.
-.pane-header-section-right {
-  justify-content: flex-end;
-};


### PR DESCRIPTION
Reverting https://github.com/code-dot-org/code-dot-org/pull/44231 due to overflow of buttons at lower screen resolutions. The issue can be repro'd by zooming in or by decreasing the screen resolution on the page.

Applitools diff (notice the buttons have some text cut off)
![image](https://user-images.githubusercontent.com/8324574/149190292-6c2268a0-12ac-429c-9997-31788b01356f.png)

Verified that reverting fixes the issue
![image](https://user-images.githubusercontent.com/8324574/149190667-79eaaff5-fa56-4d23-8905-5dfed70f10d8.png)

Additional details: https://codedotorg.slack.com/archives/C01EF4GJ9GE/p1641952583055900