### PR TITLE
Revert "Wait for sign out in code review UI tests"

### DIFF
--- a/dashboard/test/ui/features/javalab/code_review_eyes.feature
+++ b/dashboard/test/ui/features/javalab/code_review_eyes.feature
@@ -1,6 +1,7 @@
 @eyes
 @no_mobile
 @no_ie
+@skip
 Feature: Code Review Eyes
 
   @no_circle
@@ -14,9 +15,6 @@ Feature: Code Review Eyes
     And I save the section id from row 0 of the section table
     Given I create a student named "Hermione"
     And I join the section
-    # Observed flakiness trying to navigate to teacher dashboard while still signed in as Hermione.
-    # Explicitly wait for sign out to occur to avoid this.
-    And I sign out using jquery
     # Create a code review group with a student in it.
     # Save the group, and enable code review for the section.
     Given I sign in as "Dumbledore" and go home

--- a/dashboard/test/ui/features/javalab/code_review_peer_scenarios.feature
+++ b/dashboard/test/ui/features/javalab/code_review_peer_scenarios.feature
@@ -4,6 +4,7 @@
 
 @no_mobile
 @no_ie
+@skip
 Feature: Code review (peer scenarios)
 
   # At the end of the setup, we will have created
@@ -21,9 +22,6 @@ Feature: Code review (peer scenarios)
     And I join the section
     Given I create a student named "Harry"
     And I join the section
-    # Observed flakiness trying to navigate to teacher dashboard while still signed in as Harry.
-    # Explicitly wait for sign out to occur to avoid this.
-    And I sign out using jquery
     # Create a code review group with students in it.
     # Save the group, and enable code review for the section.
     Given I sign in as "Dumbledore" and go home

--- a/dashboard/test/ui/features/javalab/code_review_project_owner_and_teacher_scenarios.feature
+++ b/dashboard/test/ui/features/javalab/code_review_project_owner_and_teacher_scenarios.feature
@@ -4,6 +4,7 @@
 
 @no_mobile
 @no_ie
+@skip
 Feature: Code review (project owner/teacher scenarios)
 
   # At the end of the setup, we will have created
@@ -19,9 +20,6 @@ Feature: Code review (project owner/teacher scenarios)
     And I save the section id from row 0 of the section table
     Given I create a student named "Hermione"
     And I join the section
-    # Observed flakiness trying to navigate to teacher dashboard while still signed in as Hermione.
-    # Explicitly wait for sign out to occur to avoid this.
-    And I sign out using jquery
     # Create a code review group with students in it.
     # Save the group, and enable code review for the section.
     Given I sign in as "Dumbledore" and go home


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#45239. Observed another (different) failure in a test run with this change in it 🤦 .

Saucelabs video:
https://app.saucelabs.com/tests/9b10fd07ffe8417c8bcce0df363f91c9#64