### PR TITLE
error out of bin/dotd if github access token is invalid

### DIFF
--- a/bin/dotd
+++ b/bin/dotd
@@ -47,6 +47,19 @@ def check_for_cdo_keys
   exit
 end
 
+def check_github_token
+  GitHub.sha('test', true)
+rescue Octokit::Unauthorized
+  puts <<~EOS
+
+    Your CDO.github_access_token is out of date. Please update your
+    personal access token at github.com, put the new value in locals.yml,
+    and rerun this script.
+
+  EOS
+  exit
+end
+
 # Prints the script intro to the console.
 def puts_script_intro(dotd_name)
   puts <<~EOS
@@ -474,6 +487,7 @@ end
 # The main method of the script, responsible for dispatching control flow to other methods.
 def main
   check_for_cdo_keys
+  check_github_token
 
   dotd_name = ENV['CDODEV_DOTD_NAME'] || ENV['USER']
   @logger.info("#{Time.new.strftime('%A, %B %d %Y')}: #{dotd_name} is DOTD")


### PR DESCRIPTION
see https://codedotorg.slack.com/archives/C03CK49G9/p1643252986181700

## Testing story

```
[development] dashboard > CDO.github_access_token
=> "ghp_foobarbarbarbarbarbarbarbarbarbarbar"
```

```
Dave-MBP:~/src/cdo (dotd-github-access-token)$ bundle exec bin/dotd 
GetSecretValue: development/cdo/slack_bot_token

Your CDO.github_access_token is out of date. Please update your
personal access token at github.com, put the new value in locals.yml,
and rerun this script.

Dave-MBP:~/src/cdo (dotd-github-access-token)$ 
```

I also verified that there is no change in behavior if the access token is correct, or missing entirely.