### PR TITLE
Fix student having permission to leave section

### DIFF
--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -92,7 +92,9 @@ class Ability
       can :create, UserLevel, user_id: user.id
       can :update, UserLevel, user_id: user.id
       can :create, Follower, student_user_id: user.id
-      can :destroy, Follower, student_user_id: user.id
+      can :destroy, Follower do |follower|
+        follower.student_user_id == user.id && !user.student?
+      end
       can :read, UserPermission, user_id: user.id
       can [:show, :pull_review, :update], PeerReview, reviewer_id: user.id
       can :toggle_resolved, CodeReviewComment, project_owner_id: user.id

--- a/dashboard/test/controllers/api/v1/sections_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/sections_controller_test.rb
@@ -203,7 +203,7 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
   end
 
   test "leave with valid joined section code" do
-    sign_in @student
+    sign_in @teacher
     post :leave, params: {id: @section.code}
     assert_response :success
   end

--- a/dashboard/test/controllers/api/v1/sections_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/sections_controller_test.rb
@@ -7,6 +7,8 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
     @teacher = create(:teacher)
     @section = create(:section, user: @teacher, login_type: 'word')
     @student = create(:follower, section: @section).student_user
+    @following_teacher = create(:teacher)
+    create(:follower, section: @section, student_user: @following_teacher)
   end
 
   CSP_COURSE_NAME = 'csp-2017'
@@ -203,7 +205,7 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
   end
 
   test "leave with valid joined section code" do
-    sign_in @teacher
+    sign_in @following_teacher
     post :leave, params: {id: @section.code}
     assert_response :success
   end

--- a/dashboard/test/controllers/api/v1/sections_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/sections_controller_test.rb
@@ -210,6 +210,12 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test "student cannot leave joined section" do
+    sign_in @student
+    post :leave, params: {id: @section.code}
+    assert_response 403
+  end
+
   test "leave with valid unjoined section code" do
     student = create :student
     sign_in student


### PR DESCRIPTION
**What**: Check that the current user is not a student when trying to leave a section.

**Why**: We originally allowed students to do this through the UI, but not anymore. The user could still potentially hit the endpoint successfully. This will prevent that.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [FND-1441](https://codedotorg.atlassian.net/browse/FND-1441)

## Testing story

- Used Postman locally with proper cookies and CSRF token to leave a section as a student before and after this update.
- Did the same^ with a teacher leaving a section.
- Updated unit tests.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
