### PR TITLE
Return correct user level for users for levels

### DIFF
--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1087,7 +1087,8 @@ class User < ApplicationRecord
   # most relevant user levels are at the end. The list is then indexed by level ID, which will
   # pick up the last matching user level in the list.
   def self.index_user_levels_by_level_id(user_levels)
-    # The correct user level is the one most recently updated or the first created
+    # Sorts by updated_at asc then id desc
+    # the correct user level is the one most recently updated or the first created
     relevant_user_levels_last = user_levels.sort {|a, b| [a.updated_at, b.id] <=> [b.updated_at, a.id]}
     relevant_user_levels_last.index_by(&:level_id)
   end

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1081,10 +1081,21 @@ class User < ApplicationRecord
     )
   end
 
+  # There is a bug (fix: https://codedotorg.atlassian.net/browse/INF-571) where some users have
+  # duplicate user levels for the same level. To ensure that we return the relevant user level for
+  # each level and not one of the duplicates, the list is first sorted so that the
+  # most relevant user levels are at the end. The list is then indexed by level ID, which will
+  # pick up the last matching user level in the list.
+  def self.index_user_levels_by_level_id(user_levels)
+    # The correct user level is the one most recently updated or the first created
+    relevant_user_levels_last = user_levels.sort {|a, b| [a.updated_at, b.id] <=> [b.updated_at, a.id]}
+    relevant_user_levels_last.index_by(&:level_id)
+  end
+
   def user_levels_by_level(script)
-    user_levels.
-      where(script_id: script.id).
-      index_by(&:level_id)
+    user_levels_for_script = user_levels.
+      where(script_id: script.id)
+    User.index_user_levels_by_level_id(user_levels_for_script)
   end
 
   # Retrieves all user_level objects for the given users, script, and levels.
@@ -1131,7 +1142,7 @@ class User < ApplicationRecord
     ).
       group_by(&:user_id).
       inject(initial_hash) do |memo, (user_id, user_levels)|
-        memo[user_id] = user_levels.index_by(&:level_id)
+        memo[user_id] = User.index_user_levels_by_level_id(user_levels)
         memo
       end
   end

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -4187,6 +4187,32 @@ class UserTest < ActiveSupport::TestCase
     )
   end
 
+  test 'index_user_levels_by_level_id returns most recently updated user levels' do
+    user = create :user
+    level = create :level
+    script = create :script
+    user_level_1 = create :user_level, user: user, level: level, script: script, updated_at: 2.days.ago
+    user_level_2 = create :user_level, user: user, level: level, script: script, updated_at: 2.days.ago
+    user_level_3 = create :user_level, user: user, level: level, script: script, updated_at: 1.day.ago
+
+    result = User.index_user_levels_by_level_id([user_level_1, user_level_2, user_level_3])
+
+    assert_equal({level.id => user_level_3}, result)
+  end
+
+  test 'index_user_levels_by_level_id returns first created user level if updated_at is identical' do
+    user = create :user
+    level = create :level
+    script = create :script
+    user_level_1 = create :user_level, user: user, level: level, script: script, updated_at: 1.day.ago
+    user_level_2 = create :user_level, user: user, level: level, script: script, updated_at: 1.day.ago
+    user_level_3 = create :user_level, user: user, level: level, script: script, updated_at: 1.day.ago
+
+    result = User.index_user_levels_by_level_id([user_level_1, user_level_2, user_level_3])
+
+    assert_equal({level.id => user_level_1}, result)
+  end
+
   test 'find_by_email_or_hashed_email returns nil when no user is found' do
     assert_nil User.find_by_email_or_hashed_email 'nonexistent@example.org'
   end


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
There is a bug where duplicated user levels are created for a user on a level, this issue has been discovered by a teacher when they realized that the state of a progress bubble on their teacher dashboard for the student was not the same as the state of the progress bubble on the level page for that student. Here we've added some sorting logic to ensure the correct user level is returned for the teacher dashboard while we wait for the full fix from infra.

## Testing story
Tested that with duplicated user levels the correct one returns for the progress table. Also added unit tests
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Follow-up work
Full fix: https://codedotorg.atlassian.net/browse/INF-571
<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
