### PR TITLE
[Sprite Lab] Turn block affects sprite direction

### DIFF
--- a/apps/src/p5lab/spritelab/commands/actionCommands.js
+++ b/apps/src/p5lab/spritelab/commands/actionCommands.js
@@ -277,8 +277,10 @@ export const commands = {
     sprites.forEach(sprite => {
       if (direction === 'right') {
         sprite.rotation += degrees;
+        sprite.direction += degrees;
       } else {
         sprite.rotation -= degrees;
+        sprite.direction -= degrees;
       }
     });
   }


### PR DESCRIPTION
Quick win. Change the `turn` function to affect a sprite's `direction` the same way it currently affects `rotation`. This change would make it so `turn` blocks become compatible with other commands that use a sprite's `direction`, such as `moveForward`. 

[Slack thread](https://codedotorg.slack.com/archives/C946FMBGT/p1642196430005400)

**Before:**
![before](https://user-images.githubusercontent.com/43474485/150361153-f029b109-85ab-4568-a008-e62c155f04ba.gif)
**After:**
![after](https://user-images.githubusercontent.com/43474485/150361215-6fdf03c7-11df-4417-a831-3843381aeb0d.gif)

Works as expected with costumes with other orientations provided the user sets the correct movement direction for the sprite.
![after2](https://user-images.githubusercontent.com/43474485/150361176-341050c9-5404-4719-91f5-2ec0990a9d3c.gif)

This change benefits the curriculum but does carry the risk of changing the functionality of existing student projects. I think it is unlikely students are using blocks like `turn` today with a lot of success, so I don't anticipate this being a noticeable change for most users. If it does cause problems, it's a simple revert. New CSF lessons will teach with these blocks if the change is merged.