### PR TITLE
add ui test to create a new unit on levelbuilder

### DIFF
--- a/apps/src/lib/levelbuilder/unit-editor/NewUnitForm.jsx
+++ b/apps/src/lib/levelbuilder/unit-editor/NewUnitForm.jsx
@@ -70,7 +70,11 @@ export default function NewUnitForm(props) {
                 </HelpTip>
                 {/* Need both of these inputs because if the hidden one with name=
                   is also disabled it will not save properly*/}
-                <input value={getScriptName()} disabled={true} />
+                <input
+                  className="newUnitSlug"
+                  value={getScriptName()}
+                  disabled={true}
+                />
                 <input
                   name="script[name]"
                   value={getScriptName()}

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -1,8 +1,8 @@
 class ScriptsController < ApplicationController
   include VersionRedirectOverrider
 
-  before_action :require_levelbuilder_mode, except: [:show, :vocab, :resources, :code, :standards, :edit, :update]
-  before_action :require_levelbuilder_mode_or_test_env, only: [:edit, :update]
+  before_action :require_levelbuilder_mode, except: [:show, :vocab, :resources, :code, :standards, :edit, :update, :new]
+  before_action :require_levelbuilder_mode_or_test_env, only: [:edit, :update, :new]
   before_action :authenticate_user!, except: [:show, :vocab, :resources, :code, :standards]
   check_authorization
   before_action :set_unit, only: [:show, :vocab, :resources, :code, :standards, :edit, :update, :destroy]

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -1,8 +1,8 @@
 class ScriptsController < ApplicationController
   include VersionRedirectOverrider
 
-  before_action :require_levelbuilder_mode, except: [:show, :vocab, :resources, :code, :standards, :edit, :update, :new]
-  before_action :require_levelbuilder_mode_or_test_env, only: [:edit, :update, :new]
+  before_action :require_levelbuilder_mode, except: [:show, :vocab, :resources, :code, :standards, :edit, :update, :new, :create]
+  before_action :require_levelbuilder_mode_or_test_env, only: [:edit, :update, :new, :create]
   before_action :authenticate_user!, except: [:show, :vocab, :resources, :code, :standards]
   check_authorization
   before_action :set_unit, only: [:show, :vocab, :resources, :code, :standards, :edit, :update, :destroy]

--- a/dashboard/config/locales/scripts.en.yml
+++ b/dashboard/config/locales/scripts.en.yml
@@ -33117,3 +33117,33 @@ en:
           student_description: 'Welcome to Code.org’s free online educator course for CS Fundamentals! '
           description_short: 'Welcome to Code.org’s free self-paced online educator course for getting started with Computer Science Fundamentals! '
           description_audience: 'Welcome to Code.org’s free self-paced online educator course for getting started with Computer Science Fundamentals! '
+        temp-script-foo:
+          lessons: {}
+          lesson_groups: {}
+          name: temp-script-foo
+          title: ''
+          description_audience: ''
+          description_short: ''
+          description: ''
+          student_description: ''
+        temp-script-1646953232-47011:
+          lessons: {}
+          lesson_groups: {}
+        temp-script-1646953408-81999:
+          lessons: {}
+          lesson_groups: {}
+          name: temp-script-1646953408-81999
+          title: ''
+          description_audience: ''
+          description_short: ''
+          description: ''
+          student_description: ''
+        temp-script-1646953696-50410:
+          lessons: {}
+          lesson_groups: {}
+          name: temp-script-1646953696-50410
+          title: ''
+          description_audience: ''
+          description_short: ''
+          description: ''
+          student_description: ''

--- a/dashboard/config/locales/scripts.en.yml
+++ b/dashboard/config/locales/scripts.en.yml
@@ -33117,33 +33117,3 @@ en:
           student_description: 'Welcome to Code.org’s free online educator course for CS Fundamentals! '
           description_short: 'Welcome to Code.org’s free self-paced online educator course for getting started with Computer Science Fundamentals! '
           description_audience: 'Welcome to Code.org’s free self-paced online educator course for getting started with Computer Science Fundamentals! '
-        temp-script-foo:
-          lessons: {}
-          lesson_groups: {}
-          name: temp-script-foo
-          title: ''
-          description_audience: ''
-          description_short: ''
-          description: ''
-          student_description: ''
-        temp-script-1646953232-47011:
-          lessons: {}
-          lesson_groups: {}
-        temp-script-1646953408-81999:
-          lessons: {}
-          lesson_groups: {}
-          name: temp-script-1646953408-81999
-          title: ''
-          description_audience: ''
-          description_short: ''
-          description: ''
-          student_description: ''
-        temp-script-1646953696-50410:
-          lessons: {}
-          lesson_groups: {}
-          name: temp-script-1646953696-50410
-          title: ''
-          description_audience: ''
-          description_short: ''
-          description: ''
-          student_description: ''

--- a/dashboard/test/ui/features/ed_programs/levelbuilder/new_unit_page.feature
+++ b/dashboard/test/ui/features/ed_programs/levelbuilder/new_unit_page.feature
@@ -1,0 +1,22 @@
+@no_mobile
+Feature: Using the New Unit Page
+
+  Scenario: Create a new unit
+    Given I create a levelbuilder named "Levi"
+    And I am on "http://studio.code.org/s/new"
+    And I wait until element ".isCourseSelector" is visible
+
+    When I select the "Single Unit" option in dropdown with class "isCourseSelector"
+    And I wait until element ".familyNameSelector" is visible
+    And element ".familyNameInput" is visible
+    And I enter a temp unit name
+    And I wait until element ".isVersionedSelector" is visible
+    And I select the "No" option in dropdown with class "isVersionedSelector"
+    And the unit slug input contains the temp script name
+    And I click "button[type='submit']" to load a new page
+
+    Then I wait for the temp unit edit page to load
+    And I click "button[type='submit']" to load a new page
+
+    Then I wait for the temp unit overview page to load
+    And I delete the temp unit

--- a/dashboard/test/ui/features/step_definitions/levelbuilder_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/levelbuilder_steps.rb
@@ -22,6 +22,22 @@ Given(/^I create a temp migrated unit with lessons$/) do
   @temp_lesson_without_lesson_plan_id = data['lesson_without_lesson_plan_id']
 end
 
+Given(/^I enter a temp unit name$/) do
+  @temp_script_name = "temp-script-#{Time.now.to_i}-#{rand(1_000_000)}"
+  puts "temp unit name: #{@temp_script_name}"
+  steps %{
+    And element ".familyNameInput" is visible
+    And I press keys "#{@temp_script_name}" for element ".familyNameInput"
+  }
+end
+
+Given(/^the unit slug input contains the temp script name$/) do
+  steps %{
+    And I wait until element ".newUnitSlug" is visible
+    And element ".newUnitSlug" has value "#{@temp_script_name}"
+  }
+end
+
 Given(/^I view the temp unit overview page$/) do
   steps %{
     Given I am on "http://studio.code.org/s/#{@temp_script_name}"
@@ -33,6 +49,20 @@ Given(/^I view the temp unit edit page$/) do
   steps %{
     Given I am on "http://studio.code.org/s/#{@temp_script_name}/edit"
     And I wait until element ".edit_script" is visible
+  }
+end
+
+Given(/^I wait for the temp unit edit page to load$/) do
+  steps %{
+    And I wait until I am on "http://studio.code.org/s/#{@temp_script_name}/edit"
+    And I wait until element ".edit_script" is visible
+  }
+end
+
+Given(/^I wait for the temp unit overview page to load$/) do
+  steps %{
+    And I wait until I am on "http://studio.code.org/s/#{@temp_script_name}"
+    And I wait until element ".unit-overview-top-row" is visible
   }
 end
 
@@ -63,7 +93,7 @@ Given (/^I remove the temp unit from the cache$/) do
     body: {script_name: @temp_script_name}
   )
 end
-Given(/^I delete the temp unit with lessons$/) do
+Given(/^I delete the temp unit( with lessons)?$/) do |_|
   browser_request(
     url: '/api/test/destroy_script',
     method: 'POST',

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -374,6 +374,10 @@ When /^I select the "([^"]*)" option in dropdown "([^"]*)"( to load a new page)?
   select_dropdown(@browser.find_element(:id, element_id), option_text, load)
 end
 
+When /^I select the "([^"]*)" option in dropdown with class "([^"]*)"( to load a new page)?$/ do |option_text, class_name, load|
+  select_dropdown(@browser.find_element(:css, ".#{class_name}"), option_text, load)
+end
+
 When /^I select the "([^"]*)" option in dropdown named "([^"]*)"( to load a new page)?$/ do |option_text, element_name, load|
   select_dropdown(@browser.find_element(:css, "select[name=#{element_name}]"), option_text, load)
 end


### PR DESCRIPTION
Finishes [PLAT-1311](https://codedotorg.atlassian.net/browse/PLAT-1311). also finishes [PLAT-1317](https://codedotorg.atlassian.net/browse/PLAT-1317), which says it is about editing a unit with a non-user-facing lesson plan, but after clicking through to https://github.com/code-dot-org/code-dot-org/pull/42537 and [slack](https://codedotorg.slack.com/archives/C02EEGWLHR8/p1631894560048300), it turns out to actually be about editing a newly-created unit group (feel free to fact check me on that based on the slack thread). 

For more detail, see sample [cucumber output](https://github.com/code-dot-org/code-dot-org/files/8227769/Chrome_ed_programs_levelbuilder_new_unit_page_output.html.zip) and [saucelabs video](https://app.saucelabs.com/tests/5631c60e393045e8aa7d1d9eca51a673#56). 

## Testing story

In addition to a regular drone run, I also tested this in all browsers (see [additional drone run](https://drone.cdn-code.org/code-dot-org/code-dot-org/16166/2/1)).

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
