### PR TITLE
Only allow backpack functionality within CSA course levels

### DIFF
--- a/apps/src/javalab/Backpack.jsx
+++ b/apps/src/javalab/Backpack.jsx
@@ -21,11 +21,12 @@ const Dialog = makeEnum('IMPORT_WARNING', 'IMPORT_ERROR');
 class Backpack extends Component {
   static propTypes = {
     displayTheme: PropTypes.oneOf(Object.values(DisplayTheme)).isRequired,
-    isDisabled: PropTypes.bool.isRequired,
+    isButtonDisabled: PropTypes.bool.isRequired,
     onImport: PropTypes.func.isRequired,
     // populated by redux
     backpackApi: PropTypes.object,
-    sources: PropTypes.object
+    sources: PropTypes.object,
+    backpackEnabled: PropTypes.bool
   };
 
   state = {
@@ -193,7 +194,11 @@ class Backpack extends Component {
   };
 
   render() {
-    const {displayTheme, isDisabled} = this.props;
+    // Display nothing if the backpack feature is disabled
+    if (!this.props.backpackEnabled) {
+      return null;
+    }
+    const {displayTheme, isButtonDisabled} = this.props;
     const {
       dropdownOpen,
       backpackFilenames,
@@ -236,7 +241,7 @@ class Backpack extends Component {
           isRtl={false}
           label={javalabMsg.backpackLabel()}
           leftJustified
-          isDisabled={isDisabled}
+          isDisabled={isButtonDisabled}
           style={{
             ...(dropdownOpen && styles.dropdownOpenButton)
           }}
@@ -426,5 +431,6 @@ const styles = {
 export const UnconnectedBackpack = Backpack;
 export default connect(state => ({
   backpackApi: state.javalab.backpackApi,
-  sources: state.javalab.sources
+  sources: state.javalab.sources,
+  backpackEnabled: state.javalab.backpackEnabled
 }))(onClickOutside(Radium(UnconnectedBackpack)));

--- a/apps/src/javalab/CommitDialog.jsx
+++ b/apps/src/javalab/CommitDialog.jsx
@@ -24,18 +24,20 @@ export class UnconnectedCommitDialog extends React.Component {
   };
 
   componentDidMount() {
-    this.updateBackpackFileList();
+    if (this.props.backpackEnabled) {
+      this.updateBackpackFileList();
+    }
   }
 
   // Get updated backpack file list every time we open the modal
   componentDidUpdate(prevProps) {
-    if (this.props.isOpen && !prevProps.isOpen) {
+    if (this.props.backpackEnabled && this.props.isOpen && !prevProps.isOpen) {
       this.updateBackpackFileList();
     }
   }
 
   updateBackpackFileList() {
-    if (this.props.backpackApi.hasBackpack()) {
+    if (this.props.backpackEnabled && this.props.backpackApi.hasBackpack()) {
       this.props.backpackApi.getFileList(
         () => this.setState({hasBackpackLoadError: true}),
         filenames => this.setState({existingBackpackFiles: filenames})
@@ -112,7 +114,9 @@ export class UnconnectedCommitDialog extends React.Component {
 
   commitAndSaveToBackpack = () => {
     this.saveCommit();
-    this.saveToBackpack();
+    if (this.props.backpackEnabled) {
+      this.saveToBackpack();
+    }
   };
 
   getConflictingBackpackFiles = () => {
@@ -241,6 +245,7 @@ export class UnconnectedCommitDialog extends React.Component {
             notes={commitNotes}
             onToggleFile={this.toggleFileToBackpack}
             onChangeNotes={this.updateNotes}
+            showSaveToBackpackSection={this.props.backpackEnabled}
           />
         }
         renderFooter={this.renderFooter}
@@ -258,7 +263,8 @@ UnconnectedCommitDialog.propTypes = {
   handleCommit: PropTypes.func.isRequired,
   // populated by redux
   sources: PropTypes.object,
-  backpackApi: PropTypes.object
+  backpackApi: PropTypes.object,
+  backpackEnabled: PropTypes.bool
 };
 
 const styles = {
@@ -296,5 +302,6 @@ const styles = {
 
 export default connect(state => ({
   sources: state.javalab.sources,
-  backpackApi: state.javalab.backpackApi
+  backpackApi: state.javalab.backpackApi,
+  backpackEnabled: state.javalab.backpackEnabled
 }))(UnconnectedCommitDialog);

--- a/apps/src/javalab/CommitDialogBody.jsx
+++ b/apps/src/javalab/CommitDialogBody.jsx
@@ -16,20 +16,11 @@ export default function CommitDialogBody({
   files,
   notes,
   onToggleFile,
-  onChangeNotes
+  onChangeNotes,
+  showSaveToBackpackSection
 }) {
-  return (
-    <div>
-      <label htmlFor="commit-notes" style={{...styles.bold, ...styles.notes}}>
-        {i18n.commitNotes()}
-      </label>
-      <textarea
-        id="commit-notes"
-        placeholder={i18n.commitNotesPlaceholder()}
-        onChange={e => onChangeNotes(e.target.value)}
-        style={styles.textarea}
-        value={notes}
-      />
+  const renderSaveToBackpackSection = () => (
+    <>
       <div style={{...styles.bold, ...styles.filesHeader}}>
         {i18n.saveToBackpack()}
       </div>
@@ -42,6 +33,22 @@ export default function CommitDialogBody({
           />
         );
       })}
+    </>
+  );
+
+  return (
+    <div>
+      <label htmlFor="commit-notes" style={{...styles.bold, ...styles.notes}}>
+        {i18n.commitNotes()}
+      </label>
+      <textarea
+        id="commit-notes"
+        placeholder={i18n.commitNotesPlaceholder()}
+        onChange={e => onChangeNotes(e.target.value)}
+        style={styles.textarea}
+        value={notes}
+      />
+      {showSaveToBackpackSection && renderSaveToBackpackSection()}
     </div>
   );
 }
@@ -50,7 +57,8 @@ CommitDialogBody.propTypes = {
   files: PropTypes.arrayOf(PropTypes.shape(fileShape)).isRequired,
   notes: PropTypes.string,
   onToggleFile: PropTypes.func.isRequired,
-  onChangeNotes: PropTypes.func.isRequired
+  onChangeNotes: PropTypes.func.isRequired,
+  showSaveToBackpackSection: PropTypes.bool
 };
 
 const styles = {

--- a/apps/src/javalab/Javalab.js
+++ b/apps/src/javalab/Javalab.js
@@ -18,7 +18,8 @@ import javalab, {
   setDisableFinishButton,
   setIsTesting,
   openPhotoPrompter,
-  closePhotoPrompter
+  closePhotoPrompter,
+  setBackpackEnabled
 } from './javalabRedux';
 import playground from './playground/playgroundRedux';
 import {TestResults} from '@cdo/apps/constants';
@@ -270,9 +271,14 @@ Javalab.prototype.init = function(config) {
   // Dispatches a redux update of display theme
   getStore().dispatch(setDisplayTheme(this.displayTheme));
 
-  getStore().dispatch(
-    setBackpackApi(new BackpackClientApi(config.backpackChannel))
-  );
+  const backpackEnabled = !!config.backpackEnabled;
+  getStore().dispatch(setBackpackEnabled(backpackEnabled));
+
+  if (backpackEnabled) {
+    getStore().dispatch(
+      setBackpackApi(new BackpackClientApi(config.backpackChannel))
+    );
+  }
 
   getStore().dispatch(
     setDisableFinishButton(

--- a/apps/src/javalab/JavalabEditor.jsx
+++ b/apps/src/javalab/JavalabEditor.jsx
@@ -104,7 +104,8 @@ class JavalabEditor extends React.Component {
     displayTheme: PropTypes.oneOf(Object.values(DisplayTheme)),
     height: PropTypes.number,
     isEditingStartSources: PropTypes.bool,
-    isReadOnlyWorkspace: PropTypes.bool.isRequired
+    isReadOnlyWorkspace: PropTypes.bool.isRequired,
+    backpackEnabled: PropTypes.bool
   };
 
   constructor(props) {
@@ -601,7 +602,8 @@ class JavalabEditor extends React.Component {
       showProjectTemplateWorkspaceIcon,
       height,
       isProjectTemplateLevel,
-      handleClearPuzzle
+      handleClearPuzzle,
+      backpackEnabled
     } = this.props;
 
     let menuStyle = {
@@ -632,14 +634,16 @@ class JavalabEditor extends React.Component {
             leftJustified
             isDisabled={isReadOnlyWorkspace}
           />
-          <PaneSection style={styles.backpackSection}>
-            <Backpack
-              id={'javalab-editor-backpack'}
-              displayTheme={displayTheme}
-              isDisabled={isReadOnlyWorkspace}
-              onImport={this.onImportFile}
-            />
-          </PaneSection>
+          {backpackEnabled && (
+            <PaneSection style={styles.backpackSection}>
+              <Backpack
+                id={'javalab-editor-backpack'}
+                displayTheme={displayTheme}
+                isButtonDisabled={isReadOnlyWorkspace}
+                onImport={this.onImportFile}
+              />
+            </PaneSection>
+          )}
           <PaneButton
             id="data-mode-versions-header"
             iconClass="fa fa-clock-o"
@@ -858,7 +862,8 @@ export default connect(
     validation: state.javalab.validation,
     displayTheme: state.javalab.displayTheme,
     isEditingStartSources: state.pageConstants.isEditingStartSources,
-    isReadOnlyWorkspace: state.pageConstants.isReadOnlyWorkspace
+    isReadOnlyWorkspace: state.pageConstants.isReadOnlyWorkspace,
+    backpackEnabled: state.javalab.backpackEnabled
   }),
   dispatch => ({
     setSource: (filename, source) => dispatch(setSource(filename, source)),

--- a/apps/src/javalab/javalabRedux.js
+++ b/apps/src/javalab/javalabRedux.js
@@ -22,6 +22,7 @@ const SET_IS_TESTING = 'javalab/SET_IS_TESTING';
 const SET_CONSOLE_HEIGHT = 'javalab/SET_CONSOLE_HEIGHT';
 const EDITOR_COLUMN_HEIGHT = 'javalab/EDITOR_COLUMN_HEIGHT';
 const SET_BACKPACK_API = 'javalab/SET_BACKPACK_API';
+const SET_BACKPACK_ENABLED = 'javalab/SET_BACKPACK_ENABLED';
 const SET_IS_START_MODE = 'javalab/SET_IS_START_MODE';
 const SET_LEVEL_NAME = 'javalab/SET_LEVEL_NAME';
 const SET_DISABLE_FINISH_BUTTON = 'javalab/SET_DISABLE_FINISH_BUTTON';
@@ -45,6 +46,7 @@ export const initialState = {
   consoleHeight: 200,
   editorColumnHeight: 600,
   backpackApi: null,
+  backpackEnabled: false,
   isStartMode: false,
   levelName: undefined,
   disableFinishButton: false,
@@ -148,6 +150,11 @@ export const setIsTesting = isTesting => ({
 export const setBackpackApi = backpackApi => ({
   type: SET_BACKPACK_API,
   backpackApi
+});
+
+export const setBackpackEnabled = backpackEnabled => ({
+  type: SET_BACKPACK_ENABLED,
+  backpackEnabled
 });
 
 export const toggleVisualizationCollapsed = () => ({
@@ -394,6 +401,12 @@ export default function reducer(state = initialState, action) {
     return {
       ...state,
       backpackApi: action.backpackApi
+    };
+  }
+  if (action.type === SET_BACKPACK_ENABLED) {
+    return {
+      ...state,
+      backpackEnabled: action.backpackEnabled
     };
   }
   if (action.type === SET_IS_START_MODE) {

--- a/apps/test/unit/javalab/BackpackTest.js
+++ b/apps/test/unit/javalab/BackpackTest.js
@@ -18,9 +18,10 @@ describe('Java Lab Backpack Test', () => {
     backpackApiStub.hasBackpack.returns(true);
     defaultProps = {
       displayTheme: DisplayTheme.DARK,
-      isDisabled: false,
+      isButtonDisabled: false,
       onImport: () => {},
-      backpackApi: backpackApiStub
+      backpackApi: backpackApiStub,
+      backpackEnabled: true
     };
   });
 
@@ -124,5 +125,12 @@ describe('Java Lab Backpack Test', () => {
 
     const state = wrapper.instance().state;
     expect(state.openDialog).to.equal(null);
+  });
+
+  it('renders nothing if backpack is disabled', () => {
+    const wrapper = shallow(
+      <Backpack {...defaultProps} backpackEnabled={false} />
+    );
+    expect(wrapper.isEmptyRender()).to.be.true;
   });
 });

--- a/apps/test/unit/javalab/CommitDialogTest.js
+++ b/apps/test/unit/javalab/CommitDialogTest.js
@@ -5,6 +5,7 @@ import sinon from 'sinon';
 import i18n from '@cdo/javalab/locale';
 import BackpackClientApi from '@cdo/apps/code-studio/components/backpack/BackpackClientApi';
 import {UnconnectedCommitDialog as CommitDialog} from '@cdo/apps/javalab/CommitDialog';
+import CommitDialogBody from '@cdo/apps/javalab/CommitDialogBody';
 import CommitDialogFileRow from '@cdo/apps/javalab/CommitDialogFileRow';
 
 describe('CommitDialog test', () => {
@@ -32,7 +33,8 @@ describe('CommitDialog test', () => {
         saveFiles: backpackSaveFilesSpy,
         getFileList: backpackGetFileListStub,
         hasBackpack: hasBackpackStub
-      }
+      },
+      backpackEnabled: true
     };
   });
 
@@ -139,5 +141,17 @@ describe('CommitDialog test', () => {
 
     wrapper.instance().handleBackpackSaveSuccess();
     expect(handleCloseSpy.callCount).to.equal(1);
+  });
+
+  it('hides the backpack sesion in the dialog body if backpack disabled', () => {
+    const wrapper = mount(
+      <CommitDialog {...defaultProps} backpackEnabled={false} />
+    );
+    expect(
+      wrapper
+        .find(CommitDialogBody)
+        .first()
+        .props().showSaveToBackpackSection
+    ).to.be.false;
   });
 });

--- a/apps/test/unit/javalab/JavalabEditorTest.js
+++ b/apps/test/unit/javalab/JavalabEditorTest.js
@@ -26,7 +26,8 @@ import javalab, {
 import {DisplayTheme} from '@cdo/apps/javalab/DisplayTheme';
 import {
   setAllSources,
-  setAllValidation
+  setAllValidation,
+  setBackpackEnabled
 } from '../../../src/javalab/javalabRedux';
 import commonReducers from '@cdo/apps/redux/commonReducers';
 import {setPageConstants} from '@cdo/apps/redux/pageConstants';
@@ -71,6 +72,7 @@ describe('Java Lab Editor Test', () => {
         getFileList: backpackGetFileListStub
       })
     );
+    store.dispatch(setBackpackEnabled(true));
   });
 
   afterEach(() => {
@@ -88,11 +90,12 @@ describe('Java Lab Editor Test', () => {
     );
   };
 
+  const backpackHeaderButtonId = '#javalab-editor-backpack';
   const editorHeaderButtonIdentifiers = [
     '#javalab-editor-create-file',
     '#data-mode-versions-header',
     '#javalab-editor-save',
-    '#javalab-editor-backpack'
+    backpackHeaderButtonId
   ];
 
   describe('Editing Mode', () => {
@@ -743,13 +746,23 @@ describe('Java Lab Editor Test', () => {
     it('header buttons are enabled', () => {
       const editor = createWrapper();
       editorHeaderButtonIdentifiers.forEach(headerButtonId => {
+        const propName =
+          headerButtonId === backpackHeaderButtonId
+            ? 'isButtonDisabled'
+            : 'isDisabled';
         const isButtonDisabled = editor
           .find(headerButtonId)
           .first()
-          .props().isDisabled;
+          .props()[propName];
 
         expect(isButtonDisabled).to.be.false;
       });
+    });
+
+    it('hides backpack button if disabled', () => {
+      store.dispatch(setBackpackEnabled(false));
+      const editor = createWrapper();
+      expect(editor.find(backpackHeaderButtonId)).to.have.lengthOf(0);
     });
   });
 
@@ -775,10 +788,14 @@ describe('Java Lab Editor Test', () => {
     it('header buttons are disabled', () => {
       const editor = createWrapper();
       editorHeaderButtonIdentifiers.forEach(headerButtonId => {
+        const propName =
+          headerButtonId === backpackHeaderButtonId
+            ? 'isButtonDisabled'
+            : 'isDisabled';
         const isButtonDisabled = editor
           .find(headerButtonId)
           .first()
-          .props().isDisabled;
+          .props()[propName];
 
         expect(isButtonDisabled).to.be.true;
       });

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -216,8 +216,15 @@ module LevelsHelper
       server_project_level_id: @level.project_template_level.try(:id)
     )
 
-    # For levels with a backpack option (currently all Javalab), get the backpack channel token if it exists
-    if @level.is_a?(Javalab) && (@user || current_user)
+    # Enable backpack for levels with a backpack option (currently all non-standalone Javalab),
+    # and get the backpack channel token if it exists
+    backpack_enabled = !!(@level.is_a?(Javalab) &&
+      (ProjectsController::STANDALONE_PROJECTS["javalab"]["name"] != @level.name) &&
+      (@user || current_user))
+
+    view_options(backpack_enabled: backpack_enabled)
+
+    if backpack_enabled
       user_id = @user&.id || current_user&.id
       backpack = Backpack.find_by_user_id(user_id)
       view_options(backpack_channel: backpack&.channel)

--- a/dashboard/app/helpers/view_options_helper.rb
+++ b/dashboard/app/helpers/view_options_helper.rb
@@ -42,6 +42,7 @@ module ViewOptionsHelper
     :blocklyVersion,
     :disallowed_html_tags,
     :backpack_channel,
+    :backpack_enabled,
     :level_requires_channel,
     :reduce_channel_updates,
   )


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

Change to enable backpack only on CSA course levels, i.e. disable Backpack on Javalab standalone levels. This adds a new view option and disables the Backpack button as well as the Save to Backpack section in the commit dialog if needed.

## Links

JIRA: https://codedotorg.atlassian.net/browse/JAVA-340

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

Tested locally on various CSA levels and standalone Javalab.

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
