### PR TITLE
Pass category id to programming environment editor

### DIFF
--- a/dashboard/app/models/programming_environment_category.rb
+++ b/dashboard/app/models/programming_environment_category.rb
@@ -37,6 +37,7 @@ class ProgrammingEnvironmentCategory < ApplicationRecord
 
   def serialize_for_edit
     {
+      id: id,
       key: key,
       name: name,
       color: color,


### PR DESCRIPTION
When updating, whether or not a category has an id is how we determine whether it already exists. Without passing the id down, the editor tries to create a duplicate category and fails to save. I don't know how this stopped working but the fix is just to pass this id down.

## Testing story

tested locally. This is an end-to-end issue so eventually it would be good to add some UI tests here


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
