### PR TITLE
Add CorsConfiguration to s3_backed_subdomain CloudFormation template

### DIFF
--- a/aws/cloudformation/s3_backed_subdomain.yml
+++ b/aws/cloudformation/s3_backed_subdomain.yml
@@ -42,6 +42,16 @@ Resources:
     Properties:
       AccessControl: PublicRead
       BucketName: !Ref BucketName
+      CorsConfiguration:
+        CorsRules:
+          - AllowedMethods: [GET]
+            AllowedOrigins:
+              [
+                '*.code.org',
+                '*.code.org:3000',
+                'http://localhost-studio.code.org:*',
+              ]
+            AllowedHeaders: ['*']
       Tags:
         - Key: environment
           Value: production

--- a/aws/cloudformation/s3_backed_subdomain.yml
+++ b/aws/cloudformation/s3_backed_subdomain.yml
@@ -46,11 +46,10 @@ Resources:
         CorsRules:
           - AllowedMethods: [GET]
             AllowedOrigins:
-              [
-                '*.code.org',
-                '*.code.org:3000',
-                'http://localhost-studio.code.org:*',
-              ]
+              - !Sub "*.${Domain}"
+              # Permit local host development environments
+              - '*.code.org:3000'
+              - 'http://localhost-studio.code.org:*'
             AllowedHeaders: ['*']
       Tags:
         - Key: environment


### PR DESCRIPTION
Adding CORS configuration to our `s3_backed_subdomain` template. 

The specific goal right now is the ability to access our licensed fonts using an S3-backed CloudFront distribution. I tested this template from the codeorg-dev AWS account and confirmed that the CORS configuration here makes those fonts accessible from localhost:
<img width="1503" alt="Screen Shot 2022-02-03 at 1 50 00 PM" src="https://user-images.githubusercontent.com/9812299/152435437-d7809067-eb37-4281-aa64-46be3086b772.png">

(I invalidated the CloudFront cache before this request, but get a CloudFront hit upon page reload.)

This configuration is modeled after / similar to the [CorsConfiguration in the Javabuilder template](https://github.com/code-dot-org/javabuilder/blob/c42dba4435b3e490538e7cb23395cb061b680544/template.yml.erb#L339-L343).

### Follow-up Work
Make sure this CORS configuration works for other resources that use this CloudFormation template, such as lesson plans.