### PR TITLE
serialize lesson standards for crowdin sync in

### DIFF
--- a/dashboard/app/models/framework.rb
+++ b/dashboard/app/models/framework.rb
@@ -21,6 +21,10 @@ class Framework < ApplicationRecord
     }
   end
 
+  def crowdin_key
+    shortcode
+  end
+
   def self.seed_all
     filename = 'config/standards/frameworks.csv'
     CSV.foreach(filename, {headers: true}) do |row|

--- a/dashboard/app/models/framework.rb
+++ b/dashboard/app/models/framework.rb
@@ -25,6 +25,10 @@ class Framework < ApplicationRecord
     shortcode
   end
 
+  def localized_name
+    Services::I18n::CurriculumSyncUtils.get_localized_property(self, :name, crowdin_key)
+  end
+
   def self.seed_all
     filename = 'config/standards/frameworks.csv'
     CSV.foreach(filename, {headers: true}) do |row|

--- a/dashboard/app/models/standard.rb
+++ b/dashboard/app/models/standard.rb
@@ -61,6 +61,10 @@ class Standard < ApplicationRecord
     }
   end
 
+  def crowdin_key
+    [framework.shortcode, shortcode].join('/')
+  end
+
   # Loads/merges the data from a CSV into the Standards table.
   # Can be used to overwrite the description and category of
   # existing Standards and to create new Standards.

--- a/dashboard/app/models/standard.rb
+++ b/dashboard/app/models/standard.rb
@@ -18,6 +18,7 @@
 class Standard < ApplicationRecord
   belongs_to :framework
   belongs_to :category, class_name: 'StandardCategory'
+  has_one :parent_category, through: :category
 
   # ensures associated lessons_standards are deleted when a standard is deleted
   has_and_belongs_to_many :lessons, association_foreign_key: 'stage_id'
@@ -38,8 +39,8 @@ class Standard < ApplicationRecord
   def summarize_for_lesson_show
     {
       frameworkName: framework.name,
-      parentCategoryShortcode: category&.parent_category&.shortcode,
-      parentCategoryDescription: category&.parent_category&.description,
+      parentCategoryShortcode: parent_category&.shortcode,
+      parentCategoryDescription: parent_category&.description,
       categoryShortcode: category&.shortcode,
       categoryDescription: category&.description,
       shortcode: shortcode,
@@ -51,8 +52,8 @@ class Standard < ApplicationRecord
     {
       frameworkShortcode: framework.shortcode,
       frameworkName: framework.name,
-      parentCategoryShortcode: category&.parent_category&.shortcode,
-      parentCategoryDescription: category&.parent_category&.description,
+      parentCategoryShortcode: parent_category&.shortcode,
+      parentCategoryDescription: parent_category&.description,
       categoryShortcode: category&.shortcode,
       categoryDescription: category&.description,
       shortcode: shortcode,

--- a/dashboard/app/models/standard.rb
+++ b/dashboard/app/models/standard.rb
@@ -31,20 +31,20 @@ class Standard < ApplicationRecord
     {
       id: id,
       shortcode: shortcode,
-      category_description: category.description,
-      description: description
+      category_description: category.localized_description,
+      description: localized_description
     }
   end
 
   def summarize_for_lesson_show
     {
-      frameworkName: framework.name,
+      frameworkName: framework.localized_name,
       parentCategoryShortcode: parent_category&.shortcode,
-      parentCategoryDescription: parent_category&.description,
+      parentCategoryDescription: parent_category&.localized_description,
       categoryShortcode: category&.shortcode,
-      categoryDescription: category&.description,
+      categoryDescription: category&.localized_description,
       shortcode: shortcode,
-      description: description
+      description: localized_description
     }
   end
 
@@ -63,6 +63,10 @@ class Standard < ApplicationRecord
 
   def crowdin_key
     [framework.shortcode, shortcode].join('/')
+  end
+
+  def localized_description
+    Services::I18n::CurriculumSyncUtils.get_localized_property(self, :description, crowdin_key)
   end
 
   # Loads/merges the data from a CSV into the Standards table.

--- a/dashboard/app/models/standard_category.rb
+++ b/dashboard/app/models/standard_category.rb
@@ -26,6 +26,10 @@ class StandardCategory < ApplicationRecord
     description
   )
 
+  def crowdin_key
+    [framework.shortcode, shortcode].join('/')
+  end
+
   def self.seed_all
     Framework.all.each do |framework|
       filename = "config/standards/#{framework.shortcode}_categories.csv"

--- a/dashboard/app/models/standard_category.rb
+++ b/dashboard/app/models/standard_category.rb
@@ -30,6 +30,10 @@ class StandardCategory < ApplicationRecord
     [framework.shortcode, shortcode].join('/')
   end
 
+  def localized_description
+    Services::I18n::CurriculumSyncUtils.get_localized_property(self, :description, crowdin_key)
+  end
+
   def self.seed_all
     Framework.all.each do |framework|
       filename = "config/standards/#{framework.shortcode}_categories.csv"

--- a/dashboard/lib/services/i18n/curriculum_sync_utils/serializers.rb
+++ b/dashboard/lib/services/i18n/curriculum_sync_utils/serializers.rb
@@ -81,6 +81,36 @@ module Services
         attribute :description
       end
 
+      class FrameworkCrowdinSerializer < CrowdinSerializer
+        attributes :name
+
+        # override
+        def crowdin_key
+          object.shortcode
+        end
+      end
+
+      class StandardCategoryCrowdinSerializer < CrowdinSerializer
+        attributes :description
+
+        # override
+        def crowdin_key
+          [object.framework.shortcode, object.shortcode].join('/')
+        end
+      end
+
+      class StandardCrowdinSerializer < CrowdinSerializer
+        attributes :description
+
+        belongs_to :framework, serializer: CurriculumSyncUtils::FrameworkCrowdinSerializer
+        belongs_to :category, serializer: CurriculumSyncUtils::StandardCategoryCrowdinSerializer
+
+        # override
+        def crowdin_key
+          [object.framework.shortcode, object.shortcode].join('/')
+        end
+      end
+
       class LessonCrowdinSerializer < CrowdinSerializer
         # Note that we don't include "name" here, because that's already
         # handled by existing logic. We could in the future consider moving
@@ -97,6 +127,8 @@ module Services
         has_many :objectives, serializer: CurriculumSyncUtils::ObjectiveCrowdinSerializer
         has_many :resources, serializer: CurriculumSyncUtils::ResourceCrowdinSerializer
         has_many :vocabularies, serializer: CurriculumSyncUtils::VocabularyCrowdinSerializer
+        has_many :standards, serializer: CurriculumSyncUtils::StandardCrowdinSerializer
+        has_many :opportunity_standards, serializer: CurriculumSyncUtils::StandardCrowdinSerializer
 
         # override
         def crowdin_key

--- a/dashboard/lib/services/i18n/curriculum_sync_utils/serializers.rb
+++ b/dashboard/lib/services/i18n/curriculum_sync_utils/serializers.rb
@@ -103,6 +103,7 @@ module Services
         attributes :description
 
         belongs_to :framework, serializer: CurriculumSyncUtils::FrameworkCrowdinSerializer
+        belongs_to :parent_category, serializer: CurriculumSyncUtils::StandardCategoryCrowdinSerializer
         belongs_to :category, serializer: CurriculumSyncUtils::StandardCategoryCrowdinSerializer
 
         # override

--- a/dashboard/lib/services/i18n/curriculum_sync_utils/serializers.rb
+++ b/dashboard/lib/services/i18n/curriculum_sync_utils/serializers.rb
@@ -84,19 +84,13 @@ module Services
       class FrameworkCrowdinSerializer < CrowdinSerializer
         attributes :name
 
-        # override
-        def crowdin_key
-          object.shortcode
-        end
+        delegate :crowdin_key, to: :object
       end
 
       class StandardCategoryCrowdinSerializer < CrowdinSerializer
         attributes :description
 
-        # override
-        def crowdin_key
-          [object.framework.shortcode, object.shortcode].join('/')
-        end
+        delegate :crowdin_key, to: :object
       end
 
       class StandardCrowdinSerializer < CrowdinSerializer
@@ -106,10 +100,7 @@ module Services
         belongs_to :parent_category, serializer: CurriculumSyncUtils::StandardCategoryCrowdinSerializer
         belongs_to :category, serializer: CurriculumSyncUtils::StandardCategoryCrowdinSerializer
 
-        # override
-        def crowdin_key
-          [object.framework.shortcode, object.shortcode].join('/')
-        end
+        delegate :crowdin_key, to: :object
       end
 
       class LessonCrowdinSerializer < CrowdinSerializer


### PR DESCRIPTION
Finishes [PLAT-1627](https://codedotorg.atlassian.net/browse/PLAT-1627). See the slack thread linked there for a screenshot of the problem.

I followed the instructions for [Adding a model to the i18n sync pipeline](https://docs.google.com/document/d/1ftnniTwCsQ5zZ_GOiWXWO2F2cqqcfSBOztr1T6zWO7w/edit) as best I could, specifically the part which says:
> If the model has a relationship with our Script model, see if there is a possibility this functionality could be utilized by our [already existing CurriculumSyncUtils.sync_in](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/lib/services/i18n/curriculum_sync_utils/sync_in.rb#L4).

To clarify, this PR does two things:
1. make standards, categories and frameworks text available for sync in
2. use translated strings (if available) for standards, categories and frameworks when displaying lesson plans

## Testing story

@code-dot-org/foundations team, the doc mentions this in the intro:

> Then to test we will want to have a dummy translation that goes through the sync

is this something I should do? I didn't see exactly how to do it from the rest of the doc.

Here are the verification steps I did do:

1. verified manually that a standard with a parent category can be serialized (not all standards have parent categories). I adapted this testing step from #45003:
```
[development] dashboard > puts JSON.pretty_generate Services::I18n::CurriculumSyncUtils::StandardCrowdinSerializer.new(Script.find_by_name('aiml-2021').lessons[1].standards.first).as_json
{
  "crowdin_key": "ai4k12-2021/3-A-i.6-8",
  "description": "Contrast the unique characteristics of human learning with the ways machine learning systems operate.",
  "framework": {
    "crowdin_key": "ai4k12-2021",
    "name": "AI4K12 National Guidelines 2021"
  },
  "parent_category": {
    "crowdin_key": "ai4k12-2021/BI-3",
    "description": "Computers can learn from data"
  },
  "category": {
    "crowdin_key": "ai4k12-2021/3-A-i",
    "description": "Nature of Learning - humans vs machines"
  }
}
```

3. verified there is no change to how standards appear on teacher lesson plan:
![Screen Shot 2022-03-15 at 8 33 30 PM](https://user-images.githubusercontent.com/8001765/158511694-4505214f-fcef-447e-917c-ad8c7e412a45.png)

