### PR TITLE
Homepage: support video action in homepage.json

### DIFF
--- a/pegasus/src/homepage.rb
+++ b/pegasus/src/homepage.rb
@@ -194,7 +194,11 @@ class Homepage
         {
           text: action["text"],
           type: action["type"],
-          url: action["url"]
+          url: action["url"],
+          youtube_id: action["youtube_id"],
+          download_path: action["download_path"],
+          facebook: action["facebook"],
+          twitter: action["twitter"]
         }
       end
     elsif hoc_mode == "actual-hoc"


### PR DESCRIPTION
This adds support for a video player action in `homepage.json`.  There was already partial support, but we needed to consume additional parameters in `homepage.json`.