### PR TITLE
Do not check for family on unit in a unit group for validation across family

### DIFF
--- a/dashboard/app/models/concerns/curriculum/course_types.rb
+++ b/dashboard/app/models/concerns/curriculum/course_types.rb
@@ -29,6 +29,11 @@ module Curriculum::CourseTypes
     errors.add(:instruction_type, 'must be the same for all courses in a family.') if all_family_courses.map(&:instruction_type).any? {|type| type != instruction_type}
   end
 
+  # Get the family name for the course based on if its set on the UnitGroup or Unit
+  def get_course_family_name
+    is_a?(Script) && unit_group ? unit_group.family_name : family_name
+  end
+
   # If course we are check is a unit_group or a unit that is in a unit_group check the family_name on the UnitGroup.
   # If the course is a unit that is not in a unit_group check the unit for the family_name
   def get_family_courses

--- a/dashboard/app/models/concerns/curriculum/course_types.rb
+++ b/dashboard/app/models/concerns/curriculum/course_types.rb
@@ -29,13 +29,9 @@ module Curriculum::CourseTypes
     errors.add(:instruction_type, 'must be the same for all courses in a family.') if all_family_courses.map(&:instruction_type).any? {|type| type != instruction_type}
   end
 
-  # Get the family name for the course based on if its set on the UnitGroup or Unit
-  def get_course_family_name
-    is_a?(Script) && unit_group ? unit_group.family_name : family_name
-  end
-
-  # If course we are check is a unit_group or a unit that is in a unit_group check the family_name on the UnitGroup.
+  # If course we are check is a unit_group.
   # If the course is a unit that is not in a unit_group check the unit for the family_name
+  # If unit that is in a unit_group then family name should be nil and we should not need to check anything
   def get_family_courses
     return nil if family_name.nil_or_empty?
 

--- a/dashboard/app/models/concerns/curriculum/course_types.rb
+++ b/dashboard/app/models/concerns/curriculum/course_types.rb
@@ -29,22 +29,16 @@ module Curriculum::CourseTypes
     errors.add(:instruction_type, 'must be the same for all courses in a family.') if all_family_courses.map(&:instruction_type).any? {|type| type != instruction_type}
   end
 
-  # Get the family name for the course based on if its set on the UnitGroup or Unit
-  def get_course_family_name
-    is_a?(Script) && unit_group ? unit_group.family_name : family_name
-  end
-
   # If course we are check is a unit_group or a unit that is in a unit_group check the family_name on the UnitGroup.
   # If the course is a unit that is not in a unit_group check the unit for the family_name
   def get_family_courses
-    family_name = get_course_family_name
     return nil if family_name.nil_or_empty?
 
     all_family_courses = nil
 
-    if is_a?(UnitGroup) || (is_a?(Script) && unit_group)
+    if is_a?(UnitGroup)
       all_family_courses = UnitGroup.all.select {|c| c.family_name == family_name}
-    elsif is_a?(Script)
+    elsif is_a?(Script) && !unit_group
       all_family_courses = Script.get_family_from_cache(family_name)
     end
 

--- a/dashboard/config/scripts_json/csp1-2021.script_json
+++ b/dashboard/config/scripts_json/csp1-2021.script_json
@@ -25,7 +25,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2022-01-24 21:49:29 UTC",
+    "serialized_at": "2022-01-07 15:48:55 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/config/scripts_json/csp1-2021.script_json
+++ b/dashboard/config/scripts_json/csp1-2021.script_json
@@ -25,7 +25,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2022-01-07 15:48:55 UTC",
+    "serialized_at": "2022-01-24 21:49:29 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,

--- a/dashboard/test/models/concerns/curriculum/course_types_test.rb
+++ b/dashboard/test/models/concerns/curriculum/course_types_test.rb
@@ -238,10 +238,6 @@ class CourseTypesTests < ActiveSupport::TestCase
     assert_equal @unit_teacher_to_students_2.get_course_family_name, 'teacher-units'
   end
 
-  test 'get_family_courses should get all UnitGroups with the same family name if called for Unit in UnitGroup' do
-    assert_equal @unit_in_course_2.get_family_courses.map(&:name), ['course-instructed-by-teacher', 'course-instructed-by-teacher-2', 'course-teacher-to-student']
-  end
-
   test 'get_family_courses should get all UnitGroups with the same family name if called for UnitGroup' do
     assert_equal @unit_group_2.get_family_courses.map(&:name), ['course-instructed-by-teacher', 'course-instructed-by-teacher-2', 'course-teacher-to-student']
   end

--- a/dashboard/test/models/concerns/curriculum/course_types_test.rb
+++ b/dashboard/test/models/concerns/curriculum/course_types_test.rb
@@ -289,4 +289,13 @@ class CourseTypesTests < ActiveSupport::TestCase
       solo_unit_in_family_name.save!
     end
   end
+
+  # A unit without a family is in a unit group
+  test 'should not raise error when changing unit wihtout family' do
+    unit_without_family_name = create :script, name: 'solo-family-name', family_name: nil
+    assert_nothing_raised do
+      unit_without_family_name.participant_audience = SharedCourseConstants::PARTICIPANT_AUDIENCE.facilitator
+      unit_without_family_name.save!
+    end
+  end
 end

--- a/dashboard/test/models/concerns/curriculum/course_types_test.rb
+++ b/dashboard/test/models/concerns/curriculum/course_types_test.rb
@@ -226,18 +226,6 @@ class CourseTypesTests < ActiveSupport::TestCase
     refute @course_plc_reviewer_to_facilitator.can_be_participant?(nil)
   end
 
-  test 'get_course_family_name should get family name from UnitGroup if called for Unit in UnitGroup' do
-    assert_equal @unit_in_course_2.get_course_family_name, 'teacher-unit-groups'
-  end
-
-  test 'get_course_family_name should get family name from Unit if called for Unit that is not in UnitGroup' do
-    assert_equal @unit_group_2.get_course_family_name, 'teacher-unit-groups'
-  end
-
-  test 'get_course_family_name should get family name from UnitGroup if called for UnitGroup' do
-    assert_equal @unit_teacher_to_students_2.get_course_family_name, 'teacher-units'
-  end
-
   test 'get_family_courses should get all UnitGroups with the same family name if called for UnitGroup' do
     assert_equal @unit_group_2.get_family_courses.map(&:name), ['course-instructed-by-teacher', 'course-instructed-by-teacher-2', 'course-teacher-to-student']
   end


### PR DESCRIPTION
When saving a unit in CSP errors were showing up:

<img width="1380" alt="Screen Shot 2022-01-24 at 1 22 16 PM" src="https://user-images.githubusercontent.com/208083/150871635-67ee6001-c1b4-45fa-9ca5-66c326dce6e3.png">

When saving a unit that does not have a family name (is in a unit group) we should not be checking to see if it is consistent with other units in a family.

## Links

[Slack](https://codedotorg.slack.com/archives/C02EEGWLHR8/p1643060901151600)

## Testing story

- Added unit test
- Checked that I could save CSP units, CSP course, and course d locally.