### PR TITLE
Remove status from form data after status gets set

### DIFF
--- a/dashboard/app/models/pd/application/application_base.rb
+++ b/dashboard/app/models/pd/application/application_base.rb
@@ -59,9 +59,7 @@ module Pd::Application
     # Set the status only if (a) the application is new, or (b) the applicant updates form_data.
     # Avoid setting the status when an RP or admin changes the application status, which only happens
     # from the application dashboard, not from changing form_data.
-    before_validation -> {self.status = (sanitize_form_data_hash && sanitize_form_data_hash[:status] || :unreviewed)},
-      if: -> {form_data_changed? || new_record?}
-
+    before_validation :set_status
     validate :status_is_valid_for_application_type
     validates_presence_of :type
     validates_presence_of :user_id, unless: proc {|application| application.application_type == PRINCIPAL_APPROVAL_APPLICATION}
@@ -72,6 +70,7 @@ module Pd::Application
     # An application either has an "incomplete" or "unreviewed" state when created.
     # After creation, an RP or admin can change the status to "accepted," which triggers update_accepted_data.
     before_save :update_accepted_date, if: :status_changed?
+    before_save :remove_status_from_form_data
 
     before_create :generate_application_guid, if: -> {application_guid.blank?}
     after_destroy :delete_unsent_email
@@ -89,6 +88,17 @@ module Pd::Application
       csp
       csa
     ).index_by(&:to_sym).freeze
+
+    def set_status
+      return unless new_record? || (sanitize_form_data_hash && sanitize_form_data_hash[:status])
+      self.status = 'unreviewed' if new_record?
+      self.status = sanitize_form_data_hash[:status] if sanitize_form_data_hash && sanitize_form_data_hash[:status]
+    end
+
+    def remove_status_from_form_data
+      return unless form_data_hash && form_data_hash["status"]
+      self.form_data = form_data_hash.except("status").to_json
+    end
 
     def set_type_and_year
       # Override in derived classes and set to valid values.

--- a/dashboard/test/models/pd/application/application_base_test.rb
+++ b/dashboard/test/models/pd/application/application_base_test.rb
@@ -45,6 +45,13 @@ module Pd::Application
       assert application.sanitize_status_timestamp_change_log[0].value?('incomplete')
     end
 
+    test 'status is removed from form_data after status is set' do
+      application = create TEACHER_APPLICATION_FACTORY, form_data: {status: 'incomplete'}.to_json
+
+      assert application.incomplete?
+      assert_nil application.form_data_hash['status']
+    end
+
     test 'can update status' do
       application = create FACILITATOR_APPLICATION_FACTORY
       assert application.unreviewed?


### PR DESCRIPTION
This addresses a bug documented here https://codedotorg.slack.com/archives/C02EEGWLHR8/p1644872192626099

When a principal sends in the approval, the teacher's application form_data is modified. That triggered us to set the teacher's application status from the form_data, even if an RP had set the status as something different.

To fix, I am removing the status from form_data once it's been set. Thus, status will only be in form_data just after the teacher submits or saves an application.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
