### PR TITLE
Render a 406 if inputs are missing on videos

### DIFF
--- a/dashboard/app/controllers/videos_controller.rb
+++ b/dashboard/app/controllers/videos_controller.rb
@@ -42,6 +42,10 @@ class VideosController < ApplicationController
   end
 
   def create
+    return render(status: :not_acceptable, plain: 'Key required') if video_params[:key].blank?
+    return render(status: :not_acceptable, plain: 'YouTube code required') if video_params[:youtube_code].blank?
+    return render(status: :not_acceptable, plain: 'Download file required') unless video_params[:download]
+
     filename = upload_to_s3
     @video = Video.new(video_params.merge(download: "https://videos.code.org/#{filename}"))
 
@@ -63,6 +67,10 @@ class VideosController < ApplicationController
   # PATCH/PUT /videos/1
   # PATCH/PUT /videos/1.json
   def update
+    return render(status: :not_acceptable, plain: 'Key required') if video_params[:key].blank?
+    return render(status: :not_acceptable, plain: 'YouTube code required') if video_params[:youtube_code].blank?
+    return render(status: :not_acceptable, plain: 'Download file required') unless video_params[:download]
+
     filename = upload_to_s3
 
     if @video.update(video_params.merge(download: "https://videos.code.org/#{filename}"))

--- a/dashboard/test/controllers/videos_controller_test.rb
+++ b/dashboard/test/controllers/videos_controller_test.rb
@@ -34,7 +34,7 @@ class VideosControllerTest < ActionController::TestCase
     assert_creates(Video) do
       post :create, params: {
         title: 'Test create title',
-        video: {key: 'test_key', youtube_code: '_fake_code_'}
+        video: {key: 'test_key', youtube_code: '_fake_code_', download: 'video.mp4'}
       }
     end
 
@@ -50,7 +50,7 @@ class VideosControllerTest < ActionController::TestCase
     patch :update, params: {
       id: @video,
       title: 'Test title',
-      video: {key: @video.key, youtube_code: @video.youtube_code}
+      video: {key: @video.key, youtube_code: @video.youtube_code, download: 'video.mp4'}
     }
     assert_redirected_to videos_path
   end
@@ -59,13 +59,13 @@ class VideosControllerTest < ActionController::TestCase
     assert_creates(Video) do
       post :create, params: {
         title: 'Test create title',
-        video: {key: 'test_key', youtube_code: '_fake_code_'}
+        video: {key: 'test_key', youtube_code: '_fake_code_', download: 'video.mp4'}
       }
     end
     assert_creates(Video) do
       post :create, params: {
         title: 'Test create title',
-        video: {key: 'test_key', youtube_code: '_fake_code_', locale: 'es-MX'}
+        video: {key: 'test_key', youtube_code: '_fake_code_', download: 'video.mp4', locale: 'ex-MX'}
       }
     end
     assert_equal 2, Video.where(key: 'test_key').count
@@ -76,7 +76,7 @@ class VideosControllerTest < ActionController::TestCase
       assert_raise do
         post :create, params: {
           title: 'Test create title',
-          video: {key: 'test_key', youtube_code: '_fake_code_', locale: 'es-MX'}
+          video: {key: 'test_key', youtube_code: '_fake_code_', download: 'video.mp4', locale: 'ex-MX'}
         }
       end
     end


### PR DESCRIPTION
This [came up yesterday](https://codedotorg.slack.com/archives/C036XVC3CBF/p1647454290604289) that the error messages if fields are missing when creating a video are ...bad.

Before:
no youtube code:
<img width="928" alt="image (3)" src="https://user-images.githubusercontent.com/46464143/158844480-9b9052ea-d30f-47bf-bae1-25fcfd3a6ba4.png">

no download file:
<img width="1114" alt="image (4)" src="https://user-images.githubusercontent.com/46464143/158844492-fda8ba2b-39cc-4b3e-b75d-29728b8310be.png">

Now:
<img width="578" alt="Screen Shot 2022-03-17 at 9 10 10 AM" src="https://user-images.githubusercontent.com/46464143/158844318-cbd30960-f802-4e16-93ef-df91727c4ca5.png">

It's not pretty and there is a lot more we can do to make this flow better for curriculum writers. But this should be clearer and help curriculum writers know what went wrong.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
