### PR TITLE
remove dead code related to certificate link test

### DIFF
--- a/dashboard/app/controllers/home_controller.rb
+++ b/dashboard/app/controllers/home_controller.rb
@@ -70,10 +70,6 @@ class HomeController < ApplicationController
     render 'home/index'
   end
 
-  def certificate_link_test
-    render 'certificate_link_test', formats: [:html]
-  end
-
   # This static page combines TOS and Privacy partials all in one page
   # for easy printing.
   def terms_and_privacy

--- a/dashboard/app/helpers/application_helper.rb
+++ b/dashboard/app/helpers/application_helper.rb
@@ -198,14 +198,6 @@ module ApplicationHelper
     html.html_safe
   end
 
-  def script_certificate_image_url(user, script)
-    CertificateImage.certificate_image_url(
-      name: user.name,
-      course: script.name,
-      course_title: data_t_suffix('script.name', script.name, 'title')
-    )
-  end
-
   # Returns a client state object for the current session and cookies.
   def client_state
     @client_state ||= ClientState.new(session, cookies)

--- a/dashboard/app/views/home/certificate_link_test.haml
+++ b/dashboard/app/views/home/certificate_link_test.haml
@@ -1,4 +1,0 @@
-- if current_user && current_user.admin?
-  - Script.all.each do |script|
-    %p= script.name
-    %img{width: 350, src: "#{script_certificate_image_url(current_user, script)}"}

--- a/dashboard/test/helpers/application_helper_test.rb
+++ b/dashboard/test/helpers/application_helper_test.rb
@@ -81,21 +81,6 @@ class ApplicationHelperTest < ActionView::TestCase
     assert(browser.version.to_s.to_i == 34)
   end
 
-  test 'script_certificate_image_url helper encodes correct information' do
-    user = create :user
-    assert_certificate_url_encodes user, Script.get_from_cache(Script::HOC_2013_NAME)
-    assert_certificate_url_encodes user, Script.get_from_cache(Script::HOC_NAME)
-    assert_certificate_url_encodes user, Script.get_from_cache(Script::FROZEN_NAME)
-    assert_certificate_url_encodes user, Script.get_from_cache(Script::FLAPPY_NAME)
-    assert_certificate_url_encodes user, Script.get_from_cache(Script::PLAYLAB_NAME)
-    assert_certificate_url_encodes user, Script.get_from_cache(Script::STARWARS_NAME)
-    assert_certificate_url_encodes user, Script.get_from_cache(Script::COURSE1_NAME)
-    assert_certificate_url_encodes user, Script.get_from_cache(Script::COURSE2_NAME)
-    assert_certificate_url_encodes user, Script.get_from_cache(Script::COURSE3_NAME)
-    assert_certificate_url_encodes user, Script.get_from_cache(Script::COURSE4_NAME)
-    assert_certificate_url_encodes user, Script.get_from_cache(Script::ARTIST_NAME)
-  end
-
   test 'client state level progress' do
     script = create :script, name: 'zzz'
     sl1 = create :script_level, script: script
@@ -243,18 +228,5 @@ class ApplicationHelperTest < ActionView::TestCase
 
   def assert_equal_unordered(array1, array2)
     Set.new(array1) == Set.new(array2)
-  end
-
-  def assert_certificate_url_encodes(user, script)
-    url = script_certificate_image_url(user, script)
-    uri = URI.parse(url)
-    filename = uri.path
-    extname = File.extname(filename)
-    encoded = File.basename(filename, extname)
-    data = JSON.parse(Base64.urlsafe_decode64(encoded))
-
-    assert_equal user.name, data['name']
-    assert_equal script.name, data['course']
-    assert_equal data_t_suffix('script.name', script.name, 'title'), data['course_title']
   end
 end

--- a/lib/cdo/graphics/certificate_image.rb
+++ b/lib/cdo/graphics/certificate_image.rb
@@ -239,16 +239,6 @@ class CertificateImage
     end
   end
 
-  # generate a url for a certificate image, given options:
-  #   name: student name
-  #   course: course name
-  #   course_title: course title
-  #   sponsor: (optional)
-  def self.certificate_image_url(opts = {})
-    encoded = Base64.urlsafe_encode64(JSON.pretty_generate(opts))
-    "http://#{CDO.canonical_hostname('code.org')}/v2/hoc/certificate/#{encoded}.jpg"
-  end
-
   def self.tutorial_codes
     @@tutorial_codes ||= PEGASUS_DB[:tutorials].all.map {|t| t[:code]}
   end


### PR DESCRIPTION
as part of the congrats page work, I noticed some existing code that isn't being used. [slack history](https://codedotorg.slack.com/archives/C0T0PNTM3/p1474642970001716) suggests it was last used more than 5 years ago for manual testing of new HOC certificates. 

## Testing story

none needed that I can think of. this PR removes dead code and corresponding unit tests. 