### PR TITLE
Use under_13 to determine Dance Party Age - Clean-up

### DIFF
--- a/apps/src/code-studio/initSigninState.js
+++ b/apps/src/code-studio/initSigninState.js
@@ -35,12 +35,13 @@ export function getUserSignedInFromCookieAndDom() {
  * Determines signin state and dispatches to the store. Shows a dialog asking
  * the user for their age or to sign in if necessary.
  */
-export default function initSigninState(userType) {
+export default function initSigninState(userType, under13) {
   $(document).ready(() => {
     const store = getStore();
     store.dispatch(setUserSignedIn(getUserSignedInFromCookieAndDom()));
+
     if (userType) {
-      store.dispatch(setUserType(userType));
+      store.dispatch(setUserType(userType, under13));
     }
 
     const div = document.createElement('div');

--- a/apps/src/code-studio/initSigninState.js
+++ b/apps/src/code-studio/initSigninState.js
@@ -5,10 +5,7 @@ import {Provider} from 'react-redux';
 import cookies from 'js-cookie';
 import SignInOrAgeDialog from '@cdo/apps/templates/SignInOrAgeDialog';
 import {getStore} from './redux';
-import {
-  setUserSignedIn,
-  setUserType
-} from '@cdo/apps/templates/currentUserRedux';
+import {setUserSignedIn} from '@cdo/apps/templates/currentUserRedux';
 import {environmentSpecificCookieName} from '@cdo/apps/code-studio/utils';
 
 /**
@@ -35,13 +32,10 @@ export function getUserSignedInFromCookieAndDom() {
  * Determines signin state and dispatches to the store. Shows a dialog asking
  * the user for their age or to sign in if necessary.
  */
-export default function initSigninState(userType) {
+export default function initSigninState() {
   $(document).ready(() => {
     const store = getStore();
     store.dispatch(setUserSignedIn(getUserSignedInFromCookieAndDom()));
-    if (userType) {
-      store.dispatch(setUserType(userType));
-    }
 
     const div = document.createElement('div');
     ReactDOM.render(

--- a/apps/src/code-studio/initSigninState.js
+++ b/apps/src/code-studio/initSigninState.js
@@ -5,7 +5,10 @@ import {Provider} from 'react-redux';
 import cookies from 'js-cookie';
 import SignInOrAgeDialog from '@cdo/apps/templates/SignInOrAgeDialog';
 import {getStore} from './redux';
-import {setUserSignedIn} from '@cdo/apps/templates/currentUserRedux';
+import {
+  setUserSignedIn,
+  setUserType
+} from '@cdo/apps/templates/currentUserRedux';
 import {environmentSpecificCookieName} from '@cdo/apps/code-studio/utils';
 
 /**
@@ -32,10 +35,13 @@ export function getUserSignedInFromCookieAndDom() {
  * Determines signin state and dispatches to the store. Shows a dialog asking
  * the user for their age or to sign in if necessary.
  */
-export default function initSigninState() {
+export default function initSigninState(userType) {
   $(document).ready(() => {
     const store = getStore();
     store.dispatch(setUserSignedIn(getUserSignedInFromCookieAndDom()));
+    if (userType) {
+      store.dispatch(setUserType(userType));
+    }
 
     const div = document.createElement('div');
     ReactDOM.render(

--- a/apps/src/dance/DanceVisualizationColumn.jsx
+++ b/apps/src/dance/DanceVisualizationColumn.jsx
@@ -62,7 +62,8 @@ class DanceVisualizationColumn extends React.Component {
     levelRunIsStarting: PropTypes.bool,
     isShareView: PropTypes.bool.isRequired,
     songData: PropTypes.objectOf(PropTypes.object).isRequired,
-    userType: PropTypes.string.isRequired
+    userType: PropTypes.string.isRequired,
+    under13: PropTypes.bool.isRequired
   };
 
   state = {
@@ -83,7 +84,8 @@ class DanceVisualizationColumn extends React.Component {
     // userType - 'teacher', assumed age > 13. 'student', age > 13.
     //            'student_y', age < 13. 'unknown', signed out users
     const signedInOver13 =
-      this.props.userType === 'teacher' || this.props.userType === 'student';
+      this.props.userType === 'teacher' ||
+      (this.props.userType === 'student' && !this.props.under13);
     const signedOutAge = signedOutOver13();
     return signedInOver13 || signedOutAge;
   }
@@ -173,6 +175,7 @@ export default connect(state => ({
   songData: state.songs.songData,
   selectedSong: state.songs.selectedSong,
   userType: state.currentUser.userType,
+  under13: state.currentUser.under13,
   levelIsRunning: state.runState.isRunning,
   levelRunIsStarting: state.songs.runIsStarting
 }))(DanceVisualizationColumn);

--- a/apps/src/dance/DanceVisualizationColumn.jsx
+++ b/apps/src/dance/DanceVisualizationColumn.jsx
@@ -78,11 +78,11 @@ class DanceVisualizationColumn extends React.Component {
   };
 
   /*
-    The filter defaults to on. If the user is over 13 (identified via account or anon dialog), filter turns off
+    The filter defaults to on. If the user is over 13 (identified via account or anon dialog), filter turns off.
    */
   setFilterStatus() {
-    // userType - 'teacher', assumed age > 13. 'student', age > 13.
-    //            'student_y', age < 13. 'unknown', signed out users
+    // userType - 'teacher', 'student', 'unknown' - signed out users.
+    // under13 - boolean for signed in user representing age category. Teacher assumed > 13.
     const signedInOver13 =
       this.props.userType === 'teacher' ||
       (this.props.userType === 'student' && !this.props.under13);

--- a/apps/src/sites/studio/pages/code-studio.js
+++ b/apps/src/sites/studio/pages/code-studio.js
@@ -126,9 +126,12 @@ window.CDOSounds = Sounds.getSingleton();
 const userType = document.querySelector(`script[data-usertype]`)
   ? getScriptData('usertype')
   : null;
+const under13 = document.querySelector(`script[data-under13]`)
+  ? getScriptData('under13')
+  : null;
 checkForUnsupportedBrowsersOnLoad();
 initHamburger();
-initSigninState(userType);
+initSigninState(userType, under13);
 initResponsive();
 
 try {

--- a/apps/src/sites/studio/pages/code-studio.js
+++ b/apps/src/sites/studio/pages/code-studio.js
@@ -123,9 +123,12 @@ activateReferenceAreaOnLoad();
 // to put it on window :(
 window.CDOSounds = Sounds.getSingleton();
 
+const userType = document.querySelector(`script[data-usertype]`)
+  ? getScriptData('usertype')
+  : null;
 checkForUnsupportedBrowsersOnLoad();
 initHamburger();
-initSigninState();
+initSigninState(userType);
 initResponsive();
 
 try {

--- a/apps/src/sites/studio/pages/code-studio.js
+++ b/apps/src/sites/studio/pages/code-studio.js
@@ -123,12 +123,9 @@ activateReferenceAreaOnLoad();
 // to put it on window :(
 window.CDOSounds = Sounds.getSingleton();
 
-const userType = document.querySelector(`script[data-usertype]`)
-  ? getScriptData('usertype')
-  : null;
 checkForUnsupportedBrowsersOnLoad();
 initHamburger();
-initSigninState(userType);
+initSigninState();
 initResponsive();
 
 try {

--- a/apps/src/templates/currentUserRedux.js
+++ b/apps/src/templates/currentUserRedux.js
@@ -2,7 +2,6 @@ import {makeEnum} from '../utils';
 
 const SET_CURRENT_USER_NAME = 'currentUser/SET_CURRENT_USER_NAME';
 const SET_USER_SIGNED_IN = 'currentUser/SET_USER_SIGNED_IN';
-const SET_USER_TYPE = 'currentUser/SET_USER_TYPE';
 const SET_HAS_SEEN_STANDARDS_REPORT =
   'currentUser/SET_HAS_SEEN_STANDARDS_REPORT';
 const SET_INITIAL_DATA = 'currentUser/SET_INITIAL_DATA';
@@ -22,7 +21,6 @@ export const setUserSignedIn = isSignedIn => ({
   type: SET_USER_SIGNED_IN,
   isSignedIn
 });
-export const setUserType = userType => ({type: SET_USER_TYPE, userType});
 export const setInitialData = serverUser => ({
   type: SET_INITIAL_DATA,
   serverUser
@@ -56,12 +54,6 @@ export default function currentUser(state = initialState, action) {
       signInState: action.isSignedIn
         ? SignInState.SignedIn
         : SignInState.SignedOut
-    };
-  }
-  if (action.type === SET_USER_TYPE) {
-    return {
-      ...state,
-      userType: action.userType
     };
   }
 

--- a/apps/src/templates/currentUserRedux.js
+++ b/apps/src/templates/currentUserRedux.js
@@ -22,7 +22,11 @@ export const setUserSignedIn = isSignedIn => ({
   type: SET_USER_SIGNED_IN,
   isSignedIn
 });
-export const setUserType = userType => ({type: SET_USER_TYPE, userType});
+export const setUserType = (userType, under13) => ({
+  type: SET_USER_TYPE,
+  userType,
+  under13
+});
 export const setInitialData = serverUser => ({
   type: SET_INITIAL_DATA,
   serverUser
@@ -61,7 +65,8 @@ export default function currentUser(state = initialState, action) {
   if (action.type === SET_USER_TYPE) {
     return {
       ...state,
-      userType: action.userType
+      userType: action.userType,
+      under13: action.under13
     };
   }
 

--- a/apps/src/templates/currentUserRedux.js
+++ b/apps/src/templates/currentUserRedux.js
@@ -38,7 +38,7 @@ const initialState = {
   userType: 'unknown',
   signInState: SignInState.Unknown,
   hasSeenStandardsReportInfo: false,
-  // Setting default under13 value to true to err on the side of caution for age-restricted content
+  // Setting default under13 value to true to err on the side of caution for age-restricted content.
   under13: true
 };
 

--- a/apps/src/templates/currentUserRedux.js
+++ b/apps/src/templates/currentUserRedux.js
@@ -33,7 +33,8 @@ const initialState = {
   userName: null,
   userType: 'unknown',
   signInState: SignInState.Unknown,
-  hasSeenStandardsReportInfo: false
+  hasSeenStandardsReportInfo: false,
+  under13: true
 };
 
 export default function currentUser(state = initialState, action) {
@@ -65,12 +66,13 @@ export default function currentUser(state = initialState, action) {
   }
 
   if (action.type === SET_INITIAL_DATA) {
-    const {id, username, user_type} = action.serverUser;
+    const {id, username, user_type, under_13} = action.serverUser;
     return {
       ...state,
       userId: id,
       userName: username,
-      userType: user_type
+      userType: user_type,
+      under13: under_13
     };
   }
 

--- a/apps/src/templates/currentUserRedux.js
+++ b/apps/src/templates/currentUserRedux.js
@@ -38,6 +38,7 @@ const initialState = {
   userType: 'unknown',
   signInState: SignInState.Unknown,
   hasSeenStandardsReportInfo: false,
+  // Setting default under13 value to true to err on the side of caution for age-restricted content
   under13: true
 };
 

--- a/apps/src/templates/currentUserRedux.js
+++ b/apps/src/templates/currentUserRedux.js
@@ -2,6 +2,7 @@ import {makeEnum} from '../utils';
 
 const SET_CURRENT_USER_NAME = 'currentUser/SET_CURRENT_USER_NAME';
 const SET_USER_SIGNED_IN = 'currentUser/SET_USER_SIGNED_IN';
+const SET_USER_TYPE = 'currentUser/SET_USER_TYPE';
 const SET_HAS_SEEN_STANDARDS_REPORT =
   'currentUser/SET_HAS_SEEN_STANDARDS_REPORT';
 const SET_INITIAL_DATA = 'currentUser/SET_INITIAL_DATA';
@@ -21,6 +22,7 @@ export const setUserSignedIn = isSignedIn => ({
   type: SET_USER_SIGNED_IN,
   isSignedIn
 });
+export const setUserType = userType => ({type: SET_USER_TYPE, userType});
 export const setInitialData = serverUser => ({
   type: SET_INITIAL_DATA,
   serverUser
@@ -54,6 +56,12 @@ export default function currentUser(state = initialState, action) {
       signInState: action.isSignedIn
         ? SignInState.SignedIn
         : SignInState.SignedOut
+    };
+  }
+  if (action.type === SET_USER_TYPE) {
+    return {
+      ...state,
+      userType: action.userType
     };
   }
 

--- a/apps/test/unit/code-studio/currentUserReduxTest.js
+++ b/apps/test/unit/code-studio/currentUserReduxTest.js
@@ -2,7 +2,6 @@ import {assert} from '../../util/reconfiguredChai';
 import currentUser, {
   SignInState,
   setUserSignedIn,
-  setUserType,
   setCurrentUserHasSeenStandardsReportInfo,
   setCurrentUserName,
   setInitialData
@@ -30,15 +29,6 @@ describe('currentUserRedux', () => {
     });
     it('initially sets signInState to Unknown', () => {
       assert.equal(initialState.signInState, SignInState.Unknown);
-    });
-  });
-
-  describe('setUserType', () => {
-    it('can set the current user type', () => {
-      const action = setUserType('teacher');
-      const nextState = currentUser(initialState, action);
-
-      assert.deepEqual(nextState.userType, 'teacher');
     });
   });
 

--- a/apps/test/unit/code-studio/currentUserReduxTest.js
+++ b/apps/test/unit/code-studio/currentUserReduxTest.js
@@ -2,6 +2,7 @@ import {assert} from '../../util/reconfiguredChai';
 import currentUser, {
   SignInState,
   setUserSignedIn,
+  setUserType,
   setCurrentUserHasSeenStandardsReportInfo,
   setCurrentUserName,
   setInitialData
@@ -29,6 +30,15 @@ describe('currentUserRedux', () => {
     });
     it('initially sets signInState to Unknown', () => {
       assert.equal(initialState.signInState, SignInState.Unknown);
+    });
+  });
+
+  describe('setUserType', () => {
+    it('can set the current user type', () => {
+      const action = setUserType('teacher');
+      const nextState = currentUser(initialState, action);
+
+      assert.deepEqual(nextState.userType, 'teacher');
     });
   });
 

--- a/dashboard/app/controllers/api/v1/users_controller.rb
+++ b/dashboard/app/controllers/api/v1/users_controller.rb
@@ -23,7 +23,8 @@ class Api::V1::UsersController < Api::V1::JsonApiController
         user_type: current_user.user_type,
         is_signed_in: true,
         short_name: current_user.short_name,
-        is_verified_instructor: current_user.verified_instructor?
+        is_verified_instructor: current_user.verified_instructor?,
+        under_13: current_user.under_13?
       }
     else
       render json: {

--- a/dashboard/app/views/layouts/application.html.haml
+++ b/dashboard/app/views/layouts/application.html.haml
@@ -62,8 +62,16 @@
     - if current_user && current_user.age.nil?
       = render partial: 'layouts/age_interstitial'
 
-    - user_type = current_user ? current_user.user_type : nil
-    - under_13 = current_user ? current_user.under_13? : nil
+
+    - cookie_key = environment_specific_cookie_name('_user_type')
+    - user_type = request.cookies[cookie_key]
+    -# The _user_type cookie is set in devise.rb to differentiate under13 students as 'student_y'
+    -# Splitting that single value here into two variables to align with user_type standards of "teacher/student"
+    - if user_type ==  == 'student_y'
+      - user_type = "student"
+      - under_13 = true
+    - else
+      - under_13 = false
 
     - gdpr_data = {}
     - if current_user

--- a/dashboard/app/views/layouts/application.html.haml
+++ b/dashboard/app/views/layouts/application.html.haml
@@ -62,8 +62,6 @@
     - if current_user && current_user.age.nil?
       = render partial: 'layouts/age_interstitial'
 
-    - user_type = current_user ? current_user.user_type : 'nil'
-
     - gdpr_data = {}
     - if current_user
       - gdpr_data[:show_gdpr_dialog] = GdprDialogHelper.show?(current_user, request)
@@ -71,7 +69,7 @@
 
     #gdpr-dialog
 
-    %script{src: webpack_asset_path('js/code-studio.js'), data: {gdpr: gdpr_data.to_json, usertype: user_type.to_json}}
+    %script{src: webpack_asset_path('js/code-studio.js'), data: {gdpr: gdpr_data.to_json}}
 
     .wrapper{style: ('background-color: #ffffff' if view_options[:white_background])}
       - unless view_options[:no_header]

--- a/dashboard/app/views/layouts/application.html.haml
+++ b/dashboard/app/views/layouts/application.html.haml
@@ -67,8 +67,8 @@
     - user_type = request.cookies[cookie_key]
     -# The _user_type cookie is set in devise.rb to differentiate under13 students as 'student_y'
     -# Splitting that single value here into two variables to align with user_type standards of "teacher/student"
-    - if user_type ==  == 'student_y'
-      - user_type = "student"
+    - if user_type == 'student_y'
+      - user_type = 'student'
       - under_13 = true
     - else
       - under_13 = false

--- a/dashboard/app/views/layouts/application.html.haml
+++ b/dashboard/app/views/layouts/application.html.haml
@@ -63,6 +63,7 @@
       = render partial: 'layouts/age_interstitial'
 
     - user_type = current_user ? current_user.user_type : 'nil'
+    - under_13 = current_user ? current_user.under_13? : 'nil'
 
     - gdpr_data = {}
     - if current_user

--- a/dashboard/app/views/layouts/application.html.haml
+++ b/dashboard/app/views/layouts/application.html.haml
@@ -62,8 +62,8 @@
     - if current_user && current_user.age.nil?
       = render partial: 'layouts/age_interstitial'
 
-    - user_type = current_user ? current_user.user_type : 'nil'
-    - under_13 = current_user ? current_user.under_13? : 'nil'
+    - user_type = current_user ? current_user.user_type : nil
+    - under_13 = current_user ? current_user.under_13? : nil
 
     - gdpr_data = {}
     - if current_user
@@ -72,7 +72,7 @@
 
     #gdpr-dialog
 
-    %script{src: webpack_asset_path('js/code-studio.js'), data: {gdpr: gdpr_data.to_json, usertype: user_type.to_json}}
+    %script{src: webpack_asset_path('js/code-studio.js'), data: {gdpr: gdpr_data.to_json, usertype: user_type.to_json, under13: under_13.to_json}}
 
     .wrapper{style: ('background-color: #ffffff' if view_options[:white_background])}
       - unless view_options[:no_header]

--- a/dashboard/app/views/layouts/application.html.haml
+++ b/dashboard/app/views/layouts/application.html.haml
@@ -62,6 +62,8 @@
     - if current_user && current_user.age.nil?
       = render partial: 'layouts/age_interstitial'
 
+    - user_type = current_user ? current_user.user_type : 'nil'
+
     - gdpr_data = {}
     - if current_user
       - gdpr_data[:show_gdpr_dialog] = GdprDialogHelper.show?(current_user, request)
@@ -69,7 +71,7 @@
 
     #gdpr-dialog
 
-    %script{src: webpack_asset_path('js/code-studio.js'), data: {gdpr: gdpr_data.to_json}}
+    %script{src: webpack_asset_path('js/code-studio.js'), data: {gdpr: gdpr_data.to_json, usertype: user_type.to_json}}
 
     .wrapper{style: ('background-color: #ffffff' if view_options[:white_background])}
       - unless view_options[:no_header]

--- a/dashboard/app/views/layouts/application.html.haml
+++ b/dashboard/app/views/layouts/application.html.haml
@@ -65,8 +65,8 @@
 
     - cookie_key = environment_specific_cookie_name('_user_type')
     - user_type = request.cookies[cookie_key]
-    -# The _user_type cookie is set in devise.rb to differentiate under13 students as 'student_y'
-    -# Splitting that single value here into two variables to align with user_type standards of "teacher/student"
+    -# The _user_type cookie is set in devise.rb to differentiate under13 students as 'student_y'.
+    -# Splitting that single value here into two variables to align with user_type standards of "teacher/student".
     - if user_type == 'student_y'
       - user_type = 'student'
       - under_13 = true

--- a/dashboard/app/views/layouts/application.html.haml
+++ b/dashboard/app/views/layouts/application.html.haml
@@ -62,8 +62,7 @@
     - if current_user && current_user.age.nil?
       = render partial: 'layouts/age_interstitial'
 
-    - cookie_key = environment_specific_cookie_name('_user_type')
-    - user_type = request.cookies[cookie_key]
+    - user_type = current_user ? current_user.user_type : 'nil'
 
     - gdpr_data = {}
     - if current_user


### PR DESCRIPTION
https://codedotorg.atlassian.net/browse/STAR-2159
Summary - Teachers were reporting that <13, logged-in students were able to access pg-13 songs.

Couldn't reproduce locally, but it seems like we were having an issue differentiating 'student' and 'student_y' and were defaulting to turning the filterOff. I added a check for whether the currentUser is a student and has under_13 set to false to determine whether to turn the filterOff.

If you were able to reproduce the problem locally, please pull and test locally!

What's weird is that our tests, where we check if a under13 student can't access the filtered songs was still working (age_filter.feature), so this definitely seems like something has changed in how we register students as over/under 13. Worth looking into to further understand and eliminate potential future regressions, but my hope is that this alleviates the current need.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
