### PR TITLE
Add Helpers for ActiveRecord Read/Write Splitting

### DIFF
--- a/dashboard/app/helpers/multiple_databases_transition_helper.rb
+++ b/dashboard/app/helpers/multiple_databases_transition_helper.rb
@@ -69,4 +69,20 @@ module MultipleDatabasesTransitionHelper
       raise "unknown Rails version #{Rails.version.inspect}"
     end
   end
+
+  # Get the name of ActiveRecord "role" used for connecting to the writer
+  # database, as configured in database.yml
+  def self.get_writing_role_name
+    :primary
+  end
+
+  # Get the name of ActiveRecord "role" used for connecting to the reader
+  # database. When read/write splitting is not enabled, this will be the same
+  # as the writing role.
+  #
+  # Inspired by: https://medium.com/grailed-engineering/distributing-database-reads-across-replicas-with-rails-6-and-activerecord-23a24aa90c84
+  def self.get_reading_role_name
+    configurations = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, include_replicas: true)
+    configurations.find(&:replica?)&.spec_name&.to_sym || get_writing_role_name
+  end
 end


### PR DESCRIPTION
To be used like this once we upgrade:

    class ApplicationRecord < ActiveRecord::Base
      self.abstract_class = true

      connects_to database: {
        writing: MultipleDatabasesTransitionHelper.get_writing_role_name,
        reading: MultipleDatabasesTransitionHelper.get_reading_role_name
      }
    end

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
