### PR TITLE
Remove multiple hostnames from startWebRequest

### DIFF
--- a/dashboard/app/controllers/xhr_proxy_controller.rb
+++ b/dashboard/app/controllers/xhr_proxy_controller.rb
@@ -27,7 +27,6 @@ class XhrProxyController < ApplicationController
 
   # 'code.org' is included so applab apps can access the tables and properties of other applab apps.
   ALLOWED_HOSTNAME_SUFFIXES = %w(
-    apex.oracle.com
     api.amadeus.com
     api.blizzard.com
     api.census.gov
@@ -75,11 +74,9 @@ class XhrProxyController < ApplicationController
     deckofcardsapi.com
     distanza.org
     dweet.io
-    enclout.com
     freecurrencyapi.net
     googleapis.com
     grobchess.com
-    herokuapp.com
     hubblesite.org
     images-api.nasa.gov
     itunes.apple.com
@@ -92,7 +89,6 @@ class XhrProxyController < ApplicationController
     noaa.gov
     numbersapi.com
     opentdb.com
-    pastebin.com
     pixabay.com
     pokeapi.co
     pro-api.coinmarketcap.com
@@ -104,7 +100,6 @@ class XhrProxyController < ApplicationController
     roblox.com
     runescape.com
     sessionserver.mojang.com
-    spreadsheets.google.com
     stats.minecraftservers.org
     swapi.dev
     textures.minecraft.net


### PR DESCRIPTION
After completing a comprehensive review of all allowed hostnames, the following five are being removed: 

1. apex.oracle.com - the documentation seems to indicate this would just allow for querying of a database the student/teacher has access to https://docs.oracle.com/en/database/oracle/application-express/20.2/aeapi/preface.html - given the risk for arbitrary content, removing (we also don't think students/teachers would have access to many if any Oracle databases to use this API).

2. enclout.com- this is a domain, Entity and Language processing API, we saw cert expired and thus are removing. 

3. herokuapp.com - it was unclear what the original reasoning for this hostname being added - the hostname is a risk to us allowing arbitrary content to be passed to App Lab and has caused multiple reports on the teacher forums.

4. pastebin.com - this API stores online text, removed as we do not want to support arbitrary text access in our allowed hostnames and such use cases can be met with the data tables in App Lab.

5. spreadsheets.google.com - This API no longer works as there are no references to it from https://developers.google.com/sheets/api/reference/rest and we know the sheets API does not work for us due to its forward redirects 

Zendesk ticket: https://codedotorg.atlassian.net/browse/STAR-2040
