### PR TITLE
Revert "Revert "Accurately reflect pairing status on cached levels""

### DIFF
--- a/apps/src/code-studio/components/pairing/Pairing.jsx
+++ b/apps/src/code-studio/components/pairing/Pairing.jsx
@@ -55,9 +55,10 @@ export default class Pairing extends React.Component {
   };
 
   refreshUserMenu = () => {
+    const showCreateMenu = $('.create_menu').length > 0;
     $.ajax({
       type: 'GET',
-      url: '/dashboardapi/user_menu',
+      url: `/dashboardapi/user_menu?showCreateMenu=${showCreateMenu}`,
       success: data => $('#sign_in_or_user').html(data)
     });
   };

--- a/apps/src/code-studio/header.js
+++ b/apps/src/code-studio/header.js
@@ -1,5 +1,6 @@
 /* globals dashboard */
 
+import $ from 'jquery';
 import {
   showProjectHeader,
   showMinimalProjectHeader,
@@ -138,6 +139,25 @@ header.buildProjectInfoOnly = function() {
   );
 };
 
+// When the page is cached, this function is called to retrieve and set the
+// sign-in button or user menu in the DOM.
+header.buildUserMenu = function() {
+  // Need to wait until the document is ready so we can accurately check to see
+  // if the create menu is present.
+  $(document).ready(() => {
+    const showCreateMenu = $('.create_menu').length > 0;
+
+    fetch(`/dashboardapi/user_menu?showCreateMenu=${showCreateMenu}`, {
+      credentials: 'same-origin'
+    })
+      .then(response => response.text())
+      .then(data => $('#sign_in_or_user').html(data))
+      .catch(err => {
+        console.log(err);
+      });
+  });
+};
+
 function setupReduxSubscribers(store) {
   let state = {};
   store.subscribe(() => {
@@ -179,9 +199,6 @@ function setUpGlobalData(store) {
       if (data.is_signed_in) {
         store.dispatch(setInitialData(data));
         data.is_verified_instructor && store.dispatch(setVerified());
-        ensureHeaderSigninState(true, data.short_name);
-      } else {
-        ensureHeaderSigninState(false);
       }
     })
     .catch(err => {
@@ -189,25 +206,6 @@ function setUpGlobalData(store) {
     });
 }
 setUpGlobalData(getStore());
-
-// Some of our cached pages can become cached by the browser with the
-// wrong sign-in state. This is a temporary patch to ensure that the header
-// displays the correct sign-in state for the user.
-function ensureHeaderSigninState(isSignedIn, shortName) {
-  const userMenu = document.querySelector('#header_user_menu');
-  const signinButton = document.querySelector('#signin_button');
-
-  if (isSignedIn && userMenu.style.display === 'none') {
-    userMenu.style.display = 'block';
-    signinButton.style.display = 'none';
-
-    const displayName = document.querySelector('#header_display_name');
-    displayName.textContent = shortName;
-  } else if (!isSignedIn && signinButton.style.display === 'none') {
-    userMenu.style.display = 'none';
-    signinButton.style.display = 'inline';
-  }
-}
 
 header.showMinimalProjectHeader = function() {
   getStore().dispatch(refreshProjectName());

--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -170,6 +170,7 @@ class ApiController < ApplicationController
     @user_header_options[:show_pairing_dialog] = show_pairing_dialog
     @user_header_options[:session_pairings] = pairing_user_ids
     @user_header_options[:loc_prefix] = 'nav.user.'
+    @user_header_options[:show_create_menu] = params[:showCreateMenu]
   end
 
   def update_lockable_state

--- a/dashboard/app/views/layouts/_header.html.haml
+++ b/dashboard/app/views/layouts/_header.html.haml
@@ -156,3 +156,9 @@
 - elsif level
   :javascript
     dashboard.header.buildProjectInfoOnly()
+
+-# If the page is cached, the sign-in button / user menu must be loaded separately
+-# by the client.
+- if @public_caching
+  :javascript
+    dashboard.header.buildUserMenu()

--- a/dashboard/test/ui/features/learning_platform/pairing.feature
+++ b/dashboard/test/ui/features/learning_platform/pairing.feature
@@ -10,6 +10,7 @@ Feature: Student pairing
     And I rotate to landscape
     And I wait for the page to fully load
     Then I initiate pairing
+    And I verify the user menu shows "Thing_One" and "Thing_Two" are in a pairing group
     # complete the level
     And I wait until element "#runButton" is visible
     And I click selector "#runButton"
@@ -41,6 +42,7 @@ Feature: Student pairing
     And I rotate to landscape
     And I wait for the page to fully load
     Then I initiate pairing
+    And I verify the user menu shows "Thing_One" and "Thing_Two" are in a pairing group
     # complete the level
     And I wait until element "#runButton" is visible
     And I click selector "#runButton"
@@ -52,3 +54,18 @@ Feature: Student pairing
     Given I am on "http://studio.code.org/s/allthethings/lessons/2/levels/2"
     And I wait for the page to fully load
     And I verify progress in the header of the current page is "attempted" for level 2
+
+  Scenario: Pairing group is correctly displayed in user menu on cached levels
+    Given I create a teacher named "Dr_Seuss"
+    And I create a new section
+    Given I create a student named "Thing_One"
+    And I join the section
+    Given I create a student named "Thing_Two"
+    And I join the section
+    Given I am on "http://studio.code.org/s/starwars/lessons/1/levels/5"
+    And I rotate to landscape
+    And I wait for the page to fully load
+    Then I initiate pairing
+    And I verify the user menu shows "Thing_One" and "Thing_Two" are in a pairing group
+    Then I reload the page
+    And I verify the user menu shows "Thing_One" and "Thing_Two" are in a pairing group

--- a/dashboard/test/ui/features/step_definitions/header_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/header_steps.rb
@@ -29,12 +29,6 @@ Then /^I initiate pairing$/ do
     And I wait until element ".addPartners" is visible
     And I click selector ".addPartners"
     And I wait for 5 seconds
-    And I wait until element ".user_menu" is visible
-    And I wait until element ".pairing_name" is visible
-    And element ".pairing_name" contains text "Team"
-    And I wait until element ".fa-users" is visible
-    And I click selector ".pairing_name"
-    And I wait until element ".pairing_summary" is visible
   STEPS
 end
 

--- a/dashboard/test/ui/features/step_definitions/header_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/header_steps.rb
@@ -21,6 +21,8 @@ Then /^I initiate pairing$/ do
     And I wait until element ".display_name" is visible
     And I click selector ".display_name"
     And I wait until element "#pairing_link" is visible
+    # Wait for user menu to finish animating
+    And I wait for 0.5 seconds
     And I press "pairing_link"
     And I wait until element ".student" is visible
     And I click selector ".student"
@@ -33,5 +35,18 @@ Then /^I initiate pairing$/ do
     And I wait until element ".fa-users" is visible
     And I click selector ".pairing_name"
     And I wait until element ".pairing_summary" is visible
+  STEPS
+end
+
+Then /^I verify the user menu shows "([^"]*)" and "([^"]*)" are in a pairing group$/ do |name1, name2|
+  steps <<-STEPS
+    And I wait until element ".user_menu" is visible
+    And I wait until element ".pairing_name" is visible
+    And element ".pairing_name" contains text "Team"
+    And I wait until element ".fa-users" is visible
+    And I click selector ".pairing_name"
+    And I wait until element ".pairing_summary" is visible
+    And element ".pairing_summary" contains text "#{name1}"
+    And element ".pairing_summary" contains text "#{name2}"
   STEPS
 end

--- a/shared/haml/user_header.haml
+++ b/shared/haml/user_header.haml
@@ -2,23 +2,29 @@
 :ruby
   require 'cdo/create_header'
   require 'cdo/language_dir'
-  limit_project_types = request.cookies["_limit_project_types_#{rack_env}"]
 
-  level = defined?(local_assigns) ?
-    local_assigns[:level] :
-    false
+  # Determine if we want to show the create menu
+  if local_assigns[:show_create_menu]
+    show_create_menu = local_assigns[:show_create_menu] == "true"
+  elsif local_assigns[:level]
+    # Only show the create menu on project levels (and not on levels in units)
+    show_create_menu = local_assigns[:level].try(:is_project_level)
+  else
+    # Show the create menu on non-level pages
+    show_create_menu = true
+  end
 
-  options = {
-    limit_project_types: limit_project_types,
-    project_type: params && params[:key]
-  }
-  create_drop_down_items = CreateHeader.get_create_dropdown_contents(options)
+  if show_create_menu
+    limit_project_types = request.cookies["_limit_project_types_#{rack_env}"]
 
-  # We want to show the Create button for all pages except when working on a
-  # course level. Specifically, for any page except non-project levels.
-  should_show_create_menu = !level || level.try(:is_project_level)
+    options = {
+      limit_project_types: limit_project_types,
+      project_type: params && params[:key]
+    }
+    create_drop_down_items = CreateHeader.get_create_dropdown_contents(options)
+  end
 
-- if should_show_create_menu
+- if show_create_menu
   .header_button.create_menu{tabindex: 0, role: "button"}
     %span.create_button
       = I18n.t("#{loc_prefix}create")
@@ -34,44 +40,41 @@
       %a.project_link_box{href: CDO.studio_url('projects')}
         .project_link#view_all_projects
           = I18n.t("#{loc_prefix}view_all")
--# The user menu button is hidden using css so that we can verify the login state of the user on the client
--# and adjust as needed for cached pages (see header.js in apps)
-- user_dropdown_display = current_user.present? ? "block" : "none"
-.header_button.header_user.user_menu{id: "header_user_menu", tabindex: 0, role: "button", style: "display: #{user_dropdown_display}"}
-  - if current_user&.can_pair? && session_pairings.present?
-    %i.fa.fa-users.pairing_icon
-    %span.pairing_name= I18n.t("#{loc_prefix}team")
-  - else
-    - short_name = ERB::Util.h(current_user&.short_name)
-    %span.display_name{id: 'header_display_name', 'data-id': current_user&.id, 'data-shortname': short_name}= short_name
-  &nbsp;
-  %i.user_menu_arrow_down{class: "fa fa-caret-down"}
-  %i.user_menu_arrow_up{class: "fa fa-caret-up", style: "display: none"}
-  .user_options{style: 'display: none', dir: language_dir_class}
-    %a.linktag#my-projects{href: CDO.studio_url('projects')}= I18n.t("#{loc_prefix}my_projects")
-    - if current_user&.can_pair?
-      - if session_pairings.present?
-        = link_to '#', {id: 'pairing_link', style: 'display: none'} do
-          = I18n.t("#{loc_prefix}pair_programming")
-          .pairing_summary
-            #{I18n.t("#{loc_prefix}driver")}:
-            = h(current_user&.short_name)
-            - session_pairings.map do |id|
-              %br
-              #{I18n.t("#{loc_prefix}navigator")}:
-              = h(User.find(id).short_name)
-      - else
-        = link_to '#', {id: 'pairing_link', style: 'display: none'} do
-          = I18n.t("#{loc_prefix}pair_programming")
-    %a.linktag#user-edit{href: CDO.studio_url('users/edit')}= I18n.t("#{loc_prefix}settings")
-    %a.linktag#user-signout{href: CDO.studio_url('users/sign_out')}= I18n.t("#{loc_prefix}logout")
--# The sign-in button is hidden using css so that we can verify the login state of the user on the client
--# and adjust as needed for cached pages (see header.js in apps)
-- signin_display = current_user.present? ? "none" : "inline"
-%a.linktag{href: CDO.studio_url('users/sign_in'), class: 'button-signin', id: 'signin_button', style: "display: #{signin_display}"}
-  .header_button.header_user#header_user_signin
-    %span= I18n.t("#{loc_prefix}signin")
-    .signin_callout_wrapper
+
+- if current_user
+  .header_button.header_user.user_menu{id: "header_user_menu", tabindex: 0, role: "button"}
+    - if current_user.can_pair? && session_pairings.present?
+      %i.fa.fa-users.pairing_icon
+      %span.pairing_name= I18n.t("#{loc_prefix}team")
+    - else
+      - short_name = ERB::Util.h(current_user.short_name)
+      %span.display_name{id: 'header_display_name', 'data-id': current_user.id, 'data-shortname': short_name}= short_name
+    &nbsp;
+    %i.user_menu_arrow_down{class: "fa fa-caret-down"}
+    %i.user_menu_arrow_up{class: "fa fa-caret-up", style: "display: none"}
+    .user_options{style: 'display: none', dir: language_dir_class}
+      %a.linktag#my-projects{href: CDO.studio_url('projects')}= I18n.t("#{loc_prefix}my_projects")
+      - if current_user.can_pair?
+        - if session_pairings.present?
+          = link_to '#', {id: 'pairing_link', style: 'display: none'} do
+            = I18n.t("#{loc_prefix}pair_programming")
+            .pairing_summary
+              #{I18n.t("#{loc_prefix}driver")}:
+              = h(current_user.short_name)
+              - session_pairings.map do |id|
+                %br
+                #{I18n.t("#{loc_prefix}navigator")}:
+                = h(User.find(id).short_name)
+        - else
+          = link_to '#', {id: 'pairing_link', style: 'display: none'} do
+            = I18n.t("#{loc_prefix}pair_programming")
+      %a.linktag#user-edit{href: CDO.studio_url('users/edit')}= I18n.t("#{loc_prefix}settings")
+      %a.linktag#user-signout{href: CDO.studio_url('users/sign_out')}= I18n.t("#{loc_prefix}logout")
+- else
+  %a.linktag{href: CDO.studio_url('users/sign_in'), class: 'button-signin', id: 'signin_button'}
+    .header_button.header_user#header_user_signin
+      %span= I18n.t("#{loc_prefix}signin")
+      .signin_callout_wrapper
 
 :javascript
   window.cookieEnvSuffix = '#{rack_env?(:production) ? '' : "_#{rack_env}"}';


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#44542 which re-applies #44462.  Made one small tweak to the UI tests to address earlier failures.