### PR TITLE
Remove freeplay levels from uncacheable list

### DIFF
--- a/cookbooks/cdo-varnish/libraries/http_cache.rb
+++ b/cookbooks/cdo-varnish/libraries/http_cache.rb
@@ -20,19 +20,11 @@ class HttpCache
   ].freeze
 
   # A list of script levels that should not be cached, even though they are
-  # in a cacheable script, because teachers need to be able to review them.
-  # Currently, teachers are not able to review student work on cached levels.
+  # in a cacheable script
   UNCACHED_UNIT_LEVEL_PATHS = [
-    '/s/dance/lessons/1/levels/13',
-    '/s/dance-2019/lessons/1/levels/10',
-    '/s/poem-art-2021/lessons/1/levels/9',
+    '/s/dance-2019/lessons/1/levels/10', # plan to remove: https://codedotorg.atlassian.net/browse/LP-2225
     '/s/poem-art-2021/lessons/1/levels/2', # prediction levels are not cacheable
     '/s/poem-art-2021/lessons/1/levels/5', # prediction levels are not cacheable
-    '/s/hello-world-food-2021/lessons/1/levels/11',
-    '/s/hello-world-animals-2021/lessons/1/levels/11',
-    '/s/hello-world-retro-2021/lessons/1/levels/11',
-    '/s/hello-world-emoji-2021/lessons/1/levels/11',
-    '/s/outbreak/lessons/1/levels/10'
   ]
 
   # A map from script name to script level URL pattern.

--- a/dashboard/test/integration/routes_test.rb
+++ b/dashboard/test/integration/routes_test.rb
@@ -7,26 +7,26 @@ class RoutesTest < ActionDispatch::IntegrationTest
   end
 
   def test_dance_session_cookie_and_cache_headers
-    script = create :script, name: 'dance'
+    script = create :script, name: 'dance-2019'
     lesson_group = create :lesson_group, script: script
     lesson = create :lesson, script: script, relative_position: 1, lesson_group: lesson_group
     create :script_level, script: script, lesson: lesson
-    create :script_level, script: script, lesson: lesson, position: 12
-    create :script_level, script: script, lesson: lesson, position: 13
+    create :script_level, script: script, lesson: lesson, position: 9
+    create :script_level, script: script, lesson: lesson, position: 10
 
-    get '/s/dance/lessons/1/levels/1'
+    get '/s/dance-2019/lessons/1/levels/1'
     assert_caching_enabled response.headers['Cache-Control'],
       ScriptLevelsController::DEFAULT_PUBLIC_CLIENT_MAX_AGE,
       ScriptLevelsController::DEFAULT_PUBLIC_PROXY_MAX_AGE
     assert_nil cookies['_learn_session_test']
 
-    get '/s/dance/lessons/1/levels/12'
+    get '/s/dance-2019/lessons/1/levels/9'
     assert_caching_enabled response.headers['Cache-Control'],
       ScriptLevelsController::DEFAULT_PUBLIC_CLIENT_MAX_AGE,
       ScriptLevelsController::DEFAULT_PUBLIC_PROXY_MAX_AGE
     assert_nil cookies['_learn_session_test']
 
-    get '/s/dance/lessons/1/levels/13'
+    get '/s/dance-2019/lessons/1/levels/10'
     assert_caching_disabled response.headers['Cache-Control']
     assert_not_nil cookies['_learn_session_test']
   end


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Remove freeplay levels (except dance-2019 which is being used by Coldplay challenge) now that teacher panel is available on cached pages.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
- jira ticket: [LP-2218](https://codedotorg.atlassian.net/browse/LP-2218)
<!--
- spec: []()

-->

## Testing story
This was tested thoroughly during the teacher viewing student work on cached levels initiative, so all I did here was update a unit test.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Follow-up work
Remove dance-2019 from uncached list:
https://codedotorg.atlassian.net/browse/LP-2225
<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
