### PR TITLE
Add reset timer block

### DIFF
--- a/apps/src/p5lab/spritelab/CoreLibrary.js
+++ b/apps/src/p5lab/spritelab/CoreLibrary.js
@@ -12,8 +12,10 @@ export default class CoreLibrary {
     this.behaviors = [];
     this.userInputEventCallbacks = {};
     this.totalPauseTime = 0;
-    this.timerResetTime = 0;
-    this.timerResetFrames = 0;
+    this.timerReset = {
+      seconds: 0,
+      frames: 0
+    };
     this.numActivePrompts = 0;
     this.screenText = {};
     this.defaultSpriteSize = 100;
@@ -470,7 +472,7 @@ export default class CoreLibrary {
     if (inputEvent.args.unit === 'seconds') {
       const previousTime = inputEvent.previousTime || 0;
       const worldTime =
-        this.getAdjustedWorldTime(this.p5) - this.timerResetTime;
+        this.getAdjustedWorldTime(this.p5) - this.timerReset.seconds;
       inputEvent.previousTime = worldTime;
       // There are many ticks per second, but we only want to fire the event once (on the first tick where
       // the time matches the event argument)
@@ -483,7 +485,7 @@ export default class CoreLibrary {
         return [{}];
       }
     } else if (inputEvent.args.unit === 'frames') {
-      const worldFrames = this.p5.frameCount - this.timerResetFrames;
+      const worldFrames = this.p5.frameCount - this.timerReset.frames;
       if (worldFrames === inputEvent.args.n) {
         // Call callback with no extra args
         this.eventLog.push(`atTime: ${inputEvent.args.n}`);

--- a/apps/src/p5lab/spritelab/CoreLibrary.js
+++ b/apps/src/p5lab/spritelab/CoreLibrary.js
@@ -164,7 +164,7 @@ export default class CoreLibrary {
     this.removeSpeechBubblesForSprite(sprite);
 
     const id = createUuid();
-    const removeAt = seconds ? this.getAdjustedWorldTime() + seconds : null;
+    const removeAt = seconds ? this.getUnpausedWorldTime() + seconds : null;
     // Note: renderFrame is used by validation code.
     this.speechBubbles.push({
       id,
@@ -184,7 +184,7 @@ export default class CoreLibrary {
 
   removeExpiredSpeechBubbles() {
     this.speechBubbles = this.speechBubbles.filter(
-      ({removeAt}) => !removeAt || removeAt > this.getAdjustedWorldTime()
+      ({removeAt}) => !removeAt || removeAt > this.getUnpausedWorldTime()
     );
   }
 
@@ -202,7 +202,7 @@ export default class CoreLibrary {
   /**
    * Returns World.seconds adjusted to exclude time during which the app was paused
    */
-  getAdjustedWorldTime() {
+  getUnpausedWorldTime() {
     const current = new Date().getTime();
     return Math.round(
       (current - this.p5._startTime - this.totalPauseTime) / 1000
@@ -213,7 +213,7 @@ export default class CoreLibrary {
    * Returns time (in seconds) since last resetTimer(), excluding time during which the app was paused
    */
   getSecondsSinceReset() {
-    return this.getAdjustedWorldTime(this.p5) - this.timerResetTime.seconds;
+    return this.getUnpausedWorldTime(this.p5) - this.timerResetTime.seconds;
   }
 
   /**
@@ -511,7 +511,7 @@ export default class CoreLibrary {
 
   collectDataEvent(inputEvent) {
     const previous = inputEvent.previous || 0;
-    const worldTime = this.getAdjustedWorldTime(this.p5);
+    const worldTime = this.getUnpausedWorldTime(this.p5);
     inputEvent.previous = worldTime;
 
     // Only log data once per second

--- a/apps/src/p5lab/spritelab/CoreLibrary.js
+++ b/apps/src/p5lab/spritelab/CoreLibrary.js
@@ -12,7 +12,7 @@ export default class CoreLibrary {
     this.behaviors = [];
     this.userInputEventCallbacks = {};
     this.totalPauseTime = 0;
-    this.timerReset = {
+    this.timerResetTime = {
       seconds: 0,
       frames: 0
     };
@@ -207,6 +207,20 @@ export default class CoreLibrary {
     return Math.round(
       (current - this.p5._startTime - this.totalPauseTime) / 1000
     );
+  }
+
+  /**
+   * Returns time (in seconds) since last resetTimer(), excluding time during which the app was paused
+   */
+  getSecondsSinceReset() {
+    return this.getAdjustedWorldTime(this.p5) - this.timerResetTime.seconds;
+  }
+
+  /**
+   * Returns time (in frames) since last resetTimer()
+   */
+  getFramesSinceReset() {
+    return this.p5.frameCount - this.timerResetTime.frames;
   }
 
   /**
@@ -471,8 +485,7 @@ export default class CoreLibrary {
   atTimeEvent(inputEvent) {
     if (inputEvent.args.unit === 'seconds') {
       const previousTime = inputEvent.previousTime || 0;
-      const worldTime =
-        this.getAdjustedWorldTime(this.p5) - this.timerReset.seconds;
+      const worldTime = this.getSecondsSinceReset();
       inputEvent.previousTime = worldTime;
       // There are many ticks per second, but we only want to fire the event once (on the first tick where
       // the time matches the event argument)
@@ -485,7 +498,7 @@ export default class CoreLibrary {
         return [{}];
       }
     } else if (inputEvent.args.unit === 'frames') {
-      const worldFrames = this.p5.frameCount - this.timerReset.frames;
+      const worldFrames = this.getFramesSinceReset();
       if (worldFrames === inputEvent.args.n) {
         // Call callback with no extra args
         this.eventLog.push(`atTime: ${inputEvent.args.n}`);

--- a/apps/src/p5lab/spritelab/CoreLibrary.js
+++ b/apps/src/p5lab/spritelab/CoreLibrary.js
@@ -12,6 +12,7 @@ export default class CoreLibrary {
     this.behaviors = [];
     this.userInputEventCallbacks = {};
     this.totalPauseTime = 0;
+    this.timerResetTime = 0;
     this.numActivePrompts = 0;
     this.screenText = {};
     this.defaultSpriteSize = 100;
@@ -199,6 +200,7 @@ export default class CoreLibrary {
    * Returns World.seconds adjusted to exclude time during which the app was paused
    */
   getAdjustedWorldTime() {
+    //console.log(`gAWT time is now ${this.timerResetTime}`);
     const current = new Date().getTime();
     return Math.round(
       (current - this.p5._startTime - this.totalPauseTime) / 1000
@@ -465,9 +467,16 @@ export default class CoreLibrary {
   }
 
   atTimeEvent(inputEvent) {
+    console.log(`reset time is ${this.timerResetTime}`);
+    console.log(`adjusted time is ${this.getAdjustedWorldTime(this.p5)}`);
     if (inputEvent.args.unit === 'seconds') {
       const previousTime = inputEvent.previousTime || 0;
-      const worldTime = this.getAdjustedWorldTime(this.p5);
+      const worldTime =
+        this.getAdjustedWorldTime(this.p5) - this.timerResetTime;
+      console.log(`worldTime is ${worldTime}`);
+      //const timerTime = this.timerResetTime;
+      //console.log(`timerTime is ${timerTime}`);
+      //console.log(timerTime);
       inputEvent.previousTime = worldTime;
       // There are many ticks per second, but we only want to fire the event once (on the first tick where
       // the time matches the event argument)

--- a/apps/src/p5lab/spritelab/CoreLibrary.js
+++ b/apps/src/p5lab/spritelab/CoreLibrary.js
@@ -200,7 +200,6 @@ export default class CoreLibrary {
    * Returns World.seconds adjusted to exclude time during which the app was paused
    */
   getAdjustedWorldTime() {
-    //console.log(`gAWT time is now ${this.timerResetTime}`);
     const current = new Date().getTime();
     return Math.round(
       (current - this.p5._startTime - this.totalPauseTime) / 1000
@@ -467,16 +466,10 @@ export default class CoreLibrary {
   }
 
   atTimeEvent(inputEvent) {
-    console.log(`reset time is ${this.timerResetTime}`);
-    console.log(`adjusted time is ${this.getAdjustedWorldTime(this.p5)}`);
     if (inputEvent.args.unit === 'seconds') {
       const previousTime = inputEvent.previousTime || 0;
       const worldTime =
         this.getAdjustedWorldTime(this.p5) - this.timerResetTime;
-      console.log(`worldTime is ${worldTime}`);
-      //const timerTime = this.timerResetTime;
-      //console.log(`timerTime is ${timerTime}`);
-      //console.log(timerTime);
       inputEvent.previousTime = worldTime;
       // There are many ticks per second, but we only want to fire the event once (on the first tick where
       // the time matches the event argument)

--- a/apps/src/p5lab/spritelab/CoreLibrary.js
+++ b/apps/src/p5lab/spritelab/CoreLibrary.js
@@ -13,6 +13,7 @@ export default class CoreLibrary {
     this.userInputEventCallbacks = {};
     this.totalPauseTime = 0;
     this.timerResetTime = 0;
+    this.timerResetFrames = 0;
     this.numActivePrompts = 0;
     this.screenText = {};
     this.defaultSpriteSize = 100;
@@ -482,7 +483,8 @@ export default class CoreLibrary {
         return [{}];
       }
     } else if (inputEvent.args.unit === 'frames') {
-      if (this.p5.frameCount === inputEvent.args.n) {
+      const worldFrames = this.p5.frameCount - this.timerResetFrames;
+      if (worldFrames === inputEvent.args.n) {
         // Call callback with no extra args
         this.eventLog.push(`atTime: ${inputEvent.args.n}`);
         return [{}];

--- a/apps/src/p5lab/spritelab/commands/worldCommands.js
+++ b/apps/src/p5lab/spritelab/commands/worldCommands.js
@@ -24,16 +24,16 @@ export const commands = {
 
   getTime(unit) {
     if (unit === 'seconds') {
-      return this.getAdjustedWorldTime() - this.timerReset.seconds || 0;
+      return this.getAdjustedWorldTime() - this.timerResetTime.seconds || 0;
     } else if (unit === 'frames') {
-      return this.p5.World.frameCount - this.timerReset.frames || 0;
+      return this.p5.World.frameCount - this.timerResetTime.frames || 0;
     }
     return 0;
   },
 
   resetTimer() {
-    this.timerReset.seconds = this.getAdjustedWorldTime();
-    this.timerReset.frames = this.p5.World.frameCount;
+    this.timerResetTime.seconds = this.getAdjustedWorldTime();
+    this.timerResetTime.frames = this.currentFrame();
   },
 
   hideTitleScreen() {

--- a/apps/src/p5lab/spritelab/commands/worldCommands.js
+++ b/apps/src/p5lab/spritelab/commands/worldCommands.js
@@ -24,16 +24,16 @@ export const commands = {
 
   getTime(unit) {
     if (unit === 'seconds') {
-      return this.getAdjustedWorldTime() - this.timerResetTime || 0;
+      return this.getAdjustedWorldTime() - this.timerReset.seconds || 0;
     } else if (unit === 'frames') {
-      return this.p5.World.frameCount - this.timerResetFrames || 0;
+      return this.p5.World.frameCount - this.timerReset.frames || 0;
     }
     return 0;
   },
 
   resetTimer() {
-    this.timerResetTime = this.getAdjustedWorldTime();
-    this.timerResetFrames = this.p5.World.frameCount;
+    this.timerReset.seconds = this.getAdjustedWorldTime();
+    this.timerReset.frames = this.p5.World.frameCount;
   },
 
   hideTitleScreen() {

--- a/apps/src/p5lab/spritelab/commands/worldCommands.js
+++ b/apps/src/p5lab/spritelab/commands/worldCommands.js
@@ -24,7 +24,7 @@ export const commands = {
 
   getTime(unit) {
     if (unit === 'seconds') {
-      return this.getAdjustedWorldTime() - this.timerResetTime.seconds || 0;
+      return this.getUnpausedWorldTime() - this.timerResetTime.seconds || 0;
     } else if (unit === 'frames') {
       return this.p5.World.frameCount - this.timerResetTime.frames || 0;
     }
@@ -32,7 +32,7 @@ export const commands = {
   },
 
   resetTimer() {
-    this.timerResetTime.seconds = this.getAdjustedWorldTime();
+    this.timerResetTime.seconds = this.getUnpausedWorldTime();
     this.timerResetTime.frames = this.currentFrame();
   },
 

--- a/apps/src/p5lab/spritelab/commands/worldCommands.js
+++ b/apps/src/p5lab/spritelab/commands/worldCommands.js
@@ -32,10 +32,8 @@ export const commands = {
   },
 
   resetTimer() {
-    const currentTime = this.getAdjustedWorldTime();
-    this.timerResetTime = currentTime;
-    const currentFrames = this.p5.World.frameCount;
-    this.timerResetFrames = currentFrames;
+    this.timerResetTime = this.getAdjustedWorldTime();
+    this.timerResetFrames = this.p5.World.frameCount;
   },
 
   hideTitleScreen() {

--- a/apps/src/p5lab/spritelab/commands/worldCommands.js
+++ b/apps/src/p5lab/spritelab/commands/worldCommands.js
@@ -26,14 +26,16 @@ export const commands = {
     if (unit === 'seconds') {
       return this.getAdjustedWorldTime() - this.timerResetTime || 0;
     } else if (unit === 'frames') {
-      return this.p5.World.frameCount || 0;
+      return this.p5.World.frameCount - this.timerResetFrames || 0;
     }
     return 0;
   },
 
   resetTimer() {
-    const current = this.getAdjustedWorldTime();
-    this.timerResetTime = current;
+    const currentTime = this.getAdjustedWorldTime();
+    this.timerResetTime = currentTime;
+    const currentFrames = this.p5.World.frameCount;
+    this.timerResetFrames = currentFrames;
   },
 
   hideTitleScreen() {

--- a/apps/src/p5lab/spritelab/commands/worldCommands.js
+++ b/apps/src/p5lab/spritelab/commands/worldCommands.js
@@ -24,11 +24,19 @@ export const commands = {
 
   getTime(unit) {
     if (unit === 'seconds') {
-      return this.getAdjustedWorldTime() || 0;
+      return this.getAdjustedWorldTime() - this.timerResetTime || 0;
     } else if (unit === 'frames') {
       return this.p5.World.frameCount || 0;
     }
     return 0;
+  },
+
+  resetTimer() {
+    const current = this.getAdjustedWorldTime();
+    //console.log(`pause time was ${this.timerResetTime}`);
+    //console.log(`current time is ${current}`);
+    this.timerResetTime = current;
+    console.log(`pause time is now ${this.timerResetTime}`);
   },
 
   hideTitleScreen() {

--- a/apps/src/p5lab/spritelab/commands/worldCommands.js
+++ b/apps/src/p5lab/spritelab/commands/worldCommands.js
@@ -33,10 +33,7 @@ export const commands = {
 
   resetTimer() {
     const current = this.getAdjustedWorldTime();
-    //console.log(`pause time was ${this.timerResetTime}`);
-    //console.log(`current time is ${current}`);
     this.timerResetTime = current;
-    console.log(`pause time is now ${this.timerResetTime}`);
   },
 
   hideTitleScreen() {

--- a/dashboard/config/blocks/GamelabJr/gamelab_resetTimer.json
+++ b/dashboard/config/blocks/GamelabJr/gamelab_resetTimer.json
@@ -1,0 +1,15 @@
+{
+  "category": "World",
+  "config": {
+    "color": [
+      240,
+      0.45,
+      0.65
+    ],
+    "func": "resetTimer",
+    "blockText": "reset timer",
+    "args": [
+
+    ]
+  }
+}

--- a/dashboard/config/libraries/zTimerPrototype.interpreted.js
+++ b/dashboard/config/libraries/zTimerPrototype.interpreted.js
@@ -16,7 +16,7 @@ function drawTimer(){
     ellipse(timerX, timerY, 25, 25);
     fill("black");
     noStroke();
-    var angle=World.seconds%60*6;
+    var angle=getTime("seconds")%60*6;
     angle-=90;
     arc(timerX,timerY,18,18,270,angle+10);
     stroke("white");

--- a/dashboard/config/libraries/zTimerPrototype.interpreted.js
+++ b/dashboard/config/libraries/zTimerPrototype.interpreted.js
@@ -23,7 +23,7 @@ function drawTimer(){
     textAlign(RIGHT, CENTER);
     strokeWeight(5);
     textSize(20);
-    text(World.seconds,timerX-20,timerY);
+    text(getTime("seconds"),timerX-20,timerY);
     pop();
   }
 }


### PR DESCRIPTION
## Background 
jira ticket: [STAR-2045](https://codedotorg.atlassian.net/browse/STAR-2045)
Direct request from @amy-b:
> Hey question that is coming up from [CSC] bootcamp. We have these `at 1 second` event blocks. A teacher is asking if there is a way to reset the timer back to 0, 1, 2, etc midway through the program.

## Feature
Give Sprite Lab users the ability to reset the "timer" that is use in both `CoreLibrary.atTimeEvent` and `worldCommands.getTime`. Add a `reset timer` block that resets the number of seconds and frames used in each of these scenarios. Timer accounts for paused time. If a user never touches the new block, all code behaves exactly how it does now. 
The file "zTimerPrototype.interpreted.js" is just a helper library and not currently a standard Sprite Lab feature. (It's a prototype for drawing a stopwatch to show the current world time.) Reviewers can potentially skip this file as it's not important to the PR nor used in our curriculum.

## Sample Programs
This simple program resets the timer as soon as 4 seconds are reached:
*(Note that the stopwatch graphic in the play area in the top left is .)*

https://user-images.githubusercontent.com/43474485/150575209-25e45f8a-088e-4a65-b6ea-3bec0d158a62.mp4

Example of a game unlocked by this feature:

https://user-images.githubusercontent.com/43474485/150575228-22db73e2-128b-4a26-8953-66bf3fc643c7.mp4
