### PR TITLE
When generating PLC course set all course type and published state information

### DIFF
--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -172,7 +172,6 @@ class Script < ApplicationRecord
   include SerializedProperties
 
   after_save :generate_plc_objects
-  validate :scripts_in_same_plc_course
 
   UNIT_DIRECTORY = "#{Rails.root}/config/scripts".freeze
 
@@ -202,16 +201,6 @@ class Script < ApplicationRecord
   # This returns true if a course uses the PLC course models.
   def old_professional_learning_course?
     !professional_learning_course.nil?
-  end
-
-  def units_in_same_plc_course_must_share_settings
-    if old_professional_learning_course?
-      plc_course_scripts = all_scripts.select {|s| s.professional_learning_course == professional_learning_course}
-      errors.add(:published_state, 'must be the same for all scripts in same plc course.') if plc_course_scripts.map(&:published_state).any? {|state| state != published_state}
-      errors.add(:instructor_audience, 'must be the same for all scripts in same plc course.') if plc_course_scripts.map(&:instructor_audience).any? {|audience| audience != instructor_audience}
-      errors.add(:participant_audience, 'must be the same for all scripts in same plc course.') if plc_course_scripts.map(&:participant_audience).any? {|audience| audience != participant_audience}
-      errors.add(:instruction_type, 'must be the same for all scripts in same plc course.') if plc_course_scripts.map(&:instruction_type).any? {|type| type != instruction_type}
-    end
   end
 
   def generate_plc_objects

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -218,7 +218,7 @@ class Script < ApplicationRecord
           published_state: get_published_state,
           instruction_type: get_instruction_type,
           instructor_audience: get_instructor_audience,
-          participant_type: get_participant_audience
+          participant_audience: get_participant_audience
         )
         unit_group.plc_course = Plc::Course.create!(unit_group: unit_group)
         unit_group.save!

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -212,6 +212,7 @@ class Script < ApplicationRecord
         unit_group.instruction_type = get_instruction_type if unit_group.instruction_type != get_instruction_type
         unit_group.participant_audience = get_participant_audience if unit_group.participant_audience != get_participant_audience
         unit_group.instructor_audience = get_instructor_audience if unit_group.instructor_audience != get_instructor_audience
+        unit_group.save! if unit_group.changed?
       else
         unit_group = UnitGroup.new(
           name: professional_learning_course,

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -208,18 +208,18 @@ class Script < ApplicationRecord
       unit_group = UnitGroup.find_by_name(professional_learning_course)
       if unit_group
         # Check if anything needs to be updated on the PL course
-        unit_group.published_state = get_published_state if unit_group.published_state != get_published_state
-        unit_group.instruction_type = get_instruction_type if unit_group.instruction_type != get_instruction_type
-        unit_group.participant_audience = get_participant_audience if unit_group.participant_audience != get_participant_audience
-        unit_group.instructor_audience = get_instructor_audience if unit_group.instructor_audience != get_instructor_audience
+        unit_group.published_state = published_state
+        unit_group.instruction_type = instruction_type
+        unit_group.participant_audience = participant_audience
+        unit_group.instructor_audience = instructor_audience
         unit_group.save! if unit_group.changed?
       else
         unit_group = UnitGroup.new(
           name: professional_learning_course,
-          published_state: get_published_state,
-          instruction_type: get_instruction_type,
-          instructor_audience: get_instructor_audience,
-          participant_audience: get_participant_audience
+          published_state: published_state,
+          instruction_type: instruction_type,
+          instructor_audience: instructor_audience,
+          participant_audience: participant_audience
         )
         unit_group.plc_course = Plc::Course.create!(unit_group: unit_group)
         unit_group.save!

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -172,6 +172,7 @@ class Script < ApplicationRecord
   include SerializedProperties
 
   after_save :generate_plc_objects
+  validate :scripts_in_same_plc_course
 
   UNIT_DIRECTORY = "#{Rails.root}/config/scripts".freeze
 
@@ -203,7 +204,7 @@ class Script < ApplicationRecord
     !professional_learning_course.nil?
   end
 
-  def must_share_settings_for_scripts_in_same_plc_course
+  def units_in_same_plc_course_must_share_settings
     if old_professional_learning_course?
       plc_course_scripts = all_scripts.select {|s| s.professional_learning_course == professional_learning_course}
       errors.add(:published_state, 'must be the same for all scripts in same plc course.') if plc_course_scripts.map(&:published_state).any? {|state| state != published_state}

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -203,6 +203,16 @@ class Script < ApplicationRecord
     !professional_learning_course.nil?
   end
 
+  def must_share_settings_for_scripts_in_same_plc_course
+    if old_professional_learning_course?
+      plc_course_scripts = all_scripts.select {|s| s.professional_learning_course == professional_learning_course}
+      errors.add(:published_state, 'must be the same for all scripts in same plc course.') if plc_course_scripts.map(&:published_state).any? {|state| state != published_state}
+      errors.add(:instructor_audience, 'must be the same for all scripts in same plc course.') if plc_course_scripts.map(&:instructor_audience).any? {|audience| audience != instructor_audience}
+      errors.add(:participant_audience, 'must be the same for all scripts in same plc course.') if plc_course_scripts.map(&:participant_audience).any? {|audience| audience != participant_audience}
+      errors.add(:instruction_type, 'must be the same for all scripts in same plc course.') if plc_course_scripts.map(&:instruction_type).any? {|type| type != instruction_type}
+    end
+  end
+
   def generate_plc_objects
     if old_professional_learning_course?
       unit_group = UnitGroup.find_by_name(professional_learning_course)

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -206,8 +206,20 @@ class Script < ApplicationRecord
   def generate_plc_objects
     if old_professional_learning_course?
       unit_group = UnitGroup.find_by_name(professional_learning_course)
-      unless unit_group
-        unit_group = UnitGroup.new(name: professional_learning_course)
+      if unit_group
+        # Check if anything needs to be updated on the PL course
+        unit_group.published_state = get_published_state if unit_group.published_state != get_published_state
+        unit_group.instruction_type = get_instruction_type if unit_group.instruction_type != get_instruction_type
+        unit_group.participant_audience = get_participant_audience if unit_group.participant_audience != get_participant_audience
+        unit_group.instructor_audience = get_instructor_audience if unit_group.instructor_audience != get_instructor_audience
+      else
+        unit_group = UnitGroup.new(
+          name: professional_learning_course,
+          published_state: get_published_state,
+          instruction_type: get_instruction_type,
+          instructor_audience: get_instructor_audience,
+          participant_type: get_participant_audience
+        )
         unit_group.plc_course = Plc::Course.create!(unit_group: unit_group)
         unit_group.save!
       end

--- a/dashboard/test/fixtures/test-plc.script_json
+++ b/dashboard/test/fixtures/test-plc.script_json
@@ -11,10 +11,10 @@
     "new_name": null,
     "family_name": null,
     "serialized_at": "2021-11-01 23:56:37 UTC",
-    "published_state": null,
-    "instruction_type": null,
-    "instructor_audience": null,
-    "participant_audience": null,
+    "published_state": "beta",
+    "instruction_type": "teacher_led",
+    "instructor_audience": "plc_reviewer",
+    "participant_audience": "facilitator",
     "seeding_key": {
       "script.name": "test-plc"
     }

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1067,14 +1067,42 @@ class ScriptTest < ActiveSupport::TestCase
     assert_equal 42, unit.peer_reviews_to_complete
 
     course_unit = unit.plc_course_unit
+    unit_group = unit.plc_course_unit.plc_course.unit_group
     assert_equal 'PLC Test', course_unit.unit_name
     assert_equal 'PLC test fixture script', course_unit.unit_description
+
+    assert_equal 'plc_reviewer', unit_group.instructor_audience
+    assert_equal 'facilitator', unit_group.participant_audience
+    assert_equal 'teacher_led', unit_group.instruction_type
+    assert_equal 'beta', unit_group.published_state
 
     lm = unit.lessons.first.plc_learning_module
     assert_equal 'Sample Module', lm.name
     assert_equal 1, course_unit.plc_learning_modules.count
     assert_equal lm, course_unit.plc_learning_modules.first
     assert_equal Plc::LearningModule::CONTENT_MODULE, lm.module_type
+  end
+
+  test 'updating plc unit updates its unit group' do
+    Script.stubs(:unit_json_directory).returns(self.class.fixture_path)
+    unit = Script.seed_from_json_file('test-plc')
+
+    unit_group = unit.plc_course_unit.plc_course.unit_group
+
+    assert_equal 'plc_reviewer', unit_group.instructor_audience
+    assert_equal 'facilitator', unit_group.participant_audience
+    assert_equal 'teacher_led', unit_group.instruction_type
+    assert_equal 'beta', unit_group.published_state
+
+    unit.update!(instructor_audience: 'universal_instructor', participant_audience: 'teacher', instruction_type: 'self_paced', published_state: 'stable')
+
+    unit.reload
+    unit_group = unit.plc_course_unit.plc_course.unit_group
+
+    assert_equal 'universal_instructor', unit_group.instructor_audience
+    assert_equal 'teacher', unit_group.participant_audience
+    assert_equal 'self_paced', unit_group.instruction_type
+    assert_equal 'stable', unit_group.published_state
   end
 
   test 'unit name format validation' do


### PR DESCRIPTION
Scripts that are part of PLC courses generate a Unit Group with the same name as the one saved in the `professional_learning_course` on script. The Unit Group is created in `generate_plc_objects` and is not serialized. We need a way to set things like the audiences on the unit group in order to be able to make sure access to the plc course is set to the right audiences (as well as published states and instruction type). Therefore we must rely on the script to get the unit groups settings for instructor_audience, participant_audience, instruction_type and published_state. This is not the ideal solution to fix this, but because we do no currently have time to invest in cleaning up the plc course models and this set up of unit groups for plc courses, this is the best we can do right now. By setting the unit group based on the settings of the script which has just been saved we could end up with multiple scripts in the same plc course with different settings. We will be creating a guide to publishing plc courses to hopefully help prevent issues here.

This will be followed by a PR with a migration to update the current UnitGroups for PLC Courses in all environments: https://github.com/code-dot-org/code-dot-org/pull/44479


## Links

[Slack Thread](https://codedotorg.slack.com/archives/C02DZT72F4P/p1643046838009900)

## Testing story

- Added new unit test