### PR TITLE
Remove DCDO flag from #codeplay tweets

### DIFF
--- a/apps/src/code-studio/components/ShareAllowedDialog.jsx
+++ b/apps/src/code-studio/components/ShareAllowedDialog.jsx
@@ -21,7 +21,6 @@ import i18n from '@cdo/locale';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
 import LibraryCreationDialog from './libraries/LibraryCreationDialog';
 import QRCode from 'qrcode.react';
-import DCDO from '@cdo/apps/dcdo';
 import copyToClipboard from '@cdo/apps/util/copyToClipboard';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 
@@ -210,8 +209,7 @@ class ShareAllowedDialog extends React.Component {
       ? `Check out the dance I made featuring @${artistTwitterHandle} on @codeorg!`
       : 'Check out what I made on @codeorg!';
     const hashtags =
-      artistTwitterHandle === 'Coldplay' &&
-      !!DCDO.get('higher-power-promotion', false)
+      artistTwitterHandle === 'Coldplay'
         ? ['codeplay', 'HourOfCode']
         : ['HourOfCode'];
     const comma = '%2C';

--- a/apps/src/dance/Dance.js
+++ b/apps/src/dance/Dance.js
@@ -42,7 +42,6 @@ import {SongTitlesToArtistTwitterHandle} from '../code-studio/dancePartySongArti
 import firehoseClient from '@cdo/apps/lib/util/firehose';
 import {showArrowButtons} from '@cdo/apps/templates/arrowDisplayRedux';
 import queryString from 'query-string';
-import DCDO from '@cdo/apps/dcdo';
 
 const ButtonState = {
   UP: 0,
@@ -683,8 +682,7 @@ Dance.prototype.displayFeedback_ = function() {
 
   const comma = '%2C';
   const hashtags =
-    artistTwitterHandle === 'Coldplay' &&
-    !!DCDO.get('higher-power-promotion', false)
+    artistTwitterHandle === 'Coldplay'
       ? ['codeplay', 'HourOfCode'].join(comma)
       : ['HourOfCode'];
 

--- a/lib/dynamic_config/dcdo.rb
+++ b/lib/dynamic_config/dcdo.rb
@@ -94,8 +94,7 @@ class DCDOBase
     # For example:
     # 'my-new-feature': DCDO.get('my-new-feature', false)
     {
-      'frontend-i18n-tracking': DCDO.get('frontend-i18n-tracking', false),
-      'higher-power-promotion': DCDO.get('higher-power-promotion', false)
+      'frontend-i18n-tracking': DCDO.get('frontend-i18n-tracking', false)
     }
   end
 end


### PR DESCRIPTION
With this change, the #codeplay hashtag will be added to tweets for Dance Party projects that use a Coldplay song, even without the "higher-power-promotion" DCDO flag being set.  We disabled that DCDO flag last week, hiding the promotion from the homepage and /dance banner, but would like #codeplay to continue to be added.  This is a follow-up to https://github.com/code-dot-org/code-dot-org/pull/44656.

Before:
![image](https://user-images.githubusercontent.com/43474485/157129726-66185948-ea4e-4eed-9a98-2039cf041536.png)

After:
![image](https://user-images.githubusercontent.com/43474485/157129736-3584b88d-7afd-4135-8a27-583c499f9f84.png)


This was tested with both the `ShareAllowDialog` (share button) and `displayFeedback` (level finish dialog).