### PR TITLE
Add notification for student with verified teacher permission

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1898,6 +1898,8 @@
   "studentAnnouncementSpecial2020Heading": "Learn computer science at home",
   "studentAnnouncementSpecial2020Body": "Tune in to a CodeBytes mini-lesson, or see resources for students, parents, and teachers - including videos, fun tutorials, and projects!",
   "studentAnnouncementSpecial2020Button": "Get started",
+  "studentAsVerifiedTeacherWarning": "Your account is currently a student account - you will need to update this account to a teacher account to keep verified teacher access.",
+  "studentAsVerifiedTeacherDetails": "Click on the link and follow the instructions to upgrade your account. If you do not see the option to upgrade your account, you will need to be removed from all teacher sections.",
   "students": "Students",
   "studentFreeResponseAnswers": "Student free response answers",
   "studentsInSection": "Students in section: ",

--- a/apps/src/sites/studio/pages/home/_homepage.js
+++ b/apps/src/sites/studio/pages/home/_homepage.js
@@ -117,6 +117,9 @@ function showHomepage() {
             canViewAdvancedTools={homepageData.canViewAdvancedTools}
             studentId={homepageData.studentId}
             isEnglish={isEnglish}
+            showVerifiedTeacherWarning={
+              homepageData.showStudentAsVerifiedTeacherWarning
+            }
           />
         )}
       </div>

--- a/apps/src/templates/Notification.jsx
+++ b/apps/src/templates/Notification.jsx
@@ -1,6 +1,5 @@
-import React, {Component} from 'react';
+import React, {useState} from 'react';
 import PropTypes from 'prop-types';
-import Radium from 'radium';
 import {connect} from 'react-redux';
 import color from '@cdo/apps/util/color';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
@@ -18,63 +17,66 @@ export const NotificationType = {
   feedback: 'feedback'
 };
 
-class Notification extends Component {
-  static propTypes = {
-    type: PropTypes.oneOf(Object.keys(NotificationType)).isRequired,
-    notice: PropTypes.string.isRequired,
-    details: PropTypes.oneOfType([PropTypes.string, PropTypes.object])
-      .isRequired,
-    detailsLinkText: PropTypes.string,
-    detailsLink: PropTypes.string,
-    detailsLinkNewWindow: PropTypes.bool,
-    buttonText: PropTypes.string,
-    buttonLink: PropTypes.string,
-    dismissible: PropTypes.bool.isRequired,
-    onDismiss: PropTypes.func,
-    newWindow: PropTypes.bool,
-    // googleAnalyticsId and firehoseAnalyticsData are only used when a primary button is provided.
-    // It's not used by the array of buttons.
-    googleAnalyticsId: PropTypes.string,
-    firehoseAnalyticsData: PropTypes.object,
-    responsiveSize: PropTypes.oneOf(['lg', 'md', 'sm', 'xs']),
-    isRtl: PropTypes.bool.isRequired,
-    onButtonClick: PropTypes.func,
-    buttonClassName: PropTypes.string,
+const Notification = ({
+  buttonClassName,
+  buttonLink,
+  buttons,
+  buttonText,
+  children,
+  details,
+  detailsLink,
+  detailsLinkNewWindow,
+  detailsLinkText,
+  dismissible,
+  firehoseAnalyticsData,
+  googleAnalyticsId,
+  isRtl,
+  newWindow,
+  notice,
+  onDismiss,
+  onButtonClick,
+  responsiveSize,
+  type,
+  width
+}) => {
+  const [open, setOpen] = useState(true);
 
-    // Optionally can provide an array of buttons.
-    buttons: PropTypes.arrayOf(
-      PropTypes.shape({
-        text: PropTypes.string,
-        link: PropTypes.string,
-        newWindow: PropTypes.bool,
-        onClick: PropTypes.func,
-        className: PropTypes.string
-      })
-    ),
-
-    // Optionally can provide children, such as one or more buttons.
-    children: PropTypes.node,
-
-    // Can be specified to override default width
-    width: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
-  };
-
-  state = {open: true};
-
-  toggleContent() {
-    this.setState({open: !this.state.open});
-  }
-
-  onDismiss = () => {
-    this.toggleContent();
-    if (this.props.onDismiss) {
-      this.props.onDismiss();
+  const handleDismiss = () => {
+    setOpen(false);
+    if (onDismiss) {
+      onDismiss();
     }
   };
 
-  onAnnouncementClick() {
-    const {firehoseAnalyticsData, googleAnalyticsId} = this.props;
+  const logAnnouncementClickToFirehose = () => {
+    let record = {};
 
+    // Our firehose logging system has standalone fields for commonly used metadata (eg, user_id).
+    // Here, we separate out those fields from any other analytics data provided in the firehoseAnalyticsData prop.
+    // We include these properties in the data_json object as well, in case that is easier for our product team to use.
+    ['user_id', 'script_id', 'lesson_id'].forEach(firehoseMetadataKey => {
+      if (firehoseMetadataKey in firehoseAnalyticsData) {
+        record[firehoseMetadataKey] =
+          firehoseAnalyticsData[firehoseMetadataKey];
+      }
+    });
+
+    record = {
+      ...record,
+      study: 'notification_engagement',
+      event: 'notification_click',
+      data_json: JSON.stringify({
+        ...firehoseAnalyticsData,
+        notice: notice,
+        details: details,
+        buttonLink: buttonLink
+      })
+    };
+
+    firehoseClient.putRecord(record, {includeUserId: true});
+  };
+
+  const onAnnouncementClick = () => {
     // Log to Google Analytics
     if (googleAnalyticsId) {
       trackEvent('teacher_announcement', 'click', googleAnalyticsId);
@@ -82,150 +84,143 @@ class Notification extends Component {
 
     // Log to Firehose
     if (firehoseAnalyticsData) {
-      let record = {};
-
-      // Our firehose logging system has standalone fields for commonly used metadata (eg, user_id).
-      // Here, we separate out those fields from any other analytics data provided in the firehoseAnalyticsData prop.
-      // We include these properties in the data_json object as well, in case that is easier for our product team to use.
-      ['user_id', 'script_id', 'lesson_id'].forEach(firehoseMetadataKey => {
-        if (firehoseMetadataKey in firehoseAnalyticsData) {
-          record[firehoseMetadataKey] =
-            firehoseAnalyticsData[firehoseMetadataKey];
-        }
-      });
-
-      record = {
-        ...record,
-        study: 'notification_engagement',
-        event: 'notification_click',
-        data_json: JSON.stringify({
-          ...firehoseAnalyticsData,
-          notice: this.props.notice,
-          details: this.props.details,
-          buttonLink: this.props.buttonLink
-        })
-      };
-
-      firehoseClient.putRecord(record, {includeUserId: true});
+      logAnnouncementClickToFirehose();
     }
-    if (this.props.onButtonClick) {
-      this.props.onButtonClick();
+
+    if (onButtonClick) {
+      onButtonClick();
     }
+  };
+
+  const desktop = responsiveSize === undefined || responsiveSize === 'lg';
+
+  const icons = {
+    information: 'info-circle',
+    success: 'check-circle',
+    failure: 'exclamation-triangle',
+    warning: 'exclamation-triangle',
+    bullhorn: 'bullhorn',
+    feedback: 'envelope'
+  };
+
+  const mainStyle = {
+    ...styles.main,
+    direction: isRtl ? 'rtl' : 'ltr',
+    width: width || styles.main.width
+  };
+
+  if (!open) {
+    return null;
   }
 
-  onButtonClick() {
-    if (this.onClick) {
-      this.onClick();
-    }
-  }
+  const colorStyles = styles.colors[type];
 
-  render() {
-    const {
-      notice,
-      details,
-      detailsLinkText,
-      detailsLink,
-      detailsLinkNewWindow,
-      type,
-      buttonText,
-      buttonLink,
-      dismissible,
-      newWindow,
-      isRtl,
-      width,
-      buttonClassName,
-      buttons,
-      responsiveSize
-    } = this.props;
-
-    const desktop = responsiveSize === undefined || responsiveSize === 'lg';
-
-    const icons = {
-      information: 'info-circle',
-      success: 'check-circle',
-      failure: 'exclamation-triangle',
-      warning: 'exclamation-triangle',
-      bullhorn: 'bullhorn',
-      feedback: 'envelope'
-    };
-
-    const mainStyle = {
-      ...styles.main,
-      direction: isRtl ? 'rtl' : 'ltr',
-      width: width || styles.main.width
-    };
-
-    if (!this.state.open) {
-      return null;
-    }
-    return (
-      <div className="announcement-notification">
-        <div style={[styles.colors[type], mainStyle]}>
-          {type !== NotificationType.course && (
-            <div style={[styles.iconBox, styles.colors[type]]}>
-              <FontAwesome icon={icons[type]} style={styles.icon} />
-            </div>
-          )}
-          <div style={styles.contentBox}>
-            <div style={styles.wordBox}>
-              <div style={[styles.colors[type], styles.notice]}>{notice}</div>
-              <div style={styles.details}>
-                {details}
-                {detailsLinkText && detailsLink && (
-                  <span>
-                    &nbsp;
-                    <a
-                      href={detailsLink}
-                      style={styles.detailsLink}
-                      target={detailsLinkNewWindow ? '_blank' : null}
-                    >
-                      {detailsLinkText}
-                    </a>
-                  </span>
-                )}
-              </div>
-            </div>
-            <div style={desktop ? null : styles.buttonsMobile}>
-              {buttonText && buttonLink && (
-                <Button
-                  __useDeprecatedTag
-                  href={buttonLink}
-                  color={Button.ButtonColor.gray}
-                  text={buttonText}
-                  style={styles.button}
-                  target={newWindow ? '_blank' : null}
-                  onClick={this.onAnnouncementClick.bind(this)}
-                  className={buttonClassName}
-                />
+  return (
+    <div className="announcement-notification">
+      <div style={{...colorStyles, ...mainStyle}}>
+        {type !== NotificationType.course && (
+          <div style={{...styles.iconBox, ...colorStyles}}>
+            <FontAwesome icon={icons[type]} style={styles.icon} />
+          </div>
+        )}
+        <div style={styles.contentBox}>
+          <div style={styles.wordBox}>
+            <div style={{...colorStyles, ...styles.notice}}>{notice}</div>
+            <div style={styles.details}>
+              {details}
+              {detailsLinkText && detailsLink && (
+                <span>
+                  &nbsp;
+                  <a
+                    href={detailsLink}
+                    style={styles.detailsLink}
+                    target={detailsLinkNewWindow ? '_blank' : null}
+                  >
+                    {detailsLinkText}
+                  </a>
+                </span>
               )}
-              {buttons &&
-                buttons.map((button, index) => (
-                  <Button
-                    __useDeprecatedTag
-                    key={index}
-                    href={button.link}
-                    color={Button.ButtonColor.gray}
-                    text={button.text}
-                    style={styles.button}
-                    target={button.newWindow ? '_blank' : null}
-                    onClick={this.onButtonClick.bind(button)}
-                    className={button.className}
-                  />
-                ))}
-              {this.props.children}
             </div>
           </div>
-          {dismissible && (
-            <div style={styles.dismiss}>
-              <FontAwesome icon="times" onClick={this.onDismiss} />
-            </div>
-          )}
+          <div style={desktop ? null : styles.buttonsMobile}>
+            {buttonText && buttonLink && (
+              <Button
+                __useDeprecatedTag
+                href={buttonLink}
+                color={Button.ButtonColor.gray}
+                text={buttonText}
+                style={styles.button}
+                target={newWindow ? '_blank' : null}
+                onClick={onAnnouncementClick}
+                className={buttonClassName}
+              />
+            )}
+            {buttons &&
+              buttons.map((button, index) => (
+                <Button
+                  __useDeprecatedTag
+                  key={index}
+                  href={button.link}
+                  color={Button.ButtonColor.gray}
+                  text={button.text}
+                  style={styles.button}
+                  target={button.newWindow ? '_blank' : null}
+                  onClick={button.onClick}
+                  className={button.className}
+                />
+              ))}
+            {children}
+          </div>
         </div>
-        <div style={styles.clear} />
+        {dismissible && (
+          <div style={styles.dismiss}>
+            <FontAwesome icon="times" onClick={handleDismiss} />
+          </div>
+        )}
       </div>
-    );
-  }
-}
+      <div style={styles.clear} />
+    </div>
+  );
+};
+
+Notification.propTypes = {
+  type: PropTypes.oneOf(Object.keys(NotificationType)).isRequired,
+  notice: PropTypes.string.isRequired,
+  details: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
+  detailsLinkText: PropTypes.string,
+  detailsLink: PropTypes.string,
+  detailsLinkNewWindow: PropTypes.bool,
+  buttonText: PropTypes.string,
+  buttonLink: PropTypes.string,
+  dismissible: PropTypes.bool.isRequired,
+  onDismiss: PropTypes.func,
+  newWindow: PropTypes.bool,
+  // googleAnalyticsId and firehoseAnalyticsData are only used when a primary button is provided.
+  // It's not used by the array of buttons.
+  googleAnalyticsId: PropTypes.string,
+  firehoseAnalyticsData: PropTypes.object,
+  responsiveSize: PropTypes.oneOf(['lg', 'md', 'sm', 'xs']),
+  isRtl: PropTypes.bool.isRequired,
+  onButtonClick: PropTypes.func,
+  buttonClassName: PropTypes.string,
+
+  // Optionally can provide an array of buttons.
+  buttons: PropTypes.arrayOf(
+    PropTypes.shape({
+      text: PropTypes.string,
+      link: PropTypes.string,
+      newWindow: PropTypes.bool,
+      onClick: PropTypes.func,
+      className: PropTypes.string
+    })
+  ),
+
+  // Optionally can provide children, such as one or more buttons.
+  children: PropTypes.node,
+
+  // Can be specified to override default width
+  width: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+};
 
 const styles = {
   main: {
@@ -344,9 +339,9 @@ const styles = {
 
 export default connect(state => ({
   isRtl: state.isRtl
-}))(Radium(Notification));
+}))(Notification);
 
 export const NotificationResponsive = connect(state => ({
   isRtl: state.isRtl,
   responsiveSize: state.responsive.responsiveSize
-}))(Radium(Notification));
+}))(Notification);

--- a/apps/src/templates/studioHomepages/StudentHomepage.jsx
+++ b/apps/src/templates/studioHomepages/StudentHomepage.jsx
@@ -22,7 +22,7 @@ export default class StudentHomepage extends Component {
     canViewAdvancedTools: PropTypes.bool,
     studentId: PropTypes.number.isRequired,
     isEnglish: PropTypes.bool.isRequired,
-    showVerifiedTeacherWarning: PropTypes.bool.isRequired
+    showVerifiedTeacherWarning: PropTypes.bool
   };
 
   componentDidMount() {

--- a/apps/src/templates/studioHomepages/StudentHomepage.jsx
+++ b/apps/src/templates/studioHomepages/StudentHomepage.jsx
@@ -9,6 +9,7 @@ import ProjectWidgetWithData from '@cdo/apps/templates/projects/ProjectWidgetWit
 import StudentFeedbackNotification from '@cdo/apps/templates/feedback/StudentFeedbackNotification';
 import shapes from './shapes';
 import ProtectedStatefulDiv from '../ProtectedStatefulDiv';
+import Notification, {NotificationType} from '@cdo/apps/templates/Notification';
 import i18n from '@cdo/locale';
 import $ from 'jquery';
 
@@ -20,7 +21,8 @@ export default class StudentHomepage extends Component {
     sections: shapes.sections,
     canViewAdvancedTools: PropTypes.bool,
     studentId: PropTypes.number.isRequired,
-    isEnglish: PropTypes.bool.isRequired
+    isEnglish: PropTypes.bool.isRequired,
+    showVerifiedTeacherWarning: PropTypes.bool.isRequired
   };
 
   componentDidMount() {
@@ -31,7 +33,14 @@ export default class StudentHomepage extends Component {
   }
 
   render() {
-    const {courses, sections, topCourse, hasFeedback, isEnglish} = this.props;
+    const {
+      courses,
+      sections,
+      topCourse,
+      hasFeedback,
+      isEnglish,
+      showVerifiedTeacherWarning
+    } = this.props;
     const {canViewAdvancedTools, studentId} = this.props;
     // Verify background image works for both LTR and RTL languages.
     const backgroundUrl = '/shared/images/banners/teacher-homepage-hero.jpg';
@@ -46,6 +55,16 @@ export default class StudentHomepage extends Component {
         <div className={'container main'}>
           <ProtectedStatefulDiv ref="flashes" />
           {isEnglish && <SpecialAnnouncement isTeacher={false} />}
+          {showVerifiedTeacherWarning && (
+            <Notification
+              type={NotificationType.failure}
+              notice={i18n.studentAsVerifiedTeacherWarning()}
+              details={i18n.studentAsVerifiedTeacherDetails()}
+              buttonText={i18n.learnMore()}
+              buttonLink="https://support.code.org/hc/en-us/articles/360023222371-How-can-I-change-my-account-type-from-student-to-teacher-or-vice-versa-"
+              dismissible={false}
+            />
+          )}
           {hasFeedback && <StudentFeedbackNotification studentId={studentId} />}
           <RecentCourses
             courses={courses}

--- a/apps/test/unit/templates/studioHomepages/StudentHomepageTest.js
+++ b/apps/test/unit/templates/studioHomepages/StudentHomepageTest.js
@@ -5,6 +5,8 @@ import StudentHomepage from '@cdo/apps/templates/studioHomepages/StudentHomepage
 import HeaderBanner from '@cdo/apps/templates/HeaderBanner';
 import StudentSections from '@cdo/apps/templates/studioHomepages/StudentSections';
 import {courses, topCourse, joinedSections} from './homepagesTestData';
+import Notification from '@cdo/apps/templates/Notification';
+import i18n from '@cdo/locale';
 
 describe('StudentHomepage', () => {
   const TEST_PROPS = {
@@ -13,7 +15,8 @@ describe('StudentHomepage', () => {
     sections: joinedSections,
     codeOrgUrlPrefix: 'http://localhost:3000',
     studentId: 123,
-    isEnglish: true
+    isEnglish: true,
+    showVerifiedTeacherWarning: false
   };
 
   it('shows a non-extended Header Banner that says My Dashboard', () => {
@@ -67,5 +70,17 @@ describe('StudentHomepage', () => {
       <StudentHomepage {...TEST_PROPS} isEnglish={false} />
     );
     assert.isFalse(wrapper.find('SpecialAnnouncement').exists());
+  });
+
+  it('displays a notification for verified teacher permissions if showVerifiedTeacherWarning is true', () => {
+    const wrapper = shallow(
+      <StudentHomepage {...TEST_PROPS} showVerifiedTeacherWarning={true} />
+    );
+    const notification = wrapper.find(Notification);
+    assert(notification.exists());
+    assert.equal(
+      notification.props().notice,
+      i18n.studentAsVerifiedTeacherWarning()
+    );
   });
 });

--- a/dashboard/app/controllers/home_controller.rb
+++ b/dashboard/app/controllers/home_controller.rb
@@ -113,6 +113,9 @@ class HomeController < ApplicationController
     @homepage_data[:mapboxAccessToken] = CDO.mapbox_access_token
     @homepage_data[:currentUserId] = current_user.id
 
+    current_user_permissions = UserPermission.where(user_id: current_user.id).pluck(:permission)
+    @homepage_data[:showStudentAsVerifiedTeacherWarning] = current_user.student? && current_user_permissions.include?(UserPermission::AUTHORIZED_TEACHER)
+
     # DCDO Flag - show/hide Lock Section field - Can/Will be overwritten by DCDO.
     @homepage_data[:showLockSectionField] = DCDO.get('show_lock_section_field', true)
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

- Clean up: `Notification` component is converted to a functional component and `Radium` is removed
- A new notification is displayed on the student homepage if they have verified teacher permissions:

![Screen Shot 2022-03-02 at 9 51 20 AM](https://user-images.githubusercontent.com/24235215/156419720-f9f87fa9-d40d-487b-918a-2dfdefa6d81f.png)

## Links
- jira ticket: [LP-2213](https://codedotorg.atlassian.net/browse/LP-2213)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()

-->

## Testing story
Tested locally, added a unit test for the `StudentHomepage` component (this is a temporary feature, will be removed soon)
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
