### PR TITLE
No profanity/PII filter on Backpack files

### DIFF
--- a/shared/middleware/files_api.rb
+++ b/shared/middleware/files_api.rb
@@ -388,7 +388,11 @@ class FilesApi < Sinatra::Base
     end
 
     # Block libraries with PII/profanity from being published.
-    if endpoint == 'libraries'
+    #
+    # Javalab's "backpack" feature uses libraries to allow students to share code
+    # between their own projects -- skip this check for .java files, since in this use case
+    # the files are only being used by a single user.
+    if endpoint == 'libraries' && file_type != '.java'
       begin
         share_failure = ShareFiltering.find_failure(body, request.locale)
       rescue OpenURI::HTTPError => e


### PR DESCRIPTION
Students have reported issues saving files to their backpacks in Javalab because of our content filter. We apply this filter generally for "libraries" in applab, which are shared between students. We don't need this filter for backpack files, because they are not shared between students. We do not apply content filters to all student code that is private (ie, only shared between themselves and their teachers), so this change moves us in line with that policy.

This PR stops applying the content filter to .java files, which stops using it against backpack files.

## Links

- jira ticket: [JAVA-434](https://codedotorg.atlassian.net/browse/JAVA-434)

## Testing story

Tested manually that a file with profane content caused an error when trying to upload to my backpack locally (I had to configure webpurify to run locally) before this change, and was uploaded without issue after this change.