### PR TITLE
Setup for applied_at column

### DIFF
--- a/dashboard/app/models/pd/application/application_base.rb
+++ b/dashboard/app/models/pd/application/application_base.rb
@@ -67,7 +67,7 @@ module Pd::Application
 
     # An application either has an "incomplete" or "unreviewed" state when created.
     # The applied_at field gets set when the status becomes 'unreviewed' for the first time
-    before_save :set_applied_date, if: -> {status_changed? && ActiveRecord::Base.connection.column_exists?(:pd_applications, :applied_at)}
+    before_save :set_applied_date, if: :status_changed?
     # After creation, an RP or admin can change the status to "accepted," which triggers update_accepted_data.
     before_save :update_accepted_date, if: :status_changed?
 
@@ -338,9 +338,9 @@ module Pd::Application
     end
 
     # displays the iso8601 date (yyyy-mm-dd)
+    # [MEG] TODO: Update this method to use applied_at date
     def date_applied
-      created_at.to_date.iso8601 unless ActiveRecord::Base.connection.column_exists?(:pd_applications, :applied_at)
-      applied_at&.to_date&.iso8601 if ActiveRecord::Base.connection.column_exists?(:pd_applications, :applied_at)
+      created_at.to_date.iso8601
     end
 
     # Convert responses cores to a hash of underscore_cased symbols

--- a/dashboard/app/models/pd/application/application_base.rb
+++ b/dashboard/app/models/pd/application/application_base.rb
@@ -67,7 +67,7 @@ module Pd::Application
 
     # An application either has an "incomplete" or "unreviewed" state when created.
     # The applied_at field gets set when the status becomes 'unreviewed' for the first time
-    before_save :set_applied_date, if: -> {status_changed? && ActiveRecord::Base.connection.column_exists?(:pd_applications, :applied_at)}
+    before_save :set_applied_date, if: :status_changed?
     # After creation, an RP or admin can change the status to "accepted," which triggers update_accepted_data.
     before_save :update_accepted_date, if: :status_changed?
 

--- a/dashboard/app/models/pd/application/application_base.rb
+++ b/dashboard/app/models/pd/application/application_base.rb
@@ -67,7 +67,7 @@ module Pd::Application
 
     # An application either has an "incomplete" or "unreviewed" state when created.
     # The applied_at field gets set when the status becomes 'unreviewed' for the first time
-    before_save :set_applied_date, if: :status_changed?
+    before_save :set_applied_date, if: -> {status_changed? && ActiveRecord::Base.connection.column_exists?(:pd_applications, :applied_at)}
     # After creation, an RP or admin can change the status to "accepted," which triggers update_accepted_data.
     before_save :update_accepted_date, if: :status_changed?
 

--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -131,6 +131,8 @@ module Pd::Application
 
     # Since teacher applications may be created on save before they are submitted, we cannot rely
     # on the created_at field. When applications are submitted, they have status 'unreviewed'
+    # [MEG] TODO: Delete this method once applied_at column exists, i.e.
+    # ActiveRecord::Base.connection.column_exists?(:pd_applications, :applied_at) is true
     def date_applied
       status_log.find {|status_entry| status_entry["status"] == "unreviewed"}&.[]("at")&.to_date&.iso8601
     end

--- a/dashboard/test/models/pd/application/application_base_test.rb
+++ b/dashboard/test/models/pd/application/application_base_test.rb
@@ -213,9 +213,7 @@ module Pd::Application
       assert_equal '2018-03-09', application.date_accepted
     end
 
-    # [MEG] TODO: Remove the skip once migration is complete
     test 'applied_at is populated with the first unreviewed status' do
-      skip 'applied_at field does not exist' unless ActiveRecord::Base.connection.column_exists?(:pd_applications, :applied_at)
       application = create :pd_teacher_application, status: 'incomplete'
       assert_nil application.applied_at
 

--- a/dashboard/test/models/pd/application/application_base_test.rb
+++ b/dashboard/test/models/pd/application/application_base_test.rb
@@ -213,6 +213,25 @@ module Pd::Application
       assert_equal '2018-03-09', application.date_accepted
     end
 
+    test 'set_applied_date populates applied_at with the first unreviewed status' do
+      application = create :pd_teacher_application, status: 'incomplete'
+      assert_nil application.applied_at
+
+      tomorrow = Date.tomorrow.to_time
+      next_day = tomorrow + 1.day
+
+      Timecop.freeze(tomorrow) do
+        application.update!(status: 'unreviewed')
+      end
+
+      Timecop.freeze(next_day) do
+        application.update!(status: 'reopened')
+        application.update!(status: 'unreviewed')
+      end
+
+      assert_equal tomorrow, application.applied_at
+    end
+
     test 'memoized full_answers' do
       application = ApplicationBase.new
       application.stubs(additional_text_fields:

--- a/dashboard/test/models/pd/application/application_base_test.rb
+++ b/dashboard/test/models/pd/application/application_base_test.rb
@@ -213,7 +213,9 @@ module Pd::Application
       assert_equal '2018-03-09', application.date_accepted
     end
 
-    test 'set_applied_date populates applied_at with the first unreviewed status' do
+    # [MEG] TODO: Remove the skip once migration is complete
+    test 'applied_at is populated with the first unreviewed status' do
+      skip 'applied_at field does not exist' unless ActiveRecord::Base.connection.column_exists?(:pd_applications, :applied_at)
       application = create :pd_teacher_application, status: 'incomplete'
       assert_nil application.applied_at
 

--- a/dashboard/test/models/pd/application/teacher_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher_application_test.rb
@@ -109,9 +109,9 @@ module Pd::Application
       assert_equal Pd::Application::TeacherApplication::REVIEWING_INCOMPLETE, teacher_application.meets_criteria
     end
 
-    # [MEG] TODO: Remove this test once the applied_at column exists, i.e. once
-    # ActiveRecord::Base.connection.column_exists?(:pd_applications, :applied_at) is true
+    # [MEG] TODO: Remove this test once the applied_at column exists
     test 'date_applied finds date of first unreviewed status' do
+      skip 'now using the applied_at field' if ActiveRecord::Base.connection.column_exists?(:pd_applications, :applied_at)
       tomorrow = Date.tomorrow.to_time
       next_day = tomorrow + 1.day
       application = create :pd_teacher_application, status: 'incomplete'

--- a/dashboard/test/models/pd/application/teacher_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher_application_test.rb
@@ -109,9 +109,8 @@ module Pd::Application
       assert_equal Pd::Application::TeacherApplication::REVIEWING_INCOMPLETE, teacher_application.meets_criteria
     end
 
-    # [MEG] TODO: Remove this test once the applied_at column exists
+    # [MEG] TODO: Move and refactor this test once the date_applied method is only in application_base
     test 'date_applied finds date of first unreviewed status' do
-      skip 'now using the applied_at field' if ActiveRecord::Base.connection.column_exists?(:pd_applications, :applied_at)
       tomorrow = Date.tomorrow.to_time
       next_day = tomorrow + 1.day
       application = create :pd_teacher_application, status: 'incomplete'

--- a/dashboard/test/models/pd/application/teacher_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher_application_test.rb
@@ -109,6 +109,8 @@ module Pd::Application
       assert_equal Pd::Application::TeacherApplication::REVIEWING_INCOMPLETE, teacher_application.meets_criteria
     end
 
+    # [MEG] TODO: Remove this test once the applied_at column exists, i.e. once
+    # ActiveRecord::Base.connection.column_exists?(:pd_applications, :applied_at) is true
     test 'date_applied finds date of first unreviewed status' do
       tomorrow = Date.tomorrow.to_time
       next_day = tomorrow + 1.day


### PR DESCRIPTION
Writes to the applied_at column now that the migration is complete. Will read from this column once all records have been backfilled.

## Links

- jira ticket: [PLAT-1666](https://codedotorg.atlassian.net/browse/PLAT-1666)

## Testing story

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

Will need to:
1) backfill applied_at fields
2) start reading from the column and remove old ways

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
