### PR TITLE
Javalab: Enable decoupled javabuilder behind experiment flag

### DIFF
--- a/apps/src/javalab/JavabuilderConnection.js
+++ b/apps/src/javalab/JavabuilderConnection.js
@@ -8,6 +8,7 @@ import {handleException} from './javabuilderExceptionHandler';
 import project from '@cdo/apps/code-studio/initApp/project';
 import javalabMsg from '@cdo/javalab/locale';
 import {onTestResult} from './testResultHandler';
+import experiments from '@cdo/apps/util/experiments';
 
 // Creates and maintains a websocket connection with javabuilder while a user's code is running.
 export default class JavabuilderConnection {
@@ -59,7 +60,9 @@ export default class JavabuilderConnection {
         levelId: this.levelId,
         options: this.options,
         executionType: this.executionType,
-        useDashboardSources: true,
+        useDashboardSources: !experiments.isEnabled(
+          experiments.DECOUPLED_JAVABUILDER
+        ),
         miniAppType: this.miniAppType
       }
     })

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -39,6 +39,7 @@ experiments.CLEARER_SIGN_UP_USER_TYPE = 'clearerSignUpUserType';
 experiments.OPT_IN_EMAIL_REG_PARTNER = 'optInEmailRegPartner';
 experiments.JAVALAB_UNIT_TESTS = 'javalabUnitTests';
 experiments.STUDIO_CERTIFICATE = 'studioCertificate';
+experiments.DECOUPLED_JAVABUILDER = 'decoupledJavabuilder';
 
 /**
  * This was a gamified version of the finish dialog, built in 2018,

--- a/dashboard/app/helpers/javalab_files_helper.rb
+++ b/dashboard/app/helpers/javalab_files_helper.rb
@@ -4,6 +4,7 @@ module JavalabFilesHelper
     uri = URI.parse("#{CDO.javabuilder_upload_url}?Authorization=#{auth_token}")
     upload_request = Net::HTTP::Put.new(uri)
     upload_request['Origin'] = hostname
+    upload_request['Content-Type'] = 'application/json'
     upload_request.body = get_project_files(channel_id, level_id).to_json
 
     response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') do |http|

--- a/lib/cdo.rb
+++ b/lib/cdo.rb
@@ -136,8 +136,7 @@ module Cdo
       if rack_env?(:development)
         'http://localhost:8080/javabuilderfiles/seedsources'
       else
-        # TODO: Update this URL once the API Gateway endpoint has been set up.
-        ''
+        'https://javabuilderbeta-http.code.org/seedsources/sources.json'
       end
     end
 


### PR DESCRIPTION
Enables the decoupled javabuilder code path, hidden behind an experiment flag ('decoupledJavabuilder'). This includes uploading the sources.json payload to the API Gateway HTTP endpoint (or local fileserver if on localhost).

After this change is merged, we will monitor this change in production using the experiment flag, and once we're confident with the change, we can go ahead and remove the experiment and set `useDashboardSources: false`.

JIRA: https://codedotorg.atlassian.net/browse/JAVA-450

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Tested with localhost against both localhost and prod Javabuilder. Confirmed that without the experiment flag set, behavior defaults to normal, and with the experiment flag set, content is successfully uploaded and read by Javabuilder.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
