### PR TITLE
Remove opening of section edit when navigate to homepage with course and script id params

### DIFF
--- a/apps/src/sites/studio/pages/home/_homepage.js
+++ b/apps/src/sites/studio/pages/home/_homepage.js
@@ -8,7 +8,6 @@ import i18n from '@cdo/locale';
 import {Provider} from 'react-redux';
 import {getStore, registerReducers} from '@cdo/apps/redux';
 import {
-  beginEditingNewSection,
   pageTypes,
   setAuthProviders,
   setPageType,
@@ -16,7 +15,6 @@ import {
 } from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import currentUser from '@cdo/apps/templates/currentUserRedux';
 import {initializeHiddenScripts} from '@cdo/apps/code-studio/hiddenLessonRedux';
-import {updateQueryParam} from '@cdo/apps/code-studio/utils';
 import locales, {setLocaleCode} from '@cdo/apps/redux/localesRedux';
 import mapboxReducer, {setMapboxAccessToken} from '@cdo/apps/redux/mapbox';
 import experiments from '@cdo/apps/util/experiments';
@@ -43,22 +41,6 @@ function showHomepage() {
 
   if (homepageData.mapboxAccessToken) {
     store.dispatch(setMapboxAccessToken(homepageData.mapboxAccessToken));
-  }
-
-  let courseId;
-  let scriptId;
-  if (query.courseId) {
-    courseId = parseInt(query.courseId, 10);
-    // remove courseId/scriptId params so that if we navigate back we don't get
-    // this dialog again
-    updateQueryParam('courseId', undefined, true);
-  }
-  if (query.scriptId) {
-    scriptId = parseInt(query.scriptId, 10);
-    updateQueryParam('scriptId', undefined, true);
-  }
-  if (courseId || scriptId) {
-    store.dispatch(beginEditingNewSection(courseId, scriptId));
   }
 
   const announcement = getTeacherAnnouncement(announcementOverride);

--- a/apps/src/templates/studioHomepages/SetUpSections.jsx
+++ b/apps/src/templates/studioHomepages/SetUpSections.jsx
@@ -2,17 +2,17 @@ import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import {connect} from 'react-redux';
 import i18n from '@cdo/locale';
-import {beginEditingNewSection} from '../teacherDashboard/teacherSectionsRedux';
+import {beginEditingSection} from '../teacherDashboard/teacherSectionsRedux';
 import BorderedCallToAction from './BorderedCallToAction';
 
 class SetUpSections extends Component {
   static propTypes = {
-    beginEditingNewSection: PropTypes.func.isRequired,
+    beginEditingSection: PropTypes.func.isRequired,
     hasSections: PropTypes.bool
   };
 
   // Wrapped to avoid passing event args
-  beginEditingNewSection = () => this.props.beginEditingNewSection();
+  beginEditingSection = () => this.props.beginEditingSection();
 
   render() {
     const headingText = this.props.hasSections
@@ -27,7 +27,7 @@ class SetUpSections extends Component {
         buttonText={i18n.createSection()}
         className="uitest-set-up-sections"
         buttonClass="uitest-newsection"
-        onClick={this.beginEditingNewSection}
+        onClick={this.beginEditingSection}
         solidBorder={this.props.hasSections}
       />
     );
@@ -37,6 +37,6 @@ export const UnconnectedSetUpSections = SetUpSections;
 export default connect(
   undefined,
   {
-    beginEditingNewSection
+    beginEditingSection
   }
 )(SetUpSections);

--- a/apps/src/templates/studioHomepages/SetUpSections.story.jsx
+++ b/apps/src/templates/studioHomepages/SetUpSections.story.jsx
@@ -12,7 +12,7 @@ export default storybook =>
         description: `Information box if the teacher doesn't have any sections yet`,
         story: () => (
           <SetUpSections
-            beginEditingNewSection={action('beginEditingNewSection')}
+            beginEditingSection={action('beginEditingSection')}
             hasSections={false}
           />
         )
@@ -22,7 +22,7 @@ export default storybook =>
         description: `Information box if the teacher does have sections already`,
         story: () => (
           <SetUpSections
-            beginEditingNewSection={action('beginEditingNewSection')}
+            beginEditingSection={action('beginEditingSection')}
             hasSections={true}
           />
         )

--- a/apps/src/templates/teacherDashboard/OwnedSections.jsx
+++ b/apps/src/templates/teacherDashboard/OwnedSections.jsx
@@ -7,11 +7,7 @@ import _ from 'lodash';
 import OwnedSectionsTable from './OwnedSectionsTable';
 import RosterDialog from './RosterDialog';
 import Button from '@cdo/apps/templates/Button';
-import {
-  hiddenSectionIds,
-  beginEditingNewSection,
-  beginEditingSection
-} from './teacherSectionsRedux';
+import {hiddenSectionIds, beginEditingSection} from './teacherSectionsRedux';
 import i18n from '@cdo/locale';
 import color from '@cdo/apps/util/color';
 import styleConstants from '@cdo/apps/styleConstants';
@@ -29,7 +25,6 @@ class OwnedSections extends React.Component {
     sectionIds: PropTypes.arrayOf(PropTypes.number).isRequired,
     hiddenSectionIds: PropTypes.arrayOf(PropTypes.number).isRequired,
     asyncLoadComplete: PropTypes.bool.isRequired,
-    beginEditingNewSection: PropTypes.func.isRequired,
     beginEditingSection: PropTypes.func.isRequired
   };
 
@@ -63,7 +58,7 @@ class OwnedSections extends React.Component {
   }
 
   // Wrapped to avoid passing event args
-  beginEditingNewSection = () => this.props.beginEditingNewSection();
+  beginEditingSection = () => this.props.beginEditingSection();
 
   toggleViewHidden = () => {
     this.setState({
@@ -168,7 +163,6 @@ export default connect(
     asyncLoadComplete: state.teacherSections.asyncLoadComplete
   }),
   {
-    beginEditingNewSection,
     beginEditingSection
   }
 )(OwnedSections);

--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
@@ -265,19 +265,13 @@ export const unassignSection = (sectionId, location) => (
 };
 
 /**
- * Opens the UI for adding a new section.
- */
-export const beginEditingNewSection = () => ({
-  type: EDIT_SECTION_BEGIN
-});
-
-/**
  * Opens the UI for editing the specified section.
- * @param {number} sectionId
+ * @param {number} sectionId - Optional param for the id of the section to edit. If blank means
+ * new section
  * @param {bool} [silent] - Optional param for when we want to begin editing the
  *   section without launching our dialog
  */
-export const beginEditingSection = (sectionId, silent = false) => ({
+export const beginEditingSection = (sectionId = null, silent = false) => ({
   type: EDIT_SECTION_BEGIN,
   sectionId,
   silent

--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
@@ -544,8 +544,6 @@ const initialState = {
 /**
  * Generate shape for new section
  * @param id
- * @param courseId
- * @param scriptId
  * @param loginType
  * @returns {sectionShape}
  */

--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
@@ -267,10 +267,8 @@ export const unassignSection = (sectionId, location) => (
 /**
  * Opens the UI for adding a new section.
  */
-export const beginEditingNewSection = (courseId, scriptId) => ({
-  type: EDIT_SECTION_BEGIN,
-  courseId,
-  scriptId
+export const beginEditingNewSection = () => ({
+  type: EDIT_SECTION_BEGIN
 });
 
 /**
@@ -557,7 +555,7 @@ const initialState = {
  * @param loginType
  * @returns {sectionShape}
  */
-function newSectionData(id, courseId, scriptId, loginType) {
+function newSectionData(id, loginType) {
   return {
     id: id,
     name: '',
@@ -570,8 +568,8 @@ function newSectionData(id, courseId, scriptId, loginType) {
     sharingDisabled: false,
     studentCount: 0,
     code: '',
-    courseId: courseId || null,
-    scriptId: scriptId || null,
+    courseId: null,
+    scriptId: null,
     hidden: false,
     isAssigned: undefined,
     restrictSection: false
@@ -823,16 +821,9 @@ export default function teacherSections(state = initialState, action) {
   if (action.type === EDIT_SECTION_BEGIN) {
     const initialSectionData = action.sectionId
       ? {...state.sections[action.sectionId]}
-      : newSectionData(
-          PENDING_NEW_SECTION_ID,
-          action.courseId,
-          action.scriptId,
-          undefined
-        );
+      : newSectionData(PENDING_NEW_SECTION_ID, undefined);
     return {
       ...state,
-      initialCourseId: initialSectionData.courseId,
-      initialUnitId: initialSectionData.scriptId,
       initialLoginType: initialSectionData.loginType,
       sectionBeingEdited: initialSectionData,
       showSectionEditDialog: !action.silent

--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
@@ -824,6 +824,8 @@ export default function teacherSections(state = initialState, action) {
       : newSectionData(PENDING_NEW_SECTION_ID, undefined);
     return {
       ...state,
+      initialCourseId: initialSectionData.courseId,
+      initialUnitId: initialSectionData.scriptId,
       initialLoginType: initialSectionData.loginType,
       sectionBeingEdited: initialSectionData,
       showSectionEditDialog: !action.silent

--- a/apps/test/unit/templates/studioHomepages/SetUpSectionsTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/SetUpSectionsTest.jsx
@@ -8,9 +8,7 @@ import {UnconnectedSetUpSections as SetUpSections} from '@cdo/apps/templates/stu
 
 describe('SetUpSections', () => {
   it('renders as expected', () => {
-    const wrapper = shallow(
-      <SetUpSections beginEditingNewSection={() => {}} />
-    );
+    const wrapper = shallow(<SetUpSections beginEditingSection={() => {}} />);
     const instance = wrapper.instance();
 
     expect(
@@ -20,15 +18,15 @@ describe('SetUpSections', () => {
           headingText="Set up your classroom"
           descriptionText="Create a new classroom section to start assigning courses and seeing your student progress."
           buttonText="Create a section"
-          onClick={instance.beginEditingNewSection}
+          onClick={instance.beginEditingSection}
         />
       )
     );
   });
 
-  it('calls beginEditingNewSection with no arguments when button is clicked', () => {
+  it('calls beginEditingSection with no arguments when button is clicked', () => {
     const spy = sinon.spy();
-    const wrapper = mount(<SetUpSections beginEditingNewSection={spy} />);
+    const wrapper = mount(<SetUpSections beginEditingSection={spy} />);
     expect(spy).not.to.have.been.called;
 
     wrapper.find(Button).simulate('click', {fake: 'event'});

--- a/apps/test/unit/templates/teacherDashboard/OwnedSectionsTest.js
+++ b/apps/test/unit/templates/teacherDashboard/OwnedSectionsTest.js
@@ -13,7 +13,6 @@ const defaultProps = {
   sectionIds: [11, 12, 13],
   hiddenSectionIds: [],
   asyncLoadComplete: true,
-  beginEditingNewSection: () => {},
   beginEditingSection: () => {},
   beginImportRosterFlow: () => {}
 };
@@ -117,7 +116,7 @@ describe('OwnedSections', () => {
       <OwnedSections
         {...defaultProps}
         sectionIds={[1, 2, 3]}
-        beginEditingNewSection={spy}
+        beginEditingSection={spy}
       />
     );
     expect(spy).not.to.have.been.called;

--- a/apps/test/unit/templates/teacherDashboard/teacherSectionsReduxTest.js
+++ b/apps/test/unit/templates/teacherDashboard/teacherSectionsReduxTest.js
@@ -14,7 +14,6 @@ import reducer, {
   setSections,
   selectSection,
   removeSection,
-  beginEditingNewSection,
   beginEditingSection,
   editSectionProperties,
   cancelEditingSection,
@@ -582,10 +581,10 @@ describe('teacherSectionsRedux', () => {
     });
   });
 
-  describe('beginEditingNewSection', () => {
-    it('populates sectionBeingEdited', () => {
+  describe('beginEditingSection', () => {
+    it('populates sectionBeingEdited is no section provided', () => {
       assert.isNull(initialState.sectionBeingEdited);
-      const state = reducer(initialState, beginEditingNewSection());
+      const state = reducer(initialState, beginEditingSection());
       assert.deepEqual(state.sectionBeingEdited, {
         id: PENDING_NEW_SECTION_ID,
         name: '',
@@ -605,9 +604,7 @@ describe('teacherSectionsRedux', () => {
         restrictSection: false
       });
     });
-  });
 
-  describe('beginEditingSection', () => {
     it('populates sectionBeingEdited', () => {
       const stateWithSections = reducer(initialState, setSections(sections));
       assert.isNull(stateWithSections.sectionBeingEdited);
@@ -641,7 +638,7 @@ describe('teacherSectionsRedux', () => {
     let editingNewSectionState;
 
     before(() => {
-      editingNewSectionState = reducer(initialState, beginEditingNewSection());
+      editingNewSectionState = reducer(initialState, beginEditingSection());
     });
 
     it('throws if not currently editing a section', () => {
@@ -727,7 +724,7 @@ describe('teacherSectionsRedux', () => {
 
   describe('cancelEditingSection', () => {
     it('clears sectionBeingEdited', () => {
-      const initialState = reducer(initialState, beginEditingNewSection());
+      const initialState = reducer(initialState, beginEditingSection());
       assert.isNotNull(initialState.sectionBeingEdited);
       const state = reducer(initialState, cancelEditingSection());
       assert.isNull(state.sectionBeingEdited);
@@ -791,7 +788,7 @@ describe('teacherSectionsRedux', () => {
     });
 
     it('immediately makes saveInProgress true', () => {
-      store.dispatch(beginEditingNewSection());
+      store.dispatch(beginEditingSection());
       expect(state().saveInProgress).to.be.false;
 
       store.dispatch(finishEditingSection());
@@ -799,7 +796,7 @@ describe('teacherSectionsRedux', () => {
     });
 
     it('makes saveInProgress false after the server responds with success', () => {
-      store.dispatch(beginEditingNewSection());
+      store.dispatch(beginEditingSection());
       server.respondWith('POST', '/dashboardapi/sections', successResponse());
 
       store.dispatch(finishEditingSection());
@@ -810,7 +807,7 @@ describe('teacherSectionsRedux', () => {
     });
 
     it('makes saveInProgress false after the server responds with failure', () => {
-      store.dispatch(beginEditingNewSection());
+      store.dispatch(beginEditingSection());
       server.respondWith('POST', '/dashboardapi/sections', failureResponse);
 
       store.dispatch(finishEditingSection()).catch(() => {});
@@ -821,7 +818,7 @@ describe('teacherSectionsRedux', () => {
     });
 
     it('resolves a returned promise when the server responds with success', () => {
-      store.dispatch(beginEditingNewSection());
+      store.dispatch(beginEditingSection());
       server.respondWith('POST', '/dashboardapi/sections', successResponse());
 
       const promise = store.dispatch(finishEditingSection());
@@ -830,7 +827,7 @@ describe('teacherSectionsRedux', () => {
     });
 
     it('rejects a returned promise when the server responds with failure', () => {
-      store.dispatch(beginEditingNewSection());
+      store.dispatch(beginEditingSection());
       server.respondWith('POST', '/dashboardapi/sections', failureResponse);
 
       const promise = store.dispatch(finishEditingSection());
@@ -839,7 +836,7 @@ describe('teacherSectionsRedux', () => {
     });
 
     it('clears sectionBeingEdited after the server responds with success', () => {
-      store.dispatch(beginEditingNewSection());
+      store.dispatch(beginEditingSection());
       server.respondWith('POST', '/dashboardapi/sections', successResponse());
 
       store.dispatch(finishEditingSection());
@@ -850,7 +847,7 @@ describe('teacherSectionsRedux', () => {
     });
 
     it('keeps sectionBeingEdited after the server responds with failure', () => {
-      store.dispatch(beginEditingNewSection());
+      store.dispatch(beginEditingSection());
       const originalSectionBeingEdited = state().sectionBeingEdited;
       expect(originalSectionBeingEdited).not.to.be.null;
       server.respondWith('POST', '/dashboardapi/sections', failureResponse);
@@ -864,7 +861,7 @@ describe('teacherSectionsRedux', () => {
 
     it('adds a new section to the sections map on success', () => {
       const originalSections = state().sections;
-      store.dispatch(beginEditingNewSection());
+      store.dispatch(beginEditingSection());
       store.dispatch(
         editSectionProperties({
           name: 'Aquarius PM Block 2',
@@ -935,7 +932,7 @@ describe('teacherSectionsRedux', () => {
     });
 
     it('does not modify sections map on failure', () => {
-      store.dispatch(beginEditingNewSection());
+      store.dispatch(beginEditingSection());
       server.respondWith('POST', '/dashboardapi/sections', failureResponse);
       const originalSections = state().sections;
 
@@ -1378,7 +1375,7 @@ describe('teacherSectionsRedux', () => {
     });
 
     it('is true when creating a new section', () => {
-      const state = reducer(initialState, beginEditingNewSection());
+      const state = reducer(initialState, beginEditingSection());
       assert(isAddingSection(state));
     });
 
@@ -1389,7 +1386,7 @@ describe('teacherSectionsRedux', () => {
     });
 
     it('is false after editing is cancelled', () => {
-      const initialState = reducer(initialState, beginEditingNewSection());
+      const initialState = reducer(initialState, beginEditingSection());
       const state = reducer(initialState, cancelEditingSection());
       assert.isFalse(isAddingSection(state));
     });
@@ -1401,7 +1398,7 @@ describe('teacherSectionsRedux', () => {
     });
 
     it('is false when creating a new section', () => {
-      const state = reducer(initialState, beginEditingNewSection());
+      const state = reducer(initialState, beginEditingSection());
       assert.isFalse(isEditingSection(state));
     });
 
@@ -1412,7 +1409,7 @@ describe('teacherSectionsRedux', () => {
     });
 
     it('is false after editing is cancelled', () => {
-      const initialState = reducer(initialState, beginEditingNewSection());
+      const initialState = reducer(initialState, beginEditingSection());
       const state = reducer(initialState, cancelEditingSection());
       assert.isFalse(isEditingSection(state));
     });


### PR DESCRIPTION
Removes the behavior where if you navigate to the homepage with scriptId or courseId in the URL we would open the section edit dialog with that script or course chosen as the assigned course or script. This behavior was added 5 years ago and we have since added things like the Assignment button on Course and Unit Overview pages. I checked with @fontie715 and she said it was fine to remove it and see if anyone notices. 

Once that feature was removed from hompage.js we no longer need to be able to pass courseId and scriptId to beginEditingNewSection which allowed it to be combine with beginEditingSection. Thats where the rest of the changes in this PR come from.

This work is helping clean things up ahead of moving to the new assignment system. 

## Links

[Jira](https://codedotorg.atlassian.net/browse/PLAT-1584)
[Mini Spec](https://docs.google.com/document/d/11-dtCFuSmST_vP2MdkH0H0lb2e5AGFu1MxiWSRsnkns/edit#heading=h.pgquzxwzm1u2)

## Testing story

- Updated existing tests