### PR TITLE
Finish & Share: Add copy to clipboard button

### DIFF
--- a/apps/src/code-studio/components/ShareAllowedDialog.jsx
+++ b/apps/src/code-studio/components/ShareAllowedDialog.jsx
@@ -124,6 +124,7 @@ class ShareAllowedDialog extends React.Component {
   componentDidUpdate(prevProps, prevState, snapshot) {
     if (this.props.isOpen && !prevProps.isOpen) {
       recordShare('open');
+      this.setState({hasBeenCopied: false});
     }
   }
 

--- a/apps/src/code-studio/components/ShareAllowedDialog.jsx
+++ b/apps/src/code-studio/components/ShareAllowedDialog.jsx
@@ -312,6 +312,7 @@ class ShareAllowedDialog extends React.Component {
                       type="button"
                       id="share-dialog-copy-button"
                       style={{
+                        ...styles.button,
                         ...styles.copyButton,
                         ...(this.state.hasBeenCopied && styles.copyButtonLight)
                       }}
@@ -510,19 +511,8 @@ const styles = {
     verticalAlign: 'top'
   },
   copyButton: {
-    backgroundColor: color.purple,
-    borderWidth: 0,
-    color: color.white,
-    fontSize: 'larger',
     paddingTop: 5,
-    paddingBottom: 12.5,
-    paddingLeft: 10,
-    paddingRight: 10,
-    marginTop: 0,
-    marginBottom: 0,
     marginLeft: 8,
-    marginRight: 8,
-    verticalAlign: 'top',
     width: 30,
     height: 30
   },

--- a/apps/src/code-studio/components/ShareAllowedDialog.jsx
+++ b/apps/src/code-studio/components/ShareAllowedDialog.jsx
@@ -102,7 +102,8 @@ class ShareAllowedDialog extends React.Component {
     exportError: null,
     isTwitterAvailable: false,
     isFacebookAvailable: false,
-    replayVideoUnavailable: false
+    replayVideoUnavailable: false,
+    hasBeenCopied: false
   };
 
   componentDidMount() {
@@ -170,6 +171,16 @@ class ShareAllowedDialog extends React.Component {
 
   unpublish = () => {
     this.props.onUnpublish(this.props.channelId);
+  };
+
+  // Copy to clipboard.
+  copy = () => {
+    navigator.clipboard.writeText(this.props.shareUrl).then(
+      () => {
+        this.setState({hasBeenCopied: true});
+      },
+      () => {}
+    );
   };
 
   render() {
@@ -295,8 +306,20 @@ class ShareAllowedDialog extends React.Component {
                       onClick={select}
                       readOnly
                       value={this.props.shareUrl}
-                      style={{cursor: 'copy', width: 500}}
+                      style={{cursor: 'copy', width: 450}}
                     />
+                    <button
+                      type="button"
+                      id="share-dialog-copy-button"
+                      style={
+                        this.state.hasBeenCopied
+                          ? styles.copyButtonLight
+                          : styles.copyButton
+                      }
+                      onClick={wrapShareClick(this.copy.bind(this), 'copy')}
+                    >
+                      <i className="fa fa-clipboard" style={{fontSize: 14}} />
+                    </button>
                   </div>
                 </div>
                 <div className="social-buttons">
@@ -492,6 +515,40 @@ const styles = {
     marginLeft: 0,
     marginRight: 8,
     verticalAlign: 'top'
+  },
+  copyButton: {
+    backgroundColor: color.purple,
+    borderWidth: 0,
+    color: color.white,
+    fontSize: 'larger',
+    paddingTop: 5,
+    paddingBottom: 12.5,
+    paddingLeft: 10,
+    paddingRight: 10,
+    marginTop: 0,
+    marginBottom: 0,
+    marginLeft: 8,
+    marginRight: 8,
+    verticalAlign: 'top',
+    width: 30,
+    height: 30
+  },
+  copyButtonLight: {
+    backgroundColor: color.light_purple,
+    borderWidth: 0,
+    color: color.white,
+    fontSize: 'larger',
+    paddingTop: 5,
+    paddingBottom: 12.5,
+    paddingLeft: 10,
+    paddingRight: 10,
+    marginTop: 0,
+    marginBottom: 0,
+    marginLeft: 8,
+    marginRight: 8,
+    verticalAlign: 'top',
+    width: 30,
+    height: 30
   },
   thumbnail: {
     float: 'left',

--- a/apps/src/code-studio/components/ShareAllowedDialog.jsx
+++ b/apps/src/code-studio/components/ShareAllowedDialog.jsx
@@ -22,6 +22,8 @@ import firehoseClient from '@cdo/apps/lib/util/firehose';
 import LibraryCreationDialog from './libraries/LibraryCreationDialog';
 import QRCode from 'qrcode.react';
 import DCDO from '@cdo/apps/dcdo';
+import copyToClipboard from '@cdo/apps/util/copyToClipboard';
+import FontAwesome from '@cdo/apps/templates/FontAwesome';
 
 function recordShare(type) {
   if (!window.dashboard) {
@@ -176,11 +178,8 @@ class ShareAllowedDialog extends React.Component {
 
   // Copy to clipboard.
   copy = () => {
-    navigator.clipboard.writeText(this.props.shareUrl).then(
-      () => {
-        this.setState({hasBeenCopied: true});
-      },
-      () => {}
+    copyToClipboard(this.props.shareUrl, () =>
+      this.setState({hasBeenCopied: true})
     );
   };
 
@@ -312,14 +311,13 @@ class ShareAllowedDialog extends React.Component {
                     <button
                       type="button"
                       id="share-dialog-copy-button"
-                      style={
-                        this.state.hasBeenCopied
-                          ? styles.copyButtonLight
-                          : styles.copyButton
-                      }
-                      onClick={wrapShareClick(this.copy.bind(this), 'copy')}
+                      style={{
+                        ...styles.copyButton,
+                        ...(this.state.hasBeenCopied && styles.copyButtonLight)
+                      }}
+                      onClick={wrapShareClick(this.copy, 'copy')}
                     >
-                      <i className="fa fa-clipboard" style={{fontSize: 14}} />
+                      <FontAwesome icon="clipboard" style={{fontSize: 14}} />
                     </button>
                   </div>
                 </div>
@@ -328,11 +326,11 @@ class ShareAllowedDialog extends React.Component {
                     id="sharing-phone"
                     href=""
                     onClick={wrapShareClick(
-                      this.showSendToPhone.bind(this),
+                      this.showSendToPhone,
                       'send-to-phone'
                     )}
                   >
-                    <i className="fa fa-mobile-phone" style={{fontSize: 36}} />
+                    <FontAwesome icon="mobile-phone" style={{fontSize: 36}} />
                     <span>{i18n.sendToPhone()}</span>
                   </a>
                   {canPublish && !isPublished && (
@@ -342,10 +340,7 @@ class ShareAllowedDialog extends React.Component {
                       style={
                         hasThumbnail ? styles.button : styles.buttonDisabled
                       }
-                      onClick={wrapShareClick(
-                        this.publish.bind(this),
-                        'publish'
-                      )}
+                      onClick={wrapShareClick(this.publish, 'publish')}
                       disabled={!hasThumbnail}
                       className="no-mc"
                     >
@@ -368,11 +363,8 @@ class ShareAllowedDialog extends React.Component {
                     onError={this.replayVideoNotFound}
                   />
                   {canPrint && hasThumbnail && (
-                    <a
-                      href="#"
-                      onClick={wrapShareClick(this.print.bind(this), 'print')}
-                    >
-                      <i className="fa fa-print" style={{fontSize: 26}} />
+                    <a href="#" onClick={wrapShareClick(this.print, 'print')}>
+                      <FontAwesome icon="print" style={{fontSize: 26}} />
                       <span>{i18n.print()}</span>
                     </a>
                   )}
@@ -389,7 +381,7 @@ class ShareAllowedDialog extends React.Component {
                             'facebook'
                           )}
                         >
-                          <i className="fa fa-facebook" />
+                          <FontAwesome icon="facebook" />
                         </a>
                       )}
                       {this.state.isTwitterAvailable && (
@@ -402,7 +394,7 @@ class ShareAllowedDialog extends React.Component {
                             'twitter'
                           )}
                         >
-                          <i className="fa fa-twitter" />
+                          <FontAwesome icon="twitter" />
                         </a>
                       )}
                     </span>
@@ -535,21 +527,7 @@ const styles = {
     height: 30
   },
   copyButtonLight: {
-    backgroundColor: color.light_purple,
-    borderWidth: 0,
-    color: color.white,
-    fontSize: 'larger',
-    paddingTop: 5,
-    paddingBottom: 12.5,
-    paddingLeft: 10,
-    paddingRight: 10,
-    marginTop: 0,
-    marginBottom: 0,
-    marginLeft: 8,
-    marginRight: 8,
-    verticalAlign: 'top',
-    width: 30,
-    height: 30
+    backgroundColor: color.light_purple
   },
   thumbnail: {
     float: 'left',

--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -1005,6 +1005,17 @@ FeedbackUtils.prototype.createSharingDiv = function(options) {
       sharingInput.select();
       sharingInput.setSelectionRange(0, 9999);
     });
+    var sharingInputCopyButton = sharingDiv.querySelector(
+      '#sharing-input-copy-button'
+    );
+    dom.addClickTouchEvent(sharingInputCopyButton, function() {
+      navigator.clipboard.writeText(options.shareLink).then(
+        function() {
+          sharingInputCopyButton.className = 'sharing-input-copy-button-shared';
+        },
+        function() {}
+      );
+    });
   }
 
   var sharingFacebook = sharingDiv.querySelector('#sharing-facebook');

--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -34,6 +34,7 @@ import QRCode from 'qrcode.react';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
 import experiments from '@cdo/apps/util/experiments';
 import clientState from '@cdo/apps/code-studio/clientState';
+import copyToClipboard from '@cdo/apps/util/copyToClipboard';
 
 // Types of blocks that do not count toward displayed block count. Used
 // by FeedbackUtils.blockShouldBeCounted_
@@ -1009,12 +1010,9 @@ FeedbackUtils.prototype.createSharingDiv = function(options) {
       '#sharing-input-copy-button'
     );
     dom.addClickTouchEvent(sharingInputCopyButton, function() {
-      navigator.clipboard.writeText(options.shareLink).then(
-        function() {
-          sharingInputCopyButton.className = 'sharing-input-copy-button-shared';
-        },
-        function() {}
-      );
+      copyToClipboard(options.shareLink, () => {
+        sharingInputCopyButton.className = 'sharing-input-copy-button-shared';
+      });
     });
   }
 

--- a/apps/src/templates/sharing.html.ejs
+++ b/apps/src/templates/sharing.html.ejs
@@ -11,8 +11,11 @@
     <div><%= options.appStrings.sharingText %></div>
   <% } %>
 
-  <div>
+  <div id="sharing-input-container">
     <input type="text" id="sharing-input" value=<%= options.shareLink %> readonly>
+    <button id="sharing-input-copy-button">
+      <i class="fa fa-clipboard fa-lg"></i>
+    </button>
   </div>
   <div class='social-buttons'>
     <% if (options.facebookUrl) { -%>

--- a/apps/src/util/copyToClipboard.js
+++ b/apps/src/util/copyToClipboard.js
@@ -1,3 +1,31 @@
 export default function copyToClipboard(str, onSuccess, onFailure) {
-  navigator.clipboard.writeText(str).then(onSuccess, onFailure);
+  if (navigator.clipboard && window.isSecureContext) {
+    // Modern technique.
+    navigator.clipboard.writeText(str).then(onSuccess, onFailure);
+  } else {
+    // Legacy technique.
+    window.getSelection().removeAllRanges();
+
+    const tempDiv = document.createElement('pre');
+    tempDiv.innerText = str;
+    document.body.appendChild(tempDiv);
+
+    let errorOccurred = false;
+
+    try {
+      window.getSelection().selectAllChildren(tempDiv);
+      document.execCommand('copy');
+      window.getSelection().removeAllRanges();
+    } catch {
+      if (onFailure) {
+        onFailure();
+      }
+      errorOccurred = true;
+    } finally {
+      document.body.removeChild(tempDiv);
+      if (!errorOccurred && onSuccess) {
+        onSuccess();
+      }
+    }
+  }
 }

--- a/apps/src/util/copyToClipboard.js
+++ b/apps/src/util/copyToClipboard.js
@@ -1,4 +1,8 @@
-export default function copyToClipboard(str, onSuccess, onFailure) {
+export default function copyToClipboard(
+  str,
+  onSuccess = null,
+  onFailure = null
+) {
   if (navigator.clipboard && window.isSecureContext) {
     // Modern technique.
     navigator.clipboard.writeText(str).then(onSuccess, onFailure);

--- a/apps/src/util/copyToClipboard.js
+++ b/apps/src/util/copyToClipboard.js
@@ -1,15 +1,3 @@
-export default function copyToClipboard(str) {
-  window.getSelection().removeAllRanges();
-
-  const tempDiv = document.createElement('pre');
-  tempDiv.innerText = str;
-  document.body.appendChild(tempDiv);
-
-  try {
-    window.getSelection().selectAllChildren(tempDiv);
-    document.execCommand('copy');
-    window.getSelection().removeAllRanges();
-  } finally {
-    document.body.removeChild(tempDiv);
-  }
+export default function copyToClipboard(str, onSuccess, onFailure) {
+  navigator.clipboard.writeText(str).then(onSuccess, onFailure);
 }

--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -1417,11 +1417,28 @@ $workspace-header-button-margin: ($workspace-headers-height - $workspace-header-
     font-family: "Gotham 4i";
   }
 
+  #sharing-input-container {
+    overflow: hidden;
+  }
+
   #sharing-input {
+    float: left;
     margin: 0;
-    width: 100%;
+    width: calc(100% - 75px);
     padding: 10px;
     cursor: text;
+  }
+
+  #sharing-input-copy-button {
+    float: left;
+    margin-top: 0px;
+    margin-left: 10px;
+    width: 40px;
+    box-sizing: border-box;
+  }
+
+  .sharing-input-copy-button-shared {
+    background-color: $light_purple;
   }
 
   #copy-button {

--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -1422,17 +1422,14 @@ $workspace-header-button-margin: ($workspace-headers-height - $workspace-header-
   }
 
   #sharing-input {
-    float: left;
     margin: 0;
-    width: calc(100% - 75px);
+    width: calc(100% - 70px);
     padding: 10px;
     cursor: text;
   }
 
   #sharing-input-copy-button {
-    float: left;
-    margin-top: 0px;
-    margin-left: 10px;
+    margin-top: 1px;
     width: 40px;
     box-sizing: border-box;
   }


### PR DESCRIPTION
The Finish & Share dialogs each get a button to copy the share URL to the clipboard.

In this design, the button turns a lighter background color when the copy is first done, though it can be pressed again to recopy.

#### Technical note

The common `copyToClipboard` function is used, and updated to use the modern `navigator.clipboard.writeText` technique when possible.  However, when using an insecure connection, `navigator.clipboard` is `undefined` (in Chrome and Safari at least), and we fall back to the previous technique.  Insecure connections are used for the UI tests in our Drone test passes, as well as on local developer instances.

`copyToClipboard` has been updated to take optional `onSuccess` and `onFailure` callback functions.

### Finish

<img width="692" alt="Screen Shot 2022-02-22 at 3 06 37 PM" src="https://user-images.githubusercontent.com/2205926/155061394-d191e680-7ade-43a2-806b-af138272bf36.png">


#### After first press

<img width="685" alt="Screen Shot 2022-02-22 at 3 06 44 PM" src="https://user-images.githubusercontent.com/2205926/155061402-d602dfdf-8668-4d1a-8e32-a7cbb7f5d5fd.png">

### Share

<img width="773" alt="Screen Shot 2022-02-17 at 8 14 02 PM" src="https://user-images.githubusercontent.com/2205926/154443989-c121fc5c-0631-4987-a05f-e2826c7f889a.png">

#### After first press

<img width="781" alt="Screen Shot 2022-02-17 at 8 14 12 PM" src="https://user-images.githubusercontent.com/2205926/154444001-83bfc459-32b1-45d7-9e06-9a5f191a832e.png">

