### PR TITLE
Adding old version warning banner

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1331,7 +1331,7 @@
   "objectivesSubheading": "Students will be able to:",
   "ok": "OK",
   "okay": "Okay",
-  "oldVersionWarning": "This is not the most current version.",
+  "oldVersionWarning": "This is not the latest version.",
   "online": "Online",
   "openWorkspace": "How It Works",
   "or": "or",

--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1331,6 +1331,7 @@
   "objectivesSubheading": "Students will be able to:",
   "ok": "OK",
   "okay": "Okay",
+  "oldVersionWarning": "This is not the most current version.",
   "online": "Online",
   "openWorkspace": "How It Works",
   "or": "or",

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -3314,6 +3314,7 @@ StudioApp.prototype.setPageConstants = function(config, appSpecificConstants) {
       isEmbedView: !!config.embed,
       isResponsive: this.isResponsiveFromConfig(config),
       displayNotStartedBanner: this.displayNotStartedBanner(config),
+      displayOldVersionBanner: !!queryParams('version'),
       isShareView: !!config.share,
       pinWorkspaceToBottom: !!config.pinWorkspaceToBottom,
       noInstructionsWhenCollapsed: !!config.noInstructionsWhenCollapsed,

--- a/apps/src/redux/pageConstants.js
+++ b/apps/src/redux/pageConstants.js
@@ -21,6 +21,7 @@ var ALLOWED_KEYS = new Set([
   'isReadOnlyWorkspace',
   'isCodeReviewing',
   'displayNotStartedBanner',
+  'displayOldVersionBanner',
   'isShareView',
   'isProjectLevel',
   'isSubmittable',

--- a/apps/src/templates/CodeWorkspace.jsx
+++ b/apps/src/templates/CodeWorkspace.jsx
@@ -247,10 +247,10 @@ const styles = {
   oldVersionWarning: {
     zIndex: 99,
     backgroundColor: color.lightest_red,
-    textAlign: 'right',
+    textAlign: 'center',
     height: 20,
     padding: 5,
-    opacity: 0.7,
+    opacity: 0.8,
     position: 'relative'
   },
   studentNotStartedWarning: {

--- a/apps/src/templates/CodeWorkspace.jsx
+++ b/apps/src/templates/CodeWorkspace.jsx
@@ -20,6 +20,7 @@ import {queryParams} from '../code-studio/utils';
 class CodeWorkspace extends React.Component {
   static propTypes = {
     displayNotStartedBanner: PropTypes.bool,
+    displayOldVersionBanner: PropTypes.bool,
     isRtl: PropTypes.bool.isRequired,
     editCode: PropTypes.bool.isRequired,
     readonlyWorkspace: PropTypes.bool.isRequired,
@@ -216,6 +217,9 @@ class CodeWorkspace extends React.Component {
             {i18n.levelNotStartedWarning()}
           </div>
         )}
+        {this.props.displayOldVersionBanner && (
+          <div style={styles.oldVersionWarning}>{i18n.oldVersionWarning()}</div>
+        )}
         {props.showDebugger && (
           <JsDebugger
             onSlideShut={this.onDebuggerSlide}
@@ -240,6 +244,15 @@ const styles = {
   runningIcon: {
     color: color.dark_charcoal
   },
+  oldVersionWarning: {
+    zIndex: 99,
+    backgroundColor: color.lightest_red,
+    textAlign: 'right',
+    height: 20,
+    padding: 5,
+    opacity: 0.7,
+    position: 'relative'
+  },
   studentNotStartedWarning: {
     zIndex: 99,
     backgroundColor: color.lightest_red,
@@ -253,6 +266,7 @@ const styles = {
 export const UnconnectedCodeWorkspace = Radium(CodeWorkspace);
 export default connect(state => ({
   displayNotStartedBanner: state.pageConstants.displayNotStartedBanner,
+  displayOldVersionBanner: state.pageConstants.displayOldVersionBanner,
   editCode: state.pageConstants.isDroplet,
   isRtl: state.isRtl,
   readonlyWorkspace: state.pageConstants.isReadOnlyWorkspace,

--- a/apps/src/templates/CodeWorkspace.jsx
+++ b/apps/src/templates/CodeWorkspace.jsx
@@ -213,12 +213,14 @@ class CodeWorkspace extends React.Component {
           />
         )}
         {this.props.displayNotStartedBanner && !inCsfExampleSolution && (
-          <div style={styles.studentNotStartedWarning}>
+          <div id="notStartedBanner" style={styles.studentNotStartedWarning}>
             {i18n.levelNotStartedWarning()}
           </div>
         )}
         {this.props.displayOldVersionBanner && (
-          <div style={styles.oldVersionWarning}>{i18n.oldVersionWarning()}</div>
+          <div id="oldVersionBanner" style={styles.oldVersionWarning}>
+            {i18n.oldVersionWarning()}
+          </div>
         )}
         {props.showDebugger && (
           <JsDebugger

--- a/apps/test/unit/templates/CodeWorkspaceTest.js
+++ b/apps/test/unit/templates/CodeWorkspaceTest.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {mount} from 'enzyme';
+import {mount, shallow} from 'enzyme';
 import {expect} from '../../util/deprecatedChai';
 import {UnconnectedCodeWorkspace as CodeWorkspace} from '../../../src/templates/CodeWorkspace';
 import {singleton as studioAppSingleton} from '@cdo/apps/StudioApp';
@@ -46,5 +46,23 @@ describe('CodeWorkspace', () => {
     workspace.find(ShowCodeToggle).simulate('click');
     let counter = workspace.find('#blockCounter');
     expect(counter).to.have.style('display', 'none');
+  });
+
+  it('displays old version warning when displayOldVersionBanner is true', () => {
+    const props = {
+      ...MINIMUM_PROPS,
+      ...{displayOldVersionBanner: true}
+    };
+    const wrapper = shallow(<CodeWorkspace {...props} />);
+    expect(wrapper.find('div#oldVersionBanner')).to.have.lengthOf(1);
+  });
+
+  it('displays not started warning when displayNotStartedBanner is true', () => {
+    const props = {
+      ...MINIMUM_PROPS,
+      ...{displayNotStartedBanner: true}
+    };
+    const wrapper = shallow(<CodeWorkspace {...props} />);
+    expect(wrapper.find('div#notStartedBanner')).to.have.lengthOf(1);
   });
 });


### PR DESCRIPTION
Adds a warning banner largely matching the formatting of the Not Started warning banner, but with the text centered to prevent covering up the first row of text. 

<img width="1439" alt="Screen Shot 2022-01-25 at 11 21 23 AM" src="https://user-images.githubusercontent.com/37230822/151044783-97b5d94a-2cd6-4ff2-8475-f10091dddeea.png">

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/LP-2188

## Testing story

Added a unit test to ensure the warning banner gets displayed properly. Also added a matching unit test for the levelNotStarted banner because it didn't have one yet.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
