### PR TITLE
Allow deleting an image on code docs pages

### DIFF
--- a/apps/src/lib/levelbuilder/code-docs-editor/ExampleEditor.jsx
+++ b/apps/src/lib/levelbuilder/code-docs-editor/ExampleEditor.jsx
@@ -1,10 +1,9 @@
 import PropTypes from 'prop-types';
-import React, {useState} from 'react';
-import Button from '@cdo/apps/templates/Button';
+import React from 'react';
 import color from '@cdo/apps/util/color';
 import HelpTip from '@cdo/apps/lib/ui/HelpTip';
 import TextareaWithMarkdownPreview from '@cdo/apps/lib/levelbuilder/TextareaWithMarkdownPreview';
-import UploadImageDialog from '@cdo/apps/lib/levelbuilder/lesson-editor/UploadImageDialog';
+import ImageInput from './ImageInput';
 
 const APP_DISPLAY_OPTIONS = {
   embedAppWithCode: 'Embed app with code directly',
@@ -14,8 +13,6 @@ const APP_DISPLAY_OPTIONS = {
 const DEFAULT_EMBED_HEIGHT = 310;
 
 export default function ExampleEditor({example, updateExample}) {
-  const [uploadImageDialogOpen, setUploadImageDialogOpen] = useState(false);
-
   return (
     <div>
       <label>
@@ -47,17 +44,10 @@ export default function ExampleEditor({example, updateExample}) {
           style={styles.textInput}
         />
       </label>
-      <label>
-        Image
-        <Button
-          onClick={() => setUploadImageDialogOpen(true)}
-          text="Choose Image"
-          color="gray"
-          icon="plus-circle"
-        />
-        {example.imageUrl && <span>{example.imageUrl}</span>}
-      </label>
-
+      <ImageInput
+        imageUrl={example.image}
+        updateImageUrl={img => updateExample('image', img)}
+      />
       <label>
         Example App Display Type
         <select
@@ -89,12 +79,6 @@ export default function ExampleEditor({example, updateExample}) {
           style={styles.textInput}
         />{' '}
       </label>
-      <UploadImageDialog
-        isOpen={uploadImageDialogOpen}
-        handleClose={() => setUploadImageDialogOpen(false)}
-        uploadImage={imgUrl => updateExample('image', imgUrl)}
-        allowExpandable={false}
-      />
     </div>
   );
 }

--- a/apps/src/lib/levelbuilder/code-docs-editor/ImageInput.jsx
+++ b/apps/src/lib/levelbuilder/code-docs-editor/ImageInput.jsx
@@ -30,7 +30,10 @@ export default function ImageInput({updateImageUrl, imageUrl}) {
       {removeImageDialogOpen && (
         <StylizedBaseDialog
           body="Are you sure you want to remove this image?"
-          handleConfirmation={() => updateImageUrl(null)}
+          handleConfirmation={() => {
+            updateImageUrl(null);
+            setRemoveImageDialogOpen(false);
+          }}
           handleClose={() => setRemoveImageDialogOpen(false)}
           isOpen
         />

--- a/apps/src/lib/levelbuilder/code-docs-editor/ImageInput.jsx
+++ b/apps/src/lib/levelbuilder/code-docs-editor/ImageInput.jsx
@@ -1,0 +1,51 @@
+import React, {useState} from 'react';
+import PropTypes from 'prop-types';
+import Button from '@cdo/apps/templates/Button';
+import StylizedBaseDialog from '@cdo/apps/componentLibrary/StylizedBaseDialog';
+import UploadImageDialog from '@cdo/apps/lib/levelbuilder/lesson-editor/UploadImageDialog';
+
+export default function ImageInput({updateImageUrl, imageUrl}) {
+  const [removeImageDialogOpen, setRemoveImageDialogOpen] = useState(false);
+  const [uploadImageDialogOpen, setUploadImageDialogOpen] = useState(false);
+  return (
+    <div>
+      <label>
+        Image
+        <Button
+          onClick={() => setUploadImageDialogOpen(true)}
+          text={!!imageUrl ? 'Replace Image' : 'Choose Image'}
+          color="gray"
+          icon="plus-circle"
+        />
+        {imageUrl && <span>{imageUrl}</span>}
+        {imageUrl && (
+          <Button
+            text="Remove Image"
+            color="red"
+            icon="trash"
+            onClick={() => setRemoveImageDialogOpen(true)}
+          />
+        )}
+      </label>
+      {removeImageDialogOpen && (
+        <StylizedBaseDialog
+          body="Are you sure you want to remove this image?"
+          handleConfirmation={() => updateImageUrl(null)}
+          handleClose={() => setRemoveImageDialogOpen(false)}
+          isOpen
+        />
+      )}
+      <UploadImageDialog
+        isOpen={uploadImageDialogOpen}
+        handleClose={() => setUploadImageDialogOpen(false)}
+        uploadImage={imgUrl => updateImageUrl(imgUrl)}
+        allowExpandable={false}
+      />
+    </div>
+  );
+}
+
+ImageInput.propTypes = {
+  updateImageUrl: PropTypes.func.isRequired,
+  imageUrl: PropTypes.string
+};

--- a/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingExpressionEditor.jsx
+++ b/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingExpressionEditor.jsx
@@ -3,12 +3,11 @@ import React, {useState} from 'react';
 import OrderableList from './OrderableList';
 import ExampleEditor from './ExampleEditor';
 import ParameterEditor from './ParameterEditor';
+import ImageInput from './ImageInput';
 import TextareaWithMarkdownPreview from '@cdo/apps/lib/levelbuilder/TextareaWithMarkdownPreview';
 import CollapsibleEditorSection from '@cdo/apps/lib/levelbuilder/CollapsibleEditorSection';
 import HelpTip from '@cdo/apps/lib/ui/HelpTip';
 import SaveBar from '@cdo/apps/lib/levelbuilder/SaveBar';
-import Button from '@cdo/apps/templates/Button';
-import UploadImageDialog from '@cdo/apps/lib/levelbuilder/lesson-editor/UploadImageDialog';
 import {createUuid, navigateToHref} from '@cdo/apps/utils';
 import $ from 'jquery';
 import color from '@cdo/apps/util/color';
@@ -66,7 +65,6 @@ export default function ProgrammingExpressionEditor({
   const [isSaving, setIsSaving] = useState(false);
   const [lastUpdated, setLastUpdated] = useState(null);
   const [error, setError] = useState(null);
-  const [uploadImageDialogOpen, setUploadImageDialogOpen] = useState(false);
 
   const save = (e, shouldCloseAfterSave) => {
     if (isSaving) {
@@ -152,18 +150,12 @@ export default function ProgrammingExpressionEditor({
           ))}
         </select>
       </label>
-      <label>
-        Image
-        <Button
-          onClick={() => setUploadImageDialogOpen(true)}
-          text="Choose Image"
-          color="gray"
-          icon="plus-circle"
-        />
-        {programmingExpression.imageUrl && (
-          <span>{programmingExpression.imageUrl}</span>
-        )}
-      </label>
+      <ImageInput
+        updateImageUrl={imgUrl =>
+          updateProgrammingExpression('imageUrl', imgUrl)
+        }
+        imageUrl={programmingExpression.imageUrl}
+      />
       <label>
         Short Description
         <textarea
@@ -276,12 +268,6 @@ export default function ProgrammingExpressionEditor({
         lastSaved={lastUpdated}
         error={error}
         handleView={() => navigateToHref(showPath)}
-      />
-      <UploadImageDialog
-        isOpen={uploadImageDialogOpen}
-        handleClose={() => setUploadImageDialogOpen(false)}
-        uploadImage={imgUrl => updateProgrammingExpression('imageUrl', imgUrl)}
-        allowExpandable={false}
       />
     </div>
   );

--- a/apps/src/templates/codeDocs/Example.jsx
+++ b/apps/src/templates/codeDocs/Example.jsx
@@ -27,7 +27,7 @@ export default function Example({example, programmingEnvironmentName}) {
               ...embeddedIdeStyles[programmingEnvironmentName]
             }}
           />
-          {example.imageUrl && <img src={example.imageUrl} />}
+          {example.image && <img src={example.image} />}
         </div>
       );
     } else {
@@ -46,7 +46,7 @@ export default function Example({example, programmingEnvironmentName}) {
               }}
             />
           </div>
-          {example.imageUrl && <img src={example.imageUrl} />}
+          {example.image && <img src={example.image} />}
         </div>
       );
     }
@@ -54,7 +54,7 @@ export default function Example({example, programmingEnvironmentName}) {
     return (
       <div>
         {content}
-        {example.imageUrl && <img src={example.imageUrl} />}
+        {example.image && <img src={example.image} />}
       </div>
     );
   }

--- a/apps/test/unit/lib/levelbuilder/code-docs-editor/ExampleEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/code-docs-editor/ExampleEditorTest.jsx
@@ -65,12 +65,9 @@ describe('ExampleEditor', () => {
     );
   });
 
-  it('displays image upload dialog when button is pressed', () => {
+  it('displays ImageInput for image', () => {
     const wrapper = shallow(<ExampleEditor {...defaultProps} />);
-    const uploadButton = wrapper.find('Button').first();
-    expect(uploadButton).to.not.be.null;
-    uploadButton.simulate('click');
-    expect(wrapper.find('UploadImageDialog').length).to.equal(1);
+    expect(wrapper.find('ImageInput').length).to.equal(1);
   });
 
   it('displays a select for display type', () => {

--- a/apps/test/unit/lib/levelbuilder/code-docs-editor/ImageInputText.jsx
+++ b/apps/test/unit/lib/levelbuilder/code-docs-editor/ImageInputText.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import {expect} from '../../../../util/reconfiguredChai';
+import ImageInput from '@cdo/apps/lib/levelbuilder/code-docs-editor/ImageInput';
+
+describe('ImageInput', () => {
+  it('displays image upload dialog when upload image button is pressed', () => {
+    const wrapper = shallow(<ImageInput updateImageUrl={() => {}} />);
+    const uploadButton = wrapper.find('Button').first();
+    expect(uploadButton).to.not.be.null;
+    uploadButton.simulate('click');
+    expect(wrapper.find('UploadImageDialog').length).to.equal(1);
+  });
+
+  it('shows imageUrl if one is provided', () => {
+    const wrapper = shallow(
+      <ImageInput
+        updateImageUrl={() => {}}
+        imageUrl="code.org/images/spritelab.png"
+      />
+    );
+    expect(wrapper.text().includes('code.org/images/spritelab.png')).to.be.true;
+  });
+
+  it('shows confirmation dialog if remove image button is pressed', () => {
+    const wrapper = shallow(
+      <ImageInput
+        updateImageUrl={() => {}}
+        imageUrl="code.org/images/spritelab.png"
+      />
+    );
+    expect(wrapper.find('Button').length).to.equal(2);
+    const removeButton = wrapper.find('Button').last();
+    removeButton.simulate('click');
+    expect(wrapper.find('StylizedBaseDialog').length).to.equal(1);
+  });
+});

--- a/apps/test/unit/lib/levelbuilder/code-docs-editor/ProgrammingExpressionEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/code-docs-editor/ProgrammingExpressionEditorTest.jsx
@@ -82,12 +82,7 @@ describe('ProgrammingExpressionEditor', () => {
     ).to.eql(['', 'video1', 'video2']);
 
     // Image upload
-    expect(
-      wrapper
-        .find('Button')
-        .at(0)
-        .props().text
-    ).to.equal('Choose Image');
+    expect(wrapper.find('ImageInput').length).to.equal(1);
 
     // short description
     expect(
@@ -171,14 +166,6 @@ describe('ProgrammingExpressionEditor', () => {
     );
     const blockNameInput = wrapper.find('input').at(2);
     expect(blockNameInput.props().value).to.equal('gamelab_location_picker');
-  });
-
-  it('shows upload image dialog when choose image button is pressed', () => {
-    const wrapper = shallow(<ProgrammingExpressionEditor {...defaultProps} />);
-    const uploadButton = wrapper.find('Button').first();
-    expect(uploadButton).to.not.be.null;
-    uploadButton.simulate('click');
-    expect(wrapper.find('UploadImageDialog').length).to.equal(1);
   });
 
   it('attempts to save when save is pressed', () => {

--- a/apps/test/unit/templates/codeDocs/ExampleTest.jsx
+++ b/apps/test/unit/templates/codeDocs/ExampleTest.jsx
@@ -65,7 +65,7 @@ describe('Example', () => {
       description: 'An example',
       code: '```This is some example code```',
       app_display_type: 'codeFromCodeField',
-      imageUrl: '/image.png'
+      image: '/image.png'
     };
 
     const wrapper = shallow(


### PR DESCRIPTION
I pulled the image input into a new component (creatively named `ImageInput`) and added the ability to remove the image. 


https://user-images.githubusercontent.com/46464143/157303170-932f6ab8-82a5-4584-953b-9bb538419f2e.mov

I'll admit that the delete button is a bit aggressive. Open to thoughts on how to make it better but I didn't want to spend too much time messing with styling on this page.




## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
