### PR TITLE
Prevent updating critical parts of units and courses once they have been published

### DIFF
--- a/apps/src/lib/levelbuilder/course-editor/CourseEditor.js
+++ b/apps/src/lib/levelbuilder/course-editor/CourseEditor.js
@@ -338,7 +338,6 @@ class CourseEditor extends Component {
               onChange={() =>
                 this.setState({hasNumberedUnits: !hasNumberedUnits})
               }
-              disabled={!allowMajorCurriculumChanges}
             />
           </label>
           <AnnouncementsEditor

--- a/apps/src/lib/levelbuilder/course-editor/CourseEditor.js
+++ b/apps/src/lib/levelbuilder/course-editor/CourseEditor.js
@@ -204,7 +204,13 @@ class CourseEditor extends Component {
   };
 
   render() {
-    const {name, unitNames, courseFamilies, versionYearOptions} = this.props;
+    const {
+      name,
+      unitNames,
+      courseFamilies,
+      versionYearOptions,
+      initialPublishedState
+    } = this.props;
     const {
       announcements,
       teacherResources,
@@ -224,6 +230,11 @@ class CourseEditor extends Component {
       instructorAudience,
       participantAudience
     } = this.state;
+
+    const allowMajorCurriculumChanges =
+      initialPublishedState === PublishedState.in_development ||
+      initialPublishedState === PublishedState.pilot;
+
     return (
       <div>
         <h1>{name}</h1>
@@ -327,6 +338,7 @@ class CourseEditor extends Component {
               onChange={() =>
                 this.setState({hasNumberedUnits: !hasNumberedUnits})
               }
+              disabled={!allowMajorCurriculumChanges}
             />
           </label>
           <AnnouncementsEditor
@@ -349,9 +361,7 @@ class CourseEditor extends Component {
           handleParticipantAudienceChange={e =>
             this.setState({participantAudience: e.target.value})
           }
-          canChangeParticipantType={
-            publishedState === PublishedState.in_development
-          }
+          allowMajorCurriculumChanges={allowMajorCurriculumChanges}
         />
 
         <CollapsibleEditorSection title="Publishing Settings">
@@ -420,11 +430,13 @@ class CourseEditor extends Component {
             </div>
             <CourseUnitsEditor
               inputStyle={styles.input}
+              initialUnitsInCourse={this.props.initialUnitsInCourse}
               unitsInCourse={unitsInCourse}
               updateUnitsInCourse={unitsInCourse =>
                 this.setState({unitsInCourse})
               }
               unitNames={unitNames}
+              allowMajorCurriculumChanges={allowMajorCurriculumChanges}
             />
           </label>
         </CollapsibleEditorSection>

--- a/apps/src/lib/levelbuilder/course-editor/CourseTypeEditor.jsx
+++ b/apps/src/lib/levelbuilder/course-editor/CourseTypeEditor.jsx
@@ -107,7 +107,6 @@ export default function CourseTypeEditor({
         <label>
           Who will participate in this course?
           <select
-            className="participantAudienceSelector"
             value={participantAudience}
             style={styles.dropdown}
             onChange={handleParticipantAudienceChange}

--- a/apps/src/lib/levelbuilder/course-editor/CourseTypeEditor.jsx
+++ b/apps/src/lib/levelbuilder/course-editor/CourseTypeEditor.jsx
@@ -34,7 +34,7 @@ export default function CourseTypeEditor({
   handleInstructionTypeChange,
   handleInstructorAudienceChange,
   handleParticipantAudienceChange,
-  canChangeParticipantType
+  allowMajorCurriculumChanges
 }) {
   return (
     <div>
@@ -46,6 +46,7 @@ export default function CourseTypeEditor({
             value={instructionType}
             style={styles.dropdown}
             onChange={handleInstructionTypeChange}
+            disabled={!allowMajorCurriculumChanges}
           >
             {Object.values(InstructionType).map(state => (
               <option key={state} value={state}>
@@ -87,6 +88,7 @@ export default function CourseTypeEditor({
             value={instructorAudience}
             style={styles.dropdown}
             onChange={handleInstructorAudienceChange}
+            disabled={!allowMajorCurriculumChanges}
           >
             {Object.values(InstructorAudience).map(audience => (
               <option key={audience} value={audience}>
@@ -109,7 +111,7 @@ export default function CourseTypeEditor({
             value={participantAudience}
             style={styles.dropdown}
             onChange={handleParticipantAudienceChange}
-            disabled={!canChangeParticipantType}
+            disabled={!allowMajorCurriculumChanges}
           >
             {Object.values(ParticipantAudience).map(audience => (
               <option key={audience} value={audience}>
@@ -139,7 +141,7 @@ CourseTypeEditor.propTypes = {
   handleInstructionTypeChange: PropTypes.func,
   handleInstructorAudienceChange: PropTypes.func,
   handleParticipantAudienceChange: PropTypes.func,
-  canChangeParticipantType: PropTypes.bool.isRequired
+  allowMajorCurriculumChanges: PropTypes.bool.isRequired
 };
 
 const styles = {

--- a/apps/src/lib/levelbuilder/course-editor/CourseUnitsEditor.js
+++ b/apps/src/lib/levelbuilder/course-editor/CourseUnitsEditor.js
@@ -5,9 +5,11 @@ import ReactDOM from 'react-dom';
 export default class CourseUnitsEditor extends Component {
   static propTypes = {
     inputStyle: PropTypes.object.isRequired,
+    initialUnitsInCourse: PropTypes.arrayOf(PropTypes.string).isRequired,
     unitsInCourse: PropTypes.arrayOf(PropTypes.string).isRequired,
     unitNames: PropTypes.arrayOf(PropTypes.string).isRequired,
-    updateUnitsInCourse: PropTypes.func.isRequired
+    updateUnitsInCourse: PropTypes.func.isRequired,
+    allowMajorCurriculumChanges: PropTypes.bool.isRequired
   };
 
   handleChange = () => {
@@ -34,6 +36,10 @@ export default class CourseUnitsEditor extends Component {
             key={index}
             value={selectedUnit}
             onChange={this.handleChange}
+            disabled={
+              !this.props.allowMajorCurriculumChanges &&
+              this.props.initialUnitsInCourse.includes(selectedUnit)
+            }
           >
             <option key="-1" value="">
               Select a unit to add to course

--- a/apps/src/lib/levelbuilder/unit-editor/LessonGroupCard.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/LessonGroupCard.jsx
@@ -22,6 +22,7 @@ import MarkdownEnabledTextarea from '@cdo/apps/lib/levelbuilder/MarkdownEnabledT
 
 class LessonGroupCard extends Component {
   static propTypes = {
+    allowMajorCurriculumChanges: PropTypes.bool.isRequired,
     lessonGroup: lessonGroupShape.isRequired,
     lessonGroupsCount: PropTypes.number.isRequired,
     lessonGroupMetrics: PropTypes.object,
@@ -224,7 +225,11 @@ class LessonGroupCard extends Component {
   };
 
   render() {
-    const {lessonGroup, targetLessonGroupPos} = this.props;
+    const {
+      lessonGroup,
+      targetLessonGroupPos,
+      allowMajorCurriculumChanges
+    } = this.props;
     const {draggedLessonPos} = this.state;
     const isTargetLessonGroup = targetLessonGroupPos === lessonGroup.position;
     return (
@@ -244,11 +249,13 @@ class LessonGroupCard extends Component {
                 onChange={this.handleChangeLessonGroupName}
                 style={{width: 300}}
               />
-              <OrderControls
-                name={lessonGroup.key || '(none)'}
-                move={this.handleMoveLessonGroup}
-                remove={this.handleRemoveLessonGroup}
-              />
+              {allowMajorCurriculumChanges && (
+                <OrderControls
+                  name={lessonGroup.key || '(none)'}
+                  move={this.handleMoveLessonGroup}
+                  remove={this.handleRemoveLessonGroup}
+                />
+              )}
             </div>
             <div>
               <label>
@@ -300,19 +307,23 @@ class LessonGroupCard extends Component {
             handleDragStart={this.handleDragStart}
             removeLesson={this.handleRemoveLesson}
             cloneLesson={this.handleCloneLesson}
+            allowMajorCurriculumChanges={allowMajorCurriculumChanges}
           />
         ))}
-        <div style={styles.bottomControls}>
-          <button
-            onMouseDown={this.handleAddLesson}
-            className="btn"
-            style={styles.addButton}
-            type="button"
-          >
-            <i style={{marginRight: 7}} className="fa fa-plus-circle" />
-            Lesson
-          </button>
-        </div>
+        {allowMajorCurriculumChanges ||
+          (this.props.lessonGroup.position === this.props.lessonGroupsCount && (
+            <div style={styles.bottomControls}>
+              <button
+                onMouseDown={this.handleAddLesson}
+                className="btn"
+                style={styles.addButton}
+                type="button"
+              >
+                <i style={{marginRight: 7}} className="fa fa-plus-circle" />
+                Lesson
+              </button>
+            </div>
+          ))}
         {/* This dialog lives outside LessonToken because moving it inside can
            interfere with drag and drop or fail to show the modal backdrop. */}
         <RemoveLessonDialog

--- a/apps/src/lib/levelbuilder/unit-editor/LessonGroupCard.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/LessonGroupCard.jsx
@@ -310,20 +310,20 @@ class LessonGroupCard extends Component {
             allowMajorCurriculumChanges={allowMajorCurriculumChanges}
           />
         ))}
-        {allowMajorCurriculumChanges ||
-          (this.props.lessonGroup.position === this.props.lessonGroupsCount && (
-            <div style={styles.bottomControls}>
-              <button
-                onMouseDown={this.handleAddLesson}
-                className="btn"
-                style={styles.addButton}
-                type="button"
-              >
-                <i style={{marginRight: 7}} className="fa fa-plus-circle" />
-                Lesson
-              </button>
-            </div>
-          ))}
+        {(allowMajorCurriculumChanges ||
+          this.props.lessonGroup.position === this.props.lessonGroupsCount) && (
+          <div style={styles.bottomControls}>
+            <button
+              onMouseDown={this.handleAddLesson}
+              className="btn"
+              style={styles.addButton}
+              type="button"
+            >
+              <i style={{marginRight: 7}} className="fa fa-plus-circle" />
+              Lesson
+            </button>
+          </div>
+        )}
         {/* This dialog lives outside LessonToken because moving it inside can
            interfere with drag and drop or fail to show the modal backdrop. */}
         <RemoveLessonDialog

--- a/apps/src/lib/levelbuilder/unit-editor/LessonToken.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/LessonToken.jsx
@@ -16,7 +16,8 @@ export default class LessonToken extends Component {
     delta: PropTypes.number,
     handleDragStart: PropTypes.func,
     removeLesson: PropTypes.func.isRequired,
-    cloneLesson: PropTypes.func.isRequired
+    cloneLesson: PropTypes.func.isRequired,
+    allowMajorCurriculumChanges: PropTypes.bool.isRequired
   };
 
   render() {
@@ -53,6 +54,7 @@ export default class LessonToken extends Component {
             handleDragStart={this.props.handleDragStart}
             removeLesson={this.props.removeLesson}
             cloneLesson={this.props.cloneLesson}
+            allowMajorCurriculumChanges={this.props.allowMajorCurriculumChanges}
           />
         )}
       </Motion>
@@ -69,7 +71,8 @@ export class LessonTokenContents extends Component {
     lesson: lessonShapeForUnitEdit.isRequired,
     handleDragStart: PropTypes.func.isRequired,
     removeLesson: PropTypes.func.isRequired,
-    cloneLesson: PropTypes.func.isRequired
+    cloneLesson: PropTypes.func.isRequired,
+    allowMajorCurriculumChanges: PropTypes.bool.isRequired
   };
 
   handleEditLesson = () => {
@@ -105,9 +108,11 @@ export class LessonTokenContents extends Component {
             : 500 - this.props.lesson.position
         })}
       >
-        <div style={styles.reorder} onMouseDown={this.handleDragStart}>
-          <i className="fa fa-arrows-v" />
-        </div>
+        {this.props.allowMajorCurriculumChanges && (
+          <div style={styles.reorder} onMouseDown={this.handleDragStart}>
+            <i className="fa fa-arrows-v" />
+          </div>
+        )}
         <span style={styles.lessonTokenName}>
           <span style={styles.lessonArea}>
             <span style={styles.lessonTitle}>{this.props.lesson.name}</span>
@@ -137,9 +142,11 @@ export class LessonTokenContents extends Component {
             <i className="fa fa-clone" />
           </div>
         )}
-        <div style={styles.remove} onMouseDown={this.handleRemove}>
-          <i className="fa fa-times" />
-        </div>
+        {this.props.allowMajorCurriculumChanges && (
+          <div style={styles.remove} onMouseDown={this.handleRemove}>
+            <i className="fa fa-times" />
+          </div>
+        )}
       </div>
     );
   }

--- a/apps/src/lib/levelbuilder/unit-editor/UnitCard.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitCard.jsx
@@ -14,6 +14,8 @@ import {lessonGroupShape} from './shapes';
 
 class UnitCard extends Component {
   static propTypes = {
+    allowMajorCurriculumChanges: PropTypes.bool.isRequired,
+
     // from redux
     lessonGroups: PropTypes.arrayOf(lessonGroupShape).isRequired,
     addGroup: PropTypes.func.isRequired,
@@ -81,7 +83,7 @@ class UnitCard extends Component {
   };
 
   render() {
-    const {lessonGroups} = this.props;
+    const {lessonGroups, allowMajorCurriculumChanges} = this.props;
 
     let lessonKeys = [];
     lessonGroups.forEach(lessonGroup => {
@@ -112,6 +114,7 @@ class UnitCard extends Component {
               setTargetLessonGroup={this.setTargetLessonGroup}
               targetLessonGroupPos={this.state.targetLessonGroupPos}
               generateLessonGroupKey={this.generateLessonGroupKey}
+              allowMajorCurriculumChanges={allowMajorCurriculumChanges}
             />
           ))}
           <div style={styles.addGroupWithWarning}>

--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -370,6 +370,11 @@ class UnitEditor extends React.Component {
   render() {
     const useMigratedTeacherResources =
       this.props.isMigrated && !this.state.teacherResources?.length;
+
+    const allowMajorCurriculumChanges =
+      this.props.initialPublishedState === PublishedState.in_development ||
+      this.props.initialPublishedState === PublishedState.pilot;
+
     return (
       <div>
         <label>
@@ -639,9 +644,7 @@ class UnitEditor extends React.Component {
             handleParticipantAudienceChange={e =>
               this.setState({participantAudience: e.target.value})
             }
-            canChangeParticipantType={
-              this.state.publishedState === PublishedState.in_development
-            }
+            allowMajorCurriculumChanges={allowMajorCurriculumChanges}
           />
         )}
 
@@ -879,6 +882,7 @@ class UnitEditor extends React.Component {
                       .includeStudentLessonPlans
                   })
                 }
+                disabled={!allowMajorCurriculumChanges}
               />
               <HelpTip>
                 <p>
@@ -1074,7 +1078,7 @@ class UnitEditor extends React.Component {
         )}
 
         <CollapsibleEditorSection title="Lesson Groups and Lessons">
-          <UnitCard />
+          <UnitCard allowMajorCurriculumChanges={allowMajorCurriculumChanges} />
         </CollapsibleEditorSection>
         <SaveBar
           handleSave={this.handleSave}

--- a/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/UnitEditor.jsx
@@ -873,6 +873,7 @@ class UnitEditor extends React.Component {
             <label>
               Include student-facing lesson plans
               <input
+                className="student-facing-lesson-plan-checkbox"
                 type="checkbox"
                 checked={this.state.includeStudentLessonPlans}
                 style={styles.checkbox}

--- a/apps/test/unit/lib/levelbuilder/course-editor/CourseTypeEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/course-editor/CourseTypeEditorTest.jsx
@@ -15,13 +15,13 @@ const defaultProps = {
   handleInstructionTypeChange: () => {},
   handleInstructorAudienceChange: () => {},
   handleParticipantAudienceChange: () => {},
-  canChangeParticipantType: true
+  allowMajorCurriculumChanges: true
 };
 
 describe('CourseTypeEditor', () => {
-  it('participant audience dropdown is disabled if canChangeParticipantType is false', () => {
+  it('participant audience dropdown is disabled if allowMajorCurriculumChanges is false', () => {
     const wrapper = shallow(
-      <CourseTypeEditor {...defaultProps} canChangeParticipantType={false} />
+      <CourseTypeEditor {...defaultProps} allowMajorCurriculumChanges={false} />
     );
     assert.equal(
       wrapper.find('.participantAudienceSelector').props().disabled,
@@ -29,9 +29,9 @@ describe('CourseTypeEditor', () => {
     );
   });
 
-  it('participant audience dropdown is not disabled if canChangeParticipantType is true', () => {
+  it('participant audience dropdown is not disabled if allowMajorCurriculumChanges is true', () => {
     const wrapper = shallow(
-      <CourseTypeEditor {...defaultProps} canChangeParticipantType={true} />
+      <CourseTypeEditor {...defaultProps} allowMajorCurriculumChanges={true} />
     );
     assert.equal(
       wrapper.find('.participantAudienceSelector').props().disabled,

--- a/apps/test/unit/lib/levelbuilder/course-editor/CourseTypeEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/course-editor/CourseTypeEditorTest.jsx
@@ -19,22 +19,56 @@ const defaultProps = {
 };
 
 describe('CourseTypeEditor', () => {
-  it('participant audience dropdown is disabled if allowMajorCurriculumChanges is false', () => {
+  it('disables all selects when allowMajorCurriculumChanges is false', () => {
     const wrapper = shallow(
       <CourseTypeEditor {...defaultProps} allowMajorCurriculumChanges={false} />
     );
     assert.equal(
-      wrapper.find('.participantAudienceSelector').props().disabled,
+      wrapper
+        .find('select')
+        .at(0)
+        .props().disabled,
+      true
+    );
+    assert.equal(
+      wrapper
+        .find('select')
+        .at(1)
+        .props().disabled,
+      true
+    );
+    assert.equal(
+      wrapper
+        .find('select')
+        .at(2)
+        .props().disabled,
       true
     );
   });
 
-  it('participant audience dropdown is not disabled if allowMajorCurriculumChanges is true', () => {
+  it('allow editing selects when allowMajorCurriculumChanges is true', () => {
     const wrapper = shallow(
       <CourseTypeEditor {...defaultProps} allowMajorCurriculumChanges={true} />
     );
     assert.equal(
-      wrapper.find('.participantAudienceSelector').props().disabled,
+      wrapper
+        .find('select')
+        .at(0)
+        .props().disabled,
+      false
+    );
+    assert.equal(
+      wrapper
+        .find('select')
+        .at(1)
+        .props().disabled,
+      false
+    );
+    assert.equal(
+      wrapper
+        .find('select')
+        .at(2)
+        .props().disabled,
       false
     );
   });

--- a/apps/test/unit/lib/levelbuilder/script-editor/LessonGroupCardTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/LessonGroupCardTest.jsx
@@ -65,6 +65,7 @@ describe('LessonGroupCard', () => {
       lessonGroupMetrics: {},
       targetLessonGroupPos: null,
       lessonKeys: [],
+      allowMajorCurriculumChanges: true,
       lessonGroup: {
         key: 'lg-key',
         displayName: 'Display Name',
@@ -115,6 +116,38 @@ describe('LessonGroupCard', () => {
         .at(1)
         .props().markdown
     ).to.equal('Big questions');
+  });
+
+  it('hides OrderControls when not allowed to make major curriculum changes', () => {
+    const wrapper = shallow(
+      <LessonGroupCard {...defaultProps} allowMajorCurriculumChanges={false} />
+    );
+
+    expect(wrapper.find('OrderControls')).to.have.lengthOf(0);
+  });
+
+  it('hides button when not allowed to make major curriculum changes and not the last LessonGroupCard', () => {
+    const wrapper = shallow(
+      <LessonGroupCard
+        {...defaultProps}
+        allowMajorCurriculumChanges={false}
+        lessonGroupsCount={2}
+      />
+    );
+
+    expect(wrapper.find('button')).to.have.lengthOf(0);
+  });
+
+  it('shows button when not allowed to make major curriculum changes and is the last LessonGroupCard', () => {
+    const wrapper = shallow(
+      <LessonGroupCard
+        {...defaultProps}
+        allowMajorCurriculumChanges={false}
+        lessonGroupsCount={1}
+      />
+    );
+
+    expect(wrapper.find('button')).to.have.lengthOf(1);
   });
 
   it('displays LessonGroupCard correctly when not user facing', () => {

--- a/apps/test/unit/lib/levelbuilder/script-editor/LessonTokenTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/LessonTokenTest.jsx
@@ -31,6 +31,7 @@ describe('LessonToken', () => {
         dragging: false,
         draggedLessonPos: false,
         delta: 0,
+        allowMajorCurriculumChanges: true,
         handleDragStart,
         cloneLesson,
         removeLesson,
@@ -54,11 +55,34 @@ describe('LessonToken', () => {
         scale: 0,
         shadow: 0,
         draggedLessonPos: false,
+        allowMajorCurriculumChanges: true,
         handleDragStart,
         cloneLesson,
         removeLesson,
         lesson: defaultLesson
       };
+    });
+
+    it('hides movement and deleting buttons when not allowed to make major curriculum changes', () => {
+      const wrapper = shallow(
+        <LessonTokenContents
+          {...defaultProps}
+          allowMajorCurriculumChanges={false}
+        />
+      );
+      expect(wrapper.find('.fa-arrows-v').length).to.equal(0);
+      expect(wrapper.find('.fa-times').length).to.equal(0);
+    });
+
+    it('show movement and deleting buttons when allowed to make major curriculum changes', () => {
+      const wrapper = shallow(
+        <LessonTokenContents
+          {...defaultProps}
+          allowMajorCurriculumChanges={true}
+        />
+      );
+      expect(wrapper.find('.fa-arrows-v').length).to.equal(1);
+      expect(wrapper.find('.fa-times').length).to.equal(1);
     });
 
     it('renders existing lesson with edit and clone buttons', () => {

--- a/apps/test/unit/lib/levelbuilder/script-editor/UnitCardTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/UnitCardTest.jsx
@@ -86,7 +86,8 @@ describe('UnitCard', () => {
       addGroup,
       convertGroupToUserFacing,
       convertGroupToNonUserFacing,
-      lessonGroups
+      lessonGroups,
+      allowMajorCurriculumChanges: true
     };
   });
 

--- a/apps/test/unit/lib/levelbuilder/script-editor/UnitEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/UnitEditorTest.jsx
@@ -86,7 +86,8 @@ describe('UnitEditor', () => {
       initialInstructorAudience: InstructorAudience.teacher,
       initialParticipantAudience: ParticipantAudience.student,
       hasCourse: false,
-      scriptPath: '/s/test-unit'
+      scriptPath: '/s/test-unit',
+      allowMajorCurriculumChanges: true
     };
   });
 
@@ -130,6 +131,17 @@ describe('UnitEditor', () => {
       expect(wrapper.find('CourseTypeEditor').length).to.equal(1);
 
       expect(wrapper.find('UnitCard').length).to.equal(1);
+    });
+
+    it('disables changing student facing lesson plan checkbox when not allowed to make major curriculum changes', () => {
+      const wrapper = createWrapper({
+        allowMajorCurriculumChanges: false,
+        isMigrated: true
+      });
+
+      expect(
+        wrapper.find('.student-facing-lesson-plan-checkbox').props().disabled
+      ).to.equal(true);
     });
 
     describe('Teacher Resources', () => {


### PR DESCRIPTION
We do not want content editors to be able to make breaking changes to courses once they have moved out of the `in_development` or `pilot` published states. This PR removes the ability to make those breaking changes to courses in the UI of the course and unit editor (lesson editor updates in a follow up PR).

## Course Version

- Can't change instruction type, instructor audience and participant audience

<img width="1026" alt="Screen Shot 2022-03-08 at 10 41 51 PM" src="https://user-images.githubusercontent.com/208083/157368471-95b34b98-5c40-49c1-bc06-35c69b7a0b1b.png">

## Course Editor

### Units

- Can't remove a unit that is already added
- Can't add a unit in the middle of other units
- Can only add new unit to the end

<img width="1055" alt="Screen Shot 2022-03-09 at 9 58 13 AM" src="https://user-images.githubusercontent.com/208083/157467499-1b3b898f-86c0-47b9-8999-09238dbd16be.png">

## Unit Editor

- Can't change student facing lesson plans setting

<img width="1023" alt="Screen Shot 2022-03-08 at 10 42 31 PM" src="https://user-images.githubusercontent.com/208083/157368521-bc152071-94c8-4316-abf1-ad55b9324c77.png">

### Lessons

- Can't move lessons
- Can't remove lessons
- Can only add lessons at the end of the unit

<img width="1040" alt="Screen Shot 2022-03-08 at 10 41 29 PM" src="https://user-images.githubusercontent.com/208083/157368433-50115116-7a21-47b4-bf1c-606ede7586f1.png">


## Links

[Jira](https://codedotorg.atlassian.net/browse/PLAT-1652)

## Testing story

- Updated existing unit tests
- Added new unit tests