### PR TITLE
PaneButton in Backpack

### DIFF
--- a/apps/src/javalab/Backpack.jsx
+++ b/apps/src/javalab/Backpack.jsx
@@ -349,7 +349,8 @@ const styles = {
     maxWidth: '35%',
     maxHeight: '80%',
     minWidth: 150,
-    color: color.darkest_gray
+    color: color.darkest_gray,
+    marginLeft: 3
   },
   dropdown: {
     overflow: 'auto',

--- a/apps/src/javalab/Backpack.jsx
+++ b/apps/src/javalab/Backpack.jsx
@@ -215,7 +215,7 @@ class Backpack extends Component {
       backpackFilenames.length === 0;
 
     const backpackIcon = (
-      <i style={{marginRight: 8}}>
+      <i style={{marginRight: 8, fontSize: 13}}>
         <img
           src="/blockly/media/javalab/backpack.png"
           alt="backpack icon"

--- a/apps/src/javalab/Backpack.jsx
+++ b/apps/src/javalab/Backpack.jsx
@@ -11,6 +11,7 @@ import {setSource} from './javalabRedux';
 import {DisplayTheme} from './DisplayTheme';
 import {makeEnum} from '@cdo/apps/utils';
 import JavalabDialog from './JavalabDialog';
+import {PaneButton} from '@cdo/apps/templates/PaneHeader';
 
 const Dialog = makeEnum('IMPORT_WARNING', 'IMPORT_ERROR');
 
@@ -213,24 +214,33 @@ class Backpack extends Component {
       !backpackLoadError &&
       backpackFilenames.length === 0;
 
+    const backpackIcon = (
+      <i style={{marginRight: 8}}>
+        <img
+          src="/blockly/media/javalab/backpack.png"
+          alt="backpack icon"
+          style={styles.backpackIcon}
+        />
+      </i>
+    );
+
+    // Use PaneButton as primary Backpack button
+    // to align with other buttons in the JavalabEditor header,
+    // which all use PaneButton.
     return (
       <>
-        <JavalabButton
-          icon={
-            <img
-              src="/blockly/media/javalab/backpack.png"
-              alt="backpack icon"
-              style={styles.backpackIcon}
-            />
-          }
-          text={javalabMsg.backpackLabel()}
+        <PaneButton
+          id="javalab-editor-backpack"
+          icon={backpackIcon}
+          onClick={this.toggleDropdown}
+          headerHasFocus
+          isRtl={false}
+          label={javalabMsg.backpackLabel()}
+          leftJustified
+          isDisabled={isDisabled}
           style={{
-            ...styles.buttonStyles,
             ...(dropdownOpen && styles.dropdownOpenButton)
           }}
-          isHorizontal
-          onClick={this.toggleDropdown}
-          isDisabled={isDisabled}
         />
         {dropdownOpen && (
           <div
@@ -352,26 +362,6 @@ const styles = {
   },
   listContainer: {
     width: 'fit-content'
-  },
-  buttonStyles: {
-    cursor: 'pointer',
-    float: 'right',
-    backgroundColor: color.light_purple,
-    margin: '3px 3px 3px 0px',
-    height: 24,
-    borderWidth: 1,
-    borderStyle: 'solid',
-    // prevent jitter when the button is clicked
-    borderColor: color.purple,
-    borderRadius: 4,
-    fontSize: 13,
-    color: color.white,
-    padding: '0px 12px',
-    fontFamily: '"Gotham 5r", sans-serif',
-    lineHeight: '18px',
-    ':hover': {
-      backgroundColor: color.cyan
-    }
   },
   dropdownOpenButton: {
     backgroundColor: color.cyan

--- a/apps/src/javalab/JavalabEditor.jsx
+++ b/apps/src/javalab/JavalabEditor.jsx
@@ -792,8 +792,7 @@ const styles = {
     textAlign: 'left',
     display: 'inline-block',
     float: 'left',
-    overflow: 'visible',
-    marginLeft: 3
+    overflow: 'visible'
   }
 };
 

--- a/apps/src/templates/PaneHeader.jsx
+++ b/apps/src/templates/PaneHeader.jsx
@@ -186,7 +186,7 @@ export const PaneButton = Radium(function(props) {
       const Icon = icon.type;
       return (
         <Icon {...icon.props} style={{...iconStyle, ...icon.props.style}}>
-          {icon.children}
+          {icon.props.children}
         </Icon>
       );
     }


### PR DESCRIPTION
Wanted to get this out before I forget about it/it becomes outdated. Prefactor for https://github.com/code-dot-org/code-dot-org/pull/44341 -- moves the "Backpack" button that appears in the header of `JavalabEditor` to use `PaneHeader` like the other buttons in the header.

## Testing story

Tested manually.

**New (left) vs. old (right) -- only difference is in Backpack button:**

![image](https://user-images.githubusercontent.com/25372625/150878322-5bdfc345-92c0-4867-aff4-1e5d7557894b.png)

I am having a hard time telling if the backpack icon is appearing slightly lower than other icons -- I think it may be a pixel or two lower than it was previously, and the backpack button is slightly taller than it used to be (I think this is an improvement since it's now using the same component).

## Follow-up work

I think this should enabled us to merge the reverted centering of headers PR linked above.