### PR TITLE
Make some testing improvements ahead of assignment dropdown updates

### DIFF
--- a/dashboard/config/course_offerings/ui-test-versioned-script.json
+++ b/dashboard/config/course_offerings/ui-test-versioned-script.json
@@ -1,6 +1,0 @@
-{
-  "key": "ui-test-versioned-script",
-  "display_name": "ui-test-versioned-script",
-  "category": "other",
-  "is_featured": false
-}

--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -290,6 +290,12 @@ namespace :seed do
     CourseOffering.seed_all
   end
 
+  timed_task course_offerings_ui_tests: :environment do
+    %w(ui-test-course ui-test-versioned-script ui-test-csa-family-script).each do |course_offering_name|
+      CourseOffering.seed_record("test/ui/config/course_offerings/#{course_offering_name}.json")
+    end
+  end
+
   # Seeds Standards
   timed_task standards: :environment do
     Framework.seed_all
@@ -443,7 +449,7 @@ namespace :seed do
   end
 
   FULL_SEED_TASKS = [:check_migrations, :videos, :concepts, :scripts, :courses, :callouts, :school_districts, :schools, :secret_words, :secret_pictures, :ap_school_codes, :ap_cs_offerings, :ib_school_codes, :ib_cs_offerings, :state_cs_offerings, :donors, :donor_schools, :foorms].freeze
-  UI_TEST_SEED_TASKS = [:check_migrations, :videos, :concepts, :scripts_ui_tests, :courses_ui_tests, :callouts, :school_districts, :schools, :secret_words, :secret_pictures, :donors, :donor_schools].freeze
+  UI_TEST_SEED_TASKS = [:check_migrations, :videos, :concepts, :course_offerings_ui_tests, :scripts_ui_tests, :courses_ui_tests, :callouts, :school_districts, :schools, :secret_words, :secret_pictures, :donors, :donor_schools].freeze
   DEFAULT_SEED_TASKS = [:adhoc, :test].include?(rack_env) ? UI_TEST_SEED_TASKS : FULL_SEED_TASKS
 
   desc "seed the data needed for this type of environment by default"

--- a/dashboard/test/controllers/api/v1/sections_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/sections_controller_test.rb
@@ -15,19 +15,32 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
   setup do
     # place in setup instead of setup_all otherwise course ends up being serialized
     # to a file if levelbuilder_mode is true
-    @unit_group = create(:unit_group, published_state: SharedCourseConstants::PUBLISHED_STATE.beta)
-    @section_with_unit_group = create(:section, user: @teacher, login_type: 'word', course_id: @unit_group.id)
+    @beta_unit_group = create(:unit_group, published_state: SharedCourseConstants::PUBLISHED_STATE.beta)
+    CourseOffering.add_course_offering(@beta_unit_group)
+    @beta_unit_group.reload
+    @section_with_unit_group = create(:section, user: @teacher, login_type: 'word', course_id: @beta_unit_group.id)
 
-    @script = create(:script, published_state: SharedCourseConstants::PUBLISHED_STATE.preview)
-    @script_in_preview_state = create(:script, published_state: SharedCourseConstants::PUBLISHED_STATE.preview)
+    @script = create(:script, :is_course, published_state: SharedCourseConstants::PUBLISHED_STATE.preview)
+    CourseOffering.add_course_offering(@script)
+    @script.reload
+
+    @script_in_preview_state = create(:script, :is_course, published_state: SharedCourseConstants::PUBLISHED_STATE.preview)
+    CourseOffering.add_course_offering(@script_in_preview_state)
+    @script_in_preview_state.reload
+
     @section_with_script = create(:section, user: @teacher, script: @script_in_preview_state)
     @student_with_script = create(:follower, section: @section_with_script).student_user
 
     @csp_unit_group = create(:unit_group, name: CSP_COURSE_NAME, published_state: SharedCourseConstants::PUBLISHED_STATE.stable)
-    @csp_unit_group_soft_launched = create(:unit_group, name: CSP_COURSE_SOFT_LAUNCHED_NAME, published_state: SharedCourseConstants::PUBLISHED_STATE.preview)
+    CourseOffering.add_course_offering(@csp_unit_group)
+    @csp_unit_group.reload
     @csp_script = create(:script, name: 'csp1', published_state: SharedCourseConstants::PUBLISHED_STATE.stable)
     create(:unit_group_unit, unit_group: @csp_unit_group, script: @csp_script, position: 1)
     @csp_script.reload
+
+    @csp_unit_group_soft_launched = create(:unit_group, name: CSP_COURSE_SOFT_LAUNCHED_NAME, published_state: SharedCourseConstants::PUBLISHED_STATE.preview)
+    CourseOffering.add_course_offering(@csp_unit_group_soft_launched)
+    @csp_unit_group.reload
 
     Script.clear_cache
   end
@@ -83,7 +96,7 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
     assert_response :success
 
     course_id = returned_json.find {|section| section['id'] == @section_with_unit_group.id}['course_id']
-    assert_equal @unit_group.id, course_id
+    assert_equal @beta_unit_group.id, course_id
   end
 
   test 'logged out cannot view section detail' do
@@ -123,7 +136,7 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
     get :show, params: {id: @section_with_unit_group.id}
     assert_response :success
 
-    assert_equal @unit_group.id, returned_json['course_id']
+    assert_equal @beta_unit_group.id, returned_json['course_id']
   end
 
   test "join with invalid section code" do
@@ -463,7 +476,7 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
     sign_in @teacher
     post :create, params: {
       login_type: Section::LOGIN_TYPE_EMAIL,
-      course_id: @unit_group.id, # Not CSP or CSD
+      course_id: @beta_unit_group.id, # Not CSP or CSD
     }
     assert_response :success
     # TODO: Better to fail here?
@@ -475,6 +488,8 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
   test 'pilot teacher can assign the pilot course id' do
     pilot_teacher = create :teacher, pilot_experiment: 'my-experiment'
     pilot_unit_group = create :unit_group, pilot_experiment: 'my-experiment', published_state: SharedCourseConstants::PUBLISHED_STATE.pilot
+    CourseOffering.add_course_offering(pilot_unit_group)
+
     sign_in pilot_teacher
     post :create, params: {
       login_type: Section::LOGIN_TYPE_EMAIL,
@@ -488,6 +503,8 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
 
   test 'non pilot teacher cannot assign the pilot course id' do
     pilot_unit_group = create :unit_group, pilot_experiment: 'my-experiment', published_state: SharedCourseConstants::PUBLISHED_STATE.pilot
+    CourseOffering.add_course_offering(pilot_unit_group)
+
     sign_in @teacher
     post :create, params: {
       login_type: Section::LOGIN_TYPE_EMAIL,
@@ -502,7 +519,9 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
 
   test 'pilot teacher can assign pilot script' do
     pilot_teacher = create :teacher, pilot_experiment: 'my-experiment'
-    pilot_script = create :script, pilot_experiment: 'my-experiment', published_state: SharedCourseConstants::PUBLISHED_STATE.pilot
+    pilot_script = create :script, :is_course, pilot_experiment: 'my-experiment', published_state: SharedCourseConstants::PUBLISHED_STATE.pilot
+    CourseOffering.add_course_offering(pilot_script)
+
     sign_in pilot_teacher
     post :create, params: {
       login_type: Section::LOGIN_TYPE_EMAIL,
@@ -515,7 +534,9 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
   end
 
   test 'non pilot teacher cannot assign a pilot script' do
-    pilot_script = create :script, pilot_experiment: 'my-experiment', published_state: SharedCourseConstants::PUBLISHED_STATE.pilot
+    pilot_script = create :script, :is_course, pilot_experiment: 'my-experiment', published_state: SharedCourseConstants::PUBLISHED_STATE.pilot
+    CourseOffering.add_course_offering(pilot_script)
+
     sign_in @teacher
     post :create, params: {
       login_type: Section::LOGIN_TYPE_EMAIL,
@@ -559,6 +580,7 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
   [CSP_COURSE_NAME, CSP_COURSE_SOFT_LAUNCHED_NAME].each do |existing_unit_group_name|
     test "can create with both a course id and a script id - #{existing_unit_group_name}" do
       existing_unit_group = UnitGroup.find_by(name: existing_unit_group_name)
+      CourseOffering.add_course_offering(existing_unit_group)
 
       sign_in @teacher
       post :create, params: {
@@ -646,7 +668,7 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
 
     post :update, params: {
       id: section_with_script.id,
-      course_id: @unit_group.id,
+      course_id: @beta_unit_group.id,
       name: "My Section",
       login_type: Section::LOGIN_TYPE_PICTURE,
       grade: "K",
@@ -659,7 +681,7 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
     # Cannot use section_with_script.reload because login_type has changed
     section_with_script = Section.find(section_with_script.id)
 
-    assert_equal(@unit_group.id, section_with_script.course_id)
+    assert_equal(@beta_unit_group.id, section_with_script.course_id)
     assert_nil(section_with_script.script_id)
     assert_equal("My Section", section_with_script.name)
     assert_equal(Section::LOGIN_TYPE_PICTURE, section_with_script.login_type)
@@ -694,7 +716,7 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
 
   test "update: course_id is cleared if not provided and script has no default course" do
     sign_in @teacher
-    section = create(:section, user: @teacher, course_id: @unit_group.id)
+    section = create(:section, user: @teacher, course_id: @beta_unit_group.id)
 
     refute_nil section.course_id
 
@@ -780,7 +802,7 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
     sign_in other_teacher
     post :update, params: {
       id: @section.id,
-      course_id: @unit_group.id,
+      course_id: @beta_unit_group.id,
     }
     assert_response :forbidden
   end
@@ -788,7 +810,7 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
   test "update: cannot update section if not logged in " do
     post :update, params: {
       id: @section.id,
-      course_id: @unit_group.id,
+      course_id: @beta_unit_group.id,
     }
     assert_response :forbidden
   end
@@ -812,7 +834,7 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
     section = create(:section, user: @teacher, script_id: @script_in_preview_state.id)
     post :update, params: {
       id: section.id,
-      course_id: @unit_group.id,
+      course_id: @beta_unit_group.id,
       script_id: @script.id
     }
     assert_response 400

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -31,6 +31,9 @@ FactoryGirl.define do
     sequence(:family_name) {|n| "bogus-course-#{n}"}
     version_year "1991"
     published_state "beta"
+    instruction_type "teacher_led"
+    participant_audience "student"
+    instructor_audience "teacher"
   end
 
   factory :experiment do
@@ -757,6 +760,12 @@ FactoryGirl.define do
     instruction_type "teacher_led"
     participant_audience "student"
     instructor_audience "teacher"
+
+    trait :is_course do
+      sequence(:version_year) {|n| "bogus-version-year-#{n}"}
+      sequence(:family_name) {|n| "bogus-family-name-#{n}"}
+      is_course true
+    end
 
     trait :with_lessons do
       transient do

--- a/dashboard/test/models/unit_group_test.rb
+++ b/dashboard/test/models/unit_group_test.rb
@@ -686,9 +686,13 @@ class UnitGroupTest < ActiveSupport::TestCase
 
   test 'summarize_version' do
     csp_2017 = create(:unit_group, name: 'csp-2017', family_name: 'csp', version_year: '2017', published_state: SharedCourseConstants::PUBLISHED_STATE.stable)
+    CourseOffering.add_course_offering(csp_2017)
     csp_2018 = create(:unit_group, name: 'csp-2018', family_name: 'csp', version_year: '2018', published_state: SharedCourseConstants::PUBLISHED_STATE.stable)
+    CourseOffering.add_course_offering(csp_2018)
     csp_2019 = create(:unit_group, name: 'csp-2019', family_name: 'csp', version_year: '2019', published_state: SharedCourseConstants::PUBLISHED_STATE.preview)
+    CourseOffering.add_course_offering(csp_2019)
     csp_2020 = create(:unit_group, name: 'csp-2020', family_name: 'csp', version_year: '2019', published_state: SharedCourseConstants::PUBLISHED_STATE.beta)
+    CourseOffering.add_course_offering(csp_2020)
 
     [csp_2017, csp_2018, csp_2019].each do |c|
       summary = c.summarize_versions

--- a/dashboard/test/models/unit_group_test.rb
+++ b/dashboard/test/models/unit_group_test.rb
@@ -691,7 +691,7 @@ class UnitGroupTest < ActiveSupport::TestCase
     CourseOffering.add_course_offering(csp_2018)
     csp_2019 = create(:unit_group, name: 'csp-2019', family_name: 'csp', version_year: '2019', published_state: SharedCourseConstants::PUBLISHED_STATE.preview)
     CourseOffering.add_course_offering(csp_2019)
-    csp_2020 = create(:unit_group, name: 'csp-2020', family_name: 'csp', version_year: '2019', published_state: SharedCourseConstants::PUBLISHED_STATE.beta)
+    csp_2020 = create(:unit_group, name: 'csp-2020', family_name: 'csp', version_year: '2020', published_state: SharedCourseConstants::PUBLISHED_STATE.beta)
     CourseOffering.add_course_offering(csp_2020)
 
     [csp_2017, csp_2018, csp_2019].each do |c|

--- a/dashboard/test/ui/config/course_offerings/ui-test-course.json
+++ b/dashboard/test/ui/config/course_offerings/ui-test-course.json
@@ -1,0 +1,6 @@
+{
+  "key": "ui-test-course",
+  "display_name": "ui-test-course",
+  "category": "other",
+  "is_featured": false
+}

--- a/dashboard/test/ui/config/course_offerings/ui-test-csa-family-script.json
+++ b/dashboard/test/ui/config/course_offerings/ui-test-csa-family-script.json
@@ -1,0 +1,6 @@
+{
+  "key": "ui-test-csa-family-script",
+  "display_name": "ui-test-csa-family-script",
+  "category": "other",
+  "is_featured": false
+}

--- a/dashboard/test/ui/config/course_offerings/ui-test-versioned-script.json
+++ b/dashboard/test/ui/config/course_offerings/ui-test-versioned-script.json
@@ -1,0 +1,6 @@
+{
+  "key": "ui-test-versioned-script",
+  "display_name": "ui-test-versioned-script",
+  "category": "other",
+  "is_featured": false
+}

--- a/dashboard/test/ui/config/courses/ui-test-course-2017.course
+++ b/dashboard/test/ui/config/courses/ui-test-course-2017.course
@@ -4,6 +4,9 @@
     "ui-test-script-in-course-2017"
   ],
   "published_state": "stable",
+  "instruction_type": "teacher_led",
+  "participant_audience": "student",
+  "instructor_audience": "teacher",
   "properties": {
     "family_name": "ui-test-course",
     "version_year": "2017"

--- a/dashboard/test/ui/config/courses/ui-test-course-2019.course
+++ b/dashboard/test/ui/config/courses/ui-test-course-2019.course
@@ -4,6 +4,9 @@
     "ui-test-script-in-course-2019"
   ],
   "published_state": "stable",
+  "instruction_type": "teacher_led",
+  "participant_audience": "student",
+  "instructor_audience": "teacher",
   "properties": {
     "family_name": "ui-test-course",
     "version_year": "2019"

--- a/dashboard/test/ui/features/learning_platform/teacher_homepage.feature
+++ b/dashboard/test/ui/features/learning_platform/teacher_homepage.feature
@@ -155,7 +155,7 @@ Feature: Using the teacher homepage sections feature
     When I click selector ".ui-test-section-dropdown"
     And I click selector ".edit-section-details-link"
     And I wait until element "#assignment-version-year" is visible
-    And element "#assignment-version-year" has value "2017"
+    And element "#assignment-version-year" contains text "2017"
     And I press "assignment-version-year"
     And I click selector ".assignment-version-title:contains(2019)" once I see it
     And I press the first ".uitest-saveButton" element


### PR DESCRIPTION
A couple testing updates which will help when switching to new assignment dropdown set up.

1) Seeding test course offerings as part of UI test seeding. Updating ui test courses and scripts to have necessary data.
2) Updating factories for course type information.
3) Adding course offering and course version for scripts/courses in tests when necessary.

## Links

[Jira](https://codedotorg.atlassian.net/browse/PLAT-1584)
[Mini Spec](https://docs.google.com/document/d/11-dtCFuSmST_vP2MdkH0H0lb2e5AGFu1MxiWSRsnkns/edit#)
