### PR TITLE
Revert "add ui tests for dashboard certificate pages"

### DIFF
--- a/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
+++ b/dashboard/test/ui/features/hour_of_code/hour_of_code_finish.feature
@@ -1,7 +1,9 @@
 Feature: After completing the Hour of Code, the player is directed to a congratulations page
 
-Scenario: Completing Minecraft HoC should go to certificate page and generate a certificate
+Background:
   Given I am on "http://studio.code.org/s/mc/reset"
+
+Scenario: Completing Minecraft HoC should go to certificate page and generate a certificate
   Given I load the last Minecraft HoC level
   Then I wait until the Minecraft game is loaded
   And I press "runButton"
@@ -16,44 +18,3 @@ Scenario: Completing Minecraft HoC should go to certificate page and generate a 
   And I type "Robo Coder" into "#name"
   And I press "button:contains(Submit)" using jQuery
   And I wait to see element with ID "uitest-thanks"
-
-Scenario: Flappy customized dashboard certificate pages
-  Given I am on "http://studio.code.org/congrats?enableExperiments=studioCertificate"
-  And I wait until element "#uitest-certificate" is visible
-
-  When I am on "http://code.org/api/hour/finish/flappy"
-  And I wait until current URL contains "/congrats"
-  And I wait to see element with ID "uitest-certificate"
-  Then the href of selector ".social-print-link" contains "/print_certificates/"
-  Then I wait to see an image "/assets/js/hour_of_code_certificate"
-
-  When I type "Robo Coder" into "#name"
-  And I press "button:contains(Submit)" using jQuery
-  And I wait to see element with ID "uitest-thanks"
-  Then I wait to see an image "/certificate_images/"
-
-  When I press the first "#uitest-certificate a" element to load a new page
-  And I wait until current URL contains "/certificates/"
-  Then I wait to see an image "/certificate_images/"
-
-  When I press the first "#certificate-share a" element to load a new page
-  And I wait until current URL contains "/print_certificates/"
-  Then I wait to see an image "/certificate_images/"
-
-Scenario: Oceans uncustomized dashboard certificate pages
-  Given I am on "http://studio.code.org/congrats?enableExperiments=studioCertificate"
-  And I wait until element "#uitest-certificate" is visible
-
-  When I am on "http://code.org/api/hour/finish/oceans"
-  And I wait until current URL contains "/congrats"
-  And I wait to see element with ID "uitest-certificate"
-  Then the href of selector ".social-print-link" contains "/print_certificates/"
-  And I wait to see an image "/assets/js/oceans_hoc_certificate"
-
-  When I press the first "#uitest-certificate a" element to load a new page
-  And I wait until current URL contains "/certificates/"
-  Then I wait to see an image "/images/oceans_hoc_certificate.png"
-
-  When I press the first "#certificate-share a" element to load a new page
-  And I wait until current URL contains "/print_certificates/"
-  Then I wait to see an image "/images/oceans_hoc_certificate.png"


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#44909 since it failed in Safari
![Screen Shot 2022-02-18 at 2 29 33 PM](https://user-images.githubusercontent.com/8001765/154769781-e087c969-a63e-4438-8498-d6b6076ef61d.png)
https://app.saucelabs.com/tests/fadc8246e21343829121fb1e137213cb#39