### PR TITLE
INF-510 Stop Testing Internet Explorer 🌎 

### DIFF
--- a/dashboard/test/ui/browsers.json
+++ b/dashboard/test/ui/browsers.json
@@ -17,12 +17,6 @@
     "w3c": true
   },
   {
-    "name": "IE11",
-    "browserName": "Internet Explorer",
-    "version": "11.0",
-    "platform": "Windows 10"
-  },
-  {
     "name": "Firefox",
     "browserName": "firefox",
     "browserVersion": "79.0",

--- a/lib/rake/circle.rake
+++ b/lib/rake/circle.rake
@@ -36,8 +36,8 @@ SKIP_CHROME_TAG = 'skip chrome'.freeze
 TEST_FIREFOX_TAG = 'test firefox'.freeze
 
 # Run UI tests against IE11
-TEST_IE_TAG = 'test ie'.freeze
-TEST_IE_VERBOSE_TAG = 'test internet explorer'.freeze
+# TEST_IE_TAG = 'test ie'.freeze
+# TEST_IE_VERBOSE_TAG = 'test internet explorer'.freeze
 
 # Run UI tests against Safari
 TEST_SAFARI_TAG = 'test safari'.freeze
@@ -122,7 +122,7 @@ namespace :circle do
         RakeUtils.system_stream_output "bundle exec ./runner.rb" \
             " --eyes" \
             " --feature #{container_eyes_features.join(',')}" \
-            " --config Chrome,iPhone,IE11" \
+            " --config Chrome,iPhone" \
             " --pegasus localhost.code.org:3000" \
             " --dashboard localhost-studio.code.org:3000" \
             " --circle" \

--- a/lib/rake/circle.rake
+++ b/lib/rake/circle.rake
@@ -35,10 +35,6 @@ SKIP_CHROME_TAG = 'skip chrome'.freeze
 # Run UI tests against Firefox
 TEST_FIREFOX_TAG = 'test firefox'.freeze
 
-# Run UI tests against IE11
-# TEST_IE_TAG = 'test ie'.freeze
-# TEST_IE_VERBOSE_TAG = 'test internet explorer'.freeze
-
 # Run UI tests against Safari
 TEST_SAFARI_TAG = 'test safari'.freeze
 
@@ -177,7 +173,6 @@ def browsers_to_run
   browsers = []
   browsers << 'Chrome' unless CircleUtils.tagged?(SKIP_CHROME_TAG)
   browsers << 'Firefox' if CircleUtils.tagged?(TEST_FIREFOX_TAG) || CircleUtils.tagged?(TEST_ALL_BROWSERS_TAG)
-  browsers << 'IE11' if CircleUtils.tagged?(TEST_IE_TAG) || CircleUtils.tagged?(TEST_IE_VERBOSE_TAG) || CircleUtils.tagged?(TEST_ALL_BROWSERS_TAG)
   browsers << 'Safari' if CircleUtils.tagged?(TEST_SAFARI_TAG) || CircleUtils.tagged?(TEST_ALL_BROWSERS_TAG)
   browsers << 'iPad' if CircleUtils.tagged?(TEST_IPAD_TAG) || CircleUtils.tagged?(TEST_IOS_TAG) || CircleUtils.tagged?(TEST_ALL_BROWSERS_TAG)
   browsers << 'iPhone' if CircleUtils.tagged?(TEST_IPHONE_TAG) || CircleUtils.tagged?(TEST_IOS_TAG) || CircleUtils.tagged?(TEST_ALL_BROWSERS_TAG)

--- a/lib/rake/test.rake
+++ b/lib/rake/test.rake
@@ -54,7 +54,7 @@ namespace :test do
       eyes_features = `find features/ -name "*.feature" | xargs grep -lr '@eyes'`.split("\n")
       failed_browser_count = RakeUtils.system_with_chat_logging(
         'bundle', 'exec', './runner.rb',
-        '-c', 'Chrome,iPhone,IE11',
+        '-c', 'Chrome,iPhone',
         '-d', CDO.site_host('studio.code.org'),
         '-p', CDO.site_host('code.org'),
         '--db', # Ensure features that require database access are run even if the server name isn't "test"


### PR DESCRIPTION
Remove IE from
* Test execution calls
* Available browser configurations

Not removing IE references from
* test cases with `@eyes_ie` or `@no_ie` annotations
* assertions of IE compatability in "activity-guidelines" or other documents

We recommend that teams spend some time searching for any cleanup opportunities.

## Links

- Jira Ticket: https://codedotorg.atlassian.net/browse/INF-510
- Discussion with decision to remove support: https://docs.google.com/document/d/17AIWp9Hzc2vwcVrH47aGU3kBLQbtiDCHfDvqrqEkE8A/edit

## Testing story

I'm having issues testing this on my 8GB Macbook Air, would love someone to attempt tests locally to confirm nothing explodes.

## Deployment strategy

## Follow-up work

Individual teams will have some cleanup opportunities. @agebhardt is going to reach out.

## Privacy

N/A

## Security

N/A

## Caching

N/A

## PR Checklist:

- [ ] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
