### PR TITLE
move certificate share page content into react

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -508,6 +508,7 @@ describe('entry tests', () => {
   );
 
   var codeStudioEntries = {
+    'certificates/show': './src/sites/studio/pages/certificates/show.js',
     'code-studio': './src/sites/studio/pages/code-studio.js',
     'congrats/index': './src/sites/studio/pages/congrats/index.js',
     'courses/index': './src/sites/studio/pages/courses/index.js',

--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -255,6 +255,7 @@
   "censusRequiredSelect": "Required. Please select an option.",
   "censusTextBased": "Text-based programming in a language such as Java, JavaScript, Python, C++, etc. (Excluding HTML or CSS)",
   "censusWebDesign": "Web design using HTML or CSS",
+  "certificateForCompletion": "Certificate for Completion of One Hour of Code",
   "challengeLevelIntro": "Challenge Puzzles are lessons designed to stretch your brain! Just do the best that you can!",
   "challengeLevelPassTitle": "You did it!",
   "challengeLevelPassText": "However, you could've done it with only {idealBlocks, plural, one {1 block} other {# blocks}}. Can you make your program even better?",

--- a/apps/src/sites/studio/pages/certificates/show.js
+++ b/apps/src/sites/studio/pages/certificates/show.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import getScriptData from '@cdo/apps/util/getScriptData';
+import CertificateShare from '@cdo/apps/templates/CertificateShare';
+
+$(document).ready(function() {
+  const certificateData = getScriptData('certificate');
+  const {imageUrl, printUrl} = certificateData;
+  ReactDOM.render(
+    <CertificateShare imageUrl={imageUrl} printUrl={printUrl} />,
+    document.getElementById('certificate-share')
+  );
+});

--- a/apps/src/templates/CertificateShare.jsx
+++ b/apps/src/templates/CertificateShare.jsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import i18n from '@cdo/locale';
 
 export default function CertificateShare(props) {
   return (
     <a href={props.printUrl}>
       <img
         src={props.imageUrl}
-        alt="Certificate for Completion of One Hour of Code"
+        alt={i18n.certificateForCompletion()}
         width="100%"
       />
     </a>

--- a/apps/src/templates/CertificateShare.jsx
+++ b/apps/src/templates/CertificateShare.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default function CertificateShare(props) {
+  return (
+    <a href={props.printUrl}>
+      <img
+        src={props.imageUrl}
+        alt="Certificate for Completion of One Hour of Code"
+        width="100%"
+      />
+    </a>
+  );
+}
+
+CertificateShare.propTypes = {
+  imageUrl: PropTypes.string.isRequired,
+  printUrl: PropTypes.string.isRequired
+};

--- a/dashboard/app/controllers/certificates_controller.rb
+++ b/dashboard/app/controllers/certificates_controller.rb
@@ -13,7 +13,9 @@ class CertificatesController < ApplicationController
       return render status: :bad_request, json: {message: 'invalid base64'}
     end
 
-    @certificate_image_url = certificate_image_url(data['name'], data['course'])
-    @certificate_print_url = certificate_print_url(data['name'], data['course'])
+    @certificate_data = {
+      imageUrl: certificate_image_url(data['name'], data['course']),
+      printUrl: certificate_print_url(data['name'], data['course'])
+    }
   end
 end

--- a/dashboard/app/views/certificates/show.html.haml
+++ b/dashboard/app/views/certificates/show.html.haml
@@ -1,7 +1,3 @@
-- certificate_data = {}
-- certificate_data[:imageUrl] = @certificate_image_url
-- certificate_data[:printUrl] = @certificate_print_url
-
-%script{src: webpack_asset_path('js/certificates/show.js'), data: {certificate: certificate_data.to_json}}
+%script{src: webpack_asset_path('js/certificates/show.js'), data: {certificate: @certificate_data.to_json}}
 
 #certificate-share

--- a/dashboard/app/views/certificates/show.html.haml
+++ b/dashboard/app/views/certificates/show.html.haml
@@ -1,3 +1,4 @@
+%script{src: webpack_asset_path("js/#{js_locale}/common_locale.js")}
 %script{src: webpack_asset_path('js/certificates/show.js'), data: {certificate: @certificate_data.to_json}}
 
 #certificate-share

--- a/dashboard/app/views/certificates/show.html.haml
+++ b/dashboard/app/views/certificates/show.html.haml
@@ -1,2 +1,7 @@
-%a{href: @certificate_print_url}
-  %img{src: @certificate_image_url, alt: 'Certificate for Completion of One Hour of Code', width:"100%"}
+- certificate_data = {}
+- certificate_data[:imageUrl] = @certificate_image_url
+- certificate_data[:printUrl] = @certificate_print_url
+
+%script{src: webpack_asset_path('js/certificates/show.js'), data: {certificate: certificate_data.to_json}}
+
+#certificate-share


### PR DESCRIPTION
Starts [PLAT-1588](https://codedotorg.atlassian.net/browse/PLAT-1588). See [work plan](https://docs.google.com/document/d/1wTObDFZdWS6RzpM3R6wEm04ToY2fM1B5Kb2rUHCNq28/edit#). 

This is a small PR to extract the certificate share page into react. The next PR, which will add back the content below the certificate, is blocked on input from Product / Marketing since there will be some changes to the content there.

## Screenshots

screenshot shows translatable alt text in chrome debugger

![Screen Shot 2022-02-10 at 9 53 59 AM](https://user-images.githubusercontent.com/8001765/153467927-7842fe49-4462-4bad-932d-7d666a129d8b.png)

Also see previous PR https://github.com/code-dot-org/code-dot-org/pull/44651 which contains screenshots comparing dashboard / pegasus pages -- this PR does not introduce any additional user-visible changes since that PR.

## Testing story

existing controller tests verify the page is still rendering without errors