### PR TITLE
Add project_url to ProgrammingEnvironment

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -2008,6 +2008,7 @@
   "tryHOC": "Try the Hour of Code",
   "tryHourOfCode": "Try an Hour of Code!",
   "tryIt": "Try it",
+  "tryItOut": "Try it out",
   "tryNow": "Try Now",
   "tutorialUnavailable": "Tutorial unavailable for younger students",
   "tutorialUnavailableExplanation": "Sorry, this tutorial is not available for younger students unless they signed in as part of a classroom with a teacher. We have many more tutorials for all ages.",

--- a/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingEnvironmentEditor.jsx
+++ b/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingEnvironmentEditor.jsx
@@ -136,7 +136,16 @@ export default function ProgrammingEnvironmentEditor({
           ))}
         </select>
       </label>
-
+      <label>
+        Project URL
+        <input
+          value={programmingEnvironment.projectUrl || ''}
+          onChange={e =>
+            updateProgrammingEnvironment('projectUrl', e.target.value)
+          }
+          style={styles.textInput}
+        />
+      </label>
       <label>
         Image
         <Button

--- a/apps/src/templates/codeDocs/ProgrammingEnvironmentOverview.jsx
+++ b/apps/src/templates/codeDocs/ProgrammingEnvironmentOverview.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import EnhancedSafeMarkdown from '@cdo/apps/templates/EnhancedSafeMarkdown';
 import CodeDocLink from '@cdo/apps/templates/codeDocs/CodeDocLink';
+import i18n from '@cdo/locale';
 
 export function CategorySection({category}) {
   return (
@@ -34,6 +35,11 @@ export default function ProgrammingEnvironmentOverview({
       {programmingEnvironment.title && <h1>{programmingEnvironment.title}</h1>}
       {programmingEnvironment.description && (
         <EnhancedSafeMarkdown markdown={programmingEnvironment.description} />
+      )}
+      {programmingEnvironment.projectUrl && (
+        <div>
+          <a href={programmingEnvironment.projectUrl}>{i18n.tryItOut()}</a>
+        </div>
       )}
       {programmingEnvironment.categories.map(category => (
         <CategorySection key={category.key} category={category} />

--- a/apps/test/unit/lib/levelbuilder/code-docs-editor/ProgrammingEnvironmentEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/code-docs-editor/ProgrammingEnvironmentEditorTest.jsx
@@ -15,6 +15,7 @@ describe('ProgrammingEnvironmentEditor', () => {
         name: 'spritelab',
         title: 'Spritelab',
         imageUrl: 'images.code.org/spritelab',
+        projectUrl: '/p/spritelab',
         description: 'A description of spritelab',
         editorType: 'blockly',
         categories: [{id: 1, key: 'sprites', name: 'Sprites', color: '#00FF00'}]
@@ -36,6 +37,9 @@ describe('ProgrammingEnvironmentEditor', () => {
     const nameInput = wrapper.find('input').at(1);
     expect(nameInput.props().value).to.equal('spritelab');
     expect(nameInput.props().readOnly).to.be.true;
+
+    const projectUrlInput = wrapper.find('input').at(2);
+    expect(projectUrlInput.props().value).to.equal('/p/spritelab');
 
     const descriptionMarkdownInput = wrapper
       .find('TextareaWithMarkdownPreview')
@@ -82,11 +86,19 @@ describe('ProgrammingEnvironmentEditor', () => {
     expect(fetchCall.args[0]).to.equal('/programming_environments/spritelab');
     const fetchCallBody = JSON.parse(fetchCall.args[1].body);
     expect(Object.keys(fetchCallBody).sort()).to.eql(
-      ['title', 'description', 'editorType', 'imageUrl', 'categories'].sort()
+      [
+        'title',
+        'description',
+        'editorType',
+        'projectUrl',
+        'imageUrl',
+        'categories'
+      ].sort()
     );
     expect(fetchCallBody.title).to.equal('Spritelab');
     expect(fetchCallBody.description).to.equal('A description of spritelab');
     expect(fetchCallBody.editorType).to.equal('blockly');
+    expect(fetchCallBody.projectUrl).to.equal('/p/spritelab');
     expect(fetchCallBody.imageUrl).to.equal('images.code.org/spritelab');
   });
 });

--- a/apps/test/unit/templates/codeDocs/ProgrammingEnvironmentOverviewTest.jsx
+++ b/apps/test/unit/templates/codeDocs/ProgrammingEnvironmentOverviewTest.jsx
@@ -12,6 +12,7 @@ describe('ProgrammingEnvironmentOverview', () => {
     defaultProgrammingEnvironment = {
       title: 'Sprite Lab',
       description: 'spritelab description',
+      projectUrl: '/p/spritelab',
       categories: [
         {
           key: 'world',
@@ -61,11 +62,13 @@ describe('ProgrammingEnvironmentOverview', () => {
         .first()
         .props().markdown
     ).to.equal('spritelab description');
+    expect(wrapper.find('a').props().href).to.equal('/p/spritelab');
   });
 
   it('doesnt render title and description if not provided', () => {
     delete defaultProgrammingEnvironment.title;
     delete defaultProgrammingEnvironment.description;
+    delete defaultProgrammingEnvironment.projectUrl;
     const wrapper = shallow(
       <ProgrammingEnvironmentOverview
         programmingEnvironment={defaultProgrammingEnvironment}
@@ -73,6 +76,7 @@ describe('ProgrammingEnvironmentOverview', () => {
     );
     expect(wrapper.find('h1').length).to.equal(0);
     expect(wrapper.find('EnhancedSafeMarkdown').length).to.equal(0);
+    expect(wrapper.find('a').length).to.equal(0);
   });
 });
 

--- a/dashboard/app/controllers/programming_environments_controller.rb
+++ b/dashboard/app/controllers/programming_environments_controller.rb
@@ -68,6 +68,7 @@ class ProgrammingEnvironmentsController < ApplicationController
       :description,
       :editor_type,
       :image_url,
+      :project_url,
       categories: [:id, :name, :color]
     )
     transformed_params

--- a/dashboard/app/models/programming_environment.rb
+++ b/dashboard/app/models/programming_environment.rb
@@ -32,6 +32,7 @@ class ProgrammingEnvironment < ApplicationRecord
     title
     description
     image_url
+    project_url
   )
 
   def self.properties_from_file(content)
@@ -80,6 +81,7 @@ class ProgrammingEnvironment < ApplicationRecord
       name: name,
       title: title,
       imageUrl: image_url,
+      projectUrl: project_url,
       description: description,
       editorType: editor_type,
       categories: categories.map(&:serialize_for_edit)
@@ -90,6 +92,7 @@ class ProgrammingEnvironment < ApplicationRecord
     {
       title: title,
       description: description,
+      projectUrl: project_url,
       categories: categories.select {|c| c.programming_expressions.count > 0}.map(&:summarize_for_environment_show)
     }
   end

--- a/dashboard/test/controllers/programming_environments_controller_test.rb
+++ b/dashboard/test/controllers/programming_environments_controller_test.rb
@@ -39,7 +39,8 @@ class ProgrammingEnvironmentsControllerTest < ActionController::TestCase
       name: programming_environment.name,
       title: 'title',
       description: 'description',
-      editorType: 'blockly'
+      editorType: 'blockly',
+      projectUrl: '/p/project'
     }
     assert_response :ok
 
@@ -47,6 +48,7 @@ class ProgrammingEnvironmentsControllerTest < ActionController::TestCase
     assert_equal 'title', programming_environment.title
     assert_equal 'description', programming_environment.description
     assert_equal 'blockly', programming_environment.editor_type
+    assert_equal '/p/project', programming_environment.project_url
   end
 
   test 'can update programming expression categories from params' do


### PR DESCRIPTION
Small thing that got missed in the original spec but is in the [figma spec](https://www.figma.com/proto/vxVFVZMV51xFzsyD8QOcPq/CB--%3E-LB-move?node-id=1164%3A0&viewport=-354%2C287%2C0.5&scaling=min-zoom). Curriculumbuilder has a "url" field for IDEs that is behind the "Try it out" link on the IDE page. Here it'll be `project_url` but otherwise it will work the same.

In the editor:
<img width="1002" alt="Screen Shot 2022-02-21 at 1 31 28 PM" src="https://user-images.githubusercontent.com/46464143/155028684-f67f3e1c-6d5b-4c04-bc93-a01e8af0fdb0.png">

On the programming environment overview page:
<img width="1046" alt="Screen Shot 2022-02-21 at 1 31 39 PM" src="https://user-images.githubusercontent.com/46464143/155028699-46e75eab-0449-426f-b233-49604a41d568.png">

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
