### PR TITLE
Prevent time drift errors in Javabuilder authorization

### DIFF
--- a/dashboard/app/controllers/javabuilder_sessions_controller.rb
+++ b/dashboard/app/controllers/javabuilder_sessions_controller.rb
@@ -62,7 +62,8 @@ class JavabuilderSessionsController < ApplicationController
     mini_app_type = params[:miniAppType]
     options = options ? options.to_json : '{}'
 
-    issued_at_time = Time.now.to_i
+    # Set the IAT a little in the past to account for time drift between environments
+    issued_at_time = (Time.now - 5.seconds).to_i
     # expire token in 15 minutes
     expiration_time = (Time.now + 15.minutes).to_i
 


### PR DESCRIPTION
If one environment's clock is off by just a little from the other, Javabuilder authorization can fail due to an IAT that is issued in the future. This prevents that error by setting the IAT just a little in the past.

Details from when this was discovered: https://codedotorg.slack.com/archives/C01EF4GJ9GE/p1647455269194069

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
