### PR TITLE
End-of-lesson dialog messaging updates

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -807,6 +807,7 @@
   "enablePairProgramming": "Allow students to Pair Program?",
   "encrypted": "encrypted",
   "end": "end",
+  "endOfLesson": "Congratulations! You've reached the end of the lesson.",
   "englishOnly": "English-only",
   "englishOnlyWarning": "Sorry! This lesson is not available in your language. The levels in this lesson use a mix of English words and characters that can’t be translated right now. You can move on to Lesson {nextStage}.",
   "enterGroupName": "Enter a group name",

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -1652,13 +1652,6 @@ StudioApp.prototype.displayFeedback = function(options) {
   this.onFeedback(options);
 };
 
-StudioApp.prototype.isFinalFreePlayLevel = function(feedbackType, response) {
-  return (
-    this.feedback_.isFinalLevel(response) &&
-    this.feedback_.isFreePlay(feedbackType)
-  );
-};
-
 /**
  * Whether feedback should be displayed as a modal dialog or integrated
  * into the top instructions

--- a/apps/src/code-studio/appOptions.js
+++ b/apps/src/code-studio/appOptions.js
@@ -124,6 +124,7 @@
  * @property {array} referenceLinks
  * @property {boolean} isLastLevelInLesson
  * @property {boolean} isLastLevelInScript
+ * @property {boolean} showEndOfLessonMsgs
  */
 
 /**

--- a/apps/src/code-studio/appOptions.js
+++ b/apps/src/code-studio/appOptions.js
@@ -122,8 +122,8 @@
  * @property {array} levelVideos
  * @property {string} mapReference
  * @property {array} referenceLinks
- * @property {array} lastLevelInLesson
- * @property {array} lastLevelInScript
+ * @property {boolean} isLastLevelInLesson
+ * @property {boolean} isLastLevelInScript
  */
 
 /**

--- a/apps/src/code-studio/appOptions.js
+++ b/apps/src/code-studio/appOptions.js
@@ -119,10 +119,11 @@
  * @property {boolean} iframeEmbedAppAndCode
  * @property {?} lastAttempt
  * @property {boolean} submittable
- * @property {boolean} final_level
  * @property {array} levelVideos
  * @property {string} mapReference
  * @property {array} referenceLinks
+ * @property {array} lastLevelInLesson
+ * @property {array} lastLevelInScript
  */
 
 /**

--- a/apps/src/code-studio/reporting.js
+++ b/apps/src/code-studio/reporting.js
@@ -281,10 +281,10 @@ reporting.sendReport = function(report) {
       postMilestone = true;
       break;
     case PostMilestoneMode.successful_runs_and_final_level_only:
-      postMilestone = report.pass || appOptions.level.lastLevelInLesson;
+      postMilestone = report.pass || appOptions.level.lastLevelInScript;
       break;
     case PostMilestoneMode.final_level_only:
-      postMilestone = appOptions.level.lastLevelInLesson;
+      postMilestone = appOptions.level.lastLevelInScript;
       break;
     default:
       console.error('Unexpected postMilestoneMode ' + postMilestoneMode);

--- a/apps/src/code-studio/reporting.js
+++ b/apps/src/code-studio/reporting.js
@@ -281,10 +281,10 @@ reporting.sendReport = function(report) {
       postMilestone = true;
       break;
     case PostMilestoneMode.successful_runs_and_final_level_only:
-      postMilestone = report.pass || appOptions.level.lastLevelInScript;
+      postMilestone = report.pass || appOptions.level.isLastLevelInScript;
       break;
     case PostMilestoneMode.final_level_only:
-      postMilestone = appOptions.level.lastLevelInScript;
+      postMilestone = appOptions.level.isLastLevelInScript;
       break;
     default:
       console.error('Unexpected postMilestoneMode ' + postMilestoneMode);

--- a/apps/src/code-studio/reporting.js
+++ b/apps/src/code-studio/reporting.js
@@ -281,10 +281,10 @@ reporting.sendReport = function(report) {
       postMilestone = true;
       break;
     case PostMilestoneMode.successful_runs_and_final_level_only:
-      postMilestone = report.pass || appOptions.level.final_level;
+      postMilestone = report.pass || appOptions.level.lastLevelInLesson;
       break;
     case PostMilestoneMode.final_level_only:
-      postMilestone = appOptions.level.final_level;
+      postMilestone = appOptions.level.lastLevelInLesson;
       break;
     default:
       console.error('Unexpected postMilestoneMode ' + postMilestoneMode);

--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -698,25 +698,32 @@ FeedbackUtils.prototype.getShareFailure_ = function(options) {
 
 /**
  * Generates an appropriate feedback message
+ * The message will be one of the following, from highest to lowest precedence:
+ * 0. Failure override message specified on level (options.level.failureMessageOverride)
+ * 1. Message passed in by caller (options.message).
+ * 2. Header message due to dashboard text check fail (options.response.share_failure).
+ * 3. Level-specific message (e.g., options.level.emptyBlocksErrorMsg) for
+ *    specific result type (e.g., TestResults.EMPTY_BLOCK_FAIL).
+ * 4. System-wide message (e.g., msg.emptyBlocksErrorMsg()) for specific
+ *    result type (e.g., TestResults.EMPTY_BLOCK_FAIL).
  * @param {FeedbackOptions} options
  * @return {string} message
  */
 FeedbackUtils.prototype.getFeedbackMessage = function(options) {
   var message;
-  // Some levels have solutions that can be validated for correctness
-  // automatically by our system. Currently, level validation
-  // depends on different properties that vary by level type. Until
-  // validatability is more consistent across level types, we have to check
-  // multiple fields.
-  var validatedLevel =
-    options.level?.validationEnabled ||
-    options.level?.requiredBlocks?.length ||
-    options.level?.recommendedBlocks?.length ||
-    // Free-play levels aren't validated for correctness, but the system does
-    // check to see if they level blocks have been changed at all.
-    options.level?.freePlay;
 
-  if (!!validatedLevel) {
+  // If a message was explicitly passed in, use that.
+  if (
+    options.feedbackType < TestResults.ALL_PASS &&
+    options.level?.failureMessageOverride
+  ) {
+    message = options.level.failureMessageOverride;
+  } else if (options.message) {
+    message = options.message;
+  } else if (options.response?.share_failure) {
+    message = msg.shareFailure();
+  } else {
+    // Otherwise, the message will depend on the test result.
     switch (options.feedbackType) {
       case TestResults.FREE_PLAY_UNCHANGED_FAIL:
         logDialogActions('level_unchanged_failure', options, null);
@@ -861,6 +868,7 @@ FeedbackUtils.prototype.getFeedbackMessage = function(options) {
         // End of lesson in CSD/CSP/CSA
         if (finalLevel && options.level?.showEndOfLessonMsgs) {
           message = msg.endOfLesson();
+          break;
         }
         var lessonCompleted = null;
         if (options.response?.lesson_changing) {
@@ -892,26 +900,6 @@ FeedbackUtils.prototype.getFeedbackMessage = function(options) {
             : nextLevelMsg;
         }
         break;
-    }
-  } else {
-    if (
-      options.level?.lastLevelInLesson &&
-      options.level?.showEndOfLessonMsgs
-    ) {
-      message = msg.endOfLesson();
-    } else if (
-      options.feedbackType < TestResults.ALL_PASS &&
-      options.level?.failureMessageOverride
-    ) {
-      message = options.level.failureMessageOverride;
-    } else if (options.message) {
-      message = options.message;
-    } else if (options.response?.share_failure) {
-      message = msg.shareFailure();
-    } else {
-      message =
-        options.appStrings?.nextLevelMsg ||
-        msg.nextLevel({puzzleNumber: options.level.puzzle_number});
     }
   }
   return message;

--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -183,7 +183,7 @@ FeedbackUtils.prototype.displayFeedback = function(
       continueText: options.continueText,
       isK1: options.level.isK1,
       freePlay: options.level.freePlay,
-      finalLevel: this.isFinalLevel(options.response)
+      finalLevel: options.level.lastLevelInLesson
     })
   );
 
@@ -594,15 +594,6 @@ FeedbackUtils.saveThumbnail = function(image) {
     .then(() => project.saveIfSourcesChanged());
 };
 
-FeedbackUtils.isLastLevel = function() {
-  const lesson = getStore().getState().progress.lessons[0];
-  return (
-    lesson.levels[lesson.levels.length - 1].ids.indexOf(
-      window.appOptions.serverLevelId
-    ) !== -1
-  );
-};
-
 /**
  * Counts the number of blocks used.  Blocks are only counted if they are
  * not disabled, are deletable.
@@ -707,33 +698,25 @@ FeedbackUtils.prototype.getShareFailure_ = function(options) {
 
 /**
  * Generates an appropriate feedback message
- * The message will be one of the following, from highest to lowest precedence:
- * 0. Failure override message specified on level (options.level.failureMessageOverride)
- * 1. Message passed in by caller (options.message).
- * 2. Header message due to dashboard text check fail (options.response.share_failure).
- * 3. Level-specific message (e.g., options.level.emptyBlocksErrorMsg) for
- *    specific result type (e.g., TestResults.EMPTY_BLOCK_FAIL).
- * 4. System-wide message (e.g., msg.emptyBlocksErrorMsg()) for specific
- *    result type (e.g., TestResults.EMPTY_BLOCK_FAIL).
  * @param {FeedbackOptions} options
  * @return {string} message
  */
 FeedbackUtils.prototype.getFeedbackMessage = function(options) {
   var message;
+  // Some levels have solutions that can be validated for correctness
+  // automatically by our system. Currently, level validation
+  // depends on different properties that vary by level type. Until
+  // validatability is more consistent across level types, we have to check
+  // multiple fields.
+  var validatedLevel =
+    options.level?.validationEnabled ||
+    options.level?.requiredBlocks?.length ||
+    options.level?.recommendedBlocks?.length ||
+    // Free-play levels aren't validated for correctness, but the system does
+    // check to see if they level blocks have been changed at all.
+    options.level?.freePlay;
 
-  // If a message was explicitly passed in, use that.
-  if (
-    options.feedbackType < TestResults.ALL_PASS &&
-    options.level &&
-    options.level.failureMessageOverride
-  ) {
-    message = options.level.failureMessageOverride;
-  } else if (options.message) {
-    message = options.message;
-  } else if (options.response && options.response.share_failure) {
-    message = msg.shareFailure();
-  } else {
-    // Otherwise, the message will depend on the test result.
+  if (!!validatedLevel) {
     switch (options.feedbackType) {
       case TestResults.FREE_PLAY_UNCHANGED_FAIL:
         logDialogActions('level_unchanged_failure', options, null);
@@ -874,9 +857,13 @@ FeedbackUtils.prototype.getFeedbackMessage = function(options) {
       case TestResults.FREE_PLAY:
       case TestResults.BETTER_THAN_IDEAL:
       case TestResults.PASS_WITH_EXTRA_TOP_BLOCKS:
-        var finalLevel = this.isFinalLevel(options.response);
+        var finalLevel = options.level?.lastLevelInLesson;
+        // End of lesson in CSD/CSP/CSA
+        if (finalLevel && options.level?.showEndOfLessonMsgs) {
+          message = msg.endOfLesson();
+        }
         var lessonCompleted = null;
-        if (options.response && options.response.lesson_changing) {
+        if (options.response?.lesson_changing) {
           lessonCompleted = options.response.lesson_changing.previous.name;
         }
         var msgParams = {
@@ -885,12 +872,10 @@ FeedbackUtils.prototype.getFeedbackMessage = function(options) {
           puzzleNumber: options.level.puzzle_number || 0
         };
         if (
-          this.isFreePlay(options.feedbackType) &&
+          TestResults.FREE_PLAY === options.feedbackType &&
           !options.level.disableSharing
         ) {
-          var reinfFeedbackMsg =
-            (options.appStrings && options.appStrings.reinfFeedbackMsg) || '';
-
+          var reinfFeedbackMsg = options.appStrings?.reinfFeedbackMsg || '';
           if (options.level.disableFinalLessonMessage) {
             message = reinfFeedbackMsg;
           } else {
@@ -899,8 +884,7 @@ FeedbackUtils.prototype.getFeedbackMessage = function(options) {
           }
         } else {
           var nextLevelMsg =
-            (options.appStrings && options.appStrings.nextLevelMsg) ||
-            msg.nextLevel(msgParams);
+            options.appStrings?.nextLevelMsg || msg.nextLevel(msgParams);
           message = finalLevel
             ? msg.finalStage(msgParams)
             : lessonCompleted
@@ -908,6 +892,26 @@ FeedbackUtils.prototype.getFeedbackMessage = function(options) {
             : nextLevelMsg;
         }
         break;
+    }
+  } else {
+    if (
+      options.level?.lastLevelInLesson &&
+      options.level?.showEndOfLessonMsgs
+    ) {
+      message = msg.endOfLesson();
+    } else if (
+      options.feedbackType < TestResults.ALL_PASS &&
+      options.level?.failureMessageOverride
+    ) {
+      message = options.level.failureMessageOverride;
+    } else if (options.message) {
+      message = options.message;
+    } else if (options.response?.share_failure) {
+      message = msg.shareFailure();
+    } else {
+      message =
+        options.appStrings?.nextLevelMsg ||
+        msg.nextLevel({puzzleNumber: options.level.puzzle_number});
     }
   }
   return message;
@@ -1973,17 +1977,6 @@ FeedbackUtils.prototype.hasMatchingDescendant_ = function(node, filter) {
 FeedbackUtils.prototype.hasExceededLimitedBlocks_ = function() {
   const blockLimits = Blockly.mainBlockSpace.blockSpaceEditor.blockLimits;
   return blockLimits.blockLimitExceeded && blockLimits.blockLimitExceeded();
-};
-
-/**
- * Determine if this is the final level in a progression based on server response.
- * For details, see:
- * https://github.com/code-dot-org/code-dot-org/blob/a6d3762e5756e825fef15182042845d01c05f1e6/dashboard/app/helpers/script_levels_helper.rb#L30
- * @param {Object} response
- * @returns {boolean}
- */
-FeedbackUtils.prototype.isFinalLevel = function(response) {
-  return response?.message === 'no more levels';
 };
 
 /**

--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -183,7 +183,7 @@ FeedbackUtils.prototype.displayFeedback = function(
       continueText: options.continueText,
       isK1: options.level.isK1,
       freePlay: options.level.freePlay,
-      finalLevel: options.level.lastLevelInLesson
+      finalLevel: options.level.isLastLevelInLesson
     })
   );
 
@@ -864,7 +864,7 @@ FeedbackUtils.prototype.getFeedbackMessage = function(options) {
       case TestResults.FREE_PLAY:
       case TestResults.BETTER_THAN_IDEAL:
       case TestResults.PASS_WITH_EXTRA_TOP_BLOCKS:
-        var finalLevel = options.level?.lastLevelInLesson;
+        var finalLevel = options.level?.isLastLevelInLesson;
         // End of lesson in CSD/CSP/CSA
         if (finalLevel && options.level?.showEndOfLessonMsgs) {
           message = msg.endOfLesson();

--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -1568,7 +1568,7 @@ export default class P5Lab {
     let msg = this.getMsg();
 
     // Allow P5Labs to decide what string should be rendered in the feedback dialog.
-    const isFinalFreePlayLevel = level.freePlay && level.lastLevelInLesson;
+    const isFinalFreePlayLevel = level.freePlay && level.isLastLevelInLesson;
     const reinfFeedbackMsg = this.getReinfFeedbackMsg(isFinalFreePlayLevel);
 
     const isSignedIn =

--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -1568,10 +1568,7 @@ export default class P5Lab {
     let msg = this.getMsg();
 
     // Allow P5Labs to decide what string should be rendered in the feedback dialog.
-    const isFinalFreePlayLevel = this.studioApp_.isFinalFreePlayLevel(
-      this.testResults,
-      this.response
-    );
+    const isFinalFreePlayLevel = level.freePlay && level.lastLevelInLesson;
     const reinfFeedbackMsg = this.getReinfFeedbackMsg(isFinalFreePlayLevel);
 
     const isSignedIn =

--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -762,9 +762,7 @@ input[type="radio"] {
   color: #7E5BA0;
   font-family: $gotham-extra-bold;
   font-weight: normal;
-
 }
-
 #show-code {
   margin-bottom: 5px;
 }

--- a/apps/style/craft/style.scss
+++ b/apps/style/craft/style.scss
@@ -267,10 +267,6 @@ body {
   }
 }
 
-//.minecraft .modal a:hover {
-//  background: transparent;
-//}
-
 #codeApp {
   top: 75px !important;
 

--- a/apps/test/unit/feedbackTest.js
+++ b/apps/test/unit/feedbackTest.js
@@ -18,6 +18,7 @@ describe('FeedbackUtils', () => {
         const finalStageMsg = 'Final stage!';
         const nextStageMsg = 'Next stage!';
         const nextLevelMsg = 'Next level!';
+        const endOfLesson = 'End of lesson!';
 
         beforeEach(() => {
           options = {
@@ -31,6 +32,7 @@ describe('FeedbackUtils', () => {
           };
 
           sinon.stub(msg, 'finalStage').callsFake(() => finalStageMsg);
+          sinon.stub(msg, 'endOfLesson').callsFake(() => endOfLesson);
           sinon.stub(msg, 'nextStage').callsFake(() => nextStageMsg);
           sinon.stub(msg, 'nextLevel').callsFake(() => nextLevelMsg);
         });
@@ -63,6 +65,15 @@ describe('FeedbackUtils', () => {
             );
           });
 
+          it('returns end of lesson message if final level and level.showEndOfLessonMsgs is true', () => {
+            options.level.lastLevelInLesson = true;
+            options.level.showEndOfLessonMsgs = true;
+            assert.equal(
+              feedbackUtils.getFeedbackMessage(options),
+              endOfLesson
+            );
+          });
+
           it('returns appStrings.reinfFeedbackMsg if not final level', () => {
             assert.equal(
               feedbackUtils.getFeedbackMessage(options),
@@ -81,6 +92,15 @@ describe('FeedbackUtils', () => {
             assert.equal(
               feedbackUtils.getFeedbackMessage(options),
               finalStageMsg
+            );
+          });
+
+          it('returns final stage message if final level and level.showEndOfLessonMsgs is true', () => {
+            options.level.lastLevelInLesson = true;
+            options.level.showEndOfLessonMsgs = true;
+            assert.equal(
+              feedbackUtils.getFeedbackMessage(options),
+              endOfLesson
             );
           });
 

--- a/apps/test/unit/feedbackTest.js
+++ b/apps/test/unit/feedbackTest.js
@@ -51,7 +51,7 @@ describe('FeedbackUtils', () => {
           });
 
           it('returns final stage and appStrings.reinfFeedbackMsg if final level', () => {
-            options.level.lastLevelInLesson = true;
+            options.level.isLastLevelInLesson = true;
             assert.equal(
               feedbackUtils.getFeedbackMessage(options),
               `${finalStageMsg} ${options.appStrings.reinfFeedbackMsg}`
@@ -66,7 +66,7 @@ describe('FeedbackUtils', () => {
           });
 
           it('returns end of lesson message if final level and level.showEndOfLessonMsgs is true', () => {
-            options.level.lastLevelInLesson = true;
+            options.level.isLastLevelInLesson = true;
             options.level.showEndOfLessonMsgs = true;
             assert.equal(
               feedbackUtils.getFeedbackMessage(options),
@@ -88,7 +88,7 @@ describe('FeedbackUtils', () => {
           });
 
           it('returns final stage message if final level', () => {
-            options.level.lastLevelInLesson = true;
+            options.level.isLastLevelInLesson = true;
             assert.equal(
               feedbackUtils.getFeedbackMessage(options),
               finalStageMsg
@@ -96,7 +96,7 @@ describe('FeedbackUtils', () => {
           });
 
           it('returns final stage message if final level and level.showEndOfLessonMsgs is true', () => {
-            options.level.lastLevelInLesson = true;
+            options.level.isLastLevelInLesson = true;
             options.level.showEndOfLessonMsgs = true;
             assert.equal(
               feedbackUtils.getFeedbackMessage(options),

--- a/apps/test/unit/feedbackTest.js
+++ b/apps/test/unit/feedbackTest.js
@@ -22,7 +22,9 @@ describe('FeedbackUtils', () => {
         beforeEach(() => {
           options = {
             feedbackType: TestResults.FREE_PLAY,
-            level: {},
+            level: {
+              validationEnabled: true
+            },
             appStrings: {
               reinfFeedbackMsg: "You're finished!"
             }
@@ -47,7 +49,7 @@ describe('FeedbackUtils', () => {
           });
 
           it('returns final stage and appStrings.reinfFeedbackMsg if final level', () => {
-            options.response = {message: 'no more levels'};
+            options.level.lastLevelInLesson = true;
             assert.equal(
               feedbackUtils.getFeedbackMessage(options),
               `${finalStageMsg} ${options.appStrings.reinfFeedbackMsg}`
@@ -75,7 +77,7 @@ describe('FeedbackUtils', () => {
           });
 
           it('returns final stage message if final level', () => {
-            options.response = {message: 'no more levels'};
+            options.level.lastLevelInLesson = true;
             assert.equal(
               feedbackUtils.getFeedbackMessage(options),
               finalStageMsg

--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -39,10 +39,10 @@ class ActivitiesController < ApplicationController
     # Keep this logic in sync with code-studio/reporting#sendReport on the client.
     post_milestone = Gatekeeper.allows('postMilestone', where: {script_name: script_name}, default: true)
     post_failed_run_milestone = Gatekeeper.allows('postFailedRunMilestone', where: {script_name: script_name}, default: true)
-    final_level = @script_level.try(:end_of_lesson?)
+    final_level = @script_level.try(:end_of_script?)
     # We should only expect milestone posts if:
     #  - post_milestone is true, AND (we post on failed runs, or this was successful), or
-    #  - this is the final level - we always post on final level
+    #  - this is the final level in the script - we always post on final level
     unless (post_milestone && (post_failed_run_milestone || solved)) || final_level
       head 503
       return

--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -39,7 +39,7 @@ class ActivitiesController < ApplicationController
     # Keep this logic in sync with code-studio/reporting#sendReport on the client.
     post_milestone = Gatekeeper.allows('postMilestone', where: {script_name: script_name}, default: true)
     post_failed_run_milestone = Gatekeeper.allows('postFailedRunMilestone', where: {script_name: script_name}, default: true)
-    final_level = @script_level.try(:final_level?)
+    final_level = @script_level.try(:end_of_lesson?)
     # We should only expect milestone posts if:
     #  - post_milestone is true, AND (we post on failed runs, or this was successful), or
     #  - this is the final level - we always post on final level

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -586,7 +586,7 @@ module LevelsHelper
     level_options['lesson_total'] = script_level ? script_level.lesson_total : 1
     level_options['lastLevelInLesson'] = script_level.end_of_lesson? if script_level
     level_options['lastLevelInScript'] = script_level.end_of_script? if script_level
-    level_options['showEndOfLessonMsgs'] = script.middle_high? if script
+    level_options['showEndOfLessonMsgs'] = script.show_unit_overview_between_lessons?(current_user) if script
 
     # Edit blocks-dependent options
     if level_view_options(@level.id)[:edit_blocks]

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -584,8 +584,8 @@ module LevelsHelper
     script_level = @script_level
     level_options['puzzle_number'] = script_level ? script_level.position : 1
     level_options['lesson_total'] = script_level ? script_level.lesson_total : 1
-    level_options['lastLevelInLesson'] = script_level.end_of_lesson? if script_level
-    level_options['lastLevelInScript'] = script_level.end_of_script? if script_level
+    level_options['isLastLevelInLesson'] = script_level.end_of_lesson? if script_level
+    level_options['isLastLevelInScript'] = script_level.end_of_script? if script_level
     level_options['showEndOfLessonMsgs'] = script.show_unit_overview_between_lessons?(current_user) if script
 
     # Edit blocks-dependent options

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -584,7 +584,9 @@ module LevelsHelper
     script_level = @script_level
     level_options['puzzle_number'] = script_level ? script_level.position : 1
     level_options['lesson_total'] = script_level ? script_level.lesson_total : 1
-    level_options['final_level'] = script_level.final_level? if script_level
+    level_options['lastLevelInLesson'] = script_level.end_of_lesson? if script_level
+    level_options['lastLevelInScript'] = script_level.end_of_script? if script_level
+    level_options['showEndOfLessonMsgs'] = script.middle_high? if script
 
     # Edit blocks-dependent options
     if level_view_options(@level.id)[:edit_blocks]

--- a/dashboard/app/helpers/script_levels_helper.rb
+++ b/dashboard/app/helpers/script_levels_helper.rb
@@ -27,8 +27,6 @@ module ScriptLevelsHelper
         end
       end
     else
-      response[:message] = 'no more levels' # used by blockly to show a different feedback message on the last level
-
       if script_level.script.wrapup_video
         response[:video_info] = wrapup_video_then_redirect_response(
           script_level.script.wrapup_video,

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -866,6 +866,12 @@ class Script < ApplicationRecord
     under_curriculum_umbrella?('CSC')
   end
 
+  # TODO: (Dani) Update to use new course types framework.
+  # Currently this grouping is used to determine whether the script should have # a custom end-of-lesson experience.
+  def middle_high?
+    csd? || csp? || csa?
+  end
+
   def hour_of_code?
     under_curriculum_umbrella?('HOC')
   end
@@ -2006,6 +2012,6 @@ class Script < ApplicationRecord
   # To help teachers have more control over the pacing of certain scripts, we
   # send students on the last level of a lesson to the unit overview page.
   def show_unit_overview_between_lessons?(user)
-    (csd? || csp? || csa?) && user&.has_pilot_experiment?('end-of-lesson-redirects')
+    middle_high? && user&.has_pilot_experiment?('end-of-lesson-redirects')
   end
 end

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -144,10 +144,6 @@ class ScriptLevel < ApplicationRecord
     end
   end
 
-  def final_level?
-    !has_another_level_to_go_to?
-  end
-
   def next_level_or_redirect_path_for_user(
     user,
     extras_lesson=nil,

--- a/dashboard/test/controllers/activities_controller_test.rb
+++ b/dashboard/test/controllers/activities_controller_test.rb
@@ -41,7 +41,13 @@ class ActivitiesControllerTest < ActionController::TestCase
     @script_level_prev = create(:script_level, script: @script)
     @script_level = create(:script_level, script: @script)
     @script_level_next = create(:script_level, script: @script)
-    create(:lesson_group, lessons: [@script_level_prev.lesson, @script_level.lesson, @script_level_next.lesson], script: @script)
+
+    @lesson = create(:lesson)
+    @lesson.script_levels << @script_level_prev
+    @lesson.script_levels << @script_level
+    @lesson.script_levels << @script_level_next
+
+    create(:lesson_group, lessons: [@lesson], script: @script)
     @level = @script_level.level
 
     @blank_image = File.read('test/fixtures/artist_image_blank.png', binmode: true)

--- a/dashboard/test/helpers/levels_helper_test.rb
+++ b/dashboard/test/helpers/levels_helper_test.rb
@@ -115,6 +115,79 @@ class LevelsHelperTest < ActionView::TestCase
     refute blockly_options[:embed]
   end
 
+  test "blockly_options 'level.isLastLevelInLesson' is false if script level is not the last level in the lesson" do
+    @level = create :applab
+    @lesson = create :lesson
+    @script_level = create :script_level, levels: [@level], lesson: @lesson, position: 1
+    create :script_level, lesson: @lesson, position: 2
+
+    options = blockly_options
+
+    refute options[:level]['isLastLevelInLesson']
+  end
+
+  test "blockly_options 'level.isLastLevelInLesson' is true if script level is the last level in the lesson" do
+    @level = create :applab
+    @lesson = create :lesson
+    create :script_level, lesson: @lesson, position: 1
+    @script_level = create :script_level, levels: [@level], lesson: @lesson, position: 2
+
+    options = blockly_options
+
+    assert options[:level]['isLastLevelInLesson']
+  end
+
+  test "blockly_options 'level.isLastLevelInScript' is false if script level is not the last level in the script" do
+    @script = create :script
+    lesson_group = create :lesson_group, script: @script
+    @lesson = create :lesson, lesson_group: lesson_group, relative_position: 1
+    lesson_2 = create :lesson, lesson_group: lesson_group, relative_position: 2
+    @level = create :applab
+    @script_level = create :script_level, lesson: @lesson, levels: [@level]
+    create :script_level, lesson: lesson_2
+
+    options = blockly_options
+
+    refute options[:level]['isLastLevelInScript']
+  end
+
+  test "blockly_options 'level.isLastLevelInScript' is true if script level is the last level in the script" do
+    @script = create :script
+    lesson_group = create :lesson_group, script: @script
+    create :lesson, lesson_group: lesson_group, relative_position: 1
+    @lesson = create :lesson, lesson_group: lesson_group, relative_position: 2
+    @level = create :applab
+    @script_level = create :script_level, lesson: @lesson, levels: [@level], position: 1
+
+    options = blockly_options
+
+    assert options[:level]['isLastLevelInScript']
+  end
+
+  test "blockly_options 'level.showEndOfLessonMsgs' is true if script.show_unit_overview_between_lessons? is true" do
+    Script.any_instance.stubs(:show_unit_overview_between_lessons?).returns true
+    @script = create :script
+    @lesson = create :lesson
+    @level = create :applab
+    @script_level = create :script_level, lesson: @lesson, levels: [@level]
+
+    options = blockly_options
+
+    assert options[:level]['showEndOfLessonMsgs']
+  end
+
+  test "blockly_options 'level.showEndOfLessonMsgs' is false if script.show_unit_overview_between_lessons? is false" do
+    Script.any_instance.stubs(:show_unit_overview_between_lessons?).returns false
+    @script = create :script
+    @lesson = create :lesson
+    @level = create :applab
+    @script_level = create :script_level, lesson: @lesson, levels: [@level]
+
+    options = blockly_options
+
+    refute options[:level]['showEndOfLessonMsgs']
+  end
+
   test "get video choices" do
     choices_cached = video_key_choices
     assert_equal(choices_cached.count, Video.where(locale: 'en-US').count)

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1827,6 +1827,16 @@ class ScriptTest < ActiveSupport::TestCase
     assert @hoc_unit.hour_of_code?
   end
 
+  test "middle_high?" do
+    assert @csd_unit.middle_high?
+    assert @csp_unit.middle_high?
+    assert @csa_unit.middle_high?
+
+    refute @csf_unit.middle_high?
+    refute @csc_unit.middle_high?
+    refute @hoc_unit.middle_high?
+  end
+
   test "has_standards_associations?" do
     assert @csf_unit_2019.has_standards_associations?
     refute @csp_unit.has_standards_associations?

--- a/dashboard/test/ui/features/learning_platform/feedback.feature
+++ b/dashboard/test/ui/features/learning_platform/feedback.feature
@@ -33,5 +33,5 @@ Scenario: Solve without recommended blocks
   And I wait to see ".congrats"
 
   Then element ".congrats" is visible
-  And element ".congrats" has text "Congratulations! You completed Bee."
+  And element ".congrats" has text "Congratulations! You have completed the final puzzle."
   And element "#hint-request-button" does not exist

--- a/dashboard/test/ui/features/learning_platform/feedback.feature
+++ b/dashboard/test/ui/features/learning_platform/feedback.feature
@@ -33,5 +33,5 @@ Scenario: Solve without recommended blocks
   And I wait to see ".congrats"
 
   Then element ".congrats" is visible
-  And element ".congrats" has text "Congratulations! You have completed the final puzzle."
+  And element ".congrats" has text "Congratulations! You completed Bee."
   And element "#hint-request-button" does not exist


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#44394

The changes in this PR re-enable the work done in https://github.com/code-dot-org/code-dot-org/pull/44194 with a few tweaks.

The feature introduced in this PR is hidden behind the pilot flag `end-of-lesson-redirects`. When the flag is enabled, and for middle and high school courses only, when the user reaches the last level in a lesson the dialog will display "Congratulations! You've reached the end of the lesson." instead of the regular "Congratulations" message when the level has been passed (if there is no validation that's considered passing).

![Screen Shot 2022-01-18 at 4 36 37 PM](https://user-images.githubusercontent.com/24235215/150041386-ef00e8ac-97cf-4f5a-9ea5-2b9a0dcfe55d.png)


Note that for levels that have other important information in the final dialog, such as submit levels which display "Submit your project - You cannot edit your project after submitting it, really submit?" The dialog will remain as-is. 

## Testing
Tested on various levels types that the expected message would display in the dialog and added unit tests

## Follow-up work
Next up is https://github.com/code-dot-org/code-dot-org/pull/44333 which will enable redirecting students from the end of the lesson to the unit overview page and displaying a dialog there.