### PR TITLE
Update categories of pl course offerings

### DIFF
--- a/dashboard/config/course_offerings/alltheselfpacedplthings.json
+++ b/dashboard/config/course_offerings/alltheselfpacedplthings.json
@@ -1,7 +1,7 @@
 {
   "key": "alltheselfpacedplthings",
   "display_name": "All the Self Paced PL Things",
-  "category": "other",
+  "category": "pl_other",
   "is_featured": false,
   "assignable": true
 }

--- a/dashboard/config/course_offerings/csa-async.json
+++ b/dashboard/config/course_offerings/csa-async.json
@@ -1,6 +1,6 @@
 {
   "key": "csa-async",
-  "display_name": "csa-async",
+  "display_name": "Getting Started Modules CSA",
   "category": "pl_other",
   "is_featured": false,
   "assignable": true

--- a/dashboard/config/course_offerings/csa-async.json
+++ b/dashboard/config/course_offerings/csa-async.json
@@ -1,7 +1,7 @@
 {
   "key": "csa-async",
   "display_name": "csa-async",
-  "category": "other",
+  "category": "pl_other",
   "is_featured": false,
   "assignable": true
 }

--- a/dashboard/config/course_offerings/csa-self-paced-pl.json
+++ b/dashboard/config/course_offerings/csa-self-paced-pl.json
@@ -1,7 +1,7 @@
 {
   "key": "csa-self-paced-pl",
   "display_name": "Navigating Code.org for CSA Pilot Teachers",
-  "category": "other",
+  "category": "pl_self_paced",
   "is_featured": false,
   "assignable": true
 }

--- a/dashboard/config/course_offerings/fit2019-apprentice.json
+++ b/dashboard/config/course_offerings/fit2019-apprentice.json
@@ -1,7 +1,7 @@
 {
   "key": "fit2019-apprentice",
   "display_name": "Apprentice Reflections for Summer Workshop 2019",
-  "category": "other",
+  "category": "pl_other",
   "is_featured": false,
   "assignable": true
 }

--- a/dashboard/config/course_offerings/k5-onlinepd.json
+++ b/dashboard/config/course_offerings/k5-onlinepd.json
@@ -1,6 +1,6 @@
 {
   "key": "k5-onlinepd",
-  "display_name": "k5-onlinepd",
+  "display_name": "Teaching Computer Science Fundamentals",
   "category": "pl_self_paced",
   "is_featured": false,
   "assignable": true

--- a/dashboard/config/course_offerings/k5-onlinepd.json
+++ b/dashboard/config/course_offerings/k5-onlinepd.json
@@ -1,7 +1,7 @@
 {
   "key": "k5-onlinepd",
   "display_name": "k5-onlinepd",
-  "category": "other",
+  "category": "pl_self_paced",
   "is_featured": false,
   "assignable": true
 }

--- a/dashboard/config/course_offerings/pl-csp-academic-in-person.json
+++ b/dashboard/config/course_offerings/pl-csp-academic-in-person.json
@@ -1,7 +1,0 @@
-{
-  "key": "pl-csp-academic-in-person",
-  "display_name": "pl-csp-academic-in-person",
-  "category": "pl_other",
-  "is_featured": false,
-  "assignable": true
-}

--- a/dashboard/config/course_offerings/pl-csp-academic-in-person.json
+++ b/dashboard/config/course_offerings/pl-csp-academic-in-person.json
@@ -1,7 +1,7 @@
 {
   "key": "pl-csp-academic-in-person",
   "display_name": "pl-csp-academic-in-person",
-  "category": "other",
+  "category": "pl_other",
   "is_featured": false,
   "assignable": true
 }

--- a/dashboard/config/course_offerings/pl-csp-academic-virtual.json
+++ b/dashboard/config/course_offerings/pl-csp-academic-virtual.json
@@ -1,7 +1,0 @@
-{
-  "key": "pl-csp-academic-virtual",
-  "display_name": "pl-csp-academic-virtual",
-  "category": "pl_other",
-  "is_featured": false,
-  "assignable": true
-}

--- a/dashboard/config/course_offerings/pl-csp-academic-virtual.json
+++ b/dashboard/config/course_offerings/pl-csp-academic-virtual.json
@@ -1,7 +1,7 @@
 {
   "key": "pl-csp-academic-virtual",
   "display_name": "pl-csp-academic-virtual",
-  "category": "other",
+  "category": "pl_other",
   "is_featured": false,
   "assignable": true
 }

--- a/dashboard/config/course_offerings/pl-csp-summer-in-person.json
+++ b/dashboard/config/course_offerings/pl-csp-summer-in-person.json
@@ -1,7 +1,0 @@
-{
-  "key": "pl-csp-summer-in-person",
-  "display_name": "pl-csp-summer-in-person",
-  "category": "pl_other",
-  "is_featured": false,
-  "assignable": true
-}

--- a/dashboard/config/course_offerings/pl-csp-summer-in-person.json
+++ b/dashboard/config/course_offerings/pl-csp-summer-in-person.json
@@ -1,7 +1,7 @@
 {
   "key": "pl-csp-summer-in-person",
   "display_name": "pl-csp-summer-in-person",
-  "category": "other",
+  "category": "pl_other",
   "is_featured": false,
   "assignable": true
 }

--- a/dashboard/config/course_offerings/self-paced-pl-csa.json
+++ b/dashboard/config/course_offerings/self-paced-pl-csa.json
@@ -1,6 +1,6 @@
 {
   "key": "self-paced-pl-csa",
-  "display_name": "self-paced-pl-csa",
+  "display_name": "CSA Getting Started Modules",
   "category": "pl_self_paced",
   "is_featured": false,
   "assignable": true

--- a/dashboard/config/course_offerings/self-paced-pl-csa.json
+++ b/dashboard/config/course_offerings/self-paced-pl-csa.json
@@ -1,7 +1,7 @@
 {
   "key": "self-paced-pl-csa",
   "display_name": "self-paced-pl-csa",
-  "category": "other",
+  "category": "pl_self_paced",
   "is_featured": false,
   "assignable": true
 }

--- a/dashboard/config/course_offerings/self-paced-pl-csd5.json
+++ b/dashboard/config/course_offerings/self-paced-pl-csd5.json
@@ -1,6 +1,6 @@
 {
   "key": "self-paced-pl-csd5",
-  "display_name": "self-paced-pl-csd5",
+  "display_name": "Teaching AI and Machine Learning",
   "category": "pl_self_paced",
   "is_featured": false,
   "assignable": true

--- a/dashboard/config/course_offerings/self-paced-pl-csd5.json
+++ b/dashboard/config/course_offerings/self-paced-pl-csd5.json
@@ -1,7 +1,7 @@
 {
   "key": "self-paced-pl-csd5",
   "display_name": "self-paced-pl-csd5",
-  "category": "other",
+  "category": "pl_self_paced",
   "is_featured": false,
   "assignable": true
 }

--- a/dashboard/config/course_offerings/vpl-csd-summer-pilot-ci.json
+++ b/dashboard/config/course_offerings/vpl-csd-summer-pilot-ci.json
@@ -1,7 +1,7 @@
 {
   "key": "vpl-csd-summer-pilot-ci",
   "display_name": "vpl-csd-summer-pilot-ci",
-  "category": "other",
+  "category": "pl_virtual",
   "is_featured": false,
   "assignable": true
 }

--- a/dashboard/config/course_offerings/vpl-csd-summer-pilot-ci.json
+++ b/dashboard/config/course_offerings/vpl-csd-summer-pilot-ci.json
@@ -1,6 +1,6 @@
 {
   "key": "vpl-csd-summer-pilot-ci",
-  "display_name": "vpl-csd-summer-pilot-ci",
+  "display_name": "CS Discoveries Curriculum Investigation",
   "category": "pl_virtual",
   "is_featured": false,
   "assignable": true

--- a/dashboard/config/course_offerings/vpl-csd-summer-pilot.json
+++ b/dashboard/config/course_offerings/vpl-csd-summer-pilot.json
@@ -1,6 +1,6 @@
 {
   "key": "vpl-csd-summer-pilot",
-  "display_name": "vpl-csd-summer-pilot",
+  "display_name": "CS Discoveries Virtual Summer Workshop",
   "category": "pl_virtual",
   "is_featured": false,
   "assignable": true

--- a/dashboard/config/course_offerings/vpl-csd-summer-pilot.json
+++ b/dashboard/config/course_offerings/vpl-csd-summer-pilot.json
@@ -1,7 +1,7 @@
 {
   "key": "vpl-csd-summer-pilot",
   "display_name": "vpl-csd-summer-pilot",
-  "category": "other",
+  "category": "pl_virtual",
   "is_featured": false,
   "assignable": true
 }

--- a/dashboard/config/course_offerings/vpl-csd.json
+++ b/dashboard/config/course_offerings/vpl-csd.json
@@ -1,6 +1,6 @@
 {
   "key": "vpl-csd",
-  "display_name": "vpl-csd",
+  "display_name": "CS Discoveries Virtual Professional Learning",
   "category": "pl_virtual",
   "is_featured": false,
   "assignable": true

--- a/dashboard/config/course_offerings/vpl-csd.json
+++ b/dashboard/config/course_offerings/vpl-csd.json
@@ -1,7 +1,7 @@
 {
   "key": "vpl-csd",
   "display_name": "vpl-csd",
-  "category": "other",
+  "category": "pl_virtual",
   "is_featured": false,
   "assignable": true
 }

--- a/dashboard/config/course_offerings/vpl-csp.json
+++ b/dashboard/config/course_offerings/vpl-csp.json
@@ -1,6 +1,6 @@
 {
   "key": "vpl-csp",
-  "display_name": "vpl-csp",
+  "display_name": "CS Principles Virtual Professional Learning",
   "category": "pl_virtual",
   "is_featured": false,
   "assignable": true

--- a/dashboard/config/course_offerings/vpl-csp.json
+++ b/dashboard/config/course_offerings/vpl-csp.json
@@ -1,7 +1,7 @@
 {
   "key": "vpl-csp",
   "display_name": "vpl-csp",
-  "category": "other",
+  "category": "pl_virtual",
   "is_featured": false,
   "assignable": true
 }


### PR DESCRIPTION
Prep for adding pl course offerings to the assignment dropdown. Updating the display_name and categories of some pl course offerings. Here is what it will look like when we add these course offerings to the dropdown. 

<img width="395" alt="Screen Shot 2022-03-30 at 10 16 56 PM" src="https://user-images.githubusercontent.com/208083/160962846-9080ed5d-8661-45e4-9083-143f33228c84.png">

Nothing will show right now since these courses are not launched.