### PR TITLE
Oneoff migration pegasus.storage_apps => dashboard.projects

### DIFF
--- a/bin/oneoff/move_storage_apps_to_dashboard
+++ b/bin/oneoff/move_storage_apps_to_dashboard
@@ -1,9 +1,11 @@
+#!/usr/bin/env ruby
+
 require File.expand_path('../../../pegasus/src/env', __FILE__)
 require src_dir 'database'
 require 'optparse'
 
-# To run: ruby bin/oneoff/move_storage_apps_to_dashboard.rb
-# To revert: ruby bin/oneoff/move_storage_apps_to_dashboard.rb --revert
+# To run: bin/oneoff/move_storage_apps_to_dashboard
+# To revert: bin/oneoff/move_storage_apps_to_dashboard --revert
 
 # Parse options
 options = {

--- a/bin/oneoff/move_storage_apps_to_dashboard.rb
+++ b/bin/oneoff/move_storage_apps_to_dashboard.rb
@@ -1,0 +1,69 @@
+require File.expand_path('../../../pegasus/src/env', __FILE__)
+require src_dir 'database'
+require 'optparse'
+
+# To run: ruby bin/oneoff/move_storage_apps_to_dashboard.rb
+# To revert: ruby bin/oneoff/move_storage_apps_to_dashboard.rb --revert
+
+# Parse options
+options = {
+  revert: false,
+}
+
+OptionParser.new do |opts|
+  opts.banner = <<~BANNER
+    Usage: #{File.basename(__FILE__)} [options]
+
+    This moves the storage_apps table to the Dashboard DB and renames it to projects
+
+    Options:
+  BANNER
+
+  opts.on('--revert',
+    'Will revert the Database to its previous state (drop the view and move the table back to Pegasus)'
+  ) do |revert|
+    options[:revert] = revert
+  end
+
+  opts.on('-h', '--help', 'Prints this help message') do
+    puts opts
+    exit
+  end
+end.parse!
+puts "Options: #{options}"
+options.freeze
+
+$revert = options[:revert]
+
+def migrate_storage_apps_to_dashboard
+  pegasus_storage_apps = "#{CDO.pegasus_db_name}__storage_apps".to_sym
+  dashboard_projects = "#{CDO.dashboard_db_name}__projects".to_sym
+
+  puts "Renaming table pegasus.storage_apps -> dashboard.projects"
+  # Rename the table to move it from the Pegasus schema to Dashboard
+  # Also change the name from storage_apps to projects
+  DB.rename_table(pegasus_storage_apps, dashboard_projects)
+
+  puts "Creating view pegasus.storage_apps"
+  # This view exists as a safe-guard during the time between when the table rename is applied
+  # And the code referencing the new name is deployed, during that time queries to the old table name
+  # will hit this view and query from the renamed table
+  DB.create_view(pegasus_storage_apps, DB[dashboard_projects].select_all)
+end
+
+def revert_migrate_storage_apps_to_dashboard
+  pegasus_storage_apps = "#{CDO.pegasus_db_name}__storage_apps".to_sym
+  dashboard_projects = "#{CDO.dashboard_db_name}__projects".to_sym
+
+  puts "Dropping view pegasus.storage_apps"
+  DB.drop_view(pegasus_storage_apps)
+
+  puts "Renaming table dashboard.projects -> pegasus.storage_apps"
+  DB.rename_table(dashboard_projects, pegasus_storage_apps)
+end
+
+if $revert
+  revert_migrate_storage_apps_to_dashboard
+else
+  migrate_storage_apps_to_dashboard
+end

--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -180,12 +180,11 @@ class ProjectsController < ApplicationController
   end
 
   def prefix_storage_app_fields(field_names)
-    table_name = "storage_apps"
-    field_names.map {|field_name| "#{table_name}__#{field_name}".to_sym}
+    field_names.map {|field_name| "#{StorageApps.table_name}__#{field_name}".to_sym}
   end
 
   def combine_projects_and_featured_projects_data
-    storage_apps = "#{CDO.pegasus_db_name}__storage_apps".to_sym
+    storage_apps = DCDO.get('storage_apps_in_dashboard', false) ? "#{CDO.dashboard_db_name}__projects".to_sym : "#{CDO.pegasus_db_name}__storage_apps".to_sym
     project_featured_project_combo_data = DASHBOARD_DB[:featured_projects].
       select(*project_and_featured_project_fields).
       join(storage_apps, id: :storage_app_id, state: 'active').all

--- a/dashboard/lib/projects_list.rb
+++ b/dashboard/lib/projects_list.rb
@@ -212,7 +212,7 @@ module ProjectsList
     end
 
     def fetch_featured_projects_by_type(project_type)
-      storage_apps_table = DCDO.get('storage_apps_in_dashboard', false) ? "#{CDO.dashboard_db_name}__projects".to_sym : "#{CDO.pegasus_db_name}__#{table_name}".to_sym
+      storage_apps_table = DCDO.get('storage_apps_in_dashboard', false) ? "#{CDO.dashboard_db_name}__projects".to_sym : "#{CDO.pegasus_db_name}__storage_apps}".to_sym
       user_project_storage_ids = "#{CDO.dashboard_db_name}__user_project_storage_ids".to_sym
 
       project_featured_project_user_combo_data = DASHBOARD_DB[:featured_projects].

--- a/dashboard/lib/projects_list.rb
+++ b/dashboard/lib/projects_list.rb
@@ -212,14 +212,13 @@ module ProjectsList
     end
 
     def fetch_featured_projects_by_type(project_type)
-      storage_apps = "#{CDO.pegasus_db_name}__storage_apps".to_sym
-
+      storage_apps_table = DCDO.get('storage_apps_in_dashboard', false) ? "#{CDO.dashboard_db_name}__projects".to_sym : "#{CDO.pegasus_db_name}__#{table_name}".to_sym
       user_project_storage_ids = "#{CDO.dashboard_db_name}__user_project_storage_ids".to_sym
 
       project_featured_project_user_combo_data = DASHBOARD_DB[:featured_projects].
         select(*project_and_featured_project_and_user_fields).
-        join(storage_apps, id: :storage_app_id).
-        join(user_project_storage_ids, id: Sequel[:storage_apps][:storage_id]).
+        join(storage_apps_table, id: :storage_app_id).
+        join(user_project_storage_ids, id: Sequel[storage_apps_table][:storage_id]).
         join(:users, id: Sequel[user_project_storage_ids][:user_id]).
         where(
           unfeatured_at: nil,
@@ -357,8 +356,7 @@ module ProjectsList
     end
 
     def prefix_storage_app_fields(field_names)
-      table_name = "storage_apps"
-      field_names.map {|field_name| "#{table_name}__#{field_name}".to_sym}
+      field_names.map {|field_name| "#{StorageApps.table_name}__#{field_name}".to_sym}
     end
   end
 end

--- a/dashboard/lib/projects_list.rb
+++ b/dashboard/lib/projects_list.rb
@@ -212,7 +212,7 @@ module ProjectsList
     end
 
     def fetch_featured_projects_by_type(project_type)
-      storage_apps_table = DCDO.get('storage_apps_in_dashboard', false) ? "#{CDO.dashboard_db_name}__projects".to_sym : "#{CDO.pegasus_db_name}__storage_apps}".to_sym
+      storage_apps_table = DCDO.get('storage_apps_in_dashboard', false) ? "#{CDO.dashboard_db_name}__projects".to_sym : "#{CDO.pegasus_db_name}__storage_apps".to_sym
       user_project_storage_ids = "#{CDO.dashboard_db_name}__user_project_storage_ids".to_sym
 
       project_featured_project_user_combo_data = DASHBOARD_DB[:featured_projects].

--- a/shared/middleware/helpers/storage_apps.rb
+++ b/shared/middleware/helpers/storage_apps.rb
@@ -395,7 +395,11 @@ class StorageApps
   end
 
   def self.table
-    PEGASUS_DB[:storage_apps]
+    DCDO.get('storage_apps_in_dashboard', false) ? DASHBOARD_DB[:projects] : PEGASUS_DB[:storage_apps]
+  end
+
+  def self.table_name
+    DCDO.get('storage_apps_in_dashboard', false) ? "projects" : "storage_apps"
   end
 
   private

--- a/shared/test/test_files.rb
+++ b/shared/test/test_files.rb
@@ -176,6 +176,7 @@ class FilesTest < FilesApiTestBase
     DCDO.stubs(:get).with('s3_timeout', 15).returns(15)
     DCDO.stubs(:get).with('s3_slow_request', 15).returns(15)
     DCDO.stubs(:get).with('user_storage_ids_in_dashboard', false).returns(false)
+    DCDO.stubs(:get).with('storage_apps_in_dashboard', false).returns(false)
 
     filename = 'index.html'
     # The below HTML is valid/invalid in WebLab projects only. Other project types do not


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
This is the one-off migration to be run on production to move the pegasus storage_apps table to dashboard with the name projects. A view with the old name is created for the time between when the migration is run in production and when we flip the DCDO flag to point the code at the new table name.

To roll out this change:
1. Run the migration with `ruby bin/oneoff/move_storage_apps_to_dashboard`
2. Set the DCDO flag with `DCDO.set('storage_apps_in_dashboard', true)`

To roll back the change:
1. Set the DCDO flag with `DCDO.set('storage_apps_in_dashboard', false)`
2. Revert the migration with `ruby bin/oneoff/move_storage_apps_to_dashboard --revert`


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
- jira ticket: [LP-2267](https://codedotorg.atlassian.net/browse/LP-2267)
<!--
- spec: []()

-->

## Testing story
I've tested the steps to roll out and roll back the migration locally, verifying that projects load as expected at every step. 
To Do:
- [ ] work with Infra to run this migration while tests are running in the test env
- [ ] Do more thorough testing of more scenarios locally (maureen)
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy
These code changes will be deployed and when we're ready we'll work with Infra to find a time to run the migration.

## Follow-up work
Once the migration has been run in production, we'll want to merge https://github.com/code-dot-org/code-dot-org/pull/45480 so that every environment will match production.
<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
