### PR TITLE
Increasing line spacing in Superhero Banner

### DIFF
--- a/pegasus/sites.v3/code.org/views/professional_learning_marketing_banner.haml
+++ b/pegasus/sites.v3/code.org/views/professional_learning_marketing_banner.haml
@@ -9,10 +9,10 @@
       .professional-learning-banner-desktop.col-80.desktop-feature
         .banner
           %img{src: "/images/homepage/superhero-banner.png"}
-        .left.col-80
+        .left
           .header= header_text
           .text= text
-        .right.col-20
+        .right-button
           %button
             #{button_label}
       .professional-learning-banner-tablet.col-80.tablet-restrictive-feature

--- a/shared/css/professional_learning_marketing_banner.scss
+++ b/shared/css/professional_learning_marketing_banner.scss
@@ -90,12 +90,11 @@ $dark_blue_background_colour: #0d4172;
       }
     }
 
-    .right {
+    .right-button {
       padding-top: 30px;
       text-align: center;
       position: absolute;
-      width: 50%;
-      margin-left: 65%;
+      right: 100px;
 
       button {
         margin-top: 0px;

--- a/shared/css/professional_learning_marketing_banner.scss
+++ b/shared/css/professional_learning_marketing_banner.scss
@@ -83,7 +83,7 @@ $dark_blue_background_colour: #0d4172;
 
       .text {
         color: black;
-        line-height: 1;
+        line-height: 1.3;
         position: relative;
         left: 30px;
         width: calc(100% - 150px);


### PR DESCRIPTION
Increasing line spacing on superhero banner from 1.0 to 1.3. Also fixing right scrolling issue.

Before:
<img width="1011" alt="Screen Shot 2022-02-21 at 2 00 02 PM" src="https://user-images.githubusercontent.com/37230822/155031281-577df8c4-4d1a-4230-92b6-c7bfc20c6b8d.png">


After:
<img width="1138" alt="Screen Shot 2022-02-21 at 2 00 32 PM" src="https://user-images.githubusercontent.com/37230822/155031286-1804f083-5179-43eb-bb39-a0bb722cc129.png">


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
