### PR TITLE
The Bad Guys: new featured_tutorial partial for landing page

### DIFF
--- a/pegasus/sites.v3/code.org/public/thebadguys.md.partial
+++ b/pegasus/sites.v3/code.org/public/thebadguys.md.partial
@@ -8,7 +8,6 @@ theme: responsive
 {{ tutorial_promo2, heading: "", background_image: "/images/marketing/landingpage-thebadguys-banner.png", text_color: "white", box_background_color: "rgb(0,0,0,0.4)", left_heading: "Code with The Bad Guys", left_description: "Make a story or animation starring Ms. Tarantula, Mr. Wolf, and more!", left_specs: "", left_button_url: "https://studio.code.org/projects/thebadguys/new", left_button_text: "Start Now", right_heading: "New to coding?", right_description: "Try a tutorial, then come back to make a project with The Bad Guys.", right_specs: "", right_button_url: "https://code.org/helloworld", right_button_text: "Learn First" }}
 
 
-
 ## Sample Creations
 
 {{ featured_project, title: "Food", author: "M", age: "13+", image: "images/csc/helloworld/cschelloworld_happyfood2.gif", url: "https://studio.code.org/projects/spritelab/sC_ZiNi_x5GUqsWHE2M4CrcbjU8XvtD3VNT7TM0Y0N8" }}
@@ -18,12 +17,15 @@ theme: responsive
 {{ clearfix }}
 
 
-
 ## Keep Learning
 
 Enjoyed creating adventures with the Bad Guys? Keep the creativity going with other engaging activities: Use code to choreograph a dance to today's top hits, add moody visuals to a poem, or even clean up the ocean!
 
-
+{{ featured_tutorial, title: "Food", body: "Use your creativity and problem solving skills to explore and build underwater worlds with code!", image: "images/csc/helloworld/cschelloworld_happyfood2.gif", url: "https://studio.code.org/projects/spritelab/sC_ZiNi_x5GUqsWHE2M4CrcbjU8XvtD3VNT7TM0Y0N8" }}
+{{ featured_tutorial, title: "Emoji", body: "Featuring Katy Perry, Shawn Mendes, Panic! At The Disco, Lil Nas X, Jonas Brothers, Nicki Minaj, and 34 more!", image: "images/csc/helloworld/cschelloworld_emoji.gif", url: "https://studio.code.org/projects/spritelab/9HGWXijqhLzaIIUQbPXlNmWgMO1SXzf3TvMHNtbOXmc" }}
+{{ featured_tutorial, title: "Animals", body: "Body text goes here.", image: "images/csc/helloworld/cschelloworld_animals.gif", url: "https://studio.code.org/projects/spritelab/rYH8D8eAvWOjuiOpWbHzN4HAtis4ykKTIjGcNPP9zD4" }}
+{{ featured_tutorial, title: "Retro", body: "Body text goes here.", image: "images/csc/helloworld/cschelloworld_retro.gif", url: "https://studio.code.org/projects/spritelab/rYH8D8eAvWOjuiOpWbHzN7yo2E1S0q87VqlzaBz7oqo" }}
+{{ clearfix }}
 
 
 Want more? Browse all of our [learning resources](https://studio.code.org/courses) and collection of over 500 fun [Hour of Code activities](https://code.org/learn).

--- a/pegasus/sites.v3/code.org/views/featured_tutorial.html
+++ b/pegasus/sites.v3/code.org/views/featured_tutorial.html
@@ -1,0 +1,15 @@
+<div class="col-25 col-rtl-right" style="padding: 10px">
+  <a href="%url%" style="font-family: 'Gotham 4r', sans-serif; color: black; text-decoration: none">
+    <div style="border: 2px solid rgb(187, 187, 187); border-radius: 10px; height: 270px; overflow: hidden; text-align: center">
+      <div style="width: 100%; height: 120px; overflow: hidden">
+        <img src="%image%" style="width: 100%"/>
+      </div>
+      <div style="font-family: 'Gotham 5r', sans-serif; color: #5b6770; font-size: 24px; line-height: 1.5; padding: 5px 5px 0px 5px">
+        %title%
+      </div>
+      <div style="font-size: 13px; line-height: 1.5; color: #5b6770; padding: 5px 5px 0px 5px">
+        %body%
+      </div>
+    </div>
+  </a>
+</div>


### PR DESCRIPTION
This adds a new `featured_tutorial` partial that will be used by https://code.org/thebadguys, with placeholder content to show that longer text fits alright:

<img width="979" alt="Screen Shot 2022-04-06 at 11 26 30 AM" src="https://user-images.githubusercontent.com/2205926/161877496-f326cdd3-2df0-4ebf-b757-c5555a57efdc.png">
