### PR TITLE
Switching from gsub to ruby-i18n style string interpolation

### DIFF
--- a/pegasus/sites.v3/code.org/views/curriculum_banner.haml
+++ b/pegasus/sites.v3/code.org/views/curriculum_banner.haml
@@ -8,4 +8,4 @@
   .clear{style: "clear: both"}
 - elsif Homepage.show_courses_banner(request)
   .curriculum-banner
-    = hoc_s(:codeorg_homepage_hoc2018_curriculum, locals: {studio_url: CDO.studio_url})
+    != hoc_s(:codeorg_homepage_hoc2018_curriculum, {studio_url: CDO.studio_url})

--- a/pegasus/sites.v3/code.org/views/curriculum_banner.haml
+++ b/pegasus/sites.v3/code.org/views/curriculum_banner.haml
@@ -8,4 +8,4 @@
   .clear{style: "clear: both"}
 - elsif Homepage.show_courses_banner(request)
   .curriculum-banner
-    = hoc_s(:codeorg_homepage_hoc2018_curriculum).gsub("%{studio_url}", CDO.studio_url)
+    = hoc_s(:codeorg_homepage_hoc2018_curriculum, locals: {studio_url: CDO.studio_url})

--- a/pegasus/sites.v3/hourofcode.com/public/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/index.haml
@@ -5,7 +5,7 @@ social:
   twitter:url: https://hourofcode.com
 ---
 :ruby
-  @header["title"] = hoc_s(:front_title).gsub(/%{campaign_date}/, campaign_date('full-year'))
+  @header["title"] = hoc_s(:front_title, locals: {campaign_date: campaign_date('full-year')})
 
   hoc_mode = DCDO.get("hoc_mode", CDO.default_hoc_mode)
 

--- a/pegasus/sites.v3/hourofcode.com/views/front_header_banner.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/front_header_banner.haml
@@ -1,2 +1,2 @@
 .lines_of_code_header{style: 'font-size: 24px;'}
-  %b= hoc_s(:front_header_banner).gsub(/%{campaign_date}/, campaign_date('full-year'))
+  %b= hoc_s(:front_header_banner, locals: {campaign_date: campaign_date('full-year')})

--- a/pegasus/sites.v3/hourofcode.com/views/hoc_events_counter.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/hoc_events_counter.haml
@@ -14,7 +14,8 @@
   -country_total = "0" if country_total == ""
   = succeed "." do
     = events_text + ","
-    = hoc_s(:map_header_country).gsub('#', format_integer_with_commas(country_total)).gsub('%{country}', country_full_name)
+    -# TODO - FND-1894: Removed `gsub` usage
+    = hoc_s(:map_header_country, locals: {country_total: country_total, country: country_full_name}).gsub('#', format_integer_with_commas(country_total))
 -else
   = succeed "." do
     = events_text

--- a/pegasus/sites.v3/hourofcode.com/views/promote/share_buttons.erb
+++ b/pegasus/sites.v3/hourofcode.com/views/promote/share_buttons.erb
@@ -1,7 +1,7 @@
 <%
   facebook = {:u=>"http://#{request.host}/us"}
 
-  twitter = {:url=>"http://hourofcode.com", :related=>'codeorg', :hashtags=>'', :text=>hoc_s(:twitter_default_text_donor).gsub(/%{random_donor}/, get_random_donor_twitter)}
+  twitter = {:url=>"http://hourofcode.com", :related=>'codeorg', :hashtags=>'', :text=>hoc_s(:twitter_default_text_donor, locals: {random_donor: get_random_donor_twitter})}
   twitter[:hashtags] = 'HourOfCode' unless hoc_s(:twitter_default_text_donor).include? '#HourOfCode'
 %>
 

--- a/pegasus/sites.v3/hourofcode.com/views/signup_form.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/signup_form.haml
@@ -7,7 +7,7 @@
 - hoc_year = DCDO.get("hoc_year", 2017)
 
 #signupform
-  %h2#signup-header= hoc_s(:signup_header).gsub(/%{campaign_date}/, campaign_date("full"))
+  %h2#signup-header= hoc_s(:signup_header, locals: {campaign_date: campaign_date("full")})
   %h2#census-header{style: "display: none;"}= hoc_s(:census_header)
   #error_message
   %form{:id=>"hoc-signup-form", role: "form", onsubmit: "event.preventDefault();"}

--- a/pegasus/sites.v3/hourofcode.com/views/social_media_hoc.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/social_media_hoc.haml
@@ -1,4 +1,4 @@
 - facebook = {:u=>"http://#{request.host}/us"}
-- twitter = {:url=>"http://hourofcode.com", :related=>'codeorg', :hashtags=>'', :text=>hoc_s(:twitter_default_text_donor).gsub(/%{random_donor}/, get_random_donor_twitter)}
+- twitter = {:url=>"http://hourofcode.com", :related=>'codeorg', :hashtags=>'', :text=>hoc_s(:twitter_default_text_donor, locals: {random_donor: get_random_donor_twitter})}
 - twitter[:hashtags] = 'HourOfCode' unless hoc_s(:twitter_default_text_donor).include? '#HourOfCode'
 = view :share_buttons, facebook:facebook, twitter:twitter

--- a/pegasus/sites.v3/hourofcode.com/views/thanks_page_heading.erb
+++ b/pegasus/sites.v3/hourofcode.com/views/thanks_page_heading.erb
@@ -1,6 +1,6 @@
 <%
   facebook = {:u=>"http://#{request.host}/us"}
 
-  twitter = {:url=>"http://hourofcode.com", :related=>'codeorg', :hashtags=>'', :text=>hoc_s(:twitter_donor_text).gsub(/%{random_donor}/, get_random_donor_twitter)}
+  twitter = {:url=>"http://hourofcode.com", :related=>'codeorg', :hashtags=>'', :text=>hoc_s(:twitter_donor_text, locals: {random_donor: get_random_donor_twitter})}
   twitter[:hashtags] = 'HourOfCode' unless hoc_s(:twitter_donor_text).include? '#HourOfCode'
 %>

--- a/pegasus/sites.v3/hourofcode.com/views/whats_next.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/whats_next.haml
@@ -1,6 +1,6 @@
 #whats_next
   %h2{:style=>'margin-top:25px'}=hoc_s(:whats_next_header)
   %ul{:style=>"line-height:28px"}
-    %li=hoc_s(:whats_next_how_to).gsub('/how-to', resolve_url('/how-to'))
-    %li=hoc_s(:whats_next_how_to_promote_link).gsub('/promote', resolve_url('/promote'))
-    %li=hoc_s(:whats_next_try, locals: {learn_url: resolve_url('/learn')})
+    %li!=hoc_s(:whats_next_how_to).gsub('/how-to', resolve_url('/how-to'))
+    %li!=hoc_s(:whats_next_how_to_promote_link).gsub('/promote', resolve_url('/promote'))
+    %li!=hoc_s(:whats_next_try, locals: {learn_url: resolve_url('/learn')})

--- a/pegasus/sites.v3/hourofcode.com/views/whats_next.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/whats_next.haml
@@ -3,4 +3,4 @@
   %ul{:style=>"line-height:28px"}
     %li=hoc_s(:whats_next_how_to).gsub('/how-to', resolve_url('/how-to'))
     %li=hoc_s(:whats_next_how_to_promote_link).gsub('/promote', resolve_url('/promote'))
-    %li=hoc_s(:whats_next_try).gsub('%{learn_url}', resolve_url('/learn'))
+    %li=hoc_s(:whats_next_try, locals: {learn_url: resolve_url('/learn')})


### PR DESCRIPTION
We used to inject variables into our i18n strings by using `gsub` to find&replace variable names with a value. Now that we are using the ruby-i18n library for looking up translations, we are generating HoneyBadger errors because we are not passing the variables to the library. The library generates Honeybadger errors because it thinks we are missing data. This is a false alarm because we use gsub to manually replace the variables with a value. So no users are actually impacted. However, we should go ahead and migrate these legacy strings to use the new way so it is standard across our code base.

## Links
* [HoneyBadger Errors](https://app.honeybadger.io/projects/34365/faults/83716236)

## Testing story
* TODO

## Follow-up work
* [JIRA](https://codedotorg.atlassian.net/browse/FND-1894)