### PR TITLE
Clear commit comments on account purge

### DIFF
--- a/dashboard/test/helpers/delete_accounts_helper_test.rb
+++ b/dashboard/test/helpers/delete_accounts_helper_test.rb
@@ -1767,6 +1767,7 @@ class DeleteAccountsHelperTest < ActionView::TestCase
 
       assert_equal 1, ProjectVersion.where(storage_app_id: storage_app_id).count
       assert_nil ProjectVersion.where(storage_app_id: storage_app_id).first.comment
+      assert_logged "Cleared 1 ProjectVersion comments"
     end
   end
 

--- a/dashboard/test/helpers/delete_accounts_helper_test.rb
+++ b/dashboard/test/helpers/delete_accounts_helper_test.rb
@@ -1748,6 +1748,61 @@ class DeleteAccountsHelperTest < ActionView::TestCase
   end
 
   #
+  # Table: dashboard.project_versions
+  #
+
+  test "clears 'comment' on any version of all of a purged user's projects" do
+    student = create :student
+    with_channel_for student do |storage_app_id|
+      comment_text = 'a comment'
+      ProjectVersion.create(
+        storage_app_id: storage_app_id,
+        object_version_id: 'xyz',
+        comment: comment_text
+      )
+      assert_equal 1, ProjectVersion.where(storage_app_id: storage_app_id).count
+      assert_equal comment_text, ProjectVersion.where(storage_app_id: storage_app_id).first.comment
+
+      purge_user student
+
+      assert_equal 1, ProjectVersion.where(storage_app_id: storage_app_id).count
+      assert_nil ProjectVersion.where(storage_app_id: storage_app_id).first.comment
+    end
+  end
+
+  test "does not clear 'comment' on any version of anyone else's projects" do
+    student_to_purge = create :student
+    other_student = create :student
+    with_channel_for student_to_purge do |storage_app_id_to_purge|
+      with_channel_for other_student do |storage_app_id_other|
+        comment_text = 'a comment'
+        ProjectVersion.create(
+          storage_app_id: storage_app_id_to_purge,
+          object_version_id: 'xyz',
+          comment: comment_text
+        )
+        ProjectVersion.create(
+          storage_app_id: storage_app_id_other,
+          object_version_id: 'xyz',
+          comment: comment_text
+        )
+
+        assert_equal 1, ProjectVersion.where(storage_app_id: storage_app_id_to_purge).count
+        assert_equal comment_text, ProjectVersion.where(storage_app_id: storage_app_id_to_purge).first.comment
+        assert_equal 1, ProjectVersion.where(storage_app_id: storage_app_id_other).count
+        assert_equal comment_text, ProjectVersion.where(storage_app_id: storage_app_id_other).first.comment
+
+        purge_user student_to_purge
+
+        assert_equal 1, ProjectVersion.where(storage_app_id: storage_app_id_to_purge).count
+        assert_nil ProjectVersion.where(storage_app_id: storage_app_id_to_purge).first.comment
+        assert_equal 1, ProjectVersion.where(storage_app_id: storage_app_id_other).count
+        assert_equal comment_text, ProjectVersion.where(storage_app_id: storage_app_id_other).first.comment
+      end
+    end
+  end
+
+  #
   # Table: dashboard.featured_projects
   #
 

--- a/lib/cdo/delete_accounts_helper.rb
+++ b/lib/cdo/delete_accounts_helper.rb
@@ -40,6 +40,13 @@ class DeleteAccountsHelper
       storage_encrypt_channel_id user.user_storage_id, storage_app_id
     end
 
+    # Clear any comments associated with specific versions of projects.
+    # At time of writing, this feature is in use only in Javalab when a student
+    # commits their code.
+    project_versions = ProjectVersion.where(storage_app_id: storage_app_ids)
+    project_versions.each {|version| version.update!(comment: nil)}
+    @log.puts "Cleared #{project_versions.count} ProjectVersion" if project_versions.count > 0
+
     # Clear potential PII from user's channels
     @pegasus_db[:storage_apps].
       where(id: storage_app_ids).

--- a/lib/cdo/delete_accounts_helper.rb
+++ b/lib/cdo/delete_accounts_helper.rb
@@ -40,17 +40,17 @@ class DeleteAccountsHelper
       storage_encrypt_channel_id user.user_storage_id, storage_app_id
     end
 
+    # Clear potential PII from user's channels
+    @pegasus_db[:storage_apps].
+      where(id: storage_app_ids).
+      update(value: nil, updated_ip: '', updated_at: Time.now)
+
     # Clear any comments associated with specific versions of projects.
     # At time of writing, this feature is in use only in Javalab when a student
     # commits their code.
     project_versions = ProjectVersion.where(storage_app_id: storage_app_ids)
     project_versions.each {|version| version.update!(comment: nil)}
     @log.puts "Cleared #{project_versions.count} ProjectVersion" if project_versions.count > 0
-
-    # Clear potential PII from user's channels
-    @pegasus_db[:storage_apps].
-      where(id: storage_app_ids).
-      update(value: nil, updated_ip: '', updated_at: Time.now)
 
     # Clear S3 contents for user's channels
     @log.puts "Deleting S3 contents for #{channel_count} channels"

--- a/lib/cdo/delete_accounts_helper.rb
+++ b/lib/cdo/delete_accounts_helper.rb
@@ -50,7 +50,7 @@ class DeleteAccountsHelper
     # commits their code.
     project_versions = ProjectVersion.where(storage_app_id: storage_app_ids)
     project_versions.each {|version| version.update!(comment: nil)}
-    @log.puts "Cleared #{project_versions.count} ProjectVersion" if project_versions.count > 0
+    @log.puts "Cleared #{project_versions.count} ProjectVersion comments" if project_versions.count > 0
 
     # Clear S3 contents for user's channels
     @log.puts "Deleting S3 contents for #{channel_count} channels"


### PR DESCRIPTION
Hard deletes commit comments when account purger runs.

## Testing story

Added unit tests, and executed logic manually in dashboard console.