### PR TITLE
Fix everyInterval block

### DIFF
--- a/apps/src/p5lab/spritelab/CoreLibrary.js
+++ b/apps/src/p5lab/spritelab/CoreLibrary.js
@@ -535,13 +535,24 @@ export default class CoreLibrary {
   everyIntervalEvent(inputEvent) {
     if (inputEvent.args.unit === 'seconds') {
       const previousTime = inputEvent.previousTime || 0;
+      const previousModdedTime = inputEvent.previousModdedTime || 0;
       const worldTime = this.getSecondsSinceReset();
       // Repeat every n seconds
       const moddedWorldTime = worldTime % inputEvent.args.n;
-      inputEvent.previousTime = moddedWorldTime;
+      inputEvent.previousTime = worldTime;
+      inputEvent.previousModdedTime = moddedWorldTime;
+
+      // Case where n is 1, so we want to repeat every second, but only the first tick in each second.
+      const singleSecondInterval =
+        inputEvent.args.n === 1 && previousTime !== worldTime;
+
       // There are many ticks per second, but we only want to fire the event once (on the first tick where
       // the time matches the event argument)
-      if (moddedWorldTime === 0 && previousTime !== 0) {
+      // Determine if the current time is on the interval
+      if (
+        (moddedWorldTime === 0 && previousModdedTime !== 0) ||
+        singleSecondInterval
+      ) {
         // Call callback with no extra args
         this.eventLog.push(`everyInterval: ${inputEvent.args.n}`);
         return [{}];

--- a/apps/src/p5lab/spritelab/commands/eventCommands.js
+++ b/apps/src/p5lab/spritelab/commands/eventCommands.js
@@ -18,7 +18,8 @@ export const commands = {
   },
 
   everyInterval(n, unit, callback) {
-    this.addEvent('everyInterval', {n, unit}, callback);
+    let roundedValue = Math.round(n);
+    this.addEvent('everyInterval', {n: roundedValue, unit}, callback);
   },
 
   keyPressed(condition, key, callback) {

--- a/dashboard/config/blocks/GamelabJr/gamelab_everyInterval.json
+++ b/dashboard/config/blocks/GamelabJr/gamelab_everyInterval.json
@@ -6,7 +6,7 @@
     "args": [
       {
         "name": "N",
-        "type": "ClampedNumber(0.1,)"
+        "type": "Number"
       },
       {
         "name": "UNIT",


### PR DESCRIPTION
@mikeharv identified three issues with the everyInterval block:
[] Decimal values were behaving funky.
[] Single seconds weren't triggering the events
[] And the interval number should be "Number"

Mike started this off by fixing the type to be Number. I added a special case that handles triggering the event every 1 second when necessary (a special case in the mod implementation). I also added a value that rounds the given interval to the nearest integer.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
