### PR TITLE
Add aliases for storage_app_id columns on other tables

### DIFF
--- a/dashboard/app/controllers/featured_projects_controller.rb
+++ b/dashboard/app/controllers/featured_projects_controller.rb
@@ -2,17 +2,17 @@ class FeaturedProjectsController < ApplicationController
   authorize_resource
 
   def feature
-    _, storage_app_id = storage_decrypt_channel_id(params[:project_id])
-    return render_404 unless storage_app_id
-    @featured_project = FeaturedProject.find_or_create_by!(storage_app_id: storage_app_id)
+    _, project_id = storage_decrypt_channel_id(params[:project_id])
+    return render_404 unless project_id
+    @featured_project = FeaturedProject.find_or_create_by!(project_id: project_id)
     @featured_project.update! unfeatured_at: nil, featured_at: DateTime.now
     buffer_abuse_score
   end
 
   def unfeature
-    _, storage_app_id = storage_decrypt_channel_id(params[:project_id])
-    return render_404 unless storage_app_id
-    @featured_project = FeaturedProject.find_by! storage_app_id: storage_app_id
+    _, project_id = storage_decrypt_channel_id(params[:project_id])
+    return render_404 unless project_id
+    @featured_project = FeaturedProject.find_by! project_id: project_id
     @featured_project.update! unfeatured_at: DateTime.now
   end
 

--- a/dashboard/app/controllers/project_versions_controller.rb
+++ b/dashboard/app/controllers/project_versions_controller.rb
@@ -3,8 +3,8 @@ class ProjectVersionsController < ApplicationController
 
   # POST /project_versions
   def create
-    _, storage_app_id = storage_decrypt_channel_id(params[:storage_id])
-    project_version = ProjectVersion.new(storage_app_id: storage_app_id, object_version_id: params[:version_id], comment: params[:comment])
+    _, project_id = storage_decrypt_channel_id(params[:storage_id])
+    project_version = ProjectVersion.new(project_id: project_id, object_version_id: params[:version_id], comment: params[:comment])
     if project_version.save
       return head :ok
     else

--- a/dashboard/app/controllers/reviewable_projects_controller.rb
+++ b/dashboard/app/controllers/reviewable_projects_controller.rb
@@ -9,7 +9,7 @@ class ReviewableProjectsController < ApplicationController
   def create
     @reviewable_project = ReviewableProject.where(
       user_id: @project_owner.id,
-      storage_app_id: @storage_app_id,
+      project_id: @project_id,
       script_id: params[:script_id],
       level_id: params[:level_id]
     ).first_or_initialize
@@ -34,7 +34,7 @@ class ReviewableProjectsController < ApplicationController
   def reviewable_status
     @reviewable_project = ReviewableProject.where(
       user_id: @project_owner.id,
-      storage_app_id: @storage_app_id,
+      project_id: @project_id,
       script_id: params[:script_id],
       level_id: params[:level_id]
     ).first
@@ -81,7 +81,7 @@ class ReviewableProjectsController < ApplicationController
 
   def decrypt_channel_id
     # TO DO: handle errors in decrypting, or can't find user
-    @storage_id, @storage_app_id = storage_decrypt_channel_id(params[:channel_id])
+    @storage_id, @project_id = storage_decrypt_channel_id(params[:channel_id])
     @project_owner = User.find_by(id: user_id_for_storage_id(@storage_id))
   end
 end

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -108,11 +108,11 @@ class Ability
         code_review_comment.project_owner&.student_of?(user) ||
           (user.teacher? && user == code_review_comment.commenter)
       end
-      can :create,  CodeReviewComment do |_, project_owner, storage_app_id, level_id, script_id|
-        CodeReviewComment.user_can_review_project?(project_owner, user, storage_app_id, level_id, script_id)
+      can :create,  CodeReviewComment do |_, project_owner, project_id, level_id, script_id|
+        CodeReviewComment.user_can_review_project?(project_owner, user, project_id, level_id, script_id)
       end
-      can :project_comments, CodeReviewComment do |_, project_owner, storage_app_id|
-        CodeReviewComment.user_can_review_project?(project_owner, user, storage_app_id)
+      can :project_comments, CodeReviewComment do |_, project_owner, project_id|
+        CodeReviewComment.user_can_review_project?(project_owner, user, project_id)
       end
       can :create, ReviewableProject do |_, project_owner|
         ReviewableProject.user_can_mark_project_reviewable?(project_owner, user)

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -157,7 +157,7 @@ class Ability
             CodeReviewComment.user_can_review_project?(
               user_to_assume,
               user,
-              reviewable_project.storage_app_id,
+              reviewable_project.project_id,
               reviewable_project.level_id,
               reviewable_project.script_id
             )

--- a/dashboard/app/models/code_review_comment.rb
+++ b/dashboard/app/models/code_review_comment.rb
@@ -32,7 +32,7 @@ class CodeReviewComment < ApplicationRecord
 
   before_save :compute_is_from_teacher
 
-  # The projects table used to be named storage_apps. This column has not been updated
+  # The projects table used to be named storage_apps. This column has not been renamed
   # to reflect the new table name, so an alias is used to clarify which table this ID maps to.
   alias_attribute :project_id, :storage_app_id
 

--- a/dashboard/app/models/code_review_comment.rb
+++ b/dashboard/app/models/code_review_comment.rb
@@ -32,13 +32,17 @@ class CodeReviewComment < ApplicationRecord
 
   before_save :compute_is_from_teacher
 
-  def self.user_can_review_project?(project_owner, potential_reviewer, storage_app_id, level_id = nil, script_id = nil)
+  # The projects table used to be named storage_apps. This column has not been updated
+  # to reflect the new table name, so an alias is used to clarify which table this ID maps to.
+  alias_attribute :project_id, :storage_app_id
+
+  def self.user_can_review_project?(project_owner, potential_reviewer, project_id, level_id = nil, script_id = nil)
     # user can always review own project
     return true if project_owner == potential_reviewer
     # teacher can always review student projects
     return true if project_owner.student_of?(potential_reviewer)
     # peers can only review projects where code review has been enabled, which creates a ReviewableProject
-    return false unless ReviewableProject.project_reviewable?(storage_app_id, project_owner.id, level_id, script_id)
+    return false unless ReviewableProject.project_reviewable?(project_id, project_owner.id, level_id, script_id)
     # peers can only review projects if they are in a section that together that have code review enabled
     return false if (project_owner.sections_as_student & potential_reviewer.sections_as_student).all? {|s| !s.code_review_enabled?}
     # finally, they must be in the same code review group

--- a/dashboard/app/models/featured_project.rb
+++ b/dashboard/app/models/featured_project.rb
@@ -17,20 +17,24 @@
 class FeaturedProject < ApplicationRecord
   validates_uniqueness_of :storage_app_id
 
+  # The projects table used to be named storage_apps. This column has not been renamed
+  # to reflect the new table name, so an alias is used to clarify which table this ID maps to.
+  alias_attribute :project_id, :storage_app_id
+
   def featured?
     !featured_at.nil? && unfeatured_at.nil?
   end
 
   # Determines if a project is currently featured by decrypting the provided
-  # encrypted_channel_id, using the storage_app_id to check for a
-  # FeaturedProject with the corresponding storage_app_id.  If there is a
-  # FeaturedProject with that storage_app_id, check if it is currently featured.
+  # encrypted_channel_id, using the project_id to check for a
+  # FeaturedProject with the corresponding project_id.  If there is a
+  # FeaturedProject with that project_id, check if it is currently featured.
   # @param encrypted_channel_id [string]
   # @return [Boolean] whether the project associated with the given
   # encrypted_channel_id is currently featured
   def self.featured_channel_id?(encrypted_channel_id)
-    _, storage_app_id = storage_decrypt_channel_id encrypted_channel_id
-    find_by(storage_app_id: storage_app_id)&.featured?
+    _, project_id = storage_decrypt_channel_id encrypted_channel_id
+    find_by(project_id: project_id)&.featured?
   rescue ArgumentError
     false
   end

--- a/dashboard/app/models/project_version.rb
+++ b/dashboard/app/models/project_version.rb
@@ -15,4 +15,7 @@
 #  index_project_versions_on_storage_app_id_and_object_version_id  (storage_app_id,object_version_id) UNIQUE
 #
 class ProjectVersion < ApplicationRecord
+  # The projects table used to be named storage_apps. This column has not been renamed
+  # to reflect the new table name, so an alias is used to clarify which table this ID maps to.
+  alias_attribute :project_id, :storage_app_id
 end

--- a/dashboard/app/models/reviewable_project.rb
+++ b/dashboard/app/models/reviewable_project.rb
@@ -19,14 +19,18 @@ class ReviewableProject < ApplicationRecord
   belongs_to :level
   belongs_to :script
 
+  # The projects table used to be named storage_apps. This column has not been updated
+  # to reflect the new table name, so an alias is used to clarify which table this ID maps to.
+  alias_attribute :project_id, :storage_app_id
+
   def self.user_can_mark_project_reviewable?(project_owner, user)
     project_owner == user &&
       project_owner.sections_as_student.any?(&:code_review_enabled?) &&
       !project_owner.code_review_groups.empty?
   end
 
-  def self.project_reviewable?(storage_app_id, user_id, level_id, script_id)
-    reviewable_projects = ReviewableProject.where(storage_app_id: storage_app_id, user_id: user_id)
+  def self.project_reviewable?(project_id, user_id, level_id, script_id)
+    reviewable_projects = ReviewableProject.where(project_id: project_id, user_id: user_id)
     if level_id
       reviewable_projects = reviewable_projects.where(level_id: level_id)
     end

--- a/dashboard/app/models/reviewable_project.rb
+++ b/dashboard/app/models/reviewable_project.rb
@@ -19,7 +19,7 @@ class ReviewableProject < ApplicationRecord
   belongs_to :level
   belongs_to :script
 
-  # The projects table used to be named storage_apps. This column has not been updated
+  # The projects table used to be named storage_apps. This column has not been renamed
   # to reflect the new table name, so an alias is used to clarify which table this ID maps to.
   alias_attribute :project_id, :storage_app_id
 

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -2346,11 +2346,11 @@ class User < ApplicationRecord
     return unless user_storage_id
 
     user_storage_apps = StorageApps.new(user_storage_id)
-    storage_app_ids = user_storage_apps.get_all_storage_app_ids
+    project_ids = user_storage_apps.get_all_storage_app_ids
 
     # Unfeature any featured projects owned by the user
     FeaturedProject.
-      where(storage_app_id: storage_app_ids, unfeatured_at: nil).
+      where(project_id: project_ids, unfeatured_at: nil).
       where.not(featured_at: nil).
       update_all(unfeatured_at: Time.now)
 

--- a/dashboard/app/views/levels/_admin.html.haml
+++ b/dashboard/app/views/levels/_admin.html.haml
@@ -103,18 +103,18 @@
       %br/
       Project info:
       %ul
-        - owner_storage_id, storage_app_id = storage_decrypt_channel_id(params[:channel_id]) rescue [nil, nil]
-        - sources_link = "https://s3.console.aws.amazon.com/s3/buckets/#{CDO.sources_s3_bucket}/#{CDO.sources_s3_directory}/#{owner_storage_id}/#{storage_app_id}/"
-        - assets_link = "https://s3.console.aws.amazon.com/s3/buckets/#{CDO.assets_s3_bucket}/#{CDO.assets_s3_directory}/#{owner_storage_id}/#{storage_app_id}/"
-        - animations_link = "https://s3.console.aws.amazon.com/s3/buckets/#{CDO.animations_s3_bucket}/#{CDO.animations_s3_directory}/#{owner_storage_id}/#{storage_app_id}/"
-        - files_link = "https://s3.console.aws.amazon.com/s3/buckets/#{CDO.files_s3_bucket}/#{CDO.files_s3_directory}/#{owner_storage_id}/#{storage_app_id}/"
+        - owner_storage_id, project_id = storage_decrypt_channel_id(params[:channel_id]) rescue [nil, nil]
+        - sources_link = "https://s3.console.aws.amazon.com/s3/buckets/#{CDO.sources_s3_bucket}/#{CDO.sources_s3_directory}/#{owner_storage_id}/#{project_id}/"
+        - assets_link = "https://s3.console.aws.amazon.com/s3/buckets/#{CDO.assets_s3_bucket}/#{CDO.assets_s3_directory}/#{owner_storage_id}/#{project_id}/"
+        - animations_link = "https://s3.console.aws.amazon.com/s3/buckets/#{CDO.animations_s3_bucket}/#{CDO.animations_s3_directory}/#{owner_storage_id}/#{project_id}/"
+        - files_link = "https://s3.console.aws.amazon.com/s3/buckets/#{CDO.files_s3_bucket}/#{CDO.files_s3_directory}/#{owner_storage_id}/#{project_id}/"
 
         %li= "project owner: #{User.find_channel_owner(params[:channel_id]).try(:username)}"
         %li= "owner storage id: #{owner_storage_id}"
-        %li= "storage app id: #{storage_app_id}"
-        - exists = FeaturedProject.exists?(:storage_app_id => storage_app_id)
+        %li= "storage app id: #{project_id}"
+        - exists = FeaturedProject.exists?(:project_id => project_id)
         - if exists
-          - project = FeaturedProject.find_by storage_app_id: storage_app_id
+          - project = FeaturedProject.find_by project_id: project_id
           - currently_featured = project.unfeatured_at == nil && project.featured_at != nil
         - storage_apps = StorageApps.new(get_storage_id)
         - content_moderation_disabled = storage_apps.content_moderation_disabled?(params[:channel_id])

--- a/dashboard/test/controllers/code_review_comments_controller_test.rb
+++ b/dashboard/test/controllers/code_review_comments_controller_test.rb
@@ -7,7 +7,7 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
     @project_owner = create :student
     @project_owner_channel_id = 'encrypted_channel_id'
     @project_owner_storage_id = 123
-    @project_storage_app_id = 456
+    @project_id = 456
     @new_comment_params = {
       channel_id: @project_owner_channel_id,
       script_id: 1,
@@ -21,7 +21,7 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
 
     create :reviewable_project,
       user_id: @project_owner.id,
-      storage_app_id: @project_storage_app_id,
+      storage_app_id: @project_id,
       level_id: 2,
       script_id: 1
   end
@@ -32,7 +32,7 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
   end
 
   test 'student can create CodeReviewComment on their own project' do
-    stub_storage_apps_calls
+    stub_projects_calls
 
     sign_in @project_owner
     post :create, params: @new_comment_params
@@ -51,7 +51,7 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
   end
 
   test 'student not in same section with project owner cannot comment on project' do
-    stub_storage_apps_calls
+    stub_projects_calls
 
     sign_in @another_student
     post :create, params: @new_comment_params
@@ -60,7 +60,7 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
   end
 
   test 'student in same section and code review group with project owner can comment on project' do
-    stub_storage_apps_calls
+    stub_projects_calls
     put_students_in_section_and_code_review_group
 
     sign_in @another_student
@@ -69,9 +69,8 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
     assert_response :success
     refute JSON.parse(response.body)['isFromTeacher']
   end
-
   test 'teacher can create CodeReviewComment for student in their section' do
-    stub_storage_apps_calls
+    stub_projects_calls
 
     create :follower, student_user: @project_owner, section: @section
 
@@ -85,7 +84,7 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
   end
 
   test 'teacher cannot create CodeReviewComment for student not in their section' do
-    stub_storage_apps_calls
+    stub_projects_calls
 
     sign_in @teacher
     post :create, params: @new_comment_params
@@ -167,7 +166,7 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
   end
 
   test 'project owner can fetch peer project comments for their projects' do
-    stub_storage_apps_calls
+    stub_projects_calls
     setup_project_comments_tests
 
     sign_in @project_owner
@@ -180,14 +179,14 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
   end
 
   test 'project owner can see teacher comments' do
-    stub_storage_apps_calls
+    stub_projects_calls
     setup_project_comments_tests
 
     create :follower, student_user: @project_owner, section: @section
 
     teacher_comment = create :code_review_comment,
       commenter: @teacher,
-      storage_app_id: @project_storage_app_id,
+      project_id: @project_id,
       project_owner_id: @project_owner.id
 
     sign_in @project_owner
@@ -199,7 +198,7 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
   end
 
   test 'student in same section and code review group as project owner can see non-teacher project comments' do
-    stub_storage_apps_calls
+    stub_projects_calls
     setup_project_comments_tests
     put_students_in_section_and_code_review_group
 
@@ -213,13 +212,13 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
   end
 
   test 'student in same section and code review group as project owner cannot see teacher comments' do
-    stub_storage_apps_calls
+    stub_projects_calls
     setup_project_comments_tests
     put_students_in_section_and_code_review_group
 
     teacher_comment = create :code_review_comment,
       commenter: @teacher,
-      storage_app_id: @project_storage_app_id,
+      project_id: @project_id,
       project_owner_id: @project_owner.id
 
     sign_in @another_student
@@ -231,7 +230,7 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
   end
 
   test 'teacher of section project owner is enrolled in can fetch project comments' do
-    stub_storage_apps_calls
+    stub_projects_calls
     setup_project_comments_tests
 
     create :follower, student_user: @project_owner, section: @section
@@ -246,13 +245,13 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
   end
 
   test 'teacher of section project owner is enrolled in can fetch their own comments' do
-    stub_storage_apps_calls
+    stub_projects_calls
     setup_project_comments_tests
 
     create :follower, student_user: @project_owner, section: @section
     create :code_review_comment,
       commenter: @teacher,
-      storage_app_id: @project_storage_app_id,
+      project_id: @project_id,
       project_owner_id: @project_owner.id
 
     sign_in @teacher
@@ -265,7 +264,7 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
   end
 
   test 'student not in same section as project owner cannot fetch project comments' do
-    stub_storage_apps_calls
+    stub_projects_calls
     setup_project_comments_tests
 
     sign_in @another_student
@@ -277,7 +276,7 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
   end
 
   test 'teacher cannot fetch project comments if not leading section of project owner' do
-    stub_storage_apps_calls
+    stub_projects_calls
     setup_project_comments_tests
 
     sign_in @teacher
@@ -290,12 +289,12 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
 
   private
 
-  def stub_storage_apps_calls
+  def stub_projects_calls
     CodeReviewCommentsController.
       any_instance.
       expects(:storage_decrypt_channel_id).
       with(@project_owner_channel_id).
-      returns([@project_owner_storage_id, @project_storage_app_id])
+      returns([@project_owner_storage_id, @project_id])
     CodeReviewCommentsController.
       any_instance.
       expects(:user_id_for_storage_id).
@@ -306,7 +305,7 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
   def setup_project_comments_tests
     2.times do
       create :code_review_comment,
-        storage_app_id: @project_storage_app_id,
+        project_id: @project_id,
         project_owner_id: @project_owner.id
     end
 

--- a/dashboard/test/controllers/code_review_comments_controller_test.rb
+++ b/dashboard/test/controllers/code_review_comments_controller_test.rb
@@ -21,7 +21,7 @@ class CodeReviewCommentsControllerTest < ActionController::TestCase
 
     create :reviewable_project,
       user_id: @project_owner.id,
-      storage_app_id: @project_id,
+      project_id: @project_id,
       level_id: 2,
       script_id: 1
   end

--- a/dashboard/test/controllers/featured_projects_controller_test.rb
+++ b/dashboard/test/controllers/featured_projects_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class FeaturedProjectsControllerTest < ActionController::TestCase
   setup do
     @project_validator = create :project_validator
-    # @featured_project has a storage_app_id of 456
+    # @featured_project has a project_id of 456
     @featured_project = create :featured_project
     @teacher = create :teacher
   end
@@ -42,7 +42,7 @@ class FeaturedProjectsControllerTest < ActionController::TestCase
     assert_creates(FeaturedProject) do
       put :feature, params: {project_id: "789"}
     end
-    assert FeaturedProject.last.storage_app_id == 654
+    assert FeaturedProject.last.project_id == 654
     assert FeaturedProject.last.unfeatured_at.nil?
     assert FeaturedProject.last.featured?
   end

--- a/dashboard/test/controllers/project_versions_controller_test.rb
+++ b/dashboard/test/controllers/project_versions_controller_test.rb
@@ -9,7 +9,7 @@ class ProjectVersionsControllerTest < ActionController::TestCase
     assert_creates(ProjectVersion) do
       post :create, params: {storage_id: 'abcdef', version_id: 'fghj', comment: 'This is a comment'}
     end
-    project_version = ProjectVersion.find_by(storage_app_id: 654, object_version_id: 'fghj')
+    project_version = ProjectVersion.find_by(project_id: 654, object_version_id: 'fghj')
     assert_not_nil project_version
     assert_equal 'This is a comment', project_version.comment
   end

--- a/dashboard/test/controllers/reviewable_projects_controller_test.rb
+++ b/dashboard/test/controllers/reviewable_projects_controller_test.rb
@@ -9,7 +9,7 @@ class ReviewableProjectsControllerTest < ActionController::TestCase
     @project_level_id = 12
     @project_script_id = 34
     @project_owner_storage_id = 56
-    @project_storage_app_id = 78
+    @project_id = 78
 
     @teacher = create :teacher
 
@@ -36,7 +36,7 @@ class ReviewableProjectsControllerTest < ActionController::TestCase
   end
 
   test 'student can mark their own project reviewable' do
-    stub_storage_apps_calls
+    stub_projects_calls
 
     sign_in @project_owner
     post :create, params: {
@@ -49,7 +49,7 @@ class ReviewableProjectsControllerTest < ActionController::TestCase
   end
 
   test 'teachers cannot mark student project reviewable' do
-    stub_storage_apps_calls
+    stub_projects_calls
 
     sign_in @teacher
     post :create, params: {
@@ -62,7 +62,7 @@ class ReviewableProjectsControllerTest < ActionController::TestCase
   end
 
   test 'other students cannot mark student project reviewable' do
-    stub_storage_apps_calls
+    stub_projects_calls
 
     sign_in @teacher
     post :create, params: {
@@ -75,7 +75,7 @@ class ReviewableProjectsControllerTest < ActionController::TestCase
   end
 
   test 'reviewable_status returns correct status for student when own project is not reviewable' do
-    stub_storage_apps_calls
+    stub_projects_calls
 
     sign_in @project_owner
 
@@ -95,13 +95,13 @@ class ReviewableProjectsControllerTest < ActionController::TestCase
   end
 
   test 'reviewable_status returns correct status for student when own project is reviewable' do
-    stub_storage_apps_calls
+    stub_projects_calls
 
     sign_in @project_owner
 
     reviewable_project = create :reviewable_project,
       user_id: @project_owner.id,
-      storage_app_id: @project_storage_app_id,
+      project_id: @project_id,
       level_id: @project_level_id,
       script_id: @project_script_id
 
@@ -122,7 +122,7 @@ class ReviewableProjectsControllerTest < ActionController::TestCase
   end
 
   test 'reviewable_status returns correct status for other user when student project is not reviewable' do
-    stub_storage_apps_calls
+    stub_projects_calls
 
     sign_in @another_student
 
@@ -143,13 +143,13 @@ class ReviewableProjectsControllerTest < ActionController::TestCase
   end
 
   test 'reviewable_status returns correct status for other user when student project is reviewable' do
-    stub_storage_apps_calls
+    stub_projects_calls
 
     sign_in @another_student
 
     create :reviewable_project,
       user_id: @project_owner.id,
-      storage_app_id: @project_storage_app_id,
+      project_id: @project_id,
       level_id: @project_level_id,
       script_id: @project_script_id
 
@@ -172,7 +172,7 @@ class ReviewableProjectsControllerTest < ActionController::TestCase
   test 'students can disable review for their own projects' do
     reviewable_project = create :reviewable_project,
       user_id: @project_owner.id,
-      storage_app_id: @project_storage_app_id
+      project_id: @project_id
 
     sign_in @project_owner
     delete :destroy, params: {id: reviewable_project.id}
@@ -183,7 +183,7 @@ class ReviewableProjectsControllerTest < ActionController::TestCase
   test 'other users cannot disable review for other student projects' do
     reviewable_project = create :reviewable_project,
       user_id: @project_owner.id,
-      storage_app_id: @project_storage_app_id
+      project_id: @project_id
 
     [@another_student, @teacher].each do |user|
       sign_in user
@@ -239,12 +239,12 @@ class ReviewableProjectsControllerTest < ActionController::TestCase
     assert_equal [], JSON.parse(response.body)
   end
 
-  def stub_storage_apps_calls
+  def stub_projects_calls
     ReviewableProjectsController.
       any_instance.
       expects(:storage_decrypt_channel_id).
       with(@project_owner_channel_id).
-      returns([@project_owner_storage_id, @project_storage_app_id])
+      returns([@project_owner_storage_id, @project_id])
     ReviewableProjectsController.
       any_instance.
       expects(:user_id_for_storage_id).

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -1536,7 +1536,7 @@ FactoryGirl.define do
     association :commenter, factory: :student
     association :project_owner, factory: :student
 
-    storage_app_id 1
+    project_id 1
     comment 'a comment about your project'
   end
 
@@ -1551,7 +1551,7 @@ FactoryGirl.define do
   end
 
   factory :reviewable_project do
-    sequence(:storage_app_id)
+    sequence(:project_id)
     association :user, factory: :student
     association :level
     association :script

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -850,7 +850,7 @@ FactoryGirl.define do
   end
 
   factory :featured_project do
-    storage_app_id {456}
+    project_id {456}
   end
 
   factory :user_ml_model do

--- a/dashboard/test/helpers/delete_accounts_helper_test.rb
+++ b/dashboard/test/helpers/delete_accounts_helper_test.rb
@@ -1766,20 +1766,20 @@ class DeleteAccountsHelperTest < ActionView::TestCase
   test "clears 'comment' on any version of all of a purged user's projects" do
     skip
     student = create :student
-    with_channel_for student do |storage_app_id|
+    with_channel_for student do |project_id|
       comment_text = 'a comment'
       ProjectVersion.create(
-        storage_app_id: storage_app_id,
+        project_id: project_id,
         object_version_id: 'xyz',
         comment: comment_text
       )
-      assert_equal 1, ProjectVersion.where(storage_app_id: storage_app_id).count
-      assert_equal comment_text, ProjectVersion.where(storage_app_id: storage_app_id).first.comment
+      assert_equal 1, ProjectVersion.where(project_id: project_id).count
+      assert_equal comment_text, ProjectVersion.where(project_id: project_id).first.comment
 
       purge_user student
 
-      assert_equal 1, ProjectVersion.where(storage_app_id: storage_app_id).count
-      assert_nil ProjectVersion.where(storage_app_id: storage_app_id).first.comment
+      assert_equal 1, ProjectVersion.where(project_id: project_id).count
+      assert_nil ProjectVersion.where(project_id: project_id).first.comment
       assert_logged "Cleared 1 ProjectVersion comments"
     end
   end
@@ -1788,31 +1788,31 @@ class DeleteAccountsHelperTest < ActionView::TestCase
     skip
     student_to_purge = create :student
     other_student = create :student
-    with_channel_for student_to_purge do |storage_app_id_to_purge|
-      with_channel_for other_student do |storage_app_id_other|
+    with_channel_for student_to_purge do |project_id_to_purge|
+      with_channel_for other_student do |project_id_other|
         comment_text = 'a comment'
         ProjectVersion.create(
-          storage_app_id: storage_app_id_to_purge,
+          project_id: project_id_to_purge,
           object_version_id: 'xyz',
           comment: comment_text
         )
         ProjectVersion.create(
-          storage_app_id: storage_app_id_other,
+          project_id: project_id_other,
           object_version_id: 'xyz',
           comment: comment_text
         )
 
-        assert_equal 1, ProjectVersion.where(storage_app_id: storage_app_id_to_purge).count
-        assert_equal comment_text, ProjectVersion.where(storage_app_id: storage_app_id_to_purge).first.comment
-        assert_equal 1, ProjectVersion.where(storage_app_id: storage_app_id_other).count
-        assert_equal comment_text, ProjectVersion.where(storage_app_id: storage_app_id_other).first.comment
+        assert_equal 1, ProjectVersion.where(project_id: project_id_to_purge).count
+        assert_equal comment_text, ProjectVersion.where(project_id: project_id_to_purge).first.comment
+        assert_equal 1, ProjectVersion.where(project_id: project_id_other).count
+        assert_equal comment_text, ProjectVersion.where(project_id: project_id_other).first.comment
 
         purge_user student_to_purge
 
-        assert_equal 1, ProjectVersion.where(storage_app_id: storage_app_id_to_purge).count
-        assert_nil ProjectVersion.where(storage_app_id: storage_app_id_to_purge).first.comment
-        assert_equal 1, ProjectVersion.where(storage_app_id: storage_app_id_other).count
-        assert_equal comment_text, ProjectVersion.where(storage_app_id: storage_app_id_other).first.comment
+        assert_equal 1, ProjectVersion.where(project_id: project_id_to_purge).count
+        assert_nil ProjectVersion.where(project_id: project_id_to_purge).first.comment
+        assert_equal 1, ProjectVersion.where(project_id: project_id_other).count
+        assert_equal comment_text, ProjectVersion.where(project_id: project_id_other).first.comment
       end
     end
   end

--- a/dashboard/test/helpers/delete_accounts_helper_test.rb
+++ b/dashboard/test/helpers/delete_accounts_helper_test.rb
@@ -1824,9 +1824,9 @@ class DeleteAccountsHelperTest < ActionView::TestCase
   test "unfeatures any featured projects owned by soft-deleted user" do
     skip
     student = create :student
-    with_channel_for student do |storage_app_id|
+    with_channel_for student do |project_id|
       featured_project = create :featured_project,
-        storage_app_id: storage_app_id,
+        project_id: project_id,
         featured_at: Time.now
 
       assert featured_project.featured?
@@ -1841,9 +1841,9 @@ class DeleteAccountsHelperTest < ActionView::TestCase
   test "unfeatures any featured projects owned by purged user" do
     skip
     student = create :student
-    with_channel_for student do |storage_app_id|
+    with_channel_for student do |project_id|
       featured_project = create :featured_project,
-        storage_app_id: storage_app_id,
+        project_id: project_id,
         featured_at: Time.now
 
       assert featured_project.featured?
@@ -1860,9 +1860,9 @@ class DeleteAccountsHelperTest < ActionView::TestCase
     student = create :student
     featured_time = Time.now - 20
     unfeatured_time = Time.now - 10
-    with_channel_for student do |storage_app_id|
+    with_channel_for student do |project_id|
       featured_project = create :featured_project,
-        storage_app_id: storage_app_id,
+        project_id: project_id,
         featured_at: featured_time,
         unfeatured_at: unfeatured_time
 

--- a/dashboard/test/models/code_review_comment_test.rb
+++ b/dashboard/test/models/code_review_comment_test.rb
@@ -4,7 +4,7 @@ class CodeReviewCommentTest < ActiveSupport::TestCase
   setup_all do
     @project_level_id = 12
     @project_script_id = 34
-    @project_storage_app_id = 56
+    @project_id = 56
   end
 
   test 'must have a non-nil comment' do
@@ -65,7 +65,7 @@ class CodeReviewCommentTest < ActiveSupport::TestCase
     reviewer_follower = create :follower, section: section, student_user: reviewer
     create :reviewable_project,
       user_id: project_owner.id,
-      storage_app_id: @project_storage_app_id,
+      project_id: @project_id,
       level_id: @project_level_id,
       script_id: @project_script_id
 
@@ -73,7 +73,7 @@ class CodeReviewCommentTest < ActiveSupport::TestCase
     create :code_review_group_member, follower: project_owner_follower, code_review_group: code_review_group
     create :code_review_group_member, follower: reviewer_follower, code_review_group: code_review_group
 
-    assert CodeReviewComment.user_can_review_project?(project_owner, reviewer, @project_storage_app_id, @project_level_id, @project_script_id)
+    assert CodeReviewComment.user_can_review_project?(project_owner, reviewer, @project_id, @project_level_id, @project_script_id)
   end
 
   test 'cannot review peers project if there is no reviewable project' do
@@ -82,7 +82,7 @@ class CodeReviewCommentTest < ActiveSupport::TestCase
     section = create :section, code_review_expires_at: Time.now.utc + 1.day
     create :follower, section: section, student_user: project_owner
     create :follower, section: section, student_user: reviewer
-    refute CodeReviewComment.user_can_review_project?(project_owner, reviewer, @project_storage_app_id, @project_level_id, @project_script_id)
+    refute CodeReviewComment.user_can_review_project?(project_owner, reviewer, @project_id, @project_level_id, @project_script_id)
   end
 
   test 'cannot review peers project if code_review is disabled and students are in same code review group' do
@@ -93,14 +93,14 @@ class CodeReviewCommentTest < ActiveSupport::TestCase
     reviewer_follower = create :follower, section: section, student_user: reviewer
     create :reviewable_project,
       user_id: project_owner.id,
-      storage_app_id: @project_storage_app_id,
+      project_id: @project_id,
       level_id: @project_level_id,
       script_id: @project_script_id
     code_review_group = create :code_review_group, section: section
     create :code_review_group_member, follower: project_owner_follower, code_review_group: code_review_group
     create :code_review_group_member, follower: reviewer_follower, code_review_group: code_review_group
 
-    refute CodeReviewComment.user_can_review_project?(project_owner, reviewer, @project_storage_app_id, @project_level_id, @project_script_id)
+    refute CodeReviewComment.user_can_review_project?(project_owner, reviewer, @project_id, @project_level_id, @project_script_id)
   end
 
   test 'cannot review project of student in a different section even if both in code review groups' do
@@ -112,7 +112,7 @@ class CodeReviewCommentTest < ActiveSupport::TestCase
     reviewer_follower = create :follower, section: reviewer_section, student_user: reviewer
     create :reviewable_project,
       user_id: project_owner.id,
-      storage_app_id: @project_storage_app_id,
+      project_id: @project_id,
       level_id: @project_level_id,
       script_id: @project_script_id
 
@@ -121,6 +121,6 @@ class CodeReviewCommentTest < ActiveSupport::TestCase
     create :code_review_group_member, follower: project_owner_follower, code_review_group: project_owner_code_review_group
     create :code_review_group_member, follower: reviewer_follower, code_review_group: reviewer_code_review_group
 
-    refute CodeReviewComment.user_can_review_project?(project_owner, reviewer, @project_storage_app_id, @project_level_id, @project_script_id)
+    refute CodeReviewComment.user_can_review_project?(project_owner, reviewer, @project_id, @project_level_id, @project_script_id)
   end
 end

--- a/lib/cdo/delete_accounts_helper.rb
+++ b/lib/cdo/delete_accounts_helper.rb
@@ -35,21 +35,21 @@ class DeleteAccountsHelper
 
     @log.puts "Deleting project backed progress"
 
-    storage_app_ids = StorageApps.table.where(storage_id: user.user_storage_id).map(:id)
-    channel_count = storage_app_ids.count
-    encrypted_channel_ids = storage_app_ids.map do |storage_app_id|
-      storage_encrypt_channel_id user.user_storage_id, storage_app_id
+    project_ids = StorageApps.table.where(storage_id: user.user_storage_id).map(:id)
+    channel_count = project_ids.count
+    encrypted_channel_ids = project_ids.map do |project_id|
+      storage_encrypt_channel_id user.user_storage_id, project_id
     end
 
     # Clear potential PII from user's channels
     StorageApps.table.
-      where(id: storage_app_ids).
+      where(id: project_ids).
       update(value: nil, updated_ip: '', updated_at: Time.now)
 
     # Clear any comments associated with specific versions of projects.
     # At time of writing, this feature is in use only in Javalab when a student
     # commits their code.
-    project_versions = ProjectVersion.where(storage_app_id: storage_app_ids)
+    project_versions = ProjectVersion.where(project_id: project_ids)
     project_versions.each {|version| version.update!(comment: nil)}
     @log.puts "Cleared #{project_versions.count} ProjectVersion comments" if project_versions.count > 0
 

--- a/shared/middleware/helpers/storage_id.rb
+++ b/shared/middleware/helpers/storage_id.rb
@@ -52,10 +52,10 @@ def storage_decrypt_channel_id(encrypted)
   raise ArgumentError, "`encrypted` must be a string" unless encrypted.is_a? String
   # pad to a multiple of 4 characters to make a valid base64 string.
   encrypted += '=' * ((4 - encrypted.length % 4) % 4)
-  storage_id, storage_app_id = storage_decrypt(Base64.urlsafe_decode64(encrypted)).split(':').map(&:to_i)
+  storage_id, project_id = storage_decrypt(Base64.urlsafe_decode64(encrypted)).split(':').map(&:to_i)
   raise ArgumentError, "`storage_id` must be an integer > 0" unless storage_id > 0
-  raise ArgumentError, "`storage_app_id` must be an integer > 0" unless storage_app_id > 0
-  [storage_id, storage_app_id]
+  raise ArgumentError, "`project_id` must be an integer > 0" unless project_id > 0
+  [storage_id, project_id]
 end
 
 def valid_encrypted_channel_id(encrypted)
@@ -83,12 +83,12 @@ def storage_encrypt_id(id)
   storage_encrypt("#{SecureRandom.random_number(65536)}:#{id}:#{SecureRandom.random_number(65536)}")
 end
 
-def storage_encrypt_channel_id(storage_id, storage_app_id)
+def storage_encrypt_channel_id(storage_id, project_id)
   storage_id = storage_id.to_i
   raise ArgumentError, "`storage_id` must be an integer > 0" unless storage_id > 0
-  storage_app_id = storage_app_id.to_i
-  raise ArgumentError, "`storage_app_id` must be an integer > 0" unless storage_app_id > 0
-  Base64.urlsafe_encode64(storage_encrypt("#{storage_id}:#{storage_app_id}")).tr('=', '')
+  project_id = project_id.to_i
+  raise ArgumentError, "`project_id` must be an integer > 0" unless project_id > 0
+  Base64.urlsafe_encode64(storage_encrypt("#{storage_id}:#{project_id}")).tr('=', '')
 end
 
 def get_storage_id


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
The table `pegasus.storage_apps` has been migrated to `dashboard.projects` (https://github.com/code-dot-org/code-dot-org/pull/45480), however there are still many tables that have columns named `storage_app_id`, pointing to the ids in the `dashboard.projects` table. Instead of renaming all of these columns right now, to reduce confusion in the code, an alias `project_id` has been added to the active record models which will allow us to reference `project_id` instead of `storage_app_id` in the code. This change has been applied to 
- ReviewableProject
- CodeReviewComments
- ProjectVersions
- FeaturedProjects

## Links
- jira ticket: [LP-2272](https://codedotorg.atlassian.net/browse/LP-2272)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()

-->

## Testing story
Tested locally that I was able to query for data and update it by the alias. (Also tests passed)
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Follow-up work
The following tables also have storage_app_id column: Backpacks, ChannelTokens. I wanted to limit the scope of this PR so I didn't include those changes here. Also I need to rename StorageApps class and update remaining references.

https://github.com/code-dot-org/code-dot-org/pull/45612
<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
