### PR TITLE
Remove link from project share dialog

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -371,6 +371,7 @@
   "copied": "Copied!",
   "copy": "Copy",
   "copyId": "Copy ID",
+  "copyLinkToProject": "Copy link to project",
   "copyResourcesWarning": "**Heads Up!** Please make a copy of any documents you plan to share with students.",
   "copySectionCodeSuccess": "Link copied!",
   "copySectionCodeTooltip": "Click here to copy the link students need to join the section",

--- a/apps/src/code-studio/components/ShareAllowedDialog.jsx
+++ b/apps/src/code-studio/components/ShareAllowedDialog.jsx
@@ -51,10 +51,6 @@ function wrapShareClick(handler, type) {
   };
 }
 
-function select(event) {
-  event.target.select();
-}
-
 function checkImageReachability(imageUrl, callback) {
   const img = new Image();
   img.onabort = () => callback(false);
@@ -297,15 +293,6 @@ class ShareAllowedDialog extends React.Component {
                     <img style={styles.thumbnailImg} src={thumbnailUrl} />
                   </div>
                   <div>
-                    <p style={{fontSize: 20}}>{i18n.shareCopyLink()}</p>
-                    <input
-                      type="text"
-                      id="sharing-input"
-                      onClick={select}
-                      readOnly
-                      value={this.props.shareUrl}
-                      style={{cursor: 'copy', width: 450}}
-                    />
                     <button
                       type="button"
                       id="share-dialog-copy-button"
@@ -316,7 +303,10 @@ class ShareAllowedDialog extends React.Component {
                       }}
                       onClick={wrapShareClick(this.copy, 'copy')}
                     >
-                      <FontAwesome icon="clipboard" style={{fontSize: 14}} />
+                      <FontAwesome icon="clipboard" style={{fontSize: 16}} />
+                      <span style={{paddingLeft: 10}}>
+                        {i18n.copyLinkToProject()}
+                      </span>
                     </button>
                   </div>
                 </div>
@@ -510,9 +500,8 @@ const styles = {
   },
   copyButton: {
     paddingTop: 5,
-    marginLeft: 8,
-    width: 30,
-    height: 30
+    paddingBottom: 5,
+    marginBottom: 5
   },
   copyButtonLight: {
     backgroundColor: color.light_purple

--- a/apps/src/code-studio/components/ShareAllowedDialog.jsx
+++ b/apps/src/code-studio/components/ShareAllowedDialog.jsx
@@ -295,7 +295,7 @@ class ShareAllowedDialog extends React.Component {
                   <div>
                     <button
                       type="button"
-                      id="share-dialog-copy-button"
+                      id="sharing-input-copy-button"
                       style={{
                         ...styles.button,
                         ...styles.copyButton,

--- a/apps/src/code-studio/components/ShareAllowedDialog.jsx
+++ b/apps/src/code-studio/components/ShareAllowedDialog.jsx
@@ -309,6 +309,10 @@ class ShareAllowedDialog extends React.Component {
                         {i18n.copyLinkToProject()}
                       </span>
                     </button>
+                    <DownloadReplayVideoButton
+                      style={{...styles.button, marginBottom: 8}}
+                      onError={this.replayVideoNotFound}
+                    />
                   </div>
                 </div>
                 <div className="social-buttons">
@@ -348,10 +352,7 @@ class ShareAllowedDialog extends React.Component {
                       className="no-mc"
                     />
                   )}
-                  <DownloadReplayVideoButton
-                    style={styles.button}
-                    onError={this.replayVideoNotFound}
-                  />
+
                   {canPrint && hasThumbnail && (
                     <a href="#" onClick={wrapShareClick(this.print, 'print')}>
                       <FontAwesome icon="print" style={{fontSize: 26}} />
@@ -500,8 +501,8 @@ const styles = {
     verticalAlign: 'top'
   },
   copyButton: {
-    paddingTop: 5,
-    paddingBottom: 5,
+    paddingTop: 12.5,
+    paddingBottom: 12.5,
     marginBottom: 5
   },
   copyButtonLight: {

--- a/apps/src/code-studio/components/ShareAllowedDialog.jsx
+++ b/apps/src/code-studio/components/ShareAllowedDialog.jsx
@@ -302,6 +302,7 @@ class ShareAllowedDialog extends React.Component {
                         ...(this.state.hasBeenCopied && styles.copyButtonLight)
                       }}
                       onClick={wrapShareClick(this.copy, 'copy')}
+                      value={this.props.shareUrl}
                     >
                       <FontAwesome icon="clipboard" style={{fontSize: 16}} />
                       <span style={{paddingLeft: 10}}>

--- a/apps/src/code-studio/components/ShareAllowedDialog.jsx
+++ b/apps/src/code-studio/components/ShareAllowedDialog.jsx
@@ -295,7 +295,7 @@ class ShareAllowedDialog extends React.Component {
                   <div>
                     <button
                       type="button"
-                      id="sharing-input-copy-button"
+                      id="sharing-dialog-copy-button"
                       style={{
                         ...styles.button,
                         ...styles.copyButton,

--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -983,14 +983,13 @@ FeedbackUtils.prototype.createSharingDiv = function(options) {
       .click(window.dashboard.popupWindow);
   }
 
-  var sharingInput = sharingDiv.querySelector('#sharing-input-copy-button');
-  if (sharingInput) {
-    var sharingInputCopyButton = sharingDiv.querySelector(
-      '#sharing-input-copy-button'
-    );
-    dom.addClickTouchEvent(sharingInputCopyButton, function() {
+  var sharingCopyButton = sharingDiv.querySelector(
+    '#sharing-input-copy-button'
+  );
+  if (sharingCopyButton) {
+    dom.addClickTouchEvent(sharingCopyButton, function() {
       copyToClipboard(options.shareLink, () => {
-        sharingInputCopyButton.className = 'sharing-input-copy-button-shared';
+        sharingCopyButton.className = 'sharing-input-copy-button-shared';
       });
     });
   }

--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -984,12 +984,12 @@ FeedbackUtils.prototype.createSharingDiv = function(options) {
   }
 
   var sharingCopyButton = sharingDiv.querySelector(
-    '#sharing-input-copy-button'
+    '#sharing-dialog-copy-button'
   );
   if (sharingCopyButton) {
     dom.addClickTouchEvent(sharingCopyButton, function() {
       copyToClipboard(options.shareLink, () => {
-        sharingCopyButton.className = 'sharing-input-copy-button-shared';
+        sharingCopyButton.className = 'sharing-dialog-copy-button-shared';
       });
     });
   }

--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -983,13 +983,8 @@ FeedbackUtils.prototype.createSharingDiv = function(options) {
       .click(window.dashboard.popupWindow);
   }
 
-  var sharingInput = sharingDiv.querySelector('#sharing-input');
+  var sharingInput = sharingDiv.querySelector('#sharing-input-copy-button');
   if (sharingInput) {
-    dom.addClickTouchEvent(sharingInput, function() {
-      sharingInput.focus();
-      sharingInput.select();
-      sharingInput.setSelectionRange(0, 9999);
-    });
     var sharingInputCopyButton = sharingDiv.querySelector(
       '#sharing-input-copy-button'
     );

--- a/apps/src/templates/sharing.html.ejs
+++ b/apps/src/templates/sharing.html.ejs
@@ -16,6 +16,10 @@
       <i class="fa fa-clipboard fa-lg"></i>
         <%= msg.copyLinkToProject() %>
     </button>
+    <% if (options.downloadReplayVideo) { %>
+      <!-- Mount point for DownloadReplayVideoButton component. -->
+      <span id="download-replay-video-container"></span>
+    <% } %>
   </div>
   <div class='social-buttons'>
     <% if (options.facebookUrl) { -%>
@@ -49,11 +53,7 @@
           <%= msg.publish() %>
       </button>
     <% } %>
-    <% if (options.downloadReplayVideo) { %>
-      <!-- Mount point for DownloadReplayVideoButton component. -->
-      <span id="download-replay-video-container"></span>
-    <% } %>
-    <button id="sharing-phone">
+   <button id="sharing-phone">
       <i class="fa fa-mobile fa-lg"></i>
       &nbsp;
       <%= msg.sendToPhone() %>

--- a/apps/src/templates/sharing.html.ejs
+++ b/apps/src/templates/sharing.html.ejs
@@ -12,7 +12,7 @@
   <% } %>
 
   <div id="sharing-input-container">
-    <button id="sharing-input-copy-button">
+    <button id="sharing-input-copy-button" value=<%= options.shareLink %>>
       <i class="fa fa-clipboard fa-lg"></i>
         <%= msg.copyLinkToProject() %>
     </button>

--- a/apps/src/templates/sharing.html.ejs
+++ b/apps/src/templates/sharing.html.ejs
@@ -12,9 +12,9 @@
   <% } %>
 
   <div id="sharing-input-container">
-    <input type="text" id="sharing-input" value=<%= options.shareLink %> readonly>
     <button id="sharing-input-copy-button">
       <i class="fa fa-clipboard fa-lg"></i>
+        <%= msg.copyLinkToProject() %>
     </button>
   </div>
   <div class='social-buttons'>

--- a/apps/src/templates/sharing.html.ejs
+++ b/apps/src/templates/sharing.html.ejs
@@ -12,7 +12,7 @@
   <% } %>
 
   <div id="sharing-input-container">
-    <button id="sharing-input-copy-button" value=<%= options.shareLink %>>
+    <button id="sharing-dialog-copy-button" value=<%= options.shareLink %>>
       <i class="fa fa-clipboard fa-lg"></i>
         <%= msg.copyLinkToProject() %>
     </button>

--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -1430,7 +1430,6 @@ $workspace-header-button-margin: ($workspace-headers-height - $workspace-header-
 
   #sharing-input-copy-button {
     margin-top: 1px;
-    width: 40px;
     box-sizing: border-box;
   }
 

--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -1428,12 +1428,12 @@ $workspace-header-button-margin: ($workspace-headers-height - $workspace-header-
     cursor: text;
   }
 
-  #sharing-input-copy-button {
+  #sharing-dialog-copy-button {
     margin-top: 1px;
     box-sizing: border-box;
   }
 
-  .sharing-input-copy-button-shared {
+  .sharing-dialog-copy-button-shared {
     background-color: $light_purple;
   }
 

--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -1333,7 +1333,7 @@ $workspace-header-button-margin: ($workspace-headers-height - $workspace-header-
   }
 
   div {
-    margin: 10px 0;
+    margin: 5px 0;
     &.sharing-content {
       margin-left: $image_width + 15px;
       margin-right: 25px;

--- a/dashboard/test/ui/features/foundations/footer.feature
+++ b/dashboard/test/ui/features/foundations/footer.feature
@@ -56,7 +56,7 @@ Feature: Checking the footer appearance
     And I press "runButton"
     And I wait until element "#finishButton" is visible
     And I press "finishButton"
-    And I wait until element "#sharing-input" is visible
+    And I wait until element "#sharing-input-copy-button" is visible
     And I navigate to the share URL
     And I wait until element ".small-footer-base" is visible
 
@@ -83,13 +83,13 @@ Feature: Checking the footer appearance
 
     Then I close my eyes
 
-  # TODO: Fix and re-enable (find #sharing-input element)
+  # TODO: Fix and re-enable (find #sharing-input-copy-button element)
   @eyes @skip
   Scenario: Desktop Minecraft share small footer
     Given I am on "http://studio.code.org/s/mc/lessons/1/levels/14?noautoplay=true"
     And I wait for the page to fully load
     And I press "runButton"
-    And I wait until element "#sharing-input" is visible
+    And I wait until element "#sharing-input-copy-button" is visible
     And I navigate to the share URL
     And I wait until element ".small-footer-base" is visible
 
@@ -148,7 +148,7 @@ Feature: Checking the footer appearance
     And I press "runButton"
     And I wait until element "#finishButton" is visible
     And I press "finishButton"
-    And I wait until element "#sharing-input" is visible
+    And I wait until element "#sharing-input-copy-button" is visible
     And I rotate to portrait
     And I wait for 0.5 seconds
     And I navigate to the share URL
@@ -169,14 +169,14 @@ Feature: Checking the footer appearance
 
     Then I close my eyes
 
-  # TODO: Fix and re-enable (find #sharing-input element)
+  # TODO: Fix and re-enable (find #sharing-input-copy-button element)
   @eyes_mobile @skip
   Scenario: Mobile Minecraft share small footer
     Given I am on "http://studio.code.org/s/mc/lessons/1/levels/14?noautoplay=true"
     And I rotate to landscape
     And I wait for the page to fully load
     And I press "runButton"
-    And I wait until element "#sharing-input" is visible
+    And I wait until element "#sharing-input-copy-button" is visible
     And I rotate to portrait
     And I wait for 0.5 seconds
     And I navigate to the share URL

--- a/dashboard/test/ui/features/foundations/footer.feature
+++ b/dashboard/test/ui/features/foundations/footer.feature
@@ -56,7 +56,7 @@ Feature: Checking the footer appearance
     And I press "runButton"
     And I wait until element "#finishButton" is visible
     And I press "finishButton"
-    And I wait until element "#sharing-input-copy-button" is visible
+    And I wait until element "#sharing-dialog-copy-button" is visible
     And I navigate to the share URL
     And I wait until element ".small-footer-base" is visible
 
@@ -83,13 +83,13 @@ Feature: Checking the footer appearance
 
     Then I close my eyes
 
-  # TODO: Fix and re-enable (find #sharing-input-copy-button element)
+  # TODO: Fix and re-enable (find #sharing-dialog-copy-button element)
   @eyes @skip
   Scenario: Desktop Minecraft share small footer
     Given I am on "http://studio.code.org/s/mc/lessons/1/levels/14?noautoplay=true"
     And I wait for the page to fully load
     And I press "runButton"
-    And I wait until element "#sharing-input-copy-button" is visible
+    And I wait until element "#sharing-dialog-copy-button" is visible
     And I navigate to the share URL
     And I wait until element ".small-footer-base" is visible
 
@@ -148,7 +148,7 @@ Feature: Checking the footer appearance
     And I press "runButton"
     And I wait until element "#finishButton" is visible
     And I press "finishButton"
-    And I wait until element "#sharing-input-copy-button" is visible
+    And I wait until element "#sharing-dialog-copy-button" is visible
     And I rotate to portrait
     And I wait for 0.5 seconds
     And I navigate to the share URL
@@ -169,14 +169,14 @@ Feature: Checking the footer appearance
 
     Then I close my eyes
 
-  # TODO: Fix and re-enable (find #sharing-input-copy-button element)
+  # TODO: Fix and re-enable (find #sharing-dialog-copy-button element)
   @eyes_mobile @skip
   Scenario: Mobile Minecraft share small footer
     Given I am on "http://studio.code.org/s/mc/lessons/1/levels/14?noautoplay=true"
     And I rotate to landscape
     And I wait for the page to fully load
     And I press "runButton"
-    And I wait until element "#sharing-input-copy-button" is visible
+    And I wait until element "#sharing-dialog-copy-button" is visible
     And I rotate to portrait
     And I wait for 0.5 seconds
     And I navigate to the share URL

--- a/dashboard/test/ui/features/hour_of_code/minecraft_codebuilder.feature
+++ b/dashboard/test/ui/features/hour_of_code/minecraft_codebuilder.feature
@@ -18,7 +18,7 @@ Scenario: Importing an Agent level from a share link
   And I press "runButton"
   And I wait until element "#finishButton" is visible
   And I press "finishButton"
-  And I wait until element "#sharing-input-copy-button" is visible
+  And I wait until element "#sharing-dialog-copy-button" is visible
   And I save the share URL
 
   #
@@ -64,7 +64,7 @@ Scenario: Importing an Agent level from a project link
   Then I drag block "1" to block "10"
   And I press "runButton"
   And I click selector ".project_share"
-  And I wait until element "#sharing-input-copy-button" is visible
+  And I wait until element "#sharing-dialog-copy-button" is visible
   And I save the share URL
 
   #

--- a/dashboard/test/ui/features/hour_of_code/minecraft_codebuilder.feature
+++ b/dashboard/test/ui/features/hour_of_code/minecraft_codebuilder.feature
@@ -18,7 +18,7 @@ Scenario: Importing an Agent level from a share link
   And I press "runButton"
   And I wait until element "#finishButton" is visible
   And I press "finishButton"
-  And I wait until element "#sharing-input" is visible
+  And I wait until element "#sharing-input-copy-button" is visible
   And I save the share URL
 
   #
@@ -64,7 +64,7 @@ Scenario: Importing an Agent level from a project link
   Then I drag block "1" to block "10"
   And I press "runButton"
   And I click selector ".project_share"
-  And I wait until element "#sharing-input" is visible
+  And I wait until element "#sharing-input-copy-button" is visible
   And I save the share URL
 
   #

--- a/dashboard/test/ui/features/learning_platform/projects/prevent_report_abuse_spam.feature
+++ b/dashboard/test/ui/features/learning_platform/projects/prevent_report_abuse_spam.feature
@@ -67,7 +67,7 @@ Scenario: Abuse reports block a project for other viewers
   Given I create a student named "Creator"
   And I make a "applab" project named "Regular Project"
   And I click selector ".project_share"
-  And I wait until element "#sharing-input-copy-button" is visible
+  And I wait until element "#sharing-dialog-copy-button" is visible
   And I save the share URL
   Then I sign out
 
@@ -98,7 +98,7 @@ Scenario: Projects made by project validators are protected from abuse reports
   And I give user "Project Validator" project validator permission
   And I make a "applab" project named "Protected Project"
   And I click selector ".project_share"
-  And I wait until element "#sharing-input-copy-button" is visible
+  And I wait until element "#sharing-dialog-copy-button" is visible
   And I save the share URL
   Then I sign out
 

--- a/dashboard/test/ui/features/learning_platform/projects/prevent_report_abuse_spam.feature
+++ b/dashboard/test/ui/features/learning_platform/projects/prevent_report_abuse_spam.feature
@@ -67,7 +67,7 @@ Scenario: Abuse reports block a project for other viewers
   Given I create a student named "Creator"
   And I make a "applab" project named "Regular Project"
   And I click selector ".project_share"
-  And I wait until element "#sharing-input" is visible
+  And I wait until element "#sharing-input-copy-button" is visible
   And I save the share URL
   Then I sign out
 
@@ -98,7 +98,7 @@ Scenario: Projects made by project validators are protected from abuse reports
   And I give user "Project Validator" project validator permission
   And I make a "applab" project named "Protected Project"
   And I click selector ".project_share"
-  And I wait until element "#sharing-input" is visible
+  And I wait until element "#sharing-input-copy-button" is visible
   And I save the share URL
   Then I sign out
 

--- a/dashboard/test/ui/features/star_labs/sharepage_logo.feature
+++ b/dashboard/test/ui/features/star_labs/sharepage_logo.feature
@@ -9,7 +9,7 @@ Feature: Lab share page logo
     Given I am on "http://studio.code.org/projects/applab"
     And I wait for the page to fully load
     Then I click selector ".project_share"
-    And I wait until element "#sharing-input" is visible
+    And I wait until element "#sharing-input-copy-button" is visible
     And I navigate to the share URL
     And I wait to see "#runButton"
     And element "div:contains('STUDIO')" does not exist
@@ -21,7 +21,7 @@ Feature: Lab share page logo
     Given I am on "http://studio.code.org/projects/playlab"
     And I wait for the page to fully load
     Then I click selector ".project_share"
-    And I wait until element "#sharing-input" is visible
+    And I wait until element "#sharing-input-copy-button" is visible
     And I navigate to the share URL
     And I wait to see "#runButton"
     And element "div:contains('STUDIO')" does not exist
@@ -33,7 +33,7 @@ Feature: Lab share page logo
     Given I am on "http://studio.code.org/projects/gamelab"
     And I wait for the page to fully load
     Then I click selector ".project_share"
-    And I wait until element "#sharing-input" is visible
+    And I wait until element "#sharing-input-copy-button" is visible
     And I navigate to the share URL
     And I wait to see "#runButton"
     And element "div:contains('STUDIO')" does not exist
@@ -45,7 +45,7 @@ Feature: Lab share page logo
     Given I am on "http://studio.code.org/projects/artist"
     And I wait for the page to fully load
     Then I click selector ".project_share"
-    And I wait until element "#sharing-input" is visible
+    And I wait until element "#sharing-input-copy-button" is visible
     And I navigate to the share URL
     And I wait to see "#runButton"
     And element "div:contains('STUDIO')" does not exist
@@ -57,7 +57,7 @@ Feature: Lab share page logo
     Given I am on "http://studio.code.org/projects/playlab"
     And I wait for the page to fully load
     Then I click selector ".project_share"
-    And I wait until element "#sharing-input" is visible
+    And I wait until element "#sharing-input-copy-button" is visible
     And I navigate to the share URL
     And I wait to see "#runButton"
     And I am on "http://studio.code.org/users/sign_out"
@@ -72,7 +72,7 @@ Feature: Lab share page logo
     Given I am on "http://studio.code.org/projects/gamelab"
     And I wait for the page to fully load
     Then I click selector ".project_share"
-    And I wait until element "#sharing-input" is visible
+    And I wait until element "#sharing-input-copy-button" is visible
     And I navigate to the share URL
     And I wait to see "#runButton"
     And I am on "http://studio.code.org/users/sign_out"
@@ -87,7 +87,7 @@ Feature: Lab share page logo
     Given I am on "http://studio.code.org/projects/applab"
     And I wait for the page to fully load
     Then I click selector ".project_share"
-    And I wait until element "#sharing-input" is visible
+    And I wait until element "#sharing-input-copy-button" is visible
     And I navigate to the share URL
     And I wait to see "#runButton"
     And element "#main_logo" does not exist
@@ -97,7 +97,7 @@ Feature: Lab share page logo
     Given I am on "http://studio.code.org/projects/gamelab"
     And I wait for the page to fully load
     Then I click selector ".project_share"
-    And I wait until element "#sharing-input" is visible
+    And I wait until element "#sharing-input-copy-button" is visible
     And I navigate to the share URL
     And I wait to see "#runButton"
     And element "#main_logo" does not exist

--- a/dashboard/test/ui/features/star_labs/sharepage_logo.feature
+++ b/dashboard/test/ui/features/star_labs/sharepage_logo.feature
@@ -9,7 +9,7 @@ Feature: Lab share page logo
     Given I am on "http://studio.code.org/projects/applab"
     And I wait for the page to fully load
     Then I click selector ".project_share"
-    And I wait until element "#sharing-input-copy-button" is visible
+    And I wait until element "#sharing-dialog-copy-button" is visible
     And I navigate to the share URL
     And I wait to see "#runButton"
     And element "div:contains('STUDIO')" does not exist
@@ -21,7 +21,7 @@ Feature: Lab share page logo
     Given I am on "http://studio.code.org/projects/playlab"
     And I wait for the page to fully load
     Then I click selector ".project_share"
-    And I wait until element "#sharing-input-copy-button" is visible
+    And I wait until element "#sharing-dialog-copy-button" is visible
     And I navigate to the share URL
     And I wait to see "#runButton"
     And element "div:contains('STUDIO')" does not exist
@@ -33,7 +33,7 @@ Feature: Lab share page logo
     Given I am on "http://studio.code.org/projects/gamelab"
     And I wait for the page to fully load
     Then I click selector ".project_share"
-    And I wait until element "#sharing-input-copy-button" is visible
+    And I wait until element "#sharing-dialog-copy-button" is visible
     And I navigate to the share URL
     And I wait to see "#runButton"
     And element "div:contains('STUDIO')" does not exist
@@ -45,7 +45,7 @@ Feature: Lab share page logo
     Given I am on "http://studio.code.org/projects/artist"
     And I wait for the page to fully load
     Then I click selector ".project_share"
-    And I wait until element "#sharing-input-copy-button" is visible
+    And I wait until element "#sharing-dialog-copy-button" is visible
     And I navigate to the share URL
     And I wait to see "#runButton"
     And element "div:contains('STUDIO')" does not exist
@@ -57,7 +57,7 @@ Feature: Lab share page logo
     Given I am on "http://studio.code.org/projects/playlab"
     And I wait for the page to fully load
     Then I click selector ".project_share"
-    And I wait until element "#sharing-input-copy-button" is visible
+    And I wait until element "#sharing-dialog-copy-button" is visible
     And I navigate to the share URL
     And I wait to see "#runButton"
     And I am on "http://studio.code.org/users/sign_out"
@@ -72,7 +72,7 @@ Feature: Lab share page logo
     Given I am on "http://studio.code.org/projects/gamelab"
     And I wait for the page to fully load
     Then I click selector ".project_share"
-    And I wait until element "#sharing-input-copy-button" is visible
+    And I wait until element "#sharing-dialog-copy-button" is visible
     And I navigate to the share URL
     And I wait to see "#runButton"
     And I am on "http://studio.code.org/users/sign_out"
@@ -87,7 +87,7 @@ Feature: Lab share page logo
     Given I am on "http://studio.code.org/projects/applab"
     And I wait for the page to fully load
     Then I click selector ".project_share"
-    And I wait until element "#sharing-input-copy-button" is visible
+    And I wait until element "#sharing-dialog-copy-button" is visible
     And I navigate to the share URL
     And I wait to see "#runButton"
     And element "#main_logo" does not exist
@@ -97,7 +97,7 @@ Feature: Lab share page logo
     Given I am on "http://studio.code.org/projects/gamelab"
     And I wait for the page to fully load
     Then I click selector ".project_share"
-    And I wait until element "#sharing-input-copy-button" is visible
+    And I wait until element "#sharing-dialog-copy-button" is visible
     And I navigate to the share URL
     And I wait to see "#runButton"
     And element "#main_logo" does not exist

--- a/dashboard/test/ui/features/step_definitions/applab.rb
+++ b/dashboard/test/ui/features/step_definitions/applab.rb
@@ -345,7 +345,7 @@ end
 Then(/^the share link includes "([^"]*)"$/) do |expected_text|
   share_link_input = nil
   wait_short_until do
-    share_link_input = @browser.find_element(:css, '#sharing-input')
+    share_link_input = @browser.find_element(:css, '#sharing-input-copy-button')
   end
   expect(share_link_input.attribute('value')).to include(expected_text)
 end

--- a/dashboard/test/ui/features/step_definitions/applab.rb
+++ b/dashboard/test/ui/features/step_definitions/applab.rb
@@ -345,7 +345,7 @@ end
 Then(/^the share link includes "([^"]*)"$/) do |expected_text|
   share_link_input = nil
   wait_short_until do
-    share_link_input = @browser.find_element(:css, '#sharing-input-copy-button')
+    share_link_input = @browser.find_element(:css, '#sharing-dialog-copy-button')
   end
   expect(share_link_input.attribute('value')).to include(expected_text)
 end

--- a/dashboard/test/ui/features/step_definitions/project_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/project_steps.rb
@@ -196,8 +196,8 @@ end
 
 last_shared_url = nil
 Then /^I save the share URL$/ do
-  wait_short_until {@button = @browser.find_element(id: 'sharing-input')}
-  last_shared_url = @browser.execute_script("return document.getElementById('sharing-input').value")
+  wait_short_until {@button = @browser.find_element(id: 'sharing-input-copy-button')}
+  last_shared_url = @browser.execute_script("return document.getElementById('sharing-input-copy-button').value")
 end
 
 When /^I open the share dialog$/ do

--- a/dashboard/test/ui/features/step_definitions/project_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/project_steps.rb
@@ -196,8 +196,8 @@ end
 
 last_shared_url = nil
 Then /^I save the share URL$/ do
-  wait_short_until {@button = @browser.find_element(id: 'sharing-input-copy-button')}
-  last_shared_url = @browser.execute_script("return document.getElementById('sharing-input-copy-button').value")
+  wait_short_until {@button = @browser.find_element(id: 'sharing-dialog-copy-button')}
+  last_shared_url = @browser.execute_script("return document.getElementById('sharing-dialog-copy-button').value")
 end
 
 When /^I open the share dialog$/ do

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -631,7 +631,7 @@ Then /^I wait to see a congrats dialog with title containing "((?:[^"\\]|\\.)*)"
 end
 
 Then /^I reopen the congrats dialog unless I see the sharing input/ do
-  next if @browser.execute_script("return $('#sharing-input').length > 0;")
+  next if @browser.execute_script("return $('#sharing-input-copy-button').length > 0;")
   puts "reopening congrats dialog"
   individual_steps %{
     And I press "again-button"

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -631,7 +631,7 @@ Then /^I wait to see a congrats dialog with title containing "((?:[^"\\]|\\.)*)"
 end
 
 Then /^I reopen the congrats dialog unless I see the sharing input/ do
-  next if @browser.execute_script("return $('#sharing-input-copy-button').length > 0;")
+  next if @browser.execute_script("return $('#sharing-dialog-copy-button').length > 0;")
   puts "reopening congrats dialog"
   individual_steps %{
     And I press "again-button"


### PR DESCRIPTION
Finished [LP-1956](https://codedotorg.atlassian.net/browse/LP-1956).

Removes the URL from the project share dialogs in favor of using "Copy link to project".

Share dialog on /p/spritelab:
![Screen Shot 2022-03-29 at 10 00 08 AM](https://user-images.githubusercontent.com/46464143/160667814-176d5497-39b9-4ab6-864b-68ac3175d90f.png)

Share dialog on /p/dance:
![Screen Shot 2022-03-29 at 10 00 15 AM](https://user-images.githubusercontent.com/46464143/160667819-47e36dc5-fb6f-4d1e-86bc-fd7490d3d9d5.png)

Finish dialog on /s/dance-2019/lessons/1/levels/10:
![Screen Shot 2022-03-29 at 10 06 28 AM](https://user-images.githubusercontent.com/46464143/160667821-6cc20bf3-7c4a-4fab-b99d-d1d6fe15c4ec.png)

Finish dialog on /s/poem-art-2021/lessons/1/levels/9:
![Screen Shot 2022-03-29 at 10 08 15 AM](https://user-images.githubusercontent.com/46464143/160667822-7d4c35ad-495b-4764-ba65-42dea78c7450.png)

In [Slack](https://codedotorg.slack.com/archives/G0166MKCRST/p1647533807583839), Amanda also suggested moving the "Add to Projects" button up but there's [some logic](https://github.com/code-dot-org/code-dot-org/blob/d26cf85c82e1b9997baf8a0e8fb2d2915fd4e56a/apps/src/templates/sharing.html.ejs#L40) about which buttons to show when that I didn't want to mess with. I can look into it if it's critical.




## Testing story

tested manually, confirmed UI tests passed



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
