### PR TITLE
Also post content push exceptions in #developers

### DIFF
--- a/bin/cron/commit_content
+++ b/bin/cron/commit_content
@@ -81,6 +81,7 @@ def main
   ChatClient.log(content_committer.commit_happened_string)
 rescue Exception => e
   ChatClient.message(rack_env.to_s, "<@#{DevelopersTopic.dotd}> EXCEPTION: #{e.message}", color: 'red')
+  ChatClient.message('developers', "#{@env} content push faild. EXCEPTION: #{e.message}", color: 'red')
   content_committer.set_slack_failed
 end
 


### PR DESCRIPTION
When the content scoop fails, there's a message posted in the appropriate slack channel tagging the dotd _at the time_.

Now that we do our scoops in the middle of the night, these exceptions are easier to miss:
- The wrong dotd is tagged. Our content scoops happen at 12:30am pacific but our dotd shifts turn over at 7am pacific. This means the previous dotd is notified.
- Most developers have these channels muted by default and with less focus on the actual scoop times, it's easier to forget to check for errors
- Most people have notification settings that silence notifications in the night (as everyone should!)

I'm proposing posting the same exception that appears in the environment-specific channels in #developers so that they're a little more noticeable. They won't tag anyone but might be a bit more noticeable when the dotd starts their shift.

Thoughts?

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
