### PR TITLE
Fix links on programming environment index and in the grey box

### DIFF
--- a/apps/src/templates/codeDocs/ProgrammingEnvironmentIndex.jsx
+++ b/apps/src/templates/codeDocs/ProgrammingEnvironmentIndex.jsx
@@ -21,7 +21,7 @@ export function ProgrammingEnvironmentCard({programmingEnvironment}) {
       <Button
         __useDeprecatedTag
         color={Button.Orange}
-        href={`/docs/${programmingEnvironment.name}`}
+        href={programmingEnvironment.showPath}
         text={i18n.viewCodeDocs()}
       />
     </div>
@@ -51,7 +51,8 @@ const ProgrammingEnvironmentShape = PropTypes.shape({
   name: PropTypes.string.isRequired,
   title: PropTypes.string,
   descriotion: PropTypes.string,
-  imageUrl: PropTypes.string
+  imageUrl: PropTypes.string,
+  showPath: PropTypes.string.isRequired
 });
 
 ProgrammingEnvironmentIndex.propTypes = {

--- a/apps/test/unit/templates/codeDocs/ProgrammingEnvironmentIndexTest.jsx
+++ b/apps/test/unit/templates/codeDocs/ProgrammingEnvironmentIndexTest.jsx
@@ -14,13 +14,15 @@ describe('ProgrammingEnvironmentIndex', () => {
             name: 'spritelab',
             title: 'Sprite Lab',
             description: 'description of spritelab',
-            imageUrl: 'code.org/spritelab'
+            imageUrl: 'code.org/spritelab',
+            showPath: '/docs/spritelab'
           },
           {
             name: 'gamelab',
             title: 'Game Lab',
             description: 'description of gamelab',
-            imageUrl: 'code.org/gamelab'
+            imageUrl: 'code.org/gamelab',
+            showPath: '/docs/gamelab'
           }
         ]}
       />
@@ -37,7 +39,8 @@ describe('ProgrammingEnvironmentCard', () => {
           name: 'spritelab',
           title: 'Sprite Lab',
           description: 'description of spritelab',
-          imageUrl: 'code.org/spritelab'
+          imageUrl: 'code.org/spritelab',
+          showPath: '/docs/spritelab'
         }}
       />
     );
@@ -47,6 +50,7 @@ describe('ProgrammingEnvironmentCard', () => {
       'description of spritelab'
     );
     expect(wrapper.find('img').props().src).to.equal('code.org/spritelab');
+    expect(wrapper.find('Button').props().href).to.equal('/docs/spritelab');
   });
 
   it('doesnt render description and image for each IDE if there arent ones', () => {
@@ -54,7 +58,8 @@ describe('ProgrammingEnvironmentCard', () => {
       <ProgrammingEnvironmentCard
         programmingEnvironment={{
           name: 'spritelab',
-          title: 'Sprite Lab'
+          title: 'Sprite Lab',
+          showPath: '/docs/spritelab'
         }}
       />
     );
@@ -62,6 +67,7 @@ describe('ProgrammingEnvironmentCard', () => {
     expect(wrapper.text().includes('Sprite Lab'));
     expect(wrapper.find('EnhancedSafeMarkdown').length).to.equal(0);
     expect(wrapper.find('img').length).to.equal(0);
+    expect(wrapper.find('Button').props().href).to.equal('/docs/spritelab');
   });
 
   it('doesnt render title if there isnt one', () => {
@@ -70,7 +76,8 @@ describe('ProgrammingEnvironmentCard', () => {
         programmingEnvironment={{
           name: 'spritelab',
           description: 'description of spritelab',
-          imageUrl: 'code.org/spritelab'
+          imageUrl: 'code.org/spritelab',
+          showPath: '/docs/spritelab'
         }}
       />
     );
@@ -79,5 +86,6 @@ describe('ProgrammingEnvironmentCard', () => {
       'description of spritelab'
     );
     expect(wrapper.find('img').props().src).to.equal('code.org/spritelab');
+    expect(wrapper.find('Button').props().href).to.equal('/docs/spritelab');
   });
 });

--- a/dashboard/app/models/programming_environment.rb
+++ b/dashboard/app/models/programming_environment.rb
@@ -105,7 +105,8 @@ class ProgrammingEnvironment < ApplicationRecord
       name: name,
       title: title,
       imageUrl: image_url,
-      description: description
+      description: description,
+      showPath: programming_environment_path(name)
     }
   end
 end

--- a/dashboard/app/views/programming_expressions/show.html.haml
+++ b/dashboard/app/views/programming_expressions/show.html.haml
@@ -13,4 +13,4 @@
       - if Rails.application.config.levelbuilder_mode
         %li= link_to 'Edit', edit_programming_expression_path(@programming_expression)
       - else
-        %li= link_to 'Edit on levelbuilder', URI.join("https://levelbuilder-studio.code.org/", edit_programming_expression_path(@programming_expression)).to_s
+        %li= link_to 'View on levelbuilder', URI.join("https://levelbuilder-studio.code.org/", programming_environment_programming_expression_path(@programming_expression.programming_environment.name, @programming_expression.key)).to_s


### PR DESCRIPTION
- On /programming_environments, link to new programming environment pages (so /programming_environments/gamelab for example at this point)
- In the grey box on non-levelbuilder environments, link to the programming expression overview. This fixes an issue where the link went to a different programming expression. There isn't an edit link that will work cross-environment, so linking to the overview page will work for now




## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
