### PR TITLE
Revert end of lesson dialog

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -807,7 +807,6 @@
   "enablePairProgramming": "Allow students to Pair Program?",
   "encrypted": "encrypted",
   "end": "end",
-  "endOfLesson": "Congratulations! You've reached the end of the lesson.",
   "englishOnly": "English-only",
   "englishOnlyWarning": "Sorry! This lesson is not available in your language. The levels in this lesson use a mix of English words and characters that can’t be translated right now. You can move on to Lesson {nextStage}.",
   "enterGroupName": "Enter a group name",

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -1652,6 +1652,13 @@ StudioApp.prototype.displayFeedback = function(options) {
   this.onFeedback(options);
 };
 
+StudioApp.prototype.isFinalFreePlayLevel = function(feedbackType, response) {
+  return (
+    this.feedback_.isFinalLevel(response) &&
+    this.feedback_.isFreePlay(feedbackType)
+  );
+};
+
 /**
  * Whether feedback should be displayed as a modal dialog or integrated
  * into the top instructions

--- a/apps/src/code-studio/appOptions.js
+++ b/apps/src/code-studio/appOptions.js
@@ -119,11 +119,10 @@
  * @property {boolean} iframeEmbedAppAndCode
  * @property {?} lastAttempt
  * @property {boolean} submittable
+ * @property {boolean} final_level
  * @property {array} levelVideos
  * @property {string} mapReference
  * @property {array} referenceLinks
- * @property {array} lastLevelInLesson
- * @property {array} lastLevelInScript
  */
 
 /**

--- a/apps/src/code-studio/reporting.js
+++ b/apps/src/code-studio/reporting.js
@@ -281,10 +281,10 @@ reporting.sendReport = function(report) {
       postMilestone = true;
       break;
     case PostMilestoneMode.successful_runs_and_final_level_only:
-      postMilestone = report.pass || appOptions.level.lastLevelInLesson;
+      postMilestone = report.pass || appOptions.level.final_level;
       break;
     case PostMilestoneMode.final_level_only:
-      postMilestone = appOptions.level.lastLevelInLesson;
+      postMilestone = appOptions.level.final_level;
       break;
     default:
       console.error('Unexpected postMilestoneMode ' + postMilestoneMode);

--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -711,7 +711,6 @@ FeedbackUtils.prototype.getFeedbackMessage = function(options) {
   var validatedLevel =
     options.level?.validationEnabled ||
     options.level?.requiredBlocks?.length ||
-    options.level?.recommendedBlocks?.length ||
     // Free-play levels aren't validated for correctness, but the system does
     // check to see if they level blocks have been changed at all.
     options.level?.freePlay;

--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -710,7 +710,7 @@ FeedbackUtils.prototype.getFeedbackMessage = function(options) {
   // multiple fields.
   var validatedLevel =
     options.level?.validationEnabled ||
-    options.level?.requiredBlocks.length ||
+    options.level?.requiredBlocks ||
     // Free-play levels aren't validated for correctness, but the system does
     // check to see if they level blocks have been changed at all.
     options.level?.freePlay;

--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -719,7 +719,6 @@ FeedbackUtils.prototype.getShareFailure_ = function(options) {
  * @return {string} message
  */
 FeedbackUtils.prototype.getFeedbackMessage = function(options) {
-  console.log('options', options);
   var message;
 
   // If a message was explicitly passed in, use that.

--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -183,7 +183,7 @@ FeedbackUtils.prototype.displayFeedback = function(
       continueText: options.continueText,
       isK1: options.level.isK1,
       freePlay: options.level.freePlay,
-      finalLevel: options.level.lastLevelInLesson
+      finalLevel: this.isFinalLevel(options.response)
     })
   );
 
@@ -594,6 +594,15 @@ FeedbackUtils.saveThumbnail = function(image) {
     .then(() => project.saveIfSourcesChanged());
 };
 
+FeedbackUtils.isLastLevel = function() {
+  const lesson = getStore().getState().progress.lessons[0];
+  return (
+    lesson.levels[lesson.levels.length - 1].ids.indexOf(
+      window.appOptions.serverLevelId
+    ) !== -1
+  );
+};
+
 /**
  * Counts the number of blocks used.  Blocks are only counted if they are
  * not disabled, are deletable.
@@ -698,25 +707,34 @@ FeedbackUtils.prototype.getShareFailure_ = function(options) {
 
 /**
  * Generates an appropriate feedback message
+ * The message will be one of the following, from highest to lowest precedence:
+ * 0. Failure override message specified on level (options.level.failureMessageOverride)
+ * 1. Message passed in by caller (options.message).
+ * 2. Header message due to dashboard text check fail (options.response.share_failure).
+ * 3. Level-specific message (e.g., options.level.emptyBlocksErrorMsg) for
+ *    specific result type (e.g., TestResults.EMPTY_BLOCK_FAIL).
+ * 4. System-wide message (e.g., msg.emptyBlocksErrorMsg()) for specific
+ *    result type (e.g., TestResults.EMPTY_BLOCK_FAIL).
  * @param {FeedbackOptions} options
  * @return {string} message
  */
 FeedbackUtils.prototype.getFeedbackMessage = function(options) {
   console.log('options', options);
   var message;
-  // Some levels have solutions that can be validated for correctness
-  // automatically by our system. Currently, level validation
-  // depends on different properties that vary by level type. Until
-  // validatability is more consistent across level types, we have to check
-  // multiple fields.
-  var validatedLevel =
-    options.level?.validationEnabled ||
-    options.level?.requiredBlocks ||
-    // Free-play levels aren't validated for correctness, but the system does
-    // check to see if they level blocks have been changed at all.
-    options.level?.freePlay;
 
-  if (!!validatedLevel) {
+  // If a message was explicitly passed in, use that.
+  if (
+    options.feedbackType < TestResults.ALL_PASS &&
+    options.level &&
+    options.level.failureMessageOverride
+  ) {
+    message = options.level.failureMessageOverride;
+  } else if (options.message) {
+    message = options.message;
+  } else if (options.response && options.response.share_failure) {
+    message = msg.shareFailure();
+  } else {
+    // Otherwise, the message will depend on the test result.
     switch (options.feedbackType) {
       case TestResults.FREE_PLAY_UNCHANGED_FAIL:
         logDialogActions('level_unchanged_failure', options, null);
@@ -857,13 +875,9 @@ FeedbackUtils.prototype.getFeedbackMessage = function(options) {
       case TestResults.FREE_PLAY:
       case TestResults.BETTER_THAN_IDEAL:
       case TestResults.PASS_WITH_EXTRA_TOP_BLOCKS:
-        var finalLevel = options.level?.lastLevelInLesson;
-        // End of lesson in CSD/CSP/CSA
-        if (finalLevel && options.level?.showEndOfLessonMsgs) {
-          message = msg.endOfLesson();
-        }
+        var finalLevel = this.isFinalLevel(options.response);
         var lessonCompleted = null;
-        if (options.response?.lesson_changing) {
+        if (options.response && options.response.lesson_changing) {
           lessonCompleted = options.response.lesson_changing.previous.name;
         }
         var msgParams = {
@@ -872,10 +886,12 @@ FeedbackUtils.prototype.getFeedbackMessage = function(options) {
           puzzleNumber: options.level.puzzle_number || 0
         };
         if (
-          TestResults.FREE_PLAY === options.feedbackType &&
+          this.isFreePlay(options.feedbackType) &&
           !options.level.disableSharing
         ) {
-          var reinfFeedbackMsg = options.appStrings?.reinfFeedbackMsg || '';
+          var reinfFeedbackMsg =
+            (options.appStrings && options.appStrings.reinfFeedbackMsg) || '';
+
           if (options.level.disableFinalLessonMessage) {
             message = reinfFeedbackMsg;
           } else {
@@ -884,7 +900,8 @@ FeedbackUtils.prototype.getFeedbackMessage = function(options) {
           }
         } else {
           var nextLevelMsg =
-            options.appStrings?.nextLevelMsg || msg.nextLevel(msgParams);
+            (options.appStrings && options.appStrings.nextLevelMsg) ||
+            msg.nextLevel(msgParams);
           message = finalLevel
             ? msg.finalStage(msgParams)
             : lessonCompleted
@@ -892,22 +909,6 @@ FeedbackUtils.prototype.getFeedbackMessage = function(options) {
             : nextLevelMsg;
         }
         break;
-    }
-  } else {
-    if (
-      options.level?.lastLevelInLesson &&
-      options.level?.showEndOfLessonMsgs
-    ) {
-      message = msg.endOfLesson();
-    } else if (
-      options.feedbackType < TestResults.ALL_PASS &&
-      options.level?.failureMessageOverride
-    ) {
-      message = options.level.failureMessageOverride;
-    } else if (options.message) {
-      message = options.message;
-    } else if (options.response?.share_failure) {
-      message = msg.shareFailure();
     }
   }
   return message;
@@ -1973,6 +1974,17 @@ FeedbackUtils.prototype.hasMatchingDescendant_ = function(node, filter) {
 FeedbackUtils.prototype.hasExceededLimitedBlocks_ = function() {
   const blockLimits = Blockly.mainBlockSpace.blockSpaceEditor.blockLimits;
   return blockLimits.blockLimitExceeded && blockLimits.blockLimitExceeded();
+};
+
+/**
+ * Determine if this is the final level in a progression based on server response.
+ * For details, see:
+ * https://github.com/code-dot-org/code-dot-org/blob/a6d3762e5756e825fef15182042845d01c05f1e6/dashboard/app/helpers/script_levels_helper.rb#L30
+ * @param {Object} response
+ * @returns {boolean}
+ */
+FeedbackUtils.prototype.isFinalLevel = function(response) {
+  return response?.message === 'no more levels';
 };
 
 /**

--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -702,6 +702,7 @@ FeedbackUtils.prototype.getShareFailure_ = function(options) {
  * @return {string} message
  */
 FeedbackUtils.prototype.getFeedbackMessage = function(options) {
+  console.log('options', options);
   var message;
   // Some levels have solutions that can be validated for correctness
   // automatically by our system. Currently, level validation
@@ -907,10 +908,6 @@ FeedbackUtils.prototype.getFeedbackMessage = function(options) {
       message = options.message;
     } else if (options.response?.share_failure) {
       message = msg.shareFailure();
-    } else {
-      message =
-        options.appStrings?.nextLevelMsg ||
-        msg.nextLevel({puzzleNumber: options.level.puzzle_number});
     }
   }
   return message;

--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -710,7 +710,7 @@ FeedbackUtils.prototype.getFeedbackMessage = function(options) {
   // multiple fields.
   var validatedLevel =
     options.level?.validationEnabled ||
-    options.level?.requiredBlocks?.length ||
+    options.level?.requiredBlocks.length ||
     // Free-play levels aren't validated for correctness, but the system does
     // check to see if they level blocks have been changed at all.
     options.level?.freePlay;

--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -1568,7 +1568,10 @@ export default class P5Lab {
     let msg = this.getMsg();
 
     // Allow P5Labs to decide what string should be rendered in the feedback dialog.
-    const isFinalFreePlayLevel = level.freePlay && level.lastLevelInLesson;
+    const isFinalFreePlayLevel = this.studioApp_.isFinalFreePlayLevel(
+      this.testResults,
+      this.response
+    );
     const reinfFeedbackMsg = this.getReinfFeedbackMsg(isFinalFreePlayLevel);
 
     const isSignedIn =

--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -762,7 +762,9 @@ input[type="radio"] {
   color: #7E5BA0;
   font-family: $gotham-extra-bold;
   font-weight: normal;
+
 }
+
 #show-code {
   margin-bottom: 5px;
 }

--- a/apps/style/craft/style.scss
+++ b/apps/style/craft/style.scss
@@ -267,6 +267,10 @@ body {
   }
 }
 
+//.minecraft .modal a:hover {
+//  background: transparent;
+//}
+
 #codeApp {
   top: 75px !important;
 

--- a/apps/test/unit/feedbackTest.js
+++ b/apps/test/unit/feedbackTest.js
@@ -22,9 +22,7 @@ describe('FeedbackUtils', () => {
         beforeEach(() => {
           options = {
             feedbackType: TestResults.FREE_PLAY,
-            level: {
-              validationEnabled: true
-            },
+            level: {},
             appStrings: {
               reinfFeedbackMsg: "You're finished!"
             }
@@ -49,7 +47,7 @@ describe('FeedbackUtils', () => {
           });
 
           it('returns final stage and appStrings.reinfFeedbackMsg if final level', () => {
-            options.level.lastLevelInLesson = true;
+            options.response = {message: 'no more levels'};
             assert.equal(
               feedbackUtils.getFeedbackMessage(options),
               `${finalStageMsg} ${options.appStrings.reinfFeedbackMsg}`
@@ -77,7 +75,7 @@ describe('FeedbackUtils', () => {
           });
 
           it('returns final stage message if final level', () => {
-            options.level.lastLevelInLesson = true;
+            options.response = {message: 'no more levels'};
             assert.equal(
               feedbackUtils.getFeedbackMessage(options),
               finalStageMsg

--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -39,7 +39,7 @@ class ActivitiesController < ApplicationController
     # Keep this logic in sync with code-studio/reporting#sendReport on the client.
     post_milestone = Gatekeeper.allows('postMilestone', where: {script_name: script_name}, default: true)
     post_failed_run_milestone = Gatekeeper.allows('postFailedRunMilestone', where: {script_name: script_name}, default: true)
-    final_level = @script_level.try(:end_of_lesson?)
+    final_level = @script_level.try(:final_level?)
     # We should only expect milestone posts if:
     #  - post_milestone is true, AND (we post on failed runs, or this was successful), or
     #  - this is the final level - we always post on final level

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -584,9 +584,7 @@ module LevelsHelper
     script_level = @script_level
     level_options['puzzle_number'] = script_level ? script_level.position : 1
     level_options['lesson_total'] = script_level ? script_level.lesson_total : 1
-    level_options['lastLevelInLesson'] = script_level.end_of_lesson? if script_level
-    level_options['lastLevelInScript'] = script_level.end_of_script? if script_level
-    level_options['showEndOfLessonMsgs'] = script.middle_high? if script
+    level_options['final_level'] = script_level.final_level? if script_level
 
     # Edit blocks-dependent options
     if level_view_options(@level.id)[:edit_blocks]

--- a/dashboard/app/helpers/script_levels_helper.rb
+++ b/dashboard/app/helpers/script_levels_helper.rb
@@ -27,6 +27,8 @@ module ScriptLevelsHelper
         end
       end
     else
+      response[:message] = 'no more levels' # used by blockly to show a different feedback message on the last level
+
       if script_level.script.wrapup_video
         response[:video_info] = wrapup_video_then_redirect_response(
           script_level.script.wrapup_video,

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -866,12 +866,6 @@ class Script < ApplicationRecord
     under_curriculum_umbrella?('CSC')
   end
 
-  # TODO: (Dani) Update to use new course types framework.
-  # Currently this grouping is used to determine whether the script should have # a custom end-of-lesson experience.
-  def middle_high?
-    csd? || csp? || csa?
-  end
-
   def hour_of_code?
     under_curriculum_umbrella?('HOC')
   end
@@ -2012,6 +2006,6 @@ class Script < ApplicationRecord
   # To help teachers have more control over the pacing of certain scripts, we
   # send students on the last level of a lesson to the unit overview page.
   def show_unit_overview_between_lessons?(user)
-    middle_high? && user&.has_pilot_experiment?('end-of-lesson-redirects')
+    (csd? || csp? || csa?) && user&.has_pilot_experiment?('end-of-lesson-redirects')
   end
 end

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -144,6 +144,10 @@ class ScriptLevel < ApplicationRecord
     end
   end
 
+  def final_level?
+    !has_another_level_to_go_to?
+  end
+
   def next_level_or_redirect_path_for_user(
     user,
     extras_lesson=nil,

--- a/dashboard/test/controllers/activities_controller_test.rb
+++ b/dashboard/test/controllers/activities_controller_test.rb
@@ -41,13 +41,7 @@ class ActivitiesControllerTest < ActionController::TestCase
     @script_level_prev = create(:script_level, script: @script)
     @script_level = create(:script_level, script: @script)
     @script_level_next = create(:script_level, script: @script)
-
-    @lesson = create(:lesson)
-    @lesson.script_levels << @script_level_prev
-    @lesson.script_levels << @script_level
-    @lesson.script_levels << @script_level_next
-
-    create(:lesson_group, lessons: [@lesson], script: @script)
+    create(:lesson_group, lessons: [@script_level_prev.lesson, @script_level.lesson, @script_level_next.lesson], script: @script)
     @level = @script_level.level
 
     @blank_image = File.read('test/fixtures/artist_image_blank.png', binmode: true)

--- a/dashboard/test/ui/features/learning_platform/feedback.feature
+++ b/dashboard/test/ui/features/learning_platform/feedback.feature
@@ -33,5 +33,5 @@ Scenario: Solve without recommended blocks
   And I wait to see ".congrats"
 
   Then element ".congrats" is visible
-  And element ".congrats" has text "Congratulations! You have completed the final puzzle."
+  And element ".congrats" has text "Congratulations! You completed Bee."
   And element "#hint-request-button" does not exist


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This PR is a combination of reverts from each of:
https://github.com/code-dot-org/code-dot-org/pull/44350
https://github.com/code-dot-org/code-dot-org/pull/44375
https://github.com/code-dot-org/code-dot-org/pull/44378
https://github.com/code-dot-org/code-dot-org/pull/44379
https://github.com/code-dot-org/code-dot-org/pull/44384

The original task (https://github.com/code-dot-org/code-dot-org/pull/44194) was to add an end-of-lesson dialog to slow students down between lessons. The solution didn't work across all level types, this revert will unblock a deploy and give us more time to sort out how to handle this across all levels.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
