### PR TITLE
Javalab exemplars: allow teachers to access new exemplars

### DIFF
--- a/apps/src/javalab/Javalab.js
+++ b/apps/src/javalab/Javalab.js
@@ -86,6 +86,7 @@ Javalab.prototype.init = function(config) {
   this.displayTheme = getDisplayThemeFromString(config.displayTheme);
   this.isStartMode = !!config.level.editBlocks;
   this.isEditingExemplar = !!config.level.isEditingExemplar;
+  this.isViewingExemplar = !!config.level.exemplarSources;
   config.makeYourOwn = false;
   config.wireframeShare = true;
   config.noHowItWorks = true;
@@ -358,7 +359,7 @@ Javalab.prototype.executeJavabuilder = function(executionType) {
   }
 
   let overrideSources;
-  if (this.isEditingExemplar) {
+  if (this.isEditingExemplar || this.isViewingExemplar) {
     overrideSources = getSources(getStore().getState());
   }
 

--- a/apps/src/javalab/Javalab.js
+++ b/apps/src/javalab/Javalab.js
@@ -86,7 +86,7 @@ Javalab.prototype.init = function(config) {
   this.displayTheme = getDisplayThemeFromString(config.displayTheme);
   this.isStartMode = !!config.level.editBlocks;
   this.isEditingExemplar = !!config.level.isEditingExemplar;
-  this.isViewingExemplar = !!config.level.exemplarSources;
+  this.isViewingExemplar = !!config.level.isViewingExemplar;
   config.makeYourOwn = false;
   config.wireframeShare = true;
   config.noHowItWorks = true;
@@ -223,8 +223,7 @@ Javalab.prototype.init = function(config) {
   const startSources = config.level.lastAttempt || config.level.startSources;
   const validation = config.level.validation || {};
   if (config.level.exemplarSources) {
-    // if (this.isEditingExemplar && config.level.exemplarSources) {
-    // If we're editing an exemplar, set initial sources
+    // If we have exemplar sources (either for editing or viewing), set initial sources
     // with the exemplar code saved to the level definition.
     getStore().dispatch(setAllSources(config.level.exemplarSources));
   } else if (

--- a/apps/src/javalab/Javalab.js
+++ b/apps/src/javalab/Javalab.js
@@ -221,7 +221,8 @@ Javalab.prototype.init = function(config) {
 
   const startSources = config.level.lastAttempt || config.level.startSources;
   const validation = config.level.validation || {};
-  if (this.isEditingExemplar && config.level.exemplarSources) {
+  if (config.level.exemplarSources) {
+    // if (this.isEditingExemplar && config.level.exemplarSources) {
     // If we're editing an exemplar, set initial sources
     // with the exemplar code saved to the level definition.
     getStore().dispatch(setAllSources(config.level.exemplarSources));

--- a/apps/test/unit/javalab/javalabTest.js
+++ b/apps/test/unit/javalab/javalabTest.js
@@ -162,14 +162,13 @@ describe('Javalab', () => {
       );
     });
 
-    it('with exemplarSources if there are any and we are editing an exemplar', () => {
+    it('with exemplarSources if there are any', () => {
       config.level = {
         exemplarSources: {
           'File.java': {
             text: 'Some exemplar code'
           }
-        },
-        isEditingExemplar: true
+        }
       };
       javalab.init(config);
 

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -516,16 +516,15 @@ class ScriptLevelsController < ApplicationController
       current_user.present? &&
       (current_user.teacher? || (current_user&.sections_as_student&.any?(&:code_review_enabled?) && !current_user.code_review_groups.empty?))
 
-    # javalab specfiic
-    # should this go in show?
+    # Javalab exemplar URLs include ?exemplar=true as a URL param
     if params[:exemplar]
-      # maybe create new partial with better messaging
-      return render 'levels/no_access' unless current_user&.verified_instructor?
+      return render 'levels/no_access_exemplar' unless current_user&.verified_instructor?
 
       @is_viewing_exemplar = true
       exemplar_sources = @level.try(:exemplar_sources)
+      return render 'levels/no_exemplar' unless exemplar_sources
+
       level_view_options(@level.id, {exemplar_sources: exemplar_sources})
-      # add some cancan check that only verified teachers can view this
       readonly_view_options
     end
 

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -517,8 +517,11 @@ class ScriptLevelsController < ApplicationController
       (current_user.teacher? || (current_user&.sections_as_student&.any?(&:code_review_enabled?) && !current_user.code_review_groups.empty?))
 
     # javalab specfiic
-    # check for exemplar as URL param
+    # should this go in show?
     if params[:exemplar]
+      # maybe create new partial with better messaging
+      return render 'levels/no_access' unless current_user&.verified_instructor?
+
       @is_viewing_exemplar = true
       exemplar_sources = @level.try(:exemplar_sources)
       level_view_options(@level.id, {exemplar_sources: exemplar_sources})

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -524,7 +524,7 @@ class ScriptLevelsController < ApplicationController
       exemplar_sources = @level.try(:exemplar_sources)
       return render 'levels/no_exemplar' unless exemplar_sources
 
-      level_view_options(@level.id, {exemplar_sources: exemplar_sources})
+      level_view_options(@level.id, {is_viewing_exemplar: true, exemplar_sources: exemplar_sources})
       readonly_view_options
     end
 

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -519,10 +519,11 @@ class ScriptLevelsController < ApplicationController
     # javalab specfiic
     # check for exemplar as URL param
     if params[:exemplar]
+      @is_viewing_exemplar = true
       exemplar_sources = @level.try(:exemplar_sources)
       level_view_options(@level.id, {exemplar_sources: exemplar_sources})
       # add some cancan check that only verified teachers can view this
-      # readonly?
+      readonly_view_options
     end
 
     view_options(

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -516,6 +516,15 @@ class ScriptLevelsController < ApplicationController
       current_user.present? &&
       (current_user.teacher? || (current_user&.sections_as_student&.any?(&:code_review_enabled?) && !current_user.code_review_groups.empty?))
 
+    # javalab specfiic
+    # check for exemplar as URL param
+    if params[:exemplar]
+      exemplar_sources = @level.try(:exemplar_sources)
+      level_view_options(@level.id, {exemplar_sources: exemplar_sources})
+      # add some cancan check that only verified teachers can view this
+      # readonly?
+    end
+
     view_options(
       full_width: true,
       small_footer: @game.uses_small_footer? || @level.enable_scrolling?,

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -176,7 +176,6 @@ module LevelsHelper
 
   # Options hash for all level types
   def app_options
-    # Figure out if caching is a concern
     # Unsafe to generate these twice, so use the cached version if it exists.
     return @app_options unless @app_options.nil?
 
@@ -193,7 +192,8 @@ module LevelsHelper
     level_requires_channel = (@level.channel_backed? &&
           !@level.try(:contained_levels).present? &&
           params[:action] != 'edit_blocks')
-    # Javalab always requires a channel if Javabuilder needs to access project-specific assets.
+    # Javalab requires a channel if Javabuilder needs to access project-specific assets,
+    # or if we want to access a project's code from S3.
     # Two special cases are when we edit and view Javalab exemplar code,
     # where we load the exemplar code from the level definition, edit it locally in Javalab,
     # and pass the edited code directly to Javabuilder.

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -176,6 +176,7 @@ module LevelsHelper
 
   # Options hash for all level types
   def app_options
+    # Figure out if caching is a concern
     # Unsafe to generate these twice, so use the cached version if it exists.
     return @app_options unless @app_options.nil?
 
@@ -195,7 +196,7 @@ module LevelsHelper
         (@level.channel_backed? &&
           !@level.try(:contained_levels).present? &&
           params[:action] != 'edit_blocks')
-    level_requires_channel = false if @is_editing_exemplar
+    level_requires_channel = false if @is_editing_exemplar || @is_viewing_exemplar
 
     # If the level is cached, the channel is loaded client-side in loadApp.js
     if level_requires_channel && !@public_caching

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -188,15 +188,16 @@ module LevelsHelper
     # - For levels with contained levels, the outer level is read-only and does
     #   not write to the channel. (We currently do not support inner levels that
     #   are channel-backed.)
-    # - In edit_blocks and edit_exemplar mode, the source code is saved as a level property and
+    # - In edit_blocks mode, the source code is saved as a level property and
     #   is not written to the channel.
-    #
-    # Note that Javalab requires a channel if Javabuilder needs to access assets.
-    level_requires_channel = @level.is_a?(Javalab) ||
-        (@level.channel_backed? &&
+    level_requires_channel = (@level.channel_backed? &&
           !@level.try(:contained_levels).present? &&
           params[:action] != 'edit_blocks')
-    level_requires_channel = false if @is_editing_exemplar || @is_viewing_exemplar
+    # Javalab always requires a channel if Javabuilder needs to access project-specific assets.
+    # Two special cases are when we edit and view Javalab exemplar code,
+    # where we load the exemplar code from the level definition, edit it locally in Javalab,
+    # and pass the edited code directly to Javabuilder.
+    level_requires_channel = !@is_editing_exemplar && !@is_viewing_exemplar if @level.is_a?(Javalab)
 
     # If the level is cached, the channel is loaded client-side in loadApp.js
     if level_requires_channel && !@public_caching

--- a/dashboard/app/helpers/view_options_helper.rb
+++ b/dashboard/app/helpers/view_options_helper.rb
@@ -66,6 +66,7 @@ module ViewOptionsHelper
     :toolbox_blocks,
     :edit_blocks,
     :is_editing_exemplar,
+    :is_viewing_exemplar,
     :exemplar_sources,
     :skip_instructions_popup,
     :embed,

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -675,17 +675,18 @@ class ScriptLevel < ApplicationRecord
 
     return [] if !Policies::InlineAnswer.visible_for_script_level?(current_user, self) || CDO.properties_encryption_key.blank?
 
-    if level.try(:exemplar_sources).present? && current_user&.verified_instructor? && DCDO.get('use_new_javalab_exemplars', false)
+    # exemplar_sources is used by Javalab levels to store level solutions
+    if level.try(:exemplar_sources).present? && current_user&.verified_instructor?
       if oldest_active_level.is_a? BubbleChoice
         # If the script level has sublevels, get a link for the sublevel that looks like
         # /csa1/lessons/6/levels/5/sublevel/1?exemplar=true
         sublevel_position = oldest_active_level.sublevel_position(level)
-        link = build_script_level_url(self, {exemplar: true, sublevel_position: sublevel_position}) + '?exemplar=true'
+        link = 'https://studio.code.org' + build_script_level_path(self, {sublevel_position: sublevel_position}) + '?exemplar=true'
         level_example_links = [link]
       else
         # Otherwise, exemplar link should look like
         # csa1/lessons/2/levels/1?exemplar=true
-        link = build_script_level_url(self) + '?exemplar=true'
+        link = 'https://studio.code.org' + build_script_level_path(self) + '?exemplar=true'
         level_example_links = [link]
       end
     elsif level.try(:examples).present? && (current_user&.verified_instructor? || script&.csf?) # 'solutions' for applab-type levels

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -677,7 +677,16 @@ class ScriptLevel < ApplicationRecord
 
     # if level.is_a?(Javalab) && level.try(:exemplar_sources).present? && current_user&.verified_instructor?
     if level.is_a?(Javalab) && current_user&.verified_instructor?
-      level_example_links = [build_script_level_url(self, {exemplar: true})]
+      # should probably directly check oldest_active_level.bubble_choice?
+      if bubble_choice?
+        sublevel_position = oldest_active_level.sublevel_position(level)
+        level_example_links = [build_script_level_url(self, {exemplar: true, sublevel_position: sublevel_position}) + '?exemplar=true']
+        # Figure out what to do if we're directly on a level with bubble choices below it (should show no exemplars)
+        # Putsing is showing 3 level example links being created (one per sublevel), but none show up in blue pullout
+        puts level_example_links
+      else
+        level_example_links = [build_script_level_url(self, {exemplar: true})]
+      end
     elsif level.try(:examples).present? && (current_user&.verified_instructor? || script&.csf?) # 'solutions' for applab-type levels
       level_example_links = level.examples.map do |example|
         # We treat Sprite Lab levels as a sub-set of game lab levels right now which breaks their examples solutions

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -740,6 +740,6 @@ class ScriptLevel < ApplicationRecord
   end
 
   def build_exemplar_url(path)
-    'https://studio.code.org' + path + '?exemplar=true'
+    CDO.studio_url(path, CDO.default_scheme) + '?exemplar=true'
   end
 end

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -681,13 +681,15 @@ class ScriptLevel < ApplicationRecord
         # If the script level has sublevels, get a link for the sublevel that looks like
         # /csa1/lessons/6/levels/5/sublevel/1?exemplar=true
         sublevel_position = oldest_active_level.sublevel_position(level)
-        link = 'https://studio.code.org' + build_script_level_path(self, {sublevel_position: sublevel_position}) + '?exemplar=true'
-        level_example_links = [link]
+        return [] unless sublevel_position
+
+        path = build_script_level_path(self, {sublevel_position: sublevel_position})
+        level_example_links = [build_exemplar_url(path)]
       else
         # Otherwise, exemplar link should look like
         # csa1/lessons/2/levels/1?exemplar=true
-        link = 'https://studio.code.org' + build_script_level_path(self) + '?exemplar=true'
-        level_example_links = [link]
+        path = build_script_level_path(self)
+        level_example_links = [build_exemplar_url(path)]
       end
     elsif level.try(:examples).present? && (current_user&.verified_instructor? || script&.csf?) # 'solutions' for applab-type levels
       level_example_links = level.examples.map do |example|
@@ -735,5 +737,9 @@ class ScriptLevel < ApplicationRecord
     else
       LEVEL_KIND.puzzle
     end
+  end
+
+  def build_exemplar_url(path)
+    'https://studio.code.org' + path + '?exemplar=true'
   end
 end

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -675,7 +675,10 @@ class ScriptLevel < ApplicationRecord
 
     return [] if !Policies::InlineAnswer.visible_for_script_level?(current_user, self) || CDO.properties_encryption_key.blank?
 
-    if level.try(:examples).present? && (current_user&.verified_instructor? || script&.csf?) # 'solutions' for applab-type levels
+    # if level.is_a?(Javalab) && level.try(:exemplar_sources).present? && current_user&.verified_instructor?
+    if level.is_a?(Javalab) && current_user&.verified_instructor?
+      level_example_links = [build_script_level_url(self, {exemplar: true})]
+    elsif level.try(:examples).present? && (current_user&.verified_instructor? || script&.csf?) # 'solutions' for applab-type levels
       level_example_links = level.examples.map do |example|
         # We treat Sprite Lab levels as a sub-set of game lab levels right now which breaks their examples solutions
         # as level.game.app gets "gamelab" which makes the examples for sprite lab try to open in game lab.

--- a/dashboard/app/views/levels/no_access_exemplar.haml
+++ b/dashboard/app/views/levels/no_access_exemplar.haml
@@ -1,0 +1,2 @@
+%div
+  = current_user&.student? ? t('no_exemplar_access_student') : t('no_exemplar_access_teacher')

--- a/dashboard/app/views/levels/no_exemplar.haml
+++ b/dashboard/app/views/levels/no_exemplar.haml
@@ -1,0 +1,2 @@
+%div
+  = t('no_exemplar')

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -1026,6 +1026,9 @@ en:
   no_script_access_teacher: "You don't have access to this unit. If you believe you should have access to this unit, please write to support@code.org so that we can fix the situation."
   no_level_access_student: "You don't have access to this level. Please ask your teacher which level you should be on."
   no_level_access_teacher: "You don't have access to this level. If you believe you should have access to this level, please write to support@code.org so that we can fix the situation."
+  no_exemplar: "No exemplar exists for this level."
+  no_exemplar_access_student: "Students cannot access exemplar code. Please ask your teacher which level you should be on."
+  no_exemplar_access_teacher: "Only verified teachers can access exemplar code. If you want to become a verified teacher, please write to support@code.org."
   return_unit_overview: 'Go to unit overview'
   return_course_overview: 'Go to course overview'
   view_all_units: 'View all units'

--- a/dashboard/test/models/script_level_test.rb
+++ b/dashboard/test/models/script_level_test.rb
@@ -155,7 +155,7 @@ class ScriptLevelTest < ActiveSupport::TestCase
       script = create(:script)
       sl = create(:script_level, levels: [level], script: script)
 
-      assert_equal ["https://studio.code.org/s/#{script.name}/lessons/1/levels/1?exemplar=true"], sl.get_example_solutions(level, @authorized_teacher)
+      assert_equal ["https://test-studio.code.org/s/#{script.name}/lessons/1/levels/1?exemplar=true"], sl.get_example_solutions(level, @authorized_teacher)
     end
 
     test 'get_example_solutions for javalab sublevel level with exemplar' do
@@ -165,7 +165,7 @@ class ScriptLevelTest < ActiveSupport::TestCase
       script = create(:script)
       sl = create :script_level, levels: [bubble_choice], script: script
 
-      assert_equal ["https://studio.code.org/s/#{script.name}/lessons/1/levels/1/sublevel/1?exemplar=true"], sl.get_example_solutions(sublevel, @authorized_teacher)
+      assert_equal ["https://test-studio.code.org/s/#{script.name}/lessons/1/levels/1/sublevel/1?exemplar=true"], sl.get_example_solutions(sublevel, @authorized_teacher)
     end
 
     test 'get_example_solutions for level with ideal level source' do

--- a/dashboard/test/models/script_level_test.rb
+++ b/dashboard/test/models/script_level_test.rb
@@ -141,11 +141,29 @@ class ScriptLevelTest < ActiveSupport::TestCase
       assert_equal sl.get_example_solutions(level, @authorized_teacher), ["https://studio.code.org/projects/playlab/example-1/view", "https://studio.code.org/projects/playlab/example-2/view"]
     end
 
-    test 'get_example_solutions for javalab level' do
+    test 'get_example_solutions for javalab level with example (deprecated)' do
       level = create(:javalab, :with_example_solutions)
       sl = create(:script_level, levels: [level])
 
       assert_equal sl.get_example_solutions(level, @authorized_teacher), ["https://studio.code.org/s/csa-examples/lessons/1/levels/1/"]
+    end
+
+    test 'get_example_solutions for javalab level with exemplar' do
+      level = create(:javalab, exemplar_sources: 'some code')
+      script = create(:script)
+      sl = create(:script_level, levels: [level], script: script)
+
+      assert_equal ["https://studio.code.org/s/#{script.name}/lessons/1/levels/1?exemplar=true"], sl.get_example_solutions(level, @authorized_teacher)
+    end
+
+    test 'get_example_solutions for javalab sublevel level with exemplar' do
+      sublevel1 = create :javalab, exemplar_sources: 'some code', name: 'choice_1', display_name: 'Choice 1!', thumbnail_url: 'some-fake.url/kittens.png', bubble_choice_description: 'Choose me!'
+      sublevels = [sublevel1]
+      bubble_choice = create :bubble_choice_level, name: 'bubble_choices', display_name: 'Bubble Choices', description: 'Choose one or more!', sublevels: sublevels
+      script = create(:script)
+      sl = create :script_level, levels: [bubble_choice], script: script
+
+      assert_equal ["https://studio.code.org/s/#{script.name}/lessons/1/levels/1/sublevel/1?exemplar=true"], sl.get_example_solutions(sublevel1, @authorized_teacher)
     end
 
     test 'get_example_solutions for level with ideal level source' do

--- a/dashboard/test/models/script_level_test.rb
+++ b/dashboard/test/models/script_level_test.rb
@@ -155,7 +155,15 @@ class ScriptLevelTest < ActiveSupport::TestCase
       script = create(:script)
       sl = create(:script_level, levels: [level], script: script)
 
-      assert_equal ["https://test-studio.code.org/s/#{script.name}/lessons/1/levels/1?exemplar=true"], sl.get_example_solutions(level, @authorized_teacher)
+      # Javalab levels should only have one example solution.
+      # Remove scheme (http v https) for assertion b/c these are inconsistent between drone and development
+      # https://github.com/code-dot-org/code-dot-org/blob/986459ab24cb401efa567d0551f23fec6e3d6af3/config.yml.erb#L331
+      example_solutions = sl.get_example_solutions(level, @authorized_teacher)
+      parsed_url = URI(example_solutions.first)
+
+      assert_equal 1, example_solutions.length
+      assert_equal "test-studio.code.org/s/#{script.name}/lessons/1/levels/1?exemplar=true",
+        parsed_url.host + parsed_url.path + '?' + parsed_url.query
     end
 
     test 'get_example_solutions for javalab sublevel level with exemplar' do
@@ -165,7 +173,15 @@ class ScriptLevelTest < ActiveSupport::TestCase
       script = create(:script)
       sl = create :script_level, levels: [bubble_choice], script: script
 
-      assert_equal ["https://test-studio.code.org/s/#{script.name}/lessons/1/levels/1/sublevel/1?exemplar=true"], sl.get_example_solutions(sublevel, @authorized_teacher)
+      # Javalab levels should only have one example solution.
+      # Remove scheme (http v https) for assertion b/c these are inconsistent between drone and development
+      # https://github.com/code-dot-org/code-dot-org/blob/986459ab24cb401efa567d0551f23fec6e3d6af3/config.yml.erb#L331
+      example_solutions = sl.get_example_solutions(sublevel, @authorized_teacher)
+      parsed_url = URI(example_solutions.first)
+
+      assert_equal 1, example_solutions.length
+      assert_equal "test-studio.code.org/s/#{script.name}/lessons/1/levels/1/sublevel/1?exemplar=true",
+        parsed_url.host + parsed_url.path + '?' + parsed_url.query
     end
 
     test 'get_example_solutions for level with ideal level source' do

--- a/dashboard/test/models/script_level_test.rb
+++ b/dashboard/test/models/script_level_test.rb
@@ -141,6 +141,8 @@ class ScriptLevelTest < ActiveSupport::TestCase
       assert_equal sl.get_example_solutions(level, @authorized_teacher), ["https://studio.code.org/projects/playlab/example-1/view", "https://studio.code.org/projects/playlab/example-2/view"]
     end
 
+    # Should be removed as part of this task:
+    # https://codedotorg.atlassian.net/browse/JAVA-525
     test 'get_example_solutions for javalab level with example (deprecated)' do
       level = create(:javalab, :with_example_solutions)
       sl = create(:script_level, levels: [level])
@@ -157,13 +159,13 @@ class ScriptLevelTest < ActiveSupport::TestCase
     end
 
     test 'get_example_solutions for javalab sublevel level with exemplar' do
-      sublevel1 = create :javalab, exemplar_sources: 'some code', name: 'choice_1', display_name: 'Choice 1!', thumbnail_url: 'some-fake.url/kittens.png', bubble_choice_description: 'Choose me!'
-      sublevels = [sublevel1]
-      bubble_choice = create :bubble_choice_level, name: 'bubble_choices', display_name: 'Bubble Choices', description: 'Choose one or more!', sublevels: sublevels
+      sublevel = create :javalab, exemplar_sources: 'some code'
+      sublevels = [sublevel]
+      bubble_choice = create :bubble_choice_level, sublevels: sublevels
       script = create(:script)
       sl = create :script_level, levels: [bubble_choice], script: script
 
-      assert_equal ["https://studio.code.org/s/#{script.name}/lessons/1/levels/1/sublevel/1?exemplar=true"], sl.get_example_solutions(sublevel1, @authorized_teacher)
+      assert_equal ["https://studio.code.org/s/#{script.name}/lessons/1/levels/1/sublevel/1?exemplar=true"], sl.get_example_solutions(sublevel, @authorized_teacher)
     end
 
     test 'get_example_solutions for level with ideal level source' do


### PR DESCRIPTION
Uses a new URL param (?exemplar=true) to show exemplars to verified instructors at URLs like studio.code.org/s/csa1/lessons/1/levels/1?exemplar=true. These URLs will be used in the "Example Solution" buttons that appear in the blue teacher pullout for any level that has an `exemplar_sources` property (only new Javalab levels where a levelbuilder has built an exemplar, for now).

The exemplar page is view only, but allows teachers to run code.

If a Javalab level (or any level really) were to have both an exemplar (via `exemplar_sources` property) and an example (via the `examples` property), we'd show the new URL. I didn't include a DCDO flag or anything, because in theory these two properties should be mutually exclusive (ie, old Javalab levels would have the `examples` property, and new ones would have the `exemplar_sources` property).

Adds a couple of really simple messages to show to students/teachers who try to access exemplars without permission, and another message for levels where exemplars do not exist.

**Verified instructor viewing exemplar**
![image](https://user-images.githubusercontent.com/25372625/160204464-f81a8d02-fcaa-46b1-9146-6b76af07267f.png)

**Unverified teacher viewing exemplar (same visual for students/exemplar does not exist, just different text)**
![image](https://user-images.githubusercontent.com/25372625/160204887-31592885-0118-4d13-9261-c6dba843c0dd.png)

## Links

- [Javalab exemplar updates doc](https://docs.google.com/document/d/1G5mDxQvvfUUkH5gGW7yb_TeHEedGtX_Ez3OUITwEti0/edit)
- jira ticket: [JAVA-491](https://codedotorg.atlassian.net/browse/JAVA-491)

## Testing story

I tested manually that a Javalab level where I had added `exemplar_sources` to the level definition showed the new style of URL. I did the same with a sublevel. I also observed that an Applab level still showed the correct URL.

I added a couple of unit tests for the new behavior.

## Follow-up work

There's a bit of cleanup to do here, documented in [JAVA-525](https://codedotorg.atlassian.net/browse/JAVA-525).