### PR TITLE
Add lesson total time to top of lesson plan

### DIFF
--- a/apps/src/templates/lessonOverview/LessonAgenda.jsx
+++ b/apps/src/templates/lessonOverview/LessonAgenda.jsx
@@ -38,7 +38,7 @@ export default class LessonAgenda extends Component {
                 {section.duration > 0 && (
                   <a href={`#section-${section.key}`}>{`${
                     section.displayName
-                  } (${section.duration} ${i18n.minutes()})`}</a>
+                  }`}</a>
                 )}
                 {section.duration === 0 && (
                   <a href={`#section-${section.key}`}>{`${

--- a/apps/src/templates/lessonOverview/LessonOverview.jsx
+++ b/apps/src/templates/lessonOverview/LessonOverview.jsx
@@ -161,6 +161,7 @@ class LessonOverview extends Component {
             lessonName: lesson.displayName
           })}
         </h1>
+        <h2>{i18n.minutesLabel({number: lesson.duration})}</h2>
 
         <div style={styles.frontPage}>
           <div style={styles.left}>

--- a/apps/src/templates/lessonOverview/lessonPlanShapes.jsx
+++ b/apps/src/templates/lessonOverview/lessonPlanShapes.jsx
@@ -89,6 +89,7 @@ export const lessonShape = PropTypes.shape({
   id: PropTypes.number.isRequired,
   position: PropTypes.number.isRequired,
   key: PropTypes.string.isRequired,
+  duration: PropTypes.number.isRequired,
   displayName: PropTypes.string.isRequired,
   overview: PropTypes.string.isRequired,
   purpose: PropTypes.string.isRequired,

--- a/apps/test/unit/templates/lessonOverview/LessonAgendaTest.jsx
+++ b/apps/test/unit/templates/lessonOverview/LessonAgendaTest.jsx
@@ -66,7 +66,7 @@ describe('LessonAgenda', () => {
     const wrapper = shallow(<LessonAgenda {...defaultProps} />);
 
     expect(wrapper.text()).to.include('Main Activity (20 minutes)');
-    expect(wrapper.text()).to.include('Making programs (20 minutes)');
+    expect(wrapper.text()).to.include('Making programs');
     expect(wrapper.text()).to.include('Non Programming Progression');
     expect(wrapper.text()).to.include('2nd Activity (30 minutes)');
   });

--- a/apps/test/unit/templates/lessonOverview/LessonOverviewTest.js
+++ b/apps/test/unit/templates/lessonOverview/LessonOverviewTest.js
@@ -49,6 +49,7 @@ describe('LessonOverview', () => {
         },
         id: 1,
         key: 'lesson-1',
+        duration: 45,
         position: 1,
         lockable: false,
         displayName: 'Lesson 1',
@@ -112,6 +113,7 @@ describe('LessonOverview', () => {
     expect(wrapper.find('LessonNavigationDropdown').length).to.equal(1);
 
     expect(wrapper.contains('Lesson 1: Lesson 1'), 'Lesson Name').to.be.true;
+    expect(wrapper.contains('45 minutes'), 'Lesson Duration').to.be.true;
 
     const enhancedSafeMarkdowns = wrapper.find('EnhancedSafeMarkdown');
     expect(enhancedSafeMarkdowns.at(0).props().markdown).to.contain(

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -354,12 +354,16 @@ class Lesson < ApplicationRecord
     ScriptConfig.hoc_scripts.include?(script.name) ? lesson_path(id: id) : script_lesson_path(script, self)
   end
 
+  def total_lesson_duration
+    lesson_activities.map(&:summarize).sum {|activity| activity[:duration] || 0}
+  end
+
   def summarize_for_calendar
     {
       id: id,
       lessonNumber: relative_position,
       title: localized_title,
-      duration: lesson_activities.map(&:summarize).sum {|activity| activity[:duration] || 0},
+      duration: total_lesson_duration,
       assessment: !!assessment,
       unplugged: unplugged,
       url: script_lesson_path(script, self)
@@ -433,7 +437,7 @@ class Lesson < ApplicationRecord
       position: relative_position,
       lockable: lockable,
       key: key,
-      duration: lesson_activities.map(&:summarize).sum {|activity| activity[:duration] || 0},
+      duration: total_lesson_duration,
       displayName: localized_name_for_lesson_show,
       overview: render_property(:overview),
       announcements: announcements,

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -433,6 +433,7 @@ class Lesson < ApplicationRecord
       position: relative_position,
       lockable: lockable,
       key: key,
+      duration: lesson_activities.map(&:summarize).sum {|activity| activity[:duration] || 0},
       displayName: localized_name_for_lesson_show,
       overview: render_property(:overview),
       announcements: announcements,


### PR DESCRIPTION
Add total duration to top of lesson

<img width="1041" alt="Screen Shot 2022-03-09 at 2 04 32 PM" src="https://user-images.githubusercontent.com/208083/157513331-c46c171f-aec6-4ac9-b2d5-7ab273a97eb1.png">


Also remove time for activity sections from Agenda on lesson plan.

<img width="483" alt="Screen Shot 2022-03-10 at 12 08 24 PM" src="https://user-images.githubusercontent.com/208083/157717152-70754dc7-4af7-4ac2-9a39-9701e4c56c5d.png">



Question: In order for this change to be on the lesson plan pdfs do we need to regenerate all of them? Should we have some way to regenerate all lesson plan pdfs when a UI change is made to the lesson plan?

Doc: https://docs.google.com/document/d/15PIOiSzs3dd1nuu1Y0HUcoT7NksG8AQ_SnZ3-JycXIw/edit
