### PR TITLE
Only admins can see incomplete applications

### DIFF
--- a/apps/src/code-studio/pd/application_dashboard/constants.js
+++ b/apps/src/code-studio/pd/application_dashboard/constants.js
@@ -19,6 +19,10 @@ export const StatusColors = {
     backgroundColor: color.charcoal,
     color: color.white
   },
+  reopened: {
+    backgroundColor: color.lighter_orange,
+    color: color.black
+  },
   incomplete: {
     backgroundColor: color.lightest_cyan,
     color: color.black

--- a/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
@@ -599,8 +599,7 @@ export class DetailViewContents extends React.Component {
   };
 
   renderStatusSelect = () => {
-    // Nobody is able to set an application status to incomplete from detail view,
-    // so remove it unless the current status is incomplete
+    // Only show incomplete in the dropdown if the application is incomplete
     const statuses = _.omit(
       getApplicationStatuses(
         this.props.viewType,

--- a/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
@@ -599,13 +599,14 @@ export class DetailViewContents extends React.Component {
   };
 
   renderStatusSelect = () => {
-    // Nobody is able to set an application status to incomplete from detail view
+    // Nobody is able to set an application status to incomplete from detail view,
+    // so remove it unless the current status is incomplete
     const statuses = _.omit(
       getApplicationStatuses(
         this.props.viewType,
         this.props.applicationData.update_emails_sent_by_system
       ),
-      ['incomplete']
+      this.state.status === 'incomplete' ? [] : ['incomplete']
     );
     const selectControl = (
       <div>

--- a/apps/src/code-studio/pd/application_dashboard/summary.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/summary.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 import {connect} from 'react-redux';
 import SummaryTable from './summary_table';
 import {Row, Col} from 'react-bootstrap';
+import {mapValues, omit} from 'lodash';
 import RegionalPartnerDropdown, {
   RegionalPartnerPropType
 } from '../components/regional_partner_dropdown';
@@ -14,6 +15,9 @@ import ApplicantSearch from './applicant_search';
 import AdminNavigationButtons from './admin_navigation_buttons';
 import Spinner from '../components/spinner';
 import $ from 'jquery';
+
+export const removeIncompleteApplications = data =>
+  mapValues(data, data_by_status => omit(data_by_status, ['incomplete']));
 
 export class Summary extends React.Component {
   static propTypes = {
@@ -69,7 +73,9 @@ export class Summary extends React.Component {
     }).done(data => {
       this.setState({
         loading: false,
-        applications: data
+        applications: this.props.isWorkshopAdmin
+          ? data
+          : removeIncompleteApplications(data)
       });
     });
   }

--- a/apps/test/unit/code-studio/pd/application_dashboard/detail_view_contentsTest.js
+++ b/apps/test/unit/code-studio/pd/application_dashboard/detail_view_contentsTest.js
@@ -368,6 +368,23 @@ describe('DetailViewContents', () => {
             .find('[value="incomplete"]')
         ).to.have.lengthOf(0);
       });
+
+      it(`incomplete status is in dropdown if ${applicationType} application is incomplete`, () => {
+        const detailView = mountDetailView('Teacher', {
+          applicationData: {
+            ...DEFAULT_APPLICATION_DATA,
+            status: 'incomplete',
+            scholarship_status: null,
+            update_emails_sent_by_system: false
+          }
+        });
+        expect(
+          detailView
+            .find('#DetailViewHeader select')
+            .find('option')
+            .find('[value="incomplete"]')
+        ).to.have.lengthOf(1);
+      });
     });
   }
 

--- a/apps/test/unit/code-studio/pd/application_dashboard/summaryTest.js
+++ b/apps/test/unit/code-studio/pd/application_dashboard/summaryTest.js
@@ -1,11 +1,56 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 import {Row} from 'react-bootstrap';
-import {Summary} from '@cdo/apps/code-studio/pd/application_dashboard/summary';
+import {
+  Summary,
+  removeIncompleteApplications
+} from '@cdo/apps/code-studio/pd/application_dashboard/summary';
 import {expect} from 'chai';
 import sinon from 'sinon';
 
 describe('Summary', () => {
+  const data = {
+    csd_teachers: {
+      unreviewed: {locked: 0, total: 2},
+      incomplete: {locked: 0, total: 0},
+      reopened: {locked: 0, total: 0},
+      pending: {locked: 0, total: 0},
+      waitlisted: {locked: 0, total: 0},
+      declined: {locked: 0, total: 0},
+      accepted_not_notified: {locked: 0, total: 0},
+      accepted_notified_by_partner: {locked: 0, total: 0},
+      accepted_no_cost_registration: {locked: 0, total: 0},
+      registration_sent: {locked: 0, total: 0},
+      paid: {locked: 0, total: 0}
+    },
+    csp_teachers: {
+      unreviewed: {locked: 0, total: 2},
+      incomplete: {locked: 0, total: 0},
+      reopened: {locked: 0, total: 0},
+      pending: {locked: 0, total: 0},
+      waitlisted: {locked: 0, total: 0},
+      declined: {locked: 0, total: 0},
+      accepted_not_notified: {locked: 0, total: 0},
+      accepted_notified_by_partner: {locked: 0, total: 0},
+      accepted_no_cost_registration: {locked: 0, total: 0},
+      registration_sent: {locked: 0, total: 0},
+      paid: {locked: 0, total: 0}
+    },
+    csa_teachers: {
+      unreviewed: {locked: 0, total: 2},
+      incomplete: {locked: 0, total: 0},
+      reopened: {locked: 0, total: 0},
+      pending: {locked: 0, total: 0},
+      waitlisted: {locked: 0, total: 0},
+      declined: {locked: 0, total: 0},
+      accepted_not_notified: {locked: 0, total: 0},
+      accepted_notified_by_partner: {locked: 0, total: 0},
+      accepted_no_cost_registration: {locked: 0, total: 0},
+      registration_sent: {locked: 0, total: 0},
+      paid: {locked: 0, total: 0}
+    }
+  };
+
   const fakeRouter = {
     createHref() {}
   };
@@ -32,41 +77,7 @@ describe('Summary', () => {
     server.respondWith('GET', '/api/v1/pd/applications', [
       200,
       {'Content-Type': 'application/json'},
-      JSON.stringify({
-        csd_teachers: {
-          unreviewed: {locked: 0, total: 1},
-          pending: {locked: 0, total: 0},
-          waitlisted: {locked: 0, total: 0},
-          declined: {locked: 0, total: 0},
-          accepted_not_notified: {locked: 0, total: 0},
-          accepted_notified_by_partner: {locked: 0, total: 0},
-          accepted_no_cost_registration: {locked: 0, total: 0},
-          registration_sent: {locked: 0, total: 0},
-          paid: {locked: 0, total: 0}
-        },
-        csp_teachers: {
-          unreviewed: {locked: 0, total: 1},
-          pending: {locked: 0, total: 0},
-          waitlisted: {locked: 0, total: 0},
-          declined: {locked: 0, total: 0},
-          accepted_not_notified: {locked: 0, total: 0},
-          accepted_notified_by_partner: {locked: 0, total: 0},
-          accepted_no_cost_registration: {locked: 0, total: 0},
-          registration_sent: {locked: 0, total: 0},
-          paid: {locked: 0, total: 0}
-        },
-        csa_teachers: {
-          unreviewed: {locked: 0, total: 1},
-          pending: {locked: 0, total: 0},
-          waitlisted: {locked: 0, total: 0},
-          declined: {locked: 0, total: 0},
-          accepted_not_notified: {locked: 0, total: 0},
-          accepted_notified_by_partner: {locked: 0, total: 0},
-          accepted_no_cost_registration: {locked: 0, total: 0},
-          registration_sent: {locked: 0, total: 0},
-          paid: {locked: 0, total: 0}
-        }
-      })
+      JSON.stringify(data)
     ]);
 
     let summary = createSummary();
@@ -80,5 +91,46 @@ describe('Summary', () => {
     expect(summary.find('Spinner')).to.have.length(0);
 
     server.restore();
+  });
+
+  it('removeIncompleteApplications strips incomplete applications from data', () => {
+    expect(removeIncompleteApplications(data)).to.deep.equal({
+      csd_teachers: {
+        unreviewed: {locked: 0, total: 2},
+        reopened: {locked: 0, total: 0},
+        pending: {locked: 0, total: 0},
+        waitlisted: {locked: 0, total: 0},
+        declined: {locked: 0, total: 0},
+        accepted_not_notified: {locked: 0, total: 0},
+        accepted_notified_by_partner: {locked: 0, total: 0},
+        accepted_no_cost_registration: {locked: 0, total: 0},
+        registration_sent: {locked: 0, total: 0},
+        paid: {locked: 0, total: 0}
+      },
+      csp_teachers: {
+        unreviewed: {locked: 0, total: 2},
+        reopened: {locked: 0, total: 0},
+        pending: {locked: 0, total: 0},
+        waitlisted: {locked: 0, total: 0},
+        declined: {locked: 0, total: 0},
+        accepted_not_notified: {locked: 0, total: 0},
+        accepted_notified_by_partner: {locked: 0, total: 0},
+        accepted_no_cost_registration: {locked: 0, total: 0},
+        registration_sent: {locked: 0, total: 0},
+        paid: {locked: 0, total: 0}
+      },
+      csa_teachers: {
+        unreviewed: {locked: 0, total: 2},
+        reopened: {locked: 0, total: 0},
+        pending: {locked: 0, total: 0},
+        waitlisted: {locked: 0, total: 0},
+        declined: {locked: 0, total: 0},
+        accepted_not_notified: {locked: 0, total: 0},
+        accepted_notified_by_partner: {locked: 0, total: 0},
+        accepted_no_cost_registration: {locked: 0, total: 0},
+        registration_sent: {locked: 0, total: 0},
+        paid: {locked: 0, total: 0}
+      }
+    });
   });
 });

--- a/apps/test/unit/code-studio/pd/application_dashboard/summaryTest.js
+++ b/apps/test/unit/code-studio/pd/application_dashboard/summaryTest.js
@@ -9,45 +9,31 @@ import {expect} from 'chai';
 import sinon from 'sinon';
 
 describe('Summary', () => {
+  const dataWithoutIncompleteApps = {
+    unreviewed: {locked: 0, total: 0},
+    reopened: {locked: 0, total: 0},
+    pending: {locked: 0, total: 0},
+    waitlisted: {locked: 0, total: 0},
+    declined: {locked: 0, total: 0},
+    accepted_not_notified: {locked: 0, total: 0},
+    accepted_notified_by_partner: {locked: 0, total: 0},
+    accepted_no_cost_registration: {locked: 0, total: 0},
+    registration_sent: {locked: 0, total: 0},
+    paid: {locked: 0, total: 0}
+  };
+
   const data = {
     csd_teachers: {
-      unreviewed: {locked: 0, total: 2},
-      incomplete: {locked: 0, total: 0},
-      reopened: {locked: 0, total: 0},
-      pending: {locked: 0, total: 0},
-      waitlisted: {locked: 0, total: 0},
-      declined: {locked: 0, total: 0},
-      accepted_not_notified: {locked: 0, total: 0},
-      accepted_notified_by_partner: {locked: 0, total: 0},
-      accepted_no_cost_registration: {locked: 0, total: 0},
-      registration_sent: {locked: 0, total: 0},
-      paid: {locked: 0, total: 0}
+      ...dataWithoutIncompleteApps,
+      incomplete: {locked: 0, total: 0}
     },
     csp_teachers: {
-      unreviewed: {locked: 0, total: 2},
-      incomplete: {locked: 0, total: 0},
-      reopened: {locked: 0, total: 0},
-      pending: {locked: 0, total: 0},
-      waitlisted: {locked: 0, total: 0},
-      declined: {locked: 0, total: 0},
-      accepted_not_notified: {locked: 0, total: 0},
-      accepted_notified_by_partner: {locked: 0, total: 0},
-      accepted_no_cost_registration: {locked: 0, total: 0},
-      registration_sent: {locked: 0, total: 0},
-      paid: {locked: 0, total: 0}
+      ...dataWithoutIncompleteApps,
+      incomplete: {locked: 0, total: 0}
     },
     csa_teachers: {
-      unreviewed: {locked: 0, total: 2},
-      incomplete: {locked: 0, total: 0},
-      reopened: {locked: 0, total: 0},
-      pending: {locked: 0, total: 0},
-      waitlisted: {locked: 0, total: 0},
-      declined: {locked: 0, total: 0},
-      accepted_not_notified: {locked: 0, total: 0},
-      accepted_notified_by_partner: {locked: 0, total: 0},
-      accepted_no_cost_registration: {locked: 0, total: 0},
-      registration_sent: {locked: 0, total: 0},
-      paid: {locked: 0, total: 0}
+      ...dataWithoutIncompleteApps,
+      incomplete: {locked: 0, total: 0}
     }
   };
 
@@ -96,40 +82,13 @@ describe('Summary', () => {
   it('removeIncompleteApplications strips incomplete applications from data', () => {
     expect(removeIncompleteApplications(data)).to.deep.equal({
       csd_teachers: {
-        unreviewed: {locked: 0, total: 2},
-        reopened: {locked: 0, total: 0},
-        pending: {locked: 0, total: 0},
-        waitlisted: {locked: 0, total: 0},
-        declined: {locked: 0, total: 0},
-        accepted_not_notified: {locked: 0, total: 0},
-        accepted_notified_by_partner: {locked: 0, total: 0},
-        accepted_no_cost_registration: {locked: 0, total: 0},
-        registration_sent: {locked: 0, total: 0},
-        paid: {locked: 0, total: 0}
+        ...dataWithoutIncompleteApps
       },
       csp_teachers: {
-        unreviewed: {locked: 0, total: 2},
-        reopened: {locked: 0, total: 0},
-        pending: {locked: 0, total: 0},
-        waitlisted: {locked: 0, total: 0},
-        declined: {locked: 0, total: 0},
-        accepted_not_notified: {locked: 0, total: 0},
-        accepted_notified_by_partner: {locked: 0, total: 0},
-        accepted_no_cost_registration: {locked: 0, total: 0},
-        registration_sent: {locked: 0, total: 0},
-        paid: {locked: 0, total: 0}
+        ...dataWithoutIncompleteApps
       },
       csa_teachers: {
-        unreviewed: {locked: 0, total: 2},
-        reopened: {locked: 0, total: 0},
-        pending: {locked: 0, total: 0},
-        waitlisted: {locked: 0, total: 0},
-        declined: {locked: 0, total: 0},
-        accepted_not_notified: {locked: 0, total: 0},
-        accepted_notified_by_partner: {locked: 0, total: 0},
-        accepted_no_cost_registration: {locked: 0, total: 0},
-        registration_sent: {locked: 0, total: 0},
-        paid: {locked: 0, total: 0}
+        ...dataWithoutIncompleteApps
       }
     });
   });

--- a/dashboard/app/controllers/api/v1/pd/applications_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/applications_controller.rb
@@ -211,9 +211,7 @@ module Api::V1::Pd
 
     def get_applications_by_role(role, include_associations: true)
       # hide incomplete applications for people who are not workshop admins
-      applications_of_type = current_user.workshop_admin? ?
-        @applications.where(type: TYPES_BY_ROLE[role].try(&:name)) :
-        @applications.where.not(status: 'incomplete').where(type: TYPES_BY_ROLE[role].try(&:name))
+      applications_of_type = @applications.where(type: TYPES_BY_ROLE[role].try(&:name))
       applications_of_type = applications_of_type.where.not(status: 'incomplete') unless current_user.workshop_admin?
       applications_of_type = applications_of_type.includes(:user, :regional_partner) if include_associations
 

--- a/dashboard/app/controllers/api/v1/pd/applications_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/applications_controller.rb
@@ -197,15 +197,12 @@ module Api::V1::Pd
       user = User.find_by_email email
 
       # only workshop admins can see incomplete applications
-      filtered_applications = current_user.workshop_admin? ? @applications.where(
-        application_year: APPLICATION_CURRENT_YEAR,
-        application_type: [TEACHER_APPLICATION, FACILITATOR_APPLICATION],
-        user: user
-      ) : @applications.where.not(status: 'incomplete').where(
+      filtered_applications = @applications.where(
         application_year: APPLICATION_CURRENT_YEAR,
         application_type: [TEACHER_APPLICATION, FACILITATOR_APPLICATION],
         user: user
       )
+      filtered_applications = filtered_applications.where.not(status: 'incomplete') unless current_user.workshop_admin?
 
       render json: filtered_applications, each_serializer: ApplicationSearchSerializer
     end
@@ -217,6 +214,7 @@ module Api::V1::Pd
       applications_of_type = current_user.workshop_admin? ?
         @applications.where(type: TYPES_BY_ROLE[role].try(&:name)) :
         @applications.where.not(status: 'incomplete').where(type: TYPES_BY_ROLE[role].try(&:name))
+      applications_of_type = applications_of_type.where.not(status: 'incomplete') unless current_user.workshop_admin?
       applications_of_type = applications_of_type.includes(:user, :regional_partner) if include_associations
 
       case role

--- a/dashboard/app/controllers/api/v1/pd/applications_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/applications_controller.rb
@@ -206,7 +206,10 @@ module Api::V1::Pd
     private
 
     def get_applications_by_role(role, include_associations: true)
-      applications_of_type = @applications.where(type: TYPES_BY_ROLE[role].try(&:name))
+      # hide incomplete applications for people who are not workshop admins
+      applications_of_type = current_user.workshop_admin? ?
+        @applications.where(type: TYPES_BY_ROLE[role].try(&:name)) :
+        @applications.where.not(status: 'incomplete').where(type: TYPES_BY_ROLE[role].try(&:name))
       applications_of_type = applications_of_type.includes(:user, :regional_partner) if include_associations
 
       case role

--- a/dashboard/app/controllers/api/v1/pd/applications_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/applications_controller.rb
@@ -1,6 +1,7 @@
 module Api::V1::Pd
   class ApplicationsController < ::ApplicationController
     load_and_authorize_resource class: 'Pd::Application::ApplicationBase'
+    authorize_resource Pd::Application::TeacherApplication if @application.is_a? Pd::Application::TeacherApplication
 
     include Pd::Application::ActiveApplicationModels
 
@@ -44,8 +45,6 @@ module Api::V1::Pd
 
     # GET /api/v1/pd/applications/1
     def show
-      return head :forbidden if @application.status == 'incomplete' && !current_user.workshop_admin?
-
       serialized_application = ApplicationSerializer.new(
         @application,
         scope: {raw_form_data: params[:raw_form_data]}
@@ -116,7 +115,6 @@ module Api::V1::Pd
 
     # PATCH /api/v1/pd/applications/1
     def update
-      return head :forbidden if @application.status == 'incomplete' && !current_user.workshop_admin?
       application_data = application_params.to_h
 
       if application_data[:status] != @application.status
@@ -190,7 +188,6 @@ module Api::V1::Pd
 
     # DELETE /api/v1/pd/applications/1
     def destroy
-      return head :forbidden if @application.status == 'incomplete' && !current_user.workshop_admin?
       @application.destroy
     end
 

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -211,10 +211,8 @@ class Ability
           # regional partners by default have read, quick_view, and update permissions
           can [:read, :quick_view, :cohort_view, :update, :search, :destroy], Pd::Application::ApplicationBase, regional_partner_id: user.regional_partners.pluck(:id)
 
-          # regional partners cannot see incomplete teacher applications
-          cannot [:read, :quick_view, :cohort_view, :update, :search, :destroy], Pd::Application::TeacherApplication do |application|
-            (user.regional_partners.pluck(:id).include? application.regional_partner_id) && application.incomplete?
-          end
+          # regional partners cannot see or update incomplete teacher applications
+          cannot [:show, :update, :destroy], Pd::Application::TeacherApplication, &:incomplete?
 
           # G3 regional partners should have full management permission
           group_3_partner_ids = user.regional_partners.where(group: 3).pluck(:id)

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -208,9 +208,11 @@ class Ability
         can :read, :pd_workshop_summary_report
         can :read, :pd_teacher_attendance_report
         if user.regional_partners.any?
-          # regional partners by default have read, quick_view, and update
-          # permissions
-          can [:read, :quick_view, :cohort_view, :update, :search, :destroy], Pd::Application::ApplicationBase, regional_partner_id: user.regional_partners.pluck(:id)
+          # regional partners by default have read, quick_view, and update permissions
+          # they cannot access any incomplete applications
+          can [:read, :quick_view, :cohort_view, :update, :search, :destroy], Pd::Application::ApplicationBase do |application|
+            (user.regional_partners.pluck(:id).include? application.regional_partner_id) && !application.incomplete?
+          end
 
           # G3 regional partners should have full management permission
           group_3_partner_ids = user.regional_partners.where(group: 3).pluck(:id)

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -209,9 +209,11 @@ class Ability
         can :read, :pd_teacher_attendance_report
         if user.regional_partners.any?
           # regional partners by default have read, quick_view, and update permissions
-          # they cannot access any incomplete applications
-          can [:read, :quick_view, :cohort_view, :update, :search, :destroy], Pd::Application::ApplicationBase do |application|
-            (user.regional_partners.pluck(:id).include? application.regional_partner_id) && !application.incomplete?
+          can [:read, :quick_view, :cohort_view, :update, :search, :destroy], Pd::Application::ApplicationBase, regional_partner_id: user.regional_partners.pluck(:id)
+
+          # regional partners cannot see incomplete teacher applications
+          cannot [:read, :quick_view, :cohort_view, :update, :search, :destroy], Pd::Application::TeacherApplication do |application|
+            (user.regional_partners.pluck(:id).include? application.regional_partner_id) && application.incomplete?
           end
 
           # G3 regional partners should have full management permission

--- a/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
@@ -18,8 +18,8 @@ module Api::V1::Pd::Application
       @partner = @program_manager.regional_partners.first
       @application = create TEACHER_APPLICATION_FACTORY, regional_partner: @partner
       @incomplete_application = create :pd_teacher_application, form_data_hash: (
-        build :pd_teacher_application_hash, :incomplete
-      )
+        build :pd_teacher_application_hash
+      ), status: 'incomplete'
     end
 
     setup do

--- a/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
@@ -17,9 +17,6 @@ module Api::V1::Pd::Application
       @program_manager = create :program_manager
       @partner = @program_manager.regional_partners.first
       @application = create TEACHER_APPLICATION_FACTORY, regional_partner: @partner
-      @incomplete_application = create :pd_teacher_application, form_data_hash: (
-        build :pd_teacher_application_hash
-      ), status: 'incomplete'
     end
 
     setup do

--- a/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
@@ -51,24 +51,6 @@ module Api::V1::Pd::Application
       params: -> {{id: @application.id}},
       response: :success
 
-    test_user_gets_response_for :update,
-      name: 'program managers can update completed applications they own',
-      user:  -> {@program_manager},
-      params: -> {{id: @application.id}},
-      response: :success
-
-    test_user_gets_response_for :update,
-      name: 'program managers cannot update incomplete applications they own',
-      user:  -> {@program_manager},
-      params: -> {{id: @incomplete_application.id}},
-      response: :forbidden
-
-    test_user_gets_response_for :update,
-      name: 'a workshop admin can update applications they own',
-      user:  :workshop_admin,
-      params: -> {{id: @incomplete_application.id}},
-      response: :success
-
     test_user_gets_response_for :send_principal_approval,
       name: 'program managers can send_principal_approval for applications they own',
       user: -> {@program_manager},

--- a/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
@@ -40,6 +40,7 @@ module Api::V1::Pd
 
       @csd_teacher_application = create TEACHER_APPLICATION_FACTORY, course: 'csd'
       @csd_teacher_application_with_partner = create TEACHER_APPLICATION_FACTORY, course: 'csd', regional_partner: @regional_partner
+      @csd_incomplete_application_with_partner = create TEACHER_APPLICATION_FACTORY, course: 'csd', regional_partner: @regional_partner, status: 'incomplete'
       @csp_teacher_application = create TEACHER_APPLICATION_FACTORY, course: 'csp'
       @csp_facilitator_application = create FACILITATOR_APPLICATION_FACTORY, course: 'csp', regional_partner: @regional_partner
 
@@ -110,6 +111,14 @@ module Api::V1::Pd
       sign_in @workshop_admin
       get :quick_view, params: {role: 'csd_teachers', regional_partner_value: @regional_partner.id}
       assert_response :success
+      assert_equal [@csd_teacher_application_with_partner.id, @csd_incomplete_application_with_partner.id],
+        JSON.parse(@response.body).map {|r| r['id']}
+    end
+
+    test 'quick view if not admin returns applications without incomplete apps and with filter' do
+      sign_in @program_manager
+      get :quick_view, params: {role: 'csd_teachers', regional_partner_value: @regional_partner.id}
+      assert_response :success
       assert_equal [@csd_teacher_application_with_partner.id], JSON.parse(@response.body).map {|r| r['id']}
     end
 
@@ -117,7 +126,12 @@ module Api::V1::Pd
       sign_in @workshop_admin
       get :quick_view, params: {role: 'csd_teachers'}
       assert_response :success
-      assert_equal [@csd_teacher_application.id, @csd_teacher_application_with_partner.id], JSON.parse(@response.body).map {|r| r['id']}
+      assert_equal [
+        @csd_teacher_application.id,
+        @csd_teacher_application_with_partner.id,
+        @csd_incomplete_application_with_partner.id
+      ],
+        JSON.parse(@response.body).map {|r| r['id']}
     end
 
     test "quick view returns applications with regional partner filter set to no partner" do

--- a/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/applications_controller_test.rb
@@ -96,6 +96,40 @@ module Api::V1::Pd
       test_user_gets_response_for :update, params: -> {@test_update_params}, user: user, response: response
     end
 
+    # Auth for incomplete applications
+    {
+      program_manager: :forbidden,
+      workshop_admin: :success
+    }.each do |user, response|
+      test_user_gets_response_for :show,
+        name: "#{user} gets #{response} when showing incomplete applications",
+        user: user,
+        params: -> {{id: @csd_incomplete_application_with_partner.id}},
+        response: response
+    end
+
+    {
+      program_manager: :forbidden,
+      workshop_admin: :success
+    }.each do |user, response|
+      test_user_gets_response_for :destroy,
+        name: "#{user} gets #{response} when deleting incomplete applications",
+        user: user,
+        params: -> {{id: @csd_incomplete_application_with_partner.id}},
+        response: response
+    end
+
+    {
+      program_manager: :forbidden,
+      workshop_admin: :success
+    }.each do |user, response|
+      test_user_gets_response_for :update,
+        name: "#{user} gets #{response} when updating incomplete applications",
+        user: user,
+        params: -> {{application: {notes: 'Notes!'}, id: @csd_incomplete_application_with_partner.id}},
+        response: response
+    end
+
     test "quick view returns appropriate application type" do
       create FACILITATOR_APPLICATION_FACTORY, course: 'csf'
       create FACILITATOR_APPLICATION_FACTORY, course: 'csp'
@@ -1241,6 +1275,14 @@ module Api::V1::Pd
     test 'search does not reveal applications outside the regional partners cohort' do
       sign_in @program_manager
       get :search, params: {email: @csd_teacher_application.user.email}
+      assert_response :success
+      result = JSON.parse response.body
+      assert_equal [], result
+    end
+
+    test 'search does not reveal applications incomplete applications if not workshop admin' do
+      sign_in @program_manager
+      get :search, params: {email: @csd_incomplete_application_with_partner.user.email}
       assert_response :success
       result = JSON.parse response.body
       assert_equal [], result

--- a/dashboard/test/models/ability_test.rb
+++ b/dashboard/test/models/ability_test.rb
@@ -745,7 +745,7 @@ class AbilityTest < ActiveSupport::TestCase
     assert Ability.new(workshop_admin).can? :update_scholarship_info, pd_enrollment
   end
 
-  test 'workshop admins can see or update incomplete applications' do
+  test 'workshop admins can see and update incomplete applications' do
     workshop_admin = create :workshop_admin
     incomplete_application = create :pd_teacher_application, status: 'incomplete'
 

--- a/dashboard/test/models/ability_test.rb
+++ b/dashboard/test/models/ability_test.rb
@@ -738,10 +738,28 @@ class AbilityTest < ActiveSupport::TestCase
     refute Ability.new(student_1).can? :view_as_user_for_code_review, @login_required_script_level, student_2
   end
 
-  test 'workshop admin can update scholarship info' do
+  test 'workshop admins can update scholarship info' do
     workshop_admin = create :workshop_admin
     pd_enrollment = create :pd_enrollment
 
     assert Ability.new(workshop_admin).can? :update_scholarship_info, pd_enrollment
+  end
+
+  test 'workshop admins can see or update incomplete applications' do
+    workshop_admin = create :workshop_admin
+    incomplete_application = create :pd_teacher_application, status: 'incomplete'
+
+    assert Ability.new(workshop_admin).can? :show, incomplete_application
+    assert Ability.new(workshop_admin).can? :update, incomplete_application
+    assert Ability.new(workshop_admin).can? :destroy, incomplete_application
+  end
+
+  test 'regional partners cannot see or update incomplete applications' do
+    program_manager = create :program_manager
+    incomplete_application = create :pd_teacher_application, status: 'incomplete'
+
+    refute Ability.new(program_manager).can? :show, incomplete_application
+    refute Ability.new(program_manager).can? :update, incomplete_application
+    refute Ability.new(program_manager).can? :destroy, incomplete_application
   end
 end

--- a/dashboard/test/models/ability_test.rb
+++ b/dashboard/test/models/ability_test.rb
@@ -745,7 +745,7 @@ class AbilityTest < ActiveSupport::TestCase
     assert Ability.new(workshop_admin).can? :update_scholarship_info, pd_enrollment
   end
 
-  test 'workshop admins can see and update incomplete applications' do
+  test 'workshop admins can see, update, and delete incomplete applications' do
     workshop_admin = create :workshop_admin
     incomplete_application = create :pd_teacher_application, status: 'incomplete'
 
@@ -754,7 +754,7 @@ class AbilityTest < ActiveSupport::TestCase
     assert Ability.new(workshop_admin).can? :destroy, incomplete_application
   end
 
-  test 'regional partners cannot see or update incomplete applications' do
+  test 'regional partners cannot see, update, or delete incomplete applications' do
     program_manager = create :program_manager
     incomplete_application = create :pd_teacher_application, status: 'incomplete'
 


### PR DESCRIPTION
This should be the last big PR for saving/reopening apps!

When teachers save their teacher application, it goes to an "incomplete" status. Only workshop admins can see this in-progress state––others shouldn't be able to see the info in these applications.

Most of this logic is in the controller––either returning "forbidden" for things like search, destroy, update, show if the application is incomplete, or filtering out incomplete applications from cohort_view, summary view, and search. The side-by-side of all of these views and actions (left is workshop admin, right is not admin) can be found here: https://watch.screencastify.com/v/KNavGXLR1nvxIikp1jVY.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
