### PR TITLE
Update submitted column on workshop dashboard quick view

### DIFF
--- a/apps/src/code-studio/pd/application_dashboard/quick_view_table.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/quick_view_table.jsx
@@ -91,11 +91,12 @@ export class QuickViewTable extends React.Component {
         cell: {
           formatters: [
             date_applied =>
-              date_applied &&
-              new Date(date_applied).toLocaleDateString('en-us', {
-                month: 'long',
-                day: 'numeric'
-              })
+              date_applied
+                ? new Date(date_applied).toLocaleDateString('en-us', {
+                    month: 'long',
+                    day: 'numeric'
+                  })
+                : 'Not Yet Submitted'
           ]
         }
       },

--- a/apps/src/code-studio/pd/application_dashboard/quick_view_table.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/quick_view_table.jsx
@@ -83,15 +83,16 @@ export class QuickViewTable extends React.Component {
         }
       },
       {
-        property: 'created_at',
+        property: 'date_applied',
         header: {
           label: 'Submitted',
           transforms: [sortable]
         },
         cell: {
           formatters: [
-            created_at =>
-              new Date(created_at).toLocaleDateString('en-us', {
+            date_applied =>
+              date_applied &&
+              new Date(date_applied).toLocaleDateString('en-us', {
                 month: 'long',
                 day: 'numeric'
               })

--- a/apps/test/unit/code-studio/pd/application_dashboard/quick_viewTest.js
+++ b/apps/test/unit/code-studio/pd/application_dashboard/quick_viewTest.js
@@ -55,7 +55,7 @@ describe('Quick View', () => {
     const applicationsData = [
       {
         id: 8,
-        created_at: '2017-10-25T21:26:06.000Z',
+        date_applied: '2022-02-23',
         applicant_name: 'Clare Constantine',
         district_name: null,
         school_name: null,

--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -128,6 +128,12 @@ module Pd::Application
       application_year
     end
 
+    # Since teacher applications may be created on save before they are submitted, we cannot rely
+    # on the created_at field. When applications are submitted, they have status 'unreviewed'
+    def date_applied
+      status_log.find {|status_entry| status_entry["status"] == "unreviewed"}&.[]("at")&.to_date&.iso8601 || ""
+    end
+
     def self.next_year(year)
       current_year_index = APPLICATION_YEARS.index(year)
       current_year_index >= 0 ? APPLICATION_YEARS[current_year_index + 1] : nil

--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -131,7 +131,7 @@ module Pd::Application
     # Since teacher applications may be created on save before they are submitted, we cannot rely
     # on the created_at field. When applications are submitted, they have status 'unreviewed'
     def date_applied
-      status_log.find {|status_entry| status_entry["status"] == "unreviewed"}&.[]("at")&.to_date&.iso8601 || ""
+      status_log.find {|status_entry| status_entry["status"] == "unreviewed"}&.[]("at")&.to_date&.iso8601
     end
 
     def self.next_year(year)

--- a/dashboard/app/serializers/api/v1/pd/application_quick_view_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/application_quick_view_serializer.rb
@@ -1,7 +1,7 @@
 class Api::V1::Pd::ApplicationQuickViewSerializer < ActiveModel::Serializer
   attributes(
     :id,
-    :created_at,
+    :date_applied,
     :applicant_name,
     :district_name,
     :school_name,

--- a/dashboard/test/models/pd/application/teacher_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher_application_test.rb
@@ -109,10 +109,10 @@ module Pd::Application
       assert_equal Pd::Application::TeacherApplication::REVIEWING_INCOMPLETE, teacher_application.meets_criteria
     end
 
-    test 'date_applied finds date of first unreviewed status, or empty string' do
+    test 'date_applied finds date of first unreviewed status' do
       tomorrow = Date.tomorrow.to_time
       application = create :pd_teacher_application, status: 'incomplete'
-      assert_equal "", application.date_applied
+      assert_nil application.date_applied
 
       Timecop.freeze(tomorrow) do
         application.update!(status: 'unreviewed')

--- a/dashboard/test/models/pd/application/teacher_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher_application_test.rb
@@ -109,6 +109,17 @@ module Pd::Application
       assert_equal Pd::Application::TeacherApplication::REVIEWING_INCOMPLETE, teacher_application.meets_criteria
     end
 
+    test 'date_applied finds date of first unreviewed status, or empty string' do
+      tomorrow = Date.tomorrow.to_time
+      application = create :pd_teacher_application, status: 'incomplete'
+      assert_equal "", application.date_applied
+
+      Timecop.freeze(tomorrow) do
+        application.update!(status: 'unreviewed')
+        assert_equal tomorrow, application.date_applied.to_time
+      end
+    end
+
     test 'accepted_at updates times' do
       today = Date.today.to_time
       tomorrow = Date.tomorrow.to_time

--- a/dashboard/test/models/pd/application/teacher_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher_application_test.rb
@@ -111,13 +111,20 @@ module Pd::Application
 
     test 'date_applied finds date of first unreviewed status' do
       tomorrow = Date.tomorrow.to_time
+      next_day = tomorrow + 1.day
       application = create :pd_teacher_application, status: 'incomplete'
       assert_nil application.date_applied
 
       Timecop.freeze(tomorrow) do
         application.update!(status: 'unreviewed')
-        assert_equal tomorrow, application.date_applied.to_time
       end
+
+      Timecop.freeze(next_day) do
+        application.update!(status: 'reopened')
+        application.update!(status: 'unreviewed')
+      end
+
+      assert_equal tomorrow, application.date_applied.to_time
     end
 
     test 'accepted_at updates times' do


### PR DESCRIPTION
The "Submitted" column was using the `created_at` field from the DB. But the `created_at` date for teacher applications will be the `save` date if that's the first thing the teacher does on their application. Now, the column uses the `date_applied` method, which overrides to find the first `unreviewed` status in the `status_log`.

Updated to say "Not yet submitted" on incomplete apps:
<img width="1027" alt="image" src="https://user-images.githubusercontent.com/9142121/157776727-8f3ca642-4ea7-498e-b08f-8bf1b33543e3.png">

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
