### PR TITLE
Always save level after cloning concept difficulty

### DIFF
--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -672,7 +672,8 @@ class Level < ApplicationRecord
     # Copy the level_concept_difficulty of the parent level to the new level
     new_lcd = level_concept_difficulty.dup
     level.level_concept_difficulty = new_lcd
-    level.save! if level.changed?
+    # trigger a save to rewrite the custom level file
+    level.save!
 
     level
   end


### PR DESCRIPTION
The level concept difficulty was cloning correctly in the database but wasn't being written to the level file. This is because we write the file in an after_save hook, but we were only saving when `changed?` was true. However, when a relationship is assigned, the object itself isn't changed, so `changed?` returns false.

I couldn't figure out a good way to update the unit tests for this but I did confirm locally that this change writes the level concept difficulties on clone.



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
