### PR TITLE
use only dashboard unittest db in unit test runs

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -522,7 +522,7 @@ db_proxy_admin:
 db_writer: !Secret
 reporting_db_writer: <%=db_writer%>
 
-dashboard_db_name: dashboard_<%=env%>
+dashboard_db_name: <%= ENV['USE_DASHBOARD_UNITTEST_DB_ONE'] ? 'dashboard_test1' : "dashboard#{_env}" %>
 pegasus_db_name: <%= ENV['USE_PEGASUS_UNITTEST_DB'] ? 'pegasus_unittest' : "pegasus#{_env}" %>
 
 # Default reader endpoints to writer endpoint.

--- a/lib/rake/test.rake
+++ b/lib/rake/test.rake
@@ -200,28 +200,36 @@ namespace :test do
   task :shared_ci do
     # isolate unit tests from the pegasus_test DB
     ENV['USE_PEGASUS_UNITTEST_DB'] = '1'
+    ENV['USE_DASHBOARD_UNITTEST_DB_ONE'] = '1'
     TestRunUtils.run_shared_tests
+    ENV.delete 'USE_DASHBOARD_UNITTEST_DB_ONE'
     ENV.delete 'USE_PEGASUS_UNITTEST_DB'
   end
 
   task :pegasus_ci do
     # isolate unit tests from the pegasus_test DB
     ENV['USE_PEGASUS_UNITTEST_DB'] = '1'
+    ENV['USE_DASHBOARD_UNITTEST_DB_ONE'] = '1'
     TestRunUtils.run_pegasus_tests
+    ENV.delete 'USE_DASHBOARD_UNITTEST_DB_ONE'
     ENV.delete 'USE_PEGASUS_UNITTEST_DB'
   end
 
   task :lib_ci do
     # isolate unit tests from the pegasus_test DB
     ENV['USE_PEGASUS_UNITTEST_DB'] = '1'
+    ENV['USE_DASHBOARD_UNITTEST_DB_ONE'] = '1'
     TestRunUtils.run_lib_tests
+    ENV.delete 'USE_DASHBOARD_UNITTEST_DB_ONE'
     ENV.delete 'USE_PEGASUS_UNITTEST_DB'
   end
 
   task :bin_i18n_ci do
     # isolate unit tests from the pegasus_test DB
     ENV['USE_PEGASUS_UNITTEST_DB'] = '1'
+    ENV['USE_DASHBOARD_UNITTEST_DB_ONE'] = '1'
     TestRunUtils.run_bin_i18n_tests
+    ENV.delete 'USE_DASHBOARD_UNITTEST_DB_ONE'
     ENV.delete 'USE_PEGASUS_UNITTEST_DB'
   end
 


### PR DESCRIPTION
## Background

See [very long slack thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1647544183822909).

dashboard unit tests run in parallel against 16 dashboard unit test databases from `dashboard_test1` through `dashboard_test16`. there is also the `dashboard_test` database, which is only supposed to be used for UI tests. 

shared, lib and pegasus unit tests each need a dashboard database. today, they are incorrectly configured to use `dashboard_test`. this recently became a problem when we moved a projects table from pegasus db to dashboard db, leading to UI test failures.

## Description

the solution in this PR is to make shared, lib and pegasus unit tests use `dashboard_test1` as their dashboard database.
