### PR TITLE
make certificate share page responsive, and add call-to-action

### DIFF
--- a/apps/src/sites/studio/pages/certificates/show.js
+++ b/apps/src/sites/studio/pages/certificates/show.js
@@ -1,17 +1,22 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import {Provider} from 'react-redux';
 import getScriptData from '@cdo/apps/util/getScriptData';
 import CertificateShare from '@cdo/apps/templates/CertificateShare';
+import {getStore} from '@cdo/apps/redux';
 
 $(document).ready(function() {
+  const store = getStore();
   const certificateData = getScriptData('certificate');
   const {imageUrl, printUrl, announcement} = certificateData;
   ReactDOM.render(
-    <CertificateShare
-      imageUrl={imageUrl}
-      printUrl={printUrl}
-      announcement={announcement}
-    />,
+    <Provider store={store}>
+      <CertificateShare
+        imageUrl={imageUrl}
+        printUrl={printUrl}
+        announcement={announcement}
+      />
+    </Provider>,
     document.getElementById('certificate-share')
   );
 });

--- a/apps/src/sites/studio/pages/certificates/show.js
+++ b/apps/src/sites/studio/pages/certificates/show.js
@@ -5,9 +5,13 @@ import CertificateShare from '@cdo/apps/templates/CertificateShare';
 
 $(document).ready(function() {
   const certificateData = getScriptData('certificate');
-  const {imageUrl, printUrl} = certificateData;
+  const {imageUrl, printUrl, announcement} = certificateData;
   ReactDOM.render(
-    <CertificateShare imageUrl={imageUrl} printUrl={printUrl} />,
+    <CertificateShare
+      imageUrl={imageUrl}
+      printUrl={printUrl}
+      announcement={announcement}
+    />,
     document.getElementById('certificate-share')
   );
 });

--- a/apps/src/templates/CertificateShare.jsx
+++ b/apps/src/templates/CertificateShare.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import i18n from '@cdo/locale';
 import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
 import {TwoColumnActionBlock} from '@cdo/apps/templates/studioHomepages/TwoColumnActionBlock';
+import styleConstants from '../styleConstants';
 
 export default function CertificateShare(props) {
   const {announcement} = props;
@@ -35,7 +36,7 @@ export default function CertificateShare(props) {
 const styles = {
   wrapper: {
     with: '100%',
-    maxWidth: 980,
+    maxWidth: styleConstants['content-width'],
     marginLeft: 'auto',
     marginRight: 'auto'
   }

--- a/apps/src/templates/CertificateShare.jsx
+++ b/apps/src/templates/CertificateShare.jsx
@@ -7,12 +7,14 @@ import {UnconnectedTwoColumnActionBlock as TwoColumnActionBlock} from '@cdo/apps
 export default function CertificateShare(props) {
   const {announcement} = props;
   return (
-    <a href={props.printUrl}>
-      <img
-        src={props.imageUrl}
-        alt={i18n.certificateForCompletion()}
-        width="100%"
-      />
+    <div>
+      <a href={props.printUrl}>
+        <img
+          src={props.imageUrl}
+          alt={i18n.certificateForCompletion()}
+          width="100%"
+        />
+      </a>
       <TwoColumnActionBlock
         responsiveSize="lg"
         imageUrl={pegasus(announcement.image)}
@@ -26,7 +28,7 @@ export default function CertificateShare(props) {
           }
         ]}
       />
-    </a>
+    </div>
   );
 }
 

--- a/apps/src/templates/CertificateShare.jsx
+++ b/apps/src/templates/CertificateShare.jsx
@@ -18,7 +18,6 @@ export default function CertificateShare(props) {
         />
       </a>
       <TwoColumnActionBlock
-        isRtl={false}
         imageUrl={pegasus(announcement.image)}
         subHeading={announcement.title}
         description={announcement.body}

--- a/apps/src/templates/CertificateShare.jsx
+++ b/apps/src/templates/CertificateShare.jsx
@@ -14,6 +14,7 @@ export default function CertificateShare(props) {
           src={props.imageUrl}
           alt={i18n.certificateForCompletion()}
           width="100%"
+          style={styles.certificate}
         />
       </a>
       <TwoColumnActionBlock
@@ -39,6 +40,9 @@ const styles = {
     maxWidth: styleConstants['content-width'],
     marginLeft: 'auto',
     marginRight: 'auto'
+  },
+  certificate: {
+    marginBottom: 20
   }
 };
 

--- a/apps/src/templates/CertificateShare.jsx
+++ b/apps/src/templates/CertificateShare.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import i18n from '@cdo/locale';
 import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
-import {UnconnectedTwoColumnActionBlock as TwoColumnActionBlock} from '@cdo/apps/templates/studioHomepages/TwoColumnActionBlock';
+import {TwoColumnActionBlock} from '@cdo/apps/templates/studioHomepages/TwoColumnActionBlock';
 
 export default function CertificateShare(props) {
   const {announcement} = props;
@@ -17,7 +17,6 @@ export default function CertificateShare(props) {
       </a>
       <TwoColumnActionBlock
         isRtl={false}
-        responsiveSize="lg"
         imageUrl={pegasus(announcement.image)}
         subHeading={announcement.title}
         description={announcement.body}

--- a/apps/src/templates/CertificateShare.jsx
+++ b/apps/src/templates/CertificateShare.jsx
@@ -5,13 +5,12 @@ import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
 import {TwoColumnActionBlock} from '@cdo/apps/templates/studioHomepages/TwoColumnActionBlock';
 import styleConstants from '../styleConstants';
 
-export default function CertificateShare(props) {
-  const {announcement} = props;
+export default function CertificateShare({announcement, printUrl, imageUrl}) {
   return (
     <div style={styles.wrapper}>
-      <a href={props.printUrl}>
+      <a href={printUrl}>
         <img
-          src={props.imageUrl}
+          src={imageUrl}
           alt={i18n.certificateForCompletion()}
           width="100%"
           style={styles.certificate}

--- a/apps/src/templates/CertificateShare.jsx
+++ b/apps/src/templates/CertificateShare.jsx
@@ -16,18 +16,20 @@ export default function CertificateShare({announcement, printUrl, imageUrl}) {
           style={styles.certificate}
         />
       </a>
-      <TwoColumnActionBlock
-        imageUrl={pegasus(announcement.image)}
-        subHeading={announcement.title}
-        description={announcement.body}
-        buttons={[
-          {
-            id: announcement.buttonId,
-            url: announcement.buttonUrl,
-            text: announcement.buttonText
-          }
-        ]}
-      />
+      {announcement && (
+        <TwoColumnActionBlock
+          imageUrl={pegasus(announcement.image)}
+          subHeading={announcement.title}
+          description={announcement.body}
+          buttons={[
+            {
+              id: announcement.buttonId,
+              url: announcement.buttonUrl,
+              text: announcement.buttonText
+            }
+          ]}
+        />
+      )}
     </div>
   );
 }
@@ -47,5 +49,5 @@ const styles = {
 CertificateShare.propTypes = {
   imageUrl: PropTypes.string.isRequired,
   printUrl: PropTypes.string.isRequired,
-  announcement: PropTypes.object.isRequired
+  announcement: PropTypes.object
 };

--- a/apps/src/templates/CertificateShare.jsx
+++ b/apps/src/templates/CertificateShare.jsx
@@ -16,6 +16,7 @@ export default function CertificateShare(props) {
         />
       </a>
       <TwoColumnActionBlock
+        isRtl={false}
         responsiveSize="lg"
         imageUrl={pegasus(announcement.image)}
         subHeading={announcement.title}

--- a/apps/src/templates/CertificateShare.jsx
+++ b/apps/src/templates/CertificateShare.jsx
@@ -7,7 +7,7 @@ import {TwoColumnActionBlock} from '@cdo/apps/templates/studioHomepages/TwoColum
 export default function CertificateShare(props) {
   const {announcement} = props;
   return (
-    <div>
+    <div style={styles.wrapper}>
       <a href={props.printUrl}>
         <img
           src={props.imageUrl}
@@ -31,6 +31,15 @@ export default function CertificateShare(props) {
     </div>
   );
 }
+
+const styles = {
+  wrapper: {
+    with: '100%',
+    maxWidth: 980,
+    marginLeft: 'auto',
+    marginRight: 'auto'
+  }
+};
 
 CertificateShare.propTypes = {
   imageUrl: PropTypes.string.isRequired,

--- a/apps/src/templates/CertificateShare.jsx
+++ b/apps/src/templates/CertificateShare.jsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import i18n from '@cdo/locale';
+import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
+import {UnconnectedTwoColumnActionBlock as TwoColumnActionBlock} from '@cdo/apps/templates/studioHomepages/TwoColumnActionBlock';
 
 export default function CertificateShare(props) {
+  const {announcement} = props;
   return (
     <a href={props.printUrl}>
       <img
@@ -10,11 +13,25 @@ export default function CertificateShare(props) {
         alt={i18n.certificateForCompletion()}
         width="100%"
       />
+      <TwoColumnActionBlock
+        responsiveSize="lg"
+        imageUrl={pegasus(announcement.image)}
+        subHeading={announcement.title}
+        description={announcement.body}
+        buttons={[
+          {
+            id: announcement.buttonId,
+            url: announcement.buttonUrl,
+            text: announcement.buttonText
+          }
+        ]}
+      />
     </a>
   );
 }
 
 CertificateShare.propTypes = {
   imageUrl: PropTypes.string.isRequired,
-  printUrl: PropTypes.string.isRequired
+  printUrl: PropTypes.string.isRequired,
+  announcement: PropTypes.object.isRequired
 };

--- a/apps/test/unit/templates/CertificateShareTest.js
+++ b/apps/test/unit/templates/CertificateShareTest.js
@@ -31,14 +31,7 @@ describe('CertificateShare', () => {
   });
 
   it('renders announcement image url relative to pegasus', () => {
-    const props = {...defaultProps};
-    const wrapper = shallow(
-      <CertificateShare
-        imageUrl={props.imageUrl}
-        printUrl={props.printUrl}
-        announcement={props.announcement}
-      />
-    );
+    const wrapper = shallow(<CertificateShare {...defaultProps} />);
 
     const printLink = wrapper.find('a');
     expect(printLink.prop('href')).to.equal('/certificate-print');

--- a/apps/test/unit/templates/CertificateShareTest.js
+++ b/apps/test/unit/templates/CertificateShareTest.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import {expect} from '../../util/reconfiguredChai';
+import CertificateShare from '@cdo/apps/templates/CertificateShare';
+
+const defaultProps = {
+  imageUrl: '/certificate-image',
+  printUrl: '/certificate-print',
+  announcement: {
+    image: '/announcement-image',
+    title: 'Title Text',
+    body: 'body text',
+    buttonId: 'button-id',
+    buttonUrl: '/button-url',
+    buttonText: 'button text'
+  }
+};
+
+describe('CertificateShare', () => {
+  let storedWindowDashboard;
+
+  beforeEach(() => {
+    storedWindowDashboard = window.dashboard;
+    window.dashboard = {
+      CODE_ORG_URL: '//code.org'
+    };
+  });
+
+  afterEach(() => {
+    window.dashboard = storedWindowDashboard;
+  });
+
+  it('renders announcement image url relative to pegasus', () => {
+    const props = {...defaultProps};
+    const wrapper = shallow(
+      <CertificateShare
+        imageUrl={props.imageUrl}
+        printUrl={props.printUrl}
+        announcement={props.announcement}
+      />
+    );
+
+    const printLink = wrapper.find('a');
+    expect(printLink.prop('href')).to.equal('/certificate-print');
+    const image = printLink.find('img');
+    expect(image.prop('src')).to.equal('/certificate-image');
+
+    const block = wrapper.find('Connect(UnconnectedTwoColumnActionBlock)');
+    expect(block.prop('imageUrl')).to.equal('//code.org/announcement-image');
+  });
+});

--- a/apps/test/unit/templates/CertificateShareTest.js
+++ b/apps/test/unit/templates/CertificateShareTest.js
@@ -41,4 +41,18 @@ describe('CertificateShare', () => {
     const block = wrapper.find('Connect(UnconnectedTwoColumnActionBlock)');
     expect(block.prop('imageUrl')).to.equal('//code.org/announcement-image');
   });
+
+  it('renders no announcement without announcement prop', () => {
+    const props = {
+      ...defaultProps,
+      announcement: null
+    };
+    const wrapper = shallow(<CertificateShare {...props} />);
+
+    const printLink = wrapper.find('a');
+    expect(printLink.length).to.equal(1);
+
+    const block = wrapper.find('Connect(UnconnectedTwoColumnActionBlock)');
+    expect(block.length).to.equal(0);
+  });
 });

--- a/dashboard/app/controllers/certificates_controller.rb
+++ b/dashboard/app/controllers/certificates_controller.rb
@@ -13,9 +13,12 @@ class CertificatesController < ApplicationController
       return render status: :bad_request, json: {message: 'invalid base64'}
     end
 
+    announcement = Announcements.get_announcement_for_page('/certificates')
+
     @certificate_data = {
       imageUrl: certificate_image_url(data['name'], data['course']),
-      printUrl: certificate_print_url(data['name'], data['course'])
+      printUrl: certificate_print_url(data['name'], data['course']),
+      announcement: announcement
     }
   end
 end

--- a/dashboard/app/controllers/certificates_controller.rb
+++ b/dashboard/app/controllers/certificates_controller.rb
@@ -6,6 +6,7 @@ class CertificatesController < ApplicationController
   # GET /certificates/:encoded_params
   def show
     prevent_caching
+    view_options(full_width: true, responsive_content: true)
 
     begin
       data = JSON.parse(Base64.urlsafe_decode64(params[:encoded_params]))

--- a/pegasus/sites.v3/code.org/announcements.json
+++ b/pegasus/sites.v3/code.org/announcements.json
@@ -1,7 +1,8 @@
 {
   "pages": {
     "/projects": "home-learning-2020",
-    "/home": "pl2022"
+    "/home": "pl2022",
+    "/certificates": "congrats-certificate-share"
   },
 
   "banners": {
@@ -12,7 +13,7 @@
       "buttonText": "Learn More",
       "buttonUrl": "https://code.org/educate/professional-learning/middle-high",
       "buttonId": "pl2022-details"
-    },  
+    },
     "csjourneys": {
       "image": "/images/csjourneys/teacher-banner.png",
       "title": "Explore the wide world of computer science",
@@ -103,6 +104,14 @@
       "buttonText": "Learn more",
       "buttonUrl": "https://code.org/ai",
       "buttonId": "2020-ai"
+    },
+    "congrats-certificate-share": {
+      "image": "/images/teacherdashboard1.png",
+      "title": "Try an Hour of Code",
+      "body": "Anyone can learn!",
+      "buttonText": "Start",
+      "buttonUrl": "https://code.org/learn",
+      "buttonId": "congrats-certificate-share-button"
     }
   }
 }


### PR DESCRIPTION
Finishes [PLAT-1588](https://codedotorg.atlassian.net/browse/PLAT-1588). See [work plan](https://docs.google.com/document/d/1wTObDFZdWS6RzpM3R6wEm04ToY2fM1B5Kb2rUHCNq28/edit#). 

There was a discussion between product and marketing which landed on this new page content in [#marketing](https://codedotorg.slack.com/archives/C06E60KL4/p1644455854439959). 

## Screenshots

original (pegasus) responsive:
https://user-images.githubusercontent.com/8001765/153961522-d532e0c5-531e-4a03-aeef-b36acf3837ca.mov

new (dashboard) responsive:
https://user-images.githubusercontent.com/8001765/153961910-085f27ba-6119-43e5-bf80-5c2efdfe0bc1.mov

new (dashboard) still:

![Screen Shot 2022-02-14 at 3 38 44 PM](https://user-images.githubusercontent.com/8001765/153965186-f4288ced-d628-4558-8202-653c3d51e679.png)


## Testing story

Added a basic unit test checking that the correct urls are passed through.

## Deployment strategy

Marketing will be able to update the contents of this banner after this PR ships, before this feature is launched, by editing announcements.json via dropbox. 
