### PR TITLE
Java Lab Console: only jump to bottom when running or testing

### DIFF
--- a/apps/src/javalab/JavalabConsole.jsx
+++ b/apps/src/javalab/JavalabConsole.jsx
@@ -51,7 +51,9 @@ class JavalabConsole extends React.Component {
     displayTheme: PropTypes.oneOf(Object.values(DisplayTheme)),
     isPhotoPrompterOpen: PropTypes.bool,
     closePhotoPrompter: PropTypes.func,
-    photoPrompterPromptText: PropTypes.string
+    photoPrompterPromptText: PropTypes.string,
+    isRunning: PropTypes.bool,
+    isTesting: PropTypes.bool
   };
 
   state = {
@@ -183,7 +185,10 @@ class JavalabConsole extends React.Component {
   };
 
   onLogsClick = () => {
-    this.inputRef.focus();
+    // only jump to input if the program is currently in run or test mode.
+    if (this.props.isRunning || this.props.isTesting) {
+      this.inputRef.focus();
+    }
   };
 
   render() {
@@ -243,7 +248,9 @@ export default connect(
     consoleLogs: state.javalab.consoleLogs,
     displayTheme: state.javalab.displayTheme,
     isPhotoPrompterOpen: state.javalab.isPhotoPrompterOpen,
-    photoPrompterPromptText: state.javalab.photoPrompterPromptText
+    photoPrompterPromptText: state.javalab.photoPrompterPromptText,
+    isRunning: state.javalab.isRunning,
+    isTesting: state.javalab.isTesting
   }),
   dispatch => ({
     appendInputLog: log => dispatch(appendInputLog(log)),

--- a/apps/src/javalab/JavalabConsole.jsx
+++ b/apps/src/javalab/JavalabConsole.jsx
@@ -52,8 +52,7 @@ class JavalabConsole extends React.Component {
     isPhotoPrompterOpen: PropTypes.bool,
     closePhotoPrompter: PropTypes.func,
     photoPrompterPromptText: PropTypes.string,
-    isRunning: PropTypes.bool,
-    isTesting: PropTypes.bool
+    shouldJumpToInput: PropTypes.bool
   };
 
   state = {
@@ -186,7 +185,7 @@ class JavalabConsole extends React.Component {
 
   onLogsClick = () => {
     // only jump to input if the program is currently in run or test mode.
-    if (this.props.isRunning || this.props.isTesting) {
+    if (this.props.shouldJumpToInput) {
       this.inputRef.focus();
     }
   };
@@ -249,8 +248,7 @@ export default connect(
     displayTheme: state.javalab.displayTheme,
     isPhotoPrompterOpen: state.javalab.isPhotoPrompterOpen,
     photoPrompterPromptText: state.javalab.photoPrompterPromptText,
-    isRunning: state.javalab.isRunning,
-    isTesting: state.javalab.isTesting
+    shouldJumpToInput: state.javalab.isRunning || state.javalab.isTesting
   }),
   dispatch => ({
     appendInputLog: log => dispatch(appendInputLog(log)),


### PR DESCRIPTION
Update our jump to bottom logic to only happen when a program is actively running or testing. This will make operations such as copy/paste much easier.

## Links
- jira ticket: [JAVA-436](https://codedotorg.atlassian.net/browse/JAVA-436)


## Testing story
Tested locally. We still jump to bottom when a program is running, but don't when a program is not running.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
