### PR TITLE
Allow clearing of schools table in tests

### DIFF
--- a/dashboard/test/models/school_test.rb
+++ b/dashboard/test/models/school_test.rb
@@ -3,13 +3,6 @@ require 'test_helper'
 class SchoolTest < ActiveSupport::TestCase
   include ActiveSupport::Testing::Stream
 
-  self.use_transactional_test_case = true
-
-  # merge_from_csv dry run tests require a clean schools table.
-  setup_all do
-    School.delete_all
-  end
-
   test "schools initialized from tsv" do
     # Populate school districts, since schools depends on them as a foreign key.
     SchoolDistrict.seed_all(stub_school_data: true, force: true)
@@ -30,6 +23,20 @@ class SchoolTest < ActiveSupport::TestCase
   end
 
   test 'merge_from_csv in dry run mode with blank table makes no database writes' do
+    # Clear tables with hard dependencies (ie, MySQL foreign keys)
+    # on the schools table.
+    Census::ApSchoolCode.delete_all
+    Census::IbSchoolCode.delete_all
+    Census::CensusOverride.delete_all
+    Census::CensusSummary.delete_all
+    Census::OtherCurriculumOffering.delete_all
+    Census::StateCsOffering.delete_all
+    SchoolInfo.delete_all
+    SchoolStatsByYear.delete_all
+    CircuitPlaygroundDiscountApplication.delete_all
+
+    School.delete_all
+
     # Populate school districts, since schools depends on them as a foreign key.
     SchoolDistrict.seed_all(stub_school_data: true, force: true)
 
@@ -42,6 +49,20 @@ class SchoolTest < ActiveSupport::TestCase
   end
 
   test 'merge_from_csv in dry run mode with existing rows makes no database writes' do
+    # Clear tables with hard dependencies (ie, MySQL foreign keys)
+    # on the schools table.
+    Census::ApSchoolCode.delete_all
+    Census::IbSchoolCode.delete_all
+    Census::CensusOverride.delete_all
+    Census::CensusSummary.delete_all
+    Census::OtherCurriculumOffering.delete_all
+    Census::StateCsOffering.delete_all
+    SchoolInfo.delete_all
+    SchoolStatsByYear.delete_all
+    CircuitPlaygroundDiscountApplication.delete_all
+
+    School.delete_all
+
     # Populate school districts, since schools depends on them as a foreign key.
     SchoolDistrict.seed_all(stub_school_data: true, force: true)
     School.merge_from_csv(School.get_seed_filename(true))

--- a/dashboard/test/models/school_test.rb
+++ b/dashboard/test/models/school_test.rb
@@ -49,19 +49,7 @@ class SchoolTest < ActiveSupport::TestCase
   end
 
   test 'merge_from_csv in dry run mode with existing rows makes no database writes' do
-    # Clear tables with hard dependencies (ie, MySQL foreign keys)
-    # on the schools table.
-    Census::ApSchoolCode.delete_all
-    Census::IbSchoolCode.delete_all
-    Census::CensusOverride.delete_all
-    Census::CensusSummary.delete_all
-    Census::OtherCurriculumOffering.delete_all
-    Census::StateCsOffering.delete_all
-    SchoolInfo.delete_all
-    SchoolStatsByYear.delete_all
-    CircuitPlaygroundDiscountApplication.delete_all
-
-    School.delete_all
+    clear_schools_and_dependent_models
 
     # Populate school districts, since schools depends on them as a foreign key.
     SchoolDistrict.seed_all(stub_school_data: true, force: true)
@@ -312,5 +300,23 @@ class SchoolTest < ActiveSupport::TestCase
   test 'normalize_school_id works for 12-character ids with leading zeros missing' do
     normalized_id = School.normalize_school_id("12345678901")
     assert_equal "12345678901", normalized_id
+  end
+
+  private
+
+  def clear_schools_and_dependent_models
+    # Clear tables with hard dependencies (ie, MySQL foreign keys)
+    # on the schools table.
+    Census::ApSchoolCode.delete_all
+    Census::IbSchoolCode.delete_all
+    Census::CensusOverride.delete_all
+    Census::CensusSummary.delete_all
+    Census::OtherCurriculumOffering.delete_all
+    Census::StateCsOffering.delete_all
+    SchoolInfo.delete_all
+    SchoolStatsByYear.delete_all
+    CircuitPlaygroundDiscountApplication.delete_all
+
+    School.delete_all
   end
 end

--- a/dashboard/test/models/school_test.rb
+++ b/dashboard/test/models/school_test.rb
@@ -23,19 +23,7 @@ class SchoolTest < ActiveSupport::TestCase
   end
 
   test 'merge_from_csv in dry run mode with blank table makes no database writes' do
-    # Clear tables with hard dependencies (ie, MySQL foreign keys)
-    # on the schools table.
-    Census::ApSchoolCode.delete_all
-    Census::IbSchoolCode.delete_all
-    Census::CensusOverride.delete_all
-    Census::CensusSummary.delete_all
-    Census::OtherCurriculumOffering.delete_all
-    Census::StateCsOffering.delete_all
-    SchoolInfo.delete_all
-    SchoolStatsByYear.delete_all
-    CircuitPlaygroundDiscountApplication.delete_all
-
-    School.delete_all
+    clear_schools_and_dependent_models
 
     # Populate school districts, since schools depends on them as a foreign key.
     SchoolDistrict.seed_all(stub_school_data: true, force: true)


### PR DESCRIPTION
Fix a couple of schools tests that are failing when run in some seeded test databases (has been observed on test as well as in drone). [More discussion of the observed issues in this thread.](https://codedotorg.slack.com/archives/C0T0PNTM3/p1644360379969459)

We have a number of hard foreign key dependencies on the schools table. This change deletes all records from any models that might have a hard dependency on the schools table, as identified by this query:

```
mysql>   SELECT
    ->   TABLE_NAME,
    ->   COLUMN_NAME,
    ->   CONSTRAINT_NAME,
    ->   REFERENCED_TABLE_NAME,
    ->   REFERENCED_COLUMN_NAME
    ->   FROM
    ->   INFORMATION_SCHEMA.KEY_COLUMN_USAGE
    ->   WHERE
    ->   REFERENCED_TABLE_SCHEMA = 'dashboard_test'
    ->   AND REFERENCED_TABLE_NAME = 'schools';
+------------------------------------------+-----------------+---------------------+-----------------------+------------------------+
| TABLE_NAME                               | COLUMN_NAME     | CONSTRAINT_NAME     | REFERENCED_TABLE_NAME | REFERENCED_COLUMN_NAME |
+------------------------------------------+-----------------+---------------------+-----------------------+------------------------+
| ap_school_codes                          | school_id       | fk_rails_08d2269647 | schools               | id                     |
| census_overrides                         | school_id       | fk_rails_06131f8f87 | schools               | id                     |
| census_summaries                         | school_id       | fk_rails_a0d64ecd35 | schools               | id                     |
| circuit_playground_discount_applications | school_id       | fk_rails_1f6ef12f28 | schools               | id                     |
| ib_school_codes                          | school_id       | fk_rails_ed9c9c9f60 | schools               | id                     |
| other_curriculum_offerings               | school_id       | fk_rails_5682e60354 | schools               | id                     |
| school_infos                             | school_id       | fk_rails_c96826e231 | schools               | id                     |
| school_stats_by_years                    | school_id       | fk_rails_9f6aaaddaf | schools               | id                     |
| state_cs_offerings                       | state_school_id | fk_rails_afa40c031f | schools               | state_school_id        |
+------------------------------------------+-----------------+---------------------+-----------------------+------------------------+
```

Note that this is a different list of models than what you'd see if you looked at relationships defined in the school model:

https://github.com/code-dot-org/code-dot-org/blob/efbf3050cd147d309d035d5e9f34a9c362fe48ed/dashboard/app/models/school.rb#L40-L47

I think the more rails-y way to do this would be to [implement "dependent destroy" for the schools model.](https://stackoverflow.com/questions/29544693/cant-delete-object-due-to-foreign-key-constraint) That is a bigger change though that I'm not 100% sure we want to make though, so going with this hackier fix. There appears to be minimal data for these models (in my test DB at least), so I don't think it will take very long to delete from them.

## Testing story

Tested that running `schools_test.rb` failed locally before this change, and passed afterwards.