### PR TITLE
Remove the ability to seed callouts with script_id

### DIFF
--- a/dashboard/app/models/callout.rb
+++ b/dashboard/app/models/callout.rb
@@ -20,7 +20,7 @@ class Callout < ApplicationRecord
   CSV_HEADERS = {
     element_id: 'element_id',
     localization_key: 'localization_key',
-    script_id: 'script_id',
+    script_name: 'script_name',
     level_num: 'level_num',
     game_name: 'game_name',
     qtip_config: 'qtip_config'
@@ -39,20 +39,15 @@ class Callout < ApplicationRecord
   end
 
   def self.first_or_create_from_tsv_row!(row_data)
-    id_or_name = row_data[CSV_HEADERS[:script_id]]
+    name = row_data[CSV_HEADERS[:script_name]]
 
-    unless id_or_name.to_i.to_s == id_or_name.to_s
-      script_record = Script.where({'name' => id_or_name})
-      id_or_name = script_record.first && script_record.first.id
-    end
-
-    unless id_or_name
-      puts "Error finding id_or_name: #{id_or_name}"
+    unless name
+      puts "Error finding name: #{name}"
       return nil
     end
 
     script_level_search_conditions = {
-      'scripts.id' => id_or_name,
+      'scripts.name' => name,
       'levels.level_num' => row_data[CSV_HEADERS[:level_num]],
       'games.name' => row_data[CSV_HEADERS[:game_name]]
     }

--- a/dashboard/config/callouts.tsv
+++ b/dashboard/config/callouts.tsv
@@ -1,4 +1,4 @@
-Name	script_id	level_num	game_name	localization_key	element_id	qtip_config
+Name	script_name	level_num	game_name	localization_key	element_id	qtip_config
 Drag Blocks 20	20-hour	2_2	Maze	drag_blocks	[block-id='1']	{"position": {"my": "top left", "at": "bottom right", "adjust": {"x": 22, "y":60}}, "style": { "classes": "no-tip" }}
 Drag Blocks HoC	Hour of Code	2_2	Maze	drag_blocks	[block-id='1']	{"position": {"my": "top left", "at": "bottom right", "adjust": {"x": 22, "y":60}}, "style": { "classes": "no-tip" }}
 Run 20	20-hour	2_2	Maze	run	#runButton

--- a/dashboard/test/fixtures/callouts.tsv
+++ b/dashboard/test/fixtures/callouts.tsv
@@ -1,3 +1,3 @@
-Name	script_id	level_num	game_name	localization_key	element_id	qtip_config
-Run Button	10333	level1_2_3	Maze	run	#runButton
-Repeat Block	10321	level1_2_3	Maze	run	#repeatBlock	{"position": {"my": "bottom left", "at": "top right", "adjust": {"x": 297, "y":70}}}
+Name	script_name	level_num	game_name	localization_key	element_id	qtip_config
+Run Button	run-button-callout-script	level1_2_3	Maze	run	#runButton
+Repeat Block	repeat-button-callout-script	level1_2_3	Maze	run	#repeatBlock	{"position": {"my": "bottom left", "at": "top right", "adjust": {"x": 297, "y":70}}}

--- a/dashboard/test/fixtures/callouts_invalid.tsv
+++ b/dashboard/test/fixtures/callouts_invalid.tsv
@@ -1,2 +1,2 @@
-Name	script_id	level_num	localization_key	element_id
-Run Button	12345	invalid_level	Click here to run your program.	#runButton
+Name	script_name	level_num	localization_key	element_id
+Run Button	run-button-invalid-callout-script	invalid_level	Click here to run your program.	#runButton

--- a/dashboard/test/models/callout_test.rb
+++ b/dashboard/test/models/callout_test.rb
@@ -6,8 +6,8 @@ class CalloutTest < ActiveSupport::TestCase
   self.use_transactional_test_case = true
   setup_all do
     @level = create(:level, :blockly, level_num: 'level1_2_3')
-    @script = create(:script, id: 10333)
-    @script2 = create(:script, id: 10321)
+    @script = create(:script, name: 'run-button-callout-script')
+    @script2 = create(:script, name: 'repeat-button-callout-script')
     @script_level = create(:script_level, script: @script, levels: [@level])
     @script_level2 = create(:script_level, script: @script2, levels: [@level])
     @csv_callouts = Callout.find_or_create_all_from_tsv!('test/fixtures/callouts.tsv')


### PR DESCRIPTION
Follow up from #44894. We don't want to support seeding using `script_id` going forward, so changing that to `script_name`. I ran `bundle exec rake seed:callouts` locally and it passed without errors.


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
