### PR TITLE
Make northern sami visible in language dropdown in production

### DIFF
--- a/dashboard/config/locales.yml
+++ b/dashboard/config/locales.yml
@@ -376,7 +376,6 @@
 "se-FI":
   english: "Northern Sami"
   native: "Davvisámegiella"
-  debug: true
 
 "si": "si-LK"
 "si-LK":


### PR DESCRIPTION
In order for our international partner to fund additional translation efforts in Northern Sami, they need to prove to their government funders that Code.org supports Northern Sami as a language by showing the website has that option. Following the ["Adding a new language" instructions](https://docs.google.com/document/d/1AwBHOF1VJw7HlMdfmxpb-2d7kqbGWXjsLzUH6iUYAbI/edit), this change enables Northern Sami in our language dropdown. Northern Sami has also been enabled on code.org and hourofcode.com via the [cdo-languages gsheet](https://docs.google.com/spreadsheets/d/10dS5PJKRt846ol9f9L3pKh03JfZkN7UIEcwMmiGS4i0/edit#gid=0).

## Links
- jira ticket: [FND-1895](https://codedotorg.atlassian.net/browse/FND-1895)


## Testing story
Tested locally:
![image](https://user-images.githubusercontent.com/2933346/157775080-7a3da6a4-de8e-43e3-a79a-a6bcb571e3a0.png)

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->
## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
