### PR TITLE
Add Gatekeeper Flag to Disable Read Splitting For Specific Route

### DIFF
--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -17,7 +17,7 @@ class ActivitiesController < ApplicationController
   MIN_LINES_OF_CODE = 0
   MAX_LINES_OF_CODE = 1000
 
-  use_reader_connection_for_route(:milestone)
+  use_reader_connection_for_route(:milestone, gatekeeper_controlled: true)
 
   def milestone
     # TODO: do we use the :result and :testResult params for the same thing?

--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -17,7 +17,7 @@ class ActivitiesController < ApplicationController
   MIN_LINES_OF_CODE = 0
   MAX_LINES_OF_CODE = 1000
 
-  use_reader_connection_for_route(:milestone, gatekeeper_controlled: true)
+  use_reader_connection_for_route(:milestone)
 
   def milestone
     # TODO: do we use the :result and :testResult params for the same thing?

--- a/dashboard/app/helpers/multiple_databases_transition_helper.rb
+++ b/dashboard/app/helpers/multiple_databases_transition_helper.rb
@@ -10,16 +10,13 @@ module MultipleDatabasesTransitionHelper
   module ControllerFilter
     extend ActiveSupport::Concern
     class_methods do
-      # Use the read replica connection for the specified route. Optionally,
-      # also allow the endpoint to be selectively disabled by a gatekeeper
-      # flag.
-      def use_reader_connection_for_route(route, gatekeeper_controlled: false)
+      def use_reader_connection_for_route(route)
         if MultipleDatabasesTransitionHelper.transitioned?
           around_action :connect_to_reader, only: route
         else
           use_database_pool route => :persistent
         end
-        around_action(:gatekeeper_controlled_reader_override, only: route) if gatekeeper_controlled
+        around_action(:gatekeeper_controlled_reader_override, only: route)
       end
     end
 


### PR DESCRIPTION
Specifically, the flag `reader_connection_override`, which accepts a "where" clause with the `route` parameter:

![image](https://user-images.githubusercontent.com/244100/161659267-9ad7b245-0c8d-4539-82c8-4303413e6ad6.png)

This is in addition to the existing gatekeeper flag `dashboard_read_replica` which disables read splitting globally.

We are adding this primarily to disable splitting on the milestone post specifically, so we can test out the impact of that endpoint specifically on our metrics.

## Testing story

Tested this locally by setting my local gatekeeper flag as in the screenshot above and examining the results of `SELECT user_host, count(*) FROM mysql.general_log GROUP BY user_host`; without the flag set, I saw queries being split between the reader and writer, with it set I only saw queries on the writer.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
