### PR TITLE
Removing onContinue redirect from the default close button in Legacy Dialog

### DIFF
--- a/apps/src/dance/Dance.js
+++ b/apps/src/dance/Dance.js
@@ -689,7 +689,6 @@ Dance.prototype.displayFeedback_ = function() {
       : ['HourOfCode'];
 
   let feedbackOptions = {
-    doNothingOnHidden: true,
     feedbackType: this.testResults,
     message: this.message,
     response: this.response,

--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -230,8 +230,10 @@ FeedbackUtils.prototype.displayFeedback = function(
     project.saveIfSourcesChanged();
   }
 
-  let onHidden;
-  onHidden = function() {
+  // onHidden is called when the dialog is closed: only do something extra
+  // if there are hints for missing blocks. hideButDontContinue may change
+  // according to later events
+  let onHidden = function() {
     if (
       !continueButton ||
       (feedbackDialog && feedbackDialog.hideButDontContinue)

--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -118,7 +118,7 @@ FeedbackUtils.prototype.displayFeedback = function(
 ) {
   options.level = options.level || {};
 
-  const {onContinue, shareLink, doNothingOnHidden} = options;
+  const {onContinue, shareLink} = options;
   const hadShareFailure = options.response && options.response.share_failure;
   const showingSharing =
     options.showingSharing && !hadShareFailure && shareLink;
@@ -231,24 +231,14 @@ FeedbackUtils.prototype.displayFeedback = function(
   }
 
   let onHidden;
-  if (doNothingOnHidden) {
-    // No additional onHidden functionality upon closing the dialog
-  } else {
-    /*
-    hideButDontContinue toggles when the again button is pressed, so its value
-    may change after this definition
-    */
-    onHidden = function() {
-      if (
-        !continueButton ||
-        (feedbackDialog && feedbackDialog.hideButDontContinue)
-      ) {
-        this.studioApp_.displayMissingBlockHints(missingRecommendedBlockHints);
-      } else {
-        onContinue();
-      }
-    }.bind(this);
-  }
+  onHidden = function() {
+    if (
+      !continueButton ||
+      (feedbackDialog && feedbackDialog.hideButDontContinue)
+    ) {
+      this.studioApp_.displayMissingBlockHints(missingRecommendedBlockHints);
+    }
+  }.bind(this);
 
   var icon;
   if (!options.hideIcon) {

--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -231,13 +231,9 @@ FeedbackUtils.prototype.displayFeedback = function(
   }
 
   // onHidden is called when the dialog is closed: only do something extra
-  // if there are hints for missing blocks. hideButDontContinue may change
-  // according to later events
+  // if there are hints for missing blocks.
   let onHidden = function() {
-    if (
-      !continueButton ||
-      (feedbackDialog && feedbackDialog.hideButDontContinue)
-    ) {
+    if (!continueButton) {
       this.studioApp_.displayMissingBlockHints(missingRecommendedBlockHints);
     }
   }.bind(this);
@@ -326,9 +322,7 @@ FeedbackUtils.prototype.displayFeedback = function(
         options,
         idealBlocks === Infinity ? null : isPerfect
       );
-      feedbackDialog.hideButDontContinue = true;
       feedbackDialog.hide();
-      feedbackDialog.hideButDontContinue = false;
     });
   }
 
@@ -458,9 +452,7 @@ FeedbackUtils.prototype.displayFeedback = function(
   if (publishButton) {
     dom.addClickTouchEvent(publishButton, () => {
       // Hide the current dialog since we're about to show the publish dialog
-      feedbackDialog.hideButDontContinue = true;
       feedbackDialog.hide();
-      feedbackDialog.hideButDontContinue = false;
 
       const store = getStore();
 

--- a/dashboard/test/ui/features/hour_of_code/hour_of_code.feature
+++ b/dashboard/test/ui/features/hour_of_code/hour_of_code.feature
@@ -13,8 +13,8 @@ Scenario: Solving puzzle 1, proceeding to puzzle 2, verifying that puzzle 1 appe
   And element ".modal .congrats" contains text "You completed Puzzle 1."
   And I close the dialog
   ## Verify that closing doesn't redirect to the next level
-  And I wait until I am on "http://studio.code.org/hoc/1"
-  Then I am on "http://studio.code.org/hoc/2"
+  Then check that I am on "http://studio.code.org/hoc/1?noautoplay=true"
+  Then I am on "http://studio.code.org/hoc/2?noautoplay=true"
   And I wait for the page to fully load
   And I verify progress in the header of the current page is "perfect" for level 1
   # Course overview should also show progress

--- a/dashboard/test/ui/features/hour_of_code/hour_of_code.feature
+++ b/dashboard/test/ui/features/hour_of_code/hour_of_code.feature
@@ -11,8 +11,10 @@ Scenario: Solving puzzle 1, proceeding to puzzle 2, verifying that puzzle 1 appe
   And I press "runButton"
   Then I wait to see ".modal"
   And element ".modal .congrats" contains text "You completed Puzzle 1."
-  And I press "continue-button"
-  And I wait until I am on "http://studio.code.org/hoc/2"
+  And I close the dialog
+  ## Verify that closing doesn't redirect to the next level
+  And I wait until I am on "http://studio.code.org/hoc/1"
+  Then I am on "http://studio.code.org/hoc/2"
   And I wait for the page to fully load
   And I verify progress in the header of the current page is "perfect" for level 1
   # Course overview should also show progress

--- a/dashboard/test/ui/features/hour_of_code/hour_of_code.feature
+++ b/dashboard/test/ui/features/hour_of_code/hour_of_code.feature
@@ -11,7 +11,7 @@ Scenario: Solving puzzle 1, proceeding to puzzle 2, verifying that puzzle 1 appe
   And I press "runButton"
   Then I wait to see ".modal"
   And element ".modal .congrats" contains text "You completed Puzzle 1."
-  Then I close the dialog
+  And I press "continue-button"
   And I wait until I am on "http://studio.code.org/hoc/2"
   And I wait for the page to fully load
   And I verify progress in the header of the current page is "perfect" for level 1

--- a/dashboard/test/ui/features/hour_of_code/hour_of_code_signed_in.feature
+++ b/dashboard/test/ui/features/hour_of_code/hour_of_code_signed_in.feature
@@ -8,7 +8,7 @@ Scenario:
   And I press "runButton"
   Then I wait to see ".modal"
   And element ".modal .congrats" contains text "You completed Puzzle 1."
-  Then I close the dialog
+  And I press "continue-button"
   Then I wait until I am on "http://studio.code.org/hoc/2"
   And I wait for the page to fully load
   And I verify progress in the header of the current page is "perfect" for level 1

--- a/dashboard/test/ui/features/hour_of_code/starwars.feature
+++ b/dashboard/test/ui/features/hour_of_code/starwars.feature
@@ -12,7 +12,7 @@ Feature: Hour of Code 2015 tutorial is completable
     And I press "runButton"
     And I wait to see ".modal"
     Then element "#continue-button" is visible
-    When I close the dialog
+    And I press "continue-button"
     Then I wait until I am on "http://studio.code.org/s/starwars/lessons/1/levels/2"
     And I wait for the page to fully load
     And I verify progress in the header of the current page is "perfect" for level 1
@@ -26,7 +26,7 @@ Feature: Hour of Code 2015 tutorial is completable
     And I press "runButton"
     And I wait to see ".modal"
     Then element "#continue-button" is visible
-    When I close the dialog
+    And I press "continue-button"
     Then I wait until I am on "http://studio.code.org/s/starwars/lessons/1/levels/2"
     And I wait for the page to fully load
     And I verify progress in the header of the current page is "perfect" for level 1


### PR DESCRIPTION
The major update of this PR: when a user presses the x button on the legacy dialog feedback/finish popup, instead of being redirected to the next level, the dialog closes. This was updated in a recent pr for the level type dance (jira ticket: https://codedotorg.atlassian.net/browse/LP-2192).

This is a simplification, removing the variable 'hideButDontContinue' entirely, as well as the onContinue() default from the onHidden function.

AI lab and fish are the only level types with their own onContinue() functions that report progress: neither of these uses a dialog at all, so progress will not be lost when removing this default here. 

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->


- spec: []()
- jira ticket: https://codedotorg.atlassian.net/browse/LP-2222

## Testing story

There is now a series of steps in hour_of_code.feature to verify that when the x button is pressed in the legacy dialog, you remain on the same page instead of moving to the next level in a redirect. The other tests remain unchanged, but are updated so that the user must press the continue button to move to the next level.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
