### PR TITLE
Fix Spacing for All Languages on the User Type Buttons on the Sign-Up Page

### DIFF
--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -1750,16 +1750,16 @@ a.download-video {
     }
 
     .user-type-desc {
-      text-align: left;
+      text-align: start;
       margin-top: 10px;
       margin-left: 5px;
       margin-right: 5px;
     }
 
     .user-type-abilities-unordered-list {
-      text-align: left;
+      text-align: start;
       width: 85%;
-      margin-right: 10%;
+      margin-inline-start: 10%;
     }
   }
 

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -1740,16 +1740,16 @@ a.download-video {
     color: $selectUserTypeButtonTextColor;
     border-radius: 15px;
     border-color: $selectUserTypeButtonBorderColor;
+    display: flex;
+    flex-direction: column;
 
     .user-type-name {
-      position: absolute;
       left: 35%;
       top: 20px;
       text-align: center;
     }
 
     .user-type-desc {
-      position: absolute;
       top: 55px;
       text-align: left;
       margin-left: 5px;
@@ -1757,11 +1757,10 @@ a.download-video {
     }
 
     .user-type-abilities-unordered-list {
-      position: absolute;
       text-align: left;
       margin-left: 30px;
       margin-right: 5px;
-      top: 100px;
+      margin-top: 10px;
     }
   }
 

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -1744,23 +1744,22 @@ a.download-video {
     flex-direction: column;
 
     .user-type-name {
-      left: 35%;
-      top: 20px;
+      width: 100%;
       text-align: center;
+      margin-top: 10px;
     }
 
     .user-type-desc {
-      top: 55px;
       text-align: left;
+      margin-top: 10px;
       margin-left: 5px;
       margin-right: 5px;
     }
 
     .user-type-abilities-unordered-list {
       text-align: left;
-      margin-left: 30px;
-      margin-right: 5px;
-      margin-top: 10px;
+      width: 85%;
+      margin-right: 10%;
     }
   }
 


### PR DESCRIPTION
This PR is part of a rollout to improve clarity on the sign-up page of Student/Teacher abilities by creating user type buttons (as of 4/5/22, it is currently under a DCDO flag and toggled off). In a bug bash it was discovered that certain languages have issues with spacing within the buttons due to absolute positioning. This caused right-to-left-reading languages to have bullet points in an unordered list too far to the right and have no margins between texts if the non-English version was longer than the English version such as shown here:

_Bullet point spacing_
![Improper spacing issue](https://user-images.githubusercontent.com/56283563/161847977-5f54f7cf-2abb-4038-ae7f-f9ef96cab9b7.JPG)

_Margins between text blocks_
![Subtitle issue](https://user-images.githubusercontent.com/56283563/161847960-97d166cf-c1f1-4f8e-93e9-e2e87a663690.JPG)

Now, `display: flex` is used along with more responsive spacing that will shift with the various text lengths based on translations. Now the current buttons are styled properly:

Left-to-right-reading language (e.g. English):
![Fixed_english](https://user-images.githubusercontent.com/56283563/161847329-4f682947-8b0f-4246-9d4e-597631a20afd.JPG)

Right-to-left-reading language (e.g. Arabic):
![Fixed_arabic](https://user-images.githubusercontent.com/56283563/161850000-0620536c-88be-4007-80bb-327b54e9c0cb.JPG)

Language with longer sub-heading that requires more space (e.g. Filipino):
![Fixed_filipino](https://user-images.githubusercontent.com/56283563/161850111-36c83fc7-04d9-4bd4-b54a-258fd16884c9.JPG)

## Links
Jira ticket: [here](https://codedotorg.atlassian.net/browse/FND-1960?atlOrigin=eyJpIjoiYjExYWZjNmI1ODc4NGRiOGIwYzg5ZDE0MzhkMTIzZDYiLCJwIjoiaiJ9)
Bug bash doc: [here](https://docs.google.com/document/d/1Bp9bS4PiV3o3vafKs0clXwNXeHpfH0rNM_4NvLzEyTg/edit)
PR this follows: [here](https://github.com/code-dot-org/code-dot-org/pull/45534)

## Testing story
Local testing to ensure the text within the buttons is spaced properly and looks nice in the languages that have been translated from the list in [the bug bash doc](https://docs.google.com/document/d/1Bp9bS4PiV3o3vafKs0clXwNXeHpfH0rNM_4NvLzEyTg/edit).

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
