### PR TITLE
Revert "Revert "Use TextLink from @dsco_/link in SmallChevronLink""

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -240,6 +240,7 @@
     "@codemirror/state": "^0.19.2",
     "@codemirror/theme-one-dark": "^0.19.0",
     "@codemirror/view": "^0.19.9",
+    "@dsco_/link": "^1.1.2",
     "@microsoft/immersive-reader-sdk": "^1.1.0",
     "ace-builds": "^1.4.12",
     "blockly": "6.20210701.0",

--- a/apps/src/templates/LargeChevronLink.story.jsx
+++ b/apps/src/templates/LargeChevronLink.story.jsx
@@ -1,24 +1,12 @@
 import React from 'react';
-import SmallChevronLink from './SmallChevronLink';
 import LargeChevronLink from './LargeChevronLink';
 import i18n from '@cdo/locale';
 
 export default storybook => {
   return storybook
-    .storiesOf('ChevronLinks', module)
+    .storiesOf('LargeChevronLink', module)
     .withReduxStore()
     .addStoryTable([
-      {
-        name: 'Small teal chevron link',
-        description: `Used throughout the site for navigation`,
-        story: () => (
-          <SmallChevronLink
-            link={'/foo'}
-            linkText={i18n.viewCourse()}
-            isRtl={false}
-          />
-        )
-      },
       {
         name: 'Large teal chevron link',
         description: `Currently used on /congrats`,

--- a/apps/src/templates/SmallChevronLink.jsx
+++ b/apps/src/templates/SmallChevronLink.jsx
@@ -1,72 +1,44 @@
 import PropTypes from 'prop-types';
-import React, {Component} from 'react';
+import React from 'react';
+import {connect} from 'react-redux';
+import {TextLink} from '@dsco_/link';
 import FontAwesome from './FontAwesome';
-import color from '../util/color';
-import {makeEnum} from '@cdo/apps/utils';
 
-const ChevronSide = makeEnum('left', 'right');
-
-export default class SmallChevronLink extends Component {
-  static propTypes = {
-    linkText: PropTypes.string.isRequired,
-    link: PropTypes.string.isRequired,
-    isRtl: PropTypes.bool.isRequired,
-    chevronSide: PropTypes.oneOf(Object.values(ChevronSide))
-  };
-
-  renderChevron = () => {
-    const {isRtl} = this.props;
-    const icon = isRtl ? 'chevron-left' : 'chevron-right';
-
-    return (
-      <FontAwesome
-        icon={icon}
-        style={isRtl ? styles.chevronRtl : styles.chevron}
+export function SmallChevronLink({
+  href,
+  text,
+  iconBefore = false,
+  isRtl = false,
+  style = {margin: '10px 0'}
+}) {
+  return (
+    <div style={style}>
+      <TextLink
+        href={href}
+        text={text}
+        icon={
+          <FontAwesome
+            icon={iconBefore ? 'chevron-left' : 'chevron-right'}
+            className={isRtl ? 'fa-flip-horizontal' : undefined}
+            aria-label={text}
+          />
+        }
+        iconBefore={iconBefore}
       />
-    );
-  };
-
-  render() {
-    const {link, linkText, chevronSide} = this.props;
-
-    return (
-      <div style={styles.linkBox}>
-        <a href={link} style={styles.link}>
-          {chevronSide === ChevronSide.left && this.renderChevron()}
-          <h3 style={styles.link}>{linkText}</h3>
-          {(!chevronSide || chevronSide === ChevronSide.right) &&
-            this.renderChevron()}
-        </a>
-      </div>
-    );
-  }
+    </div>
+  );
 }
 
-const styles = {
-  link: {
-    color: color.teal,
-    fontSize: 14,
-    fontFamily: '"Gotham 4r", sans-serif',
-    fontWeight: 'bold',
-    display: 'inline',
-    textDecoration: 'none'
-  },
-  chevron: {
-    display: 'inline',
-    color: color.teal,
-    fontSize: 12,
-    fontWeight: 'bold',
-    marginLeft: 8
-  },
-  chevronRtl: {
-    display: 'inline',
-    color: color.teal,
-    fontSize: 12,
-    fontWeight: 'bold',
-    marginRight: 8
-  },
-  linkBox: {
-    display: 'block',
-    textDecoration: 'none'
-  }
+SmallChevronLink.propTypes = {
+  text: PropTypes.string.isRequired,
+  href: PropTypes.string.isRequired,
+  iconBefore: PropTypes.bool,
+  style: PropTypes.object,
+
+  // Provided by redux
+  isRtl: PropTypes.bool
 };
+
+export default connect(state => ({
+  isRtl: state.isRtl
+}))(SmallChevronLink);

--- a/apps/src/templates/SmallChevronLink.story.jsx
+++ b/apps/src/templates/SmallChevronLink.story.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import {SmallChevronLink} from './SmallChevronLink';
+
+export default storybook => {
+  return storybook.storiesOf('SmallChevronLink', module).addStoryTable([
+    {
+      name: 'Default',
+      description: 'Used throughout the site for navigation',
+      story: () => <SmallChevronLink href="/foo" text="View course" />
+    },
+    {
+      name: 'Icon before text',
+      story: () => (
+        <SmallChevronLink href="/foo" text="View course" iconBefore />
+      )
+    }
+  ]);
+};

--- a/apps/src/templates/teacherDashboard/TeacherDashboardHeader.jsx
+++ b/apps/src/templates/teacherDashboard/TeacherDashboardHeader.jsx
@@ -93,10 +93,9 @@ class TeacherDashboardHeader extends React.Component {
     return (
       <div>
         <SmallChevronLink
-          link="/home#classroom-sections"
-          linkText={i18n.viewAllSections()}
-          isRtl={true}
-          chevronSide="left"
+          href="/home#classroom-sections"
+          text={i18n.viewAllSections()}
+          iconBefore
         />
         <this.lockedSectionNotification
           restrictSection={this.props.selectedSection.restrictSection}

--- a/apps/src/templates/teacherDashboard/TeacherSectionSelector.jsx
+++ b/apps/src/templates/teacherDashboard/TeacherSectionSelector.jsx
@@ -111,9 +111,8 @@ export default class TeacherSectionSelector extends Component {
             ))}
           <div style={styles.addNewSection}>
             <SmallChevronLink
-              link={`/home?${queryParams}`}
-              linkText={i18n.addNewSection()}
-              isRtl={false}
+              href={`/home?${queryParams}`}
+              text={i18n.addNewSection()}
             />
           </div>
         </PopUpMenu>

--- a/apps/src/templates/teacherDashboard/TeacherSectionSelector.story.jsx
+++ b/apps/src/templates/teacherDashboard/TeacherSectionSelector.story.jsx
@@ -4,18 +4,21 @@ import {action} from '@storybook/addon-actions';
 import {fakeTeacherSectionsForDropdown} from './sectionAssignmentTestHelper';
 
 export default storybook => {
-  storybook.storiesOf('TeacherSectionSelector', module).addStoryTable([
-    {
-      name: 'TeacherSectionSelector',
-      story: () => (
-        <div>
-          <TeacherSectionSelector
-            selectedSection={fakeTeacherSectionsForDropdown[0]}
-            sections={fakeTeacherSectionsForDropdown}
-            onChangeSection={action('changeSection')}
-          />
-        </div>
-      )
-    }
-  ]);
+  storybook
+    .storiesOf('TeacherSectionSelector', module)
+    .withReduxStore()
+    .addStoryTable([
+      {
+        name: 'TeacherSectionSelector',
+        story: () => (
+          <div>
+            <TeacherSectionSelector
+              selectedSection={fakeTeacherSectionsForDropdown[0]}
+              sections={fakeTeacherSectionsForDropdown}
+              onChangeSection={action('changeSection')}
+            />
+          </div>
+        )
+      }
+    ]);
 };

--- a/apps/webpack.js
+++ b/apps/webpack.js
@@ -7,9 +7,10 @@ var WebpackNotifierPlugin = require('webpack-notifier');
 
 // Certain packages ship in ES6 and need to be transpiled for our purposes.
 var toTranspileWithinNodeModules = [
-  // All of our @cdo-aliased files should get transpiled as they are our own
+  // All of our @cdo- and @dsco_-aliased files should get transpiled as they are our own
   // source files.
   path.resolve(__dirname, 'node_modules', '@cdo'),
+  path.resolve(__dirname, 'node_modules', '@dsco_'),
   // playground-io ships in ES6 as of 0.3.0
   path.resolve(__dirname, 'node_modules', 'playground-io'),
   path.resolve(__dirname, 'node_modules', 'json-parse-better-errors'),

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1880,6 +1880,20 @@
     style-mod "^4.0.0"
     w3c-keyname "^2.2.4"
 
+"@dsco_/common@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@dsco_/common/-/common-1.1.0.tgz#2309bc19fe90323330b9b0000fc27f80475c5b67"
+  integrity sha512-t+ZKe9Dg67Ap9mxzKtkdHOt95tVsJFtRLpUQcr/LEdPNcsojgqmc1L/nWMv/UbWv7I0GO3Kxd2Www/tLqE1IVg==
+
+"@dsco_/link@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@dsco_/link/-/link-1.1.2.tgz#4dacabd8e9d798bdd71319d04b5e7fd97bea653d"
+  integrity sha512-JB21X/KHjMrVkRN46L5proQ2WIUOgeixjEuZoPrGp9xbDLlPJJxOJktgfn9tNo4QbRKmxaEXB3569BWiQ/KdHQ==
+  dependencies:
+    "@dsco_/common" "^1.1.0"
+    classnames "^2.3.1"
+    prop-types "^15.8.1"
+
 "@emotion/cache@^0.8.8":
   version "0.8.8"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-0.8.8.tgz#2c3bd1aa5fdb88f1cc2325176a3f3201739e726c"
@@ -4605,6 +4619,11 @@ classnames@^2.2.3, classnames@^2.2.4:
 classnames@^2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
+
+classnames@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
+  integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==
 
 clean-css@4.2.x:
   version "4.2.1"
@@ -12365,6 +12384,15 @@ prop-types@^15.7.2:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.8.1"
+
+prop-types@^15.8.1:
+  version "15.8.1"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
+  integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.13.1"
 
 property-information@^4.0.0:
   version "4.2.0"


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#44819, reintroducing #44759.

tagging original reviewers as a heads up: @code-dot-org/ed-programs-tools @code-dot-org/learning-platform @sanchitmalhotra126 

i reverted the original PR that introduced `@dsco_/link` because i missed a step. i outlined it in the revert PR, but i'll summarize everything here, too.

the original PR caused the staging build to fail with this error during `npm run build:dist`:
<img width="1067" alt="Screen Shot 2022-02-14 at 10 57 36 AM" src="https://user-images.githubusercontent.com/9812299/153931870-383f9c7d-dd08-414f-8c4c-d1d8ed0339a7.png">

this was reproducible locally, so i reverted the original PR to debug. this error was occurring because `@dsco_/link` ships in ES6 and i didn't add it to the list of packages that should be transpiled during our apps build (see [290e199](https://github.com/code-dot-org/code-dot-org/pull/44820/commits/290e19976110de7d2025293e8e5a6698a2daf0af) for how that's done).

i don't think this needs re-reviewing -- i've confirmed locally that this fixes the build issue, but i thought i'd let everyone know because i often forget we need to add this step in some cases (obviously 😅)!