### PR TITLE
Add additional code docs controller actions: clone and destroy

### DIFF
--- a/dashboard/app/controllers/programming_environments_controller.rb
+++ b/dashboard/app/controllers/programming_environments_controller.rb
@@ -62,11 +62,11 @@ class ProgrammingEnvironmentsController < ApplicationController
 
   def destroy
     return render :not_found unless @programming_environment
-    if @programming_environment.destroy
-      File.delete(@programming_environment.file_path) if File.exist?(@programming_environment.file_path)
+    begin
+      @programming_environment.destroy!
       render(status: 200, plain: "Destroyed #{@programming_environment.name}")
-    else
-      render(status: :not_acceptable, plain: @programming_environment.errors.full_messages.join('. '))
+    rescue => e
+      render(status: :not_acceptable, plain: e.message)
     end
   end
 

--- a/dashboard/app/controllers/programming_expressions_controller.rb
+++ b/dashboard/app/controllers/programming_expressions_controller.rb
@@ -79,6 +79,16 @@ class ProgrammingExpressionsController < ApplicationController
     render :not_found
   end
 
+  def destroy
+    return render :not_found unless @programming_expression
+    if @programming_expression.destroy
+      File.delete(@programming_expression.file_path) if File.exist?(@programming_expression.file_path)
+      render(status: 200, plain: "Destroyed #{@programming_expression.name}")
+    else
+      render(status: :not_acceptable, plain: @programming_expression.errors.full_messages.join('. '))
+    end
+  end
+
   private
 
   def programming_expression_params

--- a/dashboard/app/controllers/programming_expressions_controller.rb
+++ b/dashboard/app/controllers/programming_expressions_controller.rb
@@ -89,6 +89,18 @@ class ProgrammingExpressionsController < ApplicationController
     end
   end
 
+  # POST /programming_expressions/:id/clone
+  def clone
+    return render :not_found unless @programming_expression
+    return render :not_acceptable unless params[:destinationProgrammingEnvironmentName]
+    begin
+      new_exp = @programming_expression.clone_to_programming_environment(params[:destinationProgrammingEnvironmentName], params[:destinationCategoryKey])
+      render(status: 200, json: {editUrl: edit_programming_expression_path(new_exp)})
+    rescue => err
+      render(json: {error: err.message}.to_json, status: :not_acceptable)
+    end
+  end
+
   private
 
   def programming_expression_params

--- a/dashboard/app/controllers/programming_expressions_controller.rb
+++ b/dashboard/app/controllers/programming_expressions_controller.rb
@@ -81,10 +81,10 @@ class ProgrammingExpressionsController < ApplicationController
 
   def destroy
     return render :not_found unless @programming_expression
-    if @programming_expression.destroy
-      File.delete(@programming_expression.file_path) if File.exist?(@programming_expression.file_path)
+    begin
+      @programming_expression.destroy
       render(status: 200, plain: "Destroyed #{@programming_expression.name}")
-    else
+    rescue
       render(status: :not_acceptable, plain: @programming_expression.errors.full_messages.join('. '))
     end
   end

--- a/dashboard/app/models/programming_environment.rb
+++ b/dashboard/app/models/programming_environment.rb
@@ -62,6 +62,10 @@ class ProgrammingEnvironment < ApplicationRecord
     environment.name
   end
 
+  def file_path
+    Rails.root.join("config/programming_environments/#{name.parameterize}.json")
+  end
+
   def serialize
     env_hash = {name: name}.merge(properties.sort.to_h)
     env_hash.merge(categories: programming_environment_categories.map(&:serialize))
@@ -70,7 +74,6 @@ class ProgrammingEnvironment < ApplicationRecord
   def write_serialization
     return unless Rails.application.config.levelbuilder_mode
 
-    file_path = Rails.root.join("config/programming_environments/#{name.parameterize}.json")
     File.write(file_path, JSON.pretty_generate(serialize))
   end
 

--- a/dashboard/app/models/programming_environment.rb
+++ b/dashboard/app/models/programming_environment.rb
@@ -27,6 +27,8 @@ class ProgrammingEnvironment < ApplicationRecord
   has_many :programming_environment_categories, -> {order(:position)}, dependent: :destroy
   has_many :programming_expressions, dependent: :destroy
 
+  after_destroy :remove_serialization
+
   # @attr [String] editor_type - Type of editor one of the following: 'text-based', 'droplet', 'blockly'
   serialized_attrs %w(
     editor_type
@@ -75,6 +77,10 @@ class ProgrammingEnvironment < ApplicationRecord
     return unless Rails.application.config.levelbuilder_mode
 
     File.write(file_path, JSON.pretty_generate(serialize))
+  end
+
+  def remove_serialization
+    File.delete(file_path) if File.exist?(file_path)
   end
 
   def summarize_for_lesson_edit

--- a/dashboard/app/models/programming_expression.rb
+++ b/dashboard/app/models/programming_expression.rb
@@ -242,6 +242,10 @@ class ProgrammingExpression < ApplicationRecord
     end
   end
 
+  def file_path
+    Rails.root.join("config/programming_expressions/#{programming_environment.name}/#{key.parameterize(preserve_case: false)}.json")
+  end
+
   def serialize
     {
       key: key,
@@ -253,7 +257,6 @@ class ProgrammingExpression < ApplicationRecord
 
   def write_serialization
     return unless Rails.application.config.levelbuilder_mode
-    file_path = Rails.root.join("config/programming_expressions/#{programming_environment.name}/#{key.parameterize(preserve_case: false)}.json")
     object_to_serialize = serialize
     File.write(file_path, JSON.pretty_generate(object_to_serialize))
   end

--- a/dashboard/app/models/programming_expression.rb
+++ b/dashboard/app/models/programming_expression.rb
@@ -275,8 +275,8 @@ class ProgrammingExpression < ApplicationRecord
     if new_category_key
       new_category = new_env.categories.find_by_key(new_category_key)
     else
-      new_category ||= new_env.categories.find_by_key(programming_environment_category.key)
-      new_category ||= new_env.categories.find_by_name(programming_environment_category.name)
+      new_category ||= new_env.categories.find_by_key(programming_environment_category&.key)
+      new_category ||= new_env.categories.find_by_name(programming_environment_category&.name)
     end
 
     new_exp = dup

--- a/dashboard/app/models/programming_expression.rb
+++ b/dashboard/app/models/programming_expression.rb
@@ -32,6 +32,8 @@ class ProgrammingExpression < ApplicationRecord
   validates_uniqueness_of :key, scope: :programming_environment_id, case_sensitive: false
   validate :validate_key_format
 
+  after_destroy :remove_serialization
+
   serialized_attrs %w(
     color
     syntax
@@ -259,6 +261,10 @@ class ProgrammingExpression < ApplicationRecord
     return unless Rails.application.config.levelbuilder_mode
     object_to_serialize = serialize
     File.write(file_path, JSON.pretty_generate(object_to_serialize))
+  end
+
+  def remove_serialization
+    File.delete(file_path) if File.exist?(file_path)
   end
 
   def clone_to_programming_environment(environment_name, new_category_key = nil)

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -324,13 +324,16 @@ Dashboard::Application.routes.draw do
     end
   end
 
-  resources :programming_expressions, only: [:new, :create, :edit, :update, :show] do
+  resources :programming_expressions, only: [:new, :create, :edit, :update, :show, :destroy] do
     collection do
       get :search
     end
+    member do
+      post :clone
+    end
   end
 
-  resources :programming_environments, only: [:index, :new, :create, :edit, :update, :show], param: 'name' do
+  resources :programming_environments, only: [:index, :new, :create, :edit, :update, :show, :destroy], param: 'name' do
     resources :programming_expressions, param: 'programming_expression_key', constraints: {programming_expression_key: /#{CurriculumHelper::KEY_CHAR_RE}+/} do
       member do
         get :show, to: 'programming_expressions#show_by_keys'

--- a/dashboard/test/controllers/programming_environments_controller_test.rb
+++ b/dashboard/test/controllers/programming_environments_controller_test.rb
@@ -132,7 +132,22 @@ class ProgrammingEnvironmentsControllerTest < ActionController::TestCase
     delete :destroy, params: {
       name: programming_environment.name
     }
+    assert_response :ok
     assert_nil ProgrammingEnvironment.find_by_name('test-environment')
+  end
+
+  test 'destroying a programming environment fails if File cannot be deleted' do
+    sign_in @levelbuilder
+
+    programming_environment = create :programming_environment, name: 'test-environment'
+
+    File.expects(:exist?).returns(true).once
+    File.expects(:delete).throws(StandardError).once
+    delete :destroy, params: {
+      name: programming_environment.name
+    }
+    assert_response :not_acceptable
+    refute_nil ProgrammingEnvironment.find_by_name('test-environment')
   end
 
   class AccessTests < ActionController::TestCase

--- a/dashboard/test/controllers/programming_environments_controller_test.rb
+++ b/dashboard/test/controllers/programming_environments_controller_test.rb
@@ -122,6 +122,19 @@ class ProgrammingEnvironmentsControllerTest < ActionController::TestCase
     assert_response :not_acceptable
   end
 
+  test 'can destroy a programming environment' do
+    sign_in @levelbuilder
+
+    programming_environment = create :programming_environment, name: 'test-environment'
+
+    File.expects(:exist?).returns(true).once
+    File.expects(:delete).once
+    delete :destroy, params: {
+      name: programming_environment.name
+    }
+    assert_nil ProgrammingEnvironment.find_by_name('test-environment')
+  end
+
   class AccessTests < ActionController::TestCase
     setup do
       File.stubs(:write)
@@ -140,10 +153,15 @@ class ProgrammingEnvironmentsControllerTest < ActionController::TestCase
     test_user_gets_response_for :edit, params: -> {{name: @programming_environment.name}}, user: :teacher, response: :forbidden
     test_user_gets_response_for :edit, params: -> {{name: @programming_environment.name}}, user: :levelbuilder, response: :success
 
-    test_user_gets_response_for :update, params: -> {{name: @programming_environment.name}}, user: nil, response: :redirect, redirected_to: '/users/sign_in'
+    test_user_gets_response_for :update, params: -> {@update_params}, user: nil, response: :redirect, redirected_to: '/users/sign_in'
     test_user_gets_response_for :update, params: -> {@update_params}, user: :student, response: :forbidden
     test_user_gets_response_for :update, params: -> {@update_params}, user: :teacher, response: :forbidden
     test_user_gets_response_for :update, params: -> {@update_params}, user: :levelbuilder, response: :success
+
+    test_user_gets_response_for :destroy, params: -> {{name: @programming_environment.name}}, user: nil, response: :redirect, redirected_to: '/users/sign_in'
+    test_user_gets_response_for :destroy, params: -> {{name: @programming_environment.name}}, user: :student, response: :forbidden
+    test_user_gets_response_for :destroy, params: -> {{name: @programming_environment.name}}, user: :teacher, response: :forbidden
+    test_user_gets_response_for :destroy, params: -> {{name: @programming_environment.name}}, user: :levelbuilder, response: :success
 
     test_user_gets_response_for :show, params: -> {{name: @programming_environment.name}}, user: nil, response: :success
     test_user_gets_response_for :show, params: -> {{name: @programming_environment.name}}, user: :student, response: :success

--- a/dashboard/test/controllers/programming_expressions_controller_test.rb
+++ b/dashboard/test/controllers/programming_expressions_controller_test.rb
@@ -128,8 +128,24 @@ class ProgrammingExpressionsControllerTest < ActionController::TestCase
     delete :destroy, params: {
       id: programming_expression.id
     }
+    assert_response :ok
 
     assert_nil ProgrammingExpression.find_by_key('test-expression')
+  end
+
+  test 'destroying a programming expressions fails if File cannot be deleted' do
+    sign_in @levelbuilder
+    programming_expression = create :programming_expression, key: 'test-expression', programming_environment: @programming_environment
+
+    File.expects(:exist?).returns(true).once
+    File.expects(:delete).throws(StandardError).once
+
+    delete :destroy, params: {
+      id: programming_expression.id
+    }
+    assert_response :not_acceptable
+
+    refute_nil ProgrammingExpression.find_by_key('test-expression')
   end
 
   test 'can clone programming expression' do

--- a/dashboard/test/controllers/programming_expressions_controller_test.rb
+++ b/dashboard/test/controllers/programming_expressions_controller_test.rb
@@ -118,6 +118,20 @@ class ProgrammingExpressionsControllerTest < ActionController::TestCase
     assert_equal 1, JSON.parse(nav_data).length
   end
 
+  test 'can destroy programming expression' do
+    sign_in @levelbuilder
+    programming_expression = create :programming_expression, key: 'test-expression', programming_environment: @programming_environment
+
+    File.expects(:exist?).returns(true).once
+    File.expects(:delete).once
+
+    delete :destroy, params: {
+      id: programming_expression.id
+    }
+
+    assert_nil ProgrammingExpression.find_by_key('test-expression')
+  end
+
   class AccessTests < ActionController::TestCase
     setup do
       File.stubs(:write)
@@ -146,6 +160,11 @@ class ProgrammingExpressionsControllerTest < ActionController::TestCase
     test_user_gets_response_for :update, params: -> {@update_params}, user: :student, response: :forbidden
     test_user_gets_response_for :update, params: -> {@update_params}, user: :teacher, response: :forbidden
     test_user_gets_response_for :update, params: -> {@update_params}, user: :levelbuilder, response: :success
+
+    test_user_gets_response_for :destroy, params: -> {{id: @programming_expression.id}}, user: nil, response: :redirect, redirected_to: '/users/sign_in'
+    test_user_gets_response_for :destroy, params: -> {{id: @programming_expression.id}}, user: :student, response: :forbidden
+    test_user_gets_response_for :destroy, params: -> {{id: @programming_expression.id}}, user: :teacher, response: :forbidden
+    test_user_gets_response_for :destroy, params: -> {{id: @programming_expression.id}}, user: :levelbuilder, response: :success
 
     test_user_gets_response_for :show_by_keys, params: -> {{programming_environment_name: @programming_expression.programming_environment.name, programming_expression_key: @programming_expression.key}}, user: nil, response: :success
     test_user_gets_response_for :show_by_keys, params: -> {{programming_environment_name: @programming_expression.programming_environment.name, programming_expression_key: @programming_expression.key}}, user: :student, response: :success


### PR DESCRIPTION
This is the first PR to add an "All Code Docs" edit page. On that page, levelbuilders will be able to destroy programming environments and programming expressions, as well as clone programming expressions into other environments. These routes don't exist yet so adding them now before adding the front end to keep the PRs smaller.

## Links

[spec](https://docs.google.com/document/d/1CuMG8vlECM0xLs8kq5hocUS5ToyPWipjTGU841W2wvs/edit#bookmark=id.dwxvqefs3lom)

## Testing story

unit tests

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
