### PR TITLE
Add already saved warning

### DIFF
--- a/apps/src/code-studio/pd/form_components_func/FormController.jsx
+++ b/apps/src/code-studio/pd/form_components_func/FormController.jsx
@@ -334,10 +334,10 @@ const FormController = props => {
       setErrors(data.responseJSON.errors.form_data);
       setErrorHeader(i18n.formErrorsBelow());
     } else if (data?.status === 409) {
-      // We are trying to create an application that has already been created
+      // trying to create an application that has already been created
       setGlobalError(true);
       setErrorHeader(
-        'We found an application that you already started. Reload the page to continue the form you have saved.'
+        'We found an application that you already started. Reload the page to continue.'
       );
     } else {
       // Otherwise, something unknown went wrong on the server

--- a/apps/src/code-studio/pd/form_components_func/FormController.jsx
+++ b/apps/src/code-studio/pd/form_components_func/FormController.jsx
@@ -333,6 +333,12 @@ const FormController = props => {
     if (data?.responseJSON?.errors?.form_data) {
       setErrors(data.responseJSON.errors.form_data);
       setErrorHeader(i18n.formErrorsBelow());
+    } else if (data?.status === 409) {
+      // We are trying to create an application that has already been created
+      setGlobalError(true);
+      setErrorHeader(
+        'We found an application that you already started. Reload the page to continue the form you have saved.'
+      );
     } else {
       // Otherwise, something unknown went wrong on the server
       setGlobalError(true);
@@ -646,7 +652,7 @@ const FormController = props => {
 const styles = {
   pageButtons: {
     verticalAlign: 'middle',
-    margin: '0 10px'
+    margin: '0px 10px 5px'
   },
   saveButton: {
     marginLeft: '10px',

--- a/dashboard/app/controllers/api/v1/pd/forms_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/forms_controller.rb
@@ -17,7 +17,7 @@ class Api::V1::Pd::FormsController < ::ApplicationController
 
     # Check for idempotence
     existing_form = form.check_idempotency
-    return render json: {id: existing_form.id}, status: :ok if existing_form
+    return render json: {id: existing_form.id}, status: :conflict if existing_form
 
     if form.save
       render json: {id: form.id}, status: :created

--- a/dashboard/test/controllers/api/v1/pd/application/facilitator_applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/application/facilitator_applications_controller_test.rb
@@ -48,7 +48,7 @@ module Api::V1::Pd::Application
       assert_no_difference 'Pd::Application::Facilitator1920Application.count' do
         put :create, params: @test_params
       end
-      assert_response :success
+      assert_response :conflict
     end
   end
 end

--- a/dashboard/test/controllers/api/v1/pd/application/principal_approval_applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/application/principal_approval_applications_controller_test.rb
@@ -141,7 +141,7 @@ module Api::V1::Pd::Application
       assert_no_difference "#{PRINCIPAL_APPROVAL_APPLICATION_CLASS.name}.count" do
         put :create, params: @test_params
       end
-      assert_response :success
+      assert_response :conflict
     end
 
     test 'application gets autoscored upon submission' do

--- a/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/application/teacher_applications_controller_test.rb
@@ -106,7 +106,23 @@ module Api::V1::Pd::Application
       assert_no_difference "#{TEACHER_APPLICATION_CLASS.name}.count" do
         put :create, params: {form_data: @test_params}
       end
-      assert_response :success
+    end
+
+    test 'creating an application on an existing form renders conflict' do
+      sign_in @applicant
+      application = create TEACHER_APPLICATION_FACTORY, user: @applicant
+      post :create, params:  {
+        id: application.id
+      }
+      assert_response :conflict
+    end
+
+    test 'updating an application with an error renders bad_request' do
+      sign_in @applicant
+      application = create TEACHER_APPLICATION_FACTORY, user: @applicant
+      put :update, params: {id: application.id, form_data: @test_params, application_year: nil}
+
+      assert_response :bad_request
     end
 
     test 'updates user school info on successful create' do
@@ -162,14 +178,6 @@ module Api::V1::Pd::Application
       assert_nil application.form_data_hash[:cs_total_course_hours]
       assert_equal original_school_info, @applicant.school_info
       assert_response :ok
-    end
-
-    test 'updating an application with an error renders bad_request' do
-      sign_in @applicant
-      application = create TEACHER_APPLICATION_FACTORY, user: @applicant
-      put :update, params: {id: application.id, form_data: @test_params, application_year: nil}
-
-      assert_response :bad_request
     end
 
     test 'send_principal_approval queues up an email if none exist' do


### PR DESCRIPTION
If a user has a new teacher application open on two pages, saves one page, then continues working on another page, we were returning `status: ok` making it look like there were no problems. Instead, return `status: conflict` and display a more helpful error message.

Video (in Google Drive due to internet issues): https://drive.google.com/file/d/1a-FMmyLPXNHmRmUZKf0vI4kPK6qr4F8E/view?usp=sharing

<img width="907" alt="Screen Shot 2022-03-11 at 5 17 12 PM" src="https://user-images.githubusercontent.com/9142121/157980131-f2e2b685-d94c-437c-92c3-c61bd4a9d4d6.png">
<img width="912" alt="Screen Shot 2022-03-11 at 5 17 02 PM" src="https://user-images.githubusercontent.com/9142121/157980149-38304c8c-0328-4848-b4c4-f352c0aec0cc.png">

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
