### PR TITLE
Katie/fix translation events table

### DIFF
--- a/bin/i18n/test/translation_status/test_translation_service.rb
+++ b/bin/i18n/test/translation_status/test_translation_service.rb
@@ -52,4 +52,8 @@ class TranslationServiceTest < Minitest::Test
   def test_translated_given_unknown_frontend_string_should_return_false
     refute @@translation_service.translated?('de-DE', 'turtle.fill')
   end
+
+  def test_translated_given_scope_should_return_true
+    assert @@translation_service.translated?('es-MX', 'MOVES.Kick', '["data", "blocks", "Dancelab_changeMoveEachLR", "options", "MOVE"]')
+  end
 end

--- a/bin/i18n/translation_status/translation_service.rb
+++ b/bin/i18n/translation_status/translation_service.rb
@@ -13,7 +13,11 @@ class TranslationService
 
   # Returns true if a translation exists for a given key, otherwise returns false.
   def translated?(locale, key, scope = "")
-    scope == "" ? I18n.exists?(key, locale: locale) : !I18n.t(key, scope: JSON.parse(scope), smart: true).include?("translation missing:")
+    if scope == ""
+      I18n.exists?(key, locale: locale)
+    else
+      !I18n.t(key, scope: JSON.parse(scope), smart: true).include?("translation missing:")
+    end
   end
 
   # Aggregate all blockly-mooc and blockly-core translation JSON files to be loaded into i18n

--- a/bin/i18n/translation_status/translation_service.rb
+++ b/bin/i18n/translation_status/translation_service.rb
@@ -12,8 +12,8 @@ class TranslationService
   end
 
   # Returns true if a translation exists for a given key, otherwise returns false.
-  def translated?(locale, key)
-    I18n.exists?(key, locale: locale)
+  def translated?(locale, key, scope)
+    scope == "" ? I18n.exists?(key, locale: locale) : !I18n.t(key, scope: JSON.parse(scope), smart: true).include?('translation missing:')
   end
 
   # Aggregate all blockly-mooc and blockly-core translation JSON files to be loaded into i18n

--- a/bin/i18n/translation_status/translation_service.rb
+++ b/bin/i18n/translation_status/translation_service.rb
@@ -12,8 +12,8 @@ class TranslationService
   end
 
   # Returns true if a translation exists for a given key, otherwise returns false.
-  def translated?(locale, key, scope)
-    scope == "" ? I18n.exists?(key, locale: locale) : !I18n.t(key, scope: JSON.parse(scope), smart: true).include?('translation missing:')
+  def translated?(locale, key, scope = "")
+    scope == "" ? I18n.exists?(key, locale: locale) : !I18n.t(key, scope: JSON.parse(scope), smart: true).include?("translation missing:")
   end
 
   # Aggregate all blockly-mooc and blockly-core translation JSON files to be loaded into i18n

--- a/bin/i18n/translation_status/translation_status_service.rb
+++ b/bin/i18n/translation_status/translation_status_service.rb
@@ -8,15 +8,15 @@ module I18n
       def initialize
         super
       end
-      # Redshift table where known string_keys are logged to.
+      # Redshift table where known normalized_keys are logged to.
       STRING_TRACKING_TABLE = 'analysis.i18n_string_tracking_events'.freeze
-      # Redshift table where the translation status of string_key is stored.
+      # Redshift table where the translation status of normalized_key is stored.
       STRING_TRANSLATION_STATUS_TABLE = 'analysis.i18n_string_translation_status'.freeze
 
-      # Queries the analysis.i18n_string_tracking_events for all the unique string_keys we have logged in the past day_count
+      # Queries the analysis.i18n_string_tracking_events for all the unique normalized_keys we have logged in the past day_count
       # days, checks their translation status in every language we support, and then uploads the statuses to the
       # analysis.i18n_string_translation_status Redshift table.
-      # @param [Integer] day_count The number of days in the past to look for unique string_key's
+      # @param [Integer] day_count The number of days in the past to look for unique normalized_key's
       # @param [Array<String>] locales All the locale codes we support i.e. en_US, es_MX, de_DE, etc.
       # @param [String] current_time Record what time we checked the translation status for these strings.
       #   Use the same time for all the entries so we can tell which batch they were all checked in.
@@ -31,67 +31,72 @@ module I18n
         translation_service = TranslationService.new
       )
         # Updating the translation status in the Redshift table first requires deleting the existing records and then
-        # inserting them. We do this because Redshift doesn't have unique keys, so if we inserted data for a string_key which
-        # already exists, then there would be two rows in the database for the string_key.
+        # inserting them. We do this because Redshift doesn't have unique keys, so if we inserted data for a normalized_key which
+        # already exists, then there would be two rows in the database for the normalized_key.
         delete_translation_status(redshift_client, day_count)
         string_keys = get_all_unique_string_keys(redshift_client, day_count)
         insert_translation_status(redshift_client, translation_service, locales, string_keys, current_time)
       end
 
-      # Deletes the existing translation status data for string_key's in the past day_count days.
-      # This is done because we only want a single row for each string_key + language and we don't want to check if there is
+      # Deletes the existing translation status data for normalized_key's in the past day_count days.
+      # This is done because we only want a single row for each normalized_key + language and we don't want to check if there is
       # an existing pair before inserting the data (Redshift does not support UPSERT by default).
       # @param [RedshiftClient] redshift_client Access the Redshift database where translation
       # status data is stored.
-      # @param [Integer] day_count The number of days in the past to look for unique string_key's
+      # @param [Integer] day_count The number of days in the past to look for unique normalized_key's
       def delete_translation_status(redshift_client, day_count)
-        puts "Deleting unique string_keys before inserting their latest translation status"
-        unique_string_key_query = unique_string_key_sql_query(day_count)
-        # The query first retrieves all the unique string_key's logged in the analysis.i18n_string_tracking events, then it
-        # deletes every row from analysis.i18n_string_translation_status which has one of the unique string_key's.
+        puts "Deleting unique normalized_keys before inserting their latest translation status"
+        unique_normalized_key_query = unique_normalized_key_sql_query(day_count)
+        # The query first retrieves all the unique normalized_key's logged in the analysis.i18n_string_tracking events, then it
+        # deletes every row from analysis.i18n_string_translation_status which has one of the unique normalized_key's.
         query = <<~SQL.squish
           DELETE FROM #{STRING_TRANSLATION_STATUS_TABLE}
-          WHERE string_key IN (
-            #{unique_string_key_query}
+          WHERE normalized_key IN (
+            #{unique_normalized_key_query}
           )
         SQL
         redshift_client.exec(query)
       end
 
-      # Retrieves all the unique string_key's we have logged
+      # Retrieves all the unique normalized_key's we have logged
       # @param [RedshiftClient] redshift_client Access the Redshift database where translation
       # status data is stored.
-      # @param [Integer] day_count The number of days in the past to look for unique string_key's
-      def get_all_unique_string_keys(redshift_client, day_count)
-        # Retrieve all the unique string_key's we have logged in the
+      # @param [Integer] day_count The number of days in the past to look for unique normalized_key's
+      def get_all_unique_normalized_keys(redshift_client, day_count)
+        # Retrieve all the unique normalized_key's we have logged in the
         # analysis.i18n_string_tracking_events table.
-        unique_string_key_query = unique_string_key_sql_query(day_count)
-        redshift_client.exec(unique_string_key_query).map {|row| row['string_key']}
+        unique_normalized_key_query = unique_normalized_key_sql_query(day_count)
+        redshift_client.exec(unique_normalized_key_query).reduce({}) {|keys, row|
+          keys.update(row['normalized_key'] => {
+            "scope" => row['scope'],
+            "string_key" => row['string_key']
+          })
+        }
       end
 
-      # Checks if given string_keys are translated or not in each language, and then
+      # Checks if given normalized_keys are translated or not in each language, and then
       # records that info to the analysis.i18n_string_translation_status table.
       # @param [RedshiftClient] redshift_client Access the Redshift database where translation
       # status data is stored.
       # @param [TranslationService] translation_service Used to determine is a string is translated
       # @param [Array<String>] locales All the i18n locales to check the translation status for.
-      # @param [Array<String>] string_keys All the unique string_keys we have logged.
+      # @param [Array<String>] normalized_keys All the unique normalized_keys we have logged.
       # @param [String] current_time A timestamp of the current_time in a format Redshift accepts.
       # or not.
-      def insert_translation_status(redshift_client, translation_service, locales, string_keys, current_time)
+      def insert_translation_status(redshift_client, translation_service, locales, normalized_keys, current_time)
         # Loop through each locale code our platform supports, i.e. en_US, es_MX, de_DE, etc.
-        # We want to check the translation status in each language for every string_key.
+        # We want to check the translation status in each language for every normalized_key.
         locales.each_with_index do |locale, i|
           puts "Analyzing translation status of #{locale} (#{i + 1}/#{locales.size})"
           translation_statuses = []
-          # Record the translation status for every string_key, for example:
-          # "data.script.name.express-2020.title"
-          string_keys.each do |string_key|
+          # Record the translation status for every normalized_key, for example:
+          # "data -> script -> name -> express-2020 -> title"
+          normalized_keys.each do |normalized_key, values|
             # Maybe there is bad data in the database and we recorded an empty string
-            next if string_key.blank?
-            translated = translation_service.translated?(locale, string_key)
+            next if normalized_key.blank?
+            translated = translation_service.translated?(locale, values["string_key"], values["scope"])
             translation_statuses << {
-              string_key: string_key,
+              normalized_key: normalized_key,
               locale: locale,
               has_translation: translated,
               checked_at: current_time
@@ -103,7 +108,7 @@ module I18n
             # Escape special SQL characters to protect again SQL injection attacks.
             ActiveRecord::Base.sanitize_sql(
               ["('%s', '%s', '%s', '%s')",
-               status[:string_key],
+               status[:normalized_key],
                status[:locale],
                status[:has_translation],
                status[:checked_at]]
@@ -111,18 +116,18 @@ module I18n
           end.join(',')
           # Run a Redshift query to insert the translation statuses into the analysis.i18n_string_translation_status table.
           query = <<~SQL.squish
-            INSERT INTO #{STRING_TRANSLATION_STATUS_TABLE} (string_key, locale, has_translation, checked_at)
+            INSERT INTO #{STRING_TRANSLATION_STATUS_TABLE} (normalized_key, locale, has_translation, checked_at)
             VALUES #{values}
           SQL
           redshift_client.exec(query)
         end
       end
 
-      # @param [Integer] day_count The number of days in the past to look for unique string_key's
-      # @return [String] A SQL query which returns the unique string_key's logged in the past day_count days.
-      def unique_string_key_sql_query(day_count)
+      # @param [Integer] day_count The number of days in the past to look for unique normalized_key's
+      # @return [String] A SQL query which returns the unique normalized_key's logged in the past day_count days.
+      def unique_normalized_key_sql_query(day_count)
         <<~SQL.squish
-          SELECT DISTINCT string_key
+          SELECT DISTINCT normalized_key, scope, string_key
           FROM #{STRING_TRACKING_TABLE}
           WHERE environment = 'production'
           AND created_at >= current_timestamp - interval '#{day_count} days'

--- a/dashboard/app/controllers/i18n_controller.rb
+++ b/dashboard/app/controllers/i18n_controller.rb
@@ -26,10 +26,10 @@ class I18nController < ApplicationController
     # Limit the number of strings we will handle in one call.
     return render status: :bad_request, json: {error: 'Too many strings.'}  if string_keys.count > I18N_KEY_COUNT_LIMIT
 
-    # We don't expect these strings to have a scope or unique separator, and the normalized_key and string_key will be the same.
+    # We don't expect these strings to have a scope or unique separator.
     # If that changes, this endpoint will need to be updated to account for that.
     string_keys.each do |string_key|
-      I18nStringUrlTracker.instance.log(string_key, url, source, string_key, [], '.')
+      I18nStringUrlTracker.instance.log(url, source, string_key, [], '.')
     end
 
     head :ok

--- a/dashboard/app/controllers/i18n_controller.rb
+++ b/dashboard/app/controllers/i18n_controller.rb
@@ -29,7 +29,7 @@ class I18nController < ApplicationController
     # We don't expect these strings to have a scope or unique separator.
     # If that changes, this endpoint will need to be updated to account for that.
     string_keys.each do |string_key|
-      I18nStringUrlTracker.instance.log(url, source, string_key, [], '.')
+      I18nStringUrlTracker.instance.log(url, source, string_key)
     end
 
     head :ok

--- a/dashboard/app/controllers/i18n_controller.rb
+++ b/dashboard/app/controllers/i18n_controller.rb
@@ -26,8 +26,10 @@ class I18nController < ApplicationController
     # Limit the number of strings we will handle in one call.
     return render status: :bad_request, json: {error: 'Too many strings.'}  if string_keys.count > I18N_KEY_COUNT_LIMIT
 
+    # We don't expect these strings to have a scope or unique separator, and the normalized_key and string_key will be the same.
+    # If that changes, this endpoint will need to be updated to account for that.
     string_keys.each do |string_key|
-      I18nStringUrlTracker.instance.log(string_key, url, source)
+      I18nStringUrlTracker.instance.log(string_key, url, source, string_key, [], '.')
     end
 
     head :ok

--- a/dashboard/test/controllers/i18n_controller_test.rb
+++ b/dashboard/test/controllers/i18n_controller_test.rb
@@ -13,7 +13,7 @@ class I18nControllerTest < ActionController::TestCase
     }
 
     string_keys.each do |string_key|
-      I18nStringUrlTracker.instance.expects(:log).with(string_key, url, source, string_key, [], '.')
+      I18nStringUrlTracker.instance.expects(:log).with(url, source, string_key)
     end
 
     post :track_string_usage, params: args

--- a/dashboard/test/controllers/i18n_controller_test.rb
+++ b/dashboard/test/controllers/i18n_controller_test.rb
@@ -13,7 +13,7 @@ class I18nControllerTest < ActionController::TestCase
     }
 
     string_keys.each do |string_key|
-      I18nStringUrlTracker.instance.expects(:log).with(string_key, url, source)
+      I18nStringUrlTracker.instance.expects(:log).with(string_key, url, source, string_key, [], '.')
     end
 
     post :track_string_usage, params: args

--- a/lib/cdo/i18n_backend.rb
+++ b/lib/cdo/i18n_backend.rb
@@ -151,10 +151,7 @@ module Cdo
         # sufficient, then refactor the SmartTranslate module so we can use `get_valid_separator` here.
         separator = options[:separator] || ::I18n.default_separator
         # We don't pass in a locale because we want the union of all string keys across all locales.
-        # We use -> as the separator in the normalized_key for ease of searching in Crowdin, and to prevent keys
-        # that include a . from getting split in two.
-        normalized_key = ::I18n.normalize_keys(nil, key, scope, ' -> ').join(' -> ')
-        I18nStringUrlTracker.instance.log(normalized_key, url, 'ruby', key, scope, separator) if normalized_key && url
+        I18nStringUrlTracker.instance.log(url, 'ruby', key, scope, separator) if key && url
         result
       end
     end

--- a/lib/cdo/i18n_backend.rb
+++ b/lib/cdo/i18n_backend.rb
@@ -151,8 +151,10 @@ module Cdo
         # sufficient, then refactor the SmartTranslate module so we can use `get_valid_separator` here.
         separator = options[:separator] || ::I18n.default_separator
         # We don't pass in a locale because we want the union of all string keys across all locales.
-        normalized_key = ::I18n.normalize_keys(nil, key, scope, separator).join(separator)
-        I18nStringUrlTracker.instance.log(normalized_key, url, 'ruby') if normalized_key && url
+        # We use -> as the separator in the normalized_key for ease of searching in Crowdin, and to prevent keys
+        # that include a . from getting split in two.
+        normalized_key = ::I18n.normalize_keys(nil, key, scope, ' -> ').join(' -> ')
+        I18nStringUrlTracker.instance.log(normalized_key, url, 'ruby', key, scope, separator) if normalized_key && url
         result
       end
     end

--- a/lib/cdo/i18n_string_url_tracker.rb
+++ b/lib/cdo/i18n_string_url_tracker.rb
@@ -64,7 +64,9 @@ class I18nStringUrlTracker
   # @param scope [Array] Array of strings representing the hierarchy leading up to the string_key.
   # @param separator [String] The separator string used by I18n to concatenate the string_key hierarchy
   #        into a single normalized string.
-  def log(url, source, string_key, scope, separator)
+  def log(url, source, string_key, scope = nil, separator = nil)
+    scope ||= []
+    separator ||= I18n.default_separator
     return unless DCDO.get(I18N_STRING_TRACKING_DCDO_KEY, false)
     # Skip URLs we are not interested in.
     return unless allowed(url)

--- a/lib/cdo/i18n_string_url_tracker.rb
+++ b/lib/cdo/i18n_string_url_tracker.rb
@@ -61,13 +61,17 @@ class I18nStringUrlTracker
   # @param string_key [String] The key used to review the translated string from our i18n system.
   # @param url [String] The url which required the translation of the given string_key.
   # @param source [String] Context about where the string lives e.g. 'ruby', 'maze', 'turtle', etc
-  def log(normalized_key, url, source, string_key, scope, separator)
+  def log(url, source, string_key, scope, separator)
     return unless DCDO.get(I18N_STRING_TRACKING_DCDO_KEY, false)
     # Skip URLs we are not interested in.
     return unless allowed(url)
 
     url = normalize_url(url)
     return unless string_key && url && source
+
+    # We use -> as the separator in the normalized_key for ease of searching in Crowdin, and to prevent keys
+    # that include a . from getting split in two.
+    normalized_key = I18n.normalize_keys(nil, string_key, scope, ' -> ').join(' -> ')
 
     # Reverse the URL encoding on special characters so the human readable characters are logged.
     logged_url = CGI.unescape(url)

--- a/lib/cdo/i18n_string_url_tracker.rb
+++ b/lib/cdo/i18n_string_url_tracker.rb
@@ -58,9 +58,12 @@ class I18nStringUrlTracker
   end
 
   # Records the given string_key and URL so we can analyze later what strings are present on what pages.
-  # @param string_key [String] The key used to review the translated string from our i18n system.
   # @param url [String] The url which required the translation of the given string_key.
   # @param source [String] Context about where the string lives e.g. 'ruby', 'maze', 'turtle', etc
+  # @param string_key [String] The key used to locate the desired string.
+  # @param scope [Array] Array of strings representing the hierarchy leading up to the string_key.
+  # @param separator [String] The separator string used by I18n to concatenate the string_key hierarchy
+  #        into a single normalized string.
   def log(url, source, string_key, scope, separator)
     return unless DCDO.get(I18N_STRING_TRACKING_DCDO_KEY, false)
     # Skip URLs we are not interested in.
@@ -131,11 +134,11 @@ class I18nStringUrlTracker
     # If the DCDO flag has changed since data was buffered, we want to clear the buffer and not log/flush the data.
     return unless DCDO.get(I18N_STRING_TRACKING_DCDO_KEY, false)
 
-    # log every <url>:<normalized_key>:[source, string_key, scope, separator] combination to Firehose
+    # log every <url>:<normalized_key>:<source>:<string_key>:<scope>:<separator> combination to Firehose
     buffer&.each_key do |url|
       buffer[url].each_key do |normalized_key|
         buffer[url][normalized_key].each do |values|
-          # record the <url>:<normalized_key>:[source, string_key, scope, separator] association.
+          # record the <url>:<normalized_key>:<source>:<string_key>:<scope>:<separator> association.
           FirehoseClient.instance.put_record(
             :i18n,
             {url: url, normalized_key: normalized_key, source: values[0], string_key: values[1], scope: values[2], separator: values[3]}

--- a/lib/cdo/i18n_string_url_tracker.rb
+++ b/lib/cdo/i18n_string_url_tracker.rb
@@ -131,7 +131,7 @@ class I18nStringUrlTracker
     buffer&.each_key do |url|
       buffer[url].each_key do |normalized_key|
         buffer[url][normalized_key].each do |values|
-          # record the string : url association.
+          # record the <url>:<normalized_key>:[source, string_key, scope, separator] association.
           FirehoseClient.instance.put_record(
             :i18n,
             {url: url, normalized_key: normalized_key, source: values[0], string_key: values[1], scope: values[2], separator: values[3]}

--- a/lib/test/cdo/test_i18n_string_url_tracker.rb
+++ b/lib/test/cdo/test_i18n_string_url_tracker.rb
@@ -53,8 +53,8 @@ class TestI18nStringUrlTracker < Minitest::Test
   def test_log_given_no_string_key_should_not_call_firehose
     unstub_firehose
     FirehoseClient.instance.expects(:put_record).never
-    test_record = {url: 'https://code.org', normalized_key: nil, source: 'test', string_key: nil, scope: [], separator: '.'}
-    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
+    test_record = {url: 'https://code.org', source: 'test', string_key: nil, scope: [], separator: '.'}
+    I18nStringUrlTracker.instance.log(test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
     I18nStringUrlTracker.instance.send(:flush)
   end
 
@@ -62,49 +62,49 @@ class TestI18nStringUrlTracker < Minitest::Test
     unstub_firehose
     FirehoseClient.instance.expects(:put_record).never
     test_record = {url: nil, source: 'test', normalized_key: 'string.key', string_key: 'string.key', scope: [], separator: '.'}
-    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
+    I18nStringUrlTracker.instance.log(test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
     I18nStringUrlTracker.instance.send(:flush)
   end
 
   def test_log_given_no_source_should_not_call_firehose
     unstub_firehose
     FirehoseClient.instance.expects(:put_record).never
-    test_record = {url: 'https://code.org', normalized_key: 'string.key', source: nil, string_key: 'string.key', scope: [], separator: '.'}
-    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
+    test_record = {url: 'https://code.org', source: nil, string_key: 'string.key', scope: [], separator: '.'}
+    I18nStringUrlTracker.instance.log(test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
     I18nStringUrlTracker.instance.send(:flush)
   end
 
   def test_log_given_data_should_call_firehose
-    test_record = {url: 'https://code.org', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
-    expected_record = {url: 'https://code.org', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: "[]", separator: '.'}
-    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
+    test_record = {url: 'https://code.org', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
+    expected_record = {normalized_key: 'string.key', url: 'https://code.org', source: 'test', string_key: 'string.key', scope: "[]", separator: '.'}
+    I18nStringUrlTracker.instance.log(test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
     I18nStringUrlTracker.instance.send(:flush)
     assert_equal(:i18n, @firehose_stream)
     assert_equal(expected_record, @firehose_records&.first)
   end
 
   def test_log_given_url_with_query_string_should_call_firehose_without_query_string
-    test_record = {normalized: 'string.key', url: 'https://code.org/?query=true', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
-    expected_record = {url: 'https://code.org', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: "[]", separator: '.'}
-    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
+    test_record = {normalized: 'string.key', url: 'https://code.org/?query=true', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
+    expected_record = {normalized_key: 'string.key', url: 'https://code.org', source: 'test', string_key: 'string.key', scope: "[]", separator: '.'}
+    I18nStringUrlTracker.instance.log(test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
     I18nStringUrlTracker.instance.send(:flush)
     assert_equal(:i18n, @firehose_stream)
     assert_equal(expected_record, @firehose_records&.first)
   end
 
   def test_log_given_url_with_anchor_tag_should_call_firehose_without_anchor_tag
-    test_record = {url: 'https://code.org/#tag-youre-it', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
-    expected_record = {url: 'https://code.org', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: "[]", separator: '.'}
-    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
+    test_record = {url: 'https://code.org/#tag-youre-it', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
+    expected_record = {normalized_key: 'string.key', url: 'https://code.org', source: 'test', string_key: 'string.key', scope: "[]", separator: '.'}
+    I18nStringUrlTracker.instance.log(test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
     I18nStringUrlTracker.instance.send(:flush)
     assert_equal(:i18n, @firehose_stream)
     assert_equal(expected_record, @firehose_records&.first)
   end
 
   def test_log_given_projects_url_should_only_log_the_project_type
-    test_record = {url: 'https://studio.code.org/projects/flappy/zjiufOp0h-9GS-DywevS0d3tKJyjdbQZZqZVaiuAjiU/view', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
-    expected_record = {url: 'https://studio.code.org/projects/flappy', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: "[]", separator: '.'}
-    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
+    test_record = {url: 'https://studio.code.org/projects/flappy/zjiufOp0h-9GS-DywevS0d3tKJyjdbQZZqZVaiuAjiU/view', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
+    expected_record = {normalized_key: 'string.key', url: 'https://studio.code.org/projects/flappy', source: 'test', string_key: 'string.key', scope: "[]", separator: '.'}
+    I18nStringUrlTracker.instance.log(test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
     I18nStringUrlTracker.instance.send(:flush)
     assert_equal(:i18n, @firehose_stream)
     assert_equal(expected_record, @firehose_records&.first)
@@ -115,17 +115,16 @@ class TestI18nStringUrlTracker < Minitest::Test
     unstub_dcdo
     stub_dcdo(false)
     FirehoseClient.instance.expects(:put_record).never
-    test_record = {url: 'https://code.org', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
-    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
+    test_record = {url: 'https://code.org', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
+    I18nStringUrlTracker.instance.log(test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
     I18nStringUrlTracker.instance.send(:flush)
   end
 
   def test_log_given_http_url_should_call_firehose_with_https_url
-    test_record = {url: 'http://code.org', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
-    expected_record = test_record.dup
-    expected_record[:url] = 'https://code.org'
-    expected_record[:scope] = "[]"
-    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
+    test_record = {url: 'http://code.org', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
+    expected_record = {normalized_key: 'string.key', url: 'https://code.org', source: 'test', string_key: 'string.key', scope: "[]", separator: '.'}
+
+    I18nStringUrlTracker.instance.log(test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
     I18nStringUrlTracker.instance.send(:flush)
     assert_equal(:i18n, @firehose_stream)
     assert_equal(expected_record, @firehose_records&.first)
@@ -134,80 +133,80 @@ class TestI18nStringUrlTracker < Minitest::Test
   def test_log_given_unknown_studio_url_should_not_be_logged
     unstub_firehose
     FirehoseClient.instance.expects(:put_record).never
-    test_record = {url: 'https://studio.code.org/unknown/url', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
-    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
+    test_record = {url: 'https://studio.code.org/unknown/url', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
+    I18nStringUrlTracker.instance.log(test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
     I18nStringUrlTracker.instance.send(:flush)
   end
 
   def test_log_given_studio_script_url_should_only_log_the_script_name
-    test_record = {url: 'https://studio.code.org/s/dance-2019/lessons/1/levels/1', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
-    expected_record = {url: 'https://studio.code.org/s/dance-2019', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: "[]", separator: '.'}
-    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
+    test_record = {url: 'https://studio.code.org/s/dance-2019/lessons/1/levels/1', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
+    expected_record = {normalized_key: 'string.key', url: 'https://studio.code.org/s/dance-2019', source: 'test', string_key: 'string.key', scope: "[]", separator: '.'}
+    I18nStringUrlTracker.instance.log(test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
     I18nStringUrlTracker.instance.send(:flush)
     assert_equal(:i18n, @firehose_stream)
     assert_equal(expected_record, @firehose_records&.first)
   end
 
   def test_log_given_hour_of_code_url_should_be_logged
-    test_record = {url: 'https://hourofcode.com', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
-    expected_record = {url: 'https://hourofcode.com', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: "[]", separator: '.'}
-    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
+    test_record = {url: 'https://hourofcode.com', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
+    expected_record = {normalized_key: 'string.key', url: 'https://hourofcode.com', source: 'test', string_key: 'string.key', scope: "[]", separator: '.'}
+    I18nStringUrlTracker.instance.log(test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
     I18nStringUrlTracker.instance.send(:flush)
     assert_equal(:i18n, @firehose_stream)
     assert_equal(expected_record, @firehose_records&.first)
   end
 
   def test_log_given_url_with_trailing_slash_should_log_without_trailing_slash
-    test_record = {url: 'https://code.org/', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
-    expected_record = {url: 'https://code.org', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: "[]", separator: '.'}
-    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
+    test_record = {url: 'https://code.org/', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
+    expected_record = {normalized_key: 'string.key', url: 'https://code.org', source: 'test', string_key: 'string.key', scope: "[]", separator: '.'}
+    I18nStringUrlTracker.instance.log(test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
     I18nStringUrlTracker.instance.send(:flush)
     assert_equal(:i18n, @firehose_stream)
     assert_equal(expected_record, @firehose_records&.first)
   end
 
   def test_log_given_home_url_should_be_logged
-    test_record = {url: 'https://studio.code.org/home', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
-    expected_record = {url: 'https://studio.code.org/home', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: "[]", separator: '.'}
-    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
+    test_record = {url: 'https://studio.code.org/home', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
+    expected_record = {normalized_key: 'string.key', url: 'https://studio.code.org/home', source: 'test', string_key: 'string.key', scope: "[]", separator: '.'}
+    I18nStringUrlTracker.instance.log(test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
     I18nStringUrlTracker.instance.send(:flush)
     assert_equal(:i18n, @firehose_stream)
     assert_equal(expected_record, @firehose_records&.first)
   end
 
   def test_log_given_teacher_dashboard_url_should_only_log_teacher_dashboard
-    test_record = {url: 'https://studio.code.org/teacher_dashboard/sections/3263468/login_info', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
-    expected_record = {url: 'https://studio.code.org/teacher_dashboard', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: "[]", separator: '.'}
-    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
+    test_record = {url: 'https://studio.code.org/teacher_dashboard/sections/3263468/login_info', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
+    expected_record = {normalized_key: 'string.key', url: 'https://studio.code.org/teacher_dashboard', source: 'test', string_key: 'string.key', scope: "[]", separator: '.'}
+    I18nStringUrlTracker.instance.log(test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
     I18nStringUrlTracker.instance.send(:flush)
     assert_equal(:i18n, @firehose_stream)
     assert_equal(expected_record, @firehose_records&.first)
   end
 
   def test_log_given_courses_url_should_only_log_courses
-    test_record = {url: 'https://studio.code.org/courses/csd-2020?section_id=3263468', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
-    expected_record = {url: 'https://studio.code.org/courses', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: "[]", separator: '.'}
-    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
+    test_record = {url: 'https://studio.code.org/courses/csd-2020?section_id=3263468', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
+    expected_record = {normalized_key: 'string.key', url: 'https://studio.code.org/courses', source: 'test', string_key: 'string.key', scope: "[]", separator: '.'}
+    I18nStringUrlTracker.instance.log(test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
     I18nStringUrlTracker.instance.send(:flush)
     assert_equal(:i18n, @firehose_stream)
     assert_equal(expected_record, @firehose_records&.first)
   end
 
   def test_log_given_users_url_should_only_log_users
-    test_record = {url: 'https://studio.code.org/users/edit', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
-    expected_record = {url: 'https://studio.code.org/users', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: "[]", separator: '.'}
-    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
+    test_record = {url: 'https://studio.code.org/users/edit', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
+    expected_record = {normalized_key: 'string.key', url: 'https://studio.code.org/users', source: 'test', string_key: 'string.key', scope: "[]", separator: '.'}
+    I18nStringUrlTracker.instance.log(test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
     I18nStringUrlTracker.instance.send(:flush)
     assert_equal(:i18n, @firehose_stream)
     assert_equal(expected_record, @firehose_records&.first)
   end
 
   def test_log_given_interval_should_log_data_after_the_given_time_has_passed
-    test_record = {url: 'https://studio.code.org/home', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
-    expected_record = {url: 'https://studio.code.org/home', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: "[]", separator: '.'}
+    test_record = {url: 'https://studio.code.org/home', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
+    expected_record = {normalized_key: 'string.key', url: 'https://studio.code.org/home', source: 'test', string_key: 'string.key', scope: "[]", separator: '.'}
     interval = 0.2.seconds
     I18nStringUrlTracker.instance.send(:set_flush_interval, interval)
-    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
+    I18nStringUrlTracker.instance.log(test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
     # verify that no firehose information has been logged because the interval has not passed yet
     assert_nil(@firehose_stream)
     assert_nil(@firehose_records&.first)
@@ -218,20 +217,20 @@ class TestI18nStringUrlTracker < Minitest::Test
   end
 
   def test_log_given_too_much_data_should_be_automatically_flushed
-    test_record = {url: 'https://studio.code.org/home', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
-    expected_record = {url: 'https://studio.code.org/home', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: "[]", separator: '.'}
+    test_record = {url: 'https://studio.code.org/home', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
+    expected_record = {normalized_key: 'string.key', url: 'https://studio.code.org/home', source: 'test', string_key: 'string.key', scope: "[]", separator: '.'}
     I18nStringUrlTracker.instance.send(:set_buffer_size_max, 0)
-    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
+    I18nStringUrlTracker.instance.log(test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
     assert_equal(:i18n, @firehose_stream)
     assert_equal(expected_record, @firehose_records&.first)
   end
 
   def test_log_given_duplicate_data_should_only_log_once
-    test_record = {url: 'https://studio.code.org/home', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
-    expected_record = {url: 'https://studio.code.org/home', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: "[]", separator: '.'}
+    test_record = {url: 'https://studio.code.org/home', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
+    expected_record = {normalized_key: 'string.key', url: 'https://studio.code.org/home', source: 'test', string_key: 'string.key', scope: "[]", separator: '.'}
     FirehoseClient.instance.expects(:put_record).once
-    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
-    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
+    I18nStringUrlTracker.instance.log(test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
+    I18nStringUrlTracker.instance.log(test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
     I18nStringUrlTracker.instance.send(:flush)
     assert_equal(:i18n, @firehose_stream)
     assert_equal(expected_record, @firehose_records&.first)
@@ -241,19 +240,19 @@ class TestI18nStringUrlTracker < Minitest::Test
     # Normally, if a special character such as a white space is in a URL,
     # it would be URL encoded to "%20"; however we want it to be logged as
     # a normal whitespace in order to make the data easier to read by analysts.
-    test_record = {url: 'https://code.org/url%20with%20spaces', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
-    expected_record = {url: 'https://code.org/url with spaces', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: "[]", separator: '.'}
+    test_record = {url: 'https://code.org/url%20with%20spaces', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
+    expected_record = {normalized_key: 'string.key', url: 'https://code.org/url with spaces', source: 'test', string_key: 'string.key', scope: "[]", separator: '.'}
     FirehoseClient.instance.expects(:put_record).once
-    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
+    I18nStringUrlTracker.instance.log(test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
     I18nStringUrlTracker.instance.send(:flush)
     assert_equal(:i18n, @firehose_stream)
     assert_equal(expected_record, @firehose_records&.first)
   end
 
   def test_log_multiple_sources
-    test_record = {url: 'https://code.org/url', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
-    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
-    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source] + '2', test_record[:string_key], test_record[:scope], test_record[:separator])
+    test_record = {url: 'https://code.org/url', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
+    I18nStringUrlTracker.instance.log(test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
+    I18nStringUrlTracker.instance.log(test_record[:url], test_record[:source] + '2', test_record[:string_key], test_record[:scope], test_record[:separator])
     I18nStringUrlTracker.instance.send(:flush)
     assert_equal %w(test test2), @firehose_records&.map {|x| x[:source]}
   end
@@ -269,7 +268,7 @@ class BenchI18nStringUrlTracker < Minitest::Benchmark
 
   def bench_linear_performance
     assert_performance_linear(0.95) do |n|
-      n.times {|m| I18nStringUrlTracker.instance.log(m.to_s, n.to_s, m.to_s, m.to_s, [], '.')}
+      n.times {|m| I18nStringUrlTracker.instance.log(n.to_s, m.to_s, m.to_s, [], '.')}
     end
   end
 end

--- a/lib/test/cdo/test_i18n_string_url_tracker.rb
+++ b/lib/test/cdo/test_i18n_string_url_tracker.rb
@@ -249,6 +249,24 @@ class TestI18nStringUrlTracker < Minitest::Test
     assert_equal(expected_record, @firehose_records&.first)
   end
 
+  def test_log_given_no_scope_and_separator_should_use_default
+    test_record = {url: 'https://code.org/url', source: 'test', string_key: 'string.key'}
+    expected_record = {normalized_key: 'string.key', url: 'https://code.org/url', source: 'test', string_key: 'string.key', scope: "[]", separator: '.'}
+    I18nStringUrlTracker.instance.log(test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
+    I18nStringUrlTracker.instance.send(:flush)
+    assert_equal(:i18n, @firehose_stream)
+    assert_equal(expected_record, @firehose_records&.first)
+  end
+
+  def test_log_given_actual_scope_should_call_firehose
+    test_record = {url: 'https://code.org/url', source: 'test', string_key: 'string.key', scope: ['test', 'keys'], separator: '.'}
+    expected_record = {normalized_key: 'test -> keys -> string.key', url: 'https://code.org/url', source: 'test', string_key: 'string.key', scope: "[\"test\", \"keys\"]", separator: '.'}
+    I18nStringUrlTracker.instance.log(test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
+    I18nStringUrlTracker.instance.send(:flush)
+    assert_equal(:i18n, @firehose_stream)
+    assert_equal(expected_record, @firehose_records&.first)
+  end
+
   def test_log_multiple_sources
     test_record = {url: 'https://code.org/url', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
     I18nStringUrlTracker.instance.log(test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])

--- a/lib/test/cdo/test_i18n_string_url_tracker.rb
+++ b/lib/test/cdo/test_i18n_string_url_tracker.rb
@@ -53,57 +53,58 @@ class TestI18nStringUrlTracker < Minitest::Test
   def test_log_given_no_string_key_should_not_call_firehose
     unstub_firehose
     FirehoseClient.instance.expects(:put_record).never
-    test_record = {string_key: nil, url: 'https://code.org', source: 'test'}
-    I18nStringUrlTracker.instance.log(test_record[:string_key], test_record[:url], test_record[:source])
+    test_record = {url: 'https://code.org', normalized_key: nil, source: 'test', string_key: nil, scope: [], separator: '.'}
+    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
     I18nStringUrlTracker.instance.send(:flush)
   end
 
   def test_log_given_no_url_should_not_call_firehose
     unstub_firehose
     FirehoseClient.instance.expects(:put_record).never
-    test_record = {string_key: 'string.key', url: nil, source: 'test'}
-    I18nStringUrlTracker.instance.log(test_record[:string_key], test_record[:url], test_record[:source])
+    test_record = {url: nil, source: 'test', normalized_key: 'string.key', string_key: 'string.key', scope: [], separator: '.'}
+    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
     I18nStringUrlTracker.instance.send(:flush)
   end
 
   def test_log_given_no_source_should_not_call_firehose
     unstub_firehose
     FirehoseClient.instance.expects(:put_record).never
-    test_record = {string_key: 'string.key', url: 'https://code.org', source: nil}
-    I18nStringUrlTracker.instance.log(test_record[:string_key], test_record[:url], test_record[:source])
+    test_record = {url: 'https://code.org', normalized_key: 'string.key', source: nil, string_key: 'string.key', scope: [], separator: '.'}
+    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
     I18nStringUrlTracker.instance.send(:flush)
   end
 
   def test_log_given_data_should_call_firehose
-    test_record = {string_key: 'string.key', url: 'https://code.org', source: 'test'}
-    I18nStringUrlTracker.instance.log(test_record[:string_key], test_record[:url], test_record[:source])
+    test_record = {url: 'https://code.org', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
+    expected_record = {url: 'https://code.org', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: "[]", separator: '.'}
+    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
     I18nStringUrlTracker.instance.send(:flush)
     assert_equal(:i18n, @firehose_stream)
-    assert_equal(test_record, @firehose_records&.first)
+    assert_equal(expected_record, @firehose_records&.first)
   end
 
   def test_log_given_url_with_query_string_should_call_firehose_without_query_string
-    test_record = {string_key: 'string.key', url: 'https://code.org/?query=true', source: 'test'}
-    expected_record = {string_key: 'string.key', url: 'https://code.org', source: 'test'}
-    I18nStringUrlTracker.instance.log(test_record[:string_key], test_record[:url], test_record[:source])
+    test_record = {normalized: 'string.key', url: 'https://code.org/?query=true', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
+    expected_record = {url: 'https://code.org', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: "[]", separator: '.'}
+    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
     I18nStringUrlTracker.instance.send(:flush)
     assert_equal(:i18n, @firehose_stream)
     assert_equal(expected_record, @firehose_records&.first)
   end
 
   def test_log_given_url_with_anchor_tag_should_call_firehose_without_anchor_tag
-    test_record = {string_key: 'string.key', url: 'https://code.org/#tag-youre-it', source: 'test'}
-    expected_record = {string_key: 'string.key', url: 'https://code.org', source: 'test'}
-    I18nStringUrlTracker.instance.log(test_record[:string_key], test_record[:url], test_record[:source])
+    test_record = {url: 'https://code.org/#tag-youre-it', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
+    expected_record = {url: 'https://code.org', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: "[]", separator: '.'}
+    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
     I18nStringUrlTracker.instance.send(:flush)
     assert_equal(:i18n, @firehose_stream)
     assert_equal(expected_record, @firehose_records&.first)
   end
 
   def test_log_given_projects_url_should_only_log_the_project_type
-    test_record = {string_key: 'string.key', url: 'https://studio.code.org/projects/flappy/zjiufOp0h-9GS-DywevS0d3tKJyjdbQZZqZVaiuAjiU/view', source: 'test'}
-    expected_record = {string_key: 'string.key', url: 'https://studio.code.org/projects/flappy', source: 'test'}
-    I18nStringUrlTracker.instance.log(test_record[:string_key], test_record[:url], test_record[:source])
+    test_record = {url: 'https://studio.code.org/projects/flappy/zjiufOp0h-9GS-DywevS0d3tKJyjdbQZZqZVaiuAjiU/view', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
+    expected_record = {url: 'https://studio.code.org/projects/flappy', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: "[]", separator: '.'}
+    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
     I18nStringUrlTracker.instance.send(:flush)
     assert_equal(:i18n, @firehose_stream)
     assert_equal(expected_record, @firehose_records&.first)
@@ -114,16 +115,17 @@ class TestI18nStringUrlTracker < Minitest::Test
     unstub_dcdo
     stub_dcdo(false)
     FirehoseClient.instance.expects(:put_record).never
-    test_record = {string_key: 'string.key', url: 'https://code.org', source: 'test'}
-    I18nStringUrlTracker.instance.log(test_record[:string_key], test_record[:url], test_record[:source])
+    test_record = {url: 'https://code.org', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
+    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
     I18nStringUrlTracker.instance.send(:flush)
   end
 
   def test_log_given_http_url_should_call_firehose_with_https_url
-    test_record = {string_key: 'string.key', url: 'http://code.org', source: 'test'}
+    test_record = {url: 'http://code.org', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
     expected_record = test_record.dup
     expected_record[:url] = 'https://code.org'
-    I18nStringUrlTracker.instance.log(test_record[:string_key], test_record[:url], test_record[:source])
+    expected_record[:scope] = "[]"
+    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
     I18nStringUrlTracker.instance.send(:flush)
     assert_equal(:i18n, @firehose_stream)
     assert_equal(expected_record, @firehose_records&.first)
@@ -132,121 +134,126 @@ class TestI18nStringUrlTracker < Minitest::Test
   def test_log_given_unknown_studio_url_should_not_be_logged
     unstub_firehose
     FirehoseClient.instance.expects(:put_record).never
-    test_record = {string_key: 'string.key', url: 'https://studio.code.org/unknown/url', source: 'test'}
-    I18nStringUrlTracker.instance.log(test_record[:string_key], test_record[:url], test_record[:source])
+    test_record = {url: 'https://studio.code.org/unknown/url', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
+    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
     I18nStringUrlTracker.instance.send(:flush)
   end
 
   def test_log_given_studio_script_url_should_only_log_the_script_name
-    test_record = {string_key: 'string.key', url: 'https://studio.code.org/s/dance-2019/lessons/1/levels/1', source: 'test'}
-    expected_record = {string_key: 'string.key', url: 'https://studio.code.org/s/dance-2019', source: 'test'}
-    I18nStringUrlTracker.instance.log(test_record[:string_key], test_record[:url], test_record[:source])
+    test_record = {url: 'https://studio.code.org/s/dance-2019/lessons/1/levels/1', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
+    expected_record = {url: 'https://studio.code.org/s/dance-2019', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: "[]", separator: '.'}
+    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
     I18nStringUrlTracker.instance.send(:flush)
     assert_equal(:i18n, @firehose_stream)
     assert_equal(expected_record, @firehose_records&.first)
   end
 
   def test_log_given_hour_of_code_url_should_be_logged
-    test_record = {string_key: 'string.key', url: 'https://hourofcode.com', source: 'test'}
-    I18nStringUrlTracker.instance.log(test_record[:string_key], test_record[:url], test_record[:source])
+    test_record = {url: 'https://hourofcode.com', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
+    expected_record = {url: 'https://hourofcode.com', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: "[]", separator: '.'}
+    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
     I18nStringUrlTracker.instance.send(:flush)
     assert_equal(:i18n, @firehose_stream)
-    assert_equal(test_record, @firehose_records&.first)
+    assert_equal(expected_record, @firehose_records&.first)
   end
 
   def test_log_given_url_with_trailing_slash_should_log_without_trailing_slash
-    test_record = {string_key: 'string.key', url: 'https://code.org/', source: 'test'}
-    expected_record = {string_key: 'string.key', url: 'https://code.org', source: 'test'}
-    I18nStringUrlTracker.instance.log(test_record[:string_key], test_record[:url], test_record[:source])
+    test_record = {url: 'https://code.org/', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
+    expected_record = {url: 'https://code.org', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: "[]", separator: '.'}
+    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
     I18nStringUrlTracker.instance.send(:flush)
     assert_equal(:i18n, @firehose_stream)
     assert_equal(expected_record, @firehose_records&.first)
   end
 
   def test_log_given_home_url_should_be_logged
-    test_record = {string_key: 'string.key', url: 'https://studio.code.org/home', source: 'test'}
-    I18nStringUrlTracker.instance.log(test_record[:string_key], test_record[:url], test_record[:source])
+    test_record = {url: 'https://studio.code.org/home', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
+    expected_record = {url: 'https://studio.code.org/home', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: "[]", separator: '.'}
+    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
     I18nStringUrlTracker.instance.send(:flush)
     assert_equal(:i18n, @firehose_stream)
-    assert_equal(test_record, @firehose_records&.first)
+    assert_equal(expected_record, @firehose_records&.first)
   end
 
   def test_log_given_teacher_dashboard_url_should_only_log_teacher_dashboard
-    test_record = {string_key: 'string.key', url: 'https://studio.code.org/teacher_dashboard/sections/3263468/login_info', source: 'test'}
-    expected_record = {string_key: 'string.key', url: 'https://studio.code.org/teacher_dashboard', source: 'test'}
-    I18nStringUrlTracker.instance.log(test_record[:string_key], test_record[:url], test_record[:source])
+    test_record = {url: 'https://studio.code.org/teacher_dashboard/sections/3263468/login_info', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
+    expected_record = {url: 'https://studio.code.org/teacher_dashboard', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: "[]", separator: '.'}
+    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
     I18nStringUrlTracker.instance.send(:flush)
     assert_equal(:i18n, @firehose_stream)
     assert_equal(expected_record, @firehose_records&.first)
   end
 
   def test_log_given_courses_url_should_only_log_courses
-    test_record = {string_key: 'string.key', url: 'https://studio.code.org/courses/csd-2020?section_id=3263468', source: 'test'}
-    expected_record = {string_key: 'string.key', url: 'https://studio.code.org/courses', source: 'test'}
-    I18nStringUrlTracker.instance.log(test_record[:string_key], test_record[:url], test_record[:source])
+    test_record = {url: 'https://studio.code.org/courses/csd-2020?section_id=3263468', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
+    expected_record = {url: 'https://studio.code.org/courses', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: "[]", separator: '.'}
+    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
     I18nStringUrlTracker.instance.send(:flush)
     assert_equal(:i18n, @firehose_stream)
     assert_equal(expected_record, @firehose_records&.first)
   end
 
   def test_log_given_users_url_should_only_log_users
-    test_record = {string_key: 'string.key', url: 'https://studio.code.org/users/edit', source: 'test'}
-    expected_record = {string_key: 'string.key', url: 'https://studio.code.org/users', source: 'test'}
-    I18nStringUrlTracker.instance.log(test_record[:string_key], test_record[:url], test_record[:source])
+    test_record = {url: 'https://studio.code.org/users/edit', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
+    expected_record = {url: 'https://studio.code.org/users', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: "[]", separator: '.'}
+    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
     I18nStringUrlTracker.instance.send(:flush)
     assert_equal(:i18n, @firehose_stream)
     assert_equal(expected_record, @firehose_records&.first)
   end
 
   def test_log_given_interval_should_log_data_after_the_given_time_has_passed
-    test_record = {string_key: 'string.key', url: 'https://studio.code.org/home', source: 'test'}
+    test_record = {url: 'https://studio.code.org/home', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
+    expected_record = {url: 'https://studio.code.org/home', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: "[]", separator: '.'}
     interval = 0.2.seconds
     I18nStringUrlTracker.instance.send(:set_flush_interval, interval)
-    I18nStringUrlTracker.instance.log(test_record[:string_key], test_record[:url], test_record[:source])
+    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
     # verify that no firehose information has been logged because the interval has not passed yet
     assert_nil(@firehose_stream)
     assert_nil(@firehose_records&.first)
     # wait a little bit longer than the interval before checking if any data has been logged
     sleep(interval * 2)
     assert_equal(:i18n, @firehose_stream)
-    assert_equal(test_record, @firehose_records&.first)
+    assert_equal(expected_record, @firehose_records&.first)
   end
 
   def test_log_given_too_much_data_should_be_automatically_flushed
-    test_record = {string_key: 'string.key', url: 'https://studio.code.org/home', source: 'test'}
+    test_record = {url: 'https://studio.code.org/home', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
+    expected_record = {url: 'https://studio.code.org/home', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: "[]", separator: '.'}
     I18nStringUrlTracker.instance.send(:set_buffer_size_max, 0)
-    I18nStringUrlTracker.instance.log(test_record[:string_key], test_record[:url], test_record[:source])
+    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
     assert_equal(:i18n, @firehose_stream)
-    assert_equal(test_record, @firehose_records&.first)
+    assert_equal(expected_record, @firehose_records&.first)
   end
 
   def test_log_given_duplicate_data_should_only_log_once
-    test_record = {string_key: 'string.key', url: 'https://studio.code.org/home', source: 'test'}
+    test_record = {url: 'https://studio.code.org/home', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
+    expected_record = {url: 'https://studio.code.org/home', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: "[]", separator: '.'}
     FirehoseClient.instance.expects(:put_record).once
-    I18nStringUrlTracker.instance.log(test_record[:string_key], test_record[:url], test_record[:source])
-    I18nStringUrlTracker.instance.log(test_record[:string_key], test_record[:url], test_record[:source])
+    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
+    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
     I18nStringUrlTracker.instance.send(:flush)
     assert_equal(:i18n, @firehose_stream)
-    assert_equal(test_record, @firehose_records&.first)
+    assert_equal(expected_record, @firehose_records&.first)
   end
 
   def test_log_given_url_with_special_symbol_should_log_the_special_symbol
     # Normally, if a special character such as a white space is in a URL,
     # it would be URL encoded to "%20"; however we want it to be logged as
     # a normal whitespace in order to make the data easier to read by analysts.
-    test_record = {string_key: 'string.key', url: 'https://code.org/url%20with%20spaces', source: 'test'}
-    expected_record = {string_key: 'string.key', url: 'https://code.org/url with spaces', source: 'test'}
+    test_record = {url: 'https://code.org/url%20with%20spaces', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
+    expected_record = {url: 'https://code.org/url with spaces', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: "[]", separator: '.'}
     FirehoseClient.instance.expects(:put_record).once
-    I18nStringUrlTracker.instance.log(test_record[:string_key], test_record[:url], test_record[:source])
+    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
     I18nStringUrlTracker.instance.send(:flush)
     assert_equal(:i18n, @firehose_stream)
     assert_equal(expected_record, @firehose_records&.first)
   end
 
   def test_log_multiple_sources
-    test_record = {string_key: 'string.key', url: 'https://code.org/url', source: 'test'}
-    I18nStringUrlTracker.instance.log(test_record[:string_key], test_record[:url], test_record[:source])
-    I18nStringUrlTracker.instance.log(test_record[:string_key], test_record[:url], test_record[:source] + '2')
+    test_record = {url: 'https://code.org/url', normalized_key: 'string.key', source: 'test', string_key: 'string.key', scope: [], separator: '.'}
+    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
+    I18nStringUrlTracker.instance.log(test_record[:normalized_key], test_record[:url], test_record[:source] + '2', test_record[:string_key], test_record[:scope], test_record[:separator])
     I18nStringUrlTracker.instance.send(:flush)
     assert_equal %w(test test2), @firehose_records&.map {|x| x[:source]}
   end
@@ -262,7 +269,7 @@ class BenchI18nStringUrlTracker < Minitest::Benchmark
 
   def bench_linear_performance
     assert_performance_linear(0.95) do |n|
-      n.times {|m| I18nStringUrlTracker.instance.log(m.to_s, n.to_s, m.to_s)}
+      n.times {|m| I18nStringUrlTracker.instance.log(m.to_s, n.to_s, m.to_s, m.to_s, [], '.')}
     end
   end
 end


### PR DESCRIPTION
Our translation status service is erroneously reporting some strings as not having translations, even though their translations have existed for a long time. This is because some translations have a period character in their string key. For example, `data -> blocks -> Dancelab_changeMoveEachLR -> options -> MOVE -> MOVES.Kick` is normalized to `data.blocks.Dancelab_changeMoveEachLR.options.MOVE.MOVES.Kick`. So `I18n.exists?` tries to find `MOVE -> MOVES -> Kick` (which does not exist) rather than `MOVE -> MOVES.KICK` (which we should be looking for).

Let's utilize the `string_key` and `scope` separately when checking if translations exist, like we do when actually translating the strings.

## Links

- jira ticket: [FND-1793](https://codedotorg.atlassian.net/browse/FND-1793)
