### PR TITLE
Replace sectionDataRedux with teacherSectionsRedux

### DIFF
--- a/apps/src/templates/projects/SectionProjectsListWithData.jsx
+++ b/apps/src/templates/projects/SectionProjectsListWithData.jsx
@@ -55,5 +55,5 @@ class SectionProjectsListWithData extends Component {
 export const UnconnectedSectionProjectsListWithData = SectionProjectsListWithData;
 
 export default connect(state => ({
-  sectionId: state.sectionData.section.id
+  sectionId: state.teacherSections.selectedSectionId
 }))(SectionProjectsListWithData);

--- a/apps/src/templates/sectionAssessments/SectionAssessments.jsx
+++ b/apps/src/templates/sectionAssessments/SectionAssessments.jsx
@@ -368,7 +368,7 @@ export const UnconnectedSectionAssessments = SectionAssessments;
 
 export default connect(
   state => ({
-    sectionId: state.sectionData.section.id,
+    sectionId: state.teacherSections.selectedSectionId,
     isLoading: !!state.sectionAssessments.isLoading,
     validScripts: state.unitSelection.validScripts,
     assessmentList: getCurrentScriptAssessmentList(state),

--- a/apps/src/templates/sectionProgress/ProgressViewHeader.jsx
+++ b/apps/src/templates/sectionProgress/ProgressViewHeader.jsx
@@ -5,7 +5,6 @@ import i18n from '@cdo/locale';
 import {getCurrentUnitData} from './sectionProgressRedux';
 import {ViewType, scriptDataPropType} from './sectionProgressConstants';
 import {getSelectedScriptFriendlyName} from '@cdo/apps/redux/unitSelectionRedux';
-import {sectionDataPropType} from '@cdo/apps/redux/sectionDataRedux';
 import firehoseClient from '../../lib/util/firehose';
 import color from '../../util/color';
 import {h3Style} from '../../lib/ui/Headings';
@@ -16,14 +15,14 @@ class ProgressViewHeader extends Component {
     scriptId: PropTypes.number,
     //redux
     currentView: PropTypes.oneOf(Object.values(ViewType)),
-    section: sectionDataPropType.isRequired,
+    sectionId: PropTypes.number.isRequired,
     scriptFriendlyName: PropTypes.string.isRequired,
     scriptData: scriptDataPropType
   };
 
   getLinkToOverview() {
-    const {scriptData, section} = this.props;
-    return scriptData ? `${scriptData.path}?section_id=${section.id}` : null;
+    const {scriptData, sectionId} = this.props;
+    return scriptData ? `${scriptData.path}?section_id=${sectionId}` : null;
   }
 
   navigateToScript = () => {
@@ -33,7 +32,7 @@ class ProgressViewHeader extends Component {
         study_group: 'progress',
         event: 'go_to_script',
         data_json: JSON.stringify({
-          section_id: this.props.section.id,
+          section_id: this.props.sectionId,
           script_id: this.props.scriptId
         })
       },
@@ -62,7 +61,7 @@ class ProgressViewHeader extends Component {
           </a>
         </span>
         {currentView === ViewType.STANDARDS && (
-          <StandardsViewHeaderButtons sectionId={this.props.section.id} />
+          <StandardsViewHeaderButtons sectionId={this.props.sectionId} />
         )}
       </div>
     );
@@ -88,7 +87,7 @@ const styles = {
 export const UnconnectedProgressViewHeader = ProgressViewHeader;
 
 export default connect(state => ({
-  section: state.sectionData.section,
+  sectionId: state.teacherSections.selectedSectionId,
   currentView: state.sectionProgress.currentView,
   scriptData: getCurrentUnitData(state),
   scriptFriendlyName: getSelectedScriptFriendlyName(state)

--- a/apps/src/templates/sectionProgress/SectionProgress.jsx
+++ b/apps/src/templates/sectionProgress/SectionProgress.jsx
@@ -16,7 +16,6 @@ import {
 } from './sectionProgressRedux';
 import {loadScriptProgress} from './sectionProgressLoader';
 import {ViewType, scriptDataPropType} from './sectionProgressConstants';
-import {sectionDataPropType} from '@cdo/apps/redux/sectionDataRedux';
 import {
   setScriptId,
   validScriptPropType
@@ -34,7 +33,7 @@ class SectionProgress extends Component {
   static propTypes = {
     //Provided by redux
     scriptId: PropTypes.number,
-    section: sectionDataPropType.isRequired,
+    sectionId: PropTypes.number,
     validScripts: PropTypes.arrayOf(validScriptPropType).isRequired,
     currentView: PropTypes.oneOf(Object.values(ViewType)),
     setCurrentView: PropTypes.func.isRequired,
@@ -46,68 +45,47 @@ class SectionProgress extends Component {
     showStandardsIntroDialog: PropTypes.bool
   };
 
-  constructor(props) {
-    super(props);
-    this.onChangeScript = this.onChangeScript.bind(this);
-    this.onChangeLevel = this.onChangeLevel.bind(this);
-    this.navigateToScript = this.navigateToScript.bind(this);
-  }
-
   componentDidMount() {
-    loadScriptProgress(this.props.scriptId, this.props.section.id);
+    loadScriptProgress(this.props.scriptId, this.props.sectionId);
   }
 
-  onChangeScript(scriptId) {
+  onChangeScript = scriptId => {
     this.props.setScriptId(scriptId);
-    loadScriptProgress(scriptId, this.props.section.id);
+    loadScriptProgress(scriptId, this.props.sectionId);
 
-    firehoseClient.putRecord(
-      {
-        study: 'teacher_dashboard_actions',
-        study_group: 'progress',
-        event: 'change_script',
-        data_json: JSON.stringify({
-          section_id: this.props.section.id,
-          old_script_id: this.props.scriptId,
-          new_script_id: scriptId
-        })
-      },
-      {includeUserId: true}
-    );
-  }
+    this.recordEvent('change_script', {
+      old_script_id: this.props.scriptId,
+      new_script_id: scriptId
+    });
+  };
 
-  onChangeLevel(lessonOfInterest) {
+  onChangeLevel = lessonOfInterest => {
     this.props.setLessonOfInterest(lessonOfInterest);
 
-    firehoseClient.putRecord(
-      {
-        study: 'teacher_dashboard_actions',
-        study_group: 'progress',
-        event: 'jump_to_lesson',
-        data_json: JSON.stringify({
-          section_id: this.props.section.id,
-          script_id: this.props.scriptId,
-          stage_id: this.props.scriptData.lessons[lessonOfInterest].id
-        })
-      },
-      {includeUserId: true}
-    );
-  }
+    this.recordEvent('jump_to_lesson', {
+      script_id: this.props.scriptId,
+      stage_id: this.props.scriptData.lessons[lessonOfInterest].id
+    });
+  };
 
-  navigateToScript() {
+  navigateToScript = () => {
+    this.recordEvent('go_to_script', {script_id: this.props.scriptId});
+  };
+
+  recordEvent = (eventName, dataJson = {}) => {
     firehoseClient.putRecord(
       {
         study: 'teacher_dashboard_actions',
         study_group: 'progress',
-        event: 'go_to_script',
+        event: eventName,
         data_json: JSON.stringify({
-          section_id: this.props.section.id,
-          script_id: this.props.scriptId
+          section_id: this.props.sectionId,
+          ...dataJson
         })
       },
       {includeUserId: true}
     );
-  }
+  };
 
   render() {
     const {
@@ -217,7 +195,7 @@ export const UnconnectedSectionProgress = SectionProgress;
 export default connect(
   state => ({
     scriptId: state.unitSelection.scriptId,
-    section: state.sectionData.section,
+    sectionId: state.teacherSections.selectedSectionId,
     validScripts: state.unitSelection.validScripts,
     currentView: state.sectionProgress.currentView,
     scriptData: getCurrentUnitData(state),

--- a/apps/src/templates/sectionProgress/SectionProgressToggle.jsx
+++ b/apps/src/templates/sectionProgress/SectionProgressToggle.jsx
@@ -91,7 +91,7 @@ export const UnconnectedSectionProgressToggle = SectionProgressToggle;
 export default connect(
   state => ({
     currentView: state.sectionProgress.currentView,
-    sectionId: state.sectionData.section.id,
+    sectionId: state.teacherSections.selectedSectionId,
     scriptId: state.unitSelection.scriptId
   }),
   dispatch => ({

--- a/apps/src/templates/sectionProgress/sectionProgressRedux.js
+++ b/apps/src/templates/sectionProgress/sectionProgressRedux.js
@@ -122,7 +122,7 @@ export const jumpToLessonDetails = lessonOfInterest => {
         study_group: 'progress',
         event: 'view_change_toggle',
         data_json: JSON.stringify({
-          section_id: state.sectionData.section.id,
+          section_id: state.teacherSections.selectedSectionId,
           old_view: ViewType.SUMMARY,
           new_view: ViewType.DETAIL,
           script_id: state.unitSelection.scriptId

--- a/apps/src/templates/sectionProgress/sectionProgressTestHelpers.js
+++ b/apps/src/templates/sectionProgress/sectionProgressTestHelpers.js
@@ -7,6 +7,10 @@ import sectionProgress, {
 import unitSelection, {
   setValidScripts
 } from '@cdo/apps/redux/unitSelectionRedux';
+import teacherSections, {
+  setSections,
+  selectSection
+} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import locales from '@cdo/apps/redux/localesRedux';
 import {LevelStatus} from '@cdo/apps/util/sharedConstants';
 import {TestResults} from '@cdo/apps/constants';
@@ -48,12 +52,15 @@ export function createStore(numStudents, numLessons) {
     registerReducers({
       sectionProgress,
       sectionData,
+      teacherSections,
       unitSelection,
       locales
     });
   } catch {}
   const store = createStoreWithReducers();
   store.dispatch(setSection(section));
+  store.dispatch(setSections([section]));
+  store.dispatch(selectSection(section.id));
   store.dispatch(setValidScripts([scriptData], [scriptData.id], [], section));
   store.dispatch(
     addDataByUnit(buildSectionProgress(section.students, scriptData))

--- a/apps/src/templates/sectionProgress/standards/LessonStatusDialog.story.jsx
+++ b/apps/src/templates/sectionProgress/standards/LessonStatusDialog.story.jsx
@@ -7,6 +7,7 @@ import sectionStandardsProgress from './sectionStandardsProgressRedux';
 import sectionProgress from '@cdo/apps/templates/sectionProgress/sectionProgressRedux';
 import sectionData from '@cdo/apps/redux/sectionDataRedux';
 import unitSelection from '@cdo/apps/redux/unitSelectionRedux';
+import teacherSections from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 
 export default storybook => {
   const store = createStore(
@@ -14,8 +15,14 @@ export default storybook => {
       sectionStandardsProgress,
       sectionProgress,
       unitSelection,
-      sectionData
-    })
+      sectionData,
+      teacherSections
+    }),
+    {
+      teacherSections: {
+        selectedSectionId: 1
+      }
+    }
   );
 
   return storybook

--- a/apps/src/templates/sectionProgress/standards/LessonStatusList.jsx
+++ b/apps/src/templates/sectionProgress/standards/LessonStatusList.jsx
@@ -132,7 +132,7 @@ export default connect(
   state => ({
     unpluggedLessonList: getUnpluggedLessonsForScript(state),
     selectedLessons: state.sectionStandardsProgress.selectedLessons,
-    sectionId: state.sectionData.section.id,
+    sectionId: state.teacherSections.selectedSectionId,
     scriptId: state.unitSelection.scriptId
   }),
   dispatch => ({

--- a/apps/src/templates/sectionProgress/standards/LessonStatusList.story.jsx
+++ b/apps/src/templates/sectionProgress/standards/LessonStatusList.story.jsx
@@ -9,6 +9,7 @@ import sectionProgress from '@cdo/apps/templates/sectionProgress/sectionProgress
 import unitSelection from '@cdo/apps/redux/unitSelectionRedux';
 import sectionData from '@cdo/apps/redux/sectionDataRedux';
 import currentUser from '@cdo/apps/templates/currentUserRedux';
+import teacherSections from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 
 export default storybook => {
   const store = createStore(
@@ -17,8 +18,14 @@ export default storybook => {
       sectionStandardsProgress,
       unitSelection,
       sectionData,
+      teacherSections,
       currentUser
-    })
+    }),
+    {
+      teacherSections: {
+        selectedSectionId: 1
+      }
+    }
   );
 
   return storybook

--- a/apps/src/templates/sectionProgress/standards/ProgressBoxForLessonNumber.jsx
+++ b/apps/src/templates/sectionProgress/standards/ProgressBoxForLessonNumber.jsx
@@ -82,6 +82,6 @@ const styles = {
 export const UnconnectedProgressBoxForLessonNumber = ProgressBoxForLessonNumber;
 
 export default connect(state => ({
-  sectionId: state.sectionData.section.id,
+  sectionId: state.teacherSections.selectedSectionId,
   scriptId: state.unitSelection.scriptId
 }))(ProgressBoxForLessonNumber);

--- a/apps/src/templates/sectionProgress/standards/StandardsView.jsx
+++ b/apps/src/templates/sectionProgress/standards/StandardsView.jsx
@@ -7,7 +7,6 @@ import {connect} from 'react-redux';
 import {getCurrentUnitData} from '@cdo/apps/templates/sectionProgress/sectionProgressRedux';
 import {scriptDataPropType} from '../sectionProgressConstants';
 import {getSelectedScriptFriendlyName} from '@cdo/apps/redux/unitSelectionRedux';
-import {sectionDataPropType} from '@cdo/apps/redux/sectionDataRedux';
 import StandardsIntroDialog from './StandardsIntroDialog';
 import StandardsProgressTable from './StandardsProgressTable';
 import StandardsLegend from './StandardsLegend';
@@ -17,14 +16,14 @@ class StandardsView extends Component {
   static propTypes = {
     showStandardsIntroDialog: PropTypes.bool,
     //redux
-    section: sectionDataPropType.isRequired,
+    sectionId: PropTypes.number.isRequired,
     scriptFriendlyName: PropTypes.string.isRequired,
     scriptData: scriptDataPropType
   };
 
   getLinkToOverview() {
-    const {scriptData, section} = this.props;
-    return scriptData ? `${scriptData.path}?section_id=${section.id}` : null;
+    const {scriptData, sectionId} = this.props;
+    return scriptData ? `${scriptData.path}?section_id=${sectionId}` : null;
   }
 
   render() {
@@ -62,7 +61,7 @@ class StandardsView extends Component {
 export const UnconnectedStandardsView = StandardsView;
 
 export default connect(state => ({
-  section: state.sectionData.section,
+  sectionId: state.teacherSections.selectedSectionId,
   scriptData: getCurrentUnitData(state),
   scriptFriendlyName: getSelectedScriptFriendlyName(state)
 }))(StandardsView);

--- a/apps/src/templates/textResponses/TextResponses.jsx
+++ b/apps/src/templates/textResponses/TextResponses.jsx
@@ -173,7 +173,7 @@ export const UnconnectedTextResponses = TextResponses;
 
 export default connect(
   state => ({
-    sectionId: state.sectionData.section.id,
+    sectionId: state.teacherSections.selectedSectionId,
     validScripts: state.unitSelection.validScripts,
     scriptId: state.unitSelection.scriptId,
     scriptName: getSelectedScriptName(state)

--- a/apps/test/unit/templates/sectionProgress/ProgressViewHeaderTest.jsx
+++ b/apps/test/unit/templates/sectionProgress/ProgressViewHeaderTest.jsx
@@ -5,16 +5,8 @@ import {UnconnectedProgressViewHeader as ProgressViewHeader} from '@cdo/apps/tem
 
 describe('ProgressViewHeader', () => {
   let DEFAULT_PROPS = {
-    section: {
-      id: 6,
-      script: {
-        id: 132,
-        name: 'csd1-2019',
-        project_sharing: true
-      },
-      students: [],
-      lessonExtras: false
-    },
+    scriptId: 132,
+    sectionId: 6,
     currentView: 'summary',
     scriptData: {
       id: 132,

--- a/apps/test/unit/templates/sectionProgress/StandardsViewTest.jsx
+++ b/apps/test/unit/templates/sectionProgress/StandardsViewTest.jsx
@@ -9,16 +9,7 @@ describe('StandardView', () => {
   beforeEach(() => {
     DEFAULT_PROPS = {
       showStandardsIntroDialog: false,
-      section: {
-        id: 6,
-        script: {
-          id: 1163,
-          name: 'express-2019',
-          project_sharing: true
-        },
-        students: [],
-        lessonExtras: false
-      },
+      sectionId: 6,
       scriptData: {
         id: 1163,
         excludeCsfColumnInLegend: false,


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Part of a larger PR which removes sectionDataRedux: https://github.com/code-dot-org/code-dot-org/pull/44616

The changes here change components which are used on the teacher dashboard to reference `teacherSectionsRedux` instead of `sectionDataRedux`

## Links
- jira ticket: [LP-2179](https://codedotorg.atlassian.net/browse/LP-2179)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()

-->

## Testing story
Updated unit tests
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
