### PR TITLE
remove no_ie tags from ed_programs ui tests

### DIFF
--- a/dashboard/test/ui/features/ed_programs/levelbuilder/lesson_edit_page.feature
+++ b/dashboard/test/ui/features/ed_programs/levelbuilder/lesson_edit_page.feature
@@ -1,5 +1,3 @@
-# We need "press keys" to type into the React form's fields, but that doesn't work on IE.
-@no_ie
 @no_mobile
 
 Feature: Using the Lesson Edit Page

--- a/dashboard/test/ui/features/ed_programs/levelbuilder/level_edit_page.feature
+++ b/dashboard/test/ui/features/ed_programs/levelbuilder/level_edit_page.feature
@@ -1,5 +1,3 @@
-# We need "press keys" to type into the React form's fields, but that doesn't work on IE.
-@no_ie
 @no_mobile
 Feature: Using the Level Edit Page
 

--- a/dashboard/test/ui/features/ed_programs/levelbuilder/script_edit_page.feature
+++ b/dashboard/test/ui/features/ed_programs/levelbuilder/script_edit_page.feature
@@ -1,8 +1,4 @@
 @no_mobile
-
-# We need "press keys" to type into the React form's fields, but that doesn't work on IE.
-@no_ie
-
 @no_safari
 Feature: Using the Script Edit Page
 

--- a/dashboard/test/ui/features/ed_programs/pd/regional_partner_mini_contact.feature
+++ b/dashboard/test/ui/features/ed_programs/pd/regional_partner_mini_contact.feature
@@ -1,5 +1,3 @@
-# We need "press keys" to type into the React form's fields, but that doesn't work on IE or mobile Safari.
-@no_ie
 @no_mobile
 
 Feature: Regional partner mini-contact

--- a/dashboard/test/ui/features/ed_programs/video/videoplayer_eyes.feature
+++ b/dashboard/test/ui/features/ed_programs/video/videoplayer_eyes.feature
@@ -42,9 +42,6 @@ Scenario: Flash fallback player gets injected in Chrome (assuming Flash is avail
   Then I see ".video-js"
   Then I see jquery selector object[type='application/x-shockwave-flash']
 
-# no_ie because YouTube's recent change to their player is causing our
-#   fallback detection to get a false negative
-@no_ie
 @no_mobile
 Scenario: Normal player
   Given I am on "http://studio.code.org/flappy/1"

--- a/dashboard/test/ui/features/ed_programs/yourschool.feature
+++ b/dashboard/test/ui/features/ed_programs/yourschool.feature
@@ -1,6 +1,4 @@
 @no_circle
-# We need "press keys" to type into the React form's fields, but that doesn't work on IE or mobile Safari.
-@no_ie
 @no_mobile
 
 Feature: Using the YourSchool census page


### PR DESCRIPTION
remove EP Tools usages of `@no_ie` in ui tests, now that we are no longer running UI tests in IE. this follows the recommendation in https://github.com/code-dot-org/code-dot-org/pull/44336 .

## Testing story

I am trusting that there is no way to run tests in IE any more, so I am relying on just a drone run without doing too much to anticipate any kind of problem during the DTT. 
