### PR TITLE
Fixing infinite recursion in i18n string tracking

### DIFF
--- a/bin/i18n/translation_status/translation_service.rb
+++ b/bin/i18n/translation_status/translation_service.rb
@@ -16,7 +16,7 @@ class TranslationService
     if scope == ""
       I18n.exists?(key, locale: locale)
     else
-      !I18n.t(key, scope: JSON.parse(scope), smart: true).include?("translation missing:")
+      !I18n.t(key, scope: JSON.parse(scope), smart: true, tracking: false).include?("translation missing")
     end
   end
 

--- a/lib/cdo/i18n_backend.rb
+++ b/lib/cdo/i18n_backend.rb
@@ -145,6 +145,12 @@ module Cdo
     module I18nStringUrlTrackerPlugin
       def translate(locale, key, options = ::I18n::EMPTY_HASH)
         result = super
+        # If we don't want to track this string lookup, just return the translation
+        # :tracking is assumed to be true unless explicitly set to false.
+        # :tracking is a custom flag we added to skip i18n string tracking for this translation
+        # lookup.
+        return result if options[:tracking] == false
+
         url = Thread.current[:current_request_url]
         scope = options[:scope]
         # Note that the separator here might not cover some edge cases. If we find that the separator used here is not

--- a/lib/cdo/i18n_string_url_tracker.rb
+++ b/lib/cdo/i18n_string_url_tracker.rb
@@ -71,8 +71,9 @@ class I18nStringUrlTracker
     return unless string_key && url && source
 
     # We got a bad string_key if there is no English source string
-    source_string = I18n.t(string_key, locale: I18n.default_locale)
-    return if !source_string || source_string.start_with?("translation missing")
+    source_string = I18n.t(string_key, locale: I18n.default_locale, tracking: false)
+    return if !source_string ||
+      (source_string.is_a?(String) && source_string.start_with?("translation missing"))
 
     # Skip URLs we are not interested in.
     return unless allowed(url)


### PR DESCRIPTION
*Bug* - Pages which use `I18n.t` would fail to render because there was infinite recursion.
*Cause* - We recently introduced a change in the I18n String Tracker which checks that a given string-key exists by looking up if there is an English value for it. However, every time we look up a translation, the I18n String Tracker logs it which results in looking up if there is an English value for it. This is infinite recursion.
*Fix* - Add a `:tracking` flag to `I18n.t` calls which will allows callers to skip the I18n String Tracker when looking up translations.

## Testing story
* Manually verified on http://localhost-studio.code.org:3000/courses
  * Note you will need to enable `i18n_string_tracking` in `dcdo_development_temp.json`
