### PR TITLE
strip dots from lesson name when setting cloned lesson key

### DIFF
--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -777,7 +777,8 @@ class Lesson < ApplicationRecord
     raise 'Destination unit and lesson must be in a course version' if destination_unit.get_course_version.nil?
 
     copied_lesson = dup
-    copied_lesson.key = copied_lesson.name
+    # scripts.en.yml cannot handle the '.' character in key names
+    copied_lesson.key = copied_lesson.name.delete('.')
     copied_lesson.script_id = destination_unit.id
 
     destination_lesson_group = destination_unit.lesson_groups.last

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -1053,6 +1053,14 @@ class LessonTest < ActiveSupport::TestCase
       assert_equal [destination_vocab], copied_lesson.vocabularies
     end
 
+    test "dots are stripped from cloned lesson key" do
+      @destination_script.expects(:write_script_json).once
+      Script.expects(:merge_and_write_i18n).once
+      @original_lesson.update!(name: 'Problem.Lesson.')
+      copied_lesson = @original_lesson.copy_to_unit(@destination_script)
+      assert_equal 'ProblemLesson', copied_lesson.key
+    end
+
     test "can clone lesson another script in the same course version" do
       unit_group = create :unit_group
       course_version = create :course_version, content_root: unit_group


### PR DESCRIPTION
Finishes [PLAT-1594](https://codedotorg.atlassian.net/browse/PLAT-1594).

In addition to trailing periods, I noticed that non-trailing periods also broke translations (see screenshots below). 

## Testing story

new unit test covers new behavior

I also manually verified by copying lessons with trailing periods (lesson 2) and non-trailing periods (lesson 3) into a new script:

### before
![Screen Shot 2022-03-17 at 2 46 30 PM](https://user-images.githubusercontent.com/8001765/158900658-eaec6920-f4f1-4fcb-b06a-31b8e036ea61.png)

### after
![Screen Shot 2022-03-17 at 2 55 32 PM](https://user-images.githubusercontent.com/8001765/158901147-7243f142-c6b5-444c-aef0-a433d6b906ae.png)

