### PR TITLE
Enable ECS Tasks to Assume Percona Monitoring Role

### DIFF
--- a/aws/cloudformation/iam.yml.erb
+++ b/aws/cloudformation/iam.yml.erb
@@ -272,7 +272,7 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              Service: [ec2.amazonaws.com]
+              Service: [ec2.amazonaws.com, ecs-tasks.amazonaws.com]
             Action: ['sts:AssumeRole']
       Policies:
         - PolicyName: PMMRolePolicy

--- a/aws/cloudformation/iam.yml.erb
+++ b/aws/cloudformation/iam.yml.erb
@@ -361,6 +361,10 @@ Outputs:
     Description: Firehose Lambda Role ARN
     Value: !GetAtt FirehoseLambdaRole.Arn
     Export: {Name: !Sub "${AWS::StackName}-FirehoseLambdaRoleARN"}
+  PerconaMonitoringRoleARN:
+    Description: Percona Monitoring Role ARN
+    Value: !GetAtt PMMRole.Arn
+    Export: {Name: !Sub "${AWS::StackName}-PerconaMonitoringRoleARN"}
   SessionPermissions:
     Description: Session Permissions
     Value: !Ref SessionPermissions


### PR DESCRIPTION
This is needed to re-deploy our Percona Monitoring service as a Margate Task.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

``` sh
$ export AWS_PROFILE = codeorg-admin
$ bundle exec rake stack:iam:validate RAILS_ENV=production ADMIN=1

Pending update for stack `IAM`:
Modify DataAnalystRole [AWS::IAM::Role] Properties (ManagedPolicyArns)
Modify PMMRole [AWS::IAM::Role] Properties (AssumeRolePolicyDocument)
```

## Deployment strategy

``` sh
$ export AWS_PROFILE = codeorg-admin
$ bundle exec rake stack:iam:start RAILS_ENV=production ADMIN=1
```

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
