### PR TITLE
Switch to a cloudfront function for the www redirect

### DIFF
--- a/aws/cloudformation/components/www_redirect.yml.erb
+++ b/aws/cloudformation/components/www_redirect.yml.erb
@@ -21,16 +21,10 @@
               OriginProtocolPolicy: match-viewer
         DefaultCacheBehavior:
           TargetOriginId: PrimaryOrigin
-          LambdaFunctionAssociations:
-            # Trigging upon origin-request ensures redirect is cached
-            - EventType: origin-request
-              LambdaFunctionARN: !Ref <%=app%>WwwRedirectLambdaVersion1
-          ForwardedValues:
-            QueryString: "false"
-            Headers:
-              - Origin
-            Cookies:
-              Forward: none
+          CachePolicyId: !Ref RedirectCachePolicy
+          FunctionAssociations:
+            - EventType: viewer-request
+              FunctionARN: !Ref RedirectFunction
           ViewerProtocolPolicy: allow-all
           # Use shared Realtime Log config
           RealtimeLogConfigArn: !ImportValue AccessLogs-Config
@@ -80,6 +74,30 @@
               - Origin
           QueryStringsConfig: 
             QueryStringBehavior: all
+
+  <%=app%>RedirectFunction:
+    Type: AWS::CloudFront::Function
+    Properties: 
+      Name: www_redirect
+      FunctionConfig: 
+        Comment: Redirects a subdomain to the root domain
+        Runtime: cloudfront-js-1.0
+      AutoPublish: true
+      FunctionCode: !Sub |
+        function handler(event) {
+          var newUrl = 'https://<%=CDO.pegasus_hostname%>';
+
+          // Append path
+          newUrl += event.request.uri;
+
+          return {
+            statusCode: 302,
+            statusDescription: '302 Redirect to root domain',
+            headers:{
+              "location": { "value": newUrl }
+            }
+          };
+        };
 
   <%=app%>WwwRedirectLambda:
     Type: AWS::Lambda::Function

--- a/aws/cloudformation/components/www_redirect.yml.erb
+++ b/aws/cloudformation/components/www_redirect.yml.erb
@@ -21,10 +21,10 @@
               OriginProtocolPolicy: match-viewer
         DefaultCacheBehavior:
           TargetOriginId: PrimaryOrigin
-          CachePolicyId: !Ref RedirectCachePolicy
+          CachePolicyId: !Ref <%=app%>RedirectCachePolicy
           FunctionAssociations:
             - EventType: viewer-request
-              FunctionARN: !Ref RedirectFunction
+              FunctionARN: !Ref <%=app%>RedirectFunction
           ViewerProtocolPolicy: allow-all
           # Use shared Realtime Log config
           RealtimeLogConfigArn: !ImportValue AccessLogs-Config


### PR DESCRIPTION
This is a faster and more sustainable option. Using lambda@edge was leading to challenges around lambda versioning and consistently making changes. This implementation will update the live function code whenever the code in the stack is edited.

One loss is that I'm not translating query strings anymore. It's possible if we think it's necessary, but will take some time because we've got limited javascript features here.

## Links

Jira Ticket: INF-506

## Testing story

Thoroughly tested with a standalone stack. We can also easily test the function's code from the AWS Console.

POC Code: https://gist.github.com/cat5inthecradle/9a1186bf07ed07de07b063f1b0eae04c

POC Test: https://console.aws.amazon.com/cloudfront/v3/home?region=us-east-1#/functions/www_redirect?tab=build

## Deployment strategy

## Follow-up work

Delete the lambda function the day after this goes live, once the lambda@edge replicas have have time to be removed.

## Privacy

## Security

## Caching

This does not cache function responses, every request to www.code.org will result in a function execution. The redirected domain is likely cached in the main cloudfront distribution.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
