### PR TITLE
migrate legacy teacher resources for pre-2021 courses

### DIFF
--- a/dashboard/config/scripts_json/coursea-2018.script_json
+++ b/dashboard/config/scripts_json/coursea-2018.script_json
@@ -43,7 +43,7 @@
     },
     "new_name": null,
     "family_name": "coursea",
-    "serialized_at": "2022-03-11 12:07:31 UTC",
+    "serialized_at": "2022-03-22 21:15:48 UTC",
     "published_state": "stable",
     "instruction_type": "teacher_led",
     "instructor_audience": "teacher",
@@ -4074,13 +4074,79 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csf-18/coursea/",
+      "key": "lesson_plans",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csf-18/coursea/standards/",
+      "key": "standard_mappings",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "http://forum.code.org/c/csf",
+      "key": "teacher_forum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csf-18/coursea/vocab/",
+      "key": "vocabulary",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum",
+        "script.name": "coursea-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary",
+        "script.name": "coursea-2018"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/coursea-2019.script_json
+++ b/dashboard/config/scripts_json/coursea-2019.script_json
@@ -47,7 +47,7 @@
     },
     "new_name": null,
     "family_name": "coursea",
-    "serialized_at": "2022-03-11 12:07:48 UTC",
+    "serialized_at": "2022-03-22 21:15:49 UTC",
     "published_state": "stable",
     "instruction_type": "teacher_led",
     "instructor_audience": "teacher",
@@ -4730,13 +4730,96 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Curriculum Guide",
+      "url": "https://docs.google.com/document/d/1UqCgO06NzB1L6y83fnwnUcYdKr3MooJAaUZajj48DnI/preview",
+      "key": "curriculum_guide",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "curriculum_guide"
+      }
+    },
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csf-19/coursea/",
+      "key": "lesson_plans",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csf-19/coursea/standards/",
+      "key": "standard_mappings",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "http://forum.code.org/c/csf",
+      "key": "teacher_forum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csf-19/coursea/vocab/",
+      "key": "vocabulary",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "curriculum_guide",
+        "script.name": "coursea-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans",
+        "script.name": "coursea-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings",
+        "script.name": "coursea-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum",
+        "script.name": "coursea-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary",
+        "script.name": "coursea-2019"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/coursea-2020.script_json
+++ b/dashboard/config/scripts_json/coursea-2020.script_json
@@ -43,7 +43,7 @@
     },
     "new_name": null,
     "family_name": "coursea",
-    "serialized_at": "2022-03-11 12:07:58 UTC",
+    "serialized_at": "2022-03-22 21:15:50 UTC",
     "published_state": "stable",
     "instruction_type": "teacher_led",
     "instructor_audience": "teacher",
@@ -4726,13 +4726,96 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Curriculum Guide",
+      "url": "https://docs.google.com/document/d/1hstUHTGIdvtPP0TDdEfQeXG3zQ0q6ys237n2BY9CQmg/preview",
+      "key": "curriculum_guide",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "curriculum_guide"
+      }
+    },
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csf-20/coursea/",
+      "key": "lesson_plans",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csf-20/coursea/standards/",
+      "key": "standard_mappings",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "http://forum.code.org/c/csf",
+      "key": "teacher_forum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csf-20/coursea/vocab/",
+      "key": "vocabulary",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "curriculum_guide",
+        "script.name": "coursea-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans",
+        "script.name": "coursea-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings",
+        "script.name": "coursea-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum",
+        "script.name": "coursea-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary",
+        "script.name": "coursea-2020"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/courseb-2018.script_json
+++ b/dashboard/config/scripts_json/courseb-2018.script_json
@@ -43,7 +43,7 @@
     },
     "new_name": null,
     "family_name": "courseb",
-    "serialized_at": "2022-03-11 12:07:32 UTC",
+    "serialized_at": "2022-03-22 21:15:51 UTC",
     "published_state": "stable",
     "instruction_type": "teacher_led",
     "instructor_audience": "teacher",
@@ -3857,13 +3857,79 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csf-18/courseb/",
+      "key": "lesson_plans",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csf-18/courseb/standards/",
+      "key": "standard_mappings",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csf",
+      "key": "teacher_forum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csf-18/courseb/vocab/",
+      "key": "vocabulary",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum",
+        "script.name": "courseb-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary",
+        "script.name": "courseb-2018"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/courseb-2019.script_json
+++ b/dashboard/config/scripts_json/courseb-2019.script_json
@@ -47,7 +47,7 @@
     },
     "new_name": null,
     "family_name": "courseb",
-    "serialized_at": "2022-03-11 12:07:48 UTC",
+    "serialized_at": "2022-03-22 21:15:51 UTC",
     "published_state": "stable",
     "instruction_type": "teacher_led",
     "instructor_audience": "teacher",
@@ -4333,13 +4333,96 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Curriculum Guide",
+      "url": "https://docs.google.com/document/d/1UqCgO06NzB1L6y83fnwnUcYdKr3MooJAaUZajj48DnI/preview",
+      "key": "curriculum_guide",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "curriculum_guide"
+      }
+    },
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csf-19/courseb/",
+      "key": "lesson_plans",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csf-19/courseb/standards/",
+      "key": "standard_mappings",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csf",
+      "key": "teacher_forum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csf-19/courseb/vocab/",
+      "key": "vocabulary",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "curriculum_guide",
+        "script.name": "courseb-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans",
+        "script.name": "courseb-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings",
+        "script.name": "courseb-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum",
+        "script.name": "courseb-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary",
+        "script.name": "courseb-2019"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/courseb-2020.script_json
+++ b/dashboard/config/scripts_json/courseb-2020.script_json
@@ -43,7 +43,7 @@
     },
     "new_name": null,
     "family_name": "courseb",
-    "serialized_at": "2022-03-11 12:07:59 UTC",
+    "serialized_at": "2022-03-22 21:15:52 UTC",
     "published_state": "stable",
     "instruction_type": "teacher_led",
     "instructor_audience": "teacher",
@@ -4329,13 +4329,96 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Curriculum Guide",
+      "url": "https://docs.google.com/document/d/1hstUHTGIdvtPP0TDdEfQeXG3zQ0q6ys237n2BY9CQmg/preview",
+      "key": "curriculum_guide",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "curriculum_guide"
+      }
+    },
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csf-20/courseb/",
+      "key": "lesson_plans",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csf-20/courseb/standards/",
+      "key": "standard_mappings",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csf",
+      "key": "teacher_forum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csf-20/courseb/vocab/",
+      "key": "vocabulary",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "curriculum_guide",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum",
+        "script.name": "courseb-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary",
+        "script.name": "courseb-2020"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/coursec-2018.script_json
+++ b/dashboard/config/scripts_json/coursec-2018.script_json
@@ -43,7 +43,7 @@
     },
     "new_name": null,
     "family_name": "coursec",
-    "serialized_at": "2022-03-11 12:07:33 UTC",
+    "serialized_at": "2022-03-22 21:15:53 UTC",
     "published_state": "stable",
     "instruction_type": "teacher_led",
     "instructor_audience": "teacher",
@@ -5664,13 +5664,79 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csf-18/coursec/",
+      "key": "lesson_plans",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csf-18/coursec/standards/",
+      "key": "standard_mappings",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csf",
+      "key": "teacher_forum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csf-18/coursec/vocab/",
+      "key": "vocabulary",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum",
+        "script.name": "coursec-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary",
+        "script.name": "coursec-2018"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/coursec-2019.script_json
+++ b/dashboard/config/scripts_json/coursec-2019.script_json
@@ -47,7 +47,7 @@
     },
     "new_name": null,
     "family_name": "coursec",
-    "serialized_at": "2022-03-11 12:07:47 UTC",
+    "serialized_at": "2022-03-22 21:15:54 UTC",
     "published_state": "stable",
     "instruction_type": "teacher_led",
     "instructor_audience": "teacher",
@@ -6703,13 +6703,96 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Curriculum Guide",
+      "url": "https://docs.google.com/document/d/1UqCgO06NzB1L6y83fnwnUcYdKr3MooJAaUZajj48DnI/preview",
+      "key": "curriculum_guide",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "curriculum_guide"
+      }
+    },
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csf-19/coursec/",
+      "key": "lesson_plans",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csf-19/coursec/standards/",
+      "key": "standard_mappings",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csf",
+      "key": "teacher_forum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csf-19/coursec/vocab/",
+      "key": "vocabulary",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "curriculum_guide",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum",
+        "script.name": "coursec-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary",
+        "script.name": "coursec-2019"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/coursec-2020.script_json
+++ b/dashboard/config/scripts_json/coursec-2020.script_json
@@ -43,7 +43,7 @@
     },
     "new_name": null,
     "family_name": "coursec",
-    "serialized_at": "2022-03-11 12:08:00 UTC",
+    "serialized_at": "2022-03-22 21:15:56 UTC",
     "published_state": "stable",
     "instruction_type": "teacher_led",
     "instructor_audience": "teacher",
@@ -6699,13 +6699,96 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Curriculum Guide",
+      "url": "https://docs.google.com/document/d/1hstUHTGIdvtPP0TDdEfQeXG3zQ0q6ys237n2BY9CQmg/preview",
+      "key": "curriculum_guide",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "curriculum_guide"
+      }
+    },
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csf-20/coursec/",
+      "key": "lesson_plans",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csf-20/coursec/standards/",
+      "key": "standard_mappings",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csf",
+      "key": "teacher_forum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csf-20/coursec/vocab/",
+      "key": "vocabulary",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "curriculum_guide",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum",
+        "script.name": "coursec-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary",
+        "script.name": "coursec-2020"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/coursed-2018.script_json
+++ b/dashboard/config/scripts_json/coursed-2018.script_json
@@ -38,7 +38,7 @@
     },
     "new_name": null,
     "family_name": "coursed",
-    "serialized_at": "2022-03-11 12:07:33 UTC",
+    "serialized_at": "2022-03-22 21:15:57 UTC",
     "published_state": "stable",
     "instruction_type": "teacher_led",
     "instructor_audience": "teacher",
@@ -6784,13 +6784,79 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csf-18/coursed/",
+      "key": "lesson_plans",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csf-18/coursed/standards/",
+      "key": "standard_mappings",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csf",
+      "key": "teacher_forum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csf-18/coursed/vocab/",
+      "key": "vocabulary",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum",
+        "script.name": "coursed-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary",
+        "script.name": "coursed-2018"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/coursed-2019.script_json
+++ b/dashboard/config/scripts_json/coursed-2019.script_json
@@ -42,7 +42,7 @@
     },
     "new_name": null,
     "family_name": "coursed",
-    "serialized_at": "2022-03-11 12:07:41 UTC",
+    "serialized_at": "2022-03-22 21:15:59 UTC",
     "published_state": "stable",
     "instruction_type": "teacher_led",
     "instructor_audience": "teacher",
@@ -7325,13 +7325,96 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Curriculum Guide",
+      "url": "https://docs.google.com/document/d/1UqCgO06NzB1L6y83fnwnUcYdKr3MooJAaUZajj48DnI/preview",
+      "key": "curriculum_guide",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "curriculum_guide"
+      }
+    },
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csf-19/coursed/",
+      "key": "lesson_plans",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csf-19/coursed/standards/",
+      "key": "standard_mappings",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csf",
+      "key": "teacher_forum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csf-19/coursed/vocab/",
+      "key": "vocabulary",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "curriculum_guide",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum",
+        "script.name": "coursed-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary",
+        "script.name": "coursed-2019"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/coursed-2020.script_json
+++ b/dashboard/config/scripts_json/coursed-2020.script_json
@@ -38,7 +38,7 @@
     },
     "new_name": null,
     "family_name": "coursed",
-    "serialized_at": "2022-03-11 12:08:01 UTC",
+    "serialized_at": "2022-03-22 21:16:00 UTC",
     "published_state": "stable",
     "instruction_type": "teacher_led",
     "instructor_audience": "teacher",
@@ -7656,13 +7656,96 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Curriculum Guide",
+      "url": "https://docs.google.com/document/d/1hstUHTGIdvtPP0TDdEfQeXG3zQ0q6ys237n2BY9CQmg/preview",
+      "key": "curriculum_guide",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "curriculum_guide"
+      }
+    },
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csf-20/coursed/",
+      "key": "lesson_plans",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csf-20/coursed/standards/",
+      "key": "standard_mappings",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csf",
+      "key": "teacher_forum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csf-20/coursed/vocab/",
+      "key": "vocabulary",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "curriculum_guide",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum",
+        "script.name": "coursed-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary",
+        "script.name": "coursed-2020"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/coursee-2018.script_json
+++ b/dashboard/config/scripts_json/coursee-2018.script_json
@@ -43,7 +43,7 @@
     },
     "new_name": null,
     "family_name": "coursee",
-    "serialized_at": "2022-03-11 12:07:35 UTC",
+    "serialized_at": "2022-03-22 21:16:02 UTC",
     "published_state": "stable",
     "instruction_type": "teacher_led",
     "instructor_audience": "teacher",
@@ -8286,13 +8286,79 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csf-18/coursee/",
+      "key": "lesson_plans",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csf-18/coursee/standards/",
+      "key": "standard_mappings",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csf",
+      "key": "teacher_forum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csf-18/coursee/vocab/",
+      "key": "vocabulary",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum",
+        "script.name": "coursee-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary",
+        "script.name": "coursee-2018"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/coursee-2019.script_json
+++ b/dashboard/config/scripts_json/coursee-2019.script_json
@@ -47,7 +47,7 @@
     },
     "new_name": null,
     "family_name": "coursee",
-    "serialized_at": "2022-03-11 12:07:42 UTC",
+    "serialized_at": "2022-03-22 21:16:03 UTC",
     "published_state": "stable",
     "instruction_type": "teacher_led",
     "instructor_audience": "teacher",
@@ -7415,13 +7415,96 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Curriculum Guide",
+      "url": "https://docs.google.com/document/d/1UqCgO06NzB1L6y83fnwnUcYdKr3MooJAaUZajj48DnI/preview",
+      "key": "curriculum_guide",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "curriculum_guide"
+      }
+    },
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csf-19/coursee/",
+      "key": "lesson_plans",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csf-19/coursee/standards/",
+      "key": "standard_mappings",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csf",
+      "key": "teacher_forum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csf-19/coursee/vocab/",
+      "key": "vocabulary",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "curriculum_guide",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum",
+        "script.name": "coursee-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary",
+        "script.name": "coursee-2019"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/coursee-2020.script_json
+++ b/dashboard/config/scripts_json/coursee-2020.script_json
@@ -43,7 +43,7 @@
     },
     "new_name": null,
     "family_name": "coursee",
-    "serialized_at": "2022-03-11 12:08:02 UTC",
+    "serialized_at": "2022-03-22 21:16:04 UTC",
     "published_state": "stable",
     "instruction_type": "teacher_led",
     "instructor_audience": "teacher",
@@ -7520,13 +7520,96 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Curriculum Guide",
+      "url": "https://docs.google.com/document/d/1hstUHTGIdvtPP0TDdEfQeXG3zQ0q6ys237n2BY9CQmg/preview",
+      "key": "curriculum_guide",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "curriculum_guide"
+      }
+    },
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csf-20/coursee/",
+      "key": "lesson_plans",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csf-20/coursee/standards/",
+      "key": "standard_mappings",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csf",
+      "key": "teacher_forum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csf-20/coursee/vocab/",
+      "key": "vocabulary",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "curriculum_guide",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum",
+        "script.name": "coursee-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary",
+        "script.name": "coursee-2020"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/coursef-2018.script_json
+++ b/dashboard/config/scripts_json/coursef-2018.script_json
@@ -43,7 +43,7 @@
     },
     "new_name": null,
     "family_name": "coursef",
-    "serialized_at": "2022-03-11 12:07:36 UTC",
+    "serialized_at": "2022-03-22 21:16:05 UTC",
     "published_state": "stable",
     "instruction_type": "teacher_led",
     "instructor_audience": "teacher",
@@ -8370,13 +8370,79 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csf-18/coursef/",
+      "key": "lesson_plans",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csf-18/coursef/standards/",
+      "key": "standard_mappings",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csf",
+      "key": "teacher_forum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csf-18/coursef/vocab/",
+      "key": "vocabulary",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum",
+        "script.name": "coursef-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary",
+        "script.name": "coursef-2018"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/coursef-2019.script_json
+++ b/dashboard/config/scripts_json/coursef-2019.script_json
@@ -47,7 +47,7 @@
     },
     "new_name": null,
     "family_name": "coursef",
-    "serialized_at": "2022-03-11 12:07:40 UTC",
+    "serialized_at": "2022-03-22 21:16:06 UTC",
     "published_state": "stable",
     "instruction_type": "teacher_led",
     "instructor_audience": "teacher",
@@ -6462,13 +6462,96 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Curriculum Guide",
+      "url": "https://docs.google.com/document/d/1UqCgO06NzB1L6y83fnwnUcYdKr3MooJAaUZajj48DnI/preview",
+      "key": "curriculum_guide",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "curriculum_guide"
+      }
+    },
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csf-19/coursef/",
+      "key": "lesson_plans",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csf-19/coursef/standards/",
+      "key": "standard_mappings",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csf",
+      "key": "teacher_forum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csf-19/coursef/vocab/",
+      "key": "vocabulary",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "curriculum_guide",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum",
+        "script.name": "coursef-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary",
+        "script.name": "coursef-2019"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/coursef-2020.script_json
+++ b/dashboard/config/scripts_json/coursef-2020.script_json
@@ -43,7 +43,7 @@
     },
     "new_name": null,
     "family_name": "coursef",
-    "serialized_at": "2022-03-11 12:08:03 UTC",
+    "serialized_at": "2022-03-22 21:16:07 UTC",
     "published_state": "stable",
     "instruction_type": "teacher_led",
     "instructor_audience": "teacher",
@@ -6664,13 +6664,96 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Curriculum Guide",
+      "url": "https://docs.google.com/document/d/1hstUHTGIdvtPP0TDdEfQeXG3zQ0q6ys237n2BY9CQmg/preview",
+      "key": "curriculum_guide",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "curriculum_guide"
+      }
+    },
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csf-20/coursef/",
+      "key": "lesson_plans",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csf-20/coursef/standards/",
+      "key": "standard_mappings",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csf",
+      "key": "teacher_forum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csf-20/coursef/vocab/",
+      "key": "vocabulary",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "curriculum_guide",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum",
+        "script.name": "coursef-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary",
+        "script.name": "coursef-2020"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csd1-2017.script_json
+++ b/dashboard/config/scripts_json/csd1-2017.script_json
@@ -41,7 +41,7 @@
     },
     "new_name": "csd1-2017",
     "family_name": "csd1",
-    "serialized_at": "2022-03-11 12:07:20 UTC",
+    "serialized_at": "2022-03-22 21:16:08 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -962,13 +962,79 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csd/unit1",
+      "key": "lesson_plans",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csd/unit1/standards/",
+      "key": "standard_mappings",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csd1",
+      "key": "teacher_forum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csd/unit1/vocab/",
+      "key": "vocabulary",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans",
+        "script.name": "csd1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings",
+        "script.name": "csd1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum",
+        "script.name": "csd1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary",
+        "script.name": "csd1-2017"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csd1-2018.script_json
+++ b/dashboard/config/scripts_json/csd1-2018.script_json
@@ -33,7 +33,7 @@
     },
     "new_name": null,
     "family_name": "csd1",
-    "serialized_at": "2022-03-11 12:07:36 UTC",
+    "serialized_at": "2022-03-22 21:16:08 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -877,13 +877,79 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csd-18/unit1",
+      "key": "lesson_plans",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csd-18/unit1/standards/",
+      "key": "standard_mappings",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csd1",
+      "key": "teacher_forum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csd-18/unit1/vocab/",
+      "key": "vocabulary",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans",
+        "script.name": "csd1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings",
+        "script.name": "csd1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum",
+        "script.name": "csd1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary",
+        "script.name": "csd1-2018"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csd1-2019.script_json
+++ b/dashboard/config/scripts_json/csd1-2019.script_json
@@ -34,7 +34,7 @@
     },
     "new_name": null,
     "family_name": "csd1",
-    "serialized_at": "2022-03-11 12:07:46 UTC",
+    "serialized_at": "2022-03-22 21:16:08 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -1000,13 +1000,79 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csd-19/unit1",
+      "key": "lesson_plans",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csd-19/unit1/standards/",
+      "key": "standard_mappings",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csd",
+      "key": "teacher_forum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csd-19/unit1/vocab/",
+      "key": "vocabulary",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans",
+        "script.name": "csd1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings",
+        "script.name": "csd1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum",
+        "script.name": "csd1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary",
+        "script.name": "csd1-2019"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csd1-2020.script_json
+++ b/dashboard/config/scripts_json/csd1-2020.script_json
@@ -11,29 +11,11 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "teacher_resources": [
-        [
-          "lessonPlans",
-          "https://curriculum.code.org/csd-20/unit1"
-        ],
-        [
-          "teacherForum",
-          "https://forum.code.org/c/csd"
-        ],
-        [
-          "vocabulary",
-          "https://curriculum.code.org/csd-20/unit1/vocab/"
-        ],
-        [
-          "standardMappings",
-          "https://curriculum.code.org/csd-20/unit1/standards/"
-        ]
-      ],
       "use_legacy_lesson_plans": true
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2022-03-11 12:07:56 UTC",
+    "serialized_at": "2022-03-22 21:16:09 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -2116,13 +2098,79 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csd-20/unit1",
+      "key": "lesson_plans",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csd-20/unit1/standards/",
+      "key": "standard_mappings",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csd",
+      "key": "teacher_forum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csd-20/unit1/vocab/",
+      "key": "vocabulary",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum",
+        "script.name": "csd1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary",
+        "script.name": "csd1-2020"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csd2-2017.script_json
+++ b/dashboard/config/scripts_json/csd2-2017.script_json
@@ -38,7 +38,7 @@
     },
     "new_name": "csd2-2017",
     "family_name": "csd2",
-    "serialized_at": "2022-03-11 12:07:20 UTC",
+    "serialized_at": "2022-03-22 21:16:09 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -5043,13 +5043,96 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Code Introduced",
+      "url": "https://curriculum.code.org/csd/unit2/code/",
+      "key": "code_introduced",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "code_introduced"
+      }
+    },
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csd/unit2/",
+      "key": "lesson_plans_1",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_1"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csd/unit2/standards/",
+      "key": "standard_mappings_1",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings_1"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csd2",
+      "key": "teacher_forum_1",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum_1"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csd/unit2/vocab/",
+      "key": "vocabulary_1",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary_1"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "code_introduced",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum_1",
+        "script.name": "csd2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary_1",
+        "script.name": "csd2-2017"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csd2-2018.script_json
+++ b/dashboard/config/scripts_json/csd2-2018.script_json
@@ -47,7 +47,7 @@
     },
     "new_name": null,
     "family_name": "csd2",
-    "serialized_at": "2022-03-11 12:07:30 UTC",
+    "serialized_at": "2022-03-22 21:16:10 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -5055,13 +5055,96 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Code Introduced",
+      "url": "https://curriculum.code.org/csd-18/unit2/code/",
+      "key": "code_introduced",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "code_introduced"
+      }
+    },
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csd-18/unit2/",
+      "key": "lesson_plans_1",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_1"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csd-18/unit2/standards/",
+      "key": "standard_mappings_1",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings_1"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csd2",
+      "key": "teacher_forum_1",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum_1"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csd-18/unit2/vocab/",
+      "key": "vocabulary_1",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary_1"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "code_introduced",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum_1",
+        "script.name": "csd2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary_1",
+        "script.name": "csd2-2018"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csd2-2019.script_json
+++ b/dashboard/config/scripts_json/csd2-2019.script_json
@@ -39,7 +39,7 @@
     },
     "new_name": null,
     "family_name": "csd2",
-    "serialized_at": "2022-03-11 12:07:50 UTC",
+    "serialized_at": "2022-03-22 21:16:10 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -5313,13 +5313,96 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Code Introduced",
+      "url": "https://curriculum.code.org/csd-19/unit2/code/",
+      "key": "code_introduced",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "code_introduced"
+      }
+    },
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csd-19/unit2/",
+      "key": "lesson_plans_1",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_1"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csd-19/unit2/standards/",
+      "key": "standard_mappings_1",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings_1"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csd",
+      "key": "teacher_forum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csd-19/unit2/vocab/",
+      "key": "vocabulary_1",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary_1"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "code_introduced",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings_1",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum",
+        "script.name": "csd2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary_1",
+        "script.name": "csd2-2019"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csd2-2020.script_json
+++ b/dashboard/config/scripts_json/csd2-2020.script_json
@@ -11,22 +11,12 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "teacher_resources": [
-        [
-          "lessonPlans",
-          "https://curriculum.code.org/csd-20/unit2/"
-        ],
-        [
-          "teacherForum",
-          "https://forum.code.org/c/csd"
-        ]
-      ],
       "tts": true,
       "use_legacy_lesson_plans": true
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2022-03-11 12:07:56 UTC",
+    "serialized_at": "2022-03-22 21:16:11 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -5981,13 +5971,45 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csd-20/unit2/",
+      "key": "lesson_plans_1",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_1"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csd",
+      "key": "teacher_forum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_1",
+        "script.name": "csd2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum",
+        "script.name": "csd2-2020"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csd3-2017.script_json
+++ b/dashboard/config/scripts_json/csd3-2017.script_json
@@ -38,7 +38,7 @@
     },
     "new_name": "csd3-2017",
     "family_name": "csd3",
-    "serialized_at": "2022-03-11 12:07:19 UTC",
+    "serialized_at": "2022-03-22 21:16:12 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -12291,13 +12291,96 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Code Introduced",
+      "url": "https://curriculum.code.org/csd/unit3/code/",
+      "key": "code_introduced_1",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "code_introduced_1"
+      }
+    },
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csd/unit3/",
+      "key": "lesson_plans_2",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_2"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csd/unit3/standards/",
+      "key": "standard_mappings_2",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings_2"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csd3",
+      "key": "teacher_forum_2",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum_2"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csd/unit3/vocab/",
+      "key": "vocabulary_2",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary_2"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "code_introduced_1",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum_2",
+        "script.name": "csd3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary_2",
+        "script.name": "csd3-2017"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csd3-2018.script_json
+++ b/dashboard/config/scripts_json/csd3-2018.script_json
@@ -53,7 +53,7 @@
     },
     "new_name": null,
     "family_name": "csd3",
-    "serialized_at": "2022-03-11 12:07:29 UTC",
+    "serialized_at": "2022-03-22 21:16:13 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -12363,13 +12363,96 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Code Introduced",
+      "url": "https://curriculum.code.org/csd-18/unit3/code/",
+      "key": "code_introduced_1",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "code_introduced_1"
+      }
+    },
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csd-18/unit3/",
+      "key": "lesson_plans_2",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_2"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csd-18/unit3/standards/",
+      "key": "standard_mappings_2",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings_2"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csd3",
+      "key": "teacher_forum_2",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum_2"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csd-18/unit3/vocab/",
+      "key": "vocabulary_2",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary_2"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "code_introduced_1",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum_2",
+        "script.name": "csd3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary_2",
+        "script.name": "csd3-2018"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csd3-2019.script_json
+++ b/dashboard/config/scripts_json/csd3-2019.script_json
@@ -54,7 +54,7 @@
     },
     "new_name": null,
     "family_name": "csd3",
-    "serialized_at": "2022-03-11 12:07:51 UTC",
+    "serialized_at": "2022-03-22 21:16:15 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -12489,13 +12489,96 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Code Introduced",
+      "url": "https://curriculum.code.org/csd-19/unit3/code/",
+      "key": "code_introduced_1",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "code_introduced_1"
+      }
+    },
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csd-19/unit3/",
+      "key": "lesson_plans_2",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_2"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csd-19/unit3/standards/",
+      "key": "standard_mappings_2",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings_2"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csd",
+      "key": "teacher_forum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csd-19/unit3/vocab/",
+      "key": "vocabulary_2",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary_2"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "code_introduced_1",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings_2",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum",
+        "script.name": "csd3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary_2",
+        "script.name": "csd3-2019"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csd3-2020.script_json
+++ b/dashboard/config/scripts_json/csd3-2020.script_json
@@ -11,34 +11,12 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "teacher_resources": [
-        [
-          "lessonPlans",
-          "https://curriculum.code.org/csd-20/unit3/"
-        ],
-        [
-          "teacherForum",
-          "https://forum.code.org/c/csd3"
-        ],
-        [
-          "vocabulary",
-          "https://curriculum.code.org/csd-20/unit3/vocab/"
-        ],
-        [
-          "standardMappings",
-          "https://curriculum.code.org/csd-20/unit3/standards/"
-        ],
-        [
-          "codeIntroduced",
-          "https://curriculum.code.org/csd-20/unit3/code/"
-        ]
-      ],
       "tts": true,
       "use_legacy_lesson_plans": true
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2022-03-11 12:07:57 UTC",
+    "serialized_at": "2022-03-22 21:16:18 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -12574,13 +12552,96 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Code Introduced",
+      "url": "https://curriculum.code.org/csd-20/unit3/code/",
+      "key": "code_introduced",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "code_introduced"
+      }
+    },
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csd-20/unit3/",
+      "key": "lesson_plans_2",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_2"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csd-20/unit3/standards/",
+      "key": "standard_mappings_1",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings_1"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csd3",
+      "key": "teacher_forum_1",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum_1"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csd-20/unit3/vocab/",
+      "key": "vocabulary_1",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary_1"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "code_introduced",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_2",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum_1",
+        "script.name": "csd3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary_1",
+        "script.name": "csd3-2020"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csd3-virtual.script_json
+++ b/dashboard/config/scripts_json/csd3-virtual.script_json
@@ -11,17 +11,11 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "teacher_resources": [
-        [
-          "teacherForum",
-          "https://forum.code.org/c/csd3"
-        ]
-      ],
       "version_year": "unversioned"
     },
     "new_name": null,
     "family_name": "csd3-virtual",
-    "serialized_at": "2021-11-22 19:56:23 UTC",
+    "serialized_at": "2022-03-22 21:16:19 UTC",
     "published_state": "preview",
     "instruction_type": "teacher_led",
     "instructor_audience": "teacher",
@@ -7366,13 +7360,28 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csd3",
+      "key": "teacher_forum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum",
+        "script.name": "csd3-virtual"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csd4-2017.script_json
+++ b/dashboard/config/scripts_json/csd4-2017.script_json
@@ -38,7 +38,7 @@
     },
     "new_name": "csd4-2017",
     "family_name": "csd4",
-    "serialized_at": "2022-03-11 12:07:20 UTC",
+    "serialized_at": "2022-03-22 21:16:19 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -2810,13 +2810,96 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Code Introduced",
+      "url": "https://curriculum.code.org/csd/unit4/code/",
+      "key": "code_introduced_2",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "code_introduced_2"
+      }
+    },
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csd/unit4/",
+      "key": "lesson_plans_3",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_3"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csd/unit4/standards/",
+      "key": "standard_mappings_3",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings_3"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csd4",
+      "key": "teacher_forum_3",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum_3"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csd/unit4/vocab/",
+      "key": "vocabulary_3",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary_3"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "code_introduced_2",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_3",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings_3",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum_3",
+        "script.name": "csd4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary_3",
+        "script.name": "csd4-2017"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csd4-2018.script_json
+++ b/dashboard/config/scripts_json/csd4-2018.script_json
@@ -47,7 +47,7 @@
     },
     "new_name": null,
     "family_name": "csd4",
-    "serialized_at": "2022-03-11 12:07:36 UTC",
+    "serialized_at": "2022-03-22 21:16:20 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -2822,13 +2822,96 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Code Introduced",
+      "url": "https://curriculum.code.org/csd-18/unit4/code/",
+      "key": "code_introduced_2",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "code_introduced_2"
+      }
+    },
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csd-18/unit4/",
+      "key": "lesson_plans_3",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_3"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csd-18/unit4/standards/",
+      "key": "standard_mappings_3",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings_3"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csd4",
+      "key": "teacher_forum_3",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum_3"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csd-18/unit4/vocab/",
+      "key": "vocabulary_3",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary_3"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "code_introduced_2",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_3",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings_3",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum_3",
+        "script.name": "csd4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary_3",
+        "script.name": "csd4-2018"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csd4-2019.script_json
+++ b/dashboard/config/scripts_json/csd4-2019.script_json
@@ -39,7 +39,7 @@
     },
     "new_name": null,
     "family_name": "csd4",
-    "serialized_at": "2022-03-11 12:07:51 UTC",
+    "serialized_at": "2022-03-22 21:16:20 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -2955,13 +2955,96 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Code Introduced",
+      "url": "https://curriculum.code.org/csd-19/unit4/code/",
+      "key": "code_introduced_2",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "code_introduced_2"
+      }
+    },
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csd-19/unit4/",
+      "key": "lesson_plans_3",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_3"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csd-19/unit4/standards/",
+      "key": "standard_mappings_3",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings_3"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csd",
+      "key": "teacher_forum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csd-19/unit4/vocab/",
+      "key": "vocabulary_3",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary_3"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "code_introduced_2",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_3",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings_3",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum",
+        "script.name": "csd4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary_3",
+        "script.name": "csd4-2019"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csd4-2020.script_json
+++ b/dashboard/config/scripts_json/csd4-2020.script_json
@@ -11,34 +11,12 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "teacher_resources": [
-        [
-          "lessonPlans",
-          "https://curriculum.code.org/csd-20/unit4/"
-        ],
-        [
-          "teacherForum",
-          "https://forum.code.org/c/csd"
-        ],
-        [
-          "vocabulary",
-          "https://curriculum.code.org/csd-20/unit4/vocab/"
-        ],
-        [
-          "standardMappings",
-          "https://curriculum.code.org/csd-20/unit4/standards/"
-        ],
-        [
-          "codeIntroduced",
-          "https://curriculum.code.org/csd-20/unit4/code/"
-        ]
-      ],
       "tts": true,
       "use_legacy_lesson_plans": true
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2022-03-11 12:07:56 UTC",
+    "serialized_at": "2022-03-22 21:16:20 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -2654,13 +2632,96 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Code Introduced",
+      "url": "https://curriculum.code.org/csd-20/unit4/code/",
+      "key": "code_introduced_1",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "code_introduced_1"
+      }
+    },
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csd-20/unit4/",
+      "key": "lesson_plans_3",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_3"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csd-20/unit4/standards/",
+      "key": "standard_mappings_2",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings_2"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csd",
+      "key": "teacher_forum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csd-20/unit4/vocab/",
+      "key": "vocabulary_2",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary_2"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "code_introduced_1",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_3",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings_2",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum",
+        "script.name": "csd4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary_2",
+        "script.name": "csd4-2020"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csd5-2017.script_json
+++ b/dashboard/config/scripts_json/csd5-2017.script_json
@@ -33,7 +33,7 @@
     },
     "new_name": "csd5-2017",
     "family_name": "csd5",
-    "serialized_at": "2022-03-11 12:07:21 UTC",
+    "serialized_at": "2022-03-22 21:16:21 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -2355,13 +2355,79 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csd/unit5/",
+      "key": "lesson_plans_4",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_4"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csd/unit5/standards/",
+      "key": "standard_mappings_4",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings_4"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csd5",
+      "key": "teacher_forum_4",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum_4"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csd/unit5/vocab",
+      "key": "vocabulary_4",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary_4"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_4",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings_4",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum_4",
+        "script.name": "csd5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary_4",
+        "script.name": "csd5-2017"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csd5-2018.script_json
+++ b/dashboard/config/scripts_json/csd5-2018.script_json
@@ -42,7 +42,7 @@
     },
     "new_name": null,
     "family_name": "csd5",
-    "serialized_at": "2022-03-11 12:07:36 UTC",
+    "serialized_at": "2022-03-22 21:16:21 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -2415,13 +2415,79 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csd-18/unit5/",
+      "key": "lesson_plans_4",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_4"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csd-18/unit5/standards/",
+      "key": "standard_mappings_4",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings_4"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csd5",
+      "key": "teacher_forum_4",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum_4"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csd-18/unit5/vocab",
+      "key": "vocabulary_4",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary_4"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_4",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings_4",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum_4",
+        "script.name": "csd5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary_4",
+        "script.name": "csd5-2018"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csd5-2019.script_json
+++ b/dashboard/config/scripts_json/csd5-2019.script_json
@@ -34,7 +34,7 @@
     },
     "new_name": null,
     "family_name": "csd5",
-    "serialized_at": "2022-03-11 12:07:51 UTC",
+    "serialized_at": "2022-03-22 21:16:21 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -2514,13 +2514,79 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csd-19/unit5/",
+      "key": "lesson_plans_4",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_4"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csd-19/unit5/standards/",
+      "key": "standard_mappings_4",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings_4"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csd",
+      "key": "teacher_forum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csd-19/unit5/vocab",
+      "key": "vocabulary_4",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary_4"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_4",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings_4",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum",
+        "script.name": "csd5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary_4",
+        "script.name": "csd5-2019"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csd5-2020.script_json
+++ b/dashboard/config/scripts_json/csd5-2020.script_json
@@ -11,29 +11,11 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "teacher_resources": [
-        [
-          "lessonPlans",
-          "https://curriculum.code.org/csd-20/unit5/"
-        ],
-        [
-          "teacherForum",
-          "https://forum.code.org/c/csd"
-        ],
-        [
-          "vocabulary",
-          "https://curriculum.code.org/csd-20/unit5/vocab"
-        ],
-        [
-          "standardMappings",
-          "https://curriculum.code.org/csd-20/unit5/standards/"
-        ]
-      ],
       "use_legacy_lesson_plans": true
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2022-03-11 12:07:56 UTC",
+    "serialized_at": "2022-03-22 21:16:22 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -2513,13 +2495,79 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csd-20/unit5/",
+      "key": "lesson_plans_4",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_4"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csd-20/unit5/standards/",
+      "key": "standard_mappings_3",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings_3"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csd",
+      "key": "teacher_forum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csd-20/unit5/vocab",
+      "key": "vocabulary_3",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary_3"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_4",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings_3",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum",
+        "script.name": "csd5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary_3",
+        "script.name": "csd5-2020"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csd6-2017.script_json
+++ b/dashboard/config/scripts_json/csd6-2017.script_json
@@ -42,7 +42,7 @@
     },
     "new_name": "csd6-2017",
     "family_name": "csd6",
-    "serialized_at": "2022-03-11 12:07:21 UTC",
+    "serialized_at": "2022-03-22 21:16:23 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -9009,13 +9009,96 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Code Introduced",
+      "url": "https://curriculum.code.org/csd/unit6/code/",
+      "key": "code_introduced_3",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "code_introduced_3"
+      }
+    },
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csd/unit6/",
+      "key": "lesson_plans_5",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_5"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csd/unit6/standards/",
+      "key": "standard_mappings_5",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings_5"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csd6",
+      "key": "teacher_forum_5",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum_5"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csd/unit6/vocab/",
+      "key": "vocabulary_5",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary_5"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "code_introduced_3",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_5",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings_5",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum_5",
+        "script.name": "csd6-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary_5",
+        "script.name": "csd6-2017"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csd6-2018.script_json
+++ b/dashboard/config/scripts_json/csd6-2018.script_json
@@ -55,7 +55,7 @@
     },
     "new_name": null,
     "family_name": "csd6",
-    "serialized_at": "2022-03-11 12:07:34 UTC",
+    "serialized_at": "2022-03-22 21:16:24 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -9410,13 +9410,96 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Code Introduced",
+      "url": "https://curriculum.code.org/csd-18/unit6/code/",
+      "key": "code_introduced_3",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "code_introduced_3"
+      }
+    },
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csd-18/unit6/",
+      "key": "lesson_plans_5",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_5"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csd-18/unit6/standards/",
+      "key": "standard_mappings_5",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings_5"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csd6",
+      "key": "teacher_forum_5",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum_5"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csd-18/unit6/vocab/",
+      "key": "vocabulary_5",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary_5"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "code_introduced_3",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_5",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings_5",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum_5",
+        "script.name": "csd6-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary_5",
+        "script.name": "csd6-2018"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csd6-2019.script_json
+++ b/dashboard/config/scripts_json/csd6-2019.script_json
@@ -47,7 +47,7 @@
     },
     "new_name": null,
     "family_name": "csd6",
-    "serialized_at": "2022-03-11 12:07:52 UTC",
+    "serialized_at": "2022-03-22 21:16:25 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -9414,13 +9414,96 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Code Introduced",
+      "url": "https://curriculum.code.org/csd-19/unit6/code/",
+      "key": "code_introduced_3",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "code_introduced_3"
+      }
+    },
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csd-19/unit6/",
+      "key": "lesson_plans_5",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_5"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csd-19/unit6/standards/",
+      "key": "standard_mappings_5",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings_5"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csd",
+      "key": "teacher_forum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csd-19/unit6/vocab/",
+      "key": "vocabulary_5",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary_5"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "code_introduced_3",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_5",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings_5",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum",
+        "script.name": "csd6-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary_5",
+        "script.name": "csd6-2019"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csd6-2020.script_json
+++ b/dashboard/config/scripts_json/csd6-2020.script_json
@@ -19,35 +19,13 @@
       ],
       "project_widget_visible": true,
       "student_detail_progress_view": true,
-      "teacher_resources": [
-        [
-          "lessonPlans",
-          "https://curriculum.code.org/csd-20/unit6/"
-        ],
-        [
-          "teacherForum",
-          "https://forum.code.org/c/csd"
-        ],
-        [
-          "vocabulary",
-          "https://curriculum.code.org/csd-20/unit6/vocab/"
-        ],
-        [
-          "standardMappings",
-          "https://curriculum.code.org/csd-20/unit6/standards/"
-        ],
-        [
-          "codeIntroduced",
-          "https://curriculum.code.org/csd-20/unit6/code/"
-        ]
-      ],
       "tts": true,
       "use_legacy_lesson_plans": true,
       "version_year": "2020"
     },
     "new_name": null,
     "family_name": "csd6",
-    "serialized_at": "2022-03-11 12:07:57 UTC",
+    "serialized_at": "2022-03-22 21:16:26 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -8513,13 +8491,96 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Code Introduced",
+      "url": "https://curriculum.code.org/csd-20/unit6/code/",
+      "key": "code_introduced_2",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "code_introduced_2"
+      }
+    },
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csd-20/unit6/",
+      "key": "lesson_plans_5",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_5"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csd-20/unit6/standards/",
+      "key": "standard_mappings_4",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings_4"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csd",
+      "key": "teacher_forum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csd-20/unit6/vocab/",
+      "key": "vocabulary_4",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary_4"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "code_introduced_2",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_5",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings_4",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum",
+        "script.name": "csd6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary_4",
+        "script.name": "csd6-2020"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csp-create-2017.script_json
+++ b/dashboard/config/scripts_json/csp-create-2017.script_json
@@ -10,26 +10,12 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "teacher_resources": [
-        [
-          "lessonPlans",
-          "https://curriculum.code.org/csp/csp-create/"
-        ],
-        [
-          "teacherForum",
-          "https://forum.code.org/c/csp/ap-prep"
-        ],
-        [
-          "standardMappings",
-          "https://curriculum.code.org/csp/csp-create/standards/"
-        ]
-      ],
       "use_legacy_lesson_plans": true,
       "version_year": "2017"
     },
     "new_name": "csp-create-2017",
     "family_name": "csp-create",
-    "serialized_at": "2022-03-11 12:07:29 UTC",
+    "serialized_at": "2022-03-22 21:16:26 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -479,13 +465,62 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csp/csp-create/",
+      "key": "lesson_plans",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csp/csp-create/standards/",
+      "key": "standard_mappings",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csp/ap-prep",
+      "key": "teacher_forum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans",
+        "script.name": "csp-create-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings",
+        "script.name": "csp-create-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum",
+        "script.name": "csp-create-2017"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csp-create-2018.script_json
+++ b/dashboard/config/scripts_json/csp-create-2018.script_json
@@ -26,26 +26,12 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "teacher_resources": [
-        [
-          "lessonPlans",
-          "https://curriculum.code.org/csp-18/csp-create/"
-        ],
-        [
-          "teacherForum",
-          "https://forum.code.org/c/csp/ap-prep"
-        ],
-        [
-          "standardMappings",
-          "https://curriculum.code.org/csp-18/csp-create/standards/"
-        ]
-      ],
       "use_legacy_lesson_plans": true,
       "version_year": "2018"
     },
     "new_name": null,
     "family_name": "csp-create",
-    "serialized_at": "2022-03-11 12:07:37 UTC",
+    "serialized_at": "2022-03-22 21:16:27 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -495,13 +481,62 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csp-18/csp-create/",
+      "key": "lesson_plans",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csp-18/csp-create/standards/",
+      "key": "standard_mappings",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csp/ap-prep",
+      "key": "teacher_forum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans",
+        "script.name": "csp-create-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings",
+        "script.name": "csp-create-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum",
+        "script.name": "csp-create-2018"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csp-create-2019.script_json
+++ b/dashboard/config/scripts_json/csp-create-2019.script_json
@@ -11,26 +11,12 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "teacher_resources": [
-        [
-          "lessonPlans",
-          "https://curriculum.code.org/csp-19/csp-create/"
-        ],
-        [
-          "teacherForum",
-          "https://forum.code.org/c/csp/ap-prep"
-        ],
-        [
-          "standardMappings",
-          "https://curriculum.code.org/csp-19/csp-create/standards/"
-        ]
-      ],
       "use_legacy_lesson_plans": true,
       "version_year": "2019"
     },
     "new_name": null,
     "family_name": "csp-create",
-    "serialized_at": "2022-03-11 12:07:54 UTC",
+    "serialized_at": "2022-03-22 21:16:27 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -513,13 +499,62 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csp-19/csp-create/",
+      "key": "lesson_plans",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csp-19/csp-create/standards/",
+      "key": "standard_mappings",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csp/ap-prep",
+      "key": "teacher_forum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans",
+        "script.name": "csp-create-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings",
+        "script.name": "csp-create-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum",
+        "script.name": "csp-create-2019"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csp-explore-2017.script_json
+++ b/dashboard/config/scripts_json/csp-explore-2017.script_json
@@ -10,26 +10,12 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "teacher_resources": [
-        [
-          "lessonPlans",
-          "https://curriculum.code.org/csp/csp-explore/"
-        ],
-        [
-          "teacherForum",
-          "https://forum.code.org/c/csp/ap-prep"
-        ],
-        [
-          "standardMappings",
-          "https://curriculum.code.org/csp/csp-explore/standards/"
-        ]
-      ],
       "use_legacy_lesson_plans": true,
       "version_year": "2017"
     },
     "new_name": "csp-explore-2017",
     "family_name": "csp-explore",
-    "serialized_at": "2022-03-11 12:07:39 UTC",
+    "serialized_at": "2022-03-22 21:16:27 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -479,13 +465,62 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csp/csp-explore/",
+      "key": "lesson_plans_1",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_1"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csp/csp-explore/standards/",
+      "key": "standard_mappings_1",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings_1"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csp/ap-prep",
+      "key": "teacher_forum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_1",
+        "script.name": "csp-explore-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings_1",
+        "script.name": "csp-explore-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum",
+        "script.name": "csp-explore-2017"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csp-explore-2018.script_json
+++ b/dashboard/config/scripts_json/csp-explore-2018.script_json
@@ -26,26 +26,12 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "teacher_resources": [
-        [
-          "lessonPlans",
-          "https://curriculum.code.org/csp-18/csp-explore/"
-        ],
-        [
-          "teacherForum",
-          "https://forum.code.org/c/csp/ap-prep"
-        ],
-        [
-          "standardMappings",
-          "https://curriculum.code.org/csp-18/csp-explore/standards/"
-        ]
-      ],
       "use_legacy_lesson_plans": true,
       "version_year": "2018"
     },
     "new_name": null,
     "family_name": "csp-explore",
-    "serialized_at": "2022-03-11 12:07:37 UTC",
+    "serialized_at": "2022-03-22 21:16:27 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -447,13 +433,62 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csp-18/csp-explore/",
+      "key": "lesson_plans_1",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_1"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csp-18/csp-explore/standards/",
+      "key": "standard_mappings_1",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings_1"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csp/ap-prep",
+      "key": "teacher_forum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_1",
+        "script.name": "csp-explore-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings_1",
+        "script.name": "csp-explore-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum",
+        "script.name": "csp-explore-2018"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csp-explore-2019.script_json
+++ b/dashboard/config/scripts_json/csp-explore-2019.script_json
@@ -11,26 +11,12 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "teacher_resources": [
-        [
-          "lessonPlans",
-          "https://curriculum.code.org/csp-19/csp-explore/"
-        ],
-        [
-          "teacherForum",
-          "https://forum.code.org/c/csp/ap-prep"
-        ],
-        [
-          "standardMappings",
-          "https://curriculum.code.org/csp-19/csp-explore/standards/"
-        ]
-      ],
       "use_legacy_lesson_plans": true,
       "version_year": "2019"
     },
     "new_name": null,
     "family_name": "csp-explore",
-    "serialized_at": "2022-03-11 12:07:54 UTC",
+    "serialized_at": "2022-03-22 21:16:27 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -465,13 +451,62 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csp-19/csp-explore/",
+      "key": "lesson_plans_1",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_1"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csp-19/csp-explore/standards/",
+      "key": "standard_mappings_1",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings_1"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csp/ap-prep",
+      "key": "teacher_forum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_1",
+        "script.name": "csp-explore-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings_1",
+        "script.name": "csp-explore-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum",
+        "script.name": "csp-explore-2019"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csp1-2017.script_json
+++ b/dashboard/config/scripts_json/csp1-2017.script_json
@@ -10,34 +10,12 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "teacher_resources": [
-        [
-          "lessonPlans",
-          "https://curriculum.code.org/csp/unit1/"
-        ],
-        [
-          "teacherForum",
-          "https://forum.code.org/c/csp1"
-        ],
-        [
-          "vocabulary",
-          "https://curriculum.code.org/csp/unit1/vocab/"
-        ],
-        [
-          "standardMappings",
-          "https://curriculum.code.org/csp/unit1/standards/"
-        ],
-        [
-          "professionalLearning",
-          "https://studio.code.org/s/csp1-support"
-        ]
-      ],
       "use_legacy_lesson_plans": true,
       "version_year": "2017"
     },
     "new_name": "csp1-2017",
     "family_name": "csp1",
-    "serialized_at": "2022-03-11 12:07:17 UTC",
+    "serialized_at": "2022-03-22 21:16:28 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -3274,7 +3252,7 @@
     },
     {
       "seeding_key": {
-        "level.key": "csp_socialBelonging_intervention",
+        "level.key": "csp_socialBelonging_control",
         "script_level.level_keys": [
           "csp_socialBelonging_control",
           "csp_socialBelonging_intervention"
@@ -3287,7 +3265,7 @@
     },
     {
       "seeding_key": {
-        "level.key": "csp_socialBelonging_control",
+        "level.key": "csp_socialBelonging_intervention",
         "script_level.level_keys": [
           "csp_socialBelonging_control",
           "csp_socialBelonging_intervention"
@@ -4200,7 +4178,7 @@
     },
     {
       "seeding_key": {
-        "level.key": "csp_affirmation_intervention",
+        "level.key": "csp_affirmation_control",
         "script_level.level_keys": [
           "csp_affirmation_control",
           "csp_affirmation_intervention"
@@ -4213,7 +4191,7 @@
     },
     {
       "seeding_key": {
-        "level.key": "csp_affirmation_control",
+        "level.key": "csp_affirmation_intervention",
         "script_level.level_keys": [
           "csp_affirmation_control",
           "csp_affirmation_intervention"
@@ -4262,13 +4240,96 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csp/unit1/",
+      "key": "lesson_plans_2",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_2"
+      }
+    },
+    {
+      "name": "Professional Learning",
+      "url": "https://studio.code.org/s/csp1-support",
+      "key": "professional_learning",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "professional_learning"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csp/unit1/standards/",
+      "key": "standard_mappings_2",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings_2"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csp1",
+      "key": "teacher_forum_1",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum_1"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csp/unit1/vocab/",
+      "key": "vocabulary",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "professional_learning",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings_2",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum_1",
+        "script.name": "csp1-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary",
+        "script.name": "csp1-2017"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csp1-2018.script_json
+++ b/dashboard/config/scripts_json/csp1-2018.script_json
@@ -19,34 +19,12 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "teacher_resources": [
-        [
-          "lessonPlans",
-          "https://curriculum.code.org/csp-18/unit1/"
-        ],
-        [
-          "teacherForum",
-          "https://forum.code.org/c/csp1"
-        ],
-        [
-          "vocabulary",
-          "https://curriculum.code.org/csp-18/unit1/vocab/"
-        ],
-        [
-          "standardMappings",
-          "https://curriculum.code.org/csp-18/unit1/standards/"
-        ],
-        [
-          "professionalLearning",
-          "https://studio.code.org/s/csp1-support"
-        ]
-      ],
       "use_legacy_lesson_plans": true,
       "version_year": "2018"
     },
     "new_name": null,
     "family_name": "csp1",
-    "serialized_at": "2022-03-11 12:07:36 UTC",
+    "serialized_at": "2022-03-22 21:16:28 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -4002,13 +3980,96 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csp-18/unit1/",
+      "key": "lesson_plans_2",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_2"
+      }
+    },
+    {
+      "name": "Professional Learning",
+      "url": "https://studio.code.org/s/csp1-support",
+      "key": "professional_learning",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "professional_learning"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csp-18/unit1/standards/",
+      "key": "standard_mappings_2",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings_2"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csp1",
+      "key": "teacher_forum_1",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum_1"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csp-18/unit1/vocab/",
+      "key": "vocabulary",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "professional_learning",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings_2",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum_1",
+        "script.name": "csp1-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary",
+        "script.name": "csp1-2018"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csp1-2019.script_json
+++ b/dashboard/config/scripts_json/csp1-2019.script_json
@@ -11,34 +11,12 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "teacher_resources": [
-        [
-          "lessonPlans",
-          "https://curriculum.code.org/csp-19/unit1/"
-        ],
-        [
-          "teacherForum",
-          "https://forum.code.org/c/csp1"
-        ],
-        [
-          "vocabulary",
-          "https://curriculum.code.org/csp-19/unit1/vocab/"
-        ],
-        [
-          "standardMappings",
-          "https://curriculum.code.org/csp-19/unit1/standards/"
-        ],
-        [
-          "professionalLearning",
-          "https://code.org/educate/professional-learning/middle-high"
-        ]
-      ],
       "use_legacy_lesson_plans": true,
       "version_year": "2019"
     },
     "new_name": null,
     "family_name": "csp1",
-    "serialized_at": "2022-03-11 12:07:52 UTC",
+    "serialized_at": "2022-03-22 21:16:29 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -3994,13 +3972,96 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csp-19/unit1/",
+      "key": "lesson_plans_2",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_2"
+      }
+    },
+    {
+      "name": "Professional Learning",
+      "url": "https://code.org/educate/professional-learning/middle-high",
+      "key": "professional_learning",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "professional_learning"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csp-19/unit1/standards/",
+      "key": "standard_mappings_2",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings_2"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csp1",
+      "key": "teacher_forum_1",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum_1"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csp-19/unit1/vocab/",
+      "key": "vocabulary",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "professional_learning",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings_2",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum_1",
+        "script.name": "csp1-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary",
+        "script.name": "csp1-2019"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csp1-2020.script_json
+++ b/dashboard/config/scripts_json/csp1-2020.script_json
@@ -33,21 +33,11 @@
       "hideable_lessons": true,
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "teacher_resources": [
-        [
-          "lessonPlans",
-          "https://curriculum.code.org/csp-20/unit1/"
-        ],
-        [
-          "standardMappings",
-          "https://curriculum.code.org/csp-20/unit1/standards/"
-        ]
-      ],
       "use_legacy_lesson_plans": true
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2022-03-11 12:08:07 UTC",
+    "serialized_at": "2022-03-22 21:16:29 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -3100,13 +3090,45 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csp-20/unit1/",
+      "key": "lesson_plans",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csp-20/unit1/standards/",
+      "key": "standard_mappings",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans",
+        "script.name": "csp1-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings",
+        "script.name": "csp1-2020"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csp10-2020.script_json
+++ b/dashboard/config/scripts_json/csp10-2020.script_json
@@ -41,21 +41,11 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "teacher_resources": [
-        [
-          "lessonPlans",
-          "https://curriculum.code.org/csp-20/unit10/"
-        ],
-        [
-          "standardMappings",
-          "https://curriculum.code.org/csp-20/unit10/standards/"
-        ]
-      ],
       "use_legacy_lesson_plans": true
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2022-03-11 12:08:08 UTC",
+    "serialized_at": "2022-03-22 21:16:29 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -1869,13 +1859,45 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csp-20/unit10/",
+      "key": "lesson_plans_1",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_1"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csp-20/unit10/standards/",
+      "key": "standard_mappings_1",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings_1"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_1",
+        "script.name": "csp10-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings_1",
+        "script.name": "csp10-2020"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csp2-2017.script_json
+++ b/dashboard/config/scripts_json/csp2-2017.script_json
@@ -10,34 +10,12 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "teacher_resources": [
-        [
-          "lessonPlans",
-          "https://curriculum.code.org/csp/unit2/"
-        ],
-        [
-          "teacherForum",
-          "https://forum.code.org/c/csp2"
-        ],
-        [
-          "vocabulary",
-          "https://curriculum.code.org/csp/unit2/vocab/"
-        ],
-        [
-          "standardMappings",
-          "https://curriculum.code.org/csp/unit2/standards/"
-        ],
-        [
-          "professionalLearning",
-          "https://studio.code.org/s/csp2-support"
-        ]
-      ],
       "use_legacy_lesson_plans": true,
       "version_year": "2017"
     },
     "new_name": "csp2-2017",
     "family_name": "csp2",
-    "serialized_at": "2022-03-11 12:07:17 UTC",
+    "serialized_at": "2022-03-22 21:16:29 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -3766,7 +3744,7 @@
     },
     {
       "seeding_key": {
-        "level.key": "csp_affirmation_intervention_2",
+        "level.key": "csp_affirmation_control_2",
         "script_level.level_keys": [
           "csp_affirmation_control_2",
           "csp_affirmation_intervention_2"
@@ -3779,7 +3757,7 @@
     },
     {
       "seeding_key": {
-        "level.key": "csp_affirmation_control_2",
+        "level.key": "csp_affirmation_intervention_2",
         "script_level.level_keys": [
           "csp_affirmation_control_2",
           "csp_affirmation_intervention_2"
@@ -3828,13 +3806,96 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csp/unit2/",
+      "key": "lesson_plans_3",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_3"
+      }
+    },
+    {
+      "name": "Professional Learning",
+      "url": "https://studio.code.org/s/csp2-support",
+      "key": "professional_learning_1",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "professional_learning_1"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csp/unit2/standards/",
+      "key": "standard_mappings_3",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings_3"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csp2",
+      "key": "teacher_forum_2",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum_2"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csp/unit2/vocab/",
+      "key": "vocabulary_1",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary_1"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_3",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "professional_learning_1",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings_3",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum_2",
+        "script.name": "csp2-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary_1",
+        "script.name": "csp2-2017"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csp2-2018.script_json
+++ b/dashboard/config/scripts_json/csp2-2018.script_json
@@ -19,34 +19,12 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "teacher_resources": [
-        [
-          "lessonPlans",
-          "https://curriculum.code.org/csp-18/unit2/"
-        ],
-        [
-          "teacherForum",
-          "https://forum.code.org/c/csp2"
-        ],
-        [
-          "vocabulary",
-          "https://curriculum.code.org/csp-18/unit2/vocab/"
-        ],
-        [
-          "standardMappings",
-          "https://curriculum.code.org/csp-18/unit2/standards/"
-        ],
-        [
-          "professionalLearning",
-          "https://studio.code.org/s/csp2-support"
-        ]
-      ],
       "use_legacy_lesson_plans": true,
       "version_year": "2018"
     },
     "new_name": null,
     "family_name": "csp2",
-    "serialized_at": "2022-03-11 12:07:37 UTC",
+    "serialized_at": "2022-03-22 21:16:30 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -1770,13 +1748,96 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csp-18/unit2/",
+      "key": "lesson_plans_3",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_3"
+      }
+    },
+    {
+      "name": "Professional Learning",
+      "url": "https://studio.code.org/s/csp2-support",
+      "key": "professional_learning_1",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "professional_learning_1"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csp-18/unit2/standards/",
+      "key": "standard_mappings_3",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings_3"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csp2",
+      "key": "teacher_forum_2",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum_2"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csp-18/unit2/vocab/",
+      "key": "vocabulary_1",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary_1"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_3",
+        "script.name": "csp2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "professional_learning_1",
+        "script.name": "csp2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings_3",
+        "script.name": "csp2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum_2",
+        "script.name": "csp2-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary_1",
+        "script.name": "csp2-2018"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csp2-2019.script_json
+++ b/dashboard/config/scripts_json/csp2-2019.script_json
@@ -11,34 +11,12 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "teacher_resources": [
-        [
-          "lessonPlans",
-          "https://curriculum.code.org/csp-19/unit2/"
-        ],
-        [
-          "teacherForum",
-          "https://forum.code.org/c/csp2"
-        ],
-        [
-          "vocabulary",
-          "https://curriculum.code.org/csp-19/unit2/vocab/"
-        ],
-        [
-          "standardMappings",
-          "https://curriculum.code.org/csp-19/unit2/standards/"
-        ],
-        [
-          "professionalLearning",
-          "https://code.org/educate/professional-learning/middle-high"
-        ]
-      ],
       "use_legacy_lesson_plans": true,
       "version_year": "2019"
     },
     "new_name": null,
     "family_name": "csp2",
-    "serialized_at": "2022-03-11 12:07:52 UTC",
+    "serialized_at": "2022-03-22 21:16:30 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -1884,13 +1862,96 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csp-19/unit2/",
+      "key": "lesson_plans_3",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_3"
+      }
+    },
+    {
+      "name": "Professional Learning",
+      "url": "https://code.org/educate/professional-learning/middle-high",
+      "key": "professional_learning",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "professional_learning"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csp-19/unit2/standards/",
+      "key": "standard_mappings_3",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings_3"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csp2",
+      "key": "teacher_forum_2",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum_2"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csp-19/unit2/vocab/",
+      "key": "vocabulary_1",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary_1"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_3",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "professional_learning",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings_3",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum_2",
+        "script.name": "csp2-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary_1",
+        "script.name": "csp2-2019"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csp2-2020.script_json
+++ b/dashboard/config/scripts_json/csp2-2020.script_json
@@ -34,21 +34,11 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "teacher_resources": [
-        [
-          "lessonPlans",
-          "https://curriculum.code.org/csp-20/unit2/"
-        ],
-        [
-          "standardMappings",
-          "https://curriculum.code.org/csp-20/unit2/standards/"
-        ]
-      ],
       "use_legacy_lesson_plans": true
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2022-03-11 12:08:07 UTC",
+    "serialized_at": "2022-03-22 21:16:30 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -1540,13 +1530,45 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csp-20/unit2/",
+      "key": "lesson_plans_2",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_2"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csp-20/unit2/standards/",
+      "key": "standard_mappings_2",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings_2"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_2",
+        "script.name": "csp2-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings_2",
+        "script.name": "csp2-2020"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csp3-2017.script_json
+++ b/dashboard/config/scripts_json/csp3-2017.script_json
@@ -10,39 +10,13 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "teacher_resources": [
-        [
-          "lessonPlans",
-          "https://curriculum.code.org/csp/unit3/"
-        ],
-        [
-          "teacherForum",
-          "https://forum.code.org/c/csp3"
-        ],
-        [
-          "vocabulary",
-          "https://curriculum.code.org/csp/unit3/vocab/"
-        ],
-        [
-          "codeIntroduced",
-          "https://curriculum.code.org/csp/unit3/code/"
-        ],
-        [
-          "standardMappings",
-          "https://curriculum.code.org/csp/unit3/standards/"
-        ],
-        [
-          "professionalLearning",
-          "https://studio.code.org/s/csp3-support"
-        ]
-      ],
       "tts": true,
       "use_legacy_lesson_plans": true,
       "version_year": "2017"
     },
     "new_name": "csp3-2017",
     "family_name": "csp3",
-    "serialized_at": "2022-03-11 12:07:17 UTC",
+    "serialized_at": "2022-03-22 21:16:30 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -4592,7 +4566,7 @@
     },
     {
       "seeding_key": {
-        "level.key": "csp_affirmation_control_3",
+        "level.key": "csp_affirmation_intervention_3",
         "script_level.level_keys": [
           "csp_affirmation_control_3",
           "csp_affirmation_intervention_3"
@@ -4605,7 +4579,7 @@
     },
     {
       "seeding_key": {
-        "level.key": "csp_affirmation_intervention_3",
+        "level.key": "csp_affirmation_control_3",
         "script_level.level_keys": [
           "csp_affirmation_control_3",
           "csp_affirmation_intervention_3"
@@ -4654,13 +4628,113 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Code Introduced",
+      "url": "https://curriculum.code.org/csp/unit3/code/",
+      "key": "code_introduced",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "code_introduced"
+      }
+    },
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csp/unit3/",
+      "key": "lesson_plans_4",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_4"
+      }
+    },
+    {
+      "name": "Professional Learning",
+      "url": "https://studio.code.org/s/csp3-support",
+      "key": "professional_learning_2",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "professional_learning_2"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csp/unit3/standards/",
+      "key": "standard_mappings_4",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings_4"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csp3",
+      "key": "teacher_forum_3",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum_3"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csp/unit3/vocab/",
+      "key": "vocabulary_2",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary_2"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "code_introduced",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_4",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "professional_learning_2",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings_4",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum_3",
+        "script.name": "csp3-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary_2",
+        "script.name": "csp3-2017"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csp3-2018.script_json
+++ b/dashboard/config/scripts_json/csp3-2018.script_json
@@ -26,39 +26,13 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "teacher_resources": [
-        [
-          "lessonPlans",
-          "https://curriculum.code.org/csp-18/unit3/"
-        ],
-        [
-          "teacherForum",
-          "https://forum.code.org/c/csp3"
-        ],
-        [
-          "vocabulary",
-          "https://curriculum.code.org/csp-18/unit3/vocab/"
-        ],
-        [
-          "codeIntroduced",
-          "https://curriculum.code.org/csp-18/unit3/code/"
-        ],
-        [
-          "standardMappings",
-          "https://curriculum.code.org/csp-18/unit3/standards/"
-        ],
-        [
-          "professionalLearning",
-          "https://studio.code.org/s/csp3-support"
-        ]
-      ],
       "tts": true,
       "use_legacy_lesson_plans": true,
       "version_year": "2018"
     },
     "new_name": null,
     "family_name": "csp3",
-    "serialized_at": "2022-03-11 12:07:37 UTC",
+    "serialized_at": "2022-03-22 21:16:31 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -4629,13 +4603,113 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Code Introduced",
+      "url": "https://curriculum.code.org/csp-18/unit3/code/",
+      "key": "code_introduced",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "code_introduced"
+      }
+    },
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csp-18/unit3/",
+      "key": "lesson_plans_4",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_4"
+      }
+    },
+    {
+      "name": "Professional Learning",
+      "url": "https://studio.code.org/s/csp3-support",
+      "key": "professional_learning_2",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "professional_learning_2"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csp-18/unit3/standards/",
+      "key": "standard_mappings_4",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings_4"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csp3",
+      "key": "teacher_forum_3",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum_3"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csp-18/unit3/vocab/",
+      "key": "vocabulary_2",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary_2"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "code_introduced",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_4",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "professional_learning_2",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings_4",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum_3",
+        "script.name": "csp3-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary_2",
+        "script.name": "csp3-2018"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csp3-2019.script_json
+++ b/dashboard/config/scripts_json/csp3-2019.script_json
@@ -11,39 +11,13 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "teacher_resources": [
-        [
-          "lessonPlans",
-          "https://curriculum.code.org/csp-19/unit3/"
-        ],
-        [
-          "teacherForum",
-          "https://forum.code.org/c/csp3"
-        ],
-        [
-          "vocabulary",
-          "https://curriculum.code.org/csp-19/unit3/vocab/"
-        ],
-        [
-          "codeIntroduced",
-          "https://curriculum.code.org/csp-19/unit3/code/"
-        ],
-        [
-          "standardMappings",
-          "https://curriculum.code.org/csp-19/unit3/standards/"
-        ],
-        [
-          "professionalLearning",
-          "https://code.org/educate/professional-learning/middle-high"
-        ]
-      ],
       "tts": true,
       "use_legacy_lesson_plans": true,
       "version_year": "2019"
     },
     "new_name": null,
     "family_name": "csp3",
-    "serialized_at": "2022-03-11 12:07:53 UTC",
+    "serialized_at": "2022-03-22 21:16:31 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -4570,13 +4544,113 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Code Introduced",
+      "url": "https://curriculum.code.org/csp-19/unit3/code/",
+      "key": "code_introduced",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "code_introduced"
+      }
+    },
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csp-19/unit3/",
+      "key": "lesson_plans_4",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_4"
+      }
+    },
+    {
+      "name": "Professional Learning",
+      "url": "https://code.org/educate/professional-learning/middle-high",
+      "key": "professional_learning",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "professional_learning"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csp-19/unit3/standards/",
+      "key": "standard_mappings_4",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings_4"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csp3",
+      "key": "teacher_forum_3",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum_3"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csp-19/unit3/vocab/",
+      "key": "vocabulary_2",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary_2"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "code_introduced",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_4",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "professional_learning",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings_4",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum_3",
+        "script.name": "csp3-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary_2",
+        "script.name": "csp3-2019"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csp3-2020.script_json
+++ b/dashboard/config/scripts_json/csp3-2020.script_json
@@ -41,21 +41,11 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "teacher_resources": [
-        [
-          "lessonPlans",
-          "https://curriculum.code.org/csp-20/unit3/"
-        ],
-        [
-          "standardMappings",
-          "https://curriculum.code.org/csp-20/unit3/standards/"
-        ]
-      ],
       "use_legacy_lesson_plans": true
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2022-03-11 12:08:07 UTC",
+    "serialized_at": "2022-03-22 21:16:32 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -2740,13 +2730,45 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csp-20/unit3/",
+      "key": "lesson_plans_3",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_3"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csp-20/unit3/standards/",
+      "key": "standard_mappings_3",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings_3"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_3",
+        "script.name": "csp3-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings_3",
+        "script.name": "csp3-2020"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csp3-research-mxghyt.script_json
+++ b/dashboard/config/scripts_json/csp3-research-mxghyt.script_json
@@ -16,37 +16,11 @@
       "hideable_lessons": true,
       "is_migrated": true,
       "student_detail_progress_view": true,
-      "teacher_resources": [
-        [
-          "lessonPlans",
-          "https://curriculum.code.org/csp/unit3/"
-        ],
-        [
-          "teacherForum",
-          "https://forum.code.org/c/csp3"
-        ],
-        [
-          "vocabulary",
-          "https://curriculum.code.org/csp/unit3/vocab/"
-        ],
-        [
-          "codeIntroduced",
-          "https://curriculum.code.org/csp/unit3/code/"
-        ],
-        [
-          "standardMappings",
-          "https://curriculum.code.org/csp/unit3/standards/"
-        ],
-        [
-          "professionalLearning",
-          "https://studio.code.org/s/csp3-support"
-        ]
-      ],
       "use_legacy_lesson_plans": true
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2022-03-11 12:07:29 UTC",
+    "serialized_at": "2022-03-22 21:16:32 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -4705,7 +4679,7 @@
     },
     {
       "seeding_key": {
-        "level.key": "csp_affirmation_intervention_3",
+        "level.key": "csp_affirmation_control_3",
         "script_level.level_keys": [
           "csp_affirmation_control_3",
           "csp_affirmation_intervention_3"
@@ -4718,7 +4692,7 @@
     },
     {
       "seeding_key": {
-        "level.key": "csp_affirmation_control_3",
+        "level.key": "csp_affirmation_intervention_3",
         "script_level.level_keys": [
           "csp_affirmation_control_3",
           "csp_affirmation_intervention_3"
@@ -4755,13 +4729,113 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Code Introduced",
+      "url": "https://curriculum.code.org/csp/unit3/code/",
+      "key": "code_introduced",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "code_introduced"
+      }
+    },
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csp/unit3/",
+      "key": "lesson_plans_4",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_4"
+      }
+    },
+    {
+      "name": "Professional Learning",
+      "url": "https://studio.code.org/s/csp3-support",
+      "key": "professional_learning_2",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "professional_learning_2"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csp/unit3/standards/",
+      "key": "standard_mappings_4",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings_4"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csp3",
+      "key": "teacher_forum_3",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum_3"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csp/unit3/vocab/",
+      "key": "vocabulary_2",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary_2"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "code_introduced",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_4",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "professional_learning_2",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings_4",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum_3",
+        "script.name": "csp3-research-mxghyt"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary_2",
+        "script.name": "csp3-research-mxghyt"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csp4-2017.script_json
+++ b/dashboard/config/scripts_json/csp4-2017.script_json
@@ -10,34 +10,12 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "teacher_resources": [
-        [
-          "lessonPlans",
-          "https://curriculum.code.org/csp/unit4/"
-        ],
-        [
-          "teacherForum",
-          "https://forum.code.org/c/csp4"
-        ],
-        [
-          "vocabulary",
-          "https://curriculum.code.org/csp/unit4/vocab/"
-        ],
-        [
-          "standardMappings",
-          "https://curriculum.code.org/csp/unit4/standards/"
-        ],
-        [
-          "professionalLearning",
-          "https://studio.code.org/s/csp4-support"
-        ]
-      ],
       "use_legacy_lesson_plans": true,
       "version_year": "2017"
     },
     "new_name": "csp4-2017",
     "family_name": "csp4",
-    "serialized_at": "2022-03-11 12:07:17 UTC",
+    "serialized_at": "2022-03-22 21:16:32 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -2931,7 +2909,7 @@
     },
     {
       "seeding_key": {
-        "level.key": "csp_affirmation_intervention_4",
+        "level.key": "csp_affirmation_control_4",
         "script_level.level_keys": [
           "csp_affirmation_control_4",
           "csp_affirmation_intervention_4"
@@ -2944,7 +2922,7 @@
     },
     {
       "seeding_key": {
-        "level.key": "csp_affirmation_control_4",
+        "level.key": "csp_affirmation_intervention_4",
         "script_level.level_keys": [
           "csp_affirmation_control_4",
           "csp_affirmation_intervention_4"
@@ -2993,13 +2971,96 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csp/unit4/",
+      "key": "lesson_plans_5",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_5"
+      }
+    },
+    {
+      "name": "Professional Learning",
+      "url": "https://studio.code.org/s/csp4-support",
+      "key": "professional_learning_3",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "professional_learning_3"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csp/unit4/standards/",
+      "key": "standard_mappings_5",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings_5"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csp4",
+      "key": "teacher_forum_4",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum_4"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csp/unit4/vocab/",
+      "key": "vocabulary_3",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary_3"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_5",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "professional_learning_3",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings_5",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum_4",
+        "script.name": "csp4-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary_3",
+        "script.name": "csp4-2017"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csp4-2018.script_json
+++ b/dashboard/config/scripts_json/csp4-2018.script_json
@@ -26,34 +26,12 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "teacher_resources": [
-        [
-          "lessonPlans",
-          "https://curriculum.code.org/csp-18/unit4/"
-        ],
-        [
-          "teacherForum",
-          "https://forum.code.org/c/csp4"
-        ],
-        [
-          "vocabulary",
-          "https://curriculum.code.org/csp-18/unit4/vocab/"
-        ],
-        [
-          "standardMappings",
-          "https://curriculum.code.org/csp-18/unit4/standards/"
-        ],
-        [
-          "professionalLearning",
-          "https://studio.code.org/s/csp4-support"
-        ]
-      ],
       "use_legacy_lesson_plans": true,
       "version_year": "2018"
     },
     "new_name": null,
     "family_name": "csp4",
-    "serialized_at": "2022-03-11 12:07:37 UTC",
+    "serialized_at": "2022-03-22 21:16:33 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -3190,13 +3168,96 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csp-18/unit4/",
+      "key": "lesson_plans_5",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_5"
+      }
+    },
+    {
+      "name": "Professional Learning",
+      "url": "https://studio.code.org/s/csp4-support",
+      "key": "professional_learning_3",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "professional_learning_3"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csp-18/unit4/standards/",
+      "key": "standard_mappings_5",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings_5"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csp4",
+      "key": "teacher_forum_4",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum_4"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csp-18/unit4/vocab/",
+      "key": "vocabulary_3",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary_3"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_5",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "professional_learning_3",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings_5",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum_4",
+        "script.name": "csp4-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary_3",
+        "script.name": "csp4-2018"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csp4-2019.script_json
+++ b/dashboard/config/scripts_json/csp4-2019.script_json
@@ -11,34 +11,12 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "teacher_resources": [
-        [
-          "lessonPlans",
-          "https://curriculum.code.org/csp-19/unit4/"
-        ],
-        [
-          "teacherForum",
-          "https://forum.code.org/c/csp4"
-        ],
-        [
-          "vocabulary",
-          "https://curriculum.code.org/csp-19/unit4/vocab/"
-        ],
-        [
-          "standardMappings",
-          "https://curriculum.code.org/csp-19/unit4/standards/"
-        ],
-        [
-          "professionalLearning",
-          "https://code.org/educate/professional-learning/middle-high"
-        ]
-      ],
       "use_legacy_lesson_plans": true,
       "version_year": "2019"
     },
     "new_name": null,
     "family_name": "csp4",
-    "serialized_at": "2022-03-11 12:07:53 UTC",
+    "serialized_at": "2022-03-22 21:16:33 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -3342,13 +3320,96 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csp-19/unit4/",
+      "key": "lesson_plans_5",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_5"
+      }
+    },
+    {
+      "name": "Professional Learning",
+      "url": "https://code.org/educate/professional-learning/middle-high",
+      "key": "professional_learning",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "professional_learning"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csp-19/unit4/standards/",
+      "key": "standard_mappings_5",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings_5"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csp4",
+      "key": "teacher_forum_4",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum_4"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csp-19/unit4/vocab/",
+      "key": "vocabulary_3",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary_3"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_5",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "professional_learning",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings_5",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum_4",
+        "script.name": "csp4-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary_3",
+        "script.name": "csp4-2019"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csp4-2020.script_json
+++ b/dashboard/config/scripts_json/csp4-2020.script_json
@@ -41,21 +41,11 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "teacher_resources": [
-        [
-          "lessonPlans",
-          "https://curriculum.code.org/csp-20/unit4/"
-        ],
-        [
-          "standardMappings",
-          "https://curriculum.code.org/csp-20/unit4/standards/"
-        ]
-      ],
       "use_legacy_lesson_plans": true
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2022-03-11 12:07:55 UTC",
+    "serialized_at": "2022-03-22 21:16:33 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -4676,13 +4666,45 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csp-20/unit4/",
+      "key": "lesson_plans_4",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_4"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csp-20/unit4/standards/",
+      "key": "standard_mappings_4",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings_4"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_4",
+        "script.name": "csp4-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings_4",
+        "script.name": "csp4-2020"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csp5-2017.script_json
+++ b/dashboard/config/scripts_json/csp5-2017.script_json
@@ -10,39 +10,13 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "teacher_resources": [
-        [
-          "lessonPlans",
-          "https://curriculum.code.org/csp/unit5"
-        ],
-        [
-          "teacherForum",
-          "https://forum.code.org/c/csp5"
-        ],
-        [
-          "vocabulary",
-          "https://curriculum.code.org/csp/unit5/vocab/"
-        ],
-        [
-          "codeIntroduced",
-          "https://curriculum.code.org/csp/unit5/code/"
-        ],
-        [
-          "standardMappings",
-          "https://curriculum.code.org/csp/unit5/standards/"
-        ],
-        [
-          "professionalLearning",
-          "https://studio.code.org/s/csp5-support"
-        ]
-      ],
       "tts": true,
       "use_legacy_lesson_plans": true,
       "version_year": "2017"
     },
     "new_name": "csp5-2017",
     "family_name": "csp5",
-    "serialized_at": "2022-03-11 12:07:18 UTC",
+    "serialized_at": "2022-03-22 21:16:34 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -11046,7 +11020,7 @@
     },
     {
       "seeding_key": {
-        "level.key": "csp_affirmation_intervention_5",
+        "level.key": "csp_affirmation_control_5",
         "script_level.level_keys": [
           "csp_affirmation_control_5",
           "csp_affirmation_intervention_5"
@@ -11059,7 +11033,7 @@
     },
     {
       "seeding_key": {
-        "level.key": "csp_affirmation_control_5",
+        "level.key": "csp_affirmation_intervention_5",
         "script_level.level_keys": [
           "csp_affirmation_control_5",
           "csp_affirmation_intervention_5"
@@ -12044,7 +12018,7 @@
     },
     {
       "seeding_key": {
-        "level.key": "csp_affirmation_intervention_5",
+        "level.key": "csp_affirmation_control_5",
         "script_level.level_keys": [
           "csp_affirmation_control_5",
           "csp_affirmation_intervention_5"
@@ -12057,7 +12031,7 @@
     },
     {
       "seeding_key": {
-        "level.key": "csp_affirmation_control_5",
+        "level.key": "csp_affirmation_intervention_5",
         "script_level.level_keys": [
           "csp_affirmation_control_5",
           "csp_affirmation_intervention_5"
@@ -13594,13 +13568,113 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Code Introduced",
+      "url": "https://curriculum.code.org/csp/unit5/code/",
+      "key": "code_introduced_1",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "code_introduced_1"
+      }
+    },
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csp/unit5",
+      "key": "lesson_plans_6",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_6"
+      }
+    },
+    {
+      "name": "Professional Learning",
+      "url": "https://studio.code.org/s/csp5-support",
+      "key": "professional_learning_4",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "professional_learning_4"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csp/unit5/standards/",
+      "key": "standard_mappings_6",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings_6"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csp5",
+      "key": "teacher_forum_5",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum_5"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csp/unit5/vocab/",
+      "key": "vocabulary_4",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary_4"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "code_introduced_1",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_6",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "professional_learning_4",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings_6",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum_5",
+        "script.name": "csp5-2017"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary_4",
+        "script.name": "csp5-2017"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csp5-2018.script_json
+++ b/dashboard/config/scripts_json/csp5-2018.script_json
@@ -26,39 +26,13 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "teacher_resources": [
-        [
-          "lessonPlans",
-          "https://curriculum.code.org/csp-18/unit5"
-        ],
-        [
-          "teacherForum",
-          "https://forum.code.org/c/csp5"
-        ],
-        [
-          "vocabulary",
-          "https://curriculum.code.org/csp-18/unit5/vocab/"
-        ],
-        [
-          "codeIntroduced",
-          "https://curriculum.code.org/csp-18/unit5/code/"
-        ],
-        [
-          "standardMappings",
-          "https://curriculum.code.org/csp-18/unit5/standards/"
-        ],
-        [
-          "professionalLearning",
-          "https://studio.code.org/s/csp5-support"
-        ]
-      ],
       "tts": true,
       "use_legacy_lesson_plans": true,
       "version_year": "2018"
     },
     "new_name": null,
     "family_name": "csp5",
-    "serialized_at": "2022-03-11 12:07:38 UTC",
+    "serialized_at": "2022-03-22 21:16:36 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -13297,13 +13271,113 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Code Introduced",
+      "url": "https://curriculum.code.org/csp-18/unit5/code/",
+      "key": "code_introduced_1",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "code_introduced_1"
+      }
+    },
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csp-18/unit5",
+      "key": "lesson_plans_6",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_6"
+      }
+    },
+    {
+      "name": "Professional Learning",
+      "url": "https://studio.code.org/s/csp5-support",
+      "key": "professional_learning_4",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "professional_learning_4"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csp-18/unit5/standards/",
+      "key": "standard_mappings_6",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings_6"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csp5",
+      "key": "teacher_forum_5",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum_5"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csp-18/unit5/vocab/",
+      "key": "vocabulary_4",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary_4"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "code_introduced_1",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_6",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "professional_learning_4",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings_6",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum_5",
+        "script.name": "csp5-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary_4",
+        "script.name": "csp5-2018"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csp5-2019.script_json
+++ b/dashboard/config/scripts_json/csp5-2019.script_json
@@ -11,39 +11,13 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "teacher_resources": [
-        [
-          "lessonPlans",
-          "https://curriculum.code.org/csp-19/unit5"
-        ],
-        [
-          "teacherForum",
-          "https://forum.code.org/c/csp5"
-        ],
-        [
-          "vocabulary",
-          "https://curriculum.code.org/csp-19/unit5/vocab/"
-        ],
-        [
-          "codeIntroduced",
-          "https://curriculum.code.org/csp-19/unit5/code/"
-        ],
-        [
-          "standardMappings",
-          "https://curriculum.code.org/csp-19/unit5/standards/"
-        ],
-        [
-          "professionalLearning",
-          "https://code.org/educate/professional-learning/middle-high"
-        ]
-      ],
       "tts": true,
       "use_legacy_lesson_plans": true,
       "version_year": "2019"
     },
     "new_name": null,
     "family_name": "csp5",
-    "serialized_at": "2022-03-11 12:07:53 UTC",
+    "serialized_at": "2022-03-22 21:16:38 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -13315,13 +13289,113 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Code Introduced",
+      "url": "https://curriculum.code.org/csp-19/unit5/code/",
+      "key": "code_introduced_1",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "code_introduced_1"
+      }
+    },
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csp-19/unit5",
+      "key": "lesson_plans_6",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_6"
+      }
+    },
+    {
+      "name": "Professional Learning",
+      "url": "https://code.org/educate/professional-learning/middle-high",
+      "key": "professional_learning",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "professional_learning"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csp-19/unit5/standards/",
+      "key": "standard_mappings_6",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings_6"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csp5",
+      "key": "teacher_forum_5",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum_5"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csp-19/unit5/vocab/",
+      "key": "vocabulary_4",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary_4"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "code_introduced_1",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_6",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "professional_learning",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings_6",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum_5",
+        "script.name": "csp5-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary_4",
+        "script.name": "csp5-2019"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csp5-2020.script_json
+++ b/dashboard/config/scripts_json/csp5-2020.script_json
@@ -34,21 +34,11 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "teacher_resources": [
-        [
-          "lessonPlans",
-          "https://curriculum.code.org/csp-20/unit5/"
-        ],
-        [
-          "standardMappings",
-          "https://curriculum.code.org/csp-20/unit5/standards/"
-        ]
-      ],
       "use_legacy_lesson_plans": true
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2022-03-11 12:07:55 UTC",
+    "serialized_at": "2022-03-22 21:16:39 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -4486,13 +4476,45 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csp-20/unit5/",
+      "key": "lesson_plans_5",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_5"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csp-20/unit5/standards/",
+      "key": "standard_mappings_5",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings_5"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_5",
+        "script.name": "csp5-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings_5",
+        "script.name": "csp5-2020"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csp6-2020.script_json
+++ b/dashboard/config/scripts_json/csp6-2020.script_json
@@ -34,21 +34,11 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "teacher_resources": [
-        [
-          "lessonPlans",
-          "https://curriculum.code.org/csp-20/unit6/"
-        ],
-        [
-          "standardMappings",
-          "https://curriculum.code.org/csp-20/unit6/standards/"
-        ]
-      ],
       "use_legacy_lesson_plans": true
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2022-03-11 12:08:07 UTC",
+    "serialized_at": "2022-03-22 21:16:39 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -1261,13 +1251,45 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csp-20/unit6/",
+      "key": "lesson_plans_6",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_6"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csp-20/unit6/standards/",
+      "key": "standard_mappings_6",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings_6"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_6",
+        "script.name": "csp6-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings_6",
+        "script.name": "csp6-2020"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csp7-2020.script_json
+++ b/dashboard/config/scripts_json/csp7-2020.script_json
@@ -34,21 +34,11 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "teacher_resources": [
-        [
-          "lessonPlans",
-          "https://curriculum.code.org/csp-20/unit7/"
-        ],
-        [
-          "standardMappings",
-          "https://curriculum.code.org/csp-20/unit7/standards/"
-        ]
-      ],
       "use_legacy_lesson_plans": true
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2022-03-11 12:07:56 UTC",
+    "serialized_at": "2022-03-22 21:16:39 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -2371,13 +2361,45 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csp-20/unit7/",
+      "key": "lesson_plans_7",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_7"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csp-20/unit7/standards/",
+      "key": "standard_mappings_7",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings_7"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_7",
+        "script.name": "csp7-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings_7",
+        "script.name": "csp7-2020"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csp8-2020.script_json
+++ b/dashboard/config/scripts_json/csp8-2020.script_json
@@ -20,21 +20,11 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "teacher_resources": [
-        [
-          "lessonPlans",
-          "https://curriculum.code.org/csp-20/unit8"
-        ],
-        [
-          "standardMappings",
-          "https://curriculum.code.org/csp-20/unit8/standards/"
-        ]
-      ],
       "use_legacy_lesson_plans": true
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2022-03-11 12:08:07 UTC",
+    "serialized_at": "2022-03-22 21:16:40 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -394,13 +384,45 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csp-20/unit8",
+      "key": "lesson_plans_8",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_8"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csp-20/unit8/standards/",
+      "key": "standard_mappings_8",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings_8"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_8",
+        "script.name": "csp8-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings_8",
+        "script.name": "csp8-2020"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/csp9-2020.script_json
+++ b/dashboard/config/scripts_json/csp9-2020.script_json
@@ -41,21 +41,11 @@
       "is_migrated": true,
       "project_sharing": true,
       "student_detail_progress_view": true,
-      "teacher_resources": [
-        [
-          "lessonPlans",
-          "https://curriculum.code.org/csp-20/unit9/"
-        ],
-        [
-          "standardMappings",
-          "https://curriculum.code.org/csp-20/unit9/standards/"
-        ]
-      ],
       "use_legacy_lesson_plans": true
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2022-03-11 12:08:08 UTC",
+    "serialized_at": "2022-03-22 21:16:40 UTC",
     "published_state": null,
     "instruction_type": null,
     "instructor_audience": null,
@@ -1813,13 +1803,45 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csp-20/unit9/",
+      "key": "lesson_plans_9",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans_9"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csp-20/unit9/standards/",
+      "key": "standard_mappings_9",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings_9"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans_9",
+        "script.name": "csp9-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings_9",
+        "script.name": "csp9-2020"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/express-2018.script_json
+++ b/dashboard/config/scripts_json/express-2018.script_json
@@ -51,7 +51,7 @@
     },
     "new_name": null,
     "family_name": "express",
-    "serialized_at": "2022-03-11 12:07:31 UTC",
+    "serialized_at": "2022-03-22 21:16:41 UTC",
     "published_state": "stable",
     "instruction_type": "teacher_led",
     "instructor_audience": "teacher",
@@ -14562,13 +14562,79 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csf-18/express/",
+      "key": "lesson_plans",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csf-18/express/standards/",
+      "key": "standard_mappings",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csf",
+      "key": "teacher_forum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csf-18/express/vocab/",
+      "key": "vocabulary",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum",
+        "script.name": "express-2018"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary",
+        "script.name": "express-2018"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/express-2019.script_json
+++ b/dashboard/config/scripts_json/express-2019.script_json
@@ -68,7 +68,7 @@
     },
     "new_name": null,
     "family_name": "express",
-    "serialized_at": "2022-03-11 12:07:45 UTC",
+    "serialized_at": "2022-03-22 21:16:43 UTC",
     "published_state": "stable",
     "instruction_type": "teacher_led",
     "instructor_audience": "teacher",
@@ -13099,13 +13099,79 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csf-19/express/",
+      "key": "lesson_plans",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csf-19/express/standards/",
+      "key": "standard_mappings",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csf",
+      "key": "teacher_forum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csf-19/express/vocab/",
+      "key": "vocabulary",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum",
+        "script.name": "express-2019"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary",
+        "script.name": "express-2019"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/express-2020.script_json
+++ b/dashboard/config/scripts_json/express-2020.script_json
@@ -39,7 +39,7 @@
     },
     "new_name": null,
     "family_name": "express",
-    "serialized_at": "2022-03-11 12:08:05 UTC",
+    "serialized_at": "2022-03-22 21:16:45 UTC",
     "published_state": "stable",
     "instruction_type": "teacher_led",
     "instructor_audience": "teacher",
@@ -13214,13 +13214,79 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csf-20/express/",
+      "key": "lesson_plans",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csf-20/express/standards/",
+      "key": "standard_mappings",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csf",
+      "key": "teacher_forum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csf-20/express/vocab/",
+      "key": "vocabulary",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum",
+        "script.name": "express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary",
+        "script.name": "express-2020"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/pre-express-2020.script_json
+++ b/dashboard/config/scripts_json/pre-express-2020.script_json
@@ -39,7 +39,7 @@
     },
     "new_name": null,
     "family_name": "pre-express",
-    "serialized_at": "2022-03-11 12:08:07 UTC",
+    "serialized_at": "2022-03-22 21:16:46 UTC",
     "published_state": "stable",
     "instruction_type": "teacher_led",
     "instructor_audience": "teacher",
@@ -5382,13 +5382,79 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csf-20/express/",
+      "key": "lesson_plans",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans"
+      }
+    },
+    {
+      "name": "Standard Mappings",
+      "url": "https://curriculum.code.org/csf-20/express/standards",
+      "key": "standard_mappings",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "standard_mappings"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/c/csf",
+      "key": "teacher_forum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum"
+      }
+    },
+    {
+      "name": "Vocabulary",
+      "url": "https://curriculum.code.org/csf-20/express/vocab/",
+      "key": "vocabulary",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "vocabulary"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "standard_mappings",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum",
+        "script.name": "pre-express-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "vocabulary",
+        "script.name": "pre-express-2020"
+      }
+    }
   ],
   "scripts_student_resources": [
 

--- a/dashboard/config/scripts_json/vpl-csd-2020.script_json
+++ b/dashboard/config/scripts_json/vpl-csd-2020.script_json
@@ -9,29 +9,11 @@
       "is_migrated": true,
       "pilot_experiment": "20-21-virtual-AYW-CSD",
       "student_detail_progress_view": true,
-      "teacher_resources": [
-        [
-          "lessonPlans",
-          "https://curriculum.code.org/csd-20/"
-        ],
-        [
-          "teacherForum",
-          "https://forum.code.org/"
-        ],
-        [
-          "curriculumGuide",
-          "https://docs.google.com/document/d/1-O6o5yQ4I1dk0n4Qzh86quXGBtzDDtyJ3Skr6RpcpO4/preview"
-        ],
-        [
-          "professionalLearning",
-          "/link/to/professional/learning"
-        ]
-      ],
       "version_year": "2020"
     },
     "new_name": null,
     "family_name": "vpl-csd",
-    "serialized_at": "2021-11-22 19:57:19 UTC",
+    "serialized_at": "2022-03-22 21:16:46 UTC",
     "published_state": "pilot",
     "instruction_type": "teacher_led",
     "instructor_audience": "teacher",
@@ -5475,13 +5457,79 @@
     }
   ],
   "resources": [
-
+    {
+      "name": "Curriculum Guide",
+      "url": "https://docs.google.com/document/d/1-O6o5yQ4I1dk0n4Qzh86quXGBtzDDtyJ3Skr6RpcpO4/preview",
+      "key": "curriculum_guide",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "curriculum_guide"
+      }
+    },
+    {
+      "name": "Lesson Plans",
+      "url": "https://curriculum.code.org/csd-20/",
+      "key": "lesson_plans",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "lesson_plans"
+      }
+    },
+    {
+      "name": "Professional Learning",
+      "url": "/link/to/professional/learning",
+      "key": "professional_learning",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "professional_learning"
+      }
+    },
+    {
+      "name": "Teacher Forum",
+      "url": "https://forum.code.org/",
+      "key": "teacher_forum",
+      "properties": {
+        "audience": "Teacher"
+      },
+      "seeding_key": {
+        "resource.key": "teacher_forum"
+      }
+    }
   ],
   "lessons_resources": [
 
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "curriculum_guide",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "lesson_plans",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "professional_learning",
+        "script.name": "vpl-csd-2020"
+      }
+    },
+    {
+      "seeding_key": {
+        "resource.key": "teacher_forum",
+        "script.name": "vpl-csd-2020"
+      }
+    }
   ],
   "scripts_student_resources": [
 


### PR DESCRIPTION
In the rush to get all scripts migrated, I forgot to go back and finish migrating teacher resources onto the new system for showing teacher resources. This PR does the next step in that process, which is important to do now since the next step is to wait (long lead time) for translations to happen on the migrated resources. 

This work is step 1 in the work plan at [migrating teacher resources](https://docs.google.com/document/d/1yIL2Z7aqFTdbCi24-RpUhPO_B3wRdsiKRTB1EEs17EY/edit#) . This document never went through formal review process, so please feel free to question + comment there.


## screenshots

### untranslated courses

legacy teacher resources have been removed, and migrated teacher resources are displayed:

#### unit overview page

![Screen Shot 2022-03-22 at 2 25 34 PM](https://user-images.githubusercontent.com/8001765/159579411-c5ccc20a-ac88-4379-a5cf-5c54eac6dad5.png)

#### unit edit page

![Screen Shot 2022-03-22 at 2 38 45 PM](https://user-images.githubusercontent.com/8001765/159580647-3471331d-a0cf-46d9-9119-92b55fc59143.png)


### translated courses

migrated teacher resources exist, but legacy teacher resources are still being displayed while the migrated ones are being translated:

#### unit overview page

![Screen Shot 2022-03-22 at 2 27 09 PM](https://user-images.githubusercontent.com/8001765/159579427-32c9c768-7688-4ba8-b195-925e13f18435.png)

#### unit edit page

![Screen Shot 2022-03-22 at 2 38 12 PM](https://user-images.githubusercontent.com/8001765/159580566-ba50e9a2-cb9f-472a-91fc-1aefc4feb7c0.png)

# Testing story

* https://github.com/code-dot-org/code-dot-org/blob/39b60bb4d182ebabef59cb456a234ecba6904780/apps/test/unit/code-studio/components/progress/UnitOverviewTopRowTest.jsx#L221
* manual verification shown in screenshots

