### PR TITLE
Add missing param

### DIFF
--- a/apps/src/blockly/addons/cdoBlockSvg.js
+++ b/apps/src/blockly/addons/cdoBlockSvg.js
@@ -117,8 +117,8 @@ export default class BlockSvg extends GoogleBlockly.BlockSvg {
     super.onMouseDown_(e);
   }
 
-  render() {
-    super.render();
+  render(opt_bubble) {
+    super.render(opt_bubble);
     this.removeUnusedBlockFrame();
   }
 


### PR DESCRIPTION
Adding a missing param that Google Blockly is expecting. Not passing in the param was causing an error to be thrown when rendering `<shadow>` blocks. 

This change allows us to be able to change a `<block>` to a `<shadow>` block. 



## Links

[Jira Ticket](https://codedotorg.atlassian.net/browse/STAR-2134)

## Testing story

- Pull down branch and start locally 
- Create or edit a poetry level
- Create a `<shadow>` block, example:

```
      <block type="Poetry_setFontColor" id="156">
        <value name="FILL">
          <shadow type="colour_picker" id="157">
            <field name="COLOUR">#ffcc00</field>
          </shadow>
        </value>
      </block>
```
- Save and see a shadow block (color picker) is created and no errors in the console:
 
![image](https://user-images.githubusercontent.com/35442460/157307117-5dce5173-a2f7-40d0-83f1-ce2379c376c8.png)


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
