### PR TITLE
Save and submit teacher applications

### DIFF
--- a/apps/src/code-studio/pd/form_components_func/FormController.jsx
+++ b/apps/src/code-studio/pd/form_components_func/FormController.jsx
@@ -318,7 +318,7 @@ const FormController = props => {
   };
 
   const makeRequest = applicationStatus => {
-    const dataWithStatus = {status: applicationStatus, ...data};
+    const dataWithStatus = {...data, status: applicationStatus};
     setData(dataWithStatus);
 
     const ajaxRequest = (method, endpoint) =>

--- a/apps/test/unit/code-studio/pd/form_components_func/FormControllerTest.js
+++ b/apps/test/unit/code-studio/pd/form_components_func/FormControllerTest.js
@@ -180,10 +180,11 @@ describe('FormController', () => {
     });
 
     describe('Saving', () => {
-      it('Adds application status as incomplete to data', () => {
+      it('Overrides application status as incomplete to data', () => {
         const testData = {
           field1: 'value 1',
-          field2: 'value 2'
+          field2: 'value 2',
+          status: 'something'
         };
 
         form = isolateComponent(
@@ -191,7 +192,7 @@ describe('FormController', () => {
         );
         form.findAll('Button')[1].props.onClick();
 
-        expect(getData(DummyPage1)).to.eql({status: 'incomplete', ...testData});
+        expect(getData(DummyPage1)).to.eql({...testData, status: 'incomplete'});
       });
 
       it('Disables the save button during save', () => {
@@ -374,10 +375,11 @@ describe('FormController', () => {
           expect(form.findOne('#submit').props.disabled).to.be.false;
         });
 
-        it('Adds application status as unreviewed on submit', () => {
+        it('Overrides application status as unreviewed on submit', () => {
           const testData = {
             field1: 'value 1',
-            field2: 'value 2'
+            field2: 'value 2',
+            status: 'incomplete'
           };
 
           form = isolateComponent(
@@ -387,8 +389,8 @@ describe('FormController', () => {
           triggerSubmit();
 
           expect(getData(DummyPage3)).to.eql({
-            status: 'unreviewed',
-            ...testData
+            ...testData,
+            status: 'unreviewed'
           });
         });
 

--- a/dashboard/app/controllers/api/v1/pd/application/teacher_applications_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/application/teacher_applications_controller.rb
@@ -16,8 +16,6 @@ module Api::V1::Pd::Application
       form_data_hash = params.try(:[], :form_data) || {}
       form_data_json = form_data_hash.to_unsafe_h.to_json.strip_utf8mb4
 
-      # [MEG] TODO: See if update is coming from hitting the submit button (do validations)
-      # or the save button (ignore validations)
       @application.form_data_hash = JSON.parse(form_data_json)
 
       if @application.save

--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -1148,10 +1148,8 @@ module Pd::Application
 
     # Called after the application is created. Do any manipulation needed for the form data
     # hash here, as well as send emails
-    # [MEG] TODO: should only do a lot of this on a completed submitted application
     def on_successful_create
       update_user_school_info!
-      queue_email :confirmation, deliver_now: true unless status == 'incomplete'
 
       form_data_hash = sanitize_form_data_hash
 
@@ -1165,13 +1163,16 @@ module Pd::Application
         }
       )
 
-      auto_score! unless status == 'incomplete'
-      save
+      on_completed_app unless status == 'incomplete'
 
+      save
+    end
+
+    def on_completed_app
+      queue_email :confirmation, deliver_now: true
+      auto_score!
       unless regional_partner&.applications_principal_approval == RegionalPartner::SELECTIVE_APPROVAL
-        unless status == 'incomplete'
-          queue_email :principal_approval, deliver_now: true
-        end
+        queue_email :principal_approval, deliver_now: true
       end
     end
 

--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -1154,15 +1154,17 @@ module Pd::Application
 
       form_data_hash = sanitize_form_data_hash
 
-      update_form_data_hash(
-        {
-          cs_total_course_hours: form_data_hash.slice(
-            :cs_how_many_minutes,
-            :cs_how_many_days_per_week,
-            :cs_how_many_weeks_per_year
-          ).values.map(&:to_i).reduce(:*) / 60
-        }
-      )
+      if form_data_hash[:cs_how_many_minutes] && form_data_hash[:cs_how_many_days_per_week] && form_data_hash[:cs_how_many_weeks_per_year]
+        update_form_data_hash(
+          {
+            cs_total_course_hours: form_data_hash.slice(
+              :cs_how_many_minutes,
+              :cs_how_many_days_per_week,
+              :cs_how_many_weeks_per_year
+            ).values.map(&:to_i).reduce(:*) / 60
+          }
+        )
+      end
 
       on_completed_app unless status == 'incomplete'
 

--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -84,7 +84,7 @@ module Pd::Application
 
     has_many :emails, class_name: 'Pd::Application::Email', foreign_key: 'pd_application_id'
 
-    before_validation :set_course_from_program, unless: -> {program.nil?}
+    before_validation :set_course_from_program, if: -> {form_data_changed?}
     before_validation :set_total_course_hours, if: -> {form_data_changed?}
     before_validation :update_user_school_info!, if: -> {form_data_changed?}
     validates :status, exclusion: {in: ['interview'], message: '%{value} is reserved for facilitator applications.'}

--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -103,10 +103,10 @@ module Pd::Application
     # 1. Application has a specific school? always overwrite the user's school info
     # 2. User doesn't have a specific school? overwrite with the custom school info.
     def update_user_school_info!
-      if school_id || user.school_info.try(&:school).nil?
-        school_info = get_duplicate_school_info(school_info_attr) || SchoolInfo.create!(school_info_attr)
-        user.update_school_info(school_info)
-      end
+      return unless school_id || user.school_info.try(&:school).nil?
+      school_info = school_info_attr
+      return unless school_info
+      user.update_school_info(get_duplicate_school_info(school_info) || SchoolInfo.create!(school_info))
     end
 
     def update_scholarship_status(scholarship_status)
@@ -270,6 +270,7 @@ module Pd::Application
         }
       else
         hash = sanitize_form_data_hash
+        return unless hash[:school_type] && hash[:school_state] && hash[:school_zip_code] && hash[:school_name] && hash[:school_address]
         {
           country: 'US',
           # Take the first word in school type, downcased. E.g. "Public school" -> "public"

--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -104,6 +104,8 @@ module Pd::Application
     # based on these rules in order:
     # 1. Application has a specific school? always overwrite the user's school info
     # 2. User doesn't have a specific school? overwrite with the custom school info.
+    # Will only update the school info if we have enough information for it because
+    # an incomplete application may not have all the information we need to update
     def update_user_school_info!
       return unless school_id || user.school_info.try(&:school).nil?
       school_info = school_info_attr

--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -86,6 +86,7 @@ module Pd::Application
 
     before_validation :set_course_from_program, unless: -> {program.nil?}
     before_validation :set_total_course_hours, if: -> {form_data_changed?}
+    before_validation :update_user_school_info!, if: -> {form_data_changed?}
     validates :status, exclusion: {in: ['interview'], message: '%{value} is reserved for facilitator applications.'}
     validates :course, presence: true, inclusion: {in: VALID_COURSES}, unless: -> {status == 'incomplete'}
     validate :workshop_present_if_required_for_status, if: -> {status_changed?}
@@ -1172,11 +1173,7 @@ module Pd::Application
     # Called after the application is created. Do any manipulation needed for the form data
     # hash here, as well as send emails
     def on_successful_create
-      update_user_school_info!
-
       on_completed_app unless status == 'incomplete'
-
-      save
     end
 
     def on_completed_app
@@ -1185,6 +1182,7 @@ module Pd::Application
       unless regional_partner&.applications_principal_approval == RegionalPartner::SELECTIVE_APPROVAL
         queue_email :principal_approval, deliver_now: true
       end
+      save
     end
 
     # Called after principal approval has been created. Do any manipulation needed for the

--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -85,13 +85,13 @@ module Pd::Application
     has_many :emails, class_name: 'Pd::Application::Email', foreign_key: 'pd_application_id'
 
     before_validation :set_course_from_program, if: -> {form_data_changed?}
-    before_validation :set_total_course_hours, if: -> {form_data_changed?}
-    before_validation :update_user_school_info!, if: -> {form_data_changed?}
     validates :status, exclusion: {in: ['interview'], message: '%{value} is reserved for facilitator applications.'}
     validates :course, presence: true, inclusion: {in: VALID_COURSES}, unless: -> {status == 'incomplete'}
     validate :workshop_present_if_required_for_status, if: -> {status_changed?}
 
     before_save :save_partner, if: -> {form_data_changed? && regional_partner_id.nil? && !deleted?}
+    before_save :set_total_course_hours, if: -> {form_data_changed?}
+    before_save :update_user_school_info!, if: -> {form_data_changed?}
     before_save :log_status, if: -> {status_changed?}
 
     serialized_attrs %w(

--- a/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
@@ -121,26 +121,20 @@ module Api::V1::Pd::Application
       assert JSON.parse(TEACHER_APPLICATION_CLASS.last.response_scores).any?
     end
 
-    test 'does not update course hours nor autoscore on successful create if application status is incomplete' do
-      Pd::Application::TeacherApplication.expects(:auto_score).never
-      Pd::Application::TeacherApplication.expects(:queue_email).never
-
-      application_hash = build(
-        TEACHER_APPLICATION_HASH_FACTORY,
-        cs_how_many_minutes: 45,
-        cs_how_many_days_per_week: 5,
-        cs_how_many_weeks_per_year: 30
-      )
-
-      sign_in @applicant
-      put :create, params: {form_data: application_hash.merge({status: 'incomplete'})}
-    end
-
     test 'can submit an empty form if application is incomplete' do
       sign_in @applicant
       put :create, params: {form_data: {status: 'incomplete'}}
 
       assert_equal 'incomplete', TEACHER_APPLICATION_CLASS.last.status
+      assert_response :created
+    end
+
+    test 'does not update course hours nor autoscore on successful create if application status is incomplete' do
+      Pd::Application::TeacherApplication.expects(:auto_score).never
+      Pd::Application::TeacherApplication.expects(:queue_email).never
+
+      sign_in @applicant
+      put :create, params: {form_data: {status: 'incomplete'}}
       assert_response :created
     end
 

--- a/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
@@ -147,7 +147,7 @@ module Api::V1::Pd::Application
       put :update, params: {id: application.id, form_data: {status: 'incomplete'}}
       application.reload
       refute_equal original_data, application.form_data_hash
-      assert_nil application.program
+      assert_nil application.course
       assert_nil application.form_data_hash[:cs_total_course_hours]
       assert_equal original_school_info, @applicant.school_info
       assert_response :ok

--- a/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
@@ -136,6 +136,14 @@ module Api::V1::Pd::Application
       put :create, params: {form_data: application_hash.merge({status: 'incomplete'})}
     end
 
+    test 'can submit an empty form if application is incomplete' do
+      sign_in @applicant
+      put :create, params: {form_data: {status: 'incomplete'}}
+
+      assert_equal 'incomplete', TEACHER_APPLICATION_CLASS.last.status
+      assert_response :created
+    end
+
     # [MEG] TODO: verify update of params with fewer (and no) params
     test 'updating an application modifies form data' do
       sign_in @applicant

--- a/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
@@ -138,16 +138,18 @@ module Api::V1::Pd::Application
       assert_response :created
     end
 
-    test 'updating an application with empty form data updates fields' do
+    test 'updating an application with empty form data updates appropriate fields' do
       sign_in @applicant
       application = create TEACHER_APPLICATION_FACTORY, user: @applicant
       original_data = application.form_data_hash
+      original_school_info = @applicant.school_info
 
       put :update, params: {id: application.id, form_data: {status: 'incomplete'}}
       application.reload
       refute_equal original_data, application.form_data_hash
       assert_nil application.program
       assert_nil application.form_data_hash[:cs_total_course_hours]
+      assert_equal original_school_info, @applicant.school_info
       assert_response :ok
     end
 

--- a/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
@@ -138,21 +138,16 @@ module Api::V1::Pd::Application
       assert_response :created
     end
 
-    # [MEG] TODO: verify update of params with fewer (and no) params
-    test 'updating an application modifies form data' do
+    test 'updating an application with empty form data updates fields' do
       sign_in @applicant
-      @updated_form_data = build(TEACHER_APPLICATION_HASH_FACTORY).merge(
-        {
-          "firstName": "Harry",
-          "program": "Computer Science Discoveries (appropriate for 6th - 10th grade)",
-          "csdWhichGrades": ["8"]
-        }.stringify_keys
-      )
-
       application = create TEACHER_APPLICATION_FACTORY, user: @applicant
-      put :update, params: {id: application.id, form_data: @updated_form_data}
+      original_data = application.form_data_hash
+
+      put :update, params: {id: application.id, form_data: {status: 'incomplete'}}
       application.reload
-      assert_equal @updated_form_data, application.form_data_hash
+      refute_equal original_data, application.form_data_hash
+      assert_nil application.program
+      assert_nil application.form_data_hash[:cs_total_course_hours]
       assert_response :ok
     end
 

--- a/dashboard/test/factories/pd_factories.rb
+++ b/dashboard/test/factories/pd_factories.rb
@@ -813,6 +813,10 @@ FactoryGirl.define do
       status 'incomplete'
     end
 
+    trait :with_no_school do
+      school(-1)
+    end
+
     trait :with_multiple_workshops do
       able_to_attend_multiple ['December 11-15, 2017 in Indiana, USA']
 

--- a/dashboard/test/models/pd/application/teacher_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher_application_test.rb
@@ -47,7 +47,37 @@ module Pd::Application
       assert_equal 'Albus Dumbledore', application_without_principal_title.principal_greeting
     end
 
-    test 'meets criteria says an application meets critera when all YES_NO fields are marked yes' do
+    test 'set_total_course_hours calculates total course hours when there is info for it' do
+      custom_minutes_hours_weeks = {
+        cs_how_many_minutes: '45',
+        cs_how_many_days_per_week: '5',
+        cs_how_many_weeks_per_year: '30'
+      }
+
+      application = create :pd_teacher_application, form_data_hash: (
+        build :pd_teacher_application_hash, :incomplete, custom_minutes_hours_weeks
+      )
+
+      assert_equal 112, application.sanitize_form_data_hash[:cs_total_course_hours]
+    end
+
+    test 'set_total_course_hours does nothing when there is not enough info for it' do
+      empty_minutes_hours_weeks = {
+        cs_how_many_minutes: nil,
+        cs_how_many_days_per_week: nil,
+        cs_how_many_weeks_per_year: nil
+      }
+
+      %i(cs_how_many_minutes cs_how_many_days_per_week cs_how_many_weeks_per_year).each do |attribute|
+        application = create :pd_teacher_application, form_data_hash: (
+          build :pd_teacher_application_hash, :incomplete, empty_minutes_hours_weeks.slice(attribute)
+        )
+
+        assert_nil application.sanitize_form_data_hash[:cs_total_course_hours]
+      end
+    end
+
+    test 'meets criteria says an application meets criteria when all YES_NO fields are marked yes' do
       teacher_application = build :pd_teacher_application, course: 'csd',
                                   response_scores: {
                                     meets_minimum_criteria_scores: SCOREABLE_QUESTIONS[:criteria_score_questions_csd].map {|x| [x, 'Yes']}.to_h

--- a/dashboard/test/models/pd/application/teacher_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher_application_test.rb
@@ -818,21 +818,21 @@ module Pd::Application
     end
 
     test 'require assigned workshop for registration-related statuses when emails sent by system' do
-      statuses = TeacherApplication::WORKSHOP_REQUIRED_STATUSES
+      workshop_required_statuses = TeacherApplication::WORKSHOP_REQUIRED_STATUSES
       partner = build :regional_partner, applications_decision_emails: RegionalPartner::SENT_BY_SYSTEM
       workshop = create :workshop
       application = create :pd_teacher_application, {
         regional_partner: partner
       }
 
-      statuses.each do |status|
+      workshop_required_statuses.each do |status|
         application.status = status
         refute application.valid?
         assert_equal ["#{status} requires workshop to be assigned"], application.errors.messages[:status]
       end
 
       application.pd_workshop_id = workshop.id
-      statuses.each do |status|
+      workshop_required_statuses.each do |status|
         application.status = status
         assert application.valid?
       end

--- a/dashboard/test/models/pd/application/teacher_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher_application_test.rb
@@ -405,18 +405,6 @@ module Pd::Application
       )
     end
 
-    # [MEG] TODO: Test this functionality in the controller
-    test 'incomplete application is valid but does not queue an email nor score it' do
-      application = create :pd_teacher_application, form_data_hash: (
-        build :pd_teacher_application_hash, :incomplete
-      )
-      assert application.valid?
-
-      application.expects(:queue_email).never
-      application.expects(:auto_score!).never
-      application.on_successful_create
-    end
-
     test 'setting an auto-email status queues up an email' do
       application = create :pd_teacher_application
       assert_empty application.emails

--- a/dashboard/test/serializers/api/v1/pd/application_serializer_test.rb
+++ b/dashboard/test/serializers/api/v1/pd/application_serializer_test.rb
@@ -9,7 +9,7 @@ class Api::V1::Pd::ApplicationSerializerTest < ::ActionController::TestCase
   test 'Invalid application data does not break serializer result' do
     # Application data could have more than 1 invalid fields
     app_data = build :pd_teacher_application_hash, course: :csp, school: 'invalid code'
-    app = create :pd_teacher_application, form_data_hash: app_data
+    app = build :pd_teacher_application, form_data_hash: app_data
 
     serialized_app = Api::V1::Pd::ApplicationSerializer.new(app, {scope: {}}).attributes
     assert serialized_app.present?


### PR DESCRIPTION
Minus some standing to-dos, this fulfills _Req 1: Add a “Save and Return Later” Button to the application_. See below for future work.

Current functionality: https://watch.screencastify.com/v/bcDM86nsQ2hZKjqDrUgZ 

I did the following:
- (Frontend): When the user hits "save" or "submit," overwrite whatever status was in form_data to the new status ("incomplete" on save, "unreviewed" on submit)
- (Backend): Use callbacks to ensure updates are happening when a user hits save or a submit. Save a few actions for a completed application only.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- spec: [Saving Progress and Reopening Applications](https://docs.google.com/document/d/1kbRAQ3To-MHVmz2KHnyaN6Mh6EiJk8F_zRNS1F8kSK8/edit?pli=1#heading=h.86qvf1hodt)
- jira ticket: [PLAT-1466](https://codedotorg.atlassian.net/browse/PLAT-1466)

## Testing story

## Deployment strategy

## Follow-up work

In (a) separate PR(s), I'm planning to
- Address the to-dos,
- Address two `assert_nil` warnings in relevant backend tests, and
- Currently, after you save the application, if you then close the window, there's a popup saying, "Are you sure you want to leave? Data might be lost." That shouldn't happen after a save.

## Privacy

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
