### PR TITLE
Replace term "storage apps" with "projects"

### DIFF
--- a/apps/src/weblab/README.md
+++ b/apps/src/weblab/README.md
@@ -34,11 +34,11 @@ When Weblab is loaded (via `/projects/weblab/:channel_id` or a curriculum level 
 
 A Weblab project consists of 3 parts:
 
-1. A channel entry, accessed via `/v3/channels/:channel_id`, which is stored in the Pegasus database's `storage_apps` table. This entry contains metadata about the channel -- channel ID, project name, project type, and timestamps.
+1. A channel entry, accessed via `/v3/channels/:channel_id`, which is stored in the Dashboard database's `projects` table. This entry contains metadata about the channel -- channel ID, project name, project type, and timestamps.
 2. A `manifest.json` file that contains metadata about the files in the project -- file names, the current version, the file type, and timestamps. This is stored in the `cdo-v3-files` S3 bucket.
 3. The project files themselves (i.e., HTML/CSS code and image assets), also stored in the `cdo-v3-files` alongside the project's `manifest.json`.
 
-Example: If my project contains an `index.html` file and a `style.css` file, then the `cdo-v3-files` S3 entry for my project would contain 3 files: `manifest.json` (with my project's metadata), `index.html` (with my HTML code), and `style.css` (with my CSS code). There would also be a corresponding record in the Pegasus `storage_apps` table.
+Example: If my project contains an `index.html` file and a `style.css` file, then the `cdo-v3-files` S3 entry for my project would contain 3 files: `manifest.json` (with my project's metadata), `index.html` (with my HTML code), and `style.css` (with my CSS code). There would also be a corresponding record in the Dashboard `projects` table.
 
 All of the pieces above use S3's versioning system, which allows us to use our version history feature to point to any version previously saved in S3.
 

--- a/dashboard/app/controllers/admin_users_controller.rb
+++ b/dashboard/app/controllers/admin_users_controller.rb
@@ -149,7 +149,7 @@ class AdminUsersController < ApplicationController
     channel = params[:channel]
 
     if channel.present? && user_id.present?
-      StorageApps.new(storage_id_for_user_id(user_id)).restore(channel)
+      Projects.new(storage_id_for_user_id(user_id)).restore(channel)
     end
 
     redirect_to action: "user_projects_form", user_identifier: user_id

--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -242,7 +242,7 @@ class ProjectsController < ApplicationController
   def load
     return if redirect_under_13_without_tos_teacher(@level)
     if current_user
-      channel = StorageApps.new(storage_id_for_current_user).most_recent(params[:key])
+      channel = Projects.new(storage_id_for_current_user).most_recent(params[:key])
       if channel
         redirect_to action: 'edit', channel_id: channel
         return
@@ -256,7 +256,7 @@ class ProjectsController < ApplicationController
     return if redirect_under_13_without_tos_teacher(@level)
     channel = ChannelToken.create_channel(
       request.ip,
-      StorageApps.new(get_storage_id),
+      Projects.new(get_storage_id),
       data: initial_data,
       type: params[:key]
     )
@@ -338,7 +338,7 @@ class ProjectsController < ApplicationController
     end
 
     begin
-      _, storage_app_id = storage_decrypt_channel_id(params[:channel_id]) if params[:channel_id]
+      _, project_id = storage_decrypt_channel_id(params[:channel_id]) if params[:channel_id]
     rescue ArgumentError, OpenSSL::Cipher::CipherError
       # continue as normal, as we only use this value for stats.
     end
@@ -348,8 +348,8 @@ class ProjectsController < ApplicationController
       {
         study: 'project-views',
         event: project_view_event_type(iframe_embed, sharing),
-        # allow cross-referencing with the storage_apps table.
-        project_id: storage_app_id,
+        # allow cross-referencing with the projects table.
+        project_id: project_id,
         # make it easier to group by project_type.
         data_string: params[:key],
         data_json: {
@@ -379,7 +379,7 @@ class ProjectsController < ApplicationController
     project_type = params[:key]
     new_channel_id = ChannelToken.create_channel(
       request.ip,
-      StorageApps.new(get_storage_id),
+      Projects.new(get_storage_id),
       src: src_channel_id,
       type: project_type,
       remix_parent_id: remix_parent_id,
@@ -416,14 +416,14 @@ class ProjectsController < ApplicationController
     rescue ArgumentError, OpenSSL::Cipher::CipherError
       return head :bad_request
     end
-    storage_app = StorageApps.new(get_storage_id)
-    src_data = storage_app.get(src_channel_id)
+    project = Projects.new(get_storage_id)
+    src_data = project.get(src_channel_id)
     data = initial_data
     data['name'] = "Exported: #{src_data['name']}"
     data['hidden'] = true
     new_channel_id = ChannelToken.create_channel(
       request.ip,
-      storage_app,
+      project,
       data: data,
       type: params[:key],
       remix_parent_id: remix_parent_id,

--- a/dashboard/app/models/backpack.rb
+++ b/dashboard/app/models/backpack.rb
@@ -16,19 +16,23 @@
 class Backpack < ApplicationRecord
   belongs_to :user
 
+  # The projects table used to be named storage_apps. This column has not been renamed
+  # to reflect the new table name, so an alias is used to clarify which table this ID maps to.
+  alias_attribute :project_id, :storage_app_id
+
   def self.find_or_create(user_id, ip)
     backpack = find_by_user_id(user_id)
     unless backpack
       # Create a storage app for this user's backpack
       storage_app = StorageApps.new(storage_id_for_user_id(user_id))
       encrypted_id = storage_app.create({'hidden': true}, ip: ip, type: 'backpack')
-      _, storage_app_id = storage_decrypt_channel_id(encrypted_id)
-      backpack = create!(user_id: user_id, storage_app_id: storage_app_id)
+      _, project_id = storage_decrypt_channel_id(encrypted_id)
+      backpack = create!(user_id: user_id, project_id: project_id)
     end
     backpack
   end
 
   def channel
-    storage_encrypt_channel_id(storage_id_for_user_id(user_id), storage_app_id)
+    storage_encrypt_channel_id(storage_id_for_user_id(user_id), project_id)
   end
 end

--- a/dashboard/app/models/backpack.rb
+++ b/dashboard/app/models/backpack.rb
@@ -23,9 +23,9 @@ class Backpack < ApplicationRecord
   def self.find_or_create(user_id, ip)
     backpack = find_by_user_id(user_id)
     unless backpack
-      # Create a storage app for this user's backpack
-      storage_app = StorageApps.new(storage_id_for_user_id(user_id))
-      encrypted_id = storage_app.create({'hidden': true}, ip: ip, type: 'backpack')
+      # Create a project for this user's backpack
+      project = Projects.new(storage_id_for_user_id(user_id))
+      encrypted_id = project.create({'hidden': true}, ip: ip, type: 'backpack')
       _, project_id = storage_decrypt_channel_id(encrypted_id)
       backpack = create!(user_id: user_id, project_id: project_id)
     end

--- a/dashboard/app/models/channel_token.rb
+++ b/dashboard/app/models/channel_token.rb
@@ -24,18 +24,22 @@ class ChannelToken < ApplicationRecord
   belongs_to :user
   belongs_to :level
 
+  # The projects table used to be named storage_apps. This column has not been renamed
+  # to reflect the new table name, so an alias is used to clarify which table this ID maps to.
+  alias_attribute :project_id, :storage_app_id
+
   def channel
-    storage_encrypt_channel_id(storage_id, storage_app_id)
+    storage_encrypt_channel_id(storage_id, project_id)
   end
 
   # @param [Level] level The level associated with the channel token request.
   # @param [String] ip The IP address making the channel token request.
-  # @param [String] user_storage_id The ID of the storage app associated with the channel token request.
+  # @param [String] user_storage_id The ID of the project associated with the channel token request.
   # @param [Integer] script_id The ID of the script associated with the channel token.
   # @param [Hash] data
   # @return [ChannelToken] The channel token (new or existing).
   def self.find_or_create_channel_token(level, ip, user_storage_id, script_id = nil, data = {})
-    storage_app = StorageApps.new(user_storage_id)
+    project = Projects.new(user_storage_id)
     # If `create` fails because it was beat by a competing request, a second
     # `find_by` should succeed.
     # Read from primary to minimize write conflicts.
@@ -51,8 +55,8 @@ class ChannelToken < ApplicationRecord
         # but not used in the query for a channel_token yet.
         create!(level: level.host_level, storage_id: user_storage_id, script_id: script_id) do |ct|
           # Get a new channel_id.
-          channel = create_channel ip, storage_app, data: data, standalone: false
-          _, ct.storage_app_id = storage_decrypt_channel_id(channel)
+          channel = create_channel ip, project, data: data, standalone: false
+          _, ct.project_id = storage_decrypt_channel_id(channel)
         end
       end
     end
@@ -69,7 +73,7 @@ class ChannelToken < ApplicationRecord
   # is why we need to query for a channel token with script_id and fallback on one without script_id.
   #
   # @param [Level] level The level associated with the channel token request.
-  # @param [String] user_storage_id The ID of the storage app associated with the channel token request.
+  # @param [String] user_storage_id The ID of the project associated with the channel token request.
   # @param [Integer] script_id The ID of the script associated with the channel token.
   def self.find_channel_token(level, user_storage_id, script_id)
     order(script_id: 'desc').find_by(level: level.host_level, storage_id: user_storage_id, script_id: [nil, script_id])
@@ -79,16 +83,16 @@ class ChannelToken < ApplicationRecord
   # @param [Hash] data Data to store in the channel.
   # @param [String] src Optional source channel to copy data from, instead of
   #   using the value from the `data` param.
-  def self.create_channel(ip, storage_app, data: {}, src: nil, type: nil, remix_parent_id: nil, standalone: true)
+  def self.create_channel(ip, project, data: {}, src: nil, type: nil, remix_parent_id: nil, standalone: true)
     if src
-      data = storage_app.get(src)
+      data = project.get(src)
       data['name'] = "Remix: #{data['name']}"
       data['hidden'] = false
       data['frozen'] = false
     end
 
     timestamp = Time.now
-    storage_app.create(
+    project.create(
       data.merge('createdAt' => timestamp, 'updatedAt' => timestamp),
       ip: ip,
       type: type,

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -2345,8 +2345,8 @@ class User < ApplicationRecord
   private def soft_delete_channels
     return unless user_storage_id
 
-    user_storage_apps = StorageApps.new(user_storage_id)
-    project_ids = user_storage_apps.get_all_storage_app_ids
+    project = Projects.new(user_storage_id)
+    project_ids = project.get_all_project_ids
 
     # Unfeature any featured projects owned by the user
     FeaturedProject.
@@ -2354,8 +2354,8 @@ class User < ApplicationRecord
       where.not(featured_at: nil).
       update_all(unfeatured_at: Time.now)
 
-    # Soft-delete all of the user's storage_apps
-    user_storage_apps.soft_delete_all
+    # Soft-delete all of the user's projects
+    project.soft_delete_all
   end
 
   def user_storage_id
@@ -2374,7 +2374,7 @@ class User < ApplicationRecord
     # Paranoia documentation at https://github.com/rubysherpas/paranoia#usage.
     result = restore(recursive: true, recovery_window: 5.minutes)
     deleted_time = soft_delete_time - 5.minutes
-    StorageApps.new(user_storage_id).restore_if_deleted_after(deleted_time) if user_storage_id
+    Projects.new(user_storage_id).restore_if_deleted_after(deleted_time) if user_storage_id
     result
   end
 

--- a/dashboard/app/views/levels/_admin.html.haml
+++ b/dashboard/app/views/levels/_admin.html.haml
@@ -111,13 +111,13 @@
 
         %li= "project owner: #{User.find_channel_owner(params[:channel_id]).try(:username)}"
         %li= "owner storage id: #{owner_storage_id}"
-        %li= "storage app id: #{project_id}"
+        %li= "project id: #{project_id}"
         - exists = FeaturedProject.exists?(:project_id => project_id)
         - if exists
           - project = FeaturedProject.find_by project_id: project_id
           - currently_featured = project.unfeatured_at == nil && project.featured_at != nil
-        - storage_apps = StorageApps.new(get_storage_id)
-        - content_moderation_disabled = storage_apps.content_moderation_disabled?(params[:channel_id])
+        - project = Projects.new(get_storage_id)
+        - content_moderation_disabled = project.content_moderation_disabled?(params[:channel_id])
         %li
           S3 links:
           = link_to 'sources', sources_link, target: '_blank'
@@ -127,7 +127,7 @@
             = link_to 'animations', animations_link, target: '_blank'
           - elsif @level.is_a? Weblab
             = link_to 'files', files_link, target: '_blank'
-        - remix_ancestry = StorageApps.remix_ancestry(params[:channel_id], depth: 5)
+        - remix_ancestry = Projects.remix_ancestry(params[:channel_id], depth: 5)
         - if remix_ancestry.empty?
           %li Not a remix.
         - else

--- a/dashboard/config/honeybadger.yml
+++ b/dashboard/config/honeybadger.yml
@@ -1,7 +1,7 @@
 ---
 api_key: <%=CDO.dashboard_honeybadger_api_key%>
 exceptions:
-  ignore: <%= %w(Sinatra StorageApps).map{|x| "#{x}::NotFound"}.to_json%>
+  ignore: <%= %w(Sinatra Projects).map{|x| "#{x}::NotFound"}.to_json%>
   notify_at_exit: false
 breadcrumbs:
   enabled: true

--- a/dashboard/lib/projects_list.rb
+++ b/dashboard/lib/projects_list.rb
@@ -33,7 +33,7 @@ module ProjectsList
     def fetch_personal_projects(user_id)
       personal_projects_list = []
       storage_id = storage_id_for_user_id(user_id)
-      StorageApps.new(storage_id).get_active_projects.each do |project|
+      Projects.new(storage_id).get_active_projects.each do |project|
         channel_id = storage_encrypt_channel_id(storage_id, project[:id])
         project_data = get_project_row_data(project, channel_id, nil, true)
         personal_projects_list << project_data if project_data
@@ -50,9 +50,9 @@ module ProjectsList
       personal_projects_list = []
       storage_id = storage_id_for_user_id(user_id)
 
-      storage_apps_query = StorageApps.new(storage_id).get_projects_with_state(state: state, order: Sequel.desc(:updated_at))
+      projects_query = Projects.new(storage_id).get_projects_with_state(state: state, order: Sequel.desc(:updated_at))
 
-      storage_apps_query.each do |project|
+      projects_query.each do |project|
         channel_id = storage_encrypt_channel_id(storage_id, project[:id])
         project_data = get_project_row_data(project, channel_id, nil, true)
         personal_projects_list << project_data if project_data
@@ -71,7 +71,7 @@ module ProjectsList
         student_storage_ids = get_storage_ids_by_user_ids(section_students.pluck(:id))
         section_students.each do |student|
           next unless student_storage_id = student_storage_ids[student.id]
-          StorageApps.new(student_storage_id).get_active_projects.each do |project|
+          Projects.new(student_storage_id).get_active_projects.each do |project|
             # The channel id stored in the project's value field may not be reliable
             # when apps are remixed, so recompute the channel id.
             channel_id = storage_encrypt_channel_id(student_storage_id, project[:id])
@@ -147,7 +147,7 @@ module ProjectsList
       [].tap do |projects_list_data|
         user_storage_ids = get_user_ids_by_storage_ids(section_users.pluck(:id))
         user_storage_id_list = user_storage_ids.keys
-        StorageApps.table.
+        Projects.table.
           where(storage_id: user_storage_id_list, state: 'active').
           where(project_type: project_types).
           where("value->'$.libraryName' IS NOT NULL").
@@ -184,7 +184,7 @@ module ProjectsList
 
       updated_library_channels = []
 
-      StorageApps.get_by_ids(project_ids).each do |project|
+      Projects.get_by_ids(project_ids).each do |project|
         library = libraries.find {|lib| lib['project_id'] == project[:id]}
         project_value = JSON.parse(project[:value])
         next unless library && project_value['latestLibraryVersion']
@@ -239,7 +239,7 @@ module ProjectsList
         data_for_featured_project_card = {
           "channel" => channel,
           "name" => project_details_value['name'],
-          "thumbnailUrl" =>  StorageApps.make_thumbnail_url_cacheable(project_details_value['thumbnailUrl']),
+          "thumbnailUrl" =>  Projects.make_thumbnail_url_cacheable(project_details_value['thumbnailUrl']),
           "type" => project_details[:project_type],
           "publishedAt" => project_details[:published_at],
           "studentName" => UserHelpers.initial(project_details[:name]),
@@ -323,7 +323,7 @@ module ProjectsList
       {}.tap do |projects|
         project_groups.map do |project_group|
           project_types = PUBLISHED_PROJECT_TYPE_GROUPS[project_group]
-          projects[project_group] = StorageApps.table.
+          projects[project_group] = Projects.table.
             select(*project_and_user_fields).
             join(user_project_storage_ids, id: :storage_id).
             join(users, id: :user_id).
@@ -338,9 +338,9 @@ module ProjectsList
     end
 
     # Extracts published project data from a row that is a join of the
-    # storage_apps and user tables.
+    # projects and user tables.
     #
-    # @param [hash] the join of storage_apps and user tables for a published project.
+    # @param [hash] the join of projects and user tables for a published project.
     #  See project_and_user_fields for which fields it contains.
     # @returns [hash, nil] containing fields relevant to the published project or
     #  nil when the user has sharing_disabled = true for App Lab, Game Lab and Sprite Lab.
@@ -348,7 +348,7 @@ module ProjectsList
       return nil if get_sharing_disabled_from_properties(project_and_user[:properties]) && ADVANCED_PROJECT_TYPES.include?(project_and_user[:project_type])
       return nil if project_and_user[:abuse_score] > 0
       channel_id = storage_encrypt_channel_id(project_and_user[:storage_id], project_and_user[:id])
-      StorageApps.get_published_project_data(project_and_user, channel_id).merge(
+      Projects.get_published_project_data(project_and_user, channel_id).merge(
         {
           # For privacy reasons, include only the first initial of the student's name.
           studentName: UserHelpers.initial(project_and_user[:name]),

--- a/dashboard/scripts/archive/mark_unparsable_channels_as_deleted
+++ b/dashboard/scripts/archive/mark_unparsable_channels_as_deleted
@@ -9,12 +9,12 @@
 require_relative '../../config/environment'
 
 to_delete = []
-PEGASUS_DB[:storage_apps].where(state: 'active').paged_each do |row|
+DASHBOARD_DB[:projects].where(state: 'active').paged_each do |row|
   JSON.parse row[:value]
 rescue JSON::ParserError
   to_delete << row[:id]
   puts row[:id]
 end
 
-modified = PEGASUS_DB[:storage_apps].where(id: to_delete).update(state: 'deleted')
+modified = DASHBOARD_DB[:projects].where(id: to_delete).update(state: 'deleted')
 puts "Marked #{modified} channels as 'deleted'"

--- a/dashboard/test/controllers/api/v1/projects/personal_projects_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/projects/personal_projects_controller_test.rb
@@ -12,7 +12,7 @@ class Api::V1::Projects::PersonalProjectsControllerTest < ActionDispatch::Integr
     }.to_json
     personal_project = {id: 22, value: personal_project_value}
 
-    StorageApps.any_instance.stubs(:get_active_projects).returns([personal_project])
+    Projects.any_instance.stubs(:get_active_projects).returns([personal_project])
   end
 
   test 'personal projects are correct' do

--- a/dashboard/test/controllers/api/v1/projects/public_gallery_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/projects/public_gallery_controller_test.rb
@@ -21,7 +21,7 @@ class Api::V1::Projects::PublicGalleryControllerTest < ActionController::TestCas
     # return 1 applab project for initial DB request, then an empty set
     # for all subsequent db requests. Subsequent requests are only expected
     # when 'all' project types are requested.
-    StorageApps.stubs(:table).returns(db_result(stub_projects)).then.returns(db_result([]))
+    Projects.stubs(:table).returns(db_result(stub_projects)).then.returns(db_result([]))
   end
 
   test_user_gets_response_for(

--- a/dashboard/test/controllers/api/v1/projects/section_projects_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/projects/section_projects_controller_test.rb
@@ -37,7 +37,7 @@ class Api::V1::Projects::SectionProjectsControllerTest < ActionController::TestC
     other_student_project = {id: 44, value: other_student_project_value}
 
     ProjectsList.stubs(:get_storage_ids_by_user_ids).returns({@student.id => STUDENT_STORAGE_ID})
-    StorageApps.any_instance.stubs(:get_active_projects).returns([student_project, hidden_project, other_student_project])
+    Projects.any_instance.stubs(:get_active_projects).returns([student_project, hidden_project, other_student_project])
   end
 
   test_user_gets_response_for(

--- a/dashboard/test/controllers/backpacks_controller_test.rb
+++ b/dashboard/test/controllers/backpacks_controller_test.rb
@@ -19,8 +19,8 @@ class BackpacksControllerTest < ActionController::TestCase
     assert_not_nil Backpack.find_by_user_id(@user.id)
     body = JSON.parse(response.body)
     channel = body['channel']
-    storage_id, storage_app_id = storage_decrypt_channel_id(channel)
-    assert storage_id > 0 && storage_app_id > 0
+    storage_id, project_id = storage_decrypt_channel_id(channel)
+    assert storage_id > 0 && project_id > 0
   end
 
   test 'get_channel does not create a backpack if backpack already exists' do
@@ -34,6 +34,6 @@ class BackpacksControllerTest < ActionController::TestCase
     assert_response :success
     get :get_channel
     second_backpack = Backpack.find_by_user_id(@user.id)
-    assert_equal(first_backpack.storage_app_id, second_backpack.storage_app_id)
+    assert_equal(first_backpack.project_id, second_backpack.project_id)
   end
 end

--- a/dashboard/test/helpers/delete_accounts_helper_test.rb
+++ b/dashboard/test/helpers/delete_accounts_helper_test.rb
@@ -1,5 +1,5 @@
 require 'test_helper'
-require 'testing/storage_apps_test_utils'
+require 'testing/projects_test_utils'
 require 'cdo/delete_accounts_helper'
 require_relative '../../../pegasus/test/fixtures/mock_pegasus'
 
@@ -19,7 +19,7 @@ require_relative '../../../pegasus/test/fixtures/mock_pegasus'
 # reviewed by the product team.
 #
 class DeleteAccountsHelperTest < ActionView::TestCase
-  include StorageAppsTestUtils
+  include ProjectsTestUtils
 
   NULL_STREAM = File.open File::NULL, 'w'
 
@@ -1604,22 +1604,22 @@ class DeleteAccountsHelperTest < ActionView::TestCase
   end
 
   #
-  # Table: pegasus.storage_apps
+  # Table: dashboard.projects
   #
 
   test "soft-deletes all of a soft-deleted user's projects" do
     skip
     student = create :student
-    with_channel_for student do |storage_app_id, storage_id|
-      assert_equal 'active', storage_apps.where(id: storage_app_id).first[:state]
-      storage_apps.where(storage_id: storage_id).each do |app|
+    with_channel_for student do |project_id, storage_id|
+      assert_equal 'active', projects_table.where(id: project_id).first[:state]
+      projects_table.where(storage_id: storage_id).each do |app|
         assert_equal 'active', app[:state]
       end
 
       student.destroy
 
-      assert_equal 'deleted', storage_apps.where(id: storage_app_id).first[:state]
-      storage_apps.where(storage_id: storage_id).each do |app|
+      assert_equal 'deleted', projects_table.where(id: project_id).first[:state]
+      projects_table.where(storage_id: storage_id).each do |app|
         assert_equal 'deleted', app[:state]
       end
     end
@@ -1628,16 +1628,16 @@ class DeleteAccountsHelperTest < ActionView::TestCase
   test "soft-deletes all of a purged user's projects" do
     skip
     student = create :student
-    with_channel_for student do |storage_app_id, storage_id|
-      assert_equal 'active', storage_apps.where(id: storage_app_id).first[:state]
-      storage_apps.where(storage_id: storage_id).each do |app|
+    with_channel_for student do |project_id, storage_id|
+      assert_equal 'active', projects_table.where(id: project_id).first[:state]
+      projects_table.where(storage_id: storage_id).each do |app|
         assert_equal 'active', app[:state]
       end
 
       purge_user student
 
-      assert_equal 'deleted', storage_apps.where(id: storage_app_id).first[:state]
-      storage_apps.where(storage_id: storage_id).each do |app|
+      assert_equal 'deleted', projects_table.where(id: project_id).first[:state]
+      projects_table.where(storage_id: storage_id).each do |app|
         assert_equal 'deleted', app[:state]
       end
     end
@@ -1649,15 +1649,15 @@ class DeleteAccountsHelperTest < ActionView::TestCase
     skip
     student_a = create :student
     student_b = create :student
-    with_channel_for student_a do |storage_app_id_a|
-      with_channel_for student_b do |storage_app_id_b|
-        assert_equal 'active', storage_apps.where(id: storage_app_id_a).first[:state]
-        assert_equal 'active', storage_apps.where(id: storage_app_id_b).first[:state]
+    with_channel_for student_a do |project_id_a|
+      with_channel_for student_b do |project_id_b|
+        assert_equal 'active', projects_table.where(id: project_id_a).first[:state]
+        assert_equal 'active', projects_table.where(id: project_id_b).first[:state]
 
         purge_user student_a
 
-        assert_equal 'deleted', storage_apps.where(id: storage_app_id_a).first[:state]
-        assert_equal 'active', storage_apps.where(id: storage_app_id_b).first[:state]
+        assert_equal 'deleted', projects_table.where(id: project_id_a).first[:state]
+        assert_equal 'active', projects_table.where(id: project_id_b).first[:state]
       end
     end
   end
@@ -1666,17 +1666,17 @@ class DeleteAccountsHelperTest < ActionView::TestCase
     skip
     student = create :student
     Timecop.freeze do
-      with_channel_for student do |storage_app_id|
-        assert_equal 'active', storage_apps.where(id: storage_app_id).first[:state]
-        original_updated_at = storage_apps.where(id: storage_app_id).first[:updated_at]
+      with_channel_for student do |project_id|
+        assert_equal 'active', projects_table.where(id: project_id).first[:state]
+        original_updated_at = projects_table.where(id: project_id).first[:updated_at]
 
         Timecop.travel 10
 
         student.destroy
 
-        assert_equal 'deleted', storage_apps.where(id: storage_app_id).first[:state]
+        assert_equal 'deleted', projects_table.where(id: project_id).first[:state]
         refute_equal original_updated_at.utc.to_s,
-          storage_apps.where(id: storage_app_id).first[:updated_at].utc.to_s
+          projects_table.where(id: project_id).first[:updated_at].utc.to_s
       end
     end
   end
@@ -1685,19 +1685,19 @@ class DeleteAccountsHelperTest < ActionView::TestCase
     skip
     student = create :student
     Timecop.freeze do
-      with_channel_for student do |storage_app_id|
-        storage_apps.where(id: storage_app_id).update(state: 'deleted', updated_at: Time.now)
+      with_channel_for student do |project_id|
+        projects_table.where(id: project_id).update(state: 'deleted', updated_at: Time.now)
 
-        assert_equal 'deleted', storage_apps.where(id: storage_app_id).first[:state]
-        original_updated_at = storage_apps.where(id: storage_app_id).first[:updated_at]
+        assert_equal 'deleted', projects_table.where(id: project_id).first[:state]
+        original_updated_at = projects_table.where(id: project_id).first[:updated_at]
 
         Timecop.travel 10
 
         student.destroy
 
-        assert_equal 'deleted', storage_apps.where(id: storage_app_id).first[:state]
+        assert_equal 'deleted', projects_table.where(id: project_id).first[:state]
         assert_equal original_updated_at.utc.to_s,
-          storage_apps.where(id: storage_app_id).first[:updated_at].utc.to_s
+          projects_table.where(id: project_id).first[:updated_at].utc.to_s
       end
     end
   end
@@ -1706,19 +1706,19 @@ class DeleteAccountsHelperTest < ActionView::TestCase
     skip
     student = create :student
     Timecop.freeze do
-      with_channel_for student do |storage_app_id|
-        storage_apps.where(id: storage_app_id).update(state: 'deleted', updated_at: Time.now)
+      with_channel_for student do |project_id|
+        projects_table.where(id: project_id).update(state: 'deleted', updated_at: Time.now)
 
-        assert_equal 'deleted', storage_apps.where(id: storage_app_id).first[:state]
-        original_updated_at = storage_apps.where(id: storage_app_id).first[:updated_at]
+        assert_equal 'deleted', projects_table.where(id: project_id).first[:state]
+        original_updated_at = projects_table.where(id: project_id).first[:updated_at]
 
         Timecop.travel 10
 
         purge_user student
 
-        assert_equal 'deleted', storage_apps.where(id: storage_app_id).first[:state]
+        assert_equal 'deleted', projects_table.where(id: project_id).first[:state]
         refute_equal original_updated_at.utc.to_s,
-          storage_apps.where(id: storage_app_id).first[:updated_at].utc.to_s
+          projects_table.where(id: project_id).first[:updated_at].utc.to_s
       end
     end
   end
@@ -1726,16 +1726,16 @@ class DeleteAccountsHelperTest < ActionView::TestCase
   test "clears 'value' for all of a purged user's projects" do
     skip
     student = create :student
-    with_channel_for student do |storage_app_id, storage_id|
-      refute_nil storage_apps.where(id: storage_app_id).first[:value]
-      storage_apps.where(storage_id: storage_id).each do |app|
+    with_channel_for student do |project_id, storage_id|
+      refute_nil projects_table.where(id: project_id).first[:value]
+      projects_table.where(storage_id: storage_id).each do |app|
         refute_nil app[:value]
       end
 
       purge_user student
 
-      assert_nil storage_apps.where(id: storage_app_id).first[:value]
-      storage_apps.where(storage_id: storage_id).each do |app|
+      assert_nil projects_table.where(id: project_id).first[:value]
+      projects_table.where(storage_id: storage_id).each do |app|
         assert_nil app[:value]
       end
     end
@@ -1744,16 +1744,16 @@ class DeleteAccountsHelperTest < ActionView::TestCase
   test "clears 'updated_ip' for all of a purged user's projects" do
     skip
     student = create :student
-    with_channel_for student do |storage_app_id, storage_id|
-      refute_empty storage_apps.where(id: storage_app_id).first[:updated_ip]
-      storage_apps.where(storage_id: storage_id).each do |app|
+    with_channel_for student do |project_id, storage_id|
+      refute_empty projects_table.where(id: project_id).first[:updated_ip]
+      projects_table.where(storage_id: storage_id).each do |app|
         refute_empty app[:updated_ip]
       end
 
       purge_user student
 
-      assert_empty storage_apps.where(id: storage_app_id).first[:updated_ip]
-      storage_apps.where(storage_id: storage_id).each do |app|
+      assert_empty projects_table.where(id: project_id).first[:updated_ip]
+      projects_table.where(storage_id: storage_id).each do |app|
         assert_empty app[:updated_ip]
       end
     end
@@ -1915,16 +1915,16 @@ class DeleteAccountsHelperTest < ActionView::TestCase
     # in this test, we depend on the unit tests for the particular buckets to
     # verify correct hard-delete behavior for that bucket.
     student = create :student
-    with_channel_for student do |storage_app_id_a, _|
-      with_channel_for student do |storage_app_id_b, storage_id|
-        storage_apps.where(id: storage_app_id_a).update(state: 'deleted')
+    with_channel_for student do |project_id_a, _|
+      with_channel_for student do |project_id_b, storage_id|
+        projects_table.where(id: project_id_a).update(state: 'deleted')
 
         bucket.any_instance.
           expects(:hard_delete_channel_content).
-          with(storage_encrypt_channel_id(storage_id, storage_app_id_a))
+          with(storage_encrypt_channel_id(storage_id, project_id_a))
         bucket.any_instance.
           expects(:hard_delete_channel_content).
-          with(storage_encrypt_channel_id(storage_id, storage_app_id_b))
+          with(storage_encrypt_channel_id(storage_id, project_id_b))
 
         purge_user student
       end
@@ -1938,12 +1938,12 @@ class DeleteAccountsHelperTest < ActionView::TestCase
   test "Firebase: deletes content for all of user's channels" do
     skip
     student = create :student
-    with_channel_for student do |storage_app_id_a, _|
-      with_channel_for student do |storage_app_id_b, storage_id|
-        storage_apps.where(id: storage_app_id_a).update(state: 'deleted')
+    with_channel_for student do |project_id_a, _|
+      with_channel_for student do |project_id_b, storage_id|
+        projects_table.where(id: project_id_a).update(state: 'deleted')
 
-        student_channels = [storage_encrypt_channel_id(storage_id, storage_app_id_a),
-                            storage_encrypt_channel_id(storage_id, storage_app_id_b)]
+        student_channels = [storage_encrypt_channel_id(storage_id, project_id_a),
+                            storage_encrypt_channel_id(storage_id, project_id_b)]
         FirebaseHelper.
           expects(:delete_channels).
           with(student_channels)
@@ -1983,13 +1983,13 @@ class DeleteAccountsHelperTest < ActionView::TestCase
     student = create :student
 
     with_storage_id_for student do |storage_id|
-      assert_empty storage_apps.where(storage_id: storage_id)
+      assert_empty projects_table.where(storage_id: storage_id)
 
-      with_channel_for student do |storage_app_id|
-        assert_equal storage_app_id, storage_apps.where(storage_id: storage_id).first[:id]
+      with_channel_for student do |project_id|
+        assert_equal project_id, projects_table.where(storage_id: storage_id).first[:id]
       end
 
-      assert_empty storage_apps.where(storage_id: storage_id)
+      assert_empty projects_table.where(storage_id: storage_id)
     end
   end
 

--- a/dashboard/test/lib/projects_list_test.rb
+++ b/dashboard/test/lib/projects_list_test.rb
@@ -88,7 +88,7 @@ class ProjectsListTest < ActionController::TestCase
       birthday: 13.years.ago.to_datetime,
       abuse_score: 0
     }
-    StorageApps.stubs(:get_published_project_data).returns({})
+    Projects.stubs(:get_published_project_data).returns({})
     refute_nil ProjectsList.send(:get_published_project_and_user_data, project_and_user)
   end
 
@@ -101,7 +101,7 @@ class ProjectsListTest < ActionController::TestCase
       birthday: 13.years.ago.to_datetime,
       abuse_score: 0
     }
-    StorageApps.stubs(:get_published_project_data).returns({})
+    Projects.stubs(:get_published_project_data).returns({})
     refute_nil ProjectsList.send(:get_published_project_and_user_data, project_and_user)
   end
 
@@ -135,8 +135,8 @@ class ProjectsListTest < ActionController::TestCase
         abuse_score: 0
       }
     ]
-    StorageApps.stubs(:table).returns(db_result(stub_projects))
-    StorageApps.stubs(:get_published_project_data).returns({})
+    Projects.stubs(:table).returns(db_result(stub_projects))
+    Projects.stubs(:get_published_project_data).returns({})
     assert_equal 2, ProjectsList.send(:fetch_published_project_types, ['applab'], limit: 4)['applab'].length
   end
 
@@ -170,8 +170,8 @@ class ProjectsListTest < ActionController::TestCase
         abuse_score: 0
       }
     ]
-    StorageApps.stubs(:table).returns(db_result(stub_projects))
-    StorageApps.stubs(:get_published_project_data).returns({})
+    Projects.stubs(:table).returns(db_result(stub_projects))
+    Projects.stubs(:get_published_project_data).returns({})
     assert_equal 3, ProjectsList.send(:fetch_published_project_types, ['dance'], limit: 4)['dance'].length
   end
 
@@ -205,8 +205,8 @@ class ProjectsListTest < ActionController::TestCase
         abuse_score: -50
       }
     ]
-    StorageApps.stubs(:table).returns(db_result(stub_projects))
-    StorageApps.stubs(:get_published_project_data).returns({})
+    Projects.stubs(:table).returns(db_result(stub_projects))
+    Projects.stubs(:get_published_project_data).returns({})
     assert_equal 2, ProjectsList.send(:fetch_published_project_types, ['applab'], limit: 4)['applab'].length
   end
 
@@ -232,7 +232,7 @@ class ProjectsListTest < ActionController::TestCase
     fake_project = fake_project_featured_project_user_combo_data.first
 
     assert_equal JSON.parse(fake_project_value)["name"], returned_project["name"]
-    assert_equal StorageApps.make_thumbnail_url_cacheable(JSON.parse(fake_project_value)["thumbnailUrl"]), returned_project["thumbnailUrl"]
+    assert_equal Projects.make_thumbnail_url_cacheable(JSON.parse(fake_project_value)["thumbnailUrl"]), returned_project["thumbnailUrl"]
     assert_equal fake_project[:project_type], returned_project["type"]
     assert_equal fake_project[:published_at], returned_project["publishedAt"]
     assert_equal UserHelpers.initial(fake_project[:name]),
@@ -325,9 +325,9 @@ class ProjectsListTest < ActionController::TestCase
     section = Section.new([student], teacher, 321, 'sectionName', teacher.id)
 
     ProjectsList.stubs(:get_user_ids_by_storage_ids).returns(stub_users)
-    StorageApps.stubs(:table).returns(library_db_result(stub_projects))
+    Projects.stubs(:table).returns(library_db_result(stub_projects))
 
-    StorageApps.stubs(:get_published_project_data).returns({})
+    Projects.stubs(:get_published_project_data).returns({})
     lib_response = ProjectsList.send(:fetch_section_libraries, section)
     assert_equal 2, lib_response.length
     assert_equal applab_lib_name, lib_response[0][:name]
@@ -363,9 +363,9 @@ class ProjectsListTest < ActionController::TestCase
     section = Section.new([section_participant], section_owner, 321, 'sectionName', section_owner.id)
 
     ProjectsList.stubs(:get_user_ids_by_storage_ids).returns(stub_users)
-    StorageApps.stubs(:table).returns(library_db_result(stub_projects))
+    Projects.stubs(:table).returns(library_db_result(stub_projects))
 
-    StorageApps.stubs(:get_published_project_data).returns({})
+    Projects.stubs(:get_published_project_data).returns({})
     lib_response = ProjectsList.send(:fetch_section_libraries, section)
     assert_equal 1, lib_response.length
     assert_equal applab_lib_name, lib_response[0][:name]
@@ -409,9 +409,9 @@ class ProjectsListTest < ActionController::TestCase
     section = Section.new([], teacher, 321, 'sectionName', teacher.id)
 
     ProjectsList.stubs(:get_user_ids_by_storage_ids).returns(stub_users)
-    StorageApps.stubs(:table).returns(library_db_result(stub_projects))
+    Projects.stubs(:table).returns(library_db_result(stub_projects))
 
-    StorageApps.stubs(:get_published_project_data).returns({})
+    Projects.stubs(:get_published_project_data).returns({})
     lib_response = ProjectsList.send(:fetch_section_libraries, section)
     assert_equal 1, lib_response.length
     assert_equal shared_lib_name, lib_response[0][:name]
@@ -441,7 +441,7 @@ class ProjectsListTest < ActionController::TestCase
       }
     ]
 
-    StorageApps.stubs(:table).returns(stub(where: stub_projects))
+    Projects.stubs(:table).returns(stub(where: stub_projects))
 
     updated_channel_ids = ProjectsList.fetch_updated_library_channels(libraries)
     assert_equal [updated_channel_id], updated_channel_ids

--- a/dashboard/test/models/backpack_test.rb
+++ b/dashboard/test/models/backpack_test.rb
@@ -11,15 +11,15 @@ class BackpackTest < ActiveSupport::TestCase
     @storage_id = fake_storage_id_for_user_id(@user.id)
   end
 
-  test 'find_or_create creates storage_app if backpack does not exist' do
+  test 'find_or_create creates project if backpack does not exist' do
     Backpack.stubs(:storage_id_for_user_id).with(@user.id).returns(@storage_id)
     backpack = Backpack.find_or_create(@user.id, 'fake-ip')
-    assert backpack.storage_app_id > 0
+    assert backpack.project_id > 0
     assert_equal @user.id, backpack.user_id
   end
 
   # storage apps with value hidden are hidden from a user's projects list
-  test 'storage_app that is created has value hidden = true' do
+  test 'project that is created has value hidden = true' do
     Backpack.stubs(:storage_id_for_user_id).with(@user.id).returns(@storage_id)
     Backpack.any_instance.stubs(:storage_id_for_user_id).with(@user.id).returns(@storage_id)
     backpack = Backpack.find_or_create(@user.id, 'fake-ip')

--- a/dashboard/test/models/backpack_test.rb
+++ b/dashboard/test/models/backpack_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
-require 'testing/storage_apps_test_utils'
+require 'testing/projects_test_utils'
 
 class BackpackTest < ActiveSupport::TestCase
-  include StorageAppsTestUtils
+  include ProjectsTestUtils
 
   self.use_transactional_test_case = true
 
@@ -18,13 +18,13 @@ class BackpackTest < ActiveSupport::TestCase
     assert_equal @user.id, backpack.user_id
   end
 
-  # storage apps with value hidden are hidden from a user's projects list
+  # projects with value hidden are hidden from a user's projects list
   test 'project that is created has value hidden = true' do
     Backpack.stubs(:storage_id_for_user_id).with(@user.id).returns(@storage_id)
     Backpack.any_instance.stubs(:storage_id_for_user_id).with(@user.id).returns(@storage_id)
     backpack = Backpack.find_or_create(@user.id, 'fake-ip')
-    storage_app = StorageApps.new(@storage_id).get(backpack.channel)
-    assert storage_app["hidden"]
+    project = Projects.new(@storage_id).get(backpack.channel)
+    assert project["hidden"]
   end
 
   test 'find_or_create returns existing backpack if it exists' do

--- a/dashboard/test/models/channel_token_test.rb
+++ b/dashboard/test/models/channel_token_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-require_relative '../../../shared/middleware/helpers/storage_apps'
+require_relative '../../../shared/middleware/helpers/projects'
 
 class ChannelTokenTest < ActiveSupport::TestCase
   self.use_transactional_test_case = true

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -1,10 +1,10 @@
 require 'test_helper'
 require 'testing/includes_metrics'
-require 'testing/storage_apps_test_utils'
+require 'testing/projects_test_utils'
 require 'timecop'
 
 class UserTest < ActiveSupport::TestCase
-  include StorageAppsTestUtils
+  include ProjectsTestUtils
   self.use_transactional_test_case = true
 
   setup_all do
@@ -3178,24 +3178,24 @@ class UserTest < ActiveSupport::TestCase
         with_channel_for student do |channel_id_b|
           # Student deleted channel_id_a a day before they were deleted
           # so we don't expect it to be restored when we undelete them.
-          storage_apps.where(id: channel_id_a).update state: 'deleted', updated_at: Time.now
-          assert_equal 'deleted', storage_apps.where(id: channel_id_a).first[:state]
-          assert_equal 'active', storage_apps.where(id: channel_id_b).first[:state]
+          projects_table.where(id: channel_id_a).update state: 'deleted', updated_at: Time.now
+          assert_equal 'deleted', projects_table.where(id: channel_id_a).first[:state]
+          assert_equal 'active', projects_table.where(id: channel_id_b).first[:state]
 
           Timecop.travel 1.day
 
           # Soft-deleting the student also soft-deletes their projects
           student.destroy
-          assert_equal 'deleted', storage_apps.where(id: channel_id_a).first[:state]
-          assert_equal 'deleted', storage_apps.where(id: channel_id_b).first[:state]
+          assert_equal 'deleted', projects_table.where(id: channel_id_a).first[:state]
+          assert_equal 'deleted', projects_table.where(id: channel_id_b).first[:state]
 
           Timecop.travel 1.day
 
           # Restoring the student only restores projects that were deleted along
           # with the student
           student.undestroy
-          assert_equal 'deleted', storage_apps.where(id: channel_id_a).first[:state]
-          assert_equal 'active', storage_apps.where(id: channel_id_b).first[:state]
+          assert_equal 'deleted', projects_table.where(id: channel_id_a).first[:state]
+          assert_equal 'active', projects_table.where(id: channel_id_b).first[:state]
         end
       end
     end
@@ -4469,16 +4469,16 @@ class UserTest < ActiveSupport::TestCase
 
   test 'find_channel_owner finds channel owner' do
     student = create :student
-    with_channel_for student do |storage_app_id, storage_id|
-      encrypted_channel_id = storage_encrypt_channel_id storage_id, storage_app_id
+    with_channel_for student do |project_id, storage_id|
+      encrypted_channel_id = storage_encrypt_channel_id storage_id, project_id
       result = User.find_channel_owner encrypted_channel_id
       assert_equal student, result
     end
   end
 
   test 'find_channel_owner returns nil for channel with no owner' do
-    with_anonymous_channel do |storage_app_id, storage_id|
-      encrypted_channel_id = storage_encrypt_channel_id storage_id, storage_app_id
+    with_anonymous_channel do |project_id, storage_id|
+      encrypted_channel_id = storage_encrypt_channel_id storage_id, project_id
       result = User.find_channel_owner encrypted_channel_id
       assert_nil result
     end

--- a/dashboard/test/test_helper.rb
+++ b/dashboard/test/test_helper.rb
@@ -635,15 +635,15 @@ def with_locale(locale)
   end
 end
 
-# Mock StorageApps to generate random tokens
-class StorageApps
+# Mock Projects to generate random tokens
+class Projects
   def initialize(storage_id)
     @storage_id = storage_id
   end
 
   def create(_, _)
-    storage_app_id = SecureRandom.random_number(100000)
-    storage_encrypt_channel_id(@storage_id, storage_app_id)
+    project_id = SecureRandom.random_number(100000)
+    storage_encrypt_channel_id(@storage_id, project_id)
   end
 
   def most_recent(_)

--- a/dashboard/test/testing/projects_test_utils.rb
+++ b/dashboard/test/testing/projects_test_utils.rb
@@ -1,17 +1,17 @@
-require_relative '../../../shared/middleware/helpers/storage_apps'
+require_relative '../../../shared/middleware/helpers/projects'
 require_relative '../../../shared/middleware/helpers/storage_id'
 
-# Tools that help test storage apps
+# Tools that help test projects
 # To be included in any dashboard test that needs them.
-module StorageAppsTestUtils
+module ProjectsTestUtils
   # @param [User] owner - may be nil for anonymous channel
   def with_channel_for(owner)
     with_storage_id_for owner do |storage_id|
-      encrypted_channel_id = StorageApps.new(storage_id).create({projectType: 'applab'}, ip: 123)
-      _, storage_app_id = storage_decrypt_channel_id encrypted_channel_id
-      yield storage_app_id, storage_id
+      encrypted_channel_id = Projects.new(storage_id).create({projectType: 'applab'}, ip: 123)
+      _, project_id = storage_decrypt_channel_id encrypted_channel_id
+      yield project_id, storage_id
     ensure
-      storage_apps.where(id: storage_app_id).delete if storage_app_id
+      projects_table.where(id: project_id).delete if project_id
     end
   end
 
@@ -35,7 +35,7 @@ module StorageAppsTestUtils
     with_channel_for(nil, &block)
   end
 
-  def storage_apps
-    StorageApps.table
+  def projects_table
+    Projects.table
   end
 end

--- a/lib/cdo/delete_accounts_helper.rb
+++ b/lib/cdo/delete_accounts_helper.rb
@@ -1,5 +1,5 @@
 require_relative '../../shared/middleware/helpers/storage_id'
-require_relative '../../shared/middleware/helpers/storage_apps'
+require_relative '../../shared/middleware/helpers/projects'
 require 'cdo/aws/s3'
 require 'cdo/db'
 
@@ -35,14 +35,14 @@ class DeleteAccountsHelper
 
     @log.puts "Deleting project backed progress"
 
-    project_ids = StorageApps.table.where(storage_id: user.user_storage_id).map(:id)
+    project_ids = Projects.table.where(storage_id: user.user_storage_id).map(:id)
     channel_count = project_ids.count
     encrypted_channel_ids = project_ids.map do |project_id|
       storage_encrypt_channel_id user.user_storage_id, project_id
     end
 
     # Clear potential PII from user's channels
-    StorageApps.table.
+    Projects.table.
       where(id: project_ids).
       update(value: nil, updated_ip: '', updated_at: Time.now)
 

--- a/shared/middleware/channels_api.rb
+++ b/shared/middleware/channels_api.rb
@@ -12,7 +12,7 @@ class ChannelsApi < Sinatra::Base
   helpers do
     %w(
       core.rb
-      storage_apps.rb
+      projects.rb
       storage_id.rb
       auth_helpers.rb
       profanity_privacy_helper.rb
@@ -46,7 +46,7 @@ class ChannelsApi < Sinatra::Base
     dont_cache
     content_type :json
     begin
-      StorageApps.new(get_storage_id).to_a.to_json
+      Projects.new(get_storage_id).to_a.to_json
     rescue ArgumentError, OpenSSL::Cipher::CipherError
       bad_request
     end
@@ -64,7 +64,7 @@ class ChannelsApi < Sinatra::Base
     unsupported_media_type unless request.content_type.to_s.split(';').first == 'application/json'
     unsupported_media_type unless request.content_charset.to_s.downcase == 'utf-8'
 
-    storage_app = StorageApps.new(get_storage_id)
+    project = Projects.new(get_storage_id)
 
     begin
       _, remix_parent_id = storage_decrypt_channel_id(request.GET['parent']) if request.GET['parent']
@@ -95,7 +95,7 @@ class ChannelsApi < Sinatra::Base
       data.delete('shouldPublish')
     end
 
-    id = storage_app.create(
+    id = project.create(
       data.merge('createdAt' => timestamp, 'updatedAt' => timestamp),
       ip: request.ip,
       type: data['projectType'],
@@ -115,7 +115,7 @@ class ChannelsApi < Sinatra::Base
     dont_cache
     content_type :json
     begin
-      StorageApps.new(get_storage_id).get(id).to_json
+      Projects.new(get_storage_id).get(id).to_json
     rescue ArgumentError, OpenSSL::Cipher::CipherError
       bad_request
     end
@@ -129,7 +129,7 @@ class ChannelsApi < Sinatra::Base
   delete %r{/v3/channels/([^/]+)$} do |id|
     dont_cache
     begin
-      StorageApps.new(get_storage_id).delete(id)
+      Projects.new(get_storage_id).delete(id)
     rescue ArgumentError, OpenSSL::Cipher::CipherError
       bad_request
     end
@@ -165,7 +165,7 @@ class ChannelsApi < Sinatra::Base
     project_type = value.delete('projectType')
 
     begin
-      value = StorageApps.new(get_storage_id).update(id, value, request.ip, locale: request.locale, project_type: project_type)
+      value = Projects.new(get_storage_id).update(id, value, request.ip, locale: request.locale, project_type: project_type)
     rescue ArgumentError, OpenSSL::Cipher::CipherError, ProfanityPrivacyError => e
       if e.class == ProfanityPrivacyError
         dont_cache
@@ -200,7 +200,7 @@ class ChannelsApi < Sinatra::Base
 
     # Once we have back-filled the project_type column for all channels,
     # it will no longer be necessary to specify the project type here.
-    StorageApps.new(get_storage_id).publish(channel_id, project_type, current_user).to_json
+    Projects.new(get_storage_id).publish(channel_id, project_type, current_user).to_json
   end
 
   #
@@ -210,7 +210,7 @@ class ChannelsApi < Sinatra::Base
   #
   post %r{/v3/channels/([^/]+)/unpublish} do |channel_id|
     not_authorized unless owns_channel?(channel_id)
-    StorageApps.new(get_storage_id).unpublish(channel_id)
+    Projects.new(get_storage_id).unpublish(channel_id)
     {publishedAt: nil}.to_json
   end
 
@@ -224,7 +224,7 @@ class ChannelsApi < Sinatra::Base
     dont_cache
     content_type :json
     begin
-      value = StorageApps.new(get_storage_id).set_content_moderation(channel_id, true)
+      value = Projects.new(get_storage_id).set_content_moderation(channel_id, true)
     rescue ArgumentError, OpenSSL::Cipher::CipherError
       bad_request
     end
@@ -241,7 +241,7 @@ class ChannelsApi < Sinatra::Base
     dont_cache
     content_type :json
     begin
-      value = StorageApps.new(get_storage_id).set_content_moderation(channel_id, false)
+      value = Projects.new(get_storage_id).set_content_moderation(channel_id, false)
     rescue ArgumentError, OpenSSL::Cipher::CipherError
       bad_request
     end
@@ -291,7 +291,7 @@ class ChannelsApi < Sinatra::Base
     dont_cache
     content_type :json
     begin
-      value = StorageApps.new(get_storage_id).get_sharing_disabled(id, current_user_id)
+      value = Projects.new(get_storage_id).get_sharing_disabled(id, current_user_id)
     rescue ArgumentError, OpenSSL::Cipher::CipherError
       bad_request
     end
@@ -308,7 +308,7 @@ class ChannelsApi < Sinatra::Base
     dont_cache
     content_type :json
     begin
-      value = StorageApps.get_abuse(id)
+      value = Projects.get_abuse(id)
     rescue ArgumentError, OpenSSL::Cipher::CipherError
       bad_request
     end
@@ -328,7 +328,7 @@ class ChannelsApi < Sinatra::Base
     # with only one report from a verified teacher.
     amount = verified_teacher? ? 20 : 10
     begin
-      value = StorageApps.new(get_storage_id).increment_abuse(id, amount)
+      value = Projects.new(get_storage_id).increment_abuse(id, amount)
     rescue ArgumentError, OpenSSL::Cipher::CipherError
       bad_request
     end
@@ -348,7 +348,7 @@ class ChannelsApi < Sinatra::Base
     dont_cache
     content_type :json
     begin
-      value = StorageApps.new(get_storage_id).buffer_abuse_score(id)
+      value = Projects.new(get_storage_id).buffer_abuse_score(id)
     rescue ArgumentError, OpenSSL::Cipher::CipherError
       bad_request
     end
@@ -367,7 +367,7 @@ class ChannelsApi < Sinatra::Base
     dont_cache
     content_type :json
     begin
-      value = StorageApps.new(get_storage_id).reset_abuse(id)
+      value = Projects.new(get_storage_id).reset_abuse(id)
     rescue ArgumentError, OpenSSL::Cipher::CipherError
       bad_request
     end

--- a/shared/middleware/files_api.rb
+++ b/shared/middleware/files_api.rb
@@ -55,15 +55,15 @@ class FilesApi < Sinatra::Base
   def codeprojects_can_view?(encrypted_channel_id)
     owner_storage_id, _ = storage_decrypt_channel_id(encrypted_channel_id)
 
-    # Attempt to find active project in database. This will raise StorageApps::NotFound if
+    # Attempt to find active project in database. This will raise Projects::NotFound if
     # no active project exists, which is handled below.
-    StorageApps.new(owner_storage_id).get(encrypted_channel_id)
+    Projects.new(owner_storage_id).get(encrypted_channel_id)
 
     owner_user_id = user_id_for_storage_id(owner_storage_id)
     !get_user_sharing_disabled(owner_user_id)
 
   # Default to cannot view if there is an error
-  rescue StorageApps::NotFound, ArgumentError, OpenSSL::Cipher::CipherError
+  rescue Projects::NotFound, ArgumentError, OpenSSL::Cipher::CipherError
     false
   end
 
@@ -347,7 +347,7 @@ class FilesApi < Sinatra::Base
 
     # Only validate WebLab HTML files. We need to get the project from the database
     # in order to check whether or not the file belongs to a WebLab project.
-    project = StorageApps.new(get_storage_id).get(encrypted_channel_id)
+    project = Projects.new(get_storage_id).get(encrypted_channel_id)
     return false unless project
     return true unless project[:projectType]&.downcase == 'weblab'
 
@@ -434,7 +434,7 @@ class FilesApi < Sinatra::Base
     tab_id = params['tabId']
     conflict unless buckets.check_current_version(encrypted_channel_id, filename, current_version, should_replace, timestamp, tab_id, current_user_id)
 
-    abuse_score = StorageApps.get_abuse(encrypted_channel_id)
+    abuse_score = Projects.get_abuse(encrypted_channel_id)
 
     response = buckets.create_or_replace(encrypted_channel_id, filename, body, version_to_replace, abuse_score)
 
@@ -757,7 +757,7 @@ class FilesApi < Sinatra::Base
 
     # write the manifest (assuming the entry changed)
     unless manifest_is_unchanged
-      abuse_score = StorageApps.get_abuse(encrypted_channel_id)
+      abuse_score = Projects.get_abuse(encrypted_channel_id)
 
       response = bucket.create_or_replace(
         encrypted_channel_id,
@@ -866,7 +866,7 @@ class FilesApi < Sinatra::Base
     reject_result = manifest.reject! {|e| e['filename'].downcase == manifest_delete_comparison_filename}
     not_found if reject_result.nil?
 
-    abuse_score = StorageApps.get_abuse(encrypted_channel_id)
+    abuse_score = Projects.get_abuse(encrypted_channel_id)
 
     # write the manifest
     response = bucket.create_or_replace(encrypted_channel_id, FileBucket::MANIFEST_FILENAME, manifest.to_json, params['files-version'], abuse_score)
@@ -913,7 +913,7 @@ class FilesApi < Sinatra::Base
       entry['versionId'] = response.version_id
     end
 
-    abuse_score = StorageApps.get_abuse(encrypted_channel_id)
+    abuse_score = Projects.get_abuse(encrypted_channel_id)
 
     # save the new manifest
     manifest_json = manifest.to_json
@@ -988,8 +988,8 @@ class FilesApi < Sinatra::Base
     file = get_file('files', encrypted_channel_id, s3_prefix)
 
     if THUMBNAIL_FILENAME == filename
-      storage_apps = StorageApps.new(get_storage_id)
-      project_type = storage_apps.project_type_from_channel_id(encrypted_channel_id)
+      project = Projects.new(get_storage_id)
+      project_type = project.project_type_from_channel_id(encrypted_channel_id)
       if moderate_type?(project_type) && moderate_channel?(encrypted_channel_id)
         file_mime_type = mime_type(File.extname(filename.downcase))
         rating = ImageModeration.rate_image(file, file_mime_type, request.fullpath)
@@ -997,7 +997,7 @@ class FilesApi < Sinatra::Base
         case rating
         when :adult, :racy
           # Incrementing abuse score by 15 to differentiate from manually reported projects
-          new_score = storage_apps.increment_abuse(encrypted_channel_id, 15)
+          new_score = project.increment_abuse(encrypted_channel_id, 15)
           FileBucket.new.replace_abuse_score(encrypted_channel_id, s3_prefix, new_score)
           response.headers['x-cdo-content-rating'] = rating.to_s
           cache_for 1.hour
@@ -1052,7 +1052,7 @@ class FilesApi < Sinatra::Base
   end
 
   def moderate_channel?(encrypted_channel_id)
-    storage_apps = StorageApps.new(get_storage_id)
-    !storage_apps.content_moderation_disabled?(encrypted_channel_id)
+    project = Projects.new(get_storage_id)
+    !project.content_moderation_disabled?(encrypted_channel_id)
   end
 end

--- a/shared/middleware/helpers/projects.rb
+++ b/shared/middleware/helpers/projects.rb
@@ -3,16 +3,16 @@ require_relative './storage_id'
 require_relative './profanity_privacy_helper'
 
 #
-# StorageApps
+# Projects
 #
-class StorageApps
+class Projects
   class NotFound < Sinatra::NotFound
   end
 
   def initialize(storage_id)
     @storage_id = storage_id
 
-    @table = StorageApps.table
+    @table = Projects.table
   end
 
   def create(value, ip:, type: nil, published_at: nil, remix_parent_id: nil, standalone: true)
@@ -36,10 +36,10 @@ class StorageApps
   end
 
   def delete(channel_id)
-    owner, storage_app_id = storage_decrypt_channel_id(channel_id)
+    owner, project_id = storage_decrypt_channel_id(channel_id)
     raise NotFound, "channel `#{channel_id}` not found in your storage" unless owner == @storage_id
 
-    delete_count = @table.where(id: storage_app_id).update(state: 'deleted')
+    delete_count = @table.where(id: project_id).update(state: 'deleted')
     raise NotFound, "channel `#{channel_id}` not found" if delete_count == 0
 
     # TODO: Delete all storage associated with this channel (e.g. properties and tables and assets)
@@ -48,18 +48,18 @@ class StorageApps
   end
 
   def restore(channel_id)
-    owner, storage_app_id = storage_decrypt_channel_id(channel_id)
+    owner, project_id = storage_decrypt_channel_id(channel_id)
     raise NotFound, "channel `#{channel_id}` not found in your storage" unless owner == @storage_id
 
-    update_count = @table.where(id: storage_app_id).update(state: 'active')
+    update_count = @table.where(id: project_id).update(state: 'active')
     raise NotFound, "channel `#{channel_id}` not found" if update_count == 0
 
     true
   end
 
   def get(channel_id)
-    owner, storage_app_id = storage_decrypt_channel_id(channel_id)
-    row = @table.where(id: storage_app_id).exclude(state: 'deleted').first
+    owner, project_id = storage_decrypt_channel_id(channel_id)
+    row = @table.where(id: project_id).exclude(state: 'deleted').first
     raise NotFound, "channel `#{channel_id}` not found" unless row
 
     # For some apps, if it was created by a signed out user, we don't want anyone
@@ -76,15 +76,15 @@ class StorageApps
       raise NotFound, "channel `#{channel_id}` not shareable" if anonymous_age_restricted_apps.include? project_type
     end
 
-    StorageApps.merged_row_value(row, channel_id: channel_id, is_owner: owner == @storage_id)
+    Projects.merged_row_value(row, channel_id: channel_id, is_owner: owner == @storage_id)
   end
 
   def update(channel_id, value, ip_address, project_type: nil, locale: 'en')
-    owner, storage_app_id = storage_decrypt_channel_id(channel_id)
+    owner, project_id = storage_decrypt_channel_id(channel_id)
     raise NotFound, "channel `#{channel_id}` not found in your storage" unless owner == @storage_id
 
     new_name = value['name']
-    project = @table.where(id: storage_app_id).first
+    project = @table.where(id: project_id).first
     old_name = JSON.parse(project[:value])['name']
     if new_name != old_name
       share_failure = title_profanity_privacy_violation(new_name, locale)
@@ -98,7 +98,7 @@ class StorageApps
       updated_ip: ip_address,
     }
     row[:project_type] = project_type if project_type
-    update_count = @table.where(id: storage_app_id).exclude(state: 'deleted').update(row)
+    update_count = @table.where(id: project_id).exclude(state: 'deleted').update(row)
     raise NotFound, "channel `#{channel_id}` not found" if update_count == 0
 
     # We can't include :created_at here without an extra DB query. Most consumers won't need :created_at during updates, so omit it.
@@ -106,17 +106,17 @@ class StorageApps
   end
 
   def publish(channel_id, type, user)
-    owner, storage_app_id = storage_decrypt_channel_id(channel_id)
+    owner, project_id = storage_decrypt_channel_id(channel_id)
     raise NotFound, "channel `#{channel_id}` not found in your storage" unless owner == @storage_id
     row = {
       project_type: type,
       published_at: DateTime.now,
     }
-    update_count = @table.where(id: storage_app_id).exclude(state: 'deleted').update(row)
+    update_count = @table.where(id: project_id).exclude(state: 'deleted').update(row)
     raise NotFound, "channel `#{channel_id}` not found" if update_count == 0
 
-    project = @table.where(id: storage_app_id).first
-    StorageApps.get_published_project_data(project, channel_id).merge(
+    project = @table.where(id: project_id).first
+    Projects.get_published_project_data(project, channel_id).merge(
       # For privacy reasons, include only the first initial of the student's name.
       studentName: user && UserHelpers.initial(user[:name]),
       studentAgeRange: user && UserHelpers.age_range_from_birthday(user[:birthday]),
@@ -124,11 +124,11 @@ class StorageApps
   end
 
   def get_active_projects
-    StorageApps.table.where(storage_id: @storage_id, state: 'active')
+    Projects.table.where(storage_id: @storage_id, state: 'active')
   end
 
   def get_projects_with_state(state: 'active', order: nil)
-    query = StorageApps.table.where(storage_id: @storage_id, state: state)
+    query = Projects.table.where(storage_id: @storage_id, state: state)
 
     if order.present?
       query.order(order)
@@ -137,16 +137,16 @@ class StorageApps
     query
   end
 
-  # Returns an array of all ids for storage apps with storage id = @storage_id
-  def get_all_storage_app_ids
-    StorageApps.table.
+  # Returns an array of all ids for projects with storage id = @storage_id
+  def get_all_project_ids
+    Projects.table.
       where(storage_id: @storage_id).
       map(:id)
   end
 
-  # Soft-delete all of the storage apps for user with storage id @storage_id
+  # Soft-delete all of the projects for user with storage id @storage_id
   def soft_delete_all
-    StorageApps.table.
+    Projects.table.
       where(storage_id: @storage_id).
       exclude(state: 'deleted').
       update(state: 'deleted', updated_at: Time.now)
@@ -154,19 +154,19 @@ class StorageApps
 
   # Restores all of this user's projects that were soft-deleted after the given time
   def restore_if_deleted_after(deleted_time)
-    StorageApps.table.
+    Projects.table.
       where(storage_id: @storage_id, state: 'deleted').
       where(Sequel.lit('updated_at >= ?', deleted_time.localtime)).
       update(state: 'active', updated_at: Time.now)
   end
 
-  # extracts published project data from a project (aka storage_apps table row).
+  # extracts published project data from a project (aka projects table row).
   def self.get_published_project_data(project, channel_id)
     project_value = JSON.parse(project[:value])
     {
       channel: channel_id,
       name: project_value['name'],
-      thumbnailUrl: StorageApps.make_thumbnail_url_cacheable(project_value['thumbnailUrl']),
+      thumbnailUrl: Projects.make_thumbnail_url_cacheable(project_value['thumbnailUrl']),
       # Note that we are using the new :project_type field rather than extracting
       # it from :value. :project_type might not be present in unpublished projects.
       type: project[:project_type],
@@ -180,18 +180,18 @@ class StorageApps
   end
 
   def unpublish(channel_id)
-    owner, storage_app_id = storage_decrypt_channel_id(channel_id)
+    owner, project_id = storage_decrypt_channel_id(channel_id)
     raise NotFound, "channel `#{channel_id}` not found in your storage" unless owner == @storage_id
     row = {
       published_at: nil,
     }
-    update_count = @table.where(id: storage_app_id).exclude(state: 'deleted').update(row)
+    update_count = @table.where(id: project_id).exclude(state: 'deleted').update(row)
     raise NotFound, "channel `#{channel_id}` not found" if update_count == 0
   end
 
   # Determine if the current user can view the project
   def get_sharing_disabled(channel_id, current_user_id)
-    owner_storage_id, storage_app_id = storage_decrypt_channel_id(channel_id)
+    owner_storage_id, project_id = storage_decrypt_channel_id(channel_id)
     owner_user_id = user_id_for_storage_id(owner_storage_id)
 
     # Sharing of a project is not disabled for the project owner
@@ -202,7 +202,7 @@ class StorageApps
     elsif teaches_student?(owner_user_id, current_user_id)
       return false
     elsif get_user_sharing_disabled(owner_user_id)
-      !users_paired_on_level?(storage_app_id, current_user_id, owner_user_id, owner_storage_id)
+      !users_paired_on_level?(project_id, current_user_id, owner_user_id, owner_storage_id)
     else
       return false
     end
@@ -211,9 +211,9 @@ class StorageApps
     true
   end
 
-  def users_paired_on_level?(storage_app_id, current_user_id, owner_user_id, owner_storage_id)
+  def users_paired_on_level?(project_id, current_user_id, owner_user_id, owner_storage_id)
     channel_tokens_table = DASHBOARD_DB[:channel_tokens]
-    level_id_row = channel_tokens_table.where(storage_app_id: storage_app_id, storage_id: owner_storage_id).first
+    level_id_row = channel_tokens_table.where(project_id: project_id, storage_id: owner_storage_id).first
     return false if level_id_row.nil?
     level_id = level_id_row[:level_id]
 
@@ -229,26 +229,26 @@ class StorageApps
   end
 
   def increment_abuse(channel_id, amount = 10)
-    _owner, storage_app_id = storage_decrypt_channel_id(channel_id)
+    _owner, project_id = storage_decrypt_channel_id(channel_id)
 
-    row = @table.where(id: storage_app_id).exclude(state: 'deleted').first
+    row = @table.where(id: project_id).exclude(state: 'deleted').first
     raise NotFound, "channel `#{channel_id}` not found" unless row
 
     new_score = row[:abuse_score] + (JSON.parse(row[:value])['frozen'] ? 0 : amount)
 
-    update_count = @table.where(id: storage_app_id).exclude(state: 'deleted').update({abuse_score: new_score})
+    update_count = @table.where(id: project_id).exclude(state: 'deleted').update({abuse_score: new_score})
     raise NotFound, "channel `#{channel_id}` not found" if update_count == 0
 
     new_score
   end
 
   def reset_abuse(channel_id)
-    _owner, storage_app_id = storage_decrypt_channel_id(channel_id)
+    _owner, project_id = storage_decrypt_channel_id(channel_id)
 
-    row = @table.where(id: storage_app_id).exclude(state: 'deleted').first
+    row = @table.where(id: project_id).exclude(state: 'deleted').first
     raise NotFound, "channel `#{channel_id}` not found" unless row
 
-    update_count = @table.where(id: storage_app_id).exclude(state: 'deleted').update({abuse_score: 0})
+    update_count = @table.where(id: project_id).exclude(state: 'deleted').update({abuse_score: 0})
     raise NotFound, "channel `#{channel_id}` not found" if update_count == 0
 
     0
@@ -264,9 +264,9 @@ class StorageApps
   end
 
   def content_moderation_disabled?(channel_id)
-    _owner, storage_app_id = storage_decrypt_channel_id(channel_id)
+    _owner, project_id = storage_decrypt_channel_id(channel_id)
 
-    row = @table.where(id: storage_app_id).exclude(state: 'deleted').first
+    row = @table.where(id: project_id).exclude(state: 'deleted').first
     return false unless row
 
     row[:skip_content_moderation]
@@ -282,9 +282,9 @@ class StorageApps
   # value for content_moderation_disabled.
   #
   def set_content_moderation(channel_id, disable)
-    _owner, storage_app_id = storage_decrypt_channel_id(channel_id)
+    _owner, project_id = storage_decrypt_channel_id(channel_id)
     rows_changed = @table.
-      where(id: storage_app_id).
+      where(id: project_id).
       exclude(state: 'deleted').
       update({skip_content_moderation: disable})
     raise NotFound, "channel `#{channel_id}` not found" unless rows_changed > 0
@@ -296,7 +296,7 @@ class StorageApps
     @table.where(storage_id: @storage_id).exclude(state: 'deleted').map do |row|
       channel_id = storage_encrypt_channel_id(row[:storage_id], row[:id])
       begin
-        StorageApps.merged_row_value(
+        Projects.merged_row_value(
           row,
           channel_id: channel_id,
           is_owner: row[:storage_id] == @storage_id
@@ -370,10 +370,10 @@ class StorageApps
   #
   def self.remix_ancestry(channel_id, depth: 1)
     [].tap do |ancestors|
-      _, storage_app_id = storage_decrypt_channel_id(channel_id)
-      next_row = StorageApps.table.where(id: storage_app_id).first
+      _, project_id = storage_decrypt_channel_id(channel_id)
+      next_row = Projects.table.where(id: project_id).first
       while next_row&.[](:remix_parent_id)
-        next_row = StorageApps.table.where(id: next_row[:remix_parent_id]).first
+        next_row = Projects.table.where(id: next_row[:remix_parent_id]).first
         ancestors.push storage_encrypt_channel_id(next_row[:storage_id], next_row[:id]) if next_row
         break if ancestors.size >= depth
       end
@@ -383,14 +383,14 @@ class StorageApps
   end
 
   def self.get_abuse(channel_id)
-    _, storage_app_id = storage_decrypt_channel_id(channel_id)
-    project_info = StorageApps.table.where(id: storage_app_id).first
+    _, project_id = storage_decrypt_channel_id(channel_id)
+    project_info = Projects.table.where(id: project_id).first
     project_info[:abuse_score]
   end
 
-  # Returns storage apps with id in ids
+  # Returns projects with id in ids
   def self.get_by_ids(ids)
-    StorageApps.table.where(id: ids)
+    Projects.table.where(id: ids)
   end
 
   def self.table
@@ -404,7 +404,7 @@ class StorageApps
   # need to do this because the project type is usually part of the URL,
   # but for a few APIs this is needed.
   #
-  # @param [Hash] row - A storage_apps merged row value as returned by
+  # @param [Hash] row - A projects merged row value as returned by
   #   `merged_row_value` or `get`.
   # @returns [String] The discovered project type, or 'unknown' if the type
   #   can't be determined with given information.
@@ -412,7 +412,7 @@ class StorageApps
   def project_type_from_merged_row(row)
     # We can derive channel project type from a few places.
     #
-    # 1. The `project_type` column in the storage_apps table.
+    # 1. The `project_type` column in the projects table.
     #    This is often NULL for "hidden" levels, which includes project-backed
     #    script levels.
     return row[:projectType] if row[:projectType]

--- a/shared/test/middleware/helpers/test_storage_apps.rb
+++ b/shared/test/middleware/helpers/test_storage_apps.rb
@@ -1,8 +1,8 @@
 require_relative '../../test_helper'
-require_relative '../../../middleware/helpers/storage_apps'
+require_relative '../../../middleware/helpers/projects'
 require_relative '../../../middleware/helpers/storage_id'
 
-class StorageAppsTest < Minitest::Test
+class ProjectsTest < Minitest::Test
   include SetupTest
 
   def test_get_anonymous_age_restricted_app
@@ -11,28 +11,28 @@ class StorageAppsTest < Minitest::Test
 
     # Create an applab project as signed out user
     # Other users should not be able to access app
-    channel_id = StorageApps.new(signedout_storage_id).create({projectType: 'applab'}, ip: 123)
-    assert_raises StorageApps::NotFound do
-      StorageApps.new(signedin_storage_id).get(channel_id)
+    channel_id = Projects.new(signedout_storage_id).create({projectType: 'applab'}, ip: 123)
+    assert_raises Projects::NotFound do
+      Projects.new(signedin_storage_id).get(channel_id)
     end
 
     # can still get your own channel
-    StorageApps.new(signedout_storage_id).get(channel_id)
+    Projects.new(signedout_storage_id).get(channel_id)
 
     # Create an artist project as signed out user
     # Other users should be able to access it
-    channel_id = StorageApps.new(signedout_storage_id).create({projectType: 'artist'}, ip: 123)
-    StorageApps.new(signedin_storage_id).get(channel_id)
+    channel_id = Projects.new(signedout_storage_id).create({projectType: 'artist'}, ip: 123)
+    Projects.new(signedin_storage_id).get(channel_id)
 
     # Create an applab project as a signed in user
     # Other users should be able to access app
-    channel_id = StorageApps.new(signedin_storage_id).create({projectType: 'applab'}, ip: 123)
-    StorageApps.new(signedout_storage_id).get(channel_id)
+    channel_id = Projects.new(signedin_storage_id).create({projectType: 'applab'}, ip: 123)
+    Projects.new(signedout_storage_id).get(channel_id)
   end
 
   def test_users_paired_on_level_when_no_level
     signedin_storage_id = create_storage_id_for_user(123)
-    storage_apps = StorageApps.new(signedin_storage_id)
+    project = Projects.new(signedin_storage_id)
 
     mock_where = mock
     mock_where.expects(:first).returns(nil).once
@@ -41,12 +41,12 @@ class StorageAppsTest < Minitest::Test
     DASHBOARD_DB.expects(:[]).with(:channel_tokens).returns(mock_table).once
 
     # If there is no level associated with the channel, it's not possible for it to be paired.
-    refute storage_apps.users_paired_on_level?(12345, 123, 124, 67890)
+    refute project.users_paired_on_level?(12345, 123, 124, 67890)
   end
 
   def test_users_paired_on_level_with_level_not_paired
     signedin_storage_id = create_storage_id_for_user(123)
-    storage_apps = StorageApps.new(signedin_storage_id)
+    project = Projects.new(signedin_storage_id)
 
     mock_where = mock
     mock_where.expects(:first).returns(nil).once
@@ -67,12 +67,12 @@ class StorageAppsTest < Minitest::Test
     DASHBOARD_DB.expects(:[]).with(:channel_tokens).returns(mock_table).once
 
     # If there is no paired_user_level, it's not possible for it to be paired.
-    refute storage_apps.users_paired_on_level?(12345, 123, 124, 67890)
+    refute project.users_paired_on_level?(12345, 123, 124, 67890)
   end
 
   def test_users_paired_on_level_with_level_paired
     signedin_storage_id = create_storage_id_for_user(123)
-    storage_apps = StorageApps.new(signedin_storage_id)
+    project = Projects.new(signedin_storage_id)
 
     mock_where = mock
     mock_where.expects(:first).returns({paired: true}).once
@@ -93,89 +93,89 @@ class StorageAppsTest < Minitest::Test
     DASHBOARD_DB.expects(:[]).with(:channel_tokens).returns(mock_table).once
 
     # If there is a paired_user_level, then the level was paired.
-    assert storage_apps.users_paired_on_level?(12345, 123, 124, 67890)
+    assert project.users_paired_on_level?(12345, 123, 124, 67890)
   end
 
   def test_derive_project_type
     signedin_storage_id = create_storage_id_for_user(20)
-    storage_apps = StorageApps.new(signedin_storage_id)
+    project = Projects.new(signedin_storage_id)
 
     # Create without type
-    typeless = storage_apps.create({}, ip: 123)
-    assert_equal 'unknown', storage_apps.project_type_from_channel_id(typeless)
+    typeless = project.create({}, ip: 123)
+    assert_equal 'unknown', project.project_type_from_channel_id(typeless)
 
     # Create with type argument
-    type_in_column = storage_apps.create({}, ip: 123, type: 'applab')
-    assert_equal 'applab', storage_apps.project_type_from_channel_id(type_in_column)
+    type_in_column = project.create({}, ip: 123, type: 'applab')
+    assert_equal 'applab', project.project_type_from_channel_id(type_in_column)
 
     # Create with type in value JSON blob
-    type_in_json = storage_apps.create({projectType: 'gamelab'}, ip: 123)
-    assert_equal 'gamelab', storage_apps.project_type_from_channel_id(type_in_json)
+    type_in_json = project.create({projectType: 'gamelab'}, ip: 123)
+    assert_equal 'gamelab', project.project_type_from_channel_id(type_in_json)
 
     # Create with type that can be derived from the level property in the JSON blob
-    type_in_level = storage_apps.create({level: '/projects/weblab'}, ip: 123)
-    assert_equal 'weblab', storage_apps.project_type_from_channel_id(type_in_level)
+    type_in_level = project.create({level: '/projects/weblab'}, ip: 123)
+    assert_equal 'weblab', project.project_type_from_channel_id(type_in_level)
   end
 
   def test_content_moderation_disabled?
     signedin_storage_id = create_storage_id_for_user(20)
-    storage_apps = StorageApps.new(signedin_storage_id)
+    project = Projects.new(signedin_storage_id)
 
     # Create a new typeless project
     # content_moderation_disabled should be false by default on project creation for projects of any type.
-    new_project_channel_id = storage_apps.create({}, ip: 123)
-    assert_equal false, storage_apps.content_moderation_disabled?(new_project_channel_id)
+    new_project_channel_id = project.create({}, ip: 123)
+    assert_equal false, project.content_moderation_disabled?(new_project_channel_id)
   end
 
   def test_set_content_moderation
     signedin_storage_id = create_storage_id_for_user(20)
-    storage_apps = StorageApps.new(signedin_storage_id)
+    project = Projects.new(signedin_storage_id)
 
     # Create a new typeless project
     # skip_content_moderation should be false by default on project creation for projects of any type.
-    new_project_channel_id = storage_apps.create({}, ip: 123)
-    assert_equal false, storage_apps.content_moderation_disabled?(new_project_channel_id)
+    new_project_channel_id = project.create({}, ip: 123)
+    assert_equal false, project.content_moderation_disabled?(new_project_channel_id)
 
     # Set content_moderation_disabled to true.
-    storage_apps.set_content_moderation(new_project_channel_id, true)
-    assert_equal true, storage_apps.content_moderation_disabled?(new_project_channel_id)
+    project.set_content_moderation(new_project_channel_id, true)
+    assert_equal true, project.content_moderation_disabled?(new_project_channel_id)
 
     # Set skip_content_moderation back to false.
-    storage_apps.set_content_moderation(new_project_channel_id, false)
-    assert_equal false, storage_apps.content_moderation_disabled?(new_project_channel_id)
+    project.set_content_moderation(new_project_channel_id, false)
+    assert_equal false, project.content_moderation_disabled?(new_project_channel_id)
   end
 
   def test_restore
     signedin_storage_id = create_storage_id_for_user(20)
-    storage_apps = StorageApps.new(signedin_storage_id)
+    project = Projects.new(signedin_storage_id)
 
     # Create a new project
-    new_project_channel_id = storage_apps.create({projectType: 'applab'}, ip: 123)
+    new_project_channel_id = project.create({projectType: 'applab'}, ip: 123)
 
     # Delete the project
-    assert_equal true, storage_apps.delete(new_project_channel_id)
+    assert_equal true, project.delete(new_project_channel_id)
 
     # Should not be able to fetch deleted project
-    assert_raises StorageApps::NotFound do
-      storage_apps.get(new_project_channel_id)
+    assert_raises Projects::NotFound do
+      project.get(new_project_channel_id)
     end
 
     # Restore project
-    assert_equal true, storage_apps.restore(new_project_channel_id)
+    assert_equal true, project.restore(new_project_channel_id)
 
     # Can get restored project
-    storage_apps.get(new_project_channel_id)
+    project.get(new_project_channel_id)
   end
 
   def test_buffer_abuse_score
     signedin_storage_id = create_storage_id_for_user(20)
-    storage_apps = StorageApps.new(signedin_storage_id)
+    project = Projects.new(signedin_storage_id)
 
     # Create a new typeless project
     # abuse_score should be 0 by default on project creation for projects of any type.
-    new_project_channel_id = storage_apps.create({}, ip: 123)
-    assert_equal 0, StorageApps.get_abuse(new_project_channel_id)
-    storage_apps.buffer_abuse_score(new_project_channel_id)
-    assert_equal (-50), StorageApps.get_abuse(new_project_channel_id)
+    new_project_channel_id = project.create({}, ip: 123)
+    assert_equal 0, Projects.get_abuse(new_project_channel_id)
+    project.buffer_abuse_score(new_project_channel_id)
+    assert_equal (-50), Projects.get_abuse(new_project_channel_id)
   end
 end

--- a/shared/test/test_channels.rb
+++ b/shared/test/test_channels.rb
@@ -381,18 +381,18 @@ class ChannelsTest < Minitest::Test
     # User is not the owner, should return owner sharing_disabled
     ChannelsApi.any_instance.stubs(:current_user_id).returns(123)
     # Stub sharing_disabled to false for user.
-    StorageApps.any_instance.stubs(:get_user_sharing_disabled).returns(false)
+    Projects.any_instance.stubs(:get_user_sharing_disabled).returns(false)
     get "/v3/channels/#{channel_id}/sharing_disabled"
     assert last_response.ok?
     assert_equal false, JSON.parse(last_response.body)['sharing_disabled']
-    StorageApps.any_instance.unstub(:get_user_sharing_disabled)
+    Projects.any_instance.unstub(:get_user_sharing_disabled)
 
     # Stub sharing_disabled to true for user.
-    StorageApps.any_instance.stubs(:get_user_sharing_disabled).returns(true)
+    Projects.any_instance.stubs(:get_user_sharing_disabled).returns(true)
     get "/v3/channels/#{channel_id}/sharing_disabled"
     assert last_response.ok?
     assert_equal true, JSON.parse(last_response.body)['sharing_disabled']
-    StorageApps.any_instance.unstub(:get_user_sharing_disabled)
+    Projects.any_instance.unstub(:get_user_sharing_disabled)
   end
 
   def test_abuse_frozen
@@ -428,8 +428,8 @@ class ChannelsTest < Minitest::Test
 
     user_storage_id = storage_decrypt_id CGI.unescape @session.cookie_jar[storage_id_cookie_name]
 
-    assert_equal abc_channel_id, StorageApps.new(user_storage_id).most_recent('abc')
-    assert_equal xyz_channel_id, StorageApps.new(user_storage_id).most_recent('xyz')
+    assert_equal abc_channel_id, Projects.new(user_storage_id).most_recent('abc')
+    assert_equal xyz_channel_id, Projects.new(user_storage_id).most_recent('xyz')
   ensure
     Timecop.return
   end
@@ -456,18 +456,18 @@ class ChannelsTest < Minitest::Test
 
     _, storage_app_id = storage_decrypt_channel_id(response['id'])
     _, parent_storage_app_id = storage_decrypt_channel_id(encrypted_parent_channel_id)
-    assert_equal parent_storage_app_id, StorageApps.table.where(id: storage_app_id).first[:remix_parent_id]
+    assert_equal parent_storage_app_id, Projects.table.where(id: storage_app_id).first[:remix_parent_id]
   end
 
   def test_update_project_type
     post '/v3/channels', {abc: 123}.to_json, 'CONTENT_TYPE' => 'application/json;charset=utf-8'
     encrypted_channel_id = last_response.location.split('/').last
     _, storage_app_id = storage_decrypt_channel_id(encrypted_channel_id)
-    assert_nil StorageApps.table.where(id: storage_app_id).first[:project_type]
+    assert_nil Projects.table.where(id: storage_app_id).first[:project_type]
 
     post "/v3/channels/#{encrypted_channel_id}", {projectType: 'gamelab'}.to_json, 'CONTENT_TYPE' => 'application/json;charset=utf-8'
     assert last_response.successful?
-    assert_equal 'gamelab', StorageApps.table.where(id: storage_app_id).first[:project_type]
+    assert_equal 'gamelab', Projects.table.where(id: storage_app_id).first[:project_type]
   end
 
   private

--- a/shared/test/test_files.rb
+++ b/shared/test/test_files.rb
@@ -176,7 +176,6 @@ class FilesTest < FilesApiTestBase
     DCDO.stubs(:get).with('s3_timeout', 15).returns(15)
     DCDO.stubs(:get).with('s3_slow_request', 15).returns(15)
     DCDO.stubs(:get).with('user_storage_ids_in_dashboard', false).returns(false)
-    DCDO.stubs(:get).with('storage_apps_in_dashboard', false).returns(false)
 
     filename = 'index.html'
     # The below HTML is valid/invalid in WebLab projects only. Other project types do not
@@ -186,7 +185,7 @@ class FilesTest < FilesApiTestBase
     invalid_html_2 = '<meta http-equiv="refresh">'
 
     # WebLab
-    StorageApps.any_instance.stubs(:get).returns({projectType: 'weblab'})
+    Projects.any_instance.stubs(:get).returns({projectType: 'weblab'})
     @api.put_object(filename, valid_html)
     assert successful?
     @api.delete_object(filename)
@@ -200,7 +199,7 @@ class FilesTest < FilesApiTestBase
     @api.delete_object(filename)
 
     # Not WebLab
-    StorageApps.any_instance.stubs(:get).returns({projectType: 'applab'})
+    Projects.any_instance.stubs(:get).returns({projectType: 'applab'})
     @api.put_object(filename, valid_html)
     assert successful?
     @api.delete_object(filename)
@@ -211,7 +210,7 @@ class FilesTest < FilesApiTestBase
 
     # This means the channel_id does not belong to a valid project.
     # These requests should always return a 400.
-    StorageApps.any_instance.stubs(:get).returns(nil)
+    Projects.any_instance.stubs(:get).returns(nil)
     @api.put_object(filename, valid_html)
     assert bad_request?
     @api.delete_object(filename)
@@ -220,7 +219,7 @@ class FilesTest < FilesApiTestBase
     assert bad_request?
     @api.delete_object(filename)
 
-    StorageApps.any_instance.unstub(:get)
+    Projects.any_instance.unstub(:get)
     delete_all_manifest_versions
   end
 


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
The table pegasus.storage_apps has been migrated to dashboard.projects (https://github.com/code-dot-org/code-dot-org/pull/45480), however there are still many references to the term "storage apps".

In this PR 
- an alias is created for the active record models `ChannelTokens` and `Backpacks` to rename `storage_app_id` to `project_id`
- the class `StorageApps` has been renamed to `Projects` and all references have been updated

## Links
- jira ticket: [LP-2272](https://codedotorg.atlassian.net/browse/LP-2272)
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
Tested some project scenarios locally
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
