### PR TITLE
Update the panebuttons to support tab navigation

### DIFF
--- a/apps/src/templates/PaneHeader.jsx
+++ b/apps/src/templates/PaneHeader.jsx
@@ -192,10 +192,24 @@ export const PaneButton = Radium(function(props) {
     }
   }
 
+  function onKeyDownWrapper(event) {
+    const {onClick} = props;
+    if (
+      event.key === ' ' ||
+      event.key === 'Enter' ||
+      event.key === 'Spacebar'
+    ) {
+      onClick();
+    }
+  }
+
   return (
     <div
+      role="button"
+      tabIndex={0}
       id={props.id}
       style={divStyle}
+      onKeyDown={props.isDisabled ? () => {} : onKeyDownWrapper}
       onClick={props.isDisabled ? () => {} : props.onClick}
     >
       <span style={styles.headerButtonSpan}>

--- a/apps/src/templates/PaneHeader.jsx
+++ b/apps/src/templates/PaneHeader.jsx
@@ -206,7 +206,7 @@ export const PaneButton = Radium(function(props) {
   return (
     <div
       role="button"
-      tabIndex={0}
+      tabIndex="0"
       id={props.id}
       style={divStyle}
       onKeyDown={props.isDisabled ? () => {} : onKeyDownWrapper}


### PR DESCRIPTION
Just a quick update to make the PaneButton subcomponent of PaneHeader tab navigable.

Before
![NoTabNav](https://user-images.githubusercontent.com/8324574/156854103-5071ba7b-960c-4a0f-b517-c33bf37fecaa.gif)

After
![WithTabNav](https://user-images.githubusercontent.com/8324574/156854326-9b317f5a-c1d9-4a3c-bb4b-87879d31c252.gif)


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
