### PR TITLE
Change editor_type to be editor_language for ProgrammingEnvironment

### DIFF
--- a/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingEnvironmentEditor.jsx
+++ b/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingEnvironmentEditor.jsx
@@ -11,7 +11,7 @@ import HelpTip from '@cdo/apps/lib/ui/HelpTip';
 import SaveBar from '@cdo/apps/lib/levelbuilder/SaveBar';
 import {navigateToHref} from '@cdo/apps/utils';
 
-const EDITOR_TYPES = ['blockly', 'droplet', 'text'];
+const EDITOR_TYPES = ['blockly', 'droplet', 'html/css', 'java'];
 
 const useProgrammingEnvironment = initialProgrammingEnvironment => {
   const [programmingEnvironment, setProgrammingEnvironment] = useState(
@@ -145,9 +145,9 @@ export default function ProgrammingEnvironmentEditor({
       <label>
         How should this document render?
         <select
-          value={programmingEnvironment.editorType || EDITOR_TYPES[0]}
+          value={programmingEnvironment.editorLanguage || EDITOR_TYPES[0]}
           onChange={e =>
-            updateProgrammingEnvironment('editorType', e.target.value)
+            updateProgrammingEnvironment('editorLanguage', e.target.value)
           }
           style={styles.selectInput}
         >
@@ -158,7 +158,7 @@ export default function ProgrammingEnvironmentEditor({
           ))}
         </select>
       </label>
-      {programmingEnvironment.editorType === 'blockly' && (
+      {programmingEnvironment.editorLanguage === 'blockly' && (
         <label>
           Block Pool Name
           <HelpTip>

--- a/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingEnvironmentEditor.jsx
+++ b/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingEnvironmentEditor.jsx
@@ -11,7 +11,7 @@ import HelpTip from '@cdo/apps/lib/ui/HelpTip';
 import SaveBar from '@cdo/apps/lib/levelbuilder/SaveBar';
 import {navigateToHref} from '@cdo/apps/utils';
 
-const EDITOR_TYPES = ['blockly', 'droplet', 'html/css', 'java'];
+const EDITOR_LANGUAGES = ['blockly', 'droplet', 'html/css', 'java'];
 
 const useProgrammingEnvironment = initialProgrammingEnvironment => {
   const [programmingEnvironment, setProgrammingEnvironment] = useState(
@@ -145,13 +145,13 @@ export default function ProgrammingEnvironmentEditor({
       <label>
         How should this document render?
         <select
-          value={programmingEnvironment.editorLanguage || EDITOR_TYPES[0]}
+          value={programmingEnvironment.editorLanguage || EDITOR_LANGUAGES[0]}
           onChange={e =>
             updateProgrammingEnvironment('editorLanguage', e.target.value)
           }
           style={styles.selectInput}
         >
-          {EDITOR_TYPES.map(type => (
+          {EDITOR_LANGUAGES.map(type => (
             <option key={type} value={type}>
               {type}
             </option>

--- a/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingExpressionEditor.jsx
+++ b/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingExpressionEditor.jsx
@@ -144,7 +144,7 @@ export default function ProgrammingExpressionEditor({
         </HelpTip>
       </label>
 
-      {programmingExpression.environmentEditorType === 'blockly' && (
+      {programmingExpression.environmentLanguageType === 'blockly' && (
         <label>
           Block Name
           <input

--- a/apps/test/unit/lib/levelbuilder/code-docs-editor/ProgrammingEnvironmentEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/code-docs-editor/ProgrammingEnvironmentEditorTest.jsx
@@ -18,7 +18,7 @@ describe('ProgrammingEnvironmentEditor', () => {
         imageUrl: 'images.code.org/spritelab',
         projectUrl: '/p/spritelab',
         description: 'A description of spritelab',
-        editorType: 'blockly',
+        editorLanguage: 'blockly',
         blockPoolName: 'GamelabJr',
         categories: [{id: 1, key: 'sprites', name: 'Sprites', color: '#00FF00'}]
       }
@@ -43,9 +43,9 @@ describe('ProgrammingEnvironmentEditor', () => {
     const publishedCheckbox = wrapper.find('input').at(2);
     expect(publishedCheckbox.props().checked).to.be.true;
 
-    const editorTypeSelect = wrapper.find('select').at(0);
-    expect(editorTypeSelect.props().value).to.equal('blockly');
-    expect(editorTypeSelect.find('option').length).to.equal(3);
+    const editorLanguageSelect = wrapper.find('select').at(0);
+    expect(editorLanguageSelect.props().value).to.equal('blockly');
+    expect(editorLanguageSelect.find('option').length).to.equal(4);
 
     const blockPoolInput = wrapper.find('input').at(3);
     expect(blockPoolInput.props().value).to.equal('GamelabJr');
@@ -105,7 +105,7 @@ describe('ProgrammingEnvironmentEditor', () => {
         'title',
         'published',
         'description',
-        'editorType',
+        'editorLanguage',
         'blockPoolName',
         'projectUrl',
         'imageUrl',
@@ -115,7 +115,7 @@ describe('ProgrammingEnvironmentEditor', () => {
     expect(fetchCallBody.title).to.equal('Spritelab');
     expect(fetchCallBody.published).to.be.true;
     expect(fetchCallBody.description).to.equal('A description of spritelab');
-    expect(fetchCallBody.editorType).to.equal('blockly');
+    expect(fetchCallBody.editorLanguage).to.equal('blockly');
     expect(fetchCallBody.projectUrl).to.equal('/p/spritelab');
     expect(fetchCallBody.imageUrl).to.equal('images.code.org/spritelab');
   });

--- a/apps/test/unit/lib/levelbuilder/code-docs-editor/ProgrammingExpressionEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/code-docs-editor/ProgrammingExpressionEditorTest.jsx
@@ -160,7 +160,7 @@ describe('ProgrammingExpressionEditor', () => {
         {...defaultProps}
         initialProgrammingExpression={{
           ...initialProgrammingExpression,
-          environmentEditorType: 'blockly',
+          environmentLanguageType: 'blockly',
           blockName: 'gamelab_location_picker'
         }}
       />

--- a/dashboard/app/controllers/programming_environments_controller.rb
+++ b/dashboard/app/controllers/programming_environments_controller.rb
@@ -79,7 +79,7 @@ class ProgrammingEnvironmentsController < ApplicationController
       :title,
       :published,
       :description,
-      :editor_type,
+      :editor_language,
       :block_pool_name,
       :image_url,
       :project_url,

--- a/dashboard/app/models/programming_environment.rb
+++ b/dashboard/app/models/programming_environment.rb
@@ -29,9 +29,9 @@ class ProgrammingEnvironment < ApplicationRecord
 
   after_destroy :remove_serialization
 
-  # @attr [String] editor_type - Type of editor one of the following: 'text-based', 'droplet', 'blockly'
+  # @attr [String] editor_language - Type of editor one of the following: 'text-based', 'droplet', 'blockly'
   serialized_attrs %w(
-    editor_type
+    editor_language
     block_pool_name
     title
     description
@@ -97,7 +97,7 @@ class ProgrammingEnvironment < ApplicationRecord
       imageUrl: image_url,
       projectUrl: project_url,
       description: description,
-      editorType: editor_type,
+      editorLanguage: editor_language,
       blockPoolName: block_pool_name,
       categories: categories.map(&:serialize_for_edit),
       showPath: programming_environment_path(name)

--- a/dashboard/app/models/programming_expression.rb
+++ b/dashboard/app/models/programming_expression.rb
@@ -173,7 +173,7 @@ class ProgrammingExpression < ApplicationRecord
       blockName: block_name,
       categoryKey: programming_environment_category&.key,
       programmingEnvironmentName: programming_environment.name,
-      environmentEditorType: programming_environment.editor_type,
+      environmentEditorLanguage: programming_environment.editor_language,
       imageUrl: image_url,
       videoKey: video_key,
       shortDescription: short_description || '',

--- a/dashboard/config/programming_environments/applab.json
+++ b/dashboard/config/programming_environments/applab.json
@@ -2,7 +2,7 @@
   "name": "applab",
   "published": true,
   "description": "App Lab is a programming environment where you can make simple apps. Design an app, code with blocks or JavaScript to make it work, then share your app in seconds.",
-  "editor_type": "droplet",
+  "editor_language": "droplet",
   "image_url": "https://studio.code.org/shared/images/courses/logo_applab_square.png",
   "project_url": "/p/applab",
   "title": "App Lab",

--- a/dashboard/config/programming_environments/gamelab.json
+++ b/dashboard/config/programming_environments/gamelab.json
@@ -2,7 +2,7 @@
   "name": "gamelab",
   "published": true,
   "description": "Game Lab is a programming environment where you can make exciting games and animations. Draw your characters, code with blocks or JavaScript to make it work, then share your game in seconds.",
-  "editor_type": "droplet",
+  "editor_language": "droplet",
   "image_url": "https://studio.code.org/shared/images/courses/logo_gamelab_square.png",
   "project_url": "/p/gamelab",
   "title": "Game Lab",

--- a/dashboard/config/programming_environments/spritelab.json
+++ b/dashboard/config/programming_environments/spritelab.json
@@ -3,7 +3,7 @@
   "published": true,
   "block_pool_name": "GamelabJr",
   "description": "Sprite Lab is a Blockly programming environment where you can create interactive projects.",
-  "editor_type": "blockly",
+  "editor_language": "blockly",
   "image_url": "https://images.code.org/70652cecd7d72973f69b899650c6553b-logo_SpriteLab_Large.png",
   "project_url": "/p/spritelab",
   "title": "Sprite Lab",

--- a/dashboard/config/programming_environments/weblab.json
+++ b/dashboard/config/programming_environments/weblab.json
@@ -2,7 +2,7 @@
   "name": "weblab",
   "published": true,
   "description": "Web based HTML/CSS editor.",
-  "editor_type": "text",
+  "editor_language": "html/css",
   "image_url": "https://studio.code.org/shared/images/courses/logo_weblab.png",
   "project_url": "/p/weblab",
   "title": "Web Lab",

--- a/dashboard/test/controllers/programming_environments_controller_test.rb
+++ b/dashboard/test/controllers/programming_environments_controller_test.rb
@@ -57,7 +57,7 @@ class ProgrammingEnvironmentsControllerTest < ActionController::TestCase
       name: programming_environment.name,
       title: 'title',
       description: 'description',
-      editorType: 'blockly',
+      editorLanguage: 'blockly',
       blockPoolName: 'GamelabJr',
       projectUrl: '/p/project'
     }
@@ -66,7 +66,7 @@ class ProgrammingEnvironmentsControllerTest < ActionController::TestCase
     programming_environment.reload
     assert_equal 'title', programming_environment.title
     assert_equal 'description', programming_environment.description
-    assert_equal 'blockly', programming_environment.editor_type
+    assert_equal 'blockly', programming_environment.editor_language
     assert_equal 'GamelabJr', programming_environment.block_pool_name
     assert_equal '/p/project', programming_environment.project_url
   end
@@ -82,7 +82,7 @@ class ProgrammingEnvironmentsControllerTest < ActionController::TestCase
       {
         name: programming_environment.name,
         title: 'title',
-        editorType: 'blockly',
+        editorLanguage: 'blockly',
         categories: [{id: nil, name: 'brand new category', color: '#00FFFF'}, {id: category_to_keep.id, name: category_to_keep.name, color: category_to_keep.color}]
       }
     assert_response :ok

--- a/dashboard/test/models/programming_environment_test.rb
+++ b/dashboard/test/models/programming_environment_test.rb
@@ -22,7 +22,7 @@ class ProgrammingEnvironmentTest < ActiveSupport::TestCase
   end
 
   test "can serialize and seed programming environment" do
-    env = create :programming_environment, name: 'ide', editor_type: 'droplet', title: 'IDE', description: 'A description of the IDE.', image_url: 'images.code.org/ide'
+    env = create :programming_environment, name: 'ide', editor_language: 'droplet', title: 'IDE', description: 'A description of the IDE.', image_url: 'images.code.org/ide'
     serialization = env.serialize
     previous_env = env.freeze
     env.destroy!
@@ -35,7 +35,7 @@ class ProgrammingEnvironmentTest < ActiveSupport::TestCase
   end
 
   test "can serialize and seed programming environment with categories" do
-    env = create :programming_environment, name: 'ide', editor_type: 'droplet', title: 'IDE', description: 'A description of the IDE.', image_url: 'images.code.org/ide'
+    env = create :programming_environment, name: 'ide', editor_language: 'droplet', title: 'IDE', description: 'A description of the IDE.', image_url: 'images.code.org/ide'
     create :programming_environment_category, programming_environment: env
     create :programming_environment_category, programming_environment: env
     serialization = env.serialize
@@ -51,7 +51,7 @@ class ProgrammingEnvironmentTest < ActiveSupport::TestCase
   end
 
   test "can remove categories when serializings and seeding programming environment with categories" do
-    env = create :programming_environment, name: 'ide', editor_type: 'droplet', title: 'IDE', description: 'A description of the IDE.', image_url: 'images.code.org/ide'
+    env = create :programming_environment, name: 'ide', editor_language: 'droplet', title: 'IDE', description: 'A description of the IDE.', image_url: 'images.code.org/ide'
     create :programming_environment_category, programming_environment: env
     serialization = env.serialize
     # Category not included in the serialization should be deleted on seed


### PR DESCRIPTION
This will allow us to distinguish weblab from javalab more easily. Both are "text" based programming environments but javalab will have a different look.


## Links

[tech spec](https://docs.google.com/document/d/1b7CE0fJ_8_BVf_v-RPrcmwyf48eLddbrT-tKMMGTNfY/edit#heading=h.uwnkww88lzbu)

## Testing story

seeded locally

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
