### PR TITLE
Fix routing for programming expressions with periods in their keys

### DIFF
--- a/dashboard/app/helpers/curriculum_helper.rb
+++ b/dashboard/app/helpers/curriculum_helper.rb
@@ -1,4 +1,6 @@
 module CurriculumHelper
+  KEY_CHAR_RE = /[A-Za-z0-9\-\_\.]/
+
   def validate_key_format
     if key.blank?
       errors.add(:base, 'Key must not be blank')
@@ -10,8 +12,7 @@ module CurriculumHelper
       return false
     end
 
-    key_char_re = /[A-Za-z0-9\-\_\.]/
-    key_re = /\A#{key_char_re}+\Z/
+    key_re = /\A#{KEY_CHAR_RE}+\Z/
     unless key_re.match?(key)
       errors.add(:base, "must only be letters, numbers, dashes, underscores, and periods. Got ${key}")
       return false

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -328,7 +328,7 @@ Dashboard::Application.routes.draw do
   end
 
   resources :programming_environments, only: [:index, :new, :create, :edit, :update, :show], param: 'name' do
-    resources :programming_expressions, param: 'programming_expression_key' do
+    resources :programming_expressions, param: 'programming_expression_key', constraints: {programming_expression_key: /#{CurriculumHelper::KEY_CHAR_RE}+/} do
       member do
         get :show, to: 'programming_expressions#show_by_keys'
       end


### PR DESCRIPTION
Fixes urls such as https://levelbuilder-studio.code.org/programming_environments/applab/programming_expressions/lightSensor.setScale/ ignoring everything after the period. 

Docs: https://guides.rubyonrails.org/routing.html#specifying-constraints

Programming environment don't allow periods in their names, so this is only needed for programming expressions.



## Testing story

manually tested



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
