### PR TITLE
Remove codeorg-api.com support

### DIFF
--- a/dashboard/app/controllers/xhr_proxy_controller.rb
+++ b/dashboard/app/controllers/xhr_proxy_controller.rb
@@ -63,7 +63,6 @@ class XhrProxyController < ApplicationController
     api.zippopotam.us
     bible-api.com
     code.org
-    codeorg-api.com
     covidtracking.com
     cryptonator.com
     data.austintexas.gov


### PR DESCRIPTION
This domain was causing high 5xx error rates, so we are removing support for now. Support for this API was added in #44520.

See [this thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1644078002679699) for details.