### PR TITLE
Create sunsetting and deprecated publish states

### DIFF
--- a/apps/src/lib/levelbuilder/CourseVersionPublishingEditor.jsx
+++ b/apps/src/lib/levelbuilder/CourseVersionPublishingEditor.jsx
@@ -71,16 +71,35 @@ export default class CourseVersionPublishingEditor extends Component {
         PublishedState.pilot,
         PublishedState.beta,
         PublishedState.preview,
-        PublishedState.stable
+        PublishedState.stable,
+        PublishedState.sunsetting,
+        PublishedState.deprecated
       ],
-      pilot: [PublishedState.pilot],
+      pilot: [
+        PublishedState.pilot,
+        PublishedState.sunsetting,
+        PublishedState.deprecated
+      ],
       beta: [
         PublishedState.beta,
         PublishedState.preview,
-        PublishedState.stable
+        PublishedState.stable,
+        PublishedState.sunsetting,
+        PublishedState.deprecated
       ],
-      preview: [PublishedState.preview, PublishedState.stable],
-      stable: [PublishedState.stable]
+      preview: [
+        PublishedState.preview,
+        PublishedState.stable,
+        PublishedState.sunsetting,
+        PublishedState.deprecated
+      ],
+      stable: [
+        PublishedState.stable,
+        PublishedState.sunsetting,
+        PublishedState.deprecated
+      ],
+      sunsetting: [PublishedState.sunsetting, PublishedState.deprecated],
+      deprecated: [PublishedState.deprecated]
     };
 
     return availablePublishedStates[currentState];
@@ -240,6 +259,18 @@ export default class CourseVersionPublishingEditor extends Component {
                   <td style={styles.tableBorder}>
                     A course that is not changing. If it is the most recent
                     course in your language it will be the recommended course.
+                  </td>
+                </tr>
+                <tr>
+                  <td style={styles.tableBorder}>Sunsetting</td>
+                  <td style={styles.tableBorder}>
+                    A course that is in the process of being deprecated.
+                  </td>
+                </tr>
+                <tr>
+                  <td style={styles.tableBorder}>Deprecated</td>
+                  <td style={styles.tableBorder}>
+                    A course that has been deprecated.
                   </td>
                 </tr>
               </tbody>

--- a/apps/test/unit/lib/levelbuilder/CourseVersionPublishingEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/CourseVersionPublishingEditorTest.jsx
@@ -5,7 +5,7 @@ import sinon from 'sinon';
 import CourseVersionPublishingEditor from '@cdo/apps/lib/levelbuilder/CourseVersionPublishingEditor';
 import {PublishedState} from '@cdo/apps/generated/curriculum/sharedCourseConstants';
 
-describe('CourseVersionPublishedStateSelector', () => {
+describe('CourseVersionPublishingEditor', () => {
   let defaultProps,
     updatePilotExperiment,
     updateFamilyName,
@@ -46,7 +46,7 @@ describe('CourseVersionPublishedStateSelector', () => {
     );
     expect(
       wrapper.find('.publishedStateSelector').find('option').length
-    ).to.equal(5);
+    ).to.equal(7);
     expect(
       wrapper
         .find('.publishedStateSelector')
@@ -82,6 +82,20 @@ describe('CourseVersionPublishedStateSelector', () => {
         .at(4)
         .props().value
     ).to.equal('stable');
+    expect(
+      wrapper
+        .find('.publishedStateSelector')
+        .find('option')
+        .at(5)
+        .props().value
+    ).to.equal('sunsetting');
+    expect(
+      wrapper
+        .find('.publishedStateSelector')
+        .find('option')
+        .at(6)
+        .props().value
+    ).to.equal('deprecated');
   });
 
   it('published state dropdown shows only available published states when course is pilot', () => {
@@ -94,13 +108,28 @@ describe('CourseVersionPublishedStateSelector', () => {
     );
     expect(
       wrapper.find('.publishedStateSelector').find('option').length
-    ).to.equal(1);
+    ).to.equal(3);
     expect(
       wrapper
         .find('.publishedStateSelector')
         .find('option')
+        .at(0)
         .props().value
     ).to.equal('pilot');
+    expect(
+      wrapper
+        .find('.publishedStateSelector')
+        .find('option')
+        .at(1)
+        .props().value
+    ).to.equal('sunsetting');
+    expect(
+      wrapper
+        .find('.publishedStateSelector')
+        .find('option')
+        .at(2)
+        .props().value
+    ).to.equal('deprecated');
   });
 
   it('published state dropdown shows only available published states when course is beta', () => {
@@ -113,7 +142,7 @@ describe('CourseVersionPublishedStateSelector', () => {
     );
     expect(
       wrapper.find('.publishedStateSelector').find('option').length
-    ).to.equal(3);
+    ).to.equal(5);
     expect(
       wrapper
         .find('.publishedStateSelector')
@@ -135,6 +164,20 @@ describe('CourseVersionPublishedStateSelector', () => {
         .at(2)
         .props().value
     ).to.equal('stable');
+    expect(
+      wrapper
+        .find('.publishedStateSelector')
+        .find('option')
+        .at(3)
+        .props().value
+    ).to.equal('sunsetting');
+    expect(
+      wrapper
+        .find('.publishedStateSelector')
+        .find('option')
+        .at(4)
+        .props().value
+    ).to.equal('deprecated');
   });
 
   it('published state dropdown shows only available published states when course is preview', () => {
@@ -147,7 +190,7 @@ describe('CourseVersionPublishedStateSelector', () => {
     );
     expect(
       wrapper.find('.publishedStateSelector').find('option').length
-    ).to.equal(2);
+    ).to.equal(4);
     expect(
       wrapper
         .find('.publishedStateSelector')
@@ -162,6 +205,20 @@ describe('CourseVersionPublishedStateSelector', () => {
         .at(1)
         .props().value
     ).to.equal('stable');
+    expect(
+      wrapper
+        .find('.publishedStateSelector')
+        .find('option')
+        .at(2)
+        .props().value
+    ).to.equal('sunsetting');
+    expect(
+      wrapper
+        .find('.publishedStateSelector')
+        .find('option')
+        .at(3)
+        .props().value
+    ).to.equal('deprecated');
   });
 
   it('published state dropdown shows only available published states when course is stable', () => {
@@ -174,13 +231,74 @@ describe('CourseVersionPublishedStateSelector', () => {
     );
     expect(
       wrapper.find('.publishedStateSelector').find('option').length
+    ).to.equal(3);
+    expect(
+      wrapper
+        .find('.publishedStateSelector')
+        .find('option')
+        .at(0)
+        .props().value
+    ).to.equal('stable');
+    expect(
+      wrapper
+        .find('.publishedStateSelector')
+        .find('option')
+        .at(1)
+        .props().value
+    ).to.equal('sunsetting');
+    expect(
+      wrapper
+        .find('.publishedStateSelector')
+        .find('option')
+        .at(2)
+        .props().value
+    ).to.equal('deprecated');
+  });
+
+  it('published state dropdown shows only available published states when course is sunsetting', () => {
+    const wrapper = shallow(
+      <CourseVersionPublishingEditor
+        {...defaultProps}
+        initialPublishedState={PublishedState.sunsetting}
+        publishedState={PublishedState.sunsetting}
+      />
+    );
+    expect(
+      wrapper.find('.publishedStateSelector').find('option').length
+    ).to.equal(2);
+    expect(
+      wrapper
+        .find('.publishedStateSelector')
+        .find('option')
+        .at(0)
+        .props().value
+    ).to.equal('sunsetting');
+    expect(
+      wrapper
+        .find('.publishedStateSelector')
+        .find('option')
+        .at(1)
+        .props().value
+    ).to.equal('deprecated');
+  });
+
+  it('published state dropdown shows only available published states when course is deprecated', () => {
+    const wrapper = shallow(
+      <CourseVersionPublishingEditor
+        {...defaultProps}
+        initialPublishedState={PublishedState.deprecated}
+        publishedState={PublishedState.deprecated}
+      />
+    );
+    expect(
+      wrapper.find('.publishedStateSelector').find('option').length
     ).to.equal(1);
     expect(
       wrapper
         .find('.publishedStateSelector')
         .find('option')
         .props().value
-    ).to.equal('stable');
+    ).to.equal('deprecated');
   });
 
   it('pilot input field shows if published state is pilot', () => {

--- a/lib/cdo/shared_constants/curriculum/shared_course_constants.rb
+++ b/lib/cdo/shared_constants/curriculum/shared_course_constants.rb
@@ -6,7 +6,9 @@ module SharedCourseConstants
       pilot: "pilot",
       beta: "beta",
       preview: "preview",
-      stable: "stable"
+      stable: "stable",
+      sunsetting: "sunsetting",
+      deprecated: "deprecated"
     }
   ).freeze
 


### PR DESCRIPTION
Add sunsetting and deprecated to the publish states. 

<img width="490" alt="Screen Shot 2022-02-24 at 4 25 15 PM" src="https://user-images.githubusercontent.com/208083/155610537-2173d7cd-8278-4e65-a6b5-b87d7f1a4a64.png">

<img width="672" alt="Screen Shot 2022-02-24 at 4 25 21 PM" src="https://user-images.githubusercontent.com/208083/155610542-96192204-aa7c-40e9-ba91-4651481695eb.png">

## Links

[Jira](https://codedotorg.atlassian.net/browse/PLAT-1626)

## Testing story

- Update Unit Tests
- Checked that new options show in the editor