### PR TITLE
Javalab: upload sources to Javabuilder when getting access token (localhost only)

### DIFF
--- a/dashboard/app/controllers/javabuilder_sessions_controller.rb
+++ b/dashboard/app/controllers/javabuilder_sessions_controller.rb
@@ -3,6 +3,7 @@ require 'securerandom' unless defined?(SecureRandom)
 require 'cdo/firehose'
 
 class JavabuilderSessionsController < ApplicationController
+  include JavalabFilesHelper
   authorize_resource class: false
 
   PRIVATE_KEY = CDO.javabuilder_private_key
@@ -68,6 +69,12 @@ class JavabuilderSessionsController < ApplicationController
       OpenSSL::PKey::RSA.new(PRIVATE_KEY, PASSWORD),
       'RS256'
     )
+
+    if use_dashboard_sources == 'false'
+      success = JavalabFilesHelper.upload_project_files(channel_id, level_id, encoded_payload)
+      return render status: :internal_server_error, json: {error: "Error uploading sources."} unless success
+    end
+
     render json: {token: encoded_payload, session_id: session_id}
   end
 end

--- a/dashboard/app/helpers/javalab_files_helper.rb
+++ b/dashboard/app/helpers/javalab_files_helper.rb
@@ -1,7 +1,20 @@
 
 module JavalabFilesHelper
+  def self.upload_project_files(channel_id, level_id, auth_token)
+    uri = URI.parse("#{CDO.javabuilder_upload_url}?Authorization=#{auth_token}")
+    upload_request = Net::HTTP::Put.new(uri)
+    upload_request.body = get_project_files(channel_id, level_id).to_json
+
+    response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') do |http|
+      http.request(upload_request)
+    end
+    response.code == '200'
+  rescue StandardError
+    false
+  end
+
   # Get all files related to the project at the given channel id as a hash. The hash is in the format
-  # below. All values are StringIO.
+  # below. All values are strings.
   # {
   #   "sources": {"main.json": <main source file for a project>, "grid.txt": <serialized maze if it exists>},
   #   "assetUrls": {"asset_name_1": <asset_url>, ...}
@@ -13,15 +26,14 @@ module JavalabFilesHelper
     sources = {}
     # get main.json
     source_data = SourceBucket.new.get(channel_id, "main.json")
-    # Note: we can call .string on this value (and all other values for files) to get the raw string.
-    sources["main.json"] = source_data[:body]
+    sources["main.json"] = source_data[:body].string
 
     # get maze file
     level = Level.find(level_id)
     if level
       serialized_maze = level.try(:get_serialized_maze)
       if serialized_maze
-        sources["grid.txt"] = StringIO.new(serialized_maze.to_s)
+        sources["grid.txt"] = serialized_maze.to_s
       end
     end
     all_files["sources"] = sources
@@ -44,7 +56,7 @@ module JavalabFilesHelper
 
     # get validation code
     if level.respond_to?(:validation) && level.validation
-      all_files["validation"] = StringIO.new(level.validation.to_json)
+      all_files["validation"] = level.validation.to_json
     end
 
     return all_files

--- a/dashboard/test/controllers/javabuilder_sessions_controller_test.rb
+++ b/dashboard/test/controllers/javabuilder_sessions_controller_test.rb
@@ -130,4 +130,12 @@ class JavabuilderSessionsControllerTest < ActionController::TestCase
     get :get_access_token, params: {channelId: @fake_channel_id, projectVersion: 123, projectUrl: URL, executionType: 'RUN'}
     assert_response :bad_request
   end
+
+  test 'returns error if upload fails when not using dashboard sources' do
+    JavalabFilesHelper.stubs(:upload_project_files).returns(false)
+    levelbuilder = create :levelbuilder
+    sign_in(levelbuilder)
+    get :get_access_token, params: {useDashboardSources: "false", channelId: @fake_channel_id, projectVersion: 123, projectUrl: URL, levelId: 261, executionType: 'RUN', miniAppType: 'console'}
+    assert_response :internal_server_error
+  end
 end

--- a/lib/cdo.rb
+++ b/lib/cdo.rb
@@ -132,6 +132,15 @@ module Cdo
       end
     end
 
+    def javabuilder_upload_url(path = '', scheme = '')
+      if rack_env?(:development)
+        'http://localhost:8080/javabuilderfiles/seedsources'
+      else
+        # TODO: Update this URL once the API Gateway endpoint has been set up.
+        ''
+      end
+    end
+
     # Get a list of all languages for which we want to link to a localized
     # version of CurriculumBuilder. This list is distinct from the list of
     # languages officially supported by CurriculumBuilder in that there are


### PR DESCRIPTION
This has Dashboard upload the sources JSON payload while getting the Javabuilder access token, if useDashboardSources is set to false. Currently only the localhost upload URL is defined, so this will only work with localhost Javabuilder.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

JIRA: https://codedotorg.atlassian.net/browse/JAVA-448

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Tested locally + unit.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
