### PR TITLE
Courses settings fix

### DIFF
--- a/dashboard/config/courses/allthethingscourse.course
+++ b/dashboard/config/courses/allthethingscourse.course
@@ -6,6 +6,8 @@
   ],
   "published_state": "beta",
   "instruction_type": "teacher_led",
+  "participant_audience": "student",
+  "instructor_audience": "teacher",
   "properties": {
   },
   "resources": [

--- a/dashboard/config/courses/andrea-test-dlp.course
+++ b/dashboard/config/courses/andrea-test-dlp.course
@@ -5,6 +5,8 @@
   ],
   "published_state": "beta",
   "instruction_type": "teacher_led",
+  "participant_audience": "student",
+  "instructor_audience": "teacher",
   "properties": {
   },
   "resources": [

--- a/dashboard/config/courses/csa-pilot.course
+++ b/dashboard/config/courses/csa-pilot.course
@@ -13,6 +13,8 @@
   ],
   "published_state": "pilot",
   "instruction_type": "teacher_led",
+  "participant_audience": "student",
+  "instructor_audience": "teacher",
   "properties": {
     "family_name": "csa",
     "has_numbered_units": true,

--- a/dashboard/config/courses/csd-2017.course
+++ b/dashboard/config/courses/csd-2017.course
@@ -10,6 +10,8 @@
   ],
   "published_state": "stable",
   "instruction_type": "teacher_led",
+  "participant_audience": "student",
+  "instructor_audience": "teacher",
   "properties": {
     "family_name": "csd",
     "has_verified_resources": true,

--- a/dashboard/config/courses/csd-2018.course
+++ b/dashboard/config/courses/csd-2018.course
@@ -11,6 +11,8 @@
   ],
   "published_state": "stable",
   "instruction_type": "teacher_led",
+  "participant_audience": "student",
+  "instructor_audience": "teacher",
   "properties": {
     "family_name": "csd",
     "has_verified_resources": true,

--- a/dashboard/config/courses/csd-2019.course
+++ b/dashboard/config/courses/csd-2019.course
@@ -10,6 +10,8 @@
   ],
   "published_state": "stable",
   "instruction_type": "teacher_led",
+  "participant_audience": "student",
+  "instructor_audience": "teacher",
   "properties": {
     "family_name": "csd",
     "has_verified_resources": true,

--- a/dashboard/config/courses/csd-2020.course
+++ b/dashboard/config/courses/csd-2020.course
@@ -10,6 +10,8 @@
   ],
   "published_state": "stable",
   "instruction_type": "teacher_led",
+  "participant_audience": "student",
+  "instructor_audience": "teacher",
   "properties": {
     "family_name": "csd",
     "has_verified_resources": true,

--- a/dashboard/config/courses/csd-2021.course
+++ b/dashboard/config/courses/csd-2021.course
@@ -12,6 +12,8 @@
   ],
   "published_state": "stable",
   "instruction_type": "teacher_led",
+  "participant_audience": "student",
+  "instructor_audience": "teacher",
   "properties": {
     "family_name": "csd",
     "has_numbered_units": true,

--- a/dashboard/config/courses/csp-2017.course
+++ b/dashboard/config/courses/csp-2017.course
@@ -25,6 +25,8 @@
   ],
   "published_state": "stable",
   "instruction_type": "teacher_led",
+  "participant_audience": "student",
+  "instructor_audience": "teacher",
   "properties": {
     "family_name": "csp",
     "has_verified_resources": true,

--- a/dashboard/config/courses/csp-2018.course
+++ b/dashboard/config/courses/csp-2018.course
@@ -13,6 +13,8 @@
   ],
   "published_state": "stable",
   "instruction_type": "teacher_led",
+  "participant_audience": "student",
+  "instructor_audience": "teacher",
   "properties": {
     "family_name": "csp",
     "has_verified_resources": true,

--- a/dashboard/config/courses/csp-2019.course
+++ b/dashboard/config/courses/csp-2019.course
@@ -12,6 +12,8 @@
   ],
   "published_state": "stable",
   "instruction_type": "teacher_led",
+  "participant_audience": "student",
+  "instructor_audience": "teacher",
   "properties": {
     "family_name": "csp",
     "has_verified_resources": true,

--- a/dashboard/config/courses/csp-2020.course
+++ b/dashboard/config/courses/csp-2020.course
@@ -15,6 +15,8 @@
   ],
   "published_state": "stable",
   "instruction_type": "teacher_led",
+  "participant_audience": "student",
+  "instructor_audience": "teacher",
   "properties": {
     "family_name": "csp",
     "has_verified_resources": true,

--- a/dashboard/config/courses/fit2019-apprentice.course
+++ b/dashboard/config/courses/fit2019-apprentice.course
@@ -5,6 +5,8 @@
   ],
   "published_state": "in_development",
   "instruction_type": "teacher_led",
+  "participant_audience": "universal_instructor",
+  "instructor_audience": "facilitator",
   "properties": {
   },
   "resources": [

--- a/dashboard/config/courses/fit2019-apprentice.course
+++ b/dashboard/config/courses/fit2019-apprentice.course
@@ -5,8 +5,8 @@
   ],
   "published_state": "in_development",
   "instruction_type": "teacher_led",
-  "participant_audience": "universal_instructor",
-  "instructor_audience": "facilitator",
+  "participant_audience": "facilitator",
+  "instructor_audience": "universal_instructor",
   "properties": {
   },
   "resources": [

--- a/dashboard/config/courses/mike-test.course
+++ b/dashboard/config/courses/mike-test.course
@@ -5,6 +5,8 @@
   ],
   "published_state": "beta",
   "instruction_type": "teacher_led",
+  "participant_audience": "student",
+  "instructor_audience": "teacher",
   "properties": {
     "has_numbered_units": true
   },

--- a/dashboard/config/courses/time4cs-control.course
+++ b/dashboard/config/courses/time4cs-control.course
@@ -6,6 +6,8 @@
   ],
   "published_state": "beta",
   "instruction_type": "teacher_led",
+  "participant_audience": "student",
+  "instructor_audience": "teacher",
   "properties": {
   },
   "resources": [

--- a/dashboard/config/courses/time4cs-experiment.course
+++ b/dashboard/config/courses/time4cs-experiment.course
@@ -6,6 +6,8 @@
   ],
   "published_state": "beta",
   "instruction_type": "teacher_led",
+  "participant_audience": "student",
+  "instructor_audience": "teacher",
   "properties": {
   },
   "resources": [


### PR DESCRIPTION
A bunch of .course files did not have `participant_audience` or `instructor_audience` set. I think this is because we did not write the serialization of any course we did not specifically update in the one off script (bin/oneoff/set_course_audiences.rb). Courses with `participant_audience` of student and `instructor_audience` of teacher were the default so we did not update them. Everything still works because of these defaults but it would be good to update the serialization too.

## Testing story

- Seeded with these on my adhoc for testing the assignment dropdown and they worked fine