### PR TITLE
bug fix

### DIFF
--- a/apps/src/p5lab/spritelab/commands/criterionCommands.js
+++ b/apps/src/p5lab/spritelab/commands/criterionCommands.js
@@ -29,7 +29,7 @@ export const commands = {
     const spriteIds = this.getSpriteIdsInUse();
     let result = false;
     for (let i = 0; i < spriteIds.length; i++) {
-      if (validationCommands.spriteSpeechRenderedThisFrame.call(this, i)) {
+      if (commands.spriteSpeechRenderedThisFrame.call(this, i)) {
         result = true;
       }
     }
@@ -78,7 +78,7 @@ export const commands = {
     let result = false;
     let count = 0;
     for (let i = 0; i < spriteIds.length; i++) {
-      if (validationCommands.spriteSpeechRenderedThisFrame.call(this, i)) {
+      if (commands.spriteSpeechRenderedThisFrame.call(this, i)) {
         count++;
       }
     }


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/code-dot-org/code-dot-org/pull/44790
Many functions were moved from validationCommands to criterionCommands. `spriteSpeechRenderedThisFrame()` is one such function that was moved so calls to it should just use `commands`. This was causing validation to break in levels that use `say` blocks.