### PR TITLE
Wait for sign out in code review UI tests

### DIFF
--- a/dashboard/test/ui/features/javalab/code_review_eyes.feature
+++ b/dashboard/test/ui/features/javalab/code_review_eyes.feature
@@ -1,7 +1,6 @@
 @eyes
 @no_mobile
 @no_ie
-@skip
 Feature: Code Review Eyes
 
   @no_circle
@@ -15,6 +14,9 @@ Feature: Code Review Eyes
     And I save the section id from row 0 of the section table
     Given I create a student named "Hermione"
     And I join the section
+    # Observed flakiness trying to navigate to teacher dashboard while still signed in as Hermione.
+    # Explicitly wait for sign out to occur to avoid this.
+    And I sign out using jquery
     # Create a code review group with a student in it.
     # Save the group, and enable code review for the section.
     Given I sign in as "Dumbledore" and go home

--- a/dashboard/test/ui/features/javalab/code_review_peer_scenarios.feature
+++ b/dashboard/test/ui/features/javalab/code_review_peer_scenarios.feature
@@ -4,7 +4,6 @@
 
 @no_mobile
 @no_ie
-@skip
 Feature: Code review (peer scenarios)
 
   # At the end of the setup, we will have created
@@ -22,6 +21,9 @@ Feature: Code review (peer scenarios)
     And I join the section
     Given I create a student named "Harry"
     And I join the section
+    # Observed flakiness trying to navigate to teacher dashboard while still signed in as Harry.
+    # Explicitly wait for sign out to occur to avoid this.
+    And I sign out using jquery
     # Create a code review group with students in it.
     # Save the group, and enable code review for the section.
     Given I sign in as "Dumbledore" and go home

--- a/dashboard/test/ui/features/javalab/code_review_project_owner_and_teacher_scenarios.feature
+++ b/dashboard/test/ui/features/javalab/code_review_project_owner_and_teacher_scenarios.feature
@@ -4,7 +4,6 @@
 
 @no_mobile
 @no_ie
-@skip
 Feature: Code review (project owner/teacher scenarios)
 
   # At the end of the setup, we will have created
@@ -20,6 +19,9 @@ Feature: Code review (project owner/teacher scenarios)
     And I save the section id from row 0 of the section table
     Given I create a student named "Hermione"
     And I join the section
+    # Observed flakiness trying to navigate to teacher dashboard while still signed in as Hermione.
+    # Explicitly wait for sign out to occur to avoid this.
+    And I sign out using jquery
     # Create a code review group with students in it.
     # Save the group, and enable code review for the section.
     Given I sign in as "Dumbledore" and go home


### PR DESCRIPTION
Observed flakiness in updated code review UI tests last night, and [turned them off temporarily to unblock things today](https://github.com/code-dot-org/code-dot-org/pull/45216).

Looking at Saucelabs videos (links in PR linked above), it appears that the student joining a section is not properly signed out when we navigate home as the teacher. Put an explicit step to wait for the student to be signed out.

## Testing story

This is a speculative fix, I have not tested it. I did not observe this issue locally originally, so I think we'll just see if it recurs once this is merged. The step I added looks good in that it [very explicitly waits for the sign out to complete](https://github.com/code-dot-org/code-dot-org/blob/55cc493f6c2884336b47e734892e354a69264880/dashboard/test/ui/features/step_definitions/account_steps.rb#L3), so I'm hopeful it will work.