### PR TITLE
Updates and additions to startWebRequest

### DIFF
--- a/dashboard/app/controllers/xhr_proxy_controller.rb
+++ b/dashboard/app/controllers/xhr_proxy_controller.rb
@@ -52,6 +52,7 @@ class XhrProxyController < ApplicationController
     api.randomuser.me
     api.rebrandly.com
     api.scryfall.com
+    api.spoonacular.com
     api.si.edu
     api.spacexdata.com
     api.spotify.com
@@ -62,9 +63,11 @@ class XhrProxyController < ApplicationController
     api.weather.gov
     api.zippopotam.us
     bible-api.com
+    ch.tetr.io
     code.org
     covidtracking.com
     cryptonator.com
+    currencyapi.com
     data.austintexas.gov
     data.cityofchicago.org
     data.gv.at
@@ -74,7 +77,6 @@ class XhrProxyController < ApplicationController
     deckofcardsapi.com
     distanza.org
     dweet.io
-    freecurrencyapi.net
     googleapis.com
     grobchess.com
     hubblesite.org


### PR DESCRIPTION
Update freecurrencyapi.net to currencyapi.com as they are [switching hostname support on 3/21](https://7utwe.r.a.d.sendibm1.com/mk/mr/gpQup3NW_Y94pcvr6lExi4LoQI7obXbjlp4r0NYCOvQNEL-u6vF_SMvLBTd6P8AButAtgQZLdVsRIPDu2n-86pZ_wxaIzVWc2-8Y5UkphQ4ATvoX9zNSTxtBMYyYhMGrlzwvvg)
Jira ticket: https://codedotorg.atlassian.net/browse/STAR-2167

Adding ch.tetr.io, a Tetris like game info API
Documentation: https://tetr.io/about/api/#reference
Zendesk ticket: https://codeorg.zendesk.com/agent/tickets/376505
Jira ticket: https://codedotorg.atlassian.net/browse/STAR-2132

Adding api.spoonacular.com, a food data API
Documentation: https://spoonacular.com/food-api/docs
Zendesk ticket: https://codeorg.zendesk.com/agent/tickets/377610
Jira ticket: https://codedotorg.atlassian.net/browse/STAR-2166