### PR TITLE
Setup frontend to save teacher apps

### DIFF
--- a/apps/src/code-studio/pd/application/teacher/TeacherApplication.jsx
+++ b/apps/src/code-studio/pd/application/teacher/TeacherApplication.jsx
@@ -29,8 +29,6 @@ const TeacherApplication = props => {
   } = props;
 
   const getInitialData = () => {
-    // [MEG] TODO: Show savedFormData whenever it is present
-    // to avoid weirdness if changing allowPartialSaving states
     const dataOnPageLoad = savedFormData && JSON.parse(savedFormData);
 
     // Extract school info saved in sessionStorage, if any

--- a/apps/src/code-studio/pd/application/teacher/TeacherApplication.jsx
+++ b/apps/src/code-studio/pd/application/teacher/TeacherApplication.jsx
@@ -22,7 +22,6 @@ const TeacherApplication = props => {
   const {
     // [MEG] TODO: remove allowPartialSaving prop when experiment is complete (TeacherApps will always have this option)
     // instead, pass in allowPartialSaving prop to FormController
-    allowPartialSaving,
     savedFormData,
     accountEmail,
     userId,
@@ -32,8 +31,7 @@ const TeacherApplication = props => {
   const getInitialData = () => {
     // [MEG] TODO: Show savedFormData whenever it is present
     // to avoid weirdness if changing allowPartialSaving states
-    const dataOnPageLoad =
-      allowPartialSaving && savedFormData && JSON.parse(savedFormData);
+    const dataOnPageLoad = savedFormData && JSON.parse(savedFormData);
 
     // Extract school info saved in sessionStorage, if any
     const reloadedSchoolId = JSON.parse(

--- a/apps/src/code-studio/pd/application/teacher/TeacherApplication.jsx
+++ b/apps/src/code-studio/pd/application/teacher/TeacherApplication.jsx
@@ -72,12 +72,6 @@ const TeacherApplication = props => {
     window.location.reload(true);
   };
 
-  const onSuccessfulSave = () => {
-    // [MEG] TODO: Figure out what should happen on save
-    // Right now, reload page to render in_progress page (to verify)
-    window.location.reload(true);
-  };
-
   // [MEG] TODO: Should a different GA link be sent if they're working on a saved application?
   const onSetPage = newPage => {
     const nominated = queryString.parse(window.location.search).nominated;
@@ -102,7 +96,6 @@ const TeacherApplication = props => {
       onSetPage={onSetPage}
       onInitialize={onInitialize}
       onSuccessfulSubmit={onSuccessfulSubmit}
-      onSuccessfulSave={onSuccessfulSave}
       sessionStorageKey={sessionStorageKey}
       submitButtonText={submitButtonText}
       validateOnSubmitOnly={true}

--- a/apps/src/code-studio/pd/application/teacher/TeacherApplication.jsx
+++ b/apps/src/code-studio/pd/application/teacher/TeacherApplication.jsx
@@ -30,6 +30,8 @@ const TeacherApplication = props => {
   } = props;
 
   const getInitialData = () => {
+    // [MEG] TODO: Show savedFormData whenever it is present
+    // to avoid weirdness if changing allowPartialSaving states
     const dataOnPageLoad =
       allowPartialSaving && savedFormData && JSON.parse(savedFormData);
 

--- a/apps/src/code-studio/pd/form_components_func/FormController.jsx
+++ b/apps/src/code-studio/pd/form_components_func/FormController.jsx
@@ -101,6 +101,8 @@ const FormController = props => {
   const [showDataWasLoadedMessage, setShowDataWasLoadedMessage] = useState(
     applicationId && allowPartialSaving
   );
+  const applicationStatusOnSave = 'incomplete';
+  const applicationStatusOnSubmit = 'unreviewed';
 
   // do this once on mount only
   useEffect(() => {
@@ -351,7 +353,7 @@ const FormController = props => {
       onSuccessfulSave(data);
     };
 
-    makeRequest('incomplete')
+    makeRequest(applicationStatusOnSave)
       .done(data => handleSuccessfulSave(data))
       .fail(data => handleRequestFailure(data));
   };
@@ -389,7 +391,7 @@ const FormController = props => {
       onSuccessfulSubmit(data);
     };
 
-    makeRequest('unreviewed')
+    makeRequest(applicationStatusOnSubmit)
       .done(data => handleSuccessfulSubmit(data))
       .fail(data => handleRequestFailure(data));
   };

--- a/apps/src/code-studio/pd/form_components_func/FormController.jsx
+++ b/apps/src/code-studio/pd/form_components_func/FormController.jsx
@@ -326,7 +326,7 @@ const FormController = props => {
     setSubmitting(true);
 
     const handleSuccessfulSave = data => {
-      onSuccessfulSave();
+      onSuccessfulSave(data);
     };
 
     const handleRequestFailure = data => {

--- a/apps/src/code-studio/pd/form_components_func/FormController.jsx
+++ b/apps/src/code-studio/pd/form_components_func/FormController.jsx
@@ -297,6 +297,18 @@ const FormController = props => {
     };
   };
 
+  const handleRequestFailure = data => {
+    if (data?.responseJSON?.errors?.form_data) {
+      setErrors(data.responseJSON.errors.form_data);
+      setErrorHeader(i18n.formErrorsBelow());
+    } else {
+      // Otherwise, something unknown went wrong on the server
+      setGlobalError(true);
+      setErrorHeader(i18n.formServerError());
+    }
+    setSubmitting(false);
+  };
+
   const makeRequest = applicationStatus => {
     const dataWithStatus = {status: applicationStatus, ...data};
     setData(dataWithStatus);
@@ -327,18 +339,6 @@ const FormController = props => {
 
     const handleSuccessfulSave = data => {
       onSuccessfulSave(data);
-    };
-
-    const handleRequestFailure = data => {
-      if (data?.responseJSON?.errors?.form_data) {
-        setErrors(data.responseJSON.errors.form_data);
-        setErrorHeader(i18n.formErrorsBelow());
-      } else {
-        // Otherwise, something unknown went wrong on the server
-        setGlobalError(true);
-        setErrorHeader(i18n.formServerError());
-      }
-      setSubmitting(false);
     };
 
     makeRequest('incomplete')
@@ -377,18 +377,6 @@ const FormController = props => {
     const handleSuccessfulSubmit = data => {
       sessionStorage.removeItem(sessionStorageKey);
       onSuccessfulSubmit(data);
-    };
-
-    const handleRequestFailure = data => {
-      if (data?.responseJSON?.errors?.form_data) {
-        setErrors(data.responseJSON.errors.form_data);
-        setErrorHeader(i18n.formErrorsBelow());
-      } else {
-        // Otherwise, something unknown went wrong on the server
-        setGlobalError(true);
-        setErrorHeader(i18n.formServerError());
-      }
-      setSubmitting(false);
     };
 
     makeRequest('unreviewed')

--- a/apps/src/code-studio/pd/form_components_func/FormController.jsx
+++ b/apps/src/code-studio/pd/form_components_func/FormController.jsx
@@ -532,7 +532,7 @@ const FormController = props => {
         bsStyle="info"
       >
         <p>
-          Your progress has been saved! Return to this page at any time to
+          Your progress has been saved. Return to this page at any time to
           continue working on your application.
         </p>
       </Alert>

--- a/apps/src/code-studio/pd/form_components_func/FormController.jsx
+++ b/apps/src/code-studio/pd/form_components_func/FormController.jsx
@@ -287,9 +287,12 @@ const FormController = props => {
    *
    * @returns {Object}
    */
-  const serializeFormData = () => {
+  const serializeFormData = formData => {
+    if (!formData) {
+      throw new Error(`formData cannot be undefined`);
+    }
     return {
-      form_data: data,
+      form_data: formData,
       ...serializeAdditionalData()
     };
   };
@@ -304,7 +307,7 @@ const FormController = props => {
         url: endpoint,
         contentType: 'application/json',
         dataType: 'json',
-        data: JSON.stringify(serializeFormData())
+        data: JSON.stringify(serializeFormData(dataWithStatus))
       });
 
     return applicationId

--- a/apps/test/unit/code-studio/pd/application/TeacherApplicationTest.js
+++ b/apps/test/unit/code-studio/pd/application/TeacherApplicationTest.js
@@ -124,7 +124,7 @@ describe('TeacherApplication', () => {
         teacherApplication.findOne('FormController').props.getInitialData()
       ).to.deep.equal(parsedData);
     });
-    it('does not include saved form data if partial saving is not allowed', () => {
+    it('includes saved form data even if partial saving is not allowed', () => {
       teacherApplication.mergeProps({
         savedFormData,
         schoolId,
@@ -133,6 +133,7 @@ describe('TeacherApplication', () => {
       expect(
         teacherApplication.findOne('FormController').props.getInitialData()
       ).to.deep.equal({
+        ...parsedData,
         school: schoolId
       });
     });

--- a/apps/test/unit/code-studio/pd/application/TeacherApplicationTest.js
+++ b/apps/test/unit/code-studio/pd/application/TeacherApplicationTest.js
@@ -114,6 +114,7 @@ describe('TeacherApplication', () => {
       ).to.deep.equal({school: '16'});
     });
     it('has only saved form data and no school id if session storage has school info', () => {
+      // [MEG] TODO: Use FakeStorage instead
       window.sessionStorage.setItem(
         'TeacherApplication',
         JSON.stringify({data: {school: '25'}})

--- a/apps/test/unit/code-studio/pd/form_components_func/FormControllerTest.js
+++ b/apps/test/unit/code-studio/pd/form_components_func/FormControllerTest.js
@@ -253,7 +253,7 @@ describe('FormController', () => {
 
         const alert = form.findOne('Alert');
         expect(alert.content()).to.contain(
-          'Your progress has been saved! Return to this page at any time to continue working on your application.'
+          'Your progress has been saved. Return to this page at any time to continue working on your application.'
         );
 
         alert.props.onDismiss();

--- a/apps/test/unit/code-studio/pd/form_components_func/FormControllerTest.js
+++ b/apps/test/unit/code-studio/pd/form_components_func/FormControllerTest.js
@@ -304,6 +304,24 @@ describe('FormController', () => {
           expect(form.findOne('#submit').props.disabled).to.be.false;
         });
 
+        it('Adds application status as unreviewed on submit', () => {
+          const testData = {
+            field1: 'value 1',
+            field2: 'value 2'
+          };
+
+          form = isolateComponent(
+            <FormController {...defaultProps} getInitialData={() => testData} />
+          );
+          setPage(2);
+          triggerSubmit();
+
+          expect(getData(DummyPage3)).to.eql({
+            status: 'unreviewed',
+            ...testData
+          });
+        });
+
         it('Keeps the submit button disabled and calls onSuccessfulSubmit on success', () => {
           setupValid();
           server.respondWith([

--- a/apps/test/unit/code-studio/pd/form_components_func/FormControllerTest.js
+++ b/apps/test/unit/code-studio/pd/form_components_func/FormControllerTest.js
@@ -179,6 +179,22 @@ describe('FormController', () => {
       expect(form.exists('Alert')).to.be.false;
     });
 
+    describe('Saving', () => {
+      it('Adds application status as incomplete to data', () => {
+        const testData = {
+          field1: 'value 1',
+          field2: 'value 2'
+        };
+
+        form = isolateComponent(
+          <FormController {...defaultProps} getInitialData={() => testData} />
+        );
+        form.findAll('Button')[1].props.onClick();
+
+        expect(getData(DummyPage1)).to.eql({status: 'incomplete', ...testData});
+      });
+    });
+
     describe('Page validation', () => {
       it('Does not navigate when the current page has errors', () => {
         // create errors
@@ -213,6 +229,7 @@ describe('FormController', () => {
           );
           setPage(2);
         };
+
         const setUpValidWithApplicationId = applicationId =>
           setupValid(applicationId);
 


### PR DESCRIPTION
Together with the backend https://github.com/code-dot-org/code-dot-org/pull/44442, this fulfills _Req 1: Add a “Save and Return Later” Button to the application_. See below for future work.

Current functionality: https://watch.screencastify.com/v/SqvvikhJJq8mzL4Ygauv 

I did the following:
- (Frontend): Use a hook to set an applicationId after the first save––after saving, a teacher can continue working, hit save, and have their new progress updated.
- (Frontend): Add `status: "unreviewed"` on submit, and `status: "incomplete"` to `form_data` on save––allows us to check in the backend what validations and updates to do.
- (Frontend): After a save, scroll to the top and show an alert saving the application has been saved, or show generic error message already configured in `handleRequestFailure.`

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- spec: [Saving Progress and Reopening Applications](https://docs.google.com/document/d/1kbRAQ3To-MHVmz2KHnyaN6Mh6EiJk8F_zRNS1F8kSK8/edit?pli=1#heading=h.86qvf1hodt)
- jira ticket: [PLAT-1466](https://codedotorg.atlassian.net/browse/PLAT-1466)

## Testing story

## Deployment strategy

## Follow-up work

In (a) separate PR(s), I'm planning to
- address the to-dos,
- refactor `FormControllerTest.js` to make the file easier to navigate and minimize repeated code

## Privacy

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
