### PR TITLE
Allow levelbuilders to get selected block XML

### DIFF
--- a/apps/src/blockly/cdoBlocklyWrapper.js
+++ b/apps/src/blockly/cdoBlocklyWrapper.js
@@ -129,6 +129,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.wrapReadOnlyProperty('Procedures');
   blocklyWrapper.wrapReadOnlyProperty('removeChangeListener');
   blocklyWrapper.wrapReadOnlyProperty('RTL');
+  blocklyWrapper.wrapReadOnlyProperty('selected');
   blocklyWrapper.wrapReadOnlyProperty('SVG_NS');
   blocklyWrapper.wrapReadOnlyProperty('tutorialExplorer_locale');
   blocklyWrapper.wrapReadOnlyProperty('useContractEditor');

--- a/apps/src/sites/studio/pages/levelbuilder.js
+++ b/apps/src/sites/studio/pages/levelbuilder.js
@@ -50,9 +50,9 @@ window.levelbuilder.copyWorkspaceToClipboard = function() {
 };
 
 window.levelbuilder.copySelectedBlockToClipboard = function() {
-  if (Blockly.blockly_.selected) {
+  if (Blockly.selected) {
     const str = Blockly.Xml.domToPrettyText(
-      Blockly.Xml.blockToDom(Blockly.blockly_.selected)
+      Blockly.Xml.blockToDom(Blockly.selected)
     );
     copyToClipboard(str);
   }

--- a/apps/src/sites/studio/pages/levelbuilder.js
+++ b/apps/src/sites/studio/pages/levelbuilder.js
@@ -49,6 +49,15 @@ window.levelbuilder.copyWorkspaceToClipboard = function() {
   copyToClipboard(str);
 };
 
+window.levelbuilder.copySelectedBlockToClipboard = function() {
+  if (Blockly.blockly_.selected) {
+    const str = Blockly.Xml.domToPrettyText(
+      Blockly.Xml.blockToDom(Blockly.blockly_.selected)
+    );
+    copyToClipboard(str);
+  }
+};
+
 // TODO: Remove when global `CodeMirror` is no longer required.
 window.CodeMirror = codemirror;
 

--- a/dashboard/app/views/levels/_admin.html.haml
+++ b/dashboard/app/views/levels/_admin.html.haml
@@ -26,6 +26,8 @@
               - unless @level.uses_droplet?
                 %button{type: 'button', onclick: 'window.levelbuilder.copyWorkspaceToClipboard()', class: 'btn btn-default btn-sm'}
                   Copy workspace to clipboard
+                %button{type: 'button', onclick: 'window.levelbuilder.copySelectedBlockToClipboard()', class: 'btn btn-default btn-sm'}
+                  Copy selected block to clipboard
             - elsif @level.is_a? Javalab
               %ul
                 %li= link_to "[s]tart", edit_blocks_level_path(@level, :start_sources), { accesskey: 's' }

--- a/dashboard/app/views/levels/_admin.html.haml
+++ b/dashboard/app/views/levels/_admin.html.haml
@@ -26,6 +26,7 @@
               - unless @level.uses_droplet?
                 %button{type: 'button', onclick: 'window.levelbuilder.copyWorkspaceToClipboard()', class: 'btn btn-default btn-sm'}
                   Copy workspace to clipboard
+                %br
                 %button{type: 'button', onclick: 'window.levelbuilder.copySelectedBlockToClipboard()', class: 'btn btn-default btn-sm'}
                   Copy selected block to clipboard
             - elsif @level.is_a? Javalab


### PR DESCRIPTION
Add a button to levelbuilder's Extra Links for copying a selected Blockly Block.

![image](https://user-images.githubusercontent.com/43474485/150384505-35ec0929-5182-4722-bf68-732634f582fd.png)

This button gets the full XML for the currently selected Blockly block, if there is one. This feature will be invaluable for K5 curriculum writers who need to add specific blocks to level instructions or hints. 

Example usage:
Pressing the button with the background block here selected:
![image](https://user-images.githubusercontent.com/43474485/150381691-167db8aa-5229-40bb-8610-149cdf502244.png)

Generates and copies this XML:
```<block type="gamelab_setBackgroundImageAs"> <field name="IMG">"hw_plate_background_1"</field> <next> <block type="gamelab_playSound"> <field name="SOUND">Choose</field> </block> </next> </block>```

