### PR TITLE
Fix cs journeys banner, footsteps overflowing

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/csjourneys.css
+++ b/pegasus/sites.v3/code.org/public/css/csjourneys.css
@@ -5,6 +5,7 @@
     rgba(0, 173, 188, 1) 70%
   );
   margin-top: -18px;
+  overflow: hidden;
 }
 
 .csjourneys-banner-container {


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Before -
![image](https://user-images.githubusercontent.com/24235215/150846764-d02dd3e6-b018-4266-804c-7395f092b705.png)

Footsteps were overflowing banner, to reproduce you could load the page and then use the horizontal scroll and scroll right to see the gap.

I plan on merging as soon as this is approved and not waiting for drone, to get this out for marketing in today's release, let me know if you have objections.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
