### PR TITLE
Prevent script seeding test from being flaky

### DIFF
--- a/dashboard/test/lib/services/script_seed_test.rb
+++ b/dashboard/test/lib/services/script_seed_test.rb
@@ -254,8 +254,8 @@ module Services
       assert_script_trees_equal script_with_changes, script
       lesson = script.lessons.first
       assert_equal(
-        ['My Activity', 'New Activity Name', 'Updated Activity Name'],
-        lesson.lesson_activities.map(&:name).sort!
+        ["Updated Activity Name", "My Activity", "New Activity Name"],
+        lesson.lesson_activities.sort_by(&:position).map(&:name)
       )
     end
 

--- a/dashboard/test/lib/services/script_seed_test.rb
+++ b/dashboard/test/lib/services/script_seed_test.rb
@@ -254,8 +254,8 @@ module Services
       assert_script_trees_equal script_with_changes, script
       lesson = script.lessons.first
       assert_equal(
-        ['Updated Activity Name', 'My Activity', 'New Activity Name'],
-        lesson.lesson_activities.map(&:name)
+        ['My Activity', 'New Activity Name', 'Updated Activity Name'],
+        lesson.lesson_activities.map(&:name).sort!
       )
     end
 


### PR DESCRIPTION
A script seeding test kept failing where items would get out of order. [See Jira ticket](https://codedotorg.atlassian.net/browse/PLAT-1411).  I was not able to get a local repo of the test failing but I think this should possibly fix the issue by making sure we sort by position. 