### PR TITLE
Fix can read for UnitGroup

### DIFF
--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -3,8 +3,15 @@ class CoursesController < ApplicationController
 
   before_action :require_levelbuilder_mode, except: [:index, :show, :vocab, :resources, :code, :standards]
   before_action :authenticate_user!, except: [:index, :show, :vocab, :resources, :code, :standards]
+  before_action :set_unit_group, only: [:show, :vocab, :resources, :code, :standards, :edit, :update, :get_rollup_resources]
   before_action :set_redirect_override, only: [:show]
   authorize_resource class: 'UnitGroup', except: [:index]
+
+  def set_unit_group
+    @unit_group = UnitGroup.get_from_cache(params[:course_name])
+    # the standards and show actions allow redirecting when given a family name so we do not want to raise in that case
+    raise ActiveRecord::RecordNotFound unless @unit_group || (['standards', 'show'].include?(params[:action]) && UnitGroup.family_names.include?(params[:course_name]))
+  end
 
   def index
     view_options(full_width: true, responsive_content: true, no_padding_container: true, has_i18n: true)
@@ -29,25 +36,23 @@ class CoursesController < ApplicationController
       return
     end
 
-    unit_group = UnitGroup.get_from_cache(params[:course_name])
-
-    if unit_group.present?
-      if unit_group.plc_course
+    if @unit_group.present?
+      if @unit_group.plc_course
         authorize! :show, Plc::UserCourseEnrollment
-        user_course_enrollments = [Plc::UserCourseEnrollment.find_by(user: current_user, plc_course: unit_group.plc_course)]
+        user_course_enrollments = [Plc::UserCourseEnrollment.find_by(user: current_user, plc_course: @unit_group.plc_course)]
         render 'plc/user_course_enrollments/index', locals: {user_course_enrollments: user_course_enrollments}
         return
       end
 
-      if unit_group.pilot?
+      if @unit_group.pilot?
         authenticate_user!
-        unless unit_group.has_pilot_access?(current_user)
+        unless @unit_group.has_pilot_access?(current_user)
           render :no_access
           return
         end
       end
 
-      if unit_group.in_development?
+      if @unit_group.in_development?
         authenticate_user!
         unless current_user.permission?(UserPermission::LEVELBUILDER)
           render :no_access
@@ -56,16 +61,16 @@ class CoursesController < ApplicationController
       end
 
       # Attempt to redirect user if we think they ended up on the wrong course overview page.
-      override_redirect = VersionRedirectOverrider.override_course_redirect?(session, unit_group)
-      if !override_redirect && redirect_unit_group = redirect_unit_group(unit_group)
+      override_redirect = VersionRedirectOverrider.override_course_redirect?(session, @unit_group)
+      if !override_redirect && redirect_unit_group = redirect_unit_group(@unit_group)
         redirect_to "#{course_path(redirect_unit_group)}/?redirect_warning=true"
         return
       end
 
       sections = current_user.try {|u| u.sections.where(hidden: false).select(:id, :name, :course_id, :script_id)}
-      @sections_with_assigned_info = sections&.map {|section| section.attributes.merge!({"isAssigned" => section[:course_id] == unit_group.id})}
+      @sections_with_assigned_info = sections&.map {|section| section.attributes.merge!({"isAssigned" => section[:course_id] == @unit_group.id})}
 
-      render 'show', locals: {unit_group: unit_group, redirect_warning: params[:redirect_warning] == 'true'}
+      render 'show', locals: {unit_group: @unit_group, redirect_warning: params[:redirect_warning] == 'true'}
     elsif UnitGroup.family_names.include?(params[:course_name])
       # csp and csd are each "course families", each containing multiple "course versions".
       # When the url of a course family is requested, redirect to a specific course version.
@@ -82,99 +87,88 @@ class CoursesController < ApplicationController
   end
 
   def create
-    unit_group = UnitGroup.new(
+    @unit_group = UnitGroup.new(
       name: params.require(:course).require(:name),
       family_name: params.require(:family_name),
       version_year: params.require(:version_year),
       has_numbered_units: true
     )
-    if unit_group.save
-      unit_group.write_serialization
-      redirect_to action: :edit, course_name: unit_group.name
+    if @unit_group.save
+      @unit_group.write_serialization
+      redirect_to action: :edit, course_name: @unit_group.name
     else
-      render 'new', locals: {unit_group: unit_group}
+      render 'new', locals: {unit_group: @unit_group}
     end
   end
 
   def update
-    unit_group = UnitGroup.find_by_name!(params[:course_name])
-    unit_group.persist_strings_and_units_changes(params[:scripts], params[:alternate_units], i18n_params)
-    unit_group.update(course_params)
-    unit_group.write_serialization
-    CourseOffering.add_course_offering(unit_group)
-    unit_group.reload
+    @unit_group.persist_strings_and_units_changes(params[:scripts], params[:alternate_units], i18n_params)
+    @unit_group.update(course_params)
+    @unit_group.write_serialization
+    CourseOffering.add_course_offering(@unit_group)
+    @unit_group.reload
 
-    unit_group.update_teacher_resources(params[:resourceTypes], params[:resourceLinks]) unless unit_group.has_migrated_unit?
-    if unit_group.has_migrated_unit? && unit_group.course_version
-      unit_group.resources = params[:resourceIds].map {|id| Resource.find(id)} if params.key?(:resourceIds)
-      unit_group.student_resources = params[:studentResourceIds].map {|id| Resource.find(id)} if params.key?(:studentResourceIds)
+    @unit_group.update_teacher_resources(params[:resourceTypes], params[:resourceLinks]) unless @unit_group.has_migrated_unit?
+    if @unit_group.has_migrated_unit? && @unit_group.course_version
+      @unit_group.resources = params[:resourceIds].map {|id| Resource.find(id)} if params.key?(:resourceIds)
+      @unit_group.student_resources = params[:studentResourceIds].map {|id| Resource.find(id)} if params.key?(:studentResourceIds)
     end
 
-    unit_group.reload
-    render json: unit_group.summarize
+    @unit_group.reload
+    render json: @unit_group.summarize
   end
 
   def edit
-    unit_group = UnitGroup.find_by_name!(params[:course_name])
-
     # We don't support an edit experience for plc courses
-    raise ActiveRecord::ReadOnlyRecord if unit_group.try(:plc_course)
-    render 'edit', locals: {unit_group: unit_group}
+    raise ActiveRecord::ReadOnlyRecord if @unit_group.try(:plc_course)
+    render 'edit', locals: {unit_group: @unit_group}
   end
 
   def vocab
-    unit_group = UnitGroup.get_from_cache(params[:course_name])
-    raise ActiveRecord::RecordNotFound unless unit_group
     # Assumes if one unit in a unit group is migrated they all are
-    return render :forbidden unless unit_group.default_units[0].is_migrated
-    @course_summary = unit_group.summarize_for_rollup(@current_user)
+    return render :forbidden unless @unit_group.default_units[0].is_migrated
+    @course_summary = @unit_group.summarize_for_rollup(@current_user)
   end
 
   def resources
-    unit_group = UnitGroup.get_from_cache(params[:course_name])
-    raise ActiveRecord::RecordNotFound unless unit_group
     # Assumes if one unit in a unit group is migrated they all are
-    return render :forbidden unless unit_group.default_units[0].is_migrated
-    @course_summary = unit_group.summarize_for_rollup(@current_user)
+    return render :forbidden unless @unit_group.default_units[0].is_migrated
+    @course_summary = @unit_group.summarize_for_rollup(@current_user)
   end
 
   def code
-    unit_group = UnitGroup.get_from_cache(params[:course_name])
-    raise ActiveRecord::RecordNotFound unless unit_group
     # Assumes if one unit in a unit group is migrated they all are
-    return render :forbidden unless unit_group.default_units[0].is_migrated
-    @course_summary = unit_group.summarize_for_rollup(@current_user)
+    return render :forbidden unless @unit_group.default_units[0].is_migrated
+    @course_summary = @unit_group.summarize_for_rollup(@current_user)
   end
 
   def standards
-    unit_group = UnitGroup.get_from_cache(params[:course_name])
-    if !unit_group.present? && UnitGroup.family_names.include?(params[:course_name])
+    if !@unit_group.present? && UnitGroup.family_names.include?(params[:course_name])
       redirect_to_course = UnitGroup.latest_stable(params[:course_name])
       redirect_to standards_course_path(redirect_to_course)
       return
     end
-    raise ActiveRecord::RecordNotFound unless unit_group
+    raise ActiveRecord::RecordNotFound unless @unit_group
     # Assumes if one unit in a unit group is migrated they all are
-    return render :forbidden unless unit_group.default_units[0].is_migrated
-    @course_summary = unit_group.summarize_for_rollup(@current_user)
+    return render :forbidden unless @unit_group.default_units[0].is_migrated
+    @course_summary = @unit_group.summarize_for_rollup(@current_user)
   end
 
   def get_rollup_resources
-    unit_group = UnitGroup.get_from_cache(params[:course_name])
-    course_version = unit_group.course_version
+    course_version = @unit_group.course_version
     return render status: 400, json: {error: 'Course does not have course version'} unless course_version
     rollup_pages = []
-    if unit_group.default_units.any? {|s| s.lessons.any? {|l| !l.programming_expressions.empty?}}
-      rollup_pages.append(Resource.find_or_create_by!(name: 'All Code', url: code_course_path(unit_group), course_version_id: course_version.id))
+    if @unit_group.default_units.any? {|s| s.lessons.any? {|l| !l.programming_expressions.empty?}}
+      rollup_pages.append(Resource.find_or_create_by!(name: 'All Code', url: code_course_path(@unit_group), course_version_id: course_version.id))
     end
-    if unit_group.default_units.any? {|s| s.lessons.any? {|l| !l.resources.empty?}}
-      rollup_pages.append(Resource.find_or_create_by!(name: 'All Resources', url: resources_course_path(unit_group), course_version_id: course_version.id))
+    if @unit_group.default_units.any? {|s| s.lessons.any? {|l| !l.resources.empty?}}
+      rollup_pages.append(Resource.find_or_create_by!(name: 'All Resources', url: resources_course_path(@unit_group), course_version_id: course_version.id))
     end
-    if unit_group.default_units.any? {|s| s.lessons.any? {|l| !l.standards.empty?}}
-      rollup_pages.append(Resource.find_or_create_by!(name: 'All Standards', url: standards_course_path(unit_group), course_version_id: course_version.id))
+    if @unit_group.default_units.any? {|s| s.lessons.any? {|l| !l.standards.empty?}}
+      rollup_pages.append(Resource.find_or_create_by!(name: 'All Standards', url: standards_course_path(@unit_group), course_version_id: course_version.id))
     end
-    if unit_group.default_units.any? {|s| s.lessons.any? {|l| !l.vocabularies.empty?}}
-      rollup_pages.append(Resource.find_or_create_by!(name: 'All Vocabulary', url: vocab_course_path(unit_group), course_version_id: course_version.id))
+    if @unit_group.default_units.any? {|s| s.lessons.any? {|l| !l.vocabularies.empty?}}
+      rollup_pages.append(Resource.find_or_create_by!(name: 'All Vocabulary', url: vocab_course_path(@unit_group), course_version_id: course_version.id))
     end
     rollup_pages.each do |r|
       r.is_rollup = true

--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -4,7 +4,14 @@ class CoursesController < ApplicationController
   before_action :require_levelbuilder_mode, except: [:index, :show, :vocab, :resources, :code, :standards]
   before_action :authenticate_user!, except: [:index, :show, :vocab, :resources, :code, :standards]
   before_action :set_redirect_override, only: [:show]
+  before_action :set_unit_group, only: [:show, :vocab, :resources, :code, :standards, :edit, :update, :get_rollup_resources]
   authorize_resource class: 'UnitGroup', except: [:index]
+
+  def set_unit_group
+    @unit_group = UnitGroup.get_from_cache(params[:course_name])
+    # the standards and show actions allow redirecting when given a family name so we do not want to raise in that case
+    raise ActiveRecord::RecordNotFound unless @unit_group || (['standards', 'show'].include?(params[:action]) && UnitGroup.family_names.include?(params[:course_name]))
+  end
 
   def index
     view_options(full_width: true, responsive_content: true, no_padding_container: true, has_i18n: true)
@@ -29,25 +36,23 @@ class CoursesController < ApplicationController
       return
     end
 
-    unit_group = UnitGroup.get_from_cache(params[:course_name])
-
-    if unit_group.present?
-      if unit_group.plc_course
+    if @unit_group.present?
+      if @unit_group.plc_course
         authorize! :show, Plc::UserCourseEnrollment
-        user_course_enrollments = [Plc::UserCourseEnrollment.find_by(user: current_user, plc_course: unit_group.plc_course)]
+        user_course_enrollments = [Plc::UserCourseEnrollment.find_by(user: current_user, plc_course: @unit_group.plc_course)]
         render 'plc/user_course_enrollments/index', locals: {user_course_enrollments: user_course_enrollments}
         return
       end
 
-      if unit_group.pilot?
+      if @unit_group.pilot?
         authenticate_user!
-        unless unit_group.has_pilot_access?(current_user)
+        unless @unit_group.has_pilot_access?(current_user)
           render :no_access
           return
         end
       end
 
-      if unit_group.in_development?
+      if @unit_group.in_development?
         authenticate_user!
         unless current_user.permission?(UserPermission::LEVELBUILDER)
           render :no_access
@@ -56,16 +61,16 @@ class CoursesController < ApplicationController
       end
 
       # Attempt to redirect user if we think they ended up on the wrong course overview page.
-      override_redirect = VersionRedirectOverrider.override_course_redirect?(session, unit_group)
-      if !override_redirect && redirect_unit_group = redirect_unit_group(unit_group)
+      override_redirect = VersionRedirectOverrider.override_course_redirect?(session, @unit_group)
+      if !override_redirect && redirect_unit_group = redirect_unit_group(@unit_group)
         redirect_to "#{course_path(redirect_unit_group)}/?redirect_warning=true"
         return
       end
 
       sections = current_user.try {|u| u.sections.where(hidden: false).select(:id, :name, :course_id, :script_id)}
-      @sections_with_assigned_info = sections&.map {|section| section.attributes.merge!({"isAssigned" => section[:course_id] == unit_group.id})}
+      @sections_with_assigned_info = sections&.map {|section| section.attributes.merge!({"isAssigned" => section[:course_id] == @unit_group.id})}
 
-      render 'show', locals: {unit_group: unit_group, redirect_warning: params[:redirect_warning] == 'true'}
+      render 'show', locals: {unit_group: @unit_group, redirect_warning: params[:redirect_warning] == 'true'}
     elsif UnitGroup.family_names.include?(params[:course_name])
       # csp and csd are each "course families", each containing multiple "course versions".
       # When the url of a course family is requested, redirect to a specific course version.
@@ -82,99 +87,89 @@ class CoursesController < ApplicationController
   end
 
   def create
-    unit_group = UnitGroup.new(
+    @unit_group = UnitGroup.new(
       name: params.require(:course).require(:name),
       family_name: params.require(:family_name),
       version_year: params.require(:version_year),
       has_numbered_units: true
     )
-    if unit_group.save
-      unit_group.write_serialization
-      redirect_to action: :edit, course_name: unit_group.name
+    if @unit_group.save
+      @unit_group.write_serialization
+      redirect_to action: :edit, course_name: @unit_group.name
     else
-      render 'new', locals: {unit_group: unit_group}
+      render 'new', locals: {unit_group: @unit_group}
     end
   end
 
   def update
-    unit_group = UnitGroup.find_by_name!(params[:course_name])
-    unit_group.persist_strings_and_units_changes(params[:scripts], params[:alternate_units], i18n_params)
-    unit_group.update(course_params)
-    unit_group.write_serialization
-    CourseOffering.add_course_offering(unit_group)
-    unit_group.reload
+    @unit_group = UnitGroup.find_by_name!(params[:course_name])
+    @unit_group.persist_strings_and_units_changes(params[:scripts], params[:alternate_units], i18n_params)
+    @unit_group.update(course_params)
+    @unit_group.write_serialization
+    CourseOffering.add_course_offering(@unit_group)
+    @unit_group.reload
 
-    unit_group.update_teacher_resources(params[:resourceTypes], params[:resourceLinks]) unless unit_group.has_migrated_unit?
-    if unit_group.has_migrated_unit? && unit_group.course_version
-      unit_group.resources = params[:resourceIds].map {|id| Resource.find(id)} if params.key?(:resourceIds)
-      unit_group.student_resources = params[:studentResourceIds].map {|id| Resource.find(id)} if params.key?(:studentResourceIds)
+    @unit_group.update_teacher_resources(params[:resourceTypes], params[:resourceLinks]) unless @unit_group.has_migrated_unit?
+    if @unit_group.has_migrated_unit? && @unit_group.course_version
+      @unit_group.resources = params[:resourceIds].map {|id| Resource.find(id)} if params.key?(:resourceIds)
+      @unit_group.student_resources = params[:studentResourceIds].map {|id| Resource.find(id)} if params.key?(:studentResourceIds)
     end
 
-    unit_group.reload
-    render json: unit_group.summarize
+    @unit_group.reload
+    render json: @unit_group.summarize
   end
 
   def edit
-    unit_group = UnitGroup.find_by_name!(params[:course_name])
-
     # We don't support an edit experience for plc courses
-    raise ActiveRecord::ReadOnlyRecord if unit_group.try(:plc_course)
-    render 'edit', locals: {unit_group: unit_group}
+    raise ActiveRecord::ReadOnlyRecord if @unit_group.try(:plc_course)
+    render 'edit', locals: {unit_group: @unit_group}
   end
 
   def vocab
-    unit_group = UnitGroup.get_from_cache(params[:course_name])
-    raise ActiveRecord::RecordNotFound unless unit_group
     # Assumes if one unit in a unit group is migrated they all are
-    return render :forbidden unless unit_group.default_units[0].is_migrated
-    @course_summary = unit_group.summarize_for_rollup(@current_user)
+    return render :forbidden unless @unit_group.default_units[0].is_migrated
+    @course_summary = @unit_group.summarize_for_rollup(@current_user)
   end
 
   def resources
-    unit_group = UnitGroup.get_from_cache(params[:course_name])
-    raise ActiveRecord::RecordNotFound unless unit_group
     # Assumes if one unit in a unit group is migrated they all are
-    return render :forbidden unless unit_group.default_units[0].is_migrated
-    @course_summary = unit_group.summarize_for_rollup(@current_user)
+    return render :forbidden unless @unit_group.default_units[0].is_migrated
+    @course_summary = @unit_group.summarize_for_rollup(@current_user)
   end
 
   def code
-    unit_group = UnitGroup.get_from_cache(params[:course_name])
-    raise ActiveRecord::RecordNotFound unless unit_group
     # Assumes if one unit in a unit group is migrated they all are
-    return render :forbidden unless unit_group.default_units[0].is_migrated
-    @course_summary = unit_group.summarize_for_rollup(@current_user)
+    return render :forbidden unless @unit_group.default_units[0].is_migrated
+    @course_summary = @unit_group.summarize_for_rollup(@current_user)
   end
 
   def standards
-    unit_group = UnitGroup.get_from_cache(params[:course_name])
-    if !unit_group.present? && UnitGroup.family_names.include?(params[:course_name])
+    if !@unit_group.present? && UnitGroup.family_names.include?(params[:course_name])
       redirect_to_course = UnitGroup.latest_stable(params[:course_name])
       redirect_to standards_course_path(redirect_to_course)
       return
     end
-    raise ActiveRecord::RecordNotFound unless unit_group
+    raise ActiveRecord::RecordNotFound unless @unit_group
     # Assumes if one unit in a unit group is migrated they all are
-    return render :forbidden unless unit_group.default_units[0].is_migrated
-    @course_summary = unit_group.summarize_for_rollup(@current_user)
+    return render :forbidden unless @unit_group.default_units[0].is_migrated
+    @course_summary = @unit_group.summarize_for_rollup(@current_user)
   end
 
   def get_rollup_resources
-    unit_group = UnitGroup.get_from_cache(params[:course_name])
-    course_version = unit_group.course_version
+    course_version = @unit_group.course_version
     return render status: 400, json: {error: 'Course does not have course version'} unless course_version
     rollup_pages = []
-    if unit_group.default_units.any? {|s| s.lessons.any? {|l| !l.programming_expressions.empty?}}
-      rollup_pages.append(Resource.find_or_create_by!(name: 'All Code', url: code_course_path(unit_group), course_version_id: course_version.id))
+    if @unit_group.default_units.any? {|s| s.lessons.any? {|l| !l.programming_expressions.empty?}}
+      rollup_pages.append(Resource.find_or_create_by!(name: 'All Code', url: code_course_path(@unit_group), course_version_id: course_version.id))
     end
-    if unit_group.default_units.any? {|s| s.lessons.any? {|l| !l.resources.empty?}}
-      rollup_pages.append(Resource.find_or_create_by!(name: 'All Resources', url: resources_course_path(unit_group), course_version_id: course_version.id))
+    if @unit_group.default_units.any? {|s| s.lessons.any? {|l| !l.resources.empty?}}
+      rollup_pages.append(Resource.find_or_create_by!(name: 'All Resources', url: resources_course_path(@unit_group), course_version_id: course_version.id))
     end
-    if unit_group.default_units.any? {|s| s.lessons.any? {|l| !l.standards.empty?}}
-      rollup_pages.append(Resource.find_or_create_by!(name: 'All Standards', url: standards_course_path(unit_group), course_version_id: course_version.id))
+    if @unit_group.default_units.any? {|s| s.lessons.any? {|l| !l.standards.empty?}}
+      rollup_pages.append(Resource.find_or_create_by!(name: 'All Standards', url: standards_course_path(@unit_group), course_version_id: course_version.id))
     end
-    if unit_group.default_units.any? {|s| s.lessons.any? {|l| !l.vocabularies.empty?}}
-      rollup_pages.append(Resource.find_or_create_by!(name: 'All Vocabulary', url: vocab_course_path(unit_group), course_version_id: course_version.id))
+    if @unit_group.default_units.any? {|s| s.lessons.any? {|l| !l.vocabularies.empty?}}
+      rollup_pages.append(Resource.find_or_create_by!(name: 'All Vocabulary', url: vocab_course_path(@unit_group), course_version_id: course_version.id))
     end
     rollup_pages.each do |r|
       r.is_rollup = true

--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -4,14 +4,7 @@ class CoursesController < ApplicationController
   before_action :require_levelbuilder_mode, except: [:index, :show, :vocab, :resources, :code, :standards]
   before_action :authenticate_user!, except: [:index, :show, :vocab, :resources, :code, :standards]
   before_action :set_redirect_override, only: [:show]
-  before_action :set_unit_group, only: [:show, :vocab, :resources, :code, :standards, :edit, :update, :get_rollup_resources]
   authorize_resource class: 'UnitGroup', except: [:index]
-
-  def set_unit_group
-    @unit_group = UnitGroup.get_from_cache(params[:course_name])
-    # the standards and show actions allow redirecting when given a family name so we do not want to raise in that case
-    raise ActiveRecord::RecordNotFound unless @unit_group || (['standards', 'show'].include?(params[:action]) && UnitGroup.family_names.include?(params[:course_name]))
-  end
 
   def index
     view_options(full_width: true, responsive_content: true, no_padding_container: true, has_i18n: true)
@@ -36,23 +29,25 @@ class CoursesController < ApplicationController
       return
     end
 
-    if @unit_group.present?
-      if @unit_group.plc_course
+    unit_group = UnitGroup.get_from_cache(params[:course_name])
+
+    if unit_group.present?
+      if unit_group.plc_course
         authorize! :show, Plc::UserCourseEnrollment
-        user_course_enrollments = [Plc::UserCourseEnrollment.find_by(user: current_user, plc_course: @unit_group.plc_course)]
+        user_course_enrollments = [Plc::UserCourseEnrollment.find_by(user: current_user, plc_course: unit_group.plc_course)]
         render 'plc/user_course_enrollments/index', locals: {user_course_enrollments: user_course_enrollments}
         return
       end
 
-      if @unit_group.pilot?
+      if unit_group.pilot?
         authenticate_user!
-        unless @unit_group.has_pilot_access?(current_user)
+        unless unit_group.has_pilot_access?(current_user)
           render :no_access
           return
         end
       end
 
-      if @unit_group.in_development?
+      if unit_group.in_development?
         authenticate_user!
         unless current_user.permission?(UserPermission::LEVELBUILDER)
           render :no_access
@@ -61,16 +56,16 @@ class CoursesController < ApplicationController
       end
 
       # Attempt to redirect user if we think they ended up on the wrong course overview page.
-      override_redirect = VersionRedirectOverrider.override_course_redirect?(session, @unit_group)
-      if !override_redirect && redirect_unit_group = redirect_unit_group(@unit_group)
+      override_redirect = VersionRedirectOverrider.override_course_redirect?(session, unit_group)
+      if !override_redirect && redirect_unit_group = redirect_unit_group(unit_group)
         redirect_to "#{course_path(redirect_unit_group)}/?redirect_warning=true"
         return
       end
 
       sections = current_user.try {|u| u.sections.where(hidden: false).select(:id, :name, :course_id, :script_id)}
-      @sections_with_assigned_info = sections&.map {|section| section.attributes.merge!({"isAssigned" => section[:course_id] == @unit_group.id})}
+      @sections_with_assigned_info = sections&.map {|section| section.attributes.merge!({"isAssigned" => section[:course_id] == unit_group.id})}
 
-      render 'show', locals: {unit_group: @unit_group, redirect_warning: params[:redirect_warning] == 'true'}
+      render 'show', locals: {unit_group: unit_group, redirect_warning: params[:redirect_warning] == 'true'}
     elsif UnitGroup.family_names.include?(params[:course_name])
       # csp and csd are each "course families", each containing multiple "course versions".
       # When the url of a course family is requested, redirect to a specific course version.
@@ -87,89 +82,99 @@ class CoursesController < ApplicationController
   end
 
   def create
-    @unit_group = UnitGroup.new(
+    unit_group = UnitGroup.new(
       name: params.require(:course).require(:name),
       family_name: params.require(:family_name),
       version_year: params.require(:version_year),
       has_numbered_units: true
     )
-    if @unit_group.save
-      @unit_group.write_serialization
-      redirect_to action: :edit, course_name: @unit_group.name
+    if unit_group.save
+      unit_group.write_serialization
+      redirect_to action: :edit, course_name: unit_group.name
     else
-      render 'new', locals: {unit_group: @unit_group}
+      render 'new', locals: {unit_group: unit_group}
     end
   end
 
   def update
-    @unit_group = UnitGroup.find_by_name!(params[:course_name])
-    @unit_group.persist_strings_and_units_changes(params[:scripts], params[:alternate_units], i18n_params)
-    @unit_group.update(course_params)
-    @unit_group.write_serialization
-    CourseOffering.add_course_offering(@unit_group)
-    @unit_group.reload
+    unit_group = UnitGroup.find_by_name!(params[:course_name])
+    unit_group.persist_strings_and_units_changes(params[:scripts], params[:alternate_units], i18n_params)
+    unit_group.update(course_params)
+    unit_group.write_serialization
+    CourseOffering.add_course_offering(unit_group)
+    unit_group.reload
 
-    @unit_group.update_teacher_resources(params[:resourceTypes], params[:resourceLinks]) unless @unit_group.has_migrated_unit?
-    if @unit_group.has_migrated_unit? && @unit_group.course_version
-      @unit_group.resources = params[:resourceIds].map {|id| Resource.find(id)} if params.key?(:resourceIds)
-      @unit_group.student_resources = params[:studentResourceIds].map {|id| Resource.find(id)} if params.key?(:studentResourceIds)
+    unit_group.update_teacher_resources(params[:resourceTypes], params[:resourceLinks]) unless unit_group.has_migrated_unit?
+    if unit_group.has_migrated_unit? && unit_group.course_version
+      unit_group.resources = params[:resourceIds].map {|id| Resource.find(id)} if params.key?(:resourceIds)
+      unit_group.student_resources = params[:studentResourceIds].map {|id| Resource.find(id)} if params.key?(:studentResourceIds)
     end
 
-    @unit_group.reload
-    render json: @unit_group.summarize
+    unit_group.reload
+    render json: unit_group.summarize
   end
 
   def edit
+    unit_group = UnitGroup.find_by_name!(params[:course_name])
+
     # We don't support an edit experience for plc courses
-    raise ActiveRecord::ReadOnlyRecord if @unit_group.try(:plc_course)
-    render 'edit', locals: {unit_group: @unit_group}
+    raise ActiveRecord::ReadOnlyRecord if unit_group.try(:plc_course)
+    render 'edit', locals: {unit_group: unit_group}
   end
 
   def vocab
+    unit_group = UnitGroup.get_from_cache(params[:course_name])
+    raise ActiveRecord::RecordNotFound unless unit_group
     # Assumes if one unit in a unit group is migrated they all are
-    return render :forbidden unless @unit_group.default_units[0].is_migrated
-    @course_summary = @unit_group.summarize_for_rollup(@current_user)
+    return render :forbidden unless unit_group.default_units[0].is_migrated
+    @course_summary = unit_group.summarize_for_rollup(@current_user)
   end
 
   def resources
+    unit_group = UnitGroup.get_from_cache(params[:course_name])
+    raise ActiveRecord::RecordNotFound unless unit_group
     # Assumes if one unit in a unit group is migrated they all are
-    return render :forbidden unless @unit_group.default_units[0].is_migrated
-    @course_summary = @unit_group.summarize_for_rollup(@current_user)
+    return render :forbidden unless unit_group.default_units[0].is_migrated
+    @course_summary = unit_group.summarize_for_rollup(@current_user)
   end
 
   def code
+    unit_group = UnitGroup.get_from_cache(params[:course_name])
+    raise ActiveRecord::RecordNotFound unless unit_group
     # Assumes if one unit in a unit group is migrated they all are
-    return render :forbidden unless @unit_group.default_units[0].is_migrated
-    @course_summary = @unit_group.summarize_for_rollup(@current_user)
+    return render :forbidden unless unit_group.default_units[0].is_migrated
+    @course_summary = unit_group.summarize_for_rollup(@current_user)
   end
 
   def standards
-    if !@unit_group.present? && UnitGroup.family_names.include?(params[:course_name])
+    unit_group = UnitGroup.get_from_cache(params[:course_name])
+    if !unit_group.present? && UnitGroup.family_names.include?(params[:course_name])
       redirect_to_course = UnitGroup.latest_stable(params[:course_name])
       redirect_to standards_course_path(redirect_to_course)
       return
     end
-    raise ActiveRecord::RecordNotFound unless @unit_group
+    raise ActiveRecord::RecordNotFound unless unit_group
     # Assumes if one unit in a unit group is migrated they all are
-    return render :forbidden unless @unit_group.default_units[0].is_migrated
-    @course_summary = @unit_group.summarize_for_rollup(@current_user)
+    return render :forbidden unless unit_group.default_units[0].is_migrated
+    @course_summary = unit_group.summarize_for_rollup(@current_user)
   end
 
   def get_rollup_resources
-    course_version = @unit_group.course_version
+    unit_group = UnitGroup.get_from_cache(params[:course_name])
+    course_version = unit_group.course_version
     return render status: 400, json: {error: 'Course does not have course version'} unless course_version
     rollup_pages = []
-    if @unit_group.default_units.any? {|s| s.lessons.any? {|l| !l.programming_expressions.empty?}}
-      rollup_pages.append(Resource.find_or_create_by!(name: 'All Code', url: code_course_path(@unit_group), course_version_id: course_version.id))
+    if unit_group.default_units.any? {|s| s.lessons.any? {|l| !l.programming_expressions.empty?}}
+      rollup_pages.append(Resource.find_or_create_by!(name: 'All Code', url: code_course_path(unit_group), course_version_id: course_version.id))
     end
-    if @unit_group.default_units.any? {|s| s.lessons.any? {|l| !l.resources.empty?}}
-      rollup_pages.append(Resource.find_or_create_by!(name: 'All Resources', url: resources_course_path(@unit_group), course_version_id: course_version.id))
+    if unit_group.default_units.any? {|s| s.lessons.any? {|l| !l.resources.empty?}}
+      rollup_pages.append(Resource.find_or_create_by!(name: 'All Resources', url: resources_course_path(unit_group), course_version_id: course_version.id))
     end
-    if @unit_group.default_units.any? {|s| s.lessons.any? {|l| !l.standards.empty?}}
-      rollup_pages.append(Resource.find_or_create_by!(name: 'All Standards', url: standards_course_path(@unit_group), course_version_id: course_version.id))
+    if unit_group.default_units.any? {|s| s.lessons.any? {|l| !l.standards.empty?}}
+      rollup_pages.append(Resource.find_or_create_by!(name: 'All Standards', url: standards_course_path(unit_group), course_version_id: course_version.id))
     end
-    if @unit_group.default_units.any? {|s| s.lessons.any? {|l| !l.vocabularies.empty?}}
-      rollup_pages.append(Resource.find_or_create_by!(name: 'All Vocabulary', url: vocab_course_path(@unit_group), course_version_id: course_version.id))
+    if unit_group.default_units.any? {|s| s.lessons.any? {|l| !l.vocabularies.empty?}}
+      rollup_pages.append(Resource.find_or_create_by!(name: 'All Vocabulary', url: vocab_course_path(unit_group), course_version_id: course_version.id))
     end
     rollup_pages.each do |r|
       r.is_rollup = true

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -254,10 +254,6 @@ class Ability
       true
     end
 
-    can [:vocab, :resources, :code, :standards], Script do |script|
-      !!script.is_migrated
-    end
-
     # Override UnitGroup, Unit, Lesson and ScriptLevel.
     can :read, UnitGroup do |unit_group|
       if unit_group.in_development?
@@ -291,6 +287,10 @@ class Ability
         login_required = script.login_required? || (!params.nil? && params[:login_required] == "true")
         user.persisted? || !login_required
       end
+    end
+
+    can [:vocab, :resources, :code, :standards], Script do |script|
+      !!script.is_migrated
     end
 
     can [:read, :show_by_id, :student_lesson_plan], Lesson do |lesson|
@@ -369,12 +369,12 @@ class Ability
     end
 
     if user.persisted?
+      # TODO: should add editor experiment for Unit Group
       editor_experiment = Experiment.get_editor_experiment(user)
       if editor_experiment
         can :index, Level
         can :clone, Level, &:custom?
         can :manage, Level, editor_experiment: editor_experiment
-        can [:edit, :update], UnitGroup, editor_experiment: editor_experiment
         can [:edit, :update], Script, editor_experiment: editor_experiment
         can [:edit, :update], Lesson, editor_experiment: editor_experiment
       end

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -14,6 +14,7 @@ class Ability
     can :read, :all
     cannot :read, [
       TeacherFeedback,
+      UnitGroup, # see override below
       Script, # see override below
       Lesson, # see override below
       ScriptLevel, # see override below
@@ -253,6 +254,10 @@ class Ability
       true
     end
 
+    can [:vocab, :resources, :code, :standards], Script do |script|
+      !!script.is_migrated
+    end
+
     # Override UnitGroup, Unit, Lesson and ScriptLevel.
     can :read, UnitGroup do |unit_group|
       if unit_group.in_development?
@@ -286,10 +291,6 @@ class Ability
         login_required = script.login_required? || (!params.nil? && params[:login_required] == "true")
         user.persisted? || !login_required
       end
-    end
-
-    can [:vocab, :resources, :code, :standards], Script do |script|
-      !!script.is_migrated
     end
 
     can [:read, :show_by_id, :student_lesson_plan], Lesson do |lesson|
@@ -373,6 +374,7 @@ class Ability
         can :index, Level
         can :clone, Level, &:custom?
         can :manage, Level, editor_experiment: editor_experiment
+        can [:edit, :update], UnitGroup, editor_experiment: editor_experiment
         can [:edit, :update], Script, editor_experiment: editor_experiment
         can [:edit, :update], Lesson, editor_experiment: editor_experiment
       end

--- a/dashboard/test/models/ability_test.rb
+++ b/dashboard/test/models/ability_test.rb
@@ -3,6 +3,7 @@ require 'test_helper'
 class AbilityTest < ActiveSupport::TestCase
   self.use_transactional_test_case = true
   setup_all do
+    @public_unit_group = create(:unit_group)
     @public_script = create(:script).tap do |script|
       @public_script_level = create(:script_level, script: script)
     end
@@ -13,6 +14,12 @@ class AbilityTest < ActiveSupport::TestCase
 
     @login_required_migrated_script = create(:script, login_required: true, is_migrated: true).tap do |script|
       @login_required_migrated_lesson = create(:lesson, script: script, has_lesson_plan: true)
+    end
+
+    @in_development_unit_group = create(:unit_group, published_state: 'in_development')
+    @in_development_script = create(:script, published_state: 'in_development').tap do |script|
+      @in_development_lesson = create(:lesson, script: script, has_lesson_plan: true)
+      @in_development_script_level = create(:script_level, script: script)
     end
   end
 
@@ -38,6 +45,7 @@ class AbilityTest < ActiveSupport::TestCase
     assert ability.can?(:read, Script.find_by_name('ECSPD'))
     assert ability.can?(:read, Script.find_by_name('flappy'))
 
+    refute ability.can?(:read, @in_development_script)
     assert ability.can?(:read, @public_script)
     assert ability.can?(:read, @login_required_script)
 
@@ -47,6 +55,9 @@ class AbilityTest < ActiveSupport::TestCase
     assert ability.can?(:read, @public_script_level)
     refute ability.can?(:read, @public_script_level, {login_required: "true"})
     refute ability.can?(:read, @login_required_script_level)
+
+    assert ability.can?(:read, @public_unit_group)
+    refute ability.can?(:read, @in_development_unit_group)
   end
 
   test "as student" do
@@ -65,6 +76,7 @@ class AbilityTest < ActiveSupport::TestCase
     assert ability.can?(:read, Script.find_by_name('ECSPD'))
     assert ability.can?(:read, Script.find_by_name('flappy'))
 
+    refute ability.can?(:read, @in_development_script)
     assert ability.can?(:read, @public_script)
     assert ability.can?(:read, @login_required_script)
 
@@ -74,6 +86,9 @@ class AbilityTest < ActiveSupport::TestCase
     assert ability.can?(:read, @public_script_level)
     assert ability.can?(:read, @public_script_level, {login_required: "true"})
     assert ability.can?(:read, @login_required_script_level)
+
+    assert ability.can?(:read, @public_unit_group)
+    refute ability.can?(:read, @in_development_unit_group)
   end
 
   test "as teacher" do
@@ -92,6 +107,7 @@ class AbilityTest < ActiveSupport::TestCase
     assert ability.can?(:read, Script.find_by_name('ECSPD'))
     assert ability.can?(:read, Script.find_by_name('flappy'))
 
+    refute ability.can?(:read, @in_development_script)
     assert ability.can?(:read, @public_script)
     assert ability.can?(:read, @login_required_script)
 
@@ -101,6 +117,9 @@ class AbilityTest < ActiveSupport::TestCase
     assert ability.can?(:read, @public_script_level)
     assert ability.can?(:read, @public_script_level, {login_required: "true"})
     assert ability.can?(:read, @login_required_script_level)
+
+    assert ability.can?(:read, @public_unit_group)
+    refute ability.can?(:read, @in_development_unit_group)
   end
 
   test "as admin" do
@@ -121,6 +140,7 @@ class AbilityTest < ActiveSupport::TestCase
     assert ability.cannot?(:read, Script.find_by_name('ECSPD'))
     assert ability.cannot?(:read, Script.find_by_name('flappy'))
 
+    assert ability.cannot?(:read, @in_development_script)
     assert ability.cannot?(:read, @public_script)
     assert ability.cannot?(:read, @login_required_script)
 
@@ -129,6 +149,30 @@ class AbilityTest < ActiveSupport::TestCase
 
     assert ability.cannot?(:read, @public_script_level)
     assert ability.cannot?(:read, @login_required_script_level)
+
+    assert ability.cannot?(:read, @public_unit_group)
+    assert ability.cannot?(:read, @in_development_unit_group)
+  end
+
+  test "as levelbuilder" do
+    ability = Ability.new(create(:levelbuilder))
+
+    assert ability.can?(:read, Script.find_by_name('ECSPD'))
+    assert ability.can?(:read, Script.find_by_name('flappy'))
+
+    assert ability.can?(:read, @in_development_script)
+    assert ability.can?(:read, @public_script)
+    assert ability.can?(:read, @login_required_script)
+
+    assert ability.can?(:read, @login_required_migrated_lesson)
+    assert ability.can?(:student_lesson_plan, @login_required_migrated_lesson)
+
+    assert ability.can?(:read, @public_script_level)
+    assert ability.can?(:read, @public_script_level, {login_required: "true"})
+    assert ability.can?(:read, @login_required_script_level)
+
+    assert ability.can?(:read, @public_unit_group)
+    assert ability.can?(:read, @in_development_unit_group)
   end
 
   test 'teachers read their Section' do
@@ -183,6 +227,7 @@ class AbilityTest < ActiveSupport::TestCase
     refute ability.can?(:manage, Script)
     refute ability.can?(:manage, Lesson)
     refute ability.can?(:manage, ScriptLevel)
+    refute ability.can?(:manage, UnitGroup)
   end
 
   test 'levelbuilders can manage appropriate objects in levelbuilder mode' do
@@ -196,6 +241,7 @@ class AbilityTest < ActiveSupport::TestCase
     assert ability.can?(:manage, Script)
     assert ability.can?(:manage, Lesson)
     assert ability.can?(:manage, ScriptLevel)
+    assert ability.can?(:manage, UnitGroup)
   end
 
   test 'teachers can manage feedback for students in a section they own' do


### PR DESCRIPTION
`can?(:read, UnitGroup)` was not working because it was not included in the list in ability.rb of things that cannot be read. https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/ability.rb#L15-L62 . This meant the override created below was getting ignored because it thought everyone could read UnitGroup. 

This PR fixes that in ability.rb as well as adding tests to ability_test.rb to make sure that `can?` is working correctly for UnitGroup. 

In addition I have pulled out the set up of `@unit_group` in order to prepare for more changes that will be made when moving to checking if someone can be a participant or instructor to view courses.

## Testing story

- New and Existing Unit Tests