### PR TITLE
Update isolate-components to isolate-react

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -126,7 +126,7 @@
     "html2canvas": "^0.5.0-beta4",
     "http-server": "^0.9.0",
     "immutable": "3.8.1",
-    "isolate-components": "^1.4.0",
+    "isolate-react": "^2.0.0",
     "istanbul-instrumenter-loader": "^3.0.1",
     "jquery": "1.12.1",
     "jquery-ui": "^1.12.1",

--- a/apps/test/unit/code-studio/pd/application/TeacherApplicationTest.js
+++ b/apps/test/unit/code-studio/pd/application/TeacherApplicationTest.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {expect} from 'chai';
 import {mount, shallow} from 'enzyme';
 import sinon from 'sinon';
-import {isolateComponent} from 'isolate-components';
+import {isolateComponent} from 'isolate-react';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
 import {PageLabels} from '@cdo/apps/generated/pd/teacherApplicationConstants';
 import TeacherApplication from '@cdo/apps/code-studio/pd/application/teacher/TeacherApplication';

--- a/apps/test/unit/code-studio/pd/form_components_func/FormControllerTest.js
+++ b/apps/test/unit/code-studio/pd/form_components_func/FormControllerTest.js
@@ -2,7 +2,7 @@ import FormController from '@cdo/apps/code-studio/pd/form_components_func/FormCo
 import React from 'react';
 import {expect} from '../../../../util/reconfiguredChai';
 import sinon from 'sinon';
-import {isolateComponent} from 'isolate-components';
+import {isolateComponent} from 'isolate-react';
 
 let DummyPage1 = () => {
   return <div>Page 1</div>;

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/AddLevelDialogTopTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/AddLevelDialogTopTest.jsx
@@ -3,7 +3,7 @@ import {assert, expect} from '../../../../util/reconfiguredChai';
 import {UnconnectedAddLevelDialogTop as AddLevelDialogTop} from '@cdo/apps/lib/levelbuilder/lesson-editor/AddLevelDialogTop';
 import {searchOptions} from './activitiesTestData';
 import sinon from 'sinon';
-import {isolateComponent} from 'isolate-components';
+import {isolateComponent} from 'isolate-react';
 
 describe('AddLevelDialogTop', () => {
   let defaultProps, addLevel;

--- a/apps/test/unit/templates/manageStudents/CodeReviewGroupsDialogTest.js
+++ b/apps/test/unit/templates/manageStudents/CodeReviewGroupsDialogTest.js
@@ -3,7 +3,7 @@ import CodeReviewGroupsDialog from '@cdo/apps/templates/manageStudents/CodeRevie
 import {expect} from '../../../util/reconfiguredChai';
 import sinon from 'sinon';
 import Button from '@cdo/apps/templates/Button';
-import {isolateComponent} from 'isolate-components';
+import {isolateComponent} from 'isolate-react';
 import StylizedBaseDialog from '@cdo/apps/componentLibrary/StylizedBaseDialog';
 import CodeReviewGroupsManager from '@cdo/apps/templates/codeReviewGroups/CodeReviewGroupsManager';
 

--- a/apps/test/unit/templates/studioHomepages/BorderedCallToActionTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/BorderedCallToActionTest.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {expect} from '../../../util/reconfiguredChai';
-import {isolateComponent} from 'isolate-components';
+import {isolateComponent} from 'isolate-react';
 import BorderedCallToAction from '@cdo/apps/templates/studioHomepages/BorderedCallToAction';
 import sinon from 'sinon';
 import * as utils from '@cdo/apps/utils';

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -9193,17 +9193,10 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
-isolate-components@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/isolate-components/-/isolate-components-1.4.0.tgz#324082d596f8224b8e027b1b94a46fa13471ab57"
-  integrity sha512-kO99YeQIXZyDwR8wn45M7zFvuKVxCOl71cqCCwZ9Xzx0Ff33d3Mgd7jghkv5KpoBuBt6KkPUcubJczlC+G3+cQ==
-  dependencies:
-    isolate-hooks "^1.5.0"
-
-isolate-hooks@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/isolate-hooks/-/isolate-hooks-1.5.0.tgz#232d98ea3fb6393210a72965d67f4218e1efed59"
-  integrity sha512-IRGJvwngCuWr1FadRpI9L4V2HS+vR2pUK6O3hcNBlk3Mk/zM6VytSfV8Rpcb3/duxJHy+JUVHW7Yk4BPK4FrVA==
+isolate-react@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/isolate-react/-/isolate-react-2.0.0.tgz#4c88cb773baff929c15908f4a9af60c04a2b6826"
+  integrity sha512-quxb6hTC5FyEzoMrh0nwAzmmPwmkUZCgHHPMeIfi1FyhEHxEaJif1coYOKZq2F8sHl0fB7uoT4rpuKdX5poM3g==
 
 isomorphic-fetch@^2.1.1:
   version "2.2.1"


### PR DESCRIPTION
The NPM package [isolate-components](https://www.npmjs.com/package/isolate-components) was renamed to [isolate-react](https://www.npmjs.com/package/isolate-react).

(I am the author of the above packages)

This PR updates all references in `apps/`, removes isolate-components, and adds `isolate-react` as a devDependency.