### PR TITLE
Improve error logging during apps build for I18n content

### DIFF
--- a/apps/tasks/messages.js
+++ b/apps/tasks/messages.js
@@ -6,6 +6,10 @@ module.exports = function(grunt) {
     var locales = new Set();
     var namespaces = new Set();
 
+    // Tracks all the errors found when processing the I18n content.
+    const errors = [];
+    // Loop through all the I18n content used by "apps" and process it so it is usable to our
+    // javascript code.
     this.files.forEach(function(filePair) {
       filePair.src.forEach(function(src) {
         var locale = path.basename(src, '.json');
@@ -21,6 +25,21 @@ module.exports = function(grunt) {
           }
         });
         var finalData = Object.assign(englishData, localeData);
+
+        // Verify the translated content is formatted correctly.
+        const formatErrors = checkForFormatIssues(
+          locale,
+          namespace,
+          finalData,
+          src
+        );
+        if (formatErrors.length !== 0) {
+          // Format error found, track the error and move on to the next file.
+          const errorMsg = formatErrors.join('\n');
+          errors.push(new Error(errorMsg));
+          return;
+        }
+
         try {
           var formatted = process(locale, namespace, finalData);
           grunt.file.write(filePair.dest, formatted);
@@ -33,16 +52,25 @@ module.exports = function(grunt) {
             let msg = `Error processing Crowdin in-context localization file. Using the in-context translation tool will not work for strings in ${src}: ${e}`;
             grunt.log.debug(msg);
           } else {
-            let errorMsg = `Error processing localization file ${src}: ${e}`;
+            let errorMsg = `Failed to process localization file ${src}: ${e}`;
             if (grunt.option('force')) {
               grunt.log.warn(errorMsg);
             } else {
-              throw new Error(errorMsg);
+              errors.push(new Error(errorMsg));
             }
           }
         }
       });
     });
+    // If an error was found when processing the I18n content, report it and raise an error.
+    if (errors.length !== 0) {
+      const errorMsg = 'All I18n content issues:';
+      const allErrors = errors.reduce(
+        (all, error) => `${all}\n${error.message}`,
+        errorMsg
+      );
+      throw new Error(allErrors);
+    }
 
     /**
      * We want to make sure that we aren't missing any locale files in any
@@ -67,6 +95,37 @@ module.exports = function(grunt) {
     });
   });
 
+  /**
+   * Parses the given JSON for any MessageFormat issues and returns a list of exceptions found.
+   * @param locale The language/region locale code for the given JSON.
+   * @param namespace Some unique ID for the content, usually the file name e.g. 'fish' or 'maze'
+   * @param json {object} A JSON object which has string values inside it.
+   * @returns {array} A list of exceptions found when trying to parse the given JSON.
+   */
+  function checkForFormatIssues(locale, namespace, json, src) {
+    const errors = [];
+    // Process each individual key so we can quickly identify why string is having an issue.
+    Object.keys(json).forEach(function(key) {
+      try {
+        process(locale, namespace, json[key]);
+      } catch (e) {
+        if (locale !== 'in_tl') {
+          // in_tl is a pseudolanguage locale we don't fully support yet so we will ignore it.
+          let errorMsg = `key '${key}' in localization file ${src} has a format issue: ${e}`;
+          errors.push(new Error(errorMsg));
+        }
+      }
+    });
+    return errors;
+  }
+
+  /**
+   * Applies MessageFormat to all the strings found in the given JSON.
+   * @param locale The language/region locale code for the given JSON.
+   * @param namespace Some unique ID for the content, usually the file name e.g. 'fish' or 'maze'
+   * @param json A JSON object which has string values inside it.
+   * @returns {object} The given JSON object but formatted with MessageFormat.
+   */
   function process(locale, namespace, json) {
     var mf;
     try {

--- a/apps/tasks/messages.js
+++ b/apps/tasks/messages.js
@@ -104,7 +104,7 @@ module.exports = function(grunt) {
    */
   function checkForFormatIssues(locale, namespace, json, src) {
     const errors = [];
-    // Process each individual key so we can quickly identify why string is having an issue.
+    // Process each individual key so we can quickly identify which string is having an issue.
     Object.keys(json).forEach(function(key) {
       try {
         process(locale, namespace, json[key]);


### PR DESCRIPTION
When we run `yarn build` or `yarn start`, it will look for i18n JSON files owned by the `apps` project and parse the content using the MessageFormat library. If the content fails to be parsed, the build is failed and an error is logged. There are two improvements we make to this process in this PR:
* Checks for MessageFormat syntax errors one string at a time so we can produce an error for the exact string which is failing. Currently it will just log something like "Failed to parse string in ar_sa/maze.json" which isn't helpful enough because there are thousands of strings in that file.
* Check all i18n content before producing an error summary. Currently the build process reports only the first error it runs into. Usually when we run into these issues is after we have downloaded thousands of new translations from Crowdin. Usually there are many strings which need to be addressed and it is slow/tedious to rerun the build after each string fix.

## Links
* [JIRA](https://codedotorg.atlassian.net/browse/FND-1922)

## Testing story
* Manually tested
I manually created some errors in our JSON files and this was the output of `yarn build`
```
Running "messages:all" (messages) task
Warning: All I18n content issues:
Error: key 'danceFeedbackNeedNewDancer' in localization file i18n/dance/ca_es.json has a format issue: SyntaxError: Expected "," or "}" but "d" found.
Error: key 'fishshort-predicting-init1' in localization file i18n/fish/ar_sa.json has a format issue: SyntaxError: Expected "#", "{", doubled apostrophe, end of input, escaped string, or plain char but "}" found.
Error: key 'cancel' in localization file i18n/fish/bn_bd.json has a format issue: SyntaxError: Expected "," or "}" but "ক" found.
Error: key 'continue' in localization file i18n/fish/fi_fi.json has a format issue: SyntaxError: Expected "," or "}" but "J" found. Use --force to continue.
```
