### PR TITLE
Update Pegasus HoC helper to use i18 backend - fix path redirection

### DIFF
--- a/pegasus/helpers/hourofcode_helpers.rb
+++ b/pegasus/helpers/hourofcode_helpers.rb
@@ -47,10 +47,13 @@ def hoc_canonicalized_i18n_path(uri, query_string)
   end
 
   if @country || @company
-    if possible_language && I18n.backend.translations.key?(possible_language[0..1].to_sym)
+    # Checking entire possible_language string first. We do not want to
+    # unintentionally interpret a path as a language.
+    if possible_language && I18n.backend.translations.key?(possible_language.to_sym)
       # HOC uses two-letter language code. The full list of language codes is
       # in the unique_language_s column in Pegasus.cdo_languages table.
-      @user_language = possible_language[0..1]
+      short_language = possible_language[0..1]
+      @user_language = short_language if I18n.backend.translations.key?(short_language.to_sym)
     else
       path = File.join([possible_language, path].reject(&:nil_or_empty?))
     end

--- a/pegasus/src/env.rb
+++ b/pegasus/src/env.rb
@@ -24,6 +24,10 @@ def sites_v3_dir(*paths)
   pegasus_dir('sites.v3', *paths)
 end
 
+def hoc_dir(*paths)
+  pegasus_dir('sites.v3', 'hourofcode.com', *paths)
+end
+
 def src_dir(*paths)
   pegasus_dir('src', *paths)
 end
@@ -49,11 +53,20 @@ def load_pegasus_settings
   I18n.backend = CDO.i18n_backend
   I18n.backend.class.send(:include, I18n::Backend::Fallbacks)
   I18n.fallbacks = I18n::Locale::Fallbacks.new(['en-US'])
-  if rack_env?(:development) && !CDO.load_locales
+
+  # We don't load all translations in dev and test environment.
+  # Loading translations from files is slow, more than 60s sometimes. That can
+  # cause unrelated eyes tests to fail because of command timeout.
+  if (rack_env?(:development) || rack_env?(:test)) && !CDO.load_locales
     I18n.load_path += Dir[cache_dir('i18n/en-US.yml')]
     I18n.load_path += Dir[cache_dir('i18n/es-ES.yml')]
+    I18n.load_path += Dir[hoc_dir('i18n/en.yml')]
+    I18n.load_path += Dir[hoc_dir('i18n/es.yml')]
+    I18n.load_path += Dir[hoc_dir('i18n/fr.yml')]
+    I18n.load_path += Dir[hoc_dir('i18n/pt.yml')]
   else
     I18n.load_path += Dir[cache_dir('i18n/*.yml')]
+    I18n.load_path += Dir[hoc_dir('i18n/*.yml')]
   end
   I18n.enforce_available_locales = false
   I18n.backend.load_translations

--- a/pegasus/test/test_hoc_s.rb
+++ b/pegasus/test/test_hoc_s.rb
@@ -24,60 +24,60 @@ class HocI18nTest < Minitest::Test
   end
 
   def test_html_escaped
-    HOC_I18N['en']['test'] = "string with <strong>embedded html</strong>"
+    I18n.backend.store_translations 'en', {"test" => "string with <strong>embedded html</strong>"}
     resp = get('/hoc_s/generic')
     assert_equal 200, resp.status
     assert_match "<h1>string with &lt;strong&gt;embedded html&lt;/strong&gt;</h1>", resp.body
   end
 
   def test_interpolation
-    HOC_I18N['en']['test'] = "%{first}"
+    I18n.backend.store_translations 'en', {"test" => "%{first}"}
     resp = get('/hoc_s/interpolation')
     assert_equal 200, resp.status
     assert_match "<h1>primary</h1>", resp.body
 
-    HOC_I18N['en']['test'] = "%{first} %{second}"
+    I18n.backend.store_translations 'en', {"test" => "%{first} %{second}"}
     resp = get('/hoc_s/interpolation')
     assert_equal 200, resp.status
     assert_match "<h1>primary secondary</h1>", resp.body
 
-    HOC_I18N['en']['test'] = "%{first} %{second} %{first} again"
+    I18n.backend.store_translations 'en', {"test" => "%{first} %{second} %{first} again"}
     resp = get('/hoc_s/interpolation')
     assert_equal 200, resp.status
     assert_match "<h1>primary secondary primary again</h1>", resp.body
   end
 
   def test_markdown
-    HOC_I18N['en']['test'] = "string with **some** _basic_ formatting"
+    I18n.backend.store_translations 'en', {"test" => "string with **some** _basic_ formatting"}
     resp = get('/hoc_s/markdown')
     assert_equal 200, resp.status
     assert_match "<h1><p>string with <strong>some</strong> <em>basic</em> formatting</p>\n</h1>", resp.body
 
-    HOC_I18N['en']['test'] = "string with <strong>embedded html</strong>"
+    I18n.backend.store_translations 'en', {"test" => "string with <strong>embedded html</strong>"}
     resp = get('/hoc_s/markdown')
     assert_equal 200, resp.status
     assert_match "<h1><p>string with &lt;strong&gt;embedded html&lt;/strong&gt;</p>\n</h1>", resp.body
   end
 
   def test_interpolated_markdown
-    HOC_I18N['en']['test'] = "string with an [interpolated link](%{url})"
+    I18n.backend.store_translations 'en', {"test" => "string with an [interpolated link](%{url})"}
     resp = get('/hoc_s/interpolated_markdown')
     assert_equal 200, resp.status
     assert_match "<h1><p>string with an <a href=\"http://test.com\">interpolated link</a></p>\n</h1>", resp.body
   end
 
   def test_inline_markdown
-    HOC_I18N['en']['test'] = "basic string"
+    I18n.backend.store_translations 'en', {"test" => "basic string"}
     resp = get('/hoc_s/inline_markdown')
     assert_equal 200, resp.status
     assert_match "<h1>basic string</h1>", resp.body
 
-    HOC_I18N['en']['test'] = "string with\n\n- some\n- block\n\nmarkdown"
+    I18n.backend.store_translations 'en', {"test" => "string with\n\n- some\n- block\n\nmarkdown"}
     resp = get('/hoc_s/inline_markdown')
     assert_equal 200, resp.status
     assert_match "<h1>string withsome\nblock\nmarkdown</h1>", resp.body
 
-    HOC_I18N['en']['test'] = "string with <strong>embedded html</strong>"
+    I18n.backend.store_translations 'en', {"test" => "string with <strong>embedded html</strong>"}
     resp = get('/hoc_s/inline_markdown')
     assert_equal 200, resp.status
     assert_match "<h1>string with embedded html</h1>", resp.body

--- a/pegasus/test/test_hourofcode_helpers.rb
+++ b/pegasus/test/test_hourofcode_helpers.rb
@@ -46,10 +46,10 @@ class HourOfCodeHelpersTest < Minitest::Test
     response = get '/xyz', {}, {'REMOTE_ADDR' => cloudfront_ip}
     assert_equal 'http://hourofcode.com/fr/xyz', response.headers['Location']
 
-    header 'ACCEPT_LANGUAGE', 'it'
-    # French geo, Italian browser language
+    header 'ACCEPT_LANGUAGE', 'es'
+    # French geo, Spanish browser language
     response = get '/xyz', {}, {'REMOTE_ADDR' => cloudfront_ip}
-    assert_equal 'http://hourofcode.com/fr/it/xyz', response.headers['Location']
+    assert_equal 'http://hourofcode.com/fr/es/xyz', response.headers['Location']
   end
 
   # Ensure redirect goes to original (spoofable) IP-address location,

--- a/pegasus/test/test_i18n_hoc_routes.rb
+++ b/pegasus/test/test_i18n_hoc_routes.rb
@@ -13,6 +13,7 @@ class I18nHocRoutesTest < Minitest::Test
     header 'Host', 'hourofcode.com'
     languages = DB[:cdo_languages].select(:unique_language_s).where(supported_hoc_b: 1)
     subpages = load_hoc_subpages
+    load_all_hoc_translations
 
     languages.collect {|x| x[:unique_language_s]}.each do |lang|
       # Tests the homepage
@@ -48,5 +49,10 @@ class I18nHocRoutesTest < Minitest::Test
     Dir.glob(pegasus_dir('sites.v3/hourofcode.com/public/', '**/*.md')).map do |path|
       path[/public(.*)\.md/, 1]
     end
+  end
+
+  def load_all_hoc_translations
+    files = Dir[pegasus_dir('sites.v3/hourofcode.com/i18n/*.yml')]
+    I18n.backend.load_translations files
   end
 end

--- a/pegasus/test/test_volunteer_forms.rb
+++ b/pegasus/test/test_volunteer_forms.rb
@@ -8,9 +8,9 @@ class VolunteerFormsTest < Minitest::Test
     old_locale = I18n.locale
     I18n.locale = 'en-US'
     en_experiences = VolunteerEngineerSubmission2015.experiences
-    I18n.locale = 'ro-RO'
-    ro_experiences = VolunteerEngineerSubmission2015.experiences
+    I18n.locale = 'es-ES'
+    es_experiences = VolunteerEngineerSubmission2015.experiences
     I18n.locale = old_locale
-    refute_equal en_experiences['unspecified'], ro_experiences['unspecified']
+    refute_equal en_experiences['unspecified'], es_experiences['unspecified']
   end
 end


### PR DESCRIPTION
Apologies for the long chain of reverts. For context of previous updates follow [this PR](https://github.com/code-dot-org/code-dot-org/pull/44501) and the further linked resources.

Checking to make sure that the path following the country code (`possible_language` variable) is truly a language code so the request isn't redirect.

[Slack thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1643130351153300)