### PR TITLE
Remove empty code field from ProgrammingExpression examples

### DIFF
--- a/dashboard/config/programming_expressions/gamelab/mathsqrt.json
+++ b/dashboard/config/programming_expressions/gamelab/mathsqrt.json
@@ -8,7 +8,6 @@
     {
       "name": "",
       "description": "var t = Math.sqrt(16);\r\nconsole.log(t);",
-      "code": "```\n\n```",
       "app": "",
       "image": null,
       "app_display_type": "codeFromCodeField",

--- a/dashboard/config/programming_expressions/spritelab/bounce-off.json
+++ b/dashboard/config/programming_expressions/spritelab/bounce-off.json
@@ -9,7 +9,6 @@
     {
       "name": "Example 2",
       "description": "Sprites that are wandering can bounce off of each other.",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/2eIrhiV9sL-E5Go-xWW234oo8vfoevrllBpus961-SU",
       "image": null,
       "app_display_type": "embedAppWithCode",
@@ -18,7 +17,6 @@
     {
       "name": "Example 1",
       "description": "Sprites that are moving left and right using the `swimming left and right` block can bounce off of each other.",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/EYPy9gVzbivcaqdRx0CStNo4HuKqoS8kb4h_jjjSiFQ",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/codestudio_andoroperator.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_andoroperator.json
@@ -9,7 +9,6 @@
     {
       "name": "Example 1",
       "description": "These animals want to swap size. Press the spacebar to help them determine if they succeeded. \r\n(The code checks to see if the cow and the hippo are their desired sizes.)",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/ALo9mONq6hLDKK4wlONdwn8ix9O6GmwO8stpZtVU_J4",
       "image": null,
       "app_display_type": "embedAppWithCode",
@@ -18,7 +17,6 @@
     {
       "name": "Example 2",
       "description": "This program checks if the pink alien or the yellow alien can guess the same number as the green alien. If either one gets it right, they celebrate. Press “g” to make them guess.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/eZNGi36tMBiNgAE0HJSYdTupGfY5VRyVM810PW4bkFY",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/codestudio_arithmeticoperator.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_arithmeticoperator.json
@@ -9,7 +9,6 @@
     {
       "name": "Example 1",
       "description": "Help the student study for her test! Give her different math questions, and she’ll tell you the answer.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/4nneVx3iBxaDdbfn1YM2nLouzY6zm1knPuxow420DnU",
       "image": null,
       "app_display_type": "embedAppWithCode",
@@ -18,7 +17,6 @@
     {
       "name": "Example 2",
       "description": "Each time the space bar is pressed, the monster will shrink to half its size.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/hnM9t4sd6B0NNx5EEgzbCPLrTjPXGxoLYFJPD977Wtk",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/codestudio_callingfunction.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_callingfunction.json
@@ -8,7 +8,6 @@
     {
       "name": "Example 1",
       "description": "The function “switchBackgrounds” is used twice in this program. The function can be called instead of rewriting the blocks of code inside of it each time.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/qgi6Fjhv4dMzxJPux-yJObPtxRLlTW6q9tkaxQGj3Fw",
       "image": null,
       "app_display_type": "embedAppWithCode",
@@ -17,7 +16,6 @@
     {
       "name": "Example 2",
       "description": "Functions can be called inside other functions. Here, the function “dropOre” calls the function “moveNorthwest” in it so that the compass exposes the ore after creates one in its location.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/xf6d350b8wlBO2qh8K0Cr7fIol6KCOOMGXE49xEoGlM",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/codestudio_changevariable.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_changevariable.json
@@ -9,7 +9,6 @@
     {
       "name": "Example 1",
       "description": "Read and run this code to see how changing a variable works. \r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/1a6fRf_SwggrgSl36aV6CmjZp25HjIHQcd7EBeBpOUM",
       "image": null,
       "app_display_type": "embedAppWithCode",
@@ -18,7 +17,6 @@
     {
       "name": "Example 2",
       "description": "These chicks spread quickly! Each time a chick is clicked, it increases the number of new chicks made by 2.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/prPARy1fpC6i75fqzJeAfOiCoFyjTUs5X3alTbVKnQw",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/codestudio_comparisonoperator.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_comparisonoperator.json
@@ -9,7 +9,6 @@
     {
       "name": "Example 1",
       "description": "This fish is only afraid of bears whose size is greater than 90. Press space to make a bear appear and see what the fish does.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/39MEJaf-I87aQsJZjxy7aq0XTgjTTwrNVBGPqQE-R0c",
       "image": null,
       "app_display_type": "embedAppWithCode",
@@ -18,7 +17,6 @@
     {
       "name": "Example 2",
       "description": "Click on the gold coin, and the green critter will guess a random number between 1 and 25. If the green critter guesses a number that is higher than the one the princess critter was thinking of, he will get her gold coin!\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/sOXRJcZJe-z5xSkg_AapcMIhbU1JkjzNUm4Zu4rKRbA",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/codestudio_definingfunction.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_definingfunction.json
@@ -9,7 +9,6 @@
     {
       "name": "Example 1",
       "description": "Click `edit` to see how the function “switchBackgrounds” is defined.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/qgi6Fjhv4dMzxJPux-yJObPtxRLlTW6q9tkaxQGj3Fw",
       "image": null,
       "app_display_type": "embedAppWithCode",
@@ -18,7 +17,6 @@
     {
       "name": "Example 2",
       "description": "Press different keys and touch other sprites to change the crab’s property. The project uses a “reset” function that can be called with various events to return the crab to its original properties.",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/iKX5KyOzeDYm_Fu1SGD3beI7ULezMbchXd0bUp77gRs",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/codestudio_for.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_for.json
@@ -9,7 +9,6 @@
     {
       "name": "Example 1",
       "description": "The sprite will say the value of the counter. \r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/nhudy1zTMMbtzEezjWBQXj0lbF3UnOWDqsOWiaHt0j0",
       "image": null,
       "app_display_type": "embedAppWithCode",
@@ -18,7 +17,6 @@
     {
       "name": "Example 2",
       "description": "The x position of sprites is determined by the value of the counter in the loop. \r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/uL5gfcrOzDNgU-g7Z5h0qkgXHKij5IqA9UakDl2svmg",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/codestudio_ifstatement.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_ifstatement.json
@@ -9,7 +9,6 @@
     {
       "name": "Example 1",
       "description": "This simple program checks if a random addition expression equals a number greater than 50.\r\nClick on the gold coin, and the green critter will guess a random number between 1 and 25. If the green critter guesses a number that is higher than the one the princess critter was thinking of, he will get her gold coin!\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/sOXRJcZJe-z5xSkg_AapcMIhbU1JkjzNUm4Zu4rKRbA",
       "image": null,
       "app_display_type": "embedAppWithCode",
@@ -18,7 +17,6 @@
     {
       "name": "Example 2",
       "description": "The bear is looking for the perfect sized stew. Help it check the stews until it finds the right one. \r\nIf the stew is too big or small, the bear will let you know. Else, the stew is the perfect size.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/PRSgJeT7JYSp69gJQt0nLcGS6pTsUc1HnjMVnE451Mw",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/codestudio_join.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_join.json
@@ -9,7 +9,6 @@
     {
       "name": "Example 1",
       "description": "Here three string blocks with different topics are joined to create one continuous paragraph.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/Hptp8XGILFHWEcSvKOhPRhBJXyl9z998EcT-sVQsVWg",
       "image": null,
       "app_display_type": "embedAppWithCode",
@@ -18,7 +17,6 @@
     {
       "name": "Example 2",
       "description": "Text can be used to describe the value of a variable or sprite property. Here, text is used to explain the bunny’s size.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/LjB2aaHrtYzgArNr645547b5enACWshoEKmpaXg1AdU",
       "image": null,
       "app_display_type": "embedAppWithCode",
@@ -27,7 +25,6 @@
     {
       "name": "Example 3",
       "description": "This program uses a string block and math block to display a math equation.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/2dAi-tYlB0FjoNykbbqnIhG7NausDIZnQo8AMtK9z38",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/codestudio_randomint.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_randomint.json
@@ -9,7 +9,6 @@
     {
       "name": "Example 1",
       "description": "Make a sprite of a random size.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/pbcE4vEqnebD0OMqNWuafMo9idHh64ZbL-yNjHCKWck",
       "image": null,
       "app_display_type": "embedAppWithCode",
@@ -18,7 +17,6 @@
     {
       "name": "Example 2",
       "description": "The results of the race will change every time the project is run because the car and motorcycle will move a random number of pixels north each time the up arrow is pressed.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/zyJJLVj-U2uwqRqcQtKPNRO77-VXGwpz5FQPRtsSZ_U",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/codestudio_repeat.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_repeat.json
@@ -9,7 +9,6 @@
     {
       "name": "Example 1",
       "description": "The `make a new sprite` block is only used once, but repeating it five times allows five chemistry flask sprites to be created. \r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/_lrDlxY2SBYz0Ve0x3M7SF_cX0d1m9Ss2AiiYjfO6e4",
       "image": null,
       "app_display_type": "embedAppWithCode",
@@ -18,7 +17,6 @@
     {
       "name": "Example 2",
       "description": "Multiple lines of code can be used in a repeat loop, and a repeat loop can be used anywhere in a sequence of code.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/QzP4dfZKg8yImODSSczRcmM64rgv_ywJBin5_8lY3q0",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/codestudio_setvariable.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_setvariable.json
@@ -9,7 +9,6 @@
     {
       "name": "Example 1",
       "description": "Change the color input given to the variable “spriteColor.” See how changing the variable value changes what the variable then passes to the `change color` block.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/zOzSXi7WUid8owiJSoTk5UCz4grLc_91o-UN0bQi2AA",
       "image": null,
       "app_display_type": "embedAppWithCode",
@@ -18,7 +17,6 @@
     {
       "name": "Example 2",
       "description": "A variable can be used several times in a program. Here, the variable “spriteSize” sets all the food sprites to the same size. \r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/3QoJfDGrL7UbjFQl7G72ZMChOQxkxYSgAaVram0d8BA",
       "image": null,
       "app_display_type": "embedAppWithCode",
@@ -27,7 +25,6 @@
     {
       "name": "Example 3",
       "description": "If the variable value changes, it only affects the code after it. In this case, \"spriteSize\" passes one value to the apple and mushroom. It is then set to a new value that it is used in the code for the cherry and beet, but not in the code before it.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/fMJPwkFGVx5hLN1nV_iZ0npBuFZzaT_qFoqECML21bI",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/codestudio_spritename.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_spritename.json
@@ -8,7 +8,6 @@
     {
       "name": "",
       "description": "Each sprite has the same costume, but a different behavior.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/QrprIBKeCT8Trr5OdPKlSqFUV-4_ISqGnQwm01zlwFg",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/codestudio_string.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_string.json
@@ -9,7 +9,6 @@
     {
       "name": "Example 1",
       "description": "Printing text can make it look like the sprite is talking.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/9l51UN7wYsT3Gqqwn6xocQzzHyyHjk97Mn6K-oP_z3o",
       "image": null,
       "app_display_type": "embedAppWithCode",
@@ -18,7 +17,6 @@
     {
       "name": "Example 2",
       "description": "Text can be used to describe data. Here, text is used to explain the bunny’s size.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/LjB2aaHrtYzgArNr645547b5enACWshoEKmpaXg1AdU",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/codestudio_truefalse.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_truefalse.json
@@ -9,7 +9,6 @@
     {
       "name": "",
       "description": "Use the stop light to pause and play the bee's wandering behavior.",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/ibmMsAazFeAJMKmhrH7bbbstRbGNP8d5KHqp1m0McZw",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/codestudio_variablename.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_variablename.json
@@ -9,7 +9,6 @@
     {
       "name": "Example 1",
       "description": "This bunny can count by twos! Each time the bunny is clicked, the variable is updated and the new value of the variable is printed.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/NYkhX-P1oDhkPg6Eqx0kGxHNA3VRs0NaXbpV1suLRMY",
       "image": null,
       "app_display_type": "embedAppWithCode",
@@ -18,7 +17,6 @@
     {
       "name": "Example 2",
       "description": "A variable can be used several times in a program. Here, the variable “spriteSize” is used to set all the food sprites to the same size. \r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/3QoJfDGrL7UbjFQl7G72ZMChOQxkxYSgAaVram0d8BA",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/gamelab_addbehaviorsimple.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_addbehaviorsimple.json
@@ -9,7 +9,6 @@
     {
       "name": "Example 1",
       "description": "The fish will begin continuously swimming left and right when the project is run.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/QuiVqdMFx60Z7dpZ-OvosClMLhjIFo5T-6jWGeApB9c",
       "image": null,
       "app_display_type": "embedAppWithCode",
@@ -18,7 +17,6 @@
     {
       "name": "Example 2",
       "description": "When the phone is clicked, it will begin jittering. \r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/jLtVI22qRmJVvlTSqVRsShucGyNtS1YdR_eXM2h92IY",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/gamelab_allspriteswithanimation.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_allspriteswithanimation.json
@@ -9,7 +9,6 @@
     {
       "name": "Example 1",
       "description": "Make a carrot appear whenever a purple bunny sprite is clicked.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/wtBH6tieviQLkoOT1xgnAWMW1EXM0jlWOOwhfnJtmfA",
       "image": null,
       "app_display_type": "embedAppWithCode",
@@ -18,7 +17,6 @@
     {
       "name": "Example 2",
       "description": "Create five wandering purple bunnies.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/VnW0KcCZW0FagPqT6YW9LUFNlxz1NbDmM4suBczWLw8",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/gamelab_changepropby.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_changepropby.json
@@ -9,7 +9,6 @@
     {
       "name": "Example 1",
       "description": "Change a sprite's size when you click it.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/Hs2C7nuYKpQGGkbeU0EvoMzCHih3IKM8-Np2UpmlV2Y",
       "image": null,
       "app_display_type": "embedAppWithCode",
@@ -18,7 +17,6 @@
     {
       "name": "Example 2",
       "description": "Change a moving sprite's direction when you click it.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/S0L65q-fmjNMkGe38EShJnuU3XzC9OJb-UfPRvxDEvU",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/gamelab_comment.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_comment.json
@@ -9,7 +9,6 @@
     {
       "name": "Example 1",
       "description": "Comments can describe what happens when the code is run or an event happens.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/VGpIMgy5COu5DkDffqj1neGqq8lrL_iY3A4e5j8wHc4",
       "image": null,
       "app_display_type": "embedAppWithCode",
@@ -18,7 +17,6 @@
     {
       "name": "Example 2",
       "description": "Comments can help you track variables and change sprite properties.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/ge12vpygs6dn3uFU2wxS_s3UHbUVq6nhsdQ_61-ZGrk",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/gamelab_createnewsprite.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_createnewsprite.json
@@ -9,7 +9,6 @@
     {
       "name": "",
       "description": "Each sprite has the same costume, but a different behavior.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/QrprIBKeCT8Trr5OdPKlSqFUV-4_ISqGnQwm01zlwFg",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/gamelab_destroy.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_destroy.json
@@ -9,7 +9,6 @@
     {
       "name": "",
       "description": "Remove a sprite by clicking it.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/uEN-3pDeCtcnk-drengqzKe1KqTKIXMyufbrL6zrMb8",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/gamelab_edgesdisplace.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_edgesdisplace.json
@@ -9,7 +9,6 @@
     {
       "name": "",
       "description": "The sprite can move anywhere in the display, but it cannot go beyond the edges.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/SXykKIeRB5Baj96kr_Yp_ela2-gpsQJSW189K9SxMnU",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/gamelab_getprop.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_getprop.json
@@ -9,7 +9,6 @@
     {
       "name": "Example 1",
       "description": "Make the cow move forward by its size each time it is clicked.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/YF9qqbU2thaidVnAsyO5xZZg-Qyd8sbffBtHIMKqNiY",
       "image": null,
       "app_display_type": "embedAppWithCode",
@@ -18,7 +17,6 @@
     {
       "name": "Example 2",
       "description": "There is a bee hiding in a random location on the screen, but where is it? Printing the x and y positions of the sprite helps you find it faster.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/BGMPqEYSlbx-7A3K4irU0TEtqMUYXEhotBNOJpwXh7k",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/gamelab_getthissprite.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_getthissprite.json
@@ -9,7 +9,6 @@
     {
       "name": "Example 1",
       "description": "Using “this” lets an action apply to just one sprite in a costume group without creating a name for every sprite. In this example, any sun that is clicked will disappear when clicked without affecting the others.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/BB02x207ZceIeJqOAVLuDtpMBlbR_eIvs111X6gZjLU",
       "image": null,
       "app_display_type": "embedAppWithCode",
@@ -18,7 +17,6 @@
     {
       "name": "Example 2",
       "description": "“Other” only works if more than one sprite is involved. When two sprites touch, “this” and “other” can be used to make a different action occur for each sprite.  Press 'up' and 'down' arrows to have the middle sprite eat the pizza.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/vpJR48129a0EGLyJbsA01C1eH-ij1qDPLNggqQc-sN8",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/gamelab_hidetitlescreen.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_hidetitlescreen.json
@@ -9,7 +9,6 @@
     {
       "name": "",
       "description": "Here is an example of a start screen.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/_zdlsF8tJTkF0kqjiyxkIj4_cc8Jt4KkLPuF1w-1fbQ",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/gamelab_jumpto.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_jumpto.json
@@ -9,7 +9,6 @@
     {
       "name": "Example 1",
       "description": "Every time the ghost is clicked, it will jump to a random location.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/ju6-mmhqGgBZ5PDwaVz3n6TRqtUea3tPh3vG2RBNBoM",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/gamelab_keypressed.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_keypressed.json
@@ -9,7 +9,6 @@
     {
       "name": "Example 1",
       "description": "This block is most often used to control a sprite’s movement using the arrow keys. \r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/vcSPIOWG5gARFhVKCA_Uzvjq6t-bQgi-BBpEQNlOqqY",
       "image": null,
       "app_display_type": "embedAppWithCode",
@@ -18,7 +17,6 @@
     {
       "name": "Example 2",
       "description": "Compare the use of “when” and “while.” The bunny will only move 10 pixels up or down when the corresponding arrows are pressed. However it will continuously move 10 pixels east and west while the corresponding arrows are pressed.  \r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/wwdQZZB_p19abrngKn6pOSWKraA89vXFbgvyJWT86KU",
       "image": null,
       "app_display_type": "embedAppWithCode",
@@ -27,7 +25,6 @@
     {
       "name": "Example 3",
       "description": "Nearly any key can be pressed as an event. In this example, each key triggers a different action.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/Uz_ijBH2wx9qDby8OPRnJChWzgnATSFF1L3ccLLFEPY",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/gamelab_location_picker.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_location_picker.json
@@ -9,7 +9,6 @@
     {
       "name": "",
       "description": "The location picker makes it easy to place the sprites in locations that match the background. \r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/BBKcrQf3YOsE1074OqiKdpHRVONRXB8GvJLhaQygank",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/gamelab_locationat.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_locationat.json
@@ -9,7 +9,6 @@
     {
       "name": "",
       "description": "The block is used several times to make sure that all of the buttons and cars are lined up and evenly spaced for the start of a race.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/QH4A2fQG50Gq23urQskLseUBpAU_KlVzFxiu-F5VZyU",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/gamelab_locationmouse.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_locationmouse.json
@@ -9,7 +9,6 @@
     {
       "name": "Example 1",
       "description": "Sprite can be created where you point the mouse. Click the clipboard sprite to \"stamp\" apples onto the paper.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/Dh1TPhJkFx3nOmMYs1OnRzI3bt5lVhEHxSoDBiHkubs",
       "image": null,
       "app_display_type": "embedAppWithCode",
@@ -18,7 +17,6 @@
     {
       "name": "Example 2",
       "description": "Sprites can follow the mouse. Click, hold, and drag the coin.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/0LWwYIjbMxRETHGURawFH9JseB0Q2TxtmaO8QXUeiIg",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/gamelab_locationof.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_locationof.json
@@ -9,7 +9,6 @@
     {
       "name": "Example 2",
       "description": "This block allows one sprite to move towards another, no matter where it is on the screen. Here is a simple tag game where you can press the spacebar to make the chaser follow the runner.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/2rF3nhfgM0kQJLvbHd0Uw-O3QZ5KizoDo6QKsj-s7oY",
       "image": null,
       "app_display_type": "embedAppWithCode",
@@ -18,7 +17,6 @@
     {
       "name": "Example 1",
       "description": "The first sprite is drawn at a random location, but the second sprite is always drawn at the same place.",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/tewA4hP6AQUQ-LCtJl3H9ragHH0CnWI96wkEWM39Ox4",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/gamelab_makenewspriteanon.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_makenewspriteanon.json
@@ -9,7 +9,6 @@
     {
       "name": "Example 1",
       "description": "Create a new sprite with a \"pink bunny\" costume at (100, 300).\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/urrtCeUSn8OCCexM3ueoBbQN0f6vzydtME2g8a_JJI4",
       "image": null,
       "app_display_type": "embedAppWithCode",
@@ -18,7 +17,6 @@
     {
       "name": "Example 2",
       "description": "Create a carrot in a random location whenever the bunny is clicked.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/0PeIG8da8W2sfQXLz_cZ-hvIvj3Izq20IdHqUa305mg",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/gamelab_moveforward.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_moveforward.json
@@ -9,7 +9,6 @@
     {
       "name": "Example 1",
       "description": "This airplane moves \"forward\". All sprites move to the right by default.",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/f38oDFC4vPSwHNfMxitUavljGTcG3lVCxbATW2nlmZ4",
       "image": null,
       "app_display_type": "embedAppWithCode",
@@ -18,7 +17,6 @@
     {
       "name": "Example 2",
       "description": "Extra code changes the sprite's starting direction. You can also change direction with the arrow keys.",
-      "code": "```\n\n```",
       "app": "",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/gamelab_moveindirection.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_moveindirection.json
@@ -9,7 +9,6 @@
     {
       "name": "Example 1",
       "description": "The most common use of this block outside of behaviors is to make a sprite move with the arrow keys. \r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/anG6huOwRbHHLWGIAHq0WQhFGeuqPhpFOw3CEH9MvrI",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/gamelab_movetoward.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_movetoward.json
@@ -9,7 +9,6 @@
     {
       "name": "Example 3",
       "description": "No matter where the target is, the pick will always get a bullseye. Press the ‘t’ key to throw the pick.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/irjSXwc-K5iF-8qJWgJt3gk1m8Oy2hsJso_hVUnhCvQ",
       "image": null,
       "app_display_type": "embedAppWithCode",
@@ -18,7 +17,6 @@
     {
       "name": "Example 1",
       "description": "The dog loves chasing the bone! Click and hold on the bone to drag it around the display, and press the spacebar to have the dog chase it. \r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/2V6kx4dXNqnFSuUDovzaf0H2Qh6zlDypPco26OI4h94",
       "image": null,
       "app_display_type": "embedAppWithCode",
@@ -27,7 +25,6 @@
     {
       "name": "Example 2",
       "description": "This project has the same function as the one above but uses the “chasing” behavior to allow the dog to chase the bone. \r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/vEYWNKztbq0ZhHtA-6ivdo1IcDiNzmVPSEr6uDV4uv0",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/gamelab_playsound.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_playsound.json
@@ -9,7 +9,6 @@
     {
       "name": "Example 1",
       "description": "Play a happy sound whenever the sprite is clicked.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/MecP26Q6MZrKb8i55k0J66FRUQrW77KZeKN7H1ie1Yg",
       "image": null,
       "app_display_type": "embedAppWithCode",
@@ -18,7 +17,6 @@
     {
       "name": "Example 2",
       "description": "Play sounds to indicate when different events happen. \r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/WwtTeTb7Ztsx94o0m7U44FYkPM_DSfd1pLdik3cqdr0",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/gamelab_printtext.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_printtext.json
@@ -9,7 +9,6 @@
     {
       "name": "Example 1",
       "description": "Print can be used to display a summary of the project.",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/EMjD9LfR933K-2XxbiUgVEFUgEEIkzgsAi1Lg9X9EkE",
       "image": null,
       "app_display_type": "embedAppWithCode",
@@ -18,7 +17,6 @@
     {
       "name": "Example 2",
       "description": "Printing text can make it look like the sprite is talking.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/9l51UN7wYsT3Gqqwn6xocQzzHyyHjk97Mn6K-oP_z3o",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/gamelab_randomcolor.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_randomcolor.json
@@ -9,7 +9,6 @@
     {
       "name": "Example 1",
       "description": "Change the color of a sprite repeatedly when it is clicked.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/ubMFIKCmhuczdRR8hpO2yVwAoIvOQf_DqN8p_6d9Fu8",
       "image": null,
       "app_display_type": "embedAppWithCode",
@@ -18,7 +17,6 @@
     {
       "name": "Example 2",
       "description": "Change the background color randomly when the sprite is clicked.",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/4tcRFopUTN9SHeXD6oWaiy9BoKaZS4nQbzkTAzmyI8g",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/gamelab_randomlocation.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_randomlocation.json
@@ -9,7 +9,6 @@
     {
       "name": "Example 1",
       "description": "The bunny will appear at a random location each time the project is run.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/FBW78_RnfOa_uGuWP75KNmnFmq6UfDZIxFmu671HTiw",
       "image": null,
       "app_display_type": "embedAppWithCode",
@@ -18,7 +17,6 @@
     {
       "name": "Example 2",
       "description": "Every time the ghost is clicked, it will jump to a random location.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/ju6-mmhqGgBZ5PDwaVz3n6TRqtUea3tPh3vG2RBNBoM",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/gamelab_removeallbehaviors.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_removeallbehaviors.json
@@ -9,7 +9,6 @@
     {
       "name": "",
       "description": "The sprite has three behaviors: spinning, swimming, and growing. When it is clicked, all three behaviors will stop.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/7VN3d3ZyD39cXZL2occ6H7giOQ8dlrbMtkWBszyNb5Y",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/gamelab_removebehaviorsimple.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_removebehaviorsimple.json
@@ -9,7 +9,6 @@
     {
       "name": "Example 1",
       "description": "The phone will “ring” until the person touches and answers it.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/muxpC-K0WlAWaajtIcc22-1A5JruJ0hAJ3aaCNrZKcQ",
       "image": null,
       "app_display_type": "embedAppWithCode",
@@ -18,7 +17,6 @@
     {
       "name": "Example 2",
       "description": "If a sprite is doing multiple behaviors, individual behaviors can still be controlled and stopped. Click on the star to make it stop growing.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/nv7KLeJMzs-LvN3BOhNSZayUTB7Kgdo2FTR0reczY_E",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/gamelab_removetint.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_removetint.json
@@ -9,7 +9,6 @@
     {
       "name": "",
       "description": "",
-      "code": "```\n\n```",
       "app": "",
       "image": null,
       "app_display_type": "embedAppWithCode",
@@ -18,7 +17,6 @@
     {
       "name": "Example 1",
       "description": "The ghost changes colors when it touches the paint, but the color is removed when it touches the soap.",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/zwQ1w4i6LKWcID01J4fopzMC9TPeC49fIULxcA3zSEA",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/gamelab_setanimation.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_setanimation.json
@@ -9,7 +9,6 @@
     {
       "name": "Example 1",
       "description": "A costume change can be triggered by an event. For example, when the alien is pressed, it changes all the green fish costumes to pink fish costumes.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/Vy5_BjpcgKP221KLELwqS1Djv1AhpCvKH9Eq20m8JR4",
       "image": null,
       "app_display_type": "embedAppWithCode",
@@ -18,7 +17,6 @@
     {
       "name": "Example 2",
       "description": "Just one sprite can be changed by name. In this case, there is one alien pretending to be like the others. When that alien clicked, it reveals its true self.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/ohjuE1RU581tK0JXi7zgUu3f6wOONUXVbRdBFeM8gTw",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/gamelab_setbackground.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_setbackground.json
@@ -9,7 +9,6 @@
     {
       "name": "Example 2",
       "description": "When more than one background is used together in a sequence, the last background set will be the one that is used. In this example, the background will not switch from red to blue; when it is run, the background will go straight to blue.",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/l6IlcspCiPBcgJ2IUeMgqoLiw7s8eekw5Rm_PnEKGos",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/gamelab_setbackgroundimage.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_setbackgroundimage.json
@@ -9,7 +9,6 @@
     {
       "name": "Example 1",
       "description": "The background starts white in Sprite Lab, but it can be changed to any image.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/qLBVoFZUftgEwgH2kPMq_XtJp8xxO3AWA6kPCMWd6cc",
       "image": null,
       "app_display_type": "embedAppWithCode",
@@ -18,7 +17,6 @@
     {
       "name": "Example 2",
       "description": "The background can be changed multiple times throughout a project. \r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/IHitubrSGPFNtWgt-IHCdx1YYLH2PlWHQ7rIw2WVJKU",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/gamelab_setprop.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_setprop.json
@@ -9,7 +9,6 @@
     {
       "name": "Example 1",
       "description": "Each sprite is set to a different size.",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/LLivCo_Re1h4pHsRFRnS2L68tpF6RFPfinwb_dAyu2w",
       "image": null,
       "app_display_type": "embedAppWithCode",
@@ -18,7 +17,6 @@
     {
       "name": "Example 2",
       "description": "Each sprite is set to a different rotation.",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/Ems0tkcP45ZIBWpmWwCNkMabLNrQorCCiXlN7hOJVLI",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/gamelab_settint.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_settint.json
@@ -9,7 +9,6 @@
     {
       "name": "Example 1",
       "description": "The color of a sprite can be changed several times in a project.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/TXtrCtSi1V0G02g4YxEhEGcFfrBHHwsAULbGKaZyKR0",
       "image": null,
       "app_display_type": "embedAppWithCode",
@@ -18,7 +17,6 @@
     {
       "name": "Example 2",
       "description": "Change color can be used to make sprites wearing the same costume look unique and more colorful.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/ce9cGvSDaQjtmzqA0raUyZUNG67UOZUsYHg6oGg3UBM",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/gamelab_showtitlescreen.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_showtitlescreen.json
@@ -9,7 +9,6 @@
     {
       "name": "Example 1",
       "description": "A title screen is used to describe the project. \r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/O9Znd5YOetUz1qw8et-4adTSaFnSbJRnB3-bdc_LMQ0",
       "image": null,
       "app_display_type": "embedAppWithCode",
@@ -18,7 +17,6 @@
     {
       "name": "Example 2",
       "description": "The green monster is running away from the purple popsicle monsters. When the green monster is caught, a title screen appears to indicate the game is over.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/9LEF2zHnnT7efjEsLJ8MVo9Li9jyv-hTHin98NCpVJk",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/gamelab_spriteclicked.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_spriteclicked.json
@@ -9,7 +9,6 @@
     {
       "name": "Example 1",
       "description": "The paintbrush will change the background color each time it is clicked.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/NpcK_MoRv8zN7heUq18yIaPZIM690vQl35ihC6dPEZg",
       "image": null,
       "app_display_type": "embedAppWithCode",
@@ -18,7 +17,6 @@
     {
       "name": "Example 2",
       "description": "The pencil will grow as long as it is being clicked on.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/RSSlXfpAFKPsfEE_-isFfFUd0XhrIeju0kL1KdRkmY0",
       "image": null,
       "app_display_type": "embedAppWithCode",
@@ -27,7 +25,6 @@
     {
       "name": "Example 3",
       "description": "Click on the cupcake to move it away from the flies, and click on the flies to swat them away.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/n59f-yK4X-BeQwjEIsNczUC29MGN_pu1xdLGtbRF1lI",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/gamelab_turn.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_turn.json
@@ -9,7 +9,6 @@
     {
       "name": "",
       "description": "The toothbrush has been turned to make it look like it is in the sprite’s hand. \r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/_-NSBYoKUgXUNjx-ZGvUGtODsq3nC3d7q4K-7JrQn-o",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/gamelab_whentouching.json
+++ b/dashboard/config/programming_expressions/spritelab/gamelab_whentouching.json
@@ -9,7 +9,6 @@
     {
       "name": "Example 1",
       "description": "Whenever the bee touches the bear, the bear will say “Ouch!”\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/esT0EyIw1JqODNYrz-yRdLgSknzKNJ3LqbRwhiN7L3U",
       "image": null,
       "app_display_type": "embedAppWithCode",
@@ -18,7 +17,6 @@
     {
       "name": "Example 2",
       "description": "While the bubble sprite is touching the soap sprite, it will grow bigger. When the bubble touches a rock sprite, it will “pop” and return to its original size.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/kIs4wCurYo36UilsU2r8oaWvecP97NfGy6dLWBZy_WQ",
       "image": null,
       "app_display_type": "embedAppWithCode",

--- a/dashboard/config/programming_expressions/spritelab/spritelab_adding-and-removing-behaviors.json
+++ b/dashboard/config/programming_expressions/spritelab/spritelab_adding-and-removing-behaviors.json
@@ -8,7 +8,6 @@
     {
       "name": "",
       "description": "A behavior has been created to make a sprite move northwest.\r\n",
-      "code": "```\n\n```",
       "app": "https://studio.code.org/projects/spritelab/3mvIX2h-BgJZi7OK4GK9BmLTAWfO1O7KejWBxfDzBoA",
       "image": null,
       "app_display_type": "embedAppWithCode",


### PR DESCRIPTION
An unintentional side effect of #44940 was that the code tags were sometimes added around the empty string, resulting in something likes this:
<img width="919" alt="Screen Shot 2022-02-25 at 6 48 55 AM" src="https://user-images.githubusercontent.com/46464143/155735518-8a94773e-2693-4adf-8985-3b20a3c115f6.png">

I ran 
```
ProgrammingExpression.all.select {|exp| exp.examples && exp.examples.any? {|e| e['code'] == "```\n\n```" }}.each{|exp| exp.examples.each {|e| e.delete('code') if e['code'] == "```\n\n```"} ; exp.write_serialization }
```
on the Rails console to fix these fields. Not 100% sure I caught all of them but we are getting a human pass, so best effort seems like enough.



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
