### PR TITLE
Remove table truncations in common_test_helper

### DIFF
--- a/shared/test/common_test_helper.rb
+++ b/shared/test/common_test_helper.rb
@@ -39,12 +39,6 @@ VCR.configure do |c|
   end
 end
 
-# Truncate database tables to ensure repeatable tests.
-DASHBOARD_TEST_TABLES = %w(channel_tokens user_project_storage_ids projects).freeze
-DASHBOARD_TEST_TABLES.each do |table|
-  DASHBOARD_DB[table.to_sym].truncate
-end.freeze
-
 module SetupTest
   def around(&block)
     random = Random.new(0)
@@ -87,10 +81,5 @@ module SetupTest
     # so reset them to ensure that they are not reused across tests.
     BucketHelper.s3 = nil if defined?(BucketHelper)
     AWS::S3.s3 = nil
-
-    # Reset AUTO_INCREMENT, since it is unaffected by transaction rollback.
-    DASHBOARD_TEST_TABLES.each do |table|
-      DASHBOARD_DB.execute("ALTER TABLE `#{table}` AUTO_INCREMENT = 1")
-    end
   end
 end


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Now that both storage_apps and user_storage_ids have been migrated to DashboardDB, let's attempt to remove the explicit truncation logic in common_test_helper. (To test after today's release)

## Testing story
We'll need to watch and see if all tests pass in the DTT for this.
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
