### PR TITLE
Add profanity filtering to Code Review

### DIFF
--- a/apps/i18n/javalab/en_us.json
+++ b/apps/i18n/javalab/en_us.json
@@ -15,7 +15,7 @@
   "clearConsole": "Clear Console",
   "classroomBlocked": "Your section has run their code too many times and has been locked. Ask your teacher to contact support@code.org to unlock your section.",
   "classNotFound": "Error: one or more of your Java files are missing a class definition.",
-  "commentProfanityFound": "Your comment contains inappropriate language so it will not be saved. Please update your comment to remove the {wordCount, plural, one {word} other {words}} \"{words}\".",
+  "commentProfanityFound": "Your comment contains inappropriate language, so it will not be saved. Please update your comment to remove the {wordCount, plural, one {word} other {words}} \"{words}\".",
   "commentUpdateError": "There was an error processing your request, please try again.",
   "commit": "Commit",
   "commitAndSave": "Commit & Save",

--- a/apps/i18n/javalab/en_us.json
+++ b/apps/i18n/javalab/en_us.json
@@ -15,6 +15,7 @@
   "clearConsole": "Clear Console",
   "classroomBlocked": "Your section has run their code too many times and has been locked. Ask your teacher to contact support@code.org to unlock your section.",
   "classNotFound": "Error: one or more of your Java files are missing a class definition.",
+  "commentProfanityFound": "Your comment contains inappropriate language so it will not be saved. Please update your comment to remove the {wordCount, plural, one {word} other {words}} \"{words}\".",
   "commentUpdateError": "There was an error processing your request, please try again.",
   "commit": "Commit",
   "commitAndSave": "Commit & Save",

--- a/apps/src/templates/instructions/ReviewTab.jsx
+++ b/apps/src/templates/instructions/ReviewTab.jsx
@@ -20,15 +20,15 @@ const FLASH_ERROR_TIME_MS = 5000;
 class ReviewTab extends Component {
   static propTypes = {
     onLoadComplete: PropTypes.func,
+    // Used only in tests
+    dataApi: PropTypes.object,
     // Populated by redux
     codeReviewEnabled: PropTypes.bool,
     viewAsCodeReviewer: PropTypes.bool.isRequired,
     viewAsTeacher: PropTypes.bool,
     channelId: PropTypes.string,
     serverLevelId: PropTypes.number,
-    serverScriptId: PropTypes.number,
-    // Used only in tests
-    dataApi: PropTypes.object
+    serverScriptId: PropTypes.number
   };
 
   state = {

--- a/apps/src/templates/instructions/codeReview/CommentEditor.jsx
+++ b/apps/src/templates/instructions/codeReview/CommentEditor.jsx
@@ -10,16 +10,21 @@ export default class CommentEditor extends Component {
   static propTypes = {
     onNewCommentSubmit: PropTypes.func.isRequired,
     onNewCommentCancel: PropTypes.func.isRequired,
+    onCommentUpdate: PropTypes.func,
     saveError: PropTypes.bool,
-    saveInProgress: PropTypes.bool
+    saveInProgress: PropTypes.bool,
+    saveErrorMessage: PropTypes.string
   };
 
   state = {comment: ''};
 
-  commentChanged = event => this.setState({comment: event.target.value});
+  commentChanged = event => {
+    this.props.onCommentUpdate();
+    this.setState({comment: event.target.value});
+  };
 
   renderSaveStatus() {
-    const {saveError, saveInProgress} = this.props;
+    const {saveError, saveInProgress, saveErrorMessage} = this.props;
     let icon = '';
     let saveMessageTitle = '';
     let saveMessageText = '';
@@ -32,16 +37,16 @@ export default class CommentEditor extends Component {
         <span className="fa fa-exclamation-circle" style={styles.iconError} />
       );
       saveMessageTitle = javalabMsg.genericSaveErrorTitle();
-      saveMessageText = javalabMsg.genericErrorMessage();
+      saveMessageText = saveErrorMessage || javalabMsg.genericErrorMessage();
     }
 
     return (
       <div style={styles.saveStatus}>
-        <div style={styles.saveStatusIcon}>{icon}</div>
-        <div style={styles.saveMessage}>
+        <div style={styles.saveStatusHeader}>
+          <div style={styles.saveStatusIcon}>{icon}</div>
           <p style={styles.saveMessageTitle}>{saveMessageTitle}</p>
-          <p style={styles.saveMessageText}>{saveMessageText}</p>
         </div>
+        <p style={styles.saveMessageText}>{saveMessageText}</p>
       </div>
     );
   }
@@ -64,8 +69,8 @@ export default class CommentEditor extends Component {
           onChange={this.commentChanged}
           value={this.state.comment}
         />
+        {comment && this.renderSaveStatus()}
         <div style={styles.commentFooter}>
-          {comment && this.renderSaveStatus()}
           <div style={styles.buttonContainer}>
             {comment && (
               <Button
@@ -119,23 +124,29 @@ const styles = {
   },
   commentFooter: {
     display: 'flex',
-    justifyContent: 'space-between',
+    justifyContent: 'flex-end',
     alignItems: 'center',
     padding: '10px 0'
   },
   saveStatus: {
+    display: 'flex',
+    flexDirection: 'column'
+  },
+  saveStatusHeader: {
     display: 'flex',
     alignItems: 'center'
   },
   saveMessageTitle: {
     fontFamily: '"Gotham 5r", sans-serif',
     fontSize: 14,
-    marginBottom: 0
+    marginBottom: 0,
+    color: color.dark_charcoal
   },
   saveMessageText: {
     fontStyle: 'italic',
     fontSize: 12,
-    marginBottom: 0
+    marginBottom: 0,
+    color: color.dark_charcoal
   },
   saveMessage: {
     color: color.dark_charcoal

--- a/apps/test/unit/templates/instructions/ReviewTabTest.jsx
+++ b/apps/test/unit/templates/instructions/ReviewTabTest.jsx
@@ -12,53 +12,57 @@ import Spinner from '@cdo/apps/code-studio/pd/components/spinner';
 import Button from '@cdo/apps/templates/Button';
 
 describe('Code Review Tab', () => {
-  const token = 'token';
   const channelId = 'test123';
   const serverLevelId = 123;
   const serverScriptId = 123;
   const reviewableProjectId = 'reviewableProjectId123';
-  const existingComment = Factory.build('CodeReviewComment');
-  let wrapper, server, clock, onLoadComplete;
+
+  const autoResolveApiCall = () => {
+    return {
+      done: callback => {
+        callback();
+        return {
+          fail: () => {}
+        };
+      }
+    };
+  };
+
+  const autoFailApiCall = () => {
+    return {
+      done: () => {
+        return {
+          fail: errorCallback => errorCallback()
+        };
+      }
+    };
+  };
+
+  let wrapper, onLoadComplete, mockApi, existingComment;
 
   beforeEach(() => {
-    server = sinon.fakeServer.create();
-    server.respondWith(
-      'GET',
-      `/code_review_comments/project_comments?channel_id=${channelId}`,
-      [
-        200,
-        {
-          'Content-Type': 'application/json',
-          'csrf-token': token
-        },
-        JSON.stringify([existingComment])
-      ]
-    );
-    server.respondWith(
-      'DELETE',
-      `/code_review_comments/${existingComment.id}`,
-      [200, {}, '']
-    );
-    server.respondWith(
-      'PATCH',
-      `/code_review_comments/${existingComment.id}/toggle_resolved`,
-      [200, {}, '']
-    );
+    existingComment = Factory.build('CodeReviewComment');
+    mockApi = {};
+
+    mockApi.getCodeReviewCommentsForProject = onDone => {
+      onDone([existingComment]);
+    };
+
+    mockApi.deleteCodeReviewComment = autoResolveApiCall;
+    mockApi.resolveCodeReviewComment = autoResolveApiCall;
+
+    // Stub with defaults because this API call is always made on mount
+    stubReviewableStatusProjectApiCall({
+      canMarkReviewable: false,
+      reviewEnabled: true
+    });
 
     onLoadComplete = sinon.spy();
   });
 
-  afterEach(() => {
-    if (clock) {
-      clock.restore();
-    }
-
-    server.restore();
-  });
-
   describe('viewing as code owner with review enabled', () => {
-    beforeEach(() => {
-      wrapper = shallow(
+    function createWrapper() {
+      return shallow(
         <ReviewTab
           onLoadComplete={onLoadComplete}
           codeReviewEnabled
@@ -66,8 +70,13 @@ describe('Code Review Tab', () => {
           channelId={channelId}
           serverLevelId={serverLevelId}
           serverScriptId={serverScriptId}
+          dataApi={mockApi}
         />
       );
+    }
+
+    beforeEach(() => {
+      wrapper = createWrapper();
     });
 
     it('renders loading spinner before load is completed', () => {
@@ -88,19 +97,22 @@ describe('Code Review Tab', () => {
       });
 
       it('renders without error if project has no comments', () => {
-        server.respondWith(
-          'GET',
-          `/code_review_comments/project_comments?channel_id=${channelId}`,
-          [200, {'Content-Type': 'application/json'}, JSON.stringify([])]
-        );
-        server.respond();
+        mockApi.getCodeReviewCommentsForProject = onDone => {
+          onDone([]);
+        };
+
+        // Need to recreate the wrapper so the right comments are loaded on mount
+        wrapper = createWrapper();
+        wrapper.setState({loadingReviewData: false});
 
         expect(wrapper.find(Comment).length).to.equal(0);
       });
 
       it('renders a comment fetched on mount if one exists', () => {
-        expect(wrapper.find(Comment).length).to.equal(0);
-        server.respond();
+        // Need to recreate the wrapper so the right comments are loaded on mount
+        wrapper = createWrapper();
+        wrapper.setState({loadingReviewData: false});
+
         expect(wrapper.find(Comment).length).to.equal(1);
       });
 
@@ -110,17 +122,21 @@ describe('Code Review Tab', () => {
           commentText: testCommentText
         });
 
-        server.respondWith('POST', '/code_review_comments', [
-          200,
-          {'Content-Type': 'application/json'},
-          JSON.stringify(newlyCreatedComment)
-        ]);
+        mockApi.submitNewCodeReviewComment = () => {
+          return {
+            then: callback => {
+              callback(newlyCreatedComment);
+              return {
+                catch: () => {}
+              };
+            }
+          };
+        };
 
-        server.respond();
         expect(wrapper.find(Comment).length).to.equal(1);
 
         wrapper.instance().onNewCommentSubmit(testCommentText);
-        server.respond();
+
         const comment = wrapper.find(Comment);
         expect(comment.length).to.equal(2);
         expect(comment.at(1).props().comment.commentText).to.equal(
@@ -130,45 +146,62 @@ describe('Code Review Tab', () => {
 
       it('hides comment box if there is an authorization error on comment', () => {
         // first, enable peer review
-        stubReviewableStatusProjectServerCall({
+        stubReviewableStatusProjectApiCall({
           canMarkReviewable: false,
           reviewEnabled: true
         });
 
         const testCommentText = 'test comment text';
-        server.respond();
 
         // initial server response loads a comment
         expect(wrapper.find(CommentEditor).length).to.equal(1);
         expect(wrapper.find(Comment).length).to.equal(1);
 
         // fake a 404 for saving a comment
-        server.respondWith('POST', '/code_review_comments', [
-          404,
-          {'Content-Type': 'application/json'},
-          'error'
-        ]);
+        stubSubmitCommentError({status: 404});
 
         wrapper.instance().onNewCommentSubmit(testCommentText);
-        server.respond();
         // should still only have 1 comment, not 2
         expect(wrapper.find(Comment).length).to.equal(1);
         expect(wrapper.find(CommentEditor).length).to.equal(0);
         expect(wrapper.state().authorizationError).to.be.true;
       });
 
-      it('removes a comment when one is deleted', () => {
-        server.respond();
+      it('displays error message if comment contains profanity', () => {
+        // first, enable peer review
+        stubReviewableStatusProjectApiCall({
+          canMarkReviewable: false,
+          reviewEnabled: true
+        });
 
+        const testCommentText = 'test comment text';
+        const profanityErrorMessage = 'profanity error';
+
+        // initial server response loads a comment
+        expect(wrapper.find(CommentEditor).length).to.equal(1);
+        expect(wrapper.find(Comment).length).to.equal(1);
+
+        // fake a profanity error
+        stubSubmitCommentError({profanityFoundError: profanityErrorMessage});
+
+        wrapper.instance().onNewCommentSubmit(testCommentText);
+        // should still only have 1 comment, not 2
+        expect(wrapper.find(Comment).length).to.equal(1);
+        // Comment editor should still be visible
+        expect(wrapper.find(CommentEditor).length).to.equal(1);
+        expect(wrapper.state().commentSaveError).to.be.true;
+        expect(wrapper.state().commentSaveErrorMessage).to.equal(
+          profanityErrorMessage
+        );
+      });
+
+      it('removes a comment when one is deleted', () => {
         expect(wrapper.find(Comment).length).to.equal(1);
         wrapper.instance().onCommentDelete(existingComment.id);
-        server.respond();
         expect(wrapper.find(Comment).length).to.equal(0);
       });
 
       it('resolves a comment when one is resolved', () => {
-        server.respond();
-
         expect(
           wrapper
             .find(Comment)
@@ -178,7 +211,6 @@ describe('Code Review Tab', () => {
         wrapper
           .instance()
           .onCommentResolveStateToggle(existingComment.id, true);
-        server.respond();
         expect(
           wrapper
             .find(Comment)
@@ -188,37 +220,22 @@ describe('Code Review Tab', () => {
       });
 
       it('sets hasError to true when comment update request fails and does not update comment', () => {
-        clock = sinon.useFakeTimers();
-        server.respondWith(
-          'PATCH',
-          `/code_review_comments/${existingComment.id}/toggle_resolved`,
-          [400, {}, '']
-        );
-
-        server.respond();
         let firstComment = wrapper.find(Comment).at(0);
         expect(firstComment.props().comment.hasError).to.be.undefined;
         expect(firstComment.props().comment.isResolved).to.be.false;
 
+        mockApi.resolveCodeReviewComment = autoFailApiCall;
+
         wrapper
           .instance()
           .onCommentResolveStateToggle(existingComment.id, true);
-        server.respond();
         firstComment = wrapper.find(Comment).at(0);
         expect(firstComment.props().comment.hasError).to.be.true;
         expect(firstComment.props().comment.isResolved).to.be.false;
       });
 
       it('sets hasError to true when comment delete request fails and does not remove comment from UI', () => {
-        clock = sinon.useFakeTimers();
-
-        server.respondWith(
-          'DELETE',
-          `/code_review_comments/${existingComment.id}`,
-          [400, {}, '']
-        );
-
-        server.respond();
+        mockApi.deleteCodeReviewComment = autoFailApiCall;
 
         expect(
           wrapper
@@ -227,7 +244,6 @@ describe('Code Review Tab', () => {
             .props().comment.hasError
         ).to.be.undefined;
         wrapper.instance().onCommentDelete(existingComment.id, true);
-        server.respond();
         expect(
           wrapper
             .find(Comment)
@@ -237,11 +253,14 @@ describe('Code Review Tab', () => {
       });
 
       it('shows the review checkbox if enabled', () => {
-        stubReviewableStatusProjectServerCall({
+        stubReviewableStatusProjectApiCall({
           canMarkReviewable: true,
           reviewEnabled: true,
           id: reviewableProjectId
         });
+
+        wrapper = createWrapper();
+        wrapper.setState({loadingReviewData: false});
 
         const input = wrapper.find('input');
         expect(input).to.exist;
@@ -249,28 +268,37 @@ describe('Code Review Tab', () => {
       });
 
       it('hides the review checkbox if disabled', () => {
-        stubReviewableStatusProjectServerCall({
+        stubReviewableStatusProjectApiCall({
           canMarkReviewable: false,
           reviewEnabled: false
         });
+
+        wrapper = createWrapper();
+        wrapper.setState({loadingReviewData: false});
 
         expect(wrapper.find('input')).to.be.empty;
       });
 
       it('shows comment input if peer review enabled', () => {
-        stubReviewableStatusProjectServerCall({
+        stubReviewableStatusProjectApiCall({
           canMarkReviewable: false,
           reviewEnabled: true
         });
+
+        wrapper = createWrapper();
+        wrapper.setState({loadingReviewData: false});
 
         expect(wrapper.find(CommentEditor).length).to.equal(1);
       });
 
       it('hides comment input if peer review disabled', () => {
-        stubReviewableStatusProjectServerCall({
+        stubReviewableStatusProjectApiCall({
           canMarkReviewable: false,
           reviewEnabled: false
         });
+
+        wrapper = createWrapper();
+        wrapper.setState({loadingReviewData: false});
 
         expect(wrapper.find(CommentEditor).length).to.equal(0);
       });
@@ -308,7 +336,7 @@ describe('Code Review Tab', () => {
     });
 
     it('always shows comment input', () => {
-      stubReviewableStatusProjectServerCall({
+      stubReviewableStatusProjectApiCall({
         canMarkReviewable: false,
         reviewEnabled: false
       });
@@ -333,17 +361,30 @@ describe('Code Review Tab', () => {
     expect(wrapper.find("input[type='checkbox']").length).to.equal(0);
   });
 
-  function stubReviewableStatusProjectServerCall(reviewableStatus) {
-    server.respondWith(
-      'GET',
-      `/reviewable_projects/reviewable_status?channel_id=${channelId}&level_id=${serverLevelId}&script_id=${serverScriptId}`,
-      [
-        200,
-        {'Content-Type': 'application/json'},
-        JSON.stringify(reviewableStatus)
-      ]
-    );
+  function stubReviewableStatusProjectApiCall(reviewableStatus) {
+    mockApi.getPeerReviewStatus = () => {
+      return {
+        done: callback => {
+          callback(reviewableStatus);
+          return {
+            fail: () => {}
+          };
+        }
+      };
+    };
+  }
 
-    server.respond();
+  function stubSubmitCommentError(error) {
+    mockApi.submitNewCodeReviewComment = () => {
+      return {
+        then: () => {
+          return {
+            catch: callback => {
+              callback(error);
+            }
+          };
+        }
+      };
+    };
   }
 });

--- a/apps/test/unit/templates/instructions/codeReview/CommentEditorTest.jsx
+++ b/apps/test/unit/templates/instructions/codeReview/CommentEditorTest.jsx
@@ -4,15 +4,18 @@ import {expect} from '../../../../util/reconfiguredChai';
 import './CodeReviewTestHelper';
 import CommentEditor from '@cdo/apps/templates/instructions/codeReview/CommentEditor';
 import Button from '@cdo/apps/templates/Button';
+import sinon from 'sinon';
 
 describe('Code Review Comment Editor', () => {
-  let wrapper;
+  let wrapper, onCommentUpdate;
 
   beforeEach(() => {
+    onCommentUpdate = sinon.stub();
     wrapper = shallow(
       <CommentEditor
         onNewCommentSubmit={() => {}}
         onNewCommentCancel={() => {}}
+        onCommentUpdate={onCommentUpdate}
       />
     );
   });
@@ -28,6 +31,14 @@ describe('Code Review Comment Editor', () => {
       .first()
       .simulate('change', {target: {value: 'a comment'}});
     expect(wrapper.find(Button)).to.have.lengthOf(2);
+  });
+
+  it('calls onCommentUpdate callback once user starts typing', () => {
+    wrapper
+      .find('textarea')
+      .first()
+      .simulate('change', {target: {value: 'a comment'}});
+    sinon.assert.calledOnce(onCommentUpdate);
   });
 
   it('hides submit and cancel buttons and clears textbox if user hits cancel button', () => {


### PR DESCRIPTION
This adds a profanity check so that code review comments with profanity cannot be saved. This also includes a couple other small related changes including slightly reorganizing how the error message is displayed, and adding the ability to pass in a custom error message to `CommentEditor`.

I also refactored ReviewTabTest a bit to remove the server call stubbing and instead just mock the data API object directly. This was required because I couldn't make the server call mocking method work with the new additions to the comment submit API call. This also allows us to be more specific in how we stub and what data is returned, and means that this test doesn't need to be concerned with what routes CodeReviewDataApi actually hits internally.

Example profanity error:
![Screen Shot 2022-03-31 at 2 19 59 PM](https://user-images.githubusercontent.com/85528507/161339353-73b71cb1-85b5-43f9-8b03-89752d966e1c.png)

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

JIRA: https://codedotorg.atlassian.net/browse/JAVA-355

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Tested locally.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
