### PR TITLE
wrap donor helper methods in CdoDonor class

### DIFF
--- a/dashboard/app/controllers/congrats_controller.rb
+++ b/dashboard/app/controllers/congrats_controller.rb
@@ -2,6 +2,6 @@ class CongratsController < ApplicationController
   def index
     view_options(full_width: true, responsive_content: true, has_i18n: true)
 
-    @random_donor_twitter = get_random_donor_twitter
+    @random_donor_twitter = CdoDonor.get_random_donor_twitter
   end
 end

--- a/dashboard/app/views/teacher_mailer/new_teacher_email.html.haml
+++ b/dashboard/app/views/teacher_mailer/new_teacher_email.html.haml
@@ -76,7 +76,7 @@
 
 %p
   (1)
-  - donor = get_random_donor_name_and_twitter
+  - donor = CdoDonor.get_random_donor_name_and_twitter
   - tweet = "I just signed up to teach computer science using Code.org! Thanks #{donor[:twitter]} for supporting @codeorg."
   %a{href: "https://twitter.com/intent/tweet?text=#{tweet}"} Tweet a message of thanks
   to #{donor[:name]}, one of our donors.

--- a/dashboard/app/views/teacher_mailer/new_teacher_email_es-MX.html.haml
+++ b/dashboard/app/views/teacher_mailer/new_teacher_email_es-MX.html.haml
@@ -67,7 +67,7 @@
   PD Si disfrutas de Code.org, puedes apoyarnos de manera gratuita:
 %p
   (1)
-  - donor = get_random_donor_name_and_twitter
+  - donor = CdoDonor.get_random_donor_name_and_twitter
   - tweet = "¡Acabo de registrarme para enseñar ciencias de la computación con Code.org! Gracias a #{donor[:twitter]} por apoyar a @codeorg."
   %a{href: "https://twitter.com/intent/tweet?text=#{tweet}"} Envía un mensaje de agradecimiento
   a #{donor[:name]}, uno de nuestros donantes.

--- a/lib/cdo/graphics/certificate_image.rb
+++ b/lib/cdo/graphics/certificate_image.rb
@@ -165,8 +165,7 @@ class CertificateImage
     end
 
     unless sponsor
-      weight = SecureRandom.random_number
-      donor = DB[:cdo_donors].all.find {|d| d[:weight_f] - weight >= 0}
+      donor = CdoDonor.get_random_donor_by_weight
       sponsor = donor[:name_s]
     end
 

--- a/lib/cdo/pegasus/donor.rb
+++ b/lib/cdo/pegasus/donor.rb
@@ -2,7 +2,7 @@ require 'honeybadger/ruby'
 
 # Returns a random donor's twitter handle.
 def get_random_donor_twitter
-  donor, weight = get_random_donor
+  donor, weight = get_random_donor_by_twitter_weight
   if donor && donor[:twitter_s]
     donor[:twitter_s]
   else
@@ -13,7 +13,7 @@ end
 
 # @return [Hash] a donor name and their twitter handle
 def get_random_donor_name_and_twitter
-  donor, weight = get_random_donor
+  donor, weight = get_random_donor_by_twitter_weight
   if donor && donor[:twitter_s]
     {
       name: donor[:name_s],
@@ -29,7 +29,7 @@ def get_random_donor_name_and_twitter
 end
 
 # @return [Array] a donor record and the random weight used to find that record
-def get_random_donor
+def get_random_donor_by_twitter_weight
   weight = SecureRandom.random_number
   donor = DB[:cdo_donors].all.find {|d| d[:twitter_weight_f] - weight >= 0}
   [donor, weight]

--- a/lib/cdo/pegasus/donor.rb
+++ b/lib/cdo/pegasus/donor.rb
@@ -42,4 +42,9 @@ class CdoDonor
       error_message: donor ? "Donor returned nil for weight #{weight}" : "Twitter handle was nil for donor #{donor}"
     )
   end
+
+  def self.get_random_donor_by_weight
+    weight = SecureRandom.random_number
+    DB[:cdo_donors].all.find {|d| d[:weight_f] - weight >= 0}
+  end
 end

--- a/lib/cdo/pegasus/donor.rb
+++ b/lib/cdo/pegasus/donor.rb
@@ -1,43 +1,45 @@
 require 'honeybadger/ruby'
 
-# Returns a random donor's twitter handle.
-def get_random_donor_twitter
-  donor, weight = get_random_donor_by_twitter_weight
-  if donor && donor[:twitter_s]
-    donor[:twitter_s]
-  else
-    report_failure(donor, weight)
-    '@microsoft'
+class CdoDonor
+  # Returns a random donor's twitter handle.
+  def self.get_random_donor_twitter
+    donor, weight = get_random_donor_by_twitter_weight
+    if donor && donor[:twitter_s]
+      donor[:twitter_s]
+    else
+      report_failure(donor, weight)
+      '@microsoft'
+    end
   end
-end
 
-# @return [Hash] a donor name and their twitter handle
-def get_random_donor_name_and_twitter
-  donor, weight = get_random_donor_by_twitter_weight
-  if donor && donor[:twitter_s]
-    {
-      name: donor[:name_s],
-      twitter: donor[:twitter_s]
-    }
-  else
-    report_failure(donor, weight)
-    {
-      name: 'Microsoft',
-      twitter: '@microsoft'
-    }
+  # @return [Hash] a donor name and their twitter handle
+  def self.get_random_donor_name_and_twitter
+    donor, weight = get_random_donor_by_twitter_weight
+    if donor && donor[:twitter_s]
+      {
+        name: donor[:name_s],
+        twitter: donor[:twitter_s]
+      }
+    else
+      report_failure(donor, weight)
+      {
+        name: 'Microsoft',
+        twitter: '@microsoft'
+      }
+    end
   end
-end
 
-# @return [Array] a donor record and the random weight used to find that record
-def get_random_donor_by_twitter_weight
-  weight = SecureRandom.random_number
-  donor = DB[:cdo_donors].all.find {|d| d[:twitter_weight_f] - weight >= 0}
-  [donor, weight]
-end
+  # @return [Array] a donor record and the random weight used to find that record
+  def self.get_random_donor_by_twitter_weight
+    weight = SecureRandom.random_number
+    donor = DB[:cdo_donors].all.find {|d| d[:twitter_weight_f] - weight >= 0}
+    [donor, weight]
+  end
 
-def report_failure(donor, weight)
-  Honeybadger.notify(
-    error_class: 'Failed to pull a random donor twitter handle',
-    error_message: donor ? "Donor returned nil for weight #{weight}" : "Twitter handle was nil for donor #{donor}"
-  )
+  def self.report_failure(donor, weight)
+    Honeybadger.notify(
+      error_class: 'Failed to pull a random donor twitter handle',
+      error_message: donor ? "Donor returned nil for weight #{weight}" : "Twitter handle was nil for donor #{donor}"
+    )
+  end
 end

--- a/lib/cdo/pegasus/donor.rb
+++ b/lib/cdo/pegasus/donor.rb
@@ -32,7 +32,7 @@ class CdoDonor
   # @return [Array] a donor record and the random weight used to find that record
   def self.get_random_donor_by_twitter_weight
     weight = SecureRandom.random_number
-    donor = DB[:cdo_donors].all.find {|d| d[:twitter_weight_f] - weight >= 0}
+    donor = all_donors.find {|d| d[:twitter_weight_f] - weight >= 0}
     [donor, weight]
   end
 
@@ -45,6 +45,10 @@ class CdoDonor
 
   def self.get_random_donor_by_weight
     weight = SecureRandom.random_number
-    DB[:cdo_donors].all.find {|d| d[:weight_f] - weight >= 0}
+    all_donors.find {|d| d[:weight_f] - weight >= 0}
+  end
+
+  def self.all_donors
+    @@all_donors ||= DB[:cdo_donors].all
   end
 end

--- a/pegasus/sites.v3/code.org/public/about/careers.md.erb
+++ b/pegasus/sites.v3/code.org/public/about/careers.md.erb
@@ -14,7 +14,7 @@ theme: responsive
 
   <div class="col-50 careers-video">
     <% facebook = {:u=>'https://youtu.be/mTGSiB4kB18'} %>
-    <% twitter = {:url=>'https://youtu.be/mTGSiB4kB18', :related=>'codeorg', :text=>"Meet the team at @codeorg and see how much they’ve done! (Thanks #{get_random_donor_twitter} for supporting @codeorg)"} %>
+    <% twitter = {:url=>'https://youtu.be/mTGSiB4kB18', :related=>'codeorg', :text=>"Meet the team at @codeorg and see how much they’ve done! (Thanks #{CdoDonor.get_random_donor_twitter} for supporting @codeorg)"} %>
     <%=view :display_video_thumbnail, id: "codeorg_recruiting", video_code: "mTGSiB4kB18", play_button: 'center', facebook: facebook, twitter: twitter, letterbox: "false", download_path: "http://videos.code.org/social/about-codeorg.mp4" %>
   </div>
 
@@ -107,7 +107,7 @@ Code.org is based in Seattle, but many of our team members are remote; remote ca
 
 _We embrace diverse perspectives, ideas, and backgrounds at Code.org. We are committed to providing an equal opportunity to all employees and applicants. We do not discriminate on the basis of race, religion, color, national origin, gender, sexual orientation, age, marital status, veteran status, or disability (mental and physical) status._
 
-_We will ensure that individuals with disabilities are provided reasonable accommodation to participate in the job application or interview process, to perform essential job functions, and to receive other benefits and privileges of employment. If you have individual needs related to a disability, please reach out to accommodations@code.org_ 
+_We will ensure that individuals with disabilities are provided reasonable accommodation to participate in the job application or interview process, to perform essential job functions, and to receive other benefits and privileges of employment. If you have individual needs related to a disability, please reach out to accommodations@code.org_
 
 <div class="careers__banner--faq" style="margin-top: 28px">
   <i class="fa fa-question-circle-o"></i>

--- a/pegasus/sites.v3/code.org/public/about/index-old.erb.md.erb
+++ b/pegasus/sites.v3/code.org/public/about/index-old.erb.md.erb
@@ -15,7 +15,7 @@ style_min: true
 <div style="float: left; width: 280px; margin-right: 5%;">
 
 <% facebook = {:u=>'https://youtu.be/mTGSiB4kB18'} %>
-<% twitter = {:url=>'https://youtu.be/mTGSiB4kB18', :related=>'codeorg', :text=>"Meet the team at @codeorg and see how much they’ve done! (Thanks #{get_random_donor_twitter} for supporting @codeorg)"} %>
+<% twitter = {:url=>'https://youtu.be/mTGSiB4kB18', :related=>'codeorg', :text=>"Meet the team at @codeorg and see how much they’ve done! (Thanks #{CdoDonor.get_random_donor_twitter} for supporting @codeorg)"} %>
 
 <%=view :display_video_thumbnail, id: "codeorg_recruiting", video_code: "mTGSiB4kB18", play_button: 'center', facebook: facebook, twitter: twitter, letterbox: "false", download_path: "http://videos.code.org/social/about-codeorg.mp4" %>
 

--- a/pegasus/sites.v3/code.org/public/about/index.md.erb
+++ b/pegasus/sites.v3/code.org/public/about/index.md.erb
@@ -15,7 +15,7 @@ style_min: true
 <div style="float: left; width: 280px; margin-right: 5%;">
 
 <% facebook = {:u=>'https://youtu.be/mTGSiB4kB18'} %>
-<% twitter = {:url=>'https://youtu.be/mTGSiB4kB18', :related=>'codeorg', :text=>"Meet the team at @codeorg and see how much they’ve done! (Thanks #{get_random_donor_twitter} for supporting @codeorg)"} %>
+<% twitter = {:url=>'https://youtu.be/mTGSiB4kB18', :related=>'codeorg', :text=>"Meet the team at @codeorg and see how much they’ve done! (Thanks #{CdoDonor.get_random_donor_twitter} for supporting @codeorg)"} %>
 
 <%=view :display_video_thumbnail, id: "codeorg_recruiting", video_code: "mTGSiB4kB18", play_button: 'center', facebook: facebook, twitter: twitter, letterbox: "false", download_path: "http://videos.code.org/social/about-codeorg.mp4" %>
 

--- a/pegasus/sites.v3/code.org/public/about/index.md.erb.backup
+++ b/pegasus/sites.v3/code.org/public/about/index.md.erb.backup
@@ -15,7 +15,7 @@ style_min: true
 <div style="float: left; width: 280px; margin-right: 5%;">
 
 <% facebook = {:u=>'https://youtu.be/mTGSiB4kB18'} %>
-<% twitter = {:url=>'https://youtu.be/mTGSiB4kB18', :related=>'codeorg', :text=>"Meet the team at @codeorg and see how much they’ve done! (Thanks #{get_random_donor_twitter} for supporting @codeorg)"} %>
+<% twitter = {:url=>'https://youtu.be/mTGSiB4kB18', :related=>'codeorg', :text=>"Meet the team at @codeorg and see how much they’ve done! (Thanks #{CdoDonor.get_random_donor_twitter} for supporting @codeorg)"} %>
 
 <%=view :display_video_thumbnail, id: "codeorg_recruiting", video_code: "mTGSiB4kB18", play_button: 'center', facebook: facebook, twitter: twitter, letterbox: "false", download_path: "http://videos.code.org/social/about-codeorg.mp4" %>
 

--- a/pegasus/sites.v3/code.org/public/about/work-with-us.md.erb
+++ b/pegasus/sites.v3/code.org/public/about/work-with-us.md.erb
@@ -26,7 +26,7 @@ Help us change the world, one student at a time
 <div class="col-50" style="padding-right: 10px">
 
 <% facebook = {:u=>'https://youtu.be/mTGSiB4kB18'} %>
-<% twitter = {:url=>'https://youtu.be/mTGSiB4kB18', :related=>'codeorg', :text=>"Meet the team at @codeorg and see how much they’ve done! (Thanks #{get_random_donor_twitter} for supporting @codeorg)"} %>
+<% twitter = {:url=>'https://youtu.be/mTGSiB4kB18', :related=>'codeorg', :text=>"Meet the team at @codeorg and see how much they’ve done! (Thanks #{CdoDonor.get_random_donor_twitter} for supporting @codeorg)"} %>
 
 
 <%=view :display_video_thumbnail, id: "codeorg_recruiting", video_code: "mTGSiB4kB18", play_button: 'center', facebook: facebook, twitter: twitter, letterbox: "false", download_path: "http://videos.code.org/social/about-codeorg.mp4" %>
@@ -127,7 +127,7 @@ Growth and Learning Opportunities
 <h1 class="backgroundimage" style="color:white;">
 Come Work with Us
 </h1>
-## We are currently hiring for: 
+## We are currently hiring for:
 <div id='lever-jobs-container'></div>
 <script type='text/javascript'>
 

--- a/pegasus/sites.v3/code.org/public/athletes.haml
+++ b/pegasus/sites.v3/code.org/public/athletes.haml
@@ -35,7 +35,7 @@ video_player: true
     %h2= I18n.t(:sports_video_title)
     - url = "https://www.youtube.com/watch?v=ip051U7Rvds"
     - facebook = {u: url}
-    - twitter = {url: url, related: 'codeorg', text: "#{I18n.t(:sports_og_description)} (Thanks #{get_random_donor_twitter} for supporting @codeorg)"}
+    - twitter = {url: url, related: 'codeorg', text: "#{I18n.t(:sports_og_description)} (Thanks #{CdoDonor.get_random_donor_twitter} for supporting @codeorg)"}
     - if %w(es-ES es-MX).include? request.locale
       = view :display_video_thumbnail, id: 'athletes_video_es', video_code: 'f6pwwPnx7B4', play_button: 'center', facebook: facebook, twitter: twitter, download_path: '//videos.code.org/social/athletes-hour-of-code-es.mp4', letterbox: 'false'
     - else
@@ -75,7 +75,7 @@ video_player: true
       .col-50{style: "float:left; padding:10px"}
         - url = "https://www.youtube.com/watch?v=#{video[:code]}"
         - facebook = {u: url}
-        - twitter = {url: url, related: 'codeorg', text: "#{video[:text]} (Thanks #{get_random_donor_twitter} for supporting @codeorg)"}
+        - twitter = {url: url, related: 'codeorg', text: "#{video[:text]} (Thanks #{CdoDonor.get_random_donor_twitter} for supporting @codeorg)"}
         = view :display_video_thumbnail, id: video[:id], video_code: video[:code], caption: "#{video[:text]} (#{video[:duration]})", play_button: 'center', facebook: facebook, twitter: twitter, download_path: video[:download], letterbox: 'false'
 
     %div{style: 'clear: both'}

--- a/pegasus/sites.v3/code.org/public/congrats.haml
+++ b/pegasus/sites.v3/code.org/public/congrats.haml
@@ -29,7 +29,7 @@ max_age: 60
   end
 
   facebook = {:u=>share_url}
-  twitter_message = I18n.t('just_did_hoc_donor', donor_twitter: get_random_donor_twitter)
+  twitter_message = I18n.t('just_did_hoc_donor', donor_twitter: CdoDonor.get_random_donor_twitter)
   twitter = {:url=>share_url, :related=>'codeorg', :text=>twitter_message}
   twitter[:hashtags] = 'HourOfCode' unless twitter_message.include? '#HourOfCode'
 

--- a/pegasus/sites.v3/code.org/public/educate/csf.md.erb
+++ b/pegasus/sites.v3/code.org/public/educate/csf.md.erb
@@ -25,11 +25,11 @@ CS Fundamentals for Elementary Schools
 <div class="col-50" style="padding-right: 20px; float: left; margin-top: 10px">
 
 <% facebook = {:u=>'https://youtu.be/rNIM1fzJ8u0'} %>
-<% twitter = {:url=>'https://youtu.be/rNIM1fzJ8u0', :related=>'codeorg', :text=>"Introduction to CS Fundamentals. (Thanks #{get_random_donor_twitter} for supporting @codeorg)"} %>
+<% twitter = {:url=>'https://youtu.be/rNIM1fzJ8u0', :related=>'codeorg', :text=>"Introduction to CS Fundamentals. (Thanks #{CdoDonor.get_random_donor_twitter} for supporting @codeorg)"} %>
 <%=view :display_video_thumbnail, id: "introK5", video_code: "rNIM1fzJ8u0", play_button: 'center', facebook: facebook, twitter: twitter, letterbox: 'false' %>
 
 <a href="https://code.org/professional-development-workshops"><button>Learn about professional learning!</button></a>
-<a href="https://code.org/educate/curriculum/csf"><button>View full curriculum</button></a> 
+<a href="https://code.org/educate/curriculum/csf"><button>View full curriculum</button></a>
 </div>
 
 
@@ -64,7 +64,7 @@ Recent research also demonstrates positive links between learning computer scien
 
 Each course includes comprehensive lesson plans, plugged and unplugged activities, and support resources for teachers. You don't even need a user account to [try it out](https://code.org/educate/curriculum/csf). Once you get a feel for the courses and lesson plans, [sign up as a teacher](https://studio.code.org/users/sign_up) to join the teacher community forums and engage with all the resources at your fingertips. Next, quickly set up a classroom section from your roster or sync with tools like Clever or Google Classroom to view student progress and manage accounts. Then celebrate your students' learning by printing certificates they can bring home.
 
-CS Fundamentals is aligned to the 2017 [Computer Science Teachers Association (CSTA) standards](https://www.csteachers.org/page/standards). Lesson plans identify connections to CSTA standards and provide opportunities to support learning in other subjects. CS Fundamentals standards alignments can be accessed in each course of the [curriculum] (https://code.org/educate/curriculum/csf). 
+CS Fundamentals is aligned to the 2017 [Computer Science Teachers Association (CSTA) standards](https://www.csteachers.org/page/standards). Lesson plans identify connections to CSTA standards and provide opportunities to support learning in other subjects. CS Fundamentals standards alignments can be accessed in each course of the [curriculum] (https://code.org/educate/curriculum/csf).
 
 ## And, did we mention that it's fun!?
 

--- a/pegasus/sites.v3/code.org/public/educate/curriculum/elementary-school-old.md.erb
+++ b/pegasus/sites.v3/code.org/public/educate/curriculum/elementary-school-old.md.erb
@@ -25,11 +25,11 @@ CS Fundamentals for Elementary Schools
 <div class="col-50" style="padding-right: 20px; float: left; margin-top: 10px">
 
 <% facebook = {:u=>'https://youtu.be/rNIM1fzJ8u0'} %>
-<% twitter = {:url=>'https://youtu.be/rNIM1fzJ8u0', :related=>'codeorg', :text=>"Introduction to CS Fundamentals. (Thanks #{get_random_donor_twitter} for supporting @codeorg)"} %>
+<% twitter = {:url=>'https://youtu.be/rNIM1fzJ8u0', :related=>'codeorg', :text=>"Introduction to CS Fundamentals. (Thanks #{CdoDonor.get_random_donor_twitter} for supporting @codeorg)"} %>
 <%=view :display_video_thumbnail, id: "introK5", video_code: "rNIM1fzJ8u0", play_button: 'center', facebook: facebook, twitter: twitter, letterbox: 'false' %>
 
 <a href="https://code.org/professional-development-workshops"><button>Learn about professional learning!</button></a>
-<a href="https://code.org/educate/curriculum/csf"><button>View full curriculum</button></a> 
+<a href="https://code.org/educate/curriculum/csf"><button>View full curriculum</button></a>
 </div>
 
 
@@ -64,7 +64,7 @@ Recent research also demonstrates positive links between learning computer scien
 
 Each course includes comprehensive lesson plans, plugged and unplugged activities, and support resources for teachers. You don't even need a user account to [try it out](https://code.org/educate/curriculum/csf). Once you get a feel for the courses and lesson plans, [sign up as a teacher](https://studio.code.org/users/sign_up) to join the teacher community forums and engage with all the resources at your fingertips. Next, quickly set up a classroom section from your roster or sync with tools like Clever or Google Classroom to view student progress and manage accounts. Then celebrate your students' learning by printing certificates they can bring home.
 
-CS Fundamentals is aligned to the 2017 [Computer Science Teachers Association (CSTA) standards](https://www.csteachers.org/page/standards). Lesson plans identify connections to CSTA standards and provide opportunities to support learning in other subjects. CS Fundamentals standards alignments can be accessed in each course of the [curriculum] (https://code.org/educate/curriculum/csf). 
+CS Fundamentals is aligned to the 2017 [Computer Science Teachers Association (CSTA) standards](https://www.csteachers.org/page/standards). Lesson plans identify connections to CSTA standards and provide opportunities to support learning in other subjects. CS Fundamentals standards alignments can be accessed in each course of the [curriculum] (https://code.org/educate/curriculum/csf).
 
 ## And, did we mention that it's fun!?
 

--- a/pegasus/sites.v3/code.org/public/educate/curriculum/elementary-school.md.erb
+++ b/pegasus/sites.v3/code.org/public/educate/curriculum/elementary-school.md.erb
@@ -21,16 +21,16 @@ Our curriculum is available at [no cost](/commitment) for anyone, anywhere to te
 
 Did you know that computer science fosters creativity and <a href="https://code.org/educate/curriculum/elementary-school#research">teaches students critical thinking skills</a> to become proactive learners? That’s why elementary school is the ideal time for students to be introduced to CS! <a href="https://medium.com/@codeorg/cs-helps-students-outperform-in-school-college-and-workplace-66dd64a69536">Six different studies show:</a> children who study computer science perform better in other subjects, excel at problem-solving, and are 17% more likely to attend college.
 
-# Computer Science Fundamentals 
+# Computer Science Fundamentals
 
 <div class="col-50" style="padding-right: 20px; float: left; margin-top: 10px">
 
 <% facebook = {:u=>'https://youtu.be/rNIM1fzJ8u0'} %>
-<% twitter = {:url=>'https://youtu.be/rNIM1fzJ8u0', :related=>'codeorg', :text=>"Introduction to CS Fundamentals. (Thanks #{get_random_donor_twitter} for supporting @codeorg)"} %>
+<% twitter = {:url=>'https://youtu.be/rNIM1fzJ8u0', :related=>'codeorg', :text=>"Introduction to CS Fundamentals. (Thanks #{CdoDonor.get_random_donor_twitter} for supporting @codeorg)"} %>
 <%=view :display_video_thumbnail, id: "introK5", video_code: "rNIM1fzJ8u0", play_button: 'center', facebook: facebook, twitter: twitter, letterbox: 'false' %>
 
 <a href="https://code.org/professional-development-workshops"><button>Learn about professional learning!</button></a>
-<a href="https://code.org/educate/curriculum/csf"><button>View full curriculum</button></a> 
+<a href="https://code.org/educate/curriculum/csf"><button>View full curriculum</button></a>
 </div>
 
 
@@ -59,7 +59,7 @@ This curriculum allows students to learn computer science concepts at the same t
 <br>
 The curriculum has options for teachers  who’d like to incorporate computer science into their lesson plans for other subjects, as well as CS educators who want to reinforce what students are learning in other subjects. <br>
 <br>
-<a href="https://code.org/educate/csc"><button>Learn more</button></a> 
+<a href="https://code.org/educate/csc"><button>Learn more</button></a>
 </div>
 </div>
 <div style="clear: both;"></div>

--- a/pegasus/sites.v3/code.org/public/educate/curriculum/middle-school-alt.md.erb
+++ b/pegasus/sites.v3/code.org/public/educate/curriculum/middle-school-alt.md.erb
@@ -22,7 +22,7 @@ Our curriculum is available at [no cost](/commitment) for anyone, anywhere to te
 <div class="col-40" style="padding-right: 10px;">
 
 <% facebook = {:u=>'https://youtu.be/2-QpgNHknds'} %>
-<% twitter = {:url=>'https://youtu.be/2-QpgNHknds', :related=>'codeorg', :text=>"Computer Science Discoveries. (Thanks #{get_random_donor_twitter} for supporting @codeorg)"} %>
+<% twitter = {:url=>'https://youtu.be/2-QpgNHknds', :related=>'codeorg', :text=>"Computer Science Discoveries. (Thanks #{CdoDonor.get_random_donor_twitter} for supporting @codeorg)"} %>
 <%=view :display_video_thumbnail, id: "intro_csd", video_code: "2-QpgNHknds", play_button: 'center', letterbox: 'false', twitter: twitter, facebook: facebook%>
 
 </div>

--- a/pegasus/sites.v3/code.org/public/educate/curriculum/middle-school.md.erb
+++ b/pegasus/sites.v3/code.org/public/educate/curriculum/middle-school.md.erb
@@ -22,7 +22,7 @@ Our curriculum is available at [no cost](/commitment) for anyone, anywhere to te
 <div class="col-40" style="padding-right: 10px;">
 
 <% facebook = {:u=>'https://youtu.be/2-QpgNHknds'} %>
-<% twitter = {:url=>'https://youtu.be/2-QpgNHknds', :related=>'codeorg', :text=>"Computer Science Discoveries. (Thanks #{get_random_donor_twitter} for supporting @codeorg)"} %>
+<% twitter = {:url=>'https://youtu.be/2-QpgNHknds', :related=>'codeorg', :text=>"Computer Science Discoveries. (Thanks #{CdoDonor.get_random_donor_twitter} for supporting @codeorg)"} %>
 <%=view :display_video_thumbnail, id: "intro_csd", video_code: "2-QpgNHknds", play_button: 'center', letterbox: 'false', twitter: twitter, facebook: facebook%>
 
 </div>

--- a/pegasus/sites.v3/code.org/public/leaderboards.haml
+++ b/pegasus/sites.v3/code.org/public/leaderboards.haml
@@ -13,7 +13,7 @@ social:
   "twitter:image:width" : 759
   "twitter:image:height" : 208
 ---
--twitter_message = I18n.t('who_has_done_hoc_donor', donor_twitter: get_random_donor_twitter)
+-twitter_message = I18n.t('who_has_done_hoc_donor', donor_twitter: CdoDonor.get_random_donor_twitter)
 -facebook = {:u=>"https://www.facebook.com/photo.php?fbid=521364791293162"}
 -twitter = {:url=>"http://#{request.site}/leaderboards", :related=>'codeorg', :hashtags=>'', :text=>twitter_message}
 -twitter[:hashtags] = 'HourOfCode' unless twitter_message.include? '#HourOfCode'

--- a/pegasus/sites.v3/code.org/public/promote/splat.haml
+++ b/pegasus/sites.v3/code.org/public/promote/splat.haml
@@ -14,7 +14,7 @@ theme: responsive
 ---
 -state = File.basename(request.path_info)
 -facebook = {:u=>'https://code.org/promote' + (state != "thanks" ? "/" + state : "")}
--twitter = {:url=>"https://code.org/promote", :related=>'codeorg', :text=>"Most schools don't teach computer science. To help, sign the petition. (Thanks #{get_random_donor_twitter} for supporting @codeorg)"}
+-twitter = {:url=>"https://code.org/promote", :related=>'codeorg', :text=>"Most schools don't teach computer science. To help, sign the petition. (Thanks #{CdoDonor.get_random_donor_twitter} for supporting @codeorg)"}
 
 %script{:src=>"/js/jquery.placeholder.js"}
 %link{:href=>"/css/promote.css", :rel=>"stylesheet"}

--- a/pegasus/sites.v3/code.org/views/csd_information.md.erb
+++ b/pegasus/sites.v3/code.org/views/csd_information.md.erb
@@ -1,7 +1,7 @@
 <div class="col-40" style="padding-right: 10px;">
 
 <% facebook = {:u=>'https://youtu.be/2-QpgNHknds'} %>
-<% twitter = {:url=>'https://youtu.be/2-QpgNHknds', :related=>'codeorg', :text=>"Computer Science Discoveries. (Thanks #{get_random_donor_twitter} for supporting @codeorg)"} %>
+<% twitter = {:url=>'https://youtu.be/2-QpgNHknds', :related=>'codeorg', :text=>"Computer Science Discoveries. (Thanks #{CdoDonor.get_random_donor_twitter} for supporting @codeorg)"} %>
 <%=view :display_video_thumbnail, id: "intro_csd", video_code: "2-QpgNHknds", play_button: 'center', letterbox: 'false', twitter: twitter, facebook: facebook %>
 
 </div>

--- a/pegasus/sites.v3/code.org/views/csf_congrats.haml
+++ b/pegasus/sites.v3/code.org/views/csf_congrats.haml
@@ -10,7 +10,7 @@
   twitter = {
     :url=>share_url,
     :related=>'codeorg',
-    :text=> I18n.t(:"just_did_course_donor", donor_twitter: get_random_donor_twitter, course: course_name)
+    :text=> I18n.t(:"just_did_course_donor", donor_twitter: CdoDonor.get_random_donor_twitter, course: course_name)
   }
 
   rec_code_studio = ScriptConstants.csf_next_course_recommendation(course)

--- a/pegasus/sites.v3/code.org/views/csp_information.md.erb
+++ b/pegasus/sites.v3/code.org/views/csp_information.md.erb
@@ -1,7 +1,7 @@
 <div class="col-40" style="padding-right:10px;">
 
 <% facebook = {:u=>'https://youtu.be/DMr1iFYacGQ'} %>
-<% twitter = {:url=>'https://youtu.be/DMr1iFYacGQ', :related=>'codeorg', :text=>"Computer Science Principles. (Thanks #{get_random_donor_twitter} for supporting @codeorg)"} %>
+<% twitter = {:url=>'https://youtu.be/DMr1iFYacGQ', :related=>'codeorg', :text=>"Computer Science Principles. (Thanks #{CdoDonor.get_random_donor_twitter} for supporting @codeorg)"} %>
 <%=view :display_video_thumbnail, id: "CSPrinciples", video_code: "DMr1iFYacGQ", play_button: 'center', facebook: facebook, twitter: twitter, letterbox: 'false' %>
 
 </div>
@@ -11,7 +11,7 @@
 Designed for 9 - 12 grade students, CS Principles introduces students to the foundational concepts of computer science and challenges them to explore how computing and technology can impact the world. This year-long course can be taught as an introductory course and as an AP course - no prerequisites required for students or teachers new to computer science! CS Principles complements CS Discoveries with a deeper focus on concepts such as how the internet works and the societal impacts of computer science.
 
 <% facebook = {:u=>'https://youtu.be/DMr1iFYacGQ'} %>
-<% twitter = {:url=>'https://youtu.be/DMr1iFYacGQ', :related=>'codeorg', :text=>"Computer Science Principles. (Thanks #{get_random_donor_twitter} for supporting @codeorg)"} %>
+<% twitter = {:url=>'https://youtu.be/DMr1iFYacGQ', :related=>'codeorg', :text=>"Computer Science Principles. (Thanks #{CdoDonor.get_random_donor_twitter} for supporting @codeorg)"} %>
 
 [<button>Learn about CS Principles</button>](/educate/csp)
 &nbsp;

--- a/pegasus/sites.v3/code.org/views/dance_creativity_video.haml
+++ b/pegasus/sites.v3/code.org/views/dance_creativity_video.haml
@@ -5,5 +5,5 @@
   .col-50{style: "float:left; padding:10px"}
     - url = "https://www.youtube.com/watch?v=#{video[:code]}"
     - facebook = {u: url}
-    - twitter = {url: url, related: 'codeorg', text: "#{video[:text]} (Thanks #{get_random_donor_twitter} for supporting @codeorg)"}
+    - twitter = {url: url, related: 'codeorg', text: "#{video[:text]} (Thanks #{CdoDonor.get_random_donor_twitter} for supporting @codeorg)"}
     =view :display_video_thumbnail, id: video[:id], video_code: video[:code], caption: "#{video[:text]} (#{video[:duration]})", play_button: 'center', facebook: facebook, twitter: twitter, download_path: video[:download]

--- a/pegasus/sites.v3/code.org/views/dance_videos.haml
+++ b/pegasus/sites.v3/code.org/views/dance_videos.haml
@@ -14,7 +14,7 @@
   .col-50{style: "float:left; padding:10px"}
     - url = "https://www.youtube.com/watch?v=#{video[:code]}"
     - facebook = {u: url}
-    - twitter = {url: url, related: 'codeorg', text: "#{video[:text]} (Thanks #{get_random_donor_twitter} for supporting @codeorg)"}
+    - twitter = {url: url, related: 'codeorg', text: "#{video[:text]} (Thanks #{CdoDonor.get_random_donor_twitter} for supporting @codeorg)"}
     =view :display_video_thumbnail, id: video[:id], video_code: video[:code], caption: "#{video[:text]} (#{video[:duration]})", play_button: 'center', facebook: facebook, twitter: twitter, download_path: video[:download]
 
 %div{style: 'clear: both'}

--- a/pegasus/sites.v3/code.org/views/inspirational_videos.haml
+++ b/pegasus/sites.v3/code.org/views/inspirational_videos.haml
@@ -14,7 +14,7 @@
   .col-50{style: "float:left; padding:10px"}
     - url = "https://www.youtube.com/watch?v=#{video[:code]}"
     - facebook = {u: url}
-    - twitter = {url: url, related: 'codeorg', text: "#{video[:text]} (Thanks #{get_random_donor_twitter} for supporting @codeorg)"}
+    - twitter = {url: url, related: 'codeorg', text: "#{video[:text]} (Thanks #{CdoDonor.get_random_donor_twitter} for supporting @codeorg)"}
     =view :display_video_thumbnail, id: video[:id], video_code: video[:code], caption: "#{video[:text]} (#{video[:duration]})", play_button: 'center', facebook: facebook, twitter: twitter, download_path: video[:download]
 
 %div{style: 'clear: both'}

--- a/pegasus/sites.v3/code.org/views/stats_carousel.haml
+++ b/pegasus/sites.v3/code.org/views/stats_carousel.haml
@@ -1,6 +1,6 @@
 -statistics = DB[:cdo_cs_statistics].all.to_a
 -facebook = {:u=>'http://code.org/stats'}
--twitter = {:url=>"https://#{request.site}/promote", :related=>'codeorg', :text=>"Most schools don't teach computer science. To help, sign the petition. (Thanks #{get_random_donor_twitter} for supporting @codeorg)"}
+-twitter = {:url=>"https://#{request.site}/promote", :related=>'codeorg', :text=>"Most schools don't teach computer science. To help, sign the petition. (Thanks #{CdoDonor.get_random_donor_twitter} for supporting @codeorg)"}
 
 #stats-carousel-wrapper.carousel-wrapper
   #stats-carousel.carousel

--- a/pegasus/sites.v3/hourofcode.com/views/promote/share_buttons.erb
+++ b/pegasus/sites.v3/hourofcode.com/views/promote/share_buttons.erb
@@ -1,7 +1,7 @@
 <%
   facebook = {:u=>"http://#{request.host}/us"}
 
-  twitter = {:url=>"http://hourofcode.com", :related=>'codeorg', :hashtags=>'', :text=>hoc_s(:twitter_default_text_donor, locals: {random_donor: get_random_donor_twitter})}
+  twitter = {:url=>"http://hourofcode.com", :related=>'codeorg', :hashtags=>'', :text=>hoc_s(:twitter_default_text_donor, locals: {random_donor: CdoDonor.get_random_donor_twitter})}
   twitter[:hashtags] = 'HourOfCode' unless hoc_s(:twitter_default_text_donor).include? '#HourOfCode'
 %>
 

--- a/pegasus/sites.v3/hourofcode.com/views/social_media_hoc.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/social_media_hoc.haml
@@ -1,4 +1,4 @@
 - facebook = {:u=>"http://#{request.host}/us"}
-- twitter = {:url=>"http://hourofcode.com", :related=>'codeorg', :hashtags=>'', :text=>hoc_s(:twitter_default_text_donor, locals: {random_donor: get_random_donor_twitter})}
+- twitter = {:url=>"http://hourofcode.com", :related=>'codeorg', :hashtags=>'', :text=>hoc_s(:twitter_default_text_donor, locals: {random_donor: CdoDonor.get_random_donor_twitter})}
 - twitter[:hashtags] = 'HourOfCode' unless hoc_s(:twitter_default_text_donor).include? '#HourOfCode'
 = view :share_buttons, facebook:facebook, twitter:twitter

--- a/pegasus/sites.v3/hourofcode.com/views/thanks_page_heading.erb
+++ b/pegasus/sites.v3/hourofcode.com/views/thanks_page_heading.erb
@@ -1,6 +1,6 @@
 <%
   facebook = {:u=>"http://#{request.host}/us"}
 
-  twitter = {:url=>"http://hourofcode.com", :related=>'codeorg', :hashtags=>'', :text=>hoc_s(:twitter_donor_text, locals: {random_donor: get_random_donor_twitter})}
+  twitter = {:url=>"http://hourofcode.com", :related=>'codeorg', :hashtags=>'', :text=>hoc_s(:twitter_donor_text, locals: {random_donor: CdoDonor.get_random_donor_twitter})}
   twitter[:hashtags] = 'HourOfCode' unless hoc_s(:twitter_donor_text).include? '#HourOfCode'
 %>


### PR DESCRIPTION
Continues [PLAT-1531]., see [work plan](https://docs.google.com/document/d/1wTObDFZdWS6RzpM3R6wEm04ToY2fM1B5Kb2rUHCNq28/edit#heading=h.h0cd07oasonl)

This PR does pre-work that will make it easier to start selecting the sponsor on the congrats page, and then passing it down as an explicit param to the other pages. Specifically:
* wrap `get_random_donor_...` helpers in a new `CdoDonor` class (other ideas for the new class name are welcome)
* improve helper method names
* cache list of donors across requests 

## Testing story

I am relying on existing test coverage, including:
* pegasus tests that every pegasus document renders
* pegasus/test/test_certificate_image.rb covers certificate image rendering
* registration tests, fixed in fe7418bcdf2dac394b391514a3ed0e3dfb0f5162



[PLAT-1531]: https://codedotorg.atlassian.net/browse/PLAT-1531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ