### PR TITLE
Update bramble host to bramble-download.codeprojects.org

### DIFF
--- a/dashboard/app/controllers/weblab_host_controller.rb
+++ b/dashboard/app/controllers/weblab_host_controller.rb
@@ -1,7 +1,7 @@
 class WeblabHostController < ApplicationController
   layout false
 
-  BRAMBLE_URL = 'https://downloads.computinginthecore.org/bramble_0.1.30'
+  BRAMBLE_URL = 'https://bramble-download.codeprojects.org/0.1.30'
   BRAMBLE_LOCALHOST_URL = 'http://127.0.0.1:8000/src'
 
   def index

--- a/dashboard/app/controllers/weblab_host_controller.rb
+++ b/dashboard/app/controllers/weblab_host_controller.rb
@@ -5,7 +5,7 @@ class WeblabHostController < ApplicationController
   BRAMBLE_LOCALHOST_URL = 'http://127.0.0.1:8000/src'
 
   def index
-    @dev_mode = false; # Change to true to point to Bramble running on localhost
+    @dev_mode = false # Change to true to point to Bramble running on localhost
     @bramble_base_url = @dev_mode ? BRAMBLE_LOCALHOST_URL : BRAMBLE_URL
   end
 end

--- a/pegasus/sites.v3/code.org/public/educate/it.md
+++ b/pegasus/sites.v3/code.org/public/educate/it.md
@@ -37,7 +37,7 @@ For the very best experience with all Code.org content, we recommend consulting 
 | **To use YouTube hosted videos** <br/>(Deprecated late July 2018)                        | `https://s.youtube.com/*`<br/>`https://www.youtube.com/*`<br/>`https://*.googlevideo.com/*`<br/>`https://*.ytimg.com/*`                                |
 | **To use Code.org hosted videos**                                                        | **Unblock:**<br/>`https://videos.code.org`<br/>**Block:**<br/>`https://www.youtube.com/favicon.ico`<br/>`https://www.youtube-nocookie.com/favicon.ico` |
 | **To use Internet Simulator**                                                            | `https://api.pusherapp.com`<br/>`wss://ws.pusherapp.com:443`                                                                                           |
-| **To use Web Lab**                                                                       | `https://downloads.computinginthecore.org`<br/>`https://codeprojects.org`                                                                              |
+| **To use Web Lab**                                                                       | `https://*.codeprojects.org`                                                                              |
 | **To use Google Classroom Share Button**                                                 | `https://apis.google.com`                                                                                                                              |
 
 ## Mobile and Tablet Support Details


### PR DESCRIPTION
This PR changes the way we load Bramble to match the rest of our similar infrastructure. 

Previously, Bramble was provisioned manually. Now, it is provisioned from the [s3_backed_subdomain.yml](https://github.com/code-dot-org/code-dot-org/blob/staging/aws/cloudformation/s3_backed_subdomain.yml) CloudFormation template, which did the following:
- Provisioned bramble-download.codeprojects.org
- Created the [cdo-bramble-download S3 bucket](https://console.aws.amazon.com/s3/buckets/cdo-bramble-download?region=us-east-1&tab=objects) (where all versions of Bramble will now live)

This means that instead of loading v0.1.30 Bramble from `https://downloads.computinginthecore.org/bramble_0.1.30`, it will now be loaded from `https://bramble-download.codeprojects.org/0.1.30`. (I removed "bramble_" from the S3 prefixes because it is now redundant.)

## Links

- [STAR-2130](https://codedotorg.atlassian.net/browse/STAR-2130)
- [Documentation update in the Bramble repo](https://github.com/code-dot-org/bramble/pull/20)

## Testing story

Manually tested that the newly-provisioned Bramble host is loaded successfully from https://bramble-download.codeprojects.org/0.1.30. We also have a UI test that checks that Bramble loads.

## Follow-up work

- [STAR-2131](https://codedotorg.atlassian.net/browse/STAR-2131) - Clean up downloads.computinginthecore.org resources once this has been deployed.