### PR TITLE
[test all browsers] Add eyes test for saving apps with new exit warning

### DIFF
--- a/apps/src/code-studio/pd/application/teacher/TeacherApplication.jsx
+++ b/apps/src/code-studio/pd/application/teacher/TeacherApplication.jsx
@@ -103,6 +103,12 @@ const TeacherApplication = props => {
     <FormController
       {...props}
       pageComponents={pageComponents}
+      autoComputedFields={[
+        'cs_total_course_hours',
+        'regionalPartnerGroup',
+        'regionalPartnerId',
+        'regionalPartnerWorkshopIds'
+      ]}
       getPageProps={getPageProps}
       getInitialData={getInitialData}
       onSetPage={onSetPage}

--- a/apps/src/code-studio/pd/application/teacher/TeacherApplication.jsx
+++ b/apps/src/code-studio/pd/application/teacher/TeacherApplication.jsx
@@ -18,6 +18,12 @@ const pageComponents = [
   ProfessionalLearningProgramRequirements,
   AdditionalDemographicInformation
 ];
+const autoComputedFields = [
+  'cs_total_course_hours',
+  'regionalPartnerGroup',
+  'regionalPartnerId',
+  'regionalPartnerWorkshopIds'
+];
 
 const sendFirehoseEvent = (userId, event) => {
   firehoseClient.putRecord(
@@ -103,12 +109,7 @@ const TeacherApplication = props => {
     <FormController
       {...props}
       pageComponents={pageComponents}
-      autoComputedFields={[
-        'cs_total_course_hours',
-        'regionalPartnerGroup',
-        'regionalPartnerId',
-        'regionalPartnerWorkshopIds'
-      ]}
+      autoComputedFields={autoComputedFields}
       getPageProps={getPageProps}
       getInitialData={getInitialData}
       onSetPage={onSetPage}

--- a/apps/src/code-studio/pd/form_components_func/FormController.jsx
+++ b/apps/src/code-studio/pd/form_components_func/FormController.jsx
@@ -131,7 +131,7 @@ const FormController = props => {
     } else {
       setHasUserChangedData(false);
     }
-  }, [data]);
+  }, [autoComputedFields, data, savedData]);
 
   useEffect(() => {
     const showWarningOnExit =
@@ -147,7 +147,7 @@ const FormController = props => {
     return () => {
       window.removeEventListener('beforeunload', exitHandler);
     };
-  }, [submitting, saving, hasUserChangedData]);
+  }, [hasUserChangedData, submitting, saving, warnOnExit]);
 
   // on errors changed
   useEffect(() => {

--- a/apps/src/code-studio/pd/form_components_func/FormController.jsx
+++ b/apps/src/code-studio/pd/form_components_func/FormController.jsx
@@ -131,7 +131,9 @@ const FormController = props => {
     } else {
       setHasUserChangedData(false);
     }
+  }, [data]);
 
+  useEffect(() => {
     const showWarningOnExit =
       warnOnExit && !submitting && !saving && hasUserChangedData;
     const exitHandler = event => {
@@ -145,7 +147,7 @@ const FormController = props => {
     return () => {
       window.removeEventListener('beforeunload', exitHandler);
     };
-  }, [warnOnExit, submitting, saving, data]);
+  }, [submitting, saving, hasUserChangedData]);
 
   // on errors changed
   useEffect(() => {

--- a/apps/src/code-studio/pd/form_components_func/FormController.jsx
+++ b/apps/src/code-studio/pd/form_components_func/FormController.jsx
@@ -61,24 +61,23 @@ InvalidPagesSummary.propTypes = {
 const FormController = props => {
   const {
     pageComponents,
-    requiredFields = [],
+    requiredFields,
     apiEndpoint,
-    applicationId = undefined,
-    allowPartialSaving = false,
-    autoComputedFields = [],
+    applicationId,
+    allowPartialSaving,
+    autoComputedFields,
     options,
-    getInitialData = () => ({}),
-    onInitialize = () => {},
-    onSetPage = () => {},
-    onSuccessfulSubmit = () => {},
-    onSuccessfulSave = () => {},
-    savedStatus = undefined,
-    serializeAdditionalData = () => ({}),
-    sessionStorageKey = null,
-    submitButtonText = defaultSubmitButtonText,
+    getInitialData,
+    onInitialize,
+    onSetPage,
+    onSuccessfulSubmit,
+    onSuccessfulSave,
+    serializeAdditionalData,
+    sessionStorageKey,
+    submitButtonText,
     getPageProps: getAdditionalPageProps = () => ({}),
-    validateOnSubmitOnly = false,
-    warnOnExit = false
+    validateOnSubmitOnly,
+    warnOnExit
   } = props;
 
   // We use functions here as the initial value so that these values are only calculated once
@@ -671,6 +670,23 @@ FormController.propTypes = {
   submitButtonText: PropTypes.string,
   validateOnSubmitOnly: PropTypes.bool,
   warnOnExit: PropTypes.bool
+};
+
+FormController.defaultProps = {
+  requiredFields: [],
+  applicationId: undefined,
+  allowPartialSaving: false,
+  autoComputedFields: [''],
+  getInitialData: () => {},
+  onInitialize: () => {},
+  onSetPage: () => {},
+  onSuccessfulSubmit: () => {},
+  onSuccessfulSave: () => {},
+  serializeAdditionalData: () => {},
+  sessionStorageKey: null,
+  submitButtonText: defaultSubmitButtonText,
+  validateOnSubmitOnly: false,
+  warnOnExit: false
 };
 
 export default FormController;

--- a/apps/src/code-studio/pd/form_components_func/FormController.jsx
+++ b/apps/src/code-studio/pd/form_components_func/FormController.jsx
@@ -72,6 +72,7 @@ const FormController = props => {
     onSetPage,
     onSuccessfulSubmit,
     onSuccessfulSave,
+    savedStatus,
     serializeAdditionalData,
     sessionStorageKey,
     submitButtonText,
@@ -365,14 +366,15 @@ const FormController = props => {
     setGlobalError(false);
     setSaving(true);
 
-    const handleSuccessfulSave = data => {
+    const handleSuccessfulSave = response => {
+      console.log('on successful save, data is', data, response);
       scrollToTop();
       setShowSavedMessage(true);
       setShowDataWasLoadedMessage(false);
-      setUpdatedApplicationId(data.id);
-      data.form_data && setSavedData(JSON.parse(data.form_data));
+      setUpdatedApplicationId(response.id);
+      setSavedData(data);
       setSaving(false);
-      onSuccessfulSave(data);
+      onSuccessfulSave(response);
     };
 
     makeRequest(applicationStatusOnSave)

--- a/apps/src/code-studio/pd/form_components_func/FormController.jsx
+++ b/apps/src/code-studio/pd/form_components_func/FormController.jsx
@@ -130,7 +130,7 @@ const FormController = props => {
     } else {
       setHasUserChangedData(false);
     }
-  }, [data]);
+  }, [autoComputedFields, data, savedData]);
 
   useEffect(() => {
     const showWarningOnExit =

--- a/apps/src/code-studio/pd/form_components_func/FormController.jsx
+++ b/apps/src/code-studio/pd/form_components_func/FormController.jsx
@@ -370,7 +370,7 @@ const FormController = props => {
       setShowSavedMessage(true);
       setShowDataWasLoadedMessage(false);
       setUpdatedApplicationId(data.id);
-      setSavedData(JSON.parse(data.form_data));
+      data.form_data && setSavedData(JSON.parse(data.form_data));
       setSaving(false);
       onSuccessfulSave(data);
     };

--- a/apps/src/code-studio/pd/form_components_func/FormController.jsx
+++ b/apps/src/code-studio/pd/form_components_func/FormController.jsx
@@ -75,7 +75,7 @@ const FormController = props => {
     serializeAdditionalData,
     sessionStorageKey,
     submitButtonText,
-    getPageProps: getAdditionalPageProps,
+    getPageProps: getAdditionalPageProps = () => ({}),
     validateOnSubmitOnly,
     warnOnExit
   } = props;
@@ -685,7 +685,6 @@ FormController.defaultProps = {
   serializeAdditionalData: () => {},
   sessionStorageKey: null,
   submitButtonText: defaultSubmitButtonText,
-  getAdditionalPageProps: () => {},
   validateOnSubmitOnly: false,
   warnOnExit: false
 };

--- a/apps/src/code-studio/pd/form_components_func/FormController.jsx
+++ b/apps/src/code-studio/pd/form_components_func/FormController.jsx
@@ -676,7 +676,7 @@ FormController.defaultProps = {
   requiredFields: [],
   applicationId: undefined,
   allowPartialSaving: false,
-  autoComputedFields: [''],
+  autoComputedFields: [],
   getInitialData: () => {},
   onInitialize: () => {},
   onSetPage: () => {},

--- a/apps/src/code-studio/pd/form_components_func/FormController.jsx
+++ b/apps/src/code-studio/pd/form_components_func/FormController.jsx
@@ -131,7 +131,7 @@ const FormController = props => {
     } else {
       setHasUserChangedData(false);
     }
-  }, [data, savedData]);
+  }, [data]);
 
   useEffect(() => {
     const showWarningOnExit =

--- a/apps/src/code-studio/pd/form_components_func/FormController.jsx
+++ b/apps/src/code-studio/pd/form_components_func/FormController.jsx
@@ -372,7 +372,6 @@ const FormController = props => {
       setShowDataWasLoadedMessage(false);
       setUpdatedApplicationId(data.id);
       setSavedData(data.form_data);
-      setHasUserChangedData(false);
       setSaving(false);
       onSuccessfulSave(data);
     };

--- a/apps/src/code-studio/pd/form_components_func/FormController.jsx
+++ b/apps/src/code-studio/pd/form_components_func/FormController.jsx
@@ -131,7 +131,7 @@ const FormController = props => {
     } else {
       setHasUserChangedData(false);
     }
-  }, [autoComputedFields, data, savedData]);
+  }, [data, savedData]);
 
   useEffect(() => {
     const showWarningOnExit =

--- a/apps/src/code-studio/pd/form_components_func/FormController.jsx
+++ b/apps/src/code-studio/pd/form_components_func/FormController.jsx
@@ -75,7 +75,7 @@ const FormController = props => {
     serializeAdditionalData,
     sessionStorageKey,
     submitButtonText,
-    getPageProps: getAdditionalPageProps = () => ({}),
+    getPageProps: getAdditionalPageProps,
     validateOnSubmitOnly,
     warnOnExit
   } = props;
@@ -685,6 +685,7 @@ FormController.defaultProps = {
   serializeAdditionalData: () => {},
   sessionStorageKey: null,
   submitButtonText: defaultSubmitButtonText,
+  getAdditionalPageProps: () => {},
   validateOnSubmitOnly: false,
   warnOnExit: false
 };

--- a/apps/src/code-studio/pd/form_components_func/FormController.jsx
+++ b/apps/src/code-studio/pd/form_components_func/FormController.jsx
@@ -3,6 +3,7 @@ import React, {useState, useEffect} from 'react';
 import $ from 'jquery';
 import {Button, Alert, FormGroup} from 'react-bootstrap';
 import {Pagination} from '@react-bootstrap/pagination';
+import {isEqual, omit} from 'lodash';
 import i18n from '@cdo/locale';
 import usePrevious from '@cdo/apps/util/usePrevious';
 
@@ -64,6 +65,7 @@ const FormController = props => {
     apiEndpoint,
     applicationId = undefined,
     allowPartialSaving = false,
+    autoComputedFields = [],
     options,
     getInitialData = () => ({}),
     onInitialize = () => {},
@@ -89,9 +91,16 @@ const FormController = props => {
   }));
   const [submitting, setSubmitting] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [savedData, setSavedData] = useState(getInitialData());
   const [showSavedMessage, setShowSavedMessage] = useState(false);
   const [errors, setErrors] = useState([]);
   const previousErrors = usePrevious(errors);
+  const [hasUserChangedData, setHasUserChangedData] = useState(
+    !isEqual(
+      omit(data, autoComputedFields),
+      omit(savedData, autoComputedFields)
+    )
+  );
   const [errorMessages, setErrorMessages] = useState({});
   const [errorHeader, setErrorHeader] = useState(null);
   const [globalError, setGlobalError] = useState(false);
@@ -112,20 +121,31 @@ const FormController = props => {
   }, []);
 
   useEffect(() => {
-    // this function needs to be recreated because it holds 'submitting' in its closure
+    if (
+      !isEqual(
+        omit(data, autoComputedFields),
+        omit(savedData, autoComputedFields)
+      )
+    ) {
+      setHasUserChangedData(true);
+    } else {
+      setHasUserChangedData(false);
+    }
+
+    const showWarningOnExit =
+      warnOnExit && !submitting && !saving && hasUserChangedData;
     const exitHandler = event => {
-      if (!submitting) {
+      if (showWarningOnExit) {
         event.preventDefault();
         event.returnValue = 'Are you sure? Your application may not be saved.';
       }
     };
-    if (warnOnExit) {
-      window.addEventListener('beforeunload', exitHandler);
-    }
+
+    window.addEventListener('beforeunload', exitHandler);
     return () => {
       window.removeEventListener('beforeunload', exitHandler);
     };
-  }, [warnOnExit, submitting]);
+  }, [warnOnExit, submitting, saving, data]);
 
   // on errors changed
   useEffect(() => {
@@ -349,6 +369,8 @@ const FormController = props => {
       setShowSavedMessage(true);
       setShowDataWasLoadedMessage(false);
       setUpdatedApplicationId(data.id);
+      setSavedData(data.form_data);
+      setHasUserChangedData(false);
       setSaving(false);
       onSuccessfulSave(data);
     };
@@ -631,6 +653,7 @@ const styles = {
 FormController.propTypes = {
   apiEndpoint: PropTypes.string.isRequired,
   applicationId: PropTypes.number,
+  autoComputedFields: PropTypes.arrayOf(PropTypes.string),
   options: PropTypes.object.isRequired,
   requiredFields: PropTypes.arrayOf(PropTypes.string).isRequired,
   pageComponents: PropTypes.arrayOf(PropTypes.func),

--- a/apps/src/code-studio/pd/form_components_func/FormController.jsx
+++ b/apps/src/code-studio/pd/form_components_func/FormController.jsx
@@ -371,7 +371,7 @@ const FormController = props => {
       setShowSavedMessage(true);
       setShowDataWasLoadedMessage(false);
       setUpdatedApplicationId(data.id);
-      setSavedData(data.form_data);
+      setSavedData(JSON.parse(data.form_data));
       setSaving(false);
       onSuccessfulSave(data);
     };

--- a/dashboard/test/ui/features/ed_programs/pd/teacher_application.feature
+++ b/dashboard/test/ui/features/ed_programs/pd/teacher_application.feature
@@ -3,7 +3,7 @@
 
 Feature: Teacher Application
 
-Scenario: Basic teacher application submission
+Scenario: Teacher starts a new application and submits it
   Given I create a teacher named "Severus"
     And I am on "http://studio.code.org/pd/application/teacher"
     And I wait until element "h1" contains text "Professional Learning Program Teacher Application"
@@ -129,3 +129,90 @@ Scenario: Basic teacher application submission
   Then I see no difference for "Principal approval confirmation form"
   Then I close my eyes
 
+# [MEG] TODO: Remove experiment flag from the two URLs below
+Scenario: Teacher saves, re-opens, and submits an application
+  Given I create a teacher named "Severus"
+  And I am on "http://studio.code.org/pd/application/teacher?enableExperiments=teacher-application-saving-reopening"
+  And I wait until element "h1" contains text "Professional Learning Program Teacher Application"
+  And I open my eyes to test "Saving and Reopening Teacher Application"
+
+  # Saving the application
+  Then I wait until element "h3" contains text "Section 1: About You and Your School"
+  And I press the first "input[name='country']" element
+  And I press the first "input[name='completingOnBehalfOfSomeoneElse'][value='No']" element
+  And I press keys "Severus" for element "input#firstName"
+  And I press the first "button#save" element
+  Then I wait until element "p" contains text "Your progress has been saved. Return to this page at any time to continue working on your application."
+  And I see no difference for "Viewing teacher application after saving"
+  Then I sign out
+
+  # Opening an application that's been started
+  Then I am on "http://studio.code.org/pd/application/teacher?enableExperiments=teacher-application-saving-reopening"
+  Then I sign in as "Severus"
+  Then I wait until element "p" contains text "We found an application you started! Your saved responses have been loaded."
+  And I see no difference for "Viewing previously-saved teacher application"
+
+  # Finish application to submit it
+  And I press keys "Snape" for element "input#lastName"
+  And I press keys "5558675309" for element "input#phone"
+  And I press keys "1501 4th Ave" for element "input#streetAddress"
+  And I press keys "Seattle" for element "input#city"
+  And I select the "Washington" option in dropdown "state"
+  And I press keys "98101" for element "input#zipCode"
+  And I press the first "input[name='previousUsedCurriculum']" element
+  And I press the first "input[name='previousYearlongCdoPd']" element
+  And I press the first "input[name='currentRole']" element
+  And I press keys "nonexistent" for element "#school input"
+
+  # School: select other and enter manual data
+  Then I wait until element ".VirtualizedSelectOption:contains('Other school not listed below')" is visible
+  And I press ".VirtualizedSelectOption:contains('Other school not listed below')" using jQuery
+  Then I wait until element "input#schoolName" is visible
+  And I press keys "Code.org" for element "input#schoolName"
+  And I press keys "Code.org District" for element "input#schoolDistrictName"
+  And I press keys "1501 4th Ave" for element "input#schoolAddress"
+  And I press keys "Seattle" for element "input#schoolCity"
+  And I select the "Washington" option in dropdown "schoolState"
+  And I press keys "98101" for element "input#schoolZipCode"
+  And I press the first "input[name='schoolType'][value='Other']" element
+  Then I press keys "Albus" for element "input#principalFirstName"
+  And I press keys "Dumbledore" for element "input#principalLastName"
+  And I press keys "socks@hogwarts.edu" for element "input#principalEmail"
+  And I press keys "socks@hogwarts.edu" for element "input#principalConfirmEmail"
+  And I press keys "5555882300" for element "input#principalPhoneNumber"
+  And I press the first "button#next" element
+
+  # Section 2
+  Then I wait until element "h3" contains text "Section 2: Choose Your Program"
+  And I press "input[name='program']:first" using jQuery
+  And I press the first "input[name='csdWhichGrades']" element
+  And I press keys "50" for element "input#csHowManyMinutes"
+  And I press keys "5" for element "input#csHowManyDaysPerWeek"
+  And I press keys "40" for element "input#csHowManyWeeksPerYear"
+  And I press the first "input[name='planToTeach']" element
+  And I press the first "input[name='replaceExisting']" element
+  Then I wait until element "input[name='replaceWhichCourse']" is visible
+  And I press the first "input[name='replaceWhichCourse']" element
+  And I press the first "button#next" element
+
+  # Section 3
+  Then I wait until element "h3" contains text "Section 3: Professional Learning Program Requirements"
+  Then I wait until element "input[name='committed']" is visible
+  And I press "input[name='committed']:first" using jQuery
+  And I press the first "input#understandFee" element
+  And I click selector "input[name='payFee']" if I see it
+  And I press the first "button#next" element
+
+  # Section 4
+  Then I wait until element "h3" contains text "Section 4: Additional Demographic Information and Submission"
+  And I press "input[name='genderIdentity']:first" using jQuery
+  And I press the first "input[name='race']" element
+  And I press the first "input[name='howHeard']" element
+  And I press the first "input#agree" element
+  And I press the first "button[type='submit']" element
+
+  # Confirmation page
+  Then I wait until element "h1" contains text "Thank you for submitting your application!"
+  Then I see no difference for "Confirmation after submitting previously saved application"
+  Then I close my eyes
+  

--- a/dashboard/test/ui/features/ed_programs/pd/teacher_application.feature
+++ b/dashboard/test/ui/features/ed_programs/pd/teacher_application.feature
@@ -144,11 +144,10 @@ Scenario: Teacher saves, re-opens, and submits an application
   And I press the first "button#save" element
   Then I wait until element "p" contains text "Your progress has been saved. Return to this page at any time to continue working on your application."
   And I see no difference for "Viewing teacher application after saving"
-  Then I sign out
 
   # Opening an application that's been started
+  And I reload the page
   Then I am on "http://studio.code.org/pd/application/teacher?enableExperiments=teacher-application-saving-reopening"
-  Then I sign in as "Severus"
   Then I wait until element "p" contains text "We found an application you started! Your saved responses have been loaded."
   And I see no difference for "Viewing previously-saved teacher application"
 


### PR DESCRIPTION
Creates an eyes tests for saving and reopening teacher apps, and adds logic for when to see the "Are you sure you wish to leave the page?" warning.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
