### PR TITLE
Fix unexpected readonly workspace showing for teachers

### DIFF
--- a/apps/src/code-studio/components/progress/teacherPanel/TeacherPanel.jsx
+++ b/apps/src/code-studio/components/progress/teacherPanel/TeacherPanel.jsx
@@ -349,7 +349,7 @@ export default connect(
     loadLevelsWithProgress: () => dispatch(loadLevelsWithProgress()),
     selectUser: (userId, isAsync = false) => {
       updateQueryParam('user_id', userId);
-      updateQueryParam('version', '');
+      updateQueryParam('version');
       isAsync ? dispatch(queryUserProgress(userId)) : reload();
     },
     setStudentsForCurrentSection: (sectionId, students) => {

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -534,7 +534,8 @@ class ScriptLevelsController < ApplicationController
       authenticity_token: form_authenticity_token,
       disallowed_html_tags: disallowed_html_tags
     )
-    readonly_view_options if @level.channel_backed? && params[:version]
+
+    readonly_view_options if @level.channel_backed? && params[:version].present?
 
     # Add video generation URL for only the last level of Dance
     # If we eventually want to add video generation for other levels or level


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
We were getting reports in Zendesk that when a teacher switched to viewing a student's work and then back to their own, the workspace was showing in readonly mode. https://codedotorg.slack.com/archives/CA3KCSGTD/p1642700048045100

There were a couple things that led to this issue, during the version history work (https://github.com/code-dot-org/code-dot-org/pull/44000) there was an update to the Teacher panel to clear the version history param when switching users, which added a `&version=` to the url without specifying a version. In our backend the empty param was truthy and caused us to set readonly view options (https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/controllers/script_levels_controller.rb#L537).

The fix in this PR removes the empty url param completely instead of setting it to an empty string and changes the backend to check if the version param has a value before setting readonly mode.

## Testing story
Tested locally and added a couple of unit tests
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
