### PR TITLE
Remove the end-of-lesson pilot flag

### DIFF
--- a/apps/src/code-studio/components/progress/UnitOverview.jsx
+++ b/apps/src/code-studio/components/progress/UnitOverview.jsx
@@ -22,7 +22,6 @@ import {unitCalendarLesson} from '@cdo/apps/templates/progress/unitCalendarLesso
 import GoogleClassroomAttributionLabel from '@cdo/apps/templates/progress/GoogleClassroomAttributionLabel';
 import UnitCalendar from './UnitCalendar';
 import color from '@cdo/apps/util/color';
-import {queryParams} from '@cdo/apps/code-studio/utils';
 import EndOfLessonDialog from '@cdo/apps/templates/EndOfLessonDialog';
 
 /**
@@ -54,6 +53,7 @@ class UnitOverview extends React.Component {
     scriptResourcesPdfUrl: PropTypes.string,
     showUnversionedRedirectWarning: PropTypes.bool,
     isCsdOrCsp: PropTypes.bool,
+    completedLessonNumber: PropTypes.string,
 
     // redux provided
     scriptId: PropTypes.number.isRequired,
@@ -107,7 +107,8 @@ class UnitOverview extends React.Component {
       scriptOverviewPdfUrl,
       scriptResourcesPdfUrl,
       showUnversionedRedirectWarning,
-      isCsdOrCsp
+      isCsdOrCsp,
+      completedLessonNumber
     } = this.props;
 
     const displayRedirectDialog =
@@ -120,8 +121,6 @@ class UnitOverview extends React.Component {
 
     const showUnversionedRedirectWarningDialog =
       showUnversionedRedirectWarning && !this.state.showRedirectDialog;
-
-    const completedLessonNumber = queryParams('completedLessonNumber');
 
     return (
       <div>

--- a/apps/src/sites/studio/pages/scripts/show.js
+++ b/apps/src/sites/studio/pages/scripts/show.js
@@ -30,6 +30,7 @@ import progress from '@cdo/apps/code-studio/progress';
 import UnitOverview from '@cdo/apps/code-studio/components/progress/UnitOverview.jsx';
 import {convertAssignmentVersionShapeFromServer} from '@cdo/apps/templates/teacherDashboard/shapes';
 import {setStudentDefaultsSummaryView} from '@cdo/apps/code-studio/progressRedux';
+import {updateQueryParam, queryParams} from '@cdo/apps/code-studio/utils';
 
 import locales, {setLocaleCode} from '../../../../redux/localesRedux';
 
@@ -101,6 +102,9 @@ function initPage() {
   const mountPoint = document.createElement('div');
   $('.user-stats-block').prepend(mountPoint);
 
+  const completedLessonNumber = queryParams('completedLessonNumber');
+  updateQueryParam('completedLessonNumber', undefined);
+
   ReactDOM.render(
     <Provider store={store}>
       <UnitOverview
@@ -133,6 +137,7 @@ function initPage() {
           scriptData.show_unversioned_redirect_warning
         }
         isCsdOrCsp={scriptData.isCsd || scriptData.isCsp}
+        completedLessonNumber={completedLessonNumber}
       />
     </Provider>,
     mountPoint

--- a/apps/src/templates/EndOfLessonDialog.jsx
+++ b/apps/src/templates/EndOfLessonDialog.jsx
@@ -29,7 +29,9 @@ function EndOfLessonDialog({lessonNumber, isSummaryView}) {
       handleClose={handleClose}
       style={styles.dialog}
     >
-      <h2>{i18n.endOfLessonDialogHeading({lessonNumber})}</h2>
+      <h2 id="uitest-end-of-lesson-header">
+        {i18n.endOfLessonDialogHeading({lessonNumber})}
+      </h2>
       <div>{i18n.endOfLessonDialogDetails()}</div>
       <DialogFooter rightAlign={true}>
         <Button

--- a/apps/test/unit/code-studio/components/progress/UnitOverviewTest.js
+++ b/apps/test/unit/code-studio/components/progress/UnitOverviewTest.js
@@ -1,12 +1,10 @@
 import React from 'react';
 import {assert} from '../../../../util/reconfiguredChai';
 import {shallow} from 'enzyme';
-import sinon from 'sinon';
 import {UnconnectedUnitOverview as UnitOverview} from '@cdo/apps/code-studio/components/progress/UnitOverview';
 import ProgressLegend from '@cdo/apps/templates/progress/ProgressLegend';
 import ProgressTable from '@cdo/apps/templates/progress/ProgressTable';
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
-import * as utils from '@cdo/apps/code-studio/utils';
 
 const defaultProps = {
   excludeCsfColumnInLegend: true,
@@ -30,7 +28,8 @@ const defaultProps = {
   publishedState: 'beta',
   versions: [],
   redirectScriptUrl: null,
-  unitCalendarLessons: []
+  unitCalendarLessons: [],
+  completedLessonNumber: undefined
 };
 
 const setUp = (overrideProps = {}) => {
@@ -39,22 +38,14 @@ const setUp = (overrideProps = {}) => {
 };
 
 describe('UnitOverview', () => {
-  it('renders a EndOfLessonDialog if the completedLessonNumber url query param is present', () => {
-    sinon.stub(utils, 'queryParams').returns(3);
-
-    const wrapper = setUp();
+  it('renders a EndOfLessonDialog if completedLessonNumber prop is present', () => {
+    const wrapper = setUp({completedLessonNumber: '3'});
     assert.equal(wrapper.find('Connect(EndOfLessonDialog)').length, 1);
-
-    utils.queryParams.restore();
   });
 
-  it('does not render a EndOfLessonDialog if ', () => {
-    sinon.stub(utils, 'queryParams').returns(null);
-
+  it('does not render a EndOfLessonDialog if completedLessonNumber is empty', () => {
     const wrapper = setUp();
     assert.equal(wrapper.find('Connect(EndOfLessonDialog)').length, 0);
-
-    utils.queryParams.restore();
   });
 
   it('renders a UnversionedScriptRedirectDialog if showUnversionedRedirectWarning and not displaying dialog', () => {

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -582,7 +582,7 @@ module LevelsHelper
     level_options['lesson_total'] = script_level ? script_level.lesson_total : 1
     level_options['isLastLevelInLesson'] = script_level.end_of_lesson? if script_level
     level_options['isLastLevelInScript'] = script_level.end_of_script? if script_level
-    level_options['showEndOfLessonMsgs'] = script.show_unit_overview_between_lessons?(current_user) if script
+    level_options['showEndOfLessonMsgs'] = script.show_unit_overview_between_lessons? if script
 
     # Edit blocks-dependent options
     if level_view_options(@level.id)[:edit_blocks]

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -596,7 +596,7 @@ class Lesson < ApplicationRecord
   end
 
   def next_level_path_for_lesson_extras(user)
-    if script.show_unit_overview_between_lessons?(user)
+    if script.show_unit_overview_between_lessons?
       return script_path(script)
     end
     next_level = next_level_for_lesson_extras(user)

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -2011,7 +2011,7 @@ class Script < ApplicationRecord
 
   # To help teachers have more control over the pacing of certain scripts, we
   # send students on the last level of a lesson to the unit overview page.
-  def show_unit_overview_between_lessons?(user)
-    middle_high? && user&.has_pilot_experiment?('end-of-lesson-redirects')
+  def show_unit_overview_between_lessons?
+    middle_high?
   end
 end

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -187,7 +187,7 @@ class ScriptLevel < ApplicationRecord
       # To help teachers have more control over the pacing of certain
       # scripts, we send students on the last level of a lesson to the unit
       # overview page.
-      if end_of_lesson? && script.show_unit_overview_between_lessons?(user)
+      if end_of_lesson? && script.show_unit_overview_between_lessons?
         if script.lesson_extras_available
           script_lesson_extras_path(script.name, (extras_lesson || lesson).relative_position)
         else

--- a/dashboard/test/ui/features/learning_platform/script_overview.feature
+++ b/dashboard/test/ui/features/learning_platform/script_overview.feature
@@ -61,3 +61,10 @@ Feature: Script overview page
     And I wait until element "td:contains(Minecraft)" is visible
     # verify script name overrides lesson name when there is only one lesson
     And element "td:contains(1. Minecraft Hour of Code)" is visible
+
+  Scenario: Script overview end-of-lesson
+    Given I create a student named "Jean"
+    # On last level of the lesson
+    And I am on "http://studio.code.org/s/csp3-2019/lessons/3/levels/1"
+    And I click selector ".submitButton"
+    And I wait until element "#uitest-end-of-lesson-header:contains(You finished Lesson 3!)" is visible

--- a/dashboard/test/ui/utils/selenium_browser.rb
+++ b/dashboard/test/ui/utils/selenium_browser.rb
@@ -6,6 +6,7 @@ module SeleniumBrowser
     browser = browser.to_sym
     options = {}
     if browser == :chrome
+      Selenium::WebDriver::Chrome.driver_path = "/Users/Work/Downloads/chromedriver_5"
       options[:options] = Selenium::WebDriver::Chrome::Options.new
       options[:options].add_argument('headless') if headless
       options[:options].add_argument('window-size=1280,1024')

--- a/dashboard/test/ui/utils/selenium_browser.rb
+++ b/dashboard/test/ui/utils/selenium_browser.rb
@@ -6,7 +6,6 @@ module SeleniumBrowser
     browser = browser.to_sym
     options = {}
     if browser == :chrome
-      Selenium::WebDriver::Chrome.driver_path = "/Users/Work/Downloads/chromedriver_5"
       options[:options] = Selenium::WebDriver::Chrome::Options.new
       options[:options].add_argument('headless') if headless
       options[:options].add_argument('window-size=1280,1024')


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Removes the `end-of-lesson-redirects` pilot flag to enable the end-of-lesson redirect experience. 

![Screen Shot 2022-01-25 at 12 32 15 PM](https://user-images.githubusercontent.com/24235215/151054926-94453991-36e1-4b81-bdaf-51164e859349.png)

There is also a small change to how the `completedLessonNumber` query param is handled, once the value is read the query param is removed so that it is not included in other links on the page.

## Links
PRs for the feature:
- https://github.com/code-dot-org/code-dot-org/pull/44394
- https://github.com/code-dot-org/code-dot-org/pull/44333
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
- jira ticket: [LP-2185](https://codedotorg.atlassian.net/browse/LP-2185)
<!--
- spec: []()

-->

## Testing story
Added a UI test and tested locally
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

## Follow-up work
Remove the end-of-lesson-redirects pilot from the pilots list
<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
