### PR TITLE
Fix translations in Tamil

### DIFF
--- a/dashboard/config/locales/blocks.ta-IN.yml
+++ b/dashboard/config/locales/blocks.ta-IN.yml
@@ -908,7 +908,7 @@ ta:
       Dancelab_whenSetup2:
         text: செட்அப்
       gamelab_addBehaviorSimple:
-        text: ஸ்பிரைட்[SPRITE]தொடக்கம்{BEHAVIOR}
+        text: ஸ்பிரைட்{SPRITE}தொடக்கம்{BEHAVIOR}
       gamelab_addTarget:
         text: "{SPRITE}இலக்கை அடைகிறது{TARGET}க்கு{OPT}"
         options:
@@ -973,7 +973,7 @@ ta:
       gamelab_drawLine:
         text: கோடு வரைக {COLOR}  {LOC1}  {LOC2}
       gamelab_edgesDisplace:
-        text: விளிம்புகள் தொகுதி [SPRITE] [0] நகரும் இருந்து
+        text: விளிம்புகள் தொகுதி {SPRITE} நகரும் இருந்து
       gamelab_followingTargets:
         text: பின்வரும் இலக்குகள்
       gamelab_getAllSprites:
@@ -1140,7 +1140,7 @@ ta:
             '180': இடது
             '270': மேலே
       gamelab_mirrorSprite:
-        text: "[SPRITE][SPRITE]முகம்{DIRECTION}"
+        text: "{SPRITE} முகம் {DIRECTION}"
         options:
           DIRECTION:
             '"right"': வலது
@@ -1150,7 +1150,7 @@ ta:
       gamelab_moveBackward:
         text: நகர்வு {SPRITE} {DISTANCE} பிக்சல்கள் பின்னோக்கி
       gamelab_moveForward:
-        text: பிக்சல்களை {SPRITE} [DISTANCE[1] நகர்த்தவும்
+        text: பிக்சல்களை {SPRITE} {DISTANCE} நகர்த்தவும்
       gamelab_moveInDirection:
         text: பிக்சல்களை {SPRITE} {DISTANCE} நகர்த்தவும் {DIRECTION}
         options:
@@ -1347,7 +1347,7 @@ ta:
             '7': வேகமாக
             '9': extra fast
       gamelab_setTint:
-        text: இந்த [0] இன் நிறத்தை {COLOR} ஆக மாற்றவும்
+        text: இந்த {THIS} இன் நிறத்தை {COLOR} ஆக மாற்றவும்
       gamelab_setupScoreboard:
         text: |-
           ஸ்கோர்போர்டை வரையவும்
@@ -1388,7 +1388,7 @@ ta:
       gamelab_subjectSpritePointer:
         text: "{SPRITE}"
       gamelab_textJoin:
-        text: "[LEFT_QUOTE][null]{RIGHT_QUOTE}{TEXT2}"
+        text: "{LEFT_QUOTE}{TEXT1}{RIGHT_QUOTE}{TEXT2}"
       gamelab_textVariableJoin:
         text: "{VAR}{TEXT2}"
       gamelab_tumbling:
@@ -1471,7 +1471,7 @@ ta:
       gamelab_yLocationOf:
         text: y ஒருங்கிணைப்பு {SPRITE}
       Mikelab_addBehaviorSimple:
-        text: ஸ்பிரைட்[SPRITE]தொடக்கம்{BEHAVIOR}
+        text: ஸ்பிரைட்{SPRITE}தொடக்கம்{BEHAVIOR}
       Mikelab_addTrainingData:
         options:
           NAME:


### PR DESCRIPTION
Same as: https://github.com/code-dot-org/code-dot-org/pull/44767

Translation has wrong number of parameters due to syntax of {}/[]. Fixed here and applied by EPeach in CrowdIn.

Only two of the changes applied here were resulting in SpriteLab not being able to load, but the rest were just resulting in blocks that were difficult to read due to incorrect parsing, see pictures below, so I fixed those as well.

![Screenshot from 2022-02-10 12-01-15](https://user-images.githubusercontent.com/2959170/153490333-487fc0b9-ec56-4799-9066-27078d48c8e3.png)
![Screenshot from 2022-02-10 12-00-06](https://user-images.githubusercontent.com/2959170/153490369-ee82dfc4-1cb8-421e-941c-c99393a93134.png)


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
