### PR TITLE
Remove incomplete warning for surveys

### DIFF
--- a/apps/src/sites/studio/pages/levels/_level_group.js
+++ b/apps/src/sites/studio/pages/levels/_level_group.js
@@ -150,17 +150,18 @@ function initLevelGroup(levelCount, currentPage, lastAttempt) {
       appOptions.level.anonymous === true ||
       appOptions.level.anonymous === 'true';
     title = isSurvey ? i18n.submitSurvey() : i18n.submitAssessment();
-    if (validCount === requiredCount) {
+
+    if (!isSurvey && validCount !== requiredCount) {
+      // For assessments, warn if some questions were not completed
+      id = 'levelgroup-submit-incomplete-dialogcontent';
+      body = i18n.submittableIncomplete();
+    } else {
       id = 'levelgroup-submit-complete-dialogcontent';
       body = isSurvey
         ? i18n.submittableSurveyComplete()
         : i18n.submittableComplete();
-    } else {
-      id = 'levelgroup-submit-incomplete-dialogcontent';
-      body = isSurvey
-        ? i18n.submittableSurveyIncomplete()
-        : i18n.submittableIncomplete();
     }
+
     const confirmationDialog = (
       <LegacySingleLevelGroupDialog id={id} title={title} body={body} />
     );


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

When submitting surveys, we now always show the "you cannot edit..." warning and no longer check to see if there were any incomplete questions.  For more details, see this [doc](https://docs.google.com/document/d/1b5KTyGnN-g6UMRn_5azBnye2ekaCey5JiksKoDW-mDA/edit).

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [LP-1714](https://codedotorg.atlassian.net/browse/LP-1714)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

Verified manually that the incomplete warning doesn't show for surveys but does show for assessments.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
