### PR TITLE
Java Lab: enable run of validation code in start mode

### DIFF
--- a/apps/src/javalab/Javalab.js
+++ b/apps/src/javalab/Javalab.js
@@ -18,7 +18,8 @@ import javalab, {
   setDisableFinishButton,
   setIsTesting,
   openPhotoPrompter,
-  closePhotoPrompter
+  closePhotoPrompter,
+  getSourcesAndValidation
 } from './javalabRedux';
 import playground from './playground/playgroundRedux';
 import {TestResults} from '@cdo/apps/constants';
@@ -405,6 +406,9 @@ Javalab.prototype.onContinue = function(submit) {
 
 Javalab.prototype.getCode = function() {
   const storeState = getStore().getState();
+  if (this.isStartMode) {
+    return getSourcesAndValidation(storeState);
+  }
   return getSources(storeState);
 };
 

--- a/apps/src/javalab/Javalab.js
+++ b/apps/src/javalab/Javalab.js
@@ -407,6 +407,8 @@ Javalab.prototype.onContinue = function(submit) {
 Javalab.prototype.getCode = function() {
   const storeState = getStore().getState();
   if (this.isStartMode) {
+    // If we are in start mode, get both sources and validation so that
+    // levelbuilders can run validation code.
     return getSourcesAndValidation(storeState);
   }
   return getSources(storeState);

--- a/apps/src/javalab/javalabRedux.js
+++ b/apps/src/javalab/javalabRedux.js
@@ -211,14 +211,10 @@ export const getValidation = state => {
 };
 
 export const getSourcesAndValidation = state => {
-  // we need to copy sources and not send over the object itself, there is probably a
-  // cleaner way to do this.
   let sources = {};
   for (let key in state.javalab.sources) {
     sources[key] = {
-      text: state.javalab.sources[key].text,
-      isVisible: state.javalab.sources[key].isVisible,
-      isValidation: state.javalab.sources[key].isValidation
+      ...state.javalab.sources[key]
     };
   }
   return sources;

--- a/apps/src/javalab/javalabRedux.js
+++ b/apps/src/javalab/javalabRedux.js
@@ -210,6 +210,20 @@ export const getValidation = state => {
   return validation;
 };
 
+export const getSourcesAndValidation = state => {
+  // we need to copy sources and not send over the object itself, there is probably a
+  // cleaner way to do this.
+  let sources = {};
+  for (let key in state.javalab.sources) {
+    sources[key] = {
+      text: state.javalab.sources[key].text,
+      isVisible: state.javalab.sources[key].isVisible,
+      isValidation: state.javalab.sources[key].isValidation
+    };
+  }
+  return sources;
+};
+
 export const setRenderedHeight = height => ({
   type: EDITOR_HEIGHT_UPDATED,
   height


### PR DESCRIPTION
In start mode we want levelbuilders to be able to run validation code. Our overall solution for running validation code (for students and levelbuilders) is blocked on the "decouple javabuilder" work, so for now we can just save validation code as we save normal code when a user is in start mode so their validation files will run like normal unit tests. 

One interesting thing I noticed while working on this is for a single user, the start mode and normal versions of a level share a channel id. This means only a levelbuilder could see validation code run on a regular level view if they are switching between start and regular mode. However, as soon as they make a change on the regular version of the level they won't see validation code anymore.

## Links

- spec: [Java Lab Validation](https://docs.google.com/document/d/14_ka0o1YFhAoXFl-WiyukrfIvT4C0IYIVVYcFaEmV7w/edit#heading=h.3hovjifkgut)
- jira ticket: [JAVA-422](https://codedotorg.atlassian.net/browse/JAVA-422)


## Testing story
Tested locally that a levelbuilder can run validation code while in start mode, but no one else can.


## Deployment strategy

## Follow-up work
We want to enable all unit test code to have access to the new `org.code.validation` package to fully unblock levelbuilders for validation code writing. This is part 2 of this task (same Jira ticket).

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
