### PR TITLE
Read from applied_at field

### DIFF
--- a/dashboard/app/models/pd/application/application_base.rb
+++ b/dashboard/app/models/pd/application/application_base.rb
@@ -341,7 +341,7 @@ module Pd::Application
     # displays the iso8601 date (yyyy-mm-dd)
     # The applied_at date is null if an application has been started, saved, and not submitted
     def date_applied
-      applied_at&.to_date.&iso8601
+      applied_at&.to_date&.iso8601
     end
 
     # Convert responses cores to a hash of underscore_cased symbols

--- a/dashboard/app/models/pd/application/application_base.rb
+++ b/dashboard/app/models/pd/application/application_base.rb
@@ -68,6 +68,7 @@ module Pd::Application
     # An application either has an "incomplete" or "unreviewed" state when created.
     # The applied_at field gets set when the status becomes 'unreviewed' for the first time
     before_save :set_applied_date, if: :status_changed?
+
     # After creation, an RP or admin can change the status to "accepted," which triggers update_accepted_data.
     before_save :update_accepted_date, if: :status_changed?
 
@@ -338,9 +339,9 @@ module Pd::Application
     end
 
     # displays the iso8601 date (yyyy-mm-dd)
-    # [MEG] TODO: Update this method to use applied_at date
+    # The applied_at date is null if an application has been started, saved, and not submitted
     def date_applied
-      created_at.to_date.iso8601
+      applied_at&.to_date.&iso8601
     end
 
     # Convert responses cores to a hash of underscore_cased symbols

--- a/dashboard/app/models/pd/application/teacher_application.rb
+++ b/dashboard/app/models/pd/application/teacher_application.rb
@@ -129,14 +129,6 @@ module Pd::Application
       application_year
     end
 
-    # Since teacher applications may be created on save before they are submitted, we cannot rely
-    # on the created_at field. When applications are submitted, they have status 'unreviewed'
-    # [MEG] TODO: Delete this method once applied_at column exists, i.e.
-    # ActiveRecord::Base.connection.column_exists?(:pd_applications, :applied_at) is true
-    def date_applied
-      status_log.find {|status_entry| status_entry["status"] == "unreviewed"}&.[]("at")&.to_date&.iso8601
-    end
-
     def self.next_year(year)
       current_year_index = APPLICATION_YEARS.index(year)
       current_year_index >= 0 ? APPLICATION_YEARS[current_year_index + 1] : nil

--- a/dashboard/test/models/pd/application/application_base_test.rb
+++ b/dashboard/test/models/pd/application/application_base_test.rb
@@ -213,7 +213,7 @@ module Pd::Application
       assert_equal '2018-03-09', application.date_accepted
     end
 
-    test 'applied_at is populated with the first unreviewed status' do
+    test 'applied_at and date_applied have the first unreviewed status' do
       application = create :pd_teacher_application, status: 'incomplete'
       assert_nil application.applied_at
 
@@ -230,6 +230,7 @@ module Pd::Application
       end
 
       assert_equal tomorrow, application.applied_at
+      assert_equal tomorrow, application.date_applied.to_time
     end
 
     test 'memoized full_answers' do

--- a/dashboard/test/models/pd/application/teacher_application_test.rb
+++ b/dashboard/test/models/pd/application/teacher_application_test.rb
@@ -109,25 +109,6 @@ module Pd::Application
       assert_equal Pd::Application::TeacherApplication::REVIEWING_INCOMPLETE, teacher_application.meets_criteria
     end
 
-    # [MEG] TODO: Move and refactor this test once the date_applied method is only in application_base
-    test 'date_applied finds date of first unreviewed status' do
-      tomorrow = Date.tomorrow.to_time
-      next_day = tomorrow + 1.day
-      application = create :pd_teacher_application, status: 'incomplete'
-      assert_nil application.date_applied
-
-      Timecop.freeze(tomorrow) do
-        application.update!(status: 'unreviewed')
-      end
-
-      Timecop.freeze(next_day) do
-        application.update!(status: 'reopened')
-        application.update!(status: 'unreviewed')
-      end
-
-      assert_equal tomorrow, application.date_applied.to_time
-    end
-
     test 'accepted_at updates times' do
       today = Date.today.to_time
       tomorrow = Date.tomorrow.to_time


### PR DESCRIPTION
Now that the applied_at field is being written to and now that old records have been backfilled with this field, we can use this field for the `date_applied` method, which is used in the Application Dashboard.

I ran
```
Pd::Application::ApplicationBase.all.each do |application|
    application.update_column(:applied_at, application.created_at)
end
```
to backfill the records, and verified it worked with
```
total = 0
total_correct = 0
Pd::Application::ApplicationBase.all.each do |app|
    total += 1
    total_correct += 1 if app.created_at == app.applied_at
    puts "ERROR ON #{app.id}" if app.created_at != app.applied_at
end
```
result:
```
total
>> 44811
total_correct
>> 44811
```

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
