### PR TITLE
Move TTS autoplay settings to instructionRedux

### DIFF
--- a/apps/src/redux/instructions.js
+++ b/apps/src/redux/instructions.js
@@ -28,7 +28,8 @@ const SET_DYNAMIC_INSTRUCTIONS_KEY =
 const LOCALSTORAGE_OVERLAY_SEEN_FLAG = 'instructionsOverlaySeenOnce';
 const SET_DYNAMIC_INSTRUCTIONS_DISMISS_CALLBACK =
   'instructions/SET_DYNAMIC_INSTRUCTIONS_DISMISS_CALLBACK';
-const SET_TTS_AUTOPLAY_ENABLED = 'instructions/SET_TTS_AUTOPLAY_ENABLED';
+const SET_TTS_AUTOPLAY_ENABLED_FOR_PARTICIPANT =
+  'instructions/SET_TTS_AUTOPLAY_ENABLED_FOR_PARTICIPANT';
 
 /**
  * Some scenarios:
@@ -63,7 +64,9 @@ const instructionsInitialState = {
   maxAvailableHeight: Infinity,
   allowResize: true,
   hasAuthoredHints: false,
-  ttsAutoplayEnabled: false,
+  // represents if the user is in any unarchived section where tts autoplay is enabled
+  // logic defined in script_levels_controller#show
+  ttsAutoplayEnabledForParticipant: false,
   overlayVisible: false,
   levelVideos: [],
   mapReference: undefined,
@@ -161,9 +164,9 @@ export default function reducer(state = {...instructionsInitialState}, action) {
     });
   }
 
-  if (action.type === SET_TTS_AUTOPLAY_ENABLED) {
+  if (action.type === SET_TTS_AUTOPLAY_ENABLED_FOR_PARTICIPANT) {
     return Object.assign({}, state, {
-      ttsAutoplayEnabled: action.ttsAutoplayEnabled
+      ttsAutoplayEnabledForParticipant: action.ttsAutoplayEnabledForParticipant
     });
   }
 
@@ -274,9 +277,9 @@ export const setHasAuthoredHints = hasAuthoredHints => ({
   hasAuthoredHints
 });
 
-export const setTtsAutoplayEnabled = ttsAutoplayEnabled => ({
-  type: SET_TTS_AUTOPLAY_ENABLED,
-  ttsAutoplayEnabled
+export const setTtsAutoplayEnabledForParticipant = ttsAutoplayEnabledForParticipant => ({
+  type: SET_TTS_AUTOPLAY_ENABLED_FOR_PARTICIPANT,
+  ttsAutoplayEnabledForParticipant
 });
 
 export const setFeedback = feedback => ({

--- a/apps/src/redux/instructions.js
+++ b/apps/src/redux/instructions.js
@@ -28,8 +28,8 @@ const SET_DYNAMIC_INSTRUCTIONS_KEY =
 const LOCALSTORAGE_OVERLAY_SEEN_FLAG = 'instructionsOverlaySeenOnce';
 const SET_DYNAMIC_INSTRUCTIONS_DISMISS_CALLBACK =
   'instructions/SET_DYNAMIC_INSTRUCTIONS_DISMISS_CALLBACK';
-const SET_TTS_AUTOPLAY_ENABLED_FOR_PARTICIPANT =
-  'instructions/SET_TTS_AUTOPLAY_ENABLED_FOR_PARTICIPANT';
+const SET_TTS_AUTOPLAY_ENABLED_FOR_LEVEL =
+  'instructions/SET_TTS_AUTOPLAY_ENABLED_FOR_LEVEL';
 
 /**
  * Some scenarios:
@@ -66,7 +66,7 @@ const instructionsInitialState = {
   hasAuthoredHints: false,
   // represents if the user is in any unarchived section where tts autoplay is enabled
   // logic defined in script_levels_controller#show
-  ttsAutoplayEnabledForParticipant: false,
+  ttsAutoplayEnabledForLevel: false,
   overlayVisible: false,
   levelVideos: [],
   mapReference: undefined,
@@ -164,9 +164,9 @@ export default function reducer(state = {...instructionsInitialState}, action) {
     });
   }
 
-  if (action.type === SET_TTS_AUTOPLAY_ENABLED_FOR_PARTICIPANT) {
+  if (action.type === SET_TTS_AUTOPLAY_ENABLED_FOR_LEVEL) {
     return Object.assign({}, state, {
-      ttsAutoplayEnabledForParticipant: action.ttsAutoplayEnabledForParticipant
+      ttsAutoplayEnabledForLevel: action.ttsAutoplayEnabledForLevel
     });
   }
 
@@ -277,9 +277,9 @@ export const setHasAuthoredHints = hasAuthoredHints => ({
   hasAuthoredHints
 });
 
-export const setTtsAutoplayEnabledForParticipant = ttsAutoplayEnabledForParticipant => ({
-  type: SET_TTS_AUTOPLAY_ENABLED_FOR_PARTICIPANT,
-  ttsAutoplayEnabledForParticipant
+export const setTtsAutoplayEnabledForLevel = ttsAutoplayEnabledForLevel => ({
+  type: SET_TTS_AUTOPLAY_ENABLED_FOR_LEVEL,
+  ttsAutoplayEnabledForLevel
 });
 
 export const setFeedback = feedback => ({

--- a/apps/src/redux/instructions.js
+++ b/apps/src/redux/instructions.js
@@ -28,6 +28,7 @@ const SET_DYNAMIC_INSTRUCTIONS_KEY =
 const LOCALSTORAGE_OVERLAY_SEEN_FLAG = 'instructionsOverlaySeenOnce';
 const SET_DYNAMIC_INSTRUCTIONS_DISMISS_CALLBACK =
   'instructions/SET_DYNAMIC_INSTRUCTIONS_DISMISS_CALLBACK';
+const SET_TTS_AUTOPLAY_ENABLED = 'instructions/SET_TTS_AUTOPLAY_ENABLED';
 
 /**
  * Some scenarios:
@@ -62,6 +63,7 @@ const instructionsInitialState = {
   maxAvailableHeight: Infinity,
   allowResize: true,
   hasAuthoredHints: false,
+  ttsAutoplayEnabled: false,
   overlayVisible: false,
   levelVideos: [],
   mapReference: undefined,
@@ -156,6 +158,12 @@ export default function reducer(state = {...instructionsInitialState}, action) {
   if (action.type === SET_HAS_AUTHORED_HINTS) {
     return Object.assign({}, state, {
       hasAuthoredHints: action.hasAuthoredHints
+    });
+  }
+
+  if (action.type === SET_TTS_AUTOPLAY_ENABLED) {
+    return Object.assign({}, state, {
+      ttsAutoplayEnabled: action.ttsAutoplayEnabled
     });
   }
 
@@ -264,6 +272,11 @@ export const setAllowInstructionsResize = allowResize => ({
 export const setHasAuthoredHints = hasAuthoredHints => ({
   type: SET_HAS_AUTHORED_HINTS,
   hasAuthoredHints
+});
+
+export const setTtsAutoplayEnabled = ttsAutoplayEnabled => ({
+  type: SET_TTS_AUTOPLAY_ENABLED,
+  ttsAutoplayEnabled
 });
 
 export const setFeedback = feedback => ({

--- a/apps/src/redux/sectionDataRedux.js
+++ b/apps/src/redux/sectionDataRedux.js
@@ -31,7 +31,6 @@ export const sectionDataPropType = PropTypes.shape({
  * Action type constants
  */
 export const SET_SECTION = 'sectionData/SET_SECTION';
-export const SET_TTS_AUTOPLAY_ENABLED = 'sectionData/SET_TTS_AUTOPLAY_ENABLED';
 export const SET_CODE_REVIEW_ENABLED = 'sectionData/SET_CODE_REVIEW_ENABLED';
 export const SET_CODE_REVIEW_EXPIRES_AT =
   'sectionData/SET_CODE_REVIEW_EXPIRES_AT';
@@ -59,11 +58,6 @@ export const setSection = section => {
   };
   return {type: SET_SECTION, section: filteredSectionData};
 };
-
-export const setTtsAutoplayEnabled = ttsAutoplayEnabled => ({
-  type: SET_TTS_AUTOPLAY_ENABLED,
-  ttsAutoplayEnabled
-});
 
 export const setCodeReviewEnabled = codeReviewEnabled => ({
   type: SET_CODE_REVIEW_ENABLED,
@@ -93,16 +87,6 @@ export default function sectionData(state = initialState, action) {
     return {
       ...initialState,
       section: action.section
-    };
-  }
-
-  if (action.type === SET_TTS_AUTOPLAY_ENABLED) {
-    return {
-      ...state,
-      section: {
-        ...state.section,
-        ttsAutoplayEnabled: action.ttsAutoplayEnabled
-      }
     };
   }
 

--- a/apps/src/sites/studio/pages/levels/show.js
+++ b/apps/src/sites/studio/pages/levels/show.js
@@ -9,7 +9,7 @@ import sectionData, {
 } from '@cdo/apps/redux/sectionDataRedux';
 import {setIsMiniView} from '@cdo/apps/code-studio/progressRedux';
 import instructions, {
-  setTtsAutoplayEnabledForParticipant
+  setTtsAutoplayEnabledForLevel
 } from '@cdo/apps/redux/instructions';
 
 $(document).ready(initPage);
@@ -22,7 +22,7 @@ function initPage() {
   // this is the common js entry point for level pages
   // which is why ttsAutoplay is set here
   const ttsAutoplayEnabled = config.tts_autoplay_enabled;
-  getStore().dispatch(setTtsAutoplayEnabledForParticipant(ttsAutoplayEnabled));
+  getStore().dispatch(setTtsAutoplayEnabledForLevel(ttsAutoplayEnabled));
   const codeReviewEnabled = config.code_review_enabled;
   getStore().dispatch(setCodeReviewEnabled(codeReviewEnabled));
 

--- a/apps/src/sites/studio/pages/levels/show.js
+++ b/apps/src/sites/studio/pages/levels/show.js
@@ -9,7 +9,7 @@ import sectionData, {
 } from '@cdo/apps/redux/sectionDataRedux';
 import {setIsMiniView} from '@cdo/apps/code-studio/progressRedux';
 import instructions, {
-  setTtsAutoplayEnabled
+  setTtsAutoplayEnabledForParticipant
 } from '@cdo/apps/redux/instructions';
 
 $(document).ready(initPage);
@@ -22,7 +22,7 @@ function initPage() {
   // this is the common js entry point for level pages
   // which is why ttsAutoplay is set here
   const ttsAutoplayEnabled = config.tts_autoplay_enabled;
-  getStore().dispatch(setTtsAutoplayEnabled(ttsAutoplayEnabled));
+  getStore().dispatch(setTtsAutoplayEnabledForParticipant(ttsAutoplayEnabled));
   const codeReviewEnabled = config.code_review_enabled;
   getStore().dispatch(setCodeReviewEnabled(codeReviewEnabled));
 

--- a/apps/src/sites/studio/pages/levels/show.js
+++ b/apps/src/sites/studio/pages/levels/show.js
@@ -5,10 +5,12 @@ import {getStore, registerReducers} from '@cdo/apps/redux';
 import ScriptLevelRedirectDialog from '@cdo/apps/code-studio/components/ScriptLevelRedirectDialog';
 import UnversionedScriptRedirectDialog from '@cdo/apps/code-studio/components/UnversionedScriptRedirectDialog';
 import sectionData, {
-  setTtsAutoplayEnabled,
   setCodeReviewEnabled
 } from '@cdo/apps/redux/sectionDataRedux';
 import {setIsMiniView} from '@cdo/apps/code-studio/progressRedux';
+import instructions, {
+  setTtsAutoplayEnabled
+} from '@cdo/apps/redux/instructions';
 
 $(document).ready(initPage);
 
@@ -16,9 +18,9 @@ function initPage() {
   const script = document.querySelector('script[data-level]');
   const config = JSON.parse(script.dataset.level);
 
+  registerReducers({sectionData, instructions});
   // this is the common js entry point for level pages
   // which is why ttsAutoplay is set here
-  registerReducers({sectionData});
   const ttsAutoplayEnabled = config.tts_autoplay_enabled;
   getStore().dispatch(setTtsAutoplayEnabled(ttsAutoplayEnabled));
   const codeReviewEnabled = config.code_review_enabled;

--- a/apps/src/templates/instructions/InlineAudio.jsx
+++ b/apps/src/templates/instructions/InlineAudio.jsx
@@ -366,6 +366,6 @@ export default connect(function propsFromStore(state) {
     userId: state.pageConstants.userId,
     puzzleNumber: state.pageConstants.puzzleNumber,
     isOnCSFPuzzle: !state.instructions.noInstructionsWhenCollapsed,
-    ttsAutoplayEnabled: state.instructions.ttsAutoplayEnabled
+    ttsAutoplayEnabled: state.instructions.ttsAutoplayEnabledForParticipant
   };
 })(StatelessInlineAudio);

--- a/apps/src/templates/instructions/InlineAudio.jsx
+++ b/apps/src/templates/instructions/InlineAudio.jsx
@@ -366,6 +366,6 @@ export default connect(function propsFromStore(state) {
     userId: state.pageConstants.userId,
     puzzleNumber: state.pageConstants.puzzleNumber,
     isOnCSFPuzzle: !state.instructions.noInstructionsWhenCollapsed,
-    ttsAutoplayEnabled: state.sectionData.section.ttsAutoplayEnabled
+    ttsAutoplayEnabled: state.instructions.ttsAutoplayEnabled
   };
 })(StatelessInlineAudio);

--- a/apps/src/templates/instructions/InlineAudio.jsx
+++ b/apps/src/templates/instructions/InlineAudio.jsx
@@ -366,6 +366,6 @@ export default connect(function propsFromStore(state) {
     userId: state.pageConstants.userId,
     puzzleNumber: state.pageConstants.puzzleNumber,
     isOnCSFPuzzle: !state.instructions.noInstructionsWhenCollapsed,
-    ttsAutoplayEnabled: state.instructions.ttsAutoplayEnabledForParticipant
+    ttsAutoplayEnabled: state.instructions.ttsAutoplayEnabledForLevel
   };
 })(StatelessInlineAudio);

--- a/apps/src/templates/instructions/TopInstructions.story.jsx
+++ b/apps/src/templates/instructions/TopInstructions.story.jsx
@@ -5,7 +5,7 @@ import * as commonReducers from '@cdo/apps/redux/commonReducers';
 import {
   setHasAuthoredHints,
   setInstructionsConstants,
-  setTtsAutoplayEnabled
+  setTtsAutoplayEnabledForParticipant
 } from '@cdo/apps/redux/instructions';
 import {enqueueHints, showNextHint} from '@cdo/apps/redux/authoredHints';
 import isRtl, {setRtlFromDOM} from '@cdo/apps/code-studio/isRtlRedux';
@@ -111,7 +111,7 @@ const createCommonStore = function(options = {}) {
 
   store.dispatch(setPageConstants(pageConstants));
   store.dispatch(setInstructionsConstants(instructionsConstants));
-  store.dispatch(setTtsAutoplayEnabled(false));
+  store.dispatch(setTtsAutoplayEnabledForParticipant(false));
 
   return store;
 };

--- a/apps/src/templates/instructions/TopInstructions.story.jsx
+++ b/apps/src/templates/instructions/TopInstructions.story.jsx
@@ -5,7 +5,7 @@ import * as commonReducers from '@cdo/apps/redux/commonReducers';
 import {
   setHasAuthoredHints,
   setInstructionsConstants,
-  setTtsAutoplayEnabledForParticipant
+  setTtsAutoplayEnabledForLevel
 } from '@cdo/apps/redux/instructions';
 import {enqueueHints, showNextHint} from '@cdo/apps/redux/authoredHints';
 import isRtl, {setRtlFromDOM} from '@cdo/apps/code-studio/isRtlRedux';
@@ -111,7 +111,7 @@ const createCommonStore = function(options = {}) {
 
   store.dispatch(setPageConstants(pageConstants));
   store.dispatch(setInstructionsConstants(instructionsConstants));
-  store.dispatch(setTtsAutoplayEnabledForParticipant(false));
+  store.dispatch(setTtsAutoplayEnabledForLevel(false));
 
   return store;
 };

--- a/apps/src/templates/instructions/TopInstructions.story.jsx
+++ b/apps/src/templates/instructions/TopInstructions.story.jsx
@@ -4,14 +4,12 @@ import {createStore, combineReducers} from 'redux';
 import * as commonReducers from '@cdo/apps/redux/commonReducers';
 import {
   setHasAuthoredHints,
-  setInstructionsConstants
+  setInstructionsConstants,
+  setTtsAutoplayEnabled
 } from '@cdo/apps/redux/instructions';
 import {enqueueHints, showNextHint} from '@cdo/apps/redux/authoredHints';
 import isRtl, {setRtlFromDOM} from '@cdo/apps/code-studio/isRtlRedux';
 import {setPageConstants} from '@cdo/apps/redux/pageConstants';
-import sectionData, {
-  setTtsAutoplayEnabled
-} from '@cdo/apps/redux/sectionDataRedux';
 import TopInstructions from './TopInstructions';
 
 /**
@@ -24,9 +22,7 @@ import TopInstructions from './TopInstructions';
  * @param {boolean} options.tts
  */
 const createCommonStore = function(options = {}) {
-  const store = createStore(
-    combineReducers({...commonReducers, isRtl, sectionData})
-  );
+  const store = createStore(combineReducers({...commonReducers, isRtl}));
   const pageConstants = {};
   const instructionsConstants = {};
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This work is part of an effort to combine `teacherSectionsRedux` and `sectionDataRedux` to reduce confusion and duplicated data between the two. 

In this PR we're moving ttsAutoplayEnabled setting into instructions redux since this value in redux is used to determine whether ttsAutoplay should be applied for the level based on the sections that a user is in. It's also been renamed to `ttsAutoplayEnabledForLevel` to distinguish between this value and the field on a section that's also called `ttsAutoplayEnabled`

## Links
- jira ticket: [LP-2179](https://codedotorg.atlassian.net/browse/LP-2179)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()

-->

## Testing story
Tested that level pages are getting ttsAutoplayEnabled value same as before for student and teacher
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Follow-up work
Move more data out of sectionDataRedux
<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
