### PR TITLE
Show reopened dialogue and do not allow save

### DIFF
--- a/apps/src/code-studio/pd/form_components_func/FormController.jsx
+++ b/apps/src/code-studio/pd/form_components_func/FormController.jsx
@@ -601,7 +601,7 @@ const FormController = props => {
         {currentPage > 0 && backButton}
         {pageButtons}
         {shouldShowSubmit() ? submitButton : nextButton}
-        {allowPartialSaving && saveButton}
+        {allowPartialSaving && savedStatus !== 'reopened' && saveButton}
       </FormGroup>
     );
   };

--- a/apps/src/code-studio/pd/form_components_func/FormController.jsx
+++ b/apps/src/code-studio/pd/form_components_func/FormController.jsx
@@ -100,7 +100,7 @@ const FormController = props => {
     applicationId
   );
   const [showDataWasLoadedMessage, setShowDataWasLoadedMessage] = useState(
-    applicationId && allowPartialSaving
+    applicationId
   );
   const applicationStatusOnSave = 'incomplete';
   const applicationStatusOnSubmit = 'unreviewed';

--- a/apps/src/code-studio/pd/form_components_func/FormController.jsx
+++ b/apps/src/code-studio/pd/form_components_func/FormController.jsx
@@ -347,6 +347,7 @@ const FormController = props => {
     const handleSuccessfulSave = data => {
       scrollToTop();
       setShowSavedMessage(true);
+      setShowDataWasLoadedMessage(false);
       setUpdatedApplicationId(data.id);
       setSaving(false);
       onSuccessfulSave(data);

--- a/apps/src/code-studio/pd/form_components_func/FormController.jsx
+++ b/apps/src/code-studio/pd/form_components_func/FormController.jsx
@@ -70,6 +70,7 @@ const FormController = props => {
     onSetPage = () => {},
     onSuccessfulSubmit = () => {},
     onSuccessfulSave = () => {},
+    savedStatus = undefined,
     serializeAdditionalData = () => ({}),
     sessionStorageKey = null,
     submitButtonText = defaultSubmitButtonText,
@@ -514,8 +515,9 @@ const FormController = props => {
         bsStyle="info"
       >
         <p>
-          We found an application you started! Your saved responses have been
-          loaded.
+          {savedStatus === 'reopened'
+            ? 'Your Regional Partner has requested more information.  Please update and resubmit.'
+            : 'We found an application you started! Your saved responses have been loaded.'}
         </p>
       </Alert>
     );
@@ -638,6 +640,7 @@ FormController.propTypes = {
   onSetPage: PropTypes.func,
   onSuccessfulSubmit: PropTypes.func,
   onSuccessfulSave: PropTypes.func,
+  savedStatus: PropTypes.string,
   serializeAdditionalData: PropTypes.func,
   sessionStorageKey: PropTypes.string,
   submitButtonText: PropTypes.string,

--- a/apps/test/unit/code-studio/pd/form_components_func/FormControllerTest.js
+++ b/apps/test/unit/code-studio/pd/form_components_func/FormControllerTest.js
@@ -156,6 +156,25 @@ describe('FormController', () => {
       expect(form.exists('Alert')).to.be.false;
     });
 
+    it('Shows data was loaded message if status is reopened', () => {
+      form = isolateComponent(
+        <FormController
+          {...defaultProps}
+          applicationId={applicationId}
+          savedStatus={'reopened'}
+          allowPartialSaving={true}
+          validateOnSubmitOnly={true}
+        />
+      );
+      const alert = form.findOne('Alert');
+      expect(alert.content()).to.contain(
+        'Your Regional Partner has requested more information.  Please update and resubmit.'
+      );
+
+      alert.props.onDismiss();
+      expect(form.exists('Alert')).to.be.false;
+    });
+
     it('Does not show data was loaded message if partial saving is disabled', () => {
       form = isolateComponent(
         <FormController

--- a/apps/test/unit/code-studio/pd/form_components_func/FormControllerTest.js
+++ b/apps/test/unit/code-studio/pd/form_components_func/FormControllerTest.js
@@ -248,7 +248,9 @@ describe('FormController', () => {
       });
 
       it('Shows saved message alert after saving is complete, and user can close it', () => {
-        form = isolateComponent(<FormController {...defaultProps} />);
+        form = isolateComponent(
+          <FormController {...defaultProps} applicationId={applicationId} />
+        );
 
         const server = sinon.fakeServer.create();
         server.respondWith([

--- a/apps/test/unit/code-studio/pd/form_components_func/FormControllerTest.js
+++ b/apps/test/unit/code-studio/pd/form_components_func/FormControllerTest.js
@@ -138,6 +138,24 @@ describe('FormController', () => {
       });
     });
 
+    it('Never shows save button if status is reopened', () => {
+      form = isolateComponent(
+        <FormController
+          {...defaultProps}
+          allowPartialSaving={true}
+          validateOnSubmitOnly={true}
+          savedStatus={'reopened'}
+        />
+      );
+      [0, 1, 2].forEach(page => {
+        setPage(page);
+        const buttons = form.findAll('Button');
+        buttons.forEach(button =>
+          expect(button.content()).not.to.eql(saveButtonText)
+        );
+      });
+    });
+
     it('Shows data was loaded message given application id, and user can close message', () => {
       form = isolateComponent(
         <FormController

--- a/apps/test/unit/code-studio/pd/form_components_func/FormControllerTest.js
+++ b/apps/test/unit/code-studio/pd/form_components_func/FormControllerTest.js
@@ -175,18 +175,6 @@ describe('FormController', () => {
       expect(form.exists('Alert')).to.be.false;
     });
 
-    it('Does not show data was loaded message if partial saving is disabled', () => {
-      form = isolateComponent(
-        <FormController
-          {...defaultProps}
-          applicationId={applicationId}
-          allowPartialSaving={false}
-          validateOnSubmitOnly={true}
-        />
-      );
-      expect(form.exists('Alert')).to.be.false;
-    });
-
     it('Does not show data was loaded message if there is no application id', () => {
       form = isolateComponent(
         <FormController


### PR DESCRIPTION
Accommodates for the "reopened" status on the front-end:
1) Shows a dialogue when a teacher opens their reopened application
2) Does not allow a teacher to save an in-progress reopened application––they can only submit it

Also snuck in two extras 😅 :
1) Show only one dialogue about saved applications –– if the "Data was loaded" message appears, it disappears after saving to make room for the "Data saved successfully" dialogue (might refactor later to make this all one alert)
2) Ignore the "allowPartialSaving" prop for the "Data was loaded" message––data will be loaded if there's an application id has been found (regardless of the allowPartialSaving prop), so it'd be confusing to see data was loaded without a dialogue.

<img width="936" alt="Screen Shot 2022-02-23 at 4 44 11 PM" src="https://user-images.githubusercontent.com/9142121/155413925-50e8a55c-f5b4-4759-af5f-326d548404f2.png">

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
