### PR TITLE
Small fixes for the i18n sync.

### DIFF
--- a/bin/i18n/codeorg-testing_crowdin.yml
+++ b/bin/i18n/codeorg-testing_crowdin.yml
@@ -3,7 +3,7 @@
 #
 "project_identifier" : "codeorg-testing"
 "project_id" : "346087"
-"base_path" : "../../i18n/locales"
+"base_path" : "i18n/locales"
 
 # API Credentials must be loaded from a separate identity file. See
 # https://support.crowdin.com/configuration-file/#split-project-configuration-and-api-credentials

--- a/bin/i18n/codeorg_crowdin.yml
+++ b/bin/i18n/codeorg_crowdin.yml
@@ -3,7 +3,7 @@
 #
 "project_identifier" : "codeorg"
 "project_id" : "26074"
-"base_path" : "../../i18n/locales"
+"base_path" : "i18n/locales"
 
 # API Credentials must be loaded from a separate identity file. See
 # https://support.crowdin.com/configuration-file/#split-project-configuration-and-api-credentials

--- a/bin/i18n/codeorg_markdown_crowdin.yml
+++ b/bin/i18n/codeorg_markdown_crowdin.yml
@@ -1,6 +1,6 @@
 "project_identifier" : "codeorg-markdown"
 "project_id" : "314545"
-"base_path" : "../.."
+"base_path" : ""
 
 # API Credentials must be loaded from a separate identity file. See
 # https://support.crowdin.com/configuration-file/#split-project-configuration-and-api-credentials

--- a/bin/i18n/codeorg_restricted_crowdin.yml
+++ b/bin/i18n/codeorg_restricted_crowdin.yml
@@ -1,6 +1,6 @@
 "project_identifier" : "codeorg-restricted"
 "project_id" : "464582"
-"base_path" : "../../i18n/locales/source"
+"base_path" : "i18n/locales/source"
 "preserve_hierarchy": true
 
 # API Credentials must be loaded from a separate identity file. See

--- a/bin/i18n/hourofcode_crowdin.yml
+++ b/bin/i18n/hourofcode_crowdin.yml
@@ -3,7 +3,7 @@
 #
 "project_identifier" : "hour-of-code"
 "project_id" : "55536"
-"base_path" : "../../i18n/locales"
+"base_path" : "i18n/locales"
 
 # API Credentials must be loaded from a separate identity file. See
 # https://support.crowdin.com/configuration-file/#split-project-configuration-and-api-credentials

--- a/lib/cdo/crowdin/utils.rb
+++ b/lib/cdo/crowdin/utils.rb
@@ -127,6 +127,9 @@ module Crowdin
         etags[code].merge! downloaded_files
         File.write @etags_json, JSON.pretty_generate(etags)
       end
+      # Makes sure these files get written even if nothing was downloaded.
+      File.write @files_to_sync_out_json, JSON.pretty_generate(files_to_sync_out)
+      File.write @files_to_download_json, JSON.pretty_generate(files_to_download)
     end
   end
 end

--- a/lib/cdo/crowdin/utils.rb
+++ b/lib/cdo/crowdin/utils.rb
@@ -85,7 +85,10 @@ module Crowdin
       @logger.info("#{files_to_download.keys.length} languages have changes")
 
       etags = File.exist?(@etags_json) ? JSON.parse(File.read(@etags_json)) : {}
-      files_to_sync_out = File.exist?(@files_to_sync_out_json) ? JSON.parse(File.read(@files_to_sync_out_json)) : {}
+      # Initialize @files_to_sync_out file if it doesn't exist yet.
+      # It could already exist if multiple sync-down's occurred since the last sync-out.
+      File.write @files_to_sync_out_json, JSON.pretty_generate({}) unless File.exist?(@files_to_sync_out_json)
+      files_to_sync_out = JSON.parse(File.read(@files_to_sync_out_json))
 
       @project.languages.each do |language|
         code = language["code"]
@@ -127,9 +130,6 @@ module Crowdin
         etags[code].merge! downloaded_files
         File.write @etags_json, JSON.pretty_generate(etags)
       end
-      # Makes sure these files get written even if nothing was downloaded.
-      File.write @files_to_sync_out_json, JSON.pretty_generate(files_to_sync_out)
-      File.write @files_to_download_json, JSON.pretty_generate(files_to_download)
     end
   end
 end


### PR DESCRIPTION
There were two issues stopping the i18n-sync script from working.
1. The `base_path` needed to have the '../..' removed. I don't know why this needed to be changed, but it definitely fixes the "file not found" errors we were getting.
1. The `sync-down` should still produce a `files_to_sync_out.json` even if there are no translation updates for the Crowdin project. This file is required by the `sync-out` and indicates that a successful sync-down happened prior to the sync-out running.

## Testing story
* Ran these changes on the `i18n-dev` dev server and successfully produces a down & out PR.