### PR TITLE
Add a fallback for window.location.origin

### DIFF
--- a/apps/src/util/i18nStringTrackerWorker.js
+++ b/apps/src/util/i18nStringTrackerWorker.js
@@ -82,7 +82,17 @@ const RECORD_LIMIT = 500;
  * @param {I18nRecords} records The records of i18n string usage information to be sent.
  */
 function sendRecords(records) {
-  const url = window.location.origin + window.location.pathname; //strip the query string from the URL
+  let locationOrigin = window.location.origin;
+  if (!locationOrigin) {
+    locationOrigin =
+      window.location.protocol +
+      '//' +
+      window.location.hostname +
+      (window.location.port ? ':' + window.location.port : '');
+  }
+
+  const url = locationOrigin + window.location.pathname; //strip the query string from the URL
+
   Object.keys(records).forEach(source => {
     const stringKeys = Array.from(records[source]);
     // Break the keys up into smaller batches because the API has a maximum limit.


### PR DESCRIPTION
[FND-1874](https://codedotorg.atlassian.net/browse/FND-1874): Fix this [Honeybadger error](https://app.honeybadger.io/projects/3240/faults/83131546) which caused by older browsers do not implement `window.location.origin`.
 
**Testing story:**
- Enabled client string tracker locally.
- Opened http://localhost-studio.code.com:3000/s/mc (Minecraft).
- Verified that the fallback returned the same result as `window.location.origin`. 