### PR TITLE
Java Lab: center resizer ellipses

### DIFF
--- a/apps/src/templates/instructions/HeightResizer.jsx
+++ b/apps/src/templates/instructions/HeightResizer.jsx
@@ -168,14 +168,15 @@ const styles = {
   },
   ellipsisVertical: {
     width: '100%',
-    height: '100%',
     color: color.lighter_gray,
     fontSize: 24,
     textAlign: 'center',
     cursor: 'ew-resize',
     whiteSpace: 'nowrap',
     lineHeight: RESIZER_HEIGHT + 'px',
-    paddingTop: 120
+    top: '50%',
+    position: 'absolute',
+    transform: 'translateY(-50%)'
   }
 };
 


### PR DESCRIPTION
Center the ellipses in the "vertical" `HeightResizer`, which is only used in Java Lab (this is the resizer that changes the horizontal size of the editor + console). 
## Screenshot
<img width="1780" alt="Screen Shot 2022-01-24 at 1 47 13 PM" src="https://user-images.githubusercontent.com/33666587/151034648-f0c6e27f-e549-4d19-aaa9-a5e7b33762b1.png">


## Links

- spec: [UI Finalization](https://docs.google.com/document/d/1eaNGb-etGnTU4_qPHWHxuzdNIjrBISiW0khBz87_nY0/edit#bookmark=id.9dfk3h1qtyuq)
- jira ticket: [JAVA-393](https://codedotorg.atlassian.net/browse/JAVA-393)

## Testing story
Tested locally

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
