### PR TITLE
Java Lab: add helper to get all project files

### DIFF
--- a/dashboard/app/helpers/javalab_files_helper.rb
+++ b/dashboard/app/helpers/javalab_files_helper.rb
@@ -16,9 +16,14 @@ module JavalabFilesHelper
     source_data = SourceBucket.new.get(channel_id, "main.json")
     # Note: we can call .string on this value (and all other values for files) to get the raw string.
     all_files["main.json"] = source_data[:body]
-    # get starter assets
+    # get level assets
     assets = {}
     asset_bucket = AssetBucket.new
+    asset_list = asset_bucket.list(channel_id)
+    asset_list.each do |asset|
+      assets[asset[:filename]] = asset_bucket.get(channel_id, asset[:filename])[:body]
+    end
+    # get starter assets
     channel = ChannelToken.where(storage_app_id: storage_app_id, storage_id: storage_id).first
     level = Level.cache_find(channel.level_id)
     if level
@@ -28,11 +33,6 @@ module JavalabFilesHelper
         asset = starter_asset_bucket.object(filename)
         assets[friendly_name] = asset.get.body
       end
-    end
-    # get level assets
-    asset_list = asset_bucket.list(channel_id)
-    asset_list.each do |asset|
-      assets[asset[:filename]] = asset_bucket.get(channel_id, asset[:filename])[:body]
     end
     all_files["assets"] = assets
     # get validation code

--- a/dashboard/app/helpers/javalab_files_helper.rb
+++ b/dashboard/app/helpers/javalab_files_helper.rb
@@ -1,12 +1,20 @@
 
 module JavalabFilesHelper
+  # Get all files related to the project at the given channel id as a hash. The hash is in the format
+  # below. All values are StringIO.
+  # {
+  #   "main.json": <main source file for a project>
+  #   "assets": {"asset_name_1": <asset_value>, ...}
+  #   "validation": <all validation code for a project, in json format>
+  #   "maze": <serialized maze if it exists>
+  # }
+  # If the channel doesn't have validation and/or a maze, those fields will not be present.
   def self.get_project_files(channel_id)
     storage_id, storage_app_id = storage_decrypt_channel_id(channel_id)
     all_files = {}
     # get sources file
     source_data = SourceBucket.new.get(channel_id, "main.json")
-    # can call .string on this value to get raw string. Keeping as StringIO for now
-    # since we don't know how we'll use this data
+    # Note: we can call .string on this value (and all other values for files) to get the raw string.
     all_files["main.json"] = source_data[:body]
     # get starter assets
     assets = {}
@@ -28,7 +36,14 @@ module JavalabFilesHelper
     end
     all_files["assets"] = assets
     # get validation code
+    if level.respond_to?(:validation) && level.validation
+      all_files["validation"] = StringIO.new(level.validation.to_json)
+    end
     # get maze file
+    serialized_maze = level.try(:get_serialized_maze)
+    if serialized_maze
+      all_files["maze"] = StringIO.new(serialized_maze.to_s)
+    end
     return all_files
   end
 end

--- a/dashboard/app/helpers/javalab_files_helper.rb
+++ b/dashboard/app/helpers/javalab_files_helper.rb
@@ -1,0 +1,34 @@
+
+module JavalabFilesHelper
+  def self.get_project_files(channel_id)
+    storage_id, storage_app_id = storage_decrypt_channel_id(channel_id)
+    all_files = {}
+    # get sources file
+    source_data = SourceBucket.new.get(channel_id, "main.json")
+    # can call .string on this value to get raw string. Keeping as StringIO for now
+    # since we don't know how we'll use this data
+    all_files["main.json"] = source_data[:body]
+    # get starter assets
+    assets = {}
+    asset_bucket = AssetBucket.new
+    channel = ChannelToken.where(storage_app_id: storage_app_id, storage_id: storage_id).first
+    level = Level.cache_find(channel.level_id)
+    if level
+      starter_asset_bucket = Aws::S3::Bucket.new(LevelStarterAssetsController::S3_BUCKET)
+      (level&.project_template_level&.starter_assets || level.starter_assets || []).map do |friendly_name, uuid_name|
+        filename = "#{LevelStarterAssetsController::S3_PREFIX}#{uuid_name}"
+        asset = starter_asset_bucket.object(filename)
+        assets[friendly_name] = asset.get.body
+      end
+    end
+    # get level assets
+    asset_list = asset_bucket.list(channel_id)
+    asset_list.each do |asset|
+      assets[asset[:filename]] = asset_bucket.get(channel_id, asset[:filename])[:body]
+    end
+    all_files["assets"] = assets
+    # get validation code
+    # get maze file
+    return all_files
+  end
+end

--- a/dashboard/app/helpers/javalab_files_helper.rb
+++ b/dashboard/app/helpers/javalab_files_helper.rb
@@ -3,10 +3,9 @@ module JavalabFilesHelper
   # Get all files related to the project at the given channel id as a hash. The hash is in the format
   # below. All values are StringIO.
   # {
-  #   "main.json": <main source file for a project>
+  #   "sources": {"main.json": <main source file for a project>, "grid.txt": <serialized maze if it exists>},
   #   "assets": {"asset_name_1": <asset_value>, ...}
   #   "validation": <all validation code for a project, in json format>
-  #   "maze": <serialized maze if it exists>
   # }
   # If the channel doesn't have validation and/or a maze, those fields will not be present.
   def self.get_project_files(channel_id)


### PR DESCRIPTION
As part of the decoupling Javabuilder from Dashboard work, we will be sending all files relating to a Java Lab project before we run student code. While the exact format of this request has not been decided, we know we want to gather all the files in order to send them over. This PR adds a helper module which gets all the files and returns them as a hash. The format of the hash is:
```
{
  "sources": {"main.json": <main source file for a project>, "grid.txt": <serialized maze if it exists>},
  "assets": {"asset_name_1": <asset_value>, ...}
  "validation": <all validation code for a project, in json format>
}
```

## Links

- spec: [Decoupling Javabuilder & Dashboard](https://docs.google.com/document/d/1pqNGzZLe7sHb6V_j0cZ2ZjqONItDgzKfD6g8Yoj3ipc/edit)
- jira ticket: [JAVA-444](https://codedotorg.atlassian.net/browse/JAVA-444)

## Testing story
I tested this using the ruby console against java lab projects that had assets, validation and/or a maze. I did not add a unit test for this, as this helper just calls out to different existing Buckets and basic level operations. In order to unit test this we would need to write a lot of mocked code and all we would be testing is that the different mocks got called, which didn't seem worth it. It also didn't seem worth it to verify the format of the result, since that format will most likely change.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
