### PR TITLE
Revert "Revert "When generating PLC course set all course type and published state information""

### DIFF
--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -209,7 +209,7 @@ class Script < ApplicationRecord
 
       new_published_state = published_state ? published_state : SharedCourseConstants::PUBLISHED_STATE.beta
       new_instruction_type = instruction_type ? instruction_type : SharedCourseConstants::INSTRUCTION_TYPE.teacher_led
-      new_instructor_audience = instructor_audience ? instructor_audience : SharedCourseConstants::INSTRUCTION_TYPE.plc_reviewer
+      new_instructor_audience = instructor_audience ? instructor_audience : SharedCourseConstants::INSTRUCTOR_AUDIENCE.plc_reviewer
       new_participant_audience = participant_audience ? participant_audience : SharedCourseConstants::PARTICIPANT_AUDIENCE.facilitator
 
       if unit_group

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -206,8 +206,21 @@ class Script < ApplicationRecord
   def generate_plc_objects
     if old_professional_learning_course?
       unit_group = UnitGroup.find_by_name(professional_learning_course)
-      unless unit_group
-        unit_group = UnitGroup.new(name: professional_learning_course)
+      if unit_group
+        # Check if anything needs to be updated on the PL course
+        unit_group.published_state = published_state
+        unit_group.instruction_type = instruction_type
+        unit_group.participant_audience = participant_audience
+        unit_group.instructor_audience = instructor_audience
+        unit_group.save! if unit_group.changed?
+      else
+        unit_group = UnitGroup.new(
+          name: professional_learning_course,
+          published_state: published_state,
+          instruction_type: instruction_type,
+          instructor_audience: instructor_audience,
+          participant_audience: participant_audience
+        )
         unit_group.plc_course = Plc::Course.create!(unit_group: unit_group)
         unit_group.save!
       end

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -206,20 +206,26 @@ class Script < ApplicationRecord
   def generate_plc_objects
     if old_professional_learning_course?
       unit_group = UnitGroup.find_by_name(professional_learning_course)
+
+      new_published_state = published_state ? published_state : SharedCourseConstants::PUBLISHED_STATE.beta
+      new_instruction_type = instruction_type ? instruction_type : SharedCourseConstants::INSTRUCTION_TYPE.teacher_led
+      new_instructor_audience = instructor_audience ? instructor_audience : SharedCourseConstants::INSTRUCTION_TYPE.plc_reviewer
+      new_participant_audience = participant_audience ? participant_audience : SharedCourseConstants::PARTICIPANT_AUDIENCE.facilitator
+
       if unit_group
         # Check if anything needs to be updated on the PL course
-        unit_group.published_state = published_state
-        unit_group.instruction_type = instruction_type
-        unit_group.participant_audience = participant_audience
-        unit_group.instructor_audience = instructor_audience
+        unit_group.published_state = new_published_state
+        unit_group.instruction_type = new_instruction_type
+        unit_group.participant_audience = new_participant_audience
+        unit_group.instructor_audience = new_instructor_audience
         unit_group.save! if unit_group.changed?
       else
         unit_group = UnitGroup.new(
           name: professional_learning_course,
-          published_state: published_state,
-          instruction_type: instruction_type,
-          instructor_audience: instructor_audience,
-          participant_audience: participant_audience
+          published_state: new_published_state,
+          instruction_type: new_instruction_type,
+          instructor_audience: new_instructor_audience,
+          participant_audience: new_participant_audience
         )
         unit_group.plc_course = Plc::Course.create!(unit_group: unit_group)
         unit_group.save!

--- a/dashboard/config/scripts_json/andrea-test.script_json
+++ b/dashboard/config/scripts_json/andrea-test.script_json
@@ -22,9 +22,9 @@
     "family_name": null,
     "serialized_at": "2021-11-22 17:07:58 UTC",
     "published_state": "beta",
-    "instruction_type": null,
-    "instructor_audience": null,
-    "participant_audience": null,
+    "instruction_type": "teacher_led",
+    "instructor_audience": "plc_reviewer",
+    "participant_audience": "facilitator",
     "seeding_key": {
       "script.name": "andrea-test"
     }

--- a/dashboard/test/fixtures/test-plc.script_json
+++ b/dashboard/test/fixtures/test-plc.script_json
@@ -11,10 +11,10 @@
     "new_name": null,
     "family_name": null,
     "serialized_at": "2021-11-01 23:56:37 UTC",
-    "published_state": null,
-    "instruction_type": null,
-    "instructor_audience": null,
-    "participant_audience": null,
+    "published_state": "beta",
+    "instruction_type": "teacher_led",
+    "instructor_audience": "plc_reviewer",
+    "participant_audience": "facilitator",
     "seeding_key": {
       "script.name": "test-plc"
     }

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1067,14 +1067,42 @@ class ScriptTest < ActiveSupport::TestCase
     assert_equal 42, unit.peer_reviews_to_complete
 
     course_unit = unit.plc_course_unit
+    unit_group = unit.plc_course_unit.plc_course.unit_group
     assert_equal 'PLC Test', course_unit.unit_name
     assert_equal 'PLC test fixture script', course_unit.unit_description
+
+    assert_equal 'plc_reviewer', unit_group.instructor_audience
+    assert_equal 'facilitator', unit_group.participant_audience
+    assert_equal 'teacher_led', unit_group.instruction_type
+    assert_equal 'beta', unit_group.published_state
 
     lm = unit.lessons.first.plc_learning_module
     assert_equal 'Sample Module', lm.name
     assert_equal 1, course_unit.plc_learning_modules.count
     assert_equal lm, course_unit.plc_learning_modules.first
     assert_equal Plc::LearningModule::CONTENT_MODULE, lm.module_type
+  end
+
+  test 'updating plc unit updates its unit group' do
+    Script.stubs(:unit_json_directory).returns(self.class.fixture_path)
+    unit = Script.seed_from_json_file('test-plc')
+
+    unit_group = unit.plc_course_unit.plc_course.unit_group
+
+    assert_equal 'plc_reviewer', unit_group.instructor_audience
+    assert_equal 'facilitator', unit_group.participant_audience
+    assert_equal 'teacher_led', unit_group.instruction_type
+    assert_equal 'beta', unit_group.published_state
+
+    unit.update!(instructor_audience: 'universal_instructor', participant_audience: 'teacher', instruction_type: 'self_paced', published_state: 'stable')
+
+    unit.reload
+    unit_group = unit.plc_course_unit.plc_course.unit_group
+
+    assert_equal 'universal_instructor', unit_group.instructor_audience
+    assert_equal 'teacher', unit_group.participant_audience
+    assert_equal 'self_paced', unit_group.instruction_type
+    assert_equal 'stable', unit_group.published_state
   end
 
   test 'unit name format validation' do

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1105,6 +1105,17 @@ class ScriptTest < ActiveSupport::TestCase
     assert_equal 'stable', unit_group.published_state
   end
 
+  test 'generate plc objects will use defaults if script has null values' do
+    unit = create(:script, professional_learning_course: 'my-plc-course', published_state: nil, instruction_type: nil, instructor_audience: nil, participant_audience: nil)
+
+    unit_group = unit.plc_course_unit.plc_course.unit_group
+
+    assert_equal 'plc_reviewer', unit_group.instructor_audience
+    assert_equal 'facilitator', unit_group.participant_audience
+    assert_equal 'teacher_led', unit_group.instruction_type
+    assert_equal 'beta', unit_group.published_state
+  end
+
   test 'unit name format validation' do
     assert_raises ActiveRecord::RecordInvalid do
       create :script, name: 'abc 123'


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#44533. Reimplements #44478 

When this was merged to[ staging the build failed because andrea-test script](https://codedotorg.slack.com/archives/C0T0PNTM3/p1643158163168100) had null values for published_state, instruction_type, instructor_audience, participant_audience. We have been allowing null values for these fields on scripts because if they are in a unit_group then they should be null however it looks like we need some stronger validation here. Working on that in https://github.com/code-dot-org/code-dot-org/pull/44538. 

Updated the andrea-test.script_json and ran `bundle exec rake build` to make sure that the build passes. Added default values for right now in order to make sure seeding does not fail if something were to get messed up again before the validation is added.