### PR TITLE
Add reopened status

### DIFF
--- a/dashboard/app/controllers/pd/application/teacher_application_controller.rb
+++ b/dashboard/app/controllers/pd/application/teacher_application_controller.rb
@@ -22,7 +22,7 @@ module Pd::Application
         where(application_year: @year).
         find_by(user: current_user)
       if @application
-        return render :submitted if @application.status != 'incomplete'
+        return render :submitted unless @application.status == 'incomplete' || @application.status == 'reopened'
         @application_id = @application.try(:id)
         @form_data = @application.try(:form_data)
       end

--- a/dashboard/app/helpers/teacher_application_helper.rb
+++ b/dashboard/app/helpers/teacher_application_helper.rb
@@ -12,4 +12,8 @@ module TeacherApplicationHelper
   def has_incomplete_application?
     current_application && current_application.status == 'incomplete'
   end
+
+  def has_reopened_application?
+    current_application && current_application.status == 'reopened'
+  end
 end

--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -368,6 +368,7 @@ module Pd::Application
       %w(
         unreviewed
         incomplete
+        reopened
         pending
         waitlisted
         declined

--- a/dashboard/test/controllers/pd/application/teacher_application_controller_test.rb
+++ b/dashboard/test/controllers/pd/application/teacher_application_controller_test.rb
@@ -10,21 +10,21 @@ module Pd::Application
       assert_template :logged_out
     end
 
-    test 'students see the not-teacher message' do
+    test 'students see message that they are not a teacher' do
       sign_in create :student
       get :new
       assert_response :success
       assert_template :not_teacher
     end
 
-    test 'teachers without email see the no-teacher-email message' do
+    test 'teachers without email see message about not having an email' do
       sign_in create :teacher, :without_email
       get :new
       assert_response :success
       assert_template :no_teacher_email
     end
 
-    test 'teachers with a submitted application see the submitted message' do
+    test 'teachers with a submitted application see submitted message' do
       application = create :pd_teacher_application
       sign_in application.user
       get :new

--- a/dashboard/test/controllers/pd/application/teacher_application_controller_test.rb
+++ b/dashboard/test/controllers/pd/application/teacher_application_controller_test.rb
@@ -46,6 +46,20 @@ module Pd::Application
       assert_equal application.form_data, JSON.parse(@script_data.dig(:props)).dig('savedFormData')
     end
 
+    test 'teachers with a reopened application have an application id and saved form data' do
+      application = create :pd_teacher_application, form_data_hash: (
+        build :pd_teacher_application_hash, :reopened
+      )
+      sign_in application.user
+      get :new
+      assert_response :success
+      assert_template :new
+
+      @script_data = assigns(:script_data)
+      assert_equal application.id, JSON.parse(@script_data.dig(:props)).dig('applicationId')
+      assert_equal application.form_data, JSON.parse(@script_data.dig(:props)).dig('savedFormData')
+    end
+
     test 'teachers without an application have no id nor form data' do
       sign_in create :teacher
       get :new

--- a/dashboard/test/factories/pd_factories.rb
+++ b/dashboard/test/factories/pd_factories.rb
@@ -813,6 +813,10 @@ FactoryGirl.define do
       status 'incomplete'
     end
 
+    trait :reopened do
+      status 'reopened'
+    end
+
     trait :with_no_school do
       school(-1)
     end


### PR DESCRIPTION
An RP can reopen applications. When they are reopened, they will have `reopened` status. This is because RPs won't be able to see all of an incomplete application, but they will be able to see a reopened application.

This PR (different from an RP #confusing) is to set us up for that status.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

Jira Ticket: [PLAT-1609](https://codedotorg.atlassian.net/browse/PLAT-1609)

## Testing story

I added a test to ensure a teacher with a 'reopened' status can see their application. This ensures we can have in the DB an application with status 'reopened'.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
