### PR TITLE
set correct positions when appending lesson data in seed tests

### DIFF
--- a/dashboard/test/lib/services/script_seed_test.rb
+++ b/dashboard/test/lib/services/script_seed_test.rb
@@ -243,8 +243,8 @@ module Services
         lesson.lesson_activities.first.update!(name: 'Updated Activity Name')
         lesson.lesson_activities.create(
           name: 'New Activity Name',
-          position: 2,
-          key: "#{lesson.name}-activity-2"
+          position: 3,
+          key: "#{lesson.name}-activity-3"
         )
       end
 
@@ -267,8 +267,8 @@ module Services
         activity.activity_sections.first.update!(name: 'Updated Section Name')
         activity.activity_sections.create(
           name: 'New Section Name',
-          position: 2,
-          key: "#{activity.key}-section-2"
+          position: 3,
+          key: "#{activity.key}-section-3"
         )
       end
 


### PR DESCRIPTION
Speculative fix for [PLAT-1411](https://codedotorg.atlassian.net/browse/PLAT-1411). 

My first thought was to try and determine whether there was a problem with the json itself, or with the process of seeding it back into DB objects. when I looked at the json, I saw that we had duplicate / ambiguous position values:

![Screen Shot 2022-03-22 at 10 05 05 AM](https://user-images.githubusercontent.com/8001765/159536519-84d6ce1a-78cf-47db-a07f-89600b75188e.png)

lesson activities are sorted based on position: https://github.com/code-dot-org/code-dot-org/blob/0a35aaaa26b437ca4378d6e1d7bf80bb442e61a6/dashboard/app/models/lesson.rb#L36

so this seems like fixing these positions has a good chance of deflaking the test.

## Testing story

I've only verified that I haven't broken this test -- since i wasn't able to reproduce the flakiness, I haven't been able to confirm that the flakiness has gone away (speculative fix).