### PR TITLE
Do not allow application to change to incomplete

### DIFF
--- a/apps/src/code-studio/pd/application_dashboard/constants.js
+++ b/apps/src/code-studio/pd/application_dashboard/constants.js
@@ -88,6 +88,7 @@ export function getApplicationStatuses(type, addAutoEmail = true) {
       {
         unreviewed: 'Unreviewed',
         incomplete: 'Incomplete',
+        reopened: 'Reopened',
         pending: 'Pending',
         waitlisted: `Waitlisted${autoEmailText(addAutoEmail)}`,
         declined: `Declined${autoEmailText(addAutoEmail)}`,
@@ -102,7 +103,7 @@ export function getApplicationStatuses(type, addAutoEmail = true) {
       },
       experiments.isEnabled(experiments.TEACHER_APPLICATION_SAVING_REOPENING)
         ? []
-        : ['incomplete']
+        : ['incomplete', 'reopened']
     );
   } else if (type === 'facilitator') {
     return {

--- a/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
@@ -599,9 +599,13 @@ export class DetailViewContents extends React.Component {
   };
 
   renderStatusSelect = () => {
-    const statuses = getApplicationStatuses(
-      this.props.viewType,
-      this.props.applicationData.update_emails_sent_by_system
+    // Nobody is able to set an application status to incomplete from detail view
+    const statuses = _.omit(
+      getApplicationStatuses(
+        this.props.viewType,
+        this.props.applicationData.update_emails_sent_by_system
+      ),
+      ['incomplete']
     );
     const selectControl = (
       <div>

--- a/apps/test/unit/code-studio/pd/application_dashboard/detail_view_contentsTest.js
+++ b/apps/test/unit/code-studio/pd/application_dashboard/detail_view_contentsTest.js
@@ -90,7 +90,7 @@ describe('DetailViewContents', () => {
       canLock: true,
       applicationId: '1',
       applicationData: defaultApplicationData,
-      viewType: 'teacher',
+      viewType: defaultApplicationData.application_type.toLowerCase(),
       isWorkshopAdmin: false
     };
 
@@ -359,7 +359,7 @@ describe('DetailViewContents', () => {
 
   describe('Regional Partner View', () => {
     it('has delete button', () => {
-      const detailView = mountDetailView(applicationType, {
+      const detailView = mountDetailView('Teacher', {
         isWorkshopAdmin: false
       });
       const deleteButton = detailView.find('button#delete');

--- a/apps/test/unit/code-studio/pd/application_dashboard/detail_view_contentsTest.js
+++ b/apps/test/unit/code-studio/pd/application_dashboard/detail_view_contentsTest.js
@@ -81,6 +81,10 @@ describe('DetailViewContents', () => {
     school_stats: {}
   };
 
+  // Nobody is able to set an application status to incomplete from detail view
+  const getApplicationStatusesWithoutIncomplete = (type, addAutoEmail = true) =>
+    _.omit(getApplicationStatuses(type, addAutoEmail), ['incomplete']);
+
   const mountDetailView = (applicationType, overrides = {}) => {
     const defaultApplicationData = {
       ...DEFAULT_APPLICATION_DATA,
@@ -146,7 +150,7 @@ describe('DetailViewContents', () => {
       // lock button is disabled for all statuses except "finalized"
       // statuses in the constant are an object {value: label}
       Object.keys(
-        getApplicationStatuses(applicationType.toLowerCase())
+        getApplicationStatusesWithoutIncomplete(applicationType.toLowerCase())
       ).forEach(status => {
         const statusIsFinal = ApplicationFinalStatuses.includes(status);
         detailView
@@ -455,7 +459,7 @@ describe('DetailViewContents', () => {
     }
 
     for (const applicationStatus of _.difference(
-      Object.keys(getApplicationStatuses('teacher')),
+      Object.keys(getApplicationStatusesWithoutIncomplete('teacher')),
       ScholarshipStatusRequiredStatuses
     )) {
       it(`is not required to set application status to ${applicationStatus}`, () => {
@@ -488,7 +492,7 @@ describe('DetailViewContents', () => {
       });
       let options = detailView.find('#DetailViewHeader select').find('option');
       let applicationStatuses = Object.values(
-        getApplicationStatuses('teacher', true)
+        getApplicationStatusesWithoutIncomplete('teacher', true)
       );
       var i = 0;
       options.forEach(option => {
@@ -509,7 +513,7 @@ describe('DetailViewContents', () => {
       });
       let options = detailView.find('#DetailViewHeader select').find('option');
       let applicationStatuses = Object.values(
-        getApplicationStatuses('teacher', false)
+        getApplicationStatusesWithoutIncomplete('teacher', false)
       );
       var i = 0;
       options.forEach(option => {

--- a/apps/test/unit/code-studio/pd/application_dashboard/detail_view_contentsTest.js
+++ b/apps/test/unit/code-studio/pd/application_dashboard/detail_view_contentsTest.js
@@ -358,6 +358,16 @@ describe('DetailViewContents', () => {
         expect(detailView.find('textarea#notes').prop('disabled')).to.be.true;
         expect(detailView.find('textarea#notes_2').prop('disabled')).to.be.true;
       });
+
+      it(`cannot make status incomplete from dropdown in ${applicationType}`, () => {
+        const detailView = mountDetailView(applicationType);
+        expect(
+          detailView
+            .find('#DetailViewHeader select')
+            .find('option')
+            .find('[value="incomplete"]')
+        ).to.have.lengthOf(0);
+      });
     });
   }
 

--- a/apps/test/unit/code-studio/pd/application_dashboard/detail_view_contentsTest.js
+++ b/apps/test/unit/code-studio/pd/application_dashboard/detail_view_contentsTest.js
@@ -10,6 +10,7 @@ import sinon from 'sinon';
 import {expect} from '../../../../util/reconfiguredChai';
 import {mount} from 'enzyme';
 import {allowConsoleWarnings} from '../../../../util/testUtils';
+import experiments from '@cdo/apps/util/experiments';
 
 describe('DetailViewContents', () => {
   allowConsoleWarnings();
@@ -19,10 +20,18 @@ describe('DetailViewContents', () => {
   let server;
   before(() => {
     server = sinon.fakeServer.create();
+    experiments.setEnabled(
+      experiments.TEACHER_APPLICATION_SAVING_REOPENING,
+      true
+    );
   });
 
   after(() => {
     server.restore();
+    experiments.setEnabled(
+      experiments.TEACHER_APPLICATION_SAVING_REOPENING,
+      false
+    );
   });
 
   let context;
@@ -81,7 +90,7 @@ describe('DetailViewContents', () => {
       canLock: true,
       applicationId: '1',
       applicationData: defaultApplicationData,
-      viewType: 'facilitator',
+      viewType: 'teacher',
       isWorkshopAdmin: false
     };
 
@@ -488,7 +497,7 @@ describe('DetailViewContents', () => {
       });
     });
 
-    it('does not appends auto email text if set to false', () => {
+    it('does not append auto email text if set to false', () => {
       detailView = mountDetailView('Teacher', {
         applicationData: {
           ...DEFAULT_APPLICATION_DATA,


### PR DESCRIPTION
Nobody except the teacher saving their application should be able to change an application to an "incomplete" status. I removed the option from the dashboard.

Note that there is no backend validation of this––not sure we need that level of protection.

<img width="1204" alt="image" src="https://user-images.githubusercontent.com/9142121/154988848-c5daf97f-de15-4886-9c17-1892d5c5b908.png">


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Updated tests to only look at not-incomplete applications, and ensured there is no 'incomplete' option in the dashboard.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
