### PR TITLE
I18n sync In & Up 03/21

### DIFF
--- a/i18n/locales/source/dashboard/scripts.yml
+++ b/i18n/locales/source/dashboard/scripts.yml
@@ -31645,6 +31645,8 @@ en:
               description_teacher: 
             lesson-2:
               name: Using variables in Java
+              description_student: 
+              description_teacher: 
           lesson_groups: {}
           name: self-paced-pl-csa3-2022
           title: Support for text-based programming
@@ -32290,6 +32292,7 @@ en:
           student_description: In this unit, you use `ArrayList`s to store program data and differentiate between when to use 1D and 2D arrays and `ArrayList`s. You explore the benefits and functionality of an `ArrayList`, using these to solve problems involving numerical and object data. You use methods in the `String` class to analyze and process text obtained from user and file input. Throughout the unit, you write program documentation using single-line comments, multi-line comments, and Javadoc comments to create API documentation. In the process, you identify and document preconditions and postconditions of objects and methods.
           description_short: ''
           description_audience: ''
+          name: csa6-2022
         csa7-2022:
           lessons:
             Writing Methods to Satisfy Conditions:


### PR DESCRIPTION
# I18n Sync In & Up

This PR contains all changes to internationalization source strings made since the last sync (usually a week).

## To Review:

1. Look through the changes in each of the commits and verify that all changes are expected

   - We expect content changes to come in on a regular basis; individual strings will get updated, added, and deleted.

   - We _do not_ usually expect to see "comprehensive" changes - or changes that apply to large numbers of strings or whole categories of strings all at once - unless we have made specific code changes.

2. Notify the International Partners team about any changes that might appear to manifest as "lost translations"

   - For example: https://github.com/code-dot-org/code-dot-org/pull/31031/files#diff-aa1910a8cf8f9290ae3baf7e39dbae3eL397-R398

     This is a change that added new strings (with both new keys and new content) and simultaneously removed some very similar old ones; we can reasonably infer that the intent here was to swap the new strings out for the old ones. Unfortunately, because the swap also included a content change to the strings the crowdin duplication system won't automatically apply translations to the new strings and so they will need to be manually re-translated.

## To Deploy:

Once one or two people have reviewed and approved this change and the tests are passing, ship it!

It's not necessary to wait for everyone on the team to review.
