### PR TITLE
Pulling in pilots for maker homepage course selection

### DIFF
--- a/dashboard/app/controllers/maker_controller.rb
+++ b/dashboard/app/controllers/maker_controller.rb
@@ -22,7 +22,7 @@ class MakerController < ApplicationController
   ScriptAndCourse = Struct.new(:script, :course)
 
   def self.maker_script(for_user)
-    maker_units = Script.maker_units.
+    maker_units = Script.maker_units(for_user).
         sort_by(&:version_year).
         reverse.
         freeze

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -333,8 +333,10 @@ class Script < ApplicationRecord
     @@lesson_extras_script_ids ||= all_scripts.select(&:lesson_extras_available?).pluck(:id)
   end
 
-  def self.maker_units
-    @@maker_units ||= visible_units.select(&:is_maker_unit?)
+  def self.maker_units(user)
+    total_units = visible_units
+    total_units += all_scripts.select {|s| s.has_pilot_access?(user)}
+    @@maker_units ||= total_units.select(&:is_maker_unit?)
   end
 
   def self.text_to_speech_unit_ids

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -335,7 +335,7 @@ class Script < ApplicationRecord
 
   def self.maker_units(user)
     return_units = @@maker_units ||= visible_units.select(&:is_maker_unit?)
-    return_units + all_scripts.select {|s| s.has_pilot_access?(user) && s.is_maker_unit?}
+    return_units + all_scripts.select {|s| s.is_maker_unit? && s.has_pilot_access?(user)}
   end
 
   def self.text_to_speech_unit_ids

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -334,9 +334,8 @@ class Script < ApplicationRecord
   end
 
   def self.maker_units(user)
-    total_units = visible_units
-    total_units += all_scripts.select {|s| s.has_pilot_access?(user)}
-    @@maker_units ||= total_units.select(&:is_maker_unit?)
+    return_units = @@maker_units ||= visible_units.select(&:is_maker_unit?)
+    return_units + all_scripts.select {|s| s.has_pilot_access?(user) && s.is_maker_unit?}
   end
 
   def self.text_to_speech_unit_ids

--- a/dashboard/test/controllers/maker_controller_test.rb
+++ b/dashboard/test/controllers/maker_controller_test.rb
@@ -66,6 +66,22 @@ class MakerControllerTest < ActionController::TestCase
     assert_equal @csd6_2019, MakerController.maker_script(@student)
   end
 
+  test "shows pilot script if student is enrolled" do
+    @pilot_script = create(:script, name: 'csd-pilot-test', family_name: 'csd6', version_year: '2022', is_maker_unit: true, pilot_experiment: 'my-experiment').tap do |script|
+      lesson_group = create :lesson_group, script: script
+      lesson = create :lesson, script: script, lesson_group: lesson_group
+      create :script_level, script: script, lesson: lesson
+    end
+
+    @pilot_student = create :student
+    experiment = create :single_user_experiment, min_user_id: @pilot_student.id, name: 'my-experiment'
+    create :user_script, user: @pilot_student, script: @pilot_script, assigned_at: Time.now
+    assert_includes @pilot_student.scripts, @pilot_script
+
+    assert_equal @pilot_script, MakerController.maker_script(@pilot_student)
+    experiment.destroy
+  end
+
   test "shows CSD6-2018 if CSD6-2018 is assigned" do
     create :user_script, user: @student, script: @csd6_2018, assigned_at: Time.now
     refute_includes @student.scripts, @csd6_2017

--- a/dashboard/test/controllers/maker_controller_test.rb
+++ b/dashboard/test/controllers/maker_controller_test.rb
@@ -82,6 +82,20 @@ class MakerControllerTest < ActionController::TestCase
     experiment.destroy
   end
 
+  test "does not show pilot script if student is not in experiment" do
+    @pilot_script = create(:script, name: 'csd-pilot-test', family_name: 'csd6', version_year: '2022', is_maker_unit: true, pilot_experiment: 'my-experiment').tap do |script|
+      lesson_group = create :lesson_group, script: script
+      lesson = create :lesson, script: script, lesson_group: lesson_group
+      create :script_level, script: script, lesson: lesson
+    end
+
+    ## Even creating the user_script is not sufficient: the student must be enrolled in the pilot for it to show up
+    @pilot_student = create :student
+    create :user_script, user: @pilot_student, script: @pilot_script, assigned_at: Time.now
+
+    assert_equal @csd6_2019, MakerController.maker_script(@pilot_student)
+  end
+
   test "shows CSD6-2018 if CSD6-2018 is assigned" do
     create :user_script, user: @student, script: @csd6_2018, assigned_at: Time.now
     refute_includes @student.scripts, @csd6_2017


### PR DESCRIPTION
Current Behavior: The maker app populates the most recent script in the maker homepage by pulling in 'visible_units' from script.rb. Because pilot scripts are not "visible", these scripts are excluded.

This PR updates the maker controller to add to that initial pull of scripts a list of all pilots a student is enrolled in. These scripts are then sorted by most recent, and the most recent is displayed as the single course on the maker homepage. 

Here is what my screen looked like before the changes (I'm enrolled in the pilot, but the last year of the course displays instead):
<img width="1145" alt="Screen Shot 2022-03-04 at 11 22 19 AM" src="https://user-images.githubusercontent.com/37230822/156828216-7576d9d7-33b3-4f19-a4d0-26e0bc868611.png">


And now that I have pulled in pilots, the 2022 pilot shows here:
<img width="1152" alt="Screen Shot 2022-03-04 at 11 06 14 AM" src="https://user-images.githubusercontent.com/37230822/156826718-39a62042-91ed-42e8-9615-55067ae78432.png">

I tested this by adding myself to the pilot locally and ensuring that the pilot is pulled in accordingly.

## Links

- spec: []()
- jira ticket: []https://codedotorg.atlassian.net/browse/LP-2227


## Testing story

I added two unit tests for this update: one where the student is enrolled in a pilot and that pilot displays on the homepage instead of the 2019 course, and one where the pilot exists (and the user_script exists too), but the student isn't enrolled in the pilot so the 2019 course displays instead.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

https://codedotorg.atlassian.net/browse/LP-2228

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
