### PR TITLE
[Bad Guys] Reorder projects page

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1473,6 +1473,7 @@
   "projectGroupMinecraft": "Minecraft",
   "projectGroupMinecraftAllProjects": "All Minecraft Projects",
   "projectGroupMinecraftViewMore": "View more Minecraft projects",
+  "projectGroupOpenEnded": "Open-Ended Creativity",
   "projectGroupPreReader": "Pre-reader",
   "projectGroupPreReaderAllProjects": "All Pre-reader Projects",
   "projectGroupPreReaderViewMore": "View more pre-reader projects",

--- a/apps/src/templates/projects/StartNewProject.jsx
+++ b/apps/src/templates/projects/StartNewProject.jsx
@@ -110,16 +110,16 @@ export default class StartNewProject extends React.Component {
               description={i18n.projectGroupEvents()}
               projectTypes={GAMES_AND_EVENTS}
             />
-            <NewProjectButtons
-              description={i18n.projectGroupPlaylab()}
-              projectTypes={PLAYLAB}
-            />
             {canViewAdvancedTools && (
               <NewProjectButtons
                 description={i18n.projectGroupAdvancedTools()}
                 projectTypes={ADVANCED_TOOLS}
               />
             )}
+            <NewProjectButtons
+              description={i18n.projectGroupPlaylab()}
+              projectTypes={PLAYLAB}
+            />
             <NewProjectButtons
               description={i18n.projectGroupPreReader()}
               projectTypes={PREREADER}

--- a/apps/src/templates/projects/StartNewProject.jsx
+++ b/apps/src/templates/projects/StartNewProject.jsx
@@ -28,18 +28,6 @@ export default class StartNewProject extends React.Component {
     const {canViewAdvancedTools, canViewFullList} = this.props;
     const {showFullList} = this.state;
 
-    const GAMES_AND_EVENTS = [
-      'spritelab',
-      'dance',
-      'poetry',
-      'flappy',
-      'starwarsblocks',
-      'starwars',
-      'bounce',
-      'sports',
-      'basketball'
-    ];
-
     const DEFAULT_PROJECT_TYPES_ADVANCED = [
       'spritelab',
       'artist',
@@ -50,10 +38,34 @@ export default class StartNewProject extends React.Component {
     const DEFAULT_PROJECT_TYPES_BASIC = [
       'spritelab',
       'artist',
-      'minecraft_designer',
       'dance',
-      'poetry'
+      'playlab'
     ];
+
+    const OPEN_ENDED = ['spritelab', 'dance', 'poetry', 'thebadguys'];
+
+    const DRAWING = ['artist', 'frozen'];
+
+    const MINECRAFT = [
+      'minecraft_adventurer',
+      'minecraft_designer',
+      'minecraft_hero',
+      'minecraft_aquatic'
+    ];
+
+    const GAMES_AND_EVENTS = [
+      'flappy',
+      'starwarsblocks',
+      'bounce',
+      'sports',
+      'basketball'
+    ];
+
+    const PLAYLAB = ['playlab', 'infinity', 'gumball', 'iceage'];
+
+    const ADVANCED_TOOLS = ['applab', 'gamelab', 'weblab', 'starwars'];
+
+    const PREREADER = ['playlab_k1', 'artist_k1'];
 
     const defaultProjectTypes = canViewAdvancedTools
       ? DEFAULT_PROJECT_TYPES_ADVANCED
@@ -81,39 +93,34 @@ export default class StartNewProject extends React.Component {
         {showFullList && (
           <div>
             <NewProjectButtons
-              description={i18n.projectGroupPlaylab()}
-              projectTypes={['playlab', 'infinity', 'gumball', 'iceage']}
+              description={i18n.projectGroupOpenEnded()}
+              projectTypes={OPEN_ENDED}
+            />
+            <NewProjectButtons
+              description={i18n.projectGroupArtist()}
+              projectTypes={DRAWING}
+            />
+            <NewProjectButtons
+              description={i18n.projectGroupMinecraft()}
+              projectTypes={MINECRAFT}
             />
             <NewProjectButtons
               description={i18n.projectGroupEvents()}
               projectTypes={GAMES_AND_EVENTS}
             />
             <NewProjectButtons
-              description={i18n.projectGroupArtist()}
-              projectTypes={['artist', 'frozen']}
-            />
-            <NewProjectButtons
-              description={i18n.projectGroupMinecraft()}
-              projectTypes={[
-                'minecraft_aquatic',
-                'minecraft_hero',
-                'minecraft_designer',
-                'minecraft_adventurer'
-              ]}
+              description={i18n.projectGroupPlaylab()}
+              projectTypes={PLAYLAB}
             />
             {canViewAdvancedTools && (
               <NewProjectButtons
                 description={i18n.projectGroupAdvancedTools()}
-                projectTypes={['applab', 'gamelab', 'weblab']}
+                projectTypes={ADVANCED_TOOLS}
               />
             )}
             <NewProjectButtons
               description={i18n.projectGroupPreReader()}
-              projectTypes={['playlab_k1', 'artist_k1']}
-            />
-            <NewProjectButtons
-              description={i18n.projectGroupMath()}
-              projectTypes={['calc', 'eval']}
+              projectTypes={PREREADER}
             />
           </div>
         )}

--- a/apps/src/templates/projects/StartNewProject.jsx
+++ b/apps/src/templates/projects/StartNewProject.jsx
@@ -42,6 +42,10 @@ export default class StartNewProject extends React.Component {
       'playlab'
     ];
 
+    const defaultProjectTypes = canViewAdvancedTools
+      ? DEFAULT_PROJECT_TYPES_ADVANCED
+      : DEFAULT_PROJECT_TYPES_BASIC;
+
     const OPEN_ENDED = ['spritelab', 'dance', 'poetry', 'thebadguys'];
 
     const DRAWING = ['artist', 'frozen'];
@@ -67,9 +71,7 @@ export default class StartNewProject extends React.Component {
 
     const PREREADER = ['playlab_k1', 'artist_k1'];
 
-    const defaultProjectTypes = canViewAdvancedTools
-      ? DEFAULT_PROJECT_TYPES_ADVANCED
-      : DEFAULT_PROJECT_TYPES_BASIC;
+    const MATH = ['calc', 'eval'];
 
     return (
       <div>
@@ -121,6 +123,10 @@ export default class StartNewProject extends React.Component {
             <NewProjectButtons
               description={i18n.projectGroupPreReader()}
               projectTypes={PREREADER}
+            />
+            <NewProjectButtons
+              description={i18n.projectGroupMath()}
+              projectTypes={MATH}
             />
           </div>
         )}

--- a/apps/src/templates/projects/StartNewProject.jsx
+++ b/apps/src/templates/projects/StartNewProject.jsx
@@ -124,10 +124,12 @@ export default class StartNewProject extends React.Component {
               description={i18n.projectGroupPreReader()}
               projectTypes={PREREADER}
             />
-            <NewProjectButtons
-              description={i18n.projectGroupMath()}
-              projectTypes={MATH}
-            />
+            {canViewAdvancedTools && (
+              <NewProjectButtons
+                description={i18n.projectGroupMath()}
+                projectTypes={MATH}
+              />
+            )}
           </div>
         )}
         <div style={styles.spacer} />


### PR DESCRIPTION
Builds on the work started in:
- https://github.com/code-dot-org/code-dot-org/pull/45496

We need to enable starting new "The Bad Guys" projects on the Projects Page and reorder existing projects. @KylieModen and I also think it makes sense to update the default set of projects for under 13 users *not in sections*.

The new categories presented here were shared at the 3/31/21 T+L+P+E sync and approved by those in attendance.

Proposed project categories for users who are **13 or over** or **in a section**:
![160919723-ae2602b1-fff0-4fc1-b1ae-b71d7f2a6031](https://user-images.githubusercontent.com/43474485/161115234-760c0f70-5bb2-4a80-a3d1-87b2652c60e5.png)![161104094-a44d72f2-6559-4434-8123-6c44a975ed4f](https://user-images.githubusercontent.com/43474485/161115199-1e80e92c-746d-4dcc-808c-a0f89e3ca820.png)

Proposed project categories for users who are **under 13** and **not in a section**:
![160919773-95a305aa-0bc7-4612-83c5-b4c0f9fadf73](https://user-images.githubusercontent.com/43474485/161115213-6549a365-c671-475a-94de-1feb932806f4.png)

**Note:** *Today, thedefault list for these users includes Poetry and Minecraft Designer instead of Play Lab.*
<img width="1021" alt="160919849-fa264c47-eb26-4e6b-aa2d-34ac58cf9de4" src="https://user-images.githubusercontent.com/43474485/161115189-1168f313-2de6-4e38-9d75-7fc8f895a372.png">




## Links

jira tickets: 
- [STAR-2192:[Bad Guys] Enable The Bad Guys Project in /Projects](https://codedotorg.atlassian.net/browse/STAR-2192)
- [STAR-2193: Reorder projects page](https://codedotorg.atlassian.net/browse/STAR-2193)

