### PR TITLE
Update remaining references to storage_apps and user_storage_ids

### DIFF
--- a/bin/cron/update_project_count
+++ b/bin/cron/update_project_count
@@ -20,7 +20,7 @@ require 'cdo/honeybadger'
 MAX_EXECUTION_TIME = 1_200_000
 MAX_EXECUTION_TIME_SEC = MAX_EXECUTION_TIME / 1000
 
-# Connection to read from Pegasus reporting database.
+# Connection to read from Dashboard reader database.
 DASHBOARD_DB_READER = sequel_connect(
   CDO.dashboard_db_reader,
   CDO.dashboard_db_reader,

--- a/bin/cron/update_project_count
+++ b/bin/cron/update_project_count
@@ -21,9 +21,9 @@ MAX_EXECUTION_TIME = 1_200_000
 MAX_EXECUTION_TIME_SEC = MAX_EXECUTION_TIME / 1000
 
 # Connection to read from Pegasus reporting database.
-PEGASUS_DB_READER = sequel_connect(
-  CDO.pegasus_db_reader,
-  CDO.pegasus_db_reader,
+DASHBOARD_DB_READER = sequel_connect(
+  CDO.dashboard_db_reader,
+  CDO.dashboard_db_reader,
   query_timeout: MAX_EXECUTION_TIME_SEC
 )
 
@@ -34,12 +34,12 @@ NUMBER_PROJECTS_SIGNIFICANT_DECREASE = 10_000
 
 def main
   # Get the current amount of projects.
-  project_count = PEGASUS_DB_READER[:storage_apps].where(standalone: true).count
+  project_count = DASHBOARD_DB_READER[:projects].where(standalone: true).count
 
   existing_project_count = Properties.get(:metrics)['project_count'] || 0
   if (existing_project_count - project_count) >= NUMBER_PROJECTS_SIGNIFICANT_DECREASE
     # Raise error if the project count somehow went down by more than set threshold.
-    error_message = "storage_apps standalone project count decreased from #{existing_project_count} to #{project_count}"
+    error_message = "standalone project count decreased from #{existing_project_count} to #{project_count}"
     raise error_message
   end
 

--- a/bin/grep-applab-source
+++ b/bin/grep-applab-source
@@ -44,12 +44,12 @@ base_dir = CDO.sources_s3_directory
 count = 0
 key_not_found = 0
 
-puts "Fetching a list of applab apps from Pegasus DB. This step may take approximately 10 minutes"
-puts "to run over ~3M rows in storage_apps in production..."
+puts "Fetching a list of applab apps from Dashboard DB. This step may take approximately 10 minutes"
+puts "to run over ~3M rows in projects in production..."
 
 # An array of pairs of storage_owner_ids and channel_ids, each representing an applab app.
-PEGASUS_REPORTING_DB_READONLY = sequel_connect CDO.pegasus_reporting_db_reader, CDO.pegasus_reporting_db_reader
-applab_channels = PEGASUS_REPORTING_DB_READONLY[:storage_apps].grep(:value, '%applab%').map do |row|
+DASHBOARD_REPORTING_DB_READONLY = sequel_connect CDO.dashboard_reporting_db_reader, CDO.dashboard_reporting_db_reader
+applab_channels = DASHBOARD_REPORTING_DB_READONLY[:projects].grep(:value, '%applab%').map do |row|
   [row[:storage_id], row[:id]]
 end
 
@@ -57,9 +57,9 @@ puts "Scanning #{applab_channels.length} source files in S3 using #{MAX_THREADS}
 
 applab_channels.each_slice(MAX_THREADS) do |chunk|
   threads = []
-  chunk.each do |owner_storage_id, storage_app_id|
+  chunk.each do |owner_storage_id, project_id|
     threads << Thread.new do
-      s3_filename = "#{base_dir}/#{owner_storage_id}/#{storage_app_id}/main.json"
+      s3_filename = "#{base_dir}/#{owner_storage_id}/#{project_id}/main.json"
       begin
         body = s3.get_object(bucket: bucket, key: s3_filename)[:body].read
       rescue Aws::S3::Errors::NoSuchKey
@@ -71,7 +71,7 @@ applab_channels.each_slice(MAX_THREADS) do |chunk|
       if source
         commands.each do |regex, filename|
           source.scan(regex).each do |match|
-            channel = storage_encrypt_channel_id(owner_storage_id, storage_app_id)
+            channel = storage_encrypt_channel_id(owner_storage_id, project_id)
             project_url = "https://#{CDO.dashboard_hostname}/projects/applab/#{channel}/view"
 
             File.open(filename, 'a') do |file|

--- a/shared/test/test_files.rb
+++ b/shared/test/test_files.rb
@@ -175,7 +175,6 @@ class FilesTest < FilesApiTestBase
     DCDO.stubs(:get).with('disallowed_html_tags', []).returns(['script', 'meta[http-equiv]'])
     DCDO.stubs(:get).with('s3_timeout', 15).returns(15)
     DCDO.stubs(:get).with('s3_slow_request', 15).returns(15)
-    DCDO.stubs(:get).with('user_storage_ids_in_dashboard', false).returns(false)
 
     filename = 'index.html'
     # The below HTML is valid/invalid in WebLab projects only. Other project types do not


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
- `update_project_count` cron job now reads from dashboard.projects instead of pegasus.storage_apps
- `grep-applab-source` script reads from dashboard.projects instead of pegasus.storage_apps
- remove reference to old DCDO flag `user_storage_ids_in_dashboard `

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
- jira ticket: [LP-2272](https://codedotorg.atlassian.net/browse/LP-2272)
<!--
- spec: []()

-->

## Testing story
Tested scripts locally to ensure DB query was behaving correctly (ran into an error with grep-applab-source but was still able to determine query worked as expected)
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
