### PR TITLE
Remove period at the end of lesson keys in csf

### DIFF
--- a/dashboard/config/scripts_json/coursea-2022.script_json
+++ b/dashboard/config/scripts_json/coursea-2022.script_json
@@ -295,7 +295,7 @@
       }
     },
     {
-      "key": "The Big Event Jr.",
+      "key": "The Big Event Jr",
       "name": "The Big Event Jr.",
       "absolute_position": 11,
       "lockable": false,
@@ -310,7 +310,7 @@
         "unplugged": true
       },
       "seeding_key": {
-        "lesson.key": "The Big Event Jr.",
+        "lesson.key": "The Big Event Jr",
         "lesson_group.key": "csf_events",
         "script.name": "coursea-2022"
       }
@@ -1006,7 +1006,7 @@
       },
       "seeding_key": {
         "lesson_activity.key": "e68d3049-5654-4527-9c7b-8dc1426e138d",
-        "lesson.key": "The Big Event Jr.",
+        "lesson.key": "The Big Event Jr",
         "lesson_group.key": "csf_events",
         "script.name": "coursea-2022"
       }
@@ -1020,7 +1020,7 @@
       },
       "seeding_key": {
         "lesson_activity.key": "4e7b48ba-7b86-4f01-bd21-92b42a1081af",
-        "lesson.key": "The Big Event Jr.",
+        "lesson.key": "The Big Event Jr",
         "lesson_group.key": "csf_events",
         "script.name": "coursea-2022"
       }
@@ -1034,7 +1034,7 @@
       },
       "seeding_key": {
         "lesson_activity.key": "c146bd03-a9f6-417b-a954-161f2e3e0872",
-        "lesson.key": "The Big Event Jr.",
+        "lesson.key": "The Big Event Jr",
         "lesson_group.key": "csf_events",
         "script.name": "coursea-2022"
       }
@@ -1046,7 +1046,7 @@
       },
       "seeding_key": {
         "lesson_activity.key": "9ee4e1b3-41a4-4d3b-9bbd-7f7793daff4b",
-        "lesson.key": "The Big Event Jr.",
+        "lesson.key": "The Big Event Jr",
         "lesson_group.key": "csf_events",
         "script.name": "coursea-2022"
       }
@@ -1059,7 +1059,7 @@
       },
       "seeding_key": {
         "lesson_activity.key": "636ae3fe-7476-4fdc-a8f2-b97bdf300491",
-        "lesson.key": "The Big Event Jr.",
+        "lesson.key": "The Big Event Jr",
         "lesson_group.key": "csf_events",
         "script.name": "coursea-2022"
       }
@@ -4843,7 +4843,7 @@
         "script_level.level_keys": [
           "BigEvent-Unplugged2022"
         ],
-        "lesson.key": "The Big Event Jr.",
+        "lesson.key": "The Big Event Jr",
         "lesson_group.key": "csf_events",
         "script.name": "coursea-2022",
         "activity_section.key": "bad82d8b-8e16-4d89-bad6-d2d9581d3f01"
@@ -6194,7 +6194,7 @@
         "script_level.level_keys": [
           "BigEvent-Unplugged2022"
         ],
-        "lesson.key": "The Big Event Jr.",
+        "lesson.key": "The Big Event Jr",
         "lesson_group.key": "csf_events",
         "script.name": "coursea-2022",
         "activity_section.key": "bad82d8b-8e16-4d89-bad6-d2d9581d3f01"
@@ -7141,31 +7141,31 @@
     },
     {
       "seeding_key": {
-        "lesson.key": "The Big Event Jr.",
+        "lesson.key": "The Big Event Jr",
         "resource.key": "feeling_faces_-_emotion_image_1"
       }
     },
     {
       "seeding_key": {
-        "lesson.key": "The Big Event Jr.",
+        "lesson.key": "The Big Event Jr",
         "resource.key": "the_big_event"
       }
     },
     {
       "seeding_key": {
-        "lesson.key": "The Big Event Jr.",
+        "lesson.key": "The Big Event Jr",
         "resource.key": "the_big_event_1"
       }
     },
     {
       "seeding_key": {
-        "lesson.key": "The Big Event Jr.",
+        "lesson.key": "The Big Event Jr",
         "resource.key": "the_big_event_2"
       }
     },
     {
       "seeding_key": {
-        "lesson.key": "The Big Event Jr.",
+        "lesson.key": "The Big Event Jr",
         "resource.key": "the_big_event_courses_a_b_"
       }
     }
@@ -7528,7 +7528,7 @@
     },
     {
       "seeding_key": {
-        "lesson.key": "The Big Event Jr.",
+        "lesson.key": "The Big Event Jr",
         "vocabulary.key": "event"
       }
     }
@@ -7563,7 +7563,7 @@
         "description": "Practice differentiating pre-defined actions and event-driven ones."
       },
       "seeding_key": {
-        "lesson.key": "The Big Event Jr.",
+        "lesson.key": "The Big Event Jr",
         "objective.key": "11ae4f6e-9a22-4fe7-b476-d0251076f65b"
       }
     },
@@ -7663,7 +7663,7 @@
         "description": "Recognize actions of the teacher as signals to initiate commands."
       },
       "seeding_key": {
-        "lesson.key": "The Big Event Jr.",
+        "lesson.key": "The Big Event Jr",
         "objective.key": "699d524a-9ba6-430d-8ab4-fdce1b832b6f"
       }
     },
@@ -7683,7 +7683,7 @@
         "description": "Repeat commands given by an instructor."
       },
       "seeding_key": {
-        "lesson.key": "The Big Event Jr.",
+        "lesson.key": "The Big Event Jr",
         "objective.key": "805cf72f-fb59-4003-b6b5-1879ced802b9"
       }
     },
@@ -8092,14 +8092,14 @@
     },
     {
       "seeding_key": {
-        "lesson.key": "The Big Event Jr.",
+        "lesson.key": "The Big Event Jr",
         "framework.shortcode": "csta",
         "standard.shortcode": "1A-AP-09"
       }
     },
     {
       "seeding_key": {
-        "lesson.key": "The Big Event Jr.",
+        "lesson.key": "The Big Event Jr",
         "framework.shortcode": "csta",
         "standard.shortcode": "1A-AP-11"
       }

--- a/dashboard/config/scripts_json/courseb-2022.script_json
+++ b/dashboard/config/scripts_json/courseb-2022.script_json
@@ -309,7 +309,7 @@
       }
     },
     {
-      "key": "The Big Event Jr.",
+      "key": "The Big Event Jr",
       "name": "The Big Event Jr.",
       "absolute_position": 11,
       "lockable": false,
@@ -324,7 +324,7 @@
         "unplugged": true
       },
       "seeding_key": {
-        "lesson.key": "The Big Event Jr.",
+        "lesson.key": "The Big Event Jr",
         "lesson_group.key": "csf_events",
         "script.name": "courseb-2022"
       }
@@ -1037,7 +1037,7 @@
       },
       "seeding_key": {
         "lesson_activity.key": "737e13d1-e7a2-4f63-be94-b9f2e7db97ee",
-        "lesson.key": "The Big Event Jr.",
+        "lesson.key": "The Big Event Jr",
         "lesson_group.key": "csf_events",
         "script.name": "courseb-2022"
       }
@@ -1051,7 +1051,7 @@
       },
       "seeding_key": {
         "lesson_activity.key": "9699c947-4c73-43e4-bc7a-109abb746184",
-        "lesson.key": "The Big Event Jr.",
+        "lesson.key": "The Big Event Jr",
         "lesson_group.key": "csf_events",
         "script.name": "courseb-2022"
       }
@@ -1063,7 +1063,7 @@
       },
       "seeding_key": {
         "lesson_activity.key": "27483861-6d7c-42cf-bd22-9bff57c8c509",
-        "lesson.key": "The Big Event Jr.",
+        "lesson.key": "The Big Event Jr",
         "lesson_group.key": "csf_events",
         "script.name": "courseb-2022"
       }
@@ -1077,7 +1077,7 @@
       },
       "seeding_key": {
         "lesson_activity.key": "48d609f4-d565-47d0-aa71-f3c6cbae2571",
-        "lesson.key": "The Big Event Jr.",
+        "lesson.key": "The Big Event Jr",
         "lesson_group.key": "csf_events",
         "script.name": "courseb-2022"
       }
@@ -1091,7 +1091,7 @@
       },
       "seeding_key": {
         "lesson_activity.key": "de886c32-4827-44b6-a34d-ed3e07ef767d",
-        "lesson.key": "The Big Event Jr.",
+        "lesson.key": "The Big Event Jr",
         "lesson_group.key": "csf_events",
         "script.name": "courseb-2022"
       }
@@ -1104,7 +1104,7 @@
       },
       "seeding_key": {
         "lesson_activity.key": "2cba77e6-e43d-4690-949f-f0fed16b6528",
-        "lesson.key": "The Big Event Jr.",
+        "lesson.key": "The Big Event Jr",
         "lesson_group.key": "csf_events",
         "script.name": "courseb-2022"
       }
@@ -1117,7 +1117,7 @@
       },
       "seeding_key": {
         "lesson_activity.key": "bc267268-7861-46d8-876a-4272d51fa63a",
-        "lesson.key": "The Big Event Jr.",
+        "lesson.key": "The Big Event Jr",
         "lesson_group.key": "csf_events",
         "script.name": "courseb-2022"
       }
@@ -4728,7 +4728,7 @@
         "script_level.level_keys": [
           "BigEvent-Unplugged2022"
         ],
-        "lesson.key": "The Big Event Jr.",
+        "lesson.key": "The Big Event Jr",
         "lesson_group.key": "csf_events",
         "script.name": "courseb-2022",
         "activity_section.key": "ce7f096d-fa3c-425e-8e75-962fb8613e63"
@@ -5969,7 +5969,7 @@
         "script_level.level_keys": [
           "BigEvent-Unplugged2022"
         ],
-        "lesson.key": "The Big Event Jr.",
+        "lesson.key": "The Big Event Jr",
         "lesson_group.key": "csf_events",
         "script.name": "courseb-2022",
         "activity_section.key": "ce7f096d-fa3c-425e-8e75-962fb8613e63"
@@ -6946,31 +6946,31 @@
     },
     {
       "seeding_key": {
-        "lesson.key": "The Big Event Jr.",
+        "lesson.key": "The Big Event Jr",
         "resource.key": "feeling_faces"
       }
     },
     {
       "seeding_key": {
-        "lesson.key": "The Big Event Jr.",
+        "lesson.key": "The Big Event Jr",
         "resource.key": "the_big_event"
       }
     },
     {
       "seeding_key": {
-        "lesson.key": "The Big Event Jr.",
+        "lesson.key": "The Big Event Jr",
         "resource.key": "the_big_event_1"
       }
     },
     {
       "seeding_key": {
-        "lesson.key": "The Big Event Jr.",
+        "lesson.key": "The Big Event Jr",
         "resource.key": "the_big_event_2"
       }
     },
     {
       "seeding_key": {
-        "lesson.key": "The Big Event Jr.",
+        "lesson.key": "The Big Event Jr",
         "resource.key": "the_big_event_courses_a_b_"
       }
     },
@@ -7337,7 +7337,7 @@
     },
     {
       "seeding_key": {
-        "lesson.key": "The Big Event Jr.",
+        "lesson.key": "The Big Event Jr",
         "vocabulary.key": "event"
       }
     }
@@ -7372,7 +7372,7 @@
         "description": "Repeat commands given by an instructor."
       },
       "seeding_key": {
-        "lesson.key": "The Big Event Jr.",
+        "lesson.key": "The Big Event Jr",
         "objective.key": "1275ac31-dcd9-49c5-92e2-68abd8aa9955"
       }
     },
@@ -7482,7 +7482,7 @@
         "description": "Practice differentiating pre-defined actions and event-driven ones."
       },
       "seeding_key": {
-        "lesson.key": "The Big Event Jr.",
+        "lesson.key": "The Big Event Jr",
         "objective.key": "4dbb2bcf-bd83-4c90-a077-6261a6b2607c"
       }
     },
@@ -7682,7 +7682,7 @@
         "description": "Recognize actions of the teacher as signals to initiate commands."
       },
       "seeding_key": {
-        "lesson.key": "The Big Event Jr.",
+        "lesson.key": "The Big Event Jr",
         "objective.key": "ef1a9273-ff0e-4134-8456-9762728bed55"
       }
     },
@@ -7917,14 +7917,14 @@
     },
     {
       "seeding_key": {
-        "lesson.key": "The Big Event Jr.",
+        "lesson.key": "The Big Event Jr",
         "framework.shortcode": "csta",
         "standard.shortcode": "1A-AP-09"
       }
     },
     {
       "seeding_key": {
-        "lesson.key": "The Big Event Jr.",
+        "lesson.key": "The Big Event Jr",
         "framework.shortcode": "csta",
         "standard.shortcode": "1A-AP-11"
       }

--- a/dashboard/config/scripts_json/coursec-2022.script_json
+++ b/dashboard/config/scripts_json/coursec-2022.script_json
@@ -124,7 +124,7 @@
       }
     },
     {
-      "key": "My Robotic Friends Jr.",
+      "key": "My Robotic Friends Jr",
       "name": "My Robotic Friends Jr.",
       "absolute_position": 2,
       "lockable": false,
@@ -138,7 +138,7 @@
         "student_overview": "In this lesson, you'll pretend your classmates are robots and program them to build patterns of stacked cups."
       },
       "seeding_key": {
-        "lesson.key": "My Robotic Friends Jr.",
+        "lesson.key": "My Robotic Friends Jr",
         "lesson_group.key": "csf_sequencing",
         "script.name": "coursec-2022"
       }
@@ -224,7 +224,7 @@
       }
     },
     {
-      "key": "My Loopy Robotic Friends Jr.",
+      "key": "My Loopy Robotic Friends Jr",
       "name": "My Loopy Robotic Friends Jr.",
       "absolute_position": 7,
       "lockable": false,
@@ -238,7 +238,7 @@
         "student_overview": "In this lesson, you'll program your classmates again, but using loops you'll be able to solve bigger and more complicated problems."
       },
       "seeding_key": {
-        "lesson.key": "My Loopy Robotic Friends Jr.",
+        "lesson.key": "My Loopy Robotic Friends Jr",
         "lesson_group.key": "csf_loops",
         "script.name": "coursec-2022"
       }
@@ -516,7 +516,7 @@
       },
       "seeding_key": {
         "lesson_activity.key": "e56a02fc-2b09-45ef-91bc-40a40ba87709",
-        "lesson.key": "My Robotic Friends Jr.",
+        "lesson.key": "My Robotic Friends Jr",
         "lesson_group.key": "csf_sequencing",
         "script.name": "coursec-2022"
       }
@@ -530,7 +530,7 @@
       },
       "seeding_key": {
         "lesson_activity.key": "d0023712-1596-4547-ad29-d742aab5fea5",
-        "lesson.key": "My Robotic Friends Jr.",
+        "lesson.key": "My Robotic Friends Jr",
         "lesson_group.key": "csf_sequencing",
         "script.name": "coursec-2022"
       }
@@ -544,7 +544,7 @@
       },
       "seeding_key": {
         "lesson_activity.key": "cf3b92c1-1534-4b5f-aee0-d1d0fc689f07",
-        "lesson.key": "My Robotic Friends Jr.",
+        "lesson.key": "My Robotic Friends Jr",
         "lesson_group.key": "csf_sequencing",
         "script.name": "coursec-2022"
       }
@@ -833,7 +833,7 @@
       },
       "seeding_key": {
         "lesson_activity.key": "85aac025-b9a7-410d-aa32-833228487252",
-        "lesson.key": "My Loopy Robotic Friends Jr.",
+        "lesson.key": "My Loopy Robotic Friends Jr",
         "lesson_group.key": "csf_loops",
         "script.name": "coursec-2022"
       }
@@ -847,7 +847,7 @@
       },
       "seeding_key": {
         "lesson_activity.key": "bc37d277-781e-45ce-a009-5b860924fd0f",
-        "lesson.key": "My Loopy Robotic Friends Jr.",
+        "lesson.key": "My Loopy Robotic Friends Jr",
         "lesson_group.key": "csf_loops",
         "script.name": "coursec-2022"
       }
@@ -859,7 +859,7 @@
       },
       "seeding_key": {
         "lesson_activity.key": "f206c869-2761-46c7-9acd-f237e9b66d5e",
-        "lesson.key": "My Loopy Robotic Friends Jr.",
+        "lesson.key": "My Loopy Robotic Friends Jr",
         "lesson_group.key": "csf_loops",
         "script.name": "coursec-2022"
       }
@@ -873,7 +873,7 @@
       },
       "seeding_key": {
         "lesson_activity.key": "23a470c7-c3b7-472d-b6bf-f1788fb36b22",
-        "lesson.key": "My Loopy Robotic Friends Jr.",
+        "lesson.key": "My Loopy Robotic Friends Jr",
         "lesson_group.key": "csf_loops",
         "script.name": "coursec-2022"
       }
@@ -886,7 +886,7 @@
       },
       "seeding_key": {
         "lesson_activity.key": "e45b301d-d9e3-4217-a048-dc3bd80bbb09",
-        "lesson.key": "My Loopy Robotic Friends Jr.",
+        "lesson.key": "My Loopy Robotic Friends Jr",
         "lesson_group.key": "csf_loops",
         "script.name": "coursec-2022"
       }
@@ -3503,7 +3503,7 @@
         "script_level.level_keys": [
           "MyRoboticFriends-Unplugged2022"
         ],
-        "lesson.key": "My Robotic Friends Jr.",
+        "lesson.key": "My Robotic Friends Jr",
         "lesson_group.key": "csf_sequencing",
         "script.name": "coursec-2022",
         "activity_section.key": "4e9eaee6-773f-429b-b274-d6c22d4c6457"
@@ -4832,7 +4832,7 @@
         "script_level.level_keys": [
           "MyLoopyRoboticFriends-Unplugged2022"
         ],
-        "lesson.key": "My Loopy Robotic Friends Jr.",
+        "lesson.key": "My Loopy Robotic Friends Jr",
         "lesson_group.key": "csf_loops",
         "script.name": "coursec-2022",
         "activity_section.key": "3ff8ec4d-fe12-413a-975d-69e143845e37"
@@ -6738,7 +6738,7 @@
         "script_level.level_keys": [
           "MyRoboticFriends-Unplugged2022"
         ],
-        "lesson.key": "My Robotic Friends Jr.",
+        "lesson.key": "My Robotic Friends Jr",
         "lesson_group.key": "csf_sequencing",
         "script.name": "coursec-2022",
         "activity_section.key": "4e9eaee6-773f-429b-b274-d6c22d4c6457"
@@ -7374,7 +7374,7 @@
         "script_level.level_keys": [
           "MyLoopyRoboticFriends-Unplugged2022"
         ],
-        "lesson.key": "My Loopy Robotic Friends Jr.",
+        "lesson.key": "My Loopy Robotic Friends Jr",
         "lesson_group.key": "csf_loops",
         "script.name": "coursec-2022",
         "activity_section.key": "3ff8ec4d-fe12-413a-975d-69e143845e37"
@@ -8988,67 +8988,67 @@
     },
     {
       "seeding_key": {
-        "lesson.key": "My Loopy Robotic Friends Jr.",
+        "lesson.key": "My Loopy Robotic Friends Jr",
         "resource.key": "feeling_faces_emotion_image"
       }
     },
     {
       "seeding_key": {
-        "lesson.key": "My Loopy Robotic Friends Jr.",
+        "lesson.key": "My Loopy Robotic Friends Jr",
         "resource.key": "my_robotic_friends"
       }
     },
     {
       "seeding_key": {
-        "lesson.key": "My Loopy Robotic Friends Jr.",
+        "lesson.key": "My Loopy Robotic Friends Jr",
         "resource.key": "my_robotic_friends_1"
       }
     },
     {
       "seeding_key": {
-        "lesson.key": "My Loopy Robotic Friends Jr.",
+        "lesson.key": "My Loopy Robotic Friends Jr",
         "resource.key": "my_robotic_friends_3"
       }
     },
     {
       "seeding_key": {
-        "lesson.key": "My Loopy Robotic Friends Jr.",
+        "lesson.key": "My Loopy Robotic Friends Jr",
         "resource.key": "my_robotic_friends_4"
       }
     },
     {
       "seeding_key": {
-        "lesson.key": "My Robotic Friends Jr.",
+        "lesson.key": "My Robotic Friends Jr",
         "resource.key": "csf_-_course_c_-_slides_2022-2023"
       }
     },
     {
       "seeding_key": {
-        "lesson.key": "My Robotic Friends Jr.",
+        "lesson.key": "My Robotic Friends Jr",
         "resource.key": "my_robotic_friends"
       }
     },
     {
       "seeding_key": {
-        "lesson.key": "My Robotic Friends Jr.",
+        "lesson.key": "My Robotic Friends Jr",
         "resource.key": "my_robotic_friends_1"
       }
     },
     {
       "seeding_key": {
-        "lesson.key": "My Robotic Friends Jr.",
+        "lesson.key": "My Robotic Friends Jr",
         "resource.key": "my_robotic_friends_2"
       }
     },
     {
       "seeding_key": {
-        "lesson.key": "My Robotic Friends Jr.",
+        "lesson.key": "My Robotic Friends Jr",
         "resource.key": "my_robotic_friends_3"
       }
     },
     {
       "seeding_key": {
-        "lesson.key": "My Robotic Friends Jr.",
+        "lesson.key": "My Robotic Friends Jr",
         "resource.key": "my_robotic_friends_4"
       }
     },
@@ -9367,37 +9367,37 @@
     },
     {
       "seeding_key": {
-        "lesson.key": "My Loopy Robotic Friends Jr.",
+        "lesson.key": "My Loopy Robotic Friends Jr",
         "vocabulary.key": "loop"
       }
     },
     {
       "seeding_key": {
-        "lesson.key": "My Loopy Robotic Friends Jr.",
+        "lesson.key": "My Loopy Robotic Friends Jr",
         "vocabulary.key": "repeat"
       }
     },
     {
       "seeding_key": {
-        "lesson.key": "My Robotic Friends Jr.",
+        "lesson.key": "My Robotic Friends Jr",
         "vocabulary.key": "algorithm"
       }
     },
     {
       "seeding_key": {
-        "lesson.key": "My Robotic Friends Jr.",
+        "lesson.key": "My Robotic Friends Jr",
         "vocabulary.key": "bug"
       }
     },
     {
       "seeding_key": {
-        "lesson.key": "My Robotic Friends Jr.",
+        "lesson.key": "My Robotic Friends Jr",
         "vocabulary.key": "debugging"
       }
     },
     {
       "seeding_key": {
-        "lesson.key": "My Robotic Friends Jr.",
+        "lesson.key": "My Robotic Friends Jr",
         "vocabulary.key": "program"
       }
     },
@@ -9632,7 +9632,7 @@
         "description": "Identify repeated patterns in code that could be replaced with a loop"
       },
       "seeding_key": {
-        "lesson.key": "My Loopy Robotic Friends Jr.",
+        "lesson.key": "My Loopy Robotic Friends Jr",
         "objective.key": "81c36d87-10e0-4f7e-91f2-88b6065ab543"
       }
     },
@@ -9642,7 +9642,7 @@
         "description": "Attend to precision when creating instructions"
       },
       "seeding_key": {
-        "lesson.key": "My Robotic Friends Jr.",
+        "lesson.key": "My Robotic Friends Jr",
         "objective.key": "87841dc9-5cfa-4c68-9c56-9ca76b2668f8"
       }
     },
@@ -9752,7 +9752,7 @@
         "description": "Identify and address bugs or errors in sequenced instructions"
       },
       "seeding_key": {
-        "lesson.key": "My Robotic Friends Jr.",
+        "lesson.key": "My Robotic Friends Jr",
         "objective.key": "ce7a9596-845a-4d2f-b7ce-3e27b6faa99d"
       }
     },
@@ -9772,7 +9772,7 @@
         "description": "Write instructions that use loops to repeat patterns"
       },
       "seeding_key": {
-        "lesson.key": "My Loopy Robotic Friends Jr.",
+        "lesson.key": "My Loopy Robotic Friends Jr",
         "objective.key": "d96017f7-e2b0-45e1-aa9f-12055fcee5fe"
       }
     },
@@ -10043,35 +10043,35 @@
     },
     {
       "seeding_key": {
-        "lesson.key": "My Loopy Robotic Friends Jr.",
+        "lesson.key": "My Loopy Robotic Friends Jr",
         "framework.shortcode": "csta",
         "standard.shortcode": "1A-AP-09"
       }
     },
     {
       "seeding_key": {
-        "lesson.key": "My Loopy Robotic Friends Jr.",
+        "lesson.key": "My Loopy Robotic Friends Jr",
         "framework.shortcode": "csta",
         "standard.shortcode": "1A-AP-10"
       }
     },
     {
       "seeding_key": {
-        "lesson.key": "My Loopy Robotic Friends Jr.",
+        "lesson.key": "My Loopy Robotic Friends Jr",
         "framework.shortcode": "csta",
         "standard.shortcode": "1A-AP-11"
       }
     },
     {
       "seeding_key": {
-        "lesson.key": "My Loopy Robotic Friends Jr.",
+        "lesson.key": "My Loopy Robotic Friends Jr",
         "framework.shortcode": "csta",
         "standard.shortcode": "1A-AP-14"
       }
     },
     {
       "seeding_key": {
-        "lesson.key": "My Robotic Friends Jr.",
+        "lesson.key": "My Robotic Friends Jr",
         "framework.shortcode": "csta",
         "standard.shortcode": "1A-AP-09"
       }

--- a/dashboard/config/scripts_json/csa-self-paced-pl.script_json
+++ b/dashboard/config/scripts_json/csa-self-paced-pl.script_json
@@ -36,7 +36,7 @@
   ],
   "lessons": [
     {
-      "key": "Navigating the Code.org learning platform",
+      "key": "Navigating the Codeorg learning platform",
       "name": " Navigating Code.org learning platform",
       "absolute_position": 1,
       "lockable": false,
@@ -46,7 +46,7 @@
         "overview": "**You will learn how to:**\n\n* Navigate the Code.org website and teacher tools.\n\n**Suggested time:** 30 minutes"
       },
       "seeding_key": {
-        "lesson.key": "Navigating the Code.org learning platform",
+        "lesson.key": "Navigating the Codeorg learning platform",
         "lesson_group.key": "lessonGroup-2",
         "script.name": "csa-self-paced-pl"
       }
@@ -76,7 +76,7 @@
       },
       "seeding_key": {
         "lesson_activity.key": "70338c30-3b21-44fe-809c-9982e355a15f",
-        "lesson.key": "Navigating the Code.org learning platform",
+        "lesson.key": "Navigating the Codeorg learning platform",
         "lesson_group.key": "lessonGroup-2",
         "script.name": "csa-self-paced-pl"
       }
@@ -190,7 +190,7 @@
         "script_level.level_keys": [
           "CSA-SP-VPL-21-mod2-Overview-WebsiteNavigation"
         ],
-        "lesson.key": "Navigating the Code.org learning platform",
+        "lesson.key": "Navigating the Codeorg learning platform",
         "lesson_group.key": "lessonGroup-2",
         "script.name": "csa-self-paced-pl",
         "activity_section.key": "a1386539-882d-47be-a7f4-5cc9bc659a5d"
@@ -215,7 +215,7 @@
         "script_level.level_keys": [
           "CSA-SP-VPL-21-mod2-tour-vid"
         ],
-        "lesson.key": "Navigating the Code.org learning platform",
+        "lesson.key": "Navigating the Codeorg learning platform",
         "lesson_group.key": "lessonGroup-2",
         "script.name": "csa-self-paced-pl",
         "activity_section.key": "72fc070f-b25d-4e7d-9e0c-d37137ca99ea"
@@ -240,7 +240,7 @@
         "script_level.level_keys": [
           "CSA-SP-VPL-21-mod2-Task-VerifiedTeacher"
         ],
-        "lesson.key": "Navigating the Code.org learning platform",
+        "lesson.key": "Navigating the Codeorg learning platform",
         "lesson_group.key": "lessonGroup-2",
         "script.name": "csa-self-paced-pl",
         "activity_section.key": "72fc070f-b25d-4e7d-9e0c-d37137ca99ea"
@@ -265,7 +265,7 @@
         "script_level.level_keys": [
           "SP-VPL-21-mod2-StudentExperience-vid"
         ],
-        "lesson.key": "Navigating the Code.org learning platform",
+        "lesson.key": "Navigating the Codeorg learning platform",
         "lesson_group.key": "lessonGroup-2",
         "script.name": "csa-self-paced-pl",
         "activity_section.key": "eec016db-857b-4f77-9725-98af1395a7d0"
@@ -290,7 +290,7 @@
         "script_level.level_keys": [
           "CSA-SP-VPL-21-mod2-Task-StudentView"
         ],
-        "lesson.key": "Navigating the Code.org learning platform",
+        "lesson.key": "Navigating the Codeorg learning platform",
         "lesson_group.key": "lessonGroup-2",
         "script.name": "csa-self-paced-pl",
         "activity_section.key": "eec016db-857b-4f77-9725-98af1395a7d0"
@@ -315,7 +315,7 @@
         "script_level.level_keys": [
           "SP-VPL-21-mod2-ClassSection-vid"
         ],
-        "lesson.key": "Navigating the Code.org learning platform",
+        "lesson.key": "Navigating the Codeorg learning platform",
         "lesson_group.key": "lessonGroup-2",
         "script.name": "csa-self-paced-pl",
         "activity_section.key": "20d49572-26e9-4d70-ae88-9e8dc1b7900a"
@@ -340,7 +340,7 @@
         "script_level.level_keys": [
           "SP-VPL-21-mod2-Task-ClassSection"
         ],
-        "lesson.key": "Navigating the Code.org learning platform",
+        "lesson.key": "Navigating the Codeorg learning platform",
         "lesson_group.key": "lessonGroup-2",
         "script.name": "csa-self-paced-pl",
         "activity_section.key": "20d49572-26e9-4d70-ae88-9e8dc1b7900a"
@@ -365,7 +365,7 @@
         "script_level.level_keys": [
           "SP-VPL_21-mod2-MakeAPlan-StudentLogIn"
         ],
-        "lesson.key": "Navigating the Code.org learning platform",
+        "lesson.key": "Navigating the Codeorg learning platform",
         "lesson_group.key": "lessonGroup-2",
         "script.name": "csa-self-paced-pl",
         "activity_section.key": "20d49572-26e9-4d70-ae88-9e8dc1b7900a"
@@ -390,7 +390,7 @@
         "script_level.level_keys": [
           "SP-VPL-21-mod2-ProgessAndFeedback-vid"
         ],
-        "lesson.key": "Navigating the Code.org learning platform",
+        "lesson.key": "Navigating the Codeorg learning platform",
         "lesson_group.key": "lessonGroup-2",
         "script.name": "csa-self-paced-pl",
         "activity_section.key": "5cb3f843-9a00-4398-becc-03992d8c2169"
@@ -415,7 +415,7 @@
         "script_level.level_keys": [
           "SP-VPL-21-mod2-progress-c4u"
         ],
-        "lesson.key": "Navigating the Code.org learning platform",
+        "lesson.key": "Navigating the Codeorg learning platform",
         "lesson_group.key": "lessonGroup-2",
         "script.name": "csa-self-paced-pl",
         "activity_section.key": "5cb3f843-9a00-4398-becc-03992d8c2169"
@@ -582,7 +582,7 @@
         "script_level.level_keys": [
           "CSA-SP-VPL-21-mod2-Overview-WebsiteNavigation"
         ],
-        "lesson.key": "Navigating the Code.org learning platform",
+        "lesson.key": "Navigating the Codeorg learning platform",
         "lesson_group.key": "lessonGroup-2",
         "script.name": "csa-self-paced-pl",
         "activity_section.key": "a1386539-882d-47be-a7f4-5cc9bc659a5d"
@@ -594,7 +594,7 @@
         "script_level.level_keys": [
           "CSA-SP-VPL-21-mod2-tour-vid"
         ],
-        "lesson.key": "Navigating the Code.org learning platform",
+        "lesson.key": "Navigating the Codeorg learning platform",
         "lesson_group.key": "lessonGroup-2",
         "script.name": "csa-self-paced-pl",
         "activity_section.key": "72fc070f-b25d-4e7d-9e0c-d37137ca99ea"
@@ -606,7 +606,7 @@
         "script_level.level_keys": [
           "CSA-SP-VPL-21-mod2-Task-VerifiedTeacher"
         ],
-        "lesson.key": "Navigating the Code.org learning platform",
+        "lesson.key": "Navigating the Codeorg learning platform",
         "lesson_group.key": "lessonGroup-2",
         "script.name": "csa-self-paced-pl",
         "activity_section.key": "72fc070f-b25d-4e7d-9e0c-d37137ca99ea"
@@ -618,7 +618,7 @@
         "script_level.level_keys": [
           "SP-VPL-21-mod2-StudentExperience-vid"
         ],
-        "lesson.key": "Navigating the Code.org learning platform",
+        "lesson.key": "Navigating the Codeorg learning platform",
         "lesson_group.key": "lessonGroup-2",
         "script.name": "csa-self-paced-pl",
         "activity_section.key": "eec016db-857b-4f77-9725-98af1395a7d0"
@@ -630,7 +630,7 @@
         "script_level.level_keys": [
           "CSA-SP-VPL-21-mod2-Task-StudentView"
         ],
-        "lesson.key": "Navigating the Code.org learning platform",
+        "lesson.key": "Navigating the Codeorg learning platform",
         "lesson_group.key": "lessonGroup-2",
         "script.name": "csa-self-paced-pl",
         "activity_section.key": "eec016db-857b-4f77-9725-98af1395a7d0"
@@ -642,7 +642,7 @@
         "script_level.level_keys": [
           "SP-VPL-21-mod2-ClassSection-vid"
         ],
-        "lesson.key": "Navigating the Code.org learning platform",
+        "lesson.key": "Navigating the Codeorg learning platform",
         "lesson_group.key": "lessonGroup-2",
         "script.name": "csa-self-paced-pl",
         "activity_section.key": "20d49572-26e9-4d70-ae88-9e8dc1b7900a"
@@ -654,7 +654,7 @@
         "script_level.level_keys": [
           "SP-VPL-21-mod2-Task-ClassSection"
         ],
-        "lesson.key": "Navigating the Code.org learning platform",
+        "lesson.key": "Navigating the Codeorg learning platform",
         "lesson_group.key": "lessonGroup-2",
         "script.name": "csa-self-paced-pl",
         "activity_section.key": "20d49572-26e9-4d70-ae88-9e8dc1b7900a"
@@ -666,7 +666,7 @@
         "script_level.level_keys": [
           "SP-VPL_21-mod2-MakeAPlan-StudentLogIn"
         ],
-        "lesson.key": "Navigating the Code.org learning platform",
+        "lesson.key": "Navigating the Codeorg learning platform",
         "lesson_group.key": "lessonGroup-2",
         "script.name": "csa-self-paced-pl",
         "activity_section.key": "20d49572-26e9-4d70-ae88-9e8dc1b7900a"
@@ -678,7 +678,7 @@
         "script_level.level_keys": [
           "SP-VPL-21-mod2-ProgessAndFeedback-vid"
         ],
-        "lesson.key": "Navigating the Code.org learning platform",
+        "lesson.key": "Navigating the Codeorg learning platform",
         "lesson_group.key": "lessonGroup-2",
         "script.name": "csa-self-paced-pl",
         "activity_section.key": "5cb3f843-9a00-4398-becc-03992d8c2169"
@@ -690,7 +690,7 @@
         "script_level.level_keys": [
           "SP-VPL-21-mod2-progress-c4u"
         ],
-        "lesson.key": "Navigating the Code.org learning platform",
+        "lesson.key": "Navigating the Codeorg learning platform",
         "lesson_group.key": "lessonGroup-2",
         "script.name": "csa-self-paced-pl",
         "activity_section.key": "5cb3f843-9a00-4398-becc-03992d8c2169"


### PR DESCRIPTION
Names of lessons were showing that they could not be translated for some lessons. After investigating we determined it was because of a period in the key for the lesson. This removes periods from names of existing lessons that were causing issues to unblock curriculum writers.

Thanks @bethanyaconnor for your help investigating this.

## Links

[Slack Convo](https://codedotorg.slack.com/archives/C02EEGWLHR8/p1644350606411229)

## Testing story

- Ran `bundle exec rake build` to make sure things build ok
- Checked that these lessons no longer show the translation error message

## Follow-up work

- [Make sure when new lessons are made or lessons are copied we do not end up with periods in the key](https://codedotorg.atlassian.net/browse/PLAT-1594)