### PR TITLE
Add Rails 6 Compatibility to ActionViewSinatra

### DIFF
--- a/lib/test/cdo/pegasus/test_actionview_sinatra.rb
+++ b/lib/test/cdo/pegasus/test_actionview_sinatra.rb
@@ -3,7 +3,7 @@ require 'cdo/pegasus/actionview_sinatra'
 
 class ActionViewSinatraTest < Minitest::Test
   def setup
-    @actionview = ActionViewSinatra::Base.new(self)
+    @actionview = ActionViewSinatra.create_view(self)
     @locals = {variable: 'headline'}
   end
 

--- a/pegasus/router.rb
+++ b/pegasus/router.rb
@@ -173,7 +173,7 @@ class Documents < Sinatra::Base
       # This is similar to the lazy loading we need to do for Haml:
       # https://github.com/code-dot-org/code-dot-org/blob/8a49e0f39e1bc98aac462a3eb049d0eeb6af3e06/lib/cdo/pegasus/text_render.rb#L82-L97
       require 'cdo/pegasus/actionview_sinatra'
-      ActionViewSinatra::Base.new(self)
+      ActionViewSinatra.create_view(self)
     end
 
     update_actionview_assigns


### PR DESCRIPTION
Rails 6 changed the way ActionView expects to be initialized. Within Pegasus, we are using a modified version of ActionView to render templates and so that modification needs to be updated.

The nature of our modification includes storing a reference to Sinatra within the instance of ActionView that we initialize; our original implementation simply added a new required initialization variable but the new Rails 6 initialization logic makes that more difficult. So instead, we manually set the instance variable after initialization. This is obviously much clumsier than the original approach, but should be easier to maintain.

The increased complexity of our new initialization logic is all captured in a new factory method.

## Testing story

Relying on existing unit tests

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
