### PR TITLE
Seed/serialize ProgrammingClass

### DIFF
--- a/dashboard/app/controllers/programming_classes_controller.rb
+++ b/dashboard/app/controllers/programming_classes_controller.rb
@@ -13,6 +13,7 @@ class ProgrammingClassesController < ApplicationController
     end
     programming_class = ProgrammingClass.new(key: params[:key], name: params[:key], programming_environment_id: params[:programming_environment_id])
     if programming_class.save
+      programming_class.write_serialization
       redirect_to edit_programming_class_url(programming_class)
     else
       render :not_acceptable, json: programming_class.errors
@@ -34,6 +35,7 @@ class ProgrammingClassesController < ApplicationController
     @programming_class.programming_environment_category_id = programming_environment_category&.id
     begin
       @programming_class.save! if @programming_class.changed?
+      @programming_class.write_serialization
       render json: @programming_class.summarize_for_edit.to_json
     rescue ActiveRecord::RecordInvalid => e
       render(status: :not_acceptable, plain: e.message)

--- a/dashboard/app/models/programming_class.rb
+++ b/dashboard/app/models/programming_class.rb
@@ -75,7 +75,7 @@ class ProgrammingClass < ApplicationRecord
     return unless Rails.application.config.levelbuilder_mode
     object_to_serialize = serialize
     directory_name = File.dirname(file_path)
-    Dir.mkdir(directory_name) unless File.exist?(directory_name)
+    FileUtils.mkdir_p(directory_name) unless File.exist?(directory_name)
     File.write(file_path, JSON.pretty_generate(object_to_serialize))
   end
 

--- a/dashboard/app/models/programming_class.rb
+++ b/dashboard/app/models/programming_class.rb
@@ -30,6 +30,60 @@ class ProgrammingClass < ApplicationRecord
   validates_uniqueness_of :key, scope: :programming_environment_id, case_sensitive: false
   validate :validate_key_format
 
+  def self.properties_from_file(path, content)
+    expression_config = JSON.parse(content)
+
+    environment_name = File.basename(File.dirname(path))
+    programming_environment = ProgrammingEnvironment.find_by(name: environment_name)
+    throw "Cannot find ProgrammingEnvironment #{environment_name}" unless programming_environment
+    env_category = programming_environment.categories.find_by_key(expression_config['category_key'])
+    expression_config.symbolize_keys.except(:category_key).merge(
+      {
+        programming_environment_id: programming_environment.id,
+        programming_environment_category_id: env_category&.id
+      }
+    )
+  end
+
+  def self.seed_all
+    removed_records = all.pluck(:id)
+    Dir.glob(Rails.root.join("config/programming_classes/**/*.json")).each do |path|
+      removed_records -= [ProgrammingClass.seed_record(path)]
+    end
+    where(id: removed_records).destroy_all
+  end
+
+  def self.seed_record(file_path)
+    properties = properties_from_file(file_path, File.read(file_path))
+    record = ProgrammingClass.find_or_initialize_by(key: properties[:key], programming_environment_id: properties[:programming_environment_id])
+    record.assign_attributes(properties)
+    record.save! if record.changed?
+    record.id
+  end
+
+  def file_path
+    Rails.root.join("config/programming_classes/#{programming_environment.name}/#{key.parameterize(preserve_case: false)}.json")
+  end
+
+  def serialize
+    {
+      category_key: programming_environment_category&.key
+    }.merge(attributes.except('id', 'programming_environment_id', 'programming_environment_category_id', 'created_at', 'updated_at').sort.to_h)
+  end
+
+  def write_serialization
+    return unless Rails.application.config.levelbuilder_mode
+    object_to_serialize = serialize
+    directory_name = File.dirname(file_path)
+    Dir.mkdir(directory_name) unless File.exist?(directory_name)
+    File.write(file_path, JSON.pretty_generate(object_to_serialize))
+  end
+
+  def remove_serialization
+    return unless Rails.application.config.levelbuilder_mode
+    File.delete(file_path) if File.exist?(file_path)
+  end
+
   def summarize_for_edit
     {
       id: id,

--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -168,7 +168,7 @@ namespace :seed do
     :deprecated_blockly_levels,
     :custom_levels,
     :dsls,
-    :programming_expressions,
+    :code_docs,
     :blocks,
     :standards,
     :shared_blockly_functions,
@@ -303,9 +303,10 @@ namespace :seed do
     Standard.seed_all
   end
 
-  timed_task programming_expressions: :environment do
+  timed_task code_docs: :environment do
     ProgrammingEnvironment.seed_all
     ProgrammingExpression.seed_all
+    ProgrammingClass.seed_all
   end
 
   # Seeds the data in school_districts

--- a/dashboard/test/controllers/programming_classes_controller_test.rb
+++ b/dashboard/test/controllers/programming_classes_controller_test.rb
@@ -12,6 +12,7 @@ class ProgrammingClassesControllerTest < ActionController::TestCase
 
   test 'can create programming class from params' do
     sign_in @levelbuilder
+    File.expects(:write).once
     assert_creates(ProgrammingClass) do
       post :create, params: {key: 'class_key', name: 'class name', programming_environment_id: @programming_environment.id}
     end
@@ -29,6 +30,7 @@ class ProgrammingClassesControllerTest < ActionController::TestCase
 
   test 'can update programming class from params' do
     sign_in @levelbuilder
+    File.expects(:write).once
 
     programming_class = create :programming_class, programming_environment: @programming_environment
     category = create :programming_environment_category, programming_environment: @programming_environment

--- a/dashboard/test/controllers/programming_classes_controller_test.rb
+++ b/dashboard/test/controllers/programming_classes_controller_test.rb
@@ -5,6 +5,7 @@ class ProgrammingClassesControllerTest < ActionController::TestCase
 
   setup do
     File.stubs(:write)
+    Dir.stubs(:mkdir)
     Rails.application.config.stubs(:levelbuilder_mode).returns true
     @levelbuilder = create :levelbuilder
     @programming_environment = create :programming_environment

--- a/dashboard/test/controllers/programming_classes_controller_test.rb
+++ b/dashboard/test/controllers/programming_classes_controller_test.rb
@@ -5,7 +5,7 @@ class ProgrammingClassesControllerTest < ActionController::TestCase
 
   setup do
     File.stubs(:write)
-    Dir.stubs(:mkdir)
+    FileUtils.stubs(:mkdir_p)
     Rails.application.config.stubs(:levelbuilder_mode).returns true
     @levelbuilder = create :levelbuilder
     @programming_environment = create :programming_environment

--- a/dashboard/test/models/programming_class_test.rb
+++ b/dashboard/test/models/programming_class_test.rb
@@ -1,10 +1,6 @@
 require 'test_helper'
 
 class ProgrammingClassTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
-
   test "can serialize and seed programming class" do
     programming_environment = create :programming_environment
     category = create :programming_environment_category, programming_environment: programming_environment, name: 'World', color: '#ABCDEF'

--- a/dashboard/test/models/programming_class_test.rb
+++ b/dashboard/test/models/programming_class_test.rb
@@ -1,0 +1,53 @@
+require 'test_helper'
+
+class ProgrammingClassTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+
+  test "can serialize and seed programming class" do
+    programming_environment = create :programming_environment
+    category = create :programming_environment_category, programming_environment: programming_environment, name: 'World', color: '#ABCDEF'
+    programming_class = create :programming_class, key: 'myExp', examples: '[myexamples]', content: 'some content', programming_environment_id: programming_environment.id, programming_environment_category_id: category.id
+    serialization = programming_class.serialize
+    previous_programming_class = programming_class.freeze
+    programming_class.destroy!
+
+    File.stubs(:read).returns(serialization.to_json)
+
+    new_class_id = ProgrammingClass.seed_record("config/programming_classes/#{programming_environment.name}/file.json")
+    new_programming_class = ProgrammingClass.find(new_class_id)
+    assert_equal previous_programming_class.attributes.except('id', 'created_at', 'updated_at'), new_programming_class.attributes.except('id', 'created_at', 'updated_at')
+    assert_equal category, new_programming_class.programming_environment_category
+  end
+
+  test "seed_all adds, updates, and removes programming classes" do
+    programming_environment = create :programming_environment
+    category = create :programming_environment_category, programming_environment: programming_environment, name: 'World', color: '#ABCDEF'
+    create :programming_class, key: 'to_delete', programming_environment: programming_environment, programming_environment_category: category
+    to_update = create :programming_class, key: 'to_update', name: 'Old Name', programming_environment: programming_environment, programming_environment_category: category
+    to_create = build :programming_class, key: 'to_create', programming_environment: programming_environment, programming_environment_category: category
+
+    Dir.stubs(:glob).returns(["#{programming_environment.name}/#{to_update.key}.json", "#{programming_environment.name}/#{to_create.key}.json"])
+
+    to_update.name = "Updated name"
+    File.stubs(:read).with("#{programming_environment.name}/#{to_update.key}.json").returns(to_update.serialize.to_json)
+    File.stubs(:read).with("#{programming_environment.name}/#{to_create.key}.json").returns(to_create.serialize.to_json)
+    File.stubs(:delete)
+
+    to_create.destroy!
+    to_update.reload
+    assert_equal 'Old Name', to_update.name
+
+    ProgrammingClass.seed_all
+
+    to_update.reload
+    refute_nil to_update
+    assert_equal 'Updated name', to_update.name
+    assert_equal 1, ProgrammingClass.where(programming_environment_id: programming_environment.id, key: 'to_update').count
+
+    assert_equal 0, ProgrammingClass.where(programming_environment_id: programming_environment.id, key: 'to_delete').count
+
+    assert_equal 1, ProgrammingClass.where(programming_environment_id: programming_environment.id, key: 'to_create').count
+  end
+end


### PR DESCRIPTION
Adds seed and serializing ProgrammingClass! If editing starts before this is in, work could be lost so I wanted to get this in before then. Methods will also need to be serialized, but I'll add that logic later.

It'll write something like:
```
{
  "category_key": null,
  "content": null,
  "examples": null,
  "external_documentation": null,
  "fields": null,
  "key": "vector",
  "name": "vector",
  "syntax": null,
  "tips": null
}
```

I based this logic very heavily on the `ProgrammingExpression` seeding logic [here](https://github.com/code-dot-org/code-dot-org/blob/ef658a8a3d4e16be2cee897c00709414ba75566b/dashboard/app/models/programming_expression.rb#L130).

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
