### PR TITLE
only install pdftk on staging

### DIFF
--- a/cookbooks/cdo-apps/recipes/default.rb
+++ b/cookbooks/cdo-apps/recipes/default.rb
@@ -24,20 +24,22 @@ apt_package %w(
   fonts-noto
 )
 
-# Used by lesson plan generator.
-pdftk_file = 'pdftk-java_3.1.1-1_all.deb'
-pdftk_local_file = "#{Chef::Config[:file_cache_path]}/#{pdftk_file}"
-remote_file pdftk_local_file do
-  source "https://mirrors.kernel.org/ubuntu/pool/universe/p/pdftk-java/#{pdftk_file}"
-  checksum "8a28ba8b100bc0b6e9f3e91c090a9b8a83a5f8a337a91150cbaadad8accb4901"
+# Used by lesson plan generator
+if node.chef_environment == 'staging'
+  pdftk_file = 'pdftk-java_3.1.1-1_all.deb'
+  pdftk_local_file = "#{Chef::Config[:file_cache_path]}/#{pdftk_file}"
+  remote_file pdftk_local_file do
+    source "https://mirrors.kernel.org/ubuntu/pool/universe/p/pdftk-java/#{pdftk_file}"
+    checksum "8a28ba8b100bc0b6e9f3e91c090a9b8a83a5f8a337a91150cbaadad8accb4901"
+  end
+  # Dependencies of pdftk-java.
+  apt_package %w(
+    default-jre-headless
+    libbcprov-java
+    libcommons-lang3-java
+  )
+  dpkg_package("pdftk-java") {source pdftk_local_file}
 end
-# Dependencies of pdftk-java.
-apt_package %w(
-  default-jre-headless
-  libbcprov-java
-  libcommons-lang3-java
-)
-dpkg_package("pdftk-java") {source pdftk_local_file}
 
 # Used by lesson plan generator.
 apt_package 'enscript'


### PR DESCRIPTION
This PR is a short-term solution to the issues that the `pdftk` library is causing when creating adhocs. We currently only use this library to add page numbers to pdfs, which are generated in staging, and currently folks are commenting out these lines when generating adhocs, so this won't have any adverse affects on our ability to create adhocs.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

[This PR](https://github.com/code-dot-org/code-dot-org/pull/44557) contains the follow-up work of actually removing pdftk entirely.

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
