### PR TITLE
AiLab: adjust profanity filtering

### DIFF
--- a/lib/cdo/profanity_filter.rb
+++ b/lib/cdo/profanity_filter.rb
@@ -24,8 +24,8 @@ class ProfanityFilter
   # @param [String] language_code a two-character ISO 639-1 language code ('en').
   #   Will also convert a four-character locale code ('en-US').
   # @return [String, nil] The first instance of profanity (if any) or nil (if none)
-  def self.find_potential_profanity(text, language_code)
-    expletive = find_potential_profanities(text, language_code)
+  def self.find_potential_profanity(text, language_code, replace_text_list = {})
+    expletive = find_potential_profanities(text, language_code, replace_text_list)
     expletive.is_a?(Array) ? expletive.first : expletive
   end
 
@@ -36,14 +36,20 @@ class ProfanityFilter
   # @param [String] language_code a two-character ISO 639-1 language code ('en').
   #   Will also convert a four-character locale code ('en-US').
   # @return [Array<String>, nil] The profanities (if any) or nil (if none)
-  def self.find_potential_profanities(text, language_code)
+  def self.find_potential_profanities(text, language_code, replace_text_list = {})
     language_code = language(language_code)
+
+    # Replace certain words before they are sent to the profanity filter.
+    replace_pattern = replace_text_list.keys.map {|t| "\\b" + t.to_s + "\\b"}.join('|')
+    matcher = Regexp.new replace_pattern, Regexp::IGNORECASE
+    updated_text = text.gsub(matcher, replace_text_list)
+
     LANGUAGE_SPECIFIC_ALLOWLIST.each do |word, languages|
       next if languages.include? language_code
       r = Regexp.new "\\b#{word}\\b", Regexp::IGNORECASE
-      return [word.to_s] if r =~ text
+      return [word.to_s] if r =~ updated_text
     end
-    WebPurify.find_potential_profanities(text, ['en', language_code])
+    WebPurify.find_potential_profanities(updated_text, ['en', language_code])
   end
 
   # Converts a locale ('en-US') to its language ('en').

--- a/lib/cdo/profanity_filter.rb
+++ b/lib/cdo/profanity_filter.rb
@@ -23,6 +23,7 @@ class ProfanityFilter
   # @param [String] text to check for profanity
   # @param [String] language_code a two-character ISO 639-1 language code ('en').
   #   Will also convert a four-character locale code ('en-US').
+  # @param [Hash{word => replacementText}] optional words to replace.
   # @return [String, nil] The first instance of profanity (if any) or nil (if none)
   def self.find_potential_profanity(text, language_code, replace_text_list = {})
     expletive = find_potential_profanities(text, language_code, replace_text_list)
@@ -35,6 +36,7 @@ class ProfanityFilter
   # @param [String] text to check for profanity
   # @param [String] language_code a two-character ISO 639-1 language code ('en').
   #   Will also convert a four-character locale code ('en-US').
+  # @param [Hash{word => replacementText}] optional words to replace.
   # @return [Array<String>, nil] The profanities (if any) or nil (if none)
   def self.find_potential_profanities(text, language_code, replace_text_list = {})
     language_code = language(language_code)

--- a/lib/cdo/share_filtering.rb
+++ b/lib/cdo/share_filtering.rb
@@ -55,7 +55,7 @@ module ShareFiltering
     find_failure(program_name, locale)
   end
 
-  def self.find_failure(text, locale)
+  def self.find_failure(text, locale, profanity_filter_replace_text_list = {})
     return nil unless Gatekeeper.allows('webpurify', default: true)
 
     email = RegexpUtils.find_potential_email(text)
@@ -64,7 +64,7 @@ module ShareFiltering
     phone_number = RegexpUtils.find_potential_phone_number(text)
     return ShareFailure.new(FailureType::PHONE, phone_number) if phone_number
 
-    expletive = ProfanityFilter.find_potential_profanity(text, locale)
+    expletive = ProfanityFilter.find_potential_profanity(text, locale, profanity_filter_replace_text_list)
     return ShareFailure.new(FailureType::PROFANITY, expletive) if expletive
 
     street_address = Geocoder.find_potential_street_address(text)

--- a/lib/test/cdo/test_profanity_filter.rb
+++ b/lib/test/cdo/test_profanity_filter.rb
@@ -59,4 +59,12 @@ class ProfanityFilterTest < Minitest::Test
 
     WebPurify.unstub(:find_potential_profanities)
   end
+
+  def test_find_potential_profanities_replace_text_list
+    WebPurify.stubs(:find_potential_profanities).with("testing  replacenah testing", ['en', 'en']).returns(["replacee"])
+
+    assert_equal ['replacee'], ProfanityFilter.find_potential_profanities('testing replacee replacenah testing', 'en', {replacee: ''})
+
+    WebPurify.unstub(:find_potential_profanities)
+  end
 end

--- a/lib/test/cdo/test_profanity_filter.rb
+++ b/lib/test/cdo/test_profanity_filter.rb
@@ -61,9 +61,19 @@ class ProfanityFilterTest < Minitest::Test
   end
 
   def test_find_potential_profanities_replace_text_list
-    WebPurify.stubs(:find_potential_profanities).with("testing  replacenah testing", ['en', 'en']).returns(["replacee"])
+    # Ensure that when ProfanityFilter.find_potential_profanities is called with text_original,
+    # that it calls WebPurify.find_potential_profanities with text_word_removed.
+    # Note that because it only replaces standalone words, "replacenah" will not be replaced.
+    # Also note that text_word_removed has two spaces in it because we remove standalone words,
+    # leaving two spaces surrounding the place where the word used to be.
 
-    assert_equal ['replacee'], ProfanityFilter.find_potential_profanities('testing replacee replacenah testing', 'en', {replacee: ''})
+    text_original = 'testing replace replacenah testing'
+    text_word_removed = 'testing  replacenah testing'
+    word_to_remove = 'replace'
+
+    WebPurify.stubs(:find_potential_profanities).with(text_word_removed, ['en', 'en']).returns([word_to_remove])
+
+    assert_equal [word_to_remove], ProfanityFilter.find_potential_profanities(text_original, 'en', {word_to_remove => ''})
 
     WebPurify.unstub(:find_potential_profanities)
   end


### PR DESCRIPTION
Before saving a trained model in AI Lab, we run it through the profanity filtering service.  Even if a column name isn't selected as a label or a feature, it is still detected, and we have had at least one column name causing a number of data sets' models to be rejected.  

This adds an optional parameter to our share filtering, and in turn our profanity filtering, which allows the caller to specify a list of words and some text with which to replace them, before they are sent to the profanity filtering service.

For now, only AI Lab makes use of this new functionality, so the remainder of our filtering functionality is unchanged.  It simply replaces the word in question with nothing, effectively preventing that word from being detected by the filtering.
