### PR TITLE
Check Terms of Service Version Through Users Table Instead of Cookie

### DIFF
--- a/apps/src/sites/studio/pages/layouts/_implicit_new_user_terms_interstitial.js
+++ b/apps/src/sites/studio/pages/layouts/_implicit_new_user_terms_interstitial.js
@@ -19,24 +19,3 @@ $(document).ready(function() {
     $('#implicit-terms-modal').modal('hide');
   });
 });
-
-function setCookie(key, value) {
-  var expires = new Date();
-  // Kill hide_tos cookie at midnight every night
-  // so the terms interstitial pops up once a day.
-  expires.setHours(23, 59, 59, 0);
-  document.cookie = key + '=' + value + ';expires=' + expires.toUTCString();
-}
-
-function getCookie(key) {
-  var keyValue = document.cookie.match('(^|;) ?' + key + '=([^;]*)(;|$)');
-  return keyValue ? keyValue[2] : null;
-}
-
-$(document).ready(function() {
-  var already_shown = !!getCookie('hide_tos');
-  if (!already_shown) {
-    $('#implicit-terms-modal').modal('show');
-    setCookie('hide_tos', '1');
-  }
-});

--- a/dashboard/app/controllers/api/v1/users_controller.rb
+++ b/dashboard/app/controllers/api/v1/users_controller.rb
@@ -88,6 +88,11 @@ class Api::V1::UsersController < Api::V1::JsonApiController
     render json: @user.school_donor_name.nil? ? 'null' : @user.school_donor_name.inspect
   end
 
+  # GET /api/v1/users/<user_id>/tos_version
+  def get_tos_version
+    render json: @user.terms_of_service_version.nil? ? -1 : @user.terms_of_service_version.inspect
+  end
+
   # POST /api/v1/users/<user_id>/using_text_mode
   def post_using_text_mode
     @user.using_text_mode = !!params[:using_text_mode].try(:to_bool)

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -2096,6 +2096,14 @@ class User < ApplicationRecord
     TERMS_OF_SERVICE_VERSIONS.last
   end
 
+  # Updates user's most recently accepted Terms of Service version to the latest version
+  def update_user_tos_version_accept
+    terms_of_service_version = latest_terms_version
+    self.terms_of_service_version = terms_of_service_version
+
+    save!
+  end
+
   # Ideally this would just be called school, but school is already a column
   # on the user table representing the school name
   def school_info_school

--- a/dashboard/app/views/home/index.html.haml
+++ b/dashboard/app/views/home/index.html.haml
@@ -13,7 +13,8 @@
 
 -# Teacher modals
 - if current_user && current_user.teacher? && !current_user.accepted_latest_terms?
-  = render partial: 'layouts/terms_interstitial'
+  - current_user.update_user_tos_version_accept()
+  = render partial: 'layouts/implicit_new_user_terms_interstitial'
 - elsif SchoolInfoInterstitialHelper.show_confirmation_dialog?(current_user) || @force_school_info_confirmation_dialog
   - SchoolInfoInterstitialHelper.update_last_seen_timestamp(current_user)
   = render partial: 'layouts/school_info_confirmation_dialog'

--- a/dashboard/app/views/layouts/_implicit_new_user_terms_interstitial.html.haml
+++ b/dashboard/app/views/layouts/_implicit_new_user_terms_interstitial.html.haml
@@ -7,6 +7,8 @@
       = t('signup_form.go_to_account')
 
 :javascript
+  $("#implicit-terms-modal").modal('show');
+
   $("#close_btn_go_to_account").click(function () {
     $("#implicit-terms-modal").modal('hide');
   });

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -763,6 +763,7 @@ Dashboard::Application.routes.draw do
       get 'users/current', to: 'users#current'
       get 'users/:user_id/school_name', to: 'users#get_school_name'
       get 'users/:user_id/school_donor_name', to: 'users#get_school_donor_name'
+      get 'users/:user_id/tos_version', to: 'users#get_tos_version'
 
       patch 'user_school_infos/:id/update_last_confirmation_date', to: 'user_school_infos#update_last_confirmation_date'
 


### PR DESCRIPTION
The terms of service dialog that appears to Users logging in for the first time from Clever or Powerschool currently looks at a cookie, which is how it was before [we revamped the dialog to exclude the out-of-date terms of service](https://github.com/code-dot-org/code-dot-org/pull/43350). This means that if the user logs in from a different device or clears their cookies, they’ll see the dialog again, which is not desired behavior.

Since we already track terms_of_service_version (i.e. the most recent ToS version the user has accepted) in the User model, now the behavior is to just check whether the terms_of_service_version matches the most recent ToS version. If they don't match, show them the new ToS for them to accept, otherwise don't show it to them.

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/browse/FND-1812?atlOrigin=eyJpIjoiNDEwY2VlY2ExMzJhNGUwZjliN2VjNGRjNDQ0MjdmNTIiLCJwIjoiaiJ9)
PR for revamped dialog avoiding out-of-date ToS: [here](https://github.com/code-dot-org/code-dot-org/pull/43350)

## Testing story
Localhost testing through Clever test accounts to ensure that upon their first logins users see the ToS dialog but don't see it on subsequent ones (even if they clear their cookies or log in elsewhere). I specifically tested this by logging in in an incognito window and then closing it, then opening a new incognito window and repeating the process to check for the correct behavior.

Demo using the incognito windows: [here](https://user-images.githubusercontent.com/56283563/150878523-4d778a76-f29b-4821-b402-e68a0ee8250d.mp4)

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
