### PR TITLE
Implement 'use_reader_connection' block in MultipleDatabasesTransitionHelper

### DIFF
--- a/dashboard/app/controllers/admin_hoc_controller.rb
+++ b/dashboard/app/controllers/admin_hoc_controller.rb
@@ -8,7 +8,7 @@ class AdminHocController < ApplicationController
   check_authorization
 
   def students_served
-    MultipleDatabasesTransitionHelper.use_persistent_read_connection do
+    MultipleDatabasesTransitionHelper.use_reader_connection do
       @data = Properties.get(:hoc_metrics)
     end
   end

--- a/dashboard/app/controllers/admin_reports_controller.rb
+++ b/dashboard/app/controllers/admin_reports_controller.rb
@@ -13,7 +13,7 @@ class AdminReportsController < ApplicationController
   end
 
   def level_answers
-    MultipleDatabasesTransitionHelper.use_persistent_read_connection do
+    MultipleDatabasesTransitionHelper.use_reader_connection do
       @headers = ['Level ID', 'User Email', 'Data']
       @responses = {}
       @response_limit = 100
@@ -132,7 +132,7 @@ class AdminReportsController < ApplicationController
       ) && return
     end
 
-    MultipleDatabasesTransitionHelper.use_persistent_read_connection do
+    MultipleDatabasesTransitionHelper.use_reader_connection do
       locals_options = Properties.get("pd_progress_#{script.id}")
       if locals_options
         render locals: locals_options.symbolize_keys

--- a/dashboard/app/helpers/multiple_databases_transition_helper.rb
+++ b/dashboard/app/helpers/multiple_databases_transition_helper.rb
@@ -41,14 +41,14 @@ module MultipleDatabasesTransitionHelper
     end
   end
 
-  # Provide a new `use_persistent_read` method to replace our existing use of
-  # the same. ActiveRecord itself has some new logic to provide similar
-  # functionality, as does ProxySQL, so it could well be that we don't actually
-  # need this at all post-transition. More investigation needed for this TODO
-  # to be resolved.
-  def self.use_persistent_read_connection
+  # Provide a new `use_reader_connection` method to replace our existing use of
+  # `use_persistent_read_connection` with the entirely-equivalent ActiveRecord
+  # implementation.
+  def self.use_reader_connection
     if MultipleDatabasesTransitionHelper.transitioned?
-      # TODO
+      ActiveRecord::Base.connected_to(role: :reading) do
+        yield
+      end
     else
       SeamlessDatabasePool.use_persistent_read_connection do
         yield


### PR DESCRIPTION
Specifically, implement the Rails 6 version of it now that I've verified that `SeamlessDatabasePool.use_persistent_read_connection` and `ActiveRecord::Base.connected_to(role: :reading)` are functionally equivalent.

Also rename the method, for better parallelism with `use_writer_connection`

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

[`def use_persistent_read_connection`](https://github.com/bdurand/seamless_database_pool/blob/529c1d49b2c6029de7444830bce72917de79ebff/lib/seamless_database_pool.rb#L43-L49)

[`def connected_to`](https://github.com/rails/rails/blob/0d304eae601f085274b2e2c04316e025b443da62/activerecord/lib/active_record/connection_handling.rb#L81-L103)

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Manually set up a local testing environment with one writer and three readers and logged query counts to each. Tested on both Rails 5 and 6

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
