### PR TITLE
Revert "Revert "Update Pegasus HoC helper to use i18n backend""

### DIFF
--- a/pegasus/src/env.rb
+++ b/pegasus/src/env.rb
@@ -63,6 +63,7 @@ def load_pegasus_settings
     I18n.load_path += Dir[hoc_dir('i18n/en.yml')]
     I18n.load_path += Dir[hoc_dir('i18n/es.yml')]
     I18n.load_path += Dir[hoc_dir('i18n/fr.yml')]
+    I18n.load_path += Dir[hoc_dir('i18n/pt.yml')]
   else
     I18n.load_path += Dir[cache_dir('i18n/*.yml')]
     I18n.load_path += Dir[hoc_dir('i18n/*.yml')]

--- a/pegasus/src/env.rb
+++ b/pegasus/src/env.rb
@@ -24,6 +24,10 @@ def sites_v3_dir(*paths)
   pegasus_dir('sites.v3', *paths)
 end
 
+def hoc_dir(*paths)
+  pegasus_dir('sites.v3', 'hourofcode.com', *paths)
+end
+
 def src_dir(*paths)
   pegasus_dir('src', *paths)
 end
@@ -49,11 +53,19 @@ def load_pegasus_settings
   I18n.backend = CDO.i18n_backend
   I18n.backend.class.send(:include, I18n::Backend::Fallbacks)
   I18n.fallbacks = I18n::Locale::Fallbacks.new(['en-US'])
-  if rack_env?(:development) && !CDO.load_locales
+
+  # We don't load all translations in dev and test environment.
+  # Loading translations from files is slow, more than 60s sometimes. That can
+  # cause unrelated eyes tests to fail because of command timeout.
+  if (rack_env?(:development) || rack_env?(:test)) && !CDO.load_locales
     I18n.load_path += Dir[cache_dir('i18n/en-US.yml')]
     I18n.load_path += Dir[cache_dir('i18n/es-ES.yml')]
+    I18n.load_path += Dir[hoc_dir('i18n/en.yml')]
+    I18n.load_path += Dir[hoc_dir('i18n/es.yml')]
+    I18n.load_path += Dir[hoc_dir('i18n/fr.yml')]
   else
     I18n.load_path += Dir[cache_dir('i18n/*.yml')]
+    I18n.load_path += Dir[hoc_dir('i18n/*.yml')]
   end
   I18n.enforce_available_locales = false
   I18n.backend.load_translations

--- a/pegasus/test/test_hoc_s.rb
+++ b/pegasus/test/test_hoc_s.rb
@@ -24,60 +24,60 @@ class HocI18nTest < Minitest::Test
   end
 
   def test_html_escaped
-    HOC_I18N['en']['test'] = "string with <strong>embedded html</strong>"
+    I18n.backend.store_translations 'en', {"test" => "string with <strong>embedded html</strong>"}
     resp = get('/hoc_s/generic')
     assert_equal 200, resp.status
     assert_match "<h1>string with &lt;strong&gt;embedded html&lt;/strong&gt;</h1>", resp.body
   end
 
   def test_interpolation
-    HOC_I18N['en']['test'] = "%{first}"
+    I18n.backend.store_translations 'en', {"test" => "%{first}"}
     resp = get('/hoc_s/interpolation')
     assert_equal 200, resp.status
     assert_match "<h1>primary</h1>", resp.body
 
-    HOC_I18N['en']['test'] = "%{first} %{second}"
+    I18n.backend.store_translations 'en', {"test" => "%{first} %{second}"}
     resp = get('/hoc_s/interpolation')
     assert_equal 200, resp.status
     assert_match "<h1>primary secondary</h1>", resp.body
 
-    HOC_I18N['en']['test'] = "%{first} %{second} %{first} again"
+    I18n.backend.store_translations 'en', {"test" => "%{first} %{second} %{first} again"}
     resp = get('/hoc_s/interpolation')
     assert_equal 200, resp.status
     assert_match "<h1>primary secondary primary again</h1>", resp.body
   end
 
   def test_markdown
-    HOC_I18N['en']['test'] = "string with **some** _basic_ formatting"
+    I18n.backend.store_translations 'en', {"test" => "string with **some** _basic_ formatting"}
     resp = get('/hoc_s/markdown')
     assert_equal 200, resp.status
     assert_match "<h1><p>string with <strong>some</strong> <em>basic</em> formatting</p>\n</h1>", resp.body
 
-    HOC_I18N['en']['test'] = "string with <strong>embedded html</strong>"
+    I18n.backend.store_translations 'en', {"test" => "string with <strong>embedded html</strong>"}
     resp = get('/hoc_s/markdown')
     assert_equal 200, resp.status
     assert_match "<h1><p>string with &lt;strong&gt;embedded html&lt;/strong&gt;</p>\n</h1>", resp.body
   end
 
   def test_interpolated_markdown
-    HOC_I18N['en']['test'] = "string with an [interpolated link](%{url})"
+    I18n.backend.store_translations 'en', {"test" => "string with an [interpolated link](%{url})"}
     resp = get('/hoc_s/interpolated_markdown')
     assert_equal 200, resp.status
     assert_match "<h1><p>string with an <a href=\"http://test.com\">interpolated link</a></p>\n</h1>", resp.body
   end
 
   def test_inline_markdown
-    HOC_I18N['en']['test'] = "basic string"
+    I18n.backend.store_translations 'en', {"test" => "basic string"}
     resp = get('/hoc_s/inline_markdown')
     assert_equal 200, resp.status
     assert_match "<h1>basic string</h1>", resp.body
 
-    HOC_I18N['en']['test'] = "string with\n\n- some\n- block\n\nmarkdown"
+    I18n.backend.store_translations 'en', {"test" => "string with\n\n- some\n- block\n\nmarkdown"}
     resp = get('/hoc_s/inline_markdown')
     assert_equal 200, resp.status
     assert_match "<h1>string withsome\nblock\nmarkdown</h1>", resp.body
 
-    HOC_I18N['en']['test'] = "string with <strong>embedded html</strong>"
+    I18n.backend.store_translations 'en', {"test" => "string with <strong>embedded html</strong>"}
     resp = get('/hoc_s/inline_markdown')
     assert_equal 200, resp.status
     assert_match "<h1>string with embedded html</h1>", resp.body

--- a/pegasus/test/test_hourofcode_helpers.rb
+++ b/pegasus/test/test_hourofcode_helpers.rb
@@ -46,10 +46,10 @@ class HourOfCodeHelpersTest < Minitest::Test
     response = get '/xyz', {}, {'REMOTE_ADDR' => cloudfront_ip}
     assert_equal 'http://hourofcode.com/fr/xyz', response.headers['Location']
 
-    header 'ACCEPT_LANGUAGE', 'it'
-    # French geo, Italian browser language
+    header 'ACCEPT_LANGUAGE', 'es'
+    # French geo, Spanish browser language
     response = get '/xyz', {}, {'REMOTE_ADDR' => cloudfront_ip}
-    assert_equal 'http://hourofcode.com/fr/it/xyz', response.headers['Location']
+    assert_equal 'http://hourofcode.com/fr/es/xyz', response.headers['Location']
   end
 
   # Ensure redirect goes to original (spoofable) IP-address location,

--- a/pegasus/test/test_i18n_hoc_routes.rb
+++ b/pegasus/test/test_i18n_hoc_routes.rb
@@ -13,6 +13,7 @@ class I18nHocRoutesTest < Minitest::Test
     header 'Host', 'hourofcode.com'
     languages = DB[:cdo_languages].select(:unique_language_s).where(supported_hoc_b: 1)
     subpages = load_hoc_subpages
+    load_all_hoc_translations
 
     languages.collect {|x| x[:unique_language_s]}.each do |lang|
       # Tests the homepage
@@ -48,5 +49,10 @@ class I18nHocRoutesTest < Minitest::Test
     Dir.glob(pegasus_dir('sites.v3/hourofcode.com/public/', '**/*.md')).map do |path|
       path[/public(.*)\.md/, 1]
     end
+  end
+
+  def load_all_hoc_translations
+    files = Dir[pegasus_dir('sites.v3/hourofcode.com/i18n/*.yml')]
+    I18n.backend.load_translations files
   end
 end

--- a/pegasus/test/test_volunteer_forms.rb
+++ b/pegasus/test/test_volunteer_forms.rb
@@ -8,9 +8,9 @@ class VolunteerFormsTest < Minitest::Test
     old_locale = I18n.locale
     I18n.locale = 'en-US'
     en_experiences = VolunteerEngineerSubmission2015.experiences
-    I18n.locale = 'ro-RO'
-    ro_experiences = VolunteerEngineerSubmission2015.experiences
+    I18n.locale = 'es-ES'
+    es_experiences = VolunteerEngineerSubmission2015.experiences
     I18n.locale = old_locale
-    refute_equal en_experiences['unspecified'], ro_experiences['unspecified']
+    refute_equal en_experiences['unspecified'], es_experiences['unspecified']
   end
 end


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#44491 with a fix implemented.

In the original PR we updated our `test` environment to not load all locales into the i18n backend in order to fix test timeout issues. An eyes test for hourofcode.com/br was not accounted for, so we are loading the extra necessary translation file here.

[Slack thread](https://codedotorg.slack.com/archives/C03CM903Y/p1643056180318600)