### PR TITLE
Fix Brazil and Portugal translation

### DIFF
--- a/dashboard/config/locales/blocks.pt-BR.yml
+++ b/dashboard/config/locales/blocks.pt-BR.yml
@@ -1208,7 +1208,7 @@ pt:
       gamelab_mouseLocation:
         text: posição do mouse
       gamelab_moveBackward:
-        text: mover [SPRITE] [0] [DISTANCE] [1] pixels para trás
+        text: mover {SPRITE} [0] {DISTANCE} [1] pixels para trás
       gamelab_moveForward:
         text: mover {SPRITE} {DISTANCE} pixels pra frente
       gamelab_moveInDirection:

--- a/dashboard/config/locales/blocks.pt-PT.yml
+++ b/dashboard/config/locales/blocks.pt-PT.yml
@@ -1208,7 +1208,7 @@ pt:
       gamelab_mouseLocation:
         text: posição do mouse
       gamelab_moveBackward:
-        text: mover [SPRITE] [0] [DISTANCE] [1] pixels para trás
+        text: mover {SPRITE} [0] {DISTANCE} [1] pixels para trás
       gamelab_moveForward:
         text: mover {SPRITE} {DISTANCE} pixels pra frente
       gamelab_moveInDirection:


### PR DESCRIPTION
Both of our Portuguese translations had an error (using square brackets, instead of curly brackets) that was causing Spritelab not to load. Since this breaks Spritelab and has happened twice in the last month, we should work with the international team to make our system more robust against this error.

Same situation happened here - also with Portuguese: https://github.com/code-dot-org/code-dot-org/pull/44514

Before:
![Screenshot from 2022-02-09 16-51-24](https://user-images.githubusercontent.com/2959170/153315812-c4d48824-ff08-40e0-8f4e-c8efafbecdf4.png)


After:
![Screenshot from 2022-02-09 16-50-59](https://user-images.githubusercontent.com/2959170/153315802-7f856700-23fb-4d62-801d-256b6527eefe.png)


## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
