### PR TITLE
Passing `current_year` to the HoC Footer's copyright string

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/views/footer.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/footer.haml
@@ -16,7 +16,7 @@
         Code.org
         %i{:class=>"fa fa-chevron-up"}
   #copyright
-    = hoc_s(:footer_copyright_message).gsub(/%{current_year}/, "#{Time.now.year}")
+    = hoc_s(:footer_copyright_message, locals: {current_year: "#{Time.now.year}"})
     %br
     = hoc_s(:footer_trademark_message)
     %br

--- a/pegasus/sites/all/views/page_footer.haml
+++ b/pegasus/sites/all/views/page_footer.haml
@@ -17,7 +17,7 @@
       =partial("language", :host=>request.host)
     %div{:style=>"clear:both; float: left;"}
       %small.dim
-        = hoc_s(:footer_copyright_message).gsub(/%{current_year}/, "#{Time.now.year}")
+        = hoc_s(:footer_copyright_message, locals: {current_year: "#{Time.now.year}"})
         = hoc_s(:footer_trademark_message)
         %br
         = hoc_s(:footer_built_on_github)


### PR DESCRIPTION
We were getting the Honeybadger error `String "Copyright %{current_year} Code.org. All rights reserved." has unused interpolation patterns after translation` which is produced when we fail to pass a value for the `current_year` parameter when looking up the translation for the string `:footer_copyright_message`.

Note that this fix won't actually change what is displayed to the user, because we were using `gsub` to swap `%{current_year}` with  a value. This will simply fix the Honeybadger errors from getting sent out.

This change won't fix all the errors, but it should fix a majority of them because we currently are not passing a value at all.

## Links
* [Honeybadger Errors](https://app.honeybadger.io/projects/34365/faults/83684657)

## Testing story
* Manually verified the correct year is shown in the footer on http://localhost.hourofcode.com:3000/us/en

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->
## Screenshot
<img width="404" alt="image" src="https://user-images.githubusercontent.com/1372238/151103690-5ba81a4a-4735-41f2-9b10-2c3eaa3c9855.png">
