### PR TITLE
track clicks to print frozen art on bulk certificate print page

### DIFF
--- a/pegasus/sites.v3/code.org/views/frozen_print_gallery.haml
+++ b/pegasus/sites.v3/code.org/views/frozen_print_gallery.haml
@@ -39,7 +39,7 @@
     var printButton = $('#print_button');
     if (printButton) {
       printButton.click(function() {
-        trackEvent('frozen_print_gallery', 'print')
+        trackEvent('clicks', 'frozen_print_gallery', 'print');
         var item = $("#print_frame")[0];
         item.contentWindow.document.getElementsByTagName("img")[0].style.width="100%";
         if (item.contentWindow.document.execCommand('print', false, null)) {

--- a/pegasus/sites.v3/code.org/views/frozen_print_gallery.haml
+++ b/pegasus/sites.v3/code.org/views/frozen_print_gallery.haml
@@ -39,6 +39,7 @@
     var printButton = $('#print_button');
     if (printButton) {
       printButton.click(function() {
+        trackEvent('frozen_print_gallery', 'print')
         var item = $("#print_frame")[0];
         item.contentWindow.document.getElementsByTagName("img")[0].style.width="100%";
         if (item.contentWindow.document.execCommand('print', false, null)) {


### PR DESCRIPTION
Per [request](https://docs.google.com/document/d/11Q7hnP5TtuntV764f8Ib6HeCOJBApukfWigsyD9ye9M/edit?disco=AAAAUgf2m2w) in the Congrats page spec, I'm adding a metric to see how often users click the button to print frozen art. Here it is in the network tab after I click the print button:

<img width="1533" alt="Screen Shot 2022-03-23 at 5 06 06 PM" src="https://user-images.githubusercontent.com/8001765/159816591-916d3340-0458-40a4-9fbc-eb0c092d8a57.png">

For other clues as to how this is working:
* included on every pegasus page: https://github.com/code-dot-org/code-dot-org/blob/caa7b53385b5c0d7fc68bd59b4bd049c60934b4d/pegasus/sites.v3/code.org/views/theme_common_head_after.haml#L9
* https://github.com/code-dot-org/code-dot-org/blob/edb52b4c8fda2343650737a0ab4b5b13ba120f91/pegasus/sites.v3/code.org/views/google_analytics.js.erb#L10-L12
* https://github.com/code-dot-org/code-dot-org/blob/edb52b4c8fda2343650737a0ab4b5b13ba120f91/pegasus/sites.v3/code.org/views/google_analytics.js.erb#L24
* GA docs: https://developers.google.com/analytics/devguides/collection/gtagjs/events

## Testing story

I've checked everything I can think of to try and track this event properly, including reading the GA docs and getting a `200 OK` response in the screenshot. once it reaches production, I'll click the print button once on code.org/certificates to make sure I can see it show up somewhere in GA.