### PR TITLE
Workaround Rails 6 / composite_primary_keys / SetupAllAndTeardownAll bug

### DIFF
--- a/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
@@ -57,6 +57,15 @@ module Api::V1::Pd
       @markdown = Redcarpet::Markdown.new(Redcarpet::Render::StripDown)
     end
 
+    # Manually reload application between tests, to work around an unusual bug
+    # here with the interaction of three things:
+    #   1. Rails 6
+    #   2. composite_primary_keys
+    #   3. SetupAllAndTeardownAll
+    teardown do
+      @csp_facilitator_application.reload
+    end
+
     test_redirect_to_sign_in_for :index
     test_redirect_to_sign_in_for :show, params: -> {@test_show_params}
     test_redirect_to_sign_in_for :update, params: -> {@test_update_params}


### PR DESCRIPTION
There's an unusual bug here with the interaction of three things:

  1. Rails 6
  2. composite_primary_keys
  3. SetupAllAndTeardownAll

Specifically, Rails 6 (1) added some [performance optimizations to transactions which attempt to detect and skip certain unnecessary database operations.](https://github.com/rails/rails/pull/36049) Specifically, now when you update an ActiveRecord model instance it will [save in memory a record of the current state of some fields](https://github.com/rails/rails/blob/0d304eae601f085274b2e2c04316e025b443da62/activerecord/lib/active_record/persistence.rb#L619). If those changes are then rolled back and later you go to update the method again, ActiveRecord will [detect that this instance has a transaction in a rolled-back state and will update its in-memory data with the data from that saved record.](https://github.com/rails/rails/blob/0d304eae601f085274b2e2c04316e025b443da62/activerecord/lib/active_record/transactions.rb#L487)

The composite_primary_keys gem (2) as part of [their own work to accomodate this change](https://github.com/composite-primary-keys/composite_primary_keys/blob/2e16732c38d7ad94caa58872c6847e0b633ca6f4/lib/composite_primary_keys/attribute_methods/read.rb#L20-L27) removed [one of the "sync with transaction state" invocations.](https://github.com/rails/rails/blob/0d304eae601f085274b2e2c04316e025b443da62/activerecord/lib/active_record/attribute_methods/read.rb#L38) This means that if the instance is out of sync [when ActiveRecord goes to save the record prior to updating](https://github.com/rails/rails/blob/0d304eae601f085274b2e2c04316e025b443da62/activerecord/lib/active_record/transactions.rb#L392), the data that gets saved will be bad. And if that data is then used by a later update, the restored data will likewise be bad.

This scenario requires us to reuse the same model instance in memory without re-syncing with the database through several repeated updates and rollbacks. Our custom SetupAllAndTeardownAll fucntionality (3) does just that. Even then, most of our tests do not repeatedly `update` the same instance through multiple individual test cases without `reload`ing it.

As far as I can tell, it's just this one. Specifically:

https://github.com/code-dot-org/code-dot-org/blob/cb084b3d4ccb6e232b6b5d2a9bb07b153c94926e/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb#L334-L478

I've been unable to figure out a fix for this issue, but I've also been unable to find anywhere this sharp corner is likely to cut us. In lieu of a better way to move forward, I'd like to propose this simple workaround.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
