### PR TITLE
Fix files being deleted in the test environment

### DIFF
--- a/dashboard/app/models/programming_environment.rb
+++ b/dashboard/app/models/programming_environment.rb
@@ -80,6 +80,8 @@ class ProgrammingEnvironment < ApplicationRecord
   end
 
   def remove_serialization
+    return unless Rails.application.config.levelbuilder_mode
+
     File.delete(file_path) if File.exist?(file_path)
   end
 

--- a/dashboard/app/models/programming_expression.rb
+++ b/dashboard/app/models/programming_expression.rb
@@ -264,6 +264,7 @@ class ProgrammingExpression < ApplicationRecord
   end
 
   def remove_serialization
+    return unless Rails.application.config.levelbuilder_mode
     File.delete(file_path) if File.exist?(file_path)
   end
 

--- a/dashboard/test/models/programming_expression_test.rb
+++ b/dashboard/test/models/programming_expression_test.rb
@@ -79,6 +79,7 @@ class ProgrammingExpressionTest < ActiveSupport::TestCase
     to_update.name = "Updated name"
     File.stubs(:read).with("#{programming_environment.name}/#{to_update.key}.json").returns(to_update.serialize.to_json)
     File.stubs(:read).with("#{programming_environment.name}/#{to_create.key}.json").returns(to_create.serialize.to_json)
+    File.stubs(:delete)
 
     to_create.destroy!
     to_update.reload


### PR DESCRIPTION
When I added the route to destroy programming environments and programming expressions, there was an accidental side effect of deleting config files after running `programming_expression_test.rb`. I both stubbed out the File delete in the offending test (this fixed the issue locally for me) and added a check for levelbuilder mode to `remove_serialization`, which I should've done when adding that method

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
