### PR TITLE
Skipping flaky perf test

### DIFF
--- a/lib/test/cdo/test_i18n_string_url_tracker.rb
+++ b/lib/test/cdo/test_i18n_string_url_tracker.rb
@@ -312,12 +312,11 @@ class BenchI18nStringUrlTracker < Minitest::Benchmark
   end
 
   # Tests that the tracker's performance scales linearly as the data increases.
-  # This tests is commented out because we found it to be flaky when running on our build servers.
-  # If you want to verify the performance of some changes you made, uncomment this and run it
-  # locally.
-  # def bench_linear_performance
-  #   assert_performance_linear(0.95) do |n|
-  #     n.times {|m| I18nStringUrlTracker.instance.log(n.to_s, m.to_s, m.to_s, [], '.')}
-  #   end
-  # end
+  # This tests is skipped because we found it to be flaky when running on our build servers.
+  def bench_linear_performance
+    skip 'test is flaky when running on build servers'
+    assert_performance_linear(0.95) do |n|
+      n.times {|m| I18nStringUrlTracker.instance.log(n.to_s, m.to_s, m.to_s, [], '.')}
+    end
+  end
 end

--- a/lib/test/cdo/test_i18n_string_url_tracker.rb
+++ b/lib/test/cdo/test_i18n_string_url_tracker.rb
@@ -311,9 +311,13 @@ class BenchI18nStringUrlTracker < Minitest::Benchmark
     [1, 1, 1_000, 1_000, 2_000, 5_000, 10_000]
   end
 
-  def bench_linear_performance
-    assert_performance_linear(0.95) do |n|
-      n.times {|m| I18nStringUrlTracker.instance.log(n.to_s, m.to_s, m.to_s, [], '.')}
-    end
-  end
+  # Tests that the tracker's performance scales linearly as the data increases.
+  # This tests is commented out because we found it to be flaky when running on our build servers.
+  # If you want to verify the performance of some changes you made, uncomment this and run it
+  # locally.
+  # def bench_linear_performance
+  #   assert_performance_linear(0.95) do |n|
+  #     n.times {|m| I18nStringUrlTracker.instance.log(n.to_s, m.to_s, m.to_s, [], '.')}
+  #   end
+  # end
 end


### PR DESCRIPTION
Disabling a performance test for the I18n String Tracker. This test runs reliably on a dev desktop but is flaky when running in a test environment. One theory is that there are multiple tests running at the same time on the test servers and that might be impacting the performance randomly during this performance test.