### PR TITLE
Update MysqlCheckIndexUsed for Rails 6

### DIFF
--- a/dashboard/config/initializers/mysql_check_index_used.rb
+++ b/dashboard/config/initializers/mysql_check_index_used.rb
@@ -11,6 +11,14 @@ module MysqlCheckIndexUsed
 
   # Copy/extend logic in AbstractMySQLAdapter#execute, and AbstractAdapter#log.
   def execute(sql, name = nil)
+    # Rails 6 added both the materialize_transactions method and a call to it
+    # right here, so to preserve compatibility between 5 and 6 we call the
+    # method if and only if it exists. The if clause can be removed once we've
+    # fully upgraded to Rails 6.
+    #
+    # See https://github.com/rails/rails/pull/32647/files#diff-868f1dccfcbed26a288bf9f3fd8a39c863a4413ab0075e12b6805d9798f556d1
+    materialize_transactions if respond_to?(:materialize_transactions)
+
     options = {
       sql:               sql,
       name:              name,


### PR DESCRIPTION
Rails 6 added support for lazy transactions, and as part of that modified the `execute` method on the Mysql ConnectionAdapter:

https://github.com/rails/rails/pull/32647/files#diff-868f1dccfcbed26a288bf9f3fd8a39c863a4413ab0075e12b6805d9798f556d1

The same adapter whose `execute` method we overwrite in MysqlCheckIndexUsed:

https://github.com/code-dot-org/code-dot-org/blob/30f8a7454bae694a78b63ac580bfc86faadb9bea/dashboard/config/initializers/mysql_check_index_used.rb#L9-L34

To provide compatibility for both Rails 5 and 6, we simply update our overwritten method to conditionally invoke the Rails 6 modifications.

## Testing story

Relying on existing unit tests.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
