### PR TITLE
Teacher Sections Redux - selectedSectionId consistently a number

### DIFF
--- a/apps/src/code-studio/components/progress/LessonLockDialog.jsx
+++ b/apps/src/code-studio/components/progress/LessonLockDialog.jsx
@@ -9,6 +9,7 @@ import color from '../../../util/color';
 import commonMsg from '@cdo/locale';
 import SectionSelector from './SectionSelector';
 import {teacherDashboardUrl} from '@cdo/apps/templates/teacherDashboard/urlHelpers';
+import {NO_SECTION} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 
 class LessonLockDialog extends React.Component {
   static propTypes = {
@@ -20,7 +21,7 @@ class LessonLockDialog extends React.Component {
         lockStatus: PropTypes.oneOf(Object.values(LockStatus)).isRequired
       })
     ),
-    selectedSectionId: PropTypes.string.isRequired,
+    selectedSectionId: PropTypes.number,
     saving: PropTypes.bool.isRequired,
     saveDialog: PropTypes.func.isRequired
   };
@@ -94,7 +95,7 @@ class LessonLockDialog extends React.Component {
     const responsiveHeight = {
       maxHeight: window.innerHeight * 0.8 - 100
     };
-    const hasSelectedSection = this.props.selectedSectionId !== '';
+    const hasSelectedSection = this.props.selectedSectionId !== NO_SECTION;
     const hiddenUnlessSelectedSection = hasSelectedSection ? {} : styles.hidden;
     return (
       <BaseDialog
@@ -331,7 +332,7 @@ export default connect(
     initialLockStatus: state.lessonLock.lockStatus,
     isOpen: !!state.lessonLock.lockDialogLessonId,
     saving: state.lessonLock.saving,
-    selectedSectionId: state.teacherSections.selectedSectionId.toString()
+    selectedSectionId: state.teacherSections.selectedSectionId
   }),
   dispatch => ({
     saveDialog(sectionId, lockStatus) {

--- a/apps/src/code-studio/components/progress/MiniView.jsx
+++ b/apps/src/code-studio/components/progress/MiniView.jsx
@@ -64,7 +64,7 @@ MiniView.propTypes = {
   hasGroups: PropTypes.bool.isRequired,
   scriptName: PropTypes.string.isRequired,
   hasFullProgress: PropTypes.bool.isRequired,
-  selectedSectionId: PropTypes.string
+  selectedSectionId: PropTypes.number
 };
 
 const styles = {
@@ -85,5 +85,5 @@ export default connect(state => ({
   scriptName: state.progress.scriptName,
   hasFullProgress: state.progress.hasFullProgress,
   hasGroups: hasGroups(state.progress),
-  selectedSectionId: state.teacherSections.selectedSectionId.toString()
+  selectedSectionId: state.teacherSections.selectedSectionId
 }))(MiniView);

--- a/apps/src/code-studio/components/progress/MiniViewTopRow.jsx
+++ b/apps/src/code-studio/components/progress/MiniViewTopRow.jsx
@@ -13,7 +13,7 @@ export default class MiniViewTopRow extends React.Component {
     scriptName: PropTypes.string.isRequired,
     // May not have this (i.e if not logged in)
     linesOfCodeText: PropTypes.string,
-    selectedSectionId: PropTypes.string
+    selectedSectionId: PropTypes.number
   };
 
   render() {

--- a/apps/src/code-studio/components/progress/SectionSelector.jsx
+++ b/apps/src/code-studio/components/progress/SectionSelector.jsx
@@ -6,9 +6,10 @@ import {updateQueryParam} from '../../utils';
 import {reload} from '../../../utils';
 import {
   selectSection,
-  sectionsNameAndId,
-  NO_SECTION
+  sectionsNameAndId
 } from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
+
+const NO_SELECTED_SECTION_VALUE = '';
 
 function SectionSelector({
   style,
@@ -28,7 +29,7 @@ function SectionSelector({
 
     updateQueryParam(
       'section_id',
-      newSectionId === NO_SECTION ? undefined : newSectionId
+      newSectionId === NO_SELECTED_SECTION_VALUE ? undefined : newSectionId
     );
     // If we have a user_id when we switch sections we should get rid of it
     updateQueryParam('user_id', undefined);
@@ -52,11 +53,14 @@ function SectionSelector({
         ...styles.select,
         ...style
       }}
-      value={selectedSectionId}
+      value={selectedSectionId || NO_SELECTED_SECTION_VALUE}
       onChange={handleSelectChange}
     >
       {!requireSelection && (
-        <option key={''} value={''}>
+        <option
+          key={NO_SELECTED_SECTION_VALUE}
+          value={NO_SELECTED_SECTION_VALUE}
+        >
           {i18n.selectSection()}
         </option>
       )}
@@ -86,7 +90,7 @@ SectionSelector.propTypes = {
       id: PropTypes.number.isRequired
     })
   ).isRequired,
-  selectedSectionId: PropTypes.string,
+  selectedSectionId: PropTypes.number,
   selectSection: PropTypes.func.isRequired
 };
 
@@ -100,7 +104,7 @@ export const UnconnectedSectionSelector = SectionSelector;
 
 export default connect(
   state => ({
-    selectedSectionId: state.teacherSections.selectedSectionId.toString(),
+    selectedSectionId: state.teacherSections.selectedSectionId,
     sections: sectionsNameAndId(state.teacherSections)
   }),
   dispatch => ({

--- a/apps/src/code-studio/components/progress/SectionSelector.jsx
+++ b/apps/src/code-studio/components/progress/SectionSelector.jsx
@@ -9,7 +9,8 @@ import {
   sectionsNameAndId
 } from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 
-const NO_SELECTED_SECTION_VALUE = '';
+// Exported for unit testing
+export const NO_SELECTED_SECTION_VALUE = '';
 
 function SectionSelector({
   style,

--- a/apps/src/code-studio/components/progress/UnitOverview.jsx
+++ b/apps/src/code-studio/components/progress/UnitOverview.jsx
@@ -207,5 +207,5 @@ export default connect((state, ownProps) => ({
   scriptName: state.progress.scriptName,
   viewAs: state.viewAs,
   hiddenLessonState: state.hiddenLesson,
-  selectedSectionId: parseInt(state.teacherSections.selectedSectionId)
+  selectedSectionId: state.teacherSections.selectedSectionId
 }))(UnconnectedUnitOverview);

--- a/apps/src/code-studio/components/progress/UnitOverviewTopRow.jsx
+++ b/apps/src/code-studio/components/progress/UnitOverviewTopRow.jsx
@@ -271,7 +271,7 @@ const styles = {
 export const UnconnectedUnitOverviewTopRow = UnitOverviewTopRow;
 
 export default connect(state => ({
-  selectedSectionId: parseInt(state.teacherSections.selectedSectionId),
+  selectedSectionId: state.teacherSections.selectedSectionId,
   sectionsForDropdown: sectionsForDropdown(
     state.teacherSections,
     state.progress.scriptId,

--- a/apps/src/templates/courseOverview/CourseScript.js
+++ b/apps/src/templates/courseOverview/CourseScript.js
@@ -191,7 +191,7 @@ export const UnconnectedCourseScript = CourseScript;
 export default connect(
   (state, ownProps) => ({
     viewAs: state.viewAs,
-    selectedSectionId: parseInt(state.teacherSections.selectedSectionId),
+    selectedSectionId: state.teacherSections.selectedSectionId,
     sectionsForDropdown: sectionsForDropdown(
       state.teacherSections,
       ownProps.id,

--- a/apps/src/templates/instructions/teacherFeedback/EditableTeacherFeedback.jsx
+++ b/apps/src/templates/instructions/teacherFeedback/EditableTeacherFeedback.jsx
@@ -36,7 +36,7 @@ export class EditableTeacherFeedback extends Component {
     token: PropTypes.string,
     //Provided by Redux
     verifiedInstructor: PropTypes.bool,
-    selectedSectionId: PropTypes.string,
+    selectedSectionId: PropTypes.number,
     updateUserProgress: PropTypes.func.isRequired,
     canHaveFeedbackReviewState: PropTypes.bool
   };
@@ -294,8 +294,7 @@ export default connect(
   state => ({
     verifiedInstructor:
       state.verifiedInstructor && state.verifiedInstructor.isVerified,
-    selectedSectionId:
-      state.teacherSections && state.teacherSections.selectedSectionId,
+    selectedSectionId: state.teacherSections?.selectedSectionId,
     canHaveFeedbackReviewState:
       state.pageConstants && state.pageConstants.canHaveFeedbackReviewState
   }),

--- a/apps/src/templates/progress/LessonLock.jsx
+++ b/apps/src/templates/progress/LessonLock.jsx
@@ -20,7 +20,7 @@ class LessonLock extends React.Component {
     lesson: lessonType.isRequired,
 
     // redux provided
-    sectionId: PropTypes.string.isRequired,
+    sectionId: PropTypes.number,
     sectionsAreLoaded: PropTypes.bool.isRequired,
     saving: PropTypes.bool.isRequired,
     scriptId: PropTypes.number.isRequired,
@@ -84,7 +84,7 @@ const styles = {
 export const UnconnectedLessonLock = LessonLock;
 export default connect(
   state => ({
-    sectionId: state.teacherSections.selectedSectionId.toString(),
+    sectionId: state.teacherSections.selectedSectionId,
     sectionsAreLoaded: state.teacherSections.sectionsAreLoaded,
     saving: state.lessonLock.saving,
     scriptId: state.progress.scriptId

--- a/apps/src/templates/progress/ProgressBubble.jsx
+++ b/apps/src/templates/progress/ProgressBubble.jsx
@@ -26,10 +26,7 @@ export default class ProgressBubble extends React.Component {
     level: levelWithProgressType.isRequired,
     disabled: PropTypes.bool.isRequired,
     smallBubble: PropTypes.bool,
-    selectedSectionId: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number
-    ]),
+    selectedSectionId: PropTypes.number,
     selectedStudentId: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.number

--- a/apps/src/templates/progress/ProgressBubbleSet.jsx
+++ b/apps/src/templates/progress/ProgressBubbleSet.jsx
@@ -17,10 +17,7 @@ class ProgressBubbleSet extends React.Component {
     levels: PropTypes.arrayOf(levelWithProgressType).isRequired,
     disabled: PropTypes.bool.isRequired,
     style: PropTypes.object,
-    selectedSectionId: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number
-    ]),
+    selectedSectionId: PropTypes.number,
     selectedStudentId: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.number

--- a/apps/src/templates/progress/ProgressLesson.jsx
+++ b/apps/src/templates/progress/ProgressLesson.jsx
@@ -31,7 +31,7 @@ class ProgressLesson extends React.Component {
     isVisible: PropTypes.bool.isRequired,
     hiddenForStudents: PropTypes.bool.isRequired,
     isLockedForUser: PropTypes.bool.isRequired,
-    selectedSectionId: PropTypes.string,
+    selectedSectionId: PropTypes.number,
     lockableAuthorized: PropTypes.bool,
     lockableAuthorizedLoaded: PropTypes.bool.isRequired,
     isLockedForAllStudents: PropTypes.bool.isRequired,
@@ -328,7 +328,7 @@ export default connect((state, ownProps) => ({
     ownProps.lesson.id,
     state
   ),
-  selectedSectionId: state.teacherSections.selectedSectionId.toString(),
+  selectedSectionId: state.teacherSections.selectedSectionId,
   scriptId: state.progress.scriptId,
   isRtl: state.isRtl,
   isMiniView: state.progress.isMiniView,

--- a/apps/src/templates/progress/ProgressLessonContent.jsx
+++ b/apps/src/templates/progress/ProgressLessonContent.jsx
@@ -12,7 +12,7 @@ export default class ProgressLessonContent extends React.Component {
     description: PropTypes.string,
     levels: PropTypes.arrayOf(levelWithProgressType).isRequired,
     disabled: PropTypes.bool.isRequired,
-    selectedSectionId: PropTypes.string
+    selectedSectionId: PropTypes.number
   };
 
   render() {

--- a/apps/src/templates/progress/ProgressLevelSet.jsx
+++ b/apps/src/templates/progress/ProgressLevelSet.jsx
@@ -17,7 +17,7 @@ class ProgressLevelSet extends React.Component {
     name: PropTypes.string,
     levels: PropTypes.arrayOf(levelWithProgressType).isRequired,
     disabled: PropTypes.bool.isRequired,
-    selectedSectionId: PropTypes.string,
+    selectedSectionId: PropTypes.number,
     onBubbleClick: PropTypes.func,
     // Redux
     isRtl: PropTypes.bool

--- a/apps/src/templates/progress/ProgressPill.jsx
+++ b/apps/src/templates/progress/ProgressPill.jsx
@@ -28,7 +28,7 @@ class ProgressPill extends React.Component {
     text: PropTypes.string,
     tooltip: PropTypes.element,
     disabled: PropTypes.bool,
-    selectedSectionId: PropTypes.string,
+    selectedSectionId: PropTypes.number,
     progressStyle: PropTypes.bool,
     onSingleLevelClick: PropTypes.func,
     // Redux

--- a/apps/src/templates/progress/progressTestHelpers.js
+++ b/apps/src/templates/progress/progressTestHelpers.js
@@ -79,10 +79,11 @@ export const fakeProgressForLevels = (
  * @param {number?} lessonId - Lesson to hide (or null if none)
  */
 export const createStoreWithHiddenLesson = (viewAs, lessonId) => {
+  const sectionId = 11;
   return createStore(state => state, {
     lessonLock: {
       lessonsBySectionId: {
-        '11': {}
+        [sectionId]: {}
       },
       lockableAuthorized: false,
       lockableAuthorizedLoaded: true,
@@ -90,10 +91,10 @@ export const createStoreWithHiddenLesson = (viewAs, lessonId) => {
     },
     viewAs: viewAs,
     teacherSections: {
-      sectionIds: ['11'],
+      sectionIds: [sectionId],
       sectionsAreLoaded: true,
       sections: {
-        '11': {
+        [sectionId]: {
           id: 11,
           name: 'test section',
           lesson_extras: true,
@@ -107,11 +108,11 @@ export const createStoreWithHiddenLesson = (viewAs, lessonId) => {
           pairingAllowed: true
         }
       },
-      selectedSectionId: '11'
+      selectedSectionId: sectionId
     },
     hiddenLesson: Immutable.fromJS({
       lessonsBySection: {
-        '11': {[lessonId]: true}
+        [sectionId]: {[lessonId]: true}
       }
     }),
     progress: {
@@ -133,10 +134,11 @@ export const createStoreWithLockedLesson = (
   viewAs,
   lockableAuthorized = false
 ) => {
+  const sectionId = 11;
   return createStore(state => state, {
     lessonLock: {
       lessonsBySectionId: {
-        '11': {}
+        [sectionId]: {}
       },
       lessonsBySectionIdLoaded: true,
       lockableAuthorized: lockableAuthorized,
@@ -144,11 +146,11 @@ export const createStoreWithLockedLesson = (
     },
     viewAs: viewAs,
     teacherSections: {
-      selectedSectionId: '11'
+      selectedSectionId: sectionId
     },
     hiddenLesson: Immutable.fromJS({
       lessonsBySection: {
-        '11': {[lessonId]: true}
+        [sectionId]: {[lessonId]: true}
       }
     }),
     progress: {

--- a/apps/src/templates/teacherDashboard/SectionAssigner.jsx
+++ b/apps/src/templates/teacherDashboard/SectionAssigner.jsx
@@ -98,7 +98,7 @@ export const UnconnectedSectionAssigner = SectionAssigner;
 
 export default connect(
   state => ({
-    selectedSectionId: parseInt(state.teacherSections.selectedSectionId)
+    selectedSectionId: state.teacherSections.selectedSectionId
   }),
   dispatch => ({
     selectSection(sectionId) {

--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
@@ -26,8 +26,8 @@ const USER_EDITABLE_SECTION_PROPS = [
 /** @const {number} ID for a new section that has not been saved */
 const PENDING_NEW_SECTION_ID = -1;
 
-/** @const {string} Empty string used to indicate no section selected */
-export const NO_SECTION = '';
+/** @const {null} null used to indicate no section selected */
+export const NO_SECTION = null;
 
 /** @const {Object} Map oauth section type to relative "list rosters" URL. */
 const urlByProvider = {
@@ -785,13 +785,20 @@ export default function teacherSections(state = initialState, action) {
   }
 
   if (action.type === SELECT_SECTION) {
-    let sectionId = action.sectionId;
+    let sectionId;
+    if (action.sectionId) {
+      sectionId = parseInt(action.sectionId);
+    } else {
+      sectionId = NO_SECTION;
+    }
+
     if (
       sectionId !== NO_SECTION &&
       !state.sectionIds.includes(parseInt(sectionId, 10))
     ) {
       sectionId = NO_SECTION;
     }
+
     return {
       ...state,
       selectedSectionId: sectionId

--- a/apps/test/unit/code-studio/components/progress/LessonLockDialogTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/LessonLockDialogTest.jsx
@@ -9,15 +9,17 @@ const MINIMUM_PROPS = {
   isOpen: false,
   handleClose: () => {},
   initialLockStatus: [],
-  selectedSectionId: '',
+  selectedSectionId: null,
   saving: false,
   saveDialog: () => {}
 };
 
+const fakeSectionId = 1;
+
 describe('LessonLockDialog', () => {
   it('renders with a selected section', () => {
     const wrapper = shallow(
-      <LessonLockDialog {...MINIMUM_PROPS} selectedSectionId="fakeSectionId" />
+      <LessonLockDialog {...MINIMUM_PROPS} selectedSectionId={fakeSectionId} />
     );
     expect(wrapper).not.to.be.null;
   });
@@ -116,14 +118,14 @@ describe('LessonLockDialog', () => {
       const wrapper = shallow(
         <LessonLockDialog
           {...MINIMUM_PROPS}
-          selectedSectionId="fakeSectionId"
+          selectedSectionId={fakeSectionId}
         />
       );
       expect(window.open).not.to.have.been.called;
 
       wrapper.instance().viewSection();
       expect(window.open).to.have.been.calledOnce.and.calledWith(
-        '/teacher_dashboard/sections/fakeSectionId/assessments'
+        `/teacher_dashboard/sections/${fakeSectionId}/assessments`
       );
     });
   });
@@ -133,7 +135,7 @@ describe('LessonLockDialog', () => {
     const wrapper = shallow(
       <LessonLockDialog
         {...MINIMUM_PROPS}
-        selectedSectionId="fakeSectionId"
+        selectedSectionId={fakeSectionId}
         initialLockStatus={[
           {name: 'fakeLesson1', lockStatus: LockStatus.Editable},
           {name: 'fakeLesson2', lockStatus: LockStatus.Editable}
@@ -145,7 +147,7 @@ describe('LessonLockDialog', () => {
 
     wrapper.instance().handleSave();
     expect(saveDialog).to.have.been.calledOnce.and.calledWith(
-      'fakeSectionId',
+      fakeSectionId,
       wrapper.state().lockStatus
     );
   });

--- a/apps/test/unit/code-studio/components/progress/SectionSelectorTest.js
+++ b/apps/test/unit/code-studio/components/progress/SectionSelectorTest.js
@@ -1,16 +1,20 @@
 import React from 'react';
 import {assert, expect} from '../../../../util/reconfiguredChai';
 import sinon from 'sinon';
-import {UnconnectedSectionSelector as SectionSelector} from '@cdo/apps/code-studio/components/progress/SectionSelector';
+import {
+  UnconnectedSectionSelector as SectionSelector,
+  NO_SELECTED_SECTION_VALUE
+} from '@cdo/apps/code-studio/components/progress/SectionSelector';
 import {mount} from 'enzyme';
 import * as utils from '@cdo/apps/utils';
 import * as codeStudioUtils from '@cdo/apps/code-studio/utils';
-import {NO_SECTION} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 
 const fakeSection = {
   name: 'My Section',
   id: 123
 };
+
+const testSectionId = 11;
 
 describe('SectionSelector', () => {
   it('renders nothing if it has no sections', () => {
@@ -85,9 +89,9 @@ describe('SectionSelector', () => {
       );
       wrapper
         .find('select')
-        .simulate('change', {target: {value: 'testSectionId'}});
+        .simulate('change', {target: {value: testSectionId}});
       expect(codeStudioUtils.updateQueryParam)
-        .to.have.been.calledTwice.and.calledWith('section_id', 'testSectionId')
+        .to.have.been.calledTwice.and.calledWith('section_id', testSectionId)
         .and.calledWith('user_id', undefined);
     });
 
@@ -101,7 +105,9 @@ describe('SectionSelector', () => {
           selectSection={() => {}}
         />
       );
-      wrapper.find('select').simulate('change', {target: {value: NO_SECTION}});
+      wrapper
+        .find('select')
+        .simulate('change', {target: {value: NO_SELECTED_SECTION_VALUE}});
       expect(codeStudioUtils.updateQueryParam)
         .to.have.been.calledTwice.and.calledWith('section_id', undefined)
         .and.calledWith('user_id', undefined);
@@ -121,7 +127,7 @@ describe('SectionSelector', () => {
       );
       wrapper
         .find('select')
-        .simulate('change', {target: {value: 'testSectionId'}});
+        .simulate('change', {target: {value: testSectionId}});
       expect(utils.reload).to.have.been.calledOnce;
       expect(selectSection).not.to.have.been.called;
     });
@@ -140,9 +146,9 @@ describe('SectionSelector', () => {
       );
       wrapper
         .find('select')
-        .simulate('change', {target: {value: 'testSectionId'}});
+        .simulate('change', {target: {value: testSectionId}});
       expect(selectSection).to.have.been.calledOnce.and.calledWith(
-        'testSectionId'
+        testSectionId
       );
       expect(utils.reload).not.to.have.been.called;
     });

--- a/apps/test/unit/templates/instructions/teacherFeedback/EditableTeacherFeedbackTest.jsx
+++ b/apps/test/unit/templates/instructions/teacherFeedback/EditableTeacherFeedbackTest.jsx
@@ -18,7 +18,7 @@ const DEFAULT_PROPS = {
   teacher: 5,
   latestFeedback: null,
   verifiedInstructor: true,
-  selectedSectionId: '789',
+  selectedSectionId: 789,
   canHaveFeedbackReviewState: true,
   updateUserProgress: () => {}
 };

--- a/apps/test/unit/templates/progress/LessonLockTest.jsx
+++ b/apps/test/unit/templates/progress/LessonLockTest.jsx
@@ -7,7 +7,7 @@ import LessonLockDialog from '@cdo/apps/code-studio/components/progress/LessonLo
 import Button from '@cdo/apps/templates/Button';
 import i18n from '@cdo/locale';
 
-const FAKE_SECTION_ID = 'fake-section-id';
+const FAKE_SECTION_ID = 123;
 const FAKE_LESSON_ID = 33;
 const FAKE_SCRIPT_ID = 1;
 const DEFAULT_PROPS = {

--- a/apps/test/unit/templates/progress/ProgressBubbleTest.js
+++ b/apps/test/unit/templates/progress/ProgressBubbleTest.js
@@ -29,6 +29,8 @@ const defaultProps = {
   disabled: false
 };
 
+const fakeSectionId = 123456;
+
 /**
  * Helper function to retrieve the underlying `BasicBubble` of a rendered
  * bubble with the provided status and props.
@@ -336,30 +338,36 @@ describe('ProgressBubble', () => {
 
     it('includes the section_id in the queryparams if selectedSectionId is present', () => {
       const wrapper = mount(
-        <ProgressBubble {...defaultProps} selectedSectionId="12345" />
+        <ProgressBubble {...defaultProps} selectedSectionId={fakeSectionId} />
       );
-      assert.include(wrapper.find('a').prop('href'), 'section_id=12345');
+      assert.include(
+        wrapper.find('a').prop('href'),
+        `section_id=${fakeSectionId}`
+      );
     });
 
     it('includes the user_id in the queryparams if selectedStudentId is present', () => {
       const wrapper = mount(
         <ProgressBubble
           {...defaultProps}
-          selectedSectionId="12345"
+          selectedSectionId={fakeSectionId}
           selectedStudentId="207"
         />
       );
-      assert.include(wrapper.find('a').prop('href'), 'section_id=12345');
+      assert.include(
+        wrapper.find('a').prop('href'),
+        `section_id=${fakeSectionId}`
+      );
       assert.include(wrapper.find('a').prop('href'), 'user_id=207');
     });
 
     it('preserves the queryparams of the current location', () => {
       sinon
         .stub(utils, 'currentLocation')
-        .returns({search: 'section_id=212&user_id=559'});
+        .returns({search: `section_id=${fakeSectionId}&user_id=559`});
       const wrapper = mount(<ProgressBubble {...defaultProps} />);
       const href = wrapper.find('a').prop('href');
-      assert.include(href, 'section_id=212');
+      assert.include(href, `section_id=${fakeSectionId}`);
       assert.include(href, 'user_id=559');
       utils.currentLocation.restore();
     });
@@ -369,11 +377,11 @@ describe('ProgressBubble', () => {
         .stub(utils, 'currentLocation')
         .returns({search: 'section_id=212&user_id=559'});
       const wrapper = mount(
-        <ProgressBubble {...defaultProps} selectedSectionId="12345" />
+        <ProgressBubble {...defaultProps} selectedSectionId={fakeSectionId} />
       );
       const href = wrapper.find('a').prop('href');
       assert.notInclude(href, 'section_id=212');
-      assert.include(href, 'section_id=12345');
+      assert.include(href, `section_id=${fakeSectionId}`);
       assert.include(href, 'user_id=559');
       utils.currentLocation.restore();
     });

--- a/apps/test/unit/templates/progress/ProgressPillTest.js
+++ b/apps/test/unit/templates/progress/ProgressPillTest.js
@@ -91,7 +91,7 @@ describe('ProgressPill', () => {
       <ProgressPill
         levels={[levelWithUrl]}
         text="Unplugged Activity"
-        selectedSectionId="1234"
+        selectedSectionId={1234}
       />
     );
     assert.equal(wrapper.find('a').props().href, '/foo/bar?section_id=1234');


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Previously we were inconsistent about whether the `teacherSections.selectedSectionId` was a string or a number, in this PR it's been converted to a number or null across the board.

## Testing story
Tested locally, updated unit tests
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
