### PR TITLE
Add published field to ProgrammingEnvironment

### DIFF
--- a/dashboard/app/models/programming_environment.rb
+++ b/dashboard/app/models/programming_environment.rb
@@ -7,6 +7,7 @@
 #  properties :text(65535)
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  published  :boolean          default(FALSE), not null
 #
 # Indexes
 #

--- a/dashboard/db/migrate/20220301220633_add_published_to_programming_environment.rb
+++ b/dashboard/db/migrate/20220301220633_add_published_to_programming_environment.rb
@@ -1,0 +1,5 @@
+class AddPublishedToProgrammingEnvironment < ActiveRecord::Migration[5.2]
+  def change
+    add_column :programming_environments, :published, :bool, null: false, default: false
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_24_161129) do
+ActiveRecord::Schema.define(version: 2022_03_01_220633) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -1361,6 +1361,7 @@ ActiveRecord::Schema.define(version: 2022_02_24_161129) do
     t.text "properties"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "published", default: false, null: false
     t.index ["name"], name: "index_programming_environments_on_name", unique: true
   end
 


### PR DESCRIPTION
Step 1 of 2 to add the ability to hide and unhide documentation. This feature will allow curriculum writers to add a new programming environment and write the documentation without it being immediately accessible to students. This will be useful as we move Javalab documentation to levelbuilder and will allow us to decouple that process from launching code docs on code studio.

PRs:
1. (This PR) Add a `published` column to `programming_environments`
2. (#45113) Allow editing of `published` and use it to determine access rules for code docs




## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
