### PR TITLE
Re-organize props to fix linter warning

### DIFF
--- a/apps/src/templates/referenceGuides/ReferenceGuideEditAll.jsx
+++ b/apps/src/templates/referenceGuides/ReferenceGuideEditAll.jsx
@@ -35,7 +35,8 @@ const organizeReferenceGuides = (referenceGuides, parent = null, level = 0) => {
   return flatten(organizedGuides);
 };
 
-export default function ReferenceGuideEditAll({referenceGuides}) {
+export default function ReferenceGuideEditAll(props) {
+  const {referenceGuides} = props;
   // useMemo here so that we only do the organizing once
   const organizedGuides = useMemo(
     () => organizeReferenceGuides(referenceGuides),


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

A small re-organization to fix a hooks-deps warning. This isn't a logical change, but there seems to be a bug in the hooks-deps linter...

## Links
https://codedotorg.slack.com/archives/C03CK8E51/p1647295944014949