### PR TITLE
Hide reopened until experiment is over

### DIFF
--- a/apps/src/code-studio/pd/application_dashboard/summary_table.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/summary_table.jsx
@@ -41,9 +41,9 @@ export class SummaryTable extends React.Component {
     };
     const categoryRows = Object.keys(this.props.data).map((status, i) => {
       // [MEG] TODO: Eliminate this check once experiment is complete
-      // Don't show an application of "incomplete" status if there is no experiment
+      // Don't show an application of "incomplete" or "reopened" unless experiment is on
       if (
-        status !== 'incomplete' ||
+        (status !== 'incomplete' && status !== 'reopened') ||
         experiments.isEnabled(experiments.TEACHER_APPLICATION_SAVING_REOPENING)
       ) {
         const statusData = this.props.data[status];


### PR DESCRIPTION
I need to manually hide 'reopened' applications until the experiment is over.


<img width="1304" alt="Screen Shot 2022-02-22 at 12 10 20 PM" src="https://user-images.githubusercontent.com/9142121/155182888-70a8b6bd-20f6-40c3-b739-3e2a05bcad75.png">
<img width="1304" alt="Screen Shot 2022-02-22 at 12 10 00 PM" src="https://user-images.githubusercontent.com/9142121/155182890-9eeee664-db31-4beb-ad3b-f7e68149b821.png">

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
