### PR TITLE
Add verified_teachers to javabuilder token (redo)

### DIFF
--- a/dashboard/app/controllers/javabuilder_sessions_controller.rb
+++ b/dashboard/app/controllers/javabuilder_sessions_controller.rb
@@ -13,7 +13,7 @@ class JavabuilderSessionsController < ApplicationController
 
   # GET /javabuilder/access_token
   def get_access_token
-    teacher_list = get_teacher_list
+    teacher_list = get_teacher_list.join(',')
     channel_id = params[:channelId]
     project_version = params[:projectVersion]
     # TODO: remove project_url after javabuilder is deployed with update to no longer need it

--- a/dashboard/app/controllers/javabuilder_sessions_controller.rb
+++ b/dashboard/app/controllers/javabuilder_sessions_controller.rb
@@ -8,9 +8,12 @@ class JavabuilderSessionsController < ApplicationController
 
   PRIVATE_KEY = CDO.javabuilder_private_key
   PASSWORD = CDO.javabuilder_key_password
+  CSA_PILOT = 'csa-pilot'
+  CSA_PILOT_FACILITATORS = 'csa-pilot-facilitators'
 
   # GET /javabuilder/access_token
   def get_access_token
+    teacher_list = get_teacher_list
     channel_id = params[:channelId]
     project_version = params[:projectVersion]
     # TODO: remove project_url after javabuilder is deployed with update to no longer need it
@@ -50,7 +53,8 @@ class JavabuilderSessionsController < ApplicationController
       execution_type: execution_type,
       mini_app_type: mini_app_type,
       use_dashboard_sources: use_dashboard_sources,
-      options: options
+      options: options,
+      verified_teachers: teacher_list
     }
 
     # log payload to firehose
@@ -76,5 +80,24 @@ class JavabuilderSessionsController < ApplicationController
     end
 
     render json: {token: encoded_payload, session_id: session_id}
+  end
+
+  private
+
+  def get_teacher_list
+    if current_user.permission?(UserPermission::LEVELBUILDER) ||
+        current_user.verified_teacher? ||
+        current_user.has_pilot_experiment?(CSA_PILOT) ||
+        current_user.has_pilot_experiment?(CSA_PILOT_FACILITATORS)
+      return [current_user.id]
+    end
+    teachers = []
+    current_user.teachers.each do |teacher|
+      next unless teacher.verified_teacher? ||
+          teacher.has_pilot_experiment?(CSA_PILOT) ||
+          teacher.has_pilot_experiment?(CSA_PILOT_FACILITATORS)
+      teachers << teacher.id
+    end
+    teachers
   end
 end

--- a/dashboard/test/controllers/javabuilder_sessions_controller_test.rb
+++ b/dashboard/test/controllers/javabuilder_sessions_controller_test.rb
@@ -138,4 +138,46 @@ class JavabuilderSessionsControllerTest < ActionController::TestCase
     get :get_access_token, params: {useDashboardSources: "false", channelId: @fake_channel_id, projectVersion: 123, projectUrl: URL, levelId: 261, executionType: 'RUN', miniAppType: 'console'}
     assert_response :internal_server_error
   end
+
+  test 'student of csa-pilot and verified teacher has correct verified_teachers parameter' do
+    teacher = create(:teacher)
+    create(:single_user_experiment, min_user_id: teacher.id, name: CSA_PILOT_FACILITATORS)
+    section_1 = create(:section, user: teacher, login_type: 'word')
+    verified_teacher = create(:teacher)
+    verified_teacher.permission = UserPermission::AUTHORIZED_TEACHER
+    section_2 = create(:section, user: verified_teacher, login_type: 'word')
+    student_1 = create(:follower, section: section_1).student_user
+    create(:follower, section: section_2, student_user: student_1)
+    regular_teacher = create(:teacher)
+    section_3 = create(:section, user: regular_teacher, login_type: 'word')
+    create(:follower, section: section_3, student_user: student_1)
+
+    sign_in(student_1)
+    get :get_access_token, params: {channelId: @fake_channel_id, projectVersion: 123, projectUrl: URL, executionType: 'RUN', miniAppType: 'console'}
+    assert_response :success
+
+    response = JSON.parse(@response.body)
+    token = response['token']
+    decoded_token = JWT.decode(token, @rsa_key_test.public_key, true, {algorithm: 'RS256'})
+
+    teachers = decoded_token[0]['verified_teachers']
+    assert_equal 2, teachers.length
+    assert teachers.include?(teacher.id)
+    assert teachers.include?(verified_teacher.id)
+    refute teachers.include?(regular_teacher.id)
+    section_1.destroy
+    section_2.destroy
+  end
+
+  test 'levelbuilder has correct verified_teachers parameter' do
+    levelbuilder = create :levelbuilder
+    sign_in(levelbuilder)
+    get :get_access_token, params: {channelId: @fake_channel_id, projectVersion: 123, projectUrl: URL, levelId: 261, executionType: 'RUN', miniAppType: 'console'}
+
+    response = JSON.parse(@response.body)
+    token = response['token']
+    decoded_token = JWT.decode(token, @rsa_key_test.public_key, true, {algorithm: 'RS256'})
+    teachers = decoded_token[0]['verified_teachers']
+    assert_equal [levelbuilder.id], teachers
+  end
 end

--- a/dashboard/test/controllers/javabuilder_sessions_controller_test.rb
+++ b/dashboard/test/controllers/javabuilder_sessions_controller_test.rb
@@ -160,11 +160,13 @@ class JavabuilderSessionsControllerTest < ActionController::TestCase
     token = response['token']
     decoded_token = JWT.decode(token, @rsa_key_test.public_key, true, {algorithm: 'RS256'})
 
-    teachers = decoded_token[0]['verified_teachers']
+    teachers_string = decoded_token[0]['verified_teachers']
+    teachers = teachers_string.split(',')
     assert_equal 2, teachers.length
-    assert teachers.include?(teacher.id)
-    assert teachers.include?(verified_teacher.id)
-    refute teachers.include?(regular_teacher.id)
+    assert teachers.include?((teacher.id).to_s)
+    assert teachers.include?((verified_teacher.id).to_s)
+    refute teachers.include?((regular_teacher.id).to_s)
+
     section_1.destroy
     section_2.destroy
   end
@@ -177,7 +179,7 @@ class JavabuilderSessionsControllerTest < ActionController::TestCase
     response = JSON.parse(@response.body)
     token = response['token']
     decoded_token = JWT.decode(token, @rsa_key_test.public_key, true, {algorithm: 'RS256'})
-    teachers = decoded_token[0]['verified_teachers']
-    assert_equal [levelbuilder.id], teachers
+    teachers_string = decoded_token[0]['verified_teachers']
+    assert_equal (levelbuilder.id).to_s, teachers_string
   end
 end


### PR DESCRIPTION
revert-revert of [this PR](https://github.com/code-dot-org/code-dot-org/pull/45140). The issue was that AWS seems to have an issue with an array in the authorization context. The only documentation I could find on this was on [this page](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-lambda-auth.html), we put the decoded token into `authResponse.context` and there is a note describing this field as "Optional output with custom properties of the String, Number or Boolean type."

To fix this, we will now send verified_teachers as a comma separated string instead of an array.

## Testing story
Tested locally and on an adhoc against deployed Javabuilder. The issue was only present on deployed Javabuilder because it occured in the websocket authorization layer.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
