### PR TITLE
Prefix suffix with underscore and improve logging

### DIFF
--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -654,28 +654,33 @@ class Level < ApplicationRecord
     return self if key.start_with?('blockly:')
 
     # Make sure we don't go over the 70 character limit.
-    max_index = 70 - new_suffix.length - 1
-    new_name = "#{base_name[0..max_index]}#{new_suffix}"
+    suffix = new_suffix[0] == '_' ? new_suffix : "_#{new_suffix}"
+    max_index = 70 - suffix.length - 1
+    new_name = "#{base_name[0..max_index]}#{suffix}"
 
     return Level.find_by_name(new_name) if Level.find_by_name(new_name)
 
-    level = clone_with_name(new_name, editor_experiment: editor_experiment)
+    begin
+      level = clone_with_name(new_name, editor_experiment: editor_experiment)
 
-    update_params = {name_suffix: new_suffix}
-    update_params[:editor_experiment] = editor_experiment if editor_experiment
+      update_params = {name_suffix: suffix}
+      update_params[:editor_experiment] = editor_experiment if editor_experiment
 
-    child_params_to_update = Level.clone_child_levels(level, new_suffix, editor_experiment: editor_experiment)
-    update_params.merge!(child_params_to_update)
+      child_params_to_update = Level.clone_child_levels(level, new_suffix, editor_experiment: editor_experiment)
+      update_params.merge!(child_params_to_update)
 
-    level.update!(update_params)
+      level.update!(update_params)
 
-    # Copy the level_concept_difficulty of the parent level to the new level
-    new_lcd = level_concept_difficulty.dup
-    level.level_concept_difficulty = new_lcd
-    # trigger a save to rewrite the custom level file
-    level.save!
+      # Copy the level_concept_difficulty of the parent level to the new level
+      new_lcd = level_concept_difficulty.dup
+      level.level_concept_difficulty = new_lcd
+      # trigger a save to rewrite the custom level file
+      level.save!
 
-    level
+      level
+    rescue Exception => e
+      raise e, "Failed to clone #{name} as #{new_name}. Message: #{e.message}"
+    end
   end
 
   def age_13_required?

--- a/dashboard/app/models/levels/level_group.rb
+++ b/dashboard/app/models/levels/level_group.rb
@@ -170,13 +170,18 @@ class LevelGroup < DSLDefined
   # Perform a deep copy of this level by cloning all of its sublevels
   # using the same suffix, and write them to the new level definition file.
   def clone_with_suffix(new_suffix, editor_experiment: nil)
-    new_name = "#{base_name}#{new_suffix}"
+    suffix = new_suffix[0] == '_' ? new_suffix : "_#{new_suffix}"
+    new_name = "#{base_name}#{suffix}"
     return Level.find_by_name(new_name) if Level.find_by_name(new_name)
 
-    level = super(new_suffix, editor_experiment: editor_experiment)
-    level.clone_sublevels_with_suffix(get_levels_and_texts_by_page, new_suffix)
-    level.rewrite_dsl_file(LevelGroupDSL.serialize(level))
-    level
+    begin
+      level = super(suffix, editor_experiment: editor_experiment)
+      level.clone_sublevels_with_suffix(get_levels_and_texts_by_page, suffix)
+      level.rewrite_dsl_file(LevelGroupDSL.serialize(level))
+      level
+    rescue Exception => e
+      raise e, "Failed to clone #{name} as #{new_name}. Message: #{e.message}"
+    end
   end
 
   # Clone the sublevels, adding the specified suffix to the level name. Also

--- a/dashboard/test/models/level_group_test.rb
+++ b/dashboard/test/models/level_group_test.rb
@@ -362,19 +362,19 @@ level 'level7_copy'"
   level 'level1'
   "
 
-    level_group_copy1_dsl = "name 'level_group_test assessment copy1'
+    level_group_copy1_dsl = "name 'level_group_test assessment_copy1'
 title 'Assessment'
 
 page
-text 'external1 copy1'
-level 'level1 copy1'"
+text 'external1_copy1'
+level 'level1_copy1'"
 
-    level_group_copy2_dsl = "name 'level_group_test assessment copy2'
+    level_group_copy2_dsl = "name 'level_group_test assessment_copy2'
 title 'Assessment'
 
 page
-text 'external1 copy2'
-level 'level1 copy2'"
+text 'external1_copy2'
+level 'level1_copy2'"
 
     # Create the multi level
     multi_dsl = get_multi_dsl(1)
@@ -391,19 +391,19 @@ level 'level1 copy2'"
     level_group.stubs(:dsl_text).returns(level_group_input_dsl)
 
     # Copy the level group and all its sub levels.
-    level_group_copy1 = level_group.clone_with_suffix(' copy1')
+    level_group_copy1 = level_group.clone_with_suffix('copy1')
     assert_equal level_group_copy1_dsl, level_group_copy1.dsl_text
-    assert_equal 'level_group_test assessment copy1', level_group_copy1.name
-    assert_equal 'level1 copy1', level_group_copy1.pages.first.levels.first.name
-    assert_equal 'external1 copy1', level_group_copy1.pages.first.texts.first.name
+    assert_equal 'level_group_test assessment_copy1', level_group_copy1.name
+    assert_equal 'level1_copy1', level_group_copy1.pages.first.levels.first.name
+    assert_equal 'external1_copy1', level_group_copy1.pages.first.texts.first.name
 
     # Copy the level group again. copy2 suffix replaces copy1 suffix throughout,
     # rather than being concatenated, due to name_suffix field.
-    level_group_copy2 = level_group.clone_with_suffix(' copy2')
+    level_group_copy2 = level_group.clone_with_suffix('_copy2')
     assert_equal level_group_copy2_dsl, level_group_copy2.dsl_text
-    assert_equal 'level_group_test assessment copy2', level_group_copy2.name
-    assert_equal 'level1 copy2', level_group_copy2.pages.first.levels.first.name
-    assert_equal 'external1 copy2', level_group_copy2.pages.first.texts.first.name
+    assert_equal 'level_group_test assessment_copy2', level_group_copy2.name
+    assert_equal 'level1_copy2', level_group_copy2.pages.first.levels.first.name
+    assert_equal 'external1_copy2', level_group_copy2.pages.first.texts.first.name
 
     # clean up
     File.delete(level_group_copy1.filename)

--- a/dashboard/test/models/level_test.rb
+++ b/dashboard/test/models/level_test.rb
@@ -837,23 +837,31 @@ class LevelTest < ActiveSupport::TestCase
     assert_equal 'Blue', new_level.properties['answers'].last['text']
     assert new_level.encrypted, 'clone_with_name preserves encrypted flag'
 
-    new_level = old_level.clone_with_suffix(' copy')
-    assert_equal 'old multi level copy', new_level.name
+    new_level = old_level.clone_with_suffix('_copy')
+    assert_equal 'old multi level_copy', new_level.name
     assert_equal 3, new_level.properties['answers'].length
     assert new_level.encrypted, 'clone_with_suffix preserves encrypted flag'
   end
 
   test 'can clone with suffix' do
     old_level = create :level, name: 'level', start_blocks: '<xml>foo</xml>'
-    new_level = old_level.clone_with_suffix(' copy')
-    assert_equal 'level copy', new_level.name
+    new_level = old_level.clone_with_suffix('_copy')
+    assert_equal 'level_copy', new_level.name
     assert_equal '<xml>foo</xml>', new_level.start_blocks
-    assert_equal ' copy', new_level.name_suffix
+    assert_equal '_copy', new_level.name_suffix
+  end
+
+  test 'underscore is prepended to suffix on clone_with_suffix' do
+    old_level = create :level, name: 'level', start_blocks: '<xml>foo</xml>'
+    new_level = old_level.clone_with_suffix('copy')
+    assert_equal 'level_copy', new_level.name
+    assert_equal '<xml>foo</xml>', new_level.start_blocks
+    assert_equal '_copy', new_level.name_suffix
   end
 
   test 'doesnt clone with suffix deprecated blockly levels' do
     old_level = create :level, name: 'blockly', level_num: 'blockly_level', start_blocks: '<xml>foo</xml>'
-    new_level = old_level.clone_with_suffix(' copy')
+    new_level = old_level.clone_with_suffix('_copy')
     assert_equal old_level, new_level
   end
 
@@ -877,7 +885,7 @@ class LevelTest < ActiveSupport::TestCase
     tricky_suffix = '!(."'
 
     level_2 = level_1.clone_with_suffix(tricky_suffix)
-    assert_equal "your_level_1#{tricky_suffix}", level_2.name
+    assert_equal "your_level_1_#{tricky_suffix}", level_2.name
 
     level_3 = level_2.clone_with_suffix('_3')
     assert_equal 'your_level_1_3', level_3.name
@@ -904,20 +912,20 @@ class LevelTest < ActiveSupport::TestCase
     level_2 = create :level, name: 'level 2'
     level_2.project_template_level_name = template_level.name
 
-    level_1_copy = level_1.clone_with_suffix(' copy')
-    level_2_copy = level_2.clone_with_suffix(' copy')
+    level_1_copy = level_1.clone_with_suffix('_copy')
+    level_2_copy = level_2.clone_with_suffix('_copy')
 
-    template_level_copy = Level.find_by_name('template level copy')
-    assert_equal ' copy', template_level_copy.name_suffix
+    template_level_copy = Level.find_by_name('template level_copy')
+    assert_equal '_copy', template_level_copy.name_suffix
     assert_equal '<xml>template</xml>', template_level_copy.start_blocks
 
     assert_equal template_level_copy, level_1_copy.project_template_level
-    assert_equal 'level 1 copy', level_1_copy.name
-    assert_equal ' copy', level_1_copy.name_suffix
+    assert_equal 'level 1_copy', level_1_copy.name
+    assert_equal '_copy', level_1_copy.name_suffix
 
     assert_equal template_level_copy, level_2_copy.project_template_level
-    assert_equal 'level 2 copy', level_2_copy.name
-    assert_equal ' copy', level_2_copy.name_suffix
+    assert_equal 'level 2_copy', level_2_copy.name
+    assert_equal '_copy', level_2_copy.name_suffix
   end
 
   test 'clone with suffix copies contained levels' do
@@ -928,11 +936,11 @@ class LevelTest < ActiveSupport::TestCase
 
     level_1 = create :level, name: 'level 1'
     level_1.contained_level_names = [contained_level_1.name]
-    level_1_copy = level_1.clone_with_suffix(' copy')
+    level_1_copy = level_1.clone_with_suffix('_copy')
 
     refute_nil level_1_copy.contained_levels
     assert_equal 1, level_1_copy.contained_levels.size
-    contained_level_1_copy = Level.find_by_name('contained level 1 copy')
+    contained_level_1_copy = Level.find_by_name('contained level 1_copy')
     assert_equal 'FreeResponse', contained_level_1_copy.type
     assert_equal contained_level_1_copy, level_1_copy.contained_levels.first
 
@@ -943,8 +951,8 @@ class LevelTest < ActiveSupport::TestCase
       contained_level_1.name,
       contained_level_2.name
     ]
-    level_2_copy = level_2.clone_with_suffix(' copy')
-    contained_level_2_copy = Level.find_by_name('contained level 2 copy')
+    level_2_copy = level_2.clone_with_suffix('_copy')
+    contained_level_2_copy = Level.find_by_name('contained level 2_copy')
     refute_nil level_2_copy.contained_levels
     assert_equal 2, level_2_copy.contained_levels.size
     assert_equal contained_level_1_copy, level_2_copy.contained_levels.first
@@ -961,7 +969,7 @@ class LevelTest < ActiveSupport::TestCase
     assert_equal 3, level_1.level_concept_difficulty.sequencing
     assert_equal 5, level_1.level_concept_difficulty.debugging
 
-    level_1_copy = level_1.clone_with_suffix(' copy')
+    level_1_copy = level_1.clone_with_suffix('_copy')
 
     refute_nil level_1_copy.level_concept_difficulty
     assert_equal 3, level_1_copy.level_concept_difficulty.sequencing
@@ -970,8 +978,8 @@ class LevelTest < ActiveSupport::TestCase
 
   test 'clone with suffix sets editor experiment' do
     old_level = create :level, name: 'old level'
-    new_level = old_level.clone_with_suffix(' copy', editor_experiment: 'level-editors')
-    assert_equal 'old level copy', new_level.name
+    new_level = old_level.clone_with_suffix('_copy', editor_experiment: 'level-editors')
+    assert_equal 'old level_copy', new_level.name
     assert_equal 'level-editors', new_level.editor_experiment, 'clone_with_suffix adds editor experiment'
   end
 
@@ -986,7 +994,7 @@ class LevelTest < ActiveSupport::TestCase
     DSL
 
     expected_new_dsl_text = <<~DSL
-      name 'old multi level copy'
+      name 'old multi level_copy'
       editor_experiment 'level-editors'
       title 'Multiple Choice'
       question 'What is your favorite color?'
@@ -1003,8 +1011,8 @@ class LevelTest < ActiveSupport::TestCase
     old_level = create :multi, name: 'old multi level'
     old_level.stubs(:dsl_text).returns(old_dsl_text)
 
-    new_level = old_level.clone_with_suffix(' copy', editor_experiment: 'level-editors')
-    assert_equal 'old multi level copy', new_level.name
+    new_level = old_level.clone_with_suffix('_copy', editor_experiment: 'level-editors')
+    assert_equal 'old multi level_copy', new_level.name
     assert_equal 'level-editors', new_level.editor_experiment
   end
 
@@ -1020,7 +1028,7 @@ class LevelTest < ActiveSupport::TestCase
     DSL
 
     expected_new_dsl_text = <<~DSL
-      name 'old multi level copy'
+      name 'old multi level_copy'
       editor_experiment 'new-level-editors'
       title 'Multiple Choice'
       question 'What is your favorite color?'
@@ -1037,8 +1045,8 @@ class LevelTest < ActiveSupport::TestCase
     old_level = create :multi, name: 'old multi level'
     old_level.stubs(:dsl_text).returns(old_dsl_text)
 
-    new_level = old_level.clone_with_suffix(' copy', editor_experiment: 'new-level-editors')
-    assert_equal 'old multi level copy', new_level.name
+    new_level = old_level.clone_with_suffix('_copy', editor_experiment: 'new-level-editors')
+    assert_equal 'old multi level_copy', new_level.name
     assert_equal 'new-level-editors', new_level.editor_experiment
   end
 


### PR DESCRIPTION
Improves level clone in two ways:
1. Prefixes the provided suffix with an underscore if one isn't there already. So, for example, if the prefix "2022" was passed in, the prefix "_2022" would be used.
2. Improve logging on failure. This does create a bit of a weird error message when there's a nested error. For example, for the pesky csp7 level clone failure, we get `ActiveRecord::RecordInvalid (Failed to clone CSP Unit 7 AP-Style Assessment _2021 as CSP Unit 7 AP-Style Assessment _2022. Message: Failed to clone CSP Unit 7 AP-Style Assessment _2021 as CSP Unit 7 AP-Style Assessment _2022. Message: Validation failed: Child level has already been taken)` which is a bit messy but at least tells us the level that failed to clone.



## Testing story

unit tests, tested locally



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
