### PR TITLE
Correct Portuguese block text

### DIFF
--- a/dashboard/config/locales/blocks.pt-BR.yml
+++ b/dashboard/config/locales/blocks.pt-BR.yml
@@ -1178,7 +1178,7 @@ pt:
       gamelab_mouseLocation:
         text: posição do mouse
       gamelab_moveBackward:
-        text: mover [SPRITE] [0] [DISTANCE] [1] pixels para trás
+        text: mover {SPRITE} {DISTANCE} pixels para trás
       gamelab_moveForward:
         text: mover {SPRITE} {DISTANCE} pixels pra frente
       gamelab_moveInDirection:
@@ -1413,7 +1413,7 @@ pt:
             '"right"': para direita
             '"left"': para esquerda
       gamelab_updateTitleWithColor:
-        text: mostra a tela do título [BREAK] [0] título [TITLE] [1] cor [COLOR] [2]
+        text: mostra a tela do título {BREAK} título {TITLE} cor {COLOR}
       gamelab_whenAllPromptsAnswered:
         text: quando todos os prompts forem respondidos
       gamelab_whenDownArrow:

--- a/dashboard/config/locales/blocks.pt-PT.yml
+++ b/dashboard/config/locales/blocks.pt-PT.yml
@@ -1178,7 +1178,7 @@ pt:
       gamelab_mouseLocation:
         text: posição do mouse
       gamelab_moveBackward:
-        text: mover [SPRITE] [0] [DISTANCE] [1] pixels para trás
+        text: mover {SPRITE} {DISTANCE} pixels para trás
       gamelab_moveForward:
         text: mover {SPRITE} {DISTANCE} pixels pra frente
       gamelab_moveInDirection:
@@ -1414,7 +1414,7 @@ pt:
             '"right"': para a direita
             '"left"': para a esquerda
       gamelab_updateTitleWithColor:
-        text: mostra a tela do título [BREAK] [0] título [TITLE] [1] cor [COLOR] [2]
+        text: mostra a tela do título {BREAK} título {TITLE} cor {COLOR}
       gamelab_whenAllPromptsAnswered:
         text: quando todos os prompts forem respondidos
       gamelab_whenDownArrow:


### PR DESCRIPTION
Addresses [STAR-2065](https://codedotorg.atlassian.net/browse/STAR-2065)
[Slack thread](https://codedotorg.slack.com/archives/C1B3PNDL7/p1643073024055800)

Corrects the formatting of two Sprite Labs where translation strings were improperly formatted. Curly brackets should be used for block arguments, not square brackets. 

**English:** ![image (115)](https://user-images.githubusercontent.com/43474485/150979266-bdea6af5-142d-4004-ae05-6294c270a8a9.png)

**Portuguese before:** ![image (116)](https://user-images.githubusercontent.com/43474485/150979408-dc79c87e-bc96-4615-a62d-7a127efcca28.png)

**Portuguese after:** ![image](https://user-images.githubusercontent.com/43474485/150979309-1a0c6603-b648-4bce-b4b5-cfe62ec3e2d5.png)

I confirmed that Sprite Lab now runs in `pt-BR` and `pt-PT` without crashing and sprites do appear.
![image (117)](https://user-images.githubusercontent.com/43474485/150979628-ba8a6183-9237-400a-b30b-41fb21ad9b8c.png)

