### PR TITLE
Regional partner can reopen applications

### DIFF
--- a/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
@@ -374,6 +374,36 @@ export class DetailViewContents extends React.Component {
     });
   };
 
+  handleReopenApplicationClick = () => {
+    this.setState({showReopenApplicationConfirmation: true});
+  };
+
+  handleReopenApplicationCancel = () => {
+    this.setState({showReopenApplicationConfirmation: false});
+  };
+
+  handleReopenApplicationConfirmed = () => {
+    $.ajax({
+      method: 'PUT',
+      url: `/api/v1/pd/applications/${this.props.applicationId}`,
+      contentType: 'application/json',
+      dataType: 'json',
+      data: JSON.stringify({status: 'incomplete'})
+    })
+      .done(() => {
+        this.setState({
+          reopened: true,
+          showReopenApplicationConfirmation: false
+        });
+      })
+      .fail(() => {
+        this.setState({
+          reopened: false,
+          showReopenApplicationConfirmation: false
+        });
+      });
+  };
+
   handleDeleteApplicationClick = () => {
     this.setState({showDeleteApplicationConfirmation: true});
   };
@@ -557,6 +587,12 @@ export class DetailViewContents extends React.Component {
             </MenuItem>
             <MenuItem
               style={styles.delete}
+              onSelect={this.handleReopenApplicationClick}
+            >
+              Reopen Application
+            </MenuItem>
+            <MenuItem
+              style={styles.delete}
               onSelect={this.handleDeleteApplicationClick}
             >
               Delete Application
@@ -653,6 +689,14 @@ export class DetailViewContents extends React.Component {
             headerText="Delete Application"
             bodyText="Are you sure you want to delete this application? You will not be able to undo this."
             okText="Delete"
+          />
+          <ConfirmationDialog
+            show={this.state.showReopenApplicationConfirmation}
+            onOk={this.handleReopenApplicationConfirmed}
+            onCancel={this.handleReopenApplicationCancel}
+            headerText="Reopen Teacher's Application"
+            bodyText="Reopening the application will allow the teacher to change their responses."
+            okText="Reopen"
           />
         </InputGroup.Button>
       </InputGroup>
@@ -1245,6 +1289,11 @@ export class DetailViewContents extends React.Component {
       const message = this.state.deleted
         ? 'This application has been deleted.'
         : 'This application could not be deleted.';
+      return <h4>{message}</h4>;
+    } else if (this.state.hasOwnProperty('reopened')) {
+      const message = this.state.reopened
+        ? 'This application has been reopened.'
+        : 'This application could not be reopened.';
       return <h4>{message}</h4>;
     }
     return (

--- a/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
@@ -51,6 +51,7 @@ import PrincipalApprovalButtons from './principal_approval_buttons';
 import DetailViewWorkshopAssignmentResponse from './detail_view_workshop_assignment_response';
 import ChangeLog from './detail_view/change_log';
 import InlineMarkdown from '@cdo/apps/templates/InlineMarkdown';
+import experiments from '@cdo/apps/util/experiments';
 
 const NA = 'N/A';
 
@@ -585,12 +586,16 @@ export class DetailViewContents extends React.Component {
             <MenuItem onSelect={this.handleAdminEditClick}>
               (Admin) Edit Form Data
             </MenuItem>
-            <MenuItem
-              style={styles.delete}
-              onSelect={this.handleReopenApplicationClick}
-            >
-              Reopen Application
-            </MenuItem>
+            {experiments.isEnabled(
+              experiments.TEACHER_APPLICATION_SAVING_REOPENING
+            ) && (
+              <MenuItem
+                style={styles.delete}
+                onSelect={this.handleReopenApplicationClick}
+              >
+                Reopen Application
+              </MenuItem>
+            )}
             <MenuItem
               style={styles.delete}
               onSelect={this.handleDeleteApplicationClick}

--- a/apps/test/unit/code-studio/pd/application_dashboard/detail_view_contentsTest.js
+++ b/apps/test/unit/code-studio/pd/application_dashboard/detail_view_contentsTest.js
@@ -256,6 +256,22 @@ describe('DetailViewContents', () => {
         expect(deleteApplicationMenuitem).to.have.length(1);
       });
 
+      it('Has Reopen Application menu item', () => {
+        const detailView = mountDetailView(applicationType, {
+          isWorkshopAdmin: true
+        });
+        detailView
+          .find('button#admin-edit')
+          .first()
+          .simulate('click');
+        const deleteApplicationMenuitem = detailView
+          .find('.dropdown.open a')
+          .findWhere(a => a.text() === 'Reopen Application')
+          .first();
+
+        expect(deleteApplicationMenuitem).to.have.length(1);
+      });
+
       it('Has Delete FiT Weekend Registration menu item if there is a FiT weekend registration', () => {
         const overrides = {
           isWorkshopAdmin: true,

--- a/apps/test/unit/code-studio/pd/application_dashboard/detail_view_contentsTest.js
+++ b/apps/test/unit/code-studio/pd/application_dashboard/detail_view_contentsTest.js
@@ -10,6 +10,7 @@ import sinon from 'sinon';
 import {expect} from '../../../../util/reconfiguredChai';
 import {mount} from 'enzyme';
 import {allowConsoleWarnings} from '../../../../util/testUtils';
+import experiments from '@cdo/apps/util/experiments';
 
 describe('DetailViewContents', () => {
   allowConsoleWarnings();
@@ -257,6 +258,10 @@ describe('DetailViewContents', () => {
       });
 
       it('Has Reopen Application menu item', () => {
+        experiments.setEnabled(
+          experiments.TEACHER_APPLICATION_SAVING_REOPENING,
+          true
+        );
         const detailView = mountDetailView(applicationType, {
           isWorkshopAdmin: true
         });
@@ -270,6 +275,10 @@ describe('DetailViewContents', () => {
           .first();
 
         expect(deleteApplicationMenuitem).to.have.length(1);
+        experiments.setEnabled(
+          experiments.TEACHER_APPLICATION_SAVING_REOPENING,
+          false
+        );
       });
 
       it('Has Delete FiT Weekend Registration menu item if there is a FiT weekend registration', () => {

--- a/dashboard/app/controllers/api/v1/pd/application/teacher_applications_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/application/teacher_applications_controller.rb
@@ -11,12 +11,18 @@ module Api::V1::Pd::Application
       )
     end
 
-    # PATCH /api/v1/pd/application/teacher/<applicationId>
+    # PUT /api/v1/pd/application/teacher/<applicationId>
     def update
-      form_data_hash = params.try(:[], :form_data) || {}
-      form_data_json = form_data_hash.to_unsafe_h.to_json.strip_utf8mb4
+      form_data_hash = params.try(:[], :form_data)
+      new_status = params.try(:[], :status)
+      return unless form_data_hash || new_status
 
-      @application.form_data_hash = JSON.parse(form_data_json)
+      if new_status
+        @application.update!(status: new_status)
+      else
+        form_data_json = form_data_hash.to_unsafe_h.to_json.strip_utf8mb4
+        @application.form_data_hash = JSON.parse(form_data_json)
+      end
 
       if @application.save
         render json: @application, status: :ok

--- a/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
@@ -153,6 +153,17 @@ module Api::V1::Pd::Application
       assert_response :ok
     end
 
+    test 'RP can update application status without modifying form data' do
+      original_data = @application.form_data_hash
+      sign_in @program_manager
+
+      put :update, params: {id: @application.id, status: 'incomplete'}
+      @application.reload
+      assert_equal original_data, @application.form_data_hash
+      assert_equal 'incomplete', @application.status
+      assert_response :ok
+    end
+
     test 'updating an application with an error renders bad_request' do
       sign_in @applicant
       application = create TEACHER_APPLICATION_FACTORY, user: @applicant


### PR DESCRIPTION
This fulfills _Req 9: Regional Partner can reopen an application_.

Current functionality: https://watch.screencastify.com/v/DC47DOlEEOG8u154rz62

I did the following:
- (Frontend): Add Reopen menu item to the detail_view
- (Backend): Allow RPs to update status––when the `status` param is passed through, set the status, and if it's not, look at the form_data.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- spec: [Saving Progress and Reopening Applications](https://docs.google.com/document/d/1kbRAQ3To-MHVmz2KHnyaN6Mh6EiJk8F_zRNS1F8kSK8/edit?pli=1#heading=h.86qvf1hodt)
- jira ticket: [PLAT-1474](https://codedotorg.atlassian.net/browse/PLAT-1474)

## Testing story

## Deployment strategy

## Follow-up work

In (a) separate PR(s), I'm planning to
- Address the to-dos,
- Address two `assert_nil` warnings in relevant backend tests, and
- Currently, after you save the application, if you then close the window, there's a popup saying, "Are you sure you want to leave? Data might be lost." That shouldn't happen after a save.

## Privacy

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
