### PR TITLE
One-off migration for pegasus.user_storage_id => dashboard.user_project_storage_id for prod

### DIFF
--- a/bin/oneoff/move_user_storage_ids_to_dashboard.rb
+++ b/bin/oneoff/move_user_storage_ids_to_dashboard.rb
@@ -1,0 +1,73 @@
+require File.expand_path('../../../pegasus/src/env', __FILE__)
+require src_dir 'database'
+require 'optparse'
+
+# To run: ruby bin/oneoff/move_user_storage_ids_to_dashboard.rb
+# To revert: ruby bin/oneoff/move_user_storage_ids_to_dashboard.rb --revert
+
+# Parse options
+options = {
+  revert: false,
+}
+
+OptionParser.new do |opts|
+  opts.banner = <<~BANNER
+    Usage: #{File.basename(__FILE__)} [options]
+
+    This moves the user_storage_ids table to the Dashboard DB and renames it to user_project_storage_ids
+
+    Options:
+  BANNER
+
+  opts.on('--revert',
+    'Will revert the Database to its previous state (drop the view and move the table back to Pegasus)'
+  ) do |revert|
+    options[:revert] = revert
+  end
+
+  opts.on('-h', '--help', 'Prints this help message') do
+    puts opts
+    exit
+  end
+end.parse!
+puts "Options: #{options}"
+options.freeze
+
+$revert = options[:revert]
+
+def migrate_user_storage_ids_to_dashboard
+  pegasus_user_storage_ids = "#{CDO.pegasus_db_name}__user_storage_ids".to_sym
+  dashboard_user_project_storage_ids = "#{CDO.dashboard_db_name}__user_project_storage_ids".to_sym
+
+  DB.transaction do
+    puts "Renaming table pegasus.user_storage_ids -> dashboard.user_project_storage_ids"
+    # Rename the table to move it from the Pegasus schema to Dashboard
+    # Also change the name from user_storage_ids to user_project_storage_ids
+    DB.rename_table(pegasus_user_storage_ids, dashboard_user_project_storage_ids)
+
+    puts "Creating view pegasus.user_storage_ids"
+    # This view exists as a safe-guard during the time between when the table rename is applied
+    # And the code referencing the new name is deployed, during that time queries to the old table name
+    # will hit this view and query from the renamed table
+    DB.create_view(pegasus_user_storage_ids, DB[dashboard_user_project_storage_ids].select_all)
+  end
+end
+
+def revert_migrate_user_storage_ids_to_dashboard
+  pegasus_user_storage_ids = "#{CDO.pegasus_db_name}__user_storage_ids".to_sym
+  dashboard_user_project_storage_ids = "#{CDO.dashboard_db_name}__user_project_storage_ids".to_sym
+
+  DB.transaction do
+    puts "Dropping view pegasus.user_storage_ids"
+    DB.drop_view(pegasus_user_storage_ids)
+
+    puts "Renaming table dashboard.user_project_storage_ids -> pegasus.user_storage_ids"
+    DB.rename_table(dashboard_user_project_storage_ids, pegasus_user_storage_ids)
+  end
+end
+
+if $revert
+  revert_migrate_user_storage_ids_to_dashboard
+else
+  migrate_user_storage_ids_to_dashboard
+end

--- a/bin/oneoff/move_user_storage_ids_to_dashboard.rb
+++ b/bin/oneoff/move_user_storage_ids_to_dashboard.rb
@@ -39,31 +39,27 @@ def migrate_user_storage_ids_to_dashboard
   pegasus_user_storage_ids = "#{CDO.pegasus_db_name}__user_storage_ids".to_sym
   dashboard_user_project_storage_ids = "#{CDO.dashboard_db_name}__user_project_storage_ids".to_sym
 
-  DB.transaction do
-    puts "Renaming table pegasus.user_storage_ids -> dashboard.user_project_storage_ids"
-    # Rename the table to move it from the Pegasus schema to Dashboard
-    # Also change the name from user_storage_ids to user_project_storage_ids
-    DB.rename_table(pegasus_user_storage_ids, dashboard_user_project_storage_ids)
+  puts "Renaming table pegasus.user_storage_ids -> dashboard.user_project_storage_ids"
+  # Rename the table to move it from the Pegasus schema to Dashboard
+  # Also change the name from user_storage_ids to user_project_storage_ids
+  DB.rename_table(pegasus_user_storage_ids, dashboard_user_project_storage_ids)
 
-    puts "Creating view pegasus.user_storage_ids"
-    # This view exists as a safe-guard during the time between when the table rename is applied
-    # And the code referencing the new name is deployed, during that time queries to the old table name
-    # will hit this view and query from the renamed table
-    DB.create_view(pegasus_user_storage_ids, DB[dashboard_user_project_storage_ids].select_all)
-  end
+  puts "Creating view pegasus.user_storage_ids"
+  # This view exists as a safe-guard during the time between when the table rename is applied
+  # And the code referencing the new name is deployed, during that time queries to the old table name
+  # will hit this view and query from the renamed table
+  DB.create_view(pegasus_user_storage_ids, DB[dashboard_user_project_storage_ids].select_all)
 end
 
 def revert_migrate_user_storage_ids_to_dashboard
   pegasus_user_storage_ids = "#{CDO.pegasus_db_name}__user_storage_ids".to_sym
   dashboard_user_project_storage_ids = "#{CDO.dashboard_db_name}__user_project_storage_ids".to_sym
 
-  DB.transaction do
-    puts "Dropping view pegasus.user_storage_ids"
-    DB.drop_view(pegasus_user_storage_ids)
+  puts "Dropping view pegasus.user_storage_ids"
+  DB.drop_view(pegasus_user_storage_ids)
 
-    puts "Renaming table dashboard.user_project_storage_ids -> pegasus.user_storage_ids"
-    DB.rename_table(dashboard_user_project_storage_ids, pegasus_user_storage_ids)
-  end
+  puts "Renaming table dashboard.user_project_storage_ids -> pegasus.user_storage_ids"
+  DB.rename_table(dashboard_user_project_storage_ids, pegasus_user_storage_ids)
 end
 
 if $revert

--- a/dashboard/lib/projects_list.rb
+++ b/dashboard/lib/projects_list.rb
@@ -215,12 +215,15 @@ module ProjectsList
 
     def fetch_featured_projects_by_type(project_type)
       storage_apps = "#{CDO.pegasus_db_name}__storage_apps".to_sym
-      user_storage_ids = "#{CDO.pegasus_db_name}__user_storage_ids".to_sym
+
+      storage_id_table_name = DCDO.get('user_storage_ids_in_dashboard', false) ? "#{CDO.dashboard_db_name}__user_project_storage_ids" : "#{CDO.pegasus_db_name}__user_storage_ids"
+      user_project_storage_ids = storage_id_table_name.to_sym
+
       project_featured_project_user_combo_data = DASHBOARD_DB[:featured_projects].
         select(*project_and_featured_project_and_user_fields).
         join(storage_apps, id: :storage_app_id).
-        join(user_storage_ids, id: Sequel[:storage_apps][:storage_id]).
-        join(:users, id: Sequel[:user_storage_ids][:user_id]).
+        join(user_project_storage_ids, id: Sequel[:storage_apps][:storage_id]).
+        join(:users, id: Sequel[:user_project_storage_ids][:user_id]).
         where(
           unfeatured_at: nil,
           project_type: project_type.to_s,
@@ -317,12 +320,16 @@ module ProjectsList
 
     def fetch_published_project_types(project_groups, limit:, published_before: nil)
       users = "dashboard_#{CDO.rack_env}__users".to_sym
+
+      storage_id_table_name = DCDO.get('user_storage_ids_in_dashboard', false) ? "#{CDO.dashboard_db_name}__user_project_storage_ids" : "#{CDO.pegasus_db_name}__user_storage_ids"
+      user_project_storage_ids = storage_id_table_name.to_sym
+
       {}.tap do |projects|
         project_groups.map do |project_group|
           project_types = PUBLISHED_PROJECT_TYPE_GROUPS[project_group]
           projects[project_group] = PEGASUS_DB[:storage_apps].
             select(*project_and_user_fields).
-            join(:user_storage_ids, id: :storage_id).
+            join(user_project_storage_ids, id: :storage_id).
             join(users, id: :user_id).
             where(state: 'active', project_type: project_types).
             where {published_before.nil? || published_at < DateTime.parse(published_before)}.

--- a/dashboard/lib/projects_list.rb
+++ b/dashboard/lib/projects_list.rb
@@ -223,7 +223,7 @@ module ProjectsList
         select(*project_and_featured_project_and_user_fields).
         join(storage_apps, id: :storage_app_id).
         join(user_project_storage_ids, id: Sequel[:storage_apps][:storage_id]).
-        join(:users, id: Sequel[:user_project_storage_ids][:user_id]).
+        join(:users, id: Sequel[user_project_storage_ids][:user_id]).
         where(
           unfeatured_at: nil,
           project_type: project_type.to_s,

--- a/shared/middleware/helpers/storage_id.rb
+++ b/shared/middleware/helpers/storage_id.rb
@@ -163,7 +163,7 @@ end
 
 # All operations to the user_storage_ids table listed below
 def user_storage_ids_table
-  PEGASUS_DB[:user_storage_ids]
+  DCDO.get('user_storage_ids_in_dashboard', false) ? DASHBOARD_DB[:user_project_storage_ids] : PEGASUS_DB[:user_storage_ids]
 end
 
 # Returns first user storage ID row matching query

--- a/shared/test/test_files.rb
+++ b/shared/test/test_files.rb
@@ -175,6 +175,7 @@ class FilesTest < FilesApiTestBase
     DCDO.stubs(:get).with('disallowed_html_tags', []).returns(['script', 'meta[http-equiv]'])
     DCDO.stubs(:get).with('s3_timeout', 15).returns(15)
     DCDO.stubs(:get).with('s3_slow_request', 15).returns(15)
+    DCDO.stubs(:get).with('user_storage_ids_in_dashboard', false).returns(false)
 
     filename = 'index.html'
     # The below HTML is valid/invalid in WebLab projects only. Other project types do not


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
I've included the one-off migration to move user_storage_ids from pegasus to dashboard and added the DCDO flagging to hide the renamed table references.

1. Run `ruby bin/oneoff/move_user_storage_ids_to_dashboard.rb` to rename the table and create the temporary view
2. Run `DCDO.set('user_storage_ids_in_dashboard', true)` to change the application references to the new renamed table

To revert, set back the DCDO flag with `DCDO.set('user_storage_ids_in_dashboard', false)` and revert the table migration with `ruby bin/oneoff/move_user_storage_ids_to_dashboard.rb --revert`

## Testing story
Tested locally that a user's projects loaded for each step, has been tested in the test env while UI tests were running.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy
Here’s a proposed plan (this is step 2):
1) Learning Platform create Pull Request that uses a Sinatra/Sequel database migration to rename the table and create a View in its place, but NOT if the environment is production (same pattern as gh-ost migrations)
2) **Learning Platform merges Pull Request with the one-off migration script and the code changes to use the new table depending on DCDO flag, deploying to production Thursday**
3) Infrastructure merges a change that fixes how DCDO works on the managed test server, so we can practice the DCDO flip on test Thursday afternoon
4) Friday afternoon, Infrastructure takes manual Snapshot of production database
5) Friday 4PM PST - Infrastructure and Learning Platform run the one off migration script on production
6) revert the migration o production if there are issues
7) If there are no issues, Learning Platform flips the DCDO flag to start using the new table name
8) merge Pull Request with Sinatra/Sequel migration to modify all other environments

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
