### PR TITLE
Added support for onClickOutside

### DIFF
--- a/apps/src/javalab/Backpack.jsx
+++ b/apps/src/javalab/Backpack.jsx
@@ -303,6 +303,7 @@ class Backpack extends Component {
           </div>
         )}
         <JavalabDialog
+          className="ignore-react-onclickoutside"
           isOpen={openDialog === Dialog.IMPORT_WARNING}
           handleConfirm={() => this.importFiles(selectedFiles)}
           handleClose={() => this.setState({openDialog: null})}
@@ -312,6 +313,7 @@ class Backpack extends Component {
           closeButtonText={javalabMsg.cancel()}
         />
         <JavalabDialog
+          className="ignore-react-onclickoutside"
           isOpen={openDialog === Dialog.IMPORT_ERROR}
           handleConfirm={() => this.setState({openDialog: null})}
           message={fileImportMessage}

--- a/apps/src/javalab/JavalabDialog.jsx
+++ b/apps/src/javalab/JavalabDialog.jsx
@@ -6,6 +6,7 @@ import {DisplayTheme} from './DisplayTheme';
 
 export default class JavalabDialog extends Component {
   static propTypes = {
+    className: PropTypes.string,
     isOpen: PropTypes.bool.isRequired,
     displayTheme: PropTypes.oneOf(Object.values(DisplayTheme)).isRequired,
     handleConfirm: PropTypes.func,
@@ -18,6 +19,7 @@ export default class JavalabDialog extends Component {
 
   render() {
     const {
+      className,
       isOpen,
       handleClose,
       handleConfirm,
@@ -28,6 +30,7 @@ export default class JavalabDialog extends Component {
     } = this.props;
     return (
       <BaseDialog
+        bodyClassName={className}
         isOpen={isOpen}
         handleClose={handleClose}
         style={{


### PR DESCRIPTION
An issue was discovered where backpack files that overwrite the current file cannot be imported despite a dialog that appears to allow this case. After the addition of onClickOutside to the backpack dropdown, any click action outside the dropdown caused the dropdown to close, unmounting any child element. This caused the dialog to close without completing the confirmation action.

This is solved by adding "ignore-react-onclickoutside" to the class name list in Java Lab Dialog for the Backpack dialog.

There are further details in this [slack thread](https://codedotorg.slack.com/archives/C01EF4GJ9GE/p1642705160111700).

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
