### PR TITLE
Javalab: output test results from new message type

### DIFF
--- a/apps/src/javalab/JavabuilderConnection.js
+++ b/apps/src/javalab/JavabuilderConnection.js
@@ -152,6 +152,9 @@ export default class JavabuilderConnection {
       case WebSocketMessageType.SYSTEM_OUT:
         this.onOutputMessage(data.value);
         break;
+      case WebSocketMessageType.TEST_RESULT:
+        this.onOutputMessage(data.value);
+        break;
       case WebSocketMessageType.NEIGHBORHOOD:
       case WebSocketMessageType.THEATER:
       case WebSocketMessageType.PLAYGROUND:

--- a/apps/src/javalab/JavabuilderConnection.js
+++ b/apps/src/javalab/JavabuilderConnection.js
@@ -150,8 +150,6 @@ export default class JavabuilderConnection {
         this.onStatusMessage(data.value, data.detail);
         break;
       case WebSocketMessageType.SYSTEM_OUT:
-        this.onOutputMessage(data.value);
-        break;
       case WebSocketMessageType.TEST_RESULT:
         this.onOutputMessage(data.value);
         break;

--- a/apps/src/javalab/constants.js
+++ b/apps/src/javalab/constants.js
@@ -18,7 +18,8 @@ export const WebSocketMessageType = {
   SYSTEM_OUT: 'SYSTEM_OUT',
   EXCEPTION: 'EXCEPTION',
   DEBUG: 'DEBUG',
-  STATUS: 'STATUS'
+  STATUS: 'STATUS',
+  TEST_RESULT: 'TEST_RESULT'
 };
 
 export const JavabuilderExceptionType = {

--- a/apps/test/unit/javalab/JavabuilderConnectionTest.js
+++ b/apps/test/unit/javalab/JavabuilderConnectionTest.js
@@ -64,6 +64,18 @@ describe('JavabuilderConnection', () => {
       expect(onOutputMessage).to.have.been.calledWith(data.value);
     });
 
+    it('passes the data value for test results', () => {
+      const data = {
+        type: WebSocketMessageType.TEST_RESULT,
+        value: 'your test has passed!'
+      };
+      const event = {
+        data: JSON.stringify(data)
+      };
+      connection.onMessage(event);
+      expect(onOutputMessage).to.have.been.calledWith(data.value);
+    });
+
     it('appends [JAVALAB] to status messages', () => {
       const data = {
         type: WebSocketMessageType.STATUS,


### PR DESCRIPTION
Handles a new message type (`TEST_RESULT`) in the same way that existing `SYSTEM_OUT` messages are handled. We're transitioning from sending `TEST_RESULT` messages from Javabuilder instead of `SYSTEM_OUT` with test results, so making the associated change here.

## Testing story

Tested manually, and added a unit test.

![image](https://user-images.githubusercontent.com/25372625/151630420-6998720d-7819-4de3-9d5e-62a00f31c73f.png)