### PR TITLE
Fix link to send lesson to students

### DIFF
--- a/apps/src/templates/progress/ProgressLessonTeacherInfo.jsx
+++ b/apps/src/templates/progress/ProgressLessonTeacherInfo.jsx
@@ -84,14 +84,8 @@ class ProgressLessonTeacherInfo extends React.Component {
       isLessonHiddenForSection(hiddenLessonState, sectionId, lesson.id);
     const courseId =
       (section && section.code && parseInt(section.code.substring(2))) || null;
-
-    // lesson.lessonStartUrl is a protocol-relative url, it needs to be changed
-    // to an absolute URL so when the teacher copies it, they'll get the full URL
-    const loginRequiredLessonStartUrl = new URL(
-      lesson.lessonStartUrl + '?login_required=true',
-      window.location
-    ).href;
-
+    const loginRequiredLessonStartUrl =
+      lesson.lessonStartUrl + '?login_required=true';
     const shouldRender =
       lesson.lesson_plan_html_url ||
       (lesson.lockable && !hasNoSections) ||

--- a/apps/src/templates/progress/ProgressLessonTeacherInfo.jsx
+++ b/apps/src/templates/progress/ProgressLessonTeacherInfo.jsx
@@ -91,7 +91,6 @@ class ProgressLessonTeacherInfo extends React.Component {
       (lesson.lockable && !hasNoSections) ||
       loginRequiredLessonStartUrl ||
       showHiddenForSectionToggle;
-
     if (!shouldRender) {
       return null;
     }

--- a/apps/src/templates/progress/ProgressLessonTeacherInfo.jsx
+++ b/apps/src/templates/progress/ProgressLessonTeacherInfo.jsx
@@ -84,15 +84,20 @@ class ProgressLessonTeacherInfo extends React.Component {
       isLessonHiddenForSection(hiddenLessonState, sectionId, lesson.id);
     const courseId =
       (section && section.code && parseInt(section.code.substring(2))) || null;
+
+    // lesson.lessonStartUrl is a protocol-relative url, it needs to be changed
+    // to an absolute URL so when the teacher copies it, they'll get the full URL
     const loginRequiredLessonStartUrl = new URL(
       lesson.lessonStartUrl + '?login_required=true',
       window.location
     ).href;
+
     const shouldRender =
       lesson.lesson_plan_html_url ||
       (lesson.lockable && !hasNoSections) ||
       loginRequiredLessonStartUrl ||
       showHiddenForSectionToggle;
+
     if (!shouldRender) {
       return null;
     }

--- a/apps/src/templates/progress/ProgressLessonTeacherInfo.jsx
+++ b/apps/src/templates/progress/ProgressLessonTeacherInfo.jsx
@@ -84,8 +84,10 @@ class ProgressLessonTeacherInfo extends React.Component {
       isLessonHiddenForSection(hiddenLessonState, sectionId, lesson.id);
     const courseId =
       (section && section.code && parseInt(section.code.substring(2))) || null;
-    const loginRequiredLessonStartUrl =
-      lesson.lessonStartUrl + '?login_required=true';
+    const loginRequiredLessonStartUrl = new URL(
+      lesson.lessonStartUrl + '?login_required=true',
+      window.location
+    ).href;
     const shouldRender =
       lesson.lesson_plan_html_url ||
       (lesson.lockable && !hasNoSections) ||

--- a/apps/test/unit/templates/progress/ProgressLessonTeacherInfoTest.js
+++ b/apps/test/unit/templates/progress/ProgressLessonTeacherInfoTest.js
@@ -4,6 +4,7 @@ import Immutable from 'immutable';
 import {shallow} from 'enzyme';
 import {UnconnectedProgressLessonTeacherInfo as ProgressLessonTeacherInfo} from '@cdo/apps/templates/progress/ProgressLessonTeacherInfo';
 import {fakeLesson} from '@cdo/apps/templates/progress/progressTestHelpers';
+import sinon from 'sinon';
 
 const MOCK_SECTION = {
   id: 2,
@@ -52,6 +53,7 @@ describe('ProgressLessonTeacherInfo', () => {
     const lessonWithoutPlan = {
       ...fakeLesson('Maze', 1)
     };
+    const urlHrefSpy = sinon.spy(window, 'URL');
     const wrapper = shallow(
       <ProgressLessonTeacherInfo
         lesson={lessonWithoutPlan}
@@ -66,10 +68,9 @@ describe('ProgressLessonTeacherInfo', () => {
         lockableAuthorized={false}
       />
     );
-    assert.equal(
-      wrapper.find('SendLesson').props().lessonUrl,
-      'code.org?login_required=true'
-    );
+    const lessonUrl = wrapper.find('SendLesson').props().lessonUrl;
+    assert(lessonUrl.includes('code.org?login_required=true'));
+    assert(urlHrefSpy.calledOnce);
   });
 
   it('renders a purple Button if and only if we have a student lesson plan', () => {

--- a/apps/test/unit/templates/progress/ProgressLessonTeacherInfoTest.js
+++ b/apps/test/unit/templates/progress/ProgressLessonTeacherInfoTest.js
@@ -71,6 +71,7 @@ describe('ProgressLessonTeacherInfo', () => {
     const lessonUrl = wrapper.find('SendLesson').props().lessonUrl;
     assert(lessonUrl.includes('code.org?login_required=true'));
     assert(urlHrefSpy.calledOnce);
+    assert(lessonUrl.includes('http'));
   });
 
   it('renders a purple Button if and only if we have a student lesson plan', () => {

--- a/apps/test/unit/templates/progress/ProgressLessonTeacherInfoTest.js
+++ b/apps/test/unit/templates/progress/ProgressLessonTeacherInfoTest.js
@@ -4,7 +4,6 @@ import Immutable from 'immutable';
 import {shallow} from 'enzyme';
 import {UnconnectedProgressLessonTeacherInfo as ProgressLessonTeacherInfo} from '@cdo/apps/templates/progress/ProgressLessonTeacherInfo';
 import {fakeLesson} from '@cdo/apps/templates/progress/progressTestHelpers';
-import sinon from 'sinon';
 
 const MOCK_SECTION = {
   id: 2,
@@ -53,7 +52,6 @@ describe('ProgressLessonTeacherInfo', () => {
     const lessonWithoutPlan = {
       ...fakeLesson('Maze', 1)
     };
-    const urlHrefSpy = sinon.spy(window, 'URL');
     const wrapper = shallow(
       <ProgressLessonTeacherInfo
         lesson={lessonWithoutPlan}
@@ -68,10 +66,10 @@ describe('ProgressLessonTeacherInfo', () => {
         lockableAuthorized={false}
       />
     );
-    const lessonUrl = wrapper.find('SendLesson').props().lessonUrl;
-    assert(lessonUrl.includes('code.org?login_required=true'));
-    assert(urlHrefSpy.calledOnce);
-    assert(lessonUrl.includes('http'));
+    assert.equal(
+      wrapper.find('SendLesson').props().lessonUrl,
+      'code.org?login_required=true'
+    );
   });
 
   it('renders a purple Button if and only if we have a student lesson plan', () => {

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -45,8 +45,8 @@ module LevelsHelper
     url_from_path(build_script_level_path(script_level, params))
   end
 
-  def url_from_path(path)
-    CDO.studio_url(path)
+  def url_from_path(path, scheme = '')
+    CDO.studio_url(path, scheme)
   end
 
   def readonly_view_options

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -181,9 +181,9 @@ class Lesson < ApplicationRecord
   # page, and the lesson plan pdf as a backup.
   def start_url
     if script_levels.first
-      return url_from_path(build_script_level_path(script_levels.first), 'https:')
+      return url_from_path(build_script_level_path(script_levels.first), CDO.default_scheme)
     elsif script.include_student_lesson_plans && script.is_migrated
-      return url_from_path(script_lesson_student_path(script, self), 'https:')
+      return url_from_path(script_lesson_student_path(script, self), CDO.default_scheme)
     elsif student_lesson_plan_pdf_url
       return student_lesson_plan_pdf_url
     end

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -181,9 +181,9 @@ class Lesson < ApplicationRecord
   # page, and the lesson plan pdf as a backup.
   def start_url
     if script_levels.first
-      return root_url.chomp('/') + build_script_level_path(script_levels.first)
+      return url_from_path(build_script_level_path(script_levels.first), 'https:')
     elsif script.include_student_lesson_plans && script.is_migrated
-      return root_url.chomp('/') + script_lesson_student_path(script, self)
+      return url_from_path(script_lesson_student_path(script, self), 'https:')
     elsif student_lesson_plan_pdf_url
       return student_lesson_plan_pdf_url
     end

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -181,9 +181,9 @@ class Lesson < ApplicationRecord
   # page, and the lesson plan pdf as a backup.
   def start_url
     if script_levels.first
-      return url_from_path(build_script_level_path(script_levels.first))
+      return root_url.chomp('/') + build_script_level_path(script_levels.first)
     elsif script.include_student_lesson_plans && script.is_migrated
-      return url_from_path(script_lesson_student_path(script, self))
+      return root_url.chomp('/') + script_lesson_student_path(script, self)
     elsif student_lesson_plan_pdf_url
       return student_lesson_plan_pdf_url
     end

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -806,7 +806,7 @@ class LessonTest < ActiveSupport::TestCase
 
     assert_equal(
       new_lesson.start_url,
-      "https://test-studio.code.org/s/#{new_script.name}/lockable/1/levels/1"
+      CDO.studio_url("/s/#{new_script.name}/lockable/1/levels/1", CDO.default_scheme)
     )
   end
 
@@ -818,7 +818,7 @@ class LessonTest < ActiveSupport::TestCase
 
     assert_equal(
       new_lesson.start_url,
-      "https://test-studio.code.org/s/#{new_script.name}/lessons/1/levels/1"
+      CDO.studio_url("/s/#{new_script.name}/lessons/1/levels/1", CDO.default_scheme)
     )
   end
 

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -806,7 +806,7 @@ class LessonTest < ActiveSupport::TestCase
 
     assert_equal(
       new_lesson.start_url,
-      "http://test-studio.code.org/s/#{new_script.name}/lockable/1/levels/1"
+      "https://test-studio.code.org/s/#{new_script.name}/lockable/1/levels/1"
     )
   end
 
@@ -818,7 +818,7 @@ class LessonTest < ActiveSupport::TestCase
 
     assert_equal(
       new_lesson.start_url,
-      "http://test-studio.code.org/s/#{new_script.name}/lessons/1/levels/1"
+      "https://test-studio.code.org/s/#{new_script.name}/lessons/1/levels/1"
     )
   end
 

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -806,7 +806,7 @@ class LessonTest < ActiveSupport::TestCase
 
     assert_equal(
       new_lesson.start_url,
-      "//test-studio.code.org/s/#{new_script.name}/lockable/1/levels/1"
+      "http://test-studio.code.org/s/#{new_script.name}/lockable/1/levels/1"
     )
   end
 
@@ -818,7 +818,7 @@ class LessonTest < ActiveSupport::TestCase
 
     assert_equal(
       new_lesson.start_url,
-      "//test-studio.code.org/s/#{new_script.name}/lessons/1/levels/1"
+      "http://test-studio.code.org/s/#{new_script.name}/lessons/1/levels/1"
     )
   end
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
An issue was brought up from [Zendesk](https://codeorg.zendesk.com/agent/tickets/379666) where the send lesson to students button (where a teacher will copy the link to the lesson to send to the students) was not returning a full URL. This is likely due to the changes in https://github.com/code-dot-org/code-dot-org/pull/45152.

Here I have a targeted fix, where I just transform the URL into an absolute URL instead of a relative for just this case.

## Testing story
Tested locally
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
