### PR TITLE
Javalab: pass host name to upload request and convert grid to JSON

### DIFF
--- a/dashboard/app/controllers/javabuilder_sessions_controller.rb
+++ b/dashboard/app/controllers/javabuilder_sessions_controller.rb
@@ -71,7 +71,7 @@ class JavabuilderSessionsController < ApplicationController
     )
 
     if use_dashboard_sources == 'false'
-      success = JavalabFilesHelper.upload_project_files(channel_id, level_id, encoded_payload)
+      success = JavalabFilesHelper.upload_project_files(channel_id, level_id, request.host, encoded_payload)
       return render status: :internal_server_error, json: {error: "Error uploading sources."} unless success
     end
 

--- a/dashboard/app/helpers/javalab_files_helper.rb
+++ b/dashboard/app/helpers/javalab_files_helper.rb
@@ -1,8 +1,9 @@
 
 module JavalabFilesHelper
-  def self.upload_project_files(channel_id, level_id, auth_token)
+  def self.upload_project_files(channel_id, level_id, hostname, auth_token)
     uri = URI.parse("#{CDO.javabuilder_upload_url}?Authorization=#{auth_token}")
     upload_request = Net::HTTP::Put.new(uri)
+    upload_request['Origin'] = hostname
     upload_request.body = get_project_files(channel_id, level_id).to_json
 
     response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') do |http|
@@ -33,7 +34,7 @@ module JavalabFilesHelper
     if level
       serialized_maze = level.try(:get_serialized_maze)
       if serialized_maze
-        sources["grid.txt"] = serialized_maze.to_s
+        sources["grid.txt"] = serialized_maze.to_json
       end
     end
     all_files["sources"] = sources


### PR DESCRIPTION
A couple of small fixes to the Javabuilder upload project code:
- pass the host name and set the Origin header on the PUT request - this is needed because the Javabuilder authorizer lambda uses the Origin header to decided which public key to use to decode the Auth token.
- convert the maze file to JSON. Currently, it's converted to a string in Ruby hash syntax which prevented Javabuilder from parsing it correctly.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Testing: confirmed that PUT requests succeeds on both localhost and via API Gateway (using a prototype API Gateway endpoint), and confirmed that the maze file is successfully parsed as JSON in Javabuilder.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
