### PR TITLE
Explicitly Use Write Connection within Milestone Post

### DIFF
--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -62,10 +62,9 @@ class ActivitiesController < ApplicationController
       end
 
       unless share_failure || ActivityConstants.skipped?(params[:new_result].to_i)
-        # This route is configured to use the read connection. When configured
-        # that way using SeamlessDatabasePool, this write is automatically
-        # caught and sent to the writer; but when using ActiveRecord, it needs
-        # to be handled explicitly.
+        # Explicitly use the writer connection to make this write call. This
+        # isn't necessary as long as we're still using SeamlessDatabasePool,
+        # but will be once we update to Rails 6
         MultipleDatabasesTransitionHelper.use_writer_connection do
           @level_source = LevelSource.find_identical_or_create(
             @level,

--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -110,13 +110,15 @@ class ActivitiesController < ApplicationController
       params[:lines] = MAX_LINES_OF_CODE if params[:lines] > MAX_LINES_OF_CODE
     end
 
-    @level_source_image = find_or_create_level_source_image(params[:image], @level_source)
+    MultipleDatabasesTransitionHelper.use_writer_connection do
+      @level_source_image = find_or_create_level_source_image(params[:image], @level_source)
 
-    @new_level_completed = false
-    if current_user
-      track_progress_for_user if @script_level
-    else
-      track_progress_in_session
+      @new_level_completed = false
+      if current_user
+        track_progress_for_user if @script_level
+      else
+        track_progress_in_session
+      end
     end
 
     total_lines = if current_user && current_user.total_lines


### PR DESCRIPTION
SeamlessDatabasePool doesn't ask us to be explicit about writes that we do inside "read" routes, but ActiveRecord does. So, add an explicit call here to prepare for the Rails 6 upgrade.

## Testing story

Used https://github.com/code-dot-org/code-dot-org/pull/45479 to run UI tests on Rails 6 with read/write splitting enabled. Confirmed that without this change, many tests fail because of milestone posts complaining about errant writes. With this change, everything passes.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
