### PR TITLE
Add entry point to a reopened application to the homepage

### DIFF
--- a/apps/src/sites/studio/pages/home/_homepage.js
+++ b/apps/src/sites/studio/pages/home/_homepage.js
@@ -96,6 +96,10 @@ function showHomepage() {
               allowTeacherAppReopening &&
               homepageData.showFinishTeacherApplication
             }
+            showReturnToReopenedTeacherApplication={
+              allowTeacherAppReopening &&
+              homepageData.showReturnToReopenedTeacherApplication
+            }
             donorBannerName={homepageData.donorBannerName}
             teacherName={homepageData.teacherName}
             teacherId={homepageData.teacherId}

--- a/apps/src/templates/studioHomepages/BorderedCallToAction.jsx
+++ b/apps/src/templates/studioHomepages/BorderedCallToAction.jsx
@@ -12,6 +12,7 @@ const BorderedCallToAction = ({
   buttonText,
   buttonUrl,
   buttonClass,
+  buttonColor,
   onClick,
   solidBorder
 }) => {
@@ -30,7 +31,7 @@ const BorderedCallToAction = ({
       <Button
         onClick={onClick || (() => navigateToHref(buttonUrl))}
         className={buttonClass}
-        color={Button.ButtonColor.gray}
+        color={buttonColor}
         text={buttonText}
         style={styles.button}
       />

--- a/apps/src/templates/studioHomepages/TeacherHomepage.jsx
+++ b/apps/src/templates/studioHomepages/TeacherHomepage.jsx
@@ -191,7 +191,7 @@ export const UnconnectedTeacherHomepage = ({
         {showReturnToReopenedTeacherApplication && (
           <BorderedCallToAction
             headingText="Return to Your Application"
-            descriptionText="Your Regional Partner has requested updates to your Professional Learning Application. Return and finish your application."
+            descriptionText="Your Regional Partner has requested updates to your Professional Learning Application."
             buttonText="Return to Application"
             buttonColor={Button.ButtonColor.orange}
             buttonUrl="/pd/application/teacher?enableExperiments=teacher-application-saving-reopening"

--- a/apps/src/templates/studioHomepages/TeacherHomepage.jsx
+++ b/apps/src/templates/studioHomepages/TeacherHomepage.jsx
@@ -34,6 +34,7 @@ export const UnconnectedTeacherHomepage = ({
   schoolYear,
   showCensusBanner,
   showFinishTeacherApplication,
+  showReturnToReopenedTeacherApplication,
   showNpsSurvey,
   specialAnnouncement,
   teacherEmail,
@@ -187,6 +188,16 @@ export const UnconnectedTeacherHomepage = ({
             solidBorder={true}
           />
         )}
+        {showReturnToReopenedTeacherApplication && (
+          <BorderedCallToAction
+            headingText="Return to Your Application"
+            descriptionText="Your Regional Partner has requested updates to your Professional Learning Application. Return and finish your application."
+            buttonText="Return to Application"
+            buttonColor={Button.ButtonColor.orange}
+            buttonUrl="/pd/application/teacher?enableExperiments=teacher-application-saving-reopening"
+            solidBorder={true}
+          />
+        )}
         {displayCensusBanner && (
           <div>
             <CensusTeacherBanner
@@ -265,6 +276,7 @@ UnconnectedTeacherHomepage.propTypes = {
   showCensusBanner: PropTypes.bool.isRequired,
   showNpsSurvey: PropTypes.bool,
   showFinishTeacherApplication: PropTypes.bool,
+  showReturnToReopenedTeacherApplication: PropTypes.bool,
   specialAnnouncement: shapes.specialAnnouncement,
   teacherEmail: PropTypes.string,
   teacherId: PropTypes.number,

--- a/apps/test/unit/templates/studioHomepages/BorderedCallToActionTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/BorderedCallToActionTest.jsx
@@ -4,6 +4,7 @@ import {isolateComponent} from 'isolate-react';
 import BorderedCallToAction from '@cdo/apps/templates/studioHomepages/BorderedCallToAction';
 import sinon from 'sinon';
 import * as utils from '@cdo/apps/utils';
+import Button from '@cdo/apps/templates/Button';
 
 describe('BorderedCallToAction', () => {
   const headingText = 'Do Something';
@@ -73,6 +74,18 @@ describe('BorderedCallToAction', () => {
         borderStyle: 'solid',
         borderWidth: 1
       });
+    });
+
+    it('can have a custom button color', () => {
+      const borderedCtA = isolateComponent(
+        <BorderedCallToAction
+          {...defaultProps}
+          buttonColor={Button.ButtonColor.orange}
+        />
+      );
+      const button = borderedCtA.findOne('Button');
+      expect(button.props.text).to.equal(buttonText);
+      expect(button.props.color).to.equal('orange');
     });
 
     it('can use a custom onClick, which ignores buttonUrl', () => {

--- a/apps/test/unit/templates/studioHomepages/TeacherHomepageTest.js
+++ b/apps/test/unit/templates/studioHomepages/TeacherHomepageTest.js
@@ -70,6 +70,14 @@ describe('TeacherHomepage', () => {
     );
   });
 
+  it('renders a Return to Application call to action if showReturnToReopenedTeacherApplication is true', () => {
+    const wrapper = setUp({showReturnToReopenedTeacherApplication: true});
+    assert.equal(
+      wrapper.find('BorderedCallToAction').props().buttonText,
+      'Return to Application'
+    );
+  });
+
   it('renders a MarketingAnnouncementBanner if isEnglish and specialAnnouncement exists', () => {
     const specialAnnouncement = {
       title: 'An announcement',

--- a/dashboard/app/controllers/home_controller.rb
+++ b/dashboard/app/controllers/home_controller.rb
@@ -186,6 +186,7 @@ class HomeController < ApplicationController
       @homepage_data[:showCensusBanner] = show_census_banner
       @homepage_data[:showNpsSurvey] = show_nps_survey?
       @homepage_data[:showFinishTeacherApplication] = has_incomplete_application?
+      @homepage_data[:showReturnToReopenedTeacherApplication] = has_reopened_application?
       @homepage_data[:donorBannerName] = donor_banner_name
       @homepage_data[:specialAnnouncement] = Announcements.get_announcement_for_page("/home")
       @homepage_data[:textToSpeechUnitIds] = Script.text_to_speech_unit_ids

--- a/dashboard/app/helpers/teacher_application_helper.rb
+++ b/dashboard/app/helpers/teacher_application_helper.rb
@@ -10,10 +10,10 @@ module TeacherApplicationHelper
   end
 
   def has_incomplete_application?
-    current_application && current_application.status == 'incomplete'
+    !!current_application && current_application.status == 'incomplete'
   end
 
   def has_reopened_application?
-    current_application && current_application.status == 'reopened'
+    !!current_application && current_application.status == 'reopened'
   end
 end

--- a/dashboard/test/helpers/teacher_application_helper_test.rb
+++ b/dashboard/test/helpers/teacher_application_helper_test.rb
@@ -9,27 +9,33 @@ class TeacherApplicationHelperTest < ActionView::TestCase
   end
 
   setup_all do
-    # Right now, the status of a newly created application is set to 'unreviewed' in application_base.
-    # This will need to change when we allow partial teacher applications to be saved.
-    # [MEG] TODO: Can refactor these to avoid an update! call once we change how we set status
-    @applicant_with_incomplete_app = create :teacher
-    @incomplete_application = create TEACHER_APPLICATION_FACTORY, user: @applicant_with_incomplete_app
-    @incomplete_application.update!(status: 'incomplete')
+    @user_with_two_incomplete_apps = create :teacher
+    @incomplete_application = create TEACHER_APPLICATION_FACTORY, user: @user_with_two_incomplete_apps, status: 'incomplete'
+    create TEACHER_APPLICATION_FACTORY, user: @user_with_two_incomplete_apps, status: 'incomplete', application_year: '2018-2019'
 
-    @applicant_with_unreviewed_app = create :teacher
-    @unreviewed_application = create TEACHER_APPLICATION_FACTORY, user: @applicant_with_unreviewed_app
+    @user_with_reopened_app = create :teacher
+    @reopened_application = create TEACHER_APPLICATION_FACTORY, user: @user_with_reopened_app, status: 'reopened'
 
-    @teacher_with_not_current_app = create :teacher
-    create TEACHER_APPLICATION_FACTORY, user: @teacher_with_not_current_app, application_year: '2018-2019'
+    @user_with_outdated_incomplete = create :teacher
+    @not_current_incomplete_app = create TEACHER_APPLICATION_FACTORY,
+      user: @user_with_outdated_incomplete,
+      status: 'incomplete',
+      application_year: '2018-2019'
+
+    @user_with_outdated_reopened = create :teacher
+    @not_current_reopened_app = create TEACHER_APPLICATION_FACTORY,
+      user: @user_with_outdated_reopened,
+      status: 'reopened',
+      application_year: '2018-2019'
   end
 
   test 'current application returns user\'s application from this year' do
-    sign_in @applicant_with_unreviewed_app
-    assert_equal @unreviewed_application.id, current_application.id
+    sign_in @user_with_two_incomplete_apps
+    assert_equal @incomplete_application.id, current_application.id
   end
 
   test 'current application returns nil if user has no application from this year' do
-    sign_in @teacher_with_not_current_app
+    sign_in @teacher_with_not_current_incomplete_app
     assert_nil current_application
   end
 
@@ -38,22 +44,46 @@ class TeacherApplicationHelperTest < ActionView::TestCase
       {
         expected_output: true,
         condition_message: 'application exists and is incomplete',
-        user: @applicant_with_incomplete_app
+        user: @user_with_two_incomplete_apps
       },
       {
         expected_output: false,
-        condition_message: 'application exists and is unreviewed',
-        user: @applicant_with_unreviewed_app
+        condition_message: 'application exists and is reopened',
+        user: @user_with_reopened_app
       },
       {
         expected_output: false,
         condition_message: 'application is in a different year',
-        user: @teacher_with_not_current_app
+        user: @user_with_outdated_incomplete
       }
     ].each do |expected_output:, user:, condition_message:|
       sign_in user
       assert has_incomplete_application?, "expected true when #{condition_message}" if expected_output
       refute has_incomplete_application?, "expected false when #{condition_message}" unless expected_output
+    end
+  end
+
+  test "has_reopened_application" do
+    [
+      {
+        expected_output: true,
+        condition_message: 'application exists and is reopened',
+        user: @user_with_reopened_app
+      },
+      {
+        expected_output: false,
+        condition_message: 'application exists and is incomplete',
+        user: @user_with_two_incomplete_apps
+      },
+      {
+        expected_output: false,
+        condition_message: 'application is in a different year',
+        user: @user_with_outdated_reopened
+      }
+    ].each do |expected_output:, user:, condition_message:|
+      sign_in user
+      assert has_reopened_application?, "expected true when #{condition_message}" if expected_output
+      refute has_reopened_application?, "expected false when #{condition_message}" unless expected_output
     end
   end
 end

--- a/dashboard/test/helpers/teacher_application_helper_test.rb
+++ b/dashboard/test/helpers/teacher_application_helper_test.rb
@@ -14,16 +14,16 @@ class TeacherApplicationHelperTest < ActionView::TestCase
     create TEACHER_APPLICATION_FACTORY, user: @user_with_two_incomplete_apps, status: 'incomplete', application_year: '2018-2019'
 
     @user_with_reopened_app = create :teacher
-    @reopened_application = create TEACHER_APPLICATION_FACTORY, user: @user_with_reopened_app, status: 'reopened'
+    create TEACHER_APPLICATION_FACTORY, user: @user_with_reopened_app, status: 'reopened'
 
     @user_with_outdated_incomplete = create :teacher
-    @not_current_incomplete_app = create TEACHER_APPLICATION_FACTORY,
+    create TEACHER_APPLICATION_FACTORY,
       user: @user_with_outdated_incomplete,
       status: 'incomplete',
       application_year: '2018-2019'
 
     @user_with_outdated_reopened = create :teacher
-    @not_current_reopened_app = create TEACHER_APPLICATION_FACTORY,
+    create TEACHER_APPLICATION_FACTORY,
       user: @user_with_outdated_reopened,
       status: 'reopened',
       application_year: '2018-2019'
@@ -35,7 +35,7 @@ class TeacherApplicationHelperTest < ActionView::TestCase
   end
 
   test 'current application returns nil if user has no application from this year' do
-    sign_in @teacher_with_not_current_incomplete_app
+    sign_in @user_with_outdated_incomplete
     assert_nil current_application
   end
 

--- a/dashboard/test/helpers/teacher_application_helper_test.rb
+++ b/dashboard/test/helpers/teacher_application_helper_test.rb
@@ -58,8 +58,7 @@ class TeacherApplicationHelperTest < ActionView::TestCase
       }
     ].each do |expected_output:, user:, condition_message:|
       sign_in user
-      assert has_incomplete_application?, "expected true when #{condition_message}" if expected_output
-      refute has_incomplete_application?, "expected false when #{condition_message}" unless expected_output
+      assert_equal expected_output, has_incomplete_application?, "expected #{expected_output} when #{condition_message}"
     end
   end
 
@@ -82,8 +81,7 @@ class TeacherApplicationHelperTest < ActionView::TestCase
       }
     ].each do |expected_output:, user:, condition_message:|
       sign_in user
-      assert has_reopened_application?, "expected true when #{condition_message}" if expected_output
-      refute has_reopened_application?, "expected false when #{condition_message}" unless expected_output
+      assert_equal expected_output, has_reopened_application?, "expected #{expected_output} when #{condition_message}"
     end
   end
 end


### PR DESCRIPTION
If an RP re-opens a teacher application, the teacher should see a call to entry on the teacher dashboard / homepage.

<img width="1039" alt="Screen Shot 2022-02-22 at 8 06 00 AM" src="https://user-images.githubusercontent.com/9142121/155138909-63869e34-3708-44cd-95ad-3c382adca0cd.png">


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Added test coverage

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

Need to update what the teacher application dialogue says when the teacher returns to a reopened application. Might also explore a CtA component refactor to address styling.

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
