### PR TITLE
make sure we use dashboard_production db instead of dashboard db

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -523,7 +523,7 @@ db_proxy_admin:
 db_writer: !Secret
 reporting_db_writer: <%=db_writer%>
 
-dashboard_db_name: <%= "dashboard#{env}#{_test_env_num}" %>
+dashboard_db_name: <%= "dashboard_#{env}#{_test_env_num}" %>
 pegasus_db_name: <%= ENV['USE_PEGASUS_UNITTEST_DB'] ? 'pegasus_unittest' : "pegasus#{_env}" %>
 
 # Default reader endpoints to writer endpoint.

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -523,7 +523,7 @@ db_proxy_admin:
 db_writer: !Secret
 reporting_db_writer: <%=db_writer%>
 
-dashboard_db_name: <%= "dashboard#{_env}#{_test_env_num}" %>
+dashboard_db_name: <%= "dashboard#{env}#{_test_env_num}" %>
 pegasus_db_name: <%= ENV['USE_PEGASUS_UNITTEST_DB'] ? 'pegasus_unittest' : "pegasus#{_env}" %>
 
 # Default reader endpoints to writer endpoint.


### PR DESCRIPTION
Follow on to #45410 and #45376. The problem was that #45376 switched from using `env`, which equals the environment name, to `_env`, which is blank in the production environment.
