### PR TITLE
Pages to create and update ProgrammingClass

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -648,6 +648,10 @@ describe('entry tests', () => {
     'levels/editors/_studio':
       './src/sites/studio/pages/levels/editors/_studio.js',
     'libraries/edit': './src/sites/studio/pages/libraries/edit.js',
+    'programming_classes/new':
+      './src/sites/studio/pages/programming_classes/new.js',
+    'programming_classes/edit':
+      './src/sites/studio/pages/programming_classes/edit.js',
     'programming_environments/new':
       './src/sites/studio/pages/programming_environments/new.js',
     'programming_environments/edit':

--- a/apps/src/lib/levelbuilder/code-docs-editor/NewProgrammingClassForm.jsx
+++ b/apps/src/lib/levelbuilder/code-docs-editor/NewProgrammingClassForm.jsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import RailsAuthenticityToken from '@cdo/apps/lib/util/RailsAuthenticityToken';
+import HelpTip from '@cdo/apps/lib/ui/HelpTip';
+
+export default function NewProgrammingClassForm({
+  programmingEnvironmentsForSelect
+}) {
+  return (
+    <form action="/programming_classes" method="post">
+      <RailsAuthenticityToken />
+      <label>
+        Programming Class Slug
+        <input name="key" style={styles.inputStyle} required />
+        <HelpTip>
+          <p>
+            The programming expression slug is used in URLs and cannot be
+            updated once set. A slug can only contain letters, numbers, periods,
+            underscores, and dashes.
+          </p>
+        </HelpTip>
+      </label>
+      <label>
+        Programming Environment
+        <select
+          name="programming_environment_id"
+          style={styles.inputStyle}
+          required
+        >
+          {programmingEnvironmentsForSelect.map(programmingEnvironment => (
+            <option
+              key={programmingEnvironment.id}
+              value={programmingEnvironment.id}
+            >
+              {programmingEnvironment.name}
+            </option>
+          ))}
+        </select>
+      </label>
+      <br />
+      <button className="btn btn-primary" type="submit">
+        Save Changes
+      </button>
+    </form>
+  );
+}
+
+NewProgrammingClassForm.propTypes = {
+  programmingEnvironmentsForSelect: PropTypes.arrayOf(
+    PropTypes.shape({id: PropTypes.number, name: PropTypes.string})
+  ).isRequired
+};
+
+const styles = {
+  inputStyle: {
+    marginLeft: 5
+  }
+};

--- a/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingClassEditor.jsx
+++ b/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingClassEditor.jsx
@@ -1,0 +1,237 @@
+import PropTypes from 'prop-types';
+import React, {useState} from 'react';
+import OrderableList from './OrderableList';
+import ExampleEditor from './ExampleEditor';
+import TextareaWithMarkdownPreview from '@cdo/apps/lib/levelbuilder/TextareaWithMarkdownPreview';
+import CollapsibleEditorSection from '@cdo/apps/lib/levelbuilder/CollapsibleEditorSection';
+import HelpTip from '@cdo/apps/lib/ui/HelpTip';
+import SaveBar from '@cdo/apps/lib/levelbuilder/SaveBar';
+import {createUuid, navigateToHref} from '@cdo/apps/utils';
+import $ from 'jquery';
+import color from '@cdo/apps/util/color';
+
+function useProgrammingClass(initialProgrammingClass) {
+  const [programmingClass, setProgrammingClass] = useState(
+    initialProgrammingClass
+  );
+
+  function updateProgrammingClass(key, value) {
+    setProgrammingClass({...programmingClass, [key]: value});
+  }
+
+  return [programmingClass, updateProgrammingClass];
+}
+
+function renderExampleEditor(example, updateFunc) {
+  return (
+    <ExampleEditor
+      example={example}
+      updateExample={(key, value) => updateFunc(key, value)}
+    />
+  );
+}
+
+export default function ProgrammingClassEditor({
+  initialProgrammingClass,
+  environmentCategories
+}) {
+  // We don't want to update id or key
+  const {
+    id,
+    key,
+    showPath,
+    ...remainingProgrammingClass
+  } = initialProgrammingClass;
+  remainingProgrammingClass.examples.forEach(e => (e.key = createUuid()));
+  const [programmingClass, updateProgrammingClass] = useProgrammingClass(
+    remainingProgrammingClass
+  );
+  const [isSaving, setIsSaving] = useState(false);
+  const [lastUpdated, setLastUpdated] = useState(null);
+  const [error, setError] = useState(null);
+
+  const save = (e, shouldCloseAfterSave) => {
+    if (isSaving) {
+      return;
+    }
+    setIsSaving(true);
+    fetch(`/programming_classes/${id}`, {
+      method: 'PUT',
+      headers: {
+        'content-type': 'application/json',
+        'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content')
+      },
+      body: JSON.stringify(programmingClass)
+    })
+      .then(response => {
+        setIsSaving(false);
+        if (response.ok) {
+          if (shouldCloseAfterSave) {
+            navigateToHref(showPath);
+          } else {
+            setLastUpdated(Date.now());
+            setError(null);
+          }
+        } else {
+          setError(response.statusText);
+        }
+      })
+      .catch(error => {
+        setIsSaving(false);
+        setError(error.responseText);
+      });
+  };
+
+  const markdownEditorFeatures = {
+    imageUpload: true
+  };
+
+  return (
+    <div>
+      <h1>{`Editing Class "${key}"`}</h1>
+      <h2>
+        This feature is in development. Please continue to use curriculum
+        builder to edit code documentation.
+      </h2>
+      <label>
+        Display Name
+        <input
+          value={programmingClass.name}
+          onChange={e => updateProgrammingClass('name', e.target.value)}
+          style={styles.textInput}
+        />
+      </label>
+      <label>
+        Key (Used in URLs)
+        <input value={key} readOnly style={styles.textInput} />
+      </label>
+      <label>
+        Category
+        <select
+          value={programmingClass.categoryKey}
+          onChange={e => updateProgrammingClass('categoryKey', e.target.value)}
+          style={styles.selectInput}
+        >
+          <option key="none" value={''}>
+            (None)
+          </option>
+          {environmentCategories.map(category => (
+            <option key={category.key} value={category.key}>
+              {category.name}
+            </option>
+          ))}
+        </select>
+        <HelpTip>
+          Choose a category for the code documentation to fall beneath
+        </HelpTip>
+      </label>
+
+      {programmingClass.environmentEditorType === 'blockly' && (
+        <label>
+          Block Name
+          <input
+            value={programmingClass.blockName}
+            onChange={e => updateProgrammingClass('blockName', e.target.value)}
+            style={styles.textInput}
+          />
+        </label>
+      )}
+      <CollapsibleEditorSection title="Documentation" collapsed>
+        <label>
+          External Documentation
+          <HelpTip>Link to external documentation</HelpTip>
+          <input
+            value={programmingClass.externalDocumentation}
+            onChange={e =>
+              updateProgrammingClass('externalDocumentation', e.target.value)
+            }
+            style={styles.textInput}
+          />
+        </label>
+        <TextareaWithMarkdownPreview
+          markdown={programmingClass.content}
+          label={'Content'}
+          handleMarkdownChange={e =>
+            updateProgrammingClass('content', e.target.value)
+          }
+          features={markdownEditorFeatures}
+        />
+      </CollapsibleEditorSection>
+      <CollapsibleEditorSection title="Details" collapsed>
+        <TextareaWithMarkdownPreview
+          markdown={programmingClass.syntax}
+          label={'Syntax'}
+          handleMarkdownChange={e =>
+            updateProgrammingClass('syntax', e.target.value)
+          }
+          features={markdownEditorFeatures}
+        />
+      </CollapsibleEditorSection>
+      <CollapsibleEditorSection title="Tips" collapsed>
+        <TextareaWithMarkdownPreview
+          markdown={programmingClass.tips}
+          label={'Tips'}
+          handleMarkdownChange={e =>
+            updateProgrammingClass('tips', e.target.value)
+          }
+          features={markdownEditorFeatures}
+          helpTip="List of tips for using this code documentation"
+        />
+      </CollapsibleEditorSection>
+      <CollapsibleEditorSection title="Examples" collapsed>
+        <OrderableList
+          list={programmingClass.examples || []}
+          setList={list => updateProgrammingClass('examples', list)}
+          addButtonText="Add Another Example"
+          renderItem={renderExampleEditor}
+        />
+      </CollapsibleEditorSection>
+      <SaveBar
+        handleSave={save}
+        isSaving={isSaving}
+        lastSaved={lastUpdated}
+        error={error}
+        handleView={() => navigateToHref(showPath)}
+      />
+    </div>
+  );
+}
+
+const programmingClassShape = PropTypes.shape({
+  id: PropTypes.number.isRequired,
+  key: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  categoryKey: PropTypes.string,
+  externalDocumentation: PropTypes.string,
+  content: PropTypes.string,
+  syntax: PropTypes.string,
+  tips: PropTypes.string,
+  examples: PropTypes.arrayOf(PropTypes.object)
+});
+
+ProgrammingClassEditor.propTypes = {
+  initialProgrammingClass: programmingClassShape.isRequired,
+  environmentCategories: PropTypes.arrayOf(PropTypes.object).isRequired,
+  videoOptions: PropTypes.arrayOf(PropTypes.object).isRequired
+};
+
+const styles = {
+  textInput: {
+    width: '100%',
+    boxSizing: 'border-box',
+    padding: '4px 6px',
+    color: '#555',
+    border: `1px solid ${color.bootstrap_border_color}`,
+    borderRadius: 4,
+    margin: 0
+  },
+  selectInput: {
+    boxSizing: 'border-box',
+    padding: '4px 6px',
+    color: '#555',
+    border: `1px solid ${color.bootstrap_border_color}`,
+    borderRadius: 4,
+    marginBottom: 0,
+    marginLeft: 5
+  }
+};

--- a/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingClassEditor.jsx
+++ b/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingClassEditor.jsx
@@ -36,12 +36,7 @@ export default function ProgrammingClassEditor({
   environmentCategories
 }) {
   // We don't want to update id or key
-  const {
-    id,
-    key,
-    showPath,
-    ...remainingProgrammingClass
-  } = initialProgrammingClass;
+  const {id, key, ...remainingProgrammingClass} = initialProgrammingClass;
   remainingProgrammingClass.examples.forEach(e => (e.key = createUuid()));
   const [programmingClass, updateProgrammingClass] = useProgrammingClass(
     remainingProgrammingClass
@@ -67,7 +62,8 @@ export default function ProgrammingClassEditor({
         setIsSaving(false);
         if (response.ok) {
           if (shouldCloseAfterSave) {
-            navigateToHref(showPath);
+            // TODO: update this when we have a show page for classes
+            navigateToHref('/');
           } else {
             setLastUpdated(Date.now());
             setError(null);
@@ -125,17 +121,6 @@ export default function ProgrammingClassEditor({
           Choose a category for the code documentation to fall beneath
         </HelpTip>
       </label>
-
-      {programmingClass.environmentEditorType === 'blockly' && (
-        <label>
-          Block Name
-          <input
-            value={programmingClass.blockName}
-            onChange={e => updateProgrammingClass('blockName', e.target.value)}
-            style={styles.textInput}
-          />
-        </label>
-      )}
       <CollapsibleEditorSection title="Documentation" collapsed>
         <label>
           External Documentation
@@ -191,7 +176,7 @@ export default function ProgrammingClassEditor({
         isSaving={isSaving}
         lastSaved={lastUpdated}
         error={error}
-        handleView={() => navigateToHref(showPath)}
+        handleView={() => navigateToHref('/')}
       />
     </div>
   );
@@ -211,8 +196,7 @@ const programmingClassShape = PropTypes.shape({
 
 ProgrammingClassEditor.propTypes = {
   initialProgrammingClass: programmingClassShape.isRequired,
-  environmentCategories: PropTypes.arrayOf(PropTypes.object).isRequired,
-  videoOptions: PropTypes.arrayOf(PropTypes.object).isRequired
+  environmentCategories: PropTypes.arrayOf(PropTypes.object).isRequired
 };
 
 const styles = {

--- a/apps/src/sites/studio/pages/programming_classes/edit.js
+++ b/apps/src/sites/studio/pages/programming_classes/edit.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import getScriptData from '@cdo/apps/util/getScriptData';
+import ProgrammingClassEditor from '@cdo/apps/lib/levelbuilder/code-docs-editor/ProgrammingClassEditor';
+import ExpandableImageDialog from '@cdo/apps/templates/lessonOverview/ExpandableImageDialog';
+import instructionsDialog from '@cdo/apps/redux/instructionsDialog';
+import {getStore, registerReducers} from '@cdo/apps/redux';
+import {Provider} from 'react-redux';
+
+$(document).ready(() => {
+  registerReducers({
+    instructionsDialog
+  });
+  const store = getStore();
+
+  const programmingClass = getScriptData('programmingClass');
+  const environmentCategories = getScriptData('environmentCategories');
+  const videoOptions = getScriptData('videoOptions');
+  ReactDOM.render(
+    <Provider store={store}>
+      <>
+        <ProgrammingClassEditor
+          initialProgrammingClass={programmingClass}
+          environmentCategories={environmentCategories}
+          videoOptions={videoOptions}
+        />
+        <ExpandableImageDialog />
+      </>
+    </Provider>,
+    document.getElementById('edit-container')
+  );
+});

--- a/apps/src/sites/studio/pages/programming_classes/new.js
+++ b/apps/src/sites/studio/pages/programming_classes/new.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import getScriptData from '@cdo/apps/util/getScriptData';
+import NewProgrammingClassForm from '@cdo/apps/lib/levelbuilder/code-docs-editor/NewProgrammingClassForm';
+
+$(document).ready(() => {
+  const programmingEnvironmentsForSelect = getScriptData(
+    'programmingEnvironmentsForSelect'
+  );
+  ReactDOM.render(
+    <NewProgrammingClassForm
+      programmingEnvironmentsForSelect={programmingEnvironmentsForSelect}
+    />,
+    document.getElementById('form')
+  );
+});

--- a/apps/test/unit/lib/levelbuilder/code-docs-editor/NewProgrammingClassFormTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/code-docs-editor/NewProgrammingClassFormTest.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import {expect} from '../../../../util/reconfiguredChai';
+import NewProgrammingClassForm from '@cdo/apps/lib/levelbuilder/code-docs-editor/NewProgrammingClassForm';
+
+describe('NewProgrammingClassForm', () => {
+  it('renders form', () => {
+    const wrapper = shallow(
+      <NewProgrammingClassForm
+        programmingEnvironmentsForSelect={[
+          {id: 1, name: 'gamelab'},
+          {id: 2, name: 'spritelab'}
+        ]}
+      />
+    );
+
+    expect(wrapper.find('input').props().required).to.be.true;
+
+    const programmingEnvironmentSelect = wrapper.find('select');
+    expect(programmingEnvironmentSelect.props().required).to.be.true;
+    expect(
+      programmingEnvironmentSelect.find('option').map(env => env.props().value)
+    ).to.eql([1, 2]);
+  });
+});

--- a/apps/test/unit/lib/levelbuilder/code-docs-editor/ProgrammingClassEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/code-docs-editor/ProgrammingClassEditorTest.jsx
@@ -1,0 +1,170 @@
+import React from 'react';
+import {shallow, mount} from 'enzyme';
+import {expect} from '../../../../util/reconfiguredChai';
+import ProgrammingClassEditor from '@cdo/apps/lib/levelbuilder/code-docs-editor/ProgrammingClassEditor';
+import {getStore} from '@cdo/apps/redux';
+import {Provider} from 'react-redux';
+import sinon from 'sinon';
+
+describe('ProgrammingClassEditor', () => {
+  let defaultProps, initialProgrammingClass, fetchSpy;
+
+  beforeEach(() => {
+    initialProgrammingClass = {
+      id: 1,
+      name: 'Painter',
+      key: 'painter',
+      shortDescription: 'This is a short description.',
+      externalDocumentation: 'developer.mozilla.org',
+      content: 'This is a longer description of the code.',
+      syntax: 'Painter()',
+      returnValue: 'none',
+      tips: 'some tips on how to use this class',
+      examples: [{name: 'example 1'}]
+    };
+    defaultProps = {
+      initialProgrammingClass,
+      environmentCategories: [
+        {key: 'circuit', name: 'Circuit'},
+        {key: 'variables', name: 'Variables'},
+        {key: 'canvas', name: 'Canvas'}
+      ],
+      videoOptions: [
+        {
+          key: 'video1',
+          name: 'Video 1'
+        },
+        {
+          key: 'video2',
+          name: 'Video 2'
+        }
+      ]
+    };
+    fetchSpy = sinon.stub(window, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchSpy.restore();
+  });
+
+  it('displays initial values in input fields', () => {
+    const wrapper = shallow(<ProgrammingClassEditor {...defaultProps} />);
+    expect(wrapper.text().includes('Editing Class')).to.be.true;
+
+    // Display name
+    expect(
+      wrapper
+        .find('input')
+        .at(0)
+        .props().value
+    ).to.equal('Painter');
+
+    // Key
+    expect(
+      wrapper
+        .find('input')
+        .at(1)
+        .props().value
+    ).to.equal('painter');
+    expect(
+      wrapper
+        .find('input')
+        .at(1)
+        .props().readOnly
+    ).to.be.true;
+
+    // Category select
+    const categorySelect = wrapper.find('select').at(0);
+    expect(categorySelect.find('option').length).to.equal(4);
+    expect(
+      categorySelect.find('option').map(option => option.props().value)
+    ).to.eql(['', 'circuit', 'variables', 'canvas']);
+
+    // Documentation section
+    const documentationSection = wrapper.find('CollapsibleEditorSection').at(0);
+    expect(
+      documentationSection
+        .find('input')
+        .at(0)
+        .props().value
+    ).to.equal('developer.mozilla.org');
+    expect(
+      documentationSection
+        .find('TextareaWithMarkdownPreview')
+        .at(0)
+        .props().markdown
+    ).to.equal('This is a longer description of the code.');
+
+    const detailsSection = wrapper.find('CollapsibleEditorSection').at(1);
+    expect(
+      detailsSection
+        .find('TextareaWithMarkdownPreview')
+        .at(0)
+        .props().markdown
+    ).to.equal('Painter()');
+
+    // Tips section
+    const tipsSection = wrapper.find('CollapsibleEditorSection').at(2);
+    expect(
+      tipsSection
+        .find('TextareaWithMarkdownPreview')
+        .at(0)
+        .props().markdown
+    ).to.equal('some tips on how to use this class');
+
+    // Examples section
+    const examplesSection = wrapper.find('CollapsibleEditorSection').at(3);
+    const orderableExampleList = examplesSection.find('OrderableList');
+    expect(orderableExampleList.props().addButtonText).to.equal(
+      'Add Another Example'
+    );
+    expect(orderableExampleList.props().list.length).to.equal(1);
+  });
+
+  it('attempts to save when save is pressed', () => {
+    const store = getStore();
+    const wrapper = mount(
+      <Provider store={store}>
+        <ProgrammingClassEditor {...defaultProps} />
+      </Provider>
+    );
+
+    fetchSpy.returns(Promise.resolve({ok: true}));
+    const saveBar = wrapper.find('SaveBar');
+
+    const saveAndCloseButton = saveBar.find('button').at(2);
+    expect(saveAndCloseButton.contains('Save and Close')).to.be.true;
+    saveAndCloseButton.simulate('click');
+
+    expect(fetchSpy).to.be.called.once;
+    const fetchCall = fetchSpy.getCall(0);
+    expect(fetchCall.args[0]).to.equal('/programming_classes/1');
+    const fetchCallBody = JSON.parse(fetchCall.args[1].body);
+    expect(Object.keys(fetchCallBody).sort()).to.eql(
+      [
+        'name',
+        'shortDescription',
+        'content',
+        'externalDocumentation',
+        'returnValue',
+        'syntax',
+        'tips',
+        'examples'
+      ].sort()
+    );
+    expect(fetchCallBody.name).to.equal('Painter');
+    expect(fetchCallBody.shortDescription).to.equal(
+      'This is a short description.'
+    );
+    expect(fetchCallBody.content).to.equal(
+      'This is a longer description of the code.'
+    );
+    expect(fetchCallBody.externalDocumentation).to.equal(
+      'developer.mozilla.org'
+    );
+    expect(fetchCallBody.returnValue).to.equal('none');
+    expect(fetchCallBody.syntax).to.equal('Painter()');
+    expect(fetchCallBody.tips).to.equal('some tips on how to use this class');
+    expect(fetchCallBody.examples[0].name).to.equal('example 1');
+  });
+});

--- a/apps/test/unit/lib/levelbuilder/code-docs-editor/ProgrammingClassEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/code-docs-editor/ProgrammingClassEditorTest.jsx
@@ -47,7 +47,7 @@ describe('ProgrammingClassEditor', () => {
     fetchSpy.restore();
   });
 
-  it('displays initial values in input fields', () => {
+  it('displays initial values in input fields in top section', () => {
     const wrapper = shallow(<ProgrammingClassEditor {...defaultProps} />);
     expect(wrapper.text().includes('Editing Class')).to.be.true;
 
@@ -79,9 +79,15 @@ describe('ProgrammingClassEditor', () => {
     expect(
       categorySelect.find('option').map(option => option.props().value)
     ).to.eql(['', 'circuit', 'variables', 'canvas']);
+  });
+
+  it('displays initial values in input fields in documentation section', () => {
+    const wrapper = shallow(<ProgrammingClassEditor {...defaultProps} />);
+    expect(wrapper.text().includes('Editing Class')).to.be.true;
 
     // Documentation section
     const documentationSection = wrapper.find('CollapsibleEditorSection').at(0);
+    expect(documentationSection.props().title).to.equal('Documentation');
     expect(
       documentationSection
         .find('input')
@@ -102,18 +108,29 @@ describe('ProgrammingClassEditor', () => {
         .at(0)
         .props().markdown
     ).to.equal('Painter()');
+  });
+
+  it('displays initial values in input fields in tips section', () => {
+    const wrapper = shallow(<ProgrammingClassEditor {...defaultProps} />);
+    expect(wrapper.text().includes('Editing Class')).to.be.true;
 
     // Tips section
     const tipsSection = wrapper.find('CollapsibleEditorSection').at(2);
+    expect(tipsSection.props().title).to.equal('Tips');
     expect(
       tipsSection
         .find('TextareaWithMarkdownPreview')
         .at(0)
         .props().markdown
     ).to.equal('some tips on how to use this class');
+  });
 
+  it('displays initial values in input fields in examples section', () => {
+    const wrapper = shallow(<ProgrammingClassEditor {...defaultProps} />);
+    expect(wrapper.text().includes('Editing Class')).to.be.true;
     // Examples section
     const examplesSection = wrapper.find('CollapsibleEditorSection').at(3);
+    expect(examplesSection.props().title).to.equal('Examples');
     const orderableExampleList = examplesSection.find('OrderableList');
     expect(orderableExampleList.props().addButtonText).to.equal(
       'Add Another Example'

--- a/dashboard/app/controllers/programming_classes_controller.rb
+++ b/dashboard/app/controllers/programming_classes_controller.rb
@@ -1,0 +1,58 @@
+class ProgrammingClassesController < ApplicationController
+  before_action :require_levelbuilder_mode_or_test_env
+  load_and_authorize_resource
+
+  def new
+    @programming_environments_for_select = ProgrammingEnvironment.all.map {|env| {id: env.id, name: env.name}}
+  end
+
+  def create
+    unless ProgrammingEnvironment.find_by_id(params[:programming_environment_id])
+      render :not_acceptable, json: {error: 'Valid programming environment is required'}
+      return
+    end
+    programming_class = ProgrammingClass.new(key: params[:key], name: params[:key], programming_environment_id: params[:programming_environment_id])
+    if programming_class.save
+      redirect_to edit_programming_class_url(programming_class)
+    else
+      render :not_acceptable, json: programming_class.errors
+    end
+  end
+
+  def edit
+    return render :not_found unless @programming_class
+    @environment_categories = @programming_class.programming_environment.categories.map {|c| {key: c.key, name: c.name}}
+  end
+
+  def update
+    unless @programming_class
+      render :not_found
+      return
+    end
+    @programming_class.assign_attributes(programming_class_params.except(:category_key))
+    programming_environment_category = @programming_class.programming_environment.categories.find_by_key(programming_class_params[:category_key])
+    @programming_class.programming_category_id = programming_environment_category&.id
+    begin
+      @programming_class.save! if @programming_class.changed?
+      render json: @programming_class.summarize_for_edit.to_json
+    rescue ActiveRecord::RecordInvalid => e
+      render(status: :not_acceptable, plain: e.message)
+    end
+  end
+
+  private
+
+  def programming_class_params
+    transformed_params = params.transform_keys(&:underscore)
+    transformed_params = transformed_params.permit(
+      :name,
+      :category_key,
+      :external_documentation,
+      :content,
+      :syntax,
+      :tips,
+      examples: [:name, :description, :code, :app, :image, :app_display_type, :embed_app_with_code_height]
+    )
+    transformed_params
+  end
+end

--- a/dashboard/app/controllers/programming_classes_controller.rb
+++ b/dashboard/app/controllers/programming_classes_controller.rb
@@ -31,7 +31,7 @@ class ProgrammingClassesController < ApplicationController
     end
     @programming_class.assign_attributes(programming_class_params.except(:category_key))
     programming_environment_category = @programming_class.programming_environment.categories.find_by_key(programming_class_params[:category_key])
-    @programming_class.programming_category_id = programming_environment_category&.id
+    @programming_class.programming_environment_category_id = programming_environment_category&.id
     begin
       @programming_class.save! if @programming_class.changed?
       render json: @programming_class.summarize_for_edit.to_json
@@ -53,6 +53,7 @@ class ProgrammingClassesController < ApplicationController
       :tips,
       examples: [:name, :description, :code, :app, :image, :app_display_type, :embed_app_with_code_height]
     )
+    transformed_params[:examples] = transformed_params[:examples].to_json if transformed_params[:examples]
     transformed_params
   end
 end

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -355,6 +355,7 @@ class Ability
         Game,
         Level,
         Lesson,
+        ProgrammingClass,
         ProgrammingEnvironment,
         ProgrammingExpression,
         ReferenceGuide,

--- a/dashboard/app/models/programming_class.rb
+++ b/dashboard/app/models/programming_class.rb
@@ -22,21 +22,31 @@
 #  index_programming_classes_on_key_and_programming_environment_id  (key,programming_environment_id) UNIQUE
 #
 class ProgrammingClass < ApplicationRecord
+  include CurriculumHelper
+
   belongs_to :programming_environment
   belongs_to :programming_environment_category
+
+  validates_uniqueness_of :key, scope: :programming_environment_id, case_sensitive: false
+  validate :validate_key_format
 
   def summarize_for_edit
     {
       id: id,
       key: key,
-      name: name,
-      content: content,
-      fields: fields,
-      examples: examples || [],
-      tips: tips,
-      syntax: syntax,
-      external_documentation: external_documentation,
-      categoryKey: programming_environment_category&.key
+      name: name || '',
+      content: content || '',
+      examples: parsed_examples,
+      tips: tips || '',
+      syntax: syntax || '',
+      external_documentation: external_documentation || '',
+      categoryKey: programming_environment_category&.key || ''
     }
+  end
+
+  private
+
+  def parsed_examples
+    examples.blank? ? [] : JSON.parse(examples)
   end
 end

--- a/dashboard/app/models/programming_class.rb
+++ b/dashboard/app/models/programming_class.rb
@@ -22,4 +22,21 @@
 #  index_programming_classes_on_key_and_programming_environment_id  (key,programming_environment_id) UNIQUE
 #
 class ProgrammingClass < ApplicationRecord
+  belongs_to :programming_environment
+  belongs_to :programming_environment_category
+
+  def summarize_for_edit
+    {
+      id: id,
+      key: key,
+      name: name,
+      content: content,
+      fields: fields,
+      examples: examples || [],
+      tips: tips,
+      syntax: syntax,
+      external_documentation: external_documentation,
+      categoryKey: programming_environment_category&.key
+    }
+  end
 end

--- a/dashboard/app/views/programming_classes/edit.html.haml
+++ b/dashboard/app/views/programming_classes/edit.html.haml
@@ -1,0 +1,3 @@
+%script{src: webpack_asset_path('js/programming_classes/edit.js'),
+  data: {programmingClass: @programming_class.summarize_for_edit.to_json, environmentCategories: @environment_categories.to_json, videoOptions: Video.all.where(locale: 'en-US').map {|v| {key: v.key, name: v.localized_name}}.to_json}}
+#edit-container

--- a/dashboard/app/views/programming_classes/new.html.haml
+++ b/dashboard/app/views/programming_classes/new.html.haml
@@ -1,0 +1,5 @@
+%h1= t('crud.new_model', model: ProgrammingClass.model_name.human)
+%script{src: webpack_asset_path('js/programming_classes/new.js'),
+        data: {programmingEnvironmentsForSelect: @programming_environments_for_select.to_json}}
+#form
+

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -327,6 +327,8 @@ Dashboard::Application.routes.draw do
     end
   end
 
+  resources :programming_classes, only: [:new, :create, :edit, :update]
+
   resources :programming_expressions, only: [:new, :create, :edit, :update, :show, :destroy] do
     collection do
       get :search

--- a/dashboard/test/controllers/programming_classes_controller_test.rb
+++ b/dashboard/test/controllers/programming_classes_controller_test.rb
@@ -1,0 +1,101 @@
+require 'test_helper'
+
+class ProgrammingClassesControllerTest < ActionController::TestCase
+  include Devise::Test::ControllerHelpers
+
+  setup do
+    File.stubs(:write)
+    Rails.application.config.stubs(:levelbuilder_mode).returns true
+    @levelbuilder = create :levelbuilder
+    @programming_environment = create :programming_environment
+  end
+
+  test 'can create programming class from params' do
+    sign_in @levelbuilder
+    assert_creates(ProgrammingClass) do
+      post :create, params: {key: 'class_key', name: 'class name', programming_environment_id: @programming_environment.id}
+    end
+  end
+
+  test 'cannot create programming class with nonexistant programming environment' do
+    sign_in @levelbuilder
+    destroyed_programming_env_id = @programming_environment.id
+    @programming_environment.destroy!
+    refute_creates(ProgrammingClass) do
+      post :create, params: {key: 'class_key', name: 'class name', programming_environment_id: destroyed_programming_env_id}
+    end
+    assert @response.body.include? "Valid programming environment is required"
+  end
+
+  test 'can update programming class from params' do
+    sign_in @levelbuilder
+
+    programming_class = create :programming_class, programming_environment: @programming_environment
+    category = create :programming_environment_category, programming_environment: @programming_environment
+
+    post :update, params: {
+      id: programming_class.id,
+      key: programming_class.key,
+      name: 'new name',
+      categoryKey: category.key,
+      externalDocumentation: 'google.com',
+      content: 'a longer description of the code',
+      syntax: 'new Class()',
+      tips: 'some tips on how to use this class',
+      examples: [{name: 'example 1', embed_app_with_code_height: '300px'}]
+    }
+    assert_response :ok
+    programming_class.reload
+
+    assert_equal 'new name', programming_class.name
+    assert_equal category, programming_class.programming_environment_category
+    assert_equal 'google.com', programming_class.external_documentation
+    assert_equal 'a longer description of the code', programming_class.content
+    assert_equal 'new Class()', programming_class.syntax
+    assert_equal 'some tips on how to use this class', programming_class.tips
+    assert_equal [{name: 'example 1', embed_app_with_code_height: '300px'}].to_json, programming_class.examples
+  end
+
+  test 'data is passed down to edit page' do
+    sign_in @levelbuilder
+
+    programming_class = create :programming_class, programming_environment: @programming_environment
+
+    get :edit, params: {id: programming_class.id}
+    assert_response :ok
+
+    edit_data = JSON.parse(css_select('script[data-programmingclass]').first.attribute('data-programmingclass').to_s)
+    assert_equal programming_class.key, edit_data['key']
+    assert_equal programming_class.name, edit_data['name']
+  end
+
+  class ProgrammingClassesControllerAccessTests < ActionController::TestCase
+    setup do
+      File.stubs(:write)
+      programming_environment = create :programming_environment
+      @programming_class = create :programming_class, programming_environment: programming_environment
+
+      @update_params = {id: @programming_class.id, name: 'new name'}
+    end
+
+    test_user_gets_response_for :new, user: nil, response: :redirect, redirected_to: '/users/sign_in'
+    test_user_gets_response_for :new, user: :student, response: :forbidden
+    test_user_gets_response_for :new, user: :teacher, response: :forbidden
+    test_user_gets_response_for :new, user: :levelbuilder, response: :success
+
+    test_user_gets_response_for :create, params: -> {{name: 'name'}}, user: nil, response: :redirect, redirected_to: '/users/sign_in'
+    test_user_gets_response_for :create, params: -> {{name: 'name'}}, user: :student, response: :forbidden
+    test_user_gets_response_for :create, params: -> {{name: 'name'}}, user: :teacher, response: :forbidden
+    test_user_gets_response_for :create, params: -> {{name: 'name'}}, user: :levelbuilder, response: :success
+
+    test_user_gets_response_for :edit, params: -> {{id: @programming_class.id}}, user: nil, response: :redirect, redirected_to: '/users/sign_in'
+    test_user_gets_response_for :edit, params: -> {{id: @programming_class.id}}, user: :student, response: :forbidden
+    test_user_gets_response_for :edit, params: -> {{id: @programming_class.id}}, user: :teacher, response: :forbidden
+    test_user_gets_response_for :edit, params: -> {{id: @programming_class.id}}, user: :levelbuilder, response: :success
+
+    test_user_gets_response_for :update, params: -> {@update_params}, user: nil, response: :redirect, redirected_to: '/users/sign_in'
+    test_user_gets_response_for :update, params: -> {@update_params}, user: :student, response: :forbidden
+    test_user_gets_response_for :update, params: -> {@update_params}, user: :teacher, response: :forbidden
+    test_user_gets_response_for :update, params: -> {@update_params}, user: :levelbuilder, response: :success
+  end
+end

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -995,6 +995,12 @@ FactoryGirl.define do
     sequence(:key) {|n| "programming-expression-#{n}"}
   end
 
+  factory :programming_class do
+    association :programming_environment
+    sequence(:name) {|n| "programming class #{n}"}
+    sequence(:key) {|n| "programming-class-#{n}"}
+  end
+
   factory :callout do
     sequence(:element_id) {|n| "#pageElement#{n}"}
     localization_key 'drag_blocks'


### PR DESCRIPTION
PR #1 to add an editor for ProgrammngClass. This adds an editor for the basic fields of the class, plus examples, and is modeled extremely closely off `ProgrammingExpressionEditor` (ie I might have directly copied some of it). It also adds the page to create a ProgrammingClass. Sorry about the large PR -- it is mostly boilerplate and tests.

New programming class page:
![Screen Shot 2022-03-24 at 11 26 54 AM](https://user-images.githubusercontent.com/46464143/159985759-f7479acc-9c14-4342-b386-642c9cad2b78.png)


ProgrammingClassEditor:
![Screen Shot 2022-03-24 at 11 23 13 AM](https://user-images.githubusercontent.com/46464143/159985517-6dba41bd-162c-4a9d-a013-7afe2ccf6556.png)



## Links

[tech spec](https://docs.google.com/document/d/1b7CE0fJ_8_BVf_v-RPrcmwyf48eLddbrT-tKMMGTNfY/edit#)

## Testing story

unit tests, tested locally

## Deployment strategy

## Follow-up work

Editors for fields and methods

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
