### PR TITLE
[Sprite Lab] Test for workspace alert

### DIFF
--- a/apps/test/unit/p5lab/spritelab/SpritelabTest.js
+++ b/apps/test/unit/p5lab/spritelab/SpritelabTest.js
@@ -145,6 +145,28 @@ describe('SpriteLab', () => {
         expect(resultingAnimations.orderedKeys.length).to.be.equal(1);
       });
 
+      describe('react to executionError', () => {
+        beforeEach(() => {
+          console.log('start test');
+          sinon.stub(studioApp(), 'displayWorkspaceAlert');
+        });
+        afterEach(() => {
+          studioApp().displayWorkspaceAlert.restore();
+        });
+        it('displays a workspace alert if there is an executionError message'),
+          () => {
+            const msg = 'test string';
+            instance.reactToExecutionError(msg);
+            expect(studioApp().displayWorkspaceAlert).to.have.been.calledOnce;
+          };
+        it('does nothing if there is no executionError message'),
+          () => {
+            const msg = undefined;
+            instance.reactToExecutionError(msg);
+            expect(studioApp().displayWorkspaceAlert).to.not.have.been.called;
+          };
+      });
+
       describe('dispatching Blockly events', () => {
         let store, eventSpy, originalMainBlockSpace;
         beforeEach(() => {

--- a/apps/test/unit/p5lab/spritelab/SpritelabTest.js
+++ b/apps/test/unit/p5lab/spritelab/SpritelabTest.js
@@ -41,11 +41,11 @@ describe('SpriteLab', () => {
     });
     afterEach(() => document.body.removeChild(container));
 
-    let testStudioApp;
+    let mockStudioApp;
     beforeEach(() => {
       registerReducers({...commonReducers, ...reducers});
       instance = new SpriteLab();
-      testStudioApp = {
+      mockStudioApp = {
         setCheckForEmptyBlocks: sinon.spy(),
         showRateLimitAlert: sinon.spy(),
         setPageConstants: sinon.spy(),
@@ -62,7 +62,7 @@ describe('SpriteLab', () => {
     describe('After being injected with a studioApp instance', () => {
       let muteSpy;
       beforeEach(() => {
-        instance.injectStudioApp(testStudioApp);
+        instance.injectStudioApp(mockStudioApp);
         registerReducers({...commonReducers, ...reducers});
         instance.areAnimationsReady_ = sinon.stub().returns(true);
         instance.p5Wrapper = sinon.spy();
@@ -146,28 +146,27 @@ describe('SpriteLab', () => {
         expect(resultingAnimations.orderedKeys.length).to.be.equal(1);
       });
 
-      describe('react to executionError', () => {
+      describe('reactToExecutionError', () => {
         let alertSpy;
         beforeEach(() => {
           alertSpy = sinon.stub(studioApp(), 'displayWorkspaceAlert');
           sinon.stub(instance, 'getMsg').returns({
-            workspaceAlertError: () => {
-              return 'translated string';
-            }
+            workspaceAlertError: () => 'translated string'
           });
         });
+
         afterEach(() => {
           alertSpy.restore();
           instance.getMsg.restore();
         });
+
         it('displays a workspace alert if there is an executionError message', () => {
-          const msg = 'test string';
-          instance.reactToExecutionError(msg);
+          instance.reactToExecutionError('test string');
           expect(alertSpy).to.have.been.calledOnce;
         });
+
         it('does nothing if there is no executionError message', () => {
-          const msg = undefined;
-          instance.reactToExecutionError(msg);
+          instance.reactToExecutionError(undefined);
           expect(alertSpy).to.not.have.been.called;
         });
       });


### PR DESCRIPTION
This is a follow-up to https://github.com/code-dot-org/code-dot-org/pull/45055, which adds a workspace alert for execution errors in Sprite Lab. We should also add a test to be sure this is working as intended.

Due to a naming conflict, we can rename an existing use of `studioApp` and reserve that label for the singleton that is imported. (See new line 23 and changes to lines ~43 to ~65).

Created Jira ticket [STAR-2127](https://codedotorg.atlassian.net/browse/STAR-2127) as a subtask of [STAR-2099](https://codedotorg.atlassian.net/browse/STAR-2099) to track.