### PR TITLE
Consolidating references to storage apps table

### DIFF
--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -168,16 +168,20 @@ class ProjectsController < ApplicationController
   end
 
   def project_and_featured_project_fields
-    [
-      :storage_apps__id___id,
-      :storage_apps__storage_id___storage_id,
-      :storage_apps__value___value,
-      :storage_apps__project_type___project_type,
-      :storage_apps__published_at___published_at,
+    storage_apps_fields = prefix_storage_app_fields(%w(id___id storage_id___storage_id value___value project_type___project_type published_at___published_at))
+
+    featured_projects_fields = [
       :featured_projects__featured_at___featured_at,
       :featured_projects__unfeatured_at___unfeatured_at,
       :featured_projects__topic___topic
     ]
+
+    storage_apps_fields.concat(featured_projects_fields)
+  end
+
+  def prefix_storage_app_fields(field_names)
+    table_name = "storage_apps"
+    field_names.map {|field_name| "#{table_name}__#{field_name}".to_sym}
   end
 
   def combine_projects_and_featured_projects_data

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -2346,15 +2346,15 @@ class User < ApplicationRecord
     return unless user_storage_id
 
     user_storage_apps = StorageApps.new(user_storage_id)
-    channel_ids = user_storage_apps.get_all_storage_ids
+    storage_app_ids = user_storage_apps.get_all_storage_app_ids
 
     # Unfeature any featured projects owned by the user
     FeaturedProject.
-      where(storage_app_id: channel_ids, unfeatured_at: nil).
+      where(storage_app_id: storage_app_ids, unfeatured_at: nil).
       where.not(featured_at: nil).
       update_all(unfeatured_at: Time.now)
 
-    # Soft-delete all of the user's channels
+    # Soft-delete all of the user's storage_apps
     user_storage_apps.soft_delete_all
   end
 

--- a/dashboard/lib/projects_list.rb
+++ b/dashboard/lib/projects_list.rb
@@ -33,7 +33,7 @@ module ProjectsList
     def fetch_personal_projects(user_id)
       personal_projects_list = []
       storage_id = storage_id_for_user_id(user_id)
-      PEGASUS_DB[:storage_apps].where(storage_id: storage_id, state: 'active').each do |project|
+      StorageApps.new(storage_id).get_active_projects.each do |project|
         channel_id = storage_encrypt_channel_id(storage_id, project[:id])
         project_data = get_project_row_data(project, channel_id, nil, true)
         personal_projects_list << project_data if project_data
@@ -73,7 +73,7 @@ module ProjectsList
         student_storage_ids = get_storage_ids_by_user_ids(section_students.pluck(:id))
         section_students.each do |student|
           next unless student_storage_id = student_storage_ids[student.id]
-          PEGASUS_DB[:storage_apps].where(storage_id: student_storage_id, state: 'active').each do |project|
+          StorageApps.new(student_storage_id).get_active_projects.each do |project|
             # The channel id stored in the project's value field may not be reliable
             # when apps are remixed, so recompute the channel id.
             channel_id = storage_encrypt_channel_id(student_storage_id, project[:id])
@@ -185,7 +185,8 @@ module ProjectsList
       return [] if project_ids.nil_or_empty?
 
       updated_library_channels = []
-      PEGASUS_DB[:storage_apps].where(id: project_ids).each do |project|
+
+      StorageApps.get_by_ids(project_ids).each do |project|
         library = libraries.find {|lib| lib['project_id'] == project[:id]}
         project_value = JSON.parse(project[:value])
         next unless library && project_value['latestLibraryVersion']

--- a/dashboard/test/controllers/api/v1/projects/personal_projects_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/projects/personal_projects_controller_test.rb
@@ -12,9 +12,7 @@ class Api::V1::Projects::PersonalProjectsControllerTest < ActionDispatch::Integr
     }.to_json
     personal_project = {id: 22, value: personal_project_value}
 
-    PEGASUS_DB.stubs(:[]).with(:storage_apps).returns(
-      stub(where: [personal_project])
-    )
+    StorageApps.any_instance.stubs(:get_active_projects).returns([personal_project])
   end
 
   test 'personal projects are correct' do

--- a/dashboard/test/controllers/api/v1/projects/section_projects_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/projects/section_projects_controller_test.rb
@@ -37,9 +37,7 @@ class Api::V1::Projects::SectionProjectsControllerTest < ActionController::TestC
     other_student_project = {id: 44, value: other_student_project_value}
 
     ProjectsList.stubs(:get_storage_ids_by_user_ids).returns({@student.id => STUDENT_STORAGE_ID})
-    PEGASUS_DB.stubs(:[]).with(:storage_apps).returns(
-      stub(where: [student_project, hidden_project, other_student_project])
-    )
+    StorageApps.any_instance.stubs(:get_active_projects).returns([student_project, hidden_project, other_student_project])
   end
 
   test_user_gets_response_for(

--- a/dashboard/test/testing/storage_apps_test_utils.rb
+++ b/dashboard/test/testing/storage_apps_test_utils.rb
@@ -36,6 +36,6 @@ module StorageAppsTestUtils
   end
 
   def storage_apps
-    PEGASUS_DB[:storage_apps]
+    StorageApps.table
   end
 end

--- a/lib/cdo/delete_accounts_helper.rb
+++ b/lib/cdo/delete_accounts_helper.rb
@@ -1,4 +1,5 @@
 require_relative '../../shared/middleware/helpers/storage_id'
+require_relative '../../shared/middleware/helpers/storage_apps'
 require 'cdo/aws/s3'
 require 'cdo/db'
 
@@ -34,14 +35,14 @@ class DeleteAccountsHelper
 
     @log.puts "Deleting project backed progress"
 
-    storage_app_ids = @pegasus_db[:storage_apps].where(storage_id: user.user_storage_id).map(:id)
+    storage_app_ids = StorageApps.table.where(storage_id: user.user_storage_id).map(:id)
     channel_count = storage_app_ids.count
     encrypted_channel_ids = storage_app_ids.map do |storage_app_id|
       storage_encrypt_channel_id user.user_storage_id, storage_app_id
     end
 
     # Clear potential PII from user's channels
-    @pegasus_db[:storage_apps].
+    StorageApps.table.
       where(id: storage_app_ids).
       update(value: nil, updated_ip: '', updated_at: Time.now)
 

--- a/shared/middleware/helpers/storage_apps.rb
+++ b/shared/middleware/helpers/storage_apps.rb
@@ -12,7 +12,7 @@ class StorageApps
   def initialize(storage_id)
     @storage_id = storage_id
 
-    @table = PEGASUS_DB[:storage_apps]
+    @table = StorageApps.table
   end
 
   def create(value, ip:, type: nil, published_at: nil, remix_parent_id: nil, standalone: true)
@@ -121,6 +121,29 @@ class StorageApps
       studentName: user && UserHelpers.initial(user[:name]),
       studentAgeRange: user && UserHelpers.age_range_from_birthday(user[:birthday]),
     )
+  end
+
+  # Returns an array of all ids for storage apps with storage id = @storage_id
+  def get_all_storage_ids
+    StorageApps.table.
+      where(storage_id: @storage_id).
+      map(:id)
+  end
+
+  # Soft-delete all of the storage apps for user with storage id @storage_id
+  def soft_delete_all
+    StorageApps.table.
+      where(storage_id: @storage_id).
+      exclude(state: 'deleted').
+      update(state: 'deleted', updated_at: Time.now)
+  end
+
+  # Restores all of this user's projects that were soft-deleted after the given time
+  def restore_if_deleted_after(deleted_time)
+    StorageApps.table.
+      where(storage_id: @storage_id, state: 'deleted').
+      where(Sequel.lit('updated_at >= ?', deleted_time.localtime)).
+      update(state: 'active', updated_at: Time.now)
   end
 
   # extracts published project data from a project (aka storage_apps table row).
@@ -334,9 +357,9 @@ class StorageApps
   def self.remix_ancestry(channel_id, depth: 1)
     [].tap do |ancestors|
       _, storage_app_id = storage_decrypt_channel_id(channel_id)
-      next_row = PEGASUS_DB[:storage_apps].where(id: storage_app_id).first
+      next_row = StorageApps.table.where(id: storage_app_id).first
       while next_row&.[](:remix_parent_id)
-        next_row = PEGASUS_DB[:storage_apps].where(id: next_row[:remix_parent_id]).first
+        next_row = StorageApps.table.where(id: next_row[:remix_parent_id]).first
         ancestors.push storage_encrypt_channel_id(next_row[:storage_id], next_row[:id]) if next_row
         break if ancestors.size >= depth
       end
@@ -347,8 +370,12 @@ class StorageApps
 
   def self.get_abuse(channel_id)
     _, storage_app_id = storage_decrypt_channel_id(channel_id)
-    project_info = PEGASUS_DB[:storage_apps].where(id: storage_app_id).first
+    project_info = StorageApps.table.where(id: storage_app_id).first
     project_info[:abuse_score]
+  end
+
+  def self.table
+    PEGASUS_DB[:storage_apps]
   end
 
   private

--- a/shared/middleware/helpers/storage_apps.rb
+++ b/shared/middleware/helpers/storage_apps.rb
@@ -123,6 +123,10 @@ class StorageApps
     )
   end
 
+  def get_active_projects
+    StorageApps.table.where(storage_id: @storage_id, state: 'active')
+  end
+
   # Returns an array of all ids for storage apps with storage id = @storage_id
   def get_all_storage_ids
     StorageApps.table.
@@ -372,6 +376,11 @@ class StorageApps
     _, storage_app_id = storage_decrypt_channel_id(channel_id)
     project_info = StorageApps.table.where(id: storage_app_id).first
     project_info[:abuse_score]
+  end
+
+  # Returns storage apps with id in ids
+  def self.get_by_ids(ids)
+    StorageApps.table.where(id: ids)
   end
 
   def self.table

--- a/shared/middleware/helpers/storage_apps.rb
+++ b/shared/middleware/helpers/storage_apps.rb
@@ -138,8 +138,7 @@ class StorageApps
   end
 
   # Returns an array of all ids for storage apps with storage id = @storage_id
-  # Maureen the name of this method is very confusing - fix
-  def get_all_storage_ids
+  def get_all_storage_app_ids
     StorageApps.table.
       where(storage_id: @storage_id).
       map(:id)

--- a/shared/middleware/helpers/storage_apps.rb
+++ b/shared/middleware/helpers/storage_apps.rb
@@ -127,7 +127,18 @@ class StorageApps
     StorageApps.table.where(storage_id: @storage_id, state: 'active')
   end
 
+  def get_projects_with_state(state: 'active', order: nil)
+    query = StorageApps.table.where(storage_id: @storage_id, state: state)
+
+    if order.present?
+      query.order(order)
+    end
+
+    query
+  end
+
   # Returns an array of all ids for storage apps with storage id = @storage_id
+  # Maureen the name of this method is very confusing - fix
   def get_all_storage_ids
     StorageApps.table.
       where(storage_id: @storage_id).

--- a/shared/test/test_channels.rb
+++ b/shared/test/test_channels.rb
@@ -456,18 +456,18 @@ class ChannelsTest < Minitest::Test
 
     _, storage_app_id = storage_decrypt_channel_id(response['id'])
     _, parent_storage_app_id = storage_decrypt_channel_id(encrypted_parent_channel_id)
-    assert_equal parent_storage_app_id, PEGASUS_DB[:storage_apps].where(id: storage_app_id).first[:remix_parent_id]
+    assert_equal parent_storage_app_id, StorageApps.table.where(id: storage_app_id).first[:remix_parent_id]
   end
 
   def test_update_project_type
     post '/v3/channels', {abc: 123}.to_json, 'CONTENT_TYPE' => 'application/json;charset=utf-8'
     encrypted_channel_id = last_response.location.split('/').last
     _, storage_app_id = storage_decrypt_channel_id(encrypted_channel_id)
-    assert_nil PEGASUS_DB[:storage_apps].where(id: storage_app_id).first[:project_type]
+    assert_nil StorageApps.table.where(id: storage_app_id).first[:project_type]
 
     post "/v3/channels/#{encrypted_channel_id}", {projectType: 'gamelab'}.to_json, 'CONTENT_TYPE' => 'application/json;charset=utf-8'
     assert last_response.successful?
-    assert_equal 'gamelab', PEGASUS_DB[:storage_apps].where(id: storage_app_id).first[:project_type]
+    assert_equal 'gamelab', StorageApps.table.where(id: storage_app_id).first[:project_type]
   end
 
   private


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
The changes here remove direct references to the storage apps table in pegasus and replace them with references to methods in `storage_apps.rb`. This is in preparation to move the table into dashboard DB and rename it `projects`. Minimizing the number of places that we reference the table name makes this transition easier.

(Swap out behind the flag started here: https://github.com/code-dot-org/code-dot-org/pull/45476)

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
- jira ticket: [LP-2266](https://codedotorg.atlassian.net/browse/LP-2266)
<!--
- spec: []()

-->

## Testing story
Tested that project pages, creating a new project and project-backed levels still work as expected.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
