### PR TITLE
[micro:bit] Setup Checklist - Remove 4th Check

### DIFF
--- a/apps/src/lib/kits/maker/boards/microBit/MBFirmataWrapper.js
+++ b/apps/src/lib/kits/maker/boards/microBit/MBFirmataWrapper.js
@@ -15,6 +15,9 @@ export default class MicrobitFirmataWrapper extends MBFirmataClient {
       .then(() => this.setSerialPort(port))
       .then(() => {
         return this.setAnalogSamplingInterval(SAMPLE_INTERVAL);
+      })
+      .catch(() => {
+        return Promise.reject("Couldn't connect to board");
       });
   }
 

--- a/apps/src/lib/kits/maker/boards/microBit/MicroBitBoard.js
+++ b/apps/src/lib/kits/maker/boards/microBit/MicroBitBoard.js
@@ -95,7 +95,8 @@ export default class MicroBitBoard extends EventEmitter {
   checkExpectedFirmware() {
     return Promise.resolve()
       .then(() => this.openSerialPort())
-      .then(serialPort => this.boardClient_.connectBoard(serialPort));
+      .then(serialPort => this.boardClient_.connectBoard(serialPort))
+      .catch(err => Promise.reject(err));
   }
 
   /**

--- a/apps/src/lib/kits/maker/boards/microBit/MicroBitBoard.js
+++ b/apps/src/lib/kits/maker/boards/microBit/MicroBitBoard.js
@@ -10,6 +10,7 @@ import ExternalLed from './ExternalLed';
 import ExternalButton from './ExternalButton';
 import CapacitiveTouchSensor from './CapacitiveTouchSensor';
 import {isChromeOS, serialPortType} from '../../util/browserChecks';
+import {MICROBIT_FIRMWARE_VERSION} from './MicroBitConstants';
 
 /**
  * Controller interface for BBC micro:bit board using
@@ -97,7 +98,7 @@ export default class MicroBitBoard extends EventEmitter {
       .then(serialPort => this.boardClient_.connectBoard(serialPort))
       .then(() => {
         if (
-          this.boardClient_.firmwareVersion.includes('micro:bit Firmata 1.1')
+          this.boardClient_.firmwareVersion.includes(MICROBIT_FIRMWARE_VERSION)
         ) {
           return Promise.resolve();
         } else {

--- a/apps/src/lib/kits/maker/boards/microBit/MicroBitBoard.js
+++ b/apps/src/lib/kits/maker/boards/microBit/MicroBitBoard.js
@@ -1,6 +1,7 @@
 /** @file Board controller for BBC micro:bit */
 import {EventEmitter} from 'events'; // provided by webpack's node-libs-browser
 import {
+  createMicroBitComponents,
   cleanupMicroBitComponents,
   enableMicroBitComponents,
   componentConstructors
@@ -106,6 +107,21 @@ export default class MicroBitBoard extends EventEmitter {
         }
       })
       .catch(err => Promise.reject(err));
+  }
+
+  /**
+   * Initialize a set of component controllers.
+   * Exposed as a separate step here for the sake of the setup page; generally
+   * it'd be better to just call connect(), above.
+   * @throws {Error} if called before connecting to firmware
+   */
+  initializeComponents() {
+    return createMicroBitComponents(this.boardClient_).then(components => {
+      this.prewiredComponents_ = {
+        board: this.boardClient_,
+        ...components
+      };
+    });
   }
 
   /**

--- a/apps/src/lib/kits/maker/boards/microBit/MicroBitBoard.js
+++ b/apps/src/lib/kits/maker/boards/microBit/MicroBitBoard.js
@@ -1,7 +1,6 @@
 /** @file Board controller for BBC micro:bit */
 import {EventEmitter} from 'events'; // provided by webpack's node-libs-browser
 import {
-  createMicroBitComponents,
   cleanupMicroBitComponents,
   enableMicroBitComponents,
   componentConstructors
@@ -96,22 +95,16 @@ export default class MicroBitBoard extends EventEmitter {
     return Promise.resolve()
       .then(() => this.openSerialPort())
       .then(serialPort => this.boardClient_.connectBoard(serialPort))
+      .then(() => {
+        if (
+          this.boardClient_.firmwareVersion.includes('micro:bit Firmata 1.1')
+        ) {
+          return Promise.resolve();
+        } else {
+          return Promise.reject('Incorrect firmware detected');
+        }
+      })
       .catch(err => Promise.reject(err));
-  }
-
-  /**
-   * Initialize a set of component controllers.
-   * Exposed as a separate step here for the sake of the setup page; generally
-   * it'd be better to just call connect(), above.
-   * @throws {Error} if called before connecting to firmware
-   */
-  initializeComponents() {
-    return createMicroBitComponents(this.boardClient_).then(components => {
-      this.prewiredComponents_ = {
-        board: this.boardClient_,
-        ...components
-      };
-    });
   }
 
   /**

--- a/apps/src/lib/kits/maker/boards/microBit/MicroBitConstants.js
+++ b/apps/src/lib/kits/maker/boards/microBit/MicroBitConstants.js
@@ -51,3 +51,5 @@ export const MB_COMPONENT_EVENTS = {
   accelerometer: ['change', 'data', 'shake']
 };
 MB_SENSOR_VARS.forEach(sensor => (MB_COMPONENT_EVENTS[sensor] = SENSOR_EVENTS));
+
+export const MICROBIT_FIRMWARE_VERSION = 'micro:bit Firmata 1.1';

--- a/apps/src/lib/kits/maker/ui/SetupChecklist.jsx
+++ b/apps/src/lib/kits/maker/ui/SetupChecklist.jsx
@@ -114,14 +114,23 @@ export default class SetupChecklist extends Component {
       )
 
       // Can we initialize components successfully?
-      .then(() =>
-        this.detectStep(STATUS_BOARD_COMPONENTS, () =>
-          setupChecker.detectComponentsInitialize()
-        )
-      )
+      .then(() => {
+        if (this.state.boardTypeDetected !== BOARD_TYPE.MICROBIT) {
+          return this.detectStep(STATUS_BOARD_COMPONENTS, () =>
+            setupChecker.detectComponentsInitialize()
+          );
+        }
+        return Promise.resolve();
+      })
 
       // Everything looks good, let's par-tay!
-      .then(() => this.thumb(STATUS_BOARD_COMPONENTS))
+      .then(() =>
+        this.thumb(
+          this.state.boardTypeDetected === BOARD_TYPE.MICROBIT
+            ? STATUS_BOARD_CONNECT
+            : STATUS_BOARD_COMPONENTS
+        )
+      )
       .then(() => setupChecker.celebrate())
       .then(() => this.succeed(STATUS_BOARD_COMPONENTS))
       .then(() => trackEvent('MakerSetup', 'ConnectionSuccess'))
@@ -324,15 +333,17 @@ export default class SetupChecklist extends Component {
             {!linuxPermissionError && this.installFirmwareSketch()}
             {this.contactSupport()}
           </ValidationStep>
-          <ValidationStep
-            stepStatus={this.state[STATUS_BOARD_COMPONENTS]}
-            stepName={i18n.validationStepBoardComponentsUsable()}
-          >
-            {applabI18n.makerSetupVerifyComponents()}
-            <br />
-            {this.installFirmwareSketch()}
-            {this.contactSupport()}
-          </ValidationStep>
+          {this.state.boardTypeDetected !== BOARD_TYPE.MICROBIT && (
+            <ValidationStep
+              stepStatus={this.state[STATUS_BOARD_COMPONENTS]}
+              stepName={i18n.validationStepBoardComponentsUsable()}
+            >
+              {applabI18n.makerSetupVerifyComponents()}
+              <br />
+              {this.installFirmwareSketch()}
+              {this.contactSupport()}
+            </ValidationStep>
+          )}
         </div>
         <div>
           <h2>{i18n.support()}</h2>

--- a/apps/src/lib/kits/maker/ui/SetupChecklist.jsx
+++ b/apps/src/lib/kits/maker/ui/SetupChecklist.jsx
@@ -270,8 +270,7 @@ export default class SetupChecklist extends Component {
   render() {
     const linuxPermissionError =
       isLinux() &&
-      this.state.caughtError &&
-      this.state.caughtError.message.includes('Permission denied');
+      this.state.caughtError?.message?.includes('Permission denied');
 
     return (
       <div>

--- a/apps/src/lib/kits/maker/ui/SetupChecklist.jsx
+++ b/apps/src/lib/kits/maker/ui/SetupChecklist.jsx
@@ -299,6 +299,7 @@ export default class SetupChecklist extends Component {
           <ValidationStep
             stepStatus={this.state[STATUS_BOARD_PLUG]}
             stepName={i18n.validationStepBoardPluggedIn()}
+            hideWaitingSteps={true}
           >
             {this.state.caughtError && this.state.caughtError.reason && (
               <pre>{this.state.caughtError.reason}</pre>
@@ -318,6 +319,7 @@ export default class SetupChecklist extends Component {
           <ValidationStep
             stepStatus={this.state[STATUS_BOARD_CONNECT]}
             stepName={i18n.validationStepBoardConnectable()}
+            hideWaitingSteps={true}
           >
             {applabI18n.makerSetupBoardBadResponse()}
             {linuxPermissionError && (
@@ -337,6 +339,7 @@ export default class SetupChecklist extends Component {
             <ValidationStep
               stepStatus={this.state[STATUS_BOARD_COMPONENTS]}
               stepName={i18n.validationStepBoardComponentsUsable()}
+              hideWaitingSteps={true}
             >
               {applabI18n.makerSetupVerifyComponents()}
               <br />

--- a/apps/src/lib/kits/maker/util/SetupChecker.js
+++ b/apps/src/lib/kits/maker/util/SetupChecker.js
@@ -55,7 +55,9 @@ export default class SetupChecker {
   detectCorrectFirmware(boardType) {
     if (boardType === BOARD_TYPE.MICROBIT) {
       this.boardController = new MicroBitBoard(this.port);
-      return this.boardController.checkExpectedFirmware();
+      return this.boardController.checkExpectedFirmware().catch(err => {
+        return Promise.reject(err);
+      });
     } else {
       this.boardController = new CircuitPlaygroundBoard(this.port);
       return this.boardController.connectToFirmware();

--- a/apps/src/lib/ui/ValidationStep.jsx
+++ b/apps/src/lib/ui/ValidationStep.jsx
@@ -44,17 +44,28 @@ export default class ValidationStep extends Component {
     children: PropTypes.node,
     stepName: PropTypes.string.isRequired,
     stepStatus: PropTypes.oneOf(Object.values(Status)).isRequired,
-    alwaysShowChildren: PropTypes.bool
+    alwaysShowChildren: PropTypes.bool,
+    hideWaitingSteps: PropTypes.bool
   };
 
   render() {
-    const {stepName, stepStatus, alwaysShowChildren, children} = this.props;
+    const {
+      stepName,
+      stepStatus,
+      alwaysShowChildren,
+      children,
+      hideWaitingSteps
+    } = this.props;
     // By default, we only show the children if the step failed or alerted.
     // If alwaysShowChildren is set, show them regardless
     let showChildren =
       alwaysShowChildren ||
       stepStatus === Status.FAILED ||
       stepStatus === Status.ALERT;
+
+    if (hideWaitingSteps && stepStatus === Status.WAITING) {
+      return null;
+    }
 
     return (
       <div style={style.root}>

--- a/apps/test/unit/lib/kits/maker/boards/microBit/MicroBitBoardTest.js
+++ b/apps/test/unit/lib/kits/maker/boards/microBit/MicroBitBoardTest.js
@@ -5,7 +5,8 @@ import sinon from 'sinon';
 import {itImplementsTheMakerBoardInterface} from '../MakerBoardTest';
 import {
   MB_COMPONENT_COUNT,
-  MB_COMPONENTS
+  MB_COMPONENTS,
+  MICROBIT_FIRMWARE_VERSION
 } from '@cdo/apps/lib/kits/maker/boards/microBit/MicroBitConstants';
 import ExternalLed from '@cdo/apps/lib/kits/maker/boards/microBit/ExternalLed';
 import ExternalButton from '@cdo/apps/lib/kits/maker/boards/microBit/ExternalButton';
@@ -15,6 +16,7 @@ function boardSetupAndStub(board) {
   stubOpenSerialPort(board);
   sinon.stub(board.boardClient_, 'connectBoard').callsFake(() => {
     board.boardClient_.myPort = {write: () => {}};
+    board.boardClient_.firmwareVersion = `Long String Includes ${MICROBIT_FIRMWARE_VERSION}`;
     sinon.stub(board.boardClient_.myPort, 'write');
   });
 }

--- a/apps/test/unit/lib/kits/maker/ui/SetupChecklistTest.js
+++ b/apps/test/unit/lib/kits/maker/ui/SetupChecklistTest.js
@@ -42,7 +42,7 @@ describe('SetupChecklist', () => {
         <SetupChecklist setupChecker={checker} stepDelay={STEP_DELAY_MS} />
       );
       expect(wrapper.find(REDETECT_BUTTON)).to.be.disabled;
-      expect(wrapper.find(WAITING_ICON)).to.have.length(4);
+      expect(wrapper.find(WAITING_ICON)).to.have.length(1);
       await yieldUntilDoneDetecting(wrapper);
       expect(wrapper.find(REDETECT_BUTTON)).not.to.be.disabled;
       expect(wrapper.find(SUCCESS_ICON)).to.have.length(4);
@@ -58,7 +58,7 @@ describe('SetupChecklist', () => {
         await yieldUntilDoneDetecting(wrapper);
         expect(wrapper.find(SUCCESS_ICON)).to.have.length(0);
         expect(wrapper.find(FAILURE_ICON)).to.have.length(1);
-        expect(wrapper.find(WAITING_ICON)).to.have.length(3);
+        expect(wrapper.find(WAITING_ICON)).to.have.length(0);
         wrapper.find(REDETECT_BUTTON).simulate('click');
         expect(utils.reload).to.have.been.called;
       });
@@ -71,7 +71,7 @@ describe('SetupChecklist', () => {
       await yieldUntilDoneDetecting(wrapper);
       expect(wrapper.find(SUCCESS_ICON)).to.have.length(4);
       wrapper.find(REDETECT_BUTTON).simulate('click');
-      expect(wrapper.find(WAITING_ICON)).to.have.length(4);
+      expect(wrapper.find(WAITING_ICON)).to.have.length(1);
       await yieldUntilDoneDetecting(wrapper);
       expect(wrapper.find(SUCCESS_ICON)).to.have.length(4);
       expect(utils.reload).not.to.have.been.called;
@@ -89,7 +89,7 @@ describe('SetupChecklist', () => {
         <SetupChecklist setupChecker={checker} stepDelay={STEP_DELAY_MS} />
       );
       expect(wrapper.find(REDETECT_BUTTON)).to.be.disabled;
-      expect(wrapper.find(WAITING_ICON)).to.have.length(4);
+      expect(wrapper.find(WAITING_ICON)).to.have.length(1);
       await yieldUntilDoneDetecting(wrapper);
       expect(wrapper.find(REDETECT_BUTTON)).not.to.be.disabled;
       expect(wrapper.find(SUCCESS_ICON)).to.have.length(4);
@@ -103,10 +103,10 @@ describe('SetupChecklist', () => {
         const wrapper = mount(
           <SetupChecklist setupChecker={checker} stepDelay={STEP_DELAY_MS} />
         );
-        expect(wrapper.find(WAITING_ICON)).to.have.length(4);
+        expect(wrapper.find(WAITING_ICON)).to.have.length(1);
         await yieldUntilDoneDetecting(wrapper);
         expect(wrapper.find(FAILURE_ICON)).to.have.length(1);
-        expect(wrapper.find(WAITING_ICON)).to.have.length(3);
+        expect(wrapper.find(WAITING_ICON)).to.have.length(0);
         expect(window.console.error).to.have.been.calledWith(error);
       });
 
@@ -118,7 +118,7 @@ describe('SetupChecklist', () => {
         await yieldUntilDoneDetecting(wrapper);
         expect(wrapper.find(SUCCESS_ICON)).to.have.length(0);
         expect(wrapper.find(FAILURE_ICON)).to.have.length(1);
-        expect(wrapper.find(WAITING_ICON)).to.have.length(3);
+        expect(wrapper.find(WAITING_ICON)).to.have.length(0);
         wrapper.find(REDETECT_BUTTON).simulate('click');
         expect(utils.reload).to.have.been.called;
       });
@@ -131,7 +131,7 @@ describe('SetupChecklist', () => {
       await yieldUntilDoneDetecting(wrapper);
       expect(wrapper.find(SUCCESS_ICON)).to.have.length(4);
       wrapper.find(REDETECT_BUTTON).simulate('click');
-      expect(wrapper.find(WAITING_ICON)).to.have.length(4);
+      expect(wrapper.find(WAITING_ICON)).to.have.length(1);
       await yieldUntilDoneDetecting(wrapper);
       expect(wrapper.find(SUCCESS_ICON)).to.have.length(4);
       expect(utils.reload).not.to.have.been.called;


### PR DESCRIPTION
The previous code here wasn't catching connection errors. As we move closer to a Beta release, I wanted to loop back and make sure we were handling connection errors appropriately.

This change adds a catch to the 'connect' process for the micro:bit to catch and throw errors when needed. I tested locally by forcing the connection to fail (returning a failed promise in MBFirmataWrapper).

This PR also includes changes to add an additional check at the third step for the micro:bit. This check requests the firmware version from the micro:bit. The value we expect back includes markers that can help us determine if the board has outdated firmware on it. If the firmware version doesn't match our expectations, we fail the step and the user is served information about flashing the correct Firmata to their board.

Finally, this board removes the 4th step, see gif. This fourth step is relevant to the set-up for the Circuit Playground and doesn't have an analogous step for micro:bit. The expected behavior is that once a micro:bit is detected, we no longer render the fourth step and the third step now displays the thumbs-up icon when the process is complete.

Before:
![Screenshot from 2022-02-21 15-45-56](https://user-images.githubusercontent.com/2959170/155041551-2302a349-f1ce-4a82-ae4a-a64a141a9ce0.png)


After:
![ThreeSteps](https://user-images.githubusercontent.com/2959170/155041572-fe8e08c2-3de5-4042-96a8-a76f8418d0bd.gif)


After discussing in the comments below, we are updating the final outcome so that 'waiting' steps aren't shown. See gifs.
![4stepLoad](https://user-images.githubusercontent.com/2959170/156076008-1ce51dd4-007c-4157-a978-caa3e998059a.gif)


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
