### PR TITLE
Add verified_teachers to javabuilder token

### DIFF
--- a/dashboard/app/controllers/javabuilder_sessions_controller.rb
+++ b/dashboard/app/controllers/javabuilder_sessions_controller.rb
@@ -85,19 +85,18 @@ class JavabuilderSessionsController < ApplicationController
   private
 
   def get_teacher_list
-    teachers = []
     if current_user.permission?(UserPermission::LEVELBUILDER) ||
         current_user.verified_teacher? ||
         current_user.has_pilot_experiment?(CSA_PILOT) ||
         current_user.has_pilot_experiment?(CSA_PILOT_FACILITATORS)
-      teachers << current_user.id
-    else
-      current_user.teachers.each do |teacher|
-        next unless teacher.verified_teacher? ||
-            teacher.has_pilot_experiment?(CSA_PILOT) ||
-            teacher.has_pilot_experiment?(CSA_PILOT_FACILITATORS)
-        teachers << teacher.id
-      end
+      return [current_user.id]
+    end
+    teachers = []
+    current_user.teachers.each do |teacher|
+      next unless teacher.verified_teacher? ||
+          teacher.has_pilot_experiment?(CSA_PILOT) ||
+          teacher.has_pilot_experiment?(CSA_PILOT_FACILITATORS)
+      teachers << teacher.id
     end
     teachers
   end

--- a/dashboard/test/controllers/javabuilder_sessions_controller_test.rb
+++ b/dashboard/test/controllers/javabuilder_sessions_controller_test.rb
@@ -148,6 +148,10 @@ class JavabuilderSessionsControllerTest < ActionController::TestCase
     section_2 = create(:section, user: verified_teacher, login_type: 'word')
     student_1 = create(:follower, section: section_1).student_user
     create(:follower, section: section_2, student_user: student_1)
+    regular_teacher = create(:teacher)
+    section_3 = create(:section, user: regular_teacher, login_type: 'word')
+    create(:follower, section: section_3, student_user: student_1)
+
     sign_in(student_1)
     get :get_access_token, params: {channelId: @fake_channel_id, projectVersion: 123, projectUrl: URL, executionType: 'RUN', miniAppType: 'console'}
     assert_response :success
@@ -160,6 +164,7 @@ class JavabuilderSessionsControllerTest < ActionController::TestCase
     assert_equal 2, teachers.length
     assert teachers.include?(teacher.id)
     assert teachers.include?(verified_teacher.id)
+    refute teachers.include?(regular_teacher.id)
     section_1.destroy
     section_2.destroy
   end

--- a/dashboard/test/controllers/javabuilder_sessions_controller_test.rb
+++ b/dashboard/test/controllers/javabuilder_sessions_controller_test.rb
@@ -96,6 +96,30 @@ class JavabuilderSessionsControllerTest < ActionController::TestCase
     section.destroy
   end
 
+  test 'student of csa-pilot and verified teacher has correct verified_teachers parameter' do
+    teacher = create(:teacher)
+    create(:single_user_experiment, min_user_id: teacher.id, name: CSA_PILOT_FACILITATORS)
+    section_1 = create(:section, user: teacher, login_type: 'word')
+    verified_teacher = create(:teacher)
+    verified_teacher.permission = UserPermission::AUTHORIZED_TEACHER
+    section_2 = create(:section, user: verified_teacher, login_type: 'word')
+    student_1 = create(:follower, section: section_1).student_user
+    create(:follower, section: section_2, student_user: student_1)
+    sign_in(student_1)
+    get :get_access_token, params: {channelId: @fake_channel_id, projectVersion: 123, projectUrl: URL, executionType: 'RUN', miniAppType: 'console'}
+    assert_response :success
+
+    response = JSON.parse(@response.body)
+    token = response['token']
+    decoded_token = JWT.decode(token, @rsa_key_test.public_key, true, {algorithm: 'RS256'})
+
+    # decoded_token[0] is the JWT payload. Spot check some params
+    teachers = decoded_token[0]['verified_teachers']
+    assert_equal [teacher.id, verified_teacher.id], teachers
+    section_1.destroy
+    section_2.destroy
+  end
+
   test 'param for channel id is required' do
     levelbuilder = create :levelbuilder
     sign_in(levelbuilder)


### PR DESCRIPTION
Add a verified_teachers parameter to the javabuilder token. The parameter is an array of teacher ids. If the current user is a verified teacher, csa pilot teacher or levelbuilder the array will just be their id. If they are not, the array will be a list of all teachers of the user that are verified teachers or csa pilot teachers.

## Links

- jira ticket: [JAVA-457](https://codedotorg.atlassian.net/browse/JAVA-457)

## Testing story
Tested locally that users can still connect to javabuilder and added unit tests that the list of teachers is as expected.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
