### PR TITLE
Move things to codeStudioEntries list instead of internalEntries list

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -516,6 +516,11 @@ describe('entry tests', () => {
     'courses/resources': './src/sites/studio/pages/courses/resources.js',
     'courses/code': './src/sites/studio/pages/courses/code.js',
     'courses/standards': './src/sites/studio/pages/courses/standards.js',
+    'lessons/show': './src/sites/studio/pages/lessons/show.js',
+    'lessons/student_lesson_plan':
+      './src/sites/studio/pages/lessons/student_lesson_plan.js',
+    'programming_expressions/show':
+      './src/sites/studio/pages/programming_expressions/show.js',
     'devise/registrations/_finish_sign_up':
       './src/sites/studio/pages/devise/registrations/_finish_sign_up.js',
     'devise/registrations/edit':
@@ -600,9 +605,6 @@ describe('entry tests', () => {
     'datasets/edit_manifest':
       './src/sites/studio/pages/datasets/edit_manifest.js',
     'lessons/edit': './src/sites/studio/pages/lessons/edit.js',
-    'lessons/show': './src/sites/studio/pages/lessons/show.js',
-    'lessons/student_lesson_plan':
-      './src/sites/studio/pages/lessons/student_lesson_plan.js',
     levelbuilder: './src/sites/studio/pages/levelbuilder.js',
     'levels/editors/_applab':
       './src/sites/studio/pages/levels/editors/_applab.js',
@@ -642,8 +644,6 @@ describe('entry tests', () => {
       './src/sites/studio/pages/programming_expressions/new.js',
     'programming_expressions/edit':
       './src/sites/studio/pages/programming_expressions/edit.js',
-    'programming_expressions/show':
-      './src/sites/studio/pages/programming_expressions/show.js',
     'scripts/edit': './src/sites/studio/pages/scripts/edit.js',
     'scripts/new': './src/sites/studio/pages/scripts/new.js',
     'shared/_check_admin': './src/sites/studio/pages/shared/_check_admin.js',


### PR DESCRIPTION
During a bug bash people noted that the student facing lesson plans were slow to load. @davidsbailey found that it was because things were in the wrong list in the gruntfile. This updates them to the correct list.
https://codedotorg.atlassian.net/browse/PLAT-1597