### PR TITLE
Set status directly instead of in form data

### DIFF
--- a/apps/src/code-studio/pd/form_components_func/FormController.jsx
+++ b/apps/src/code-studio/pd/form_components_func/FormController.jsx
@@ -294,12 +294,13 @@ const FormController = props => {
    *
    * @returns {Object}
    */
-  const serializeFormData = formData => {
+  const serializeFormData = (formData, status) => {
     if (!formData) {
       throw new Error(`formData cannot be undefined`);
     }
     return {
       form_data: formData,
+      status: status,
       ...serializeAdditionalData()
     };
   };
@@ -318,16 +319,13 @@ const FormController = props => {
   };
 
   const makeRequest = applicationStatus => {
-    const dataWithStatus = {...data, status: applicationStatus};
-    setData(dataWithStatus);
-
     const ajaxRequest = (method, endpoint) =>
       $.ajax({
         method: method,
         url: endpoint,
         contentType: 'application/json',
         dataType: 'json',
-        data: JSON.stringify(serializeFormData(dataWithStatus))
+        data: JSON.stringify(serializeFormData(data, applicationStatus))
       });
 
     return updatedApplicationId

--- a/apps/test/unit/code-studio/pd/form_components_func/FormControllerTest.js
+++ b/apps/test/unit/code-studio/pd/form_components_func/FormControllerTest.js
@@ -180,6 +180,7 @@ describe('FormController', () => {
     });
 
     describe('Saving', () => {
+      // [MEG] TODO: Refactor this to use savedStatus instead of form_data
       it('Overrides application status as incomplete to data', () => {
         const testData = {
           field1: 'value 1',
@@ -192,7 +193,7 @@ describe('FormController', () => {
         );
         form.findAll('Button')[1].props.onClick();
 
-        expect(getData(DummyPage1)).to.eql({...testData, status: 'incomplete'});
+        expect(getData(DummyPage1)).to.eql({...testData});
       });
 
       it('Disables the save button during save', () => {
@@ -375,6 +376,7 @@ describe('FormController', () => {
           expect(form.findOne('#submit').props.disabled).to.be.false;
         });
 
+        // [MEG] TODO: Refactor this to use savedStatus instead of form_data
         it('Overrides application status as unreviewed on submit', () => {
           const testData = {
             field1: 'value 1',
@@ -389,8 +391,7 @@ describe('FormController', () => {
           triggerSubmit();
 
           expect(getData(DummyPage3)).to.eql({
-            ...testData,
-            status: 'unreviewed'
+            ...testData
           });
         });
 

--- a/dashboard/app/controllers/api/v1/pd/application/teacher_applications_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/application/teacher_applications_controller.rb
@@ -13,10 +13,16 @@ module Api::V1::Pd::Application
 
     # PATCH /api/v1/pd/application/teacher/<applicationId>
     def update
-      form_data_hash = params.try(:[], :form_data) || {}
-      form_data_json = form_data_hash.to_unsafe_h.to_json.strip_utf8mb4
+      form_data_hash = params.try(:[], :form_data)
+      if form_data_hash
+        form_data_json = form_data_hash.to_unsafe_h.to_json.strip_utf8mb4
+        @application.form_data_hash = JSON.parse(form_data_json)
+      end
 
-      @application.form_data_hash = JSON.parse(form_data_json)
+      status = params.try(:[], :status)
+      if status
+        @application.status = status
+      end
 
       if @application.save
         render json: @application, status: :ok

--- a/dashboard/app/controllers/api/v1/pd/forms_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/forms_controller.rb
@@ -4,11 +4,16 @@ class Api::V1::Pd::FormsController < ::ApplicationController
   end
 
   def create
-    form_data_hash = params.try(:[], :form_data) || {}
-    form_data_json = form_data_hash.to_unsafe_h.to_json.strip_utf8mb4
-
     form = new_form
+
+    form_data_hash = params.try(:[], :form_data)
+    form_data_json = form_data_hash ? form_data_hash.to_unsafe_h.to_json.strip_utf8mb4 : {}.to_json
     form.form_data_hash = JSON.parse(form_data_json)
+
+    status = params.try(:[], :status)
+    if status
+      @application.status = status
+    end
 
     # Check for idempotence
     existing_form = form.check_idempotency

--- a/dashboard/app/controllers/pd/application/teacher_application_controller.rb
+++ b/dashboard/app/controllers/pd/application/teacher_application_controller.rb
@@ -24,6 +24,7 @@ module Pd::Application
       if @application
         return render :submitted if @application.status != 'incomplete'
         @application_id = @application.try(:id)
+        @saved_status = @application.try(:status)
         @form_data = @application.try(:form_data)
       end
 
@@ -36,6 +37,7 @@ module Pd::Application
           userId: current_user.id,
           schoolId: current_user.school_info&.school&.id,
           applicationId: @application_id,
+          savedStatus: @saved_status,
           savedFormData: @form_data
         }.to_json
       }

--- a/dashboard/app/models/concerns/pd/form.rb
+++ b/dashboard/app/models/concerns/pd/form.rb
@@ -70,7 +70,7 @@ module Pd::Form
     hash = sanitize_and_trim_form_data_hash
 
     # No validation is required if the application is still in progress
-    return if hash && hash[:status] == 'incomplete'
+    return if status == 'incomplete'
 
     self.class.required_fields.each do |key|
       add_key_error(key) unless hash.key?(key)

--- a/dashboard/app/models/concerns/pd/form.rb
+++ b/dashboard/app/models/concerns/pd/form.rb
@@ -70,6 +70,7 @@ module Pd::Form
     hash = sanitize_and_trim_form_data_hash
 
     # No validation is required if an application is still in progress
+    # Check that status is defined because not all forms have status
     return if defined?(status) && status == 'incomplete'
 
     self.class.required_fields.each do |key|

--- a/dashboard/app/models/concerns/pd/form.rb
+++ b/dashboard/app/models/concerns/pd/form.rb
@@ -69,8 +69,8 @@ module Pd::Form
 
     hash = sanitize_and_trim_form_data_hash
 
-    # No validation is required if the application is still in progress
-    return if status == 'incomplete'
+    # No validation is required if an application is still in progress
+    return if defined?(status) && status == 'incomplete'
 
     self.class.required_fields.each do |key|
       add_key_error(key) unless hash.key?(key)

--- a/dashboard/app/models/pd/application/application_base.rb
+++ b/dashboard/app/models/pd/application/application_base.rb
@@ -56,10 +56,7 @@ module Pd::Application
 
     after_initialize :set_type_and_year
 
-    # Set the status only if (a) the application is new, or (b) the applicant updates form_data.
-    # Avoid setting the status when an RP or admin changes the application status, which only happens
-    # from the application dashboard, not from changing form_data.
-    before_validation :set_status
+    before_validation -> {self.status = 'unreviewed' unless status}
     validate :status_is_valid_for_application_type
     validates_presence_of :type
     validates_presence_of :user_id, unless: proc {|application| application.application_type == PRINCIPAL_APPROVAL_APPLICATION}
@@ -70,7 +67,6 @@ module Pd::Application
     # An application either has an "incomplete" or "unreviewed" state when created.
     # After creation, an RP or admin can change the status to "accepted," which triggers update_accepted_data.
     before_save :update_accepted_date, if: :status_changed?
-    before_save :remove_status_from_form_data
 
     before_create :generate_application_guid, if: -> {application_guid.blank?}
     after_destroy :delete_unsent_email
@@ -88,17 +84,6 @@ module Pd::Application
       csp
       csa
     ).index_by(&:to_sym).freeze
-
-    def set_status
-      return unless new_record? || (sanitize_form_data_hash && sanitize_form_data_hash[:status])
-      self.status = 'unreviewed' if new_record?
-      self.status = sanitize_form_data_hash[:status] if sanitize_form_data_hash && sanitize_form_data_hash[:status]
-    end
-
-    def remove_status_from_form_data
-      return unless form_data_hash && form_data_hash["status"]
-      self.form_data = form_data_hash.except("status").to_json
-    end
 
     def set_type_and_year
       # Override in derived classes and set to valid values.

--- a/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
@@ -123,7 +123,7 @@ module Api::V1::Pd::Application
 
     test 'can submit an empty form if application is incomplete' do
       sign_in @applicant
-      put :create, params: {form_data: {status: 'incomplete'}}
+      put :create, params: {status: 'incomplete'}
 
       assert_equal 'incomplete', TEACHER_APPLICATION_CLASS.last.status
       assert_response :created
@@ -134,7 +134,7 @@ module Api::V1::Pd::Application
       Pd::Application::TeacherApplication.expects(:queue_email).never
 
       sign_in @applicant
-      put :create, params: {form_data: {status: 'incomplete'}}
+      put :create, params: {status: 'incomplete'}
       assert_response :created
     end
 
@@ -144,7 +144,8 @@ module Api::V1::Pd::Application
       original_data = application.form_data_hash
       original_school_info = @applicant.school_info
 
-      put :update, params: {id: application.id, form_data: {status: 'incomplete'}}
+      # Keep cs_total_course_hours because it is calculated on create or update
+      put :update, params: {id: application.id, status: 'incomplete', form_data: {"cs_total_course_hours": 80}}
       application.reload
       refute_equal original_data, application.form_data_hash
       assert_nil application.course

--- a/dashboard/test/controllers/pd/application/teacher_application_controller_test.rb
+++ b/dashboard/test/controllers/pd/application/teacher_application_controller_test.rb
@@ -34,8 +34,8 @@ module Pd::Application
 
     test 'teachers with an incomplete application have an application id and saved form data' do
       application = create :pd_teacher_application, form_data_hash: (
-        build :pd_teacher_application_hash, :incomplete
-      )
+        build :pd_teacher_application_hash
+      ), status: 'incomplete'
       sign_in application.user
       get :new
       assert_response :success
@@ -44,6 +44,7 @@ module Pd::Application
       @script_data = assigns(:script_data)
       assert_equal application.id, JSON.parse(@script_data.dig(:props)).dig('applicationId')
       assert_equal application.form_data, JSON.parse(@script_data.dig(:props)).dig('savedFormData')
+      assert_equal application.status, JSON.parse(@script_data.dig(:props)).dig('savedStatus')
     end
 
     test 'teachers without an application have no id nor form data' do

--- a/dashboard/test/factories/pd_factories.rb
+++ b/dashboard/test/factories/pd_factories.rb
@@ -809,10 +809,6 @@ FactoryGirl.define do
       school_type 'Public school'
     end
 
-    trait :incomplete do
-      status 'incomplete'
-    end
-
     trait :with_no_school do
       school(-1)
     end

--- a/dashboard/test/models/concerns/pd/form_test.rb
+++ b/dashboard/test/models/concerns/pd/form_test.rb
@@ -91,14 +91,6 @@ class Pd::FormTest < ActiveSupport::TestCase
     refute form.valid?
   end
 
-  test 'pd form does not check required fields if status is incomplete' do
-    expects(:dynamic_required_fields).never
-    form = DummyFormWithRequiredFields.new
-    form.form_data = {status: "incomplete"}.to_json
-
-    assert form.valid?
-  end
-
   test 'pd form enforces required fields' do
     form = DummyFormWithRequiredFields.new
 

--- a/dashboard/test/models/pd/application/application_base_test.rb
+++ b/dashboard/test/models/pd/application/application_base_test.rb
@@ -36,20 +36,13 @@ module Pd::Application
       assert application.unreviewed?
     end
 
-    test 'form data overwrites default status' do
-      application = create TEACHER_APPLICATION_FACTORY, form_data: {status: 'incomplete'}.to_json
+    test 'can set a different status from the default' do
+      application = create TEACHER_APPLICATION_FACTORY, status: 'incomplete'
       application.update_status_timestamp_change_log(nil)
 
       assert application.incomplete?
       assert_equal application.sanitize_status_timestamp_change_log.length, 1
       assert application.sanitize_status_timestamp_change_log[0].value?('incomplete')
-    end
-
-    test 'status is removed from form_data after status is set' do
-      application = create TEACHER_APPLICATION_FACTORY, form_data: {status: 'incomplete'}.to_json
-
-      assert application.incomplete?
-      assert_nil application.form_data_hash['status']
     end
 
     test 'can update status' do

--- a/dashboard/test/models/pd/application/teacher_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher_application_test.rb
@@ -55,8 +55,8 @@ module Pd::Application
       }
 
       application = create :pd_teacher_application, form_data_hash: (
-        build :pd_teacher_application_hash, :incomplete, custom_minutes_hours_weeks
-      )
+        build :pd_teacher_application_hash, custom_minutes_hours_weeks
+      ), status: 'incomplete'
 
       assert_equal 112, application.sanitize_form_data_hash[:cs_total_course_hours]
     end
@@ -70,8 +70,8 @@ module Pd::Application
 
       %i(cs_how_many_minutes cs_how_many_days_per_week cs_how_many_weeks_per_year).each do |attribute|
         application = create :pd_teacher_application, form_data_hash: (
-          build :pd_teacher_application_hash, :incomplete, empty_minutes_hours_weeks.slice(attribute)
-        )
+          build :pd_teacher_application_hash, empty_minutes_hours_weeks.slice(attribute)
+        ), status: 'incomplete'
 
         assert_nil application.sanitize_form_data_hash[:cs_total_course_hours]
       end


### PR DESCRIPTION
To save teacher applications, I was originally passing in the status via the form_data: if the user hits "submit application," {"status": "unreviewed"} would be added to the form data, and if the user hits "save application," {"status": "incomplete"} would be added to the form data.

This presented some challenges:
1) When an RP sets the status, we want to ignore the form_data status. I did some work https://github.com/code-dot-org/code-dot-org/pull/44845 due to a bug from this.
2) We now pass in the status to the form_data and then remove the status from the form_data as soon as the application is saved––it's a bit clunky.
3) I had to do a bit of work in application_base to allow for the status to be set via the form_data––we can avoid this if we set status in a separate param.

Here, the status is set through a separate param in the frontend. Now we don't need to worry about removing form data. It seems cleaner to me, but I'm curious to hear y'all's thoughts!

See recording here: https://watch.screencastify.com/v/hA8VKZ573lGMF6I5oAou

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

Need to add an eyes test for the application_dashboard. Will do this after (a) the "reopened" application status is set, and (b) RP's can't modify form data while an application is "incomplete" (maybe "reopened" too––not sure)

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
