### PR TITLE
allow course offering json edits during levelbuilder scoop

### DIFF
--- a/tools/hooks/restrict_levelbuilder_changes.rb
+++ b/tools/hooks/restrict_levelbuilder_changes.rb
@@ -17,7 +17,7 @@ WHITELISTED_FILES = %w(
   dashboard/config/locales/data.en.yml
   dashboard/config/videos.csv
 ).map {|f| File.join(REPO_DIR, f)}.freeze
-ERROR_MESSAGE = "Levelbuilder branch should only commit files in levels directory and specific whitelisted files. See #{__FILE__} for details.".freeze
+ERROR_MESSAGE = "Levelbuilder branch should only commit files in levels directory and specific allowed files. See #{__FILE__} for details.".freeze
 
 Dir.chdir REPO_DIR
 branchname = `git rev-parse --abbrev-ref HEAD`.strip

--- a/tools/hooks/restrict_levelbuilder_changes.rb
+++ b/tools/hooks/restrict_levelbuilder_changes.rb
@@ -6,6 +6,7 @@ SHARED_FUNCTIONS_DIR = File.expand_path(REPO_DIR + '/dashboard/config/shared_fun
 LIBRARIES_DIR = File.expand_path(REPO_DIR + '/dashboard/config/libraries', __FILE__).freeze
 LEVELS_DIR = File.expand_path(REPO_DIR + '/dashboard/config/scripts', __FILE__).freeze
 COURSES_DIR = File.expand_path(REPO_DIR + '/dashboard/config/courses', __FILE__).freeze
+COURSE_OFFERINGS_DIR = File.expand_path(REPO_DIR + '/dashboard/config/course_offerings', __FILE__).freeze
 VIDEO_THUMBNAILS_DIR = File.expand_path(REPO_DIR + '/dashboard/public/c/video_thumbnails', __FILE__).freeze
 FOORM_DIR = File.expand_path(REPO_DIR + '/dashboard/config/foorm', __FILE__).freeze
 WHITELISTED_FILES = %w(
@@ -26,6 +27,6 @@ staged_files = HooksUtils.get_staged_files
 
 staged_files.each do |filename|
   raise "#{ERROR_MESSAGE}\nFile blocked: #{filename}" unless filename.start_with?(
-    BLOCKS_DIR, SHARED_FUNCTIONS_DIR, LIBRARIES_DIR, LEVELS_DIR, COURSES_DIR, VIDEO_THUMBNAILS_DIR, FOORM_DIR
+    BLOCKS_DIR, SHARED_FUNCTIONS_DIR, LIBRARIES_DIR, LEVELS_DIR, COURSES_DIR, COURSE_OFFERINGS_DIR, VIDEO_THUMBNAILS_DIR, FOORM_DIR
   ) || WHITELISTED_FILES.include?(filename)
 end


### PR DESCRIPTION
Fixes a problem with the levelbuilder scoop (see [slack](https://codedotorg.slack.com/archives/C0T0PNTM3/p1644873184212019)). This is due to a new type of curriculum file added in https://github.com/code-dot-org/code-dot-org/pull/44613. 

## Testing story

manually verified that the following fails without this PR, but succeeds with it:
1. make a local edit to `config/course_offerings/20-hour.json`
2. `git checkout -b levelbuilder`
3. `git commit -a -m 'test levelbuilder hooks'`