### PR TITLE
Update new CodeDocLink test to look for TextLink instead of anchor tag

### DIFF
--- a/apps/test/unit/templates/codeDocs/CodeDocLinkTest.jsx
+++ b/apps/test/unit/templates/codeDocs/CodeDocLinkTest.jsx
@@ -50,14 +50,13 @@ describe('CodeDocLink', () => {
         showBlocks={false}
       />
     );
-    expect(wrapper.find('a').length).to.equal(1);
+    expect(wrapper.find('TextLink').length).to.equal(1);
     expect(
       wrapper
-        .find('a')
+        .find('TextLink')
         .first()
         .props().href
     ).to.equal('/docs/spritelab/code');
-    expect(wrapper.text().includes('Sprite Lab Block')).to.be.true;
     expect(wrapper.find('EmbeddedBlock').length).to.equal(0);
   });
 });


### PR DESCRIPTION
Test was added in #44961 but I changed from anchor tags to `TextLink` in #45010. The two branches first met in staging, causing a test failure in staging. Decided to fix forward as this is a small and well-understood change.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
