### PR TITLE
When delegating to content root if none exists allow to return nil

### DIFF
--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -58,14 +58,14 @@ class CourseVersion < ApplicationRecord
   # accessing them via course version. In the future, these fields will be moved
   # into the course version itself.
 
-  delegate :name, to: :content_root
-  delegate :pl_course?, to: :content_root
-  delegate :stable?, to: :content_root
-  delegate :launched?, to: :content_root
-  delegate :in_development?, to: :content_root
-  delegate :has_pilot_access?, to: :content_root
-  delegate :can_be_instructor?, to: :content_root
-  delegate :course_assignable?, to: :content_root
+  delegate :name, to: :content_root, allow_nil: true
+  delegate :pl_course?, to: :content_root, allow_nil: true
+  delegate :stable?, to: :content_root, allow_nil: true
+  delegate :launched?, to: :content_root, allow_nil: true
+  delegate :in_development?, to: :content_root, allow_nil: true
+  delegate :has_pilot_access?, to: :content_root, allow_nil: true
+  delegate :can_be_instructor?, to: :content_root, allow_nil: true
+  delegate :course_assignable?, to: :content_root, allow_nil: true
 
   # Seeding method for creating / updating / deleting the CourseVersion for the given
   # potential content root, i.e. a Script or UnitGroup.


### PR DESCRIPTION
We got this [honeybadger error](https://app.honeybadger.io/projects/3240/faults/84545742) which was a result of a course_version not having a valid content_root to point to. I found this [stackoverflow](https://stackoverflow.com/questions/1721433/active-record-with-delegate-and-conditions) about how to deal with this issue when using delegate. So I have updated the delegates in course_version.rb based on that suggestion.