### PR TITLE
Use CB field names in the example editor and component

### DIFF
--- a/apps/src/lib/levelbuilder/code-docs-editor/ExampleEditor.jsx
+++ b/apps/src/lib/levelbuilder/code-docs-editor/ExampleEditor.jsx
@@ -7,9 +7,11 @@ import TextareaWithMarkdownPreview from '@cdo/apps/lib/levelbuilder/TextareaWith
 import UploadImageDialog from '@cdo/apps/lib/levelbuilder/lesson-editor/UploadImageDialog';
 
 const APP_DISPLAY_OPTIONS = {
-  directly: 'Embed app with code directly',
-  displayApp: 'Display app with code from code field above'
+  embedAppWithCode: 'Embed app with code directly',
+  codeFromCodeField: 'Display app with code from code field above'
 };
+
+const DEFAULT_EMBED_HEIGHT = 310;
 
 export default function ExampleEditor({example, updateExample}) {
   const [uploadImageDialogOpen, setUploadImageDialogOpen] = useState(false);
@@ -59,8 +61,8 @@ export default function ExampleEditor({example, updateExample}) {
       <label>
         Example App Display Type
         <select
-          value={example.appDisplayType || 'directly'}
-          onChange={e => updateExample('appDisplayType', e.target.value)}
+          value={example.app_display_type || 'embedAppWithCode'}
+          onChange={e => updateExample('app_display_type', e.target.value)}
           style={styles.selectInput}
         >
           {Object.keys(APP_DISPLAY_OPTIONS).map(key => (
@@ -80,15 +82,17 @@ export default function ExampleEditor({example, updateExample}) {
           with the "Embed app with code" display type
         </HelpTip>
         <input
-          value={example.appEmbedHeight || ''}
-          onChange={e => updateExample('appEmbedHeight', e.target.value)}
+          value={example.embed_app_with_code_height || DEFAULT_EMBED_HEIGHT}
+          onChange={e =>
+            updateExample('embed_app_with_code_height', e.target.value)
+          }
           style={styles.textInput}
         />{' '}
       </label>
       <UploadImageDialog
         isOpen={uploadImageDialogOpen}
         handleClose={() => setUploadImageDialogOpen(false)}
-        uploadImage={imgUrl => updateExample('imageUrl', imgUrl)}
+        uploadImage={imgUrl => updateExample('image', imgUrl)}
         allowExpandable={false}
       />
     </div>

--- a/apps/src/templates/codeDocs/Example.jsx
+++ b/apps/src/templates/codeDocs/Example.jsx
@@ -13,7 +13,7 @@ export default function Example({example, programmingEnvironmentName}) {
     </>
   );
   if (example.app) {
-    if (example.appDisplayType === 'displayApp') {
+    if (example.app_display_type === 'codeFromCodeField') {
       const embedUrl = example.app.endsWith('embed')
         ? example.app
         : example.app + '/embed';
@@ -42,7 +42,7 @@ export default function Example({example, programmingEnvironmentName}) {
               src={embedUrl}
               style={{
                 width: '100%',
-                height: Number(example.appEmbedHeight) || 310
+                height: Number(example.embed_app_with_code_height) || 310
               }}
             />
           </div>

--- a/apps/test/unit/lib/levelbuilder/code-docs-editor/ExampleEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/code-docs-editor/ExampleEditorTest.jsx
@@ -15,8 +15,8 @@ describe('ExampleEditor', () => {
         description: 'this is the first example',
         code: 'return foo;',
         app: 'studio.code.org/p/spritelab',
-        appDisplayType: 'withCode',
-        appEmbedHeight: '100'
+        app_display_type: 'withCode',
+        embed_app_with_code_height: '100'
       },
       updateExample: updateSpy
     };
@@ -85,7 +85,7 @@ describe('ExampleEditor', () => {
     const displayTypeSelect = wrapper.find('select').at(0);
     displayTypeSelect.simulate('change', {target: {value: 'directly'}});
     expect(updateSpy).to.be.calledOnce.and.calledWith(
-      'appDisplayType',
+      'app_display_type',
       'directly'
     );
   });
@@ -100,6 +100,9 @@ describe('ExampleEditor', () => {
     const wrapper = shallow(<ExampleEditor {...defaultProps} />);
     const appEmbedHeightField = wrapper.find('input').at(2);
     appEmbedHeightField.simulate('change', {target: {value: '250'}});
-    expect(updateSpy).to.be.calledOnce.and.calledWith('appEmbedHeight', '250');
+    expect(updateSpy).to.be.calledOnce.and.calledWith(
+      'embed_app_with_code_height',
+      '250'
+    );
   });
 });

--- a/apps/test/unit/templates/codeDocs/ExampleTest.jsx
+++ b/apps/test/unit/templates/codeDocs/ExampleTest.jsx
@@ -10,7 +10,7 @@ describe('Example', () => {
       description: 'An example',
       code: '```This is the code that the embedded app uses```',
       app: '/p/applab/abcde',
-      appDisplayType: 'displayApp'
+      app_display_type: 'codeFromCodeField'
     };
     const wrapper = shallow(
       <Example example={example} programmingEnvironmentName="applab" />
@@ -29,7 +29,7 @@ describe('Example', () => {
       name: 'Example 1',
       description: 'An example',
       app: '/p/spritelab/abcde',
-      appDisplayType: 'directly'
+      app_display_type: 'embedAppWithCode'
     };
     const wrapper = shallow(
       <Example example={example} programmingEnvironmentName="spritelab" />
@@ -48,7 +48,7 @@ describe('Example', () => {
       name: 'Example 1',
       description: 'An example',
       code: '```This is some example code```',
-      appDisplayType: 'displayApp'
+      app_display_type: 'codeFromCodeField'
     };
 
     const wrapper = shallow(
@@ -64,7 +64,7 @@ describe('Example', () => {
       name: 'Example 1',
       description: 'An example',
       code: '```This is some example code```',
-      appDisplayType: 'displayApp',
+      app_display_type: 'codeFromCodeField',
       imageUrl: '/image.png'
     };
 

--- a/dashboard/app/controllers/programming_expressions_controller.rb
+++ b/dashboard/app/controllers/programming_expressions_controller.rb
@@ -96,7 +96,7 @@ class ProgrammingExpressionsController < ApplicationController
       :return_value,
       :tips,
       parameters: [:name, :type, :required, :description],
-      examples: [:name, :description, :code, :app, :imageUrl, :appDisplayType, :appEmbedHeight]
+      examples: [:name, :description, :code, :app, :image, :app_display_type, :embed_app_with_code_height]
     )
     transformed_params
   end

--- a/dashboard/config/programming_expressions/spritelab/codestudio_defining-behaviors.json
+++ b/dashboard/config/programming_expressions/spritelab/codestudio_defining-behaviors.json
@@ -9,13 +9,13 @@
       "name": "Example 1",
       "description": "A behavior has been created to make a sprite move northwest across the display area. Click on the `edit` button to see how this behavior has been defined.\n",
       "app": "https://studio.code.org/projects/spritelab/3mvIX2h-BgJZi7OK4GK9BmLTAWfO1O7KejWBxfDzBoA",
-      "appEmbedHeight": "430"
+      "embed_app_with_code_height": "430"
     },
     {
       "name": "Example 2",
       "description": "Multiple behaviors have been defined to make this space scene come to life. One behavior is also applied to multiple sprites.\n",
       "app": "https://studio.code.org/projects/spritelab/-BCg7UOrQsIwRB5KkPLZtW5NX3Nimoqf_CH5YHH2BWg",
-      "appEmbedHeight": "560"
+      "embed_app_with_code_height": "560"
     }
   ],
   "short_description": "When you define a behavior you give a name to a set of actions you want a sprite to perform over and over. When a sprite begins that behavior you are telling the computer to run that set of actions on the sprite over and over until the behavior stops.",

--- a/dashboard/config/programming_expressions/weblab/text-dec.json
+++ b/dashboard/config/programming_expressions/weblab/text-dec.json
@@ -9,15 +9,15 @@
       "name": "Multiple Text Decorations",
       "description": "Setting different text decorations for a `<h1>` element. ",
       "code": "```\nh2 {\n  text-decoration: underline overline wavy blue;\n}\n```",
-      "appDisplayType": "displayApp",
-      "appEmbedHeight": "310"
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": "310"
     },
     {
       "name": "Overline text decoration",
       "description": "Setting an overline text decoration for a `<h1>` element. ",
       "code": "```\nh1 {\n  text-decoration: overline;\n}\n```",
-      "appDisplayType": "displayApp",
-      "appEmbedHeight": "310"
+      "app_display_type": "codeFromCodeField",
+      "embed_app_with_code_height": "310"
     }
   ],
   "external_documentation": "http://www.w3schools.com/cssref/pr_text_text-decoration.asp",

--- a/dashboard/test/controllers/programming_expressions_controller_test.rb
+++ b/dashboard/test/controllers/programming_expressions_controller_test.rb
@@ -50,7 +50,7 @@ class ProgrammingExpressionsControllerTest < ActionController::TestCase
       returnValue: 'none',
       tips: 'some tips on how to use this block',
       parameters: [{name: "id", type: "string", required: true, description: "description"}, {name: "text"}],
-      examples: [{name: 'example 1', appEmbedHeight: '300px'}]
+      examples: [{name: 'example 1', embed_app_with_code_height: '300px'}]
     }
     assert_response :ok
     programming_expression.reload
@@ -67,7 +67,7 @@ class ProgrammingExpressionsControllerTest < ActionController::TestCase
     assert_equal 'none', programming_expression.return_value
     assert_equal 'some tips on how to use this block', programming_expression.tips
     assert_equal [{name: 'id', type: 'string', required: 'true', description: 'description'}, {name: 'text'}].to_json, programming_expression.palette_params.to_json
-    assert_equal [{name: 'example 1', appEmbedHeight: '300px'}].to_json, programming_expression.examples.to_json
+    assert_equal [{name: 'example 1', embed_app_with_code_height: '300px'}].to_json, programming_expression.examples.to_json
   end
 
   test 'data is passed down to edit page' do


### PR DESCRIPTION
When I wrote the code docs import script, I forgot to map the fields from Example in CB to examples on LB. As a result, examples are currently pretty broken on levelbuilder.

To fix this, I decided to move to the field names that curriculumbuilder used. In particular:
- CB used snake case instead of camel case. I have no preference so I reverted to that
- The keys for app_display_type were different so I used CB's.

This ended up meaning the following strings were replaced:
- `appDisplayType` -> `app_display_type`
- `appEmbedHeight` -> `embed_app_with_code_height`
- `imageUrl` -> `image`
- `directly` (from `APP_DISPLAY_OPTIONS`) -> `embedAppWithCode`
- `displayApp` (from `APP_DISPLAY_OPTIONS`) -> `codeFromCodeField`

## Links

[example model in CB](https://github.com/code-dot-org/curriculumbuilder/blob/5e5b493b5f861a39a5b6193d8ad172dc27013573/documentation/models.py#L274)

## Testing story

tested changing examples and making sure they looked as expected on the overview. 

## Follow-up work

add a UI test to at least save and check that everything looks correct


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
