### PR TITLE
I18n sync In & Up 03/14

### DIFF
--- a/i18n/locales/source/blockly-mooc/javalab.json
+++ b/i18n/locales/source/blockly-mooc/javalab.json
@@ -1,6 +1,8 @@
 {
   "abortedTestResult": "{className} > {methodName} ABORTED",
   "addAComment": "Add a comment",
+  "authorizerNearLimit": "You have run your code too many times in the last hour. You have {attemptsLeft} attempts left before your account will be permanently locked and you will be unable to run Java code. Please wait 15 minutes before trying again.",
+  "authorizerTokenUsed": "You are attempting to reuse a token that has already run your code. Please check that you are on a secure network before trying again. If you believe this message is in error, contact support@code.org.",
   "authorLabel": "author",
   "allFilesCompile": "All Files Compile!",
   "backpackFileNameConflictWarning": "Saving will overwrite an existing file in your backpack",
@@ -11,6 +13,7 @@
   "backpackSaveErrorMessage": "Please try again",
   "cancel": "Cancel",
   "clearConsole": "Clear Console",
+  "classroomBlocked": "Your section has run their code too many times and has been locked. Ask your teacher to contact support@code.org to unlock your section.",
   "classNotFound": "Error: one or more of your Java files are missing a class definition.",
   "commentUpdateError": "There was an error processing your request, please try again.",
   "commit": "Commit",
@@ -24,6 +27,7 @@
   "compilerError": "We couldn't compile your program. Look for bugs in your program and try again.",
   "compiling": "Compiling...",
   "compilingProgram": "'Compiling program...",
+  "connecting": "Connecting...",
   "console": "Console",
   "delete": "Delete",
   "deleteFileConfirmation": "Are you sure you want to delete {filename}?",
@@ -116,5 +120,6 @@
   "teacherLabel": "teacher",
   "togglePeerReviewError": "Error enabling/disabling peer review, please try again.",
   "unknownError": "Oops. We hit an error on our side. Try running your program again. If this error continues, contact us at support@code.org. Be sure to include the connection ID {connectionId} in your message.\n{type}",
+  "userBlocked": "You have run your code too many times and your account has been locked. Contact support@code.org to unlock your account.",
   "yourPeer": "your peer"
 }

--- a/i18n/locales/source/dashboard/course_offerings.json
+++ b/i18n/locales/source/dashboard/course_offerings.json
@@ -101,5 +101,6 @@
   "csa-pilot-extra": "csa-pilot-extra",
   "csd6-projects": "csd6-projects",
   "coursef-2022-pilot": "coursef-2022-pilot",
-  "vpl-csd-summer-pilot": "vpl-csd-summer-pilot"
+  "vpl-csd-summer-pilot": "vpl-csd-summer-pilot",
+  "csa-async": "csa-async"
 }

--- a/i18n/locales/source/dashboard/scripts.yml
+++ b/i18n/locales/source/dashboard/scripts.yml
@@ -4011,6 +4011,7 @@ en:
             'Anonymous student survey: Taking the AP exam':
               name: 'Anonymous student survey: Taking the AP exam'
           student_description: ''
+          name: csp-pre-survey
         csd1-2017:
           title: CSD Unit 1 - Problem Solving ('17-'18)
           description_short: "  Learn how humans work with computers to solve problems."
@@ -6005,6 +6006,7 @@ en:
             CSP post-course survey:
               name: CSP Student Post-Course Survey ('17-'18)
           student_description: Welcome to the Code.org CS Principles Post-Course Survey.  This survey takes about 15 minutes to complete.  Your responses are private and anonymous -- your teacher can see anonymous aggregate results for the whole class.  The results are vital for your teacher and for Code.org to sustain and improve the course.  Thanks for your time and consideration.
+          name: csp-post-survey
         public-key-cryptography:
           title: Public Key Cryptography Widgets
           description_audience: ''
@@ -10582,6 +10584,7 @@ en:
             CSD post-course survey:
               name: CSD Student Post-Course Survey ('18-'19)
           student_description: Welcome to the Code.org CS Discoveries Post-Course Survey.  This survey takes about 15 minutes to complete.  Your responses are private and anonymous -- your teacher can see anonymous aggregate results for the whole class.  The results are vital for your teacher and for Code.org to sustain and improve the course.  Thanks for your time and consideration.
+          name: csd-post-survey
         csd-novice-18:
           title: CS Discoveries Novice Reflections 2018-2019
           description_audience: CS Discoveries Facilitators in Training 2018-2019
@@ -12017,6 +12020,7 @@ en:
             CSP Mid-year survey:
               name: CSP Student Mid-year Survey
           student_description: Welcome to the Code.org CS Principles Mid-Year Survey.  This survey takes about 15 minutes to complete.  Your responses are private and anonymous -- your teacher can see anonymous aggregate results for the whole class.  The results are vital for your teacher and for Code.org to sustain and improve the course.  Thanks for your time and consideration.
+          name: csp-mid-survey
         gamelab:
           title: Game Lab
           description_audience: ''
@@ -14251,6 +14255,7 @@ en:
             CSD post-course survey:
               name: CSD Student Post-Course Survey ('18-'19)
           student_description: "The CS Discoveries Post-Course Survey is an important tool we use to get feedback from you and make improvements to the course. \n The survey is private and anonymous -- your teacher can see anonymous aggregate results for the whole class.  The results are vital for your teacher and for Code.org to sustain and improve the course.  Thanks for your time and consideration."
+          name: csd-post-survey-2018
         csp-post-survey-2018:
           title: CSP Student Post-Course Survey ('18-'19)
           description_audience: CSP Students
@@ -14263,6 +14268,7 @@ en:
             CSP post-course survey:
               name: CSP Student Post-Course Survey ('18-'19)
           student_description: Welcome to the Code.org CS Principles Post-Course Survey.  This survey takes about 15 minutes to complete.  Your responses are private and anonymous -- your teacher can see anonymous aggregate results for the whole class.  The results are vital for your teacher and for Code.org to sustain and improve the course.  Thanks for your time and consideration.
+          name: csp-post-survey-2018
         csp5-pilot:
           title: CSP Unit 5 Pilot - Lists, Loops, and Traversals
           description_audience: ''
@@ -23286,8 +23292,8 @@ en:
             For Loops:
               key: For Loops
               name: For Loops
-              description_student: ''
-              description_teacher: ''
+              description_student: 
+              description_teacher: 
             Sprite Lab:
               key: Sprite Lab
               name: Sequencing with Sprites
@@ -28175,10 +28181,7 @@ en:
             Board Events:
               name: Board Events
               description_student: In this lesson, you will learn how to use the Circuit Playground's hardware buttons and switch which will give the Circuit Playground input.
-              description_teacher: |-
-                This lesson transitions students from considering the Circuit Playground as strictly an output device and instead introduces the buttons and toggle switches as tools for input. Starting with the hardware buttons and switch, students learn to use `onBoardEvent()`, analogously to `onEvent()`, in order to take input from their Circuit Playgrounds.
-
-                **Question of the Day:** How can the user interact with the circuit playground for input?
+              description_teacher: "This lesson transitions students from considering the Circuit Playground as strictly an output device and instead introduces the buttons and toggle switches as tools for input. Starting with the hardware buttons and switch, students learn to use [`onBoardEvent()`(#f78183)](/docs/applab/onBoardEvent/), analogously to [`onEvent()`(#fff176)](/docs/applab/onEvent/), in order to take input from their Circuit Playgrounds.\n\n**Question of the Day:** How can the user interact with the circuit playground for input?"
             Arrays and Color LEDs:
               name: Color LEDs
               description_student: In this lesson, you will learn how to access and control the colored LEDs on the Circuit Playground.
@@ -31120,40 +31123,148 @@ en:
           lessons:
             lesson-1:
               name: Store Management Project – Day 1
-              description_student: 
-              description_teacher: 
+              description_student: |-
+                **What business or service do I want to manage using a program?**
+
+                For this project, you use the skills you have developed throughout this unit to create a store management system for a business or service. You choose the objects for your business that represent something you are interested in or meaningful to you. After brainstorming and planning, you develop your program to create your store management system.
+              description_teacher: |-
+                **What business or service do I want to manage using a program?**
+
+                For this project, students use the skills they have developed throughout this unit to create a store management system for a business or service. Students choose the objects for their business that represent something they are interested in or meaningful to them. After brainstorming and planning, students develop their programs to create their store management system.
             lesson-2:
               name: Store Management Project – Day 2
-              description_student: 
-              description_teacher: 
+              description_student: |-
+                **How will I implement my plans to create my program?**
+
+                You have now designed classes to represent objects in a business of your choice to create a store management program. In this lesson, you decide how users interact with your program and use the Scanner class to receive user input. You reinforce software development skills and processes as you participate in a code review to give and use feedback as you develop your program.
+              description_teacher: |-
+                **How will I implement my plans to create my program?**
+
+                Students designed classes to represent objects in a business of their choice to create a store management program. Students decide how users interact with their program and use the Scanner class to receive user input. Students reinforce software development skills and processes as they participate in a code review to give and use feedback as they develop their program.
             lesson-3:
               name: Store Management Project – Day 3
-              description_student: 
-              description_teacher: 
+              description_student: |-
+                **How is my growth as a software engineer reflected in my project?**
+
+                You participated in a code review at the end of the previous lesson to give and receive feedback to identify areas of improvement and fixes for problems you encountered. Consider this feedback as you finalize development in this lesson. You then share your final project with your peers to celebrate your success.
+              description_teacher: |-
+                **How is my growth as a software engineer reflected in my project?**
+
+                Students conducted code reviews at the end of the previous lesson to give and receive feedback that assists in identifying areas of improvement and fixes for problems they encountered. At this stage of the project, students consider this feedback as they finalize development in this lesson. Students share their final projects with their peers to celebrate their successes.
             lesson-4:
               name: FRQ Practice
+              description_student: |-
+                **How will I use what I know about classes and objects to answer a Free Response Question?**
+
+                You practice developing solutions to AP CSA FRQs on a mock Classes and Objects FRQ. You apply decomposition and annotation strategies to identify the key components of the problem and validate your solutions using Scoring Guidelines.
+              description_teacher: |-
+                **How will I use what I know about classes and objects to answer a Free Response Question?**
+
+                Students practice developing solutions to AP CSA FRQs on a mock Classes and Objects FRQ. Students apply decomposition and annotation strategies to identify the key components of the problem and validate their solutions using Scoring Guidelines.
             lesson-5:
               name: Unit 2 Assessment
+              description_student: Assess your progress through the Unit 2 Assessment.
+              description_teacher: Students complete a multiple-choice assessment that covers the unit topics.
             lesson-6:
               name: Variables
+              description_student: |-
+                **How can I store values so I can reuse them?**
+
+                You learned about the `boolean` data type to represent a `true` or `false` value in the previous unit. In this lesson, you expand your knowledge of data types to learn about the `int` and `double` types and differentiate between primitive and reference variables. You use manipulatives to explore how variables are declared, initialized, and used as you write and trace code segments and identify the current value stored in a variable.
+              description_teacher: |-
+                **How can I store values so I can reuse them?**
+
+                Students expand their knowledge of data types to learn about the `int` and `double` types and differentiate between primitive and reference variables. Students use manipulatives to explore how variables are declared, initialized, and used as they write and trace code segments and identify the current value stored in a variable.
             lesson-7:
               name: Operators and Expressions
+              description_student: |-
+                **How can I use variables to perform calculations?**
+
+                You learned about primitive and reference variables and how to store values and pointers to objects in these variables. In this lesson, you discover how arithmetic and compound assignment operators function in Java when used with different data types. You practice evaluating expressions and explore scenarios that result in errors or unexpected results.
+              description_teacher: |-
+                **How can I use variables to perform calculations?**
+
+                Students discover how arithmetic and compound assignment operators function in Java with different data types. Students practice evaluating expressions and explore scenarios that result in errors or unexpected results.
             lesson-8:
               name: Attributes
+              description_student: |-
+                **How do I decide what attributes an object should have?**
+
+                In the previous unit, you created subclasses of the `Painter` class and objects of different types. You revisit classes and objects to learn how to design classes and identify appropriate attributes for these classes. You define instance variables to represent these attributes while exploring encapsulation and learn the difference between `public` and `private` access.
+              description_teacher: |-
+                **How do I decide what attributes an object should have?**
+
+                In the previous unit, students created subclasses of the `Painter` class and objects of different types. Students revisit classes and objects to learn how to design classes and identify appropriate attributes for these classes. Students define instance variables to represent these attributes while exploring encapsulation and learn the difference between `public` and `private` access.
             lesson-9:
               name: Constructors
+              description_student: |-
+                **How can I create objects with specific values?**
+
+                In the previous unit, you wrote constructors in your `Painter` subclasses that instantiated an object using the `Painter` class constructor. In this lesson, you revisit constructors to identify the need for parameterized constructors and learn how to implement these in a class. In the process, you learn the difference between actual and formal parameters and explore how constructor calls function in programs.
+              description_teacher: |-
+                **How can I create objects with specific values?**
+
+                Students revisit constructors to identify the need for parameterized constructors and learn how to implement these in a class. In the process, students differentiate between actual and formal parameters and explore how constructor calls function in programs.
             lesson-10:
               name: User Input
+              description_student: |-
+                **How do I get input from the user?**
+
+                In this lesson, you learn to obtain user input using the `Scanner` class. You incorporate user input to decide the starting values of `Dessert` objects. In the process, you discover the `NullPointerException`, its cause, and strategies for debugging this error.
+              description_teacher: |-
+                **How do I get input from the user?**
+
+                Students learn how to obtain user input using the `Scanner` class. As students create `Dessert` objects based on user input, they discover the `NullPointerException`, its cause, and strategies for debugging this error.
             lesson-11:
               name: Class Hierarchies
+              description_student: |-
+                **How can I create hierarchies of classes to simplify program code?**
+
+                You learned about inheritance in the previous unit to create subclasses of the `Painter` class. In this lesson, you revisit inheritance to learn about using the DRY principle to refactor redundant code. You also learn about the `Object` class and deepen your understanding of inheritance.
+              description_teacher: |-
+                **How can I create hierarchies of classes to simplify program code?**
+
+                Students learned about inheritance in the previous unit to create subclasses of the `Painter` class. In this lesson, students revisit inheritance to learn about using the DRY principle to refactor redundant code. Students also learn about the `Object` class and deepen their understanding of inheritance.
             lesson-12:
               name: Accessor Methods
+              description_student: |-
+                **How can I access the values of an object's instance variables?**
+
+                You have learned that `private` instance variables cannot be directly accessed from outside the class. In this lesson, you discover the need for accessor methods to obtain the values stored in the instance variables of a class. You review the components of a method signature and how methods return values. You practice writing accessor methods in the Project Mercury Pastries Food Truck classes and calling them within expressions.
+              description_teacher: |-
+                **How can I access the values of an object's instance variables?**
+
+                Students discover the need for accessor methods to obtain the values stored in the instance variables of a class. Students review the components of a method signature and how methods return values. Students practice writing accessor methods in the Project Mercury Pastries Food Truck classes and calling them within expressions.
             lesson-13:
               name: Mutator Methods
+              description_student: |-
+                **How can I change the values of an object's instance variables after the object has been created?**
+
+                Your programs currently cannot directly change the values stored in the instance variables of a class. In this lesson, you discover the need for mutator methods to change these values. You also revisit the `void` keyword and recall edge cases. You practice writing and calling mutator methods for your classes.
+              description_teacher: |-
+                **How can I change the values of an object's instance variables after the object has been created?**
+
+                Students discover the need for mutator methods to change the values stored in the instance variables of a class. Students also revisit the `void` keyword and recall edge cases. Students practice writing and calling mutator methods for their classes.
             lesson-14:
               name: Printing Objects
+              description_student: |-
+                **How can I easily display information about an object?**
+
+                You have learned to obtain information about an object using its accessor methods. In this lesson, you discover the need for an easier way to get the state of an object. You revisit the `Object` class and learn how to override its `toString()` method to display object information to the console. You also learn to format output using escape sequences and concatenating instance variables and `String`s.
+              description_teacher: |-
+                **How can I easily display information about an object?**
+
+                Students have learned to obtain information about an object using its accessor methods. In this lesson, students discover the need for an easier way to get the state of an object. Students revisit the `Object` class and learn how to override its `toString()` method to display object information to the console. Students also learn to format output using escape sequences and concatenating instance variables and `String`s.
             lesson-15:
               name: Scope
+              description_student: |-
+                **How does the scope of a variable impact its accessibility and use?**
+
+                You learned about local variables that are used by a constructor or a method. In this lesson, you explore the scope of variables in a program and discover that the local variable is used when it has the same name as an instance variable. You learn to use the `this` keyword to refer to the current object in constructors and methods.
+              description_teacher: |-
+                **How does the scope of a variable impact its accessibility and use?**
+
+                Students explore the scope of variables in a program and discover that the local variable is used when it has the same name as an instance variable. Students learn to use the `this` keyword to refer to the current object in constructors and methods.
           lesson_groups:
             lessonGroup-2:
               display_name: Content
@@ -31448,8 +31559,24 @@ en:
           lessons:
             lesson-1:
               name: Welcome to Code.org
+              description_student: |-
+                You will:
+
+                * Get an introduction to Code.org.
+                * Learn how to engage in these professional learning modules.
+
+                **Estimated time:** 20 minutes
+              description_teacher: |
+                You will:
+
+                * Get an introduction to Code.org.
+                * Learn how to engage in these professional learning modules.
+
+                **Estimated time:** 20 minutes
             lesson-2:
-              name: Welcome to "Teaching CSA"
+              name: Get to know Computer Science A
+              description_student: "You will:\n\n* Get an introduction to the AP Computer Science A course\n* Learn Code.org’s curricular approach to CSA \n\n**Estimated time:** 40 minutes\n"
+              description_teacher: "You will:\n\n* Get an introduction to the AP Computer Science A course\n* Learn Code.org’s curricular approach to CSA \n\n**Estimated time:** 40 minutes\n"
           lesson_groups: {}
           name: self-paced-pl-csa1-2022
           title: 'Unit 1 - Module 1: Welcome'
@@ -31458,7 +31585,51 @@ en:
           description: "This module is a short introduction to both Code.org and professional learning modules. \n\n**You will:**\n\n-   Get an introduction to Code.org and CS Principles.\n-   Learn how to engage in professional learning modules.\n\n**Suggested Time:** 10 minutes"
           student_description: ''
         self-paced-pl-csa2-2022:
-          lessons: {}
+          lessons:
+            lesson-1:
+              name: Navigating the Code.org learning platform
+              description_student: |-
+                **You will:**
+
+                * Navigate the Code.org website and teacher tools.
+                * Set up a classroom section.
+
+                **Suggested time:** 30 minutes
+              description_teacher: |-
+                **You will:**
+
+                * Navigate the Code.org website and teacher tools.
+                * Set up a classroom section.
+
+                **Suggested time:** 30 minutes
+            lesson-2:
+              name: Navigating lesson plans and resources
+              description_student: |-
+                **You will:**
+
+                * Locate and use course lesson plans and teacher resources.
+
+                **Suggested time:** 25 minutes
+              description_teacher: |-
+                **You will:**
+
+                * Locate and use course lesson plans and teacher resources.
+
+                **Suggested time:** 25 minutes
+            lesson-3:
+              name: Navigating Support
+              description_student: |-
+                **You will:**
+
+                * Learn how to access support while teaching the course.
+
+                **Suggested time:** 15 minutes
+              description_teacher: |-
+                **You will:**
+
+                * Learn how to access support while teaching the course.
+
+                **Suggested time:** 15 minutes
           lesson_groups: {}
           name: self-paced-pl-csa2-2022
           title: ''
@@ -32351,6 +32522,17 @@ en:
           student_description: In this unit, you implement searching and sorting algorithms to work with lists of primitive and object data stored in 1D and 2D arrays and `ArrayList`s. You analyze the efficiency of searching and sorting algorithms and expand the standard algorithms you have developed throughout the course to solve more complex problems. Throughout the unit, you apply your knowledge and programming skills to develop a game that incorporates object-oriented design and efficiency. You wrap up the unit and course considering the privacy and security of their programs and users.
           description_short: ''
           description_audience: ''
+        ui-test-csa-family-script:
+          lessons:
+            lesson-1:
+              name: UI Test CSA Family Lesson
+          lesson_groups: {}
+          name: ui-test-csa-family-script
+          title: UI Test CSA Family Script
+          description_audience: ''
+          description_short: ''
+          description: ''
+          student_description: ''
         csa-preview:
           lessons:
             lesson-1:
@@ -32483,30 +32665,56 @@ en:
           lessons:
             lesson-1:
               name: Variables
+              description_student: 
+              description_teacher: 
             lesson-2:
               name: Operators and Expressions
+              description_student: 
+              description_teacher: 
             lesson-3:
               name: Attributes
+              description_student: 
+              description_teacher: 
             lesson-4:
               name: Constructors
+              description_student: 
+              description_teacher: 
             lesson-5:
               name: User Input
+              description_student: 
+              description_teacher: 
             lesson-6:
               name: Class Hierarchies
+              description_student: 
+              description_teacher: 
             lesson-7:
               name: Accessor Methods
+              description_student: 
+              description_teacher: 
             lesson-8:
               name: Mutator Methods
+              description_student: 
+              description_teacher: 
             lesson-9:
               name: Printing Objects
+              description_student: 
+              description_teacher: 
             lesson-10:
               name: Scope and this
+              description_student: 
+              description_teacher: 
             lesson-11:
               name: Store Management Project – Day 1
+              description_student: 
+              description_teacher: 
             lesson-12:
               name: Store Management Project – Day 2
+              description_student: 
+              description_teacher: 
             lesson-13:
               name: Store Management Project – Day 3
+              description_student: 
+              description_teacher: 
             lesson-14:
               name: FRQ Practice
               description_student: 
@@ -32526,3 +32734,122 @@ en:
           description_short: ''
           description: ''
           student_description: ''
+        k5-onlinepd-2022:
+          lessons:
+            Welcome and Introduction:
+              name: Welcome and Introduction
+              description_student: 
+              description_teacher: 
+            Getting Started:
+              name: Getting Started
+              description_student: ''
+              description_teacher: ''
+              key: Getting Started
+            Teaching Practices and Strategies:
+              name: Teaching Practices and Strategies
+              description_student: 
+              description_teacher: 
+            Teaching a Lesson:
+              name: Teaching a Lesson
+              description_student: 
+              description_teacher: 
+            Addressing Barriers:
+              name: Addressing Barriers
+              description_student: 
+              description_teacher: 
+            Part II Overview:
+              name: Part II Overview
+              description_student: ''
+              description_teacher: ''
+              key: Part II Overview
+            Sequencing:
+              name: Sequencing
+              description_student: ''
+              description_teacher: ''
+              key: Sequencing
+            Sequencing with Sprites:
+              name: Sequencing with Sprites
+              description_student: ''
+              description_teacher: ''
+              key: Sequencing with Sprites
+            Loops:
+              name: Loops
+              description_student: ''
+              description_teacher: ''
+              key: Loops
+            Events:
+              name: Events
+              description_student: ''
+              description_teacher: ''
+              key: Events
+            Conditionals:
+              name: Conditionals
+              description_student: ''
+              description_teacher: ''
+              key: Conditionals
+            Functions:
+              name: Functions
+              description_student: ''
+              description_teacher: ''
+              key: Functions
+            Variables:
+              name: Variables
+              description_student: ''
+              description_teacher: ''
+              key: Variables
+            For Loops:
+              name: For Loops
+              description_student: ''
+              description_teacher: ''
+              key: For Loops
+            End of Course projects:
+              name: End of Course projects
+              description_student: ''
+              description_teacher: ''
+              key: End of Course projects
+            Reviewing your reflections:
+              name: Reviewing your reflections
+              description_student: ''
+              description_teacher: ''
+              key: Reviewing your reflections
+            Taking next steps:
+              name: Taking next steps
+              description_student: 
+              description_teacher: 
+            Welcome to "Teaching Computer Science Fundamentals":
+              key: Welcome to "Teaching Computer Science Fundamentals"
+              name: Welcome and Introduction
+              description_student: ''
+              description_teacher: ''
+            CS Teaching and Student Practices:
+              key: CS Teaching and Student Practices
+              name: Teaching Practices and Strategies
+              description_student: ''
+              description_teacher: ''
+            Lesson Planning:
+              key: Lesson Planning
+              name: Teaching a Lesson
+              description_student: ''
+              description_teacher: ''
+            Implementation Approaches and Barriers:
+              key: Implementation Approaches and Barriers
+              name: Addressing Barriers
+              description_student: ''
+              description_teacher: ''
+            Next steps:
+              key: Next steps
+              name: Taking next steps
+              description_student: ''
+              description_teacher: ''
+          lesson_groups:
+            Implementing and Teaching CS:
+              display_name: 'Part I:  Teaching and Implementing Computer Science'
+            k5_basic_concepts_1:
+              display_name: 'Part II:  Concepts in Courses A - F'
+            k5_next_steps_1:
+              display_name: 'Part III:  Next Steps'
+          title: Teaching Computer Science Fundamentals ('21-'22)
+          description: 'Welcome to Code.org’s free self-paced online educator course for getting started with Computer Science Fundamentals! '
+          student_description: 'Welcome to Code.org’s free online educator course for CS Fundamentals! '
+          description_short: 'Welcome to Code.org’s free self-paced online educator course for getting started with Computer Science Fundamentals! '
+          description_audience: 'Welcome to Code.org’s free self-paced online educator course for getting started with Computer Science Fundamentals! '


### PR DESCRIPTION
# I18n Sync In & Up

This PR contains all changes to internationalization source strings made since the last sync (usually a week).

## To Review:

1. Look through the changes in each of the commits and verify that all changes are expected

   - We expect content changes to come in on a regular basis; individual strings will get updated, added, and deleted.

   - We _do not_ usually expect to see "comprehensive" changes - or changes that apply to large numbers of strings or whole categories of strings all at once - unless we have made specific code changes.

2. Notify the International Partners team about any changes that might appear to manifest as "lost translations"

   - For example: https://github.com/code-dot-org/code-dot-org/pull/31031/files#diff-aa1910a8cf8f9290ae3baf7e39dbae3eL397-R398

     This is a change that added new strings (with both new keys and new content) and simultaneously removed some very similar old ones; we can reasonably infer that the intent here was to swap the new strings out for the old ones. Unfortunately, because the swap also included a content change to the strings the crowdin duplication system won't automatically apply translations to the new strings and so they will need to be manually re-translated.

## To Deploy:

Once one or two people have reviewed and approved this change and the tests are passing, ship it!

It's not necessary to wait for everyone on the team to review.
