### PR TITLE
Pin Drone to Specific Image Version

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -187,6 +187,6 @@ trigger:
     - pull_request
 ---
 kind: signature
-hmac: 44de2cd71efea1f3179ea8efe094b937b5b899c96149c18a18813d0026e03f77
+hmac: ea2b6b015f9bee1820bc7b3add10da2c79ebc0872a4d42a1627508a32b1864da
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -26,7 +26,7 @@ steps:
       filename: unit-tests-cache.tar
 
   - name: unit-tests
-    image: codedotorg/code-dot-org:latest
+    image: codedotorg/code-dot-org:1.2
     pull: always
     volumes:
       - name: rbenv

--- a/.drone.yml
+++ b/.drone.yml
@@ -120,7 +120,7 @@ steps:
       restore: true
 
   - name: ui-tests
-    image: codedotorg/code-dot-org:latest
+    image: codedotorg/code-dot-org:1.2
     volumes:
       - name: rbenv
         path: /home/circleci/.rbenv
@@ -187,6 +187,6 @@ trigger:
     - pull_request
 ---
 kind: signature
-hmac: ea2b6b015f9bee1820bc7b3add10da2c79ebc0872a4d42a1627508a32b1864da
+hmac: 3315742acecada4bfb2964c19fcded2cfc85efb967ed7449f92d453539520207
 
 ...


### PR DESCRIPTION
Currently, we always use the latest uploaded docker image for drone.  This makes it difficult to test changes, since images need to be uploaded to be tested against drone. Rather than continue to test on personal dockerhub accounts, I suggest we simply pin to a version in the drone config.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
