### PR TITLE
Move codeReviewEnabled out of sectionData redux

### DIFF
--- a/apps/src/redux/instructions.js
+++ b/apps/src/redux/instructions.js
@@ -30,6 +30,8 @@ const SET_DYNAMIC_INSTRUCTIONS_DISMISS_CALLBACK =
   'instructions/SET_DYNAMIC_INSTRUCTIONS_DISMISS_CALLBACK';
 const SET_TTS_AUTOPLAY_ENABLED_FOR_LEVEL =
   'instructions/SET_TTS_AUTOPLAY_ENABLED_FOR_LEVEL';
+const SET_CODE_REVIEW_ENABLED_FOR_LEVEL =
+  'instructions/SET_CODE_REVIEW_ENABLED_FOR_LEVEL';
 
 /**
  * Some scenarios:
@@ -67,6 +69,7 @@ const instructionsInitialState = {
   // represents if the user is in any unarchived section where tts autoplay is enabled
   // logic defined in script_levels_controller#show
   ttsAutoplayEnabledForLevel: false,
+  codeReviewEnabledForLevel: false,
   overlayVisible: false,
   levelVideos: [],
   mapReference: undefined,
@@ -167,6 +170,12 @@ export default function reducer(state = {...instructionsInitialState}, action) {
   if (action.type === SET_TTS_AUTOPLAY_ENABLED_FOR_LEVEL) {
     return Object.assign({}, state, {
       ttsAutoplayEnabledForLevel: action.ttsAutoplayEnabledForLevel
+    });
+  }
+
+  if (action.type === SET_CODE_REVIEW_ENABLED_FOR_LEVEL) {
+    return Object.assign({}, state, {
+      codeReviewEnabledForLevel: action.codeReviewEnabledForLevel
     });
   }
 
@@ -280,6 +289,11 @@ export const setHasAuthoredHints = hasAuthoredHints => ({
 export const setTtsAutoplayEnabledForLevel = ttsAutoplayEnabledForLevel => ({
   type: SET_TTS_AUTOPLAY_ENABLED_FOR_LEVEL,
   ttsAutoplayEnabledForLevel
+});
+
+export const setCodeReviewEnabledForLevel = codeReviewEnabledForLevel => ({
+  type: SET_CODE_REVIEW_ENABLED_FOR_LEVEL,
+  codeReviewEnabledForLevel
 });
 
 export const setFeedback = feedback => ({

--- a/apps/src/redux/sectionDataRedux.js
+++ b/apps/src/redux/sectionDataRedux.js
@@ -31,7 +31,6 @@ export const sectionDataPropType = PropTypes.shape({
  * Action type constants
  */
 export const SET_SECTION = 'sectionData/SET_SECTION';
-export const SET_CODE_REVIEW_ENABLED = 'sectionData/SET_CODE_REVIEW_ENABLED';
 export const SET_CODE_REVIEW_EXPIRES_AT =
   'sectionData/SET_CODE_REVIEW_EXPIRES_AT';
 
@@ -59,11 +58,6 @@ export const setSection = section => {
   return {type: SET_SECTION, section: filteredSectionData};
 };
 
-export const setCodeReviewEnabled = codeReviewEnabled => ({
-  type: SET_CODE_REVIEW_ENABLED,
-  codeReviewEnabled
-});
-
 export const setCodeReviewExpiresAt = codeReviewExpiresAt => ({
   type: SET_CODE_REVIEW_EXPIRES_AT,
   codeReviewExpiresAt
@@ -87,16 +81,6 @@ export default function sectionData(state = initialState, action) {
     return {
       ...initialState,
       section: action.section
-    };
-  }
-
-  if (action.type === SET_CODE_REVIEW_ENABLED) {
-    return {
-      ...state,
-      section: {
-        ...state.section,
-        codeReviewEnabled: action.codeReviewEnabled
-      }
     };
   }
 

--- a/apps/src/redux/sectionDataRedux.js
+++ b/apps/src/redux/sectionDataRedux.js
@@ -23,16 +23,13 @@ export const sectionDataPropType = PropTypes.shape({
   ).isRequired,
   isAssignedCSA: PropTypes.bool,
   lessonExtras: PropTypes.bool,
-  ttsAutoplayEnabled: PropTypes.bool,
-  codeReviewExpiresAt: PropTypes.number
+  ttsAutoplayEnabled: PropTypes.bool
 });
 
 /**
  * Action type constants
  */
 export const SET_SECTION = 'sectionData/SET_SECTION';
-export const SET_CODE_REVIEW_EXPIRES_AT =
-  'sectionData/SET_CODE_REVIEW_EXPIRES_AT';
 
 /**
  * Action creators
@@ -50,18 +47,10 @@ export const setSection = section => {
     students: sortedStudents,
     isAssignedCSA: section.is_assigned_csa,
     lessonExtras: section.lesson_extras,
-    ttsAutoplayEnabled: section.tts_autoplay_enabled,
-    codeReviewExpiresAt: section.code_review_expires_at
-      ? Date.parse(section.code_review_expires_at)
-      : null
+    ttsAutoplayEnabled: section.tts_autoplay_enabled
   };
   return {type: SET_SECTION, section: filteredSectionData};
 };
-
-export const setCodeReviewExpiresAt = codeReviewExpiresAt => ({
-  type: SET_CODE_REVIEW_EXPIRES_AT,
-  codeReviewExpiresAt
-});
 
 /**
  * Initial state of sectionDataRedux
@@ -81,19 +70,6 @@ export default function sectionData(state = initialState, action) {
     return {
       ...initialState,
       section: action.section
-    };
-  }
-
-  if (action.type === SET_CODE_REVIEW_EXPIRES_AT) {
-    const expirationTime = action.codeReviewExpiresAt
-      ? Date.parse(action.codeReviewExpiresAt)
-      : null;
-    return {
-      ...state,
-      section: {
-        ...state.section,
-        codeReviewExpiresAt: expirationTime
-      }
     };
   }
 

--- a/apps/src/sites/studio/pages/levels/show.js
+++ b/apps/src/sites/studio/pages/levels/show.js
@@ -4,12 +4,10 @@ import ReactDOM from 'react-dom';
 import {getStore, registerReducers} from '@cdo/apps/redux';
 import ScriptLevelRedirectDialog from '@cdo/apps/code-studio/components/ScriptLevelRedirectDialog';
 import UnversionedScriptRedirectDialog from '@cdo/apps/code-studio/components/UnversionedScriptRedirectDialog';
-import sectionData, {
-  setCodeReviewEnabled
-} from '@cdo/apps/redux/sectionDataRedux';
 import {setIsMiniView} from '@cdo/apps/code-studio/progressRedux';
 import instructions, {
-  setTtsAutoplayEnabledForLevel
+  setTtsAutoplayEnabledForLevel,
+  setCodeReviewEnabledForLevel
 } from '@cdo/apps/redux/instructions';
 
 $(document).ready(initPage);
@@ -18,13 +16,13 @@ function initPage() {
   const script = document.querySelector('script[data-level]');
   const config = JSON.parse(script.dataset.level);
 
-  registerReducers({sectionData, instructions});
+  registerReducers({instructions});
   // this is the common js entry point for level pages
   // which is why ttsAutoplay is set here
   const ttsAutoplayEnabled = config.tts_autoplay_enabled;
   getStore().dispatch(setTtsAutoplayEnabledForLevel(ttsAutoplayEnabled));
   const codeReviewEnabled = config.code_review_enabled;
-  getStore().dispatch(setCodeReviewEnabled(codeReviewEnabled));
+  getStore().dispatch(setCodeReviewEnabledForLevel(codeReviewEnabled));
 
   // If viewing the unit overview components on the level page it is in
   // the mini view

--- a/apps/src/templates/codeReviewGroups/CodeReviewGroupsStatusToggle.jsx
+++ b/apps/src/templates/codeReviewGroups/CodeReviewGroupsStatusToggle.jsx
@@ -37,7 +37,7 @@ function CodeReviewGroupsStatusToggle({
       .setCodeReviewEnabled(toggledValue)
       .success(result => {
         const newExpiration = result.expiration;
-        setCodeReviewExpiration(newExpiration);
+        setCodeReviewExpiration(sectionId, newExpiration);
         setSaveInProgress(false);
       })
       .fail(() => {

--- a/apps/src/templates/codeReviewGroups/CodeReviewGroupsStatusToggle.jsx
+++ b/apps/src/templates/codeReviewGroups/CodeReviewGroupsStatusToggle.jsx
@@ -3,10 +3,13 @@ import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import i18n from '@cdo/locale';
 import CodeReviewGroupsDataApi from './CodeReviewGroupsDataApi';
-import {setCodeReviewExpiresAt} from '../../redux/sectionDataRedux';
 import Spinner from '@cdo/apps/code-studio/pd/components/spinner';
 import ToggleSwitch from '@cdo/apps/code-studio/components/ToggleSwitch';
 import color from '@cdo/apps/util/color';
+import {
+  setSectionCodeReviewExpiresAt,
+  selectedSection
+} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 
 function CodeReviewGroupsStatusToggle({
   codeReviewExpiresAt,
@@ -80,12 +83,12 @@ export const UnconnectedCodeReviewGroupsStatusToggle = CodeReviewGroupsStatusTog
 
 export default connect(
   state => ({
-    codeReviewExpiresAt: state.sectionData.section.codeReviewExpiresAt,
-    sectionId: state.sectionData.section.id
+    codeReviewExpiresAt: selectedSection(state).codeReviewExpiresAt,
+    sectionId: selectedSection(state).id
   }),
   dispatch => ({
-    setCodeReviewExpiration: expiration =>
-      dispatch(setCodeReviewExpiresAt(expiration))
+    setCodeReviewExpiration: (sectionId, expiration) =>
+      dispatch(setSectionCodeReviewExpiresAt(sectionId, expiration))
   })
 )(CodeReviewGroupsStatusToggle);
 

--- a/apps/src/templates/instructions/ReviewTab.jsx
+++ b/apps/src/templates/instructions/ReviewTab.jsx
@@ -433,7 +433,7 @@ class ReviewTab extends Component {
 
 export const UnconnectedReviewTab = ReviewTab;
 export default connect(state => ({
-  codeReviewEnabled: state.sectionData.section.codeReviewEnabled,
+  codeReviewEnabled: state.instructions.codeReviewEnabledForLevel,
   viewAsCodeReviewer: state.pageConstants.isCodeReviewing,
   viewAsTeacher: state.viewAs === ViewType.Instructor,
   channelId: state.pageConstants.channelId,

--- a/apps/test/unit/redux/sectionDataReduxTest.js
+++ b/apps/test/unit/redux/sectionDataReduxTest.js
@@ -19,8 +19,7 @@ const fakeSectionData = {
   },
   lesson_extras: false,
   tts_autoplay_enabled: false,
-  is_assigned_csa: false,
-  codeReviewExpiresAt: null
+  is_assigned_csa: false
 };
 
 const sortedFakeSectionData = {
@@ -41,8 +40,7 @@ const sortedFakeSectionData = {
   },
   isAssignedCSA: false,
   lessonExtras: false,
-  ttsAutoplayEnabled: false,
-  codeReviewExpiresAt: null
+  ttsAutoplayEnabled: false
 };
 
 describe('sectionDataRedux', () => {

--- a/apps/test/unit/templates/teacherDashboard/teacherSectionsReduxTest.js
+++ b/apps/test/unit/templates/teacherDashboard/teacherSectionsReduxTest.js
@@ -642,7 +642,8 @@ describe('teacherSectionsRedux', () => {
         hidden: false,
         isAssigned: undefined,
         restrictSection: false,
-        postMilestoneDisabled: false
+        postMilestoneDisabled: false,
+        codeReviewExpiresAt: null
       });
     });
   });
@@ -916,7 +917,8 @@ describe('teacherSectionsRedux', () => {
           hidden: false,
           isAssigned: undefined,
           restrictSection: false,
-          postMilestoneDisabled: false
+          postMilestoneDisabled: false,
+          codeReviewExpiresAt: null
         }
       });
     });

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -510,18 +510,15 @@ class ScriptLevelsController < ApplicationController
       )
     end
 
-    # To do: rename this variable, as it gets passed into redux as sectionData.section.codeReviewEnabled,
-    # which is confusing as there is a section-level method (used below, code_review_enabled?)
-    # that is different from what is returned here.
-    @code_review_enabled = if DCDO.get('code_review_groups_enabled', false)
-                             @level.is_a?(Javalab) &&
-                               current_user.present? &&
-                               (current_user.teacher? || (current_user&.sections_as_student&.any?(&:code_review_enabled?) && !current_user.code_review_groups.empty?))
-                           else
-                             @level.is_a?(Javalab) &&
-                               current_user.present? &&
-                               (current_user.teacher? || current_user&.sections_as_student&.all?(&:code_review_enabled?))
-                           end
+    @code_review_enabled_for_level = if DCDO.get('code_review_groups_enabled', false)
+                                       @level.is_a?(Javalab) &&
+                                        current_user.present? &&
+                                        (current_user.teacher? || (current_user&.sections_as_student&.any?(&:code_review_enabled?) && !current_user.code_review_groups.empty?))
+                                     else
+                                       @level.is_a?(Javalab) &&
+                                         current_user.present? &&
+                                         (current_user.teacher? || current_user&.sections_as_student&.all?(&:code_review_enabled?))
+                                     end
 
     view_options(
       full_width: true,

--- a/dashboard/app/views/levels/show.html.haml
+++ b/dashboard/app/views/levels/show.html.haml
@@ -15,7 +15,7 @@
       %a{href: '#notes-outer'}= I18n.t('video.notes')
 
 - if @script_level
-  - level_data = { redirect_script_url: @redirect_unit_url, script_name: @script_level.script&.name, course_name: @script_level.script&.unit_group&.name, tts_autoplay_enabled: @tts_autoplay_enabled, code_review_enabled: @code_review_enabled, show_unversioned_redirect_warning: @show_unversioned_redirect_warning}
+  - level_data = { redirect_script_url: @redirect_unit_url, script_name: @script_level.script&.name, course_name: @script_level.script&.unit_group&.name, tts_autoplay_enabled: @tts_autoplay_enabled, code_review_enabled: @code_review_enabled_for_level, show_unversioned_redirect_warning: @show_unversioned_redirect_warning}
   %link{href: asset_path('css/levels.css'), rel: 'stylesheet', type: 'text/css'}
   %script{ src: webpack_asset_path('js/levels/show.js'), data: { level: level_data.to_json } }
   -# Mount point for RedirectDialog React component.


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This is part of a larger effort to consolidate `teacherSectionsRedux` and `sectionDataRedux`. In this PR I've moved a couple of things out of `sectionDataRedux`
1. `codeReviewEnabled` which is used on a level to determine if the user should see the code review experience, this has been moved to instructions redux and renamed to `codeReviewEnabledForLevel` since at this point the data represents more than just the section level setting (whether the dcdo flag is on, the type of level, whether the user is in code review groups etc)
2. I've moved `codeReviewExpiresAt` to `teacherSectionsRedux`, this data _does_ represent a section-level setting and `teacherSectionsRedux` is populated for the page where this field is used, so it will live there with the rest of the section-related data

## Links
- jira ticket: [LP-2179](https://codedotorg.atlassian.net/browse/LP-2179)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()

-->

## Testing story
Tested locally that manage students enable and disable was working as expected
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Follow-up work
Remove `sectionData` redux and replace with `teacherSectionsRedux`
<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
