### PR TITLE
No section selected represented by empty string

### DIFF
--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
@@ -26,8 +26,8 @@ const USER_EDITABLE_SECTION_PROPS = [
 /** @const {number} ID for a new section that has not been saved */
 const PENDING_NEW_SECTION_ID = -1;
 
-/** @const {number} -1 used to indicate no section selected */
-export const NO_SECTION = -1;
+/** @const {string} empty string used to indicate no section selected */
+export const NO_SECTION = '';
 
 /** @const {Object} Map oauth section type to relative "list rosters" URL. */
 const urlByProvider = {


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This is a temporary revert of a change I made to unblock our pipeline.

The reason I originally changed from the empty string to -1 is so that we'd have a consistent type for the selected section ID. Turns out other places were relying on the empty string (without checking for the value of `NO_SECTION`) to do other calculations. What I'd really like to do here is change `NO_SECTION` to be `null` when there is no selected section, but I'm going to do it as a separate PR to keep from blocking anyone.


## Testing story
Tested locally that hidden courses are properly hidden.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Follow-up work
Change no section in `teacherSectionsRedux` to null
<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
