### PR TITLE
Styling polish for code review groups

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -810,7 +810,7 @@
   "endOfLesson": "Congratulations! You've reached the end of the lesson.",
   "englishOnly": "English-only",
   "englishOnlyWarning": "Sorry! This lesson is not available in your language. The levels in this lesson use a mix of English words and characters that can’t be translated right now. You can move on to Lesson {nextStage}.",
-  "enterGroupName": "Enter a group name",
+  "enterGroupName": "Enter a group name (optional)",
   "enterSectionCode": "Enter section code",
   "enrollmentDescription": "Join your teacher's classroom by entering their section code below. Teachers will be able to see your course progress, projects, and reset your password in case you forget it.",
   "equalTo": "Equal to",

--- a/apps/src/templates/codeReviewGroups/AssignedStudentsPanel.jsx
+++ b/apps/src/templates/codeReviewGroups/AssignedStudentsPanel.jsx
@@ -7,7 +7,8 @@ import CodeReviewGroup from './CodeReviewGroup';
 import {
   HEADER_STYLE,
   BUTTON_STYLE,
-  GROUPS_CONTAINER_STYLE
+  GROUPS_CONTAINER_STYLE,
+  HEADER_TITLE_STYLE
 } from './UnassignedStudentsPanel';
 
 export default function AssignedStudentsPanel({
@@ -21,7 +22,7 @@ export default function AssignedStudentsPanel({
   return (
     <div style={styles.groupsPanel}>
       <div style={styles.header}>
-        <span>{i18n.groups()}</span>
+        <span style={styles.headerTitle}>{i18n.groups()}</span>
         <JavalabButton
           onClick={onCreateGroupClick}
           icon={<FontAwesome icon="plus" className="fa" />}
@@ -60,6 +61,7 @@ const styles = {
     width: 500
   },
   header: HEADER_STYLE,
+  headerTitle: HEADER_TITLE_STYLE,
   button: BUTTON_STYLE,
   groupsContainer: GROUPS_CONTAINER_STYLE
 };

--- a/apps/src/templates/codeReviewGroups/CodeReviewGroup.jsx
+++ b/apps/src/templates/codeReviewGroups/CodeReviewGroup.jsx
@@ -66,7 +66,8 @@ const styles = {
   nameInput: {
     padding: '5px 12px',
     borderRadius: 4,
-    border: `1px solid ${color.lighter_gray}`
+    border: `1px solid ${color.lighter_gray}`,
+    width: '210px'
   },
   deleteButtonContainer: {
     display: 'flex',

--- a/apps/src/templates/codeReviewGroups/UnassignedStudentsPanel.jsx
+++ b/apps/src/templates/codeReviewGroups/UnassignedStudentsPanel.jsx
@@ -10,12 +10,10 @@ export default function UnassignedStudentsPanel({
   unassignedGroup,
   onUnassignAllClick
 }) {
-  // TO DO: implement unassigning students and style
-  // https://codedotorg.atlassian.net/browse/CSA-1028
   return (
     <div style={styles.unassignedStudentsPanel}>
       <div style={styles.header}>
-        <span>{i18n.unassignedStudents()}</span>
+        <span style={styles.headerTitle}>{i18n.unassignedStudents()}</span>
         <JavalabButton
           onClick={onUnassignAllClick}
           icon={<FontAwesome icon="times" className="fa" />}
@@ -46,11 +44,15 @@ export const HEADER_STYLE = {
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'space-between',
-  padding: '5px 10px 5px 5px',
+  padding: '5px 10px',
   border: `1px solid ${color.lighter_gray}`,
   background: color.lightest_gray,
   fontFamily: '"Gotham 5r", sans-serif',
   fontSize: 14
+};
+
+export const HEADER_TITLE_STYLE = {
+  margin: '5px'
 };
 
 export const BUTTON_STYLE = {
@@ -75,6 +77,7 @@ const styles = {
     width: 400
   },
   header: HEADER_STYLE,
+  headerTitle: HEADER_TITLE_STYLE,
   button: BUTTON_STYLE,
   groupsContainer: GROUPS_CONTAINER_STYLE,
   studentGroup: {

--- a/apps/src/templates/manageStudents/CodeReviewGroupsDialog.jsx
+++ b/apps/src/templates/manageStudents/CodeReviewGroupsDialog.jsx
@@ -9,7 +9,7 @@ import {addDroppableIdToGroups} from '../codeReviewGroups/CodeReviewGroupsUtils'
 import CodeReviewGroupsStatusToggle from '../codeReviewGroups/CodeReviewGroupsStatusToggle';
 import CodeReviewGroupsManager from '@cdo/apps/templates/codeReviewGroups/CodeReviewGroupsManager';
 
-const DIALOG_WIDTH = 1000;
+const DIALOG_WIDTH = 934;
 
 const SUBMIT_STATES = {
   DEFAULT: 'default',

--- a/apps/src/templates/manageStudents/CodeReviewGroupsDialog.jsx
+++ b/apps/src/templates/manageStudents/CodeReviewGroupsDialog.jsx
@@ -9,6 +9,7 @@ import {addDroppableIdToGroups} from '../codeReviewGroups/CodeReviewGroupsUtils'
 import CodeReviewGroupsStatusToggle from '../codeReviewGroups/CodeReviewGroupsStatusToggle';
 import CodeReviewGroupsManager from '@cdo/apps/templates/codeReviewGroups/CodeReviewGroupsManager';
 
+// Width taken from UI mocks (meant to fit in a minimum screen width of 1024px with some extra space)
 const DIALOG_WIDTH = 934;
 
 const SUBMIT_STATES = {


### PR DESCRIPTION
Small styling fixes for Code Review Groups
1. Reduced width from 1000px to 934px.
2. Changed placeholder to "Enter group name (optional)" and slightly increased input width accordingly
3. Adjusted margin on column titles so they're the same distance from the left edge as the buttons are from the right edge.

UI with fixes:

![Screen Shot 2022-01-19 at 4 08 21 PM](https://user-images.githubusercontent.com/85528507/150238674-b7cc9a4c-5584-483b-bf69-2767ae37875d.png)

## Links

JIRA: https://codedotorg.atlassian.net/browse/JAVA-310

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Tested locally

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
