### PR TITLE
Implement stack refactor and add codeprojects stack

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -549,6 +549,8 @@ Resources:
 <%=  component 'database'%>
 <% end -%>
 
+<%= resource_component 'codeprojects_resources' %>
+
   ChefConfig:
     Type: AWS::SecretsManager::Secret
     Properties:

--- a/aws/cloudformation/components/www_redirect.yml.erb
+++ b/aws/cloudformation/components/www_redirect.yml.erb
@@ -4,9 +4,7 @@
     # Since this line is restricted to only run in production, we are comfortable using it.
     redirected_domains << "www.#{CDO.pegasus_hostname}" if rack_env?(:production)
     
-    www_redirect_hosted_zone = Aws::Route53::Client.new.list_hosted_zones_by_name(dns_name: domain).hosted_zones.first
-    raise "Could not find #{domain} in hosted zones" unless www_redirect_hosted_zone.name.delete_suffix('.') == domain
-    www_redirect_hosted_zone_id = www_redirect_hosted_zone.id.delete_prefix("/hostedzone/")
+    www_redirect_hosted_zone_id = CDO.hostedzone_id(domain)
   -%>
 
   <%=app%>RedirectDNS:

--- a/lib/cdo.rb
+++ b/lib/cdo.rb
@@ -87,6 +87,20 @@ module Cdo
       canonical_hostname('advocacy.code.org')
     end
 
+    def codeprojects_hostname
+      canonical_hostname('codeprojects.org')
+    end
+
+    def hostedzone_id(domain)
+      hosted_zone = Aws::Route53::Client.new.list_hosted_zones_by_name(dns_name: domain).hosted_zones.first
+      raise "Could not find #{domain} in hosted zones" unless hosted_zone.name.delete_suffix('.') == domain
+      return hosted_zone.id.delete_prefix("/hostedzone/")
+    end
+
+    def codeprojects_hostedzone_id
+      hostedzone_id('codeprojects.org')
+    end
+
     def site_host(domain)
       host = canonical_hostname(domain)
       if (rack_env?(:development) && !https_development) ||

--- a/lib/cdo/cloud_formation/stack_template.rb
+++ b/lib/cdo/cloud_formation/stack_template.rb
@@ -77,6 +77,13 @@ module Cdo::CloudFormation
       erb_file(aws_dir("cloudformation/components/#{name}.yml.erb"), vars)
     end
 
+    # Inline stack resources into the template using local variables as parameters
+    # This allows component file to be unindented, and will add a 2-space indent when loaded
+    def resource_component(name, vars = {})
+      resource_indent = 2
+      indent(erb_file(aws_dir("cloudformation/components/#{name}.yml.erb"), vars), resource_indent)
+    end
+
     # Adds the specified properties to a YAML document.
     def add_properties(properties)
       properties.transform_values(&:to_json).map {|p| p.join(': ')}.join


### PR DESCRIPTION
Create new environment-specific certificates for codeprojects.org with automatic DNS validation to replace the manual wildcard cert used today.

Once created, any resources using [the old certificate](https://console.aws.amazon.com/acm/home?region=us-east-1#/certificates/a72e9bd5-fab2-402d-9194-0a38115c2253) would need to be updated to use these. After all resources are switched, the old certificate can be deleted.

## Links

Jira ticket: STAR-1893 INF-598

## Testing story

## Deployment strategy

If DNS validation fails, then this will get stuck in the cloudformation update step of the DTP. The domain could be manually approved before the timeout, but that kind of defeats the purpose.

To avoid that I'm making this PR deploy as part of staging-only, confirm the validation works, then move on to the test and prod certs.

## Follow-up work

- Deploy the test and prod certs in #45066 
- migrate resources tied to [the old cert](https://console.aws.amazon.com/acm/home?region=us-east-1#/certificates/a72e9bd5-fab2-402d-9194-0a38115c2253)
- delete the old certs

## PR Checklist:

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked