### PR TITLE
Add api.nal.usda.gov

### DIFF
--- a/dashboard/app/controllers/xhr_proxy_controller.rb
+++ b/dashboard/app/controllers/xhr_proxy_controller.rb
@@ -41,6 +41,7 @@ class XhrProxyController < ApplicationController
     api.github.com
     api.mathjs.org
     api.mojang.com
+    api.nal.usda.gov
     api.nasa.gov
     api.nookipedia.com
     api.opencagedata.com


### PR DESCRIPTION
A student requested api.nal.usda.gov be added for USDA Food data 

Zendesk ticket: https://codeorg.zendesk.com/agent/tickets/375865
API documentation: https://www.nal.usda.gov/

