### PR TITLE
[Sprite Lab] Bug in Criteria Command

### DIFF
--- a/apps/src/p5lab/spritelab/commands/criterionCommands.js
+++ b/apps/src/p5lab/spritelab/commands/criterionCommands.js
@@ -90,10 +90,14 @@ export const commands = {
         let type = typeof speechText;
         switch (type) {
           case 'string':
-            result = speechText.includes(value);
+            if (speechText.includes(value)) {
+              result = true;
+            }
             break;
           case 'number':
-            result = speechText === value;
+            if (speechText === value) {
+              result = true;
+            }
             break;
           default:
             break;

--- a/apps/src/p5lab/spritelab/commands/criterionCommands.js
+++ b/apps/src/p5lab/spritelab/commands/criterionCommands.js
@@ -88,6 +88,8 @@ export const commands = {
         let speechText = this.getLastSpeechBubbleForSpriteId(spriteIds[i])
           ?.text;
         let type = typeof speechText;
+        // We only want to set result to true here, so that any positive test
+        // allows the overall criterion to pass.
         switch (type) {
           case 'string':
             if (speechText.includes(value)) {


### PR DESCRIPTION
A curriculum level has the following instructions:
>Change a variable's value each time a sprite is clicked. Have the sprite say the new value each time it changes.

Emma W communicated a teacher bug report to me where students were failing this task depending on the order of their `say` and `change variable` blocks.

| Passes | Fails |
|-|-|
| <img width="500" alt="Screen Shot 2022-03-10 at 4 31 10 PM" src="https://user-images.githubusercontent.com/43474485/157898759-4b0cc405-9e7f-48e4-bc64-8944d72cb3fb.png"> |<img width="500" alt="Screen Shot 2022-03-10 at 4 31 10 PM" src="https://user-images.githubusercontent.com/43474485/157899120-eb3bd05c-f020-427f-80a8-c35842a1a125.png"> |

Upon investigation, I found a bug in how we reported success for whether a sprite had said a value from two given objects (variable values from the current frame and previous frame). Fixing this bug allows students to pass with either block order, which is the lesson's intent.

After testing locally, both expected solutions pass.
![image](https://user-images.githubusercontent.com/43474485/157896223-7d651b8f-3d1b-4cd7-92b1-39bd2bd465e4.png)

![image](https://user-images.githubusercontent.com/43474485/157896119-fc502262-1aa6-4a74-962e-0bfcced18bf3.png)

This logic affect 3 levels that are currently being piloted. It can be tested locally at http://localhost-studio.code.org:3000/levels/30954 and compared against production at https://studio.code.org/levels/32325
