### PR TITLE
AiLab: fix some profanity filtering

### DIFF
--- a/lib/cdo/profanity_filter.rb
+++ b/lib/cdo/profanity_filter.rb
@@ -44,7 +44,7 @@ class ProfanityFilter
     # Replace certain words before they are sent to the profanity filter.
     replace_pattern = replace_text_list.keys.map {|t| "\\b" + t.to_s + "\\b"}.join('|')
     matcher = Regexp.new replace_pattern, Regexp::IGNORECASE
-    updated_text = text.gsub(matcher, replace_text_list)
+    updated_text = text&.gsub(matcher, replace_text_list)
 
     LANGUAGE_SPECIFIC_ALLOWLIST.each do |word, languages|
       next if languages.include? language_code

--- a/lib/test/cdo/test_profanity_filter.rb
+++ b/lib/test/cdo/test_profanity_filter.rb
@@ -77,4 +77,12 @@ class ProfanityFilterTest < Minitest::Test
 
     WebPurify.unstub(:find_potential_profanities)
   end
+
+  def test_nil_text
+    WebPurify.stubs(:find_potential_profanities).with(nil, ['en', 'en']).returns(nil)
+
+    assert_nil ProfanityFilter.find_potential_profanities(nil, 'en')
+
+    WebPurify.unstub(:find_potential_profanities)
+  end
 end


### PR DESCRIPTION
It turns out we have non-AI Lab code which passes nil text to the profanity filter, and we need to continue supporting that usage.

Follow-up to https://github.com/code-dot-org/code-dot-org/pull/45515.