### PR TITLE
Clearer Sign-up User Type Selection Buttons that Default to Original Behavior and Remove Optimizely Code

### DIFF
--- a/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
+++ b/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
@@ -40,31 +40,39 @@ let schoolData = {
 // Keep track of whether the current user is in the U.S. or not (for regional partner email sharing)
 let isInUnitedStates = schoolData.countryCode === 'US';
 
-// TO-DELETE ONCE SHARE EMAIL WITH REGIONAL PARTNER OPTIMIZELY-EXPERIMENT IS COMPLETE (start)
-let userInOptimizelyVariant = experiments.isEnabled(
+// Track whether clearer user type buttons rollout is enabled
+const inClearerUserTypeRollout = experiments.isEnabled(
+  experiments.CLEARER_SIGN_UP_USER_TYPE
+);
+
+let userInRegionalPartnerVariant = experiments.isEnabled(
   experiments.OPT_IN_EMAIL_REG_PARTNER
 );
-// TO-DELETE ONCE SHARE EMAIL WITH REGIONAL PARTNER OPTIMIZELY-EXPERIMENT IS COMPLETE (end)
 
 $(document).ready(() => {
   const schoolInfoMountPoint = document.getElementById('school-info-inputs');
+  let user_type = $('#user_user_type').val();
   init();
 
   function init() {
-    // TO-DELETE ONCE CLEARER USER TYPE BUTTONS OPTIMIZELY-EXPERIMENT IS COMPLETE (start)
-    if (experiments.isEnabled(experiments.CLEARER_SIGN_UP_USER_TYPE)) {
+    if (inClearerUserTypeRollout) {
       // If in variant, toggle large buttons
       document.getElementById('select-user-type-original').style.cssText =
         'display:none;';
+      document.getElementById('select-user-type-variant').style.cssText =
+        'display:flex;';
+      document.getElementById('signup-select-user-type-label').style.cssText =
+        'width:135px;';
     } else {
       // Otherwise (also the default), keep original dropdown
       document.getElementById('select-user-type-variant').style.cssText =
         'display:none;';
+      document.getElementById('select-user-type-original').style.cssText =
+        'display:flex;';
       document.getElementById('signup-select-user-type-label').style.cssText =
         'width:220px;';
     }
-    // TO-DELETE ONCE CLEARER USER TYPE BUTTONS OPTIMIZELY-EXPERIMENT IS COMPLETE (end)
-    setUserType(getUserType());
+    setUserType(user_type);
     renderSchoolInfo();
     renderParentSignUpSection();
   }
@@ -79,17 +87,9 @@ $(document).ready(() => {
       return false;
     }
 
-    // Optimizely-related code for new sign-up user-type buttons (start)
-    optimizelyCountUserTypeSelection(getUserType());
-    // Optimizely-related code for new sign-up user-type buttons (end)
-
-    // Optimizely-related code for teacher opting to share email with regional partner (start)
-    optimizelyCountSuccessSignupWithRegPartnerOpt();
-    // Optimizely-related code for teacher opting to share email with regional partner (end)
-
     alreadySubmitted = true;
     // Clean up school data and set age for teachers.
-    if (getUserType() === 'teacher') {
+    if (user_type === 'teacher') {
       cleanSchoolInfo();
       $('#user_age').val('21+');
     }
@@ -115,7 +115,8 @@ $(document).ready(() => {
   $('#user_parent_email_preference_opt_in_required').change(function() {
     // If the user_type is currently blank, switch the user_type to 'student' because that is the only user_type which
     // allows the parent sign up section of the form.
-    if (getUserType() === '') {
+    if (user_type === '') {
+      setUserType('student');
       $('#user_user_type')
         .val('student')
         .change();
@@ -134,19 +135,39 @@ $(document).ready(() => {
     }
   }
 
-  // Keep if sign-up user type experiment favors variant (start)
+  // Keep if sign-up user type experiment favors original (just func. below)
+  $('#user_user_type').change(function() {
+    var value = $(this).val();
+    setUserType(value);
+  });
   // Event listeners for changing the user type
   document.addEventListener('selectUserTypeTeacher', e => {
     $('#user_user_type').val('teacher');
-    styleSelectedUserTypeButton('teacher');
     setUserType('teacher');
   });
   document.addEventListener('selectUserTypeStudent', e => {
     $('#user_user_type').val('student');
-    styleSelectedUserTypeButton('student');
     setUserType('student');
   });
 
+  function setUserType(new_user_type) {
+    if (new_user_type) {
+      trackUserType(new_user_type);
+    }
+    // Switch to new user type
+    if (new_user_type === 'teacher') {
+      switchToTeacher();
+    } else {
+      // Show student fields by default.
+      switchToStudent();
+    }
+    if (inClearerUserTypeRollout) {
+      styleSelectedUserTypeButton(new_user_type);
+    }
+    user_type = new_user_type;
+  }
+
+  // Style selected user type button to show it has been clicked
   function styleSelectedUserTypeButton(value) {
     if (value === 'teacher') {
       teacherButton.classList.add('select-user-type-button-selected');
@@ -154,44 +175,6 @@ $(document).ready(() => {
     } else if (value === 'student') {
       studentButton.classList.add('select-user-type-button-selected');
       teacherButton.classList.remove('select-user-type-button-selected');
-    }
-  }
-  // Keep if sign-up user type experiment favors variant (end)
-
-  // Optimizely-related code for new sign-up user-type buttons
-  function optimizelyCountUserTypeSelection(userType) {
-    window['optimizely'] = window['optimizely'] || [];
-    window['optimizely'].push({type: 'event', eventName: userType});
-  }
-
-  // Optimizely-related code for sharing email with regional partners experiment
-  function optimizelyCountSuccessSignupWithRegPartnerOpt() {
-    window['optimizely'] = window['optimizely'] || [];
-    window['optimizely'].push({type: 'event', eventName: 'successSignUp'});
-  }
-
-  // Keep if sign-up user type experiment favors original (just func. below)
-  $('#user_user_type').change(function() {
-    var value = $(this).val();
-    setUserType(value);
-  });
-
-  function getUserType() {
-    var value = $('#user_user_type')[0].value;
-    styleSelectedUserTypeButton(value);
-    return value;
-  }
-
-  function setUserType(userType) {
-    if (userType) {
-      trackUserType(userType);
-    }
-
-    if (userType === 'teacher') {
-      switchToTeacher();
-    } else {
-      // Show student fields by default.
-      switchToStudent();
     }
   }
 
@@ -227,7 +210,7 @@ $(document).ready(() => {
   // Show opt-in for teachers in the U.S. for sharing their email with
   // Code.org regional partners.
   function toggleVisShareEmailRegPartner(isTeacherInUnitedStates) {
-    if (userInOptimizelyVariant && isTeacherInUnitedStates) {
+    if (userInRegionalPartnerVariant && isTeacherInUnitedStates) {
       $('#share-email-reg-part-preference-radio').fadeIn();
     } else {
       $('#share-email-reg-part-preference-radio').hide();

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -1765,6 +1765,14 @@ a.download-video {
     }
   }
 
+  #select-user-type-original {
+    display: flex;
+  }
+
+  #select-user-type-variant {
+    display: none;
+  }
+
   .select-user-type-teacher-button:hover, .select-user-type-student-button:hover {
     background-color: $selectUserTypeButtonBackgroundColorHover;
     color: $selectUserTypeButtonTextColorHover;
@@ -1919,7 +1927,7 @@ a.download-video {
     }
 
     #signup-select-user-type-label {
-      width: 135px;
+      width: 220px;
     }
 
     .padded-container {

--- a/lib/dynamic_config/dcdo.rb
+++ b/lib/dynamic_config/dcdo.rb
@@ -40,7 +40,8 @@ class DCDOBase < DynamicConfigBase
     # For example:
     # 'my-new-feature': DCDO.get('my-new-feature', false)
     {
-      'frontend-i18n-tracking': DCDO.get('frontend-i18n-tracking', false)
+      'frontend-i18n-tracking': DCDO.get('frontend-i18n-tracking', false),
+      'clearerSignUpUserType': DCDO.get('clearerSignUpUserType', false)
     }
   end
 end


### PR DESCRIPTION
Same as [this PR](https://github.com/code-dot-org/code-dot-org/pull/45280) (which was reverted) with a minor change to ensure that the logic defaults to the original behavior in case of an issue. Now, it has to explicitly detect that the DCDO flag is set to true for the new user type buttons to show up, otherwise it will show the original dropdown.

The previous PR was reverted so that this small change could be made. In addition, all Optimizely code is being removed since Code.org is not going to be using Optimizely anymore.

## Testing story
Re-tested locally to ensure the same behavior and defaulting to the original.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
