### PR TITLE
dashboard certificate share page

### DIFF
--- a/apps/src/templates/Certificate.jsx
+++ b/apps/src/templates/Certificate.jsx
@@ -51,7 +51,7 @@ function Certificate(props) {
     });
   };
 
-  const getCertificatePath = () => {
+  const getCertificateImagePath = () => {
     if (!props.showStudioCertificate) {
       return `${
         dashboard.CODE_ORG_URL
@@ -102,7 +102,7 @@ function Certificate(props) {
   } = props;
 
   const certificate = certificateId || 'blank';
-  const personalizedCertificate = getCertificatePath();
+  const personalizedCertificate = getCertificateImagePath();
   const blankCertificate =
     blankCertificates[tutorial] || blankCertificates.hourOfCode;
   const imgSrc = personalized ? personalizedCertificate : blankCertificate;

--- a/apps/src/templates/Certificate.jsx
+++ b/apps/src/templates/Certificate.jsx
@@ -92,6 +92,10 @@ function Certificate(props) {
     return `/print_certificates/${encoded}`;
   };
 
+  const getCertificateSharePath = certificate => {
+    return `https:${dashboard.CODE_ORG_URL}/certificates/${certificate}`;
+  };
+
   const {
     responsiveSize,
     tutorial,
@@ -106,9 +110,7 @@ function Certificate(props) {
   const blankCertificate =
     blankCertificates[tutorial] || blankCertificates.hourOfCode;
   const imgSrc = personalized ? personalizedCertificate : blankCertificate;
-  const certificateLink = `https:${
-    dashboard.CODE_ORG_URL
-  }/certificates/${certificate}`;
+  const certificateLink = getCertificateSharePath(certificate);
   const desktop =
     responsiveSize === ResponsiveSize.lg ||
     responsiveSize === ResponsiveSize.md;

--- a/apps/src/templates/Certificate.jsx
+++ b/apps/src/templates/Certificate.jsx
@@ -51,6 +51,14 @@ function Certificate(props) {
     });
   };
 
+  const getEncodedParams = () => {
+    const data = {
+      name: studentName,
+      course: props.tutorial
+    };
+    return btoa(JSON.stringify(data));
+  };
+
   const getCertificateImagePath = () => {
     if (!props.showStudioCertificate) {
       return `${
@@ -58,11 +66,7 @@ function Certificate(props) {
       }/api/hour/certificate/${certificate}.jpg`;
     }
 
-    const data = {
-      name: studentName,
-      course: props.tutorial
-    };
-    const filename = btoa(JSON.stringify(data));
+    const filename = getEncodedParams();
     return `/certificate_images/${filename}.jpg`;
   };
 
@@ -84,11 +88,7 @@ function Certificate(props) {
       return print;
     }
 
-    const data = {
-      name: studentName,
-      course: props.tutorial
-    };
-    const encoded = btoa(JSON.stringify(data));
+    const encoded = getEncodedParams();
     return `/print_certificates/${encoded}`;
   };
 
@@ -97,11 +97,7 @@ function Certificate(props) {
       return `https:${dashboard.CODE_ORG_URL}/certificates/${certificate}`;
     }
 
-    const data = {
-      name: studentName,
-      course: props.tutorial
-    };
-    const encoded = btoa(JSON.stringify(data));
+    const encoded = getEncodedParams();
     return `/certificates/${encoded}`;
   };
 

--- a/apps/src/templates/Certificate.jsx
+++ b/apps/src/templates/Certificate.jsx
@@ -93,7 +93,16 @@ function Certificate(props) {
   };
 
   const getCertificateSharePath = certificate => {
-    return `https:${dashboard.CODE_ORG_URL}/certificates/${certificate}`;
+    if (!props.showStudioCertificate) {
+      return `https:${dashboard.CODE_ORG_URL}/certificates/${certificate}`;
+    }
+
+    const data = {
+      name: studentName,
+      course: props.tutorial
+    };
+    const encoded = btoa(JSON.stringify(data));
+    return `/certificates/${encoded}`;
   };
 
   const {

--- a/apps/src/templates/Certificate.jsx
+++ b/apps/src/templates/Certificate.jsx
@@ -59,7 +59,7 @@ function Certificate(props) {
     return btoa(JSON.stringify(data));
   };
 
-  const getCertificateImagePath = () => {
+  const getCertificateImagePath = certificate => {
     if (!props.showStudioCertificate) {
       return `${
         dashboard.CODE_ORG_URL
@@ -111,7 +111,7 @@ function Certificate(props) {
   } = props;
 
   const certificate = certificateId || 'blank';
-  const personalizedCertificate = getCertificateImagePath();
+  const personalizedCertificate = getCertificateImagePath(certificate);
   const blankCertificate =
     blankCertificates[tutorial] || blankCertificates.hourOfCode;
   const imgSrc = personalized ? personalizedCertificate : blankCertificate;

--- a/apps/src/templates/Certificate.jsx
+++ b/apps/src/templates/Certificate.jsx
@@ -119,7 +119,7 @@ function Certificate(props) {
   const blankCertificate =
     blankCertificates[tutorial] || blankCertificates.hourOfCode;
   const imgSrc = personalized ? personalizedCertificate : blankCertificate;
-  const certificateLink = getCertificateSharePath(certificate);
+  const certificateShareLink = getCertificateSharePath(certificate);
   const desktop =
     responsiveSize === ResponsiveSize.lg ||
     responsiveSize === ResponsiveSize.md;
@@ -127,11 +127,11 @@ function Certificate(props) {
   const certificateStyle = desktop ? styles.desktopHalf : styles.mobileFull;
 
   const facebook = queryString.stringify({
-    u: certificateLink
+    u: certificateShareLink
   });
 
   const twitter = queryString.stringify({
-    url: certificateLink,
+    url: certificateShareLink,
     related: 'codeorg',
     text: randomDonorTwitter
       ? i18n.justDidHourOfCodeDonor({donor_twitter: randomDonorTwitter})
@@ -151,7 +151,7 @@ function Certificate(props) {
       )}
       <div id="uitest-certificate" style={certificateStyle}>
         <BackToFrontConfetti active={personalized} style={styles.confetti} />
-        <a href={certificateLink}>
+        <a href={certificateShareLink}>
           <img src={imgSrc} />
         </a>
       </div>

--- a/apps/test/unit/templates/CertificateTest.js
+++ b/apps/test/unit/templates/CertificateTest.js
@@ -103,6 +103,14 @@ describe('Certificate', () => {
         'https://code.org/printcertificate/sessionId'
       );
 
+      // the share link is used in the image thumbnail as well as the facebook
+      // and twitter links. just test its value in the thumbnail, because it is
+      // harder to extract from the facebook and twitter links.
+      const thumbnailLink = wrapper.find('#uitest-certificate a');
+      expect(thumbnailLink.prop('href')).to.equal(
+        'https:https://code.org/certificates/sessionId'
+      );
+
       const input = wrapper.find('input#name');
       input.simulate('change', {target: {value: 'Student'}});
       const submitButton = wrapper
@@ -141,6 +149,12 @@ describe('Certificate', () => {
 
       const printLink = wrapper.find('.social-print-link');
       expect(printLink.prop('href')).to.match(/^\/print_certificates/);
+
+      // the share link is used in the image thumbnail as well as the facebook
+      // and twitter links. just test its value in the thumbnail, because it is
+      // harder to extract from the facebook and twitter links.
+      const thumbnailLink = wrapper.find('#uitest-certificate a');
+      expect(thumbnailLink.prop('href')).to.match(/^\/certificates/);
 
       const input = wrapper.find('input#name');
       input.simulate('change', {target: {value: 'Student'}});

--- a/apps/test/unit/templates/CertificateTest.js
+++ b/apps/test/unit/templates/CertificateTest.js
@@ -24,7 +24,7 @@ describe('Certificate', () => {
   beforeEach(() => {
     storedWindowDashboard = window.dashboard;
     window.dashboard = {
-      CODE_ORG_URL: 'https://code.org'
+      CODE_ORG_URL: '//code.org'
     };
   });
 
@@ -100,7 +100,7 @@ describe('Certificate', () => {
 
       const printLink = wrapper.find('.social-print-link');
       expect(printLink.prop('href')).to.equal(
-        'https://code.org/printcertificate/sessionId'
+        '//code.org/printcertificate/sessionId'
       );
 
       // the share link is used in the image thumbnail as well as the facebook
@@ -108,7 +108,7 @@ describe('Certificate', () => {
       // harder to extract from the facebook and twitter links.
       const thumbnailLink = wrapper.find('#uitest-certificate a');
       expect(thumbnailLink.prop('href')).to.equal(
-        'https:https://code.org/certificates/sessionId'
+        'https://code.org/certificates/sessionId'
       );
 
       const input = wrapper.find('input#name');
@@ -122,7 +122,7 @@ describe('Certificate', () => {
       wrapper.update();
       image = wrapper.find('#uitest-certificate img');
       expect(image.prop('src')).to.equal(
-        'https://code.org/api/hour/certificate/sessionId.jpg'
+        '//code.org/api/hour/certificate/sessionId.jpg'
       );
     });
 

--- a/dashboard/app/controllers/certificates_controller.rb
+++ b/dashboard/app/controllers/certificates_controller.rb
@@ -1,0 +1,18 @@
+require 'base64'
+
+class CertificatesController < ApplicationController
+  include CertificatesHelper
+
+  # GET /certificates/:encoded_params
+  def show
+    prevent_caching
+
+    begin
+      data = JSON.parse(Base64.urlsafe_decode64(params[:encoded_params]))
+    rescue ArgumentError, OpenSSL::Cipher::CipherError
+      return render status: :bad_request, json: {message: 'invalid base64'}
+    end
+
+    @certificate_image_url = certificate_image_url(data['name'], data['course'])
+  end
+end

--- a/dashboard/app/controllers/certificates_controller.rb
+++ b/dashboard/app/controllers/certificates_controller.rb
@@ -14,5 +14,6 @@ class CertificatesController < ApplicationController
     end
 
     @certificate_image_url = certificate_image_url(data['name'], data['course'])
+    @certificate_print_url = certificate_print_url(data['name'], data['course'])
   end
 end

--- a/dashboard/app/controllers/print_certificates_controller.rb
+++ b/dashboard/app/controllers/print_certificates_controller.rb
@@ -1,6 +1,8 @@
 require 'base64'
 
 class PrintCertificatesController < ApplicationController
+  include CertificatesHelper
+
   # GET /print_certificates/:encoded_params
   def show
     prevent_caching
@@ -14,18 +16,5 @@ class PrintCertificatesController < ApplicationController
 
     @student_name = data['name']
     @certificate_image_url = certificate_image_url(data['name'], data['course'])
-  end
-
-  private
-
-  def certificate_image_url(name, course)
-    return '/images/hour_of_code_certificate.jpg' unless course
-
-    opts = {
-      name: name,
-      course: course
-    }.compact
-    encoded = Base64.urlsafe_encode64(opts.to_json)
-    "/certificate_images/#{encoded}.jpg"
   end
 end

--- a/dashboard/app/helpers/certificates_helper.rb
+++ b/dashboard/app/helpers/certificates_helper.rb
@@ -1,12 +1,15 @@
 module CertificatesHelper
-  def certificate_image_url(name, course)
-    return '/images/hour_of_code_certificate.jpg' unless course
-
+  def encode_params(name, course)
     opts = {
       name: name,
       course: course
     }.compact
-    encoded = Base64.urlsafe_encode64(opts.to_json)
+    Base64.urlsafe_encode64(opts.to_json)
+  end
+
+  def certificate_image_url(name, course)
+    return '/images/hour_of_code_certificate.jpg' unless course
+    encoded = encode_params(name, course)
     "/certificate_images/#{encoded}.jpg"
   end
 end

--- a/dashboard/app/helpers/certificates_helper.rb
+++ b/dashboard/app/helpers/certificates_helper.rb
@@ -1,0 +1,12 @@
+module CertificatesHelper
+  def certificate_image_url(name, course)
+    return '/images/hour_of_code_certificate.jpg' unless course
+
+    opts = {
+      name: name,
+      course: course
+    }.compact
+    encoded = Base64.urlsafe_encode64(opts.to_json)
+    "/certificate_images/#{encoded}.jpg"
+  end
+end

--- a/dashboard/app/helpers/certificates_helper.rb
+++ b/dashboard/app/helpers/certificates_helper.rb
@@ -12,4 +12,9 @@ module CertificatesHelper
     encoded = encode_params(name, course)
     "/certificate_images/#{encoded}.jpg"
   end
+
+  def certificate_print_url(name, course)
+    encoded = encode_params(name, course)
+    "/print_certificates/#{encoded}"
+  end
 end

--- a/dashboard/app/views/certificates/show.html.haml
+++ b/dashboard/app/views/certificates/show.html.haml
@@ -1,1 +1,2 @@
-%img{src: @certificate_image_url, alt: 'Certificate for Completion of One Hour of Code', width:"100%"}
+%a{href: @certificate_print_url}
+  %img{src: @certificate_image_url, alt: 'Certificate for Completion of One Hour of Code', width:"100%"}

--- a/dashboard/app/views/certificates/show.html.haml
+++ b/dashboard/app/views/certificates/show.html.haml
@@ -1,0 +1,1 @@
+%img{src: @certificate_image_url, alt: 'Certificate for Completion of One Hour of Code', width:"100%"}

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -404,6 +404,8 @@ Dashboard::Application.routes.draw do
 
   get '/print_certificates/:encoded_params', to: 'print_certificates#show'
 
+  get '/certificates/:encoded_params', to: 'certificates#show'
+
   get '/beta', to: redirect('/')
 
   get '/hoc/reset', to: 'script_levels#reset', script_id: Script::HOC_NAME, as: 'hoc_reset'

--- a/dashboard/test/controllers/certificates_controller_test.rb
+++ b/dashboard/test/controllers/certificates_controller_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+require 'base64'
+
+class CertificatesControllerTest < ActionController::TestCase
+  test 'can show given name and course' do
+    data = {name: 'student', course: 'hourofcode'}
+    encoded_params = Base64.urlsafe_encode64(data.to_json)
+    get :show, params: {encoded_params: encoded_params}
+    assert_response :success
+    assert_equal "max-age=0, private, must-revalidate, no-store", @response.headers["Cache-Control"]
+  end
+
+  test 'can show given bogus course' do
+    data = {name: 'student', course: 'bogus'}
+    encoded_params = Base64.urlsafe_encode64(data.to_json)
+    get :show, params: {encoded_params: encoded_params}
+    assert_response :success
+  end
+
+  test 'can show without name or course' do
+    data = {}
+    encoded_params = Base64.urlsafe_encode64(data.to_json)
+    get :show, params: {encoded_params: encoded_params}
+    assert_response :success
+  end
+
+  test 'returns bad request given invalid base64' do
+    get :show, params: {encoded_params: 'bogus'}
+    assert_response :bad_request
+    assert_includes response.body, 'invalid base64'
+  end
+end


### PR DESCRIPTION
Continues [PLAT-1531]., see [work plan](https://docs.google.com/document/d/1wTObDFZdWS6RzpM3R6wEm04ToY2fM1B5Kb2rUHCNq28/edit#heading=h.h0cd07oasonl)

This PR adds the "certificates" page on dashboard. you get to this page from the congrats page by clicking the certificate image itself, or by clicking the facebook or twitter share links.

after this PR, the following parts of the system are working entirely on dashboard when the experiment is enabled:
![Screen Shot 2022-02-02 at 4 59 55 PM](https://user-images.githubusercontent.com/8001765/152263553-ae621d0a-611b-4c70-a8b2-49c52a778280.png)

## Screenshots

### new user flow

https://user-images.githubusercontent.com/8001765/152263590-e75d2d12-729d-4fba-b3b8-2e5fbae5404b.mov

## before and after

note there is a substantial part of the new page missing. this will be addressed in a subsequent PR (see below).

![Screen Shot 2022-02-02 at 5 01 53 PM](https://user-images.githubusercontent.com/8001765/152263777-cb34e922-500c-4d96-b438-c573e9317c06.png)

## Testing story

* basic controller tests for the new controller
* js unit tests verify that the experiment controls whether clicking the certificate image takes you to the dashboard or pegasus version of the /certificates/ page 
  * manually tested that the facebook and twitter share links are also controlled by the experiment

## Follow-up work

we'll need to do the following before we launch this experiment:
* extract the sponsors param, so that it is set on the congrats page and then passed down to the other pages
* enable caching on the 3 new controllers. this seems important because the /certificates/ page can be shared on social media, and this page has caching enabled on pegasus
* finish building out the certificates page: https://codedotorg.atlassian.net/browse/PLAT-1588


[PLAT-1531]: https://codedotorg.atlassian.net/browse/PLAT-1531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ