### PR TITLE
Javalab exemplars: add exemplar option to levelbuilder menu

### DIFF
--- a/dashboard/app/views/levels/_admin.html.haml
+++ b/dashboard/app/views/levels/_admin.html.haml
@@ -32,6 +32,7 @@
             - elsif @level.is_a? Javalab
               %ul
                 %li= link_to "[s]tart", edit_blocks_level_path(@level, :start_sources), { accesskey: 's' }
+                %li= link_to "e[x]emplar", edit_exemplar_level_path(@level), { accesskey: 'x'}
         - else
           %li (Cannot edit)
         - if can? :delete, @level

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -259,7 +259,7 @@ Dashboard::Application.routes.draw do
       get 'get_rubric'
       get 'embed_level'
       get 'edit_blocks/:type', to: 'levels#edit_blocks', as: 'edit_blocks'
-      get 'edit_exemplar'
+      get 'edit_exemplar', to: 'levels#edit_exemplar', as: 'edit_exemplar'
       get 'get_serialized_maze'
       post 'update_properties'
       post 'update_blocks/:type', to: 'levels#update_blocks', as: 'update_blocks'


### PR DESCRIPTION
Adds an "exemplar" option to the levelbuilder menu to open the edit exemplar page for levelbuilders.

## Testing story

Tested manually, including keyboard navigation via "x".