### PR TITLE
Remove Event Param from OnBoardEvent [Circuit Playground]

### DIFF
--- a/apps/src/lib/kits/maker/dropletConfig.js
+++ b/apps/src/lib/kits/maker/dropletConfig.js
@@ -168,7 +168,7 @@ const circuitPlaygroundBlocks = [
     parent: api,
     category: CIRCUIT_CATEGORY,
     paletteParams: ['component', 'event', 'callback'],
-    params: ['buttonL', '"down"', 'function(event) {\n  \n}'],
+    params: ['buttonL', '"down"', 'function() {\n  \n}'],
     allowFunctionDrop: {2: true},
     dropdown: {
       0: Object.keys(CP_COMPONENT_EVENTS),


### PR DESCRIPTION
Extension of https://github.com/code-dot-org/code-dot-org/pull/43973/ to apply to Circuit Playground blocks.

We want to remove the 'event' parameter from onBoardEvent since we don't require it to be used and it adds a linter warning to student code (yellow triangle). Per curriculum request.

![Screenshot from 2022-02-15 15-44-04](https://user-images.githubusercontent.com/2959170/154168811-6485b38d-f03e-443c-b436-2907a59cca0f.png)


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
