### PR TITLE
Javalab: set token timeout to 1 minute

### DIFF
--- a/dashboard/app/controllers/javabuilder_sessions_controller.rb
+++ b/dashboard/app/controllers/javabuilder_sessions_controller.rb
@@ -77,8 +77,8 @@ class JavabuilderSessionsController < ApplicationController
 
     # Set the IAT a little in the past to account for time drift between environments
     issued_at_time = (Time.now - 5.seconds).to_i
-    # expire token in 15 minutes
-    expiration_time = (Time.now + 15.minutes).to_i
+    # expire token in 1 minute
+    expiration_time = (Time.now + 1.minute).to_i
 
     payload = {
       iat: issued_at_time,


### PR DESCRIPTION
Reduces the Javabuilder token timeout from 15 minutes to 1 minute. This will be used for Javabuilder service throttling.

JIRA: https://codedotorg.atlassian.net/browse/JAVA-486

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Confirmed that the token expires after 1 minute by reissuing a previously valid request in Postman after waiting 1 minute.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
