### PR TITLE
Add reference guide index page

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -346,6 +346,10 @@ describe('entry tests', () => {
           ['build/package/css/levels.css', 'style/curriculum/levels.scss'],
           ['build/package/css/rollups.css', 'style/curriculum/rollups.scss'],
           [
+            'build/package/css/reference_guides.css',
+            'style/curriculum/reference_guides.scss'
+          ],
+          [
             'build/package/css/levelbuilder.css',
             'style/code-studio/levelbuilder.scss'
           ],
@@ -581,6 +585,8 @@ describe('entry tests', () => {
     'projects/index': './src/sites/studio/pages/projects/index.js',
     'report_abuse/report_abuse_form':
       './src/sites/studio/pages/report_abuse/report_abuse_form.js',
+    'reference_guides/index':
+      './src/sites/studio/pages/reference_guides/index.js',
     'reference_guides/show':
       './src/sites/studio/pages/reference_guides/show.js',
     'scripts/show': './src/sites/studio/pages/scripts/show.js',

--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -585,8 +585,6 @@ describe('entry tests', () => {
     'projects/index': './src/sites/studio/pages/projects/index.js',
     'report_abuse/report_abuse_form':
       './src/sites/studio/pages/report_abuse/report_abuse_form.js',
-    'reference_guides/index':
-      './src/sites/studio/pages/reference_guides/index.js',
     'reference_guides/show':
       './src/sites/studio/pages/reference_guides/show.js',
     'scripts/show': './src/sites/studio/pages/scripts/show.js',
@@ -658,6 +656,8 @@ describe('entry tests', () => {
       './src/sites/studio/pages/programming_expressions/new.js',
     'programming_expressions/edit':
       './src/sites/studio/pages/programming_expressions/edit.js',
+    'reference_guides/edit_all':
+      './src/sites/studio/pages/reference_guides/edit_all.js',
     'scripts/edit': './src/sites/studio/pages/scripts/edit.js',
     'scripts/new': './src/sites/studio/pages/scripts/new.js',
     'shared/_check_admin': './src/sites/studio/pages/shared/_check_admin.js',

--- a/apps/src/sites/studio/pages/reference_guides/edit_all.js
+++ b/apps/src/sites/studio/pages/reference_guides/edit_all.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import getScriptData from '@cdo/apps/util/getScriptData';
-import ReferenceGuideIndex from '@cdo/apps/templates/referenceGuides/ReferenceGuideIndex';
+import ReferenceGuideEditAll from '@cdo/apps/templates/referenceGuides/ReferenceGuideEditAll';
 
 $(() => {
   const referenceGuides = getScriptData('referenceGuides');
   ReactDOM.render(
-    <ReferenceGuideIndex referenceGuides={referenceGuides} />,
+    <ReferenceGuideEditAll referenceGuides={referenceGuides} />,
     document.getElementById('show-container')
   );
 });

--- a/apps/src/sites/studio/pages/reference_guides/index.js
+++ b/apps/src/sites/studio/pages/reference_guides/index.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import getScriptData from '@cdo/apps/util/getScriptData';
+import ReferenceGuideIndex from '@cdo/apps/templates/referenceGuides/ReferenceGuideIndex';
+
+$(() => {
+  const referenceGuides = getScriptData('referenceGuides');
+  ReactDOM.render(
+    <ReferenceGuideIndex referenceGuides={referenceGuides} />,
+    document.getElementById('show-container')
+  );
+});

--- a/apps/src/templates/referenceGuides/ReferenceGuideEditAll.jsx
+++ b/apps/src/templates/referenceGuides/ReferenceGuideEditAll.jsx
@@ -35,7 +35,7 @@ const organizeReferenceGuides = (referenceGuides, parent = null, level = 0) => {
   return flatten(organizedGuides);
 };
 
-export default function ReferenceGuideIndex({referenceGuides}) {
+export default function ReferenceGuideEditAll({referenceGuides}) {
   // useMemo here so that we only do the organizing once
   const organizedGuides = useMemo(
     () => organizeReferenceGuides(referenceGuides),
@@ -85,6 +85,6 @@ const referenceGuideShape = PropTypes.shape({
   position: PropTypes.number
 });
 
-ReferenceGuideIndex.propTypes = {
+ReferenceGuideEditAll.propTypes = {
   referenceGuides: PropTypes.arrayOf(referenceGuideShape).isRequired
 };

--- a/apps/src/templates/referenceGuides/ReferenceGuideEditAll.jsx
+++ b/apps/src/templates/referenceGuides/ReferenceGuideEditAll.jsx
@@ -53,20 +53,20 @@ export default function ReferenceGuideEditAll({referenceGuides}) {
         />
       </div>
 
-      <div className="categories-table">
+      <div className="guides-table">
         <span className="header">Actions</span>
-        <span className="header">Categories</span>
+        <span className="header">Reference Guides</span>
         {organizedGuides.map(guide => {
           return [
             <div key={`${guide.key}-actions`} className="actions-box">
               <MiniIconButton icon="pencil-square-o" alt="edit" />
               <MiniIconButton icon="trash" alt="delete" />
-              <MiniIconButton icon="caret-up" alt="move category up" />
-              <MiniIconButton icon="caret-down" alt="move category down" />
+              <MiniIconButton icon="caret-up" alt="move guide up" />
+              <MiniIconButton icon="caret-down" alt="move guide down" />
             </div>,
             <div
-              key={`${guide.key}-categories`}
-              className="categories-box"
+              key={`${guide.key}-guide`}
+              className="guide-box"
               style={{paddingLeft: `${guide.level * 20 + 4}px`}}
             >
               {guide.display_name}

--- a/apps/src/templates/referenceGuides/ReferenceGuideIndex.jsx
+++ b/apps/src/templates/referenceGuides/ReferenceGuideIndex.jsx
@@ -1,0 +1,90 @@
+import React, {useMemo} from 'react';
+import PropTypes from 'prop-types';
+import {TextLink} from '@dsco_/link';
+import FontAwesome from '@cdo/apps/templates/FontAwesome';
+import {flatten} from 'lodash';
+
+const MiniIconButton = ({icon, alt, func, href}) =>
+  func ? (
+    <button onClick={func} type="button">
+      <FontAwesome icon={icon} title={alt} />
+    </button>
+  ) : (
+    <TextLink href={href} icon={<FontAwesome icon={icon} title={alt} />} />
+  );
+MiniIconButton.propTypes = {
+  icon: FontAwesome.propTypes.icon,
+  alt: PropTypes.string,
+  func: PropTypes.func,
+  href: PropTypes.string
+};
+
+const getGuideChildren = (key, guides) =>
+  guides
+    .filter(guide => guide.parent_reference_guide_key === key)
+    .sort((a, b) => a.position - b.position);
+
+// take a list of reference guides and build a tree data structure and then flatten it
+const organizeReferenceGuides = (referenceGuides, parent = null, level = 0) => {
+  const organizedGuides = getGuideChildren(parent, referenceGuides).map(
+    guide => [
+      {...guide, level}, // add the depth of this guide so we can render the indentation
+      ...organizeReferenceGuides(referenceGuides, guide.key, level + 1) // put the children right after the parent
+    ]
+  );
+  return flatten(organizedGuides);
+};
+
+export default function ReferenceGuideIndex({referenceGuides}) {
+  // useMemo here so that we only do the organizing once
+  const organizedGuides = useMemo(
+    () => organizeReferenceGuides(referenceGuides),
+    [referenceGuides]
+  );
+  return (
+    <div>
+      <h1>Reference Guides</h1>
+      <div className="page-actions">
+        <TextLink
+          className="create-btn"
+          icon={<FontAwesome icon="plus" />}
+          iconBefore={true}
+          text="Create New Guide"
+        />
+      </div>
+
+      <div className="categories-table">
+        <span className="header">Actions</span>
+        <span className="header">Categories</span>
+        {organizedGuides.map(guide => {
+          return [
+            <div key={`${guide.key}-actions`} className="actions-box">
+              <MiniIconButton icon="pencil-square-o" alt="edit" />
+              <MiniIconButton icon="trash" alt="delete" />
+              <MiniIconButton icon="caret-up" alt="move category up" />
+              <MiniIconButton icon="caret-down" alt="move category down" />
+            </div>,
+            <div
+              key={`${guide.key}-categories`}
+              className="categories-box"
+              style={{paddingLeft: `${guide.level * 20 + 4}px`}}
+            >
+              {guide.display_name}
+            </div>
+          ];
+        })}
+      </div>
+    </div>
+  );
+}
+
+const referenceGuideShape = PropTypes.shape({
+  key: PropTypes.string,
+  parent_reference_guide_key: PropTypes.string,
+  display_name: PropTypes.string,
+  position: PropTypes.number
+});
+
+ReferenceGuideIndex.propTypes = {
+  referenceGuides: PropTypes.arrayOf(referenceGuideShape).isRequired
+};

--- a/apps/style/curriculum/reference_guides.scss
+++ b/apps/style/curriculum/reference_guides.scss
@@ -6,7 +6,7 @@
   padding-bottom: 16px;
 }
 
-.categories-table {
+.guides-table {
   display: grid;
   grid-template-columns: 100px 1fr;
   grid-template-rows: auto;

--- a/apps/style/curriculum/reference_guides.scss
+++ b/apps/style/curriculum/reference_guides.scss
@@ -1,0 +1,28 @@
+@import 'color';
+
+.page-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.categories-table {
+  display: grid;
+  grid-template-columns: 100px 1fr;
+  grid-template-rows: auto;
+
+  .header {
+    background-color: $dark_gray;
+    font-weight: bold;
+    color: $white;
+  }
+
+  & > * {
+    border: 1px solid $light_gray;
+    padding: 4px;
+  }
+}
+
+.actions-box {
+  display: flex;
+  justify-content: space-around;
+}

--- a/apps/style/curriculum/reference_guides.scss
+++ b/apps/style/curriculum/reference_guides.scss
@@ -3,6 +3,7 @@
 .page-actions {
   display: flex;
   justify-content: flex-end;
+  padding-bottom: 16px;
 }
 
 .categories-table {

--- a/apps/test/unit/templates/referenceGuides/ReferenceGuidesEditAllTest.js
+++ b/apps/test/unit/templates/referenceGuides/ReferenceGuidesEditAllTest.js
@@ -16,9 +16,7 @@ describe('ReferenceGuideEditAll', () => {
     const wrapper = isolateComponent(
       <ReferenceGuideEditAll referenceGuides={referenceGuides} />
     );
-    expect(wrapper.findOne('.categories-box').content()).to.equal(
-      'hello_world'
-    );
+    expect(wrapper.findOne('.guide-box').content()).to.equal('hello_world');
   });
 
   it('sets up all the actions for a ref guide', () => {
@@ -56,7 +54,7 @@ describe('ReferenceGuideEditAll', () => {
       <ReferenceGuideEditAll referenceGuides={referenceGuides} />
     );
     expect(
-      wrapper.findAll('.categories-box').map(box => box.content())
+      wrapper.findAll('.guide-box').map(box => box.content())
     ).to.deep.equal(['a', 'b', 'c', 'e', 'f', 'd']);
 
     // input order shouldn't matter
@@ -74,7 +72,7 @@ describe('ReferenceGuideEditAll', () => {
       <ReferenceGuideEditAll referenceGuides={referenceGuides} />
     );
     expect(
-      wrapper.findAll('.categories-box').map(box => box.content())
+      wrapper.findAll('.guide-box').map(box => box.content())
     ).to.deep.equal(['a', 'b', 'c', 'e', 'f', 'g', 'h', 'd']);
   });
 
@@ -91,7 +89,7 @@ describe('ReferenceGuideEditAll', () => {
       <ReferenceGuideEditAll referenceGuides={referenceGuides} />
     );
     expect(
-      wrapper.findAll('.categories-box').map(box => box.props.style.paddingLeft)
+      wrapper.findAll('.guide-box').map(box => box.props.style.paddingLeft)
     ).to.deep.equal(['4px', '24px', '24px', '44px', '44px', '24px']); // a b c e f d
   });
 });

--- a/apps/test/unit/templates/referenceGuides/ReferenceGuidesEditAllTest.js
+++ b/apps/test/unit/templates/referenceGuides/ReferenceGuidesEditAllTest.js
@@ -65,31 +65,17 @@ describe('ReferenceGuideEditAll', () => {
       makeReferenceGuide('e', 'c', 0),
       makeReferenceGuide('d', 'a', 2),
       makeReferenceGuide('c', 'a', 1),
+      makeReferenceGuide('g', 'c', 3),
       makeReferenceGuide('b', 'a', 0),
-      makeReferenceGuide('a', null, 0)
+      makeReferenceGuide('a', null, 0),
+      makeReferenceGuide('h', 'c', 4)
     ];
     wrapper = isolateComponent(
       <ReferenceGuideEditAll referenceGuides={referenceGuides} />
     );
     expect(
       wrapper.findAll('.categories-box').map(box => box.content())
-    ).to.deep.equal(['a', 'b', 'c', 'e', 'f', 'd']);
-  });
-
-  it('sorts reference guides within a category', () => {
-    const referenceGuides = [
-      makeReferenceGuide('a', null, 0),
-      makeReferenceGuide('b', null, 4),
-      makeReferenceGuide('c', null, 1),
-      makeReferenceGuide('d', null, 3),
-      makeReferenceGuide('e', null, 2)
-    ];
-    const wrapper = isolateComponent(
-      <ReferenceGuideEditAll referenceGuides={referenceGuides} />
-    );
-    expect(
-      wrapper.findAll('.categories-box').map(box => box.content())
-    ).to.deep.equal(['a', 'c', 'e', 'd', 'b']);
+    ).to.deep.equal(['a', 'b', 'c', 'e', 'f', 'g', 'h', 'd']);
   });
 
   it('indents the reference guides by level depth', () => {

--- a/apps/test/unit/templates/referenceGuides/ReferenceGuidesEditAllTest.js
+++ b/apps/test/unit/templates/referenceGuides/ReferenceGuidesEditAllTest.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import {isolateComponent} from 'isolate-react';
 import {expect} from '../../../util/reconfiguredChai';
-import ReferenceGuideIndex from '@cdo/apps/templates/referenceGuides/ReferenceGuideIndex';
+import ReferenceGuideEditAll from '@cdo/apps/templates/referenceGuides/ReferenceGuideEditAll';
 
 const makeReferenceGuide = (key, parent = null, pos = 0) => ({
   display_name: key,
@@ -10,11 +10,11 @@ const makeReferenceGuide = (key, parent = null, pos = 0) => ({
   position: pos
 });
 
-describe('ReferenceGuideIndex', () => {
+describe('ReferenceGuideEditAll', () => {
   it('displays the name of the reference guide', () => {
     const referenceGuides = [makeReferenceGuide('hello_world')];
     const wrapper = isolateComponent(
-      <ReferenceGuideIndex referenceGuides={referenceGuides} />
+      <ReferenceGuideEditAll referenceGuides={referenceGuides} />
     );
     expect(wrapper.findOne('.categories-box').content()).to.equal(
       'hello_world'
@@ -24,7 +24,7 @@ describe('ReferenceGuideIndex', () => {
   it('sets up all the actions for a ref guide', () => {
     const referenceGuides = [makeReferenceGuide('hello_world')];
     const wrapper = isolateComponent(
-      <ReferenceGuideIndex referenceGuides={referenceGuides} />
+      <ReferenceGuideEditAll referenceGuides={referenceGuides} />
     );
     expect(wrapper.findAll('MiniIconButton').length).to.equal(4);
     expect(wrapper.findOne('.actions-box').toString()).to.contain('edit');
@@ -53,7 +53,7 @@ describe('ReferenceGuideIndex', () => {
       makeReferenceGuide('f', 'c', 1)
     ];
     let wrapper = isolateComponent(
-      <ReferenceGuideIndex referenceGuides={referenceGuides} />
+      <ReferenceGuideEditAll referenceGuides={referenceGuides} />
     );
     expect(
       wrapper.findAll('.categories-box').map(box => box.content())
@@ -69,7 +69,7 @@ describe('ReferenceGuideIndex', () => {
       makeReferenceGuide('a', null, 0)
     ];
     wrapper = isolateComponent(
-      <ReferenceGuideIndex referenceGuides={referenceGuides} />
+      <ReferenceGuideEditAll referenceGuides={referenceGuides} />
     );
     expect(
       wrapper.findAll('.categories-box').map(box => box.content())
@@ -85,7 +85,7 @@ describe('ReferenceGuideIndex', () => {
       makeReferenceGuide('e', null, 2)
     ];
     const wrapper = isolateComponent(
-      <ReferenceGuideIndex referenceGuides={referenceGuides} />
+      <ReferenceGuideEditAll referenceGuides={referenceGuides} />
     );
     expect(
       wrapper.findAll('.categories-box').map(box => box.content())
@@ -102,7 +102,7 @@ describe('ReferenceGuideIndex', () => {
       makeReferenceGuide('f', 'c', 1)
     ];
     const wrapper = isolateComponent(
-      <ReferenceGuideIndex referenceGuides={referenceGuides} />
+      <ReferenceGuideEditAll referenceGuides={referenceGuides} />
     );
     expect(
       wrapper.findAll('.categories-box').map(box => box.props.style.paddingLeft)

--- a/apps/test/unit/templates/referenceGuides/ReferenceGuidesIndexTest.js
+++ b/apps/test/unit/templates/referenceGuides/ReferenceGuidesIndexTest.js
@@ -1,0 +1,111 @@
+import React from 'react';
+import {isolateComponent} from 'isolate-react';
+import {expect} from '../../../util/reconfiguredChai';
+import ReferenceGuideIndex from '@cdo/apps/templates/referenceGuides/ReferenceGuideIndex';
+
+const makeReferenceGuide = (key, parent = null, pos = 0) => ({
+  display_name: key,
+  key: key,
+  parent_reference_guide_key: parent,
+  position: pos
+});
+
+describe('ReferenceGuideIndex', () => {
+  it('displays the name of the reference guide', () => {
+    const referenceGuides = [makeReferenceGuide('hello_world')];
+    const wrapper = isolateComponent(
+      <ReferenceGuideIndex referenceGuides={referenceGuides} />
+    );
+    expect(wrapper.findOne('.categories-box').content()).to.equal(
+      'hello_world'
+    );
+  });
+
+  it('sets up all the actions for a ref guide', () => {
+    const referenceGuides = [makeReferenceGuide('hello_world')];
+    const wrapper = isolateComponent(
+      <ReferenceGuideIndex referenceGuides={referenceGuides} />
+    );
+    expect(wrapper.findAll('MiniIconButton').length).to.equal(4);
+    expect(wrapper.findOne('.actions-box').toString()).to.contain('edit');
+    expect(wrapper.findOne('.actions-box').toString()).to.contain('delete');
+    expect(wrapper.findOne('.actions-box').toString()).to.contain('up');
+    expect(wrapper.findOne('.actions-box').toString()).to.contain('down');
+  });
+
+  it('sorts reference guides by tree heirarchy', () => {
+    /*
+        a
+      / | \
+     b  c  d
+       / \
+      e   f
+
+    should render in this order:
+    a, b, c, e, f, d
+    */
+    let referenceGuides = [
+      makeReferenceGuide('a', null, 0),
+      makeReferenceGuide('b', 'a', 0),
+      makeReferenceGuide('c', 'a', 1),
+      makeReferenceGuide('d', 'a', 2),
+      makeReferenceGuide('e', 'c', 0),
+      makeReferenceGuide('f', 'c', 1)
+    ];
+    let wrapper = isolateComponent(
+      <ReferenceGuideIndex referenceGuides={referenceGuides} />
+    );
+    expect(
+      wrapper.findAll('.categories-box').map(box => box.content())
+    ).to.deep.equal(['a', 'b', 'c', 'e', 'f', 'd']);
+
+    // input order shouldn't matter
+    referenceGuides = [
+      makeReferenceGuide('f', 'c', 1),
+      makeReferenceGuide('e', 'c', 0),
+      makeReferenceGuide('d', 'a', 2),
+      makeReferenceGuide('c', 'a', 1),
+      makeReferenceGuide('b', 'a', 0),
+      makeReferenceGuide('a', null, 0)
+    ];
+    wrapper = isolateComponent(
+      <ReferenceGuideIndex referenceGuides={referenceGuides} />
+    );
+    expect(
+      wrapper.findAll('.categories-box').map(box => box.content())
+    ).to.deep.equal(['a', 'b', 'c', 'e', 'f', 'd']);
+  });
+
+  it('sorts reference guides within a category', () => {
+    const referenceGuides = [
+      makeReferenceGuide('a', null, 0),
+      makeReferenceGuide('b', null, 4),
+      makeReferenceGuide('c', null, 1),
+      makeReferenceGuide('d', null, 3),
+      makeReferenceGuide('e', null, 2)
+    ];
+    const wrapper = isolateComponent(
+      <ReferenceGuideIndex referenceGuides={referenceGuides} />
+    );
+    expect(
+      wrapper.findAll('.categories-box').map(box => box.content())
+    ).to.deep.equal(['a', 'c', 'e', 'd', 'b']);
+  });
+
+  it('indents the reference guides by level depth', () => {
+    const referenceGuides = [
+      makeReferenceGuide('a', null, 0),
+      makeReferenceGuide('b', 'a', 0),
+      makeReferenceGuide('c', 'a', 1),
+      makeReferenceGuide('d', 'a', 2),
+      makeReferenceGuide('e', 'c', 0),
+      makeReferenceGuide('f', 'c', 1)
+    ];
+    const wrapper = isolateComponent(
+      <ReferenceGuideIndex referenceGuides={referenceGuides} />
+    );
+    expect(
+      wrapper.findAll('.categories-box').map(box => box.props.style.paddingLeft)
+    ).to.deep.equal(['4px', '24px', '24px', '44px', '44px', '24px']); // a b c e f d
+  });
+});

--- a/dashboard/app/controllers/reference_guides_controller.rb
+++ b/dashboard/app/controllers/reference_guides_controller.rb
@@ -1,12 +1,12 @@
 class ReferenceGuidesController < ApplicationController
   include CurriculumHelper
   before_action :find_reference_guide, only: [:show]
-  before_action :find_reference_guides, only: [:index]
+  before_action :find_reference_guides, only: [:edit_all]
   before_action :require_levelbuilder_mode_or_test_env, except: [:show]
   authorize_resource id_param: :key
 
   # GET /courses/:course_name/guides/edit
-  def index
+  def edit_all
     render :not_found unless params[:course_course_name]
   end
 

--- a/dashboard/app/controllers/reference_guides_controller.rb
+++ b/dashboard/app/controllers/reference_guides_controller.rb
@@ -29,11 +29,12 @@ class ReferenceGuidesController < ApplicationController
   end
 
   def find_reference_guides
-    course_version_id = find_matching_course_version(params[:course_course_name])&.id
-    unless course_version_id
+    course_version = find_matching_course_version(params[:course_course_name])
+    authorize! :read, course_version.content_root
+    unless course_version&.id
       flash[:alert] = 'No matching course version found.'
       render :not_found
     end
-    @reference_guides = ReferenceGuide.where(course_version_id: course_version_id).map(&:summarize_for_index)
+    @reference_guides = ReferenceGuide.where(course_version_id: course_version&.id).map(&:summarize_for_index)
   end
 end

--- a/dashboard/app/controllers/reference_guides_controller.rb
+++ b/dashboard/app/controllers/reference_guides_controller.rb
@@ -1,11 +1,16 @@
 class ReferenceGuidesController < ApplicationController
   include CurriculumHelper
   before_action :find_reference_guide, only: [:show]
-  before_action :require_levelbuilder_mode_or_test_env, except: [:show]
+  before_action :find_reference_guides, only: [:index]
+  before_action :require_levelbuilder_mode_or_test_env, except: [:show, :index]
   authorize_resource id_param: :key
 
+  def index
+    render :not_found unless params[:course_course_name]
+  end
+
   def show
-    render :not_found if !params[:course_course_name] || !params[:key]
+    render :not_found unless params[:course_course_name] && params[:key]
   end
 
   private
@@ -21,5 +26,14 @@ class ReferenceGuidesController < ApplicationController
       flash[:alert] = 'No matching reference guide found.'
       render :not_found
     end
+  end
+
+  def find_reference_guides
+    course_version_id = find_matching_course_version(params[:course_course_name])&.id
+    unless course_version_id
+      flash[:alert] = 'No matching course version found.'
+      render :not_found
+    end
+    @reference_guides = ReferenceGuide.where(course_version_id: course_version_id).map(&:summarize_for_index)
   end
 end

--- a/dashboard/app/controllers/reference_guides_controller.rb
+++ b/dashboard/app/controllers/reference_guides_controller.rb
@@ -2,13 +2,15 @@ class ReferenceGuidesController < ApplicationController
   include CurriculumHelper
   before_action :find_reference_guide, only: [:show]
   before_action :find_reference_guides, only: [:index]
-  before_action :require_levelbuilder_mode_or_test_env, except: [:show, :index]
+  before_action :require_levelbuilder_mode_or_test_env, except: [:show]
   authorize_resource id_param: :key
 
+  # GET /courses/:course_name/guides/edit
   def index
     render :not_found unless params[:course_course_name]
   end
 
+  # GET /courses/:course_name/guides/:key
   def show
     render :not_found unless params[:course_course_name] && params[:key]
   end

--- a/dashboard/app/helpers/curriculum_helper.rb
+++ b/dashboard/app/helpers/curriculum_helper.rb
@@ -1,7 +1,13 @@
 module CurriculumHelper
   KEY_CHAR_RE = /[A-Za-z0-9\-\_\.]/
+  RESERVED_KEYS = ['edit']
 
   def validate_key_format
+    if RESERVED_KEYS.include?(key)
+      errors.add(:base, "Key must not be one of: ${RESERVED_KEYS}")
+      return false
+    end
+
     if key.blank?
       errors.add(:base, 'Key must not be blank')
       return false

--- a/dashboard/app/models/reference_guide.rb
+++ b/dashboard/app/models/reference_guide.rb
@@ -101,4 +101,13 @@ class ReferenceGuide < ApplicationRecord
       content: content
     }
   end
+
+  def summarize_for_index
+    {
+      key: key,
+      parent_reference_guide_key: parent_reference_guide_key,
+      display_name: display_name,
+      position: position
+    }
+  end
 end

--- a/dashboard/app/views/reference_guides/edit_all.html.haml
+++ b/dashboard/app/views/reference_guides/edit_all.html.haml
@@ -1,5 +1,5 @@
 %link{href: asset_path('css/reference_guides.css'), rel: 'stylesheet', type: 'text/css'}
-%script{src: webpack_asset_path('js/reference_guides/index.js'),
+%script{src: webpack_asset_path('js/reference_guides/edit_all.js'),
   data: {referenceGuides: @reference_guides.to_json}}
 
 #show-container

--- a/dashboard/app/views/reference_guides/index.html.haml
+++ b/dashboard/app/views/reference_guides/index.html.haml
@@ -1,0 +1,5 @@
+%link{href: asset_path('css/reference_guides.css'), rel: 'stylesheet', type: 'text/css'}
+%script{src: webpack_asset_path('js/reference_guides/index.js'),
+  data: {referenceGuides: @reference_guides.to_json}}
+
+#show-container

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -281,7 +281,7 @@ Dashboard::Application.routes.draw do
   get '/course/:course_name', to: redirect('/courses/%{course_name}')
   get '/courses/:course_name/vocab/edit', to: 'vocabularies#edit'
   # this route uses course_course_name to match generated routes below that are nested within courses
-  get '/courses/:course_course_name/guides/edit', to: 'reference_guides#index'
+  get '/courses/:course_course_name/guides/edit', to: 'reference_guides#edit_all'
 
   resources :courses, param: 'course_name' do
     member do

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -280,6 +280,8 @@ Dashboard::Application.routes.draw do
 
   get '/course/:course_name', to: redirect('/courses/%{course_name}')
   get '/courses/:course_name/vocab/edit', to: 'vocabularies#edit'
+  # this route uses course_course_name to match generated routes below that are nested within courses
+  get '/courses/:course_course_name/guides/edit', to: 'reference_guides#index'
 
   resources :courses, param: 'course_name' do
     member do
@@ -290,7 +292,7 @@ Dashboard::Application.routes.draw do
       get 'get_rollup_resources'
     end
 
-    resources :reference_guides, only: [:show, :index], param: 'key', path: 'guides' do
+    resources :reference_guides, only: [:show], param: 'key', path: 'guides' do
     end
   end
 

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -290,7 +290,7 @@ Dashboard::Application.routes.draw do
       get 'get_rollup_resources'
     end
 
-    resources :reference_guides, only: [:show], param: 'key', path: 'guides' do
+    resources :reference_guides, only: [:show, :index], param: 'key', path: 'guides' do
     end
   end
 

--- a/dashboard/test/controllers/reference_guides_controller_test.rb
+++ b/dashboard/test/controllers/reference_guides_controller_test.rb
@@ -42,10 +42,10 @@ class ReferenceGuidesControllerTest < ActionController::TestCase
     assert_equal reference_guide.summarize_for_show.to_json, show_data
   end
 
-  test 'data is passed to index page' do
+  test 'data is passed to edit_all page' do
     sign_in @levelbuilder
 
-    get :index, params: {
+    get :edit_all, params: {
       course_course_name: @reference_guide.course_offering_version
     }
     assert_response :ok
@@ -56,13 +56,18 @@ class ReferenceGuidesControllerTest < ActionController::TestCase
   end
 
   test_user_gets_response_for :show, params: -> {{course_course_name: @reference_guide.course_offering_version, key: 'unknown_ref_guide'}}, user: :student, response: :not_found
-  test_user_gets_response_for :index, params: -> {{course_course_name: @reference_guide.course_offering_version}}, user: :student, response: :success
 
   # everyone can see basic reference guides
   test_user_gets_response_for :show, params: -> {{course_course_name: @reference_guide.course_offering_version, key: @reference_guide.key}}, user: nil, response: :success
   test_user_gets_response_for :show, params: -> {{course_course_name: @reference_guide.course_offering_version, key: @reference_guide.key}}, user: :student, response: :success
   test_user_gets_response_for :show, params: -> {{course_course_name: @reference_guide.course_offering_version, key: @reference_guide.key}}, user: :teacher, response: :success
   test_user_gets_response_for :show, params: -> {{course_course_name: @reference_guide.course_offering_version, key: @reference_guide.key}}, user: :levelbuilder, response: :success
+
+  # edit_all page is levelbuilder only
+  test_user_gets_response_for :edit_all, params: -> {{course_course_name: @reference_guide.course_offering_version}}, user: nil, response: :redirect
+  test_user_gets_response_for :edit_all, params: -> {{course_course_name: @reference_guide.course_offering_version}}, user: :student, response: :forbidden
+  test_user_gets_response_for :edit_all, params: -> {{course_course_name: @reference_guide.course_offering_version}}, user: :teacher, response: :forbidden
+  test_user_gets_response_for :edit_all, params: -> {{course_course_name: @reference_guide.course_offering_version}}, user: :levelbuilder, response: :success
 
   # pilot reference guides are restricted
   test_user_gets_response_for :show, name: 'not signed-in cannot view pilot ref guide',
@@ -71,7 +76,7 @@ class ReferenceGuidesControllerTest < ActionController::TestCase
     params: -> {{course_course_name: @reference_guide_pilot.course_offering_version, key: @reference_guide_pilot.key}}, user: :student, response: :forbidden
   test_user_gets_response_for :show, name: 'regular teacher cannot view pilot ref guide',
     params: -> {{course_course_name: @reference_guide_pilot.course_offering_version, key: @reference_guide_pilot.key}}, user: :teacher, response: :forbidden
-  test_user_gets_response_for :index, name: 'regular teacher cannot view pilot ref guide index',
+  test_user_gets_response_for :edit_all, name: 'regular teacher cannot view pilot ref guide edit_all',
     params: -> {{course_course_name: @reference_guide_pilot.course_offering_version}}, user: :teacher, response: :forbidden
   test_user_gets_response_for :show, name: 'pilot student can view pilot ref guide',
     params: -> {{course_course_name: @reference_guide_pilot.course_offering_version, key: @reference_guide_pilot.key}}, user: -> {@pilot_student}, response: :success

--- a/dashboard/test/controllers/reference_guides_controller_test.rb
+++ b/dashboard/test/controllers/reference_guides_controller_test.rb
@@ -42,7 +42,21 @@ class ReferenceGuidesControllerTest < ActionController::TestCase
     assert_equal reference_guide.summarize_for_show.to_json, show_data
   end
 
+  test 'data is passed to index page' do
+    sign_in @levelbuilder
+
+    get :index, params: {
+      course_course_name: @reference_guide.course_offering_version
+    }
+    assert_response :ok
+
+    show_data = css_select('script[data-referenceguides]').first.attribute('data-referenceguides').to_s
+
+    assert_equal [@reference_guide.summarize_for_index].to_json, show_data
+  end
+
   test_user_gets_response_for :show, params: -> {{course_course_name: @reference_guide.course_offering_version, key: 'unknown_ref_guide'}}, user: :student, response: :not_found
+  test_user_gets_response_for :index, params: -> {{course_course_name: @reference_guide.course_offering_version}}, user: :student, response: :success
 
   # everyone can see basic reference guides
   test_user_gets_response_for :show, params: -> {{course_course_name: @reference_guide.course_offering_version, key: @reference_guide.key}}, user: nil, response: :success
@@ -57,6 +71,8 @@ class ReferenceGuidesControllerTest < ActionController::TestCase
     params: -> {{course_course_name: @reference_guide_pilot.course_offering_version, key: @reference_guide_pilot.key}}, user: :student, response: :forbidden
   test_user_gets_response_for :show, name: 'regular teacher cannot view pilot ref guide',
     params: -> {{course_course_name: @reference_guide_pilot.course_offering_version, key: @reference_guide_pilot.key}}, user: :teacher, response: :forbidden
+  test_user_gets_response_for :index, name: 'regular teacher cannot view pilot ref guide index',
+    params: -> {{course_course_name: @reference_guide_pilot.course_offering_version}}, user: :teacher, response: :not_found
   test_user_gets_response_for :show, name: 'pilot student can view pilot ref guide',
     params: -> {{course_course_name: @reference_guide_pilot.course_offering_version, key: @reference_guide_pilot.key}}, user: -> {@pilot_student}, response: :success
   test_user_gets_response_for :show, name: 'pilot teacher can view pilot ref guide',

--- a/dashboard/test/controllers/reference_guides_controller_test.rb
+++ b/dashboard/test/controllers/reference_guides_controller_test.rb
@@ -72,7 +72,7 @@ class ReferenceGuidesControllerTest < ActionController::TestCase
   test_user_gets_response_for :show, name: 'regular teacher cannot view pilot ref guide',
     params: -> {{course_course_name: @reference_guide_pilot.course_offering_version, key: @reference_guide_pilot.key}}, user: :teacher, response: :forbidden
   test_user_gets_response_for :index, name: 'regular teacher cannot view pilot ref guide index',
-    params: -> {{course_course_name: @reference_guide_pilot.course_offering_version}}, user: :teacher, response: :not_found
+    params: -> {{course_course_name: @reference_guide_pilot.course_offering_version}}, user: :teacher, response: :forbidden
   test_user_gets_response_for :show, name: 'pilot student can view pilot ref guide',
     params: -> {{course_course_name: @reference_guide_pilot.course_offering_version, key: @reference_guide_pilot.key}}, user: -> {@pilot_student}, response: :success
   test_user_gets_response_for :show, name: 'pilot teacher can view pilot ref guide',

--- a/dashboard/test/models/reference_guide_test.rb
+++ b/dashboard/test/models/reference_guide_test.rb
@@ -17,6 +17,9 @@ class ReferenceGuideTest < ActiveSupport::TestCase
     assert_raises ActiveRecord::RecordInvalid do
       create :reference_guide, key: '\\ $ % * & @'
     end
+    assert_raises ActiveRecord::RecordInvalid do
+      create :reference_guide, key: 'edit'
+    end
   end
 
   test "reference guides are unique by key in course version" do


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Adds an index page to display all reference guides associated with a course version.
- Reference guides are sorted by category and position on the client.
- Icon buttons for edit/delete/move are displayed, but currently not hooked up to anything (pending update api).

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- spec: [product spec](https://docs.google.com/document/d/1VZGle7QA-06ZNNxy2SkvA8Msrok8pyN7fuq5hzek888/edit)
- jira ticket: [PLAT-1357](https://codedotorg.atlassian.net/browse/PLAT-1357)

## Testing story

Unit tests + manual testing

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

## Screenshots
![image](https://user-images.githubusercontent.com/82416901/157134232-1a3c7ef1-7221-4bfd-99a0-a4a3e7b38237.png)

