### PR TITLE
Adding open.mapquestapi.com

### DIFF
--- a/dashboard/app/controllers/xhr_proxy_controller.rb
+++ b/dashboard/app/controllers/xhr_proxy_controller.rb
@@ -88,6 +88,7 @@ class XhrProxyController < ApplicationController
     newsapi.org
     noaa.gov
     numbersapi.com
+    open.mapquestapi.com
     opentdb.com
     pixabay.com
     pokeapi.co


### PR DESCRIPTION
A student has requested addition of open.mapquestapi.com, which after review will work with startWebRequest in most cases - I did find two API calls would not work as they return map images instead of JSON, although the majority is JSON responses and the usage the student requested is of one of the JSON response usages: https://developer.mapquest.com/documentation/open/geocoding-api/address/get/. 

Zendesk ticket: https://codeorg.zendesk.com/agent/tickets/376203
Jira tiket: https://codedotorg.atlassian.net/browse/STAR-2128
API documentation: https://developer.mapquest.com/documentation/open/
Hostnames for startWebRequest Sheet for tracking: https://docs.google.com/spreadsheets/d/1z6wMoR_q1iETUmOoq-hKJwxgDdsq8mI9-WoYkfrlyac/edit?usp=sharing