### PR TITLE
Check for level validation for MC and Sprite Lab

### DIFF
--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -712,6 +712,9 @@ FeedbackUtils.prototype.getFeedbackMessage = function(options) {
     options.level?.validationEnabled ||
     options.level?.requiredBlocks?.length ||
     options.level?.recommendedBlocks?.length ||
+    options.level?.appSpecificFailError ||
+    options.level?.tooFewBlocksMsg ||
+    options.level?.validationCode ||
     // Free-play levels aren't validated for correctness, but the system does
     // check to see if they level blocks have been changed at all.
     options.level?.freePlay;


### PR DESCRIPTION
The failure messages in the top instructions components were not being shown when they should be for Minecraft and SpriteLab. Minecraft validation is based on the properties `appSpecificFailure` and `tooFewBlocksMsg`. SpriteLab level validation uses the `validationCode` property. By checking those properties to determine if the level is validated or not, we now show the correct message from `getFeedbackMessage`. 
