### PR TITLE
Don't ping the dotd when ci_build fails on a development server

### DIFF
--- a/aws/ci_build
+++ b/aws/ci_build
@@ -176,7 +176,7 @@ def main
     else
       message = "<b>#{projects}</b> failed to build!" + time_message + log_link
       ChatClient.log message, color: 'red'
-      ChatClient.log "<@#{DevelopersTopic.dotd}> build failure", color: 'red' unless rack_env?(:adhoc)
+      ChatClient.log "<@#{DevelopersTopic.dotd}> build failure", color: 'red' unless rack_env?(:adhoc, :development)
 
       ChatClient.message 'server operations', message, color: 'red', notify: 1
       ChatClient.message 'server operations', commit_url, color: 'gray', message_format: 'text'


### PR DESCRIPTION
Our ci_build script pings the dotd in Slack when a build fails on all servers except adhoc environments. Let's also exclude development environments so the dotd stops getting pinged when the i18n-dev server fails to build (this is the responsibility of the Foundations team point person, not the dotd).