### PR TITLE
Editor theming

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -762,6 +762,7 @@
   "editSectionLoginTypePicDesc": "Students sign in with a secret picture that was selected for them by Code.org.",
   "editSectionLoginTypeWordDesc": "Students sign in with two secret words that were selected for them by Code.org.",
   "editable": "Editable",
+  "editorManage": "Manage editor",
   "eligibilityExplanation": "In order to be eligible to receive a code for a subsidized Circuit Playground kit, you must meet the following requirements:",
   "eligibilityReqPD": "You attended a 5-day summer workshop for CS Discoveries in 2019 or are participating in the 2019-20 Facilitator Development Program as a new CS Discoveries facilitator.",
   "eligibilityReqStudentCount": "Ten students in one of your sections have completed the first three units of CS Discoveries.",

--- a/apps/lib/ace/src-noconflict/ace.js
+++ b/apps/lib/ace/src-noconflict/ace.js
@@ -17888,6 +17888,19 @@ exports.LineWidgets = LineWidgets;
 
 });
 
+function getCookie(cookieName) {
+    var name = cookieName + "=";
+    var ca = document.cookie.split(';');
+    for (var i = 0; i < ca.length; i++) {
+        var c = ca[i].trim();
+        if ((c.indexOf(name)) == 0) {
+            return c.substr(name.length);
+        }
+
+    }
+    return null;
+}
+
 ace.define("ace/ext/error_marker",["require","exports","module","ace/line_widgets","ace/lib/dom","ace/range"], function(require, exports, module) {
 "use strict";
 var LineWidgets = require("../line_widgets").LineWidgets;
@@ -18138,6 +18151,14 @@ exports.createEditSession = function(text, mode) {
     var doc = new EditSession(text, mode);
     doc.setUndoManager(new UndoManager());
     return doc;
+}
+if (document.cookie.indexOf('theme=') === 0) {
+    const theme = getCookie('theme')
+    try {
+        exports.setTheme(`ace/theme/${theme}`);
+    } catch (error) {
+        exports.setTheme('ace/theme/chrome');
+    }
 }
 exports.EditSession = EditSession;
 exports.UndoManager = UndoManager;

--- a/apps/lib/ace/src-noconflict/theme-monokai.js
+++ b/apps/lib/ace/src-noconflict/theme-monokai.js
@@ -1,0 +1,106 @@
+ace.define("ace/theme/monokai",["require","exports","module","ace/lib/dom"], function(require, exports, module) {
+
+exports.isDark = true;
+exports.cssClass = "ace-monokai";
+exports.cssText = ".ace-monokai .ace_gutter {\
+  background: #2F3129;\
+  color: #8F908A;\
+}\
+.ace-monokai .ace_print-margin {\
+  width: 1px;\
+  background: #555651;\
+}\
+.ace-monokai {\
+  background-color: #272822;\
+  color: #F8F8F2;\
+}\
+.ace-monokai .ace_cursor {\
+  color: #F8F8F0;\
+}\
+.ace-monokai .ace_marker-layer .ace_selection {\
+  background: #49483E;\
+}\
+.ace-monokai.ace_multiselect .ace_selection.ace_start {\
+  box-shadow: 0 0 3px 0px #272822;\
+}\
+.ace-monokai .ace_marker-layer .ace_step {\
+  background: rgb(102, 82, 0);\
+}\
+.ace-monokai .ace_marker-layer .ace_bracket {\
+  margin: -1px 0 0 -1px;\
+  border: 1px solid #49483E;\
+}\
+.ace-monokai .ace_marker-layer .ace_active-line {\
+  background: #202020;\
+}\
+.ace-monokai .ace_gutter-active-line {\
+  background-color: #272727;\
+}\
+.ace-monokai .ace_marker-layer .ace_selected-word {\
+  border: 1px solid #49483E;\
+}\
+.ace-monokai .ace_invisible {\
+  color: #52524d;\
+}\
+.ace-monokai .ace_entity.ace_name.ace_tag,\
+.ace-monokai .ace_keyword,\
+.ace-monokai .ace_meta.ace_tag,\
+.ace-monokai .ace_storage {\
+  color: #F92672;\
+}\
+.ace-monokai .ace_punctuation,\
+.ace-monokai .ace_punctuation.ace_tag {\
+  color: #fff;\
+}\
+.ace-monokai .ace_constant.ace_character,\
+.ace-monokai .ace_constant.ace_language,\
+.ace-monokai .ace_constant.ace_numeric,\
+.ace-monokai .ace_constant.ace_other {\
+  color: #AE81FF;\
+}\
+.ace-monokai .ace_invalid {\
+  color: #F8F8F0;\
+  background-color: #F92672;\
+}\
+.ace-monokai .ace_invalid.ace_deprecated {\
+  color: #F8F8F0;\;\
+  background-color: #AE81FF;\
+}\
+.ace-monokai .ace_support.ace_constant,\
+.ace-monokai .ace_support.ace_function {\
+  color: #66D9EF;\
+}\
+.ace-monokai .ace_fold {\
+  background-color: #A6E22E;\
+  border-color: #F8F8F2;\
+}\
+.ace-monokai .ace_storage.ace_type,\
+.ace-monokai .ace_support.ace_class,\
+.ace-monokai .ace_support.ace_type {\
+  font-style: italic;\
+  color: #66D9EF;\
+}\
+.ace-monokai .ace_entity.ace_name.ace_function,\
+.ace-monokai .ace_entity.ace_other,\
+.ace-monokai .ace_entity.ace_other.ace_attribute-name,\
+.ace-monokai .ace_variable {\
+  color: #A6E22E;\
+}\
+.ace-monokai .ace_variable.ace_parameter {\
+  font-style: italic;\
+  color: #FD971F;\
+}\
+.ace-monokai .ace_string {\
+  color: #E6DB74;\
+}\
+.ace-monokai .ace_comment {\
+  color: #75715E;\
+}\
+.ace-monokai .ace_indent-guide {\
+  background: url(data:image/png;base64,\iVBORw0KGgoAAAANSUhEUgAAAAEAAAACCAYAAACZgbYnAAAAEklEQVQImWPQ0FD0ZXBzd/wPAAjVAoxeSgNeAAAAAElFTkSuQmCC) right repeat-y;\
+}\
+";
+
+var dom = require("../lib/dom");
+dom.importCssString(exports.cssText, exports.cssClass);
+});

--- a/apps/src/code-studio/components/EditorManagerDialog.jsx
+++ b/apps/src/code-studio/components/EditorManagerDialog.jsx
@@ -1,0 +1,14 @@
+/*globals dashboard*/
+import $ from 'jquery';
+import PropTypes from 'prop-types';
+import React from 'react';
+import Radium from 'radium';
+import i18n from '@cdo/locale';
+import BaseDialog from '@cdo/apps/templates/BaseDialog';
+import Button from '@cdo/apps/templates/Button';
+import FontAwesome from '@cdo/apps/templates/FontAwesome';
+import LibraryClientApi from '@cdo/apps/code-studio/components/libraries/LibraryClientApi';
+import LibraryListItem from '@cdo/apps/code-studio/components/libraries/LibraryListItem';
+import LibraryViewCode from '@cdo/apps/code-studio/components/libraries/LibraryViewCode';
+import libraryParser from './libraryParser';
+import color from '@cdo/apps/util/color';

--- a/apps/src/code-studio/components/EditorManagerDialog.jsx
+++ b/apps/src/code-studio/components/EditorManagerDialog.jsx
@@ -1,14 +1,103 @@
-/*globals dashboard*/
-import $ from 'jquery';
 import PropTypes from 'prop-types';
 import React from 'react';
-import Radium from 'radium';
-import i18n from '@cdo/locale';
 import BaseDialog from '@cdo/apps/templates/BaseDialog';
 import Button from '@cdo/apps/templates/Button';
-import FontAwesome from '@cdo/apps/templates/FontAwesome';
-import LibraryClientApi from '@cdo/apps/code-studio/components/libraries/LibraryClientApi';
-import LibraryListItem from '@cdo/apps/code-studio/components/libraries/LibraryListItem';
-import LibraryViewCode from '@cdo/apps/code-studio/components/libraries/LibraryViewCode';
-import libraryParser from './libraryParser';
 import color from '@cdo/apps/util/color';
+
+export default class EditorManagerDialog extends React.Component {
+  static propTypes = {
+    isOpen: PropTypes.bool.isRequired,
+    onClose: PropTypes.func.isRequired,
+  };
+
+  state = {
+    selectedTheme: undefined,
+    themes: [],
+  };
+
+  componentDidUpdate(prevProps) {
+    if (this.props.isOpen && !prevProps.isOpen) {
+      this.setState({selectedTheme: undefined, themes: []});
+      this.getThemeList();
+    }
+  }
+
+  closeEditorManager = () => {
+    this.props.onClose();
+  };
+
+  getThemeList = () => {
+    this.setState({
+        // having the themes in this way is dumb
+        themes: [
+          {name: "chrome", fullName: "Chrome"},
+          {name : "monokai", fullName: "Monokai"}
+        ],
+        selectedTheme: themes[0].name
+    });
+  };
+
+  setCookie = async () => {
+    const editorTheme = this.root.value;
+    const expirationDate = new Date(new Date().setFullYear(new Date().getFullYear() + 1)).toUTCString; // 10 years
+    document.cookie = `theme=${editorTheme}; expires=${expirationDate}`
+    this.closeEditorManager();
+    window.location.reload()
+  };
+
+  handleChange = e => {
+    this.setState({selectedTheme: e.target.value});
+  };
+
+  render() {
+    const {isOpen} = this.props;
+
+    return (
+      <div className="editor-modal">
+        <BaseDialog
+          isOpen={isOpen}
+          handleClose={this.closeEditorManager}
+          useUpdatedStyles
+          style={styles.dialog}
+        >
+          <h1 style={styles.header}>Editor theme</h1>
+          <div>
+            <div>
+              <select
+                name="theme"
+                ref={element => (this.root = element)}
+                onChange={this.handleChange}
+                style={{marginBottom: 0}}
+              >
+                {this.state.themes.map(theme => (
+                  <option key={theme.name} value={theme.name}>
+                    {theme.fullName}
+                  </option>
+                ))}
+              </select>
+              <br />
+              <Button
+                text={'Save'}
+                color={Button.ButtonColor.orange}
+                onClick={this.setCookie}
+              />
+            </div>
+          </div>
+        )
+        </BaseDialog>
+      </div>
+    );
+  }
+}
+
+const styles = {
+  dialog: {
+    padding: '0 15px',
+    cursor: 'default'
+  },
+  header: {
+    textAlign: 'center',
+    fontSize: 24,
+    marginTop: 20
+  },
+};

--- a/apps/src/lib/ui/SettingsCog.jsx
+++ b/apps/src/lib/ui/SettingsCog.jsx
@@ -12,6 +12,7 @@ import * as makerToolkitRedux from '../kits/maker/redux';
 import PopUpMenu from './PopUpMenu';
 import ConfirmEnableMakerDialog from './ConfirmEnableMakerDialog';
 import LibraryManagerDialog from '@cdo/apps/code-studio/components/libraries/LibraryManagerDialog';
+import EditorManagerDialog from '@cdo/apps/code-studio/components/EditorManagerDialog';
 import {getStore} from '../../redux';
 import ModelManagerDialog from '@cdo/apps/code-studio/components/ModelManagerDialog';
 
@@ -27,7 +28,8 @@ class SettingsCog extends Component {
     open: false,
     confirmingEnableMaker: false,
     managingLibraries: false,
-    managingModels: false
+    managingModels: false,
+    managingEditor: false
   };
 
   targetPoint = {top: 0, left: 0};
@@ -48,6 +50,11 @@ class SettingsCog extends Component {
   manageModels = () => {
     this.close();
     this.setState({managingModels: true});
+  };
+
+  manageEditor = () => {
+    this.close();
+    this.setState({managingEditor: true});
   };
 
   toggleMakerToolkit = () => {
@@ -71,6 +78,7 @@ class SettingsCog extends Component {
   hideConfirmation = () => this.setState({confirmingEnableMaker: false});
   closeLibraryManager = () => this.setState({managingLibraries: false});
   closeModelManager = () => this.setState({managingModels: false});
+  closeEditorManager = () => this.setState({managingEditor: false})
 
   setTargetPoint(icon) {
     if (!icon) {
@@ -88,6 +96,11 @@ class SettingsCog extends Component {
   areLibrariesEnabled() {
     let pageConstants = getStore().getState().pageConstants;
     return pageConstants && pageConstants.librariesEnabled;
+  }
+
+  isEditorEnabled() {
+    let pageConstants = getStore().getState().pageConstants;
+    return pageConstants && pageConstants.editorEnabled;
   }
 
   areAIToolsEnabled() {
@@ -140,6 +153,9 @@ class SettingsCog extends Component {
           {this.props.showMakerToggle && (
             <ToggleMaker onClick={this.toggleMakerToolkit} />
           )}
+          {this.isEditorEnabled() && (
+            <ManageEditor onClick={this.manageEditor} />
+          )}
         </PopUpMenu>
         {this.areAIToolsEnabled() && (
           <ModelManagerDialog
@@ -157,6 +173,10 @@ class SettingsCog extends Component {
         <LibraryManagerDialog
           isOpen={this.state.managingLibraries}
           onClose={this.closeLibraryManager}
+        />
+        <EditorManagerDialog 
+          isOpen={this.state.managingEditor}
+          onclose={this.closeEditorManager}
         />
       </span>
     );


### PR DESCRIPTION
the basic chrome theme in App Lab is a bit bland. considering [there's intention to add a dark mode to code.org](https://github.com/code-dot-org/dsco_/pull/24), editor theming is a nice feature to have.

the current implementation adds a new option to the settings code in App Lab to configure the editor. when the user selects an option from the dropdown, a cookie is set (for 10 years) as theme=themeoption. when Ace is loaded, it checks for the cookie and attempts to set the theme accordingly.

the current test uses monokai. this is likely not a good theme on code.org; something like Abyss or Solarized Dark would work much better with the blue theme (or, better yet, the theme could be custom made to fit the design standards in dsco).

I will refine the implementation later today but for now I just wanted to get the basics.

## Testing story
my PR does not have any tests, this will be fixed later today.

## Privacy
a cookie is stored, but cookies aren't PII so the privacy impact should be minimal. the cookie is set for 10 years (it shouldn't be a session cookie).

## PR Checklist:

- [x] Tests provide adequate coverage
- [X] Privacy and Security impacts have been assessed
- [X] Code is well-commented
- [X] New features are translatable or updates will not break translations
- [X] Relevant documentation has been added or updated
- [X] User impact is well-understood and desirable
- [X] Pull Request is labeled appropriately
- [X] Follow-up work items (including potential tech debt) are tracked and linked
