### PR TITLE
Unit tests should not use dashboard_test database

### DIFF
--- a/lib/rake/test.rake
+++ b/lib/rake/test.rake
@@ -200,6 +200,7 @@ namespace :test do
   task :shared_ci do
     # isolate unit tests from the pegasus_test DB
     ENV['USE_PEGASUS_UNITTEST_DB'] = '1'
+    ENV['TEST_ENV_NUMBER'] = '1'  # use dashboard_test1 DB
     TestRunUtils.run_shared_tests
     ENV.delete 'USE_PEGASUS_UNITTEST_DB'
   end
@@ -207,6 +208,7 @@ namespace :test do
   task :pegasus_ci do
     # isolate unit tests from the pegasus_test DB
     ENV['USE_PEGASUS_UNITTEST_DB'] = '1'
+    ENV['TEST_ENV_NUMBER'] = '1'  # use dashboard_test1 DB
     TestRunUtils.run_pegasus_tests
     ENV.delete 'USE_PEGASUS_UNITTEST_DB'
   end
@@ -214,6 +216,7 @@ namespace :test do
   task :lib_ci do
     # isolate unit tests from the pegasus_test DB
     ENV['USE_PEGASUS_UNITTEST_DB'] = '1'
+    ENV['TEST_ENV_NUMBER'] = '1'  # use dashboard_test1 DB
     TestRunUtils.run_lib_tests
     ENV.delete 'USE_PEGASUS_UNITTEST_DB'
   end
@@ -221,6 +224,7 @@ namespace :test do
   task :bin_i18n_ci do
     # isolate unit tests from the pegasus_test DB
     ENV['USE_PEGASUS_UNITTEST_DB'] = '1'
+    ENV['TEST_ENV_NUMBER'] = '1'  # use dashboard_test1 DB
     TestRunUtils.run_bin_i18n_tests
     ENV.delete 'USE_PEGASUS_UNITTEST_DB'
   end


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

In the test environment, `pegasus_test` and `dashboard_test` are the databases used by the running test web application server (used for UI/eyes tests).  When running unit tests for pegasus, lib, shared, and i18n, `USE_PEGASUS_UNITTEST_DB` is set to make the unit tests run against `pegasus_unittest` and thus not affect the running test server.  However, the unit tests also alter `dashboard_test` in ways that affect the later UI/eyes tests now that `user_storage_ids` has been moved from pegasus to dashboard.

This change sets `TEST_ENV_NUMBER` on the pegasus, lib, shared, and i18n unit tests in an effort to have the unit test use `dashboard_test1` for unit tests instead of `dashboard_test`.

This fix may be incomplete but it is intended as just a short-term workaround which can be removed after project-related data, code, and tests are all fully moved over to dashboard.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
