### PR TITLE
Wrap text for validation code field

### DIFF
--- a/dashboard/app/views/levels/editors/fields/_validation_code.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_validation_code.html.haml
@@ -9,7 +9,8 @@
   - if (!(@level.is_a?(Gamelab) || @level.is_a?(Applab) || @level.is_a?(Weblab)) && (@level.is_a?(Blockly)))
     .field
       = f.label :failure_message_override, 'Failure Message Override'
-      %p If specified this error message will be used to replace ALL error messages in the puzzle. Be certain this is what you want before using.
+      %p If specified this error message will be used to replace ALL error
+      messages in the puzzle. Be certain this is what you want before using.
       = f.text_field :failure_message_override, style: 'width: 600px;', placeholder: 'Type Override Failure Message Here'
   -# Dance and Poetry are special types of GamelabJr (Sprite Lab) levels
   - if @level.is_a?(GamelabJr) && !(@level.is_a?(Dancelab) || @level.is_a?(Poetry))
@@ -18,7 +19,13 @@
   -# GamelabJr, Dancelab, and Poetry are also Gamelab levels
   - if @level.is_a?(Gamelab)
     %p
-      This is a snippet of javascript that is run after every draw loop. Call levelSuccess() in here to stop the level as a success. You can also pass a number into levelSuccess() to give the student a non-perfect test result (see <a href="https://github.com/code-dot-org/code-dot-org/blob/101fbfd2dcdd635d7359e991559ba782f9fd00be/apps/src/constants.js#L33-L106">TestResults</a> for the list of valid test results). There is also a `validationProps` object that you can stick arbitrary properties on to track state across draw loops.
+      This is a snippet of javascript that is run after every draw loop. Call
+      levelSuccess() in here to stop the level as a success. You can also
+      pass a number into levelSuccess() to give the student a non-perfect
+      test result (see <a href="https://github.com/code-dot-org/code-dot-org/blob/101fbfd2dcdd635d7359e991559ba782f9fd00be/apps/src/constants.js#L33-L106">TestResults</a>
+      for the list of valid test results). There is also a `validationProps`
+      object that you can stick arbitrary properties on to track state across
+      draw loops.
     = f.text_area :validation_code
 
   = render partial: 'levels/editors/fields/applab_validations', locals: {f: f} if @level.is_a?(Applab)

--- a/dashboard/app/views/levels/editors/fields/_validation_code.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_validation_code.html.haml
@@ -15,14 +15,22 @@
   -# Dance and Poetry are special types of GamelabJr (Sprite Lab) levels
   - if @level.is_a?(GamelabJr) && !(@level.is_a?(Dancelab) || @level.is_a?(Poetry))
     %p
-      Sprite Lab validation can utilize a number of <a href="https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/p5lab/spritelab/commands/criterionCommands.js">criterion commands</a>. Available feedback strings are located in <a href="https://github.com/code-dot-org/code-dot-org/blob/staging/apps/i18n/spritelab/en_us.json">spritelab/en_us.json</a>. Additional criterion functions and feedback strings need to be added by an engineer.
+      Sprite Lab validation can utilize a number of
+      %a{:href => "https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/p5lab/spritelab/commands/criterionCommands.js"}
+        criterion commands
+      \. Available feedback strings are located in
+      %a{:href => "https://github.com/code-dot-org/code-dot-org/blob/staging/apps/i18n/spritelab/en_us.json"}
+        spritelab/en_us.json
+      \. Additional criterion functions and feedback strings need to be added by an engineer.
   -# GamelabJr, Dancelab, and Poetry are also Gamelab levels
   - if @level.is_a?(Gamelab)
     %p
       This is a snippet of javascript that is run after every draw loop. Call
       levelSuccess() in here to stop the level as a success. You can also
       pass a number into levelSuccess() to give the student a non-perfect
-      test result (see <a href="https://github.com/code-dot-org/code-dot-org/blob/101fbfd2dcdd635d7359e991559ba782f9fd00be/apps/src/constants.js#L33-L106">TestResults</a>
+      test result (see
+      %a{:href => "https://github.com/code-dot-org/code-dot-org/blob/101fbfd2dcdd635d7359e991559ba782f9fd00be/apps/src/constants.js#L33-L106"}
+        TestResults
       for the list of valid test results). There is also a `validationProps`
       object that you can stick arbitrary properties on to track state across
       draw loops.


### PR DESCRIPTION
There was a [request](https://github.com/code-dot-org/code-dot-org/pull/45065#discussion_r816387983) from @breville to add some line-wrapping to `_validation_code.html.haml` as a follow-up to https://github.com/code-dot-org/code-dot-org/pull/45065. This change adds some wrapping to the worst-offending lines. I'm not sure if we can do more to improve readability where long elements, like anchors with URLs, are included.