### PR TITLE
Add schema_cache.yml to the list of ignored files for running dashboard tests in Drone

### DIFF
--- a/lib/rake/test.rake
+++ b/lib/rake/test.rake
@@ -301,7 +301,7 @@ namespace :test do
           'lib/**/*',
           'shared/**/*'
         ],
-        ignore: ['dashboard/test/ui/**/*']
+        ignore: ['dashboard/test/ui/**/*', 'dashboard/db/schema_cache.yml']
       ) do
         TestRunUtils.run_dashboard_tests
       end


### PR DESCRIPTION
tl;dr: No developer should be checking in `schema_cache.yml` directly, so ignore it when deciding whether to run dashboard tests.

Slightly longer version: I have noticed that when I have a PR that has no changes in the apps/ directory, the apps/ tests are not run. However, if there are no changes in the dashboard/ directory, the dashboard unit tests are still run. [This drone run](https://drone.cdn-code.org/code-dot-org/code-dot-org/16960/1/3) for #45316 is one example. The relevant part of the logs read:
```
[test] Files affecting dashboard    tests *modified* from origin/staging. Starting tests. Changed files:
--
12548 | [test]
12549 | dashboard/db/schema_cache.yml
12550 | [test] Running dashboard tests...
```
showing that the dashboard tests are running only because of a schema_cache.yml change, which was definitely not part of the PR.

If we think that this is a feature not a bug, I can shift to removing this logic all together, but it seems like this logic isn't working as intended. Also this won't actually do much to shorten Drone running times as UI tests are the bottleneck, but it'll save half an hour of machine time on some PRs.



## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
