### PR TITLE
Save teacher apps

### DIFF
--- a/apps/src/code-studio/pd/application/teacher/TeacherApplication.jsx
+++ b/apps/src/code-studio/pd/application/teacher/TeacherApplication.jsx
@@ -72,12 +72,6 @@ const TeacherApplication = props => {
     window.location.reload(true);
   };
 
-  const onSuccessfulSave = () => {
-    // [MEG] TODO: Figure out what should happen on save
-    // Right now, reload page to render in_progress page (to verify)
-    window.location.reload(true);
-  };
-
   // [MEG] TODO: Should a different GA link be sent if they're working on a saved application?
   const onSetPage = newPage => {
     const nominated = queryString.parse(window.location.search).nominated;
@@ -102,7 +96,6 @@ const TeacherApplication = props => {
       onSetPage={onSetPage}
       onInitialize={onInitialize}
       onSuccessfulSubmit={onSuccessfulSubmit}
-      onSuccessfulSave={onSuccessfulSave}
       sessionStorageKey={sessionStorageKey}
       submitButtonText={submitButtonText}
       validateOnSubmitOnly={true}

--- a/apps/src/code-studio/pd/application/teacher/TeacherApplication.jsx
+++ b/apps/src/code-studio/pd/application/teacher/TeacherApplication.jsx
@@ -30,6 +30,8 @@ const TeacherApplication = props => {
   } = props;
 
   const getInitialData = () => {
+    // [MEG] TODO: Show savedFormData whenever it is present
+    // to avoid weirdness if changing allowPartialSaving states
     const dataOnPageLoad =
       allowPartialSaving && savedFormData && JSON.parse(savedFormData);
 

--- a/apps/src/code-studio/pd/form_components_func/FormController.jsx
+++ b/apps/src/code-studio/pd/form_components_func/FormController.jsx
@@ -326,7 +326,7 @@ const FormController = props => {
     setSubmitting(true);
 
     const handleSuccessfulSave = data => {
-      onSuccessfulSave();
+      onSuccessfulSave(data);
     };
 
     const handleRequestFailure = data => {

--- a/apps/src/code-studio/pd/form_components_func/FormController.jsx
+++ b/apps/src/code-studio/pd/form_components_func/FormController.jsx
@@ -297,6 +297,18 @@ const FormController = props => {
     };
   };
 
+  const handleRequestFailure = data => {
+    if (data?.responseJSON?.errors?.form_data) {
+      setErrors(data.responseJSON.errors.form_data);
+      setErrorHeader(i18n.formErrorsBelow());
+    } else {
+      // Otherwise, something unknown went wrong on the server
+      setGlobalError(true);
+      setErrorHeader(i18n.formServerError());
+    }
+    setSubmitting(false);
+  };
+
   const makeRequest = applicationStatus => {
     const dataWithStatus = {status: applicationStatus, ...data};
     setData(dataWithStatus);
@@ -327,18 +339,6 @@ const FormController = props => {
 
     const handleSuccessfulSave = data => {
       onSuccessfulSave(data);
-    };
-
-    const handleRequestFailure = data => {
-      if (data?.responseJSON?.errors?.form_data) {
-        setErrors(data.responseJSON.errors.form_data);
-        setErrorHeader(i18n.formErrorsBelow());
-      } else {
-        // Otherwise, something unknown went wrong on the server
-        setGlobalError(true);
-        setErrorHeader(i18n.formServerError());
-      }
-      setSubmitting(false);
     };
 
     makeRequest('incomplete')
@@ -377,18 +377,6 @@ const FormController = props => {
     const handleSuccessfulSubmit = data => {
       sessionStorage.removeItem(sessionStorageKey);
       onSuccessfulSubmit(data);
-    };
-
-    const handleRequestFailure = data => {
-      if (data?.responseJSON?.errors?.form_data) {
-        setErrors(data.responseJSON.errors.form_data);
-        setErrorHeader(i18n.formErrorsBelow());
-      } else {
-        // Otherwise, something unknown went wrong on the server
-        setGlobalError(true);
-        setErrorHeader(i18n.formServerError());
-      }
-      setSubmitting(false);
     };
 
     makeRequest('unreviewed')

--- a/apps/src/code-studio/pd/form_components_func/FormController.jsx
+++ b/apps/src/code-studio/pd/form_components_func/FormController.jsx
@@ -532,7 +532,7 @@ const FormController = props => {
         bsStyle="info"
       >
         <p>
-          Your progress has been saved! Return to this page at any time to
+          Your progress has been saved. Return to this page at any time to
           continue working on your application.
         </p>
       </Alert>

--- a/apps/src/code-studio/pd/form_components_func/FormController.jsx
+++ b/apps/src/code-studio/pd/form_components_func/FormController.jsx
@@ -287,9 +287,12 @@ const FormController = props => {
    *
    * @returns {Object}
    */
-  const serializeFormData = () => {
+  const serializeFormData = formData => {
+    if (!formData) {
+      throw new Error(`formData cannot be undefined`);
+    }
     return {
-      form_data: data,
+      form_data: formData,
       ...serializeAdditionalData()
     };
   };
@@ -304,7 +307,7 @@ const FormController = props => {
         url: endpoint,
         contentType: 'application/json',
         dataType: 'json',
-        data: JSON.stringify(serializeFormData())
+        data: JSON.stringify(serializeFormData(dataWithStatus))
       });
 
     return applicationId

--- a/apps/test/unit/code-studio/pd/application/TeacherApplicationTest.js
+++ b/apps/test/unit/code-studio/pd/application/TeacherApplicationTest.js
@@ -114,6 +114,7 @@ describe('TeacherApplication', () => {
       ).to.deep.equal({school: '16'});
     });
     it('has only saved form data and no school id if session storage has school info', () => {
+      // [MEG] TODO: Use FakeStorage instead
       window.sessionStorage.setItem(
         'TeacherApplication',
         JSON.stringify({data: {school: '25'}})

--- a/apps/test/unit/code-studio/pd/form_components_func/FormControllerTest.js
+++ b/apps/test/unit/code-studio/pd/form_components_func/FormControllerTest.js
@@ -253,7 +253,7 @@ describe('FormController', () => {
 
         const alert = form.findOne('Alert');
         expect(alert.content()).to.contain(
-          'Your progress has been saved! Return to this page at any time to continue working on your application.'
+          'Your progress has been saved. Return to this page at any time to continue working on your application.'
         );
 
         alert.props.onDismiss();

--- a/apps/test/unit/code-studio/pd/form_components_func/FormControllerTest.js
+++ b/apps/test/unit/code-studio/pd/form_components_func/FormControllerTest.js
@@ -304,6 +304,24 @@ describe('FormController', () => {
           expect(form.findOne('#submit').props.disabled).to.be.false;
         });
 
+        it('Adds application status as unreviewed on submit', () => {
+          const testData = {
+            field1: 'value 1',
+            field2: 'value 2'
+          };
+
+          form = isolateComponent(
+            <FormController {...defaultProps} getInitialData={() => testData} />
+          );
+          setPage(2);
+          triggerSubmit();
+
+          expect(getData(DummyPage3)).to.eql({
+            status: 'unreviewed',
+            ...testData
+          });
+        });
+
         it('Keeps the submit button disabled and calls onSuccessfulSubmit on success', () => {
           setupValid();
           server.respondWith([

--- a/apps/test/unit/code-studio/pd/form_components_func/FormControllerTest.js
+++ b/apps/test/unit/code-studio/pd/form_components_func/FormControllerTest.js
@@ -179,6 +179,22 @@ describe('FormController', () => {
       expect(form.exists('Alert')).to.be.false;
     });
 
+    describe('Saving', () => {
+      it('Adds application status as incomplete to data', () => {
+        const testData = {
+          field1: 'value 1',
+          field2: 'value 2'
+        };
+
+        form = isolateComponent(
+          <FormController {...defaultProps} getInitialData={() => testData} />
+        );
+        form.findAll('Button')[1].props.onClick();
+
+        expect(getData(DummyPage1)).to.eql({status: 'incomplete', ...testData});
+      });
+    });
+
     describe('Page validation', () => {
       it('Does not navigate when the current page has errors', () => {
         // create errors
@@ -213,6 +229,7 @@ describe('FormController', () => {
           );
           setPage(2);
         };
+
         const setUpValidWithApplicationId = applicationId =>
           setupValid(applicationId);
 

--- a/dashboard/app/controllers/api/v1/pd/application/teacher_applications_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/application/teacher_applications_controller.rb
@@ -16,8 +16,6 @@ module Api::V1::Pd::Application
       form_data_hash = params.try(:[], :form_data) || {}
       form_data_json = form_data_hash.to_unsafe_h.to_json.strip_utf8mb4
 
-      # [MEG] TODO: See if update is coming from hitting the submit button (do validations)
-      # or the save button (ignore validations)
       @application.form_data_hash = JSON.parse(form_data_json)
 
       if @application.save

--- a/dashboard/app/controllers/api/v1/pd/application/teacher_applications_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/application/teacher_applications_controller.rb
@@ -17,8 +17,14 @@ module Api::V1::Pd::Application
       form_data_json = form_data_hash.to_unsafe_h.to_json.strip_utf8mb4 if form_data_hash
 
       @application.form_data_hash = JSON.parse(form_data_json)
+      @application.set_status
+      @application.set_course_from_program
+      @application.update_user_school_info!
+
+      @application.on_completed_application unless @application.status == 'incomplete'
 
       if @application.save
+        @application.update_status_timestamp_change_log(current_user)
         render json: @application, status: :ok
       else
         return render json: {errors: @application.errors.full_messages}, status: :bad_request
@@ -40,6 +46,7 @@ module Api::V1::Pd::Application
     protected
 
     def on_successful_create
+      @application.set_status
       @application.on_successful_create
       @application.update_status_timestamp_change_log(current_user)
     end

--- a/dashboard/app/controllers/api/v1/pd/application/teacher_applications_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/application/teacher_applications_controller.rb
@@ -13,8 +13,8 @@ module Api::V1::Pd::Application
 
     # PATCH /api/v1/pd/application/teacher/<applicationId>
     def update
-      form_data_hash = params.try(:[], :form_data) || {}
-      form_data_json = form_data_hash.to_unsafe_h.to_json.strip_utf8mb4
+      form_data_hash = params.try(:[], :form_data)
+      form_data_json = form_data_hash.to_unsafe_h.to_json.strip_utf8mb4 if form_data_hash
 
       @application.form_data_hash = JSON.parse(form_data_json)
 

--- a/dashboard/app/controllers/api/v1/pd/forms_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/forms_controller.rb
@@ -4,8 +4,8 @@ class Api::V1::Pd::FormsController < ::ApplicationController
   end
 
   def create
-    form_data_hash = params.try(:[], :form_data) || {}
-    form_data_json = form_data_hash.to_unsafe_h.to_json.strip_utf8mb4
+    form_data_hash = params.try(:[], :form_data)
+    form_data_json = form_data_hash.to_unsafe_h.to_json.strip_utf8mb4 if form_data_hash
 
     form = new_form
     form.form_data_hash = JSON.parse(form_data_json)

--- a/dashboard/app/models/concerns/pd/form.rb
+++ b/dashboard/app/models/concerns/pd/form.rb
@@ -69,6 +69,9 @@ module Pd::Form
 
     hash = sanitize_and_trim_form_data_hash
 
+    # No validation is required if the application is still in progress
+    return if hash[:status] == 'incomplete'
+
     self.class.required_fields.each do |key|
       add_key_error(key) unless hash.key?(key)
     end

--- a/dashboard/app/models/pd/application/application_base.rb
+++ b/dashboard/app/models/pd/application/application_base.rb
@@ -110,6 +110,7 @@ module Pd::Application
     before_create -> {self.status = :unreviewed}
     after_initialize :set_type_and_year
     before_validation :set_type_and_year
+    validate :status_is_valid_for_application_type
     before_save :update_accepted_date, if: :status_changed?
     before_create :generate_application_guid, if: -> {application_guid.blank?}
     after_destroy :delete_unsent_email
@@ -222,7 +223,6 @@ module Pd::Application
     # This is equivalent to
     #   validates_inclusion_of :status, in: statuses
     # but it will work with derived classes that override statuses
-    validate :status_is_valid_for_application_type
     def status_is_valid_for_application_type
       unless status.nil? || self.class.statuses.include?(status)
         errors.add(:status, 'is not included in the list.')

--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -1157,34 +1157,32 @@ module Pd::Application
       0
     end
 
-    # Called after the application is created. Do any manipulation needed for the form data
-    # hash here, as well as send emails
     def on_successful_create
       update_user_school_info!
-
-      unless status == 'incomplete'
-        queue_email :confirmation, deliver_now: true
-
-        form_data_hash = sanitize_form_data_hash
-
-        update_form_data_hash(
-          {
-            cs_total_course_hours: form_data_hash.slice(
-              :cs_how_many_minutes,
-              :cs_how_many_days_per_week,
-              :cs_how_many_weeks_per_year
-            ).values.map(&:to_i).reduce(:*) / 60
-          }
-        )
-
-        auto_score!
-
-        unless regional_partner&.applications_principal_approval == RegionalPartner::SELECTIVE_APPROVAL
-          queue_email :principal_approval, deliver_now: true
-        end
-      end
-
+      on_completed_application unless status == 'incomplete'
       save
+    end
+
+    def on_completed_application
+      queue_email :confirmation, deliver_now: true
+
+      form_data_hash = sanitize_form_data_hash
+
+      update_form_data_hash(
+        {
+          cs_total_course_hours: form_data_hash.slice(
+            :cs_how_many_minutes,
+            :cs_how_many_days_per_week,
+            :cs_how_many_weeks_per_year
+          ).values.map(&:to_i).reduce(:*) / 60
+        }
+      )
+
+      auto_score!
+
+      unless regional_partner&.applications_principal_approval == RegionalPartner::SELECTIVE_APPROVAL
+        queue_email :principal_approval, deliver_now: true
+      end
     end
 
     # Called after principal approval has been created. Do any manipulation needed for the

--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -91,7 +91,6 @@ module Pd::Application
     before_save :save_partner, if: -> {form_data_changed? && regional_partner_id.nil? && !deleted?}
     before_save :course, presence: true, inclusion: {in: VALID_COURSES}, unless: -> {status == 'incomplete'}
     before_save :log_status, if: -> {status_changed?}
-    before_create :set_status, if: -> {form_data_changed?}
 
     serialized_attrs %w(
       pd_workshop_id

--- a/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
@@ -149,8 +149,15 @@ module Api::V1::Pd::Application
     test 'updating an application with an error renders bad_request' do
       sign_in @applicant
       application = create TEACHER_APPLICATION_FACTORY, user: @applicant
-      put :update, params: {id: application.id, form_data: @test_params, application_year: nil}
 
+      errored_form_data = build(TEACHER_APPLICATION_HASH_FACTORY).merge(
+        {
+          "program": ""
+        }.stringify_keys
+      )
+      put :update, params: {id: application.id, form_data: errored_form_data}
+
+      application.reload
       assert_response :bad_request
     end
 

--- a/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
@@ -145,6 +145,14 @@ module Api::V1::Pd::Application
       assert_nil TEACHER_APPLICATION_CLASS.last.sanitize_form_data_hash[:cs_total_course_hours]
     end
 
+    test 'can submit an empty form if application is incomplete' do
+      sign_in @applicant
+      put :create, params: {form_data: {status: 'incomplete'}}
+
+      assert_equal 'incomplete', TEACHER_APPLICATION_CLASS.last.status
+      assert_response :created
+    end
+
     test 'updating an application with an error renders bad_request' do
       sign_in @applicant
       application = create TEACHER_APPLICATION_FACTORY, user: @applicant

--- a/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
@@ -61,7 +61,7 @@ module Api::V1::Pd::Application
       assert_response :success
     end
 
-    test 'do not send principal approval email on successful create if RP has selective principal approval' do
+    test 'does not send principal approval email on successful create if RP has selective principal approval' do
       Pd::Application::TeacherApplicationMailer.expects(:confirmation).
         with(instance_of(TEACHER_APPLICATION_CLASS)).
         returns(mock {|mail| mail.expects(:deliver_now)})
@@ -121,22 +121,28 @@ module Api::V1::Pd::Application
       assert JSON.parse(TEACHER_APPLICATION_CLASS.last.response_scores).any?
     end
 
-    # [MEG] TODO: verify update of params with fewer (and no) params
-    test 'updating an application modifies form data' do
+    test 'submitting without a program renders bad request on successful create if application is complete' do
       sign_in @applicant
-      @updated_form_data = build(TEACHER_APPLICATION_HASH_FACTORY).merge(
-        {
-          "firstName": "Harry",
-          "program": "Computer Science Discoveries (appropriate for 6th - 10th grade)",
-          "csdWhichGrades": ["8"]
-        }.stringify_keys
+      put :create, params: {form_data: {status: 'unreviewed'}}
+
+      assert_response :bad_request
+    end
+
+    test 'does not update course hours nor autoscore on successful create if application status is incomplete' do
+      Pd::Application::TeacherApplication.expects(:auto_score).never
+      Pd::Application::TeacherApplication.expects(:queue_email).never
+
+      application_hash = build(
+        TEACHER_APPLICATION_HASH_FACTORY,
+        cs_how_many_minutes: 45,
+        cs_how_many_days_per_week: 5,
+        cs_how_many_weeks_per_year: 30
       )
 
-      application = create TEACHER_APPLICATION_FACTORY, user: @applicant
-      put :update, params: {id: application.id, form_data: @updated_form_data}
-      application.reload
-      assert_equal @updated_form_data, application.form_data_hash
-      assert_response :ok
+      sign_in @applicant
+      put :create, params: {form_data: application_hash.merge({status: 'incomplete'})}
+
+      assert_nil TEACHER_APPLICATION_CLASS.last.sanitize_form_data_hash[:cs_total_course_hours]
     end
 
     test 'updating an application with an error renders bad_request' do

--- a/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
@@ -146,6 +146,25 @@ module Api::V1::Pd::Application
       assert_response :created
     end
 
+    test 'updating an application with empty, incomplete form correctly updates attributes' do
+      application = create TEACHER_APPLICATION_FACTORY, status: 'incomplete', user: @applicant
+      original_school_info = application.user.school_info
+
+      assert application.first_name
+      assert application.course
+
+      sign_in @applicant
+      no_form_content = {status: 'incomplete'}
+      put :update, params: {id: application.id, form_data: no_form_content}
+      application.reload
+
+      assert_nil application.first_name
+      assert_nil application.course
+      assert_equal original_school_info, application.user.school_info
+      assert_equal no_form_content.to_json, application.form_data
+      assert_response :ok
+    end
+
     test 'updating an application with an error renders bad_request' do
       sign_in @applicant
       application = create TEACHER_APPLICATION_FACTORY, user: @applicant

--- a/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
@@ -121,13 +121,6 @@ module Api::V1::Pd::Application
       assert JSON.parse(TEACHER_APPLICATION_CLASS.last.response_scores).any?
     end
 
-    test 'submitting without a program renders bad request on successful create if application is complete' do
-      sign_in @applicant
-      put :create, params: {form_data: {status: 'unreviewed'}}
-
-      assert_response :bad_request
-    end
-
     test 'does not update course hours nor autoscore on successful create if application status is incomplete' do
       Pd::Application::TeacherApplication.expects(:auto_score).never
       Pd::Application::TeacherApplication.expects(:queue_email).never

--- a/dashboard/test/models/concerns/pd/form_test.rb
+++ b/dashboard/test/models/concerns/pd/form_test.rb
@@ -91,6 +91,14 @@ class Pd::FormTest < ActiveSupport::TestCase
     refute form.valid?
   end
 
+  test 'pd form does not check required fields if status is incomplete' do
+    expects(:dynamic_required_fields).never
+    form = DummyFormWithRequiredFields.new
+    form.form_data = {status: "incomplete"}.to_json
+
+    assert form.valid?
+  end
+
   test 'pd form enforces required fields' do
     form = DummyFormWithRequiredFields.new
 

--- a/dashboard/test/models/pd/application/teacher_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher_application_test.rb
@@ -390,16 +390,6 @@ module Pd::Application
       )
     end
 
-    # [MEG] TODO: Test this functionality in the controller
-    test 'incomplete application is valid but does not queue an email nor score it' do
-      application = create :pd_teacher_application, :incomplete
-      assert application.valid?
-
-      application.expects(:queue_email).never
-      application.expects(:auto_score!).never
-      application.on_successful_create
-    end
-
     test 'setting an auto-email status queues up an email' do
       application = create :pd_teacher_application
       assert_empty application.emails


### PR DESCRIPTION
### UPDATE: I split this PR into the frontend side and the backend side. See https://github.com/code-dot-org/code-dot-org/pull/44442 and https://github.com/code-dot-org/code-dot-org/pull/44441



Minus some standing to-dos, this fulfills _Req 1: Add a “Save and Return Later” Button to the application_. See below for future work.

Current functionality: https://watch.screencastify.com/v/SqvvikhJJq8mzL4Ygauv 

I did the following:
- (Frontend): Use a hook to set an applicationId after the first save––after saving, a teacher can continue working, hit save, and have their new progress updated.
- (Frontend): Add `status: "unreviewed"` on submit, and `status: "incomplete"` to `form_data` on save––allows us to check in the backend what validations and updates to do.
- (Frontend): After a save, scroll to the top and show an alert saving the application has been saved, or show generic error message already configured in `handleRequestFailure.`
- (Backend): Ignore validations if the application is incomplete.
- (Backend): Manually set some fields on an update, and only do some actions on a completed application.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- spec: [Saving Progress and Reopening Applications](https://docs.google.com/document/d/1kbRAQ3To-MHVmz2KHnyaN6Mh6EiJk8F_zRNS1F8kSK8/edit?pli=1#heading=h.86qvf1hodt)
- jira ticket: [PLAT-1466](https://codedotorg.atlassian.net/browse/PLAT-1466)

## Testing story

## Deployment strategy

## Follow-up work

In (a) separate PR(s), I'm planning to
- address the to-dos,
- address two `assert_nil` warnings in relevant backend tests, and
- refactor `FormControllerTest.js` to make the file easier to navigate.

## Privacy

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
