### PR TITLE
When removing units from unit group make sure to reset course types

### DIFF
--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -262,7 +262,12 @@ class UnitGroup < ApplicationRecord
 
     units_to_remove.each do |unit|
       # Units that are not in a unit group need to have these fields set in order to determine course type and visibility of course
-      unit.update!(published_state: published_state, instruction_type: instruction_type, participant_audience: participant_audience, instructor_audience: instructor_audience)
+      unit.update!(
+        published_state: (unit.published_state ? unit.published_state : published_state),
+        instruction_type: instruction_type,
+        participant_audience: participant_audience,
+        instructor_audience: instructor_audience
+      )
 
       UnitGroupUnit.where(unit_group: self, script: unit).destroy_all
     end

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -261,6 +261,9 @@ class UnitGroup < ApplicationRecord
     end
 
     units_to_remove.each do |unit|
+      # Units that are not in a unit group need to have these fields set in order to determine course type and visibility of course
+      unit.update!(published_state: published_state, instruction_type: instruction_type, participant_audience: participant_audience, instructor_audience: instructor_audience)
+
       UnitGroupUnit.where(unit_group: self, script: unit).destroy_all
     end
     # Reload model so that default_unit_group_units is up to date

--- a/dashboard/test/models/unit_group_test.rb
+++ b/dashboard/test/models/unit_group_test.rb
@@ -318,7 +318,7 @@ class UnitGroupTest < ActiveSupport::TestCase
       assert_nil unit1.instructor_audience
       assert_nil unit1.participant_audience
 
-      unit2.update!(instructor_audience: SharedCourseConstants::INSTRUCTOR_AUDIENCE.teacher, participant_audience: SharedCourseConstants::INSTRUCTOR_AUDIENCE.student)
+      unit2.update!(instructor_audience: SharedCourseConstants::INSTRUCTOR_AUDIENCE.teacher, participant_audience: SharedCourseConstants::PARTICIPANT_AUDIENCE.student)
 
       unit_group.update_scripts(['unit1', 'unit2'])
 
@@ -413,6 +413,48 @@ class UnitGroupTest < ActiveSupport::TestCase
       assert_equal 1, unit_group.default_unit_group_units.length
       assert_equal 1, unit_group.default_unit_group_units[0].position
       assert_equal 'unit2', unit_group.default_unit_group_units[0].script.name
+    end
+
+    test "removed units have their published state instruction type participant audience and instructor audience reset" do
+      unit_group = create :unit_group
+      unit1 = create(:script, name: 'unit1')
+      unit2 = create(:script, name: 'unit2')
+
+      unit_group.update_scripts(['unit1', 'unit2'])
+
+      unit_group.reload
+      unit1.reload
+      unit2.reload
+
+      assert_nil unit1.published_state
+      assert_nil unit1.instruction_type
+      assert_nil unit1.instructor_audience
+      assert_nil unit1.participant_audience
+
+      assert_nil unit2.published_state
+      assert_nil unit2.instruction_type
+      assert_nil unit2.instructor_audience
+      assert_nil unit2.participant_audience
+
+      unit_group.update_scripts(['unit2'])
+
+      unit_group.reload
+      unit1.reload
+      unit2.reload
+
+      assert_equal unit_group.published_state, unit1.published_state
+      refute_nil unit1.published_state
+      assert_equal unit_group.instruction_type, unit1.instruction_type
+      refute_nil unit1.instruction_type
+      assert_equal unit_group.instructor_audience, unit1.instructor_audience
+      refute_nil unit1.instructor_audience
+      assert_equal unit_group.participant_audience, unit1.participant_audience
+      refute_nil unit1.participant_audience
+
+      assert_nil unit2.published_state
+      assert_nil unit2.instruction_type
+      assert_nil unit2.instructor_audience
+      assert_nil unit2.participant_audience
     end
   end
 

--- a/dashboard/test/models/unit_group_test.rb
+++ b/dashboard/test/models/unit_group_test.rb
@@ -456,6 +456,47 @@ class UnitGroupTest < ActiveSupport::TestCase
       assert_nil unit2.instructor_audience
       assert_nil unit2.participant_audience
     end
+
+    test "units with published state set independent of the unit group maintain that published state when removed" do
+      unit_group = create :unit_group
+      unit1 = create(:script, name: 'unit1')
+      unit2 = create(:script, name: 'unit2')
+
+      unit_group.update_scripts(['unit1', 'unit2'])
+
+      unit_group.reload
+      unit1.reload
+      unit2.reload
+
+      assert_nil unit1.published_state
+      assert_nil unit1.instruction_type
+      assert_nil unit1.instructor_audience
+      assert_nil unit1.participant_audience
+
+      assert_nil unit2.published_state
+      assert_nil unit2.instruction_type
+      assert_nil unit2.instructor_audience
+      assert_nil unit2.participant_audience
+
+      unit2.published_state = SharedCourseConstants::PUBLISHED_STATE.in_development
+      unit2.save!
+
+      assert_equal SharedCourseConstants::PUBLISHED_STATE.in_development, unit2.published_state
+
+      unit_group.update_scripts(['unit1'])
+
+      unit_group.reload
+      unit2.reload
+
+      refute_equal unit_group.published_state, unit2.published_state
+      assert_equal SharedCourseConstants::PUBLISHED_STATE.in_development, unit2.published_state
+      assert_equal unit_group.instruction_type, unit2.instruction_type
+      refute_nil unit2.instruction_type
+      assert_equal unit_group.instructor_audience, unit2.instructor_audience
+      refute_nil unit2.instructor_audience
+      assert_equal unit_group.participant_audience, unit2.participant_audience
+      refute_nil unit2.participant_audience
+    end
   end
 
   test "summarize" do


### PR DESCRIPTION
When units are added to unit groups we set participant_audience, instructor_audience, instruction_type, and published_state to nil.  We need to make sure these fields are reset to something other than nil when the unit is removed form the unit group.  We will set the unit to use all the values for the unit group it was in except if the published_state was set separately on the unit in which cases the published_state will remain set as is.

## Links


[Product Spec](https://docs.google.com/document/d/1qZpc90daxQiiqpcQUiUiGV2tQoaYEQUzOA72UZzBlVE/edit#)
[Eng Plan](https://docs.google.com/document/d/1V61xONU0-mleMEEdHWNxhvZtYIPRCB31mT_hbUXusCQ/edit#heading=h.n9isd44okbq7)

## Testing story

- Added unit tests