### PR TITLE
Revert "Make sure if is_course for script then set course type fields"

### DIFF
--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -91,33 +91,8 @@ class ScriptsController < ApplicationController
 
   def create
     return head :bad_request unless general_params[:is_migrated]
-
-    # These fields should be set unless a unit is in a unit group
-    # and are required to be set if is_course is true. When creating
-    # a unit it is not yet in a unit group so we set default values here
-    #
-    # Setting default values for the columns would not work because those
-    # are not used when you call new() just when you call create
-    updated_unit_params = unit_params.merge(
-      {
-        published_state: SharedCourseConstants::PUBLISHED_STATE.in_development,
-        instructor_audience: SharedCourseConstants::INSTRUCTOR_AUDIENCE.teacher,
-        participant_audience: SharedCourseConstants::PARTICIPANT_AUDIENCE.student,
-        instruction_type: SharedCourseConstants::INSTRUCTION_TYPE.teacher_led
-      }
-    )
-
-    updated_general_params = general_params.merge(
-      {
-        published_state: SharedCourseConstants::PUBLISHED_STATE.in_development,
-        instructor_audience: SharedCourseConstants::INSTRUCTOR_AUDIENCE.teacher,
-        participant_audience: SharedCourseConstants::PARTICIPANT_AUDIENCE.student,
-        instruction_type: SharedCourseConstants::INSTRUCTION_TYPE.teacher_led
-      }
-    )
-
-    @script = Script.new(updated_unit_params)
-    if @script.save && @script.update_text(unit_params, i18n_params, updated_general_params)
+    @script = Script.new(unit_params)
+    if @script.save && @script.update_text(unit_params, i18n_params, general_params)
       redirect_to edit_script_url(@script), notice: I18n.t('crud.created', model: Script.model_name.human)
     else
       render json: @script.errors

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -158,17 +158,6 @@ class Script < ApplicationRecord
 
   validates :published_state, acceptance: {accept: SharedCourseConstants::PUBLISHED_STATE.to_h.values.push(nil), message: 'must be nil, in_development, pilot, beta, preview or stable'}
 
-  after_save :check_course_type_settings
-
-  def check_course_type_settings
-    if is_course?
-      raise 'Published state must be set on the unit if its a standalone unit.' if published_state.nil?
-      raise 'Instructor audience must be set on the unit if its a standalone unit.' if instructor_audience.nil?
-      raise 'Participant audience must be set on the unit if its a standalone unit.' if participant_audience.nil?
-      raise 'Instruction type must be set on the unit if its a standalone unit.' if instruction_type.nil?
-    end
-  end
-
   def prevent_new_duplicate_levels(old_dup_level_keys = [])
     new_dup_level_keys = duplicate_level_keys - old_dup_level_keys
     raise "new duplicate levels detected in unit: #{new_dup_level_keys}" if new_dup_level_keys.any?

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -238,8 +238,7 @@ class UnitGroup < ApplicationRecord
     new_units_objects.each_with_index do |unit, index|
       unit_group_unit = UnitGroupUnit.find_or_create_by!(unit_group: self, script: unit) do |ugu|
         ugu.position = index + 1
-        unit.update!(published_state: nil, instruction_type: nil, participant_audience: nil, instructor_audience: nil, is_course: false, version_year: nil, family_name: nil)
-        unit.course_version.destroy if unit.course_version
+        unit.update!(published_state: nil, instruction_type: nil, participant_audience: nil, instructor_audience: nil)
       end
       unit_group_unit.update!(position: index + 1)
     end

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -388,10 +388,6 @@ class ScriptsControllerTest < ActionController::TestCase
     unit = Script.find_by_name(unit_name)
     assert_equal unit_name, unit.name
     assert unit.is_migrated
-    assert_equal unit.published_state, SharedCourseConstants::PUBLISHED_STATE.in_development
-    assert_equal unit.instruction_type, SharedCourseConstants::INSTRUCTION_TYPE.teacher_led
-    assert_equal unit.instructor_audience, SharedCourseConstants::INSTRUCTOR_AUDIENCE.teacher
-    assert_equal unit.participant_audience, SharedCourseConstants::PARTICIPANT_AUDIENCE.student
   end
 
   test 'cannot create legacy unit' do
@@ -900,9 +896,6 @@ class ScriptsControllerTest < ActionController::TestCase
       lesson_extras_available: 'on',
       has_verified_resources: 'on',
       published_state: SharedCourseConstants::PUBLISHED_STATE.pilot,
-      instruction_type: SharedCourseConstants::INSTRUCTION_TYPE.teacher_led,
-      participant_audience: SharedCourseConstants::PARTICIPANT_AUDIENCE.student,
-      instructor_audience: SharedCourseConstants::INSTRUCTOR_AUDIENCE.teacher,
       tts: 'on',
       project_sharing: 'on',
       is_course: 'on',

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -792,49 +792,42 @@ FactoryGirl.define do
     factory :csf_script do
       after(:create) do |csf_script|
         csf_script.curriculum_umbrella = SharedCourseConstants::CURRICULUM_UMBRELLA.CSF
-        csf_script.save!
+        csf_script.save
       end
     end
 
     factory :csd_script do
       after(:create) do |csd_script|
         csd_script.curriculum_umbrella = SharedCourseConstants::CURRICULUM_UMBRELLA.CSD
-        csd_script.save!
+        csd_script.save
       end
     end
 
     factory :csp_script do
       after(:create) do |csp_script|
         csp_script.curriculum_umbrella = SharedCourseConstants::CURRICULUM_UMBRELLA.CSP
-        csp_script.save!
+        csp_script.save
       end
     end
 
     factory :csa_script do
       after(:create) do |csa_script|
         csa_script.curriculum_umbrella = SharedCourseConstants::CURRICULUM_UMBRELLA.CSA
-        csa_script.save!
+        csa_script.save
       end
     end
 
     factory :csc_script do
       after(:create) do |csc_script|
         csc_script.curriculum_umbrella = SharedCourseConstants::CURRICULUM_UMBRELLA.CSC
-        csc_script.save!
+        csc_script.save
       end
     end
 
     factory :hoc_script do
       after(:create) do |hoc_script|
         hoc_script.curriculum_umbrella = SharedCourseConstants::CURRICULUM_UMBRELLA.HOC
-        hoc_script.save!
-      end
-    end
-
-    factory :standalone_unit do
-      after(:create) do |standalone_unit|
-        standalone_unit.is_course = true
-        standalone_unit.save!
+        hoc_script.save
       end
     end
   end

--- a/dashboard/test/fixtures/config/scripts_json/test-migrated-models.script_json
+++ b/dashboard/test/fixtures/config/scripts_json/test-migrated-models.script_json
@@ -9,10 +9,6 @@
     },
     "new_name": null,
     "family_name": null,
-    "published_state": "stable",
-    "instruction_type": "teacher_led",
-    "instructor_audience": "teacher",
-    "participant_audience": "student",
     "seeding_key": {
       "script.name": "test-migrated-models"
     }

--- a/dashboard/test/fixtures/test-new-seed-course-offering.script_json
+++ b/dashboard/test/fixtures/test-new-seed-course-offering.script_json
@@ -10,10 +10,6 @@
     },
     "new_name": null,
     "family_name": "xyz",
-    "published_state": "beta",
-    "instruction_type": "teacher_led",
-    "instructor_audience": "teacher",
-    "participant_audience": "student",
     "seeding_key": {
       "script.name": "test-new-seed-course-offering"
     }

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -2197,46 +2197,6 @@ class ScriptTest < ActiveSupport::TestCase
     end
   end
 
-  test 'should raise error if participant audience is nil for standalone unit' do
-    unit = create(:standalone_unit)
-    error = assert_raises do
-      unit.participant_audience = nil
-      unit.save!
-    end
-
-    assert_includes error.message, 'Participant audience must be set on the unit if its a standalone unit.'
-  end
-
-  test 'should raise error if instructor audience is nil for standalone unit' do
-    unit = create(:standalone_unit)
-    error = assert_raises do
-      unit.instructor_audience = nil
-      unit.save!
-    end
-
-    assert_includes error.message, 'Instructor audience must be set on the unit if its a standalone unit.'
-  end
-
-  test 'should raise error if published state is nil for standalone unit' do
-    unit = create(:standalone_unit)
-    error = assert_raises do
-      unit.published_state = nil
-      unit.save!
-    end
-
-    assert_includes error.message, 'Published state must be set on the unit if its a standalone unit.'
-  end
-
-  test 'should raise error if instruction type is nil for standalone unit' do
-    unit = create(:standalone_unit)
-    error = assert_raises do
-      unit.instruction_type = nil
-      unit.save!
-    end
-
-    assert_includes error.message, 'Instruction type must be set on the unit if its a standalone unit.'
-  end
-
   private
 
   def has_unlaunched_unit?(units)

--- a/dashboard/test/models/unit_group_test.rb
+++ b/dashboard/test/models/unit_group_test.rb
@@ -282,22 +282,6 @@ class UnitGroupTest < ActiveSupport::TestCase
       assert_equal 'unit2', unit_group.default_unit_group_units[1].script.name
     end
 
-    test "removes course version for new UnitGroupUnits" do
-      unit_group = create :unit_group
-
-      unit1 = create(:script, name: 'unit1', family_name: 'family-unit1', version_year: '1991', is_course: true)
-      CourseOffering.add_course_offering(unit1)
-
-      unit1.reload
-      assert unit1.course_version
-
-      unit_group.update_scripts(['unit1'])
-
-      unit1.reload
-      assert_nil unit1.published_state
-      refute unit1.course_version
-    end
-
     test "set published state to nil for new UnitGroupUnits" do
       unit_group = create :unit_group
 
@@ -418,50 +402,17 @@ class UnitGroupTest < ActiveSupport::TestCase
     end
 
     test "remove UnitGroupUnits" do
-      unit_group = create(
-        :unit_group,
-        published_state: SharedCourseConstants::PUBLISHED_STATE.in_development,
-        instruction_type: SharedCourseConstants::INSTRUCTION_TYPE.teacher_led,
-        instructor_audience: SharedCourseConstants::INSTRUCTOR_AUDIENCE.teacher,
-        participant_audience: SharedCourseConstants::PARTICIPANT_AUDIENCE.student
-      )
-      unit1 = create(
-        :script,
-        name: 'unit1',
-        published_state: SharedCourseConstants::PUBLISHED_STATE.in_development,
-        instruction_type: SharedCourseConstants::INSTRUCTION_TYPE.teacher_led,
-        instructor_audience: SharedCourseConstants::INSTRUCTOR_AUDIENCE.teacher,
-        participant_audience: SharedCourseConstants::PARTICIPANT_AUDIENCE.student,
-        family_name: 'unit1-family',
-        version_year: '1991',
-        is_course: true
-      )
-      create(:script, name: 'unit2')
+      unit_group = create :unit_group
 
-      unit_group.update_scripts(['unit1', 'unit2'])
-
-      unit1.reload
-
-      assert_nil unit1.published_state
-      assert_nil unit1.instruction_type
-      assert_nil unit1.instructor_audience
-      assert_nil unit1.participant_audience
-      assert_nil unit1.family_name
-      assert_nil unit1.is_course
-      assert_nil unit1.version_year
+      create(:unit_group_unit, unit_group: unit_group, position: 0, script: create(:script, name: 'unit1'))
+      create(:unit_group_unit, unit_group: unit_group, position: 1, script: create(:script, name: 'unit2'))
 
       unit_group.update_scripts(['unit2'])
 
       unit_group.reload
-      unit1.reload
-
       assert_equal 1, unit_group.default_unit_group_units.length
       assert_equal 1, unit_group.default_unit_group_units[0].position
       assert_equal 'unit2', unit_group.default_unit_group_units[0].script.name
-      assert_equal unit1.published_state, SharedCourseConstants::PUBLISHED_STATE.in_development
-      assert_equal unit1.instruction_type, SharedCourseConstants::INSTRUCTION_TYPE.teacher_led
-      assert_equal unit1.instructor_audience, SharedCourseConstants::INSTRUCTOR_AUDIENCE.teacher
-      assert_equal unit1.participant_audience, SharedCourseConstants::PARTICIPANT_AUDIENCE.student
     end
 
     test "removed units have their published state instruction type participant audience and instructor audience reset" do


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#44538.

This (we think) broke Drone. Prepping this revert in case the fix forward in #44683 doesn't work.