### PR TITLE
UI Testing Updates to Prep for Assignment Dropdown

### DIFF
--- a/dashboard/app/controllers/test_controller.rb
+++ b/dashboard/app/controllers/test_controller.rb
@@ -50,6 +50,29 @@ class TestController < ApplicationController
     head :ok
   end
 
+  def assign_course_and_unit_as_student
+    return unless (user = current_user)
+    script = Script.find_by_name(params.require(:script_name))
+    course = UnitGroup.find_by_name(params.require(:course_name))
+
+    name = "Fake User"
+    email = "user#{Time.now.to_i}_#{rand(1_000_000)}@test.xx"
+    password = name + "password"
+    attributes = {
+      name: name,
+      email: email,
+      password: password,
+      user_type: "teacher",
+      age: "21+"
+    }
+    fake_user = User.create!(attributes)
+
+    section = Section.create(name: "New Section", user: fake_user, script_id: script.id, course_id: course.id)
+    section.students << user
+    section.save!
+    head :ok
+  end
+
   def assign_script_as_student
     return unless (user = current_user)
     script = Script.find_by_name(params.require(:script_name))

--- a/dashboard/test/ui/features/learning_platform/course_versions.feature
+++ b/dashboard/test/ui/features/learning_platform/course_versions.feature
@@ -12,7 +12,7 @@ Scenario: Version warning announcement on course and script overview pages
 
   # students must be assigned or have progress to view older unit versions
 
-  Given I am assigned to unit "ui-test-script-in-course-2017"
+  Given I am assigned to course "ui-test-course-2017" and unit "ui-test-script-in-course-2017"
   When I am on "http://studio.code.org/courses/ui-test-course-2019"
   And I wait to see ".uitest-CourseScript"
   And element "#uitest-version-selector" is visible

--- a/dashboard/test/ui/features/learning_platform/teacher_homepage.feature
+++ b/dashboard/test/ui/features/learning_platform/teacher_homepage.feature
@@ -14,16 +14,6 @@ Feature: Using the teacher homepage sections feature
     When I create a new section and go home
     Then the section table should have 2 rows
 
-  Scenario: Loading teacher homepage with course experiment enabled
-    Given I am on "http://studio.code.org/home"
-    Given I enable the "subgoals-group-a" course experiment
-    And I reload the page
-    And I wait to see ".uitest-newsection"
-    And check that the URL contains "/home"
-    And I create a new section with course "Computer Science Principles", version "'17-'18" and unit "CSP Unit 3 - Subgoals Group A *"
-    Then the section table should have 1 row
-    And the section table row at index 0 has secondary assignment path "/s/csp3-a"
-
   @no_firefox @no_safari
   Scenario: Navigate to course and unit pages
     # No sections, ensure that levels load correctly after navigating from MiniView

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -943,6 +943,14 @@ Given(/^I am assigned to unit "([^"]*)"$/) do |script_name|
   )
 end
 
+Given(/^I am assigned to course "([^"]*)" and unit "([^"]*)"$/) do |course_name, script_name|
+  browser_request(
+    url: '/api/test/assign_course_and_unit_as_student',
+    method: 'POST',
+    body: {script_name: script_name, course_name: course_name}
+  )
+end
+
 Then(/^I fake completion of the assessment$/) do
   browser_request(url: '/api/test/fake_completion_assessment', method: 'POST', code: 204)
 end


### PR DESCRIPTION
Updates a couple things about UI tests in preparation for assignment dropdown updates.

1. Removes the UI test for assigning alternative units since we are not going to maintain that feature going forward
2. Updates the course versions test to assign a unit and course instead of just a unit which matches how the assignment system actually works.

## Links

[Jira](https://codedotorg.atlassian.net/browse/PLAT-1584)
[Mini Spec](https://docs.google.com/document/d/11-dtCFuSmST_vP2MdkH0H0lb2e5AGFu1MxiWSRsnkns/edit#)