### PR TITLE
Don't try to seed parameters from programming expressions

### DIFF
--- a/dashboard/app/models/programming_expression.rb
+++ b/dashboard/app/models/programming_expression.rb
@@ -59,7 +59,7 @@ class ProgrammingExpression < ApplicationRecord
       else
         environment_name == 'spritelab' ? expression_config['color'] : ProgrammingExpression.get_category_color(expression_config['category'])
       end
-    expression_config.symbolize_keys.except(:category_key).merge(
+    expression_config.symbolize_keys.except(:category_key, :parameters).merge(
       {
         programming_environment_id: programming_environment.id,
         programming_environment_category_id: env_category&.id,


### PR DESCRIPTION
A couple months ago I noticed that some environments had a `parameters` property on programming expressions then completely forgot about it. When I imported and wrote all these files on levelbuilder yesterday, this field got re-added to the config files, causing seed failures. This is a quick fix to unblock the pipeline -- I will follow up by cleaning up these configs.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
