### PR TITLE
Add a Fields section to the programming class editor

### DIFF
--- a/apps/src/lib/levelbuilder/code-docs-editor/FieldEditor.jsx
+++ b/apps/src/lib/levelbuilder/code-docs-editor/FieldEditor.jsx
@@ -1,0 +1,60 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import color from '@cdo/apps/util/color';
+import TextareaWithMarkdownPreview from '@cdo/apps/lib/levelbuilder/TextareaWithMarkdownPreview';
+
+export default function FieldEditor({field, updateField}) {
+  return (
+    <div>
+      <label>
+        Name
+        <input
+          value={field.name || ''}
+          onChange={e => updateField('name', e.target.value)}
+          style={styles.textInput}
+        />
+      </label>
+      <label>
+        Type
+        <input
+          value={field.type || ''}
+          onChange={e => updateField('type', e.target.value)}
+          style={styles.textInput}
+        />
+      </label>
+
+      <TextareaWithMarkdownPreview
+        markdown={field.description || ''}
+        label={'Description'}
+        handleMarkdownChange={e => updateField('description', e.target.value)}
+        features={{imageUpload: true}}
+      />
+    </div>
+  );
+}
+
+FieldEditor.propTypes = {
+  field: PropTypes.object,
+  updateField: PropTypes.func
+};
+
+const styles = {
+  textInput: {
+    width: '100%',
+    boxSizing: 'border-box',
+    padding: '4px 6px',
+    color: '#555',
+    border: `1px solid ${color.bootstrap_border_color}`,
+    borderRadius: 4,
+    margin: 0
+  },
+  selectInput: {
+    boxSizing: 'border-box',
+    padding: '4px 6px',
+    color: '#555',
+    border: `1px solid ${color.bootstrap_border_color}`,
+    borderRadius: 4,
+    marginLeft: 5,
+    width: 350
+  }
+};

--- a/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingClassEditor.jsx
+++ b/apps/src/lib/levelbuilder/code-docs-editor/ProgrammingClassEditor.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 import OrderableList from './OrderableList';
 import ExampleEditor from './ExampleEditor';
+import FieldEditor from './FieldEditor';
 import TextareaWithMarkdownPreview from '@cdo/apps/lib/levelbuilder/TextareaWithMarkdownPreview';
 import CollapsibleEditorSection from '@cdo/apps/lib/levelbuilder/CollapsibleEditorSection';
 import HelpTip from '@cdo/apps/lib/ui/HelpTip';
@@ -31,6 +32,15 @@ function renderExampleEditor(example, updateFunc) {
   );
 }
 
+function renderFieldEditor(field, updateFunc) {
+  return (
+    <FieldEditor
+      field={field}
+      updateField={(key, value) => updateFunc(key, value)}
+    />
+  );
+}
+
 export default function ProgrammingClassEditor({
   initialProgrammingClass,
   environmentCategories
@@ -38,6 +48,7 @@ export default function ProgrammingClassEditor({
   // We don't want to update id or key
   const {id, key, ...remainingProgrammingClass} = initialProgrammingClass;
   remainingProgrammingClass.examples.forEach(e => (e.key = createUuid()));
+  remainingProgrammingClass.fields.forEach(f => (f.key = createUuid()));
   const [programmingClass, updateProgrammingClass] = useProgrammingClass(
     remainingProgrammingClass
   );
@@ -169,6 +180,14 @@ export default function ProgrammingClassEditor({
           setList={list => updateProgrammingClass('examples', list)}
           addButtonText="Add Another Example"
           renderItem={renderExampleEditor}
+        />
+      </CollapsibleEditorSection>
+      <CollapsibleEditorSection title="Fields" collapsed>
+        <OrderableList
+          list={programmingClass.fields || []}
+          setList={list => updateProgrammingClass('fields', list)}
+          addButtonText="Add Another Field"
+          renderItem={renderFieldEditor}
         />
       </CollapsibleEditorSection>
       <SaveBar

--- a/apps/test/unit/lib/levelbuilder/code-docs-editor/FieldEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/code-docs-editor/FieldEditorTest.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import {expect} from '../../../../util/reconfiguredChai';
+import FieldEditor from '@cdo/apps/lib/levelbuilder/code-docs-editor/FieldEditor';
+import sinon from 'sinon';
+
+describe('FieldEditor', () => {
+  let defaultProps, updateSpy;
+
+  beforeEach(() => {
+    updateSpy = sinon.spy();
+    defaultProps = {
+      field: {
+        name: 'field 1',
+        type: 'int',
+        description: 'this is the first field'
+      },
+      updateField: updateSpy
+    };
+  });
+
+  it('displays input for name field', () => {
+    const wrapper = shallow(<FieldEditor {...defaultProps} />);
+    const nameField = wrapper.find('input').at(0);
+    expect(nameField.props().value).to.equal('field 1');
+  });
+
+  it('calls update when name is updated', () => {
+    const wrapper = shallow(<FieldEditor {...defaultProps} />);
+    const nameField = wrapper.find('input').at(0);
+    nameField.simulate('change', {target: {value: 'new name'}});
+    expect(updateSpy).to.be.calledOnce.and.calledWith('name', 'new name');
+  });
+
+  it('displays input for type field', () => {
+    const wrapper = shallow(<FieldEditor {...defaultProps} />);
+    const typeField = wrapper.find('input').at(1);
+    expect(typeField.props().value).to.equal('int');
+  });
+
+  it('calls update when type is updated', () => {
+    const wrapper = shallow(<FieldEditor {...defaultProps} />);
+    const typeField = wrapper.find('input').at(1);
+    typeField.simulate('change', {target: {value: 'String'}});
+    expect(updateSpy).to.be.calledOnce.and.calledWith('type', 'String');
+  });
+
+  it('displays markdown editor for description', () => {
+    const wrapper = shallow(<FieldEditor {...defaultProps} />);
+    const descriptionEditor = wrapper.find('TextareaWithMarkdownPreview').at(0);
+    expect(descriptionEditor.props().markdown).to.equal(
+      'this is the first field'
+    );
+  });
+});

--- a/apps/test/unit/lib/levelbuilder/code-docs-editor/ProgrammingClassEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/code-docs-editor/ProgrammingClassEditorTest.jsx
@@ -20,7 +20,8 @@ describe('ProgrammingClassEditor', () => {
       syntax: 'Painter()',
       returnValue: 'none',
       tips: 'some tips on how to use this class',
-      examples: [{name: 'example 1'}]
+      examples: [{name: 'example 1'}],
+      fields: [{name: 'fields 1'}]
     };
     defaultProps = {
       initialProgrammingClass,
@@ -138,6 +139,18 @@ describe('ProgrammingClassEditor', () => {
     expect(orderableExampleList.props().list.length).to.equal(1);
   });
 
+  it('displays initial values in input fields in fields section', () => {
+    const wrapper = shallow(<ProgrammingClassEditor {...defaultProps} />);
+    // Fields section
+    const fieldsSection = wrapper.find('CollapsibleEditorSection').at(4);
+    expect(fieldsSection.props().title).to.equal('Fields');
+    const orderableFieldList = fieldsSection.find('OrderableList');
+    expect(orderableFieldList.props().addButtonText).to.equal(
+      'Add Another Field'
+    );
+    expect(orderableFieldList.props().list.length).to.equal(1);
+  });
+
   it('attempts to save when save is pressed', () => {
     const store = getStore();
     const wrapper = mount(
@@ -166,7 +179,8 @@ describe('ProgrammingClassEditor', () => {
         'returnValue',
         'syntax',
         'tips',
-        'examples'
+        'examples',
+        'fields'
       ].sort()
     );
     expect(fetchCallBody.name).to.equal('Painter');

--- a/dashboard/app/controllers/programming_classes_controller.rb
+++ b/dashboard/app/controllers/programming_classes_controller.rb
@@ -51,9 +51,11 @@ class ProgrammingClassesController < ApplicationController
       :content,
       :syntax,
       :tips,
-      examples: [:name, :description, :code, :app, :image, :app_display_type, :embed_app_with_code_height]
+      examples: [:name, :description, :code, :app, :image, :app_display_type, :embed_app_with_code_height],
+      fields: [:name, :type, :description]
     )
     transformed_params[:examples] = transformed_params[:examples].to_json if transformed_params[:examples]
+    transformed_params[:fields] = transformed_params[:fields].to_json if transformed_params[:fields]
     transformed_params
   end
 end

--- a/dashboard/app/models/programming_class.rb
+++ b/dashboard/app/models/programming_class.rb
@@ -37,6 +37,7 @@ class ProgrammingClass < ApplicationRecord
       name: name || '',
       content: content || '',
       examples: parsed_examples,
+      fields: parsed_fields,
       tips: tips || '',
       syntax: syntax || '',
       external_documentation: external_documentation || '',
@@ -48,5 +49,9 @@ class ProgrammingClass < ApplicationRecord
 
   def parsed_examples
     examples.blank? ? [] : JSON.parse(examples)
+  end
+
+  def parsed_fields
+    fields.blank? ? [] : JSON.parse(fields)
   end
 end

--- a/dashboard/test/controllers/programming_classes_controller_test.rb
+++ b/dashboard/test/controllers/programming_classes_controller_test.rb
@@ -42,7 +42,8 @@ class ProgrammingClassesControllerTest < ActionController::TestCase
       content: 'a longer description of the code',
       syntax: 'new Class()',
       tips: 'some tips on how to use this class',
-      examples: [{name: 'example 1', embed_app_with_code_height: '300px'}]
+      examples: [{name: 'example 1', embed_app_with_code_height: '300px'}],
+      fields: [{name: 'field 1', type: 'int'}]
     }
     assert_response :ok
     programming_class.reload
@@ -54,6 +55,7 @@ class ProgrammingClassesControllerTest < ActionController::TestCase
     assert_equal 'new Class()', programming_class.syntax
     assert_equal 'some tips on how to use this class', programming_class.tips
     assert_equal [{name: 'example 1', embed_app_with_code_height: '300px'}].to_json, programming_class.examples
+    assert_equal [{name: 'field 1', type: 'int'}].to_json, programming_class.fields
   end
 
   test 'data is passed down to edit page' do


### PR DESCRIPTION
Adds a FieldsEditor to ProgrammingClassEditor. `FieldEditor` is a very simple component that is used by `OrderableList`, an existing component, to be reorderable in the editor.

`FieldEditor`:
<img width="989" alt="Screen Shot 2022-03-29 at 7 53 23 AM" src="https://user-images.githubusercontent.com/46464143/160640796-60e45c02-48d1-4b86-b3ce-e7b6e267db2f.png">

Adding and reordering fields:
https://user-images.githubusercontent.com/46464143/160640743-3012bcfe-808a-4a88-970b-e77180f9fd65.mov






## Follow-up work

an editor for methods, which will be created very similarly to this one


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
