### PR TITLE
Javalab: revert to darker line highlight color in dark mode

### DIFF
--- a/apps/src/javalab/JavalabEditor.jsx
+++ b/apps/src/javalab/JavalabEditor.jsx
@@ -59,7 +59,7 @@ export const editorDarkModeThemeOverride = EditorView.theme(
     },
     // Sets the background color for the currently selected line
     '.cm-activeLine': {
-      backgroundColor: color.dark_charcoal
+      backgroundColor: color.dark_gray
     },
     // Sets the background color for the left-hand side gutters
     '.cm-gutters': {

--- a/shared/css/color.scss
+++ b/shared/css/color.scss
@@ -6,6 +6,7 @@
 
 $black: #000;
 $background_black: #121416;
+$dark_gray: #2D3139;
 $darkest_gray: #272822;
 $dark_slate_gray: #282c34;
 $darkest_slate_gray: #25292d;


### PR DESCRIPTION
Reverts to our previous line highlight color (darker than current), due to issues with contrast with other colors in dark mode (in particular, red). Follow-up to https://github.com/code-dot-org/code-dot-org/pull/44643.

**Before**

![image](https://user-images.githubusercontent.com/25372625/154595993-eb1a6af2-1b58-45da-8db7-d15d06d49122.png)

**After**

![image](https://user-images.githubusercontent.com/25372625/154596011-9773d91d-3238-459e-97e9-9f023be8818d.png)
