### PR TITLE
Javalab exemplars: create route to allow arbitrary sources in request

### DIFF
--- a/dashboard/app/controllers/javabuilder_sessions_controller.rb
+++ b/dashboard/app/controllers/javabuilder_sessions_controller.rb
@@ -13,18 +13,8 @@ class JavabuilderSessionsController < ApplicationController
 
   # GET /javabuilder/access_token
   def get_access_token
-    teacher_list = get_teacher_list.join(',')
     channel_id = params[:channelId]
-    project_version = params[:projectVersion]
-    # TODO: remove project_url after javabuilder is deployed with update to no longer need it
-    project_url = params[:projectUrl]
-    level_id = params[:levelId]
-    options = params[:options]
-    execution_type = params[:executionType]
-    use_dashboard_sources = params[:useDashboardSources]
-    mini_app_type = params[:miniAppType]
-    options = options ? options.to_json : '{}'
-    if !channel_id || !project_version || !project_url || !execution_type || !mini_app_type
+    unless channel_id
       return render status: :bad_request, json: {}
     end
 
@@ -34,45 +24,17 @@ class JavabuilderSessionsController < ApplicationController
       return render status: :bad_request, json: {}
     end
 
-    issued_at_time = Time.now.to_i
-    # expire token in 15 minutes
-    expiration_time = (Time.now + 15.minutes).to_i
     session_id = SecureRandom.uuid
-    payload = {
-      iat: issued_at_time,
-      iss: CDO.dashboard_hostname,
-      exp: expiration_time,
-      sid: session_id,
-      uid: current_user.id,
-      storage_id: storage_id,
-      storage_app_id: storage_app_id,
+    payload = get_shared_payload(session_id)
+    channel_specific_payload = {
       channel_id: channel_id,
-      project_version: project_version,
-      project_url: project_url,
-      level_id: level_id,
-      execution_type: execution_type,
-      mini_app_type: mini_app_type,
-      use_dashboard_sources: use_dashboard_sources,
-      options: options,
-      verified_teachers: teacher_list
+      storage_id: storage_id,
+      storage_app_id: storage_app_id
     }
+    payload.merge! channel_specific_payload
 
-    # log payload to firehose
-    FirehoseClient.instance.put_record(
-      :analysis,
-      {
-        study: 'java-builder-sessions',
-        event: "new-token-created",
-        user_id: current_user.id,
-        data_json: payload.to_json
-      }
-    )
-
-    encoded_payload = JWT.encode(
-      payload,
-      OpenSSL::PKey::RSA.new(PRIVATE_KEY, PASSWORD),
-      'RS256'
-    )
+    log_token_creation
+    encoded_payload = create_encoded_payload(payload)
 
     if use_dashboard_sources == 'false'
       success = JavalabFilesHelper.upload_project_files(channel_id, level_id, request.host, encoded_payload)
@@ -80,6 +42,25 @@ class JavabuilderSessionsController < ApplicationController
     end
 
     render json: {token: encoded_payload, session_id: session_id}
+  end
+
+  def get_access_token_provided_sources
+    # require levelbuilder
+
+    override_sources = params[:overrideSources]
+    unless override_sources
+      return render status: :bad_request, json: {}
+    end
+
+    session_id = SecureRandom.uuid
+    payload = get_shared_payload(session_id)
+
+    log_token_creation
+    encoded_payload = create_encoded_payload(payload)
+
+    # add in uploading of project files here
+    # update return value here
+    return encoded_payload
   end
 
   private
@@ -99,5 +80,62 @@ class JavabuilderSessionsController < ApplicationController
       teachers << teacher.id
     end
     teachers
+  end
+
+  def get_shared_payload(session_id)
+    teacher_list = get_teacher_list.join(',')
+    project_version = params[:projectVersion]
+    # TODO: remove project_url after javabuilder is deployed with update to no longer need it
+    project_url = params[:projectUrl]
+    level_id = params[:levelId]
+    options = params[:options]
+    execution_type = params[:executionType]
+    use_dashboard_sources = params[:useDashboardSources]
+    mini_app_type = params[:miniAppType]
+    options = options ? options.to_json : '{}'
+    if !project_version || !project_url || !execution_type || !mini_app_type
+      return render status: :bad_request, json: {}
+    end
+
+    issued_at_time = Time.now.to_i
+    # expire token in 15 minutes
+    expiration_time = (Time.now + 15.minutes).to_i
+    shared_payload = {
+      iat: issued_at_time,
+      iss: CDO.dashboard_hostname,
+      exp: expiration_time,
+      sid: session_id,
+      uid: current_user.id,
+      project_version: project_version,
+      project_url: project_url,
+      level_id: level_id,
+      execution_type: execution_type,
+      mini_app_type: mini_app_type,
+      use_dashboard_sources: use_dashboard_sources,
+      options: options,
+      verified_teachers: teacher_list
+    }
+
+    shared_payload
+  end
+
+  def log_token_creation
+    FirehoseClient.instance.put_record(
+      :analysis,
+      {
+        study: 'java-builder-sessions',
+        event: "new-token-created",
+        user_id: current_user.id,
+        data_json: payload.to_json
+      }
+    )
+  end
+
+  def create_encoded_payload(payload)
+    JWT.encode(
+      payload,
+      OpenSSL::PKey::RSA.new(PRIVATE_KEY, PASSWORD),
+      'RS256'
+    )
   end
 end

--- a/dashboard/app/controllers/javabuilder_sessions_controller.rb
+++ b/dashboard/app/controllers/javabuilder_sessions_controller.rb
@@ -13,10 +13,7 @@ class JavabuilderSessionsController < ApplicationController
 
   # GET /javabuilder/access_token
   def get_access_token
-    begin
-      require_default_params
-      params.require(:channelId)
-    rescue ActionController::ParameterMissing
+    unless has_required_params?([:channelId])
       return render status: :bad_request, json: {}
     end
     channel_id = params[:channelId]
@@ -49,10 +46,7 @@ class JavabuilderSessionsController < ApplicationController
 
   # GET /javabuilder/access_token_with_override_sources
   def get_access_token_with_override_sources
-    begin
-      require_default_params
-      params.require(:overrideSources)
-    rescue ActionController::ParameterMissing
+    unless has_required_params?([:overrideSources])
       return render status: :bad_request, json: {}
     end
     override_sources = params[:overrideSources]
@@ -143,7 +137,15 @@ class JavabuilderSessionsController < ApplicationController
     )
   end
 
-  def require_default_params
-    params.require([:projectVersion, :projectUrl, :executionType, :miniAppType])
+  def has_required_params?(additional_params)
+    default_params = [:projectVersion, :projectUrl, :executionType, :miniAppType]
+
+    begin
+      params.require(default_params.concat(additional_params))
+    rescue ActionController::ParameterMissing
+      return false
+    end
+
+    true
   end
 end

--- a/dashboard/app/controllers/javabuilder_sessions_controller.rb
+++ b/dashboard/app/controllers/javabuilder_sessions_controller.rb
@@ -98,8 +98,8 @@ class JavabuilderSessionsController < ApplicationController
     level_id = params[:levelId]
     options = params[:options]
     execution_type = params[:executionType]
-    mini_app_type = params[:miniAppType]
     use_dashboard_sources = 'false'
+    mini_app_type = params[:miniAppType]
     options = options ? options.to_json : '{}'
 
     issued_at_time = Time.now.to_i

--- a/dashboard/app/controllers/javabuilder_sessions_controller.rb
+++ b/dashboard/app/controllers/javabuilder_sessions_controller.rb
@@ -19,7 +19,7 @@ class JavabuilderSessionsController < ApplicationController
     channel_id = params[:channelId]
 
     session_id = SecureRandom.uuid
-    encoded_payload = get_encoded_payload({session_id: session_id, channel_id: channel_id})
+    encoded_payload = get_encoded_payload({sid: session_id, channel_id: channel_id})
 
     level_id = params[:levelId].to_i
     project_files = JavalabFilesHelper.get_project_files(channel_id, level_id)
@@ -34,7 +34,7 @@ class JavabuilderSessionsController < ApplicationController
     override_sources = params[:overrideSources]
 
     session_id = SecureRandom.uuid
-    encoded_payload = get_encoded_payload({session_id: session_id})
+    encoded_payload = get_encoded_payload({sid: session_id})
 
     level_id = params[:levelId].to_i
     project_files = JavalabFilesHelper.get_project_files_with_override_sources(override_sources, level_id)
@@ -70,7 +70,6 @@ class JavabuilderSessionsController < ApplicationController
       iat: issued_at_time,
       iss: CDO.dashboard_hostname,
       exp: expiration_time,
-      sid: session_id,
       uid: current_user.id,
       project_version: project_version,
       project_url: project_url,

--- a/dashboard/app/helpers/javalab_files_helper.rb
+++ b/dashboard/app/helpers/javalab_files_helper.rb
@@ -57,22 +57,6 @@ module JavalabFilesHelper
     all_files
   end
 
-  def self.generate_asset_url(filename, channel_id)
-    prefix = get_dashboard_url_prefix
-    prefix + "/v3/assets/" + channel_id + "/" + filename
-  end
-
-  def self.generate_starter_asset_url(filename, level)
-    prefix = get_dashboard_url_prefix
-    prefix + "/level_starter_assets/" + URI.encode(level.name) + "/" + filename
-  end
-
-  def self.get_dashboard_url_prefix
-    rack_env?(:development) ?
-      "http://" + CDO.dashboard_hostname + ":3000" :
-      "https://" + CDO.dashboard_hostname
-  end
-
   # Get all files that can be derived from the level where a project was built (ie, files that are not user-specific).
   # The hash is in the format below. All values are strings.
   # Note that this hash does **not** include a "main.json" entry in under "sources", which is required for Javabuilder.
@@ -108,5 +92,21 @@ module JavalabFilesHelper
     end
 
     all_level_files
+  end
+
+  def self.generate_asset_url(filename, channel_id)
+    prefix = get_dashboard_url_prefix
+    prefix + "/v3/assets/" + channel_id + "/" + filename
+  end
+
+  def self.generate_starter_asset_url(filename, level)
+    prefix = get_dashboard_url_prefix
+    prefix + "/level_starter_assets/" + URI.encode(level.name) + "/" + filename
+  end
+
+  def self.get_dashboard_url_prefix
+    rack_env?(:development) ?
+      "http://" + CDO.dashboard_hostname + ":3000" :
+      "https://" + CDO.dashboard_hostname
   end
 end

--- a/dashboard/app/helpers/javalab_files_helper.rb
+++ b/dashboard/app/helpers/javalab_files_helper.rb
@@ -38,10 +38,14 @@ module JavalabFilesHelper
       all_files["assetUrls"][asset[:filename]] = generate_asset_url(asset[:filename], channel_id)
     end
 
-    return all_files
+    all_files
   end
 
-  # def self.get_project_files_with_provided_sources(sources, level_id)
+  def self.get_project_files_with_provided_sources(sources, level_id)
+    all_files = get_level_project_files(level_id)
+    all_files["sources"]["main.json"] = sources
+    all_files
+  end
 
   def self.generate_asset_url(filename, channel_id)
     prefix = get_dashboard_url_prefix

--- a/dashboard/app/helpers/javalab_files_helper.rb
+++ b/dashboard/app/helpers/javalab_files_helper.rb
@@ -1,11 +1,10 @@
-
 module JavalabFilesHelper
-  def self.upload_project_files(channel_id, level_id, hostname, auth_token)
+  def self.upload_project_files(project_files, hostname, auth_token)
     uri = URI.parse("#{CDO.javabuilder_upload_url}?Authorization=#{auth_token}")
     upload_request = Net::HTTP::Put.new(uri)
     upload_request['Origin'] = hostname
     upload_request['Content-Type'] = 'application/json'
-    upload_request.body = get_project_files(channel_id, level_id).to_json
+    upload_request.body = project_files.to_json
 
     response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') do |http|
       http.request(upload_request)
@@ -15,54 +14,34 @@ module JavalabFilesHelper
     false
   end
 
-  # Get all files related to the project at the given channel id as a hash. The hash is in the format
-  # below. All values are strings.
+  # Get all files related to the project at the given channel id as a hash.
+  # Much of this can be constructed from the level where this project was created (get_level_project_files).
+  # This method adds in user-specific code and assets uploaded on the level where the project was created.
+  # The returned hash is in the format below. All values are strings.
   # {
   #   "sources": {"main.json": <main source file for a project>, "grid.txt": <serialized maze if it exists>},
   #   "assetUrls": {"asset_name_1": <asset_url>, ...}
   #   "validation": <all validation code for a project, in json format>
   # }
-  # If the channel doesn't have validation and/or a maze, those fields will not be present.
+  # If the level doesn't have validation and/or a maze, those fields will not be present.
   def self.get_project_files(channel_id, level_id)
-    all_files = {}
-    sources = {}
+    all_files = get_level_project_files(level_id)
+
     # get main.json
     source_data = SourceBucket.new.get(channel_id, "main.json")
-    sources["main.json"] = source_data[:body].string
-
-    # get maze file
-    level = Level.find(level_id)
-    if level
-      serialized_maze = level.try(:get_serialized_maze)
-      if serialized_maze
-        sources["grid.txt"] = serialized_maze.to_json
-      end
-    end
-    all_files["sources"] = sources
+    all_files["sources"]["main.json"] = source_data[:body].string
 
     # get level assets
-    assets = {}
     asset_bucket = AssetBucket.new
     asset_list = asset_bucket.list(channel_id)
     asset_list.each do |asset|
-      assets[asset[:filename]] = generate_asset_url(asset[:filename], channel_id)
-    end
-
-    # get starter assets
-    if level
-      (level&.project_template_level&.starter_assets || level.starter_assets || []).map do |friendly_name, _|
-        assets[friendly_name] = generate_starter_asset_url(friendly_name, level)
-      end
-    end
-    all_files["assetUrls"] = assets
-
-    # get validation code
-    if level.respond_to?(:validation) && level.validation
-      all_files["validation"] = level.validation.to_json
+      all_files["assetUrls"][asset[:filename]] = generate_asset_url(asset[:filename], channel_id)
     end
 
     return all_files
   end
+
+  # def self.get_project_files_with_provided_sources(sources, level_id)
 
   def self.generate_asset_url(filename, channel_id)
     prefix = get_dashboard_url_prefix
@@ -78,5 +57,57 @@ module JavalabFilesHelper
     rack_env?(:development) ?
       "http://" + CDO.dashboard_hostname + ":3000" :
       "https://" + CDO.dashboard_hostname
+  end
+
+  def self.get_javabuilder_uri(auth_token)
+    URI.parse("#{CDO.javabuilder_upload_url}?Authorization=#{auth_token}")
+  end
+
+  def self.create_default_javabuilder_request(uri, hostname)
+    default_javabuilder_request = Net::HTTP::Put.new(uri)
+    default_javabuilder_request['Origin'] = hostname
+    default_javabuilder_request['Content-Type'] = 'application/json'
+
+    default_javabuilder_request
+  end
+
+  # Get all files that can be derived from the level where a project was built (ie, files that are not user-specific).
+  # The hash is in the format below. All values are strings.
+  # Note that this hash does not include a "main.json" entry in under "sources", which is required for Javabuilder.
+  # {
+  #   "sources": {"grid.txt": <serialized maze if it exists>},
+  #   "assetUrls": {"asset_name_1": <asset_url>, ...}
+  #   "validation": <all validation code for a project, in json format>
+  # }
+  # If the level doesn't have validation and/or a maze, those fields will not be present.
+  def self.get_level_project_files(level_id)
+    default_files = {}
+    default_sources = {}
+    default_assets = {}
+
+    # get maze file
+    level = Level.find(level_id)
+    if level
+      serialized_maze = level.try(:get_serialized_maze)
+      if serialized_maze
+        default_sources["grid.txt"] = serialized_maze.to_json
+      end
+    end
+    default_files["sources"] = default_sources
+
+    # get starter assets
+    if level
+      (level&.project_template_level&.starter_assets || level.starter_assets || []).map do |friendly_name, _|
+        default_assets[friendly_name] = generate_starter_asset_url(friendly_name, level)
+      end
+    end
+    default_files["assetUrls"] = default_assets
+
+    # get validation code
+    if level.respond_to?(:validation) && level.validation
+      default_files["validation"] = level.validation.to_json
+    end
+
+    default_files
   end
 end

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -409,6 +409,11 @@ class Ability
       end
     end
 
+    # This action allows levelbuilders to work on exemplars in levelbuilder
+    if user.persisted? && user.permission?(UserPermission::LEVELBUILDER)
+      can :get_access_token_provided_sources, :javabuilder_session
+    end
+
     if user.persisted? && user.permission?(UserPermission::PROJECT_VALIDATOR)
       # let them change the hidden state
       can :manage, LevelSource

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -411,7 +411,7 @@ class Ability
 
     # This action allows levelbuilders to work on exemplars in levelbuilder
     if user.persisted? && user.permission?(UserPermission::LEVELBUILDER)
-      can :get_access_token_provided_sources, :javabuilder_session
+      can :get_access_token_with_override_sources, :javabuilder_session
     end
 
     if user.persisted? && user.permission?(UserPermission::PROJECT_VALIDATOR)

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -887,6 +887,7 @@ Dashboard::Application.routes.draw do
   post '/i18n/track_string_usage', action: :track_string_usage, controller: :i18n
 
   get '/javabuilder/access_token', to: 'javabuilder_sessions#get_access_token'
+  get '/javabuilder/access_token_with_override_sources', to: 'javabuilder_sessions#get_access_token_with_override_sources'
 
   resources :sprites, only: [:index], controller: 'sprite_management' do
     collection do

--- a/dashboard/test/controllers/javabuilder_sessions_controller_test.rb
+++ b/dashboard/test/controllers/javabuilder_sessions_controller_test.rb
@@ -12,7 +12,7 @@ class JavabuilderSessionsControllerTest < ActionController::TestCase
     @fake_channel_id = storage_encrypt_channel_id(1, 1)
 
     JavalabFilesHelper.stubs(:get_project_files).returns({})
-    JavalabFilesHelper.stubs(:get_project_files_with_provided_sources).returns({})
+    JavalabFilesHelper.stubs(:get_project_files_with_override_sources).returns({})
     JavalabFilesHelper.stubs(:upload_project_files).returns(true)
   end
 
@@ -24,13 +24,13 @@ class JavabuilderSessionsControllerTest < ActionController::TestCase
     user: :levelbuilder,
     response: :success
 
-  test_user_gets_response_for :get_access_token_with_provided_sources,
+  test_user_gets_response_for :get_access_token_with_override_sources,
     user: :student,
     response: :forbidden
-  test_user_gets_response_for :get_access_token_with_provided_sources,
+  test_user_gets_response_for :get_access_token_with_override_sources,
     user: :teacher,
     response: :forbidden
-  test_user_gets_response_for :get_access_token_with_provided_sources,
+  test_user_gets_response_for :get_access_token_with_override_sources,
     params: {overrideSources: "{'source': {}}", projectVersion: 123, projectUrl: URL, executionType: 'RUN', miniAppType: 'console'},
     user: :levelbuilder,
     response: :success
@@ -121,7 +121,7 @@ class JavabuilderSessionsControllerTest < ActionController::TestCase
   test 'param for override sources is required when using override sources route' do
     levelbuilder = create :levelbuilder
     sign_in(levelbuilder)
-    get :get_access_token_with_provided_sources, params: {projectVersion: 123, projectUrl: URL, executionType: 'RUN', miniAppType: 'console'}
+    get :get_access_token_with_override_sources, params: {projectVersion: 123, projectUrl: URL, executionType: 'RUN', miniAppType: 'console'}
     assert_response :bad_request
   end
 

--- a/dashboard/test/controllers/javabuilder_sessions_controller_test.rb
+++ b/dashboard/test/controllers/javabuilder_sessions_controller_test.rb
@@ -10,6 +10,10 @@ class JavabuilderSessionsControllerTest < ActionController::TestCase
     @rsa_key_test = OpenSSL::PKey::RSA.new(2048)
     OpenSSL::PKey::RSA.stubs(:new).returns(@rsa_key_test)
     @fake_channel_id = storage_encrypt_channel_id(1, 1)
+
+    JavalabFilesHelper.stubs(:get_project_files).returns({})
+    JavalabFilesHelper.stubs(:get_project_files_with_provided_sources).returns({})
+    JavalabFilesHelper.stubs(:upload_project_files).returns(true)
   end
 
   test_user_gets_response_for :get_access_token,
@@ -17,6 +21,17 @@ class JavabuilderSessionsControllerTest < ActionController::TestCase
     response: :forbidden
   test_user_gets_response_for :get_access_token,
     params: {channelId: storage_encrypt_channel_id(1, 1), projectVersion: 123, projectUrl: URL, executionType: 'RUN', miniAppType: 'console'},
+    user: :levelbuilder,
+    response: :success
+
+  test_user_gets_response_for :get_access_token_with_provided_sources,
+    user: :student,
+    response: :forbidden
+  test_user_gets_response_for :get_access_token_with_provided_sources,
+    user: :teacher,
+    response: :forbidden
+  test_user_gets_response_for :get_access_token_with_provided_sources,
+    params: {overrideSources: "{'source': {}}", projectVersion: 123, projectUrl: URL, executionType: 'RUN', miniAppType: 'console'},
     user: :levelbuilder,
     response: :success
 
@@ -103,6 +118,13 @@ class JavabuilderSessionsControllerTest < ActionController::TestCase
     assert_response :bad_request
   end
 
+  test 'param for override sources is required when using override sources route' do
+    levelbuilder = create :levelbuilder
+    sign_in(levelbuilder)
+    get :get_access_token_with_provided_sources, params: {projectVersion: 123, projectUrl: URL, executionType: 'RUN', miniAppType: 'console'}
+    assert_response :bad_request
+  end
+
   test 'param for project version is required' do
     levelbuilder = create :levelbuilder
     sign_in(levelbuilder)
@@ -131,11 +153,11 @@ class JavabuilderSessionsControllerTest < ActionController::TestCase
     assert_response :bad_request
   end
 
-  test 'returns error if upload fails when not using dashboard sources' do
+  test 'returns error if upload fails' do
     JavalabFilesHelper.stubs(:upload_project_files).returns(false)
     levelbuilder = create :levelbuilder
     sign_in(levelbuilder)
-    get :get_access_token, params: {useDashboardSources: "false", channelId: @fake_channel_id, projectVersion: 123, projectUrl: URL, levelId: 261, executionType: 'RUN', miniAppType: 'console'}
+    get :get_access_token, params: {channelId: @fake_channel_id, projectVersion: 123, projectUrl: URL, levelId: 261, executionType: 'RUN', miniAppType: 'console'}
     assert_response :internal_server_error
   end
 


### PR DESCRIPTION
Creates a new route (`/javabuilder/access_token_with_override_sources`) that takes an `overrideSources` parameter that can be passed directly to Javabuilder, along with shared level assets (eg, starter assets, maze file). The new route is only accessible to levelbuilder accounts.

Did a fair amount of moving around of existing pieces of the session controller and files helper to reuse things, which didn't translate well in diffs, so it looks like a bigger change than it really is.

## Links

- jira: [JAVA-496](https://codedotorg.atlassian.net/browse/JAVA-496)
- doc: [Javalab exemplars update doc](https://docs.google.com/document/d/1G5mDxQvvfUUkH5gGW7yb_TeHEedGtX_Ez3OUITwEti0/edit#heading=h.qf0ju7sm1wsi)

## Testing story

The new route has not been tested really yet, although it seems reasonably straightforward. I did test manually that allthethings levels for each of the mini-app types functioned as expected (including ones that had starter assets or project-specific assets).

I added basic tests for the new route on the controller side -- we basically are treating `JavabuilderFilesHelper` as a black box at the moment and do not have any test coverage there.

## Follow-up work

Next steps are to tweak Javabuilder to allow a nil channel ID, and to add an exemplar mode for levelbuilders in Javalab to use this new route.