### PR TITLE
Make sure get correct error page when trying to access an incorrect family url

### DIFF
--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -619,7 +619,7 @@ class Script < ApplicationRecord
 
     family_units = Script.get_family_from_cache(family_name).sort_by(&:version_year).reverse
 
-    return nil unless family_units.last.can_be_instructor?(user) || family_units.last.can_be_participant?(user)
+    return nil unless family_units&.last&.can_be_instructor?(user) || family_units&.last&.can_be_participant?(user)
 
     # Only signed in participants should be redirected based on unit progress and/or section assignments.
     if user && family_units.last.can_be_participant?(user)


### PR DESCRIPTION
We got this [honeybadger error](https://app.honeybadger.io/projects/3240/faults/84464028) recently. Someone was trying to access studio.code.org/s/csp8. We have stopped supporting redirecting between units for new courses after 2019. CSP Unit 8 did not exist before 2020 therefore this redirect should not work. However we need to fail gracefully. We can do this by just updating the checks in `get_unit_family_redirect_for_user`