### PR TITLE
Reorder express mc levels

### DIFF
--- a/dashboard/config/scripts_json/express-2021.script_json
+++ b/dashboard/config/scripts_json/express-2021.script_json
@@ -30,7 +30,7 @@
     },
     "new_name": null,
     "family_name": "express",
-    "serialized_at": "2022-03-21 20:53:13 UTC",
+    "serialized_at": "2022-03-21 20:59:30 UTC",
     "published_state": "stable",
     "instruction_type": "teacher_led",
     "instructor_audience": "teacher",
@@ -9452,6 +9452,9 @@
       "activity_section_position": 10,
       "assessment": false,
       "properties": {
+        "level_keys": [
+          "Underground Iron_2021"
+        ],
         "progression": "Skill Building"
       },
       "bonus": false,
@@ -9526,6 +9529,9 @@
       "activity_section_position": 3,
       "assessment": false,
       "properties": {
+        "level_keys": [
+          "Overworld Powered Minecart_2021"
+        ],
         "progression": "Challenge"
       },
       "bonus": false,

--- a/dashboard/config/scripts_json/express-2021.script_json
+++ b/dashboard/config/scripts_json/express-2021.script_json
@@ -30,7 +30,7 @@
     },
     "new_name": null,
     "family_name": "express",
-    "serialized_at": "2022-03-11 12:08:32 UTC",
+    "serialized_at": "2022-03-21 20:53:13 UTC",
     "published_state": "stable",
     "instruction_type": "teacher_led",
     "instructor_audience": "teacher",
@@ -9428,31 +9428,6 @@
       "assessment": false,
       "properties": {
         "level_keys": [
-          "Overworld Powered Minecart_2021"
-        ],
-        "progression": "Skill Building"
-      },
-      "bonus": false,
-      "seeding_key": {
-        "script_level.level_keys": [
-          "Overworld Powered Minecart_2021"
-        ],
-        "lesson.key": "Looking Ahead with Minecraft ",
-        "lesson_group.key": "csf_conditionals",
-        "script.name": "express-2021",
-        "activity_section.key": "db402396-6473-4942-a3b9-e3833beb0cd8"
-      },
-      "level_keys": [
-        "Overworld Powered Minecart_2021"
-      ]
-    },
-    {
-      "chapter": 167,
-      "position": 10,
-      "activity_section_position": 10,
-      "assessment": false,
-      "properties": {
-        "level_keys": [
           "Underground Mining Coal_2021"
         ],
         "progression": "Skill Building"
@@ -9469,6 +9444,28 @@
       },
       "level_keys": [
         "Underground Mining Coal_2021"
+      ]
+    },
+    {
+      "chapter": 167,
+      "position": 10,
+      "activity_section_position": 10,
+      "assessment": false,
+      "properties": {
+        "progression": "Skill Building"
+      },
+      "bonus": false,
+      "seeding_key": {
+        "script_level.level_keys": [
+          "Underground Iron_2021"
+        ],
+        "lesson.key": "Looking Ahead with Minecraft ",
+        "lesson_group.key": "csf_conditionals",
+        "script.name": "express-2021",
+        "activity_section.key": "db402396-6473-4942-a3b9-e3833beb0cd8"
+      },
+      "level_keys": [
+        "Underground Iron_2021"
       ]
     },
     {
@@ -9529,15 +9526,12 @@
       "activity_section_position": 3,
       "assessment": false,
       "properties": {
-        "level_keys": [
-          "Underground Iron_2021"
-        ],
         "progression": "Challenge"
       },
       "bonus": false,
       "seeding_key": {
         "script_level.level_keys": [
-          "Underground Iron_2021"
+          "Overworld Powered Minecart_2021"
         ],
         "lesson.key": "Looking Ahead with Minecraft ",
         "lesson_group.key": "csf_conditionals",
@@ -9545,7 +9539,7 @@
         "activity_section.key": "3ab2228f-c257-4ffd-bcc0-1e5b29118ccf"
       },
       "level_keys": [
-        "Underground Iron_2021"
+        "Overworld Powered Minecart_2021"
       ]
     },
     {
@@ -15863,9 +15857,9 @@
     },
     {
       "seeding_key": {
-        "level.key": "Overworld Powered Minecart_2021",
+        "level.key": "Underground Mining Coal_2021",
         "script_level.level_keys": [
-          "Overworld Powered Minecart_2021"
+          "Underground Mining Coal_2021"
         ],
         "lesson.key": "Looking Ahead with Minecraft ",
         "lesson_group.key": "csf_conditionals",
@@ -15875,9 +15869,9 @@
     },
     {
       "seeding_key": {
-        "level.key": "Underground Mining Coal_2021",
+        "level.key": "Underground Iron_2021",
         "script_level.level_keys": [
-          "Underground Mining Coal_2021"
+          "Underground Iron_2021"
         ],
         "lesson.key": "Looking Ahead with Minecraft ",
         "lesson_group.key": "csf_conditionals",
@@ -15911,9 +15905,9 @@
     },
     {
       "seeding_key": {
-        "level.key": "Underground Iron_2021",
+        "level.key": "Overworld Powered Minecart_2021",
         "script_level.level_keys": [
-          "Underground Iron_2021"
+          "Overworld Powered Minecart_2021"
         ],
         "lesson.key": "Looking Ahead with Minecraft ",
         "lesson_group.key": "csf_conditionals",


### PR DESCRIPTION
Finishes [PLAT-1507](https://codedotorg.atlassian.net/browse/PLAT-1507).  Follows request details from Mike in [Progress Fix for Express Minecraft Lesson](https://docs.google.com/document/d/1LyDAdRcHHQ4oZU7uuScrYcBaxHNfcpojCpkGr_O-z48/edit#). 

For thoughts on why this is safe, see [safely modifying launched curriculum](https://docs.google.com/document/d/1fy-tHoKwU5VnsqVpzk_nxoYJ5c_hdBNGkozCuUOavOY/edit#). comments are welcome there and in the linked gsheet.

## screenshots

### before --> after

![Screen Shot 2022-03-21 at 2 15 51 PM](https://user-images.githubusercontent.com/8001765/159365459-2e57e262-74f0-4621-bce3-5d2649dcc909.png)

## Testing story

* verified that levels 8, 11, 12 and 14 (not moved) still show up at the same urls
* verified that progress is preserved (see screenshots) as follows:
    *  seeded the staging branch
    * made progress
    * took "before" screenshot
    * re-seeded on this branch
    * took "after" screenshot
