### PR TITLE
replace USE_DASHBOARD_UNITTEST_DB_ONE with TEST_ENV_NUMBER

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -2,6 +2,7 @@
 
 env:
 _env:       <%=env == 'production' ? '' : "_#{env}"%>
+_test_env_num: <%=env == 'test' ? ENV['TEST_ENV_NUMBER'] : '' %>
 unit_test:  <%=!!ENV['UNIT_TEST']%>
 ci:         <%=!!ENV['CI']%>
 ci_test:    <%=unit_test || ci%>
@@ -522,7 +523,7 @@ db_proxy_admin:
 db_writer: !Secret
 reporting_db_writer: <%=db_writer%>
 
-dashboard_db_name: <%= ENV['USE_DASHBOARD_UNITTEST_DB_ONE'] ? 'dashboard_test1' : "dashboard#{_env}" %>
+dashboard_db_name: <%= "dashboard#{_env}#{_test_env_num}" %>
 pegasus_db_name: <%= ENV['USE_PEGASUS_UNITTEST_DB'] ? 'pegasus_unittest' : "pegasus#{_env}" %>
 
 # Default reader endpoints to writer endpoint.

--- a/lib/rake/test.rake
+++ b/lib/rake/test.rake
@@ -200,36 +200,36 @@ namespace :test do
   task :shared_ci do
     # isolate unit tests from the pegasus_test DB
     ENV['USE_PEGASUS_UNITTEST_DB'] = '1'
-    ENV['USE_DASHBOARD_UNITTEST_DB_ONE'] = '1'
+    ENV['TEST_ENV_NUMBER'] = '1'
     TestRunUtils.run_shared_tests
-    ENV.delete 'USE_DASHBOARD_UNITTEST_DB_ONE'
+    ENV.delete 'TEST_ENV_NUMBER'
     ENV.delete 'USE_PEGASUS_UNITTEST_DB'
   end
 
   task :pegasus_ci do
     # isolate unit tests from the pegasus_test DB
     ENV['USE_PEGASUS_UNITTEST_DB'] = '1'
-    ENV['USE_DASHBOARD_UNITTEST_DB_ONE'] = '1'
+    ENV['TEST_ENV_NUMBER'] = '1'
     TestRunUtils.run_pegasus_tests
-    ENV.delete 'USE_DASHBOARD_UNITTEST_DB_ONE'
+    ENV.delete 'TEST_ENV_NUMBER'
     ENV.delete 'USE_PEGASUS_UNITTEST_DB'
   end
 
   task :lib_ci do
     # isolate unit tests from the pegasus_test DB
     ENV['USE_PEGASUS_UNITTEST_DB'] = '1'
-    ENV['USE_DASHBOARD_UNITTEST_DB_ONE'] = '1'
+    ENV['TEST_ENV_NUMBER'] = '1'
     TestRunUtils.run_lib_tests
-    ENV.delete 'USE_DASHBOARD_UNITTEST_DB_ONE'
+    ENV.delete 'TEST_ENV_NUMBER'
     ENV.delete 'USE_PEGASUS_UNITTEST_DB'
   end
 
   task :bin_i18n_ci do
     # isolate unit tests from the pegasus_test DB
     ENV['USE_PEGASUS_UNITTEST_DB'] = '1'
-    ENV['USE_DASHBOARD_UNITTEST_DB_ONE'] = '1'
+    ENV['TEST_ENV_NUMBER'] = '1'
     TestRunUtils.run_bin_i18n_tests
-    ENV.delete 'USE_DASHBOARD_UNITTEST_DB_ONE'
+    ENV.delete 'TEST_ENV_NUMBER'
     ENV.delete 'USE_PEGASUS_UNITTEST_DB'
   end
 


### PR DESCRIPTION
Follow-on to https://github.com/code-dot-org/code-dot-org/pull/45376. See [slack](https://codedotorg.slack.com/archives/C0T0PNTM3/p1647880708767399) for discussion. makes sure that dashboard unit tests which use the sequel via `DASHBOARD_DB` to access the dashboard database will point to the right unit test databases (e.g. dashboard_test1 thru 16, not dashboard_test).

## Testing story

open to ideas for how to test this. otherwise, since it is blocking the deploy, I was thinking of just merging it and then debugging further on the test machine if needed.