### PR TITLE
Setup backend to save teacher apps

### DIFF
--- a/dashboard/app/controllers/api/v1/pd/application/teacher_applications_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/application/teacher_applications_controller.rb
@@ -16,8 +16,6 @@ module Api::V1::Pd::Application
       form_data_hash = params.try(:[], :form_data) || {}
       form_data_json = form_data_hash.to_unsafe_h.to_json.strip_utf8mb4
 
-      # [MEG] TODO: See if update is coming from hitting the submit button (do validations)
-      # or the save button (ignore validations)
       @application.form_data_hash = JSON.parse(form_data_json)
 
       if @application.save

--- a/dashboard/app/controllers/api/v1/pd/application/teacher_applications_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/application/teacher_applications_controller.rb
@@ -14,7 +14,7 @@ module Api::V1::Pd::Application
     # PATCH /api/v1/pd/application/teacher/<applicationId>
     def update
       form_data_hash = params.try(:[], :form_data)
-      form_data_json = form_data_hash.to_unsafe_h.to_json.strip_utf8mb4 if form_data_hash || '{}'
+      form_data_json = form_data_hash.to_unsafe_h.to_json.strip_utf8mb4
 
       @application.form_data_hash = JSON.parse(form_data_json)
       @application.set_status

--- a/dashboard/app/controllers/api/v1/pd/application/teacher_applications_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/application/teacher_applications_controller.rb
@@ -17,8 +17,14 @@ module Api::V1::Pd::Application
       form_data_json = form_data_hash.to_unsafe_h.to_json.strip_utf8mb4 if form_data_hash
 
       @application.form_data_hash = JSON.parse(form_data_json)
+      @application.set_status
+      @application.set_course_from_program
+      @application.update_user_school_info!
+
+      @application.on_completed_application unless @application.status == 'incomplete'
 
       if @application.save
+        @application.update_status_timestamp_change_log(current_user)
         render json: @application, status: :ok
       else
         return render json: {errors: @application.errors.full_messages}, status: :bad_request
@@ -40,6 +46,7 @@ module Api::V1::Pd::Application
     protected
 
     def on_successful_create
+      @application.set_status
       @application.on_successful_create
       @application.update_status_timestamp_change_log(current_user)
     end

--- a/dashboard/app/controllers/api/v1/pd/application/teacher_applications_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/application/teacher_applications_controller.rb
@@ -13,7 +13,7 @@ module Api::V1::Pd::Application
 
     # PATCH /api/v1/pd/application/teacher/<applicationId>
     def update
-      form_data_hash = params.try(:[], :form_data)
+      form_data_hash = params.try(:[], :form_data) || {}
       form_data_json = form_data_hash.to_unsafe_h.to_json.strip_utf8mb4
 
       @application.form_data_hash = JSON.parse(form_data_json)

--- a/dashboard/app/controllers/api/v1/pd/application/teacher_applications_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/application/teacher_applications_controller.rb
@@ -14,7 +14,7 @@ module Api::V1::Pd::Application
     # PATCH /api/v1/pd/application/teacher/<applicationId>
     def update
       form_data_hash = params.try(:[], :form_data)
-      form_data_json = form_data_hash.to_unsafe_h.to_json.strip_utf8mb4 if form_data_hash
+      form_data_json = form_data_hash.to_unsafe_h.to_json.strip_utf8mb4 if form_data_hash || '{}'
 
       @application.form_data_hash = JSON.parse(form_data_json)
       @application.set_status

--- a/dashboard/app/controllers/api/v1/pd/application/teacher_applications_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/application/teacher_applications_controller.rb
@@ -13,8 +13,8 @@ module Api::V1::Pd::Application
 
     # PATCH /api/v1/pd/application/teacher/<applicationId>
     def update
-      form_data_hash = params.try(:[], :form_data) || {}
-      form_data_json = form_data_hash.to_unsafe_h.to_json.strip_utf8mb4
+      form_data_hash = params.try(:[], :form_data)
+      form_data_json = form_data_hash.to_unsafe_h.to_json.strip_utf8mb4 if form_data_hash
 
       @application.form_data_hash = JSON.parse(form_data_json)
 

--- a/dashboard/app/controllers/api/v1/pd/application/teacher_applications_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/application/teacher_applications_controller.rb
@@ -18,7 +18,6 @@ module Api::V1::Pd::Application
 
       @application.form_data_hash = JSON.parse(form_data_json)
       @application.set_status
-      @application.set_course_from_program
       @application.update_user_school_info!
 
       @application.on_completed_application unless @application.status == 'incomplete'

--- a/dashboard/app/controllers/api/v1/pd/forms_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/forms_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::Pd::FormsController < ::ApplicationController
   end
 
   def create
-    form_data_hash = params.try(:[], :form_data)
+    form_data_hash = params.try(:[], :form_data) || {}
     form_data_json = form_data_hash.to_unsafe_h.to_json.strip_utf8mb4
 
     form = new_form

--- a/dashboard/app/controllers/api/v1/pd/forms_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/forms_controller.rb
@@ -5,7 +5,7 @@ class Api::V1::Pd::FormsController < ::ApplicationController
 
   def create
     form_data_hash = params.try(:[], :form_data)
-    form_data_json = form_data_hash.to_unsafe_h.to_json.strip_utf8mb4 if form_data_hash
+    form_data_json = form_data_hash.to_unsafe_h.to_json.strip_utf8mb4 if form_data_hash || '{}'
 
     form = new_form
     form.form_data_hash = JSON.parse(form_data_json)

--- a/dashboard/app/controllers/api/v1/pd/forms_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/forms_controller.rb
@@ -4,8 +4,8 @@ class Api::V1::Pd::FormsController < ::ApplicationController
   end
 
   def create
-    form_data_hash = params.try(:[], :form_data) || {}
-    form_data_json = form_data_hash.to_unsafe_h.to_json.strip_utf8mb4
+    form_data_hash = params.try(:[], :form_data)
+    form_data_json = form_data_hash.to_unsafe_h.to_json.strip_utf8mb4 if form_data_hash
 
     form = new_form
     form.form_data_hash = JSON.parse(form_data_json)

--- a/dashboard/app/controllers/api/v1/pd/forms_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/forms_controller.rb
@@ -5,7 +5,7 @@ class Api::V1::Pd::FormsController < ::ApplicationController
 
   def create
     form_data_hash = params.try(:[], :form_data)
-    form_data_json = form_data_hash.to_unsafe_h.to_json.strip_utf8mb4 if form_data_hash || '{}'
+    form_data_json = form_data_hash.to_unsafe_h.to_json.strip_utf8mb4
 
     form = new_form
     form.form_data_hash = JSON.parse(form_data_json)

--- a/dashboard/app/models/concerns/pd/form.rb
+++ b/dashboard/app/models/concerns/pd/form.rb
@@ -69,6 +69,9 @@ module Pd::Form
 
     hash = sanitize_and_trim_form_data_hash
 
+    # No validation is required if the application is still in progress
+    return if hash[:status] == 'incomplete'
+
     self.class.required_fields.each do |key|
       add_key_error(key) unless hash.key?(key)
     end

--- a/dashboard/app/models/pd/application/application_base.rb
+++ b/dashboard/app/models/pd/application/application_base.rb
@@ -110,6 +110,7 @@ module Pd::Application
     before_create -> {self.status = :unreviewed}
     after_initialize :set_type_and_year
     before_validation :set_type_and_year
+    validate :status_is_valid_for_application_type
     before_save :update_accepted_date, if: :status_changed?
     before_create :generate_application_guid, if: -> {application_guid.blank?}
     after_destroy :delete_unsent_email
@@ -222,7 +223,6 @@ module Pd::Application
     # This is equivalent to
     #   validates_inclusion_of :status, in: statuses
     # but it will work with derived classes that override statuses
-    validate :status_is_valid_for_application_type
     def status_is_valid_for_application_type
       unless status.nil? || self.class.statuses.include?(status)
         errors.add(:status, 'is not included in the list.')

--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -84,7 +84,7 @@ module Pd::Application
 
     has_many :emails, class_name: 'Pd::Application::Email', foreign_key: 'pd_application_id'
 
-    before_validation :set_course_from_program, unless: -> {program.nil?}
+    before_validation :set_course_from_program
     validates :status, exclusion: {in: ['interview'], message: '%{value} is reserved for facilitator applications.'}
     validate :workshop_present_if_required_for_status, if: -> {status_changed?}
 

--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -1157,34 +1157,32 @@ module Pd::Application
       0
     end
 
-    # Called after the application is created. Do any manipulation needed for the form data
-    # hash here, as well as send emails
     def on_successful_create
       update_user_school_info!
-
-      unless status == 'incomplete'
-        queue_email :confirmation, deliver_now: true
-
-        form_data_hash = sanitize_form_data_hash
-
-        update_form_data_hash(
-          {
-            cs_total_course_hours: form_data_hash.slice(
-              :cs_how_many_minutes,
-              :cs_how_many_days_per_week,
-              :cs_how_many_weeks_per_year
-            ).values.map(&:to_i).reduce(:*) / 60
-          }
-        )
-
-        auto_score!
-
-        unless regional_partner&.applications_principal_approval == RegionalPartner::SELECTIVE_APPROVAL
-          queue_email :principal_approval, deliver_now: true
-        end
-      end
-
+      on_completed_application unless status == 'incomplete'
       save
+    end
+
+    def on_completed_application
+      queue_email :confirmation, deliver_now: true
+
+      form_data_hash = sanitize_form_data_hash
+
+      update_form_data_hash(
+        {
+          cs_total_course_hours: form_data_hash.slice(
+            :cs_how_many_minutes,
+            :cs_how_many_days_per_week,
+            :cs_how_many_weeks_per_year
+          ).values.map(&:to_i).reduce(:*) / 60
+        }
+      )
+
+      auto_score!
+
+      unless regional_partner&.applications_principal_approval == RegionalPartner::SELECTIVE_APPROVAL
+        queue_email :principal_approval, deliver_now: true
+      end
     end
 
     # Called after principal approval has been created. Do any manipulation needed for the

--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -91,7 +91,6 @@ module Pd::Application
     before_save :save_partner, if: -> {form_data_changed? && regional_partner_id.nil? && !deleted?}
     before_save :course, presence: true, inclusion: {in: VALID_COURSES}, unless: -> {status == 'incomplete'}
     before_save :log_status, if: -> {status_changed?}
-    before_create :set_status, if: -> {form_data_changed?}
 
     serialized_attrs %w(
       pd_workshop_id

--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -105,10 +105,10 @@ module Pd::Application
     # Will only update the school info if we have enough information for it
     # An incomplete application may not have all the information we need to update
     def update_user_school_info!
-      if school_id || user.school_info.try(&:school).nil?
-        school_info = school_info_attr
-        user.update_school_info(get_duplicate_school_info(school_info) || SchoolInfo.create!(school_info)) if school_info
-      end
+      return unless school_id || user.school_info.try(&:school).nil?
+      school_info = school_info_attr
+      return unless school_info
+      user.update_school_info(get_duplicate_school_info(school_info) || SchoolInfo.create!(school_info))
     end
 
     def update_scholarship_status(scholarship_status)

--- a/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
@@ -149,8 +149,15 @@ module Api::V1::Pd::Application
     test 'updating an application with an error renders bad_request' do
       sign_in @applicant
       application = create TEACHER_APPLICATION_FACTORY, user: @applicant
-      put :update, params: {id: application.id, form_data: @test_params, application_year: nil}
 
+      errored_form_data = build(TEACHER_APPLICATION_HASH_FACTORY).merge(
+        {
+          "program": ""
+        }.stringify_keys
+      )
+      put :update, params: {id: application.id, form_data: errored_form_data}
+
+      application.reload
       assert_response :bad_request
     end
 

--- a/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
@@ -145,6 +145,14 @@ module Api::V1::Pd::Application
       assert_nil TEACHER_APPLICATION_CLASS.last.sanitize_form_data_hash[:cs_total_course_hours]
     end
 
+    test 'can submit an empty form if application is incomplete' do
+      sign_in @applicant
+      put :create, params: {form_data: {status: 'incomplete'}}
+
+      assert_equal 'incomplete', TEACHER_APPLICATION_CLASS.last.status
+      assert_response :created
+    end
+
     test 'updating an application with an error renders bad_request' do
       sign_in @applicant
       application = create TEACHER_APPLICATION_FACTORY, user: @applicant

--- a/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
@@ -61,7 +61,7 @@ module Api::V1::Pd::Application
       assert_response :success
     end
 
-    test 'do not send principal approval email on successful create if RP has selective principal approval' do
+    test 'does not send principal approval email on successful create if RP has selective principal approval' do
       Pd::Application::TeacherApplicationMailer.expects(:confirmation).
         with(instance_of(TEACHER_APPLICATION_CLASS)).
         returns(mock {|mail| mail.expects(:deliver_now)})
@@ -121,22 +121,28 @@ module Api::V1::Pd::Application
       assert JSON.parse(TEACHER_APPLICATION_CLASS.last.response_scores).any?
     end
 
-    # [MEG] TODO: verify update of params with fewer (and no) params
-    test 'updating an application modifies form data' do
+    test 'submitting without a program renders bad request on successful create if application is complete' do
       sign_in @applicant
-      @updated_form_data = build(TEACHER_APPLICATION_HASH_FACTORY).merge(
-        {
-          "firstName": "Harry",
-          "program": "Computer Science Discoveries (appropriate for 6th - 10th grade)",
-          "csdWhichGrades": ["8"]
-        }.stringify_keys
+      put :create, params: {form_data: {status: 'unreviewed'}}
+
+      assert_response :bad_request
+    end
+
+    test 'does not update course hours nor autoscore on successful create if application status is incomplete' do
+      Pd::Application::TeacherApplication.expects(:auto_score).never
+      Pd::Application::TeacherApplication.expects(:queue_email).never
+
+      application_hash = build(
+        TEACHER_APPLICATION_HASH_FACTORY,
+        cs_how_many_minutes: 45,
+        cs_how_many_days_per_week: 5,
+        cs_how_many_weeks_per_year: 30
       )
 
-      application = create TEACHER_APPLICATION_FACTORY, user: @applicant
-      put :update, params: {id: application.id, form_data: @updated_form_data}
-      application.reload
-      assert_equal @updated_form_data, application.form_data_hash
-      assert_response :ok
+      sign_in @applicant
+      put :create, params: {form_data: application_hash.merge({status: 'incomplete'})}
+
+      assert_nil TEACHER_APPLICATION_CLASS.last.sanitize_form_data_hash[:cs_total_course_hours]
     end
 
     test 'updating an application with an error renders bad_request' do

--- a/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
@@ -146,6 +146,25 @@ module Api::V1::Pd::Application
       assert_response :created
     end
 
+    test 'updating an application with empty, incomplete form correctly updates attributes' do
+      application = create TEACHER_APPLICATION_FACTORY, status: 'incomplete', user: @applicant
+      original_school_info = application.user.school_info
+
+      assert application.first_name
+      assert application.course
+
+      sign_in @applicant
+      no_form_content = {status: 'incomplete'}
+      put :update, params: {id: application.id, form_data: no_form_content}
+      application.reload
+
+      assert_nil application.first_name
+      assert_nil application.course
+      assert_equal original_school_info, application.user.school_info
+      assert_equal no_form_content.to_json, application.form_data
+      assert_response :ok
+    end
+
     test 'updating an application with an error renders bad_request' do
       sign_in @applicant
       application = create TEACHER_APPLICATION_FACTORY, user: @applicant

--- a/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
@@ -121,13 +121,6 @@ module Api::V1::Pd::Application
       assert JSON.parse(TEACHER_APPLICATION_CLASS.last.response_scores).any?
     end
 
-    test 'submitting without a program renders bad request on successful create if application is complete' do
-      sign_in @applicant
-      put :create, params: {form_data: {status: 'unreviewed'}}
-
-      assert_response :bad_request
-    end
-
     test 'does not update course hours nor autoscore on successful create if application status is incomplete' do
       Pd::Application::TeacherApplication.expects(:auto_score).never
       Pd::Application::TeacherApplication.expects(:queue_email).never

--- a/dashboard/test/factories/pd_factories.rb
+++ b/dashboard/test/factories/pd_factories.rb
@@ -809,13 +809,8 @@ FactoryGirl.define do
       school_type 'Public school'
     end
 
-    trait :with_incomplete_school do
+    trait :with_no_school do
       school(-1)
-      school_address '1501 4th Ave'
-      school_city 'Seattle'
-      school_state 'Washington'
-      school_zip_code '98101'
-      school_type 'Public school'
     end
 
     trait :with_multiple_workshops do

--- a/dashboard/test/factories/pd_factories.rb
+++ b/dashboard/test/factories/pd_factories.rb
@@ -809,6 +809,15 @@ FactoryGirl.define do
       school_type 'Public school'
     end
 
+    trait :with_incomplete_school do
+      school(-1)
+      school_address '1501 4th Ave'
+      school_city 'Seattle'
+      school_state 'Washington'
+      school_zip_code '98101'
+      school_type 'Public school'
+    end
+
     trait :with_multiple_workshops do
       able_to_attend_multiple ['December 11-15, 2017 in Indiana, USA']
 

--- a/dashboard/test/models/concerns/pd/form_test.rb
+++ b/dashboard/test/models/concerns/pd/form_test.rb
@@ -91,6 +91,14 @@ class Pd::FormTest < ActiveSupport::TestCase
     refute form.valid?
   end
 
+  test 'pd form does not check required fields if status is incomplete' do
+    expects(:dynamic_required_fields).never
+    form = DummyFormWithRequiredFields.new
+    form.form_data = {status: "incomplete"}.to_json
+
+    assert form.valid?
+  end
+
   test 'pd form enforces required fields' do
     form = DummyFormWithRequiredFields.new
 

--- a/dashboard/test/models/pd/application/teacher_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher_application_test.rb
@@ -390,16 +390,6 @@ module Pd::Application
       )
     end
 
-    # [MEG] TODO: Test this functionality in the controller
-    test 'incomplete application is valid but does not queue an email nor score it' do
-      application = create :pd_teacher_application, :incomplete
-      assert application.valid?
-
-      application.expects(:queue_email).never
-      application.expects(:auto_score!).never
-      application.on_successful_create
-    end
-
     test 'setting an auto-email status queues up an email' do
       application = create :pd_teacher_application
       assert_empty application.emails

--- a/dashboard/test/models/pd/application/teacher_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher_application_test.rb
@@ -125,13 +125,16 @@ module Pd::Application
     end
 
     test 'update_user_school_info with specific school overwrites user school info' do
-      user = create :teacher, school_info: create(:school_info)
+      user = create :teacher
       application_school_info = create :school_info
+      original_user_school_info = user.school_info
+
       application = create :pd_teacher_application, user: user, form_data_hash: (
         build :pd_teacher_application_hash, school: application_school_info.school
       )
 
       application.update_user_school_info!
+      refute_equal original_user_school_info, user.school_info
       assert_equal application_school_info, user.school_info
     end
 

--- a/dashboard/test/models/pd/application/teacher_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher_application_test.rb
@@ -142,7 +142,7 @@ module Pd::Application
       assert_equal application_school_info, user.school_info
     end
 
-    test 'update_user_school_info with custom school does nothing when the user already a specific school' do
+    test 'update_user_school_info with custom school does nothing when the user already has a specific school' do
       original_school_info = create :school_info
       user = create :teacher, school_info: original_school_info
       application = create :pd_teacher_application, user: user, form_data_hash: (
@@ -163,6 +163,16 @@ module Pd::Application
       application.update_user_school_info!
       refute_equal original_school_info.id, user.school_info_id
       assert_not_nil user.school_info_id
+    end
+
+    test 'update_user_school_info does nothing when user has no specific school and does not have enough info for new school' do
+      user = create :teacher, school_info: nil
+      application = create :pd_teacher_application, user: user, form_data_hash: (
+        build :pd_teacher_application_hash, :with_incomplete_school
+      )
+
+      application.update_user_school_info!
+      assert_nil user.school_info
     end
 
     test 'get_first_selected_workshop single local workshop' do

--- a/dashboard/test/models/pd/application/teacher_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher_application_test.rb
@@ -154,14 +154,14 @@ module Pd::Application
     end
 
     test 'update_user_school_info with custom school updates user info when user does not have a specific school' do
-      original_school_info = create :school_info_us_other
-      user = create :teacher, school_info: original_school_info
+      user = create :teacher, school_info: nil
+      original_user_school_info_id = user.school_info_id
       application = create :pd_teacher_application, user: user, form_data_hash: (
-      build :pd_teacher_application_hash, :with_custom_school
+        build :pd_teacher_application_hash, :with_custom_school
       )
 
       application.update_user_school_info!
-      refute_equal original_school_info.id, user.school_info_id
+      refute_equal original_user_school_info_id, user.school_info_id
       assert_not_nil user.school_info_id
     end
 

--- a/dashboard/test/models/pd/application/teacher_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher_application_test.rb
@@ -108,14 +108,7 @@ module Pd::Application
 
     test 'school_info_attr for custom school' do
       application = create :pd_teacher_application, form_data_hash: (
-      build :pd_teacher_application_hash,
-        :with_custom_school,
-        school_name: 'Code.org',
-        school_address: '1501 4th Ave',
-        school_city: 'Seattle',
-        school_state: 'Washington',
-        school_zip_code: '98101',
-        school_type: 'Public school'
+        build :pd_teacher_application_hash, :with_custom_school
       )
       assert_equal(
         {
@@ -135,7 +128,7 @@ module Pd::Application
       user = create :teacher, school_info: create(:school_info)
       application_school_info = create :school_info
       application = create :pd_teacher_application, user: user, form_data_hash: (
-      build :pd_teacher_application_hash, school: application_school_info.school
+        build :pd_teacher_application_hash, school: application_school_info.school
       )
 
       application.update_user_school_info!
@@ -146,7 +139,7 @@ module Pd::Application
       original_school_info = create :school_info
       user = create :teacher, school_info: original_school_info
       application = create :pd_teacher_application, user: user, form_data_hash: (
-      build :pd_teacher_application_hash, :with_custom_school
+        build :pd_teacher_application_hash, :with_custom_school
       )
 
       application.update_user_school_info!
@@ -176,8 +169,7 @@ module Pd::Application
       }
       %i(school_name school_address school_state school_zip_code school_type).each do |attribute|
         application = create :pd_teacher_application, user: user, form_data_hash: (
-          build :pd_teacher_application_hash, :with_no_school,
-            completed_custom_school_info.except(attribute)
+          build :pd_teacher_application_hash, :with_no_school, completed_custom_school_info.except(attribute)
         )
 
         application.update_user_school_info!

--- a/dashboard/test/models/pd/application/teacher_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher_application_test.rb
@@ -165,14 +165,24 @@ module Pd::Application
       assert_not_nil user.school_info_id
     end
 
-    test 'update_user_school_info does nothing when user has no specific school and does not have enough info for new school' do
+    test 'update_user_school_info does nothing when user has no school info and does not have enough info for new school' do
       user = create :teacher, school_info: nil
-      application = create :pd_teacher_application, user: user, form_data_hash: (
-        build :pd_teacher_application_hash, :with_incomplete_school
-      )
+      completed_custom_school_info = {
+        school_name: 'Code.org',
+        school_address: '1501 4th Ave',
+        school_state: 'Washington',
+        school_zip_code: '98101',
+        school_type: 'Public school'
+      }
+      %i(school_name school_address school_state school_zip_code school_type).each do |attribute|
+        application = create :pd_teacher_application, user: user, form_data_hash: (
+          build :pd_teacher_application_hash, :with_no_school,
+            completed_custom_school_info.except(attribute)
+        )
 
-      application.update_user_school_info!
-      assert_nil user.school_info
+        application.update_user_school_info!
+        assert_nil user.school_info
+      end
     end
 
     test 'get_first_selected_workshop single local workshop' do


### PR DESCRIPTION
Together with the frontend https://github.com/code-dot-org/code-dot-org/pull/44441, this fulfills _Req 1: Add a “Save and Return Later” Button to the application_. See below for future work.

Current functionality: https://watch.screencastify.com/v/SqvvikhJJq8mzL4Ygauv 

I did the following:
- (Backend): Ignore validations if the application is incomplete.
- (Backend): Manually set some fields on an update, and only do some actions on a completed application.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- spec: [Saving Progress and Reopening Applications](https://docs.google.com/document/d/1kbRAQ3To-MHVmz2KHnyaN6Mh6EiJk8F_zRNS1F8kSK8/edit?pli=1#heading=h.86qvf1hodt)
- jira ticket: [PLAT-1466](https://codedotorg.atlassian.net/browse/PLAT-1466)

## Testing story

## Deployment strategy

## Follow-up work

In (a) separate PR(s), I'm planning to
- address the to-dos,
- address two `assert_nil` warnings in relevant backend tests, and

## Privacy

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
