### PR TITLE
Update user_storage_ids migration to handle error "table already exists"

### DIFF
--- a/pegasus/migrations/137_rename_user_storage_ids.rb
+++ b/pegasus/migrations/137_rename_user_storage_ids.rb
@@ -3,7 +3,7 @@ Sequel.migration do
     pegasus_user_storage_ids = "#{CDO.pegasus_db_name}__user_storage_ids".to_sym
     dashboard_user_project_storage_ids = "#{CDO.dashboard_db_name}__user_project_storage_ids".to_sym
 
-    unless [:production].include?(rack_env) || ENV['CI']
+    unless [:production].include?(rack_env)
 
       begin
         # Rename the table to move it from the Pegasus schema to Dashboard

--- a/pegasus/migrations/137_rename_user_storage_ids.rb
+++ b/pegasus/migrations/137_rename_user_storage_ids.rb
@@ -29,14 +29,6 @@ Sequel.migration do
         end
       end
     end
-
-    # In Drone CI, the table will be created from from schema.rb file. After that, this migration
-    # will get run, we can't do a table rename at that point because user_project_storage_ids will already
-    # exist. So we just need to drop the old table and create the view for consistency between envs.
-    if ENV['CI']
-      drop_table(pegasus_user_storage_ids)
-      create_view(pegasus_user_storage_ids, DB[dashboard_user_project_storage_ids].select_all)
-    end
   end
 
   down do

--- a/pegasus/migrations/137_rename_user_storage_ids.rb
+++ b/pegasus/migrations/137_rename_user_storage_ids.rb
@@ -5,14 +5,29 @@ Sequel.migration do
 
     unless [:production].include?(rack_env) || ENV['CI']
 
-      # Rename the table to move it from the Pegasus schema to Dashboard
-      # Also change the name from user_storage_ids to user_project_storage_ids
-      rename_table(pegasus_user_storage_ids, dashboard_user_project_storage_ids)
+      begin
+        # Rename the table to move it from the Pegasus schema to Dashboard
+        # Also change the name from user_storage_ids to user_project_storage_ids
+        rename_table(pegasus_user_storage_ids, dashboard_user_project_storage_ids)
 
-      # This view exists as a safe-guard during the time between when the table rename is applied
-      # And the code referencing the new name is deployed, during that time queries to the old table name
-      # will hit this view and query from the renamed table
-      create_view(pegasus_user_storage_ids, DB[dashboard_user_project_storage_ids].select_all)
+        # This view exists as a safe-guard during the time between when the table rename is applied
+        # And the code referencing the new name is deployed, during that time queries to the old table name
+        # will hit this view and query from the renamed table
+        create_view(pegasus_user_storage_ids, DB[dashboard_user_project_storage_ids].select_all)
+      rescue Sequel::DatabaseError => e
+        is_table_already_exists_error = e.message.include? "Table 'user_project_storage_ids' already exists"
+        is_pegasus_table_empty = DB[pegasus_user_storage_ids].count == 0
+        # When setting up environments from scratch, the new table will be created from the dashboard schema.rb
+        # and there will be no previously existing user_storage_ids data, so the old pegasus table can be dropped.
+        # The view will be created for consistency across environments.
+        if is_table_already_exists_error && is_pegasus_table_empty
+          puts "user_project_storage_ids has already been created, dropping pegasus user_storage_ids..."
+          drop_table(pegasus_user_storage_ids)
+          create_view(pegasus_user_storage_ids, DB[dashboard_user_project_storage_ids].select_all)
+        else
+          raise e
+        end
+      end
     end
 
     # In Drone CI, the table will be created from from schema.rb file. After that, this migration


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
The issue with the migration of user_storage_ids from pegasus to dashboard is that for environments built from scratch (such as when a new developer onboards or creating an adhoc) the migrated table in dashboard will be created by the schema before the pegasus migrations are run, so when the migrations are run, the table already exists. In this case, when there is no data that needs to be migrated, we can just drop the old table.

We already knew that this was necessary for the CI env where the database is always built from scratch, but we didn't think of the other scenarios.

## Testing story
Tested locally that the error was caught when the table already existed and that the query for count works as expected
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
