### PR TITLE
Katleiah/custom costumes prompts

### DIFF
--- a/apps/src/p5lab/spritelab/SpritelabInput.jsx
+++ b/apps/src/p5lab/spritelab/SpritelabInput.jsx
@@ -6,10 +6,11 @@ import * as shapes from '../shapes';
 import {KeyCodes} from '@cdo/apps/constants';
 import {selectors} from '@cdo/apps/lib/tools/jsdebugger/redux';
 import {PromptType} from '../redux/spritelabInput';
-import {animations as animationsApi} from '@cdo/apps/clientApi';
+import {animationSourceUrl} from '../redux/animationList';
 class SpritelabInput extends React.Component {
   static propTypes = {
     animationList: shapes.AnimationList.isRequired,
+    channelId: PropTypes.string,
     inputList: PropTypes.arrayOf(
       PropTypes.shape({
         promptType: PropTypes.string,
@@ -61,8 +62,13 @@ class SpritelabInput extends React.Component {
     const spriteMap = {};
 
     Object.entries(animationPropsByKey).forEach(animation => {
-      spriteMap[`image_${animation[1].name}`] =
-        animation[1].sourceUrl || animationsApi.basePath(animation[0]) + '.png'; // this could be confusing since we expect sourceUrl to be null sometimes?
+      const animationKey = animation[0];
+      const animationData = animation[1];
+      const url =
+        animationData.sourceUrl ||
+        // If custom animation, generate URL from animations API
+        animationSourceUrl(animationKey, animationData, this.props.channelId);
+      spriteMap[`image_${animation[1].name}`] = url;
     });
     return spriteMap;
   });
@@ -242,6 +248,7 @@ const styles = {
 
 export default connect(state => ({
   animationList: state.animationList,
+  channelId: state.pageConstants.channelId,
   inputList: state.spritelabInputList || [],
   isRunning: selectors.isRunning(state),
   isPaused: selectors.isPaused(state)

--- a/apps/src/p5lab/spritelab/SpritelabInput.jsx
+++ b/apps/src/p5lab/spritelab/SpritelabInput.jsx
@@ -7,6 +7,7 @@ import {KeyCodes} from '@cdo/apps/constants';
 import {selectors} from '@cdo/apps/lib/tools/jsdebugger/redux';
 import {PromptType} from '../redux/spritelabInput';
 import {animationSourceUrl} from '../redux/animationList';
+
 class SpritelabInput extends React.Component {
   static propTypes = {
     animationList: shapes.AnimationList.isRequired,
@@ -68,7 +69,7 @@ class SpritelabInput extends React.Component {
         animationData.sourceUrl ||
         // If custom animation, generate URL from animations API
         animationSourceUrl(animationKey, animationData, this.props.channelId);
-      spriteMap[`image_${animation[1].name}`] = url;
+      spriteMap[`image_${animationData.name}`] = url;
     });
     return spriteMap;
   });

--- a/apps/src/p5lab/spritelab/SpritelabInput.jsx
+++ b/apps/src/p5lab/spritelab/SpritelabInput.jsx
@@ -6,7 +6,7 @@ import * as shapes from '../shapes';
 import {KeyCodes} from '@cdo/apps/constants';
 import {selectors} from '@cdo/apps/lib/tools/jsdebugger/redux';
 import {PromptType} from '../redux/spritelabInput';
-
+import {animations as animationsApi} from '@cdo/apps/clientApi';
 class SpritelabInput extends React.Component {
   static propTypes = {
     animationList: shapes.AnimationList.isRequired,
@@ -59,9 +59,11 @@ class SpritelabInput extends React.Component {
 
   constructSpriteMap = memoize(animationPropsByKey => {
     const spriteMap = {};
-    Object.values(animationPropsByKey).forEach(
-      animation => (spriteMap[`image_${animation.name}`] = animation.sourceUrl)
-    );
+
+    Object.entries(animationPropsByKey).forEach(animation => {
+      spriteMap[`image_${animation[1].name}`] =
+        animation[1].sourceUrl || animationsApi.basePath(animation[0]) + '.png'; // this could be confusing since we expect sourceUrl to be null sometimes?
+    });
     return spriteMap;
   });
 


### PR DESCRIPTION
This PR fixes the issue of customized or drawn sprite images note showing when selected as a prompt option. 

Before:
![image](https://user-images.githubusercontent.com/35442460/161636521-9d7cfefa-6274-43b5-9421-c019f19ef19c.png)

Changes in this PR:
![image](https://user-images.githubusercontent.com/35442460/161637316-78698185-c667-443f-929e-282c212ae363.png)

## Links
[Jira Ticket](https://codedotorg.atlassian.net/browse/STAR-2185) 

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work
This fix requires populating source urls for custom animations in the `SpritelabInput` component. It would be great to see if there is a way to centralize how and when we fetch and generate these urls, rather than having to generate them in a duplicate way in multiple locations in the code. A further investigation into the ways in which we rely on `sourceUrl` to be null for custom animations is needed. 

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
