### PR TITLE
Cleaning up files used by the i18n sync-out after a successful run

### DIFF
--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -13,6 +13,7 @@ require 'fileutils'
 require 'json'
 require 'parallel'
 require 'tempfile'
+require 'tmpdir'
 require 'yaml'
 
 require_relative 'hoc_sync_utils'
@@ -34,10 +35,32 @@ def sync_out(upload_manifests=false)
   I18nScriptUtils.with_synchronous_stdout do
     I18nScriptUtils.run_standalone_script "dashboard/scripts/update_tts_i18n.rb"
   end
+  clean_up_sync_out(CROWDIN_PROJECTS)
   puts "Sync out completed successfully"
 rescue => e
   puts "Sync out failed from the error: #{e}"
   raise e
+end
+
+# Cleans up any files the sync-out is responsible for managing. When this function is done running,
+# the locale filesystem should be ready for a new i18n-sync cycle.
+# @param projects [Hash] The Crowdin project configurations used by the i18n-sync.
+def clean_up_sync_out(projects)
+  # Cycle through each project and move temp files to /tmp/i18n-sync
+  projects.each do |_project_identifier, project_options|
+    # Move *_files_to_sync_out.json to /tmp/i18n-sync/ because these files have been successfully
+    # synced and we don't want the next i18n-sync-out to redistribute the files.
+    files_to_sync_out_path = project_options[:files_to_sync_out_json]
+    if File.exist?(files_to_sync_out_path)
+      i18n_sync_tmp_dir = '/tmp/i18n-sync'
+      FileUtils.mkdir_p(i18n_sync_tmp_dir)
+      puts "Backing up temp file #{files_to_sync_out_path} to #{i18n_sync_tmp_dir}"
+      FileUtils.mv(files_to_sync_out_path, i18n_sync_tmp_dir)
+    else
+      # This will happen if a sync-down hasn't happened since the last successful sync-out.
+      puts "No temp file #{files_to_sync_out_path} found to backup."
+    end
+  end
 end
 
 # Return true iff the specified file in the specified locale had changes

--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -13,7 +13,6 @@ require 'fileutils'
 require 'json'
 require 'parallel'
 require 'tempfile'
-require 'tmpdir'
 require 'yaml'
 
 require_relative 'hoc_sync_utils'


### PR DESCRIPTION
This PR updates the i18n-sync to move the temporary _*_files_to_sync_out.json_ files to `/tmp/i18n-sync` after a successful i18n `sync-out` because they are no longer needed. The files are moved instead of deleted because we might want to rerun the `sync-out` (debugging, bug fixes).

_*_files_to_sync_out.json_ records the files which were downloaded in `sync-down` and need to be distributed by the sync-out step. After a successful sync-out we no longer need to record that these files need to be synced out, so it should be cleared.

Since the files will be moved to `/tmp/i18n-sync`, if you want to re-run the sync out, you will need to move them back into the `bin/i18n/crowdin` directory:
```
cp /tmp/i18n-sync/*files_to_sync_out.json ~/code-dot-org/bin/i18n/crowdin
```

## Notes
I have considered adding a timestamp to the backed up JSON file names, but I decided against it because I suspect this simpler solution will be good enough. If we find that we wish we had backed up more files, this could should be simple to update. Complication introduced by adding timestamps:
* The command to recover the latest JSON files become more complicated because you need to filter only the most recent files.
* After the files are recovered, the filenames will need to be updated to remove the timestamp from them.
* We will need a Cron job to remove JSON files which are "too old", otherwise the disk will slowly fill up.

## Links
- [JIRA](https://codedotorg.atlassian.net/browse/FND-1854)

## Testing story
* Manually tested. Verified the files are moved to `/tmp/i18n-sync`

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
