### PR TITLE
Add firehose logging to aid investigation into unmigrated Google OAuth accounts

### DIFF
--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -394,6 +394,16 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
     # Transfer sections and destroy new user if takeover is possible
     if allows_section_takeover(oauth_user)
+      if (oauth_user.id == lookup_user.id) && (provider == AuthenticationOption::GOOGLE)
+        # Duplicate params only because this log is temporary and will be removed
+        firehose_params = {
+          source_user: oauth_user,
+          destination_user: lookup_user,
+          type: 'silent',
+          provider: provider,
+        }
+        log_self_takeover_investigation_to_firehose(firehose_params)
+      end
       return unless move_sections_and_destroy_source_user(
         source_user: oauth_user,
         destination_user: lookup_user,

--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -394,8 +394,9 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
     # Transfer sections and destroy new user if takeover is possible
     if allows_section_takeover(oauth_user)
+      # TODO: Remove this block https://codedotorg.atlassian.net/browse/FND-1927
       if (oauth_user.id == lookup_user.id)
-        # Duplicate params only because this log is temporary and will be removed
+        # Duplicate params only because this log is temporary
         firehose_params = {
           source_user: oauth_user,
           destination_user: lookup_user,

--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -394,12 +394,12 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
     # Transfer sections and destroy new user if takeover is possible
     if allows_section_takeover(oauth_user)
-      if (oauth_user.id == lookup_user.id) && (provider == AuthenticationOption::GOOGLE)
+      if (oauth_user.id == lookup_user.id)
         # Duplicate params only because this log is temporary and will be removed
         firehose_params = {
           source_user: oauth_user,
           destination_user: lookup_user,
-          type: 'silent',
+          type: 'silent-self',
           provider: provider,
         }
         log_self_takeover_investigation_to_firehose(firehose_params)

--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -29,6 +29,7 @@ module UsersHelper
       return false
     end
 
+    # TODO: Remove this call https://codedotorg.atlassian.net/browse/FND-1927
     log_self_takeover_investigation_to_firehose(firehose_params.merge({type: 'self'})) if source_user&.id == destination_user&.id
 
     ActiveRecord::Base.transaction do
@@ -50,6 +51,7 @@ module UsersHelper
     log_account_takeover_to_firehose(firehose_params)
     true
   rescue => e
+    # TODO: Remove this block https://codedotorg.atlassian.net/browse/FND-1927
     if source_user && destination_user
       log_self_takeover_investigation_to_firehose({
         source_user: source_user,
@@ -79,6 +81,7 @@ module UsersHelper
     )
   end
 
+  # TODO: Remove this function https://codedotorg.atlassian.net/browse/FND-1927
   def log_self_takeover_investigation_to_firehose(source_user:, destination_user:, type:, provider:, error: nil)
     FirehoseClient.instance.put_record(
       :analysis,

--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -91,9 +91,7 @@ module UsersHelper
         error: error,   # Move error outside of data_json to query easier
         data_json: {
           session_sign_up_type: session[:sign_up_type],
-          destination_user_email: destination_user.email,
           destination_user_hashed_email: destination_user.hashed_email,
-          source_user_email: source_user.email,
           source_user_hashed_email: source_user.hashed_email,
           # Including the auth_option_ids for reference, but not confident they will reveal much
           destination_user_auth_option_ids: destination_user.authentication_options.map(&:id).join(', '),


### PR DESCRIPTION
**What:** Added temporary Firehose logs to several areas of our User account creation and login.

**Why:** After [investigating our creation of unmigrated accounts](https://docs.google.com/document/d/1LC0uZ-uy99sT-BSWvalXHZsBZmlto7qT_L5rKKWaSzQ/edit#), Google OAuth type accounts seem to be the only unknown root cause of failing to migrate to multi-auth. The hypothesis is that silent takeover is being done on the same User its being called for. This deletes the User as well as its AuthenticationOptions leaving a [new AuthenticationOption](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/controllers/omniauth_callbacks_controller.rb#L407) in existence to cause conflicts the next time that user tries to login. Adding these Firehose logs to potential areas of interest during sign up/login will hopefully shed some light on if/why silent takeover is being incorrectly called.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [FND-1926](https://codedotorg.atlassian.net/browse/FND-1926)
- [Investigation](https://docs.google.com/document/d/1LC0uZ-uy99sT-BSWvalXHZsBZmlto7qT_L5rKKWaSzQ/edit#)

## Testing story

Tested locally that Firehose logs would be triggered.

## Follow-up work

Remove this logging
[Ticket](https://codedotorg.atlassian.net/browse/FND-1927)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
