### PR TITLE
Add assignable field to course offering

### DIFF
--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -9,6 +9,7 @@
 #  updated_at   :datetime         not null
 #  category     :string(255)      default("other"), not null
 #  is_featured  :boolean          default(FALSE), not null
+#  assignable   :boolean          default(TRUE), not null
 #
 # Indexes
 #

--- a/dashboard/db/migrate/20220325185859_add_assignable_to_course_offering.rb
+++ b/dashboard/db/migrate/20220325185859_add_assignable_to_course_offering.rb
@@ -1,0 +1,5 @@
+class AddAssignableToCourseOffering < ActiveRecord::Migration[5.2]
+  def change
+    add_column :course_offerings, :assignable, :boolean, null: false, default: true
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_17_180504) do
+ActiveRecord::Schema.define(version: 2022_03_25_185859) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -395,6 +395,7 @@ ActiveRecord::Schema.define(version: 2022_03_17_180504) do
     t.datetime "updated_at", null: false
     t.string "category", default: "other", null: false
     t.boolean "is_featured", default: false, null: false
+    t.boolean "assignable", default: true, null: false
     t.index ["key"], name: "index_course_offerings_on_key", unique: true
   end
 


### PR DESCRIPTION
Add new field `assignable` to course offering. This will be a check box which curriculum writers can choose if a course offering should show up in the dropdown or not for assignment. We need do this now because we don't want the UI test scripts showing up in the production dropdown.

[Jira](https://codedotorg.atlassian.net/browse/PLAT-1676)