### PR TITLE
Turn teacher_lesonn_plan ui test into eyes test

### DIFF
--- a/dashboard/test/ui/features/ed_programs/teacher_lesson_plan.feature
+++ b/dashboard/test/ui/features/ed_programs/teacher_lesson_plan.feature
@@ -1,7 +1,9 @@
 @no_mobile
 Feature: Teacher Lesson Plan
 
+  @eyes
   Scenario: Viewing Teacher Lesson Plan
+    When I open my eyes to test "teacher lesson plan"
     Given I create a teacher named "Ms_Frizzle"
     And I am on "http://studio.code.org/s/allthemigratedthings/lessons/1"
     And I wait until element "#show-container" is visible
@@ -53,6 +55,9 @@ Feature: Teacher Lesson Plan
     And I wait until element "h2:contains(Activity 1)" is visible
     And I wait until element ".uitest-ProgressPill" is visible
 
+    # Check that the lesson plan looks correct
+    And I see no difference for "teacher lesson plan"
+
     # Discussion goal is collapsible
     And I wait until element ".unit-test-tip-tab" is visible
     And I wait until element "p:contains(Get students to talk)" is visible
@@ -83,6 +88,7 @@ Feature: Teacher Lesson Plan
     And I wait until element "a:contains(All the Migrated Things)" is visible
     And I click selector "a:contains(All the Migrated Things)"
     And I wait until I am on "http://studio.code.org/s/allthemigratedthings"
+    And I close my eyes
 
   @eyes
   Scenario: Viewing Level Details Dialogs


### PR DESCRIPTION
I used the existing lesson on studio.code.org/s/allthemigratedthings/lessons/1 because it has the core things we want to catch from an eyes test. 

<img width="353" alt="Screen Shot 2022-02-15 at 5 15 01 PM" src="https://user-images.githubusercontent.com/46464143/154159039-130a39f3-539b-4bb6-8660-694f47b620b6.png">


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
