### PR TITLE
Aligning dashboard and pegasus header links

### DIFF
--- a/shared/css/header.scss
+++ b/shared/css/header.scss
@@ -64,8 +64,6 @@
     #headerlinks {
       float: left;
       position: relative;
-      padding-left: 6px;
-      position: relative;
 
       .rtl & {
         float: right;
@@ -74,7 +72,7 @@
       .headerlink {
         display: inline-block;
         font-size: 14px;
-        margin: 14px 0 0 30px;
+        margin: 12px 0 0 30px;
         font-family: 'Gotham 4r', sans-serif;
         color: $white;
         text-decoration: none;


### PR DESCRIPTION
We have different code for rendering the Navbar Header on studio.code.org (Dashboard) and code.org (Pegasus). When tabbing between the two pages, we noticed the links in the header we slightly shifting diagonally.

This PR introduces a quick fix to make the vertical and horizontal spacing of the Header on code.org match the spacing used on studio.code.org.

## Screenshots
### Before
![home-page-text-shift](https://user-images.githubusercontent.com/1372238/149570232-a2a9848e-e474-4efa-b879-b0be9789c893.gif)

### After
https://user-images.githubusercontent.com/1372238/149570044-c9570274-ba74-49d6-9d81-7815fb3c2589.mov


## Links
- [JIRA](https://codedotorg.atlassian.net/browse/FND-1787)

## Testing story
* Tested on localhost.

## Follow-up work
* After it is deployed to staging, I will need to update a lot of the Applitools Eyes test baseline screenshots.



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
