### PR TITLE
Use current_user age to filter dance party

### DIFF
--- a/apps/src/dance/DanceVisualizationColumn.jsx
+++ b/apps/src/dance/DanceVisualizationColumn.jsx
@@ -62,7 +62,8 @@ class DanceVisualizationColumn extends React.Component {
     levelRunIsStarting: PropTypes.bool,
     isShareView: PropTypes.bool.isRequired,
     songData: PropTypes.objectOf(PropTypes.object).isRequired,
-    userType: PropTypes.string.isRequired
+    userType: PropTypes.string.isRequired,
+    under13: PropTypes.bool.isRequired
   };
 
   state = {
@@ -83,7 +84,8 @@ class DanceVisualizationColumn extends React.Component {
     // userType - 'teacher', assumed age > 13. 'student', age > 13.
     //            'student_y', age < 13. 'unknown', signed out users
     const signedInOver13 =
-      this.props.userType === 'teacher' || this.props.userType === 'student';
+      this.props.userType === 'teacher' ||
+      (this.props.userType === 'student' && !this.props.under13);
     const signedOutAge = signedOutOver13();
     return signedInOver13 || signedOutAge;
   }
@@ -173,6 +175,7 @@ export default connect(state => ({
   songData: state.songs.songData,
   selectedSong: state.songs.selectedSong,
   userType: state.currentUser.userType,
+  under13: state.currentUser.under13,
   levelIsRunning: state.runState.isRunning,
   levelRunIsStarting: state.songs.runIsStarting
 }))(DanceVisualizationColumn);

--- a/apps/src/templates/currentUserRedux.js
+++ b/apps/src/templates/currentUserRedux.js
@@ -65,12 +65,13 @@ export default function currentUser(state = initialState, action) {
   }
 
   if (action.type === SET_INITIAL_DATA) {
-    const {id, username, user_type} = action.serverUser;
+    const {id, username, user_type, under_13} = action.serverUser;
     return {
       ...state,
       userId: id,
       userName: username,
-      userType: user_type
+      userType: user_type,
+      under13: under_13
     };
   }
 

--- a/dashboard/app/controllers/api/v1/users_controller.rb
+++ b/dashboard/app/controllers/api/v1/users_controller.rb
@@ -23,7 +23,8 @@ class Api::V1::UsersController < Api::V1::JsonApiController
         user_type: current_user.user_type,
         is_signed_in: true,
         short_name: current_user.short_name,
-        is_verified_instructor: current_user.verified_instructor?
+        is_verified_instructor: current_user.verified_instructor?,
+        under_13: current_user.under_13?
       }
     else
       render json: {


### PR DESCRIPTION
Breaking out the first part of this PR: https://github.com/code-dot-org/code-dot-org/pull/45233

This will allow us to fix the high priority live-site bug and follow-up by cleaning up how the `user_type` and `under_13` is set in https://github.com/code-dot-org/code-dot-org/pull/45233 without the time crunch of a live-site.
