### PR TITLE
Fix reordering categories within a programming environment

### DIFF
--- a/dashboard/app/controllers/programming_environments_controller.rb
+++ b/dashboard/app/controllers/programming_environments_controller.rb
@@ -36,14 +36,14 @@ class ProgrammingEnvironmentsController < ApplicationController
       if programming_environment_params[:categories]
         programming_environment.categories =
           programming_environment_params[:categories].each_with_index.map do |category, i|
-            if category['id']
+            if category['id'].blank?
+              ProgrammingEnvironmentCategory.create!(category.merge(programming_environment_id: programming_environment.id, position: i))
+            else
               existing_category = programming_environment.categories.find(category['id'])
               existing_category.assign_attributes(category.except('id'))
               existing_category.position = i
               existing_category.save! if existing_category.changed?
               existing_category
-            else
-              ProgrammingEnvironmentCategory.create!(category.merge(programming_environment_id: programming_environment.id, position: i))
             end
           end
       end

--- a/dashboard/app/controllers/programming_environments_controller.rb
+++ b/dashboard/app/controllers/programming_environments_controller.rb
@@ -35,14 +35,15 @@ class ProgrammingEnvironmentsController < ApplicationController
     begin
       if programming_environment_params[:categories]
         programming_environment.categories =
-          programming_environment_params[:categories].map do |category|
+          programming_environment_params[:categories].each_with_index.map do |category, i|
             if category['id']
               existing_category = programming_environment.categories.find(category['id'])
               existing_category.assign_attributes(category.except('id'))
+              existing_category.position = i
               existing_category.save! if existing_category.changed?
               existing_category
             else
-              ProgrammingEnvironmentCategory.create!(category.merge(programming_environment_id: programming_environment.id))
+              ProgrammingEnvironmentCategory.create!(category.merge(programming_environment_id: programming_environment.id, position: i))
             end
           end
       end

--- a/dashboard/app/models/programming_environment.rb
+++ b/dashboard/app/models/programming_environment.rb
@@ -22,7 +22,7 @@ class ProgrammingEnvironment < ApplicationRecord
   validates_uniqueness_of :name, case_sensitive: false
 
   alias_attribute :categories, :programming_environment_categories
-  has_many :programming_environment_categories, dependent: :destroy
+  has_many :programming_environment_categories, -> {order(:position)}, dependent: :destroy
   has_many :programming_expressions, dependent: :destroy
 
   # @attr [String] editor_type - Type of editor one of the following: 'text-based', 'droplet', 'blockly'

--- a/dashboard/app/models/programming_environment_category.rb
+++ b/dashboard/app/models/programming_environment_category.rb
@@ -32,7 +32,8 @@ class ProgrammingEnvironmentCategory < ApplicationRecord
     {
       key: key,
       name: name,
-      color: color
+      color: color,
+      position: position
     }
   end
 

--- a/dashboard/config/programming_environments/applab.json
+++ b/dashboard/config/programming_environments/applab.json
@@ -9,57 +9,68 @@
     {
       "key": "ui_controls",
       "name": "UI controls",
-      "color": "#fff176"
+      "color": "#fff176",
+      "position": 0
     },
     {
       "key": "canvas",
       "name": "Canvas",
-      "color": "#f78183"
+      "color": "#f78183",
+      "position": 1
     },
     {
       "key": "data",
       "name": "Data",
-      "color": "#d3e965"
+      "color": "#d3e965",
+      "position": 2
     },
     {
       "key": "turtle",
       "name": "Turtle",
-      "color": "#4dd0e1"
+      "color": "#4dd0e1",
+      "position": 3
     },
     {
       "key": "control",
       "name": "Control",
-      "color": "#64B5F6"
+      "color": "#64B5F6",
+      "position": 4
     },
     {
       "key": "math",
       "name": "Math",
-      "color": "#FFB74D"
+      "color": "#FFB74D",
+      "position": 5
     },
     {
       "key": "variables",
       "name": "Variables",
-      "color": "#BB77C7"
+      "color": "#BB77C7",
+      "position": 6
     },
     {
       "key": "functions",
       "name": "Functions",
-      "color": "#68D995"
+      "color": "#68D995",
+      "position": 7
     },
     {
       "key": "advanced",
       "name": "Advanced",
-      "color": "#19c3e1"
+      "color": "#19c3e1",
+      "position": 8
     },
     {
       "key": "maker",
       "name": "Maker",
-      "color": "#4dd0e1"
+      "color": "#4dd0e1",
+      "position": 9
     },
     {
       "key": "circuit",
       "name": "Circuit",
-      "color": "#f78183"
+      "color": "#f78183",
+      "position": 10
     }
   ]
 }

--- a/dashboard/config/programming_environments/gamelab.json
+++ b/dashboard/config/programming_environments/gamelab.json
@@ -7,59 +7,58 @@
   "title": "Game Lab",
   "categories": [
     {
+      "key": "game_lab",
+      "name": "Game Lab",
+      "color": "#fff176",
+      "position": 0
+    },
+    {
       "key": "sprites",
       "name": "Sprites",
-      "color": "#f78183"
+      "color": "#f78183",
+      "position": 1
     },
     {
       "key": "groups",
       "name": "Groups",
-      "color": "#f78183"
+      "color": "#f78183",
+      "position": 2
     },
     {
       "key": "drawing",
       "name": "Drawing",
-      "color": "#4dd0e1"
+      "color": "#4dd0e1",
+      "position": 3
     },
     {
       "key": "control",
       "name": "Control",
-      "color": "#64B5F6"
+      "color": "#64B5F6",
+      "position": 4
     },
     {
       "key": "math",
       "name": "Math",
-      "color": "#FFB74D"
+      "color": "#FFB74D",
+      "position": 5
     },
     {
       "key": "variables",
       "name": "Variables",
-      "color": "#BB77C7"
+      "color": "#BB77C7",
+      "position": 6
     },
     {
       "key": "functions",
       "name": "Functions",
-      "color": "#68D995"
+      "color": "#68D995",
+      "position": 7
     },
     {
       "key": "world",
       "name": "World",
-      "color": "#fff176"
-    },
-    {
-      "key": "animations",
-      "name": "Animations",
-      "color": "#f78183"
-    },
-    {
-      "key": "ui_controls",
-      "name": "UI controls",
-      "color": "#fff176"
-    },
-    {
-      "key": "game_lab",
-      "name": "Game Lab",
-      "color": "#fff176"
+      "color": "#fff176",
+      "position": 8
     }
   ]
 }

--- a/dashboard/config/programming_environments/spritelab.json
+++ b/dashboard/config/programming_environments/spritelab.json
@@ -10,67 +10,80 @@
     {
       "key": "sprites",
       "name": "Sprites",
-      "color": "#df9399"
+      "color": "#df9399",
+      "position": 0
     },
     {
       "key": "world",
       "name": "World",
-      "color": "#acacd2"
+      "color": "#acacd2",
+      "position": 1
     },
     {
       "key": "location",
       "name": "Locations",
-      "color": "#f5ebaa"
+      "color": "#f5ebaa",
+      "position": 2
     },
     {
       "key": "actions",
       "name": "Actions",
-      "color": "#5ef3ff"
+      "color": "#5ef3ff",
+      "position": 3
     },
     {
       "key": "events",
       "name": "Events",
-      "color": "#62fc94"
+      "color": "#62fc94",
+      "position": 4
     },
     {
       "key": "behaviors",
       "name": "Behaviors",
-      "color": "#89eba4"
+      "color": "#89eba4",
+      "position": 5
     },
     {
       "key": "loops",
       "name": "Loops",
-      "color": "#f98bd0"
+      "color": "#f98bd0",
+      "position": 6
     },
     {
       "key": "variables",
       "name": "Variables",
-      "color": "#0cfb4c"
+      "color": "#cfc4b9",
+      "position": 7
     },
     {
       "key": "math",
       "name": "Math",
-      "color": "#bbb3ce"
+      "color": "#bbb3ce",
+      "position": 8
     },
     {
       "key": "logic",
       "name": "Logic",
-      "color": "#64d5ff"
+      "color": "#64d5ff",
+      "position": 9
     },
     {
       "key": "functions",
       "name": "Functions",
-      "color": "#a3e770"
+      "color": "#a3e770",
+      "position": 10
     },
     {
       "key": "text",
       "name": "Text",
-      "color": "#acd2c6"
+      "color": "#acd2c6",
+      "position": 11
     },
     {
       "key": "comments",
       "name": "Comments",
-      "color": "#d9d9d9"
+      "color": "#d9d9d9",
+      "position": 12
     }
   ]
 }

--- a/dashboard/config/programming_environments/weblab.json
+++ b/dashboard/config/programming_environments/weblab.json
@@ -9,12 +9,14 @@
     {
       "key": "html_tags",
       "name": "HTML Tags",
-      "color": "#fff176"
+      "color": "#fff176",
+      "position": 0
     },
     {
       "key": "css_properties",
       "name": "CSS Properties",
-      "color": "#d3e965"
+      "color": "#d3e965",
+      "position": 1
     }
   ]
 }

--- a/dashboard/test/controllers/programming_environments_controller_test.rb
+++ b/dashboard/test/controllers/programming_environments_controller_test.rb
@@ -76,12 +76,13 @@ class ProgrammingEnvironmentsControllerTest < ActionController::TestCase
     category_to_keep = create :programming_environment_category, programming_environment: programming_environment, position: 0
     category_to_destroy = create :programming_environment_category, programming_environment: programming_environment, position: 1
     File.expects(:write).with {|filename, _| filename.to_s.end_with? "#{programming_environment.name}.json"}.once
-    post :update, params: {
-      name: programming_environment.name,
-      title: 'title',
-      editorType: 'blockly',
-      categories: [{name: 'brand new category', color: '#00FFFF'}, {id: category_to_keep.id, name: category_to_keep.name, color: category_to_keep.color}]
-    }
+    post :update, params:
+      {
+        name: programming_environment.name,
+        title: 'title',
+        editorType: 'blockly',
+        categories: [{id: nil, name: 'brand new category', color: '#00FFFF'}, {id: category_to_keep.id, name: category_to_keep.name, color: category_to_keep.color}]
+      }
     assert_response :ok
 
     programming_environment.reload

--- a/dashboard/test/controllers/programming_environments_controller_test.rb
+++ b/dashboard/test/controllers/programming_environments_controller_test.rb
@@ -73,14 +73,14 @@ class ProgrammingEnvironmentsControllerTest < ActionController::TestCase
     sign_in @levelbuilder
 
     programming_environment = create :programming_environment
-    category_to_keep = create :programming_environment_category, programming_environment: programming_environment
-    category_to_destroy = create :programming_environment_category, programming_environment: programming_environment
+    category_to_keep = create :programming_environment_category, programming_environment: programming_environment, position: 0
+    category_to_destroy = create :programming_environment_category, programming_environment: programming_environment, position: 1
     File.expects(:write).with {|filename, _| filename.to_s.end_with? "#{programming_environment.name}.json"}.once
     post :update, params: {
       name: programming_environment.name,
       title: 'title',
       editorType: 'blockly',
-      categories: [{id: category_to_keep.id, name: category_to_keep.name, color: category_to_keep.color}, {name: 'brand new category', color: '#00FFFF'}]
+      categories: [{name: 'brand new category', color: '#00FFFF'}, {id: category_to_keep.id, name: category_to_keep.name, color: category_to_keep.color}]
     }
     assert_response :ok
 
@@ -88,6 +88,7 @@ class ProgrammingEnvironmentsControllerTest < ActionController::TestCase
     assert programming_environment.categories.include?(category_to_keep)
     refute programming_environment.categories.include?(category_to_destroy)
     assert_equal 2, programming_environment.categories.count
+    assert_equal ['brand new category', category_to_keep.name], programming_environment.categories.map(&:name)
   end
 
   test 'returns not_found if updating a non-existant programming environment' do


### PR DESCRIPTION
Allows reordering of categories within a programming environment. When we save the programming environment, each category is given a position based on its position in the update request. I zero indexed these as this number isn't user facing (it only affects the order the categories are listed in).

The UI is unchanged -- reordering was supported in the editor, it just didn't persist. 




## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
