### PR TITLE
Silence some new deprecation warnings added in Rails 6

### DIFF
--- a/dashboard/config/initializers/backtrace_silencers.rb
+++ b/dashboard/config/initializers/backtrace_silencers.rb
@@ -17,6 +17,8 @@ silenced = [
   /Uniqueness validator will no longer enforce case sensitive comparison in Rails 6.1/,
   /The asset ".*" is not present in the asset pipeline.Falling back to an asset that may be in the public folder./,
   /NOT conditions will no longer behave as NOR in Rails 6.1. To continue using NOR conditions, NOT each condition individually/,
+  /Rails 6.1 will return Content-Type header without modification/,
+  /update_attributes!? is deprecated and will be removed from Rails 6.1/,
 ]
 
 silenced_expr = Regexp.new(silenced.join('|'))


### PR DESCRIPTION
In advance of actually upgrading. These will of course have to be addressed as part of the work to upgrade to 6.1, but there's no reason for them to be cluttering up logs until then.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
