### PR TITLE
Switch to course_assignable and add summarize_course_versions

### DIFF
--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -68,6 +68,7 @@ class CourseVersion < ApplicationRecord
   delegate :has_editor_experiment?, to: :content_root, allow_nil: true
   delegate :can_be_instructor?, to: :content_root, allow_nil: true
   delegate :course_assignable?, to: :content_root, allow_nil: true
+  delegate :can_view_version?, to: :content_root, allow_nil: true
 
   # Seeding method for creating / updating / deleting the CourseVersion for the given
   # potential content root, i.e. a Script or UnitGroup.

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1675,7 +1675,9 @@ class Script < ApplicationRecord
   def summarize_course_versions(user = nil, locale_code = 'en-us')
     return {} if unit_group
 
-    course_version&.course_offering&.course_versions&.select {|cv| cv.course_assignable?(user) || (cv.launched? && cv.can_view_version?(user, locale: locale_code))}&.map {|cv| cv.summarize_for_assignment_dropdown(user, locale_code)}.to_h
+    all_course_versions = course_version&.course_offering&.course_versions
+    course_versions_for_user = all_course_versions&.select {|cv| cv.course_assignable?(user) || (cv.launched? && cv.can_view_version?(user, locale: locale_code))}
+    course_versions_for_user&.map {|cv| cv.summarize_for_assignment_dropdown(user, locale_code)}.to_h
   end
 
   # Returns an array of objects showing the name and version year for all units

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1671,7 +1671,10 @@ class Script < ApplicationRecord
   end
 
   # Returns summary object of all the course versions that an instructor can
-  # assign or all the launched versions a participant can view
+  # assign or all the launched versions a participant can view. 'course_assignable'
+  # will always return false for participants so they will fall into the second check for
+  # launched and can_view_version?. For instructors if course_assignable? is false then
+  # launched will also be false.
   def summarize_course_versions(user = nil, locale_code = 'en-us')
     return {} if unit_group
 

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -380,17 +380,6 @@ class Script < ApplicationRecord
     end
   end
 
-  # @param user [User]
-  # @returns [Boolean] Whether the user can assign this unit.
-  # Users should only be able to assign one of their valid units.
-  # This includes the units that are assignable for everyone as well
-  # as unit that might be assignable based on users permissions
-  def assignable_for_user?(user)
-    if user&.teacher?
-      Script.valid_unit_id?(user, id)
-    end
-  end
-
   # @param [User] user
   # @param script_id [String] id of the unit we're checking the validity of
   # @return [Boolean] Whether this is a valid unit ID
@@ -1515,11 +1504,12 @@ class Script < ApplicationRecord
       show_course_unit_version_warning: !unit_group&.has_dismissed_version_warning?(user) && has_older_course_progress,
       show_script_version_warning: !user_unit&.version_warning_dismissed && !has_older_course_progress && has_older_unit_progress,
       versions: summarize_versions(user, locale_code),
+      course_versions: summarize_course_versions(user, locale_code),
       supported_locales: supported_locales,
       section_hidden_unit_info: section_hidden_unit_info(user),
       pilot_experiment: get_pilot_experiment,
       editor_experiment: editor_experiment,
-      show_assign_button: assignable_for_user?(user),
+      show_assign_button: course_assignable?(user),
       project_sharing: project_sharing,
       curriculum_umbrella: curriculum_umbrella,
       family_name: family_name,
@@ -1678,6 +1668,14 @@ class Script < ApplicationRecord
     data = summarize_i18n_for_edit(include_lessons)
     data[:title] = title_for_display
     data
+  end
+
+  # Returns summary object of all the course versions that an instructor can
+  # assign or all the launched versions a participant can view
+  def summarize_course_versions(user = nil, locale_code = 'en-us')
+    return {} if unit_group
+
+    course_version&.course_offering&.course_versions&.select {|cv| cv.course_assignable?(user) || (cv.launched? && cv.can_view_version?(user, locale: locale_code))}&.map {|cv| cv.summarize_for_assignment_dropdown(user, locale_code)}.to_h
   end
 
   # Returns an array of objects showing the name and version year for all units

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -345,15 +345,6 @@ class UnitGroup < ApplicationRecord
     UnitGroup.valid_courses(user: user).any? {|unit_group| unit_group.id == course_id.to_i}
   end
 
-  # @param user [User]
-  # @returns [Boolean] Whether the user can assign this course.
-  # Users should only be able to assign one of their valid courses.
-  def assignable_for_user?(user)
-    if user&.teacher?
-      UnitGroup.valid_course_id?(id, user)
-    end
-  end
-
   # A course that the general public can assign. Has been soft or
   # hard launched.
   def launched?
@@ -388,7 +379,8 @@ class UnitGroup < ApplicationRecord
       has_verified_resources: has_verified_resources?,
       has_numbered_units: has_numbered_units?,
       versions: summarize_versions(user, locale_code),
-      show_assign_button: assignable_for_user?(user),
+      course_versions: summarize_course_versions(user, locale_code),
+      show_assign_button: course_assignable?(user),
       announcements: announcements,
       course_offering_id: course_version&.course_offering&.id,
       course_version_id: course_version&.id,
@@ -420,6 +412,14 @@ class UnitGroup < ApplicationRecord
       description: I18n.t("data.course.name.#{name}.description_short", default: ''),
       link: link,
     }
+  end
+
+  # Returns summary object of all the course versions that an instructor can
+  # assign or all the launched versions a participant can view
+  def summarize_course_versions(user = nil, locale_code = 'en-us')
+    return {} unless user
+
+    course_version&.course_offering&.course_versions&.select {|cv| cv.course_assignable?(user) || (cv.launched? && cv.can_view_version?(user))}&.map {|cv| cv.summarize_for_assignment_dropdown(user, locale_code)}.to_h
   end
 
   # Returns an array of objects showing the name and version year for all courses

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -415,7 +415,10 @@ class UnitGroup < ApplicationRecord
   end
 
   # Returns summary object of all the course versions that an instructor can
-  # assign or all the launched versions a participant can view
+  # assign or all the launched versions a participant can view. 'course_assignable'
+  # will always return false for participants so they will fall into the second check for
+  # launched and can_view_version?. For instructors if course_assignable? is false then
+  # launched will also be false.
   def summarize_course_versions(user = nil, locale_code = 'en-us')
     return {} unless user
 

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -419,7 +419,9 @@ class UnitGroup < ApplicationRecord
   def summarize_course_versions(user = nil, locale_code = 'en-us')
     return {} unless user
 
-    course_version&.course_offering&.course_versions&.select {|cv| cv.course_assignable?(user) || (cv.launched? && cv.can_view_version?(user))}&.map {|cv| cv.summarize_for_assignment_dropdown(user, locale_code)}.to_h
+    all_course_versions = course_version&.course_offering&.course_versions
+    course_versions_for_user = all_course_versions&.select {|cv| cv.course_assignable?(user) || (cv.launched? && cv.can_view_version?(user))}
+    course_versions_for_user&.map {|cv| cv.summarize_for_assignment_dropdown(user, locale_code)}.to_h
   end
 
   # Returns an array of objects showing the name and version year for all courses

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1015,7 +1015,7 @@ class ScriptTest < ActiveSupport::TestCase
     assert_equal '2018', course_versions.values[1][:version_year]
   end
 
-  test 'summarize_course_versions' do
+  test 'summarize course_versions for teacher' do
     foo16 = create(
       :script, name: 'foo-2016', family_name: 'foo', version_year: '2016', is_course: true,
       published_state: SharedCourseConstants::PUBLISHED_STATE.stable

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1008,6 +1008,66 @@ class ScriptTest < ActiveSupport::TestCase
     assert_equal '2017', versions[1][:version_title]
   end
 
+  test 'summarize_course_versions' do
+    foo16 = create(
+      :script, name: 'foo-2016', family_name: 'foo', version_year: '2016', is_course: true,
+      published_state: SharedCourseConstants::PUBLISHED_STATE.stable
+    )
+    CourseOffering.add_course_offering(foo16)
+    foo17 = create(
+      :script, name: 'foo-2017', family_name: 'foo', version_year: '2017', is_course: true,
+      published_state: SharedCourseConstants::PUBLISHED_STATE.stable
+    )
+    CourseOffering.add_course_offering(foo17)
+    foo18 = create(
+      :script, name: 'foo-2018', family_name: 'foo', version_year: '2018', is_course: true,
+      published_state: SharedCourseConstants::PUBLISHED_STATE.preview
+    )
+    CourseOffering.add_course_offering(foo18)
+    foo19 = create(
+      :script, name: 'foo-2019', family_name: 'foo', version_year: '2019', is_course: true,
+      published_state: SharedCourseConstants::PUBLISHED_STATE.beta
+    )
+    CourseOffering.add_course_offering(foo19)
+
+    [foo16, foo17, foo18, foo19].each do |s|
+      summary = s.summarize_course_versions(create(:teacher))
+      assert_equal ["foo-2016", "foo-2017", "foo-2018"], summary.values.map {|h| h[:name]}
+      assert_equal [true, true, false], summary.values.map {|h| h[:is_stable]}
+      assert_equal [false, true, false], summary.values.map {|h| h[:is_recommended]}
+    end
+  end
+
+  test 'summarize_course_versions for student' do
+    foo16 = create(
+      :script, name: 'foo-2016', family_name: 'foo', version_year: '2016', is_course: true,
+      published_state: SharedCourseConstants::PUBLISHED_STATE.stable
+    )
+    CourseOffering.add_course_offering(foo16)
+    foo17 = create(
+      :script, name: 'foo-2017', family_name: 'foo', version_year: '2017', is_course: true,
+      published_state: SharedCourseConstants::PUBLISHED_STATE.stable
+    )
+    CourseOffering.add_course_offering(foo17)
+    foo18 = create(
+      :script, name: 'foo-2018', family_name: 'foo', version_year: '2018', is_course: true,
+      published_state: SharedCourseConstants::PUBLISHED_STATE.preview
+    )
+    CourseOffering.add_course_offering(foo18)
+    foo19 = create(
+      :script, name: 'foo-2019', family_name: 'foo', version_year: '2019', is_course: true,
+      published_state: SharedCourseConstants::PUBLISHED_STATE.beta
+    )
+    CourseOffering.add_course_offering(foo19)
+
+    [foo17, foo18, foo19].each do |s|
+      summary = s.summarize_course_versions(create(:student))
+      assert_equal ["foo-2017"], summary.values.map {|h| h[:name]}
+      assert_equal [true], summary.values.map {|h| h[:is_stable]}
+      assert_equal [true], summary.values.map {|h| h[:is_recommended]}
+    end
+  end
+
   test 'summarize excludes unlaunched versions' do
     foo17 = create(
       :script, name: 'foo-2017', family_name: 'foo', version_year: '2017', is_course: true,
@@ -1038,23 +1098,24 @@ class ScriptTest < ActiveSupport::TestCase
 
   test 'summarize includes show assign button' do
     unit = create(:script, name: 'script', published_state: SharedCourseConstants::PUBLISHED_STATE.preview)
+    teacher = create(:teacher)
 
-    # No user, show_assign_button set to nil
-    assert_nil unit.summarize[:show_assign_button]
+    # No user, show_assign_button set to false
+    refute unit.summarize[:show_assign_button]
 
     # Teacher should be able to assign a launched unit.
     assert_equal SharedCourseConstants::PUBLISHED_STATE.preview, unit.summarize[:publishedState]
-    assert_equal true, unit.summarize(true, create(:teacher))[:show_assign_button]
+    assert unit.summarize(true, teacher)[:show_assign_button]
 
     # Teacher should not be able to assign a unlaunched script.
     hidden_unit = create(:script, name: 'unassignable-hidden', published_state: SharedCourseConstants::PUBLISHED_STATE.beta)
     assert_equal SharedCourseConstants::PUBLISHED_STATE.beta, hidden_unit.summarize[:publishedState]
-    assert_equal false, hidden_unit.summarize(true, create(:teacher))[:show_assign_button]
+    refute hidden_unit.summarize(true, teacher)[:show_assign_button]
 
     # Student should not be able to assign a unit,
     # regardless of visibility.
     assert_equal SharedCourseConstants::PUBLISHED_STATE.preview, unit.summarize[:publishedState]
-    assert_nil unit.summarize(true, create(:student))[:show_assign_button]
+    refute unit.summarize(true, create(:student))[:show_assign_button]
   end
 
   test 'summarize includes bonus levels for lessons if include_bonus_levels and include_lessons are true' do

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1006,6 +1006,13 @@ class ScriptTest < ActiveSupport::TestCase
     assert_equal 'foo-2017', versions[1][:name]
     assert_equal '2017', versions[1][:version_year]
     assert_equal '2017', versions[1][:version_title]
+
+    course_versions = foo17.summarize(false, create(:teacher))[:course_versions]
+    assert_equal 2, course_versions.keys.length
+    assert_equal 'foo-2017', course_versions.values[0][:name]
+    assert_equal '2017', course_versions.values[0][:version_year]
+    assert_equal 'foo-2018', course_versions.values[1][:name]
+    assert_equal '2018', course_versions.values[1][:version_year]
   end
 
   test 'summarize_course_versions' do
@@ -1069,6 +1076,7 @@ class ScriptTest < ActiveSupport::TestCase
   end
 
   test 'summarize excludes unlaunched versions' do
+    teacher = create(:teacher)
     foo17 = create(
       :script, name: 'foo-2017', family_name: 'foo', version_year: '2017', is_course: true,
       published_state: SharedCourseConstants::PUBLISHED_STATE.preview
@@ -1090,10 +1098,18 @@ class ScriptTest < ActiveSupport::TestCase
     assert_equal 'foo-2018', versions[0][:name]
     assert_equal 'foo-2017', versions[1][:name]
 
-    versions = foo17.summarize(true, create(:teacher))[:versions]
+    versions = foo17.summarize(true, teacher)[:versions]
     assert_equal 2, versions.length
     assert_equal 'foo-2018', versions[0][:name]
     assert_equal 'foo-2017', versions[1][:name]
+
+    course_versions = foo17.summarize[:course_versions]
+    assert_equal 0, course_versions.keys.length
+
+    course_versions = foo17.summarize(true, teacher)[:course_versions]
+    assert_equal 2, course_versions.keys.length
+    assert_equal 'foo-2017', course_versions.values[0][:name]
+    assert_equal 'foo-2018', course_versions.values[1][:name]
   end
 
   test 'summarize includes show assign button' do

--- a/dashboard/test/models/unit_group_test.rb
+++ b/dashboard/test/models/unit_group_test.rb
@@ -610,6 +610,8 @@ class UnitGroupTest < ActiveSupport::TestCase
     assert_equal 'my-unit-group', summary[:versions].first[:name]
     assert_equal '1999', summary[:versions].first[:version_year]
 
+    assert_equal 1, summary[:course_versions].keys.length
+
     # make sure we dont have lesson info
     assert_nil summary[:scripts][0][:lessons]
     assert_nil summary[:scripts][0][:lessonDescriptions]

--- a/dashboard/test/models/unit_group_test.rb
+++ b/dashboard/test/models/unit_group_test.rb
@@ -584,13 +584,13 @@ class UnitGroupTest < ActiveSupport::TestCase
 
     unit_group.teacher_resources = [['curriculum', '/link/to/curriculum']]
 
-    summary = unit_group.summarize
+    summary = unit_group.summarize(create(:teacher))
 
     assert_equal [:name, :id, :title, :assignment_family_title,
                   :family_name, :version_year, :published_state, :instruction_type, :instructor_audience, :participant_audience,
                   :pilot_experiment, :description_short, :description_student,
                   :description_teacher, :version_title, :scripts, :teacher_resources, :migrated_teacher_resources,
-                  :student_resources, :is_migrated, :has_verified_resources, :has_numbered_units, :versions, :show_assign_button,
+                  :student_resources, :is_migrated, :has_verified_resources, :has_numbered_units, :versions, :course_versions, :show_assign_button,
                   :announcements, :course_offering_id, :course_version_id, :course_path, :course_offering_edit_path], summary.keys
     assert_equal 'my-unit-group', summary[:name]
     assert_equal 'my-unit-group-title', summary[:title]
@@ -695,7 +695,7 @@ class UnitGroupTest < ActiveSupport::TestCase
     CourseOffering.add_course_offering(csp_2020)
 
     [csp_2017, csp_2018, csp_2019].each do |c|
-      summary = c.summarize_versions
+      summary = c.summarize_versions(create(:teacher))
       assert_equal ['csp-2019', 'csp-2018', 'csp-2017'], summary.map {|h| h[:name]}
       assert_equal [false, true, true], summary.map {|h| h[:is_stable]}
     end
@@ -703,6 +703,42 @@ class UnitGroupTest < ActiveSupport::TestCase
     # Result should include self, even if it's not launched
     summary = csp_2020.summarize_versions
     assert_equal ['csp-2020', 'csp-2019', 'csp-2018', 'csp-2017'], summary.map {|h| h[:name]}
+  end
+
+  test 'summarize_course_versions' do
+    csp_2017 = create(:unit_group, name: 'csp-2017', family_name: 'csp', version_year: '2017', published_state: SharedCourseConstants::PUBLISHED_STATE.stable)
+    CourseOffering.add_course_offering(csp_2017)
+    csp_2018 = create(:unit_group, name: 'csp-2018', family_name: 'csp', version_year: '2018', published_state: SharedCourseConstants::PUBLISHED_STATE.stable)
+    CourseOffering.add_course_offering(csp_2018)
+    csp_2019 = create(:unit_group, name: 'csp-2019', family_name: 'csp', version_year: '2019', published_state: SharedCourseConstants::PUBLISHED_STATE.preview)
+    CourseOffering.add_course_offering(csp_2019)
+    csp_2020 = create(:unit_group, name: 'csp-2020', family_name: 'csp', version_year: '2020', published_state: SharedCourseConstants::PUBLISHED_STATE.beta)
+    CourseOffering.add_course_offering(csp_2020)
+
+    [csp_2017, csp_2018, csp_2019, csp_2020].each do |c|
+      summary = c.summarize_course_versions(create(:teacher))
+      assert_equal ["Computer Science Principles ('17-'18)", "Computer Science Principles ('18-'19)", "Computer Science Principles ('19-'20)"], summary.values.map {|h| h[:name]}
+      assert_equal [true, true, false], summary.values.map {|h| h[:is_stable]}
+      assert_equal [false, true, false], summary.values.map {|h| h[:is_recommended]}
+    end
+  end
+
+  test 'summarize_course_versions for student' do
+    csp_2017 = create(:unit_group, name: 'csp-2017', family_name: 'csp', version_year: '2017', published_state: SharedCourseConstants::PUBLISHED_STATE.stable)
+    CourseOffering.add_course_offering(csp_2017)
+    csp_2018 = create(:unit_group, name: 'csp-2018', family_name: 'csp', version_year: '2018', published_state: SharedCourseConstants::PUBLISHED_STATE.stable)
+    CourseOffering.add_course_offering(csp_2018)
+    csp_2019 = create(:unit_group, name: 'csp-2019', family_name: 'csp', version_year: '2019', published_state: SharedCourseConstants::PUBLISHED_STATE.preview)
+    CourseOffering.add_course_offering(csp_2019)
+    csp_2020 = create(:unit_group, name: 'csp-2020', family_name: 'csp', version_year: '2020', published_state: SharedCourseConstants::PUBLISHED_STATE.beta)
+    CourseOffering.add_course_offering(csp_2020)
+
+    [csp_2017, csp_2018, csp_2019, csp_2020].each do |c|
+      summary = c.summarize_course_versions(create(:student))
+      assert_equal ["Computer Science Principles ('18-'19)"], summary.values.map {|h| h[:name]}
+      assert_equal [true], summary.values.map {|h| h[:is_stable]}
+      assert_equal [true], summary.values.map {|h| h[:is_recommended]}
+    end
   end
 
   class SelectCourseScriptTests < ActiveSupport::TestCase
@@ -1107,31 +1143,6 @@ class UnitGroupTest < ActiveSupport::TestCase
     assert_equal UnitGroup.valid_courses(user: pilot_teacher), [csp_2019, csp_2020]
     assert_equal UnitGroup.valid_courses, [csp_2019]
     assert_equal UnitGroup.valid_courses(user: teacher), [csp_2019]
-  end
-
-  test "assignable_for_user?: normal courses" do
-    student = create :student
-    teacher = create :teacher
-    levelbuilder = create :levelbuilder
-    course = create :unit_group, published_state: SharedCourseConstants::PUBLISHED_STATE.stable
-
-    refute course.assignable_for_user?(student)
-    assert course.assignable_for_user?(teacher)
-    assert course.assignable_for_user?(levelbuilder)
-  end
-
-  test "assignable_for_user?: works for pilot courses" do
-    student = create :student
-    teacher = create :teacher
-    levelbuilder = create :levelbuilder
-    pilot_teacher = create :teacher, pilot_experiment: 'my-experiment'
-    pilot_course = create :unit_group, pilot_experiment: 'my-experiment'
-    assert UnitGroup.any?(&:pilot?)
-
-    refute pilot_course.assignable_for_user?(student)
-    refute pilot_course.assignable_for_user?(teacher)
-    assert pilot_course.assignable_for_user?(pilot_teacher)
-    assert pilot_course.assignable_for_user?(levelbuilder)
   end
 
   test "update_teacher_resources" do


### PR DESCRIPTION
Breaking apart https://github.com/code-dot-org/code-dot-org/pull/45042/

- Use course_assignable? to determine if we should show the assign button on the Course and Unit Overview pages
- Summarize the course versions and pass them to the Course and Unit Overview pages for future use in the AssignmentVersionSelector on those pages.

## Links

[Jira](https://codedotorg.atlassian.net/browse/PLAT-1584)
[Eng Plan - Self Paced Pl](https://docs.google.com/document/d/1V61xONU0-mleMEEdHWNxhvZtYIPRCB31mT_hbUXusCQ/edit#heading=h.d0b9vmlcrsox)
[Mini Spec - Course Assignment Dropdown Updates](https://docs.google.com/document/d/11-dtCFuSmST_vP2MdkH0H0lb2e5AGFu1MxiWSRsnkns/edit#)

## Testing story

- Add/updated unit tests
