### PR TITLE
add reference guide model serialization, tests

### DIFF
--- a/bin/curriculum/import_reference_guides.rb
+++ b/bin/curriculum/import_reference_guides.rb
@@ -106,24 +106,25 @@ def main(options)
 
     # find a unique key based on the end of the slug
     # if there are duplicates, append _N where N is a number that makes it unique
-    key = guide['slug'].rpartition('/').last
+    key_base = guide['slug'].rpartition('/').last
+    unique_key = key_base
     iteration = 2
-    while guide_key_set.include?(key)
-      key = "#{key.chomp("_#{iteration - 1}")}_#{iteration}"
+    while guide_key_set.include?(unique_key)
+      unique_key = "#{key_base}-#{iteration}"
       iteration += 1
     end
 
     # don't reuse that key
-    guide_key_set.add(key)
+    guide_key_set.add(unique_key)
 
     # store the children with their parent key
-    guide_stack.concat(guide['children'].map {|child| [child, key]})
+    guide_stack.concat(guide['children'].map {|child| [child, unique_key]})
 
     next if options.dry_run
 
     reference_guide = ReferenceGuide.find_or_initialize_by(
       {
-        key: key,
+        key: unique_key,
         course_version_id: course_version.id
       }
     )

--- a/bin/curriculum/import_reference_guides.rb
+++ b/bin/curriculum/import_reference_guides.rb
@@ -105,7 +105,7 @@ def main(options)
     updated_reference_guide_count += 1
 
     # find a unique key based on the end of the slug
-    # if there are duplicates, append _N where N is a number that makes it unique
+    # if there are duplicates, append -N where N is a number that makes it unique
     key_base = guide['slug'].rpartition('/').last
     unique_key = key_base
     iteration = 2

--- a/bin/curriculum/import_reference_guides.rb
+++ b/bin/curriculum/import_reference_guides.rb
@@ -6,7 +6,6 @@ require 'optparse'
 require 'uri'
 require 'net/http'
 require_relative '../../deployment'
-require 'cdo/lesson_import_helper'
 
 raise unless [:development, :adhoc, :levelbuilder].include? rack_env
 

--- a/bin/curriculum/import_reference_guides.rb
+++ b/bin/curriculum/import_reference_guides.rb
@@ -1,0 +1,156 @@
+#!/usr/bin/env ruby
+
+require 'set'
+require 'json'
+require 'optparse'
+require 'uri'
+require 'net/http'
+require_relative '../../deployment'
+require 'cdo/lesson_import_helper'
+
+raise unless [:development, :adhoc, :levelbuilder].include? rack_env
+
+$verbose = false
+def log(str)
+  puts str if $verbose
+end
+
+$quiet = false
+def warn(str)
+  puts str unless $quiet && !$verbose
+end
+
+# Wait until after initial error checking before loading the rails environment.
+def require_rails_env
+  log "loading rails environment..."
+  start_time = Time.now
+  require_relative '../../dashboard/config/environment'
+  log "rails environment loaded in #{(Time.now - start_time).to_i} seconds."
+end
+
+def parse_options
+  OpenStruct.new.tap do |options|
+    options.local = false
+    options.dry_run = false
+    options.course_offering = 'csp'
+    options.course_version = '2022'
+
+    opt_parser = OptionParser.new do |opts|
+      opts.banner = <<~BANNER
+        Usage: #{$0} [options]
+      BANNER
+
+      opts.separator ""
+
+      opts.on('-c', '--course-offering course_offering', 'Specify course offering key. Default: csp') do |course_offering|
+        options.course_offering = course_offering
+      end
+
+      opts.on('-v', '--course-version course_version', 'Specify course version key. Default: 2022') do |course_version|
+        options.course_version = course_version
+      end
+
+      opts.on('-l', '--local', 'Use local curriculum builder running on localhost:8000.') do
+        options.local = true
+      end
+
+      opts.on('-n', '--dry-run', 'Perform basic validation without importing any data.') do
+        options.dry_run = true
+      end
+
+      opts.on('-q', '--quiet', 'Silence warnings.') do
+        $quiet = true
+      end
+
+      opts.on('-b', '--verbose', 'Use verbose debug logging.') do
+        $verbose = true
+      end
+
+      opts.on_tail("-h", "--help", "Show this message") do
+        puts opts
+        exit
+      end
+    end
+
+    opt_parser.parse!(ARGV)
+  end
+end
+
+def main(options)
+  cb_url_prefix = options.local ? 'http://localhost:8000' : 'http://www.codecurricula.com'
+
+  # recursively find all the guides!
+  guide_stack = [['concepts', nil]]
+  guide_key_set = Set[]
+  updated_reference_guide_count = 0
+
+  course_version = CourseOffering.where(key: options.course_offering).last.
+    course_versions.where(key: options.course_version).last
+
+  puts "Confirm course version (y/n):"
+  puts course_version.to_json
+  return unless gets.chomp == "y"
+
+  until guide_stack.empty?
+    guide_to_fetch, guide_to_fetch_parent = guide_stack.pop
+
+    # skip the Data Library category (to be imported separately as Data Docs)
+    next if guide_to_fetch.start_with?('concepts/data-library')
+
+    puts "Fetching #{guide_to_fetch}"
+
+    url = "#{cb_url_prefix}/documentation/export/#{guide_to_fetch}.json?format=json"
+    guide_json = fetch(url)
+
+    guide = JSON.parse(guide_json)
+    updated_reference_guide_count += 1
+
+    # find a unique key based on the end of the slug
+    # if there are duplicates, append _N where N is a number that makes it unique
+    key = guide['slug'].rpartition('/').last
+    iteration = 2
+    while guide_key_set.include?(key)
+      key = "#{key.chomp("_#{iteration - 1}")}_#{iteration}"
+      iteration += 1
+    end
+
+    # don't reuse that key
+    guide_key_set.add(key)
+
+    # store the children with their parent key
+    guide_stack.concat(guide['children'].map {|child| [child, key]})
+
+    next if options.dry_run
+
+    reference_guide = ReferenceGuide.find_or_initialize_by(
+      {
+        key: key,
+        course_version_id: course_version.id
+      }
+    )
+
+    reference_guide.parent_reference_guide_key = guide_to_fetch_parent
+    reference_guide.display_name = guide['title']
+    reference_guide.content = guide['content']
+    reference_guide.position = guide['order']
+
+    reference_guide.save!
+    reference_guide.write_serialization
+  end
+
+  puts "updated #{updated_reference_guide_count} reference guides"
+end
+
+def fetch(url)
+  uri = URI(url)
+  response = Net::HTTP.get_response(uri)
+  raise "HTTP status #{response.code} fetching #{uri}" unless response.is_a? Net::HTTPSuccess
+  body = response.body
+  log "fetched #{body.length} bytes of unit json from #{uri}"
+  body
+end
+
+options = parse_options
+
+require_rails_env
+main(options)

--- a/dashboard/app/helpers/curriculum_helper.rb
+++ b/dashboard/app/helpers/curriculum_helper.rb
@@ -1,0 +1,21 @@
+module CurriculumHelper
+  def key_format
+    if key.blank?
+      errors.add(:base, 'Key must not be blank')
+      return false
+    end
+
+    if key[0] == '.' || key[-1] == '.'
+      errors.add(:base, 'Key cannot start or end with period')
+      return false
+    end
+
+    key_char_re = /[A-Za-z0-9\-\_\.]/
+    key_re = /\A#{key_char_re}+\Z/
+    unless key_re.match?(key)
+      errors.add(:base, "must only be letters, numbers, dashes, underscores, and periods. Got ${key}")
+      return false
+    end
+    return true
+  end
+end

--- a/dashboard/app/helpers/curriculum_helper.rb
+++ b/dashboard/app/helpers/curriculum_helper.rb
@@ -1,5 +1,5 @@
 module CurriculumHelper
-  def key_format
+  def validate_key_format
     if key.blank?
       errors.add(:base, 'Key must not be blank')
       return false

--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -26,6 +26,7 @@ class CourseVersion < ApplicationRecord
   belongs_to :course_offering
   has_many :resources
   has_many :vocabularies
+  has_many :reference_guides
 
   attr_readonly :content_root_type
   attr_readonly :content_root_id

--- a/dashboard/app/models/programming_expression.rb
+++ b/dashboard/app/models/programming_expression.rb
@@ -20,6 +20,7 @@
 #  programming_environment_key                                  (programming_environment_id,key) UNIQUE
 #
 class ProgrammingExpression < ApplicationRecord
+  include CurriculumHelper
   include SerializedProperties
 
   belongs_to :programming_environment
@@ -43,26 +44,6 @@ class ProgrammingExpression < ApplicationRecord
     video_key
     block_name
   )
-
-  def key_format
-    if key.blank?
-      errors.add(:base, 'Key must not be blank')
-      return false
-    end
-
-    if key[0] == '.' || key[-1] == '.'
-      errors.add(:base, 'Key cannot start or end with period')
-      return false
-    end
-
-    key_char_re = /[A-Za-z0-9\-\_\.]/
-    key_re = /\A#{key_char_re}+\Z/
-    unless key_re.match?(key)
-      errors.add(:base, "must only be letters, numbers, dashes, underscores, and periods. Got ${key}")
-      return false
-    end
-    return true
-  end
 
   def self.properties_from_file(path, content)
     expression_config = JSON.parse(content)

--- a/dashboard/app/models/programming_expression.rb
+++ b/dashboard/app/models/programming_expression.rb
@@ -28,7 +28,7 @@ class ProgrammingExpression < ApplicationRecord
   has_many :lessons_programming_expressions
 
   validates_uniqueness_of :key, scope: :programming_environment_id, case_sensitive: false
-  validate :key_format
+  validate :validate_key_format
 
   serialized_attrs %w(
     color

--- a/dashboard/app/models/reference_guide.rb
+++ b/dashboard/app/models/reference_guide.rb
@@ -22,7 +22,7 @@ class ReferenceGuide < ApplicationRecord
 
   belongs_to :course_version
   validates_uniqueness_of :key, scope: :course_version_id
-  validate :key_format
+  validate :validate_key_format
 
   def children
     ReferenceGuide.where(course_version_id: course_version_id, parent_reference_guide_key: key)

--- a/dashboard/app/models/reference_guide.rb
+++ b/dashboard/app/models/reference_guide.rb
@@ -18,4 +18,70 @@
 #  index_reference_guides_on_course_version_id_and_parent_key  (course_version_id,parent_reference_guide_key)
 #
 class ReferenceGuide < ApplicationRecord
+  belongs_to :course_version
+  validates_uniqueness_of :key, scope: :course_version_id
+
+  def children
+    ReferenceGuide.where(course_version_id: course_version_id, parent_reference_guide_key: key)
+  end
+
+  def serialize
+    {
+      key: key,
+      course_version_key: course_version.key,
+      course_offering_key: course_version.course_offering.key,
+      parent_reference_guide_key: parent_reference_guide_key,
+      display_name: display_name,
+      content: content,
+      position: position
+    }
+  end
+
+  def write_serialization
+    return unless Rails.application.config.levelbuilder_mode
+    offering_and_version = "#{course_version.course_offering.key}_#{course_version.key}"
+    file_path = Rails.root.join("config/reference_guides/#{offering_and_version}/#{key}.json")
+    object_to_serialize = serialize
+    dirname = File.dirname(file_path)
+    unless File.directory?(dirname)
+      FileUtils.mkdir_p(dirname)
+    end
+    File.write(file_path, JSON.pretty_generate(object_to_serialize))
+  end
+
+  def self.seed_all
+    # collect all existing ids
+    removed_records = all.pluck(:id)
+    Dir.glob(Rails.root.join("config/reference_guides/**/*.json")).each do |path|
+      # for each file, seed the reference guide and remove from the original set the found ids
+      # (new ids won't change anything)
+      removed_records -= [ReferenceGuide.seed_record(path)]
+    end
+    # the remaining ids that were not seeded should be removed
+    where(id: removed_records).destroy_all
+  end
+
+  def self.properties_from_file(content)
+    config = JSON.parse(content)
+    course_version_id = CourseOffering.find_by(key: config['course_offering_key'])&.
+      course_versions&.where(key: config['course_version_key'])&.last&.id
+    {
+      key: config['key'],
+      course_version_id: course_version_id,
+      parent_reference_guide_key: config['parent_reference_guide_key'],
+      display_name: config['display_name'],
+      content: config['content'],
+      position: config['position']
+    }
+  end
+
+  def self.seed_record(file_path)
+    properties = properties_from_file(File.read(file_path))
+    reference_guide = ReferenceGuide.find_or_initialize_by(
+      key: properties[:key],
+      course_version_id: properties[:course_version_id]
+    )
+    reference_guide.update! properties
+    reference_guide.id
+  end
 end

--- a/dashboard/app/models/reference_guide.rb
+++ b/dashboard/app/models/reference_guide.rb
@@ -40,9 +40,10 @@ class ReferenceGuide < ApplicationRecord
     }
   end
 
+  # writes reference guide to a seed file in the config directory
   def write_serialization
     return unless Rails.application.config.levelbuilder_mode
-    offering_and_version = "#{course_version.course_offering.key}_#{course_version.key}"
+    offering_and_version = "#{course_version.course_offering.key}-#{course_version.key}"
     file_path = Rails.root.join("config/reference_guides/#{offering_and_version}/#{key}.json")
     object_to_serialize = serialize
     dirname = File.dirname(file_path)
@@ -52,6 +53,7 @@ class ReferenceGuide < ApplicationRecord
     File.write(file_path, JSON.pretty_generate(object_to_serialize))
   end
 
+  # runs through all seed files, creating and deleting records to match the seed files
   def self.seed_all
     # collect all existing ids
     removed_records = all.pluck(:id)
@@ -64,6 +66,7 @@ class ReferenceGuide < ApplicationRecord
     where(id: removed_records).destroy_all
   end
 
+  # parses a seed file and generates a hash with the course version mapped
   def self.properties_from_file(content)
     config = JSON.parse(content)
     course_version_id = CourseOffering.find_by(key: config['course_offering_key'])&.
@@ -78,6 +81,7 @@ class ReferenceGuide < ApplicationRecord
     }
   end
 
+  # returns the local id of the reference guide that was created/updated
   def self.seed_record(file_path)
     properties = properties_from_file(File.read(file_path))
     reference_guide = ReferenceGuide.find_or_initialize_by(

--- a/dashboard/app/models/reference_guide.rb
+++ b/dashboard/app/models/reference_guide.rb
@@ -18,8 +18,11 @@
 #  index_reference_guides_on_course_version_id_and_parent_key  (course_version_id,parent_reference_guide_key)
 #
 class ReferenceGuide < ApplicationRecord
+  include CurriculumHelper
+
   belongs_to :course_version
   validates_uniqueness_of :key, scope: :course_version_id
+  validate :key_format
 
   def children
     ReferenceGuide.where(course_version_id: course_version_id, parent_reference_guide_key: key)

--- a/dashboard/test/factories/curriculum_factories.rb
+++ b/dashboard/test/factories/curriculum_factories.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :reference_guide do
     association :course_version
 
-    key "ref_guide_key"
+    sequence(:key, 1) {|c| "bogus-reference-guide-#{c}"}
     display_name "Sample Reference Guide"
     content "Some markdown *text*"
 

--- a/dashboard/test/factories/curriculum_factories.rb
+++ b/dashboard/test/factories/curriculum_factories.rb
@@ -1,0 +1,13 @@
+FactoryGirl.define do
+  factory :reference_guide do
+    association :course_version
+
+    key "ref_guide_key"
+    display_name "Sample Reference Guide"
+    content "Some markdown *text*"
+
+    position do |reference_guide|
+      (reference_guide.course_version.reference_guides.maximum(:position) || 0) + 1 if reference_guide.course_version
+    end
+  end
+end

--- a/dashboard/test/factories/curriculum_factories.rb
+++ b/dashboard/test/factories/curriculum_factories.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :reference_guide do
     association :course_version
 
-    sequence(:key, 1) {|c| "bogus-reference-guide-#{c}"}
+    sequence(:key) {|n| "bogus-reference-guide-#{n}"}
     display_name "Sample Reference Guide"
     content "Some markdown *text*"
 

--- a/dashboard/test/fixtures/config/reference_guides/test-reference-guide.json
+++ b/dashboard/test/fixtures/config/reference_guides/test-reference-guide.json
@@ -1,0 +1,9 @@
+{
+  "key": "test-serialization",
+  "course_version_key": "2022",
+  "course_offering_key": "csp",
+  "parent_reference_guide_key": null,
+  "display_name": "Test Serialization",
+  "content": "There is some content here that is being serialized.\r\n",
+  "position": 0
+}

--- a/dashboard/test/models/reference_guide_test.rb
+++ b/dashboard/test/models/reference_guide_test.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+
+class ReferenceGuideTest < ActiveSupport::TestCase
+  test "can create reference guide" do
+    reference_guide = create :reference_guide
+    assert reference_guide.id
+  end
+
+  test "reference guides are unique by key in course version" do
+    create :reference_guide, key: 'page', course_version_id: 1
+    create :reference_guide, key: 'page', course_version_id: 2
+    assert_raises ActiveRecord::RecordInvalid do
+      create :reference_guide, key: 'page', course_version_id: 1
+    end
+  end
+
+  test "reference guides seed from files correctly" do
+    co = create :course_offering, key: 'csp'
+    cv = create :course_version, key: '2022', course_offering: co
+    guide = create :reference_guide, id: '1', display_name: 'Hello World', key: 'page', content: 'page content', course_version: cv, position: 2
+    serialization = guide.serialize
+    previous_guide = guide.freeze
+    guide.destroy!
+
+    File.stubs(:read).returns(serialization.to_json)
+
+    new_guide_id = ReferenceGuide.seed_record("config/reference_guides/csp_2022/page.json")
+    new_guide = ReferenceGuide.find_by(id: new_guide_id)
+    assert_equal previous_guide.attributes.except('id', 'created_at', 'updated_at'),
+      new_guide.attributes.except('id', 'created_at', 'updated_at')
+  end
+
+  test "reference guides can be nested" do
+    guide = create :reference_guide, key: 'page', course_version_id: 1, parent_reference_guide_key: 'category_page'
+    category = create :reference_guide, key: 'category_page', course_version_id: 1
+    assert_equal [guide], category.children
+  end
+end

--- a/dashboard/test/models/reference_guide_test.rb
+++ b/dashboard/test/models/reference_guide_test.rb
@@ -20,32 +20,32 @@ class ReferenceGuideTest < ActiveSupport::TestCase
   end
 
   test "reference guides are unique by key in course version" do
-    create :reference_guide, key: 'page', course_version_id: 1
-    create :reference_guide, key: 'page', course_version_id: 2
+    ref1 = create :reference_guide, key: 'page'
+    create :reference_guide, key: 'page'
     assert_raises ActiveRecord::RecordInvalid do
-      create :reference_guide, key: 'page', course_version_id: 1
+      create :reference_guide, key: 'page', course_version_id: ref1.course_version_id
     end
   end
 
   test "reference guides seed from files correctly" do
-    co = create :course_offering, key: 'csp'
-    cv = create :course_version, key: '2022', course_offering: co
-    guide = create :reference_guide, id: '1', display_name: 'Hello World', key: 'page', content: 'page content', course_version: cv, position: 2
+    co = create :course_offering, key: 'test-offering'
+    cv = create :course_version, key: '20xx', course_offering: co
+    guide = create :reference_guide, display_name: 'Test Serialization', key: 'test-serialization', content: 'There is some content here that is being serialized.\r\n', course_version: cv, position: 0
     serialization = guide.serialize
     previous_guide = guide.freeze
     guide.destroy!
 
     File.stubs(:read).returns(serialization.to_json)
 
-    new_guide_id = ReferenceGuide.seed_record("config/reference_guides/csp_2022/page.json")
+    new_guide_id = ReferenceGuide.seed_record("test/fixtures/config/reference_guides/test-reference-guide.json")
     new_guide = ReferenceGuide.find_by(id: new_guide_id)
     assert_equal previous_guide.attributes.except('id', 'created_at', 'updated_at'),
       new_guide.attributes.except('id', 'created_at', 'updated_at')
   end
 
   test "reference guides can be nested" do
-    guide = create :reference_guide, key: 'page', course_version_id: 1, parent_reference_guide_key: 'category_page'
-    category = create :reference_guide, key: 'category_page', course_version_id: 1
+    guide = create :reference_guide, key: 'page', parent_reference_guide_key: 'category_page'
+    category = create :reference_guide, key: 'category_page', course_version_id: guide.course_version_id
     assert_equal [guide], category.children
   end
 end

--- a/dashboard/test/models/reference_guide_test.rb
+++ b/dashboard/test/models/reference_guide_test.rb
@@ -6,6 +6,19 @@ class ReferenceGuideTest < ActiveSupport::TestCase
     assert reference_guide.id
   end
 
+  test "do not allow invalid keys" do
+    create :reference_guide, key: 'valid.KEY_'
+    assert_raises ActiveRecord::RecordInvalid do
+      create :reference_guide, key: 'fgsfds.'
+    end
+    assert_raises ActiveRecord::RecordInvalid do
+      create :reference_guide, key: '.fgsfds'
+    end
+    assert_raises ActiveRecord::RecordInvalid do
+      create :reference_guide, key: '\\ $ % * & @'
+    end
+  end
+
   test "reference guides are unique by key in course version" do
     create :reference_guide, key: 'page', course_version_id: 1
     create :reference_guide, key: 'page', course_version_id: 2


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Adds seeding and serialization logic for reference guides.
Also adds import script for seeding from curriculumbuilder.

Minor changes to the eng plan:
- renamed `parent_reference_guide_id` to `parent_reference_guide_key` because of seeding race condition problems
- removed categories from the seed file path (going with unique keys for ref guides)

Ref guides after import script has run:
![image](https://user-images.githubusercontent.com/82416901/153317736-e729605e-c81e-43a0-8555-ae0a45c38f6a.png)

Example of config seed file:
![image](https://user-images.githubusercontent.com/82416901/153317793-8dd03618-8d68-480d-a54a-8e57996f17be.png)


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- spec: [product spec](https://docs.google.com/document/d/1VZGle7QA-06ZNNxy2SkvA8Msrok8pyN7fuq5hzek888/edit)
- eng [plan](https://docs.google.com/document/d/1mrGDWR6cWuf22x178OMvDFG6yfRNxBOB73d34ASyOT0/edit#)
- jira ticket: [PLAT-604](https://codedotorg.atlassian.net/browse/PLAT-604)

## Testing story

Tested import manually against local curriculumbuilder instance with a copy of the cb db.
Added unit tests.

## Follow-up work

TODO: add script to rename curriculum objects and fields when cloning a set of reference guides into a course version.
