### PR TITLE
Speculative deflake for assessments_controller_test

### DIFF
--- a/dashboard/test/controllers/api/v1/assessments_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/assessments_controller_test.rb
@@ -233,13 +233,13 @@ class Api::V1::AssessmentsControllerTest < ActionController::TestCase
     ]
 
     # create user_level for level_group
-    user_level = create :user_level, user: @student_1, best_result: 100, script: script, level: level1, submitted: true
+    level_group_user_level = create :user_level, user: @student_1, best_result: 100, script: script, level: level1, submitted: true
 
     # create user_levels for sublevels
     student_answers.each do |level_and_answer|
       level, answer = level_and_answer
       level_source = create :level_source, level: level, data: answer
-      user_level = create :user_level, user: @student_1, script: script, level: level, level_source: level_source
+      create :user_level, user: @student_1, script: script, level: level, level_source: level_source
     end
 
     # Call the controller method.
@@ -264,7 +264,7 @@ class Api::V1::AssessmentsControllerTest < ActionController::TestCase
             "match_correct" => 1,
             "match_count" => 3,
             "submitted" => true,
-            "timestamp" => user_level[:updated_at],
+            "timestamp" => level_group_user_level[:updated_at],
             "level_results" => [
               {"student_result" => "This is a free response", "status" => "", "type" => "FreeResponse"},
               {"type" => "Multi", "student_result" => [0], "status" => "correct",},


### PR DESCRIPTION
This has failed a few times recently in the DTT.

Example log:
```
==========[0m[1000D[K FAIL["test_verified_teacher_should_get_assessments_responses", "Api::V1::AssessmentsControllerTest", 1207.9027286842465]
 test_verified_teacher_should_get_assessments_responses#Api::V1::AssessmentsControllerTest (1207.90s)
        --- expected
        +++ actual
        @@ -1 +1 @@
        -{"914"=>{"student_name"=>"student_0", "responses_by_assessment"=>{"2118"=>{"lesson"=>"bogus-script-16", "puzzle"=>1, "question"=>"Long assessment 1", "url"=>"//test-studio.code.org/s/bogus-script-16/lessons/1/levels/1?section_id=1&user_id=914", "multi_correct"=>1, "multi_count"=>4, "match_correct"=>1, "match_count"=>3, "submitted"=>true, "timestamp"=>Mon, 04 Apr 2022 21:38:23 UTC +00:00, "level_results"=>[{"student_result"=>"This is a free response", "status"=>"", "type"=>"FreeResponse"}, {"type"=>"Multi", "student_result"=>[0], "status"=>"correct"}, {"type"=>"Multi", "student_result"=>[1], "status"=>"incorrect"}, {"type"=>"Multi", "student_result"=>[], "status"=>"unsubmitted"}, {"type"=>"Match", "student_result"=>[nil, nil], "status"=>["unsubmitted", "unsubmitted"]}, {"type"=>"Match", "student_result"=>[0, 1], "status"=>["submitted", "submitted"]}, {"type"=>"Match", "student_result"=>[1, 0], "status"=>["submitted", "submitted"]}, {"type"=>"Multi", "status"=>"unsubmitted"}]}}}}
        +{"914"=>{"student_name"=>"student_0", "responses_by_assessment"=>{"2118"=>{"lesson"=>"bogus-script-16", "puzzle"=>1, "question"=>"Long assessment 1", "url"=>"//test-studio.code.org/s/bogus-script-16/lessons/1/levels/1?section_id=1&user_id=914", "multi_correct"=>1, "multi_count"=>4, "match_correct"=>1, "match_count"=>3, "submitted"=>true, "timestamp"=>"2022-04-04T21:38:22.000+00:00", "level_results"=>[{"type"=>"FreeResponse", "student_result"=>"This is a free response", "status"=>""}, {"type"=>"Multi", "student_result"=>[0], "status"=>"correct"}, {"type"=>"Multi", "student_result"=>[1], "status"=>"incorrect"}, {"type"=>"Multi", "student_result"=>[], "status"=>"unsubmitted"}, {"type"=>"Match", "student_result"=>[nil, nil], "status"=>["unsubmitted", "unsubmitted"]}, {"type"=>"Match", "student_result"=>[0, 1], "status"=>["submitted", "submitted"]}, {"type"=>"Match", "student_result"=>[1, 0], "status"=>["submitted", "submitted"]}, {"type"=>"Multi", "status"=>"unsubmitted"}]}}}}
        test/controllers/api/v1/assessments_controller_test.rb:282:in `block in <class:AssessmentsControllerTest>'
        test/testing/setup_all_and_teardown_all.rb:36:in `run'
```

It's a bit difficult to read but the only difference is the timestamp. The expected timestamp is one second later than the actual timestamp. I can repro this locally by sleeping for half a second before creating the sublevel user levels (line 237 in this PR).

Looking at [the code](https://github.com/code-dot-org/code-dot-org/blob/2fd5d2ba8bf4eaeb650ee40e4f73203706135e68/dashboard/app/controllers/api/v1/assessments_controller.rb#L162), timestamp in the response is supposed to be the level group's timestamp, not the sublevel's. Likely, assigning the sublevels to `user_level` was a mistake that just went unnoticed until recently. I renamed that variable to be more clear as well.

This is a new area of the codebase for me so let me know if I misunderstood anything!




## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
