### PR TITLE
Do a full seed on adhoc setup

### DIFF
--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -443,7 +443,7 @@ namespace :seed do
 
   FULL_SEED_TASKS = [:check_migrations, :videos, :concepts, :scripts, :courses, :callouts, :school_districts, :schools, :secret_words, :secret_pictures, :ap_school_codes, :ap_cs_offerings, :ib_school_codes, :ib_cs_offerings, :state_cs_offerings, :donors, :donor_schools, :foorms].freeze
   UI_TEST_SEED_TASKS = [:check_migrations, :videos, :concepts, :scripts_ui_tests, :courses_ui_tests, :callouts, :school_districts, :schools, :secret_words, :secret_pictures, :donors, :donor_schools].freeze
-  DEFAULT_SEED_TASKS = [:adhoc, :test].include?(rack_env) ? UI_TEST_SEED_TASKS : FULL_SEED_TASKS
+  DEFAULT_SEED_TASKS = rack_env == 'test' ? UI_TEST_SEED_TASKS : FULL_SEED_TASKS
 
   desc "seed the data needed for this type of environment by default"
   timed_task default: DEFAULT_SEED_TASKS


### PR DESCRIPTION
A common pain point with adhoc setup is that not all scripts are seeded. We do this for performance reasons, but it doesn't really help if engineers are then sshing into the adhoc and seeding all the scripts anyway.

This change would slow adhoc start time by about 15-20 minutes (based on seeding times in staging and production). Starting an adhoc already takes around 80 minutes, so the argument could be made both ways for whether this increase is acceptable. On one hand, we already need to find something else to do while it's being created, on the other hand, 20 minutes is still a 25% increase in set up time.

An alternative would be to have a list of scripts to seed only on adhocs, which would include the scripts people likely will want to access (i.e. our more recent ones). This would be yet another list to maintain, plus it would likely need to be updated with every curriculum cycle, so I didn't go this route.

I propose we try seeding all scripts on adhocs and if it becomes too slow, we can always revert this PR.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

created an adhoc and newer courses are seeded -- https://adhoc-full-seed-in-adhoc-studio.cdn-code.org/s/coursea-2021. It took about 1.5 hours.
## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
