### PR TITLE
Use id to determine which programming expressions to destroy during seeding

### DIFF
--- a/dashboard/app/models/programming_expression.rb
+++ b/dashboard/app/models/programming_expression.rb
@@ -125,11 +125,11 @@ class ProgrammingExpression < ApplicationRecord
   end
 
   def self.seed_all
-    removed_records = all.pluck(:name)
+    removed_records = all.pluck(:id)
     Dir.glob(Rails.root.join("config/programming_expressions/{applab,gamelab,weblab,spritelab}/*.json")).each do |path|
       removed_records -= [ProgrammingExpression.seed_record(path)]
     end
-    where(name: removed_records).destroy_all
+    where(id: removed_records).destroy_all
   end
 
   def self.seed_record(file_path)
@@ -137,7 +137,7 @@ class ProgrammingExpression < ApplicationRecord
     record = ProgrammingExpression.find_or_initialize_by(key: properties[:key], programming_environment_id: properties[:programming_environment_id])
     record.assign_attributes(properties)
     record.save! if record.changed?
-    record.name
+    record.id
   end
 
   def documentation_path

--- a/dashboard/test/models/programming_expression_test.rb
+++ b/dashboard/test/models/programming_expression_test.rb
@@ -61,9 +61,38 @@ class ProgrammingExpressionTest < ActiveSupport::TestCase
 
     File.stubs(:read).returns(serialization.to_json)
 
-    new_exp_name = ProgrammingExpression.seed_record("config/programming_expressions/#{programming_environment.name}/file.json")
-    new_exp = ProgrammingExpression.find_by_name(new_exp_name)
+    new_exp_id = ProgrammingExpression.seed_record("config/programming_expressions/#{programming_environment.name}/file.json")
+    new_exp = ProgrammingExpression.find(new_exp_id)
     assert_equal previous_exp.attributes.except('id', 'created_at', 'updated_at'), new_exp.attributes.except('id', 'created_at', 'updated_at')
     assert_equal category, new_exp.programming_environment_category
+  end
+
+  test "seed_all adds, updates, and removes programming expressions" do
+    programming_environment = create :programming_environment
+    category = create :programming_environment_category, programming_environment: programming_environment, name: 'World', color: '#ABCDEF'
+    create :programming_expression, key: 'to_delete', programming_environment: programming_environment, programming_environment_category: category
+    to_update = create :programming_expression, key: 'to_update', name: 'Old Name', programming_environment: programming_environment, programming_environment_category: category
+    to_create = build :programming_expression, key: 'to_create', programming_environment: programming_environment, programming_environment_category: category
+
+    Dir.stubs(:glob).returns(["#{programming_environment.name}/#{to_update.key}.json", "#{programming_environment.name}/#{to_create.key}.json"])
+
+    to_update.name = "Updated name"
+    File.stubs(:read).with("#{programming_environment.name}/#{to_update.key}.json").returns(to_update.serialize.to_json)
+    File.stubs(:read).with("#{programming_environment.name}/#{to_create.key}.json").returns(to_create.serialize.to_json)
+
+    to_create.destroy!
+    to_update.reload
+    assert_equal 'Old Name', to_update.name
+
+    ProgrammingExpression.seed_all
+
+    to_update.reload
+    refute_nil to_update
+    assert_equal 'Updated name', to_update.name
+    assert_equal 1, ProgrammingExpression.where(programming_environment_id: programming_environment.id, key: 'to_update').count
+
+    assert_equal 0, ProgrammingExpression.where(programming_environment_id: programming_environment.id, key: 'to_delete').count
+
+    assert_equal 1, ProgrammingExpression.where(programming_environment_id: programming_environment.id, key: 'to_create').count
   end
 end


### PR DESCRIPTION
Because keys only need to be unique within a programming environment, a few programming expressions that should've been deleted, weren't. An example is `moveBackward`, which is a deleted spritelab programming expressions but applab also has a `moveBackward` programming expression, so it wasn't being deleted. Because we use `find_or_initialize_by` for seeding, the ids should stay the same if a record is only being updated.


## Testing story

seeded locally and results were as expected. also added a unit test



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
