### PR TITLE
Fix assign button on unit overview page

### DIFF
--- a/apps/src/code-studio/components/progress/UnitOverviewTopRow.jsx
+++ b/apps/src/code-studio/components/progress/UnitOverviewTopRow.jsx
@@ -270,12 +270,12 @@ const styles = {
 
 export const UnconnectedUnitOverviewTopRow = UnitOverviewTopRow;
 
-export default connect((state, ownProps) => ({
+export default connect(state => ({
   selectedSectionId: parseInt(state.teacherSections.selectedSectionId),
   sectionsForDropdown: sectionsForDropdown(
     state.teacherSections,
-    ownProps.scriptId,
-    ownProps.currentCourseId,
+    state.progress.scriptId,
+    state.progress.courseId,
     false
   ),
   professionalLearningCourse: state.progress.professionalLearningCourse,

--- a/dashboard/test/ui/features/learning_platform/script_overview.feature
+++ b/dashboard/test/ui/features/learning_platform/script_overview.feature
@@ -36,7 +36,7 @@ Feature: Script overview page
   Scenario: Assigning to section
     Given I create an authorized teacher-associated student named "Sally"
     When I sign in as "Teacher_Sally"
-    And I am on "http://studio.code.org/s/csp1-2021"
+    And I am on "http://studio.code.org/s/csp3-2019"
     When I click selector ".uitest-assign-button" once I see it
     And I wait to see ".uitest-unassign-button"
     # Make sure unassign button is in the right state when the page loads

--- a/dashboard/test/ui/features/learning_platform/script_overview.feature
+++ b/dashboard/test/ui/features/learning_platform/script_overview.feature
@@ -33,6 +33,16 @@ Feature: Script overview page
     # Make sure we only see student progress, not teacher progress.
     Then I verify progress for lesson 29 level 4 is "not_tried"
 
+  Scenario: Assigning to section
+    Given I create an authorized teacher-associated student named "Sally"
+    When I sign in as "Teacher_Sally"
+    And I am on "http://studio.code.org/s/csp1-2021"
+    When I click selector ".uitest-assign-button" once I see it
+    And I wait to see ".uitest-unassign-button"
+    # Make sure unassign button is in the right state when the page loads
+    And I reload the page
+    And I wait to see ".uitest-unassign-button"
+
   Scenario: Script overview contents
     Given I create a student named "Jean"
     And I am on "http://studio.code.org/s/allthethings"


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
During a recent refactor of the unit overview page that I did, I broke the assign button state on load (it always shows unassigned even if the unit has been assigned to the section. The changes here fix the issue.

## Testing story
I tested locally and added a feature test to catch this issue.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
