### PR TITLE
Revert "Revert "Wait for sign out in code review UI tests""

### DIFF
--- a/dashboard/test/ui/features/javalab/code_review_eyes.feature
+++ b/dashboard/test/ui/features/javalab/code_review_eyes.feature
@@ -1,7 +1,6 @@
 @eyes
 @no_mobile
 @no_ie
-@skip
 Feature: Code Review Eyes
 
   @no_circle
@@ -15,6 +14,9 @@ Feature: Code Review Eyes
     And I save the section id from row 0 of the section table
     Given I create a student named "Hermione"
     And I join the section
+    # Observed flakiness trying to navigate to teacher dashboard while still signed in as Hermione.
+    # Explicitly wait for sign out to occur to avoid this.
+    And I sign out using jquery
     # Create a code review group with a student in it.
     # Save the group, and enable code review for the section.
     Given I sign in as "Dumbledore" and go home

--- a/dashboard/test/ui/features/javalab/code_review_eyes.feature
+++ b/dashboard/test/ui/features/javalab/code_review_eyes.feature
@@ -16,6 +16,7 @@ Feature: Code Review Eyes
     And I join the section
     # Observed flakiness trying to navigate to teacher dashboard while still signed in as Hermione.
     # Explicitly wait for sign out to occur to avoid this.
+    And I wait to see ".alert-success"
     And I sign out using jquery
     # Create a code review group with a student in it.
     # Save the group, and enable code review for the section.

--- a/dashboard/test/ui/features/javalab/code_review_eyes.feature
+++ b/dashboard/test/ui/features/javalab/code_review_eyes.feature
@@ -1,6 +1,5 @@
 @eyes
 @no_mobile
-@no_ie
 Feature: Code Review Eyes
 
   @no_circle

--- a/dashboard/test/ui/features/javalab/code_review_peer_scenarios.feature
+++ b/dashboard/test/ui/features/javalab/code_review_peer_scenarios.feature
@@ -23,6 +23,7 @@ Feature: Code review (peer scenarios)
     And I join the section
     # Observed flakiness trying to navigate to teacher dashboard while still signed in as Harry.
     # Explicitly wait for sign out to occur to avoid this.
+    And I wait to see ".alert-success"
     And I sign out using jquery
     # Create a code review group with students in it.
     # Save the group, and enable code review for the section.

--- a/dashboard/test/ui/features/javalab/code_review_peer_scenarios.feature
+++ b/dashboard/test/ui/features/javalab/code_review_peer_scenarios.feature
@@ -4,7 +4,6 @@
 
 @no_mobile
 @no_ie
-@skip
 Feature: Code review (peer scenarios)
 
   # At the end of the setup, we will have created
@@ -22,6 +21,9 @@ Feature: Code review (peer scenarios)
     And I join the section
     Given I create a student named "Harry"
     And I join the section
+    # Observed flakiness trying to navigate to teacher dashboard while still signed in as Harry.
+    # Explicitly wait for sign out to occur to avoid this.
+    And I sign out using jquery
     # Create a code review group with students in it.
     # Save the group, and enable code review for the section.
     Given I sign in as "Dumbledore" and go home

--- a/dashboard/test/ui/features/javalab/code_review_peer_scenarios.feature
+++ b/dashboard/test/ui/features/javalab/code_review_peer_scenarios.feature
@@ -3,7 +3,6 @@
 # and those that do not (code_review_project_owner_and_teacher_scenarios.feature)
 
 @no_mobile
-@no_ie
 Feature: Code review (peer scenarios)
 
   # At the end of the setup, we will have created

--- a/dashboard/test/ui/features/javalab/code_review_project_owner_and_teacher_scenarios.feature
+++ b/dashboard/test/ui/features/javalab/code_review_project_owner_and_teacher_scenarios.feature
@@ -21,6 +21,7 @@ Feature: Code review (project owner/teacher scenarios)
     And I join the section
     # Observed flakiness trying to navigate to teacher dashboard while still signed in as Hermione.
     # Explicitly wait for sign out to occur to avoid this.
+    And I wait to see ".alert-success"
     And I sign out using jquery
     # Create a code review group with students in it.
     # Save the group, and enable code review for the section.

--- a/dashboard/test/ui/features/javalab/code_review_project_owner_and_teacher_scenarios.feature
+++ b/dashboard/test/ui/features/javalab/code_review_project_owner_and_teacher_scenarios.feature
@@ -4,7 +4,6 @@
 
 @no_mobile
 @no_ie
-@skip
 Feature: Code review (project owner/teacher scenarios)
 
   # At the end of the setup, we will have created
@@ -20,6 +19,9 @@ Feature: Code review (project owner/teacher scenarios)
     And I save the section id from row 0 of the section table
     Given I create a student named "Hermione"
     And I join the section
+    # Observed flakiness trying to navigate to teacher dashboard while still signed in as Hermione.
+    # Explicitly wait for sign out to occur to avoid this.
+    And I sign out using jquery
     # Create a code review group with students in it.
     # Save the group, and enable code review for the section.
     Given I sign in as "Dumbledore" and go home

--- a/dashboard/test/ui/features/javalab/code_review_project_owner_and_teacher_scenarios.feature
+++ b/dashboard/test/ui/features/javalab/code_review_project_owner_and_teacher_scenarios.feature
@@ -3,7 +3,6 @@
 # and those that do not (code_review_project_owner_and_teacher_scenarios.feature)
 
 @no_mobile
-@no_ie
 Feature: Code review (project owner/teacher scenarios)
 
   # At the end of the setup, we will have created


### PR DESCRIPTION
Restore changes from https://github.com/code-dot-org/code-dot-org/pull/45239, with an additional fix.

One more try to fix code review UI tests -- the "fix" I implemented to assure sign out before switching between student and teacher users resulting in the test hanging, as the sign out request occurred before navigating from the section join page to the course overview page. The test is then looking for a flag marking that the sign out has completed after the navigation, which it never receives. Example video of the issue here:

https://app.saucelabs.com/tests/9b10fd07ffe8417c8bcce0df363f91c9#64

Additional fix in this PR is to wait until the test navigates to the course overview page (which happens after you join a section) before signing out the student.

## Testing story

I just looked at a Saucelabs video from the Drone run, where the change I'm expecting looks to have worked appropriately (make sign-out ajax call after navigating to course overview page).