### PR TITLE
avoid pulling in code studio redux when initializing responsive redux

### DIFF
--- a/apps/src/code-studio/responsive.js
+++ b/apps/src/code-studio/responsive.js
@@ -1,5 +1,5 @@
 import debounce from 'lodash/debounce';
-import {getStore} from './redux';
+import {getStore} from '../redux';
 import {getResponsiveBreakpoint, setResponsiveSize} from './responsiveRedux';
 
 /**


### PR DESCRIPTION
as part of splitting pegasus from dashboard, we are looking at how to split up the apps directory. while doing that, I noticed that several pegasus entry points were pulling in a lot of unneeded code from code-studio. the problem turned out to be that the responsive redux was using getStore from apps/src/code-studio/redux instead of just apps/src/redux. 

This change will make it easier for us to split up the apps code. The bundle analysis below shows the difference.

### before

 https://github.com/code-dot-org/code-dot-org/files/8111259/pegasus-entry-points.html.zip

![Screen Shot 2022-02-21 at 11 37 43 AM](https://user-images.githubusercontent.com/8001765/155017069-08c2c6a0-5e40-430f-9a6d-788545921b07.png)

### after

 https://github.com/code-dot-org/code-dot-org/files/8111683/streamlined-pegasus-bundles-report.html.zip

![Screen Shot 2022-02-21 at 11 37 59 AM](https://user-images.githubusercontent.com/8001765/155017057-bb7e404d-47b7-48a4-91fd-c56b78b6c238.png)

## Testing story

I am relying on existing test coverage to make sure nothing broke. I also manually verified that the yourschool/thankyou page still works and that its redux still gets updated with the correct responsive size as I change the size of the page.