### PR TITLE
Create ReferenceGuide model and import script from curriculumbuilder

### DIFF
--- a/bin/curriculum/import_reference_guides.rb
+++ b/bin/curriculum/import_reference_guides.rb
@@ -1,0 +1,121 @@
+#!/usr/bin/env ruby
+
+require 'json'
+require 'optparse'
+require 'uri'
+require 'net/http'
+require_relative '../../deployment'
+require 'cdo/lesson_import_helper'
+
+raise unless [:development, :adhoc, :levelbuilder].include? rack_env
+
+$verbose = false
+def log(str)
+  puts str if $verbose
+end
+
+$quiet = false
+def warn(str)
+  puts str unless $quiet && !$verbose
+end
+
+# Wait until after initial error checking before loading the rails environment.
+def require_rails_env
+  log "loading rails environment..."
+  start_time = Time.now
+  require_relative '../../dashboard/config/environment'
+  log "rails environment loaded in #{(Time.now - start_time).to_i} seconds."
+end
+
+def parse_options
+  OpenStruct.new.tap do |options|
+    options.local = false
+    options.dry_run = false
+
+    opt_parser = OptionParser.new do |opts|
+      opts.banner = <<~BANNER
+
+        Usage: #{$0} [options]
+      BANNER
+
+      opts.separator ""
+
+      opts.on('-l', '--local', 'Use local curriculum builder running on localhost:8000.') do
+        options.local = true
+      end
+
+      opts.on('-n', '--dry-run', 'Perform basic validation without importing any data.') do
+        options.dry_run = true
+      end
+
+      opts.on('-q', '--quiet', 'Silence warnings.') do
+        $quiet = true
+      end
+
+      opts.on('-v', '--verbose', 'Use verbose debug logging.') do
+        $verbose = true
+      end
+
+      opts.on_tail("-h", "--help", "Show this message") do
+        puts opts
+        exit
+      end
+    end
+
+    opt_parser.parse!(ARGV)
+  end
+end
+
+def main(options)
+  cb_url_prefix = options.local ? 'http://localhost:8000' : 'http://www.codecurricula.com'
+
+  # recursively find all the maps!
+  map_stack = ['concepts']
+  updated_reference_guide_count = 0
+
+  until map_stack.empty?
+    map_to_fetch = map_stack.pop
+
+    puts "Fetching #{map_to_fetch}"
+
+    url = "#{cb_url_prefix}/documentation/export/#{map_to_fetch}.json?format=json"
+    map_json = fetch(url)
+
+    map = JSON.parse(map_json)
+    updated_reference_guide_count += 1
+
+    map_stack.concat(map['children'])
+
+    next if options.dry_run
+
+    # <CourseVersion id: 107, key: "2022", display_name: "2022"...
+    default_course_version = CourseVersion.find_by(id: 107)
+
+    reference_guide = ReferenceGuide.find_or_initialize_by(
+      {
+        name: map['title'],
+        slug: map['slug'],
+        content: map['content'],
+      }
+    )
+    reference_guide.course_version = default_course_version
+    reference_guide.save! if reference_guide.changed?
+    reference_guide.write_serialization
+  end
+
+  puts "updated #{updated_reference_guide_count} reference guides"
+end
+
+def fetch(url)
+  uri = URI(url)
+  response = Net::HTTP.get_response(uri)
+  raise "HTTP status #{response.code} fetching #{uri}" unless response.is_a? Net::HTTPSuccess
+  body = response.body
+  log "fetched #{body.length} bytes of unit json from #{uri}"
+  body
+end
+
+options = parse_options
+
+require_rails_env
+main(options)

--- a/bin/curriculum/import_reference_guides.rb
+++ b/bin/curriculum/import_reference_guides.rb
@@ -42,7 +42,7 @@ def parse_options
 
       opts.separator ""
 
-      opts.on('-c', '--course-offering course_offering', 'Specify course offering key. Default: csd') do |course_offering|
+      opts.on('-c', '--course-offering course_offering', 'Specify course offering key. Default: csp') do |course_offering|
         options.course_offering = course_offering
       end
 
@@ -110,14 +110,14 @@ def main(options)
 
     reference_guide = ReferenceGuide.find_or_initialize_by(
       {
-        display_name: map['title'],
         key: map['slug'],
-        content: map['content'],
-        position: map['order'],
+        course_version_id: course_version.id
       }
     )
 
-    reference_guide.course_version = course_version
+    reference_guide.display_name = map['title']
+    reference_guide.content = map['content']
+    reference_guide.position = map['order']
     reference_guide.save!
     reference_guide.write_serialization
   end

--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -26,6 +26,7 @@ class CourseVersion < ApplicationRecord
   belongs_to :course_offering
   has_many :resources
   has_many :vocabularies
+  has_many :reference_guides
 
   attr_readonly :content_root_type
   attr_readonly :content_root_id

--- a/dashboard/app/models/reference_guide.rb
+++ b/dashboard/app/models/reference_guide.rb
@@ -44,7 +44,6 @@ class ReferenceGuide < ApplicationRecord
   def self.seed_all
     removed_records = all.pluck(:id)
     Dir.glob(Rails.root.join("config/reference_guides/**/*.json")).each do |path|
-      puts path
       removed_records -= [ReferenceGuide.seed_record(path)]
     end
     where(id: removed_records).destroy_all

--- a/dashboard/app/models/reference_guide.rb
+++ b/dashboard/app/models/reference_guide.rb
@@ -1,3 +1,5 @@
+require 'fileutils'
+
 # == Schema Information
 #
 # Table name: reference_guides
@@ -12,4 +14,57 @@
 #  updated_at        :datetime         not null
 #
 class ReferenceGuide < ApplicationRecord
+  belongs_to :course_version
+
+  validates_uniqueness_of :slug, scope: :course_version_id
+
+  def serialize
+    {
+      id: id,
+      name: name,
+      slug: slug,
+      course_version_id: course_version_id,
+      content: content,
+      order: order
+    }
+  end
+
+  def write_serialization
+    return unless Rails.application.config.levelbuilder_mode
+    file_path = Rails.root.join("config/reference_guides/#{slug}.json")
+    object_to_serialize = serialize
+    dirname = File.dirname(file_path)
+    unless File.directory?(dirname)
+      FileUtils.mkdir_p(dirname)
+    end
+    File.write(file_path, JSON.pretty_generate(object_to_serialize))
+  end
+
+  def self.seed_all
+    removed_records = all.pluck(:id)
+    Dir.glob(Rails.root.join("config/reference_guides/**/*.json")).each do |path|
+      puts path
+      removed_records -= [ReferenceGuide.seed_record(path)]
+    end
+    where(id: removed_records).destroy_all
+  end
+
+  def self.properties_from_file(content)
+    config = JSON.parse(content)
+    {
+      id: config['id'],
+      name: config['name'],
+      course_version_id: config['course_version_id'],
+      slug: config['slug'],
+      content: config['content'],
+      order: config['order']
+    }
+  end
+
+  def self.seed_record(file_path)
+    properties = properties_from_file(File.read(file_path))
+    environment = ReferenceGuide.find_or_initialize_by(id: properties[:id])
+    environment.update! properties
+    environment.id
+  end
 end

--- a/dashboard/app/models/reference_guide.rb
+++ b/dashboard/app/models/reference_guide.rb
@@ -1,0 +1,15 @@
+# == Schema Information
+#
+# Table name: reference_guides
+#
+#  id                :bigint           not null, primary key
+#  display_name      :string(255)
+#  key               :string(255)      not null
+#  course_version_id :integer          not null
+#  content           :text(65535)
+#  position          :integer          not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#
+class ReferenceGuide < ApplicationRecord
+end

--- a/dashboard/db/migrate/20211217193721_create_reference_guides.rb
+++ b/dashboard/db/migrate/20211217193721_create_reference_guides.rb
@@ -1,0 +1,13 @@
+class CreateReferenceGuides < ActiveRecord::Migration[5.2]
+  def change
+    create_table :reference_guides do |t|
+      t.string :display_name
+      t.string :key, null: false
+      t.integer :course_version_id, null: false
+      t.text :content
+      t.integer :position, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -1393,6 +1393,16 @@ ActiveRecord::Schema.define(version: 2021_12_19_004355) do
     t.index ["user_id"], name: "index_queued_account_purges_on_user_id", unique: true
   end
 
+  create_table "reference_guides", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+    t.string "display_name"
+    t.string "key", null: false
+    t.integer "course_version_id", null: false
+    t.text "content"
+    t.integer "position", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "regional_partner_program_managers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "program_manager_id", null: false
     t.integer "regional_partner_id", null: false

--- a/dashboard/test/factories/curriculum_factories.rb
+++ b/dashboard/test/factories/curriculum_factories.rb
@@ -1,22 +1,13 @@
-# == Schema Information
-#
-# Table name: reference_guides
-#
-#  id                :bigint           not null, primary key
-#  display_name      :string(255)
-#  key               :string(255)      not null
-#  course_version_id :integer          not null
-#  content           :text(65535)
-#  position          :integer          not null
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#
 FactoryGirl.define do
   factory :reference_guide do
+    association :course_version
+
+    position do |reference_guide|
+      (reference_guide.course_version.reference_guides.maximum(:position) || 0) + 1 if reference_guide.course_version
+    end
+
     display_name "reference guide"
     key "category/reference-guide"
-    course_version_id 1
     content "Some text is here\r\nand here also"
-    position 1
   end
 end

--- a/dashboard/test/factories/curriculum_factories.rb
+++ b/dashboard/test/factories/curriculum_factories.rb
@@ -3,20 +3,20 @@
 # Table name: reference_guides
 #
 #  id                :bigint           not null, primary key
-#  name              :string(255)
-#  slug              :string(255)
-#  course_version_id :integer
+#  display_name      :string(255)
+#  key               :string(255)      not null
+#  course_version_id :integer          not null
 #  content           :text(65535)
-#  order             :integer
+#  position          :integer          not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #
 FactoryGirl.define do
   factory :reference_guide do
-    name "reference guide"
-    slug "category/reference-guide"
+    display_name "reference guide"
+    key "category/reference-guide"
     course_version_id 1
     content "Some text is here\r\nand here also"
-    order 1
+    position 1
   end
 end

--- a/dashboard/test/factories/reference_guides.rb
+++ b/dashboard/test/factories/reference_guides.rb
@@ -1,4 +1,22 @@
+# == Schema Information
+#
+# Table name: reference_guides
+#
+#  id                :bigint           not null, primary key
+#  name              :string(255)
+#  slug              :string(255)
+#  course_version_id :integer
+#  content           :text(65535)
+#  order             :integer
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#
 FactoryGirl.define do
   factory :reference_guide do
+    name "reference guide"
+    slug "category/reference-guide"
+    course_version_id 1
+    content "Some text is here\r\nand here also"
+    order 1
   end
 end

--- a/dashboard/test/factories/reference_guides.rb
+++ b/dashboard/test/factories/reference_guides.rb
@@ -1,0 +1,4 @@
+FactoryGirl.define do
+  factory :reference_guide do
+  end
+end

--- a/dashboard/test/models/reference_guide_test.rb
+++ b/dashboard/test/models/reference_guide_test.rb
@@ -7,24 +7,24 @@ class ReferenceGuideTest < ActiveSupport::TestCase
   end
 
   test "reference guides are unique by slug in course version" do
-    create :reference_guide, key: 'hello/world', course_version_id: 1
-    create :reference_guide, key: 'hello/world', course_version_id: 2
+    create :reference_guide, key: 'category/page', course_version_id: 1
+    create :reference_guide, key: 'category/page', course_version_id: 2
     assert_raises ActiveRecord::RecordInvalid do
-      create :reference_guide, key: 'hello/world', course_version_id: 1
+      create :reference_guide, key: 'category/page', course_version_id: 1
     end
   end
 
   test "reference guides seed from files correctly" do
-    co = create :course_offering, key: 'course'
-    cv = create :course_version, key: 'version', course_offering: co
-    guide = create :reference_guide, id: '1', display_name: 'World', key: 'hello/world', content: 'hello world', course_version_id: cv.id, position: 2
+    co = create :course_offering, key: 'csp'
+    cv = create :course_version, key: '2022', course_offering: co
+    guide = create :reference_guide, id: '1', display_name: 'Hello World', key: 'category/page', content: 'page content', course_version_id: cv.id, position: 2
     serialization = guide.serialize
     previous_guide = guide.freeze
     guide.destroy!
 
     File.stubs(:read).returns(serialization.to_json)
 
-    new_guide_id = ReferenceGuide.seed_record("config/reference_guides/course_version/hello/world.json")
+    new_guide_id = ReferenceGuide.seed_record("config/reference_guides/csp_2022/category/page.json")
     new_guide = ReferenceGuide.find_by(id: new_guide_id)
     assert_equal previous_guide.attributes.except('id', 'created_at', 'updated_at'),
       new_guide.attributes.except('id', 'created_at', 'updated_at')

--- a/dashboard/test/models/reference_guide_test.rb
+++ b/dashboard/test/models/reference_guide_test.rb
@@ -7,27 +7,24 @@ class ReferenceGuideTest < ActiveSupport::TestCase
   end
 
   test "reference guides are unique by slug in course version" do
-    create :reference_guide, slug: 'hello/world', course_version_id: 1
-    create :reference_guide, slug: 'hello/world', course_version_id: 2
+    create :reference_guide, key: 'hello/world', course_version_id: 1
+    create :reference_guide, key: 'hello/world', course_version_id: 2
     assert_raises ActiveRecord::RecordInvalid do
-      create :reference_guide, slug: 'hello/world', course_version_id: 1
+      create :reference_guide, key: 'hello/world', course_version_id: 1
     end
   end
 
-  test "serialization creates files correctly" do
-    reference_guide = create :reference_guide
-    reference_guide.write_serialization
-  end
-
   test "reference guides seed from files correctly" do
-    guide = create :reference_guide, id: '1', name: 'World', slug: 'hello/world', content: 'hello world', course_version_id: 3, order: 2
+    co = create :course_offering, key: 'course'
+    cv = create :course_version, key: 'version', course_offering: co
+    guide = create :reference_guide, id: '1', display_name: 'World', key: 'hello/world', content: 'hello world', course_version_id: cv.id, position: 2
     serialization = guide.serialize
     previous_guide = guide.freeze
     guide.destroy!
 
     File.stubs(:read).returns(serialization.to_json)
 
-    new_guide_id = ReferenceGuide.seed_record("config/reference_guides/hello/world.json")
+    new_guide_id = ReferenceGuide.seed_record("config/reference_guides/course_version/hello/world.json")
     new_guide = ReferenceGuide.find_by(id: new_guide_id)
     assert_equal previous_guide.attributes.except('id', 'created_at', 'updated_at'),
       new_guide.attributes.except('id', 'created_at', 'updated_at')

--- a/dashboard/test/models/reference_guide_test.rb
+++ b/dashboard/test/models/reference_guide_test.rb
@@ -1,7 +1,35 @@
 require 'test_helper'
 
 class ReferenceGuideTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "can create reference guide" do
+    reference_guide = create :reference_guide
+    assert reference_guide.id
+  end
+
+  test "reference guides are unique by slug in course version" do
+    create :reference_guide, slug: 'hello/world', course_version_id: 1
+    create :reference_guide, slug: 'hello/world', course_version_id: 2
+    assert_raises ActiveRecord::RecordInvalid do
+      create :reference_guide, slug: 'hello/world', course_version_id: 1
+    end
+  end
+
+  test "serialization creates files correctly" do
+    reference_guide = create :reference_guide
+    reference_guide.write_serialization
+  end
+
+  test "reference guides seed from files correctly" do
+    guide = create :reference_guide, id: '1', name: 'World', slug: 'hello/world', content: 'hello world', course_version_id: 3, order: 2
+    serialization = guide.serialize
+    previous_guide = guide.freeze
+    guide.destroy!
+
+    File.stubs(:read).returns(serialization.to_json)
+
+    new_guide_id = ReferenceGuide.seed_record("config/reference_guides/hello/world.json")
+    new_guide = ReferenceGuide.find_by(id: new_guide_id)
+    assert_equal previous_guide.attributes.except('id', 'created_at', 'updated_at'),
+      new_guide.attributes.except('id', 'created_at', 'updated_at')
+  end
 end

--- a/dashboard/test/models/reference_guide_test.rb
+++ b/dashboard/test/models/reference_guide_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ReferenceGuideTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Adds a ReferenceGuide model in dashboard and an import script to import concept maps and store them as reference guides.
Serializes reference guides as json on import.
Relies on [PR](https://github.com/code-dot-org/curriculumbuilder/pull/377) for curriculumbuilder endpoint.

Currently, on import, new reference guides get attached to the '2022' course version. Is this right for an initial import at least? Eventually they would get cloned out to other course versions.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- spec: [eng plan](https://docs.google.com/document/d/1aYDcmHWY5mqHLk26IPxsC3hDNfotixd8u6ubaKDknJw/edit#heading=h.3i8gd730jmak)
- jira ticket: [PLAT-604](https://codedotorg.atlassian.net/browse/PLAT-604) [PLAT-356](https://codedotorg.atlassian.net/browse/PLAT-356)

## Testing story

Added unit tests.
Tested a local import from local cb server.
![image](https://user-images.githubusercontent.com/82416901/151087292-f216e303-802d-4df3-9118-d80f2c4fa443.png)


<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

No impact yet

## Follow-up work

Build out crud pages for reference guide editing.
Run import script once view page is ready.
