### PR TITLE
Higher Power: Dance Party shares on Twitter get additional hashtag

### DIFF
--- a/apps/src/code-studio/components/ShareAllowedDialog.jsx
+++ b/apps/src/code-studio/components/ShareAllowedDialog.jsx
@@ -197,12 +197,17 @@ class ShareAllowedDialog extends React.Component {
     const tweetText = artistTwitterHandle
       ? `Check out the dance I made featuring @${artistTwitterHandle} on @codeorg!`
       : 'Check out what I made on @codeorg!';
+    const hashtags = this.props.selectedSong
+      ? ['codeplay', 'HourOfCode']
+      : ['HourOfCode'];
+    const comma = '%2C';
     const twitterShareUrl =
       'https://twitter.com/intent/tweet?text=' +
       encodeURIComponent(tweetText) +
       '&url=' +
       encodeURIComponent(this.props.shareUrl) +
-      '&hashtags=HourOfCode&related=codeorg';
+      `&hashtags=${hashtags.join(comma)}` +
+      '&related=codeorg';
 
     const showShareWarning = !this.props.canShareSocial && isDroplet;
     let embedOptions;

--- a/apps/src/code-studio/components/ShareAllowedDialog.jsx
+++ b/apps/src/code-studio/components/ShareAllowedDialog.jsx
@@ -21,6 +21,7 @@ import i18n from '@cdo/locale';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
 import LibraryCreationDialog from './libraries/LibraryCreationDialog';
 import QRCode from 'qrcode.react';
+import DCDO from '@cdo/apps/dcdo';
 
 function recordShare(type) {
   if (!window.dashboard) {
@@ -198,7 +199,8 @@ class ShareAllowedDialog extends React.Component {
       ? `Check out the dance I made featuring @${artistTwitterHandle} on @codeorg!`
       : 'Check out what I made on @codeorg!';
     const hashtags =
-      artistTwitterHandle === 'Coldplay'
+      artistTwitterHandle === 'Coldplay' &&
+      !!DCDO.get('higher-power-promotion', false)
         ? ['codeplay', 'HourOfCode']
         : ['HourOfCode'];
     const comma = '%2C';

--- a/apps/src/code-studio/components/ShareAllowedDialog.jsx
+++ b/apps/src/code-studio/components/ShareAllowedDialog.jsx
@@ -197,9 +197,10 @@ class ShareAllowedDialog extends React.Component {
     const tweetText = artistTwitterHandle
       ? `Check out the dance I made featuring @${artistTwitterHandle} on @codeorg!`
       : 'Check out what I made on @codeorg!';
-    const hashtags = this.props.selectedSong
-      ? ['codeplay', 'HourOfCode']
-      : ['HourOfCode'];
+    const hashtags =
+      artistTwitterHandle === 'Coldplay'
+        ? ['codeplay', 'HourOfCode']
+        : ['HourOfCode'];
     const comma = '%2C';
     const twitterShareUrl =
       'https://twitter.com/intent/tweet?text=' +

--- a/apps/src/dance/Dance.js
+++ b/apps/src/dance/Dance.js
@@ -42,6 +42,7 @@ import {SongTitlesToArtistTwitterHandle} from '../code-studio/dancePartySongArti
 import firehoseClient from '@cdo/apps/lib/util/firehose';
 import {showArrowButtons} from '@cdo/apps/templates/arrowDisplayRedux';
 import queryString from 'query-string';
+import DCDO from '@cdo/apps/dcdo';
 
 const ButtonState = {
   UP: 0,
@@ -682,7 +683,8 @@ Dance.prototype.displayFeedback_ = function() {
 
   const comma = '%2C';
   const hashtags =
-    artistTwitterHandle === 'Coldplay'
+    artistTwitterHandle === 'Coldplay' &&
+    !!DCDO.get('higher-power-promotion', false)
       ? ['codeplay', 'HourOfCode'].join(comma)
       : ['HourOfCode'];
 

--- a/apps/src/dance/Dance.js
+++ b/apps/src/dance/Dance.js
@@ -680,6 +680,9 @@ Dance.prototype.displayFeedback_ = function() {
     artistTwitterHandle +
     ' on @codeorg!';
 
+  const comma = '%2C';
+  const hashtags = ['codeplay', 'HourOfCode'].join(comma);
+
   let feedbackOptions = {
     feedbackType: this.testResults,
     message: this.message,
@@ -691,7 +694,7 @@ Dance.prototype.displayFeedback_ = function() {
     appStrings: {
       reinfFeedbackMsg: 'TODO: localized feedback message.'
     },
-    twitter: {text: twitterText}
+    twitter: {text: twitterText, hashtag: hashtags}
   };
 
   // Disable social share for users under 13 if we have the cookie set.

--- a/apps/src/dance/Dance.js
+++ b/apps/src/dance/Dance.js
@@ -681,7 +681,10 @@ Dance.prototype.displayFeedback_ = function() {
     ' on @codeorg!';
 
   const comma = '%2C';
-  const hashtags = ['codeplay', 'HourOfCode'].join(comma);
+  const hashtags =
+    artistTwitterHandle === 'Coldplay'
+      ? ['codeplay', 'HourOfCode'].join(comma)
+      : ['HourOfCode'];
 
   let feedbackOptions = {
     feedbackType: this.testResults,

--- a/lib/dynamic_config/dcdo.rb
+++ b/lib/dynamic_config/dcdo.rb
@@ -94,7 +94,8 @@ class DCDOBase
     # For example:
     # 'my-new-feature': DCDO.get('my-new-feature', false)
     {
-      'frontend-i18n-tracking': DCDO.get('frontend-i18n-tracking', false)
+      'frontend-i18n-tracking': DCDO.get('frontend-i18n-tracking', false),
+      'higher-power-promotion': DCDO.get('higher-power-promotion', false)
     }
   end
 end


### PR DESCRIPTION
When sharing a Dance Party creation, a new hashtag, `codeplay`, appears for Twitter shares via both the Finish dialog and the Share dialog (which have separate implementations).

The new hashtag is only included when DCDO key `"higher-power-promotion"` is `true`.