### PR TITLE
Update playlab course offering to be in hoc category

### DIFF
--- a/dashboard/config/course_offerings/playlab.json
+++ b/dashboard/config/course_offerings/playlab.json
@@ -1,6 +1,6 @@
 {
   "key": "playlab",
   "display_name": "Play Lab",
-  "category": "other",
+  "category": "hoc",
   "is_featured": false
 }


### PR DESCRIPTION
In reviewing the assignment dropdown for the bug bash I noticed that this course offering was in the wrong category. Play Lab should be in Hour of Code.