### PR TITLE
Clearer sign up user type remove opt rollout

### DIFF
--- a/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
+++ b/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
@@ -40,6 +40,11 @@ let schoolData = {
 // Keep track of whether the current user is in the U.S. or not (for regional partner email sharing)
 let isInUnitedStates = schoolData.countryCode === 'US';
 
+// Track whether clearer user type buttons rollout is enabled
+const inClearerUserTypeRollout = experiments.isEnabled(
+  experiments.CLEARER_SIGN_UP_USER_TYPE
+);
+
 // TO-DELETE ONCE SHARE EMAIL WITH REGIONAL PARTNER OPTIMIZELY-EXPERIMENT IS COMPLETE (start)
 let userInOptimizelyVariant = experiments.isEnabled(
   experiments.OPT_IN_EMAIL_REG_PARTNER
@@ -52,14 +57,20 @@ $(document).ready(() => {
 
   function init() {
     // TO-DELETE ONCE CLEARER USER TYPE BUTTONS OPTIMIZELY-EXPERIMENT IS COMPLETE (start)
-    if (experiments.isEnabled(experiments.CLEARER_SIGN_UP_USER_TYPE)) {
+    if (inClearerUserTypeRollout) {
       // If in variant, toggle large buttons
       document.getElementById('select-user-type-original').style.cssText =
         'display:none;';
+      document.getElementById('select-user-type-variant').style.cssText =
+        'display:flex;';
+      document.getElementById('signup-select-user-type-label').style.cssText =
+        'width:135px;';
     } else {
       // Otherwise (also the default), keep original dropdown
       document.getElementById('select-user-type-variant').style.cssText =
         'display:none;';
+      document.getElementById('select-user-type-original').style.cssText =
+        'display:flex;';
       document.getElementById('signup-select-user-type-label').style.cssText =
         'width:220px;';
     }
@@ -133,35 +144,6 @@ $(document).ready(() => {
     }
   }
 
-  // Event listeners for changing the user type
-  document.addEventListener('selectUserTypeTeacher', e => {
-    $('#user_user_type').val('teacher');
-    styleSelectedUserTypeButton('teacher');
-    setUserType('teacher');
-  });
-  document.addEventListener('selectUserTypeStudent', e => {
-    $('#user_user_type').val('student');
-    styleSelectedUserTypeButton('student');
-    setUserType('student');
-  });
-
-  // Style selected user type button to show it has been clicked
-  function styleSelectedUserTypeButton(value) {
-    if (value === 'teacher') {
-      teacherButton.classList.add('select-user-type-button-selected');
-      studentButton.classList.remove('select-user-type-button-selected');
-    } else if (value === 'student') {
-      studentButton.classList.add('select-user-type-button-selected');
-      teacherButton.classList.remove('select-user-type-button-selected');
-    }
-  }
-
-  // Optimizely Event to track user type selection
-  function optimizelyCountUserTypeSelection(userType) {
-    window['optimizely'] = window['optimizely'] || [];
-    window['optimizely'].push({type: 'event', eventName: userType});
-  }
-
   // Optimizely-related code for sharing email with regional partners experiment
   function optimizelyCountSuccessSignupWithRegPartnerOpt() {
     window['optimizely'] = window['optimizely'] || [];
@@ -172,6 +154,18 @@ $(document).ready(() => {
   $('#user_user_type').change(function() {
     var value = $(this).val();
     setUserType(value);
+  });
+
+  // Event listeners for changing the user type
+  document.addEventListener('selectUserTypeTeacher', e => {
+    $('#user_user_type').val('teacher');
+    styleSelectedUserTypeButton('teacher');
+    setUserType('teacher');
+  });
+  document.addEventListener('selectUserTypeStudent', e => {
+    $('#user_user_type').val('student');
+    styleSelectedUserTypeButton('student');
+    setUserType('student');
   });
 
   function getUserType() {
@@ -190,6 +184,17 @@ $(document).ready(() => {
     } else {
       // Show student fields by default.
       switchToStudent();
+    }
+  }
+
+  // Style selected user type button to show it has been clicked
+  function styleSelectedUserTypeButton(value) {
+    if (value === 'teacher') {
+      teacherButton.classList.add('select-user-type-button-selected');
+      studentButton.classList.remove('select-user-type-button-selected');
+    } else if (value === 'student') {
+      studentButton.classList.add('select-user-type-button-selected');
+      teacherButton.classList.remove('select-user-type-button-selected');
     }
   }
 
@@ -212,6 +217,12 @@ $(document).ready(() => {
       event: 'select-' + type,
       data_string: signUpUID
     });
+  }
+
+  // Optimizely Event to track user type selection
+  function optimizelyCountUserTypeSelection(userType) {
+    window['optimizely'] = window['optimizely'] || [];
+    window['optimizely'].push({type: 'event', eventName: userType});
   }
 
   function fadeInFields(fields) {

--- a/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
+++ b/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
@@ -53,6 +53,7 @@ let userInOptimizelyVariant = experiments.isEnabled(
 
 $(document).ready(() => {
   const schoolInfoMountPoint = document.getElementById('school-info-inputs');
+  let user_type = $('#user_user_type').val();
   init();
 
   function init() {
@@ -75,7 +76,7 @@ $(document).ready(() => {
         'width:220px;';
     }
     // TO-DELETE ONCE CLEARER USER TYPE BUTTONS OPTIMIZELY-EXPERIMENT IS COMPLETE (end)
-    setUserType(getUserType());
+    setUserType(user_type);
     renderSchoolInfo();
     renderParentSignUpSection();
   }
@@ -91,7 +92,7 @@ $(document).ready(() => {
     }
 
     // Track user type selection in Optimizely Event
-    optimizelyCountUserTypeSelection(getUserType());
+    optimizelyCountUserTypeSelection(user_type);
 
     // Optimizely-related code for teacher opting to share email with regional partner (start)
     optimizelyCountSuccessSignupWithRegPartnerOpt();
@@ -99,7 +100,7 @@ $(document).ready(() => {
 
     alreadySubmitted = true;
     // Clean up school data and set age for teachers.
-    if (getUserType() === 'teacher') {
+    if (user_type === 'teacher') {
       cleanSchoolInfo();
       $('#user_age').val('21+');
     }
@@ -125,7 +126,8 @@ $(document).ready(() => {
   $('#user_parent_email_preference_opt_in_required').change(function() {
     // If the user_type is currently blank, switch the user_type to 'student' because that is the only user_type which
     // allows the parent sign up section of the form.
-    if (getUserType() === '') {
+    if (user_type === '') {
+      setUserType('student');
       $('#user_user_type')
         .val('student')
         .change();
@@ -153,32 +155,28 @@ $(document).ready(() => {
   // Event listeners for changing the user type
   document.addEventListener('selectUserTypeTeacher', e => {
     $('#user_user_type').val('teacher');
-    styleSelectedUserTypeButton('teacher');
     setUserType('teacher');
   });
   document.addEventListener('selectUserTypeStudent', e => {
     $('#user_user_type').val('student');
-    styleSelectedUserTypeButton('student');
     setUserType('student');
   });
 
-  function getUserType() {
-    var value = $('#user_user_type')[0].value;
-    styleSelectedUserTypeButton(value);
-    return value;
-  }
-
-  function setUserType(userType) {
-    if (userType) {
-      trackUserType(userType);
+  function setUserType(new_user_type) {
+    if (new_user_type) {
+      trackUserType(new_user_type);
     }
-
-    if (userType === 'teacher') {
+    // Switch to new user type
+    if (new_user_type === 'teacher') {
       switchToTeacher();
     } else {
       // Show student fields by default.
       switchToStudent();
     }
+    if (inClearerUserTypeRollout) {
+      styleSelectedUserTypeButton(new_user_type);
+    }
+    user_type = new_user_type;
   }
 
   // Style selected user type button to show it has been clicked
@@ -214,9 +212,9 @@ $(document).ready(() => {
   }
 
   // Optimizely Event to track user type selection
-  function optimizelyCountUserTypeSelection(userType) {
+  function optimizelyCountUserTypeSelection(selected_user_type) {
     window['optimizely'] = window['optimizely'] || [];
-    window['optimizely'].push({type: 'event', eventName: userType});
+    window['optimizely'].push({type: 'event', eventName: selected_user_type});
   }
 
   // Optimizely-related code for sharing email with regional partners experiment

--- a/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
+++ b/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
@@ -144,12 +144,6 @@ $(document).ready(() => {
     }
   }
 
-  // Optimizely-related code for sharing email with regional partners experiment
-  function optimizelyCountSuccessSignupWithRegPartnerOpt() {
-    window['optimizely'] = window['optimizely'] || [];
-    window['optimizely'].push({type: 'event', eventName: 'successSignUp'});
-  }
-
   // Keep if sign-up user type experiment favors original (just func. below)
   $('#user_user_type').change(function() {
     var value = $(this).val();
@@ -223,6 +217,12 @@ $(document).ready(() => {
   function optimizelyCountUserTypeSelection(userType) {
     window['optimizely'] = window['optimizely'] || [];
     window['optimizely'].push({type: 'event', eventName: userType});
+  }
+
+  // Optimizely-related code for sharing email with regional partners experiment
+  function optimizelyCountSuccessSignupWithRegPartnerOpt() {
+    window['optimizely'] = window['optimizely'] || [];
+    window['optimizely'].push({type: 'event', eventName: 'successSignUp'});
   }
 
   function fadeInFields(fields) {

--- a/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
+++ b/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
@@ -79,9 +79,8 @@ $(document).ready(() => {
       return false;
     }
 
-    // Optimizely-related code for new sign-up user-type buttons (start)
+    // Track user type selection in Optimizely Event
     optimizelyCountUserTypeSelection(getUserType());
-    // Optimizely-related code for new sign-up user-type buttons (end)
 
     // Optimizely-related code for teacher opting to share email with regional partner (start)
     optimizelyCountSuccessSignupWithRegPartnerOpt();
@@ -134,7 +133,6 @@ $(document).ready(() => {
     }
   }
 
-  // Keep if sign-up user type experiment favors variant (start)
   // Event listeners for changing the user type
   document.addEventListener('selectUserTypeTeacher', e => {
     $('#user_user_type').val('teacher');
@@ -147,6 +145,7 @@ $(document).ready(() => {
     setUserType('student');
   });
 
+  // Style selected user type button to show it has been clicked
   function styleSelectedUserTypeButton(value) {
     if (value === 'teacher') {
       teacherButton.classList.add('select-user-type-button-selected');
@@ -156,9 +155,8 @@ $(document).ready(() => {
       teacherButton.classList.remove('select-user-type-button-selected');
     }
   }
-  // Keep if sign-up user type experiment favors variant (end)
 
-  // Optimizely-related code for new sign-up user-type buttons
+  // Optimizely Event to track user type selection
   function optimizelyCountUserTypeSelection(userType) {
     window['optimizely'] = window['optimizely'] || [];
     window['optimizely'].push({type: 'event', eventName: userType});

--- a/lib/dynamic_config/dcdo.rb
+++ b/lib/dynamic_config/dcdo.rb
@@ -94,7 +94,8 @@ class DCDOBase
     # For example:
     # 'my-new-feature': DCDO.get('my-new-feature', false)
     {
-      'frontend-i18n-tracking': DCDO.get('frontend-i18n-tracking', false)
+      'frontend-i18n-tracking': DCDO.get('frontend-i18n-tracking', false),
+      'clearerSignUpUserType': DCDO.get('clearerSignUpUserType', false)
     }
   end
 end


### PR DESCRIPTION
Remove most Optimizely code and (nearly) fully ship clearer student vs teacher login type sign up buttons (under a DCDO flag). With most of the Optimizely code gone, I also cleaned up and re-ordered some of the functions to group together the functions for the new user type buttons and the functions for the old dropdown so that once the changes have been rolled out successfully, one final PR can be done to remove any final traces of the original dropdown menu user type selecetion.
_Note: not all Optimizely code is being removed from this file since 1) some of the event trackers are being kept in so that they can be used in other experiments, and 2) an experiment for [another PR]() uses Optimizely code in `_finish_sign_up.js`_

The groundwork from [this PR](https://github.com/code-dot-org/code-dot-org/pull/43950) allows me to create a DCDO variable for toggling on/off this new front-end variation (similar to [this PR](https://github.com/code-dot-org/code-dot-org/pull/43951)). Since it's in the sign-up page, the DCDO flag will help switch it off in case something goes wrong (the file also defaults to the original unless it sees that the flag is turned on).

## Links
Jira task: [here](https://codedotorg.atlassian.net/browse/FND-1740?atlOrigin=eyJpIjoiZDRjOWUxNTk4N2JhNDYwMjgxYTY0YTk0MGIwNWJkMGMiLCJwIjoiaiJ9)
PR for the new user type buttons: [here](https://github.com/code-dot-org/code-dot-org/pull/41608)
PR for adding Optimizely events to track the new user type button selections: [here](https://github.com/code-dot-org/code-dot-org/pull/41751)
PR that allows DCDO to interact with front-end: [here](https://github.com/code-dot-org/code-dot-org/pull/43950)
PR that this PR mirrors for setting the DCDO flag: [here](https://github.com/code-dot-org/code-dot-org/pull/43951)

## Testing story
First, localhost testing to ensure correct behavior. Then, created an adhoc to test that it naturally defaulted to the original view, then ssh'd into the adhoc to toggle the DCDO variable and checked that the new user type buttons showed up consistently (in multiple browsers and in multiple languages).

## Deployment strategy
Once pushed, ensure that the sign up page looks the same as if nothing happened. Then, toggle the DCDO flag and check to see that users see the new user type buttons in the sign-up page.

## Follow-up work
Once fully rolled out, one final PR can remove the code for the old drop-down menu for user type selection.


## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
