### PR TITLE
Show test button when editing start sources

### DIFF
--- a/apps/src/javalab/JavalabView.jsx
+++ b/apps/src/javalab/JavalabView.jsx
@@ -248,9 +248,10 @@ class JavalabView extends React.Component {
                     disableTestButton={awaitingContainedResponse || !canTest}
                     onContinue={() => onContinue(isSubmittable)}
                     renderSettings={this.renderSettings}
-                    showTestButton={experiments.isEnabled(
-                      experiments.JAVALAB_UNIT_TESTS
-                    )}
+                    showTestButton={
+                      isEditingStartSources ||
+                      experiments.isEnabled(experiments.JAVALAB_UNIT_TESTS)
+                    }
                     isSubmittable={isSubmittable}
                     isSubmitted={isSubmitted}
                   />


### PR DESCRIPTION
Shows "Test" button when in start mode on levelbuilder.

## Testing story

Tested manually that the test button appeared in levelbuilder locally and that I could run a test successfully. Also observed button not appearing in other Javalab settings (eg, allthethings).