### PR TITLE
Redirect from reference guide index route

### DIFF
--- a/dashboard/app/controllers/reference_guides_controller.rb
+++ b/dashboard/app/controllers/reference_guides_controller.rb
@@ -14,6 +14,17 @@ class ReferenceGuidesController < ApplicationController
   def show
   end
 
+  # GET /courses/:course_name/guides
+  def index
+    # redirect to the show page for the first guide within a category
+    course_version_id = find_matching_course_version(params[:course_course_name])&.id
+    first_category_key = ReferenceGuide.where(course_version_id: course_version_id, parent_reference_guide_key: nil).
+      order('position').first&.key
+    first_child_key = ReferenceGuide.where(course_version_id: course_version_id, parent_reference_guide_key: first_category_key).
+      order('position').first&.key
+    redirect_to course_reference_guide_path(params[:course_course_name], first_child_key)
+  end
+
   # PATCH /courses/:course_name/guides/:key
   def update
     @reference_guide.update!(reference_guide_params.except(:key, :course_course_name))

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -293,7 +293,7 @@ Dashboard::Application.routes.draw do
 
   get '/course/:course_name', to: redirect('/courses/%{course_name}')
   get '/courses/:course_name/vocab/edit', to: 'vocabularies#edit'
-  # this route uses course_course_name to match generated routes below that are nested within courses
+  # these routes use course_course_name to match generated routes below that are nested within courses
   get '/courses/:course_course_name/guides/edit', to: 'reference_guides#edit_all', as: :edit_all_reference_guides
 
   resources :courses, param: 'course_name' do
@@ -305,7 +305,7 @@ Dashboard::Application.routes.draw do
       get 'get_rollup_resources'
     end
 
-    resources :reference_guides, only: [:show, :update, :destroy], param: 'key', path: 'guides' do
+    resources :reference_guides, only: [:show, :update, :destroy, :index], param: 'key', path: 'guides' do
       member do
         get 'edit'
       end

--- a/dashboard/test/controllers/reference_guides_controller_test.rb
+++ b/dashboard/test/controllers/reference_guides_controller_test.rb
@@ -9,7 +9,10 @@ class ReferenceGuidesControllerTest < ActionController::TestCase
     @levelbuilder = create :levelbuilder
     @unit_group = create :unit_group, family_name: 'bogus-course', version_year: '2022', name: 'bogus-course-2022'
     CourseOffering.add_course_offering(@unit_group)
+    # category
     @reference_guide = create :reference_guide, course_version: @unit_group.course_version
+    # subcategory
+    @reference_guide_subcategory = create :reference_guide, course_version: @unit_group.course_version, parent_reference_guide_key: @reference_guide.key
 
     @in_development_unit_group = create :unit_group, published_state: SharedCourseConstants::PUBLISHED_STATE.in_development,
       family_name: 'indev-course', version_year: '2022', name: 'indev-course-2022'
@@ -50,7 +53,7 @@ class ReferenceGuidesControllerTest < ActionController::TestCase
 
     show_data = css_select('script[data-referenceguides]').first.attribute('data-referenceguides').to_s
 
-    assert_equal [@reference_guide.summarize_for_index].to_json, show_data
+    assert_equal [@reference_guide.summarize_for_index, @reference_guide_subcategory.summarize_for_index].to_json, show_data
   end
 
   test 'ref guide is updated through update route' do
@@ -86,6 +89,15 @@ class ReferenceGuidesControllerTest < ActionController::TestCase
     assert_raise ActiveRecord::RecordNotFound do
       editable_reference_guide.reload
     end
+  end
+
+  test 'index redirects to the first guide' do
+    sign_in @levelbuilder
+
+    get :index, params: {
+      course_course_name: @reference_guide.course_offering_version
+    }
+    assert_response :redirect
   end
 
   test_user_gets_response_for :show, params: -> {{course_course_name: @reference_guide.course_offering_version, key: 'unknown_ref_guide'}}, user: :student, response: :not_found

--- a/dashboard/test/controllers/reference_guides_controller_test.rb
+++ b/dashboard/test/controllers/reference_guides_controller_test.rb
@@ -98,6 +98,7 @@ class ReferenceGuidesControllerTest < ActionController::TestCase
       course_course_name: @reference_guide.course_offering_version
     }
     assert_response :redirect
+    assert_redirected_to "/courses/#{@reference_guide_subcategory.course_offering_version}/guides/#{@reference_guide_subcategory.key}"
   end
 
   test_user_gets_response_for :show, params: -> {{course_course_name: @reference_guide.course_offering_version, key: 'unknown_ref_guide'}}, user: :student, response: :not_found


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Makes the index route "/courses/:course_key/guides" redirect to the show page for the first guide within a top-level category. I.e. in the case of the current ref guides: "/courses/csp-2021/guides/drawing-shapes"

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- spec: [eng spec](https://docs.google.com/document/d/1VZGle7QA-06ZNNxy2SkvA8Msrok8pyN7fuq5hzek888/edit#)
- jira ticket: [PLAT-1703](https://codedotorg.atlassian.net/browse/PLAT-1703)

## Testing story

Added some unit tests, tested locally
