### PR TITLE
Update import script to ignore 'concepts' entry

### DIFF
--- a/apps/src/lib/levelbuilder/reference-guide-editor/ReferenceGuideEditor.jsx
+++ b/apps/src/lib/levelbuilder/reference-guide-editor/ReferenceGuideEditor.jsx
@@ -84,13 +84,17 @@ export default function ReferenceGuideEditor(props) {
         <select
           className="input"
           value={referenceGuide.parent_reference_guide_key}
-          onChange={e =>
+          onChange={e => {
+            const value = e.target.value === 'null' ? null : e.target.value;
             setReferenceGuide({
               ...referenceGuide,
-              parent_reference_guide_key: e.target.value
-            })
-          }
+              parent_reference_guide_key: value
+            });
+          }}
         >
+          <option key={'null'} value="null">
+            No parent
+          </option>
           {referenceGuides
             .filter(guide => guide.key !== referenceGuide.key) // don't let a guide parent to itself
             .sort((a, b) => a.key.localeCompare(b.key)) // sort alphabetically

--- a/apps/src/templates/referenceGuides/ReferenceGuideView.jsx
+++ b/apps/src/templates/referenceGuides/ReferenceGuideView.jsx
@@ -22,14 +22,13 @@ const referenceGuideShape = PropTypes.shape({
 
 export default function ReferenceGuideView({referenceGuide, referenceGuides}) {
   let rootCategory = referenceGuide;
-  // TODO(tim): re-organize things to get rid of the concepts guide
-  while (rootCategory.parent_reference_guide_key !== 'concepts') {
+  while (rootCategory.parent_reference_guide_key !== null) {
     rootCategory = referenceGuides.find(
       guide => guide.key === rootCategory.parent_reference_guide_key
     );
   }
   const topLevelGuides = referenceGuides.filter(
-    guide => guide.parent_reference_guide_key === 'concepts'
+    guide => guide.parent_reference_guide_key === null
   );
   const navCategories = topLevelGuides
     .sort((a, b) => a.position - b.position)

--- a/apps/test/unit/lib/levelbuilder/reference-guide-editor/ReferenceGuideEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/reference-guide-editor/ReferenceGuideEditorTest.jsx
@@ -63,15 +63,11 @@ describe('ReferenceGuideEditorTest', () => {
       />
     );
 
-    expect(
-      wrapper.findOne('select').children.map(c => c.toString())
-    ).to.not.include('<option>hello_world</option>');
-    expect(
-      wrapper.findOne('select').children.map(c => c.toString())
-    ).to.include('<option>hello_world2</option>');
-    expect(
-      wrapper.findOne('select').children.map(c => c.toString())
-    ).to.include('<option>hello_world3</option>');
+    const options = wrapper.findAll('option').map(c => c.toString());
+    expect(options).to.include('<option value="null">No parent</option>');
+    expect(options).to.not.include('<option>hello_world</option>');
+    expect(options).to.include('<option>hello_world2</option>');
+    expect(options).to.include('<option>hello_world3</option>');
 
     // change the display name
     wrapper
@@ -86,6 +82,38 @@ describe('ReferenceGuideEditorTest', () => {
       JSON.stringify({
         ...referenceGuide,
         display_name: 'new_display_name'
+      })
+    );
+  });
+
+  it('submitting with no parent selected sends null', () => {
+    fetchSpy.returns(Promise.resolve({ok: true}));
+    const referenceGuide = makeReferenceGuide('hello_world', 'parent_key');
+    const referenceGuides = [
+      makeReferenceGuide('hello_world', 'parent_key'),
+      makeReferenceGuide('hello_world2', 'parent_key'),
+      makeReferenceGuide('hello_world3', 'parent_key')
+    ];
+    const wrapper = isolateComponent(
+      <ReferenceGuideEditor
+        referenceGuide={referenceGuide}
+        referenceGuides={referenceGuides}
+        updateUrl={'/courses/etc/guides/'}
+        editAllUrl={'/courses/etc/guides/edit'}
+      />
+    );
+
+    // change the display name
+    wrapper.findOne('select').props.onChange({target: {value: 'null'}});
+
+    // click save
+    wrapper.findOne('SaveBar').props.handleSave();
+
+    expect(fetchSpy).to.have.been.calledOnce;
+    expect(fetchSpy.getCall(0).args[1].body).to.equal(
+      JSON.stringify({
+        ...referenceGuide,
+        parent_reference_guide_key: null
       })
     );
   });

--- a/apps/test/unit/templates/referenceGuides/ReferenceGuidesViewTest.js
+++ b/apps/test/unit/templates/referenceGuides/ReferenceGuidesViewTest.js
@@ -10,7 +10,7 @@ describe('ReferenceGuideView', () => {
       content: 'markdown text',
       position: 0,
       key: 'guide',
-      parent_reference_guide_key: 'concepts'
+      parent_reference_guide_key: null
     };
     const wrapper = isolateComponent(
       <ReferenceGuideView
@@ -29,7 +29,7 @@ describe('ReferenceGuideView', () => {
       content: 'markdown text',
       position: 0,
       key: 'guide',
-      parent_reference_guide_key: 'concepts'
+      parent_reference_guide_key: null
     };
     const wrapper = isolateComponent(
       <ReferenceGuideView
@@ -61,14 +61,14 @@ describe('ReferenceGuideView', () => {
         content: 'content 1',
         key: 'guide1',
         position: 0,
-        parent_reference_guide_key: 'concepts'
+        parent_reference_guide_key: null
       },
       {
         display_name: 'display name 2',
         content: 'content 2',
         key: 'guide2',
         position: 1,
-        parent_reference_guide_key: 'concepts'
+        parent_reference_guide_key: null
       },
       referenceGuide,
       {

--- a/bin/curriculum/import_reference_guides.rb
+++ b/bin/curriculum/import_reference_guides.rb
@@ -79,6 +79,7 @@ def main(options)
   cb_url_prefix = options.local ? 'http://localhost:8000' : 'http://www.codecurricula.com'
 
   # recursively find all the guides!
+  # guide stack holds [slug, parent key] objects
   guide_stack = [['concepts', nil]]
   guide_key_set = Set[]
   updated_reference_guide_count = 0
@@ -117,9 +118,14 @@ def main(options)
     # don't reuse that key
     guide_key_set.add(unique_key)
 
+    # import children of 'concepts' map as top level guides
+    unique_key = nil if guide['slug'] == 'concepts'
+
     # store the children with their parent key
     guide_stack.concat(guide['children'].map {|child| [child, unique_key]})
 
+    # skip serializing the 'concepts' map
+    next if guide['slug'] == 'concepts'
     next if options.dry_run
 
     reference_guide = ReferenceGuide.find_or_initialize_by(


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

A bit of clean up to prepare for imports.
Grabs all the children of the 'concept' concept map, but doesn't commit to db/serialize it.
Updates the logic in the nav bar to treat null parent_key as top level.
Also updates the parent key dropdown to include a null option to set a guide to top level.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [PLAT-1705](https://codedotorg.atlassian.net/browse/PLAT-1705)

## Testing story

Added some tests and tested manually by running the import against local curriculumbuilder.

