### PR TITLE
Passing variables to I18n.t in hoc_s

### DIFF
--- a/pegasus/helpers/hourofcode_helpers.rb
+++ b/pegasus/helpers/hourofcode_helpers.rb
@@ -16,17 +16,10 @@ HOC_COUNTRIES = hoc_load_countries
 #
 # Can be called with markdown: true to render the string as (HTML-safe)
 # markdown, or with markdown: :inline to render as inline markdown.
-def hoc_s(id, markdown: false, locals: nil)
+def hoc_s(id, markdown: false, locals: {})
   id = id.to_s
   language = @language || Languages.get_hoc_unique_language_by_locale(request.locale)
-  string = I18n.t(id, locale: language)
-
-  # manually implement a very simple version of string interpolation
-  if locals.present?
-    locals.each do |key, value|
-      string.gsub!(/%{#{key}}/, value)
-    end
-  end
+  string = I18n.t(id, locals.merge({locale: language}))
 
   if markdown
     type = markdown == :inline ? :inline_md : :safe_md


### PR DESCRIPTION
The `hoc_s` function is used by Pegasus to lookup string translations. We recently updated `hoc_s` to use the same translation lookup logic as dashboard, but didn't pass in the variables needed by some strings (such as the "Copyright 2022" string). When `I18n.t` looks up a string translation and notices that there are variables missing, then it generates a HoneyBadger error. This PR updates the `I18n.t` usage to pass in the string variables defined in the Hash `locals`.

## Links
* [HoneyBadger Errors](https://app.honeybadger.io/projects/34365/faults/83716236)
* [PR where reports started](https://github.com/code-dot-org/code-dot-org/commit/364ca1b25b10ce4d0a2e8379156de02672bbe39d)

## Testing story
* Manually tested on http://localhost.hourofcode.com:3000/es and verified the "Copyright" string in the footer shows the correct year.

## Screenshots
Note that "Copyright 2022..." has the correct year in it. The year is a variable injected into the string.
<img width="383" alt="image" src="https://user-images.githubusercontent.com/1372238/151319055-431815d8-ad89-4380-9f02-636cdd8ef792.png">
