### PR TITLE
Do not let students get verified teacher permissions when they enroll in workshops

### DIFF
--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -374,7 +374,7 @@ class Pd::Enrollment < ApplicationRecord
   end
 
   def authorize_teacher_account
-    user.permission = UserPermission::AUTHORIZED_TEACHER if user && [COURSE_CSD, COURSE_CSP, COURSE_CSA].include?(workshop.course)
+    user.permission = UserPermission::AUTHORIZED_TEACHER if user&.teacher? && [COURSE_CSD, COURSE_CSP, COURSE_CSA].include?(workshop.course)
   end
 
   private_class_method def self.filter_for_pegasus_survey_completion(enrollments, select_completed)

--- a/dashboard/app/models/plc/user_course_enrollment.rb
+++ b/dashboard/app/models/plc/user_course_enrollment.rb
@@ -30,7 +30,6 @@ class Plc::UserCourseEnrollment < ApplicationRecord
   validates :user_id, uniqueness: {scope: :plc_course_id}, on: :create
 
   after_save :create_enrollment_unit_assignments, :create_authorized_teacher_user_permission
-  before_destroy :delete_authorized_teacher_user_permission
 
   # Method for
   # @param user_keys: list of user IDs or email addresses
@@ -97,18 +96,8 @@ class Plc::UserCourseEnrollment < ApplicationRecord
   private
 
   def create_authorized_teacher_user_permission
-    unless user.verified_teacher?
+    if user.teacher? && !user.verified_teacher?
       user.permission = UserPermission::AUTHORIZED_TEACHER
-    end
-  end
-
-  def delete_authorized_teacher_user_permission
-    # De-authorize teacher unless they have other plc enrollments
-    unless user.plc_enrollments.length > 1
-      UserPermission.find_by(
-        user_id: user_id,
-        permission: UserPermission::AUTHORIZED_TEACHER
-      ).try(:destroy)
     end
   end
 end

--- a/dashboard/test/models/pd/enrollment_test.rb
+++ b/dashboard/test/models/pd/enrollment_test.rb
@@ -591,6 +591,16 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
     refute teacher.permission? UserPermission::AUTHORIZED_TEACHER
   end
 
+  test 'Enrolling student user in CSD course does not make them authorized teacher' do
+    student = create :student
+    assert_empty student.permissions
+
+    workshop = create :workshop, course: Pd::SharedWorkshopConstants::COURSE_CSD
+    create :pd_enrollment, workshop: workshop, user: student
+
+    refute student.permission? UserPermission::AUTHORIZED_TEACHER
+  end
+
   test 'Updating existing enrollment sets permission' do
     workshop = create :workshop, course: Pd::SharedWorkshopConstants::COURSE_CSD
     enrollment = create :pd_enrollment, workshop: workshop, user: nil


### PR DESCRIPTION
We have been verifying any account that joins a Workshop or a PLC Course associated to a workshop. However this means we have verified some student accounts. We do not want to be verifying student accounts. As a first step here we are going to stop verifying student accounts that are in a Workshop or PLC Course associated with a workshop. There is follow up work to do here to help facilitators and workshop participants know if they have been verified or not because of their account type. Product is going to follow up on that. However this prevents us from adding more student accounts that are verified in the meantime.

I also found some old code that if you unenrolled from PLC Courses we would remove your verified teacher status. I don't think we want to take that away once someone is verified so removing that.

## Links

[Slack Thread](https://codedotorg.slack.com/archives/CA3KCSGTD/p1643229641056900)

## Testing story

- Unit Tests