### PR TITLE
add ui tests for dashboard certificate pages

### DIFF
--- a/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
+++ b/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
@@ -1,9 +1,7 @@
 Feature: After completing the Hour of Code, the player is directed to a congratulations page
 
-Background:
-  Given I am on "http://studio.code.org/s/mc/reset"
-
 Scenario: Completing Minecraft HoC should go to certificate page and generate a certificate
+  Given I am on "http://studio.code.org/s/mc/reset"
   Given I load the last Minecraft HoC level
   Then I wait until the Minecraft game is loaded
   And I press "runButton"
@@ -18,3 +16,27 @@ Scenario: Completing Minecraft HoC should go to certificate page and generate a 
   And I type "Robo Coder" into "#name"
   And I press "button:contains(Submit)" using jQuery
   And I wait to see element with ID "uitest-thanks"
+
+Scenario: Flappy customized dashboard certificate pages
+  Given I am on "http://studio.code.org/congrats?enableExperiments=studioCertificate"
+  And I wait until element "#uitest-certificate" is visible
+
+  When I am on "http://code.org/api/hour/finish/flappy"
+  And I wait until current URL contains "/congrats"
+  And I wait to see element with ID "uitest-certificate"
+  Then the href of selector ".social-print-link" contains "/print_certificates/"
+  Then I wait to see an image "/assets/js/hour_of_code_certificate"
+
+  When I type "Robo Coder" into "#name"
+  And I press "button:contains(Submit)" using jQuery
+  And I wait to see element with ID "uitest-thanks"
+  Then I wait to see an image "/certificate_images/"
+
+  When I press the first "#uitest-certificate a" element to load a new page
+  And I wait until current URL contains "/certificates/"
+  Then I wait to see an image "/certificate_images/"
+
+  When I press the first "#certificate-share a" element to load a new page
+  And I wait until current URL contains "/print_certificates/"
+  Then I wait to see an image "/certificate_images/"
+

--- a/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
+++ b/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
@@ -40,3 +40,20 @@ Scenario: Flappy customized dashboard certificate pages
   And I wait until current URL contains "/print_certificates/"
   Then I wait to see an image "/certificate_images/"
 
+Scenario: Oceans uncustomized dashboard certificate pages
+  Given I am on "http://studio.code.org/congrats?enableExperiments=studioCertificate"
+  And I wait until element "#uitest-certificate" is visible
+
+  When I am on "http://code.org/api/hour/finish/oceans"
+  And I wait until current URL contains "/congrats"
+  And I wait to see element with ID "uitest-certificate"
+  Then the href of selector ".social-print-link" contains "/print_certificates/"
+  And I wait to see an image "/assets/js/oceans_hoc_certificate"
+
+  When I press the first "#uitest-certificate a" element to load a new page
+  And I wait until current URL contains "/certificates/"
+  Then I wait to see an image "/images/oceans_hoc_certificate.png"
+
+  When I press the first "#certificate-share a" element to load a new page
+  And I wait until current URL contains "/print_certificates/"
+  Then I wait to see an image "/images/oceans_hoc_certificate.png"


### PR DESCRIPTION
Continues [PLAT-1531](https://codedotorg.atlassian.net/browse/PLAT-1531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ). Depends on #44866. see [work plan](https://docs.google.com/document/d/1wTObDFZdWS6RzpM3R6wEm04ToY2fM1B5Kb2rUHCNq28/edit#heading=h.h0cd07oasonl)

## Testing story

Add new UI test coverage for two basic flows with experiment enabled:
* without customizing certificate, look at image on congrats page, share page and print page
* after customizing certificate, look at image on congrats page, share page and print page

I am relying on unit tests in CertificateTest.js to enforce that we do not end up on any of these new pages when the experiment is not enabled.

These are all the UI tests I am planning to add before shipping the experiment, so if you think others would be good to add then now would be a good time to suggest them.