### PR TITLE
Small code docs fixes

### DIFF
--- a/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingEnvironmentEditor.jsx
+++ b/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingEnvironmentEditor.jsx
@@ -158,6 +158,21 @@ export default function ProgrammingEnvironmentEditor({
           ))}
         </select>
       </label>
+      {programmingEnvironment.editorType === 'blockly' && (
+        <label>
+          Block Pool Name
+          <HelpTip>
+            The block pool that will be used to show embedded blocks.{' '}
+          </HelpTip>
+          <input
+            value={programmingEnvironment.blockPoolName || ''}
+            onChange={e =>
+              updateProgrammingEnvironment('blockPoolName', e.target.value)
+            }
+            style={styles.textInput}
+          />
+        </label>
+      )}
       <label>
         Project URL
         <input

--- a/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingExpressionEditor.jsx
+++ b/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingExpressionEditor.jsx
@@ -140,7 +140,7 @@ export default function ProgrammingExpressionEditor({
           ))}
         </select>
         <HelpTip>
-          Chose a category for the code documentation to fall beneath
+          Choose a category for the code documentation to fall beneath
         </HelpTip>
       </label>
 

--- a/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingExpressionEditor.jsx
+++ b/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingExpressionEditor.jsx
@@ -121,6 +121,29 @@ export default function ProgrammingExpressionEditor({
         Key (Used in URLs)
         <input value={key} readOnly style={styles.textInput} />
       </label>
+      <label>
+        Category
+        <select
+          value={programmingExpression.categoryKey}
+          onChange={e =>
+            updateProgrammingExpression('categoryKey', e.target.value)
+          }
+          style={styles.selectInput}
+        >
+          <option key="none" value={''}>
+            (None)
+          </option>
+          {environmentCategories.map(category => (
+            <option key={category.key} value={category.key}>
+              {category.name}
+            </option>
+          ))}
+        </select>
+        <HelpTip>
+          Chose a category for the code documentation to fall beneath
+        </HelpTip>
+      </label>
+
       {programmingExpression.environmentEditorType === 'blockly' && (
         <label>
           Block Name
@@ -180,28 +203,6 @@ export default function ProgrammingExpressionEditor({
             }
             style={styles.textInput}
           />
-        </label>
-        <label>
-          Category
-          <select
-            value={programmingExpression.categoryKey}
-            onChange={e =>
-              updateProgrammingExpression('categoryKey', e.target.value)
-            }
-            style={styles.selectInput}
-          >
-            <option key="none" value={''}>
-              (None)
-            </option>
-            {environmentCategories.map(category => (
-              <option key={category.key} value={category.key}>
-                {category.name}
-              </option>
-            ))}
-          </select>
-          <HelpTip>
-            Chose a category for the code documentation to fall beneath
-          </HelpTip>
         </label>
         <TextareaWithMarkdownPreview
           markdown={programmingExpression.content}

--- a/apps/src/sites/studio/pages/programming_expressions/show.js
+++ b/apps/src/sites/studio/pages/programming_expressions/show.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import getScriptData from '@cdo/apps/util/getScriptData';
+import getScriptData, {hasScriptData} from '@cdo/apps/util/getScriptData';
 import PageContainer from '@cdo/apps/templates/codeDocs/PageContainer';
 import ProgrammingExpressionOverview from '@cdo/apps/templates/codeDocs/ProgrammingExpressionOverview';
 import ExpandableImageDialog from '@cdo/apps/templates/lessonOverview/ExpandableImageDialog';
@@ -24,7 +24,9 @@ $(document).ready(() => {
     'programmingEnvironmentTitle'
   );
   const categoriesForNavigation = getScriptData('categoriesForNavigation');
-  const currentCategoryKey = getScriptData('currentCategoryKey');
+  const currentCategoryKey = hasScriptData('currentCategoryKey')
+    ? getScriptData('currentCategoryKey')
+    : null;
   ReactDOM.render(
     <Provider store={store}>
       <>

--- a/apps/src/templates/codeDocs/ProgrammingExpressionOverview.jsx
+++ b/apps/src/templates/codeDocs/ProgrammingExpressionOverview.jsx
@@ -78,18 +78,20 @@ export default function ProgrammingExpressionOverview({programmingExpression}) {
   return (
     <div>
       <div>{getTitle()}</div>
-      <div>
-        <strong>{`${i18n.category()}:`}</strong>
-        <span
-          style={{
-            backgroundColor: getColor(),
-            marginLeft: 10,
-            padding: '5px 10px'
-          }}
-        >
-          {programmingExpression.category}
-        </span>
-      </div>
+      {programmingExpression.category && (
+        <div>
+          <strong>{`${i18n.category()}:`}</strong>
+          <span
+            style={{
+              backgroundColor: getColor(),
+              marginLeft: 10,
+              padding: '5px 10px'
+            }}
+          >
+            {programmingExpression.category}
+          </span>
+        </div>
+      )}
       {programmingExpression.video && (
         <div
           id={'programming-expression-video'}

--- a/apps/test/unit/lib/levelbuilder/code-docs-editor/ProgrammingEnvironmentEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/code-docs-editor/ProgrammingEnvironmentEditorTest.jsx
@@ -19,6 +19,7 @@ describe('ProgrammingEnvironmentEditor', () => {
         projectUrl: '/p/spritelab',
         description: 'A description of spritelab',
         editorType: 'blockly',
+        blockPoolName: 'GamelabJr',
         categories: [{id: 1, key: 'sprites', name: 'Sprites', color: '#00FF00'}]
       }
     };
@@ -42,7 +43,14 @@ describe('ProgrammingEnvironmentEditor', () => {
     const publishedCheckbox = wrapper.find('input').at(2);
     expect(publishedCheckbox.props().checked).to.be.true;
 
-    const projectUrlInput = wrapper.find('input').at(3);
+    const editorTypeSelect = wrapper.find('select').at(0);
+    expect(editorTypeSelect.props().value).to.equal('blockly');
+    expect(editorTypeSelect.find('option').length).to.equal(3);
+
+    const blockPoolInput = wrapper.find('input').at(3);
+    expect(blockPoolInput.props().value).to.equal('GamelabJr');
+
+    const projectUrlInput = wrapper.find('input').at(4);
     expect(projectUrlInput.props().value).to.equal('/p/spritelab');
 
     const descriptionMarkdownInput = wrapper
@@ -51,10 +59,6 @@ describe('ProgrammingEnvironmentEditor', () => {
     expect(descriptionMarkdownInput.props().markdown).to.equal(
       'A description of spritelab'
     );
-
-    const editorTypeSelect = wrapper.find('select').at(0);
-    expect(editorTypeSelect.props().value).to.equal('blockly');
-    expect(editorTypeSelect.find('option').length).to.equal(3);
 
     const categoriesSection = wrapper.find('CollapsibleEditorSection');
     expect(
@@ -102,6 +106,7 @@ describe('ProgrammingEnvironmentEditor', () => {
         'published',
         'description',
         'editorType',
+        'blockPoolName',
         'projectUrl',
         'imageUrl',
         'categories'

--- a/apps/test/unit/lib/levelbuilder/code-docs-editor/ProgrammingExpressionEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/code-docs-editor/ProgrammingExpressionEditorTest.jsx
@@ -74,8 +74,15 @@ describe('ProgrammingExpressionEditor', () => {
         .props().readOnly
     ).to.be.true;
 
+    // Category select
+    const categorySelect = wrapper.find('select').at(0);
+    expect(categorySelect.find('option').length).to.equal(4);
+    expect(
+      categorySelect.find('option').map(option => option.props().value)
+    ).to.eql(['', 'circuit', 'variables', 'canvas']);
+
     // Video select
-    const videoSelect = wrapper.find('select').at(0);
+    const videoSelect = wrapper.find('select').at(1);
     expect(videoSelect.find('option').length).to.equal(3);
     expect(
       videoSelect.find('option').map(option => option.props().value)
@@ -100,12 +107,6 @@ describe('ProgrammingExpressionEditor', () => {
         .at(0)
         .props().value
     ).to.equal('developer.mozilla.org');
-    expect(
-      documentationSection
-        .find('select')
-        .at(0)
-        .find('option').length
-    ).to.equal(4);
     expect(
       documentationSection
         .find('TextareaWithMarkdownPreview')

--- a/dashboard/app/controllers/programming_environments_controller.rb
+++ b/dashboard/app/controllers/programming_environments_controller.rb
@@ -80,6 +80,7 @@ class ProgrammingEnvironmentsController < ApplicationController
       :published,
       :description,
       :editor_type,
+      :block_pool_name,
       :image_url,
       :project_url,
       categories: [:id, :name, :color]

--- a/dashboard/app/models/programming_environment.rb
+++ b/dashboard/app/models/programming_environment.rb
@@ -96,6 +96,7 @@ class ProgrammingEnvironment < ApplicationRecord
       projectUrl: project_url,
       description: description,
       editorType: editor_type,
+      blockPoolName: block_pool_name,
       categories: categories.map(&:serialize_for_edit),
       showPath: programming_environment_path(name)
     }

--- a/dashboard/app/models/programming_expression.rb
+++ b/dashboard/app/models/programming_expression.rb
@@ -260,6 +260,8 @@ class ProgrammingExpression < ApplicationRecord
   def write_serialization
     return unless Rails.application.config.levelbuilder_mode
     object_to_serialize = serialize
+    directory_name = File.dirname(file_path)
+    Dir.mkdir(directory_name) unless File.exist?(directory_name)
     File.write(file_path, JSON.pretty_generate(object_to_serialize))
   end
 

--- a/dashboard/test/controllers/programming_environments_controller_test.rb
+++ b/dashboard/test/controllers/programming_environments_controller_test.rb
@@ -58,6 +58,7 @@ class ProgrammingEnvironmentsControllerTest < ActionController::TestCase
       title: 'title',
       description: 'description',
       editorType: 'blockly',
+      blockPoolName: 'GamelabJr',
       projectUrl: '/p/project'
     }
     assert_response :ok
@@ -66,6 +67,7 @@ class ProgrammingEnvironmentsControllerTest < ActionController::TestCase
     assert_equal 'title', programming_environment.title
     assert_equal 'description', programming_environment.description
     assert_equal 'blockly', programming_environment.editor_type
+    assert_equal 'GamelabJr', programming_environment.block_pool_name
     assert_equal '/p/project', programming_environment.project_url
   end
 


### PR DESCRIPTION
A handful of fixes to code docs:
- Allow updating `block_pool_name` in the editor (I must've forgotten when I added that functionality)
- Fix a crash when a programming expression doesn't have a category
- Pull the category selector into the main section of the programming expression edit page
- Fix an issue where programming expressions can't be serialized when added to a new programming environment because the directory doesn't exist

This PR ended up a bit bigger than expected because I kept finding just one more thing to fix 😅  

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
