### PR TITLE
Fnd 1805 add offline service worker

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -4,6 +4,7 @@ var path = require('path');
 var fs = require('fs');
 var _ = require('lodash');
 var webpackConfig = require('./webpack');
+var offlineWebpackConfig = require('./webpackOffline.config');
 var envConstants = require('./envConstants');
 var checkEntryPoints = require('./script/checkEntryPoints');
 var {BundleAnalyzerPlugin} = require('webpack-bundle-analyzer');
@@ -1055,6 +1056,8 @@ describe('entry tests', () => {
       watch: false
     }),
 
+    buildOffline: offlineWebpackConfig,
+
     uglify: createConfig({
       minify: true,
       watch: false
@@ -1272,10 +1275,13 @@ describe('entry tests', () => {
     // exist in our repo. Skip minification in development environment.
     envConstants.DEV ? 'noop' : 'uglify:lib',
     envConstants.DEV ? 'webpack:build' : 'webpack:uglify',
+    'webpack:buildOffline',
     'notify:js-build',
     'postbuild',
     envConstants.DEV ? 'noop' : 'newer:copy:unhash'
   ]);
+
+  grunt.registerTask('buildOffline', ['webpack:buildOffline']);
 
   grunt.registerTask('rebuild', ['clean', 'build']);
 

--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -1281,6 +1281,7 @@ describe('entry tests', () => {
     envConstants.DEV ? 'noop' : 'newer:copy:unhash'
   ]);
 
+  // Builds the Service Worker used for the Code.org offline experience.
   grunt.registerTask('buildOffline', ['webpack:buildOffline']);
 
   grunt.registerTask('rebuild', ['clean', 'build']);

--- a/apps/package.json
+++ b/apps/package.json
@@ -17,6 +17,7 @@
     "test:interpreter": "TZ=UTC js-interpreter-tyrant --run --diff --root ./test/interpreter --interpreter ./test/interpreter/patched-interpreter.js --progress",
     "clean": "grunt clean",
     "build": "DEV=1 node --max_old_space_size=4096 ./node_modules/.bin/grunt build",
+    "build:offline": "DEV=1 node --max_old_space_size=4096 ./node_modules/.bin/grunt buildOffline",
     "build:analyze": "ANALYZE_BUNDLE=1 DEV=1 node --max_old_space_size=4096 ./node_modules/.bin/grunt build",
     "build:dist": "NODE_ENV=production node --max_old_space_size=4096 ./node_modules/.bin/grunt clean build",
     "build:dist:debug": "NODE_ENV=production DEBUG_MINIFIED=1 node --max_old_space_size=4096 ./node_modules/.bin/grunt clean build",

--- a/apps/src/offline/offline-service-worker.js
+++ b/apps/src/offline/offline-service-worker.js
@@ -1,3 +1,8 @@
+/**
+ * The Service Worker which enables the offline PWA experience for Code.org. It is responsible for
+ * caching html, javascript, images, etc so that they can be used when students don't have an
+ * internet connection.
+ */
 const cacheVersion = 1;
 const cacheName = `code-org-pwa-v${cacheVersion}`;
 const cachedFiles = ['/s/express-2021/lessons/1/levels/1'];

--- a/apps/src/offline/offline-service-worker.js
+++ b/apps/src/offline/offline-service-worker.js
@@ -1,0 +1,14 @@
+const cacheVersion = 1;
+const cacheName = `code-org-pwa-v${cacheVersion}`;
+const cachedFiles = ['/s/express-2021/lessons/1/levels/1'];
+
+self.addEventListener('install', e => {
+  console.log('[Service Worker] installing offline service worker!');
+  e.waitUntil(
+    (async () => {
+      const cache = await caches.open(cacheName);
+      console.log('[Service Worker] Caching:', cachedFiles);
+      await cache.addAll(cachedFiles);
+    })()
+  );
+});

--- a/apps/src/sites/studio/pages/code-studio.js
+++ b/apps/src/sites/studio/pages/code-studio.js
@@ -16,6 +16,7 @@ import initResponsive from '@cdo/apps/code-studio/responsive';
 import hashEmail from '@cdo/apps/code-studio/hashEmail';
 import GDPRDialog from '@cdo/apps/templates/GDPRDialog';
 import getScriptData from '@cdo/apps/util/getScriptData';
+import Cookie from 'js-cookie';
 
 const store = getStore();
 store.dispatch(setRtlFromDOM());
@@ -129,3 +130,17 @@ checkForUnsupportedBrowsersOnLoad();
 initHamburger();
 initSigninState(userType);
 initResponsive();
+
+try {
+  // Gate the Offline Pilot features using the offline_pilot experiment cookie.
+  const offlinePilotCookie = Cookie.get('offline_pilot');
+  const offlinePilot = offlinePilotCookie && JSON.parse(offlinePilotCookie);
+  if (offlinePilot) {
+    // Register the offline service worker.
+    if ('serviceWorker' in navigator && window.OFFLINE_SERVICE_WORKER_PATH) {
+      navigator.serviceWorker.register(window.OFFLINE_SERVICE_WORKER_PATH);
+    }
+  }
+} catch (e) {
+  console.error('Unable to setup the offline pilot experiment', e);
+}

--- a/apps/webpackOffline.config.js
+++ b/apps/webpackOffline.config.js
@@ -1,3 +1,7 @@
+/**
+ * This is a Webpack configuration for building the Service Worker used to enable the offline Code.org
+ * experience.
+ */
 const path = require('path');
 const ManifestPlugin = require('webpack-manifest-plugin');
 
@@ -20,6 +24,8 @@ const config = {
           {
             loader: 'babel-loader',
             options: {
+              // Do no load the global babel.config.json because it is incompatible with "webworker"
+              // code.
               configFile: false
             }
           }
@@ -28,10 +34,13 @@ const config = {
     ]
   },
   plugins: [
+    // Generates a key/value mapping of a source file's name to its final name.
+    // e.g. 'js/offline-service-worker.js': 'offline-service-workerwpfb055f24d3026d753ccc.min.js'
     new ManifestPlugin({
       basePath: 'js/',
       fileName: 'offline-manifest.json',
       filter: file => {
+        // This webpack build is only concerned with the offline service worker code.
         return file.name === 'js/offline-service-worker.js';
       }
     })

--- a/apps/webpackOffline.config.js
+++ b/apps/webpackOffline.config.js
@@ -1,0 +1,40 @@
+const path = require('path');
+const ManifestPlugin = require('webpack-manifest-plugin');
+
+const config = {
+  target: 'webworker',
+  entry: {
+    'offline-service-worker': './src/offline/offline-service-worker.js'
+  },
+  output: {
+    path: path.resolve(__dirname, 'build/package/js/'),
+    publicPath: '/',
+    filename: '[name]wp[contenthash].min.js'
+  },
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        include: [path.resolve(__dirname, 'src/offline')],
+        use: [
+          {
+            loader: 'babel-loader',
+            options: {
+              configFile: false
+            }
+          }
+        ]
+      }
+    ]
+  },
+  plugins: [
+    new ManifestPlugin({
+      basePath: 'js/',
+      fileName: 'offline-manifest.json',
+      filter: file => {
+        return file.name === 'js/offline-service-worker.js';
+      }
+    })
+  ]
+};
+module.exports = config;

--- a/apps/webpackOffline.config.js
+++ b/apps/webpackOffline.config.js
@@ -4,9 +4,13 @@
  */
 const path = require('path');
 const ManifestPlugin = require('webpack-manifest-plugin');
+const envConstants = require('./envConstants');
+const mode = envConstants.DEV ? 'development' : 'production';
 
 const config = {
   target: 'webworker',
+  mode: mode,
+  devtool: 'source-map',
   entry: {
     'offline-service-worker': './src/offline/offline-service-worker.js'
   },
@@ -38,12 +42,9 @@ const config = {
     // e.g. 'js/offline-service-worker.js': 'offline-service-workerwpfb055f24d3026d753ccc.min.js'
     new ManifestPlugin({
       basePath: 'js/',
-      fileName: 'offline-manifest.json',
-      filter: file => {
-        // This webpack build is only concerned with the offline service worker code.
-        return file.name === 'js/offline-service-worker.js';
-      }
+      fileName: 'offline-manifest.json'
     })
   ]
 };
+
 module.exports = config;

--- a/dashboard/app/controllers/offline_controller.rb
+++ b/dashboard/app/controllers/offline_controller.rb
@@ -4,4 +4,10 @@ class OfflineController < ApplicationController
     cookies[:offline_pilot] = {value: true, domain: :all, expires: 1.year.from_now}
     redirect_to '/home'
   end
+
+  # Responds with the offline-service-worker.js file.
+  def offline_service_worker
+    file_path = webpack_offline_asset_path('js/offline-service-worker.js')
+    send_file(dashboard_dir('public', 'blockly', 'js', file_path), type: 'application/javascript')
+  end
 end

--- a/dashboard/app/controllers/offline_controller.rb
+++ b/dashboard/app/controllers/offline_controller.rb
@@ -5,7 +5,7 @@ class OfflineController < ApplicationController
     redirect_to '/home'
   end
 
-  # Responds with the offline-service-worker.js file.
+  # Responds with the offline-service-worker.js or .js.map files.
   def offline_service_worker
     filename = ActiveStorage::Filename.new(params[:file]).sanitized
     send_file(dashboard_dir('public', 'blockly', 'js', filename), type: 'application/javascript')

--- a/dashboard/app/controllers/offline_controller.rb
+++ b/dashboard/app/controllers/offline_controller.rb
@@ -7,7 +7,7 @@ class OfflineController < ApplicationController
 
   # Responds with the offline-service-worker.js file.
   def offline_service_worker
-    file_path = webpack_offline_asset_path('js/offline-service-worker.js')
-    send_file(dashboard_dir('public', 'blockly', 'js', file_path), type: 'application/javascript')
+    filename = ActiveStorage::Filename.new(params[:file]).sanitized
+    send_file(dashboard_dir('public', 'blockly', 'js', filename), type: 'application/javascript')
   end
 end

--- a/dashboard/app/views/layouts/application.html.haml
+++ b/dashboard/app/views/layouts/application.html.haml
@@ -9,6 +9,7 @@
         var _jipt = [];
         _jipt.push(['project', 'codeorg']);
       %script{type: "text/javascript", src: "//cdn.crowdin.com/jipt/jipt.js"}
+    -# Setup variables used by the Offline feature.
     :javascript
       window.OFFLINE_SERVICE_WORKER_PATH =
         "#{webpack_offline_asset_path('js/offline-service-worker.js')}"

--- a/dashboard/app/views/layouts/application.html.haml
+++ b/dashboard/app/views/layouts/application.html.haml
@@ -41,8 +41,8 @@
     %script{src: webpack_asset_path('js/code-studio-common.js')}
     = csrf_meta_tags
     -# Load the manifest.webmanifest for Maze if user is in the offline pilot
-    - if request.cookies[:offline_pilot] && !@script.nil? && @script.name == 'express-2021' && !@lesson.nil? && @lesson.absolute_position == 1
-      %link{rel: 'manifest', href: '/s/#{@script.name}/lessons/#{@lesson.absolute_position}/manifest.webmanifest'}
+    - if request.cookies['offline_pilot'] && !@script.nil? && @script.name == 'express-2021' && !@lesson.nil? && @lesson.absolute_position == 1
+      %link{rel: 'manifest', href: "/s/#{@script.name}/lessons/#{@lesson.absolute_position}/manifest.webmanifest"}
     = yield :head
     - if content_for? :og
       = yield :og

--- a/dashboard/app/views/layouts/application.html.haml
+++ b/dashboard/app/views/layouts/application.html.haml
@@ -9,6 +9,9 @@
         var _jipt = [];
         _jipt.push(['project', 'codeorg']);
       %script{type: "text/javascript", src: "//cdn.crowdin.com/jipt/jipt.js"}
+    :javascript
+      window.OFFLINE_SERVICE_WORKER_PATH =
+        "#{webpack_offline_asset_path('js/offline-service-worker.js')}"
     - appname = Rails.env.production? ? t(:appname) : "#{t(:appname)} [#{Rails.env}]"
     - title = @page_title ? "#{@page_title} - #{appname}" : appname
     %title= title

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -931,5 +931,9 @@ Dashboard::Application.routes.draw do
   get 'reviewable_projects/for_level', to: 'reviewable_projects#for_level'
   get 'reviewable_projects/reviewable_status', to: 'reviewable_projects#reviewable_status'
 
+  # offline-service-worker*.js needs to be loaded the the root level of the
+  # domain('studio.code.org/').
+  get '/:file', action: :offline_service_worker, controller: :offline, constraints: {file: /offline-service-worker.*\.js/}
+  # Adds the experiment cookie in the User's browser which allows them to experience offline features
   get '/offline/join_pilot', action: :set_offline_cookie, controller: :offline
 end

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -933,7 +933,8 @@ Dashboard::Application.routes.draw do
 
   # offline-service-worker*.js needs to be loaded the the root level of the
   # domain('studio.code.org/').
-  get '/:file', action: :offline_service_worker, controller: :offline, constraints: {file: /offline-service-worker.*\.js/}
+  # Matches on ".js" or ".map" in order to serve source-map files for the service worker javascript.
+  get '/:file', action: :offline_service_worker, controller: :offline, constraints: {file: /offline-service-worker.*\.(js|map)/}
   # Adds the experiment cookie in the User's browser which allows them to experience offline features
   get '/offline/join_pilot', action: :set_offline_cookie, controller: :offline
 end

--- a/lib/cdo/asset_helper.rb
+++ b/lib/cdo/asset_helper.rb
@@ -7,8 +7,16 @@ class AssetHelper
     "#{CDO.root_dir}/dashboard/public/blockly/js/manifest.json"
   end
 
+  def offline_webpack_manifest_path
+    "#{CDO.root_dir}/dashboard/public/blockly/js/offline-manifest.json"
+  end
+
   def webpack_manifest
     @webpack_manifest ||= JSON.parse(File.read(webpack_manifest_path))
+  end
+
+  def webpack_offline_manifest
+    @webpack_offline_manifest ||= JSON.parse(File.read(offline_webpack_manifest_path))
   end
 
   #
@@ -40,8 +48,18 @@ class AssetHelper
     raise "Invalid webpack asset name: '#{asset}'" unless path
     path
   end
+
+  def webpack_offline_asset_path(asset)
+    path = webpack_offline_manifest[asset]
+    raise "Invalid webpack asset name: '#{asset}'" unless path
+    path
+  end
 end
 
 def webpack_asset_path(asset)
   AssetHelper.instance.webpack_asset_path(asset)
+end
+
+def webpack_offline_asset_path(asset)
+  AssetHelper.instance.webpack_offline_asset_path(asset)
 end

--- a/lib/cdo/asset_helper.rb
+++ b/lib/cdo/asset_helper.rb
@@ -7,6 +7,7 @@ class AssetHelper
     "#{CDO.root_dir}/dashboard/public/blockly/js/manifest.json"
   end
 
+  # Manifest file for the offline feature's webpack build output.
   def offline_webpack_manifest_path
     "#{CDO.root_dir}/dashboard/public/blockly/js/offline-manifest.json"
   end
@@ -49,6 +50,7 @@ class AssetHelper
     path
   end
 
+  # Returns the asset path for assets handled by the offline feature's webpack build.
   def webpack_offline_asset_path(asset)
     path = webpack_offline_manifest[asset]
     raise "Invalid webpack asset name: '#{asset}'" unless path
@@ -60,6 +62,7 @@ def webpack_asset_path(asset)
   AssetHelper.instance.webpack_asset_path(asset)
 end
 
+# Returns the asset path for assets handled by the offline feature's webpack build.
 def webpack_offline_asset_path(asset)
   AssetHelper.instance.webpack_offline_asset_path(asset)
 end


### PR DESCRIPTION
## Goal
Create the foundation for building, delivering, and installing the offline service worker.
1. Create a PWA Service Worker javascript file which creates an offline cache.
2. The Service Worker javascript is available at the root of the dashboard site (https://studio.code.org/service-worker.js)
3. *service-worker.js* is managed by a webpack config in the *apps* directory.

## Context
We are working on a pilot project for making part of studio.code.org work offline. The first step is setting up a Service Worker which can manage the offline content. This PR does the foundational work of setting up some skeleton javascript code which gets built by our webpack pipeline and delivered by our rails router.

## Links
* [JIRA](https://codedotorg.atlassian.net/browse/FND-1805)

## Testing story
* Manually tested
  * Visit http://localhost-studio.code.org:3000/offline/join_pilot in order to get the cookie which enables the offline feature.
  * Open the developer tools in the Chrome browser.
  * Visit http://localhost-studio.code.org:3000/s/express-2021/lessons/1/levels/1
  * Observe that the "Service worker installed" messages in the Javascript console.
  * Open the Application tab -> Cache Storage. Observe that `code-org-pwa-v1` cache was created.

## Deployment strategy
* Changes are all behind an experiment flag, so this shouldn't affect production.

## Follow-up work
* Created a JIRA task to setup unit tests.

## Caching
* We will address this before launch
