### PR TITLE
update child levels when seeding contained levels

### DIFF
--- a/dashboard/app/models/concerns/text_to_speech.rb
+++ b/dashboard/app/models/concerns/text_to_speech.rb
@@ -221,6 +221,7 @@ module TextToSpeech
   end
 
   def tts_update(update_all = false)
+    return unless Rails.application.config.levelbuilder_mode
     context = 'update_level'
     tts_upload_to_s3(tts_short_instructions_text, context) if tts_should_update_short_instructions?(update_all)
 

--- a/dashboard/app/models/concerns/text_to_speech.rb
+++ b/dashboard/app/models/concerns/text_to_speech.rb
@@ -221,7 +221,6 @@ module TextToSpeech
   end
 
   def tts_update(update_all = false)
-    return unless Rails.application.config.levelbuilder_mode
     context = 'update_level'
     tts_upload_to_s3(tts_short_instructions_text, context) if tts_should_update_short_instructions?(update_all)
 

--- a/dashboard/lib/level_loader.rb
+++ b/dashboard/lib/level_loader.rb
@@ -85,6 +85,17 @@ class LevelLoader
       update_columns = Level.columns.map(&:name).map(&:to_sym).
         reject {|column| %i(id name created_at).include? column}
       Level.import! changed_levels, on_duplicate_key_update: update_columns
+
+      # now we want to run some after_save callbacks, which didn't get run when
+      # by run_callbacks earlier. it seems too risky to run all after_save
+      # callbacks automatically, because someone modifying the level edit
+      # experience of any individual level could add an after_save callback
+      # which modifies the DB and which they expect to get run only on
+      # levelbuilder. so, just run the callbacks we're sure we need instead.
+      changed_levels.each do |level|
+        level.setup_contained_levels
+        level.setup_project_template_level
+      end
     end
   end
 


### PR DESCRIPTION
Finishes [PLAT-1689](https://codedotorg.atlassian.net/browse/PLAT-1689). This PR contains the long-term fix to make it so that changes to contained levels in levelbuilder are properly reflected in production. For more background, see slack threads [1](https://codedotorg.slack.com/archives/C02EEGWLHR8/p1648589537381939), [2](https://codedotorg.slack.com/archives/C02EEGWLHR8/p1648654463734759), [3](https://codedotorg.slack.com/archives/CFGAVL2CA/p1648679441389269)

When a contained level is saved on levelbuilder, we set up the child levels (contained levels and project template levels) via  `after_save` [ActiveRecord callbacks](https://guides.rubyonrails.org/active_record_callbacks.html): https://github.com/code-dot-org/code-dot-org/blob/0956d7a58d0e741ed323cbc0f833b4efc1ab152b/dashboard/app/models/concerns/levels/levels_within_levels.rb#L46-L47

during seeding, we take extra steps to run before_save and before_validation callbacks, but not after_save callbacks. because of this, the child levels do not get set up properly in production and other environments during seeding.

My first thought was to update the seeding code to also run all after_save callbacks. To see what this would affect, I made a list of [all level save callbacks](https://docs.google.com/spreadsheets/d/1u_0NDQa7QCcLUBQyBr6PjmkxbXI89qbIfv4IIacSLfE/edit#gid=0) I could find. while I didn't find any that would cause an immediate problem, it seemed like doing so might be laying a trap for future developers, so I went with just explicitly calling the methods I need to set up child levels instead. I am open to pushback on this strategy.

## Testing story

Due to a quirk in our configuration, the problem does NOT reproduce locally. so, instead of explicitly testing that the problem is fixed locally, I used `puts` statements to verify that the `setup_contained_levels` callback is now getting called when I run `rake seed:custom_levels LEVEL_NAME="CSD U6 - If Variables - P_2022"`, whereas previously it was not.

I couldn't think of a good way to write an automated test for this end-to-end, because we don't really have existing test infrastructure for propagating levelbuilder edits to other environments. maybe we should build that... or maybe we should focus on moving level data out of our repo instead :-p

