### PR TITLE
Track section progress loader time

### DIFF
--- a/apps/src/logToCloud.js
+++ b/apps/src/logToCloud.js
@@ -17,7 +17,8 @@ const PageAction = makeEnum(
   'JotFormFrameLoaded',
   'JotFormLoadFailed',
   'BlockLoadFailed',
-  'MapboxMarkerLoadError'
+  'MapboxMarkerLoadError',
+  'SectionProgressLoaded'
 );
 
 const MAX_FIELD_LENGTH = 4095;

--- a/apps/src/templates/sectionProgress/sectionProgressLoader.js
+++ b/apps/src/templates/sectionProgress/sectionProgressLoader.js
@@ -18,7 +18,7 @@ import {
 } from '@cdo/apps/templates/sectionProgress/standards/sectionStandardsProgressRedux';
 import {getStore} from '@cdo/apps/redux';
 import _ from 'lodash';
-import firehoseClient from '@cdo/apps/lib/util/firehose';
+import logToCloud from '@cdo/apps/logToCloud';
 
 const NUM_STUDENTS_PER_PAGE = 50;
 
@@ -100,7 +100,9 @@ export function loadScriptProgress(scriptId, sectionId) {
   // Combine and transform the data
   requests.push(scriptRequest);
   Promise.all(requests).then(() => {
-    recordTimeToLoadSectionProgress(scriptId, performance.now() - startTime);
+    logToCloud.addPageAction(logToCloud.PageAction.SectionProgressLoaded, {
+      timeInMs: performance.now() - startTime
+    });
 
     sectionProgress.studentLessonProgressByUnit = {
       ...sectionProgress.studentLessonProgressByUnit,
@@ -154,15 +156,4 @@ function postProcessLessonData(lesson, includeBonusLevels) {
     ...lesson,
     levels: levels.map(level => processedLevel(level))
   };
-}
-
-function recordTimeToLoadSectionProgress(scriptId, time) {
-  firehoseClient.putRecord({
-    study: 'sectionProgressLoader',
-    event: 'loaded_section_level_progress',
-    data_json: JSON.stringify({
-      script_id: scriptId,
-      timeInMs: time
-    })
-  });
 }


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
We had a Zendesk report that the progress table was taking a long time to load, based on some investigation, it seems that retrieving section_level_progress may take a long time. One potential solution may be to making the page size smaller for the requests, there will be more requests but if they're done in parallel and each one is faster, it may be faster over all. 

The changes in this PR add newrelic tracking to see how long the requests are taking right now, so that if we change the page size we'll be able to determine whether it made a difference.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
