### PR TITLE
Adding freecurrencyapi.net and pro-api.coinmarketcap.com

### DIFF
--- a/dashboard/app/controllers/xhr_proxy_controller.rb
+++ b/dashboard/app/controllers/xhr_proxy_controller.rb
@@ -75,6 +75,7 @@ class XhrProxyController < ApplicationController
     distanza.org
     dweet.io
     enclout.com
+    freecurrencyapi.net
     googleapis.com
     grobchess.com
     herokuapp.com
@@ -93,6 +94,7 @@ class XhrProxyController < ApplicationController
     pastebin.com
     pixabay.com
     pokeapi.co
+    pro-api.coinmarketcap.com
     qrng.anu.edu.au
     quandl.com
     random.org


### PR DESCRIPTION
A user requested freecurrencyapi.net be added to supported hostnames as it has a larger limit than other currency APIs

Zendesk ticket: https://codeorg.zendesk.com/agent/tickets/373935
API documentation: https://freecurrencyapi.net/documentation
Jira ticket: https://codedotorg.atlassian.net/browse/STAR-2101

A user reported that api.coinmarketcap.com is now using pro-api.coinmarketcap.com for its' requests, so we need to update the hostname. We had actually removed this hostname because a user reported it was not working, when it should have been updated at that time but we didn't know about the hostname change: https://github.com/code-dot-org/code-dot-org/pull/33053

Zendesk ticket: https://codeorg.zendesk.com/agent/tickets/375344
API documentation: https://coinmarketcap.com/api/documentation/v1/
Jira ticket: https://codedotorg.atlassian.net/browse/STAR-2109
