### PR TITLE
Update `haml` gem to 5.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -174,10 +174,7 @@ gem 'omniauth-rails_csrf_protection', '~> 0.1'
 
 gem 'bootstrap-sass', '~> 2.3.2.2'
 
-# Ref: https://github.com/haml/haml/issues/940
-# https://github.com/haml/haml/issues/982
-# https://github.com/haml/haml/issues/985
-gem 'haml', github: 'wjordan/haml', ref: 'cdo'
+gem 'haml', '~> 5.2.0'
 
 gem 'jquery-ui-rails', '~> 6.0.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,15 +82,6 @@ GIT
     gnista (1.0.1)
 
 GIT
-  remote: https://github.com/wjordan/haml.git
-  revision: 22739a012fb34765d9d4b733f997862547a2b9cf
-  ref: cdo
-  specs:
-    haml (5.0.4)
-      temple (>= 0.8.0)
-      tilt
-
-GIT
   remote: https://github.com/wjordan/image_optim.git
   revision: 939996f7ad102227c73b42bfda0058f9c66698aa
   ref: cdo
@@ -463,16 +454,19 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (~> 0.12)
-    haml-rails (1.0.0)
-      actionpack (>= 4.0.1)
-      activesupport (>= 4.0.1)
+    haml (5.2.2)
+      temple (>= 0.8.0)
+      tilt
+    haml-rails (2.0.1)
+      actionpack (>= 5.1)
+      activesupport (>= 5.1)
       haml (>= 4.0.6, < 6.0)
       html2haml (>= 1.0.1)
-      railties (>= 4.0.1)
-    haml_lint (0.27.0)
-      haml (>= 4.0, < 5.1)
+      railties (>= 5.1)
+    haml_lint (0.37.1)
+      haml (>= 4.0, < 5.3)
+      parallel (~> 1.10)
       rainbow
-      rake (>= 10, < 13)
       rubocop (>= 0.50.0)
       sysexits (~> 1.1)
     hammerspace (0.1.7)
@@ -762,8 +756,8 @@ GEM
     ruby-progressbar (1.10.1)
     ruby-rc4 (0.1.5)
     ruby_dep (1.3.1)
-    ruby_parser (3.11.0)
-      sexp_processor (~> 4.9)
+    ruby_parser (3.18.1)
+      sexp_processor (~> 4.16)
     rubyzip (1.2.2)
     safe_yaml (1.0.4)
     sass (3.4.22)
@@ -792,7 +786,7 @@ GEM
       childprocess (~> 0.5)
       rubyzip (~> 1.2, >= 1.2.2)
     sequel (5.9.0)
-    sexp_processor (4.10.1)
+    sexp_processor (4.16.0)
     shotgun (0.9.1)
       rack (>= 1.0)
     signet (0.12.0)
@@ -831,7 +825,7 @@ GEM
       i18n
       json (>= 1.4.3)
     sysexits (1.2.0)
-    temple (0.8.0)
+    temple (0.8.2)
     thin (1.7.2)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
@@ -959,7 +953,7 @@ DEPENDENCIES
   gnista!
   google-api-client (~> 0.23)
   google_drive
-  haml!
+  haml (~> 5.2.0)
   haml-rails
   haml_lint
   hammerspace

--- a/dashboard/config/initializers/haml.rb
+++ b/dashboard/config/initializers/haml.rb
@@ -1,3 +1,3 @@
 # Disable escaping HTML in interpolated strings, for backwards compatibility with Haml < 5 behavior.
 # See: https://github.com/haml/haml/pull/984
-Haml::Template.options[:escape_interpolated_html] = false
+Haml::Template.options[:escape_filter_interpolations] = false


### PR DESCRIPTION
Switching us back to the mainline gem, from our custom fork. All modifications we made to our custom fork were accepted into the mainline gem [as part of the 5.1.0 release](https://github.com/haml/haml/blob/main/CHANGELOG.md#510).

## Links

Original Issues

- https://github.com/haml/haml/issues/940
- https://github.com/haml/haml/issues/982
- https://github.com/haml/haml/issues/985

Fix PRs

- https://github.com/haml/haml/pull/984
- https://github.com/haml/haml/pull/986
- https://github.com/haml/haml/pull/983

## Testing story

Relying on existing unit tests.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
