### PR TITLE
Pass course offering summaries to front end

### DIFF
--- a/apps/src/code-studio/components/progress/UnitOverviewHeader.jsx
+++ b/apps/src/code-studio/components/progress/UnitOverviewHeader.jsx
@@ -49,6 +49,7 @@ class UnitOverviewHeader extends Component {
       courseViewPath: PropTypes.string.isRequired
     }),
     announcements: PropTypes.arrayOf(announcementShape),
+    courseVersionId: PropTypes.number.isRequired,
     scriptId: PropTypes.number.isRequired,
     scriptName: PropTypes.string.isRequired,
     unitTitle: PropTypes.string.isRequired,
@@ -261,6 +262,7 @@ export const UnconnectedUnitOverviewHeader = UnitOverviewHeader;
 export default connect(state => ({
   plcHeaderProps: state.plcHeader,
   announcements: state.announcements || [],
+  courseVersionId: state.progress.courseVersionId,
   scriptId: state.progress.scriptId,
   scriptName: state.progress.scriptName,
   unitTitle: state.progress.unitTitle,

--- a/apps/src/code-studio/progress.js
+++ b/apps/src/code-studio/progress.js
@@ -348,6 +348,7 @@ function initializeStoreWithProgress(
       unitTitle: scriptData.title,
       unitDescription: scriptData.description,
       unitStudentDescription: scriptData.studentDescription,
+      courseVersionId: scriptData.courseVersionId,
       courseId: scriptData.course_id,
       isFullProgress: isFullProgress,
       isLessonExtras: isLessonExtras,

--- a/apps/src/code-studio/progressRedux.js
+++ b/apps/src/code-studio/progressRedux.js
@@ -104,6 +104,7 @@ export default function reducer(state = initialState, action) {
       unitDescription: action.unitDescription,
       unitStudentDescription: action.unitStudentDescription,
       courseId: action.courseId,
+      courseVersionId: action.courseVersionId,
       currentLessonId: currentLessonId,
       hasFullProgress: action.isFullProgress,
       isLessonExtras: action.isLessonExtras,
@@ -398,6 +399,7 @@ export const initProgress = ({
   unitDescription,
   unitStudentDescription,
   courseId,
+  courseVersionId,
   isFullProgress,
   isLessonExtras,
   currentPageNumber
@@ -415,6 +417,7 @@ export const initProgress = ({
   unitDescription,
   unitStudentDescription,
   courseId,
+  courseVersionId,
   isFullProgress,
   isLessonExtras,
   currentPageNumber

--- a/apps/src/sites/studio/pages/teacher_dashboard/show.js
+++ b/apps/src/sites/studio/pages/teacher_dashboard/show.js
@@ -13,6 +13,7 @@ import teacherSections, {
   selectSection,
   setRosterProvider,
   setValidAssignments,
+  setCourseOfferings,
   setShowLockSectionField, // DCDO Flag - show/hide Lock Section field
   setStudentsForCurrentSection
 } from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
@@ -39,6 +40,7 @@ const {
   validScripts,
   studentScriptIds,
   validCourses,
+  validCourseOfferings,
   localeCode,
   hasSeenStandardsReportInfo
 } = scriptData;
@@ -66,6 +68,7 @@ $(document).ready(function() {
   store.dispatch(setRosterProvider(section.login_type));
   store.dispatch(setLoginType(section.login_type));
   store.dispatch(setValidAssignments(validCourses, validScripts));
+  store.dispatch(setCourseOfferings(validCourseOfferings));
   store.dispatch(setLocaleCode(localeCode));
 
   // DCDO Flag - show/hide Lock Section field

--- a/apps/src/templates/teacherDashboard/AssignmentSelector.jsx
+++ b/apps/src/templates/teacherDashboard/AssignmentSelector.jsx
@@ -2,7 +2,12 @@ import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import _ from 'lodash';
 import i18n from '@cdo/locale';
-import {sectionShape, assignmentShape, assignmentFamilyShape} from './shapes';
+import {
+  sectionShape,
+  assignmentShape,
+  assignmentFamilyShape,
+  assignmentCourseOfferingShape
+} from './shapes';
 import {assignmentId, assignmentFamilyFields} from './teacherSectionsRedux';
 import AssignmentVersionSelector, {
   setRecommendedAndSelectedVersions
@@ -53,6 +58,8 @@ export default class AssignmentSelector extends Component {
     section: sectionShape,
     assignments: PropTypes.objectOf(assignmentShape).isRequired,
     assignmentFamilies: PropTypes.arrayOf(assignmentFamilyShape).isRequired,
+    courseOfferings: PropTypes.objectOf(assignmentCourseOfferingShape)
+      .isRequired,
     chooseLaterOption: PropTypes.bool,
     dropdownStyle: PropTypes.object,
     onChange: PropTypes.func,

--- a/apps/src/templates/teacherDashboard/EditSectionForm.jsx
+++ b/apps/src/templates/teacherDashboard/EditSectionForm.jsx
@@ -5,7 +5,12 @@ import {Heading1, h3Style} from '../../lib/ui/Headings';
 import * as styleConstants from '@cdo/apps/styleConstants';
 import Button from '../Button';
 import AssignmentSelector from '@cdo/apps/templates/teacherDashboard/AssignmentSelector';
-import {sectionShape, assignmentShape, assignmentFamilyShape} from './shapes';
+import {
+  sectionShape,
+  assignmentShape,
+  assignmentFamilyShape,
+  assignmentCourseOfferingShape
+} from './shapes';
 import DialogFooter from './DialogFooter';
 import i18n from '@cdo/locale';
 import {
@@ -42,6 +47,8 @@ class EditSectionForm extends Component {
     initialCourseId: PropTypes.number,
     validAssignments: PropTypes.objectOf(assignmentShape).isRequired,
     assignmentFamilies: PropTypes.arrayOf(assignmentFamilyShape).isRequired,
+    courseOfferings: PropTypes.objectOf(assignmentCourseOfferingShape)
+      .isRequired,
     section: sectionShape.isRequired,
     editSectionProperties: PropTypes.func.isRequired,
     handleSave: PropTypes.func.isRequired,
@@ -136,6 +143,7 @@ class EditSectionForm extends Component {
       title,
       validAssignments,
       assignmentFamilies,
+      courseOfferings,
       isSaveInProgress,
       editSectionProperties,
       handleClose,
@@ -211,6 +219,7 @@ class EditSectionForm extends Component {
             onChange={ids => editSectionProperties(ids)}
             validAssignments={validAssignments}
             assignmentFamilies={assignmentFamilies}
+            courseOfferings={courseOfferings}
             disabled={isSaveInProgress}
             localeCode={localeCode}
             isNewSection={isNewSection}
@@ -372,6 +381,7 @@ const AssignmentField = ({
   onChange,
   validAssignments,
   assignmentFamilies,
+  courseOfferings,
   disabled,
   localeCode,
   isNewSection
@@ -384,6 +394,7 @@ const AssignmentField = ({
       onChange={ids => onChange(ids)}
       assignments={validAssignments}
       assignmentFamilies={assignmentFamilies}
+      courseOfferings={courseOfferings}
       chooseLaterOption={true}
       dropdownStyle={style.dropdown}
       disabled={disabled}
@@ -397,6 +408,7 @@ AssignmentField.propTypes = {
   onChange: PropTypes.func.isRequired,
   validAssignments: PropTypes.objectOf(assignmentShape).isRequired,
   assignmentFamilies: PropTypes.arrayOf(assignmentFamilyShape).isRequired,
+  courseOfferings: PropTypes.objectOf(assignmentCourseOfferingShape).isRequired,
   disabled: PropTypes.bool,
   localeCode: PropTypes.string,
   isNewSection: PropTypes.bool
@@ -543,6 +555,7 @@ let defaultPropsFromState = state => ({
   initialUnitId: state.teacherSections.initialUnitId,
   validAssignments: state.teacherSections.validAssignments,
   assignmentFamilies: state.teacherSections.assignmentFamilies,
+  courseOfferings: state.teacherSections.courseOfferings,
   section: state.teacherSections.sectionBeingEdited,
   isSaveInProgress: state.teacherSections.saveInProgress,
   assignedUnitLessonExtrasAvailable: assignedUnitLessonExtrasAvailable(state),

--- a/apps/src/templates/teacherDashboard/EditSectionForm.story.jsx
+++ b/apps/src/templates/teacherDashboard/EditSectionForm.story.jsx
@@ -5,7 +5,8 @@ import {SectionLoginType} from '@cdo/apps/util/sharedConstants';
 import {
   assignmentFamilies,
   validAssignments,
-  testSection
+  testSection,
+  courseOfferings
 } from './teacherDashboardTestHelpers';
 
 export default storybook => {
@@ -20,6 +21,7 @@ export default storybook => {
         editSectionProperties={action('editSectionProperties')}
         validAssignments={validAssignments}
         assignmentFamilies={assignmentFamilies}
+        courseOfferings={courseOfferings}
         sections={{}}
         section={{
           ...testSection,
@@ -41,6 +43,7 @@ export default storybook => {
         editSectionProperties={action('editSectionProperties')}
         validAssignments={validAssignments}
         assignmentFamilies={assignmentFamilies}
+        courseOfferings={courseOfferings}
         sections={{}}
         section={{
           ...testSection,
@@ -62,6 +65,7 @@ export default storybook => {
         editSectionProperties={action('editSectionProperties')}
         validAssignments={validAssignments}
         assignmentFamilies={assignmentFamilies}
+        courseOfferings={courseOfferings}
         sections={{}}
         section={testSection}
         isSaveInProgress={true}

--- a/apps/src/templates/teacherDashboard/OwnedSectionsTable.story.jsx
+++ b/apps/src/templates/teacherDashboard/OwnedSectionsTable.story.jsx
@@ -4,8 +4,10 @@ import {combineReducers, createStore} from 'redux';
 import OwnedSectionsTable from './OwnedSectionsTable';
 import teacherSections, {
   setValidAssignments,
+  setCourseOfferings,
   setSections
 } from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
+import {courseOfferings} from '@cdo/apps/templates/teacherDashboard/teacherDashboardTestHelpers';
 
 const serverSections = [
   {
@@ -173,6 +175,7 @@ export default storybook => {
         story: () => {
           const store = createStore(combineReducers({teacherSections}));
           store.dispatch(setValidAssignments(validCourses, validScripts));
+          store.dispatch(setCourseOfferings(courseOfferings));
           store.dispatch(setSections(serverSections));
           return (
             <Provider store={store}>

--- a/apps/src/templates/teacherDashboard/shapes.jsx
+++ b/apps/src/templates/teacherDashboard/shapes.jsx
@@ -69,6 +69,35 @@ export const assignmentShape = PropTypes.shape({
   supported_locale_codes: PropTypes.arrayOf(PropTypes.string)
 });
 
+export const assignmentUnitShape = PropTypes.shape({
+  id: PropTypes.number.isRequired,
+  name: PropTypes.string.isRequired,
+  path: PropTypes.string.isRequired,
+  lesson_extras_available: PropTypes.bool.isRequired,
+  text_to_speech_enabled: PropTypes.bool.isRequired
+});
+
+export const assignmentCourseVersionShape = PropTypes.shape({
+  id: PropTypes.number.isRequired,
+  version_year: PropTypes.string.isRequired,
+  content_root_id: PropTypes.number.isRequired,
+  name: PropTypes.string.isRequired,
+  path: PropTypes.string.isRequired,
+  type: PropTypes.string.isRequired,
+  is_stable: PropTypes.bool.isRequired,
+  is_recommended: PropTypes.bool.isRequired,
+  locales: PropTypes.array,
+  units: PropTypes.object.isRequired
+});
+
+export const assignmentCourseOfferingShape = PropTypes.shape({
+  id: PropTypes.number.isRequired,
+  display_name: PropTypes.string.isRequired,
+  category: PropTypes.string.isRequired,
+  is_featured: PropTypes.bool.isRequired,
+  course_versions: PropTypes.object.isRequired
+});
+
 // An assignment family is a collection of versions of a course or script like
 // "csd" or "coursea". For example, the assignment family "csd" could contain the
 // courses csd-2017 and csd-2018.

--- a/apps/src/templates/teacherDashboard/teacherDashboardTestHelpers.js
+++ b/apps/src/templates/teacherDashboard/teacherDashboardTestHelpers.js
@@ -81,3 +81,261 @@ export const assignmentFamilies = [
     assignment_family_title: 'Unit 1: Problem Solving'
   }
 ];
+
+export const courseOfferings = {
+  1: {
+    id: 1,
+    display_name: 'Course A',
+    category: 'csf',
+    is_featured: false,
+    course_versions: {
+      1: {
+        id: 1,
+        version_year: '2017',
+        content_root_id: 10,
+        name: 'Course A',
+        path: '/s/coursea-2017',
+        type: 'Script',
+        is_stable: true,
+        is_recommended: false,
+        locales: ['العربية', 'Čeština', 'Deutsch', 'English'],
+        units: {
+          1: {
+            id: 1,
+            name: 'Course A',
+            path: '/s/coursea-2017',
+            lesson_extras_available: true
+          }
+        }
+      },
+      2: {
+        id: 2,
+        version_year: '2018',
+        content_root_id: 11,
+        name: 'Course A',
+        path: '/s/coursea-2018',
+        type: 'Script',
+        is_stable: true,
+        is_recommended: true,
+        locales: ['English', 'Italiano', 'Slovenčina'],
+        units: {
+          2: {
+            id: 2,
+            name: 'Course A (2018)',
+            path: '/s/coursea-2018',
+            lesson_extras_available: true
+          }
+        }
+      }
+    }
+  },
+  2: {
+    id: 2,
+    display_name: 'Computer Science Discoveries',
+    category: 'full_course',
+    is_featured: false,
+    course_versions: {
+      3: {
+        id: 3,
+        version_year: '2017',
+        content_root_id: 12,
+        name: 'CS Discoveries 2017',
+        path: '/courses/csd-2017',
+        type: 'UnitGroup',
+        is_stable: true,
+        is_recommended: false,
+        locales: [],
+        units: {
+          3: {
+            id: 3,
+            name: 'Unit 1',
+            path: '/s/csd1-2017',
+            lesson_extras_available: false,
+            text_to_speech_enabled: false
+          },
+          4: {
+            id: 4,
+            name: 'Unit 2',
+            path: '/s/csd2-2017',
+            lesson_extras_available: false,
+            text_to_speech_enabled: false
+          }
+        }
+      },
+      4: {
+        id: 4,
+        version_year: '2018',
+        content_root_id: 13,
+        name: 'CS Discoveries 2018',
+        path: '/courses/csd-2018',
+        type: 'UnitGroup',
+        is_stable: true,
+        is_recommended: true,
+        locales: [],
+        units: {
+          5: {
+            id: 5,
+            name: 'Unit 1',
+            path: '/s/csd1-2018',
+            lesson_extras_available: false,
+            text_to_speech_enabled: false
+          },
+          6: {
+            id: 6,
+            name: 'Unit 2',
+            path: '/s/csd2-2018',
+            lesson_extras_available: false,
+            text_to_speech_enabled: false
+          }
+        }
+      }
+    }
+  },
+  3: {
+    id: 3,
+    display_name: 'Computer Science A',
+    category: 'full_course',
+    is_featured: false,
+    course_versions: {
+      5: {
+        id: 5,
+        version_year: '2022',
+        content_root_id: 14,
+        name: 'CS A',
+        path: '/courses/csa-2022',
+        type: 'UnitGroup',
+        is_stable: true,
+        is_recommended: true,
+        locales: [],
+        units: {
+          7: {
+            id: 7,
+            name: 'Unit 1',
+            path: '/s/csa1-2022',
+            lesson_extras_available: false,
+            text_to_speech_enabled: false
+          },
+          8: {
+            id: 8,
+            name: 'Unit 2',
+            path: '/s/csa2-2022',
+            lesson_extras_available: false,
+            text_to_speech_enabled: false
+          }
+        }
+      }
+    }
+  },
+  4: {
+    id: 4,
+    display_name: 'Flappy',
+    category: 'hoc',
+    is_featured: false,
+    course_versions: {
+      6: {
+        id: 6,
+        version_year: 'unversioned',
+        content_root_id: 15,
+        name: 'Flappy',
+        path: '/s/flappy',
+        type: 'Script',
+        is_stable: true,
+        is_recommended: false,
+        locales: [],
+        units: {
+          9: {
+            id: 9,
+            name: 'Flappy',
+            path: '/s/flappy',
+            lesson_extras_available: false,
+            text_to_speech_enabled: false
+          }
+        }
+      }
+    }
+  },
+  5: {
+    id: 5,
+    display_name: 'Hello World',
+    category: 'hoc',
+    is_featured: true,
+    course_versions: {
+      7: {
+        id: 7,
+        version_year: 'unversioned',
+        content_root_id: 16,
+        name: 'Hello World',
+        path: '/s/hello-world',
+        type: 'Script',
+        is_stable: true,
+        is_recommended: true,
+        locales: [],
+        units: {
+          10: {
+            id: 10,
+            name: 'Hello World',
+            path: '/s/hello-world',
+            lesson_extras_available: false,
+            text_to_speech_enabled: false
+          }
+        }
+      }
+    }
+  },
+  6: {
+    id: 6,
+    display_name: 'Poem Art',
+    category: 'hoc',
+    is_featured: true,
+    course_versions: {
+      8: {
+        id: 8,
+        version_year: 'unversioned',
+        content_root_id: 17,
+        name: 'Poem Art',
+        path: '/s/poem-art',
+        type: 'Script',
+        is_stable: true,
+        is_recommended: true,
+        locales: [],
+        units: {
+          11: {
+            id: 11,
+            name: 'Poem Art',
+            path: '/s/poem-art',
+            lesson_extras_available: false,
+            text_to_speech_enabled: false
+          }
+        }
+      }
+    }
+  },
+  7: {
+    id: 7,
+    display_name: 'Artist',
+    category: 'hoc',
+    is_featured: false,
+    course_versions: {
+      9: {
+        id: 9,
+        version_year: 'unversioned',
+        content_root_id: 18,
+        name: 'Artist',
+        path: '/s/artist',
+        type: 'Script',
+        is_stable: true,
+        is_recommended: true,
+        locales: [],
+        units: {
+          12: {
+            id: 12,
+            name: 'Artist',
+            path: '/s/artist',
+            lesson_extras_available: false,
+            text_to_speech_enabled: false
+          }
+        }
+      }
+    }
+  }
+};

--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
@@ -44,6 +44,7 @@ const importUrlByProvider = {
 //
 // Action keys
 //
+const SET_COURSE_OFFERINGS = 'teacherDashboard/SET_COURSE_OFFERINGS';
 const SET_VALID_ASSIGNMENTS = 'teacherDashboard/SET_VALID_ASSIGNMENTS';
 const SET_STUDENT_SECTION = 'teacherDashboard/SET_STUDENT_SECTION';
 const SET_PAGE_TYPE = 'teacherDashboard/SET_PAGE_TYPE';
@@ -119,6 +120,10 @@ export const setValidAssignments = (validCourses, validScripts) => ({
   type: SET_VALID_ASSIGNMENTS,
   validCourses,
   validScripts
+});
+export const setCourseOfferings = courseOfferings => ({
+  type: SET_COURSE_OFFERINGS,
+  courseOfferings
 });
 export const setStudentsForCurrentSection = (sectionId, studentInfo) => ({
   type: SET_STUDENT_SECTION,
@@ -380,20 +385,30 @@ export const asyncLoadSectionData = id => dispatch => {
   let apis = [
     '/dashboardapi/sections',
     `/dashboardapi/courses`,
-    '/dashboardapi/sections/valid_scripts'
+    '/dashboardapi/sections/valid_scripts',
+    '/dashboardapi/sections/valid_course_offerings'
   ];
   if (id) {
     apis.push('/dashboardapi/sections/' + id + '/students');
   }
 
   return Promise.all(apis.map(fetchJSON))
-    .then(([sections, validCourses, validScripts, students]) => {
-      dispatch(setValidAssignments(validCourses, validScripts));
-      dispatch(setSections(sections));
-      if (id) {
-        dispatch(setStudentsForCurrentSection(id, students));
+    .then(
+      ([
+        sections,
+        validCourses,
+        validScripts,
+        validCourseOfferings,
+        students
+      ]) => {
+        dispatch(setValidAssignments(validCourses, validScripts));
+        dispatch(setCourseOfferings(validCourseOfferings));
+        dispatch(setSections(sections));
+        if (id) {
+          dispatch(setStudentsForCurrentSection(id, students));
+        }
       }
-    })
+    )
     .catch(err => {
       console.error(err.message);
     })
@@ -521,6 +536,10 @@ const initialState = {
   // with options like "CSD", "Course A", or "Frozen". See the
   // assignmentFamilyShape PropType.
   assignmentFamilies: [],
+  // Object of assignable course offerings to populate the assignment dropdown
+  // with options like "CSD", "Course A", or "Frozen". See the
+  // assignmentCourseOfferingShape PropType.
+  courseOfferings: {},
   // Mapping from sectionId to section object
   sections: {},
   // List of students in section currently being edited (see studentShape PropType)
@@ -614,6 +633,13 @@ export default function teacherSections(state = initialState, action) {
     return {
       ...state,
       pageType: action.pageType
+    };
+  }
+
+  if (action.type === SET_COURSE_OFFERINGS) {
+    return {
+      ...state,
+      courseOfferings: action.courseOfferings
     };
   }
 

--- a/apps/test/unit/code-studio/components/progress/UnitOverviewHeaderTest.js
+++ b/apps/test/unit/code-studio/components/progress/UnitOverviewHeaderTest.js
@@ -23,7 +23,8 @@ const defaultProps = {
     '# TEACHER Title \n This is the unit description with [link](https://studio.code.org/home) **Bold** *italics*',
   unitStudentDescription:
     '# STUDENT Title \n This is the unit description with [link](https://studio.code.org/home) **Bold** *italics*',
-  versions: []
+  versions: [],
+  courseVersionId: 1
 };
 
 describe('UnitOverviewHeader', () => {

--- a/apps/test/unit/templates/teacherDashboard/AssignmentSelectorTest.js
+++ b/apps/test/unit/templates/teacherDashboard/AssignmentSelectorTest.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 import sinon from 'sinon';
-import {assert, expect} from '../../../util/deprecatedChai';
+import {assert, expect} from '../../../util/reconfiguredChai';
 import AssignmentSelector from '@cdo/apps/templates/teacherDashboard/AssignmentSelector';
+import {courseOfferings} from '@cdo/apps/templates/teacherDashboard/teacherDashboardTestHelpers';
 
 const defaultProps = {
   localeCode: 'en-US',
+  courseOfferings: courseOfferings,
   section: {
     id: 11,
     name: 'foo',
@@ -114,6 +116,7 @@ const defaultProps = {
 };
 
 const hiddenSectionProps = {
+  courseOfferings: courseOfferings,
   section: {
     id: 11,
     name: 'foo',

--- a/apps/test/unit/templates/teacherDashboard/EditSectionFormTest.js
+++ b/apps/test/unit/templates/teacherDashboard/EditSectionFormTest.js
@@ -3,6 +3,7 @@ import {mount} from 'enzyme';
 import {assert} from '../../../util/reconfiguredChai';
 import {UnconnectedEditSectionForm as EditSectionForm} from '@cdo/apps/templates/teacherDashboard/EditSectionForm';
 import {
+  courseOfferings,
   assignmentFamilies,
   validAssignments,
   testSection,
@@ -18,6 +19,7 @@ describe('EditSectionForm', () => {
         handleSave={() => {}}
         handleClose={() => {}}
         editSectionProperties={() => {}}
+        courseOfferings={courseOfferings}
         validAssignments={validAssignments}
         assignmentFamilies={assignmentFamilies}
         sections={{}}
@@ -55,6 +57,7 @@ describe('EditSectionForm', () => {
         handleSave={() => {}}
         handleClose={() => {}}
         editSectionProperties={() => {}}
+        courseOfferings={courseOfferings}
         validAssignments={validAssignments}
         assignmentFamilies={assignmentFamilies}
         sections={{}}
@@ -92,6 +95,7 @@ describe('EditSectionForm', () => {
         handleSave={() => {}}
         handleClose={() => {}}
         editSectionProperties={() => {}}
+        courseOfferings={courseOfferings}
         validAssignments={validAssignments}
         assignmentFamilies={assignmentFamilies}
         sections={{}}
@@ -129,6 +133,7 @@ describe('EditSectionForm', () => {
         handleSave={() => {}}
         handleClose={() => {}}
         editSectionProperties={() => {}}
+        courseOfferings={courseOfferings}
         validAssignments={validAssignments}
         assignmentFamilies={assignmentFamilies}
         sections={{}}
@@ -166,6 +171,7 @@ describe('EditSectionForm', () => {
         handleSave={() => {}}
         handleClose={() => {}}
         editSectionProperties={() => {}}
+        courseOfferings={courseOfferings}
         validAssignments={validAssignments}
         assignmentFamilies={assignmentFamilies}
         sections={{}}
@@ -191,6 +197,7 @@ describe('EditSectionForm', () => {
         handleSave={() => {}}
         handleClose={() => {}}
         editSectionProperties={() => {}}
+        courseOfferings={courseOfferings}
         validAssignments={validAssignments}
         assignmentFamilies={assignmentFamilies}
         sections={{}}
@@ -216,6 +223,7 @@ describe('EditSectionForm', () => {
         handleSave={() => {}}
         handleClose={() => {}}
         editSectionProperties={() => {}}
+        courseOfferings={courseOfferings}
         validAssignments={validAssignments}
         assignmentFamilies={assignmentFamilies}
         sections={{}}
@@ -238,6 +246,7 @@ describe('EditSectionForm', () => {
         handleSave={() => {}}
         handleClose={() => {}}
         editSectionProperties={() => {}}
+        courseOfferings={courseOfferings}
         validAssignments={validAssignments}
         assignmentFamilies={assignmentFamilies}
         sections={{}}
@@ -263,6 +272,7 @@ describe('EditSectionForm', () => {
         handleSave={() => {}}
         handleClose={() => {}}
         editSectionProperties={() => {}}
+        courseOfferings={courseOfferings}
         validAssignments={validAssignments}
         assignmentFamilies={assignmentFamilies}
         sections={{}}
@@ -285,6 +295,7 @@ describe('EditSectionForm', () => {
         handleSave={() => {}}
         handleClose={() => {}}
         editSectionProperties={() => {}}
+        courseOfferings={courseOfferings}
         validAssignments={validAssignments}
         assignmentFamilies={assignmentFamilies}
         sections={{}}
@@ -309,7 +320,7 @@ describe('EditSectionForm', () => {
         handleSave={() => {}}
         handleClose={() => {}}
         editSectionProperties={() => {}}
-        validGrades={['K', '1', '2', '3']}
+        courseOfferings={courseOfferings}
         validAssignments={validAssignments}
         assignmentFamilies={assignmentFamilies}
         sections={{}}
@@ -334,7 +345,7 @@ describe('EditSectionForm', () => {
         handleSave={() => {}}
         handleClose={() => {}}
         editSectionProperties={() => {}}
-        validGrades={['K', '1', '2', '3']}
+        courseOfferings={courseOfferings}
         validAssignments={validAssignments}
         assignmentFamilies={assignmentFamilies}
         sections={{}}
@@ -358,7 +369,7 @@ describe('EditSectionForm', () => {
         handleSave={() => {}}
         handleClose={() => {}}
         editSectionProperties={() => {}}
-        validGrades={['K', '1', '2', '3']}
+        courseOfferings={courseOfferings}
         validAssignments={validAssignments}
         assignmentFamilies={assignmentFamilies}
         sections={{}}
@@ -382,7 +393,7 @@ describe('EditSectionForm', () => {
         handleSave={() => {}}
         handleClose={() => {}}
         editSectionProperties={() => {}}
-        validGrades={['K', '1', '2', '3']}
+        courseOfferings={courseOfferings}
         validAssignments={validAssignments}
         assignmentFamilies={assignmentFamilies}
         sections={{}}

--- a/apps/test/unit/templates/teacherDashboard/teacherSectionsReduxTest.js
+++ b/apps/test/unit/templates/teacherDashboard/teacherSectionsReduxTest.js
@@ -1177,7 +1177,7 @@ describe('teacherSectionsRedux', () => {
       const promise = store.dispatch(asyncLoadSectionData());
       expect(state().validAssignments).to.deep.equal({});
 
-      expect(server.requests).to.have.length(3);
+      expect(server.requests).to.have.length(4);
       server.respondWith('GET', '/dashboardapi/sections', successResponse());
       server.respondWith(
         'GET',
@@ -1188,6 +1188,11 @@ describe('teacherSectionsRedux', () => {
         'GET',
         '/dashboardapi/sections/valid_scripts',
         successResponse(validScripts)
+      );
+      server.respondWith(
+        'GET',
+        '/dashboardapi/sections/valid_course_offerings',
+        successResponse(courseOfferings)
       );
       server.respond();
 
@@ -1202,13 +1207,18 @@ describe('teacherSectionsRedux', () => {
       const promise = store.dispatch(asyncLoadSectionData('id'));
       expect(state().validAssignments).to.deep.equal({});
 
-      expect(server.requests).to.have.length(4);
+      expect(server.requests).to.have.length(5);
       server.respondWith('GET', '/dashboardapi/sections', successResponse());
       server.respondWith('GET', '/dashboardapi/courses', successResponse());
       server.respondWith(
         'GET',
         '/dashboardapi/sections/valid_scripts',
         successResponse()
+      );
+      server.respondWith(
+        'GET',
+        '/dashboardapi/sections/valid_course_offerings',
+        successResponse(courseOfferings)
       );
       server.respondWith(
         'GET',
@@ -1632,6 +1642,11 @@ describe('teacherSectionsRedux', () => {
         '/dashboardapi/sections/valid_scripts',
         successResponse([])
       );
+      server.respondWith(
+        'GET',
+        '/dashboardapi/sections/valid_course_offerings',
+        successResponse([])
+      );
     });
     afterEach(() => server.restore());
 
@@ -1723,7 +1738,7 @@ describe('teacherSectionsRedux', () => {
         importOrUpdateRoster(TEST_COURSE_ID, TEST_COURSE_NAME)
       );
       return expect(promise).to.be.fulfilled.then(() => {
-        expect(server.requests).to.have.length(4);
+        expect(server.requests).to.have.length(5);
         expect(server.requests[1].method).to.equal('GET');
         expect(server.requests[1].url).to.equal('/dashboardapi/sections');
         expect(server.requests[2].method).to.equal('GET');
@@ -1731,6 +1746,10 @@ describe('teacherSectionsRedux', () => {
         expect(server.requests[3].method).to.equal('GET');
         expect(server.requests[3].url).to.equal(
           '/dashboardapi/sections/valid_scripts'
+        );
+        expect(server.requests[4].method).to.equal('GET');
+        expect(server.requests[4].url).to.equal(
+          '/dashboardapi/sections/valid_course_offerings'
         );
         expect(Object.keys(getState().teacherSections.sections)).to.have.length(
           sections.length

--- a/dashboard/app/controllers/api/v1/sections_controller.rb
+++ b/dashboard/app/controllers/api/v1/sections_controller.rb
@@ -191,6 +191,14 @@ class Api::V1::SectionsController < Api::V1::JsonApiController
     render json: scripts
   end
 
+  # GET /api/v1/sections/valid_course_offerings
+  def valid_course_offerings
+    return head :forbidden unless current_user
+
+    course_offerings = CourseOffering.assignable_course_offerings_info(current_user)
+    render json: course_offerings
+  end
+
   # GET /api/v1/sections/require_captcha
   # Get the recaptcha site key for frontend and whether current user requires captcha verification
   def require_captcha

--- a/dashboard/app/views/teacher_dashboard/show.html.haml
+++ b/dashboard/app/views/teacher_dashboard/show.html.haml
@@ -7,6 +7,7 @@
   teacher_dashboard_data[:section] = @section_summary
   teacher_dashboard_data[:validScripts] = Script.valid_scripts(current_user).map(&:assignable_info)
   teacher_dashboard_data[:validCourses] = UnitGroup.valid_course_infos(user: @current_user)
+  teacher_dashboard_data[:validCourseOfferings] = CourseOffering.assignable_course_offerings_info(current_user)
   teacher_dashboard_data[:studentScriptIds] = @section.student_script_ids
   teacher_dashboard_data[:currentUserId] = @current_user.id
   teacher_dashboard_data[:hasSeenStandardsReportInfo] = @current_user.has_seen_standards_report_info_dialog || false

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -96,6 +96,7 @@ Dashboard::Application.routes.draw do
       collection do
         get 'membership'
         get 'valid_scripts'
+        get 'valid_course_offerings'
         get 'require_captcha'
       end
     end


### PR DESCRIPTION
Follow up to #44285. Prep for using new course offering summaries in components.

This PR passes the new course offering summaries to the front end. It does not yet use them. In addition it passes a courseVersionId which will be needed to move to using course offering summaries on the Unit Overview page.

<img width="1792" alt="Screen Shot 2022-03-11 at 6 46 14 AM" src="https://user-images.githubusercontent.com/208083/157861274-60704c32-e1d6-4c14-b7df-be86af73df62.png">


## Links

[Jira](https://codedotorg.atlassian.net/browse/PLAT-1584)
[Mini Spec](https://docs.google.com/document/d/11-dtCFuSmST_vP2MdkH0H0lb2e5AGFu1MxiWSRsnkns/edit#heading=h.pgquzxwzm1u2)

## Testing story

- Updated unit tests