### PR TITLE
Poetry: Polish poems

### DIFF
--- a/apps/src/p5lab/poetry/PoemSelector.jsx
+++ b/apps/src/p5lab/poetry/PoemSelector.jsx
@@ -185,6 +185,7 @@ function PoemSelector(props) {
   const getPoemOptions = () => {
     const options = Object.keys(POEMS)
       .map(poemKey => getPoem(poemKey))
+      .filter(poem => !poem.locale || poem.locale === appOptions.locale)
       .sort((a, b) => (a.title > b.title ? 1 : -1))
       .map(poem => ({value: poem.key, label: poem.title}));
     // Add option to create your own poem to the top of the dropdown.

--- a/apps/src/p5lab/poetry/PoetryLibrary.js
+++ b/apps/src/p5lab/poetry/PoetryLibrary.js
@@ -321,6 +321,10 @@ export default class PoetryLibrary extends CoreLibrary {
       desiredSize,
       (desiredSize * (PLAYSPACE_SIZE - OUTER_MARGIN)) / fullWidth
     );
+    // We can also cap the font height.  If it's only a single line of text
+    // (say the title or author) then we cap at 30.  Otherwise, we take
+    // (PLAYSPACE_SIZE / 2) and divide it by the number of lines in the poem;
+    // even in this case, the cap only has an effect on particulary long poems.
     const maxLineHeight =
       lines.length === 1 ? 30 : PLAYSPACE_SIZE / 2 / lines.length;
 

--- a/apps/src/p5lab/poetry/PoetryLibrary.js
+++ b/apps/src/p5lab/poetry/PoetryLibrary.js
@@ -321,7 +321,8 @@ export default class PoetryLibrary extends CoreLibrary {
       desiredSize,
       (desiredSize * (PLAYSPACE_SIZE - OUTER_MARGIN)) / fullWidth
     );
-    const maxLineHeight = 30 / lines.length;
+    const maxLineHeight =
+      lines.length === 1 ? 30 : PLAYSPACE_SIZE / 2 / lines.length;
 
     this.p5.pop();
     return Math.min(scaledSize, maxLineHeight);
@@ -442,13 +443,8 @@ export default class PoetryLibrary extends CoreLibrary {
       yCursor += LINE_HEIGHT;
     }
     const lineHeight = (PLAYSPACE_SIZE - yCursor) / poemState.lines.length;
-    const longestLine = poemState.lines.reduce(
-      (accumulator, current) =>
-        accumulator.length > current.length ? accumulator : current,
-      '' /* default value */
-    );
     const lineSize = this.getScaledFontSize(
-      longestLine,
+      poemState.lines.join('\n'),
       poemState.font.font,
       FONT_SIZE
     );

--- a/apps/src/p5lab/poetry/constants.js
+++ b/apps/src/p5lab/poetry/constants.js
@@ -55,5 +55,99 @@ export const POEMS = {
   hughes1: {author: 'Langston Hughes'},
   lomeli1: {author: 'Caia Lomeli'},
   lomeli2: {author: 'Caia Lomeli'},
-  frost: {author: 'Robert Frost'}
+  frost: {author: 'Robert Frost'},
+  rusinek1: {
+    locale: 'pl_pl',
+    author: 'Michał Rusinek, Wierszyki domowe, Znak, 2021',
+    title: 'WIESZAKI',
+    linesSplit: [
+      'Wszystkie dzieciaki',
+      'wiedzą, co to wieszaki',
+      'i że służą one zwłaszcza',
+      'do wieszania płaszcza',
+      'lub kurtki, lub pelerynki',
+      'chłopczyka i dziewczynki.',
+      '',
+      'Lecz tak naprawdę wieszaki',
+      'to są dzikie zwierzaki:',
+      'zaczepne, rogate',
+      'i okropnie pyskate!',
+      'Kto słyszy ich awantury,',
+      'chowa się do mysiej dziury.'
+    ]
+  },
+  rusinek2: {
+    locale: 'pl_pl',
+    author: 'Michał Rusinek, Wierszyki domowe, Znak, 2021',
+    title: 'PRYSZNIC',
+    linesSplit: [
+      'Prysznic to nie jest zabawka.',
+      'Prysznic to taka słuchawka',
+      'do rozmów międzywannowych',
+      'i międzyprysznicowych.',
+      ' ',
+      'Ważne, by podczas rozmowy',
+      'nie przyszło ci czasem do głowy',
+      'kręcić kurkiem, uparciuszku,',
+      'bo będziesz mieć wodę w uszku!'
+    ]
+  },
+  rusinek3: {
+    locale: 'pl_pl',
+    author: 'Michał Rusinek, Wierszyki domowe, Znak, 2021',
+    title: 'TOSTER',
+    linesSplit: [
+      'Do czego służy toster?',
+      'To bardzo, bardzo proste:',
+      'do opiekania grzanek,',
+      'kiedy nadchodzi ranek.',
+      '  ',
+      'A kiedy się pozmienia',
+      'tostera ustawienia,',
+      'to służyć mu jest dane',
+      'i do zwęglania grzanek.',
+      '  ',
+      'Ech, męczą się górnicy',
+      'tak trochę po próżnicy,',
+      'bo gdyby mieli toster,',
+      'życie by było proste:',
+      '  ',
+      'Ustawiałby górnik na full',
+      'swój toster – i siadał jak król.',
+      'A węgiel by robił się sam.',
+      'No, mówię wam!'
+    ]
+  },
+  rusinek4: {
+    locale: 'pl_pl',
+    author: 'Michał Rusinek, Wierszyki domowe, Znak, 2021',
+    title: 'WAZON',
+    linesSplit: [
+      'Bez względu na to, czy w wazonie',
+      'stoją żonkile, czy piwonie,',
+      'wazon jest przede wszystkim po to,',
+      'by dać się czasem rozbić kotom.'
+    ]
+  },
+  rusinek5: {
+    locale: 'pl_pl',
+    author: 'Michał Rusinek, Wierszyki domowe, Znak, 2021',
+    title: 'SŁOIKI',
+    linesSplit: [
+      'Stoją w piwnicy puste słoiki.',
+      'W jednym z nich były raz borowiki,',
+      'w innym pieczarki marynowane,',
+      'a w jeszcze innym ćwikła wraz z chrzanem.',
+      '  ',
+      'Gdy ze słoików wszystko zjedzono,',
+      'to je umyto i wysuszono.',
+      'Zniesiono tutaj ich zapas spory*,',
+      'bo mogą przydać się na przetwory.',
+      '  ',
+      'Ten, kto na podróż w czasie ma chętkę,',
+      'może odkręcić jedną zakrętkę:',
+      'wtedy ze środka uleci wokół',
+      'trochę powietrza – z zeszłego roku!'
+    ]
+  }
 };

--- a/apps/src/p5lab/poetry/constants.js
+++ b/apps/src/p5lab/poetry/constants.js
@@ -26,7 +26,12 @@ export const PALETTES = {
   roses: ['#4C0606', '#86003C', '#E41F7B', '#FF8BA0 ', '#FFB6B3']
 };
 
-// Author is the only attribute not translated
+// Notes:
+// - author is not translated.
+// - Poems are shown in all languages, unless there is a locale attribute, in which case
+//   the poem is shown in the dropdown only for users with that current locale.
+// - If the locale attribute is set, then title is used and is not translated.
+// - If the locale attribute is set, then linesSplit is used and is not translated.
 export const POEMS = {
   hafez: {author: 'Hafez'},
   field: {author: 'Eugene Field'},

--- a/apps/src/p5lab/poetry/poem.js
+++ b/apps/src/p5lab/poetry/poem.js
@@ -7,8 +7,9 @@ export function getPoem(key) {
   }
   return {
     key: key,
+    locale: POEMS[key].locale,
     author: POEMS[key].author,
-    title: msg[`${key}Title`](),
-    lines: msg[`${key}Lines`]().split('\n')
+    title: POEMS[key].title || msg[`${key}Title`](),
+    lines: POEMS[key].linesSplit || msg[`${key}Lines`]().split('\n')
   };
 }


### PR DESCRIPTION
This adds five new poems, listed in the selector only when the page is in Polish.

It also adjusts the font sizing logic.

### Font sizing

Until now, a poem with many lines could end up with vertically overlapping text, because the font sized remained too big.  The `getScaledFontSize` function was only being called with the longest line of the poem, and the font size was determined based on that line's width.  It turns out that `getScaledFontSize` had additional support for being passed many lines and  restricting the font size based on the count, but it didn't seem to be used.  This change revives that functionality, adjusting the calculation so that a poem's text no longer overlaps.  When passed a single line of text, say for the title or author, the previous maximum on size remains.

#### before

<img width="415" alt="Screen Shot 2022-02-23 at 11 09 22 AM" src="https://user-images.githubusercontent.com/2205926/155257732-d64977a0-a7ed-4239-a063-2be1d8b08732.png">

#### after

<img width="417" alt="Screen Shot 2022-02-23 at 2 19 26 PM" src="https://user-images.githubusercontent.com/2205926/155257762-89202785-289e-4ebc-a69b-3600ab33e878.png">

