### PR TITLE
automatically seed reference guides from config

### DIFF
--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -295,6 +295,10 @@ namespace :seed do
       CourseOffering.seed_record("test/ui/config/course_offerings/#{course_offering_name}.json")
     end
   end
+  
+  timed_task reference_guides: :environment do
+    ReferenceGuide.seed_all
+  end
 
   # Seeds Standards
   timed_task standards: :environment do
@@ -449,7 +453,7 @@ namespace :seed do
     sh('mysqldump -u root -B dashboard_test > db/ui_test_data.sql')
   end
 
-  FULL_SEED_TASKS = [:check_migrations, :videos, :concepts, :scripts, :courses, :callouts, :school_districts, :schools, :secret_words, :secret_pictures, :ap_school_codes, :ap_cs_offerings, :ib_school_codes, :ib_cs_offerings, :state_cs_offerings, :donors, :donor_schools, :foorms].freeze
+  FULL_SEED_TASKS = [:check_migrations, :videos, :concepts, :scripts, :courses, :reference_guides, :callouts, :school_districts, :schools, :secret_words, :secret_pictures, :ap_school_codes, :ap_cs_offerings, :ib_school_codes, :ib_cs_offerings, :state_cs_offerings, :donors, :donor_schools, :foorms].freeze
   UI_TEST_SEED_TASKS = [:check_migrations, :videos, :concepts, :course_offerings_ui_tests, :scripts_ui_tests, :courses_ui_tests, :callouts, :school_districts, :schools, :secret_words, :secret_pictures, :donors, :donor_schools].freeze
   DEFAULT_SEED_TASKS = [:adhoc, :test].include?(rack_env) ? UI_TEST_SEED_TASKS : FULL_SEED_TASKS
 

--- a/tools/hooks/restrict_levelbuilder_changes.rb
+++ b/tools/hooks/restrict_levelbuilder_changes.rb
@@ -7,6 +7,7 @@ LIBRARIES_DIR = File.expand_path(REPO_DIR + '/dashboard/config/libraries', __FIL
 LEVELS_DIR = File.expand_path(REPO_DIR + '/dashboard/config/scripts', __FILE__).freeze
 COURSES_DIR = File.expand_path(REPO_DIR + '/dashboard/config/courses', __FILE__).freeze
 COURSE_OFFERINGS_DIR = File.expand_path(REPO_DIR + '/dashboard/config/course_offerings', __FILE__).freeze
+REFERENCE_GUIDES_DIR = File.expand_path(REPO_DIR + '/dashboard/config/reference_guides', __FILE__).freeze
 PROGRAMMING_ENVIRONMENTS_DIR = File.expand_path(REPO_DIR + '/dashboard/config/programming_environments', __FILE__).freeze
 PROGRAMMING_EXPRESSIONS_DIR = File.expand_path(REPO_DIR + '/dashboard/config/programming_expressions', __FILE__).freeze
 VIDEO_THUMBNAILS_DIR = File.expand_path(REPO_DIR + '/dashboard/public/c/video_thumbnails', __FILE__).freeze
@@ -29,6 +30,6 @@ staged_files = HooksUtils.get_staged_files
 
 staged_files.each do |filename|
   raise "#{ERROR_MESSAGE}\nFile blocked: #{filename}" unless filename.start_with?(
-    BLOCKS_DIR, SHARED_FUNCTIONS_DIR, LIBRARIES_DIR, LEVELS_DIR, COURSES_DIR, COURSE_OFFERINGS_DIR, PROGRAMMING_ENVIRONMENTS_DIR, PROGRAMMING_EXPRESSIONS_DIR, VIDEO_THUMBNAILS_DIR, FOORM_DIR
+    BLOCKS_DIR, SHARED_FUNCTIONS_DIR, LIBRARIES_DIR, LEVELS_DIR, COURSES_DIR, COURSE_OFFERINGS_DIR, REFERENCE_GUIDES_DIR, PROGRAMMING_ENVIRONMENTS_DIR, PROGRAMMING_EXPRESSIONS_DIR, VIDEO_THUMBNAILS_DIR, FOORM_DIR
   ) || ALLOWED_FILES.include?(filename)
 end


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Adds the call to seed_all to get each environment in sync once config files are on levelbuilder.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [PLAT-1699](https://codedotorg.atlassian.net/browse/PLAT-1699)
