### PR TITLE
STAR-1893 create and validate codeprojects wildcard cert

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -549,6 +549,8 @@ Resources:
 <%=  component 'database'%>
 <% end -%>
 
+<%=  component 'codeprojects'%>
+
   ChefConfig:
     Type: AWS::SecretsManager::Secret
     Properties:

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -549,7 +549,7 @@ Resources:
 <%=  component 'database'%>
 <% end -%>
 
-<%= resource_component 'codeprojects' %>
+<%= resource_component 'codeprojects_resources' %>
 
   ChefConfig:
     Type: AWS::SecretsManager::Secret

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -549,7 +549,7 @@ Resources:
 <%=  component 'database'%>
 <% end -%>
 
-<%=  component 'codeprojects'%>
+<%= indent(component('codeprojects'), 2) %>
 
   ChefConfig:
     Type: AWS::SecretsManager::Secret

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -549,7 +549,7 @@ Resources:
 <%=  component 'database'%>
 <% end -%>
 
-<%= indent(component('codeprojects'), 2) %>
+<%= resource_component 'codeprojects' %>
 
   ChefConfig:
     Type: AWS::SecretsManager::Secret

--- a/aws/cloudformation/components/codeprojects.yml.erb
+++ b/aws/cloudformation/components/codeprojects.yml.erb
@@ -1,0 +1,73 @@
+<%# Note this file must be indented one level, as it is a child of 'Resources'. %>
+  # -----------------------------------------------
+  # Begin codeprojects.org resources
+  # 
+  # This template component includes resources for the codeprojects.org
+  # infrastructure. Currently this is mostly manually deployed.
+  # 
+  # -----------------------------------------------
+
+<%-
+  domain = "codeprojects.org"
+
+  hosted_zone = Aws::Route53::Client.new.list_hosted_zones_by_name(dns_name: domain).hosted_zones.first
+  raise "Could not find #{domain} in hosted zones" unless hosted_zone.name.delete_suffix('.') == domain
+  hosted_zone_id = hosted_zone.id.delete_prefix("/hostedzone/")
+
+  envs = {
+    staging: {
+      domain_name: "staging.#{domain}",
+      alternative_names: []
+    },
+    # test: {
+    #   domain_name: "test.#{domain}",
+    #   alternative_names: []
+    # },
+    # production: {
+    #   domain_name: domain,
+    #   alternative_names: ["www.#{domain}"]
+    # },
+  }
+-%>
+
+<%- if rack_env?(:staging) -%>
+  # Developer Resources (Deployed with Staging)
+  LocalhostCodeprojectsRecord:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneId: <%=domain%>
+      Name: <%="localhost.#{domain}"%>
+      Type: A
+      TTL: 3600
+      ResourceRecords:
+        - 127.0.0.1
+<%- end -%>
+
+<%- envs.each do |env, config| -%>
+<%- if rack_env?(env) -%>
+
+  # <%= env %> Resources
+  Codeprojects<%= env.capitalize %>Certificate:
+    Type: AWS::CertificateManager::Certificate
+    Properties:
+      DomainName: <%= config[:domain_name] %>
+      <%- unless config[:alternative_names].empty? -%>
+      SubjectAlternativeNames:
+        <%- config[:alternative_names].each do | alt_name | -%>
+        - <%= alt_name %>
+        <%- end -%>
+      <%- end -%>
+      ValidationMethod: DNS
+      DomainValidationOptions:
+        - DomainName: <%= config[:domain_name] %>
+          HostedZoneId: <%= hosted_zone_id %>
+        <%- config[:alternative_names].each do | alt_name | -%>
+        - DomainName: <%= alt_name %>
+          HostedZoneId: <%= hosted_zone_id %>
+        <%- end -%>
+<%- end -%>
+<%- end -%>
+
+  # -----------------------------------------------
+  # End codeprojects.org resources
+  # -----------------------------------------------

--- a/aws/cloudformation/components/codeprojects.yml.erb
+++ b/aws/cloudformation/components/codeprojects.yml.erb
@@ -1,4 +1,5 @@
-<%# Note this file must be indented one level, as it is a child of 'Resources'. %>
+<%- # Note this file must be indented one level, as it is a child of 'Resources'. %>
+<%- unless rack_env?(:adhoc) -%>
 # -----------------------------------------------
 # Begin codeprojects.org resources
 # 
@@ -12,7 +13,7 @@
 LocalhostCodeprojectsRecord:
   Type: AWS::Route53::RecordSet
   Properties:
-    HostedZoneId: <%= codeprojects_hostedzone_id %>
+    HostedZoneId: <%= CDO.codeprojects_hostedzone_id %>
     Name: <%="localhost.#{domain}"%>
     Type: A
     TTL: 3600
@@ -23,20 +24,21 @@ LocalhostCodeprojectsRecord:
 CodeprojectsCertificate:
   Type: AWS::CertificateManager::Certificate
   Properties:
-    DomainName: <%= codeprojects_hostname %>
+    DomainName: <%= CDO.codeprojects_hostname %>
     <%- if rack_env?(:production) -%>
     SubjectAlternativeNames:
-      - www.<%= codeprojects_hostname %>
+      - www.<%= CDO.codeprojects_hostname %>
     <%- end -%>
     ValidationMethod: DNS
     DomainValidationOptions:
-      - DomainName: <%= codeprojects_hostname %>
-        HostedZoneId: <%= codeprojects_hostedzone_id %>
+      - DomainName: <%= CDO.codeprojects_hostname %>
+        HostedZoneId: <%= CDO.codeprojects_hostedzone_id %>
       <%- if rack_env?(:production) -%>
-      - DomainName: www.<%= codeprojects_hostname %>
-        HostedZoneId: <%= codeprojects_hostedzone_id %>
+      - DomainName: www.<%= CDO.codeprojects_hostname %>
+        HostedZoneId: <%= CDO.codeprojects_hostedzone_id %>
       <%- end -%>
 
 # -----------------------------------------------
 # End codeprojects.org resources
 # -----------------------------------------------
+<%- end -%>

--- a/aws/cloudformation/components/codeprojects.yml.erb
+++ b/aws/cloudformation/components/codeprojects.yml.erb
@@ -1,73 +1,42 @@
 <%# Note this file must be indented one level, as it is a child of 'Resources'. %>
-  # -----------------------------------------------
-  # Begin codeprojects.org resources
-  # 
-  # This template component includes resources for the codeprojects.org
-  # infrastructure. Currently this is mostly manually deployed.
-  # 
-  # -----------------------------------------------
-
-<%-
-  domain = "codeprojects.org"
-
-  hosted_zone = Aws::Route53::Client.new.list_hosted_zones_by_name(dns_name: domain).hosted_zones.first
-  raise "Could not find #{domain} in hosted zones" unless hosted_zone.name.delete_suffix('.') == domain
-  hosted_zone_id = hosted_zone.id.delete_prefix("/hostedzone/")
-
-  envs = {
-    staging: {
-      domain_name: "staging.#{domain}",
-      alternative_names: []
-    },
-    # test: {
-    #   domain_name: "test.#{domain}",
-    #   alternative_names: []
-    # },
-    # production: {
-    #   domain_name: domain,
-    #   alternative_names: ["www.#{domain}"]
-    # },
-  }
--%>
+# -----------------------------------------------
+# Begin codeprojects.org resources
+# 
+# This template component includes resources for the codeprojects.org
+# infrastructure. Currently this is mostly manually deployed.
+# 
+# -----------------------------------------------
 
 <%- if rack_env?(:staging) -%>
-  # Developer Resources (Deployed with Staging)
-  LocalhostCodeprojectsRecord:
-    Type: AWS::Route53::RecordSet
-    Properties:
-      HostedZoneId: <%=hosted_zone_id%>
-      Name: <%="localhost.#{domain}"%>
-      Type: A
-      TTL: 3600
-      ResourceRecords:
-        - 127.0.0.1
+# Developer Resources (Deployed with Staging)
+LocalhostCodeprojectsRecord:
+  Type: AWS::Route53::RecordSet
+  Properties:
+    HostedZoneId: <%= codeprojects_hostedzone_id %>
+    Name: <%="localhost.#{domain}"%>
+    Type: A
+    TTL: 3600
+    ResourceRecords:
+      - 127.0.0.1
 <%- end -%>
 
-<%- envs.each do |env, config| -%>
-<%- if rack_env?(env) -%>
-
-  # <%= env %> Resources
-  Codeprojects<%= env.capitalize %>Certificate:
-    Type: AWS::CertificateManager::Certificate
-    Properties:
-      DomainName: <%= config[:domain_name] %>
-      <%- unless config[:alternative_names].empty? -%>
-      SubjectAlternativeNames:
-        <%- config[:alternative_names].each do | alt_name | -%>
-        - <%= alt_name %>
-        <%- end -%>
+CodeprojectsCertificate:
+  Type: AWS::CertificateManager::Certificate
+  Properties:
+    DomainName: <%= codeprojects_hostname %>
+    <%- if rack_env?(:production) -%>
+    SubjectAlternativeNames:
+      - www.<%= codeprojects_hostname %>
+    <%- end -%>
+    ValidationMethod: DNS
+    DomainValidationOptions:
+      - DomainName: <%= codeprojects_hostname %>
+        HostedZoneId: <%= codeprojects_hostedzone_id %>
+      <%- if rack_env?(:production) -%>
+      - DomainName: www.<%= codeprojects_hostname %>
+        HostedZoneId: <%= codeprojects_hostedzone_id %>
       <%- end -%>
-      ValidationMethod: DNS
-      DomainValidationOptions:
-        - DomainName: <%= config[:domain_name] %>
-          HostedZoneId: <%= hosted_zone_id %>
-        <%- config[:alternative_names].each do | alt_name | -%>
-        - DomainName: <%= alt_name %>
-          HostedZoneId: <%= hosted_zone_id %>
-        <%- end -%>
-<%- end -%>
-<%- end -%>
 
-  # -----------------------------------------------
-  # End codeprojects.org resources
-  # -----------------------------------------------
+# -----------------------------------------------
+# End codeprojects.org resources
+# -----------------------------------------------

--- a/aws/cloudformation/components/codeprojects.yml.erb
+++ b/aws/cloudformation/components/codeprojects.yml.erb
@@ -35,7 +35,7 @@
   LocalhostCodeprojectsRecord:
     Type: AWS::Route53::RecordSet
     Properties:
-      HostedZoneId: <%=domain%>
+      HostedZoneId: <%=hosted_zone_id%>
       Name: <%="localhost.#{domain}"%>
       Type: A
       TTL: 3600

--- a/aws/cloudformation/components/codeprojects_resources.yml.erb
+++ b/aws/cloudformation/components/codeprojects_resources.yml.erb
@@ -1,4 +1,3 @@
-<%- # Note this file must be indented one level, as it is a child of 'Resources'. %>
 <%- if rack_env?(:staging, :test, :production) -%>
 # -----------------------------------------------
 # Begin codeprojects.org resources
@@ -36,7 +35,15 @@ CodeprojectsCertificate:
       <%- if rack_env?(:production) -%>
       - DomainName: www.<%= CDO.codeprojects_hostname %>
         HostedZoneId: <%= CDO.codeprojects_hostedzone_id %>
+      - DomainName: static.<%= CDO.codeprojects_hostname %>
+        HostedZoneId: <%= CDO.codeprojects_hostedzone_id %>
       <%- end -%>
+
+# Import/Recreate Additional Resources - TODO
+#   - Route53 DNS RecordSets
+#   - S3-Backed Cloudfront Distributions
+#   - Classic Load Balancers
+#   - S3 Buckets
 
 # -----------------------------------------------
 # End codeprojects.org resources

--- a/aws/cloudformation/components/codeprojects_resources.yml.erb
+++ b/aws/cloudformation/components/codeprojects_resources.yml.erb
@@ -1,5 +1,5 @@
 <%- # Note this file must be indented one level, as it is a child of 'Resources'. %>
-<%- unless rack_env?(:adhoc) -%>
+<%- if rack_env?(:staging, :test, :production) -%>
 # -----------------------------------------------
 # Begin codeprojects.org resources
 # 

--- a/aws/cloudformation/components/www_redirect.yml.erb
+++ b/aws/cloudformation/components/www_redirect.yml.erb
@@ -4,9 +4,7 @@
     # Since this line is restricted to only run in production, we are comfortable using it.
     redirected_domains << "www.#{CDO.pegasus_hostname}" if rack_env?(:production)
     
-    www_redirect_hosted_zone = Aws::Route53::Client.new.list_hosted_zones_by_name(dns_name: domain).hosted_zones.first
-    raise "Could not find #{domain} in hosted zones" unless www_redirect_hosted_zone.name.delete_suffix('.') == domain
-    www_redirect_hosted_zone_id = www_redirect_hosted_zone.id.delete_prefix("/hostedzone/")
+    www_redirect_hosted_zone_id = hostedzone_id(domain)
   -%>
 
   <%=app%>RedirectDNS:

--- a/lib/cdo.rb
+++ b/lib/cdo.rb
@@ -87,6 +87,10 @@ module Cdo
       canonical_hostname('advocacy.code.org')
     end
 
+    def codeprojects_hostname
+      canonical_hostname('codeprojects.org')
+    end
+
     def site_host(domain)
       host = canonical_hostname(domain)
       if (rack_env?(:development) && !https_development) ||
@@ -95,6 +99,16 @@ module Cdo
         host += ":#{port}"
       end
       host
+    end
+
+    def hostedzone_id(domain)
+      hosted_zone = Aws::Route53::Client.new.list_hosted_zones_by_name(dns_name: domain).hosted_zones.first
+      raise "Could not find #{domain} in hosted zones" unless hosted_zone.name.delete_suffix('.') == domain
+      return hosted_zone.id.delete_prefix("/hostedzone/")
+    end
+
+    def codeprojects_hostedzone_id
+      hostedzone_id('codeprojects.org')
     end
 
     def site_url(domain, path = '', scheme = '')

--- a/lib/cdo/cloud_formation/stack_template.rb
+++ b/lib/cdo/cloud_formation/stack_template.rb
@@ -77,6 +77,12 @@ module Cdo::CloudFormation
       erb_file(aws_dir("cloudformation/components/#{name}.yml.erb"), vars)
     end
 
+    # Inline stack resources into the template using local variables as parameters
+    def resource_component(name, var = {})
+      resource_indent = 2 # allow component file to be unindented
+      indent(erb_file(aws_dir("cloudformation/components/#{name}.yml.erb"), vars), resource_indent)
+    end
+
     # Adds the specified properties to a YAML document.
     def add_properties(properties)
       properties.transform_values(&:to_json).map {|p| p.join(': ')}.join

--- a/lib/cdo/cloud_formation/stack_template.rb
+++ b/lib/cdo/cloud_formation/stack_template.rb
@@ -78,8 +78,9 @@ module Cdo::CloudFormation
     end
 
     # Inline stack resources into the template using local variables as parameters
+    # This allows component file to be unindented, and will add a 2-space indent when loaded
     def resource_component(name, var = {})
-      resource_indent = 2 # allow component file to be unindented
+      resource_indent = 2
       indent(erb_file(aws_dir("cloudformation/components/#{name}.yml.erb"), vars), resource_indent)
     end
 


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#45420, which is a revert from the failed first attempt at this.

---

Create new environment-specific certificates for codeprojects.org with automatic DNS validation to replace the manual wildcard cert used today.

Once created, any resources using [the old certificate](https://console.aws.amazon.com/acm/home?region=us-east-1#/certificates/a72e9bd5-fab2-402d-9194-0a38115c2253) would need to be updated to use these. After all resources are switched, the old certificate can be deleted.

## Links

Jira ticket: STAR-1893

## Testing story

## Deployment strategy

If DNS validation fails, then this will get stuck in the cloudformation update step of the DTP. The domain could be manually approved before the timeout, but that kind of defeats the purpose.

To avoid that I'm making this PR deploy as part of staging-only, confirm the validation works, then move on to the test and prod certs.

## Follow-up work

- Deploy the test and prod certs in #45066 
- migrate resources tied to [the old cert](https://console.aws.amazon.com/acm/home?region=us-east-1#/certificates/a72e9bd5-fab2-402d-9194-0a38115c2253)
- delete the old certs

## PR Checklist:

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
