### PR TITLE
Temporary workaround for flaky lesson lock tests

### DIFF
--- a/dashboard/test/ui/features/step_definitions/lesson_management_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/lesson_management_steps.rb
@@ -13,6 +13,7 @@ Then /^I open the lesson lock dialog$/ do
   wait_short_until {@browser.execute_script("return $('.uitest-locksettings').length") > 0}
   @browser.execute_script("$('.uitest-locksettings').children().first().click()")
   wait_short_until {jquery_is_element_visible('.modal-body')}
+  sleep 2 # Temporary workaround for LP-2194
 end
 
 Then /^I open the lesson lock dialog for lockable lesson (\d+)$/ do |lockable_lesson_num|
@@ -20,6 +21,7 @@ Then /^I open the lesson lock dialog for lockable lesson (\d+)$/ do |lockable_le
   wait_short_until {@browser.execute_script("return $('.uitest-locksettings').length") > 0}
   @browser.execute_script("$('.uitest-locksettings').eq(#{lockable_lesson_num - 1}).children().first().click()")
   wait_short_until {jquery_is_element_visible('.modal-body')}
+  sleep 2 # Temporary workaround for LP-2194
 end
 
 Then /^I open the send lesson dialog for lesson (\d+)$/ do |lesson_num|
@@ -30,20 +32,16 @@ Then /^I open the send lesson dialog for lesson (\d+)$/ do |lesson_num|
 end
 
 Then /^I unlock the lesson for students$/ do
-  # allow editing
-  @browser.execute_script("$('.modal-body button').first().click()")
-  # save
-  @browser.execute_script('$(".modal-body button:contains(Save)").first().click()')
+  @browser.execute_script("$('.modal-body button:contains(Allow editing)').click()")
+  @browser.execute_script("$('.modal-body button:contains(Save)').click()")
 end
 
 Then /^I lock the lesson for students$/ do
-  # lock assessment
-  @browser.execute_script('$(".modal-body button:contains(Lock)").click()')
-  # save
-  @browser.execute_script('$(".modal-body button:contains(Save)").first().click()')
+  @browser.execute_script("$('.modal-body button:contains(Lock lesson)').click()")
+  @browser.execute_script("$('.modal-body button:contains(Save)').click()")
 end
 
 Then /^I show lesson answers for students$/ do
   @browser.execute_script("$('.modal-body button:contains(Show answers)').click()")
-  @browser.execute_script('$(".modal-body button:contains(Save)").click()')
+  @browser.execute_script("$('.modal-body button:contains(Save)').click()")
 end


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

It turns out that the flaky behavior we've been seeing in the lesson lock tests is a race condition in the product code!  I'm planning to do a deeper fix for that issue that will take a little bit of time.  In the meantime, I'm putting in this temporary workaround (some sleeps) so the tests can be less flaky.  The sleeps will be removed when the full fix (tracked as [LP-2204](https://codedotorg.atlassian.net/browse/LP-2204)) is complete.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [LP-2194](https://codedotorg.atlassian.net/browse/LP-2194)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
