### PR TITLE
Write custom level file even if level is unchanged

### DIFF
--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -256,8 +256,7 @@ class Level < ApplicationRecord
   end
 
   def should_write_custom_level_file?
-    changed = saved_changes? || (level_concept_difficulty && level_concept_difficulty.saved_changes?)
-    changed && write_to_file? && published
+    write_to_file? && published
   end
 
   def write_custom_level_file


### PR DESCRIPTION
In a Slack discussion, we couldn't think of a compelling reason to keep this check. This check blocks us regenerating the level files if there's an issues (for example, if the level concept difficulties didn't get written but do exist in the database...).

In addition, if you go to a level edit page and hit save without making changes, the file is written as the audit log changed under the hood. I can't think of a reason we'd want to prevent trying to write the file when we save via dashboard-console but I am open to push back if there are concerns. 


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
