### PR TITLE
Javalab: pass content manager flag to Javabuilder

### DIFF
--- a/apps/src/javalab/JavabuilderConnection.js
+++ b/apps/src/javalab/JavabuilderConnection.js
@@ -58,7 +58,7 @@ export default class JavabuilderConnection {
         levelId: this.levelId,
         options: this.options,
         executionType: this.executionType,
-        useContentManager: false,
+        useDashboardSources: true,
         miniAppType: this.miniAppType
       }
     })

--- a/apps/src/javalab/JavabuilderConnection.js
+++ b/apps/src/javalab/JavabuilderConnection.js
@@ -2,7 +2,8 @@ import {
   WebSocketMessageType,
   StatusMessageType,
   STATUS_MESSAGE_PREFIX,
-  ExecutionType
+  ExecutionType,
+  ContentManagerType
 } from './constants';
 import {handleException} from './javabuilderExceptionHandler';
 import project from '@cdo/apps/code-studio/initApp/project';
@@ -58,6 +59,7 @@ export default class JavabuilderConnection {
         levelId: this.levelId,
         options: this.options,
         executionType: this.executionType,
+        contentManagerType: ContentManagerType.DASHBOARD,
         miniAppType: this.miniAppType
       }
     })

--- a/apps/src/javalab/JavabuilderConnection.js
+++ b/apps/src/javalab/JavabuilderConnection.js
@@ -2,8 +2,7 @@ import {
   WebSocketMessageType,
   StatusMessageType,
   STATUS_MESSAGE_PREFIX,
-  ExecutionType,
-  ContentManagerType
+  ExecutionType
 } from './constants';
 import {handleException} from './javabuilderExceptionHandler';
 import project from '@cdo/apps/code-studio/initApp/project';
@@ -59,7 +58,7 @@ export default class JavabuilderConnection {
         levelId: this.levelId,
         options: this.options,
         executionType: this.executionType,
-        contentManagerType: ContentManagerType.DASHBOARD,
+        useContentManager: false,
         miniAppType: this.miniAppType
       }
     })

--- a/apps/src/javalab/constants.js
+++ b/apps/src/javalab/constants.js
@@ -182,8 +182,3 @@ export const ExecutionType = {
   // Compile and run tests
   TEST: 'TEST'
 };
-
-export const ContentManagerType = {
-  // Javabuilder assets fetched via dashboard
-  DASHBOARD: 'dashboard'
-};

--- a/apps/src/javalab/constants.js
+++ b/apps/src/javalab/constants.js
@@ -182,3 +182,8 @@ export const ExecutionType = {
   // Compile and run tests
   TEST: 'TEST'
 };
+
+export const ContentManagerType = {
+  // Javabuilder assets fetched via dashboard
+  DASHBOARD: 'dashboard'
+};

--- a/dashboard/app/controllers/javabuilder_sessions_controller.rb
+++ b/dashboard/app/controllers/javabuilder_sessions_controller.rb
@@ -17,7 +17,7 @@ class JavabuilderSessionsController < ApplicationController
     level_id = params[:levelId]
     options = params[:options]
     execution_type = params[:executionType]
-    use_content_manager = params[:useContentManager]
+    use_dashboard_sources = params[:useDashboardSources]
     mini_app_type = params[:miniAppType]
     options = options ? options.to_json : '{}'
     if !channel_id || !project_version || !project_url || !execution_type || !mini_app_type
@@ -48,7 +48,7 @@ class JavabuilderSessionsController < ApplicationController
       level_id: level_id,
       execution_type: execution_type,
       mini_app_type: mini_app_type,
-      use_content_manager: use_content_manager,
+      use_dashboard_sources: use_dashboard_sources,
       options: options
     }
 

--- a/dashboard/app/controllers/javabuilder_sessions_controller.rb
+++ b/dashboard/app/controllers/javabuilder_sessions_controller.rb
@@ -17,7 +17,7 @@ class JavabuilderSessionsController < ApplicationController
     level_id = params[:levelId]
     options = params[:options]
     execution_type = params[:executionType]
-    content_manager_type = params[:contentManagerType]
+    use_content_manager = params[:useContentManager]
     mini_app_type = params[:miniAppType]
     options = options ? options.to_json : '{}'
     if !channel_id || !project_version || !project_url || !execution_type || !mini_app_type
@@ -48,7 +48,7 @@ class JavabuilderSessionsController < ApplicationController
       level_id: level_id,
       execution_type: execution_type,
       mini_app_type: mini_app_type,
-      content_manager_type: content_manager_type,
+      use_content_manager: use_content_manager,
       options: options
     }
 

--- a/dashboard/app/controllers/javabuilder_sessions_controller.rb
+++ b/dashboard/app/controllers/javabuilder_sessions_controller.rb
@@ -17,6 +17,7 @@ class JavabuilderSessionsController < ApplicationController
     level_id = params[:levelId]
     options = params[:options]
     execution_type = params[:executionType]
+    content_manager_type = params[:contentManagerType]
     mini_app_type = params[:miniAppType]
     options = options ? options.to_json : '{}'
     if !channel_id || !project_version || !project_url || !execution_type || !mini_app_type
@@ -47,6 +48,7 @@ class JavabuilderSessionsController < ApplicationController
       level_id: level_id,
       execution_type: execution_type,
       mini_app_type: mini_app_type,
+      content_manager_type: content_manager_type,
       options: options
     }
 


### PR DESCRIPTION
Passes a new `use_dashboard_sources` param (value `true` currently) to Javabuilder in preparation for allowing Javabuilder to fetch content via a content manager.

## Links

- [tech spec](https://docs.google.com/document/d/1pqNGzZLe7sHb6V_j0cZ2ZjqONItDgzKfD6g8Yoj3ipc/edit#)
- [jira](https://codedotorg.atlassian.net/browse/JAVA-419)

## Testing story

Tested manually that Javabuilder received the new `content_manager_type` param locally.