### PR TITLE
Finish: Firehose Logging for the Download Replay Video button

### DIFF
--- a/apps/src/code-studio/components/DownloadReplayVideoButton.jsx
+++ b/apps/src/code-studio/components/DownloadReplayVideoButton.jsx
@@ -9,6 +9,7 @@ import firehoseClient from '@cdo/apps/lib/util/firehose';
 //   - see the download button,
 //   - click it,
 //   - actually get a download started,
+//   - successfully get a file and trigger the client download,
 //   - have the download fail,
 //   - have the download attempts timeout.
 
@@ -17,6 +18,7 @@ const FIREHOSE_STUDY_GROUP = 'replay_video';
 const FIREHOSE_EVENT_DOWNLOAD_BUTTON_SEEN = 'download_button_seen';
 const FIREHOSE_EVENT_DOWNLOAD_CLICKED = 'download_clicked';
 const FIREHOSE_EVENT_DOWNLOAD_STARTED = 'download_started';
+const FIREHOSE_EVENT_DOWNLOAD_SUCCEEDED = 'download_succeeded';
 const FIREHOSE_EVENT_DOWNLOAD_FAILED = 'download_failed';
 const FIREHOSE_EVENT_DOWNLOAD_FAILED_TIMEOUT = 'download_failed_timeout';
 
@@ -47,6 +49,12 @@ function downloadRemoteUrl(url, downloadName) {
       document.body.appendChild(element);
       element.click();
       document.body.removeChild(element);
+
+      firehoseClient.putRecord({
+        study: FIREHOSE_STUDY,
+        study_group: FIREHOSE_STUDY_GROUP,
+        event: FIREHOSE_EVENT_DOWNLOAD_SUCCEEDED
+      });
     })
     .catch(error => {
       console.log(error);

--- a/apps/src/code-studio/components/DownloadReplayVideoButton.jsx
+++ b/apps/src/code-studio/components/DownloadReplayVideoButton.jsx
@@ -2,8 +2,23 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
 import i18n from '@cdo/locale';
-
 import color from '../../util/color';
+import firehoseClient from '@cdo/apps/lib/util/firehose';
+
+// Record events to Firehose to understand how often users:
+//   - see the download button,
+//   - click it,
+//   - actually get a download started,
+//   - have the download fail,
+//   - have the download attempts timeout.
+
+const FIREHOSE_STUDY = 'finish_dialog';
+const FIREHOSE_STUDY_GROUP = 'replay_video';
+const FIREHOSE_EVENT_DOWNLOAD_BUTTON_SEEN = 'download_button_seen';
+const FIREHOSE_EVENT_DOWNLOAD_CLICKED = 'download_clicked';
+const FIREHOSE_EVENT_DOWNLOAD_STARTED = 'download_started';
+const FIREHOSE_EVENT_DOWNLOAD_FAILED = 'download_failed';
+const FIREHOSE_EVENT_DOWNLOAD_FAILED_TIMEOUT = 'download_failed_timeout';
 
 /**
  * Trigger a download from the given url with the given name.
@@ -13,6 +28,12 @@ import color from '../../util/color';
  * URLs.
  */
 function downloadRemoteUrl(url, downloadName) {
+  firehoseClient.putRecord({
+    study: FIREHOSE_STUDY,
+    study_group: FIREHOSE_STUDY_GROUP,
+    event: FIREHOSE_EVENT_DOWNLOAD_STARTED
+  });
+
   fetch(url, {
     method: 'GET'
   })
@@ -29,6 +50,12 @@ function downloadRemoteUrl(url, downloadName) {
     })
     .catch(error => {
       console.log(error);
+
+      firehoseClient.putRecord({
+        study: FIREHOSE_STUDY,
+        study_group: FIREHOSE_STUDY_GROUP,
+        event: FIREHOSE_EVENT_DOWNLOAD_FAILED
+      });
     });
 }
 
@@ -70,6 +97,14 @@ class DownloadReplayVideoButton extends React.Component {
   componentDidMount() {
     this.tryCreateReplayVideo();
     this.checkVideoUntilSuccess();
+
+    if (this.shouldRenderButton()) {
+      firehoseClient.putRecord({
+        study: FIREHOSE_STUDY,
+        study_group: FIREHOSE_STUDY_GROUP,
+        event: FIREHOSE_EVENT_DOWNLOAD_BUTTON_SEEN
+      });
+    }
   }
 
   componentWillUnmount() {
@@ -101,6 +136,16 @@ class DownloadReplayVideoButton extends React.Component {
   // Show the button as enabled if we know the video exists; also show it as
   // enabled on initial load, until the first time the user clicks it
   buttonEnabled = () => this.state.videoExists || !this.state.downloadInitiated;
+
+  clickDownloadVideo = event => {
+    firehoseClient.putRecord({
+      study: FIREHOSE_STUDY,
+      study_group: FIREHOSE_STUDY_GROUP,
+      event: FIREHOSE_EVENT_DOWNLOAD_CLICKED
+    });
+
+    this.tryDownloadVideo(event);
+  };
 
   tryDownloadVideo = event => {
     if (!this.state.downloadInitiated) {
@@ -158,6 +203,12 @@ class DownloadReplayVideoButton extends React.Component {
         this.props.onError();
       }
 
+      firehoseClient.putRecord({
+        study: FIREHOSE_STUDY,
+        study_group: FIREHOSE_STUDY_GROUP,
+        event: FIREHOSE_EVENT_DOWNLOAD_FAILED_TIMEOUT
+      });
+
       return;
     }
 
@@ -179,8 +230,12 @@ class DownloadReplayVideoButton extends React.Component {
     });
   };
 
+  shouldRenderButton() {
+    return this.props.channelId && this.hasReplayVideo();
+  }
+
   render() {
-    if (!this.props.channelId || !this.hasReplayVideo()) {
+    if (!this.shouldRenderButton()) {
       return null;
     }
 
@@ -200,7 +255,7 @@ class DownloadReplayVideoButton extends React.Component {
         className="download-replay-video-button"
         style={style}
         disabled={!this.buttonEnabled()}
-        onClick={this.tryDownloadVideo}
+        onClick={this.clickDownloadVideo}
       >
         <i className={`fa ${icon}`} style={styles.icon} />
         <span style={styles.span}>


### PR DESCRIPTION
This adds Firehose logging for a variety of events in the Finish dialog related to the Download Replay Video button.  This button is labeled as "Animation" and is shown at the end of Dance Party levels so that users can download a server-rendered clip of their dance.

We log five events to understand how often users:
- see the download button,
- click it,
- actually get a download started,
- successfully get a file and trigger the client download,
- have the download fail,
- have the download attempts timeout.

Note that if the server returns a non-2xx for the actual file (i.e. the `fetch` `response` is not `ok`) then we will not record a fail event here.  However, that shouldn't happen as we make sure that we have a `response` that is `ok` immediately before this, by fetching the file's `HEAD` in `checkVideo()`.