### PR TITLE
Fixes for assessments dashboard

### DIFF
--- a/apps/src/templates/sectionAssessments/MultipleChoiceAssessmentsOverviewTable.jsx
+++ b/apps/src/templates/sectionAssessments/MultipleChoiceAssessmentsOverviewTable.jsx
@@ -162,7 +162,6 @@ class MultipleChoiceAssessmentsOverviewTable extends Component {
       props: {
         style: {
           ...tableLayoutStyles.cell,
-          ...styles.questionCell,
           maxWidth:
             styleConstants['content-width'] -
             numAnswers * (ANSWER_COLUMN_WIDTH + PADDING)
@@ -230,13 +229,12 @@ const styles = {
     padding: 0,
     height: 40
   },
-  questionCell: {
+  link: {
+    color: color.teal,
+    display: 'block',
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap'
-  },
-  link: {
-    color: color.teal
   }
 };
 

--- a/apps/src/templates/sectionAssessments/PercentAnsweredCell.jsx
+++ b/apps/src/templates/sectionAssessments/PercentAnsweredCell.jsx
@@ -69,6 +69,7 @@ const styles = {
     justifyContent: 'space-between',
     flexDirection: 'row',
     alignItems: 'center',
+    boxSizing: 'border-box',
     height: '100%',
     padding: 10
   },

--- a/dashboard/app/controllers/api/v1/assessments_controller.rb
+++ b/dashboard/app/controllers/api/v1/assessments_controller.rb
@@ -83,166 +83,186 @@ class Api::V1::AssessmentsController < Api::V1::JsonApiController
     assessment_script_levels = @script.get_assessment_script_levels
 
     @section.students.in_batches(of: 20).each do |student_batch|
-      student_ids = student_batch.pluck(:id)
-
-      # Get data from the database for each script_level for the entire batch
-      # of students. progress_data will have this structure:
-      # {
-      #   script_level_id: {
-      #     student_id: [<UserLevel>]
-      #   },
-      # }
-      progress_data = {}
-      assessment_script_levels.each do |script_level|
-        # each level in script_level here is a LevelGroup representing the assessment
-        level_groups = script_level.levels
-        level_group_ids = level_groups.pluck(:id)
-        sublevel_ids = level_groups.map {|level_group| level_group.all_child_levels.pluck(:id)}.flatten
-
-        # retrieve the UserLevels for the level group and sublevels all in one shot
-        progress_data[script_level.id] =
-          User.progress_for_users(student_ids, script_id, level_group_ids + sublevel_ids)
-      end
+      # Retrieve progress data (UserLevel + associated LevelSource objects) for all
+      # students in this batch.
+      progress_data = get_assessment_progress_data(student_batch, script_id, assessment_script_levels)
 
       student_batch.each do |student|
-        # Initialize student hash
-        student_hash = {
-          student_name: student.name
-        }
         responses_by_level_group = {}
 
         assessment_script_levels.each do |script_level|
-          # Get the progress data for this assessment / student from batch_data;
-          # student_progress is an array of UserLevel objects
+          # student_progress is an array of UserLevel objects corresponding to the
+          # current student and the level_group and sublevels of the current script_level
           student_progress = progress_data[script_level.id][student.id]
           next unless student_progress
 
-          # Find the UserLevel that represents overall progress of the LevelGroup.
-          # This logic is analogous to User#last_attempt_for_any.
-          # Note: we intentionally no longer use the aggregated answers stored on
-          # this UserLevel, see LP-1926 for details.
-          level_group_ids = script_level.levels.pluck(:id)
-          level_group_progress = student_progress.find do |user_level|
-            level_group_ids.include?(user_level.level_id)
-          end
-          next unless level_group_progress
-
-          level_group = level_group_progress.level
-
-          # Summarize some key data.
-          stats = {
-            multi_count: 0,
-            multi_count_correct: 0,
-            match_count: 0,
-            match_count_correct: 0
-          }
-
-          # And construct a listing of all the individual levels and their results.
-          level_results = []
-
-          level_group.levels.each do |level|
-            if level.is_a? Multi
-              stats[:multi_count] += 1
-            elsif level.is_a? Match
-              stats[:match_count] += 1
-            end
-
-            # Find the UserLevel that corresponds to this level. This may be nil
-            # if the student skipped a question.
-            level_progress = student_progress.find do |user_level|
-              user_level.level_id == level.id
-            end
-            student_answer = level_progress&.level_source&.data
-
-            level_result = {}
-
-            case level
-            when TextMatch, FreeResponse
-              level_result[:type] = "FreeResponse"
-            when Multi
-              level_result[:type] = "Multi"
-            when Match
-              level_result[:type] = "Match"
-            end
-
-            if student_answer
-              case level
-              when TextMatch, FreeResponse
-                level_result[:student_result] = student_answer
-                level_result[:status] = ""
-              when Multi
-                answer_indexes = Script.cache_find_level(level.id).correct_answer_indexes_array
-                student_result = student_answer.split(",").map(&:to_i).sort
-                level_result[:student_result] = student_result
-
-                if student_result == [-1]
-                  level_result[:student_result] = []
-                  level_result[:status] = "unsubmitted"
-                # Deep comparison of arrays of indexes
-                elsif student_result.present? && student_result - answer_indexes == [] && answer_indexes.length == student_result.length
-                  stats[:multi_count_correct] += 1
-                  level_result[:status] = "correct"
-                else
-                  level_result[:status] = "incorrect"
-                end
-              when Match
-                student_result = student_answer.split(",", -1)
-                # If a student did not answer some of the matching question we will record that as nil
-                student_result = student_result.map do |result|
-                  result.empty? ? nil : result.to_i
-                end
-                level_result[:student_result] = student_result
-                option_status = []
-                number_correct = 0
-                student_result.each_with_index do |answer, index|
-                  if answer.nil?
-                    option_status[index] = "unsubmitted"
-                  else
-                    option_status[index] = "submitted"
-                    if answer == index
-                      number_correct += 1
-                    end
-                  end
-                end
-                if number_correct == student_result.length
-                  stats[:match_count_correct] += 1
-                end
-                level_result[:status] = option_status
-              end
-            else
-              level_result[:status] = "unsubmitted"
-            end
-
-            level_results << level_result
-          end
-
-          submitted = level_group_progress[:submitted]
-          timestamp = level_group_progress[:updated_at].to_datetime
-
-          responses_by_level_group[level_group.id] = {
-            lesson: script_level.lesson.localized_title,
-            puzzle: script_level.position,
-            question: level_group.properties["title"],
-            url: build_script_level_url(script_level, section_id: @section.id, user_id: student.id),
-            multi_correct: stats[:multi_count_correct],
-            multi_count: stats[:multi_count],
-            match_correct: stats[:match_count_correct],
-            match_count: stats[:match_count],
-            submitted: submitted,
-            timestamp: timestamp,
-            level_results: level_results
-          }
+          level_group_id, assessment_response = summarize_assessment_response(student.id, script_level, student_progress)
+          responses_by_level_group[level_group_id] = assessment_response unless assessment_response.nil?
         end
 
-        # If a student has made responses, add them to the hash
-        if responses_by_level_group.keys.count > 0
-          student_hash[:responses_by_assessment] = responses_by_level_group
-          responses_by_student[student.id] = student_hash
-        end
+        next unless responses_by_level_group.keys.count > 0
+
+        responses_by_student[student.id] = {
+          student_name: student.name,
+          responses_by_assessment: responses_by_level_group
+        }
       end
     end
 
     render json: responses_by_student
+  end
+
+  # Retrieve UserLevel and associated LevelSource objects associated with the
+  # given students and assessment script levels. The return value is a nested
+  # hash with the following structure:
+  # {
+  #   script_level_id: {
+  #     student_id: [<UserLevel>]
+  #   },
+  # }
+  #
+  # The array of UserLevel objects includes the UserLevel associated with the
+  # LevelGroup representing the assessment as well as UserLevels associated with
+  # each sublevel that the user has completed.  UserLevel objects are sorted in
+  # descending order by updated_at.
+  private def get_assessment_progress_data(student_batch, script_id, assessment_script_levels)
+    student_ids = student_batch.pluck(:id)
+    progress_data = {}
+
+    assessment_script_levels.each do |script_level|
+      # each level in script_level here is a LevelGroup representing the assessment
+      level_groups = script_level.levels
+      level_group_ids = level_groups.pluck(:id)
+      sublevel_ids = level_groups.map {|level_group| level_group.all_child_levels.pluck(:id)}.flatten
+
+      # retrieve the UserLevels for the level group and sublevels all in one shot
+      progress_data[script_level.id] =
+        User.user_levels_by_user(student_ids, script_id, level_group_ids + sublevel_ids)
+    end
+
+    progress_data
+  end
+
+  # Helper function that builds the part of the section_responses response
+  # corresponding to a given user and assessment. The third parameter is expected
+  # to be the array of UserLevel objects returned by get_assessment_progress_data.
+  private def summarize_assessment_response(student_id, script_level, student_progress)
+    # Find the UserLevel that represents overall progress of the LevelGroup.
+    # This logic is analogous to User#last_attempt_for_any.
+    # Note: we intentionally no longer use the aggregated answers stored on
+    # this UserLevel, see LP-1926 for details.
+    level_group_ids = script_level.levels.pluck(:id)
+    level_group_progress = student_progress.find do |user_level|
+      level_group_ids.include?(user_level.level_id)
+    end
+    return [nil, nil] unless level_group_progress
+
+    level_group = level_group_progress.level
+    submitted = level_group_progress.submitted
+    timestamp = level_group_progress.updated_at.to_datetime
+
+    stats = {
+      multi_count: 0,
+      multi_count_correct: 0,
+      match_count: 0,
+      match_count_correct: 0
+    }
+
+    level_results = []
+    level_group.levels.each do |level|
+      # Find the UserLevel that corresponds to this level. This may be nil
+      # if the student skipped a question.
+      level_progress = student_progress.find do |user_level|
+        user_level.level_id == level.id
+      end
+      student_answer = level_progress&.level_source&.data
+
+      level_result = summarize_level_result(level, student_answer, stats)
+      level_results << level_result
+    end
+
+    assessment_response = {
+      lesson: script_level.lesson.localized_title,
+      puzzle: script_level.position,
+      question: level_group.properties["title"],
+      url: build_script_level_url(script_level, section_id: @section.id, user_id: student_id),
+      multi_correct: stats[:multi_count_correct],
+      multi_count: stats[:multi_count],
+      match_correct: stats[:match_count_correct],
+      match_count: stats[:match_count],
+      submitted: submitted,
+      timestamp: timestamp,
+      level_results: level_results
+    }
+
+    [level_group.id, assessment_response]
+  end
+
+  # Summarizes the given level and student answer into the format expected by
+  # section_responses. Also updates the relevant counts in the given stats hash.
+  private def summarize_level_result(level, student_answer, stats)
+    level_result = {}
+
+    case level
+    when TextMatch, FreeResponse
+      level_result[:type] = "FreeResponse"
+    when Multi
+      level_result[:type] = "Multi"
+      stats[:multi_count] += 1
+    when Match
+      level_result[:type] = "Match"
+      stats[:match_count] += 1
+    end
+
+    if student_answer
+      case level
+      when TextMatch, FreeResponse
+        level_result[:student_result] = student_answer
+        level_result[:status] = ""
+      when Multi
+        answer_indexes = Script.cache_find_level(level.id).correct_answer_indexes_array
+        student_result = student_answer.split(",").map(&:to_i).sort
+        level_result[:student_result] = student_result
+
+        if student_result == [-1]
+          level_result[:student_result] = []
+          level_result[:status] = "unsubmitted"
+          # Deep comparison of arrays of indexes
+        elsif student_result.present? && student_result - answer_indexes == [] && answer_indexes.length == student_result.length
+          stats[:multi_count_correct] += 1
+          level_result[:status] = "correct"
+        else
+          level_result[:status] = "incorrect"
+        end
+      when Match
+        student_result = student_answer.split(",", -1)
+        # If a student did not answer some of the matching question we will record that as nil
+        student_result = student_result.map do |result|
+          result.empty? ? nil : result.to_i
+        end
+        level_result[:student_result] = student_result
+        option_status = []
+        number_correct = 0
+        student_result.each_with_index do |answer, index|
+          if answer.nil?
+            option_status[index] = "unsubmitted"
+          else
+            option_status[index] = "submitted"
+            if answer == index
+              number_correct += 1
+            end
+          end
+        end
+        if number_correct == student_result.length
+          stats[:match_count_correct] += 1
+        end
+        level_result[:status] = option_status
+      end
+    else
+      level_result[:status] = "unsubmitted"
+    end
+
+    level_result
   end
 
   # Return results for surveys, which are long-assessment LevelGroup levels with the anonymous property.

--- a/dashboard/app/controllers/api/v1/assessments_controller.rb
+++ b/dashboard/app/controllers/api/v1/assessments_controller.rb
@@ -79,128 +79,163 @@ class Api::V1::AssessmentsController < Api::V1::JsonApiController
   def section_responses
     responses_by_student = {}
 
+    script_id = @script.id
     assessment_script_levels = @script.get_assessment_script_levels
 
-    @section.students.each do |student|
-      # Initialize student hash
-      student_hash = {
-        student_name: student.name
-      }
-      responses_by_level_group = {}
+    @section.students.in_batches(of: 20).each do |student_batch|
+      student_ids = student_batch.pluck(:id)
 
+      # Get data from the database for each script_level for the entire batch
+      # of students. batch_data will eventually have this structure:
+      # {
+      #   script_level_id: {
+      #     "level_group_data": {
+      #       student_id: <UserLevel>
+      #     },
+      #     "sublevels_data": {
+      #       student_id: [<UserLevel>]
+      #     }
+      #   }
+      # }
+      batch_data = {}
       assessment_script_levels.each do |script_level|
-        last_attempt = student.last_attempt_for_any(script_level.levels, script_id: @script.id)
-        next unless last_attempt
+        # each level in script_level should be a LevelGroup which represents an
+        # assessment
+        level_group_ids = script_level.levels.pluck(:id)
+        sublevel_ids = script_level.levels.map {|level| level.all_child_levels.pluck(:id)}.flatten
 
-        level_group = last_attempt.level
-        sublevel_ids = level_group.all_child_levels.pluck(:id)
-        student_answers_by_level_id = UserLevel.includes(:level_source).
-          where({user_id: student.id, script_id: @script.id, level_id: sublevel_ids}).
-          map {|user_level| [user_level.level_id, user_level.level_source&.data]}.  # [key, value] in returned hash
-          to_h
-
-        # Summarize some key data.
-        multi_count = 0
-        multi_count_correct = 0
-        match_count = 0
-        match_count_correct = 0
-
-        # And construct a listing of all the individual levels and their results.
-        level_results = []
-
-        level_group.levels.each do |level|
-          if level.is_a? Multi
-            multi_count += 1
-          elsif level.is_a? Match
-            match_count += 1
-          end
-
-          student_answer = student_answers_by_level_id[level.id]
-
-          level_result = {}
-
-          case level
-          when TextMatch, FreeResponse
-            level_result[:type] = "FreeResponse"
-          when Multi
-            level_result[:type] = "Multi"
-          when Match
-            level_result[:type] = "Match"
-          end
-
-          if student_answer
-            case level
-            when TextMatch, FreeResponse
-              level_result[:student_result] = student_answer
-              level_result[:status] = ""
-            when Multi
-              answer_indexes = Multi.find_by_id(level.id).correct_answer_indexes_array
-              student_result = student_answer.split(",").map(&:to_i).sort
-              level_result[:student_result] = student_result
-
-              if student_result == [-1]
-                level_result[:student_result] = []
-                level_result[:status] = "unsubmitted"
-              # Deep comparison of arrays of indexes
-              elsif student_result.present? && student_result - answer_indexes == [] && answer_indexes.length == student_result.length
-                multi_count_correct += 1
-                level_result[:status] = "correct"
-              else
-                level_result[:status] = "incorrect"
-              end
-            when Match
-              student_result = student_answer.split(",", -1)
-              # If a student did not answer some of the matching question we will record that as nil
-              student_result = student_result.map do |result|
-                result.empty? ? nil : result.to_i
-              end
-              level_result[:student_result] = student_result
-              option_status = []
-              number_correct = 0
-              student_result.each_with_index do |answer, index|
-                if answer.nil?
-                  option_status[index] = "unsubmitted"
-                else
-                  option_status[index] = "submitted"
-                  if answer == index
-                    number_correct += 1
-                  end
-                end
-              end
-              if number_correct == student_result.length
-                match_count_correct += 1
-              end
-              level_result[:status] = option_status
-            end
-          else
-            level_result[:status] = "unsubmitted"
-          end
-
-          level_results << level_result
-        end
-
-        submitted = last_attempt[:submitted]
-        timestamp = last_attempt[:updated_at].to_datetime
-
-        responses_by_level_group[level_group.id] = {
-          lesson: script_level.lesson.localized_title,
-          puzzle: script_level.position,
-          question: level_group.properties["title"],
-          url: build_script_level_url(script_level, section_id: @section.id, user_id: student.id),
-          multi_correct: multi_count_correct,
-          multi_count: multi_count,
-          match_correct: match_count_correct,
-          match_count: match_count,
-          submitted: submitted,
-          timestamp: timestamp,
-          level_results: level_results
+        batch_data[script_level.id] = {
+          level_group_data: User.batched_last_attempt_for_any(student_ids, script_id, level_group_ids),
+          sublevels_data: User.progress_for_users(student_ids, script_id, sublevel_ids)
         }
       end
 
-      # If a student has made responses, add them to the hash
-      if responses_by_level_group.keys.count > 0
-        student_hash[:responses_by_assessment] = responses_by_level_group
-        responses_by_student[student.id] = student_hash
+      student_batch.each do |student|
+        # Initialize student hash
+        student_hash = {
+          student_name: student.name
+        }
+        responses_by_level_group = {}
+
+        assessment_script_levels.each do |script_level|
+          # Get the progress data for this assessment / student from batch_data
+          level_group_progress = batch_data[script_level.id][:level_group_data][student.id]
+          sublevels_progress = batch_data[script_level.id][:sublevels_data][student.id]
+
+          next unless level_group_progress
+
+          level_group = level_group_progress.level
+
+          # Summarize some key data.
+          multi_count = 0
+          multi_count_correct = 0
+          match_count = 0
+          match_count_correct = 0
+
+          # And construct a listing of all the individual levels and their results.
+          level_results = []
+
+          level_group.levels.each do |level|
+            if level.is_a? Multi
+              multi_count += 1
+            elsif level.is_a? Match
+              match_count += 1
+            end
+
+            # Find the UserLevel that corresponds to this level.  Note that the
+            # first two checks should always be true by this point and we're
+            # including the checks just for extra safety.
+            student_answer = sublevels_progress && sublevels_progress.find do |user_level|
+              user_level.user_id == student.id &&
+              user_level.script_id == script_id &&
+              user_level.level_id == level.id
+            end.level_source.data
+
+            level_result = {}
+
+            case level
+            when TextMatch, FreeResponse
+              level_result[:type] = "FreeResponse"
+            when Multi
+              level_result[:type] = "Multi"
+            when Match
+              level_result[:type] = "Match"
+            end
+
+            if student_answer
+              case level
+              when TextMatch, FreeResponse
+                level_result[:student_result] = student_answer
+                level_result[:status] = ""
+              when Multi
+                answer_indexes = Multi.find_by_id(level.id).correct_answer_indexes_array
+                student_result = student_answer.split(",").map(&:to_i).sort
+                level_result[:student_result] = student_result
+
+                if student_result == [-1]
+                  level_result[:student_result] = []
+                  level_result[:status] = "unsubmitted"
+                # Deep comparison of arrays of indexes
+                elsif student_result.present? && student_result - answer_indexes == [] && answer_indexes.length == student_result.length
+                  multi_count_correct += 1
+                  level_result[:status] = "correct"
+                else
+                  level_result[:status] = "incorrect"
+                end
+              when Match
+                student_result = student_answer.split(",", -1)
+                # If a student did not answer some of the matching question we will record that as nil
+                student_result = student_result.map do |result|
+                  result.empty? ? nil : result.to_i
+                end
+                level_result[:student_result] = student_result
+                option_status = []
+                number_correct = 0
+                student_result.each_with_index do |answer, index|
+                  if answer.nil?
+                    option_status[index] = "unsubmitted"
+                  else
+                    option_status[index] = "submitted"
+                    if answer == index
+                      number_correct += 1
+                    end
+                  end
+                end
+                if number_correct == student_result.length
+                  match_count_correct += 1
+                end
+                level_result[:status] = option_status
+              end
+            else
+              level_result[:status] = "unsubmitted"
+            end
+
+            level_results << level_result
+          end
+
+          submitted = level_group_progress[:submitted]
+          timestamp = level_group_progress[:updated_at].to_datetime
+
+          responses_by_level_group[level_group.id] = {
+            lesson: script_level.lesson.localized_title,
+            puzzle: script_level.position,
+            question: level_group.properties["title"],
+            url: build_script_level_url(script_level, section_id: @section.id, user_id: student.id),
+            multi_correct: multi_count_correct,
+            multi_count: multi_count,
+            match_correct: match_count_correct,
+            match_count: match_count,
+            submitted: submitted,
+            timestamp: timestamp,
+            level_results: level_results
+          }
+        end
+
+        # If a student has made responses, add them to the hash
+        if responses_by_level_group.keys.count > 0
+          student_hash[:responses_by_assessment] = responses_by_level_group
+          responses_by_student[student.id] = student_hash
+        end
       end
     end
 

--- a/dashboard/app/controllers/api/v1/assessments_controller.rb
+++ b/dashboard/app/controllers/api/v1/assessments_controller.rb
@@ -171,7 +171,7 @@ class Api::V1::AssessmentsController < Api::V1::JsonApiController
                 level_result[:student_result] = student_answer
                 level_result[:status] = ""
               when Multi
-                answer_indexes = Multi.find_by_id(level.id).correct_answer_indexes_array
+                answer_indexes = Script.cache_find_level(level.id).correct_answer_indexes_array
                 student_result = student_answer.split(",").map(&:to_i).sort
                 level_result[:student_result] = student_result
 

--- a/dashboard/app/controllers/api/v1/assessments_controller.rb
+++ b/dashboard/app/controllers/api/v1/assessments_controller.rb
@@ -117,8 +117,10 @@ class Api::V1::AssessmentsController < Api::V1::JsonApiController
           student_progress = progress_data[script_level.id][student.id]
           next unless student_progress
 
-          # Find the UserLevel that represents overall progress of the level_group.
+          # Find the UserLevel that represents overall progress of the LevelGroup.
           # This logic is analogous to User#last_attempt_for_any.
+          # Note: we intentionally no longer use the aggregated answers stored on
+          # this UserLevel, see LP-1926 for details.
           level_group_ids = script_level.levels.pluck(:id)
           level_group_progress = student_progress.find do |user_level|
             user_level.user_id == student.id &&

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1253,21 +1253,6 @@ class User < ApplicationRecord
       first
   end
 
-  # Similar to User#last_attempt_for_any but returns data for a set of users
-  # in a single query. The return value is a hash of user_id to a UserLevel.
-  # A user_id with no UserLevel matching the given criteria is omitted from
-  # the returned hash.
-  def self.batched_last_attempt_for_any(user_ids, script_id, level_ids)
-    UserLevel.
-      where({user_id: user_ids, script_id: script_id, level_id: level_ids}).
-      order('updated_at DESC').
-      each_with_object({}) do |user_level, hash|
-        # add this user_level to the hash only if it's the first one for this user
-        user_id = user_level.user_id
-        hash[user_id] = user_level unless hash.include?(user_id)
-      end
-  end
-
   # Returns progress data corresponding to the given users, script, and levels.
   # The return value is a hash from user_id to array of UserLevel objects sorted
   # in descending order by updated_at. A user_id with no UserLevel matching the

--- a/dashboard/test/controllers/api/v1/assessments_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/assessments_controller_test.rb
@@ -222,18 +222,25 @@ class Api::V1::AssessmentsControllerTest < ActionController::TestCase
 
     create :script_level, script: script, levels: [level1], assessment: true, lesson: lesson
 
-    # Student has completed an assessment.
-    level_source = create(
-      :level_source,
-      level: level1,
-      data: %Q({"#{sub_level1.id}":{"result":"This is a free response"},"#{sub_level2.id}":{"result":"0"},"#{sub_level3.id}":{"result":"1"},"#{sub_level4.id}":{"result":"-1"},"#{sub_level5.id}":{"result":","},"#{sub_level6.id}":{"result":"0,1"},"#{sub_level7.id}":{"result":"1,0"}})
-    )
-    create :activity, user: @student_1, level: level1,
-      level_source: level_source
+    student_answers = [
+      [sub_level1, "This is a free response"],
+      [sub_level2, "0"],
+      [sub_level3, "1"],
+      [sub_level4, "-1"],
+      [sub_level5, ","],
+      [sub_level6, "0,1"],
+      [sub_level7, "1,0"]
+    ]
 
-    updated_at = Time.now
+    # create user_level for level_group
+    user_level = create :user_level, user: @student_1, best_result: 100, script: script, level: level1, submitted: true
 
-    user_level = create :user_level, user: @student_1, best_result: 100, script: script, level: level1, submitted: true, updated_at: updated_at, level_source: level_source
+    # create user_levels for sublevels
+    student_answers.each do |level_and_answer|
+      level, answer = level_and_answer
+      level_source = create :level_source, level: level, data: answer
+      user_level = create :user_level, user: @student_1, script: script, level: level, level_source: level_source
+    end
 
     # Call the controller method.
     get :section_responses, params: {
@@ -306,18 +313,20 @@ class Api::V1::AssessmentsControllerTest < ActionController::TestCase
 
     create :script_level, script: script, levels: [level1], assessment: true, lesson: lesson
 
-    # Student has completed an assessment.
-    level_source = create(
-      :level_source,
-      level: level1,
-      data: %Q({"#{sub_level1.id}":{"result":"2,3"},"#{sub_level2.id}":{"result":"3"}})
-    )
-    create :activity, user: @student_1, level: level1,
-           level_source: level_source
+    student_answers = [
+      [sub_level1, "2,3"],
+      [sub_level2, "3"]
+    ]
 
-    updated_at = Time.now
+    # create user_level for level_group
+    user_level = create :user_level, user: @student_1, best_result: 100, script: script, level: level1, submitted: true
 
-    user_level = create :user_level, user: @student_1, best_result: 100, script: script, level: level1, submitted: true, updated_at: updated_at, level_source: level_source
+    # create user_levels for sublevels
+    student_answers.each do |level_and_answer|
+      level, answer = level_and_answer
+      level_source = create :level_source, level: level, data: answer
+      user_level = create :user_level, user: @student_1, script: script, level: level, level_source: level_source
+    end
 
     # Call the controller method.
     get :section_responses, params: {


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

This PR contains several fixes for the assessments dashboard.

The biggest change is a medium-term workaround for a bug where the assessments dashboard displays incorrect data.  This bug arises because student answers for assessments are stored in two places: (1) the answer for each individual question is stored on the UserLevel corresponding to the individual question (a.k.a. sublevel), and (2) a JSON blob with the answers to all questions in the assessment is stored on the UserLevel corresponding to the assessment (a.k.a. LevelGroup).  These two places are updated separately by the client so they can and do get out of sync.

This PR changes the assessments dashboard to read the student answers from the individual questions like other parts of the website.  In order to not regress performance, we now process students in batches of 20, retrieving all UserLevel rows needed to construct the response for the 20 students in a single query.

The long-term direction here is still TBD.  After this change, the JSON blob on the UserLevel for the assessment is not currently being used.  I've left the related code and data alone for now and will revisit and cleanup as appropriate when we take a deeper look at assessments next year.  This is tracked as [LP-2220](https://codedotorg.atlassian.net/browse/LP-2220).

While I was in this area, I also fixed some cosmetic issues that made the page look really sloppy.

Before:
![Screen Shot 2022-02-11 at 4 54 39 PM](https://user-images.githubusercontent.com/71532552/155196170-9b3a259c-ef8c-4228-bb72-f9eef35243f9.png)

After:
![Screen Shot 2022-02-22 at 10 19 06 AM](https://user-images.githubusercontent.com/71532552/155196195-96c0c3db-63c1-42df-a803-68542a9edf43.png)


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [LP-1926](https://codedotorg.atlassian.net/browse/LP-1926)
- more technical background: [LP-1799](https://codedotorg.atlassian.net/browse/LP-1799)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
