### PR TITLE
Remove no_ie flag for learning platform tests

### DIFF
--- a/dashboard/test/ui/features/learning_platform/assignment_on_overview_pages.feature
+++ b/dashboard/test/ui/features/learning_platform/assignment_on_overview_pages.feature
@@ -1,5 +1,4 @@
 @skip
-@no_ie
 @no_firefox
 @no_safari
 @no_mobile

--- a/dashboard/test/ui/features/learning_platform/authored_hints.feature
+++ b/dashboard/test/ui/features/learning_platform/authored_hints.feature
@@ -1,4 +1,3 @@
-@no_ie
 Feature: Authored Hints
 
 Scenario: View Authored Hints

--- a/dashboard/test/ui/features/learning_platform/disallowedsharing.feature
+++ b/dashboard/test/ui/features/learning_platform/disallowedsharing.feature
@@ -1,5 +1,3 @@
-# Brad (2018-11-14) Skip on IE due to webdriver exception
-@no_ie
 @no_mobile
 Feature: Shared content restrictions
 

--- a/dashboard/test/ui/features/learning_platform/instructions/feedback_tab.feature
+++ b/dashboard/test/ui/features/learning_platform/instructions/feedback_tab.feature
@@ -25,9 +25,6 @@ Scenario: As student 'Feedback' tab is not visible if no feedback
   And element "ui-test-feedback-input" does not exist
   Then I sign out
 
-@no_ie
-# Disabling IE due to bug where text changes in the feedback text input are not registered
-# so submit button remains disabled
 Scenario: As teacher, when viewing a level with student work,
 feedback can be submitted and displayed. If there is a mini rubric, teacher can give feedback on rubric.
 If a teacher on a level with mini rubric can see the rubric without viewing student work.

--- a/dashboard/test/ui/features/learning_platform/level_types/level_group.feature
+++ b/dashboard/test/ui/features/learning_platform/level_types/level_group.feature
@@ -32,7 +32,6 @@ Scenario: Submit three answers.
   And element ".level-group-content:nth(2) #checked_2" is visible
   And element ".level-group-content:nth(2) #checked_0" is visible
 
-@no_ie
 Scenario: Match levels within level group
   Given I create a teacher-associated student named "Lilian"
   Given I am on "http://studio.code.org/s/allthethings/lessons/33/levels/1?noautoplay=true"
@@ -92,7 +91,6 @@ Scenario: Match levels within level group
   # no answers are draggable
   And element ".ui-draggable" is not visible
 
-@no_ie
 Scenario: Submit all answers, including match levels
   Given I am on "http://studio.code.org/s/allthethings/lessons/33/levels/1?noautoplay=true"
   And I wait to see ".submitButton"

--- a/dashboard/test/ui/features/learning_platform/level_types/match.feature
+++ b/dashboard/test/ui/features/learning_platform/level_types/match.feature
@@ -9,8 +9,6 @@ Background:
 Scenario: Loading the level
   And element ".match .content2" has text "Match the blocks"
 
-# drag simulation does not work in IE/iOS, so we exclude them for now
-@no_ie
 @no_mobile
 Scenario: Solving puzzle
   And I dismiss the login reminder
@@ -22,7 +20,6 @@ Scenario: Solving puzzle
   Then I wait to see ".modal"
   And element ".modal .dialog-title" contains text "Correct"
 
-@no_ie
 @no_mobile
 @as_student
 Scenario: Submitting an incorrect solution

--- a/dashboard/test/ui/features/learning_platform/projects/applab_project.feature
+++ b/dashboard/test/ui/features/learning_platform/projects/applab_project.feature
@@ -2,10 +2,8 @@ Feature: Applab Project
 
 # as_student to actually perform sign-in/out before/after scenario
 # no_mobile because we don't end up with open-workspace on mobile
-# no_ie because applab is broken on IE9, and on IE10 this test crashes when we
-#   try to execute any JS after our redirect on line 42
 @as_student
-@no_mobile @no_ie
+@no_mobile
 Scenario: Applab Flow
   Given I am on "http://studio.code.org/projects/applab"
   And I get redirected to "/projects/applab/([^\/]*?)/edit" via "dashboard"

--- a/dashboard/test/ui/features/learning_platform/projects/personal_project_gallery.feature
+++ b/dashboard/test/ui/features/learning_platform/projects/personal_project_gallery.feature
@@ -22,8 +22,6 @@ Scenario: Can Publish and Unpublish a Project (Button Version)
   Then I click selector ".ui-personal-projects-unpublish-button"
   And I wait until element ".ui-personal-projects-publish-button" is visible
 
-@no_ie
-# Disabling IE due to bug where key changes are not registered,
 Scenario: Can Rename a Project
   Given I make a "playlab" project named "Old Name"
   Given I am on "http://studio.code.org/projects"

--- a/dashboard/test/ui/features/learning_platform/projects/prevent_report_abuse_spam.feature
+++ b/dashboard/test/ui/features/learning_platform/projects/prevent_report_abuse_spam.feature
@@ -63,7 +63,6 @@ Scenario: Report Abuse link hidden if the user already reported Game Lab project
   And element ".ui-test-how-it-works" is visible
   And element ".ui-test-report-abuse" is not visible
 
-@no_ie
 Scenario: Abuse reports block a project for other viewers
   Given I create a student named "Creator"
   And I make a "applab" project named "Regular Project"
@@ -94,7 +93,6 @@ Scenario: Abuse reports block a project for other viewers
   And I navigate to the last shared URL
   And I wait until element ".exclamation-abuse" is visible
 
-@no_ie
 Scenario: Projects made by project validators are protected from abuse reports
   Given I create a teacher named "Project Validator"
   And I give user "Project Validator" project validator permission

--- a/dashboard/test/ui/features/learning_platform/section_action_dropdown.feature
+++ b/dashboard/test/ui/features/learning_platform/section_action_dropdown.feature
@@ -1,7 +1,6 @@
 @single_session
 Feature: Using the SectionActionDropdown
 
-  @no_ie
   # * Check that we get redirected to the right page
   Scenario: Viewing progress from SectionActionDropdown
     Given I create a teacher-associated student named "Sally"

--- a/dashboard/test/ui/features/learning_platform/teacher_dashboard/teacher_dashboard.feature
+++ b/dashboard/test/ui/features/learning_platform/teacher_dashboard/teacher_dashboard.feature
@@ -222,8 +222,6 @@ Feature: Using the teacher dashboard
     Then I wait until element "#flashes" is visible
     And element "div.alert" contains text matching "Sorry, you can't join your own section"
 
-  # Omit IE because it does not respond to press keys step for React forms
-  @no_ie
   Scenario: Attempt to join an invalid section through the homepage
     Given I am a teacher and go home
     And I wait until element "div.ui-test-join-section" is visible
@@ -232,7 +230,6 @@ Feature: Using the teacher dashboard
     Then I wait until element ".announcement-notification" is visible
     And element ".announcement-notification" contains text matching "Section INVALID doesn't exist"
 
-  @no_ie
   Scenario: Attempt to join a section you own from teacher dashboard provides notification
     Given I am a teacher
     And I create a new section and go home

--- a/dashboard/test/ui/features/learning_platform/teacher_homepage.feature
+++ b/dashboard/test/ui/features/learning_platform/teacher_homepage.feature
@@ -24,7 +24,7 @@ Feature: Using the teacher homepage sections feature
     Then the section table should have 1 row
     And the section table row at index 0 has secondary assignment path "/s/csp3-a"
 
-  @no_firefox @no_safari @no_ie
+  @no_firefox @no_safari
   Scenario: Navigate to course and unit pages
     # No sections, ensure that levels load correctly after navigating from MiniView
     Given I am on "http://studio.code.org/s/csp2-2017/lessons/1/levels/1"


### PR DESCRIPTION
W no longer support Internet Explorer, and therefore no longer include it as a browser option for UI tests; thus, we can delete the flag that skips IE in our features!
