### PR TITLE
Set application ids in enrollments table

### DIFF
--- a/bin/oneoff/set_app_id_in_enrollments.rb
+++ b/bin/oneoff/set_app_id_in_enrollments.rb
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+
+require_relative '../../dashboard/config/environment'
+
+puts "Updating application_id in enrollments ...\n\n"
+
+total_changed = 0
+
+Pd::Enrollment.where.not(user_id: nil).each do |enrollment|
+  old_app_id = enrollment.application_id
+  enrollment.set_application_id
+
+  new_app_id = enrollment.application_id
+  total_changed += 1 unless new_app_id == old_app_id
+end
+
+puts "Finished updating enrollments: set #{total_changed} application ids"

--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -329,13 +329,13 @@ class Pd::Enrollment < ApplicationRecord
   # workshop id
   # @return [Integer, nil] application id or nil if cannot find any application
   def set_application_id
-    course_match = ->(application) {Pd::Application::ApplicationBase::COURSE_NAME_MAP.dig(application.try(:course).to_sym) == workshop.try(:course)}
+    course_match = ->(application) {Pd::Application::ApplicationBase::COURSE_NAME_MAP.dig(application.try(:course)&.to_sym) == workshop.try(:course)}
     pd_match = ->(application) {application.try(:pd_workshop_id) == pd_workshop_id}
 
     application_id = nil
     # Finds application from the school year of the workshop. Assumes workshops start after 6/1
     # because workshop.school_year assumes 6/1 is the start of the school year
-    Pd::Application::ApplicationBase.where(user_id: user_id, application_year: workshop.school_year).each do |application|
+    Pd::Application::ApplicationBase.where(user_id: user_id, application_year: workshop&.school_year).each do |application|
       application_id = application.id if course_match.call(application) || pd_match.call(application)
       break if application_id
     end


### PR DESCRIPTION
I used an adhoc (finally) to ensure this method worked to set application ids correctly in the enrollments table.

Originally (see https://github.com/code-dot-org/code-dot-org/pull/44205), I called `.save!` in enrollments to trigger `set_application_id`. This approach threw `Validation failed: Email already enrolled in workshop (ActiveRecord::RecordInvalid)`, which stopped the process. I could modify the script to continue in cases where the validation failed, but we want to update the application id even if the email is already enrolled in a workshop (we don't care––they should still have their application id linked to their enrollment). Happy to chat more if this seems bad.

So, I switched to calling `.set_application_id` directly. Originally, this approach threw `from dashboard/app/models/pd/enrollment.rb:336:in 'set_application_id': undefined method 'school_year' for nil:NilClass (NoMethodError)`. I modified the `enrollments.rb` to instead use `&.` for that. That approach should also fix the errors popping up when we need to purge accounts (see [discussion](https://codedotorg.slack.com/archives/C55JZ1BPZ/p1642897640004000)).

When run on an adhoc, the script displayed at the end, `Finished updating enrollments: set 41759 application ids`.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
