### PR TITLE
Remove the globally mocked user storage id methods in test

### DIFF
--- a/dashboard/test/controllers/api/v1/projects/personal_projects_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/projects/personal_projects_controller_test.rb
@@ -19,6 +19,9 @@ class Api::V1::Projects::PersonalProjectsControllerTest < ActionDispatch::Integr
 
   test 'personal projects are correct' do
     sign_in(@project_owner)
+    storage_id = fake_storage_id_for_user_id(@project_owner.id)
+    ProjectsList.stubs(:storage_id_for_user_id).with(@project_owner.id).returns(storage_id)
+
     get "/api/v1/projects/personal/"
     assert_response :success
     assert_match "no-store", response.headers["Cache-Control"]

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -994,10 +994,10 @@ class ApiControllerTest < ActionController::TestCase
 
   test "user_app_options should return existing channel if one exists" do
     sign_in @student_1
-    stub_get_storage_id(@student_1.id)
-    stub_storage_id_for_user_id(@student_1.id)
+    storage_id = fake_storage_id_for_user_id(@student_1.id)
+    ApiController.any_instance.stubs(:get_storage_id).returns(storage_id)
 
-    channel_token = create :channel_token, level: @level, script_id: @script.id, storage_id: fake_storage_id_for_user_id(@student_1.id)
+    channel_token = create :channel_token, level: @level, script_id: @script.id, storage_id: storage_id
     expected_channel = channel_token.channel
 
     get :user_app_options, params: {

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -994,8 +994,10 @@ class ApiControllerTest < ActionController::TestCase
 
   test "user_app_options should return existing channel if one exists" do
     sign_in @student_1
+    stub_get_storage_id(@student_1.id)
+    stub_storage_id_for_user_id(@student_1.id)
 
-    channel_token = create :channel_token, level: @level, script_id: @script.id, storage_id: storage_id_for_user_id(@student_1.id)
+    channel_token = create :channel_token, level: @level, script_id: @script.id, storage_id: fake_storage_id_for_user_id(@student_1.id)
     expected_channel = channel_token.channel
 
     get :user_app_options, params: {
@@ -1059,8 +1061,9 @@ class ApiControllerTest < ActionController::TestCase
   test "user_app_options should not return channel when param get_channel_id is false" do
     user = @student_1
     sign_in user
+    stub_get_storage_id(user.id)
 
-    create :channel_token, level: @level, script_id: @script.id, storage_id: storage_id_for_user_id(user.id)
+    create :channel_token, level: @level, script_id: @script.id, storage_id: fake_storage_id_for_user_id(user.id)
 
     get :user_app_options, params: {
       script: @script.name,

--- a/dashboard/test/controllers/backpacks_controller_test.rb
+++ b/dashboard/test/controllers/backpacks_controller_test.rb
@@ -3,12 +3,16 @@ require 'test_helper'
 class BackpacksControllerTest < ActionController::TestCase
   setup_all do
     @user = create :user
+    @storage_id = fake_storage_id_for_user_id(@user.id)
   end
 
   test_redirect_to_sign_in_for :get_channel
 
   test 'get_channel creates backpack if one does not exist' do
     sign_in @user
+    Backpack.stubs(:storage_id_for_user_id).with(@user.id).returns(@storage_id)
+    Backpack.any_instance.stubs(:storage_id_for_user_id).with(@user.id).returns(@storage_id)
+
     assert_nil Backpack.find_by_user_id(@user.id)
     response = get :get_channel
     assert_response :success
@@ -21,6 +25,9 @@ class BackpacksControllerTest < ActionController::TestCase
 
   test 'get_channel does not create a backpack if backpack already exists' do
     sign_in @user
+    Backpack.stubs(:storage_id_for_user_id).with(@user.id).returns(@storage_id)
+    Backpack.any_instance.stubs(:storage_id_for_user_id).with(@user.id).returns(@storage_id)
+
     assert_nil Backpack.find_by_user_id(@user.id)
     get :get_channel
     first_backpack = Backpack.find_by_user_id(@user.id)

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -1141,7 +1141,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
 
     fake_last_attempt = 'STUDENT_LAST_ATTEMPT_SOURCE'
 
-    user_storage_id = storage_id_for_user_id(@student.id)
+    user_storage_id = fake_storage_id_for_user_id(@student.id)
 
     script = create :script
     lesson_group = create(:lesson_group, script: script)
@@ -1173,7 +1173,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   test 'loads level in view only if viewing own work, channel backed level and version param is present' do
     sign_in @teacher
 
-    user_storage_id = storage_id_for_user_id(@teacher.id)
+    user_storage_id = fake_storage_id_for_user_id(@teacher.id)
 
     script = create :script
     lesson_group = create(:lesson_group, script: script)
@@ -1202,7 +1202,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   test 'loads level not in readonly if viewing own work, level is channel backed and version param is empty' do
     sign_in @teacher
 
-    user_storage_id = storage_id_for_user_id(@teacher.id)
+    user_storage_id = fake_storage_id_for_user_id(@teacher.id)
 
     script = create :script
     lesson_group = create(:lesson_group, script: script)
@@ -1233,7 +1233,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
 
     fake_last_attempt = 'STUDENT_LAST_ATTEMPT_SOURCE'
 
-    user_storage_id = storage_id_for_user_id(@student.id)
+    user_storage_id = fake_storage_id_for_user_id(@student.id)
 
     script = create :script
     lesson_group = create(:lesson_group, script: script)
@@ -1266,7 +1266,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     sign_in @teacher
 
     other_student = create :student
-    user_storage_id = storage_id_for_user_id(other_student.id)
+    user_storage_id = fake_storage_id_for_user_id(other_student.id)
 
     fake_last_attempt = 'STUDENT_LAST_ATTEMPT_SOURCE'
 

--- a/dashboard/test/controllers/xhr_proxy_controller_test.rb
+++ b/dashboard/test/controllers/xhr_proxy_controller_test.rb
@@ -13,6 +13,7 @@ class XhrProxyControllerTest < ActionController::TestCase
   setup do
     @user = create :user
     sign_in @user
+    stub_storage_id_for_user_id(@user.id)
     @channel_id = storage_encrypt_channel_id(storage_id_for_user_id(@user.id), 123)
   end
 

--- a/dashboard/test/helpers/levels_helper_test.rb
+++ b/dashboard/test/helpers/levels_helper_test.rb
@@ -8,6 +8,7 @@ class LevelsHelperTest < ActionView::TestCase
     user.reload
     # override the default sign_in helper because we don't actually have a request or anything here
     stubs(:current_user).returns user
+    stub_get_storage_id(user.id)
   end
 
   setup do
@@ -22,6 +23,7 @@ class LevelsHelperTest < ActionView::TestCase
     end
 
     stubs(:current_user).returns nil
+    stub_get_storage_id(nil)
     stubs(:storage_decrypt_channel_id).returns([123, 456])
   end
 
@@ -410,13 +412,14 @@ class LevelsHelperTest < ActionView::TestCase
     # two different users
     @user = create :user
     sign_in create(:user)
+    stub_storage_id_for_user_id(@user.id)
 
     script = create(:script)
     @level = create :applab
     create(:script_level, script: script, levels: [@level])
 
     # channel exists
-    create :channel_token, level: @level, storage_id: storage_id_for_user_id(@user.id)
+    create :channel_token, level: @level, storage_id: fake_storage_id_for_user_id(@user.id)
     assert_not_nil get_channel_for(@level, script.id, @user)
 
     # calling app_options should set readonly_workspace, since we're viewing for
@@ -427,10 +430,13 @@ class LevelsHelperTest < ActionView::TestCase
 
   test 'level_started? should return true if a channel exists for a channel backed level' do
     user = create :user
+    stub_storage_id_for_user_id(user.id)
+
     applab_level = create :applab # is channel backed
     script = create(:script)
     create(:script_level, levels: [applab_level], script: script)
-    create :channel_token, level: applab_level, storage_id: storage_id_for_user_id(user.id)
+
+    create :channel_token, level: applab_level, storage_id: fake_storage_id_for_user_id(user.id)
 
     assert_equal true, level_started?(applab_level, script, user)
   end
@@ -469,10 +475,13 @@ class LevelsHelperTest < ActionView::TestCase
     @script = script = create(:script)
     create(:script_level, levels: [@level], script: script)
 
+    stub_storage_id_for_user_id(@user.id)
+
     teacher = create :teacher
     sign_in teacher
+
     # create progress on level for teacher to ensure we get back student isStarted value
-    create :channel_token, level: @level, storage_id: storage_id_for_user_id(teacher.id)
+    create :channel_token, level: @level, storage_id: fake_storage_id_for_user_id(teacher.id)
 
     assert_equal false, app_options[:level][:isStarted]
   end
@@ -491,6 +500,7 @@ class LevelsHelperTest < ActionView::TestCase
   test 'applab levels should include pairing_driver and pairing_channel_id when viewed by navigator' do
     @level = create :applab
     @driver = create :student
+    stub_storage_id_for_user_id(@driver.id)
     @navigator = create :student
     create_applab_progress_for_pair @level, @driver, @navigator
 
@@ -536,7 +546,7 @@ class LevelsHelperTest < ActionView::TestCase
     navigator_user_level = create :user_level, user: navigator, level: level
     create :paired_user_level,
       driver_user_level: driver_user_level, navigator_user_level: navigator_user_level
-    create :channel_token, level: level, storage_id: storage_id_for_user_id(driver.id)
+    create :channel_token, level: level, storage_id: fake_storage_id_for_user_id(driver.id)
   end
 
   def stub_country(code)

--- a/dashboard/test/lib/projects_list_test.rb
+++ b/dashboard/test/lib/projects_list_test.rb
@@ -3,11 +3,11 @@ require 'test_helper'
 class ProjectsListTest < ActionController::TestCase
   setup do
     @student = create :student
-    @storage_id = storage_id_for_user_id(@student.id)
-    @channel_id = storage_encrypt_channel_id(@storage_id, 123)
+    @storage_id = fake_storage_id_for_user_id(@student.id)
+    stub_storage_id_for_user_id(@student.id)
 
     @teacher = create :teacher
-    @teacher_storage_id = storage_id_for_user_id(@teacher.id)
+    stub_storage_id_for_user_id(@teacher.id)
 
     student_project_value = {
       name: 'Bobs App',

--- a/dashboard/test/models/backpack_test.rb
+++ b/dashboard/test/models/backpack_test.rb
@@ -8,9 +8,11 @@ class BackpackTest < ActiveSupport::TestCase
 
   setup_all do
     @user = create :user
+    @storage_id = fake_storage_id_for_user_id(@user.id)
   end
 
   test 'find_or_create creates storage_app if backpack does not exist' do
+    Backpack.stubs(:storage_id_for_user_id).with(@user.id).returns(@storage_id)
     backpack = Backpack.find_or_create(@user.id, 'fake-ip')
     assert backpack.storage_app_id > 0
     assert_equal @user.id, backpack.user_id
@@ -18,12 +20,15 @@ class BackpackTest < ActiveSupport::TestCase
 
   # storage apps with value hidden are hidden from a user's projects list
   test 'storage_app that is created has value hidden = true' do
+    Backpack.stubs(:storage_id_for_user_id).with(@user.id).returns(@storage_id)
+    Backpack.any_instance.stubs(:storage_id_for_user_id).with(@user.id).returns(@storage_id)
     backpack = Backpack.find_or_create(@user.id, 'fake-ip')
-    storage_app = StorageApps.new(backpack.storage_app_id).get(backpack.channel)
+    storage_app = StorageApps.new(@storage_id).get(backpack.channel)
     assert storage_app["hidden"]
   end
 
   test 'find_or_create returns existing backpack if it exists' do
+    Backpack.stubs(:storage_id_for_user_id).with(@user.id).returns(@storage_id)
     backpack = Backpack.find_or_create(@user.id, 'fake-ip')
     backpack2 = Backpack.find_or_create(@user.id, 'fake-ip')
     assert_equal(backpack, backpack2)

--- a/dashboard/test/models/channel_token_test.rb
+++ b/dashboard/test/models/channel_token_test.rb
@@ -10,13 +10,14 @@ class ChannelTokenTest < ActiveSupport::TestCase
     @level = create :level
     create :script_level, script: @script, levels: [@level]
     @fake_ip = '127.0.0.1'
+    @storage_id = fake_storage_id_for_user_id(nil)
   end
 
   test 'find_or_create_channel_token sets storage_id and storage_app_id' do
     channel_token = ChannelToken.find_or_create_channel_token(
       @level,
       @fake_ip,
-      get_storage_id,
+      @storage_id,
       @script.id
     )
 
@@ -27,13 +28,12 @@ class ChannelTokenTest < ActiveSupport::TestCase
 
   test 'find_or_create_channel_token returns the channel_token if one exists' do
     level = create :level
-    storage_id = get_storage_id
-    expected_channel_token = create :channel_token, level: level, storage_id: storage_id
+    expected_channel_token = create :channel_token, level: level, storage_id: @storage_id
 
     channel_token = ChannelToken.find_or_create_channel_token(
       level,
       @fake_ip,
-      storage_id,
+      @storage_id,
       @script.id
     )
 
@@ -41,14 +41,13 @@ class ChannelTokenTest < ActiveSupport::TestCase
   end
 
   test 'find_or_create_channel_token returns a channel_token for the script_id if one exists' do
-    storage_id = get_storage_id
-    create :channel_token, level: @level, storage_id: storage_id, script_id: nil
-    expected_channel_token = create :channel_token, level: @level, storage_id: storage_id, script_id: @script.id
+    create :channel_token, level: @level, storage_id: @storage_id, script_id: nil
+    expected_channel_token = create :channel_token, level: @level, storage_id: @storage_id, script_id: @script.id
 
     channel_token = ChannelToken.find_or_create_channel_token(
       @level,
       @fake_ip,
-      storage_id,
+      @storage_id,
       @script.id
     )
 
@@ -60,7 +59,7 @@ class ChannelTokenTest < ActiveSupport::TestCase
     channel_token = ChannelToken.find_or_create_channel_token(
       level,
       @fake_ip,
-      get_storage_id,
+      @storage_id,
       @script.id
     )
 

--- a/dashboard/test/test_helper.rb
+++ b/dashboard/test/test_helper.rb
@@ -659,6 +659,20 @@ class StorageApps
   end
 end
 
+def stub_storage_id_for_user_id(user_id)
+  storage_id = fake_storage_id_for_user_id(user_id)
+  stubs(:storage_id_for_user_id).with(user_id).returns(storage_id)
+end
+
+def stub_get_storage_id(user_id)
+  fake_storage_id = fake_storage_id_for_user_id(user_id)
+  stubs(:get_storage_id).returns fake_storage_id
+end
+
+def fake_storage_id_for_user_id(user_id)
+  Random.new(user_id.to_i).rand(1_000_000)
+end
+
 def json_response
   JSON.parse @response.body
 end

--- a/dashboard/test/test_helper.rb
+++ b/dashboard/test/test_helper.rb
@@ -659,17 +659,6 @@ class StorageApps
   end
 end
 
-# Mock get_storage_id to generate random IDs. Seed with current user so that a user maintains
-# the same id
-def get_storage_id
-  return storage_id_for_user_id(current_user.id) if current_user
-  Random.new.rand(1_000_000)
-end
-
-def storage_id_for_user_id(user_id)
-  Random.new(user_id.to_i).rand(1_000_000)
-end
-
 def json_response
   JSON.parse @response.body
 end


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
In areas of our codebase such as https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/user.rb#L2346-L2351 we reference `PEGASUS_DB[:user_storage_ids]` directly because the helper method `storage_id_for_user_id` is stubbed globally in tests and we want to do real testing in this area. I'm working on extracting all direct references to the table into `storage_ids.rb` so that in the future we can swap out the data source without too much trouble (https://github.com/code-dot-org/code-dot-org/pull/44801). As part of this, I'd like to remove the global stubbing of `storage_id_for_user_id` so that we can use the method in more places and if it needs to be stubbed in a specific test, the stubbing is limited to those places.

What I've done is removed the global stubbing to determine which tests are depending on it and then fixed those tests.

## Links
Discussion about this issue in 2018: https://github.com/code-dot-org/code-dot-org/pull/24309#discussion_r210439826
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
This change only impacts tests and related tests have been updated.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
