### PR TITLE
Javalab: Disallow user file names that are the same as validation file names

### DIFF
--- a/apps/src/javalab/JavalabEditor.jsx
+++ b/apps/src/javalab/JavalabEditor.jsx
@@ -391,16 +391,10 @@ class JavalabEditor extends React.Component {
     }
     const {fileMetadata, editTabKey} = this.state;
     // check for duplicate filename
-    if (Object.keys(this.props.sources).includes(newFilename)) {
+    const duplicateFileError = this.checkDuplicateFileName(newFilename);
+    if (duplicateFileError) {
       this.setState({
-        renameFileError: this.props.sources[newFilename].isVisible
-          ? this.duplicateFileError(newFilename)
-          : this.duplicateSupportFileError(newFilename)
-      });
-      return;
-    } else if (Object.keys(this.props.validation).includes(newFilename)) {
-      this.setState({
-        renameFileError: this.duplicateSupportFileError(newFilename)
+        renameFileError: duplicateFileError
       });
       return;
     }
@@ -426,9 +420,10 @@ class JavalabEditor extends React.Component {
       return;
     }
     fileContents = fileContents || '';
-    if (Object.keys(this.props.sources).includes(filename)) {
+    const duplicateFileError = this.checkDuplicateFileName(filename);
+    if (duplicateFileError) {
       this.setState({
-        newFileError: this.duplicateFileError(filename)
+        newFileError: duplicateFileError
       });
       return;
     }
@@ -535,6 +530,20 @@ class JavalabEditor extends React.Component {
 
   duplicateSupportFileError(filename) {
     return javalabMsg.duplicateSupportFilenameError({filename: filename});
+  }
+
+  /**
+   * Checks if the new file name already exists in the project in both user and support code.
+   * Returns the appropriate error message if so.
+   */
+  checkDuplicateFileName(newFilename) {
+    if (Object.keys(this.props.sources).includes(newFilename)) {
+      return this.props.sources[newFilename].isVisible
+        ? this.duplicateFileError(newFilename)
+        : this.duplicateSupportFileError(newFilename);
+    } else if (Object.keys(this.props.validation).includes(newFilename)) {
+      return this.duplicateSupportFileError(newFilename);
+    }
   }
 
   // This is called from the file explorer when we want to jump to a file

--- a/dashboard/app/models/levels/javalab.rb
+++ b/dashboard/app/models/levels/javalab.rb
@@ -130,6 +130,16 @@ class Javalab < Level
       # Set the javabuilder url
       level_prop['javabuilderUrl'] = CDO.javabuilder_url
 
+      # Send validation file names without code to prevent naming collisions. If we are in start mode,
+      # the actual validation code will be sent by levels_controller.
+      if validation
+        validation_names_only = validation
+        validation_names_only.each do |key, _|
+          validation_names_only[key] = ""
+        end
+        level_prop['validation'] = validation_names_only
+      end
+
       # Don't set nil values
       level_prop.reject! {|_, value| value.nil?}
     end


### PR DESCRIPTION
This change has Javalab always send the validation file names if they exist so that we can prevent naming collisions. The logic in Javalab was already in place, but previously we were only sending validation in start mode.

Note: one thing here - levels_controller sets validation in the level view options, which seems to guarantee that the validation field in the level config has the actual validation code and not just the file names. However, I'm not 100% if this is always guaranteed. From my testing, it seemed to be consistent, but let me know if there's a safer way to ensure that we're not overwriting the validation code in start mode with just the file names.

JIRA: https://codedotorg.atlassian.net/browse/JAVA-507 

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Tested on Javalab All The Things 12 - ensured that in both standard mode and start mode I couldn't create or rename files to be the same as existing validation files.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
