### PR TITLE
Fix programming environment seeding error when removing category that used to have expressions

### DIFF
--- a/dashboard/app/models/programming_environment_category.rb
+++ b/dashboard/app/models/programming_environment_category.rb
@@ -18,7 +18,7 @@
 #
 class ProgrammingEnvironmentCategory < ApplicationRecord
   belongs_to :programming_environment
-  has_many :programming_expressions, dependent: :restrict_with_error
+  has_many :programming_expressions
 
   KEY_CHAR_RE = /[a-z_]/
   KEY_RE = /\A#{KEY_CHAR_RE}+\Z/


### PR DESCRIPTION
Reported in [Slack](https://codedotorg.slack.com/archives/C0T0PNTM3/p1646422889222859). 

Background:
We have `ProgrammingEnvironment` (eg applab) which has many `ProgrammingExpressions` (eg "button"). We *also* have `ProgrammingEnvironmentCategory` which belongs to `ProgrammingEnvironment` and has many `ProgrammingExpressions`. This model largely functions as a tool for navigation on our code docs pages, so a ProgrammingExpression that isn't in a category won't be linked from the navigation bar but the route will work. However, this seemed like a bit of a sharp corner, so I added a protection against destroying a `ProgrammingEnvironmentCategory` that contains any programming expressions.

I didn't think about seeding when I added this though. So the error that a developer saw was likely due to someone removing all the expressions in a category then removing the category itself. This would succeed on levelbuilder but when we get to seeding it would throw an error. ProgrammingEnvironments are seeded first, which seed their categories. The programming expressions aren't updated until after the categories are created *and* destroyed, leading to an error.

I decided to remove the `dependent: :restrict_with_error` line as the UI does still prevent removing categories that still have programming expressions. I also considered conditionally deleting categories that weren't in the config and didn't have any programming expressions, which would eventually be consistent, and merging the seeding of programming environments and programming expressions, which I didn't do because it would be more complex logic.

Open to other ideas or pushback on this path! This is an unfortunate side effect of us managing most of our content through Rails seeding, which we've run into before with script seeding as well.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
