### PR TITLE
Move references to user_storage_ids_table to one place

### DIFF
--- a/dashboard/app/controllers/report_abuse_controller.rb
+++ b/dashboard/app/controllers/report_abuse_controller.rb
@@ -25,7 +25,7 @@ class ReportAbuseController < ApplicationController
   def protected_project?
     return false if params[:channel_id].blank?
     owner_storage_id, _ = storage_decrypt_channel_id(params[:channel_id])
-    owner_user_id = user_storage_ids_table.where(id: owner_storage_id).first[:user_id]
+    owner_user_id = user_id_for_storage_id(owner_storage_id)
     return false unless owner_user_id
     project_owner = User.find(owner_user_id)
     project_owner.permission?(UserPermission::PROJECT_VALIDATOR)

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -2347,7 +2347,7 @@ class User < ApplicationRecord
   # Note: Known that this duplicates some logic in storage_id_for_user_id, but
   # that method is globally stubbed in tests :cry: and therefore not very helpful.
   def user_storage_id
-    @user_storage_id ||= PEGASUS_DB[:user_storage_ids].where(user_id: id).first&.[](:id)
+    @user_storage_id ||= storage_id_for_user_id(id)
   end
 
   # Via the paranoia gem, undelete / undestroy the deleted / destroyed user and any (dependent)

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -656,7 +656,7 @@ class User < ApplicationRecord
 
   def self.find_channel_owner(encrypted_channel_id)
     owner_storage_id, _ = storage_decrypt_channel_id(encrypted_channel_id)
-    user_id = PEGASUS_DB[:user_storage_ids].first(id: owner_storage_id)[:user_id]
+    user_id = user_id_for_storage_id(owner_storage_id)
     User.find(user_id)
   rescue ArgumentError, OpenSSL::Cipher::CipherError, ActiveRecord::RecordNotFound
     nil

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -2343,9 +2343,6 @@ class User < ApplicationRecord
       update(state: 'active', updated_at: Time.now)
   end
 
-  # Gets the user's user_storage_id from the pegasus database, if it's available.
-  # Note: Known that this duplicates some logic in storage_id_for_user_id, but
-  # that method is globally stubbed in tests :cry: and therefore not very helpful.
   def user_storage_id
     @user_storage_id ||= storage_id_for_user_id(id)
   end

--- a/dashboard/lib/projects_list.rb
+++ b/dashboard/lib/projects_list.rb
@@ -147,7 +147,7 @@ module ProjectsList
       section_users = section.students + [section.user]
 
       [].tap do |projects_list_data|
-        user_storage_ids = get_storage_ids_by_user_ids(section_users.pluck(:id))
+        user_storage_ids = get_user_ids_by_storage_ids(section_users.pluck(:id))
         user_storage_id_list = user_storage_ids.keys
         PEGASUS_DB[:storage_apps].
           where(storage_id: user_storage_id_list, state: 'active').

--- a/dashboard/lib/projects_list.rb
+++ b/dashboard/lib/projects_list.rb
@@ -147,7 +147,8 @@ module ProjectsList
       section_users = section.students + [section.user]
 
       [].tap do |projects_list_data|
-        user_storage_id_list = get_storage_ids_for_users(section_users.pluck(:id))
+        user_storage_ids = get_storage_ids_by_user_ids(section_users.pluck(:id))
+        user_storage_id_list = user_storage_ids.keys
         PEGASUS_DB[:storage_apps].
           where(storage_id: user_storage_id_list, state: 'active').
           where(project_type: project_types).

--- a/dashboard/lib/projects_list.rb
+++ b/dashboard/lib/projects_list.rb
@@ -70,9 +70,7 @@ module ProjectsList
     def fetch_section_projects(section)
       section_students = section.students
       [].tap do |projects_list_data|
-        student_storage_ids = PEGASUS_DB[:user_storage_ids].
-          where(user_id: section_students.pluck(:id)).
-          select_hash(:user_id, :id)
+        student_storage_ids = get_storage_ids_by_user_ids(section_students.pluck(:id))
         section_students.each do |student|
           next unless student_storage_id = student_storage_ids[student.id]
           PEGASUS_DB[:storage_apps].where(storage_id: student_storage_id, state: 'active').each do |project|
@@ -149,10 +147,7 @@ module ProjectsList
       section_users = section.students + [section.user]
 
       [].tap do |projects_list_data|
-        user_storage_ids = PEGASUS_DB[:user_storage_ids].
-          where(user_id: section_users.pluck(:id)).
-          select_hash(:id, :user_id)
-        user_storage_id_list = user_storage_ids.keys
+        user_storage_id_list = get_storage_ids_for_users(section_users.pluck(:id))
         PEGASUS_DB[:storage_apps].
           where(storage_id: user_storage_id_list, state: 'active').
           where(project_type: project_types).

--- a/dashboard/lib/sample_data.rb
+++ b/dashboard/lib/sample_data.rb
@@ -228,7 +228,7 @@ class SampleData
     end
   end
 
-  # For the given user id, looks up the storage id, or creates a new one if the user doesn't have one.
+  # Look up or create a storage id for the sample data (used for testing purposes)
   def self.find_or_create_storage_id_for_user_id(user_id)
     environment_check!
     storage_id = storage_id_for_user_id(user_id)

--- a/dashboard/lib/sample_data.rb
+++ b/dashboard/lib/sample_data.rb
@@ -231,9 +231,9 @@ class SampleData
   # For the given user id, looks up the storage id, or creates a new one if the user doesn't have one.
   def self.find_or_create_storage_id_for_user_id(user_id)
     environment_check!
-    row = user_storage_ids_table.where(user_id: user_id)
-    return row[:id] if row
-    user_storage_ids_table.insert(user_id: user_id)
+    storage_id = storage_id_for_user_id(user_id)
+    return storage_id if storage_id
+    create_storage_id_for_user(user_id)
   end
 
   # Helper that generates a few sentences of plausible latin-esqe text, for use as obviously

--- a/dashboard/test/controllers/api/v1/projects/section_projects_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/projects/section_projects_controller_test.rb
@@ -36,9 +36,7 @@ class Api::V1::Projects::SectionProjectsControllerTest < ActionController::TestC
     }.to_json
     other_student_project = {id: 44, value: other_student_project_value}
 
-    PEGASUS_DB.stubs(:[]).with(:user_storage_ids).returns(
-      stub(where: stub(select_hash: {@student.id => STUDENT_STORAGE_ID}))
-    )
+    ProjectsList.stubs(:get_storage_ids_by_user_ids).returns({@student.id => STUDENT_STORAGE_ID})
     PEGASUS_DB.stubs(:[]).with(:storage_apps).returns(
       stub(where: [student_project, hidden_project, other_student_project])
     )

--- a/dashboard/test/helpers/delete_accounts_helper_test.rb
+++ b/dashboard/test/helpers/delete_accounts_helper_test.rb
@@ -1973,31 +1973,31 @@ class DeleteAccountsHelperTest < ActionView::TestCase
   test 'with_storage_id_for owns id if it does not exist' do
     student = create :student
 
-    assert_empty user_storage_ids.where(user_id: student.id)
+    assert_nil storage_id_for_user_id(student.id)
 
     with_storage_id_for student do |storage_id|
-      assert_equal storage_id, user_storage_ids.where(user_id: student.id).first[:id]
+      assert_equal storage_id, storage_id_for_user_id(student.id)
     end
 
-    assert_empty user_storage_ids.where(user_id: student.id)
+    assert_nil storage_id_for_user_id(student.id)
   end
 
   test 'with_storage_id_for does not own id if it does exist' do
     student = create :student
-    assert_empty user_storage_ids.where(user_id: student.id)
+    assert_nil storage_id_for_user_id(student.id)
 
-    user_storage_ids.insert(user_id: student.id)
+    create_storage_id_for_user(student.id)
 
-    refute_empty user_storage_ids.where(user_id: student.id)
+    refute_nil storage_id_for_user_id(student.id)
 
     with_storage_id_for student do |storage_id|
-      assert_equal storage_id, user_storage_ids.where(user_id: student.id).first[:id]
+      assert_equal storage_id, storage_id_for_user_id(student.id)
     end
 
-    refute_empty user_storage_ids.where(user_id: student.id)
+    refute_nil storage_id_for_user_id(student.id)
 
-    user_storage_ids.where(user_id: student.id).delete
-    assert_empty user_storage_ids.where(user_id: student.id)
+    delete_storage_id_for_user(student.id)
+    assert_nil storage_id_for_user_id(student.id)
   end
 
   #

--- a/dashboard/test/lib/account_purger_test.rb
+++ b/dashboard/test/lib/account_purger_test.rb
@@ -85,7 +85,7 @@ class AccountPurgerTest < ActiveSupport::TestCase
     test_name = 'Boaty McBoatface'
 
     refute_equal test_name, @student.name
-    assert_empty storage_id_for_user_id(@student.id)
+    assert_nil storage_id_for_user_id(@student.id)
 
     # Perform Dashboard (Activerecord) and Pegasus DB operations as
     # a side effect, then raise, and prove the changes weren't saved
@@ -104,7 +104,7 @@ class AccountPurgerTest < ActiveSupport::TestCase
     @student.reload
 
     assert stub_code_ran
-    assert_empty storage_id_for_user_id(@student.id)
+    assert_nil storage_id_for_user_id(@student.id)
     refute_equal test_name, @student.name
   end
 end

--- a/dashboard/test/lib/account_purger_test.rb
+++ b/dashboard/test/lib/account_purger_test.rb
@@ -85,14 +85,14 @@ class AccountPurgerTest < ActiveSupport::TestCase
     test_name = 'Boaty McBoatface'
 
     refute_equal test_name, @student.name
-    assert_empty PEGASUS_DB[:user_storage_ids].where user_id: @student.id
+    assert_empty storage_id_for_user_id(@student.id)
 
     # Perform Dashboard (Activerecord) and Pegasus DB operations as
     # a side effect, then raise, and prove the changes weren't saved
     stub_code_ran = false
     DeleteAccountsHelper.any_instance.stubs(:purge_user).with do |user|
       user.update(name: test_name)
-      PEGASUS_DB[:user_storage_ids].insert(user_id: user.id)
+      create_storage_id_for_user(user.id)
       stub_code_ran = true
       raise 'Intentional failure during transaction'
     end
@@ -104,7 +104,7 @@ class AccountPurgerTest < ActiveSupport::TestCase
     @student.reload
 
     assert stub_code_ran
-    assert_empty PEGASUS_DB[:user_storage_ids].where(user_id: @student.id)
+    assert_empty storage_id_for_user_id(@student.id)
     refute_equal test_name, @student.name
   end
 end

--- a/dashboard/test/testing/storage_apps_test_utils.rb
+++ b/dashboard/test/testing/storage_apps_test_utils.rb
@@ -1,4 +1,5 @@
 require_relative '../../../shared/middleware/helpers/storage_apps'
+require_relative '../../../shared/middleware/helpers/storage_id'
 
 # Tools that help test storage apps
 # To be included in any dashboard test that needs them.
@@ -19,15 +20,15 @@ module StorageAppsTestUtils
     owns_storage_id = false
     user_id = user&.id
 
-    storage_id = user_storage_ids.where(user_id: user_id).first&.[](:id)
+    storage_id = storage_id_for_user_id(user_id)
     unless storage_id
-      storage_id = user_storage_ids.insert(user_id: user_id)
+      storage_id = create_storage_id_for_user(user_id)
       owns_storage_id = true
     end
 
     yield storage_id
   ensure
-    user_storage_ids.where(id: storage_id).delete if owns_storage_id
+    delete_storage_id_for_user(user_id) if owns_storage_id
   end
 
   def with_anonymous_channel(&block)
@@ -36,9 +37,5 @@ module StorageAppsTestUtils
 
   def storage_apps
     PEGASUS_DB[:storage_apps]
-  end
-
-  def user_storage_ids
-    PEGASUS_DB[:user_storage_ids]
   end
 end

--- a/shared/middleware/files_api.rb
+++ b/shared/middleware/files_api.rb
@@ -47,7 +47,7 @@ class FilesApi < Sinatra::Base
 
     # teachers can see abusive assets of their students
     owner_storage_id, _ = storage_decrypt_channel_id(encrypted_channel_id)
-    owner_user_id = user_storage_ids_table.where(id: owner_storage_id).first[:user_id]
+    owner_user_id = user_id_for_storage_id(owner_storage_id)
 
     teaches_student?(owner_user_id)
   end
@@ -59,7 +59,7 @@ class FilesApi < Sinatra::Base
     # no active project exists, which is handled below.
     StorageApps.new(owner_storage_id).get(encrypted_channel_id)
 
-    owner_user_id = user_storage_ids_table.where(id: owner_storage_id).first[:user_id]
+    owner_user_id = user_id_for_storage_id(owner_storage_id)
     !get_user_sharing_disabled(owner_user_id)
 
   # Default to cannot view if there is an error
@@ -104,7 +104,7 @@ class FilesApi < Sinatra::Base
     return unless CDO.newrelic_logging
 
     owner_storage_id, _ = storage_decrypt_channel_id(encrypted_channel_id)
-    owner_user_id = user_storage_ids_table.where(id: owner_storage_id).first[:user_id]
+    owner_user_id = user_id_for_storage_id(owner_storage_id)
     event_details = {
       quota_type: quota_type,
       encrypted_channel_id: encrypted_channel_id,

--- a/shared/middleware/helpers/storage_apps.rb
+++ b/shared/middleware/helpers/storage_apps.rb
@@ -155,7 +155,7 @@ class StorageApps
   # Determine if the current user can view the project
   def get_sharing_disabled(channel_id, current_user_id)
     owner_storage_id, storage_app_id = storage_decrypt_channel_id(channel_id)
-    owner_user_id = user_storage_ids_table.where(id: owner_storage_id).first[:user_id]
+    owner_user_id = user_id_for_storage_id(owner_storage_id)
 
     # Sharing of a project is not disabled for the project owner
     # or the teachers of the project owner

--- a/shared/middleware/helpers/storage_id.rb
+++ b/shared/middleware/helpers/storage_id.rb
@@ -171,11 +171,6 @@ def get_user_storage_id(query)
   user_storage_ids_table.where(query).first
 end
 
-# Takes an array of user ids and returns an array of storage ids
-def get_storage_ids_for_users(user_ids)
-  user_storage_ids_table.where({user_id: user_ids}).pluck(:id)
-end
-
 # Takes an array of user ids and returns a mapping from user id to storage id
 def get_storage_ids_by_user_ids(user_ids)
   user_storage_ids_table.where({user_id: user_ids}).select_hash(:user_id, :id)

--- a/shared/middleware/helpers/storage_id.rb
+++ b/shared/middleware/helpers/storage_id.rb
@@ -195,3 +195,8 @@ rescue Sequel::UniqueConstraintViolation
   raise "no user storage id on second try" unless user_storage_id
   user_storage_id
 end
+
+# Used in tests only
+def delete_storage_id_for_user(user_id)
+  user_storage_ids_table.where(user_id: user_id).delete
+end

--- a/shared/middleware/helpers/storage_id.rb
+++ b/shared/middleware/helpers/storage_id.rb
@@ -176,6 +176,11 @@ def get_storage_ids_by_user_ids(user_ids)
   user_storage_ids_table.where({user_id: user_ids}).select_hash(:user_id, :id)
 end
 
+# Takes an array of user ids and returns a mapping from storage id to user id
+def get_user_ids_by_storage_ids(user_ids)
+  user_storage_ids_table.where({user_id: user_ids}).select_hash(:id, :user_id)
+end
+
 def update_annoymous_user_storage_id(storage_id, user_id)
   user_storage_ids_table.where(id: storage_id, user_id: nil).update(user_id: user_id)
 end

--- a/shared/test/middleware/helpers/test_storage_apps.rb
+++ b/shared/test/middleware/helpers/test_storage_apps.rb
@@ -1,16 +1,13 @@
 require_relative '../../test_helper'
 require_relative '../../../middleware/helpers/storage_apps'
+require_relative '../../../middleware/helpers/storage_id'
 
 class StorageAppsTest < Minitest::Test
   include SetupTest
 
-  def setup
-    @user_storage_ids_table = PEGASUS_DB[:user_storage_ids]
-  end
-
   def test_get_anonymous_age_restricted_app
-    signedout_storage_id = @user_storage_ids_table.insert(user_id: nil)
-    signedin_storage_id = @user_storage_ids_table.insert(user_id: 20)
+    signedout_storage_id = create_storage_id_for_user(nil)
+    signedin_storage_id = create_storage_id_for_user(20)
 
     # Create an applab project as signed out user
     # Other users should not be able to access app
@@ -34,7 +31,7 @@ class StorageAppsTest < Minitest::Test
   end
 
   def test_users_paired_on_level_when_no_level
-    signedin_storage_id = @user_storage_ids_table.insert(user_id: 123)
+    signedin_storage_id = create_storage_id_for_user(123)
     storage_apps = StorageApps.new(signedin_storage_id)
 
     mock_where = mock
@@ -48,7 +45,7 @@ class StorageAppsTest < Minitest::Test
   end
 
   def test_users_paired_on_level_with_level_not_paired
-    signedin_storage_id = @user_storage_ids_table.insert(user_id: 123)
+    signedin_storage_id = create_storage_id_for_user(123)
     storage_apps = StorageApps.new(signedin_storage_id)
 
     mock_where = mock
@@ -74,7 +71,7 @@ class StorageAppsTest < Minitest::Test
   end
 
   def test_users_paired_on_level_with_level_paired
-    signedin_storage_id = @user_storage_ids_table.insert(user_id: 123)
+    signedin_storage_id = create_storage_id_for_user(123)
     storage_apps = StorageApps.new(signedin_storage_id)
 
     mock_where = mock
@@ -100,7 +97,7 @@ class StorageAppsTest < Minitest::Test
   end
 
   def test_derive_project_type
-    signedin_storage_id = @user_storage_ids_table.insert(user_id: 20)
+    signedin_storage_id = create_storage_id_for_user(20)
     storage_apps = StorageApps.new(signedin_storage_id)
 
     # Create without type
@@ -121,7 +118,7 @@ class StorageAppsTest < Minitest::Test
   end
 
   def test_content_moderation_disabled?
-    signedin_storage_id = @user_storage_ids_table.insert(user_id: 20)
+    signedin_storage_id = create_storage_id_for_user(20)
     storage_apps = StorageApps.new(signedin_storage_id)
 
     # Create a new typeless project
@@ -131,7 +128,7 @@ class StorageAppsTest < Minitest::Test
   end
 
   def test_set_content_moderation
-    signedin_storage_id = @user_storage_ids_table.insert(user_id: 20)
+    signedin_storage_id = create_storage_id_for_user(20)
     storage_apps = StorageApps.new(signedin_storage_id)
 
     # Create a new typeless project
@@ -149,7 +146,7 @@ class StorageAppsTest < Minitest::Test
   end
 
   def test_restore
-    signedin_storage_id = @user_storage_ids_table.insert(user_id: 20)
+    signedin_storage_id = create_storage_id_for_user(20)
     storage_apps = StorageApps.new(signedin_storage_id)
 
     # Create a new project
@@ -171,7 +168,7 @@ class StorageAppsTest < Minitest::Test
   end
 
   def test_buffer_abuse_score
-    signedin_storage_id = @user_storage_ids_table.insert(user_id: 20)
+    signedin_storage_id = create_storage_id_for_user(20)
     storage_apps = StorageApps.new(signedin_storage_id)
 
     # Create a new typeless project

--- a/shared/test/middleware/helpers/test_storage_id.rb
+++ b/shared/test/middleware/helpers/test_storage_id.rb
@@ -51,7 +51,7 @@ class StorageIdTest < Minitest::Test
     mock_table.stubs(:where).with({user_id: table_user_id}).returns(mock_rows).twice
     mock_table.stubs(:insert).with({user_id: table_user_id}).raises(Sequel::UniqueConstraintViolation).once
 
-    PEGASUS_DB.stubs(:[]).with(:user_storage_ids).returns(mock_table)
+    stubs(:user_storage_ids_table).returns(mock_table)
 
     assert_equal table_storage_id, storage_id_for_current_user
   end

--- a/shared/test/middleware/helpers/test_storage_id.rb
+++ b/shared/test/middleware/helpers/test_storage_id.rb
@@ -4,10 +4,6 @@ require_relative '../../../middleware/helpers/storage_id'
 class StorageIdTest < Minitest::Test
   include SetupTest
 
-  def setup
-    @user_storage_ids_table = PEGASUS_DB[:user_storage_ids]
-  end
-
   def test_storage_id_for_current_user
     request = mock
     stubs(:request).returns(request)
@@ -16,9 +12,9 @@ class StorageIdTest < Minitest::Test
     request.stubs(:user_id).returns(nil)
     assert_nil storage_id_for_current_user
 
-    # # Gets value from table if it exists
+    # Gets value from table if it exists
     request.stubs(:user_id).returns(2)
-    table_storage_id = @user_storage_ids_table.insert(user_id: 2)
+    table_storage_id = create_storage_id_for_user(2)
     assert_equal table_storage_id, storage_id_for_current_user
 
     # Returns value from cookie if we have one
@@ -31,8 +27,7 @@ class StorageIdTest < Minitest::Test
     stubs(:take_storage_id_ownership_from_cookie).returns(nil)
     storage_id = storage_id_for_current_user
 
-    row = @user_storage_ids_table.where(user_id: 4).first
-    assert_equal row[:id], storage_id
+    assert_equal storage_id_for_user_id(4), storage_id
   end
 
   def test_storage_id_for_current_user_race_condition
@@ -74,23 +69,22 @@ class StorageIdTest < Minitest::Test
     # takes ownership if id is unused
     user_id = 7
     # this row would get created as part of create_storage_id_cookie
-    table_storage_id = @user_storage_ids_table.insert(user_id: nil, id: 123)
+    table_storage_id = create_storage_id_for_user(nil)
     stubs(:storage_id_from_cookie).returns(table_storage_id)
     response.expects(:delete_cookie)
     storage_id = take_storage_id_ownership_from_cookie(user_id)
     assert_equal table_storage_id, storage_id
-    row = @user_storage_ids_table.where(user_id: user_id).first
-    assert_equal row[:id], table_storage_id
+    assert_equal storage_id_for_user_id(user_id), table_storage_id
 
     # returns nil if owned by a different user
     other_user_id = 8
     user_id = 9
-    table_storage_id = @user_storage_ids_table.insert(user_id: other_user_id)
+    table_storage_id = create_storage_id_for_user(other_user_id)
     stubs(:storage_id_from_cookie).returns(table_storage_id)
     response.expects(:delete_cookie)
     storage_id = take_storage_id_ownership_from_cookie(user_id)
     assert_nil storage_id
-    assert_nil @user_storage_ids_table.where(user_id: user_id).first
+    assert_nil storage_id_for_user_id(user_id)
   end
 
   def test_storage_id_from_cookie
@@ -105,11 +99,14 @@ class StorageIdTest < Minitest::Test
     assert_nil storage_id_from_cookie
 
     # returns storage id from cookie if unowned
-    @user_storage_ids_table.insert(user_id: nil, id: cookie_storage_id)
-    assert_equal cookie_storage_id, storage_id_from_cookie
+    storage_id_in_table = create_storage_id_for_user(nil)
+    cookie_value = CGI.escape(storage_encrypt_id(storage_id_in_table))
+    request.stubs(:cookies).returns({storage_id_cookie_name => cookie_value})
+
+    assert_equal storage_id_in_table, storage_id_from_cookie
 
     # returns nil if storage id from cookie is owned by a user
-    @user_storage_ids_table.where(id: cookie_storage_id).update(user_id: 2)
+    update_annoymous_user_storage_id(storage_id_in_table, 2)
     assert_nil storage_id_from_cookie
   end
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
The intent of this PR is to replace references to `PEGASUS_DB[:user_storage_ids]` with helper methods to create a layer of abstraction and have less direct references to the table since the table is going to change. Note that there are still direct queries through joins in `projects_list.rb` which don't make sense to replace.

For a sneak peek of where this could be headed see: https://github.com/code-dot-org/code-dot-org/pull/44957/files

One option that I was considering was making a new class `UserStorageIds` which would have methods like `get_by_id`, `get_by_user_id`, `exists?` and `create`, but I wasn't sure if it was worth the effort because we'll be replacing a lot of this code soon anyway.

## Testing story
This is a refactor with no increase in test coverage, however I did update some unit tests where it made sense.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
