### PR TITLE
[Google Blockly][Utils] Use getFieldValue instead of getTitleValue

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -2897,7 +2897,7 @@ StudioApp.prototype.getUnfilledFunctionalExample = function() {
       return false;
     }
     var actual = rootBlock.getInputTargetBlock('ACTUAL');
-    return actual && actual.getTitleValue('NAME');
+    return actual && actual.getFieldValue('NAME');
   });
 };
 
@@ -2947,10 +2947,10 @@ StudioApp.prototype.getFunctionWithoutTwoExamples = function() {
       // Only care about functional_examples that have an ACTUAL input (i.e. it's
       // clear which function they're for
       var actual = block.getInputTargetBlock('ACTUAL');
-      return actual && actual.getTitleValue('NAME');
+      return actual && actual.getFieldValue('NAME');
     })
     .map(function(exampleBlock) {
-      return exampleBlock.getInputTargetBlock('ACTUAL').getTitleValue('NAME');
+      return exampleBlock.getInputTargetBlock('ACTUAL').getFieldValue('NAME');
     });
 
   var definitionWithLessThanTwoExamples;
@@ -2984,7 +2984,7 @@ StudioApp.prototype.getUnfilledFunctionalBlockError = function(topLevelType) {
 
   if (unfilled.type === topLevelType) {
     return msg.emptyTopLevelBlock({
-      topLevelBlockName: unfilled.getTitleValue()
+      topLevelBlockName: unfilled.getFieldValue()
     });
   }
 
@@ -3020,7 +3020,7 @@ StudioApp.prototype.checkForFailingExamples = function(failureChecker) {
     if (failure) {
       failingBlockName = exampleBlock
         .getInputTargetBlock('ACTUAL')
-        .getTitleValue('NAME');
+        .getFieldValue('NAME');
     }
   });
   return failingBlockName;

--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -715,7 +715,7 @@ const STANDARD_INPUT_TYPES = {
         .appendField(dropdown, inputConfig.name);
     },
     generateCode(block, inputConfig) {
-      let code = block.getTitleValue(inputConfig.name);
+      let code = block.getFieldValue(inputConfig.name);
       if (
         inputConfig.type === Blockly.BlockValueType.STRING &&
         !code.startsWith('"') &&
@@ -733,7 +733,7 @@ const STANDARD_INPUT_TYPES = {
       block.getVars = function() {
         return {
           [Blockly.Variables.DEFAULT_CATEGORY]: [
-            block.getTitleValue(inputConfig.name)
+            block.getFieldValue(inputConfig.name)
           ]
         };
       };
@@ -741,14 +741,14 @@ const STANDARD_INPUT_TYPES = {
       // The following functions make sure that the variable naming/renaming options work for this block
       block.renameVar = function(oldName, newName) {
         if (
-          Blockly.Names.equals(oldName, block.getTitleValue(inputConfig.name))
+          Blockly.Names.equals(oldName, block.getFieldValue(inputConfig.name))
         ) {
           block.setTitleValue(newName, inputConfig.name);
         }
       };
       block.removeVar = function(oldName) {
         if (
-          Blockly.Names.equals(oldName, block.getTitleValue(inputConfig.name))
+          Blockly.Names.equals(oldName, block.getFieldValue(inputConfig.name))
         ) {
           block.dispose(true, true);
         }
@@ -768,7 +768,7 @@ const STANDARD_INPUT_TYPES = {
     },
     generateCode(block, inputConfig) {
       return Blockly.JavaScript.translateVarName(
-        block.getTitleValue(inputConfig.name)
+        block.getFieldValue(inputConfig.name)
       );
     }
   },
@@ -784,7 +784,7 @@ const STANDARD_INPUT_TYPES = {
         .appendField(field, inputConfig.name);
     },
     generateCode(block, inputConfig) {
-      let code = block.getTitleValue(inputConfig.name);
+      let code = block.getFieldValue(inputConfig.name);
       if (inputConfig.type === Blockly.BlockValueType.STRING) {
         // Wraps the value in quotes, and escapes quotes/newlines
         code = JSON.stringify(code);

--- a/apps/src/blockly/addons/cdoBlockSvg.js
+++ b/apps/src/blockly/addons/cdoBlockSvg.js
@@ -54,10 +54,6 @@ export default class BlockSvg extends GoogleBlockly.BlockSvg {
     return fields;
   }
 
-  getTitleValue(name) {
-    return super.getFieldValue(name);
-  }
-
   isUserVisible() {
     return false; // TODO - used for EXTRA_TOP_BLOCKS_FAIL feedback
   }

--- a/apps/src/blockly/cdoBlocklyWrapper.js
+++ b/apps/src/blockly/cdoBlocklyWrapper.js
@@ -222,6 +222,8 @@ function initializeBlocklyWrapper(blocklyInstance) {
   // Code.org's old Blockly fork uses title in place of all field tags.
   blocklyWrapper.Input.prototype.appendField =
     blocklyWrapper.Input.prototype.appendTitle;
+  blocklyWrapper.Block.prototype.getFieldValue =
+    blocklyWrapper.Block.prototype.getTitleValue;
 
   blocklyWrapper.cdoUtils = {
     setHSV: function(block, h, s, v) {

--- a/apps/src/blocksCommon.js
+++ b/apps/src/blocksCommon.js
@@ -319,7 +319,7 @@ function installCommentBlock(blockly) {
   };
 
   blockly.JavaScript.comment = function() {
-    var comment = this.getTitleValue('TEXT');
+    var comment = this.getFieldValue('TEXT');
     return `// ${comment}\n`;
   };
 }

--- a/apps/src/bounce/blocks.js
+++ b/apps/src/bounce/blocks.js
@@ -7,7 +7,7 @@
 var msg = require('./locale');
 
 var generateSetterCode = function(ctx, name) {
-  var value = ctx.getTitleValue('VALUE');
+  var value = ctx.getFieldValue('VALUE');
   if (value === 'random') {
     var allValues = ctx.VALUES.slice(1).map(function(item) {
       return item[1];
@@ -260,7 +260,7 @@ exports.install = function(blockly, blockInstallOptions) {
       "Bounce.playSound('block_id_" +
       this.id +
       "', '" +
-      this.getTitleValue('SOUND') +
+      this.getFieldValue('SOUND') +
       "');\n"
     );
   };

--- a/apps/src/calc/calc.js
+++ b/apps/src/calc/calc.js
@@ -875,7 +875,7 @@ Calc.checkExamples_ = function() {
     var name = unfilled
       .getRootBlock()
       .getInputTargetBlock('ACTUAL')
-      .getTitleValue('NAME');
+      .getFieldValue('NAME');
     outcome.message = commonMsg.emptyExampleBlockErrorMsg({functionName: name});
     return outcome;
   }

--- a/apps/src/calc/equationSet.js
+++ b/apps/src/calc/equationSet.js
@@ -380,7 +380,7 @@ EquationSet.getEquationFromBlock = function(block) {
 
     case 'functional_math_number':
     case 'functional_math_number_dropdown':
-      var val = block.getTitleValue('NUM') || 0;
+      var val = block.getFieldValue('NUM') || 0;
       if (val === '???') {
         val = 0;
       }
@@ -410,7 +410,7 @@ EquationSet.getEquationFromBlock = function(block) {
       }
 
     case 'functional_definition':
-      name = block.getTitleValue('NAME');
+      name = block.getFieldValue('NAME');
 
       var expression = firstChild
         ? EquationSet.getEquationFromBlock(firstChild).expression
@@ -426,7 +426,7 @@ EquationSet.getEquationFromBlock = function(block) {
       return new Equation(
         null,
         [],
-        new ExpressionNode(block.getTitleValue('VAR'))
+        new ExpressionNode(block.getFieldValue('VAR'))
       );
 
     case 'functional_example':

--- a/apps/src/craft/agent/blocks.js
+++ b/apps/src/craft/agent/blocks.js
@@ -117,7 +117,7 @@ exports.install = function(blockly, blockInstallOptions) {
 
   blockly.getGenerator().craft_turn = function() {
     // Generate JavaScript for turning left or right.
-    var dir = this.getTitleValue('DIR');
+    var dir = this.getFieldValue('DIR');
     var methodCall = dir === 'left' ? 'turnLeft' : 'turnRight';
     return methodCall + "('block_id_" + this.id + "');\n";
   };
@@ -159,7 +159,7 @@ exports.install = function(blockly, blockInstallOptions) {
 
   blockly.getGenerator().craft_ifBlockAhead = function() {
     var innerCode = blockly.getGenerator().statementToCode(this, 'DO');
-    var blockType = this.getTitleValue('TYPE');
+    var blockType = this.getFieldValue('TYPE');
     return (
       'ifBlockAhead("' +
       blockType +
@@ -212,7 +212,7 @@ exports.install = function(blockly, blockInstallOptions) {
   };
 
   blockly.getGenerator().craft_placeBlock = function() {
-    var blockType = this.getTitleValue('TYPE');
+    var blockType = this.getFieldValue('TYPE');
     return 'placeBlock("' + blockType + '", \'block_id_' + this.id + "');\n";
   };
 
@@ -244,8 +244,8 @@ exports.install = function(blockly, blockInstallOptions) {
   };
 
   blockly.getGenerator().craft_placeBlockDirection = function() {
-    var blockType = this.getTitleValue('TYPE');
-    var direction = this.getTitleValue('DIR');
+    var blockType = this.getFieldValue('TYPE');
+    var direction = this.getFieldValue('DIR');
     return (
       'placeDirection("' +
       blockType +

--- a/apps/src/craft/code-connection/blocks.js
+++ b/apps/src/craft/code-connection/blocks.js
@@ -144,7 +144,7 @@ export const install = (blockly, blockInstallOptions) => {
   };
 
   blockly.JavaScript.craft_move = function() {
-    var dir = this.getTitleValue('DIR');
+    var dir = this.getFieldValue('DIR');
     return `move('block_id_${this.id}','${dir}');`;
   };
 
@@ -166,7 +166,7 @@ export const install = (blockly, blockInstallOptions) => {
   };
 
   blockly.JavaScript.craft_turn = function() {
-    var dir = this.getTitleValue('DIR');
+    var dir = this.getFieldValue('DIR');
     return `turn('block_id_${this.id}','${dir}');`;
   };
 
@@ -191,7 +191,7 @@ export const install = (blockly, blockInstallOptions) => {
   };
 
   blockly.JavaScript.craft_place = function() {
-    var dir = this.getTitleValue('DIR');
+    var dir = this.getFieldValue('DIR');
     var value = Blockly.JavaScript.valueToCode(
       this,
       'SLOTNUM',
@@ -218,7 +218,7 @@ export const install = (blockly, blockInstallOptions) => {
   };
 
   blockly.JavaScript.craft_till = function() {
-    var dir = this.getTitleValue('DIR');
+    var dir = this.getFieldValue('DIR');
     return `till('block_id_${this.id}','${dir}');`;
   };
 
@@ -240,7 +240,7 @@ export const install = (blockly, blockInstallOptions) => {
   };
 
   blockly.JavaScript.craft_attack = function() {
-    var dir = this.getTitleValue('DIR');
+    var dir = this.getFieldValue('DIR');
     return `attack('block_id_${this.id}','${dir}');`;
   };
 
@@ -262,7 +262,7 @@ export const install = (blockly, blockInstallOptions) => {
   };
 
   blockly.JavaScript.craft_destroy = function() {
-    var dir = this.getTitleValue('DIR');
+    var dir = this.getFieldValue('DIR');
     return `destroy('block_id_${this.id}','${dir}');`;
   };
 
@@ -337,7 +337,7 @@ export const install = (blockly, blockInstallOptions) => {
   };
 
   blockly.JavaScript.craft_drop = function() {
-    var dir = this.getTitleValue('DIR');
+    var dir = this.getFieldValue('DIR');
     var slotNumber = Blockly.JavaScript.valueToCode(
       this,
       'SLOTNUM',
@@ -369,7 +369,7 @@ export const install = (blockly, blockInstallOptions) => {
   };
 
   blockly.JavaScript.craft_dropall = function() {
-    var dir = this.getTitleValue('DIR');
+    var dir = this.getFieldValue('DIR');
     return `dropall('block_id_${this.id}','${dir}');`;
   };
 
@@ -390,7 +390,7 @@ export const install = (blockly, blockInstallOptions) => {
   };
 
   blockly.JavaScript.craft_detect = function() {
-    var dir = this.getTitleValue('DIR');
+    var dir = this.getFieldValue('DIR');
     return [
       `detect('block_id_${this.id}','${dir}')`,
       Blockly.JavaScript.ORDER_FUNCTION_CALL
@@ -414,7 +414,7 @@ export const install = (blockly, blockInstallOptions) => {
   };
 
   blockly.JavaScript.craft_inspect = function() {
-    var dir = this.getTitleValue('DIR');
+    var dir = this.getFieldValue('DIR');
     return [
       `inspect('block_id_${this.id}','${dir}')`,
       Blockly.JavaScript.ORDER_FUNCTION_CALL
@@ -438,7 +438,7 @@ export const install = (blockly, blockInstallOptions) => {
   };
 
   blockly.JavaScript.craft_inspectdata = function() {
-    var dir = this.getTitleValue('DIR');
+    var dir = this.getFieldValue('DIR');
     return [
       `inspectdata('block_id_${this.id}','${dir}')`,
       Blockly.JavaScript.ORDER_FUNCTION_CALL
@@ -462,7 +462,7 @@ export const install = (blockly, blockInstallOptions) => {
   };
 
   blockly.JavaScript.craft_detectredstone = function() {
-    var dir = this.getTitleValue('DIR');
+    var dir = this.getFieldValue('DIR');
     return [
       `detectredstone('block_id_${this.id}','${dir}')`,
       Blockly.JavaScript.ORDER_FUNCTION_CALL
@@ -652,7 +652,7 @@ export const install = (blockly, blockInstallOptions) => {
   };
 
   blockly.JavaScript.craft_wait = function() {
-    var milliseconds = window.parseInt(this.getTitleValue('MILLISECONDS'), 10);
+    var milliseconds = window.parseInt(this.getFieldValue('MILLISECONDS'), 10);
     return `wait('block_id_${this.id}','${milliseconds}');`;
   };
 
@@ -682,14 +682,14 @@ export const install = (blockly, blockInstallOptions) => {
   };
 
   blockly.JavaScript.craft_executeasother = function() {
-    var target = encodeURIComponent(this.getTitleValue('TARGET'));
-    var positionType = this.getTitleValue('POSITIONTYPE');
+    var target = encodeURIComponent(this.getFieldValue('TARGET'));
+    var positionType = this.getFieldValue('POSITIONTYPE');
     var vec3 = Blockly.JavaScript.valueToCode(
       this,
       'VEC3',
       Blockly.JavaScript.ORDER_NONE
     );
-    var command = this.getTitleValue('COMMAND');
+    var command = this.getFieldValue('COMMAND');
     return `executeasother('block_id_${
       this.id
     }','${target}',createBlockPosFromVec3(${vec3}, "${positionType}"),'${command}');`;
@@ -713,7 +713,7 @@ export const install = (blockly, blockInstallOptions) => {
   };
 
   blockly.JavaScript.craft_timesetbyname = function() {
-    var time = this.getTitleValue('TIME');
+    var time = this.getFieldValue('TIME');
     return `timesetbyname('block_id_${this.id}','${time}');`;
   };
 
@@ -764,7 +764,7 @@ export const install = (blockly, blockInstallOptions) => {
   };
 
   blockly.JavaScript.craft_weather = function() {
-    var weather = this.getTitleValue('WEATHER');
+    var weather = this.getFieldValue('WEATHER');
     return `weather('block_id_${this.id}','${weather}');`;
   };
 
@@ -790,8 +790,8 @@ export const install = (blockly, blockInstallOptions) => {
   };
 
   blockly.JavaScript.craft_tptotarget = function() {
-    var victim = encodeURIComponent(this.getTitleValue('VICTIM'));
-    var destination = encodeURIComponent(this.getTitleValue('DESTINATION'));
+    var victim = encodeURIComponent(this.getFieldValue('VICTIM'));
+    var destination = encodeURIComponent(this.getFieldValue('DESTINATION'));
     return `tptotarget('block_id_${this.id}','${victim}','${destination}');`;
   };
 
@@ -818,8 +818,8 @@ export const install = (blockly, blockInstallOptions) => {
   };
 
   blockly.JavaScript.craft_tptopos = function() {
-    var victim = encodeURIComponent(this.getTitleValue('VICTIM'));
-    var positionType = this.getTitleValue('POSITIONTYPE');
+    var victim = encodeURIComponent(this.getFieldValue('VICTIM'));
+    var positionType = this.getFieldValue('POSITIONTYPE');
     var vec3 = Blockly.JavaScript.valueToCode(
       this,
       'VEC3',
@@ -867,13 +867,13 @@ export const install = (blockly, blockInstallOptions) => {
   };
 
   blockly.JavaScript.craft_fill = function() {
-    var fromPositionType = this.getTitleValue('FROMPOSITIONTYPE');
+    var fromPositionType = this.getFieldValue('FROMPOSITIONTYPE');
     var fromVec3 = Blockly.JavaScript.valueToCode(
       this,
       'FROM_VEC3',
       Blockly.JavaScript.ORDER_NONE
     );
-    var toPositionType = this.getTitleValue('TOPOSITIONTYPE');
+    var toPositionType = this.getFieldValue('TOPOSITIONTYPE');
     var toVec3 = Blockly.JavaScript.valueToCode(
       this,
       'TO_VEC3',
@@ -914,7 +914,7 @@ export const install = (blockly, blockInstallOptions) => {
   };
 
   blockly.JavaScript.craft_give = function() {
-    var player = encodeURIComponent(this.getTitleValue('PLAYER'));
+    var player = encodeURIComponent(this.getFieldValue('PLAYER'));
     var item = Blockly.JavaScript.valueToCode(
       this,
       'ITEM',
@@ -948,7 +948,7 @@ export const install = (blockly, blockInstallOptions) => {
   };
 
   blockly.JavaScript.craft_kill = function() {
-    var target = encodeURIComponent(this.getTitleValue('TARGET'));
+    var target = encodeURIComponent(this.getFieldValue('TARGET'));
     return `kill('block_id_${this.id}','${target}');`;
   };
 
@@ -984,8 +984,8 @@ export const install = (blockly, blockInstallOptions) => {
   };
 
   blockly.JavaScript.craft_setblock = function() {
-    var positionType = this.getTitleValue('POSITIONTYPE');
-    var oldBlockHandling = this.getTitleValue('OLDBLOCKHANDLING');
+    var positionType = this.getFieldValue('POSITIONTYPE');
+    var oldBlockHandling = this.getFieldValue('OLDBLOCKHANDLING');
     var vec3 = Blockly.JavaScript.valueToCode(
       this,
       'VEC3',
@@ -1026,8 +1026,8 @@ export const install = (blockly, blockInstallOptions) => {
   };
 
   blockly.JavaScript.craft_summon = function() {
-    var entityType = this.getTitleValue('ENTITYTYPE');
-    var positionType = this.getTitleValue('POSITIONTYPE');
+    var entityType = this.getFieldValue('ENTITYTYPE');
+    var positionType = this.getFieldValue('POSITIONTYPE');
     var vec3 = Blockly.JavaScript.valueToCode(
       this,
       'VEC3',
@@ -1064,7 +1064,7 @@ export const install = (blockly, blockInstallOptions) => {
   };
 
   blockly.JavaScript.craft_testforblock = function() {
-    var positionType = this.getTitleValue('POSITIONTYPE');
+    var positionType = this.getFieldValue('POSITIONTYPE');
     var vec3 = Blockly.JavaScript.valueToCode(
       this,
       'VEC3',
@@ -1125,25 +1125,25 @@ export const install = (blockly, blockInstallOptions) => {
   };
 
   blockly.JavaScript.craft_testforblocks = function() {
-    var fromPositionType = this.getTitleValue('FROMPOSITIONTYPE');
+    var fromPositionType = this.getFieldValue('FROMPOSITIONTYPE');
     var fromVec3 = Blockly.JavaScript.valueToCode(
       this,
       'FROM_VEC3',
       Blockly.JavaScript.ORDER_NONE
     );
-    var toPositionType = this.getTitleValue('TOPOSITIONTYPE');
+    var toPositionType = this.getFieldValue('TOPOSITIONTYPE');
     var toVec3 = Blockly.JavaScript.valueToCode(
       this,
       'TO_VEC3',
       Blockly.JavaScript.ORDER_NONE
     );
-    var positionType = this.getTitleValue('POSITIONTYPE');
+    var positionType = this.getFieldValue('POSITIONTYPE');
     var vec3 = Blockly.JavaScript.valueToCode(
       this,
       'VEC3',
       Blockly.JavaScript.ORDER_NONE
     );
-    var testMode = this.getTitleValue('TESTMODE');
+    var testMode = this.getFieldValue('TESTMODE');
     return [
       `testforblocks('block_id_${
         this.id
@@ -1197,26 +1197,26 @@ export const install = (blockly, blockInstallOptions) => {
   };
 
   blockly.JavaScript.craft_clone = function() {
-    var fromPositionType = this.getTitleValue('FROMPOSITIONTYPE');
+    var fromPositionType = this.getFieldValue('FROMPOSITIONTYPE');
     var fromVec3 = Blockly.JavaScript.valueToCode(
       this,
       'FROM_VEC3',
       Blockly.JavaScript.ORDER_NONE
     );
-    var toPositionType = this.getTitleValue('TOPOSITIONTYPE');
+    var toPositionType = this.getFieldValue('TOPOSITIONTYPE');
     var toVec3 = Blockly.JavaScript.valueToCode(
       this,
       'TO_VEC3',
       Blockly.JavaScript.ORDER_NONE
     );
-    var positionType = this.getTitleValue('POSITIONTYPE');
+    var positionType = this.getFieldValue('POSITIONTYPE');
     var vec3 = Blockly.JavaScript.valueToCode(
       this,
       'VEC3',
       Blockly.JavaScript.ORDER_NONE
     );
-    var maskMode = this.getTitleValue('MASKMODE');
-    var cloneMode = this.getTitleValue('CLONEMODE');
+    var maskMode = this.getFieldValue('MASKMODE');
+    var cloneMode = this.getFieldValue('CLONEMODE');
     return `clone('block_id_${
       this.id
     }',createBlockPosFromVec3(${fromVec3}, "${fromPositionType}"),createBlockPosFromVec3(${toVec3}, "${toPositionType}"),createBlockPosFromVec3(${vec3}, "${positionType}"),'${maskMode}','${cloneMode}');`;
@@ -1265,25 +1265,25 @@ export const install = (blockly, blockInstallOptions) => {
   };
 
   blockly.JavaScript.craft_clonefiltered = function() {
-    var fromPositionType = this.getTitleValue('FROMPOSITIONTYPE');
+    var fromPositionType = this.getFieldValue('FROMPOSITIONTYPE');
     var fromVec3 = Blockly.JavaScript.valueToCode(
       this,
       'FROM_VEC3',
       Blockly.JavaScript.ORDER_NONE
     );
-    var toPositionType = this.getTitleValue('TOPOSITIONTYPE');
+    var toPositionType = this.getFieldValue('TOPOSITIONTYPE');
     var toVec3 = Blockly.JavaScript.valueToCode(
       this,
       'TO_VEC3',
       Blockly.JavaScript.ORDER_NONE
     );
-    var positionType = this.getTitleValue('POSITIONTYPE');
+    var positionType = this.getFieldValue('POSITIONTYPE');
     var vec3 = Blockly.JavaScript.valueToCode(
       this,
       'VEC3',
       Blockly.JavaScript.ORDER_NONE
     );
-    var cloneMode = this.getTitleValue('CLONEMODE');
+    var cloneMode = this.getFieldValue('CLONEMODE');
     var item = Blockly.JavaScript.valueToCode(
       this,
       'ITEM',
@@ -1350,7 +1350,7 @@ export const install = (blockly, blockInstallOptions) => {
   };
 
   blockly.JavaScript.craft_block = function() {
-    var block = this.getTitleValue('BLOCK');
+    var block = this.getFieldValue('BLOCK');
     return [
       `item('block_id_${this.id}','${getName(block)}','${getData(block)}')`,
       Blockly.JavaScript.ORDER_FUNCTION_CALL
@@ -1376,7 +1376,7 @@ export const install = (blockly, blockInstallOptions) => {
   };
 
   blockly.JavaScript.craft_miscellaneous = function() {
-    var item = this.getTitleValue('ITEM');
+    var item = this.getFieldValue('ITEM');
     return [
       `item('block_id_${this.id}','${getName(item)}','${getData(item)}')`,
       Blockly.JavaScript.ORDER_FUNCTION_CALL
@@ -1402,7 +1402,7 @@ export const install = (blockly, blockInstallOptions) => {
   };
 
   blockly.JavaScript.craft_decoration = function() {
-    var item = this.getTitleValue('ITEM');
+    var item = this.getFieldValue('ITEM');
     return [
       `item('block_id_${this.id}','${getName(item)}','${getData(item)}')`,
       Blockly.JavaScript.ORDER_FUNCTION_CALL
@@ -1428,7 +1428,7 @@ export const install = (blockly, blockInstallOptions) => {
   };
 
   blockly.JavaScript.craft_tool = function() {
-    var item = this.getTitleValue('ITEM');
+    var item = this.getFieldValue('ITEM');
     return [
       `item('block_id_${this.id}','${getName(item)}','${getData(item)}')`,
       Blockly.JavaScript.ORDER_FUNCTION_CALL

--- a/apps/src/craft/designer/blocks.js
+++ b/apps/src/craft/designer/blocks.js
@@ -191,7 +191,7 @@ export const install = (blockly, blockInstallOptions) => {
 
   blockly.getGenerator().craft_entityTurn = function() {
     // Generate JavaScript for turning left or right.
-    const dir = this.getTitleValue('DIR');
+    const dir = this.getFieldValue('DIR');
     const methodCalls = {
       left: 'turnLeft',
       right: 'turnRight',
@@ -226,7 +226,7 @@ export const install = (blockly, blockInstallOptions) => {
 
   blockly.getGenerator().craft_entityTurnLR = function() {
     // Generate JavaScript for turning left or right.
-    const dir = this.getTitleValue('DIR');
+    const dir = this.getFieldValue('DIR');
     const methodCalls = {
       left: 'turnLeft',
       right: 'turnRight',
@@ -265,7 +265,7 @@ export const install = (blockly, blockInstallOptions) => {
 
   blockly.getGenerator().craft_turn = function() {
     // Generate JavaScript for turning left or right.
-    const dir = this.getTitleValue('DIR');
+    const dir = this.getFieldValue('DIR');
     const methodCall = dir === 'left' ? 'turnLeft' : 'turnRight';
     return methodCall + "('block_id_" + this.id + "');\n";
   };
@@ -481,7 +481,7 @@ export const install = (blockly, blockInstallOptions) => {
     };
 
     blockly.getGenerator()[`craft_${simpleFunctionName}`] = function() {
-      const dropdownValue = this.getTitleValue('TYPE');
+      const dropdownValue = this.getFieldValue('TYPE');
       return `${simpleFunctionName}('${dropdownValue}', event.targetIdentifier, 'block_id_${
         this.id
       }');\n`;
@@ -529,7 +529,7 @@ export const install = (blockly, blockInstallOptions) => {
     };
 
     blockly.getGenerator()[`craft_${blockName}`] = function() {
-      const thingToTarget = this.getTitleValue('TYPE');
+      const thingToTarget = this.getFieldValue('TYPE');
       return `${simpleFunctionName}(event.targetIdentifier, '${thingToTarget}', 'block_id_${
         this.id
       }');\n`;
@@ -610,7 +610,7 @@ export const install = (blockly, blockInstallOptions) => {
   };
 
   blockly.getGenerator().craft_repeatTimes = function() {
-    const times = this.getTitleValue('TIMES');
+    const times = this.getFieldValue('TIMES');
     const innerCode = blockly.getGenerator().statementToCode(this, 'DO');
     return `repeat('block_id_${
       this.id
@@ -656,7 +656,7 @@ export const install = (blockly, blockInstallOptions) => {
   };
 
   blockly.getGenerator().craft_repeatDropdown = function() {
-    const times = this.getTitleValue('TIMES');
+    const times = this.getFieldValue('TIMES');
     const innerCode = blockly.getGenerator().statementToCode(this, 'DO');
     return `repeat('block_id_${
       this.id
@@ -695,8 +695,8 @@ export const install = (blockly, blockInstallOptions) => {
   };
 
   blockly.getGenerator()[`craft_spawnEntity`] = function() {
-    const type = this.getTitleValue('TYPE');
-    const direction = this.getTitleValue('DIRECTION');
+    const type = this.getFieldValue('TYPE');
+    const direction = this.getFieldValue('DIRECTION');
     return `spawnEntity('${type}', '${direction}', 'block_id_${this.id}');\n`;
   };
 
@@ -721,7 +721,7 @@ export const install = (blockly, blockInstallOptions) => {
   };
 
   blockly.getGenerator()[`craft_spawnEntityRandom`] = function() {
-    const type = this.getTitleValue('TYPE');
+    const type = this.getFieldValue('TYPE');
     return `spawnEntityRandom('${type}', 'block_id_${this.id}');\n`;
   };
 
@@ -811,7 +811,7 @@ export const install = (blockly, blockInstallOptions) => {
   };
 
   blockly.getGenerator().craft_playSound = function() {
-    const blockType = this.getTitleValue('TYPE');
+    const blockType = this.getFieldValue('TYPE');
     return `playSound('${blockType}', event.targetIdentifier, 'block_id_${
       this.id
     }');\n`;
@@ -837,7 +837,7 @@ export const install = (blockly, blockInstallOptions) => {
   };
 
   blockly.getGenerator().craft_addScore = function() {
-    const score = this.getTitleValue('SCORE');
+    const score = this.getFieldValue('SCORE');
     return `addScore('${score}', 'block_id_${this.id}');\n`;
   };
 };

--- a/apps/src/craft/simple/blocks.js
+++ b/apps/src/craft/simple/blocks.js
@@ -101,7 +101,7 @@ exports.install = function(blockly, blockInstallOptions) {
 
   blockly.getGenerator().craft_turn = function() {
     // Generate JavaScript for turning left or right.
-    var dir = this.getTitleValue('DIR');
+    var dir = this.getFieldValue('DIR');
     var methodCall = dir === 'left' ? 'turnLeft' : 'turnRight';
     return methodCall + "('block_id_" + this.id + "');\n";
   };
@@ -159,7 +159,7 @@ exports.install = function(blockly, blockInstallOptions) {
 
   blockly.getGenerator().craft_ifBlockAhead = function() {
     var innerCode = blockly.getGenerator().statementToCode(this, 'DO');
-    var blockType = this.getTitleValue('TYPE');
+    var blockType = this.getFieldValue('TYPE');
     return (
       'ifBlockAhead("' +
       blockType +
@@ -212,7 +212,7 @@ exports.install = function(blockly, blockInstallOptions) {
   };
 
   blockly.getGenerator().craft_placeBlock = function() {
-    var blockType = this.getTitleValue('TYPE');
+    var blockType = this.getFieldValue('TYPE');
     return 'placeBlock("' + blockType + '", \'block_id_' + this.id + "');\n";
   };
 
@@ -278,7 +278,7 @@ exports.install = function(blockly, blockInstallOptions) {
   };
 
   blockly.getGenerator().craft_placeBlockAhead = function() {
-    var blockType = this.getTitleValue('TYPE');
+    var blockType = this.getFieldValue('TYPE');
     return (
       'placeBlockAhead("' + blockType + '", \'block_id_' + this.id + "');\n"
     );

--- a/apps/src/dance/blocks.js
+++ b/apps/src/dance/blocks.js
@@ -26,20 +26,20 @@ const customInputTypes = {
       block.getVars = function() {
         return {
           [Blockly.BlockValueType.SPRITE]: [
-            block.getTitleValue(inputConfig.name)
+            block.getFieldValue(inputConfig.name)
           ]
         };
       };
       block.renameVar = function(oldName, newName) {
         if (
-          Blockly.Names.equals(oldName, block.getTitleValue(inputConfig.name))
+          Blockly.Names.equals(oldName, block.getFieldValue(inputConfig.name))
         ) {
           block.setTitleValue(newName, inputConfig.name);
         }
       };
       block.removeVar = function(oldName) {
         if (
-          Blockly.Names.equals(oldName, block.getTitleValue(inputConfig.name))
+          Blockly.Names.equals(oldName, block.getFieldValue(inputConfig.name))
         ) {
           block.dispose(true, true);
         }
@@ -66,7 +66,7 @@ const customInputTypes = {
         );
     },
     generateCode(block, arg) {
-      return `'${block.getTitleValue(arg.name)}'`;
+      return `'${block.getFieldValue(arg.name)}'`;
     }
   },
   limitedColourPicker: {
@@ -83,7 +83,7 @@ const customInputTypes = {
         );
     },
     generateCode(block, arg) {
-      return `'${block.getTitleValue(arg.name)}'`;
+      return `'${block.getFieldValue(arg.name)}'`;
     }
   }
 };
@@ -146,7 +146,7 @@ export default {
         );
       },
       renameVar: function(oldName, newName) {
-        if (Blockly.Names.equals(oldName, this.getTitleValue('VAR'))) {
+        if (Blockly.Names.equals(oldName, this.getFieldValue('VAR'))) {
           this.setTitleValue(newName, 'VAR');
         }
       },
@@ -154,7 +154,7 @@ export default {
     };
     generator.sprite_variables_get = function() {
       return [
-        `'${this.getTitleValue('VAR')}'`,
+        `'${this.getFieldValue('VAR')}'`,
         Blockly.JavaScript.ORDER_ATOMIC
       ];
     };
@@ -215,7 +215,7 @@ export default {
 
       openEditor(e) {
         e.stopPropagation();
-        behaviorEditor.openEditorForFunction(this, this.getTitleValue('VAR'));
+        behaviorEditor.openEditorForFunction(this, this.getFieldValue('VAR'));
       },
 
       getVars() {
@@ -225,19 +225,19 @@ export default {
       },
 
       renameVar(oldName, newName) {
-        if (Blockly.Names.equals(oldName, this.getTitleValue('VAR'))) {
+        if (Blockly.Names.equals(oldName, this.getFieldValue('VAR'))) {
           this.setTitleValue(newName, 'VAR');
         }
       },
 
       renameProcedure(oldName, newName) {
-        if (Blockly.Names.equals(oldName, this.getTitleValue('VAR'))) {
+        if (Blockly.Names.equals(oldName, this.getFieldValue('VAR'))) {
           this.setTitleValue(newName, 'VAR');
         }
       },
 
       getCallName() {
-        return this.getTitleValue('VAR');
+        return this.getFieldValue('VAR');
       },
 
       setProcedureParameters(paramNames, paramIds, typeNames) {
@@ -283,7 +283,7 @@ export default {
 
     generator.gamelab_behavior_get = function() {
       const name = Blockly.JavaScript.variableDB_.getName(
-        this.getTitleValue('VAR'),
+        this.getFieldValue('VAR'),
         Blockly.Procedures.NAME_TYPE
       );
       const extraArgs = [];
@@ -311,7 +311,7 @@ export default {
         overrides: {
           getVars(category) {
             return {
-              Behavior: [this.getTitleValue('NAME')]
+              Behavior: [this.getFieldValue('NAME')]
             };
           },
           callType_: 'gamelab_behavior_get'

--- a/apps/src/eval/eval.js
+++ b/apps/src/eval/eval.js
@@ -553,7 +553,7 @@ Eval.checkExamples_ = function(resetPlayspace) {
     var name = unfilled
       .getRootBlock()
       .getInputTargetBlock('ACTUAL')
-      .getTitleValue('NAME');
+      .getFieldValue('NAME');
     Eval.message = commonMsg.emptyExampleBlockErrorMsg({functionName: name});
     return;
   }

--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -1432,7 +1432,7 @@ FeedbackUtils.prototype.checkForEmptyContainerBlockFailure_ = function() {
     const emptyBlockInfo = emptyBlock.getProcedureInfo();
     const findUsages = block =>
       block.type === emptyBlockInfo.callType &&
-      block.getTitleValue('NAME') === emptyBlockInfo.name;
+      block.getFieldValue('NAME') === emptyBlockInfo.name;
 
     if (Blockly.mainBlockSpace.getAllUsedBlocks().filter(findUsages).length) {
       return TestResults.EMPTY_FUNCTION_BLOCK_FAIL;
@@ -1877,7 +1877,7 @@ FeedbackUtils.prototype.hasUnusedParam_ = function() {
             (block.type === 'parameters_get' ||
               block.type === 'functional_parameters_get' ||
               block.type === 'variables_get') &&
-            block.getTitleValue('VAR') === paramName
+            block.getFieldValue('VAR') === paramName
           );
         });
       })
@@ -1912,7 +1912,7 @@ FeedbackUtils.prototype.hasUnusedFunction_ = function() {
   var userDefs = [];
   var callBlocks = {};
   Blockly.mainBlockSpace.getAllUsedBlocks().forEach(function(block) {
-    var name = block.getTitleValue('NAME');
+    var name = block.getFieldValue('NAME');
     if (/^procedures_def/.test(block.type) && block.userCreated) {
       userDefs.push(name);
     } else if (/^procedures_call/.test(block.type)) {

--- a/apps/src/flappy/blocks.js
+++ b/apps/src/flappy/blocks.js
@@ -14,7 +14,7 @@ var FLAPPY_VALUE = '"flappy"';
 var RANDOM_VALUE = 'random';
 
 var generateSetterCode = function(ctx, name) {
-  var value = ctx.getTitleValue('VALUE');
+  var value = ctx.getFieldValue('VALUE');
   if (value === RANDOM_VALUE) {
     var possibleValues = _(ctx.VALUES)
       .map(function(item) {
@@ -653,7 +653,7 @@ exports.install = function(blockly, blockInstallOptions) {
   generator.flappy_setScore = function() {
     // Generate JavaScript for moving forward or backward the internal number of
     // pixels.
-    var value = window.parseInt(this.getTitleValue('VALUE'), 10);
+    var value = window.parseInt(this.getFieldValue('VALUE'), 10);
     return "Flappy.setScore('block_id_" + this.id + "', " + value + ');\n';
   };
 

--- a/apps/src/flappy/levels.js
+++ b/apps/src/flappy/levels.js
@@ -323,7 +323,7 @@ module.exports = {
             /* eslint-disable prettier/prettier */
             return (block.type === 'flappy_setBackground' ||
                 block.type === 'flappy_setPlayer') &&
-              block.getTitleValue('VALUE') === 'random';
+              block.getFieldValue('VALUE') === 'random';
             /* eslint-enable prettier/prettier */
           },
           type: 'flappy_setBackground',

--- a/apps/src/level_base.js
+++ b/apps/src/level_base.js
@@ -12,7 +12,7 @@ exports.call = function(name) {
     test: function(block) {
       return (
         block.type === 'procedures_callnoreturn' &&
-        block.getTitleValue('NAME').toLowerCase() === name.toLowerCase()
+        block.getFieldValue('NAME').toLowerCase() === name.toLowerCase()
       );
     },
     type: 'procedures_callnoreturn',
@@ -32,7 +32,7 @@ exports.callWithArg = function(func_name, arg_name) {
     test: function(block) {
       return (
         block.type === 'procedures_callnoreturn' &&
-        block.getTitleValue('NAME').toLowerCase() === func_name.toLowerCase()
+        block.getFieldValue('NAME').toLowerCase() === func_name.toLowerCase()
       );
     },
     type: 'procedures_callnoreturn',
@@ -58,7 +58,7 @@ exports.define = function(name) {
     test: function(block) {
       return (
         block.type === 'procedures_defnoreturn' &&
-        block.getTitleValue('NAME').toLowerCase() === name.toLowerCase()
+        block.getFieldValue('NAME').toLowerCase() === name.toLowerCase()
       );
     },
     type: 'procedures_defnoreturn',

--- a/apps/src/maze/beeBlocks.js
+++ b/apps/src/maze/beeBlocks.js
@@ -177,7 +177,7 @@ function addIfFlowerHive(blockly, generator) {
   generator.bee_ifFlower = function() {
     // Generate JavaScript for 'if' conditional if we're at a flower/hive
     var argument =
-      'Maze.' + this.getTitleValue('LOC') + "('block_id_" + this.id + "')";
+      'Maze.' + this.getFieldValue('LOC') + "('block_id_" + this.id + "')";
     var branch = generator.statementToCode(this, 'DO');
     var code = 'if (' + argument + ') {\n' + branch + '}\n';
     return code;
@@ -217,7 +217,7 @@ function addIfElseFlowerHive(blockly, generator) {
   generator.bee_ifElseFlower = function() {
     // Generate JavaScript for 'if' conditional if we're at a flower/hive
     var argument =
-      'Maze.' + this.getTitleValue('LOC') + "('block_id_" + this.id + "')";
+      'Maze.' + this.getFieldValue('LOC') + "('block_id_" + this.id + "')";
     var branch0 = generator.statementToCode(this, 'DO');
     var branch1 = generator.statementToCode(this, 'ELSE');
     var code =
@@ -312,7 +312,7 @@ function addConditionalComparisonBlock(blockly, generator, name, type, arg1) {
       this.setNextStatement(true);
 
       this.setTooltip(function() {
-        var op = self.getTitleValue('OP');
+        var op = self.getFieldValue('OP');
         return TOOLTIPS[op];
       });
     }
@@ -323,9 +323,9 @@ function addConditionalComparisonBlock(blockly, generator, name, type, arg1) {
   generator[name] = function() {
     // Generate JavaScript for 'if' conditional if we're at a flower/hive
     var argument1 =
-      'Maze.' + this.getTitleValue('ARG1') + "('block_id_" + this.id + "')";
-    var operator = this.getTitleValue('OP');
-    var argument2 = this.getTitleValue('ARG2');
+      'Maze.' + this.getFieldValue('ARG1') + "('block_id_" + this.id + "')";
+    var operator = this.getFieldValue('OP');
+    var argument2 = this.getFieldValue('ARG2');
     var branch0 = generator.statementToCode(this, 'DO');
     var elseBlock = '';
     if (type === 'ifelse') {

--- a/apps/src/maze/blocks.js
+++ b/apps/src/maze/blocks.js
@@ -158,7 +158,7 @@ exports.install = function(blockly, blockInstallOptions) {
 
   generator.maze_move = function() {
     // Generate JavaScript for moving forward/backward
-    var dir = this.getTitleValue('DIR');
+    var dir = this.getFieldValue('DIR');
     return 'Maze.' + dir + "('block_id_" + this.id + "');\n";
   };
 
@@ -184,7 +184,7 @@ exports.install = function(blockly, blockInstallOptions) {
 
   generator.maze_turn = function() {
     // Generate JavaScript for turning left or right.
-    var dir = this.getTitleValue('DIR');
+    var dir = this.getFieldValue('DIR');
     return 'Maze.' + dir + "('block_id_" + this.id + "');\n";
   };
 
@@ -210,7 +210,7 @@ exports.install = function(blockly, blockInstallOptions) {
 
   generator.maze_isPath = function() {
     // Generate JavaScript for checking if there is a path.
-    var code = 'Maze.' + this.getTitleValue('DIR') + '()';
+    var code = 'Maze.' + this.getFieldValue('DIR') + '()';
     return [code, generator.ORDER_FUNCTION_CALL];
   };
 
@@ -236,7 +236,7 @@ exports.install = function(blockly, blockInstallOptions) {
   generator.maze_if = function() {
     // Generate JavaScript for 'if' conditional if there is a path.
     var argument =
-      'Maze.' + this.getTitleValue('DIR') + "('block_id_" + this.id + "')";
+      'Maze.' + this.getFieldValue('DIR') + "('block_id_" + this.id + "')";
     var branch = generator.statementToCode(this, 'DO');
     var code = 'if (' + argument + ') {\n' + branch + '}\n';
     return code;
@@ -265,7 +265,7 @@ exports.install = function(blockly, blockInstallOptions) {
   generator.maze_ifElse = function() {
     // Generate JavaScript for 'if/else' conditional if there is a path.
     var argument =
-      'Maze.' + this.getTitleValue('DIR') + "('block_id_" + this.id + "')";
+      'Maze.' + this.getFieldValue('DIR') + "('block_id_" + this.id + "')";
     var branch0 = generator.statementToCode(this, 'DO');
     var branch1 = generator.statementToCode(this, 'ELSE');
     var code =
@@ -294,7 +294,7 @@ exports.install = function(blockly, blockInstallOptions) {
   generator.karel_if = function() {
     // Generate JavaScript for 'if' conditional if there is a path.
     var argument =
-      'Maze.' + this.getTitleValue('DIR') + "('block_id_" + this.id + "')";
+      'Maze.' + this.getFieldValue('DIR') + "('block_id_" + this.id + "')";
     var branch = generator.statementToCode(this, 'DO');
     var code = 'if (' + argument + ') {\n' + branch + '}\n';
     return code;
@@ -329,7 +329,7 @@ exports.install = function(blockly, blockInstallOptions) {
   generator.karel_ifElse = function() {
     // Generate JavaScript for 'if/else' conditional if there is a path.
     var argument =
-      'Maze.' + this.getTitleValue('DIR') + "('block_id_" + this.id + "')";
+      'Maze.' + this.getFieldValue('DIR') + "('block_id_" + this.id + "')";
     var branch0 = generator.statementToCode(this, 'DO');
     var branch1 = generator.statementToCode(this, 'ELSE');
     var code =
@@ -356,7 +356,7 @@ exports.install = function(blockly, blockInstallOptions) {
 
   generator.maze_whileNotClear = function() {
     var argument =
-      'Maze.' + this.getTitleValue('DIR') + "('block_id_" + this.id + "')";
+      'Maze.' + this.getFieldValue('DIR') + "('block_id_" + this.id + "')";
     var branch = generator.statementToCode(this, 'DO');
     branch = Blockly.getInfiniteLoopTrap() + branch;
     return 'while (' + argument + ') {\n' + branch + '}\n';
@@ -427,7 +427,7 @@ exports.install = function(blockly, blockInstallOptions) {
 
   generator.maze_untilBlockedOrNotClear = function() {
     var argument =
-      'Maze.' + this.getTitleValue('DIR') + "('block_id_" + this.id + "')";
+      'Maze.' + this.getFieldValue('DIR') + "('block_id_" + this.id + "')";
     var branch = generator.statementToCode(this, 'DO');
     branch = Blockly.getInfiniteLoopTrap() + branch;
     return 'while (' + argument + ') {\n' + branch + '}\n';

--- a/apps/src/maze/harvesterBlocks.js
+++ b/apps/src/maze/harvesterBlocks.js
@@ -245,7 +245,7 @@ exports.install = function(blockly, blockInstallOptions) {
   };
 
   generator.harvester_ifAtCrop = function() {
-    var argument = `Maze.at${this.getTitleValue('LOC')}('block_id_${this.id}')`;
+    var argument = `Maze.at${this.getFieldValue('LOC')}('block_id_${this.id}')`;
     var branch = generator.statementToCode(this, 'DO');
     var code = `if (${argument}) {\n${branch}}\n`;
     return code;
@@ -269,7 +269,7 @@ exports.install = function(blockly, blockInstallOptions) {
   };
 
   generator.harvester_ifAtCropElse = function() {
-    var argument = `Maze.at${this.getTitleValue('LOC')}('block_id_${this.id}')`;
+    var argument = `Maze.at${this.getFieldValue('LOC')}('block_id_${this.id}')`;
     var doCode = generator.statementToCode(this, 'DO');
     var elseCode = generator.statementToCode(this, 'ELSE');
     var code = `if (${argument}) {\n${doCode}} else {\n${elseCode}}\n`;
@@ -295,7 +295,7 @@ exports.install = function(blockly, blockInstallOptions) {
   };
 
   generator.harvester_untilAtCrop = function() {
-    var atCrop = `Maze.at${this.getTitleValue('LOC')}('block_id_${this.id}')`;
+    var atCrop = `Maze.at${this.getFieldValue('LOC')}('block_id_${this.id}')`;
     var branch = generator.statementToCode(this, 'DO');
     branch = Blockly.getInfiniteLoopTrap() + branch;
     var code = `while (!${atCrop}) {\n${branch}}\n`;
@@ -319,7 +319,7 @@ exports.install = function(blockly, blockInstallOptions) {
   };
 
   generator.harvester_ifHasCrop = function() {
-    var argument = `Maze.has${this.getTitleValue('LOC')}('block_id_${
+    var argument = `Maze.has${this.getFieldValue('LOC')}('block_id_${
       this.id
     }')`;
     var branch = generator.statementToCode(this, 'DO');
@@ -345,7 +345,7 @@ exports.install = function(blockly, blockInstallOptions) {
   };
 
   generator.harvester_ifHasCropElse = function() {
-    var argument = `Maze.has${this.getTitleValue('LOC')}('block_id_${
+    var argument = `Maze.has${this.getFieldValue('LOC')}('block_id_${
       this.id
     }')`;
     var doCode = generator.statementToCode(this, 'DO');
@@ -371,7 +371,7 @@ exports.install = function(blockly, blockInstallOptions) {
   };
 
   generator.harvester_whileHasCrop = function() {
-    var argument = `Maze.has${this.getTitleValue('LOC')}('block_id_${
+    var argument = `Maze.has${this.getFieldValue('LOC')}('block_id_${
       this.id
     }')`;
     var branch = generator.statementToCode(this, 'DO');
@@ -397,7 +397,7 @@ exports.install = function(blockly, blockInstallOptions) {
   };
 
   generator.harvester_untilHasCrop = function() {
-    var argument = `Maze.has${this.getTitleValue('LOC')}('block_id_${
+    var argument = `Maze.has${this.getFieldValue('LOC')}('block_id_${
       this.id
     }')`;
     var branch = generator.statementToCode(this, 'DO');

--- a/apps/src/maze/karelLevels.js
+++ b/apps/src/maze/karelLevels.js
@@ -142,7 +142,7 @@ var IF_ELSE = {test: '} else {', type: 'karel_ifElse'};
 var fill = function(num) {
   return {
     test: function(block) {
-      return block.getTitleValue('NAME') === msg.fillN({shovelfuls: num});
+      return block.getFieldValue('NAME') === msg.fillN({shovelfuls: num});
     },
     type: 'procedures_callnoreturn',
     titles: {NAME: msg.fillN({shovelfuls: num})}
@@ -153,7 +153,7 @@ var fill = function(num) {
 var remove = function(num) {
   return {
     test: function(block) {
-      return block.getTitleValue('NAME') === msg.removeN({shovelfuls: num});
+      return block.getFieldValue('NAME') === msg.removeN({shovelfuls: num});
     },
     type: 'procedures_callnoreturn',
     titles: {NAME: msg.removeN({shovelfuls: num})}
@@ -163,7 +163,7 @@ var remove = function(num) {
 // This tests for and creates the "avoid the cow and remove 1" block.
 var AVOID_OBSTACLE_AND_REMOVE = {
   test: function(block) {
-    return block.getTitleValue('NAME') === msg.avoidCowAndRemove();
+    return block.getFieldValue('NAME') === msg.avoidCowAndRemove();
   },
   type: 'procedures_callnoreturn',
   titles: {NAME: msg.avoidCowAndRemove()}
@@ -172,7 +172,7 @@ var AVOID_OBSTACLE_AND_REMOVE = {
 // This tests for and creates the "remove piles" block.
 var REMOVE_PILES = {
   test: function(block) {
-    return block.getTitleValue('NAME') === msg.removeStack({shovelfuls: 4});
+    return block.getFieldValue('NAME') === msg.removeStack({shovelfuls: 4});
   },
   type: 'procedures_callnoreturn',
   titles: {NAME: msg.removeStack({shovelfuls: 4})}
@@ -181,7 +181,7 @@ var REMOVE_PILES = {
 // This tests for and creates the "fill holes" block.
 var FILL_HOLES = {
   test: function(block) {
-    return block.getTitleValue('NAME') === msg.fillStack({shovelfuls: 2});
+    return block.getFieldValue('NAME') === msg.fillStack({shovelfuls: 2});
   },
   type: 'procedures_callnoreturn',
   titles: {NAME: msg.fillStack({shovelfuls: 2})}

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -110,7 +110,7 @@ const customInputTypes = {
       currentInputRow.appendField(button, inputConfig.name);
     },
     generateCode(block, arg) {
-      return `(${block.getTitleValue(arg.name)})`;
+      return `(${block.getFieldValue(arg.name)})`;
     }
   },
   locationVariableDropdown: {
@@ -118,20 +118,20 @@ const customInputTypes = {
       block.getVars = function() {
         return {
           [Blockly.BlockValueType.LOCATION]: [
-            block.getTitleValue(inputConfig.name)
+            block.getFieldValue(inputConfig.name)
           ]
         };
       };
       block.renameVar = function(oldName, newName) {
         if (
-          Blockly.Names.equals(oldName, block.getTitleValue(inputConfig.name))
+          Blockly.Names.equals(oldName, block.getFieldValue(inputConfig.name))
         ) {
           block.setTitleValue(newName, inputConfig.name);
         }
       };
       block.removeVar = function(oldName) {
         if (
-          Blockly.Names.equals(oldName, block.getTitleValue(inputConfig.name))
+          Blockly.Names.equals(oldName, block.getFieldValue(inputConfig.name))
         ) {
           block.dispose(true, true);
         }
@@ -153,7 +153,7 @@ const customInputTypes = {
         .appendField(Blockly.Msg.VARIABLES_GET_TAIL);
     },
     generateCode(block, arg) {
-      return Blockly.JavaScript.translateVarName(block.getTitleValue(arg.name));
+      return Blockly.JavaScript.translateVarName(block.getFieldValue(arg.name));
     }
   },
   soundPicker: {
@@ -171,7 +171,7 @@ const customInputTypes = {
       );
     },
     generateCode(block, arg) {
-      return `'${block.getTitleValue(arg.name)}'`;
+      return `'${block.getFieldValue(arg.name)}'`;
     }
   },
   costumePicker: {
@@ -200,7 +200,7 @@ const customInputTypes = {
         );
     },
     generateCode(block, arg) {
-      return block.getTitleValue(arg.name);
+      return block.getFieldValue(arg.name);
     }
   },
   backgroundPicker: {
@@ -227,7 +227,7 @@ const customInputTypes = {
         );
     },
     generateCode(block, arg) {
-      return block.getTitleValue(arg.name);
+      return block.getFieldValue(arg.name);
     }
   },
   spritePointer: {
@@ -290,20 +290,20 @@ const customInputTypes = {
       block.getVars = function() {
         return {
           [Blockly.BlockValueType.SPRITE]: [
-            block.getTitleValue(inputConfig.name)
+            block.getFieldValue(inputConfig.name)
           ]
         };
       };
       block.renameVar = function(oldName, newName) {
         if (
-          Blockly.Names.equals(oldName, block.getTitleValue(inputConfig.name))
+          Blockly.Names.equals(oldName, block.getFieldValue(inputConfig.name))
         ) {
           block.setTitleValue(newName, inputConfig.name);
         }
       };
       block.removeVar = function(oldName) {
         if (
-          Blockly.Names.equals(oldName, block.getTitleValue(inputConfig.name))
+          Blockly.Names.equals(oldName, block.getFieldValue(inputConfig.name))
         ) {
           block.dispose(true, true);
         }
@@ -331,7 +331,7 @@ const customInputTypes = {
     },
     generateCode(block, arg) {
       return `{name: '${Blockly.JavaScript.translateVarName(
-        block.getTitleValue(arg.name)
+        block.getFieldValue(arg.name)
       )}'}`;
     }
   },
@@ -349,7 +349,7 @@ const customInputTypes = {
         );
     },
     generateCode(block, arg) {
-      return `'${block.getTitleValue(arg.name)}'`;
+      return `'${block.getFieldValue(arg.name)}'`;
     }
   },
   // Custom input for a variable input that generates the name of the variable
@@ -431,7 +431,7 @@ export default {
         );
       },
       renameVar: function(oldName, newName) {
-        if (Blockly.Names.equals(oldName, this.getTitleValue('VAR'))) {
+        if (Blockly.Names.equals(oldName, this.getFieldValue('VAR'))) {
           this.setTitleValue(newName, 'VAR');
         }
       },
@@ -440,7 +440,7 @@ export default {
     generator.sprite_variables_get = function() {
       return [
         `{name: '${Blockly.JavaScript.translateVarName(
-          this.getTitleValue('VAR')
+          this.getFieldValue('VAR')
         )}'}`,
         Blockly.JavaScript.ORDER_ATOMIC
       ];
@@ -524,13 +524,13 @@ export default {
       },
 
       renameVar(oldName, newName) {
-        if (Blockly.Names.equals(oldName, this.getTitleValue('VAR'))) {
+        if (Blockly.Names.equals(oldName, this.getFieldValue('VAR'))) {
           this.setTitleValue(newName, 'VAR');
         }
       },
 
       renameProcedure(oldName, newName, userCreated) {
-        if (Blockly.Names.equals(oldName, this.getTitleValue('VAR'))) {
+        if (Blockly.Names.equals(oldName, this.getFieldValue('VAR'))) {
           this.setTitleValue(newName, 'VAR');
           if (userCreated) {
             this.getTitle_('VAR').id = newName;
@@ -539,7 +539,7 @@ export default {
       },
 
       getCallName() {
-        return this.getTitleValue('VAR');
+        return this.getFieldValue('VAR');
       },
 
       setProcedureParameters(paramNames, paramIds, typeNames) {

--- a/apps/src/sharedFunctionalBlocks.js
+++ b/apps/src/sharedFunctionalBlocks.js
@@ -310,7 +310,7 @@ function installBoolean(blockly, generator, gensym) {
   ];
 
   generator.functional_boolean = function() {
-    return this.getTitleValue('VAL') === 'true';
+    return this.getFieldValue('VAL') === 'true';
   };
 }
 
@@ -340,7 +340,7 @@ function installMathNumber(blockly, generator, gensym) {
   };
 
   generator.functional_math_number = function() {
-    return +this.getTitleValue('NUM');
+    return +this.getFieldValue('NUM');
   };
 
   blockly.Blocks.functional_math_number_dropdown = {
@@ -385,7 +385,7 @@ function installString(blockly, generator) {
   };
 
   generator.functional_string = function() {
-    return blockly.JavaScript.quote_(this.getTitleValue('VAL'));
+    return blockly.JavaScript.quote_(this.getFieldValue('VAL'));
   };
 }
 

--- a/apps/src/studio/blocks.js
+++ b/apps/src/studio/blocks.js
@@ -45,7 +45,7 @@ var POSITION_VALUES = [
 ];
 
 var generateSetterCode = function(opts) {
-  var value = opts.value || opts.ctx.getTitleValue('VALUE');
+  var value = opts.value || opts.ctx.getFieldValue('VALUE');
   if (value === RANDOM_VALUE) {
     var possibleValues = _(opts.ctx.VALUES)
       .map(function(item) {
@@ -127,7 +127,7 @@ function getSpriteOrDropdownIndex(
   inputName = 'SPRITE'
 ) {
   return actorSelectDropdown
-    ? block.getTitleValue(inputName) || 0
+    ? block.getFieldValue(inputName) || 0
     : getSpriteIndex(block, inputName);
 }
 
@@ -656,7 +656,7 @@ exports.install = function(blockly, blockInstallOptions) {
   };
 
   generator.studio_allowSpritesOutsidePlayspace = function() {
-    const allowSpritesOutsidePlayspace = this.getTitleValue('VALUE') === 'true';
+    const allowSpritesOutsidePlayspace = this.getFieldValue('VALUE') === 'true';
     return `Studio.setAllowSpritesOutsidePlayspace('block_id_${this.id}',
         ${allowSpritesOutsidePlayspace});\n`;
   };
@@ -702,7 +702,7 @@ exports.install = function(blockly, blockInstallOptions) {
       "Studio.stop('block_id_" +
       this.id +
       "', " +
-      (this.getTitleValue('SPRITE') || '0') +
+      (this.getFieldValue('SPRITE') || '0') +
       ');\n'
     );
   };
@@ -735,7 +735,7 @@ exports.install = function(blockly, blockInstallOptions) {
     var allValues = skin.itemChoices.slice(0, -1).map(function(item) {
       return item[1];
     });
-    var valParam = this.getTitleValue('VALUE');
+    var valParam = this.getFieldValue('VALUE');
     if (valParam === 'random') {
       valParam = 'Studio.random([' + allValues + '])';
     }
@@ -770,14 +770,14 @@ exports.install = function(blockly, blockInstallOptions) {
     var allValues = skin.itemChoices.slice(0, -1).map(function(item) {
       return item[1];
     });
-    var valParam = this.getTitleValue('VALUE');
+    var valParam = this.getFieldValue('VALUE');
     if (valParam === 'random') {
       valParam = 'Studio.random([' + allValues + '])';
     }
     var allTypes = skin.activityChoices.slice(0, -1).map(function(item) {
       return item[1];
     });
-    var typeParam = this.getTitleValue('TYPE');
+    var typeParam = this.getFieldValue('TYPE');
     if (typeParam === 'random') {
       typeParam = 'Studio.random([' + allTypes + '])';
     }
@@ -826,7 +826,7 @@ exports.install = function(blockly, blockInstallOptions) {
   generator.studio_setItemSpeed = function() {
     return generateSetterCode({
       ctx: this,
-      extraParams: this.getTitleValue('CLASS'),
+      extraParams: this.getFieldValue('CLASS'),
       name: 'setItemSpeed'
     });
   };
@@ -858,14 +858,14 @@ exports.install = function(blockly, blockInstallOptions) {
           return item[1];
         }
       );
-      var dirParam = this.getTitleValue('DIR');
+      var dirParam = this.getFieldValue('DIR');
       if (dirParam === 'random') {
         dirParam = 'Studio.random([' + allDirections + '])';
       }
       var allValues = skin.projectileChoices.slice(0, -1).map(function(item) {
         return item[1];
       });
-      var valParam = this.getTitleValue('VALUE');
+      var valParam = this.getFieldValue('VALUE');
       if (valParam === 'random') {
         valParam = 'Studio.random([' + allValues + '])';
       }
@@ -928,9 +928,9 @@ exports.install = function(blockly, blockInstallOptions) {
       "Studio.makeProjectile('block_id_" +
       this.id +
       "', " +
-      this.getTitleValue('VALUE') +
+      this.getFieldValue('VALUE') +
       ', ' +
-      this.getTitleValue('ACTION') +
+      this.getFieldValue('ACTION') +
       ');\n'
     );
   };
@@ -978,7 +978,7 @@ exports.install = function(blockly, blockInstallOptions) {
   generator.studio_setSpritePosition = function() {
     return generateSetterCode({
       ctx: this,
-      extraParams: this.getTitleValue('SPRITE') || '0',
+      extraParams: this.getFieldValue('SPRITE') || '0',
       name: 'setSpritePosition'
     });
   };
@@ -1091,7 +1091,7 @@ exports.install = function(blockly, blockInstallOptions) {
   blockly.Blocks.studio_addGoal.VALUES = POSITION_VALUES;
 
   generator.studio_addGoal = function() {
-    var value = this.getTitleValue('VALUE');
+    var value = this.getFieldValue('VALUE');
     if (value === RANDOM_VALUE) {
       var possibleValues = _(this.VALUES)
         .map(function(item) {
@@ -1261,7 +1261,7 @@ exports.install = function(blockly, blockInstallOptions) {
       var directionConfig = SimpleMove.DIRECTION_CONFIGS[direction];
 
       return function() {
-        var sprite = this.getTitleValue('SPRITE') || '0';
+        var sprite = this.getFieldValue('SPRITE') || '0';
         var direction = directionConfig.studioValue.toString();
         var methodName = isEventMove ? 'move' : 'moveDistance';
         // For diagonal move blocks, the move distance is longer than normal by
@@ -1272,7 +1272,7 @@ exports.install = function(blockly, blockInstallOptions) {
         )
           ? SimpleMove.DEFAULT_MOVE_DISTANCE
           : SimpleMove.DEFAULT_MOVE_DISTANCE * Math.sqrt(2);
-        var distance = this.getTitleValue('DISTANCE') || defaultDistance;
+        var distance = this.getFieldValue('DISTANCE') || defaultDistance;
         return (
           'Studio.' +
           methodName +
@@ -1351,9 +1351,9 @@ exports.install = function(blockly, blockInstallOptions) {
       "Studio.move('block_id_" +
       this.id +
       "', " +
-      (this.getTitleValue('SPRITE') || '0') +
+      (this.getFieldValue('SPRITE') || '0') +
       ', ' +
-      this.getTitleValue('DIR') +
+      this.getFieldValue('DIR') +
       ');\n'
     );
   };
@@ -1467,14 +1467,14 @@ exports.install = function(blockly, blockInstallOptions) {
     var allDistances = this.DISTANCE.slice(0, -1).map(function(item) {
       return item[1];
     });
-    var distParam = this.getTitleValue('DISTANCE');
+    var distParam = this.getFieldValue('DISTANCE');
     if (distParam === 'random') {
       distParam = 'Studio.random([' + allDistances + '])';
     }
     var allDirections = this.DIR.slice(0, -1).map(function(item) {
       return item[1];
     });
-    var dirParam = this.getTitleValue('DIR');
+    var dirParam = this.getFieldValue('DIR');
     if (dirParam === 'random') {
       dirParam = 'Studio.random([' + allDirections + '])';
     }
@@ -1483,7 +1483,7 @@ exports.install = function(blockly, blockInstallOptions) {
       "Studio.moveDistance('block_id_" +
       this.id +
       "', " +
-      (this.getTitleValue('SPRITE') || '0') +
+      (this.getFieldValue('SPRITE') || '0') +
       ', ' +
       dirParam +
       ', ' +
@@ -1498,7 +1498,7 @@ exports.install = function(blockly, blockInstallOptions) {
     var allDirections = this.DIR.slice(0, -1).map(function(item) {
       return item[1];
     });
-    var dirParam = this.getTitleValue('DIR');
+    var dirParam = this.getFieldValue('DIR');
     if (dirParam === 'random') {
       dirParam = 'Studio.random([' + allDirections + '])';
     }
@@ -1513,7 +1513,7 @@ exports.install = function(blockly, blockInstallOptions) {
       "Studio.moveDistance('block_id_" +
       this.id +
       "', " +
-      (this.getTitleValue('SPRITE') || '0') +
+      (this.getFieldValue('SPRITE') || '0') +
       ', ' +
       dirParam +
       ', ' +
@@ -1530,7 +1530,7 @@ exports.install = function(blockly, blockInstallOptions) {
     var allDirections = this.DIR.slice(0, -1).map(function(item) {
       return item[1];
     });
-    var dirParam = this.getTitleValue('DIR');
+    var dirParam = this.getFieldValue('DIR');
     if (dirParam === 'random') {
       dirParam = 'Studio.random([' + allDirections + '])';
     }
@@ -1576,7 +1576,7 @@ exports.install = function(blockly, blockInstallOptions) {
 
   generator.studio_moveOrientation = function() {
     // Generate JavaScript for moving forward/backward
-    var dir = this.getTitleValue('DIR');
+    var dir = this.getFieldValue('DIR');
     return 'Studio.' + dir + "('block_id_" + this.id + "');\n";
   };
 
@@ -1602,7 +1602,7 @@ exports.install = function(blockly, blockInstallOptions) {
 
   generator.studio_turnOrientation = function() {
     // Generate JavaScript for turning left or right.
-    var dir = this.getTitleValue('DIR');
+    var dir = this.getFieldValue('DIR');
     return 'Studio.' + dir + "('block_id_" + this.id + "');\n";
   };
 
@@ -1671,7 +1671,7 @@ exports.install = function(blockly, blockInstallOptions) {
       "Studio.playSound('block_id_" +
       this.id +
       "', '" +
-      this.getTitleValue('SOUND') +
+      this.getFieldValue('SOUND') +
       "');\n"
     );
   };
@@ -1710,7 +1710,7 @@ exports.install = function(blockly, blockInstallOptions) {
       "Studio.changeScore('block_id_" +
       this.id +
       "', '" +
-      (this.getTitleValue('VALUE') || '1') +
+      (this.getFieldValue('VALUE') || '1') +
       "');\n"
     );
   };
@@ -1744,7 +1744,7 @@ exports.install = function(blockly, blockInstallOptions) {
       "Studio.addPoints('block_id_" +
       this.id +
       "', '" +
-      (this.getTitleValue('VALUE') || '1') +
+      (this.getFieldValue('VALUE') || '1') +
       "');\n"
     );
   };
@@ -1778,7 +1778,7 @@ exports.install = function(blockly, blockInstallOptions) {
       "Studio.removePoints('block_id_" +
       this.id +
       "', '" +
-      (this.getTitleValue('VALUE') || '1') +
+      (this.getFieldValue('VALUE') || '1') +
       "');\n"
     );
   };
@@ -1939,7 +1939,7 @@ exports.install = function(blockly, blockInstallOptions) {
       "Studio.setDroidSpeed('block_id_" +
       this.id +
       '\', "' +
-      this.getTitleValue('VALUE') +
+      this.getFieldValue('VALUE') +
       '");\n'
     );
   };
@@ -2020,7 +2020,7 @@ exports.install = function(blockly, blockInstallOptions) {
   generator.studio_setSpriteSpeed = function() {
     return generateSetterCode({
       ctx: this,
-      extraParams: this.getTitleValue('SPRITE') || '0',
+      extraParams: this.getFieldValue('SPRITE') || '0',
       name: 'setSpriteSpeed'
     });
   };
@@ -2101,7 +2101,7 @@ exports.install = function(blockly, blockInstallOptions) {
   generator.studio_setSpriteSize = function() {
     return generateSetterCode({
       ctx: this,
-      extraParams: this.getTitleValue('SPRITE') || '0',
+      extraParams: this.getFieldValue('SPRITE') || '0',
       name: 'setSpriteSize'
     });
   };
@@ -2573,9 +2573,9 @@ exports.install = function(blockly, blockInstallOptions) {
       "Studio.showTitleScreen('block_id_" +
       this.id +
       "', " +
-      blockly.JavaScript.quote_(this.getTitleValue('TITLE')) +
+      blockly.JavaScript.quote_(this.getFieldValue('TITLE')) +
       ', ' +
-      blockly.JavaScript.quote_(this.getTitleValue('TEXT')) +
+      blockly.JavaScript.quote_(this.getFieldValue('TEXT')) +
       ');\n'
     );
   };
@@ -2712,7 +2712,7 @@ exports.install = function(blockly, blockInstallOptions) {
   };
 
   generator.studio_setSprite = function() {
-    var indexString = this.getTitleValue('SPRITE') || '0';
+    var indexString = this.getFieldValue('SPRITE') || '0';
     return generateSetterCode({
       ctx: this,
       extraParams: indexString,
@@ -2730,7 +2730,7 @@ exports.install = function(blockly, blockInstallOptions) {
   };
 
   generator.studio_setSpriteParamValue = function() {
-    var indexString = this.getTitleValue('SPRITE') || '0';
+    var indexString = this.getFieldValue('SPRITE') || '0';
     var spriteValue = blockly.JavaScript.valueToCode(
       this,
       'VALUE',
@@ -2822,7 +2822,7 @@ exports.install = function(blockly, blockInstallOptions) {
   generator.studio_setSpriteEmotion = function() {
     return generateSetterCode({
       ctx: this,
-      extraParams: this.getTitleValue('SPRITE') || '0',
+      extraParams: this.getFieldValue('SPRITE') || '0',
       name: 'setSpriteEmotion'
     });
   };
@@ -2920,9 +2920,9 @@ exports.install = function(blockly, blockInstallOptions) {
       "Studio.saySprite('block_id_" +
       this.id +
       "', " +
-      (this.getTitleValue('SPRITE') || '0') +
+      (this.getFieldValue('SPRITE') || '0') +
       ', ' +
-      blockly.JavaScript.quote_(this.getTitleValue('TEXT')) +
+      blockly.JavaScript.quote_(this.getFieldValue('TEXT')) +
       ');\n'
     );
   };
@@ -2933,9 +2933,9 @@ exports.install = function(blockly, blockInstallOptions) {
       "Studio.saySprite('block_id_" +
       this.id +
       "', " +
-      (this.getTitleValue('SPRITE') || '0') +
+      (this.getFieldValue('SPRITE') || '0') +
       ", '" +
-      (this.getTitleValue('VALUE') || ' ') +
+      (this.getFieldValue('VALUE') || ' ') +
       "');\n"
     );
   };
@@ -2952,7 +2952,7 @@ exports.install = function(blockly, blockInstallOptions) {
       "Studio.saySprite('block_id_" +
       this.id +
       "', " +
-      (this.getTitleValue('SPRITE') || '0') +
+      (this.getFieldValue('SPRITE') || '0') +
       ', ' +
       textParam +
       ');\n'
@@ -3089,7 +3089,7 @@ exports.install = function(blockly, blockInstallOptions) {
       "Studio.endGame('block_id_" +
       this.id +
       "','" +
-      this.getTitleValue('VALUE') +
+      this.getFieldValue('VALUE') +
       "');\n"
     );
   };
@@ -3403,7 +3403,7 @@ exports.install = function(blockly, blockInstallOptions) {
 
   generator.functional_sprite_dropdown = function() {
     // returns the sprite index
-    return blockly.JavaScript.quote_(this.getTitleValue('SPRITE_INDEX'));
+    return blockly.JavaScript.quote_(this.getFieldValue('SPRITE_INDEX'));
   };
 
   /**
@@ -3433,7 +3433,7 @@ exports.install = function(blockly, blockInstallOptions) {
   generator.functional_background_dropdown = function() {
     // returns the sprite index
     return generateSetterCode({
-      value: this.getTitleValue('BACKGROUND'),
+      value: this.getFieldValue('BACKGROUND'),
       ctx: this,
       returnValue: true
     });
@@ -3503,9 +3503,9 @@ exports.install = function(blockly, blockInstallOptions) {
 
   generator.studio_ask = function() {
     var blockId = `block_id_${this.id}`;
-    var question = this.getTitleValue('TEXT');
+    var question = this.getFieldValue('TEXT');
     var varName = Blockly.JavaScript.translateVarName(
-      this.getTitleValue('VAR')
+      this.getFieldValue('VAR')
     );
 
     var nextBlock = this.nextConnection && this.nextConnection.targetBlock();
@@ -3552,7 +3552,7 @@ function installVanish(
   };
 
   generator.studio_vanish = function() {
-    var sprite = this.getTitleValue('SPRITE');
+    var sprite = this.getFieldValue('SPRITE');
     return "Studio.vanish('block_id_" + this.id + "', " + sprite + ');\n';
   };
 }
@@ -3649,9 +3649,9 @@ function installConditionals(
     },
     function(actorSelectDropdown, includeElseStatement) {
       let sprite = actorSelectDropdown
-        ? this.getTitleValue('SPRITE') || 0
+        ? this.getFieldValue('SPRITE') || 0
         : getSpriteIndex(this);
-      let emotion = this.getTitleValue('EMOTION');
+      let emotion = this.getFieldValue('EMOTION');
       let branch = generator.statementToCode(this, 'DO');
       let callback = `function (emotion) {\n  if (emotion === ${emotion}) {\n  ${branch}  }\n}`;
 
@@ -3732,10 +3732,10 @@ function installConditionals(
         GTE: '>='
       };
       let sprite = actorSelectDropdown
-        ? this.getTitleValue('SPRITE') || 0
+        ? this.getFieldValue('SPRITE') || 0
         : getSpriteIndex(this);
-      let position = this.getTitleValue('POSITION');
-      let operator = this.getTitleValue('OPERATOR');
+      let position = this.getFieldValue('POSITION');
+      let operator = this.getFieldValue('OPERATOR');
       let order =
         operator === 'EQ' || operator === 'NEQ'
           ? Blockly.JavaScript.ORDER_EQUALITY
@@ -3790,9 +3790,9 @@ function installConditionals(
     },
     function(actorSelectDropdown, includeElseStatement) {
       let sprite = actorSelectDropdown
-        ? this.getTitleValue('SPRITE') || 0
+        ? this.getFieldValue('SPRITE') || 0
         : getSpriteIndex(this);
-      let visibility = this.getTitleValue('VISIBILITY');
+      let visibility = this.getFieldValue('VISIBILITY');
       let branch = generator.statementToCode(this, 'DO');
       let callback = `function (visibility) {\n  if (visibility === ${visibility}) {\n  ${branch}  }\n}`;
 
@@ -3844,9 +3844,9 @@ function installConditionals(
     },
     function(actorSelectDropdown, includeElseStatement) {
       let sprite = actorSelectDropdown
-        ? this.getTitleValue('SPRITE') || 0
+        ? this.getFieldValue('SPRITE') || 0
         : getSpriteIndex(this);
-      let value = this.getTitleValue('VALUE');
+      let value = this.getFieldValue('VALUE');
       let branch = generator.statementToCode(this, 'DO');
       let callback = `function (value) {\n  if (value === ${value}) {\n  ${branch}  }\n}`;
 

--- a/apps/src/studio/levels.js
+++ b/apps/src/studio/levels.js
@@ -37,13 +37,13 @@ function saySpriteRequiredBlock(options) {
         }
         if (
           options.sprite &&
-          block.getTitleValue('SPRITE') !== options.sprite
+          block.getFieldValue('SPRITE') !== options.sprite
         ) {
           return false;
         }
         if (
           (options.notDefaultText || options.requiredText) &&
-          block.getTitleValue('TEXT') === msg.defaultSayText()
+          block.getFieldValue('TEXT') === msg.defaultSayText()
         ) {
           return false;
         }
@@ -82,11 +82,11 @@ function moveRequiredBlock(options) {
         }
         if (
           options.sprite &&
-          block.getTitleValue('SPRITE') !== options.sprite
+          block.getFieldValue('SPRITE') !== options.sprite
         ) {
           return false;
         }
-        if (options.dir && block.getTitleValue('DIR') !== options.dir) {
+        if (options.dir && block.getFieldValue('DIR') !== options.dir) {
           return false;
         }
 
@@ -499,8 +499,8 @@ levels.k1_4 = extend(levels.dog_move_cat_hello, {
           // text
           return (
             block.type === 'studio_saySprite' &&
-            block.getTitleValue('SPRITE') === '1' &&
-            block.getTitleValue('TEXT') !== msg.defaultSayText()
+            block.getFieldValue('SPRITE') === '1' &&
+            block.getFieldValue('TEXT') !== msg.defaultSayText()
           );
         },
         type: 'studio_saySprite',
@@ -916,7 +916,7 @@ levels.playlab_7 = {
       {
         test: function(b) {
           return (
-            b.type === 'studio_moveDistance' && b.getTitleValue('DIR') === '2'
+            b.type === 'studio_moveDistance' && b.getFieldValue('DIR') === '2'
           );
         },
         type: 'studio_moveDistance',
@@ -927,7 +927,7 @@ levels.playlab_7 = {
       {
         test: function(b) {
           return (
-            b.type === 'studio_moveDistance' && b.getTitleValue('DIR') === '8'
+            b.type === 'studio_moveDistance' && b.getFieldValue('DIR') === '8'
           );
         },
         type: 'studio_moveDistance',

--- a/apps/src/studio/studio.js
+++ b/apps/src/studio/studio.js
@@ -3135,8 +3135,8 @@ var registerHandlers = function(
     var block = blocks[x];
     // default title values to '0' for case when there is only one sprite
     // and no title value is set through a dropdown
-    var titleVal1 = block.getTitleValue(nameParam1) || '0';
-    var titleVal2 = block.getTitleValue(nameParam2) || '0';
+    var titleVal1 = block.getFieldValue(nameParam1) || '0';
+    var titleVal2 = block.getFieldValue(nameParam2) || '0';
     if (
       block.type === blockName &&
       (!nameParam1 || matchParam1Val === titleVal1) &&
@@ -3397,7 +3397,7 @@ Studio.checkExamples_ = function() {
     var name = unfilled
       .getRootBlock()
       .getInputTargetBlock('ACTUAL')
-      .getTitleValue('NAME');
+      .getFieldValue('NAME');
     outcome.message = commonMsg.emptyExampleBlockErrorMsg({functionName: name});
     return outcome;
   }

--- a/apps/src/turtle/blocks.js
+++ b/apps/src/turtle/blocks.js
@@ -169,10 +169,10 @@ exports.install = function(blockly, blockInstallOptions) {
   generator.draw_move_by_constant = function() {
     // Generate JavaScript for moving forward or backward the internal number of
     // pixels.
-    var value = window.parseFloat(this.getTitleValue('VALUE')) || 0;
+    var value = window.parseFloat(this.getFieldValue('VALUE')) || 0;
     return (
       'Turtle.' +
-      this.getTitleValue('DIR') +
+      this.getFieldValue('DIR') +
       '(' +
       value +
       ", 'block_id_" +
@@ -223,10 +223,10 @@ exports.install = function(blockly, blockInstallOptions) {
   generator.draw_turn_by_constant_restricted = function() {
     // Generate JavaScript for turning either left or right from among a fixed
     // set of angles.
-    var value = window.parseFloat(this.getTitleValue('VALUE'));
+    var value = window.parseFloat(this.getFieldValue('VALUE'));
     return (
       'Turtle.' +
-      this.getTitleValue('DIR') +
+      this.getFieldValue('DIR') +
       '(' +
       value +
       ", 'block_id_" +
@@ -285,10 +285,10 @@ exports.install = function(blockly, blockInstallOptions) {
 
   generator.draw_turn_by_constant = function() {
     // Generate JavaScript for turning left or right.
-    var value = window.parseFloat(this.getTitleValue('VALUE')) || 0;
+    var value = window.parseFloat(this.getFieldValue('VALUE')) || 0;
     return (
       'Turtle.' +
-      this.getTitleValue('DIR') +
+      this.getFieldValue('DIR') +
       '(' +
       value +
       ", 'block_id_" +
@@ -301,10 +301,10 @@ exports.install = function(blockly, blockInstallOptions) {
   generator.draw_move_inline = function() {
     // Generate JavaScript for moving forward or backward the internal number of
     // pixels.
-    var value = window.parseFloat(this.getTitleValue('VALUE'));
+    var value = window.parseFloat(this.getFieldValue('VALUE'));
     return (
       'Turtle.' +
-      this.getTitleValue('DIR') +
+      this.getFieldValue('DIR') +
       '(' +
       value +
       ", 'block_id_" +
@@ -354,10 +354,10 @@ exports.install = function(blockly, blockInstallOptions) {
   generator.draw_turn_inline_restricted = function() {
     // Generate JavaScript for turning either left or right from among a fixed
     // set of angles.
-    var value = window.parseFloat(this.getTitleValue('VALUE'));
+    var value = window.parseFloat(this.getFieldValue('VALUE'));
     return (
       'Turtle.' +
-      this.getTitleValue('DIR') +
+      this.getFieldValue('DIR') +
       '(' +
       value +
       ", 'block_id_" +
@@ -421,7 +421,7 @@ exports.install = function(blockly, blockInstallOptions) {
   });
 
   generator.point_to = function() {
-    let value = window.parseFloat(this.getTitleValue('DIRECTION')) || 0;
+    let value = window.parseFloat(this.getFieldValue('DIRECTION')) || 0;
     return `Turtle.pointTo(${value}, 'block_id_${this.id}');\n`;
   };
 
@@ -476,16 +476,16 @@ exports.install = function(blockly, blockInstallOptions) {
   });
 
   generator.point_to_by_constant_restricted = function() {
-    let value = window.parseFloat(this.getTitleValue('VALUE'));
+    let value = window.parseFloat(this.getFieldValue('VALUE'));
     return `Turtle.pointTo(${value}, 'block_id_${this.id}');\n`;
   };
 
   generator.draw_turn_inline = function() {
     // Generate JavaScript for turning left or right.
-    var value = window.parseFloat(this.getTitleValue('VALUE'));
+    var value = window.parseFloat(this.getFieldValue('VALUE'));
     return (
       'Turtle.' +
-      this.getTitleValue('DIR') +
+      this.getFieldValue('DIR') +
       '(' +
       value +
       ", 'block_id_" +
@@ -679,7 +679,7 @@ exports.install = function(blockly, blockInstallOptions) {
       this.setTooltip(
         blockly.Msg.CONTROLS_FOR_TOOLTIP.replace(
           '%1',
-          this.getTitleValue('VAR')
+          this.getFieldValue('VAR')
         )
       );
     },
@@ -688,7 +688,7 @@ exports.install = function(blockly, blockInstallOptions) {
     // different locales
     mutationToDom: function() {
       var container = document.createElement('mutation');
-      var counter = this.getTitleValue('VAR');
+      var counter = this.getFieldValue('VAR');
       container.setAttribute('counter', counter);
       return container;
     },
@@ -736,7 +736,7 @@ exports.install = function(blockly, blockInstallOptions) {
       generator.valueToCode(this, 'VALUE', generator.ORDER_NONE) || '0';
     return (
       'Turtle.' +
-      this.getTitleValue('DIR') +
+      this.getFieldValue('DIR') +
       '(' +
       value +
       ", 'block_id_" +
@@ -1015,7 +1015,7 @@ exports.install = function(blockly, blockInstallOptions) {
         var length = directionConfig.defaultLength;
 
         if (hasLengthInput) {
-          length = SimpleMove[this.getTitleValue('length')];
+          length = SimpleMove[this.getFieldValue('length')];
         }
         return (
           'Turtle.' +
@@ -1039,7 +1039,7 @@ exports.install = function(blockly, blockInstallOptions) {
       generator.valueToCode(this, 'VALUE', generator.ORDER_NONE) || '0';
     return (
       'Turtle.' +
-      this.getTitleValue('DIR') +
+      this.getFieldValue('DIR') +
       '(' +
       value +
       ", 'block_id_" +
@@ -1097,10 +1097,10 @@ exports.install = function(blockly, blockInstallOptions) {
   generator.jump_by_constant = function() {
     // Generate JavaScript for moving forward or backward the internal number
     // of pixels without drawing.
-    var value = window.parseFloat(this.getTitleValue('VALUE')) || 0;
+    var value = window.parseFloat(this.getFieldValue('VALUE')) || 0;
     return (
       'Turtle.' +
-      this.getTitleValue('DIR') +
+      this.getFieldValue('DIR') +
       '(' +
       value +
       ", 'block_id_" +
@@ -1134,7 +1134,7 @@ exports.install = function(blockly, blockInstallOptions) {
   blockly.Blocks.jump_to.VALUES = POSITION_VALUES;
 
   generator.jump_to = function() {
-    let value = this.getTitleValue('VALUE');
+    let value = this.getFieldValue('VALUE');
     if (value === RANDOM_VALUE) {
       let possibleValues = this.VALUES.map(item => item[1]).filter(
         item => item !== RANDOM_VALUE
@@ -1179,8 +1179,8 @@ exports.install = function(blockly, blockInstallOptions) {
   };
 
   generator.jump_to_xy = function() {
-    const xParam = window.parseFloat(this.getTitleValue('XPOS')) || 0;
-    const yParam = window.parseFloat(this.getTitleValue('YPOS')) || 0;
+    const xParam = window.parseFloat(this.getFieldValue('XPOS')) || 0;
+    const yParam = window.parseFloat(this.getFieldValue('YPOS')) || 0;
     return `Turtle.jumpToXY(${xParam}, ${yParam}, 'block_id_${this.id}');\n`;
   };
 
@@ -1221,7 +1221,7 @@ exports.install = function(blockly, blockInstallOptions) {
       generator.valueToCode(this, 'VALUE', generator.ORDER_NONE) || '0';
     return (
       'Turtle.' +
-      this.getTitleValue('DIR') +
+      this.getFieldValue('DIR') +
       '(' +
       value +
       ", 'block_id_" +
@@ -1273,7 +1273,7 @@ exports.install = function(blockly, blockInstallOptions) {
 
   generator.draw_width_inline = function() {
     // Generate JavaScript for setting the pen width.
-    var width = this.getTitleValue('WIDTH');
+    var width = this.getFieldValue('WIDTH');
     return 'Turtle.penWidth(' + width + ", 'block_id_" + this.id + "');\n";
   };
 
@@ -1300,7 +1300,7 @@ exports.install = function(blockly, blockInstallOptions) {
   generator.draw_pen = function() {
     // Generate JavaScript for pen up/down.
     return (
-      'Turtle.' + this.getTitleValue('PEN') + "('block_id_" + this.id + "');\n"
+      'Turtle.' + this.getFieldValue('PEN') + "('block_id_" + this.id + "');\n"
     );
   };
 
@@ -1378,7 +1378,7 @@ exports.install = function(blockly, blockInstallOptions) {
 
   generator.draw_colour_simple = function() {
     // Generate JavaScript for setting the colour.
-    var colour = this.getTitleValue('COLOUR') || "'#000000'";
+    var colour = this.getFieldValue('COLOUR') || "'#000000'";
     return 'Turtle.penColour("' + colour + '", \'block_id_' + this.id + "');\n";
   };
 
@@ -1401,7 +1401,7 @@ exports.install = function(blockly, blockInstallOptions) {
 
   generator.draw_line_style_pattern = function() {
     // Generate JavaScript for setting the image for a patterned line.
-    var pattern = this.getTitleValue('VALUE') || "'DEFAULT'";
+    var pattern = this.getFieldValue('VALUE') || "'DEFAULT'";
     return (
       'Turtle.penPattern("' + pattern + '", \'block_id_' + this.id + "');\n"
     );
@@ -1453,7 +1453,7 @@ exports.install = function(blockly, blockInstallOptions) {
     // Generate JavaScript for changing turtle visibility.
     return (
       'Turtle.' +
-      this.getTitleValue('VISIBILITY') +
+      this.getFieldValue('VISIBILITY') +
       "('block_id_" +
       this.id +
       "');\n"
@@ -1519,7 +1519,7 @@ exports.install = function(blockly, blockInstallOptions) {
   generator.sticker = generator.turtle_stamp = function() {
     return (
       'Turtle.drawSticker("' +
-      this.getTitleValue('VALUE') +
+      this.getFieldValue('VALUE') +
       '", null, \'block_id_' +
       this.id +
       "');\n"
@@ -1536,7 +1536,7 @@ exports.install = function(blockly, blockInstallOptions) {
       'SIZE',
       Blockly.JavaScript.ORDER_NONE
     );
-    return `Turtle.drawSticker('${this.getTitleValue('VALUE')}',${size},
+    return `Turtle.drawSticker('${this.getFieldValue('VALUE')}',${size},
         'block_id_${this.id}');\n`;
   };
 
@@ -1545,8 +1545,8 @@ exports.install = function(blockly, blockInstallOptions) {
   );
 
   generator.turtle_sticker_with_size_non_param = function() {
-    let size = window.parseFloat(this.getTitleValue('SIZE')) || 0;
-    return `Turtle.drawSticker('${this.getTitleValue('VALUE')}',${size},
+    let size = window.parseFloat(this.getFieldValue('SIZE')) || 0;
+    return `Turtle.drawSticker('${this.getFieldValue('VALUE')}',${size},
         'block_id_${this.id}');\n`;
   };
 
@@ -1607,7 +1607,7 @@ exports.install = function(blockly, blockInstallOptions) {
   generator.shape = function() {
     return (
       'Turtle.drawShape("' +
-      this.getTitleValue('VALUE') +
+      this.getFieldValue('VALUE') +
       '", null, \'block_id_' +
       this.id +
       "');\n"
@@ -1624,7 +1624,7 @@ exports.install = function(blockly, blockInstallOptions) {
       'SIZE',
       Blockly.JavaScript.ORDER_NONE
     );
-    return `Turtle.drawShape('${this.getTitleValue('VALUE')}',${size},
+    return `Turtle.drawShape('${this.getFieldValue('VALUE')}',${size},
         'block_id_${this.id}');\n`;
   };
 
@@ -1633,8 +1633,8 @@ exports.install = function(blockly, blockInstallOptions) {
   );
 
   generator.turtle_shape_with_side_length_non_param = function() {
-    let size = window.parseFloat(this.getTitleValue('SIZE')) || 0;
-    return `Turtle.drawShape('${this.getTitleValue('VALUE')}',${size},
+    let size = window.parseFloat(this.getFieldValue('SIZE')) || 0;
+    return `Turtle.drawShape('${this.getFieldValue('VALUE')}',${size},
         'block_id_${this.id}');\n`;
   };
 
@@ -1658,7 +1658,7 @@ exports.install = function(blockly, blockInstallOptions) {
   };
 
   generator.turtle_setArtist = function() {
-    return `Turtle.setArtist('${this.getTitleValue('VALUE')}',
+    return `Turtle.setArtist('${this.getFieldValue('VALUE')}',
       'block_id_${this.id}');\n`;
   };
 

--- a/apps/src/turtle/customLevelBlocks.js
+++ b/apps/src/turtle/customLevelBlocks.js
@@ -589,7 +589,7 @@ function installCreateASnowflakeDropdown(blockly, generator, gensym) {
   };
 
   generator.create_snowflake_dropdown = function() {
-    var type = this.getTitleValue('TYPE');
+    var type = this.getFieldValue('TYPE');
     return "Turtle.drawSnowflake('" + type + "', 'block_id_" + this.id + "');";
   };
 }

--- a/apps/src/turtle/requiredBlocks.js
+++ b/apps/src/turtle/requiredBlocks.js
@@ -105,7 +105,7 @@ var turnRight = function(degrees) {
   return {
     test: function(block) {
       return (
-        block.type === 'draw_turn' && block.getTitleValue('DIR') === 'turnRight'
+        block.type === 'draw_turn' && block.getFieldValue('DIR') === 'turnRight'
       );
     },
     type: 'draw_turn',
@@ -121,7 +121,7 @@ var turnLeft = function(degrees) {
   return {
     test: function(block) {
       return (
-        block.type === 'draw_turn' && block.getTitleValue('DIR') === 'turnLeft'
+        block.type === 'draw_turn' && block.getFieldValue('DIR') === 'turnLeft'
       );
     },
     type: 'draw_turn',
@@ -196,7 +196,7 @@ var defineWithArg = function(func_name, arg_name) {
     test: function(block) {
       return (
         block.type === 'procedures_defnoreturn' &&
-        block.getTitleValue('NAME') === func_name &&
+        block.getFieldValue('NAME') === func_name &&
         block.parameterNames_ &&
         block.parameterNames_.length &&
         block.parameterNames_[0] === arg_name

--- a/apps/test/integration/blockUtilTests.js
+++ b/apps/test/integration/blockUtilTests.js
@@ -16,7 +16,7 @@ describe('blockUtils', function() {
     assert(Blockly.mainBlockSpace.getBlockCount() === 0);
     var newBlock = blockUtils.domStringToBlock(blockXMLString);
     assert(Blockly.mainBlockSpace.getBlockCount() === 1);
-    assert(newBlock.getTitleValue('NUM') === '10');
+    assert(newBlock.getFieldValue('NUM') === '10');
     assert(newBlock.getTitles().length === 1);
   });
 

--- a/apps/test/integration/studioBlocksTest.js
+++ b/apps/test/integration/studioBlocksTest.js
@@ -27,7 +27,7 @@ describe('Custom studio blocks', function() {
       var block = Blockly.mainBlockSpace.getAllBlocks()[0];
       var lastTitle = block.getTitles()[block.getTitles().length - 1];
 
-      assert(block.getTitleValue('SPRITENAME') === '"witch"');
+      assert(block.getFieldValue('SPRITENAME') === '"witch"');
       assert(lastTitle.getText().indexOf('witch') !== -1);
     });
 
@@ -44,7 +44,7 @@ describe('Custom studio blocks', function() {
       var block = Blockly.mainBlockSpace.getAllBlocks()[0];
       var lastTitle = block.getTitles()[block.getTitles().length - 1];
 
-      assert(block.getTitleValue('SPRITENAME') === '"dinosaur"');
+      assert(block.getFieldValue('SPRITENAME') === '"dinosaur"');
       assert(lastTitle.getText().indexOf('dinosaur') !== -1);
     });
   });

--- a/apps/test/unit/blockUtilsTest.js
+++ b/apps/test/unit/blockUtilsTest.js
@@ -701,7 +701,7 @@ describe('block utils', () => {
           'test'
         );
         const fakeBlock = {
-          getTitleValue: sinon.stub().returns('someVar')
+          getFieldValue: sinon.stub().returns('someVar')
         };
         const code = generator['test_foo'].bind(fakeBlock)();
         expect(code).to.equal('someVar = foo(someVar);\n');
@@ -728,7 +728,7 @@ describe('block utils', () => {
           'test'
         );
         const fakeBlock = {
-          getTitleValue: title =>
+          getFieldValue: title =>
             ({
               NAME1: 'a',
               NAME2: 'b'
@@ -1073,7 +1073,7 @@ describe('block utils', () => {
           'test'
         );
         const fakeBlock = {
-          getTitleValue: () => 7
+          getFieldValue: () => 7
         };
         const code = generator['test_selectOne'].bind(fakeBlock)();
 
@@ -1095,7 +1095,7 @@ describe('block utils', () => {
           'test'
         );
         const fakeBlock = {
-          getTitleValue: () => 42
+          getFieldValue: () => 42
         };
         const code = generator['test_processValue'].bind(fakeBlock)();
 
@@ -1118,7 +1118,7 @@ describe('block utils', () => {
           'test'
         );
         const fakeBlock = {
-          getTitleValue: () => 'some input'
+          getFieldValue: () => 'some input'
         };
         const code = generator['test_processStringValue'].bind(fakeBlock)();
 
@@ -1141,7 +1141,7 @@ describe('block utils', () => {
           'test'
         );
         const fakeBlock = {
-          getTitleValue: () => 'some input with a "quote" in it'
+          getFieldValue: () => 'some input with a "quote" in it'
         };
         const code = generator['test_processAnotherStringValue'].bind(
           fakeBlock


### PR DESCRIPTION
We have Blockly classes that contain functions that we can pull out as utility functions. To better understand exactly what Google Blockly functionality we’re overriding in our wrapper classes, we need to move all utility-type functions out of the classes. This PR aims to replace `getTitleValue` with `getFieldValue`, removing the former from `cdoBlockSvg` and ensuring compatibility with the latter in `cdoBlocklyWrapper`.

Acceptance Criteria: 

- Ensure backward compatibility with cdoBlocklyWrapper 
- Update all files to use getFieldValue instead of getTitleValue  
- Remove getTitleValue out of cdoBlockSvg 
- Update relevant unit/integration tests

QA Notes: 

- [x] Check for regressions in live google blockly V6 labs. 
- [x] Check for regressions in cdo blockly labs
- [x] Ensure all related tests pass locally


## Links

- jira ticket: [STAR-2173: [Google Blockly][Utils] Use getFieldValue instead of getTitleValue](https://codedotorg.atlassian.net/browse/STAR-2173)



## Testing story

Throughout testing, all relevant labs were loaded to before and after changes to ensure there were no regressions. 

Tested after each commit in a variety of Blockly labs.
*Links are for a local server, for the convenience of any reviewer who wants to pull these changes.*
* [Poetry](http://localhost-studio.code.org:3000/projects/poetry)
* [Flappy](http://localhost-studio.code.org:3000/projects/flappy)
* [Sprite Lab](http://localhost-studio.code.org:3000/projects/spritelab)
* [The Bad Guys](http://localhost-studio.code.org:3000/projects/thebadguys)
* [Dance](http://localhost-studio.code.org:3000/projects/dance)
* [Bounce](http://localhost-studio.code.org:3000/projects/bounce)
* Minecraft:
  * [Simple](http://localhost-studio.code.org:3000/projects/minecraft_adventurer)
  * [Designer](http://localhost-studio.code.org:3000/projects/minecraft_designer)
  * [Agent](http://localhost-studio.code.org:3000/projects/minecraft_hero)
  * [Code Connection](http://localhost-studio.code.org:3000/projects/minecraft_codebuilder)
* [Play Lab](http://localhost-studio.code.org:3000/projects/playlab)
* [Artist](http://localhost-studio.code.org:3000/projects/artist)
* [Calc](http://localhost-studio.code.org:3000/projects/calc)
* [Eval](http://localhost-studio.code.org:3000/projects/eval)
* [Jigsaw](http://localhost-studio.code.org:3000/s/jigsaw/lessons/1/levels/10)
* Maze:
  * [Bee](http://localhost-studio.code.org:3000/s/express-2021/lessons/15/levels/13)
  * [Collector](http://localhost-studio.code.org:3000/levels?utf8=%E2%9C%93&name=grade3_RunningFarm_8) - *not used in any curricula*
  * [Harvester](http://localhost-studio.code.org:3000/s/express-2021/lessons/19/levels/10)
  * [Planter](http://localhost-studio.code.org:3000/levels?utf8=%E2%9C%93&name=Planter) - *not used in any curricula*

## Follow-up work

Continue moving all utility-type functions out of the Blockly classes.

