### PR TITLE
Update DeleteAccountsHelperTest transaction rollback logic

### DIFF
--- a/dashboard/test/helpers/delete_accounts_helper_test.rb
+++ b/dashboard/test/helpers/delete_accounts_helper_test.rb
@@ -24,7 +24,11 @@ class DeleteAccountsHelperTest < ActionView::TestCase
   NULL_STREAM = File.open File::NULL, 'w'
 
   def run(*_args, &_block)
-    PEGASUS_DB.transaction(rollback: :always, auto_savepoint: true) {super}
+    PEGASUS_DB.transaction(rollback: :always, auto_savepoint: true) do
+      DASHBOARD_DB.transaction(rollback: :always, auto_savepoint: true) do
+        super
+      end
+    end
   end
 
   setup do


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Follow-up to #44957.  Adding a new dashboard transaction to a unit test that now touches the dashboard database now that the user_storage_ids table has been moved from pegasus to dashboard.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
