### PR TITLE
Katie/practice cookies

### DIFF
--- a/dashboard/app/views/layouts/application.html.haml
+++ b/dashboard/app/views/layouts/application.html.haml
@@ -1,6 +1,8 @@
 !!! 5
 %html{dir: locale_dir}
   %head
+    = render inline: File.read(Rails.root.join('..', 'shared', 'haml', 'onetrust_cookie_scripts.haml')), type: :haml, locals: {dashboard: true}
+
     -# The Crowdin In-Context tool (https://crowdin.com/project/codeorg/settings#in-context) allows
     -# us to view original & translated strings in Crowdin.
     -# "in-TL" is a pseudo-language locale where the Crowdin strings are stored

--- a/dashboard/test/ui/features/learning_platform/instructions/help_and_tips.feature
+++ b/dashboard/test/ui/features/learning_platform/instructions/help_and_tips.feature
@@ -11,7 +11,7 @@ Feature: Help and Tips Map Link
     And I wait until ".editor-column" contains text "Circuit Playground"
     When I click selector "a:contains(Circuit Playground)"
     And I wait until element ".instructions-container" is visible
-    And I switch to the first iframe
+    And I switch to the iframe "iframe.instructions-container"
     And I wait for 1 seconds
     And I wait until element ".documentation-ui-test" is visible
     And I wait until ".content" contains text "Circuit Playground"

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -125,6 +125,11 @@ When /^I switch to the first iframe$/ do
   @browser.switch_to.frame @browser.find_element(tag_name: 'iframe')
 end
 
+When /^I switch to the iframe "([^"]*)"$/ do |iframe_selector|
+  $default_window = @browser.window_handle
+  @browser.switch_to.frame @browser.find_element(:css, iframe_selector)
+end
+
 # Can switch out of iframe content
 When /^I switch to the default content$/ do
   @browser.switch_to.default_content

--- a/pegasus/sites.v3/code.org/public/cookies/index.haml
+++ b/pegasus/sites.v3/code.org/public/cookies/index.haml
@@ -1,0 +1,8 @@
+---
+title: Code.org Cookie Notice
+theme: responsive
+---
+
+%link{ :href => "/css/cookies.css", :rel => "stylesheet" }
+
+= render inline: File.read(deploy_dir('shared/partials/cookie_notice.partial')), type: :partial

--- a/pegasus/sites.v3/code.org/public/cookies/index.partial
+++ b/pegasus/sites.v3/code.org/public/cookies/index.partial
@@ -1,0 +1,57 @@
+---
+title: Cookie Policy
+theme: responsive
+---
+
+<link href="/css/cookies.css" rel="stylesheet" />
+
+<a id="top"></a>
+<h1>Code.org Cookie Policy</h1>
+
+<strong>Date Last Updated:</strong> 01/07/2022
+<p class="cookies-intro">When you visit our website it may ask your browser to store a small piece of data (text file) called a cookie on your device to remember specific information, such as your language preference or login status.  We may use both session cookies and persistent cookies. A session cookie disappears automatically after the User closes their browser. A persistent cookie remains after the browser is closed and may be used by the browser on subsequent visits to the Services.  Cookies set by us and called first-party cookies. We also use third-party cookies, which are cookies from a domain other than the domain of the website you are visiting.  We use cookies and related technologies as follows:</p>
+
+<h2>Strictly Necessary Cookies</h2>
+
+<p>Some cookies are necessary for our website to function and cannot be switched off in our systems.  They are usually only set in response to actions made by you that amount to a request for services.   You can set your browser to block or alert you about these cookies, but that may cause some parts of the site to not work properly.  These cookies do not store any personally identifiable information.</p>
+Performance/Analytics Cookies
+
+<p>These cookies allow us to count and assess visits and traffic sources so we can measure and improve the performance of our site. They help us assess which pages are the most and least popular and see how users move around the site and use the curriculum. If these cookies are disabled, we will not know when a user like yourself has visited our site or be able to monitor the site’s performance.</p>
+<h2>Functional Cookies</h2>
+<p>These cookies enable the website to provide enhanced functionality and personalisation. They may be set by us or by third party providers whose services we have added to our pages. If you do not allow these cookies then some or all of these services may not function properly.
+<h2>Social Media Cookies</h2>
+<p>These cookies are set by social media services that we have added to the site to enable you to share content with your friends and networks. They are capable of tracking your browser across other sites and building up a profile of your interests. This may impact the content and messages you see on other websites you visit. If you do not allow these cookies you may not be able to use or see these sharing tools.</p>
+
+<h2>Marketing Cookies</h2>
+
+We may use marketing cookies to assess when a user interacts with marketing communications, such as a marketing email or a marketing-based landing page on our website.  Collected information is used to evaluate the effectiveness of our email campaigns or to provide better understanding of how our outreach is working so we can improve our communications and provide the most relevant information to our users.   </p> 
+<h2>How To Control and Delete Cookies</h2>
+
+<h3>Consent Tool</h3>
+<p>
+    The consent tool on our site can be utilized to customize your cookie preferences.  The consent tool specifically controls the performance/analytics, functional, social media, and  marketing cookies set by using our primary public websites (code.org and hourofcode.com).  Strictly necessary cookies cannot be disabled, nor can the tool be used to block cookies on third party websites linked from our website.<br>
+    <div class="cookies-consent-tool">
+        You can access the Cookie Consent tool anytime by clicking here: <button id="ot-sdk-btn" class="ot-sdk-show-settings cookies-settings-btn">Cookies Settings</button>
+    </div>
+</p>
+
+<h3>Using Your Browser</h3>
+<p>
+    Many of the cookies used on our website and through emails can be enabled or disabled through through your browser. To disable cookies through your browser, follow the instructions usually located within the “Help,” “Tools” or “Edit” menus in your browser. Please note that disabling a cookie or category of cookies does not delete the cookie from your browser unless manually completed through your browser function.  The following provides information on how to manage cookies on several popular browsers:
+    <ul>
+        <li><a href="https://support.google.com/accounts/answer/61416?co=GENIE.Platform%3DDesktop&hl=en">Google Chrome</a></li>
+        <li><a href="https://privacy.microsoft.com/en-us/windows-10-microsoft-edge-and-privacy">Microsoft Edge</a></li>
+        <li><a href="https://support.mozilla.org/en-US/kb/enable-and-disable-cookies-website-preferences">Mozilla Firefox</a></li>
+        <li><a href="https://support.microsoft.com/en-gb/help/17442/windows-internet-explorer-delete-manage-cookies">Microsoft Internet Explorer</a></li>
+        <li><a href="https://www.opera.com/help/tutorials/security/privacy/">Opera</a></li>
+        <li><a href="https://support.apple.com/en-gb/safari">Apple Safari</a></li>
+    </ul>
+    To find information relating to other browsers, visit the browser developer's website.
+</p>
+<br /><br />
+<p>To find out more about cookies, including how to see what cookies have been set, visit www.aboutcookies.org or www.allaboutcookies.org.</p>
+<p>To opt out of being tracked by Google Analytics across all websites, visit <a href="http://tools.google.com/dlpage/gaoptout">http://tools.google.com/dlpage/gaoptout</a>.</p>
+
+<h2>Questions?</h2>
+
+<p>For more information, you may contact us at <a href="mailto:privacy@code.org">privacy@code.org</a>.</p>

--- a/pegasus/sites.v3/code.org/public/cookies/index.partial
+++ b/pegasus/sites.v3/code.org/public/cookies/index.partial
@@ -1,30 +1,28 @@
 ---
-title: Cookie Policy
+title: Code.org Cookie Notice
 theme: responsive
 ---
 
 <link href="/css/cookies.css" rel="stylesheet" />
 
 <a id="top"></a>
-<h1>Code.org Cookie Policy</h1>
+<h1>Code.org Cookie Notice</h1>
 
-<strong>Date Last Updated:</strong> 01/07/2022
+<strong>Date Last Updated:</strong> 02/22/2022
 <p class="cookies-intro">When you visit our website it may ask your browser to store a small piece of data (text file) called a cookie on your device to remember specific information, such as your language preference or login status.  We may use both session cookies and persistent cookies. A session cookie disappears automatically after the User closes their browser. A persistent cookie remains after the browser is closed and may be used by the browser on subsequent visits to the Services.  Cookies set by us and called first-party cookies. We also use third-party cookies, which are cookies from a domain other than the domain of the website you are visiting.  We use cookies and related technologies as follows:</p>
 
 <h2>Strictly Necessary Cookies</h2>
-
 <p>Some cookies are necessary for our website to function and cannot be switched off in our systems.  They are usually only set in response to actions made by you that amount to a request for services.   You can set your browser to block or alert you about these cookies, but that may cause some parts of the site to not work properly.  These cookies do not store any personally identifiable information.</p>
-Performance/Analytics Cookies
 
+<h2>Performance/Analytics Cookies<h2>
 <p>These cookies allow us to count and assess visits and traffic sources so we can measure and improve the performance of our site. They help us assess which pages are the most and least popular and see how users move around the site and use the curriculum. If these cookies are disabled, we will not know when a user like yourself has visited our site or be able to monitor the site’s performance.</p>
+
 <h2>Functional Cookies</h2>
 <p>These cookies enable the website to provide enhanced functionality and personalisation. They may be set by us or by third party providers whose services we have added to our pages. If you do not allow these cookies then some or all of these services may not function properly.
-<h2>Social Media Cookies</h2>
-<p>These cookies are set by social media services that we have added to the site to enable you to share content with your friends and networks. They are capable of tracking your browser across other sites and building up a profile of your interests. This may impact the content and messages you see on other websites you visit. If you do not allow these cookies you may not be able to use or see these sharing tools.</p>
 
 <h2>Marketing Cookies</h2>
+<p>We may use marketing cookies to assess when a user interacts with marketing communications, such as a marketing email or a marketing-based landing page on our website.  Collected information is used to evaluate the effectiveness of our email campaigns or to provide better understanding of how our outreach is working so we can improve our communications and provide the most relevant information to our users.</p>
 
-We may use marketing cookies to assess when a user interacts with marketing communications, such as a marketing email or a marketing-based landing page on our website.  Collected information is used to evaluate the effectiveness of our email campaigns or to provide better understanding of how our outreach is working so we can improve our communications and provide the most relevant information to our users.   </p> 
 <h2>How To Control and Delete Cookies</h2>
 
 <h3>Consent Tool</h3>
@@ -36,20 +34,17 @@ We may use marketing cookies to assess when a user interacts with marketing comm
 </p>
 
 <h3>Using Your Browser</h3>
-<p>
-    Many of the cookies used on our website and through emails can be enabled or disabled through through your browser. To disable cookies through your browser, follow the instructions usually located within the “Help,” “Tools” or “Edit” menus in your browser. Please note that disabling a cookie or category of cookies does not delete the cookie from your browser unless manually completed through your browser function.  The following provides information on how to manage cookies on several popular browsers:
-    <ul>
-        <li><a href="https://support.google.com/accounts/answer/61416?co=GENIE.Platform%3DDesktop&hl=en">Google Chrome</a></li>
-        <li><a href="https://privacy.microsoft.com/en-us/windows-10-microsoft-edge-and-privacy">Microsoft Edge</a></li>
-        <li><a href="https://support.mozilla.org/en-US/kb/enable-and-disable-cookies-website-preferences">Mozilla Firefox</a></li>
-        <li><a href="https://support.microsoft.com/en-gb/help/17442/windows-internet-explorer-delete-manage-cookies">Microsoft Internet Explorer</a></li>
-        <li><a href="https://www.opera.com/help/tutorials/security/privacy/">Opera</a></li>
-        <li><a href="https://support.apple.com/en-gb/safari">Apple Safari</a></li>
-    </ul>
-    To find information relating to other browsers, visit the browser developer's website.
-</p>
-<br /><br />
-<p>To find out more about cookies, including how to see what cookies have been set, visit www.aboutcookies.org or www.allaboutcookies.org.</p>
+<p>Many of the cookies used on our website and through emails can be enabled or disabled through through your browser. To disable cookies through your browser, follow the instructions usually located within the “Help,” “Tools” or “Edit” menus in your browser. Please note that disabling a cookie or category of cookies does not delete the cookie from your browser unless manually completed through your browser function.  The following provides information on how to manage cookies on several popular browsers:</p>
+<ul>
+    <li><a href="https://support.google.com/accounts/answer/61416?co=GENIE.Platform%3DDesktop&hl=en">Google Chrome</a></li>
+    <li><a href="https://privacy.microsoft.com/en-us/windows-10-microsoft-edge-and-privacy">Microsoft Edge</a></li>
+    <li><a href="https://support.mozilla.org/en-US/kb/enable-and-disable-cookies-website-preferences">Mozilla Firefox</a></li>
+    <li><a href="https://support.microsoft.com/en-gb/help/17442/windows-internet-explorer-delete-manage-cookies">Microsoft Internet Explorer</a></li>
+    <li><a href="https://www.opera.com/help/tutorials/security/privacy/">Opera</a></li>
+    <li><a href="https://support.apple.com/en-gb/safari">Apple Safari</a></li>
+</ul>
+<p>To find information relating to other browsers, visit the browser developer's website.</p>
+<p>To find out more about cookies, including how to see what cookies have been set, visit <a href="www.aboutcookies.org">www.aboutcookies.org</a> or <a href="www.allaboutcookies.org">www.allaboutcookies.org</a>.</p>
 <p>To opt out of being tracked by Google Analytics across all websites, visit <a href="http://tools.google.com/dlpage/gaoptout">http://tools.google.com/dlpage/gaoptout</a>.</p>
 
 <h2>Questions?</h2>

--- a/pegasus/sites.v3/code.org/public/css/cookies.css
+++ b/pegasus/sites.v3/code.org/public/css/cookies.css
@@ -1,0 +1,20 @@
+.cookies-intro {
+  margin-top: 32px;
+}
+
+.cookies-settings-btn {
+  color: #fff !important;
+  margin: auto;
+  margin-left: 10px;
+  border: 0 !important;
+  height: 100% !important;
+}
+
+.cookies-settings-btn:hover {
+  background-color: #ffa400 !important;
+}
+
+.cookies-consent-tool {
+  display: flex;
+  align-items: center;
+}

--- a/pegasus/sites.v3/code.org/public/css/cookies.css
+++ b/pegasus/sites.v3/code.org/public/css/cookies.css
@@ -18,3 +18,8 @@
   display: flex;
   align-items: center;
 }
+
+.ot-cat-item:before,
+.ot-abt-tab:before {
+  content: none;
+}

--- a/pegasus/sites.v3/code.org/themes/default.haml
+++ b/pegasus/sites.v3/code.org/themes/default.haml
@@ -1,6 +1,8 @@
 !!! 5
 %html
   %head
+    = render inline: File.read(deploy_dir('shared/haml/onetrust_cookie_scripts.haml')), type: :haml
+
     =view :theme_common_head_before
 
     %link{rel:'stylesheet', type:'text/css', href:'/css/common.css'}

--- a/pegasus/sites.v3/code.org/themes/responsive.haml
+++ b/pegasus/sites.v3/code.org/themes/responsive.haml
@@ -5,6 +5,7 @@
 
 %html{dir: dir}
   %head
+    = render inline: File.read(deploy_dir('shared/haml/onetrust_cookie_scripts.haml')), type: :haml
 
     %meta{name: "google-site-verification", content: "EWBLxcxuqqtcdWikkxAOnMoaawa6XDoEPlvwO6wOg-A"}
 

--- a/pegasus/sites.v3/code.org/themes/responsive_wide.haml
+++ b/pegasus/sites.v3/code.org/themes/responsive_wide.haml
@@ -1,6 +1,7 @@
 !!! 5
 %html
   %head
+    = render inline: File.read(deploy_dir('shared/haml/onetrust_cookie_scripts.haml')), type: :haml
 
     %meta{name: "google-site-verification", content: "EWBLxcxuqqtcdWikkxAOnMoaawa6XDoEPlvwO6wOg-A"}
 

--- a/pegasus/sites.v3/hourofcode.com/public/cookies.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/cookies.haml
@@ -1,0 +1,8 @@
+---
+title: Code.org Cookie Notice
+layout: wide
+---
+
+%link{ :href => "/css/cookies.css", :rel => "stylesheet" }
+
+= render inline: File.read(deploy_dir('shared/partials/cookie_notice.partial')), type: :partial

--- a/pegasus/sites.v3/hourofcode.com/public/css/cookies.css
+++ b/pegasus/sites.v3/hourofcode.com/public/css/cookies.css
@@ -1,0 +1,20 @@
+.cookies-intro {
+  margin-top: 32px;
+}
+
+.cookies-settings-btn {
+  color: #fff !important;
+  margin: auto;
+  margin-left: 10px;
+  border: 0 !important;
+  height: 100% !important;
+}
+
+.cookies-settings-btn:hover {
+  background-color: #ffa400 !important;
+}
+
+.cookies-consent-tool {
+  display: flex;
+  align-items: center;
+}

--- a/pegasus/sites.v3/hourofcode.com/public/css/cookies.css
+++ b/pegasus/sites.v3/hourofcode.com/public/css/cookies.css
@@ -18,3 +18,8 @@
   display: flex;
   align-items: center;
 }
+
+.ot-cat-item:before,
+.ot-abt-tab:before {
+  content: none;
+}

--- a/pegasus/sites.v3/hourofcode.com/themes/default.haml
+++ b/pegasus/sites.v3/hourofcode.com/themes/default.haml
@@ -1,6 +1,8 @@
 !!! 5
 %html
   %head
+    = render inline: File.read(deploy_dir('shared/haml/hoc_onetrust_cookie_scripts.haml')), type: :haml
+
     =view :theme_common_head_before
 
     -unless page_translated?

--- a/shared/haml/hoc_onetrust_cookie_scripts.haml
+++ b/shared/haml/hoc_onetrust_cookie_scripts.haml
@@ -1,0 +1,8 @@
+-# OneTrust Cookies Consent Notice scripts for hourofcode.com
+- if rack_env?(:production)
+  %script{src: 'https://cdn.cookielaw.org/scripttemplates/otSDKStub.js', type: 'text/javascript', charset: 'UTF-8', 'data-domain-script' => '7c79c547-a2fc-4998-9b21-0c7a5e67e345'}
+- else
+  %script{src: 'https://cdn.cookielaw.org/scripttemplates/otSDKStub.js', type: 'text/javascript', charset: 'UTF-8', 'data-domain-script' => '7c79c547-a2fc-4998-9b21-0c7a5e67e345-test'}
+
+:javascript
+  function OptanonWrapper() { }

--- a/shared/haml/onetrust_cookie_scripts.haml
+++ b/shared/haml/onetrust_cookie_scripts.haml
@@ -1,0 +1,9 @@
+-# OneTrust Cookies Consent Notice scripts for code.org
+- if rack_env?(:production)
+  %script{src: 'https://cdn.cookielaw.org/scripttemplates/otSDKStub.js', type: 'text/javascript', charset: 'UTF-8', 'data-domain-script' => '27cca70a-7db3-4852-9ef0-a6660fd0977d'}
+- else
+  %script{src: 'https://cdn.cookielaw.org/consent/27cca70a-7db3-4852-9ef0-a6660fd0977d-test/OtAutoBlock.js', type: 'text/javascript'}
+  %script{src: 'https://cdn.cookielaw.org/scripttemplates/otSDKStub.js', type: 'text/javascript', charset: 'UTF-8', 'data-domain-script' => '27cca70a-7db3-4852-9ef0-a6660fd0977d-test'}
+
+:javascript
+  function OptanonWrapper() { }

--- a/shared/partials/cookie_notice.partial
+++ b/shared/partials/cookie_notice.partial
@@ -1,10 +1,3 @@
----
-title: Code.org Cookie Notice
-theme: responsive
----
-
-<link href="/css/cookies.css" rel="stylesheet" />
-
 <a id="top"></a>
 <h1>Code.org Cookie Notice</h1>
 


### PR DESCRIPTION
Adds a new code.org/cookies page with the details of our cookie policy and a link to the OneTrust tool for managing cookie preferences.

A link to the /cookies page will be added to the footer in [a separate PR](https://github.com/code-dot-org/code-dot-org/pull/44980) so the OneTrust tool can be tested in production before making it available to users.

## Links

- jira ticket: [https://codedotorg.atlassian.net/browse/FND-1886](FND-1886)
