### PR TITLE
Codify, seed, and serialize ProgrammingEnvironment and ProgrammingEnvironmentCategory relationships

### DIFF
--- a/dashboard/app/controllers/programming_expressions_controller.rb
+++ b/dashboard/app/controllers/programming_expressions_controller.rb
@@ -35,7 +35,7 @@ class ProgrammingExpressionsController < ApplicationController
   def edit
     @programming_expression = ProgrammingExpression.find_by_id(params[:id])
     return render :not_found unless @programming_expression
-    @environment_categories = @programming_expression.programming_environment.categories
+    @environment_categories = @programming_expression.programming_environment.category_options
   end
 
   def update

--- a/dashboard/app/models/programming_environment.rb
+++ b/dashboard/app/models/programming_environment.rb
@@ -47,9 +47,10 @@ class ProgrammingEnvironment < ApplicationRecord
     properties = properties_from_file(File.read(file_path))
     environment = ProgrammingEnvironment.find_or_initialize_by(name: properties[:name])
     environment.update! properties.except(:categories)
-    properties[:categories].each do |category_config|
+    environment.categories = properties[:categories].map do |category_config|
       category = ProgrammingEnvironmentCategory.find_or_initialize_by(programming_environment_id: environment.id, key: category_config['key'])
       category.update! category_config
+      category
     end
     environment.name
   end

--- a/dashboard/app/models/programming_environment.rb
+++ b/dashboard/app/models/programming_environment.rb
@@ -80,4 +80,8 @@ class ProgrammingEnvironment < ApplicationRecord
       editorType: editor_type
     }
   end
+
+  def category_options
+    programming_expressions.pluck(:category).uniq
+  end
 end

--- a/dashboard/app/models/programming_environment.rb
+++ b/dashboard/app/models/programming_environment.rb
@@ -17,8 +17,9 @@ class ProgrammingEnvironment < ApplicationRecord
 
   validates_uniqueness_of :name, case_sensitive: false
 
-  has_many :programming_environment_categories
-  has_many :programming_expressions
+  alias_attribute :categories, :programming_environment_categories
+  has_many :programming_environment_categories, dependent: :destroy
+  has_many :programming_expressions, dependent: :destroy
 
   # @attr [String] editor_type - Type of editor one of the following: 'text-based', 'droplet', 'blockly'
   serialized_attrs %w(

--- a/dashboard/app/models/programming_environment_category.rb
+++ b/dashboard/app/models/programming_environment_category.rb
@@ -16,4 +16,13 @@
 #  index_programming_environment_categories_on_key_and_env_id  (key,programming_environment_id) UNIQUE
 #
 class ProgrammingEnvironmentCategory < ApplicationRecord
+  belongs_to :programming_environment
+
+  def serialize
+    {
+      key: key,
+      name: name,
+      color: color
+    }
+  end
 end

--- a/dashboard/config/programming_environments/applab.json
+++ b/dashboard/config/programming_environments/applab.json
@@ -3,7 +3,7 @@
   "editor_type": "droplet",
   "categories": [
     {
-      "key": "ui controls",
+      "key": "ui_controls",
       "name": "UI controls",
       "color": "#fff176"
     },

--- a/dashboard/config/programming_environments/applab.json
+++ b/dashboard/config/programming_environments/applab.json
@@ -1,4 +1,61 @@
 {
   "name": "applab",
-  "editor_type": "droplet"
+  "editor_type": "droplet",
+  "categories": [
+    {
+      "key": "ui controls",
+      "name": "UI controls",
+      "color": "#fff176"
+    },
+    {
+      "key": "canvas",
+      "name": "Canvas",
+      "color": "#f78183"
+    },
+    {
+      "key": "data",
+      "name": "Data",
+      "color": "#d3e965"
+    },
+    {
+      "key": "turtle",
+      "name": "Turtle",
+      "color": "#4dd0e1"
+    },
+    {
+      "key": "control",
+      "name": "Control",
+      "color": "#64B5F6"
+    },
+    {
+      "key": "math",
+      "name": "Math",
+      "color": "#FFB74D"
+    },
+    {
+      "key": "variables",
+      "name": "Variables",
+      "color": "#BB77C7"
+    },
+    {
+      "key": "functions",
+      "name": "Functions",
+      "color": "#68D995"
+    },
+    {
+      "key": "advanced",
+      "name": "Advanced",
+      "color": "#19c3e1"
+    },
+    {
+      "key": "maker",
+      "name": "Maker",
+      "color": "#4dd0e1"
+    },
+    {
+      "key": "circuit",
+      "name": "Circuit",
+      "color": "#f78183"
+    }
+  ]
 }

--- a/dashboard/config/programming_environments/gamelab.json
+++ b/dashboard/config/programming_environments/gamelab.json
@@ -1,4 +1,56 @@
 {
   "name": "gamelab",
-  "editor_type": "droplet"
+  "editor_type": "droplet",
+  "categories": [
+    {
+      "key": "sprites",
+      "name": "Sprites",
+      "color": "#f78183"
+    },
+    {
+      "key": "groups",
+      "name": "Groups",
+      "color": "#f78183"
+    },
+    {
+      "key": "drawing",
+      "name": "Drawing",
+      "color": "#4dd0e1"
+    },
+    {
+      "key": "control",
+      "name": "Control",
+      "color": "#64B5F6"
+    },
+    {
+      "key": "math",
+      "name": "Math",
+      "color": "#FFB74D"
+    },
+    {
+      "key": "variables",
+      "name": "Variables",
+      "color": "#BB77C7"
+    },
+    {
+      "key": "functions",
+      "name": "Functions",
+      "color": "#68D995"
+    },
+    {
+      "key": "world",
+      "name": "World",
+      "color": "#fff176"
+    },
+    {
+      "key": "animations",
+      "name": "Animations",
+      "color": "#f78183"
+    },
+    {
+      "key": "ui controls",
+      "name": "UI controls",
+      "color": "#fff176"
+    }
+  ]
 }

--- a/dashboard/config/programming_environments/gamelab.json
+++ b/dashboard/config/programming_environments/gamelab.json
@@ -48,7 +48,7 @@
       "color": "#f78183"
     },
     {
-      "key": "ui controls",
+      "key": "ui_controls",
       "name": "UI controls",
       "color": "#fff176"
     }

--- a/dashboard/config/programming_environments/spritelab.json
+++ b/dashboard/config/programming_environments/spritelab.json
@@ -1,5 +1,94 @@
 {
   "name": "spritelab",
+  "block_pool_name": "GamelabJr",
+  "description": "Spritelab description",
   "editor_type": "blockly",
-  "block_pool_name": "GamelabJr"
+  "title": "Spritelab",
+  "categories": [
+    {
+      "key": "sprites",
+      "name": "Sprites",
+      "color": "#df9399"
+    },
+    {
+      "key": "world",
+      "name": "World",
+      "color": "#acacd2"
+    },
+    {
+      "key": "location",
+      "name": "Location",
+      "color": "#f5ebaa"
+    },
+    {
+      "key": "actions",
+      "name": "Actions",
+      "color": "#5ef3ff"
+    },
+    {
+      "key": "events",
+      "name": "Events",
+      "color": "#62fc94"
+    },
+    {
+      "key": "behaviors",
+      "name": "Behaviors",
+      "color": "#89eba4"
+    },
+    {
+      "key": "loops",
+      "name": "Loops",
+      "color": "#f98bd0"
+    },
+    {
+      "key": "variables",
+      "name": "Variables",
+      "color": "#0cfb4c"
+    },
+    {
+      "key": "math",
+      "name": "Math",
+      "color": "#bbb3ce"
+    },
+    {
+      "key": "logic",
+      "name": "Logic",
+      "color": "#64d5ff"
+    },
+    {
+      "key": "functions",
+      "name": "Functions",
+      "color": "#a3e770"
+    },
+    {
+      "key": "text",
+      "name": "Text",
+      "color": "#acd2c6"
+    },
+    {
+      "key": "comments",
+      "name": "Comments",
+      "color": "#d9d9d9"
+    },
+    {
+      "key": "sl1",
+      "name": "SL1",
+      "color": null
+    },
+    {
+      "key": "unused",
+      "name": "Unused",
+      "color": null
+    },
+    {
+      "key": "control",
+      "name": "Control",
+      "color": "#64B5F6"
+    },
+    {
+      "key": "experimental",
+      "name": "Experimental",
+      "color": null
+    }
+  ]
 }

--- a/dashboard/config/programming_environments/spritelab.json
+++ b/dashboard/config/programming_environments/spritelab.json
@@ -71,24 +71,9 @@
       "color": "#d9d9d9"
     },
     {
-      "key": "sl1",
-      "name": "SL1",
-      "color": null
-    },
-    {
-      "key": "unused",
-      "name": "Unused",
-      "color": null
-    },
-    {
       "key": "control",
       "name": "Control",
       "color": "#64B5F6"
-    },
-    {
-      "key": "experimental",
-      "name": "Experimental",
-      "color": null
     }
   ]
 }

--- a/dashboard/config/programming_environments/weblab.json
+++ b/dashboard/config/programming_environments/weblab.json
@@ -3,12 +3,12 @@
   "editor_type": "text",
   "categories": [
     {
-      "key": "html tags",
+      "key": "html_tags",
       "name": "HTML Tags",
       "color": "#fff176"
     },
     {
-      "key": "css properties",
+      "key": "css_properties",
       "name": "CSS Properties",
       "color": "#d3e965"
     }

--- a/dashboard/config/programming_environments/weblab.json
+++ b/dashboard/config/programming_environments/weblab.json
@@ -1,4 +1,16 @@
 {
   "name": "weblab",
-  "editor_type": "text"
+  "editor_type": "text",
+  "categories": [
+    {
+      "key": "html tags",
+      "name": "HTML Tags",
+      "color": "#fff176"
+    },
+    {
+      "key": "css properties",
+      "name": "CSS Properties",
+      "color": "#d3e965"
+    }
+  ]
 }

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -966,6 +966,11 @@ FactoryGirl.define do
     sequence(:name) {|n| "programming-environment-#{n}"}
   end
 
+  factory :programming_environment_category do
+    sequence(:key) {|n| "programming-environment-category-#{n}"}
+    sequence(:name) {|n| "programming-environment-category-#{n}"}
+  end
+
   factory :programming_expression do
     association :programming_environment
     sequence(:name) {|n| "programming expression #{n}"}

--- a/dashboard/test/models/programming_environment_test.rb
+++ b/dashboard/test/models/programming_environment_test.rb
@@ -34,4 +34,19 @@ class ProgrammingEnvironmentTest < ActiveSupport::TestCase
     assert_equal previous_env.attributes.except('id', 'created_at', 'updated_at'), new_env.attributes.except('id', 'created_at', 'updated_at')
     assert_equal 2, new_env.categories.count
   end
+
+  test "can remove categories when serializings and seeding programming environment with categories" do
+    env = create :programming_environment, name: 'ide', editor_type: 'droplet', title: 'IDE', description: 'A description of the IDE.', image_url: 'images.code.org/ide'
+    create :programming_environment_category, programming_environment: env
+    serialization = env.serialize
+    # Category not included in the serialization should be deleted on seed
+    create :programming_environment_category, programming_environment: env
+    assert_equal 2, env.categories.count
+
+    File.stubs(:read).returns(serialization.to_json)
+
+    ProgrammingEnvironment.seed_record("config/programming_environments/ide.json")
+    env.categories.reload
+    assert_equal 1, env.categories.count
+  end
 end

--- a/dashboard/test/models/programming_environment_test.rb
+++ b/dashboard/test/models/programming_environment_test.rb
@@ -18,4 +18,20 @@ class ProgrammingEnvironmentTest < ActiveSupport::TestCase
     new_env = ProgrammingEnvironment.find_by_name(new_env_name)
     assert_equal previous_env.attributes.except('id', 'created_at', 'updated_at'), new_env.attributes.except('id', 'created_at', 'updated_at')
   end
+
+  test "can serialize and seed programming environment with categories" do
+    env = create :programming_environment, name: 'ide', editor_type: 'droplet', title: 'IDE', description: 'A description of the IDE.', image_url: 'images.code.org/ide'
+    create :programming_environment_category, programming_environment: env
+    create :programming_environment_category, programming_environment: env
+    serialization = env.serialize
+    previous_env = env.freeze
+    env.destroy!
+
+    File.stubs(:read).returns(serialization.to_json)
+
+    new_env_name = ProgrammingEnvironment.seed_record("config/programming_environments/ide.json")
+    new_env = ProgrammingEnvironment.find_by_name(new_env_name)
+    assert_equal previous_env.attributes.except('id', 'created_at', 'updated_at'), new_env.attributes.except('id', 'created_at', 'updated_at')
+    assert_equal 2, new_env.categories.count
+  end
 end


### PR DESCRIPTION
This PR:
- Adds the associations between ProgrammingEnvironment and ProgrammingEnvironmentCategory
- Seeds and serializes ProgrammingEnvironmentCategory with ProgrammingEnvironment
- Creates the ProgrammingEnvironmentCategory config from what is in curriculumbuilder (I did this manually when I was working on the edit interface -- to come in a future PR -- and it was still in my local DB)
- Adds tests

See [the doc](https://docs.google.com/document/d/14SEPqLHFEpX_H8HrMQQdnSV4nlno0QnRzmVh7HgEidA/edit#heading=h.zf5a9zeklx3h)

## Testing story

seeded locally a few times, unit tests


## Follow-up work

add an edit interface for categories (#44663, still a work in progress), add the association between ProgrammingEnvironmentCategory and ProgrammingExpression


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
