### PR TITLE
Revert "Update Pegasus HoC helper to use i18n backend"

### DIFF
--- a/pegasus/helpers/hourofcode_helpers.rb
+++ b/pegasus/helpers/hourofcode_helpers.rb
@@ -7,6 +7,15 @@ def hoc_load_countries
 end
 HOC_COUNTRIES = hoc_load_countries
 
+def hoc_load_i18n
+  i18n = {}
+  Dir.glob(hoc_dir('i18n/*.yml')).each do |string_file|
+    i18n.merge!(YAML.load_file(string_file))
+  end
+  i18n
+end
+HOC_I18N = hoc_load_i18n
+
 # Can be called by pages on hourofcode.com, code.org, or csedweek.org to retrieve
 # a string from the hourofcode.com translations.
 # When called on hourofcode.com, it uses @language.
@@ -19,7 +28,7 @@ HOC_COUNTRIES = hoc_load_countries
 def hoc_s(id, markdown: false, locals: nil)
   id = id.to_s
   language = @language || Languages.get_hoc_unique_language_by_locale(request.locale)
-  string = I18n.t(id, locale: language)
+  string = HOC_I18N[language][id] || HOC_I18N['en'][id]
 
   # manually implement a very simple version of string interpolation
   if locals.present?
@@ -47,10 +56,8 @@ def hoc_canonicalized_i18n_path(uri, query_string)
   end
 
   if @country || @company
-    if possible_language && I18n.backend.translations.key?(possible_language[0..1].to_sym)
-      # HOC uses two-letter language code. The full list of language codes is
-      # in the unique_language_s column in Pegasus.cdo_languages table.
-      @user_language = possible_language[0..1]
+    if HOC_I18N[possible_language]
+      @user_language = possible_language
     else
       path = File.join([possible_language, path].reject(&:nil_or_empty?))
     end
@@ -72,7 +79,6 @@ def hoc_canonicalized_i18n_path(uri, query_string)
   browser_non_english = !hoc_detect_language.nil? && hoc_detect_language != 'en'
   default_language = browser_non_english ? hoc_detect_language : country_language
 
-  # Expected to be in short string format (ex. 'en')
   @language = @user_language || default_language
 
   canonical_urls = [File.join(["/#{(@company || @country)}/#{@language}", path].reject(&:nil_or_empty?))]
@@ -99,12 +105,12 @@ def hoc_detect_country
   country_code
 end
 
-# Get browser language from HTTP_ACCEPT_LANGUAGE header, then return a two-letter
-# language code or nil if we don't have translation for that language.
 def hoc_detect_language
-  language = request.env['rack.locale'] || ''
-  language_short = language[0..1]
-  return I18n.backend.translations.key?(language_short.to_sym) ? language_short : nil
+  language = request.env['rack.locale']
+  return language if HOC_I18N.keys.include?(language)
+  language = language[0..1]
+  return language if HOC_I18N.keys.include?(language)
+  nil
 end
 
 # Called by pages on hourofcode.com to convert the current two-letter language (stored
@@ -178,7 +184,7 @@ def campaign_date(format)
     id = "#{type}_#{id}"
   end
 
-  return I18n.t(id, locale: language)
+  return HOC_I18N[language][id] || HOC_I18N['en'][id]
 end
 
 def company_count

--- a/pegasus/src/env.rb
+++ b/pegasus/src/env.rb
@@ -24,10 +24,6 @@ def sites_v3_dir(*paths)
   pegasus_dir('sites.v3', *paths)
 end
 
-def hoc_dir(*paths)
-  pegasus_dir('sites.v3', 'hourofcode.com', *paths)
-end
-
 def src_dir(*paths)
   pegasus_dir('src', *paths)
 end
@@ -53,19 +49,11 @@ def load_pegasus_settings
   I18n.backend = CDO.i18n_backend
   I18n.backend.class.send(:include, I18n::Backend::Fallbacks)
   I18n.fallbacks = I18n::Locale::Fallbacks.new(['en-US'])
-
-  # We don't load all translations in dev and test environment.
-  # Loading translations from files is slow, more than 60s sometimes. That can
-  # cause unrelated eyes tests to fail because of command timeout.
-  if (rack_env?(:development) || rack_env?(:test)) && !CDO.load_locales
+  if rack_env?(:development) && !CDO.load_locales
     I18n.load_path += Dir[cache_dir('i18n/en-US.yml')]
     I18n.load_path += Dir[cache_dir('i18n/es-ES.yml')]
-    I18n.load_path += Dir[hoc_dir('i18n/en.yml')]
-    I18n.load_path += Dir[hoc_dir('i18n/es.yml')]
-    I18n.load_path += Dir[hoc_dir('i18n/fr.yml')]
   else
     I18n.load_path += Dir[cache_dir('i18n/*.yml')]
-    I18n.load_path += Dir[hoc_dir('i18n/*.yml')]
   end
   I18n.enforce_available_locales = false
   I18n.backend.load_translations

--- a/pegasus/test/test_hoc_s.rb
+++ b/pegasus/test/test_hoc_s.rb
@@ -24,60 +24,60 @@ class HocI18nTest < Minitest::Test
   end
 
   def test_html_escaped
-    I18n.backend.store_translations 'en', {"test" => "string with <strong>embedded html</strong>"}
+    HOC_I18N['en']['test'] = "string with <strong>embedded html</strong>"
     resp = get('/hoc_s/generic')
     assert_equal 200, resp.status
     assert_match "<h1>string with &lt;strong&gt;embedded html&lt;/strong&gt;</h1>", resp.body
   end
 
   def test_interpolation
-    I18n.backend.store_translations 'en', {"test" => "%{first}"}
+    HOC_I18N['en']['test'] = "%{first}"
     resp = get('/hoc_s/interpolation')
     assert_equal 200, resp.status
     assert_match "<h1>primary</h1>", resp.body
 
-    I18n.backend.store_translations 'en', {"test" => "%{first} %{second}"}
+    HOC_I18N['en']['test'] = "%{first} %{second}"
     resp = get('/hoc_s/interpolation')
     assert_equal 200, resp.status
     assert_match "<h1>primary secondary</h1>", resp.body
 
-    I18n.backend.store_translations 'en', {"test" => "%{first} %{second} %{first} again"}
+    HOC_I18N['en']['test'] = "%{first} %{second} %{first} again"
     resp = get('/hoc_s/interpolation')
     assert_equal 200, resp.status
     assert_match "<h1>primary secondary primary again</h1>", resp.body
   end
 
   def test_markdown
-    I18n.backend.store_translations 'en', {"test" => "string with **some** _basic_ formatting"}
+    HOC_I18N['en']['test'] = "string with **some** _basic_ formatting"
     resp = get('/hoc_s/markdown')
     assert_equal 200, resp.status
     assert_match "<h1><p>string with <strong>some</strong> <em>basic</em> formatting</p>\n</h1>", resp.body
 
-    I18n.backend.store_translations 'en', {"test" => "string with <strong>embedded html</strong>"}
+    HOC_I18N['en']['test'] = "string with <strong>embedded html</strong>"
     resp = get('/hoc_s/markdown')
     assert_equal 200, resp.status
     assert_match "<h1><p>string with &lt;strong&gt;embedded html&lt;/strong&gt;</p>\n</h1>", resp.body
   end
 
   def test_interpolated_markdown
-    I18n.backend.store_translations 'en', {"test" => "string with an [interpolated link](%{url})"}
+    HOC_I18N['en']['test'] = "string with an [interpolated link](%{url})"
     resp = get('/hoc_s/interpolated_markdown')
     assert_equal 200, resp.status
     assert_match "<h1><p>string with an <a href=\"http://test.com\">interpolated link</a></p>\n</h1>", resp.body
   end
 
   def test_inline_markdown
-    I18n.backend.store_translations 'en', {"test" => "basic string"}
+    HOC_I18N['en']['test'] = "basic string"
     resp = get('/hoc_s/inline_markdown')
     assert_equal 200, resp.status
     assert_match "<h1>basic string</h1>", resp.body
 
-    I18n.backend.store_translations 'en', {"test" => "string with\n\n- some\n- block\n\nmarkdown"}
+    HOC_I18N['en']['test'] = "string with\n\n- some\n- block\n\nmarkdown"
     resp = get('/hoc_s/inline_markdown')
     assert_equal 200, resp.status
     assert_match "<h1>string withsome\nblock\nmarkdown</h1>", resp.body
 
-    I18n.backend.store_translations 'en', {"test" => "string with <strong>embedded html</strong>"}
+    HOC_I18N['en']['test'] = "string with <strong>embedded html</strong>"
     resp = get('/hoc_s/inline_markdown')
     assert_equal 200, resp.status
     assert_match "<h1>string with embedded html</h1>", resp.body

--- a/pegasus/test/test_hourofcode_helpers.rb
+++ b/pegasus/test/test_hourofcode_helpers.rb
@@ -46,10 +46,10 @@ class HourOfCodeHelpersTest < Minitest::Test
     response = get '/xyz', {}, {'REMOTE_ADDR' => cloudfront_ip}
     assert_equal 'http://hourofcode.com/fr/xyz', response.headers['Location']
 
-    header 'ACCEPT_LANGUAGE', 'es'
-    # French geo, Spanish browser language
+    header 'ACCEPT_LANGUAGE', 'it'
+    # French geo, Italian browser language
     response = get '/xyz', {}, {'REMOTE_ADDR' => cloudfront_ip}
-    assert_equal 'http://hourofcode.com/fr/es/xyz', response.headers['Location']
+    assert_equal 'http://hourofcode.com/fr/it/xyz', response.headers['Location']
   end
 
   # Ensure redirect goes to original (spoofable) IP-address location,

--- a/pegasus/test/test_i18n_hoc_routes.rb
+++ b/pegasus/test/test_i18n_hoc_routes.rb
@@ -13,7 +13,6 @@ class I18nHocRoutesTest < Minitest::Test
     header 'Host', 'hourofcode.com'
     languages = DB[:cdo_languages].select(:unique_language_s).where(supported_hoc_b: 1)
     subpages = load_hoc_subpages
-    load_all_hoc_translations
 
     languages.collect {|x| x[:unique_language_s]}.each do |lang|
       # Tests the homepage
@@ -49,10 +48,5 @@ class I18nHocRoutesTest < Minitest::Test
     Dir.glob(pegasus_dir('sites.v3/hourofcode.com/public/', '**/*.md')).map do |path|
       path[/public(.*)\.md/, 1]
     end
-  end
-
-  def load_all_hoc_translations
-    files = Dir[pegasus_dir('sites.v3/hourofcode.com/i18n/*.yml')]
-    I18n.backend.load_translations files
   end
 end

--- a/pegasus/test/test_volunteer_forms.rb
+++ b/pegasus/test/test_volunteer_forms.rb
@@ -8,9 +8,9 @@ class VolunteerFormsTest < Minitest::Test
     old_locale = I18n.locale
     I18n.locale = 'en-US'
     en_experiences = VolunteerEngineerSubmission2015.experiences
-    I18n.locale = 'es-ES'
-    es_experiences = VolunteerEngineerSubmission2015.experiences
+    I18n.locale = 'ro-RO'
+    ro_experiences = VolunteerEngineerSubmission2015.experiences
     I18n.locale = old_locale
-    refute_equal en_experiences['unspecified'], es_experiences['unspecified']
+    refute_equal en_experiences['unspecified'], ro_experiences['unspecified']
   end
 end


### PR DESCRIPTION
An eyes test was failing due to lack of a locale being loaded in the i18n backend. Reverted to unblock our build process.

Reverts code-dot-org/code-dot-org#44240