### PR TITLE
Center headers in javalab + bug fix

### DIFF
--- a/apps/src/javalab/JavalabConsole.jsx
+++ b/apps/src/javalab/JavalabConsole.jsx
@@ -192,17 +192,28 @@ class JavalabConsole extends React.Component {
     return (
       <div style={style}>
         <PaneHeader id="pane-header" style={styles.header} hasFocus>
-          <PaneButton
-            id="javalab-console-clear"
-            headerHasFocus
-            isRtl={false}
-            onClick={() => {
-              clearConsoleLogs();
-            }}
-            iconClass="fa fa-eraser"
-            label={javalabMsg.clearConsole()}
+          <PaneSection
+            className={'pane-header-section pane-header-section-left'}
           />
-          <PaneSection>{javalabMsg.console()}</PaneSection>
+          <PaneSection
+            className={'pane-header-section pane-header-section-center'}
+          >
+            {javalabMsg.console()}
+          </PaneSection>
+          <PaneSection
+            className={'pane-header-section pane-header-section-right'}
+          >
+            <PaneButton
+              id="javalab-console-clear"
+              headerHasFocus
+              isRtl={false}
+              onClick={() => {
+                clearConsoleLogs();
+              }}
+              iconClass="fa fa-eraser"
+              label={javalabMsg.clearConsole()}
+            />
+          </PaneSection>
         </PaneHeader>
         <div style={styles.container}>
           <div
@@ -299,7 +310,8 @@ const styles = {
     position: 'absolute',
     textAlign: 'center',
     lineHeight: '30px',
-    width: '100%'
+    width: '100%',
+    display: 'flex'
   },
   log: {
     padding: 0,

--- a/apps/src/javalab/JavalabEditor.jsx
+++ b/apps/src/javalab/JavalabEditor.jsx
@@ -565,48 +565,58 @@ class JavalabEditor extends React.Component {
             isOpen={versionHistoryOpen}
           />
         )}
-        <PaneHeader hasFocus>
-          <PaneButton
-            id="javalab-editor-create-file"
-            iconClass="fa fa-plus-circle"
-            onClick={() => this.setState({openDialog: Dialog.CREATE_FILE})}
-            headerHasFocus
-            isRtl={false}
-            label={javalabMsg.newFile()}
-            leftJustified
-            isDisabled={isReadOnlyWorkspace}
-          />
-          <PaneSection style={styles.backpackSection}>
-            <Backpack
-              id={'javalab-editor-backpack'}
-              displayTheme={displayTheme}
+        <PaneHeader hasFocus style={{display: 'flex'}}>
+          <PaneSection
+            className={'pane-header-section pane-header-section-left'}
+          >
+            <PaneButton
+              id="javalab-editor-create-file"
+              iconClass="fa fa-plus-circle"
+              onClick={() => this.setState({openDialog: Dialog.CREATE_FILE})}
+              headerHasFocus
+              isRtl={false}
+              label={javalabMsg.newFile()}
+              leftJustified
               isDisabled={isReadOnlyWorkspace}
-              onImport={this.onImportFile}
             />
+            <PaneSection style={styles.backpackSection}>
+              <Backpack
+                id={'javalab-editor-backpack'}
+                displayTheme={displayTheme}
+                isDisabled={isReadOnlyWorkspace}
+                onImport={this.onImportFile}
+              />
+            </PaneSection>
           </PaneSection>
-          <PaneButton
-            id="data-mode-versions-header"
-            iconClass="fa fa-clock-o"
-            label={msg.showVersionsHeader()}
-            headerHasFocus
-            isRtl={false}
-            onClick={() => this.handleVersionHistory()}
-            isDisabled={isReadOnlyWorkspace}
-          />
-          <PaneButton
-            id="javalab-editor-save"
-            iconClass="fa fa-check-circle"
-            onClick={this.onOpenCommitDialog}
-            headerHasFocus
-            isRtl={false}
-            label={javalabMsg.commitCode()}
-            isDisabled={isReadOnlyWorkspace}
-          />
-          <PaneSection>
+          <PaneSection
+            className={'pane-header-section pane-header-section-center'}
+          >
             {showProjectTemplateWorkspaceIcon && (
               <ProjectTemplateWorkspaceIcon />
             )}
             {this.editorHeaderText()}
+          </PaneSection>
+          <PaneSection
+            className={'pane-header-section pane-header-section-right'}
+          >
+            <PaneButton
+              id="javalab-editor-save"
+              iconClass="fa fa-check-circle"
+              onClick={this.onOpenCommitDialog}
+              headerHasFocus
+              isRtl={false}
+              label={javalabMsg.commitCode()}
+              isDisabled={isReadOnlyWorkspace}
+            />
+            <PaneButton
+              id="data-mode-versions-header"
+              iconClass="fa fa-clock-o"
+              label={msg.showVersionsHeader()}
+              headerHasFocus
+              isRtl={false}
+              onClick={() => this.handleVersionHistory()}
+              isDisabled={isReadOnlyWorkspace}
+            />
           </PaneSection>
         </PaneHeader>
         <Tab.Container

--- a/apps/src/javalab/JavalabEditor.jsx
+++ b/apps/src/javalab/JavalabEditor.jsx
@@ -568,6 +568,7 @@ class JavalabEditor extends React.Component {
         <PaneHeader hasFocus style={{display: 'flex'}}>
           <PaneSection
             className={'pane-header-section pane-header-section-left'}
+            style={styles.headerSection}
           >
             <PaneButton
               id="javalab-editor-create-file"
@@ -590,6 +591,7 @@ class JavalabEditor extends React.Component {
           </PaneSection>
           <PaneSection
             className={'pane-header-section pane-header-section-center'}
+            style={styles.headerSection}
           >
             {showProjectTemplateWorkspaceIcon && (
               <ProjectTemplateWorkspaceIcon />
@@ -598,6 +600,7 @@ class JavalabEditor extends React.Component {
           </PaneSection>
           <PaneSection
             className={'pane-header-section pane-header-section-right'}
+            style={styles.headerSection}
           >
             <PaneButton
               id="javalab-editor-save"
@@ -804,6 +807,9 @@ const styles = {
     float: 'left',
     overflow: 'visible',
     marginLeft: 3
+  },
+  headerSection: {
+    overflowX: 'visible'
   }
 };
 

--- a/apps/src/javalab/PreviewPaneHeader.jsx
+++ b/apps/src/javalab/PreviewPaneHeader.jsx
@@ -18,44 +18,56 @@ export default function PreviewPaneHeader({
   showPreviewTitle = true
 }) {
   return (
-    <PaneHeader hasFocus>
-      <PaneButton
-        headerHasFocus
-        icon={<CollapserIcon isCollapsed={isCollapsed} />}
-        onClick={toggleVisualizationCollapsed}
-        label=""
-        isRtl={false}
-        style={styles.transparent}
-        leftJustified
-      />
-      {showPreviewTitle && (
-        <PaneSection style={styles.headerTitle}>{i18n.preview()}</PaneSection>
-      )}
-      {/* TODO: Uncomment fullscreen button when we are ready to implement fullscreen.
-      <PaneButton
-        headerHasFocus
-        iconClass={isFullscreen ? 'fa fa-compress' : 'fa fa-arrows-alt'}
-        onClick={() => {}}
-        label=""
-        isRtl={false}
-        style={styles.transparent}
-      />
-       */}
-      {showAssetManagerButton && (
+    <PaneHeader hasFocus style={{display: 'flex'}}>
+      <PaneSection className={'pane-header-section pane-header-section-left'}>
         <PaneButton
           headerHasFocus
-          onClick={() =>
-            assets.showAssetManager(null, null, null, {
-              customAllowedExtensions: '.wav, .jpg, .jpeg, .jfif, .png',
-              recordingFileType: RecordingFileType.WAV
-            })
-          }
-          iconClass="fa fa-upload"
-          label={i18n.manageAssets()}
+          icon={<CollapserIcon isCollapsed={isCollapsed} />}
+          onClick={toggleVisualizationCollapsed}
+          label=""
           isRtl={false}
-          isDisabled={disableAssetManagerButton}
+          style={styles.transparent}
+          leftJustified
         />
-      )}
+      </PaneSection>
+      <PaneSection className={'pane-header-section pane-header-section-center'}>
+        {showPreviewTitle && (
+          <PaneSection style={styles.headerTitle}>{i18n.preview()}</PaneSection>
+        )}
+      </PaneSection>
+      {/* This overflowX styling should ideally be in style.scss.
+          See that file for more details.
+       */}
+      <PaneSection
+        className={'pane-header-section pane-header-section-right'}
+        style={{overflowX: 'visible'}}
+      >
+        {/* TODO: Uncomment fullscreen button when we are ready to implement fullscreen.
+        <PaneButton
+          headerHasFocus
+          iconClass={isFullscreen ? 'fa fa-compress' : 'fa fa-arrows-alt'}
+          onClick={() => {}}
+          label=""
+          isRtl={false}
+          style={styles.transparent}
+        />
+       */}
+        {showAssetManagerButton && (
+          <PaneButton
+            headerHasFocus
+            onClick={() =>
+              assets.showAssetManager(null, null, null, {
+                customAllowedExtensions: '.wav, .jpg, .jpeg, .jfif, .png',
+                recordingFileType: RecordingFileType.WAV
+              })
+            }
+            iconClass="fa fa-upload"
+            label={i18n.manageAssets()}
+            isRtl={false}
+            isDisabled={disableAssetManagerButton}
+          />
+        )}
+      </PaneSection>
     </PaneHeader>
   );
 }

--- a/apps/src/templates/codeReviewGroups/UnassignedStudentsPanel.jsx
+++ b/apps/src/templates/codeReviewGroups/UnassignedStudentsPanel.jsx
@@ -10,8 +10,6 @@ export default function UnassignedStudentsPanel({
   unassignedGroup,
   onUnassignAllClick
 }) {
-  // TO DO: implement unassigning students and style
-  // https://codedotorg.atlassian.net/browse/CSA-1028
   return (
     <div style={styles.unassignedStudentsPanel}>
       <div style={styles.header}>

--- a/apps/style/javalab/style.scss
+++ b/apps/style/javalab/style.scss
@@ -125,3 +125,25 @@ div#visualizationResizeBar {
     transform-origin: 0 0;
   }
 }
+
+.pane-header-section {
+  flex: 1;
+  display: flex;
+  align-items: center;
+};
+
+.pane-header-section-left {
+  justify-content: flex-start;
+};
+
+.pane-header-section-center {
+  justify-content: center;
+};
+
+// Note that in PreviewPaneHeader,
+// we (in addition to what is in the class below)
+// add element-specific styling of overflow-x to the right header section
+// to override some element-specific styling in PaneSection.
+.pane-header-section-right {
+  justify-content: flex-end;
+};

--- a/apps/style/javalab/style.scss
+++ b/apps/style/javalab/style.scss
@@ -143,7 +143,7 @@ div#visualizationResizeBar {
 .pane-header-section-center {
   justify-content: center;
 };
-.
+
 .pane-header-section-right {
   justify-content: flex-end;
 };

--- a/apps/style/javalab/style.scss
+++ b/apps/style/javalab/style.scss
@@ -132,6 +132,10 @@ div#visualizationResizeBar {
   align-items: center;
 };
 
+// Note that in PreviewPaneHeader and the header in JavalabEditor,
+// we (in addition to what is in the class below)
+// add element-specific styling of overflow-x to header sections
+// to override some element-specific styling in PaneSection
 .pane-header-section-left {
   justify-content: flex-start;
 };
@@ -139,11 +143,7 @@ div#visualizationResizeBar {
 .pane-header-section-center {
   justify-content: center;
 };
-
-// Note that in PreviewPaneHeader,
-// we (in addition to what is in the class below)
-// add element-specific styling of overflow-x to the right header section
-// to override some element-specific styling in PaneSection.
+.
 .pane-header-section-right {
   justify-content: flex-end;
 };


### PR DESCRIPTION
Most of this is in https://github.com/code-dot-org/code-dot-org/pull/44231, except the ~~last commit~~ (now second to last commit).

The `Backpack` button uses a different component (`JavalabButton`) than the other three buttons in the editor header, so it still looks a little funky on small screens. Not sure if we should prefactor the backpack button to use the same button as the others, or ship this and then do that (or do we want all 4 buttons to be `JavalabButton`)? I'm well past my 2 hour timebox on this, so let me know how you all think we should proceed (totally fine with not merging this if that's the direction we choose).

This is how it looks in Applitools (the padding looks fine on the backpack button on larger screens):
![image](https://user-images.githubusercontent.com/25372625/149239777-dd3b7ef1-8a55-4f26-9971-feed792f0ce1.png)

## Testing story

Tested manually locally and via Applitools/Saucelabs.