### PR TITLE
Prevent logging bad string keys

### DIFF
--- a/lib/cdo/i18n_string_url_tracker.rb
+++ b/lib/cdo/i18n_string_url_tracker.rb
@@ -70,6 +70,10 @@ class I18nStringUrlTracker
     return unless DCDO.get(I18N_STRING_TRACKING_DCDO_KEY, false)
     return unless string_key && url && source
 
+    # We got a bad string_key if there is no English source string
+    source_string = I18n.t(string_key, locale: I18n.default_locale)
+    return if !source_string || source_string.start_with?("translation missing")
+
     # Skip URLs we are not interested in.
     return unless allowed(url)
     url = normalize_url(url)

--- a/lib/test/cdo/test_i18n_string_url_tracker.rb
+++ b/lib/test/cdo/test_i18n_string_url_tracker.rb
@@ -33,6 +33,7 @@ module SetupI18nStringUrlTracker
     super
     stub_firehose
     stub_dcdo(true)
+    I18n.backend.store_translations(I18n.default_locale, {'string': {'key': 'a valid string'}})
   end
 
   def teardown
@@ -291,6 +292,14 @@ class TestI18nStringUrlTracker < Minitest::Test
     I18nStringUrlTracker.instance.log(test_record[:url], test_record[:source] + '2', test_record[:string_key], test_record[:scope], test_record[:separator])
     I18nStringUrlTracker.instance.send(:flush)
     assert_equal %w(test test2), @firehose_records&.map {|x| x[:source]}
+  end
+
+  def test_log_given_unknown_string_key_should_not_be_logged
+    unstub_firehose
+    FirehoseClient.instance.expects(:put_record).never
+    test_record = {url: 'https://studio.code.org/s/outbreak', source: 'test', string_key: 'invalid_key', scope: [], separator: '.'}
+    I18nStringUrlTracker.instance.log(test_record[:url], test_record[:source], test_record[:string_key], test_record[:scope], test_record[:separator])
+    I18nStringUrlTracker.instance.send(:flush)
   end
 end
 


### PR DESCRIPTION
[Task FND-1915](https://codedotorg.atlassian.net/browse/FND-1915)

**Problem**:
The string keys we collected contain translated names for behavior blocks and shared functions. 
![image-20220224-011043](https://user-images.githubusercontent.com/46507039/157324091-0946b684-f151-4996-b230-567e968b145b.png)
![image-20220224-011344](https://user-images.githubusercontent.com/46507039/157324096-b7bb8220-324b-4b83-9891-161a10272791.png)

**Reason:**
The best explanation we have is when saving progress made to a non-English project, we also save the translated function and behavior names. When loading the project again, the same texts are looked up as if they are english texts, results in logging invalid string keys. 

**Solution:**
This PR doesn't address the root cause of the problem. It just prevents logging bad keys that don't have corresponding English source strings. 
Fixing the root cause is tracked separately by https://codedotorg.atlassian.net/browse/FND-1486. 
