### PR TITLE
update curriculum builder banner link targets

### DIFF
--- a/aws/s3/cdo-curriculum/redirection_rules.rb
+++ b/aws/s3/cdo-curriculum/redirection_rules.rb
@@ -18,7 +18,7 @@ routing_rules = [
     },
     redirect: {
       host_name: CODE_STUDIO_HOST_NAME,
-      replace_key_prefix_with: "courses/csp-2021/"
+      replace_key_prefix_with: "courses/csp/"
     }
   },
   {
@@ -27,7 +27,7 @@ routing_rules = [
     },
     redirect: {
       host_name: CODE_STUDIO_HOST_NAME,
-      replace_key_prefix_with: "courses/csp-2021/",
+      replace_key_prefix_with: "courses/csp/",
       http_redirect_code: "302"
     }
   },
@@ -37,7 +37,7 @@ routing_rules = [
     },
     redirect: {
       host_name: CODE_STUDIO_HOST_NAME,
-      replace_key_prefix_with: "courses/csd-2021/"
+      replace_key_prefix_with: "courses/csd/"
     }
   },
   {
@@ -46,7 +46,7 @@ routing_rules = [
     },
     redirect: {
       host_name: CODE_STUDIO_HOST_NAME,
-      replace_key_prefix_with: "courses/csd-2021/",
+      replace_key_prefix_with: "courses/csd/",
       http_redirect_code: "302"
     }
   },

--- a/aws/s3/cdo-curriculum/redirection_rules.rb
+++ b/aws/s3/cdo-curriculum/redirection_rules.rb
@@ -71,15 +71,6 @@ routing_rules = [
   },
   {
     condition: {
-      key_prefix_equals: "hoc/"
-    },
-    redirect: {
-      host_name: CODE_ORG_HOST_NAME,
-      replace_key_prefix_with: "learn/"
-    }
-  },
-  {
-    condition: {
       key_prefix_equals: "hoc-current/"
     },
     redirect: {

--- a/aws/s3/cdo-curriculum/redirection_rules.rb
+++ b/aws/s3/cdo-curriculum/redirection_rules.rb
@@ -74,7 +74,7 @@ routing_rules = [
       key_prefix_equals: "hoc/"
     },
     redirect: {
-      host_name: CODE_STUDIO_HOST_NAME,
+      host_name: CODE_ORG_HOST_NAME,
       replace_key_prefix_with: "learn/"
     }
   },
@@ -83,7 +83,7 @@ routing_rules = [
       key_prefix_equals: "hoc-current/"
     },
     redirect: {
-      host_name: CODE_STUDIO_HOST_NAME,
+      host_name: CODE_ORG_HOST_NAME,
       replace_key_prefix_with: "learn/",
       http_redirect_code: "302"
     }

--- a/aws/s3/cdo-curriculum/redirection_rules.rb
+++ b/aws/s3/cdo-curriculum/redirection_rules.rb
@@ -71,6 +71,26 @@ routing_rules = [
   },
   {
     condition: {
+      key_prefix_equals: "hoc/"
+    },
+    redirect: {
+      host_name: CODE_STUDIO_HOST_NAME,
+      replace_key_prefix_with: "learn/"
+    }
+  },
+  {
+    condition: {
+      key_prefix_equals: "hoc-current/"
+    },
+    redirect: {
+      host_name: CODE_STUDIO_HOST_NAME,
+      replace_key_prefix_with: "learn/",
+      http_redirect_code: "302"
+    }
+  },
+
+  {
+    condition: {
       key_prefix_equals: "plcsf/"
     },
     redirect: {

--- a/aws/s3/cdo-curriculum/redirection_rules.rb
+++ b/aws/s3/cdo-curriculum/redirection_rules.rb
@@ -56,7 +56,7 @@ routing_rules = [
     },
     redirect: {
       host_name: CODE_ORG_HOST_NAME,
-      replace_key_prefix_with: "educate/curriculum/elementary-school"
+      replace_key_prefix_with: "educate/curriculum/csf"
     }
   },
   {
@@ -65,7 +65,7 @@ routing_rules = [
     },
     redirect: {
       host_name: CODE_ORG_HOST_NAME,
-      replace_key_prefix_with: "educate/curriculum/elementary-school",
+      replace_key_prefix_with: "educate/curriculum/csf",
       http_redirect_code: "302"
     }
   },


### PR DESCRIPTION
Completes Step 2 from https://codedotorg.atlassian.net/browse/PLAT-1601. We use config in our main repo to control where redirects like https://curriculum.code.org/csf-current go to. This PR updates that config. 

Once this is deployed, the curriculum builder edit UI can be used to add banners to HOC courses pointing to https://curriculum.code.org/hoc-current .

## Testing story

TESTING UPDATE: I followed the instructions at the top of the script to deploy these changes, and verified that the redirects are working from the banners on csf / csd / csp pages on CB, as well as when navigating directly to curriculum.code.org/hoc-current/ . 

~I have not tested this. I will keep an eye out during the deploy. if something goes wrong, the original config can be restored manually at https://s3.console.aws.amazon.com/s3/bucket/cdo-curriculum/property/website/edit?region=us-east-1 .~