### PR TITLE
Update the Core Course Field

### DIFF
--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -679,7 +679,7 @@ class UnitEditor extends React.Component {
                     Our RED(research, evaluation, and data) team uses the
                     setting of this field to determine which initiative to
                     connect this unit to in order to track progress of students
-                    in our various work stream.
+                    in our various work streams.
                   </p>
                   <p>
                     Until we finalizing moving onto using Course Type for

--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -659,7 +659,7 @@ class UnitEditor extends React.Component {
           {this.props.isLevelbuilder && (
             <div>
               <label>
-                Core Course
+                Code.org Initiative
                 <select
                   style={styles.dropdown}
                   value={this.state.curriculumUmbrella}
@@ -676,16 +676,18 @@ class UnitEditor extends React.Component {
                 </select>
                 <HelpTip>
                   <p>
-                    By selecting, this unit will have a property,
-                    curriculum_umbrella, specific to that course regardless of
-                    version.
+                    Our RED(research, evaluation, and data) team uses the
+                    setting of this field to determine which initiative to
+                    connect this unit to in order to track progress of students
+                    in our various work stream.
                   </p>
                   <p>
-                    If you select CSF, CSF-specific elements will show in the
-                    progress tab of the teacher dashboard. For example, the
-                    progress legend will include a separate column for levels
-                    completed with too many blocks and there will be information
-                    about CSTA Standards.
+                    Until we finalizing moving onto using Course Type for
+                    determining UI features of a course, if you select CSF,
+                    CSF-specific elements will show in the progress tab of the
+                    teacher dashboard. For example, the progress legend will
+                    include a separate column for levels completed with too many
+                    blocks and there will be information about CSTA Standards.
                   </p>
                 </HelpTip>
               </label>

--- a/lib/cdo/shared_constants/curriculum/shared_course_constants.rb
+++ b/lib/cdo/shared_constants/curriculum/shared_course_constants.rb
@@ -45,7 +45,14 @@ module SharedCourseConstants
       CSP: 'CSP',
       CSA: 'CSA',
       CSC: 'CSC',
-      HOC: 'HOC'
+      HOC: 'HOC',
+      CSA_self_paced_pl: 'CSA Self Paced PL',
+      CSP_self_paced_pl: 'CSP Self Paced PL',
+      CSD_self_paced_pl: 'CSD Self Paced PL',
+      CSF_self_paced_pl: 'CSF Self Paced PL',
+      CSP_virtual_pl: 'CSP Virtual PL',
+      CSD_virtual_pl: 'CSD Virtual PL',
+      student_self_paced: 'Student Self Paced Courses'
     }
   ).freeze
 


### PR DESCRIPTION
Add new `curriculum_umbrella` options to the dropdown. Rename the dropdown in the UI to make it clear that this fields main purpose is now for marking scripts for data analysis purposes. 

Dropdown
<img width="508" alt="Screen Shot 2022-02-24 at 4 50 58 PM" src="https://user-images.githubusercontent.com/208083/155613723-5d37f5ea-878d-4f97-914b-3576f6fe03b0.png">

Help Tip
<img width="706" alt="Screen Shot 2022-02-24 at 4 51 03 PM" src="https://user-images.githubusercontent.com/208083/155613725-3ded5954-aa2f-411c-b76a-4f2c98383925.png">


## Links

[Jira](https://codedotorg.atlassian.net/browse/PLAT-1628)

## Testing story

- Manually checked the list