### PR TITLE
Remove unused level key list methods

### DIFF
--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -129,11 +129,6 @@ class Level < ApplicationRecord
     @@specified_autoplay_video[video_key + ":" + I18n.locale.to_s] ||= Video.current_locale.find_by_key(video_key) unless video_key.nil?
   end
 
-  def self.key_list
-    @@all_level_keys ||= Level.all.map {|l| [l.id, l.key]}.to_h
-    @@all_level_keys
-  end
-
   def summarize_concepts
     concepts.pluck(:name).map {|c| "'#{c}'"}.join(', ')
   end

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -56,7 +56,6 @@ class Level < ApplicationRecord
   validate :validate_game, on: [:create, :update]
 
   after_save :write_custom_level_file
-  after_save :update_key_list
   after_destroy :delete_custom_level_file
 
   accepts_nested_attributes_for :level_concept_difficulty, update_only: true
@@ -133,11 +132,6 @@ class Level < ApplicationRecord
   def self.key_list
     @@all_level_keys ||= Level.all.map {|l| [l.id, l.key]}.to_h
     @@all_level_keys
-  end
-
-  def update_key_list
-    @@all_level_keys ||= nil
-    @@all_level_keys[id] = key if @@all_level_keys
   end
 
   def summarize_concepts

--- a/dashboard/test/models/level_test.rb
+++ b/dashboard/test/models/level_test.rb
@@ -1103,7 +1103,7 @@ class LevelTest < ActiveSupport::TestCase
   test 'key list' do
     # Make sure there are no levels from test fixtures for which computing a
     # level key raises errors.
-    Level.key_list
+    Level.all.map(&:key)
   end
 
   test "get search options" do

--- a/dashboard/test/models/level_test.rb
+++ b/dashboard/test/models/level_test.rb
@@ -1100,9 +1100,7 @@ class LevelTest < ActiveSupport::TestCase
     assert_includes error.message, 'Game required for non-custom levels'
   end
 
-  test 'key list' do
-    # Make sure there are no levels from test fixtures for which computing a
-    # level key raises errors.
+  test 'can compute keys for all levels from test fixtures without errors' do
     Level.all.map(&:key)
   end
 


### PR DESCRIPTION
as part of untangling the contained levels problem, i discovered some cruft we no longer need related to level keys. these were part of the old script seeding as well as the old script editor. 

## Testing story

existing test coverage, plus updated one existing test. searched the codebase for other instances of the removed method names and didn't find any.